### PR TITLE
[Blazor] Fixes encoded `/` on Blazor Router

### DIFF
--- a/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
+++ b/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
@@ -19,10 +19,11 @@
     <Compile Include="$(ComponentsSharedSourceRoot)src\HotReloadManager.cs" LinkBase="HotReload" />
     <Compile Include="$(SharedSourceRoot)LinkerFlags.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)QueryStringEnumerable.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)UrlDecoder\UrlDecoder.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <Import Project="Microsoft.AspNetCore.Components.Routing.targets" />
-  
+
   <ItemGroup>
     <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />

--- a/src/Components/Components/src/Routing/RouteContext.cs
+++ b/src/Components/Components/src/Routing/RouteContext.cs
@@ -1,7 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Microsoft.AspNetCore.Internal;
 using Microsoft.AspNetCore.Routing.Tree;
 using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
@@ -11,7 +15,28 @@ internal sealed class RouteContext
 {
     public RouteContext(string path)
     {
-        Path = Uri.UnescapeDataString(path);
+        Path = path.Contains('%') ? GetDecodedPath(path) : path;
+
+        [SkipLocalsInit]
+        static string GetDecodedPath(string path)
+        {
+            using var uriBuffer = path.Length < 128 ?
+                new UriBuffer(stackalloc byte[path.Length]) :
+                new UriBuffer(path.Length);
+
+            var utf8Span = uriBuffer.Buffer;
+
+            if (Encoding.UTF8.TryGetBytes(path.AsSpan(), utf8Span, out var written))
+            {
+                utf8Span = utf8Span[..written];
+                var decodedLength = UrlDecoder.DecodeInPlace(utf8Span, isFormEncoding: false);
+                utf8Span = utf8Span[..decodedLength];
+                path = Encoding.UTF8.GetString(utf8Span);
+                return path;
+            }
+
+            return path;
+        }
     }
 
     public string Path { get; set; }
@@ -24,4 +49,27 @@ internal sealed class RouteContext
     public Type? Handler => Entry?.Handler;
 
     public IReadOnlyDictionary<string, object?>? Parameters => RouteValues;
+
+    private readonly ref struct UriBuffer
+    {
+        private readonly byte[]? _pooled;
+
+        public Span<byte> Buffer { get; }
+
+        public UriBuffer(int length)
+        {
+            _pooled = ArrayPool<byte>.Shared.Rent(length);
+            Buffer = _pooled.AsSpan(0, length);
+        }
+
+        public UriBuffer(Span<byte> buffer) => Buffer = buffer;
+
+        public void Dispose()
+        {
+            if (_pooled != null)
+            {
+                ArrayPool<byte>.Shared.Return(_pooled);
+            }
+        }
+    }
 }

--- a/src/Components/test/E2ETest/ServerRenderingTests/UnifiedRoutingTests.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/UnifiedRoutingTests.cs
@@ -24,10 +24,19 @@ public class UnifiedRoutingTests : ServerTestBase<BasicTestAppServerSiteFixture<
     public override Task InitializeAsync()
         => InitializeAsync(BrowserFixture.StreamingContext);
 
-    [Fact]
-    public void Routing_CanRenderPagesWithParameters_And_TransitionToInteractive()
+    [Theory]
+    [InlineData("routing/parameters/value", "value")]
+    // Issue 53138
+    [InlineData("%F0%9F%99%82/routing/parameters/http%3A%2F%2Fwww.example.com%2Flogin%2Fcallback", "http://www.example.com/login/callback")]
+    // Note this double encodes the final 2 slashes
+    [InlineData("%F0%9F%99%82/routing/parameters/http%3A%2F%2Fwww.example.com%2520login%2520callback", "http://www.example.com%20login%20callback")]
+    // Issue 53262
+    [InlineData("routing/parameters/%21%40%23%24%25%5E%26%2A%28%29_%2B-%3D%5B%5D%7B%7D%5C%5C%7C%3B%27%3A%5C%22%3E%3F.%2F", """!@#$%^&*()_+-=[]{}\\|;':\">?./""")]
+    // Issue 52808
+    [InlineData("routing/parameters/parts%20w%2F%20issue", "parts w/ issue")]
+    public void Routing_CanRenderPagesWithParameters_And_TransitionToInteractive(string url, string expectedValue)
     {
-        ExecuteRoutingTestCore("routing/parameters/value", "value");
+        ExecuteRoutingTestCore(url, expectedValue);
     }
 
     [Fact]
@@ -36,10 +45,12 @@ public class UnifiedRoutingTests : ServerTestBase<BasicTestAppServerSiteFixture<
         ExecuteRoutingTestCore("routing/constraints/5", "5");
     }
 
-    [Fact]
-    public void Routing_CanRenderPagesWithComplexSegments_And_TransitionToInteractive()
+    [Theory]
+    [InlineData("routing/complex-segment(value)", "value")]
+    [InlineData("%F0%9F%99%82/routing/%F0%9F%99%82complex-segment(http%3A%2F%2Fwww.example.com%2Flogin%2Fcallback)", "http://www.example.com/login/callback")]
+    public void Routing_CanRenderPagesWithComplexSegments_And_TransitionToInteractive(string url, string expectedValue)
     {
-        ExecuteRoutingTestCore("routing/complex-segment(value)", "value");
+        ExecuteRoutingTestCore(url, expectedValue);
     }
 
     [Fact]
