### PR TITLE
Pass template tests when project reference contains ".db"

### DIFF
--- a/src/ProjectTemplates/test/Templates.Mvc.Tests/BlazorTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Mvc.Tests/BlazorTemplateTest.cs
@@ -69,7 +69,7 @@ public class BlazorTemplateTest : LoggedTest
         if (!args.Contains(ArgConstants.IndividualAuth))
         {
             Assert.DoesNotContain("Microsoft.EntityFrameworkCore.Tools", projectFileContents);
-            Assert.DoesNotContain(".db", projectFileContents);
+            Assert.DoesNotContain("app.db", projectFileContents);
         }
         else
         {
@@ -77,11 +77,11 @@ public class BlazorTemplateTest : LoggedTest
 
             if (args.Contains(ArgConstants.UseLocalDb))
             {
-                Assert.DoesNotContain(".db", projectFileContents);
+                Assert.DoesNotContain("app.db", projectFileContents);
             }
             else
             {
-                Assert.Contains(".db", projectFileContents);
+                Assert.Contains("app.db", projectFileContents);
             }
         }
 

--- a/src/ProjectTemplates/test/Templates.Mvc.Tests/MvcTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Mvc.Tests/MvcTemplateTest.cs
@@ -65,7 +65,7 @@ public class MvcTemplateTest : LoggedTest
 
         var projectExtension = languageOverride == "F#" ? "fsproj" : "csproj";
         var projectFileContents = project.ReadFile($"{project.ProjectName}.{projectExtension}");
-        Assert.DoesNotContain(".db", projectFileContents);
+        Assert.DoesNotContain("app.db", projectFileContents);
         Assert.DoesNotContain("Microsoft.EntityFrameworkCore.Tools", projectFileContents);
         Assert.DoesNotContain("Microsoft.VisualStudio.Web.CodeGeneration.Design", projectFileContents);
         Assert.DoesNotContain("Microsoft.EntityFrameworkCore.Tools.DotNet", projectFileContents);
@@ -164,7 +164,7 @@ public class MvcTemplateTest : LoggedTest
         var projectFileContents = project.ReadFile($"{project.ProjectName}.csproj");
         if (!useLocalDB)
         {
-            Assert.Contains(".db", projectFileContents);
+            Assert.Contains("app.db", projectFileContents);
         }
 
         await project.RunDotNetPublishAsync();

--- a/src/ProjectTemplates/test/Templates.Mvc.Tests/RazorPagesTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Mvc.Tests/RazorPagesTemplateTest.cs
@@ -59,7 +59,7 @@ public class RazorPagesTemplateTest : LoggedTest
         await project.VerifyLaunchSettings(expectedLaunchProfileNames);
 
         var projectFileContents = ReadFile(project.TemplateOutputDir, $"{project.ProjectName}.csproj");
-        Assert.DoesNotContain(".db", projectFileContents);
+        Assert.DoesNotContain("app.db", projectFileContents);
         Assert.DoesNotContain("Microsoft.EntityFrameworkCore.Tools", projectFileContents);
         Assert.DoesNotContain("Microsoft.VisualStudio.Web.CodeGeneration.Design", projectFileContents);
         Assert.DoesNotContain("Microsoft.EntityFrameworkCore.Tools.DotNet", projectFileContents);
@@ -155,7 +155,7 @@ public class RazorPagesTemplateTest : LoggedTest
         var projectFileContents = ReadFile(project.TemplateOutputDir, $"{project.ProjectName}.csproj");
         if (!useLocalDB)
         {
-            Assert.Contains(".db", projectFileContents);
+            Assert.Contains("app.db", projectFileContents);
         }
 
         await project.RunDotNetPublishAsync();


### PR DESCRIPTION
This probably only affects the Blazor template test since it's the only one with the ProjectReference to the randomly named client, but I decided to update the pattern for MVC and Razor too.

```
Assert.DoesNotContain() Failure
Found:    .db
In value: <Project Sdk="Microsoft.NET.Sdk.Web">


        <PropertyGroup>
          <TargetFramework>net9.0</TargetFramework>
          <Nullable>enable</Nullable>
          <ImplicitUsings>enable</ImplicitUsings>
        </PropertyGroup>
      
        <ItemGroup>
          <ProjectReference Include="..AspNet.dbbwu3mcwvuc.ClientAspNet.dbbwu3mcwvuc.Client.csproj" />
          <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.0-ci" />
        </ItemGroup>
      
      </Project>
```

```
   at Templates.Mvc.Test.BlazorTemplateTest.BlazorWebTemplate_Core(String[] args) in /_/src/ProjectTemplates/test/Templates.Mvc.Tests/BlazorTemplateTest.cs:line 80
--- End of stack trace from previous location ---
```

https://dev.azure.com/dnceng-public/public/_build/results?buildId=532631&view=ms.vss-test-web.build-test-results-tab&runId=12567162&resultId=123726&paneView=debug