### PR TITLE
Fixes encoded values on Blazor Router

### DIFF
--- a/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
+++ b/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
@@ -21,6 +21,7 @@
     <Compile Include="$(SharedSourceRoot)QueryStringEnumerable.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)Debugger\DictionaryItemDebugView.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)Debugger\DictionaryDebugView.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)UrlDecoder\UrlDecoder.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <Import Project="Microsoft.AspNetCore.Components.Routing.targets" />

--- a/src/Components/Components/src/Routing/RouteContext.cs
+++ b/src/Components/Components/src/Routing/RouteContext.cs
@@ -1,7 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Microsoft.AspNetCore.Internal;
 using Microsoft.AspNetCore.Routing.Tree;
 using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
@@ -11,7 +15,28 @@ internal sealed class RouteContext
 {
     public RouteContext(string path)
     {
-        Path = Uri.UnescapeDataString(path);
+        Path = path.Contains('%') ? GetDecodedPath(path) : path;
+
+        [SkipLocalsInit]
+        static string GetDecodedPath(string path)
+        {
+            using var uriBuffer = path.Length < 128 ?
+                new UriBuffer(stackalloc byte[path.Length]) :
+                new UriBuffer(path.Length);
+
+            var utf8Span = uriBuffer.Buffer;
+
+            if (Encoding.UTF8.TryGetBytes(path.AsSpan(), utf8Span, out var written))
+            {
+                utf8Span = utf8Span[..written];
+                var decodedLength = UrlDecoder.DecodeInPlace(utf8Span, isFormEncoding: false);
+                utf8Span = utf8Span[..decodedLength];
+                path = Encoding.UTF8.GetString(utf8Span);
+                return path;
+            }
+
+            return path;
+        }
     }
 
     public string Path { get; set; }
@@ -24,4 +49,27 @@ internal sealed class RouteContext
     public Type? Handler => Entry?.Handler;
 
     public IReadOnlyDictionary<string, object?>? Parameters => RouteValues;
+
+    private readonly ref struct UriBuffer
+    {
+        private readonly byte[]? _pooled;
+
+        public Span<byte> Buffer { get; }
+
+        public UriBuffer(int length)
+        {
+            _pooled = ArrayPool<byte>.Shared.Rent(length);
+            Buffer = _pooled.AsSpan(0, length);
+        }
+
+        public UriBuffer(Span<byte> buffer) => Buffer = buffer;
+
+        public void Dispose()
+        {
+            if (_pooled != null)
+            {
+                ArrayPool<byte>.Shared.Return(_pooled);
+            }
+        }
+    }
 }

--- a/src/Components/test/E2ETest/ServerRenderingTests/UnifiedRoutingTests.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/UnifiedRoutingTests.cs
@@ -24,10 +24,19 @@ public class UnifiedRoutingTests : ServerTestBase<BasicTestAppServerSiteFixture<
     public override Task InitializeAsync()
         => InitializeAsync(BrowserFixture.StreamingContext);
 
-    [Fact]
-    public void Routing_CanRenderPagesWithParameters_And_TransitionToInteractive()
+    [Theory]
+    [InlineData("routing/parameters/value", "value")]
+    // Issue 53138
+    [InlineData("%F0%9F%99%82/routing/parameters/http%3A%2F%2Fwww.example.com%2Flogin%2Fcallback", "http://www.example.com/login/callback")]
+    // Note this double encodes the final 2 slashes
+    [InlineData("%F0%9F%99%82/routing/parameters/http%3A%2F%2Fwww.example.com%2520login%2520callback", "http://www.example.com%20login%20callback")]
+    // Issue 53262
+    [InlineData("routing/parameters/%21%40%23%24%25%5E%26%2A%28%29_%2B-%3D%5B%5D%7B%7D%5C%5C%7C%3B%27%3A%5C%22%3E%3F.%2F", """!@#$%^&*()_+-=[]{}\\|;':\">?./""")]
+    // Issue 52808
+    [InlineData("routing/parameters/parts%20w%2F%20issue", "parts w/ issue")]
+    public void Routing_CanRenderPagesWithParameters_And_TransitionToInteractive(string url, string expectedValue)
     {
-        ExecuteRoutingTestCore("routing/parameters/value", "value");
+        ExecuteRoutingTestCore(url, expectedValue);
     }
 
     [Fact]
@@ -36,10 +45,12 @@ public class UnifiedRoutingTests : ServerTestBase<BasicTestAppServerSiteFixture<
         ExecuteRoutingTestCore("routing/constraints/5", "5");
     }
 
-    [Fact]
-    public void Routing_CanRenderPagesWithComplexSegments_And_TransitionToInteractive()
+    [Theory]
+    [InlineData("routing/complex-segment(value)", "value")]
+    [InlineData("%F0%9F%99%82/routing/%F0%9F%99%82complex-segment(http%3A%2F%2Fwww.example.com%2Flogin%2Fcallback)", "http://www.example.com/login/callback")]
+    public void Routing_CanRenderPagesWithComplexSegments_And_TransitionToInteractive(string url, string expectedValue)
     {
-        ExecuteRoutingTestCore("routing/complex-segment(value)", "value");
+        ExecuteRoutingTestCore(url, expectedValue);
     }
 
     [Fact]
@@ -54,10 +65,12 @@ public class UnifiedRoutingTests : ServerTestBase<BasicTestAppServerSiteFixture<
         ExecuteRoutingTestCore("routing/optional", "null");
     }
 