@@ -54,10 +65,12 @@ public class UnifiedRoutingTests : ServerTestBase<BasicTestAppServerSiteFixture<
         ExecuteRoutingTestCore("routing/optional", "null");
     }
 
-    [Fact]
-    public void Routing_CanRenderPagesWithCatchAllParameters_And_TransitionToInteractive()
+    [Theory]
+    [InlineData("routing/catch-all/rest/of/the/path", "rest/of/the/path")]
+    [InlineData("%F0%9F%99%82/routing/catch-all/http%3A%2F%2Fwww.example.com%2Flogin%2Fcallback/another", "http://www.example.com/login/callback/another")]
+    public void Routing_CanRenderPagesWithCatchAllParameters_And_TransitionToInteractive(string url, string expectedValue)
     {
-        ExecuteRoutingTestCore("routing/catch-all/rest/of/the/path", "rest/of/the/path");
+        ExecuteRoutingTestCore(url, expectedValue);
     }
 
     [Fact]

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Routing/Encoded/EncodedCatchAll.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Routing/Encoded/EncodedCatchAll.razor
@@ -1,0 +1,25 @@
+﻿@page "/🙂/routing/catch-all/{*parameter}"
+
+<h3>Catch all</h3>
+
+<p id="parameter-value">@Parameter</p>
+
+@if (_interactive)
+{
+    <p id="interactive">Rendered interactive.</p>
+}
+
+@code {
+    private bool _interactive;
+
+    [Parameter] public string Parameter { get; set; }
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _interactive = true;
+            StateHasChanged();
+        }
+    }
+}

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Routing/Encoded/EncodedComplexSegments.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Routing/Encoded/EncodedComplexSegments.razor
@@ -1,0 +1,24 @@
+﻿@page "/🙂/routing/🙂complex-segment({parameter})"
+<h3>Complex segment parameters</h3>
+
+<p id="parameter-value">@Parameter</p>
+
+@if(_interactive)
+{
+    <p id="interactive">Rendered interactive.</p>
+}
+
+@code {
+    private bool _interactive;
+
+    [Parameter] public string Parameter { get; set; }
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _interactive = true;
+            StateHasChanged();
+        }
+    }
+}

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Routing/Encoded/EncodedParameters.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Routing/Encoded/EncodedParameters.razor
@@ -1,0 +1,24 @@
+﻿@page "/🙂/routing/parameters/{parameter}"
+<h3>Parameters</h3>
+
+<p id="parameter-value">@Parameter</p>
+
+@if (_interactive)
+{
+    <p id="interactive">Rendered interactive.</p>
+}
+
+@code {
+    private bool _interactive;
+
+    [Parameter] public string Parameter { get; set; }
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _interactive = true;
+            StateHasChanged();
+        }
+    }
+}

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Routing/RoutingTestCasesWithEncoding.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Routing/RoutingTestCasesWithEncoding.razor
@@ -1,0 +1,15 @@
+﻿@page "/🙂/routing"
+@inject NavigationManager NavigationManager
+<h3>Routing test cases with encoded urls</h3>
+
+<ul>
+    <li>
+        <a href="%F0%9F%99%82/routing/catch-all/http%3A%2F%2Fwww.example.com%2Flogin%2Fcallback/another">Catch all</a>
+    </li>
+    <li>
+        <a href="%F0%9F%99%82/routing/parameters/http%3A%2F%2Fwww.example.com%2Flogin%2Fcallback">Parameters</a>
+    </li>
+    <li>
+        <a href="%F0%9F%99%82/routing/%F0%9F%99%82complex-segment(http%3A%2F%2Fwww.example.com%2Flogin%2Fcallback)">Complex segments</a>
+    </li>
+</ul>


### PR DESCRIPTION
# Fixes handling of encoded values within Blazor Routing

As part of .NET 8.0 we replaced the Blazor Router implementation with an equivalent implementation provided by ASP.NET to bring the Blazor implementation to out of the box feature parity with the ASP.NET implementation.

As part of that, we changed the way encoded are processed before we handle them to the Blazor router, which resulted in a regression as we were eagerly decoding `%2F` (`/`) values. In addition to that, we also determined that the values were not being decoded (a custom step that Blazor does) 

## Description

* .NET 8.0 is incorrectly decoding `%2F` characters in the path before running routing.
* .NET 8.0 SSR is not decoding the route values on the server before passing them as parameters to a component.

Fixes https://github.com/dotnet/aspnetcore/issues/52808, https://github.com/dotnet/aspnetcore/issues/53138, https://github.com/dotnet/aspnetcore/issues/53262 https://github.com/dotnet/aspnetcore/issues/53668

## Customer Impact

* Customers that put encoded `/` in their application paths (for example, route parameters that take in a URL) won't be able to do so.
* Customers that use values that are URL encoded, will see the URL encoded value in server implementations and the unencoded value in the interactive implementations.

## Regression?

- [X] Yes
- [ ] No

7.0, the values were presented unencoded to the user and `%2F` was handled correctly and route values were decoded before being passed as parameters.

## Risk

- [ ] High
- [ ] Medium
- [X] Low

We've added automated tests to validate that the scenario behaves correctly and tests that verify that the implementation on the server and the client behaves consistently and accordingly to previous Blazor versions.

We've replaced the implementation that was handling the decoding in the Blazor Router (which was the source of the problem) with the implementation used by ASP.NET Core.

## Verification

- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A

----

## When servicing release/2.1

- [ ] Make necessary changes in eng/PatchConfig.props