-    [Fact]
-    public void Routing_CanRenderPagesWithCatchAllParameters_And_TransitionToInteractive()
+    [Theory]
+    [InlineData("routing/catch-all/rest/of/the/path", "rest/of/the/path")]
+    [InlineData("%F0%9F%99%82/routing/catch-all/http%3A%2F%2Fwww.example.com%2Flogin%2Fcallback/another", "http://www.example.com/login/callback/another")]
+    public void Routing_CanRenderPagesWithCatchAllParameters_And_TransitionToInteractive(string url, string expectedValue)
     {
-        ExecuteRoutingTestCore("routing/catch-all/rest/of/the/path", "rest/of/the/path");
+        ExecuteRoutingTestCore(url, expectedValue);
     }
 
     [Fact]

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Routing/Encoded/EncodedCatchAll.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Routing/Encoded/EncodedCatchAll.razor
@@ -1,0 +1,25 @@
+﻿@page "/🙂/routing/catch-all/{*parameter}"
+
+<h3>Catch all</h3>
+
+<p id="parameter-value">@Parameter</p>
+
+@if (_interactive)
+{
+    <p id="interactive">Rendered interactive.</p>
+}
+
+@code {
+    private bool _interactive;
+
+    [Parameter] public string Parameter { get; set; }
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _interactive = true;
+            StateHasChanged();
+        }
+    }
+}

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Routing/Encoded/EncodedComplexSegments.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Routing/Encoded/EncodedComplexSegments.razor
@@ -1,0 +1,24 @@
+﻿@page "/🙂/routing/🙂complex-segment({parameter})"
+<h3>Complex segment parameters</h3>
+
+<p id="parameter-value">@Parameter</p>
+
+@if(_interactive)
+{
+    <p id="interactive">Rendered interactive.</p>
+}
+
+@code {
+    private bool _interactive;
+
+    [Parameter] public string Parameter { get; set; }
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _interactive = true;
+            StateHasChanged();
+        }
+    }
+}

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Routing/Encoded/EncodedParameters.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Routing/Encoded/EncodedParameters.razor
@@ -1,0 +1,24 @@
+﻿@page "/🙂/routing/parameters/{parameter}"
+<h3>Parameters</h3>
+
+<p id="parameter-value">@Parameter</p>
+
+@if (_interactive)
+{
+    <p id="interactive">Rendered interactive.</p>
+}
+
+@code {
+    private bool _interactive;
+
+    [Parameter] public string Parameter { get; set; }
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _interactive = true;
+            StateHasChanged();
+        }
+    }
+}

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Routing/RoutingTestCasesWithEncoding.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Routing/RoutingTestCasesWithEncoding.razor
@@ -1,0 +1,15 @@
+﻿@page "/🙂/routing"
+@inject NavigationManager NavigationManager
+<h3>Routing test cases with encoded urls</h3>
+
+<ul>
+    <li>
+        <a href="%F0%9F%99%82/routing/catch-all/http%3A%2F%2Fwww.example.com%2Flogin%2Fcallback/another">Catch all</a>
+    </li>
+    <li>
+        <a href="%F0%9F%99%82/routing/parameters/http%3A%2F%2Fwww.example.com%2Flogin%2Fcallback">Parameters</a>
+    </li>
+    <li>
+        <a href="%F0%9F%99%82/routing/%F0%9F%99%82complex-segment(http%3A%2F%2Fwww.example.com%2Flogin%2Fcallback)">Complex segments</a>
+    </li>
+</ul>


### PR DESCRIPTION
Fix handling of encoded `/` in URLs within the Blazor router.

Fixes https://github.com/dotnet/aspnetcore/issues/52808, https://github.com/dotnet/aspnetcore/issues/53138, https://github.com/dotnet/aspnetcore/issues/53262

In .NET 8.0 we unified the routing system for ASP.NET Core and Blazor in order to bridge the functionality gaps and provide a consistent experience for SSR and interactive routing. 
As part of such, we had to make adjustments to account for some of the quirks of the Blazor router (where it would behave slightly different than the ASP.NET Core router).
As part of this, we were decoding the entire URL before passing it to the Blazor router instead of (as it did before), splitting each segment and decoding each segment individually.

This introduced a regression when using URLs that contained encoded segments with `/` in them, as the router would then treat the `/` as a path separator instead of part of the segment and we would not be able to route correctly.

To fix this, we now decode each segment individually inside the router when the code runs as part of Blazor. In addition to that, when the routing happens server side, we now post-process the resulting values to URL decode them so that they match the behavior of the Blazor router.

To summarize, here is the before and after behavior:

Before:
Framework version and router | pattern | request | result
|--- | --- | --- | --- |
7.0 interactive | `/some/{parameter}` | `/some/encoded%2Fvalue` | `parameter = "encoded/value"`
8.0 SSR | `/some/{parameter}` | `/some/encoded%2Fvalue` | `parameter = "encoded%2Fvalue"`
8.0 interactive | `/some/{parameter}` | `/some/encoded%2Fvalue` | Not Found (URI got decoded as /some/encoded/value)

After:
Framework version and router | pattern | request | result
|--- | --- | --- | --- |
7.0 interactive | `/some/{parameter}` | `/some/encoded%2Fvalue` | `parameter = "encoded/value"`
8.0 SSR | `/some/{parameter}` | `/some/encoded%2Fvalue` | `parameter = "encoded/value"`
8.0 interactive | `/some/{parameter}` | `/some/encoded%2Fvalue` | `parameter = "encoded/value"`
