### PR TITLE
Introduce a read-only mode for data protection keyring consumers

### DIFF
--- a/src/DataProtection/DataProtection/src/DataProtectionServiceCollectionExtensions.cs
+++ b/src/DataProtection/DataProtection/src/DataProtectionServiceCollectionExtensions.cs
@@ -68,6 +68,8 @@ public static class DataProtectionServiceCollectionExtensions
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IConfigureOptions<KeyManagementOptions>, KeyManagementOptionsSetup>());
         services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IPostConfigureOptions<KeyManagementOptions>, KeyManagementOptionsPostSetup>());
+        services.TryAddEnumerable(
             ServiceDescriptor.Transient<IConfigureOptions<DataProtectionOptions>, DataProtectionOptionsSetup>());
 
         services.TryAddSingleton<IKeyManager, XmlKeyManager>();

--- a/src/DataProtection/DataProtection/src/Internal/KeyManagementOptionsPostSetup.cs
+++ b/src/DataProtection/DataProtection/src/Internal/KeyManagementOptionsPostSetup.cs
@@ -1,0 +1,90 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Xml.Linq;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using Microsoft.AspNetCore.DataProtection.Repositories;
+using Microsoft.AspNetCore.DataProtection.XmlEncryption;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.DataProtection.Internal;
+
+/// <summary>
+/// Performs additional <see cref="KeyManagementOptions" /> configuration, after the user's configuration has been applied.
+/// </summary>
+/// <remarks>
+/// In practice, this type is used to set key management to readonly mode if an environment variable is set and the user
+/// has not explicitly configured data protection.
+/// </remarks>
+internal sealed class KeyManagementOptionsPostSetup : IPostConfigureOptions<KeyManagementOptions>
+{
+    /// <remarks>
+    /// Settable as `ReadOnlyDataProtectionKeyDirectory`, `DOTNET_ReadOnlyDataProtectionKeyDirectory`,
+    /// or `ASPNETCORE_ReadOnlyDataProtectionKeyDirectory`, in descending order of precedence.
+    /// </remarks>
+    internal const string ReadOnlyDataProtectionKeyDirectoryKey = "ReadOnlyDataProtectionKeyDirectory";
+
+    private readonly string? _keyDirectoryPath;
+    private readonly ILoggerFactory? _loggerFactory; // Null iff _keyDirectoryPath is null
+
+    public KeyManagementOptionsPostSetup()
+    {
+        // If there's no IConfiguration, there's no _keyDirectoryPath and this type will do nothing.
+        // This is mostly a convenience for tests since ASP.NET Core apps will have an IConfiguration.
+    }
+
+    public KeyManagementOptionsPostSetup(IConfiguration configuration, ILoggerFactory loggerFactory)
+    {
+        _keyDirectoryPath = configuration[ReadOnlyDataProtectionKeyDirectoryKey];
+        _loggerFactory = loggerFactory;
+    }
+
+    void IPostConfigureOptions<KeyManagementOptions>.PostConfigure(string? name, KeyManagementOptions options)
+    {
+        if (_keyDirectoryPath is null || name != Options.DefaultName)
+        {
+            return;
+        }
+
+        // If Data Protection has not been configured, then set it up according to the environment variable
+        if (options is { XmlRepository: null, XmlEncryptor: null })
+        {
+            var keyDirectory = new DirectoryInfo(_keyDirectoryPath);
+
+            options.AutoGenerateKeys = false;
+            options.XmlEncryptor = InvalidEncryptor.Instance;
+            options.XmlRepository = new ReadOnlyFileSystemXmlRepository(keyDirectory, _loggerFactory!);
+        }
+    }
+
+    private sealed class InvalidEncryptor : IXmlEncryptor
+    {
+        public static readonly IXmlEncryptor Instance = new InvalidEncryptor();
+
+        private InvalidEncryptor()
+        {
+        }
+
+        EncryptedXmlInfo IXmlEncryptor.Encrypt(XElement plaintextElement)
+        {
+            throw new InvalidOperationException("Keys access is set up as read-only, so nothing should be encrypting");
+        }
+    }
+
+    private sealed class ReadOnlyFileSystemXmlRepository : FileSystemXmlRepository
+    {
+        public ReadOnlyFileSystemXmlRepository(DirectoryInfo directory, ILoggerFactory loggerFactory)
+            : base(directory, loggerFactory)
+        {
+        }
+
+        public override void StoreElement(XElement element, string friendlyName)
+        {
+            throw new InvalidOperationException("Keys access is set up as read-only, so nothing should be storing keys");
+        }
+    }
+}

--- a/src/DataProtection/DataProtection/src/Internal/KeyManagementOptionsPostSetup.cs
+++ b/src/DataProtection/DataProtection/src/Internal/KeyManagementOptionsPostSetup.cs
@@ -45,7 +45,7 @@ internal sealed class KeyManagementOptionsPostSetup : IPostConfigureOptions<KeyM
 
     void IPostConfigureOptions<KeyManagementOptions>.PostConfigure(string? name, KeyManagementOptions options)
     {
-        if (_keyDirectoryPath is null || name != Options.DefaultName)
+        if (string.IsNullOrEmpty(_keyDirectoryPath) || name != Options.DefaultName)
         {
             return;
         }

--- a/src/DataProtection/DataProtection/src/LoggingExtensions.cs
+++ b/src/DataProtection/DataProtection/src/LoggingExtensions.cs
@@ -241,7 +241,7 @@ internal static partial class LoggingExtensions
     [LoggerMessage(61, LogLevel.Trace, "Ignoring configuration '{PropertyName}' for options instance '{OptionsName}'", EventName = "IgnoringReadOnlyConfigurationForNonDefaultOptions")]
     public static partial void IgnoringReadOnlyConfigurationForNonDefaultOptions(this ILogger logger, string propertyName, string? optionsName);
 
-    [LoggerMessage(62, LogLevel.Debug, "Enabling read-only key access with repository directory '{Path}'", EventName = "UsingReadOnlyKeyConfiguration")]
+    [LoggerMessage(62, LogLevel.Information, "Enabling read-only key access with repository directory '{Path}'", EventName = "UsingReadOnlyKeyConfiguration")]
     public static partial void UsingReadOnlyKeyConfiguration(this ILogger logger, string path);
 
     [LoggerMessage(63, LogLevel.Debug, "Not enabling read-only key access because an XML repository has been specified", EventName = "NotUsingReadOnlyKeyConfigurationBecauseOfRepository")]

--- a/src/DataProtection/DataProtection/src/LoggingExtensions.cs
+++ b/src/DataProtection/DataProtection/src/LoggingExtensions.cs
@@ -237,4 +237,16 @@ internal static partial class LoggingExtensions
 
     [LoggerMessage(60, LogLevel.Warning, "Storing keys in a directory '{path}' that may not be persisted outside of the container. Protected data will be unavailable when container is destroyed. For more information go to https://aka.ms/aspnet/dataprotectionwarning", EventName = "UsingEphemeralFileSystemLocationInContainer")]
     public static partial void UsingEphemeralFileSystemLocationInContainer(this ILogger logger, string path);
+
+    [LoggerMessage(61, LogLevel.Trace, "Ignoring configuration '{PropertyName}' for options instance '{OptionsName}'", EventName = "IgnoringReadOnlyConfigurationForNonDefaultOptions")]
+    public static partial void IgnoringReadOnlyConfigurationForNonDefaultOptions(this ILogger logger, string propertyName, string? optionsName);
+
+    [LoggerMessage(62, LogLevel.Debug, "Enabling read-only key access with repository directory '{Path}'", EventName = "UsingReadOnlyKeyConfiguration")]
+    public static partial void UsingReadOnlyKeyConfiguration(this ILogger logger, string path);
+
+    [LoggerMessage(63, LogLevel.Debug, "Not enabling read-only key access because an XML repository has been specified", EventName = "NotUsingReadOnlyKeyConfigurationBecauseOfRepository")]
+    public static partial void NotUsingReadOnlyKeyConfigurationBecauseOfRepository(this ILogger logger);
+
+    [LoggerMessage(64, LogLevel.Debug, "Not enabling read-only key access because an XML encryptor has been specified", EventName = "NotUsingReadOnlyKeyConfigurationBecauseOfEncryptor")]
+    public static partial void NotUsingReadOnlyKeyConfigurationBecauseOfEncryptor(this ILogger logger);
 }

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/Internal/KeyManagementOptionsPostSetupTest.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/Internal/KeyManagementOptionsPostSetupTest.cs
@@ -1,0 +1,171 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Xml.Linq;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using Microsoft.AspNetCore.DataProtection.Repositories;
+using Microsoft.AspNetCore.DataProtection.XmlEncryption;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.DataProtection.Internal;
+
+public class KeyManagementOptionsPostSetupTest
+{
+    private static readonly string keyDir = new DirectoryInfo("/testpath").FullName;
+    private static readonly XElement xElement = new("element");
+
+    [Fact]
+    public void ConfigureReadOnly()
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(
+        [
+            new KeyValuePair<string, string>(KeyManagementOptionsPostSetup.ReadOnlyDataProtectionKeyDirectoryKey, keyDir),
+        ]).Build();
+
+        IPostConfigureOptions<KeyManagementOptions> setup = new KeyManagementOptionsPostSetup(config, NullLoggerFactory.Instance);
+
+        var options = new KeyManagementOptions();
+
+        setup.PostConfigure(Options.DefaultName, options);
+
+        AssertReadOnly(options, keyDir);
+    }
+
+    [Fact]
+    public void ConfigureReadOnly_NonDefaultInstance()
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(
+        [
+            new KeyValuePair<string, string>(KeyManagementOptionsPostSetup.ReadOnlyDataProtectionKeyDirectoryKey, keyDir),
+        ]).Build();
+
+        IPostConfigureOptions<KeyManagementOptions> setup = new KeyManagementOptionsPostSetup(config, NullLoggerFactory.Instance);
+
+        var options = new KeyManagementOptions();
+
+        setup.PostConfigure(Options.DefaultName + 1, options);
+
+        AssertNotReadOnly(options, keyDir);
+
+        Assert.True(options.AutoGenerateKeys);
+    }
+
+    [Fact]
+    public void ConfigureReadOnly_ExplicitRepository()
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(
+        [
+            new KeyValuePair<string, string>(KeyManagementOptionsPostSetup.ReadOnlyDataProtectionKeyDirectoryKey, keyDir),
+        ]).Build();
+
+        IPostConfigureOptions<KeyManagementOptions> setup = new KeyManagementOptionsPostSetup(config, NullLoggerFactory.Instance);
+
+        var options = new KeyManagementOptions()
+        {
+            XmlRepository = new FileSystemXmlRepository(new DirectoryInfo("/testpath2"), NullLoggerFactory.Instance),
+        };
+
+        setup.PostConfigure(Options.DefaultName, options);
+
+        AssertNotReadOnly(options, keyDir);
+
+        Assert.True(options.AutoGenerateKeys);
+    }
+
+    [Fact]
+    public void ConfigureReadOnly_ExplicitEncryptor()
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(
+        [
+            new KeyValuePair<string, string>(KeyManagementOptionsPostSetup.ReadOnlyDataProtectionKeyDirectoryKey, keyDir),
+        ]).Build();
+
+        IPostConfigureOptions<KeyManagementOptions> setup = new KeyManagementOptionsPostSetup(config, NullLoggerFactory.Instance);
+
+        var options = new KeyManagementOptions()
+        {
+            XmlEncryptor = new NullXmlEncryptor(),
+        };
+
+        setup.PostConfigure(Options.DefaultName, options);
+
+        AssertNotReadOnly(options, keyDir);
+
+        Assert.True(options.AutoGenerateKeys);
+    }
+
+    [Fact]
+    public void NotConfigured_NoProperty()
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+
+        IPostConfigureOptions<KeyManagementOptions> setup = new KeyManagementOptionsPostSetup(config, NullLoggerFactory.Instance);
+
+        var options = new KeyManagementOptions();
+
+        setup.PostConfigure(Options.DefaultName, options);
+
+        AssertNotReadOnly(options, keyDir);
+
+        Assert.True(options.AutoGenerateKeys);
+    }
+
+    [Fact]
+    public void NotConfigured_NoIConfiguration()
+    {
+        IPostConfigureOptions<KeyManagementOptions> setup = new KeyManagementOptionsPostSetup();
+
+        var options = new KeyManagementOptions();
+
+        setup.PostConfigure(Options.DefaultName, options);
+
+        AssertNotReadOnly(options, keyDir);
+
+        Assert.True(options.AutoGenerateKeys);
+    }
+
+    private static void AssertReadOnly(KeyManagementOptions options, string keyDir)
+    {
+        // Effect 1: No key generation
+        Assert.False(options.AutoGenerateKeys);
+
+        var repository = options.XmlRepository as FileSystemXmlRepository;
+        Assert.NotNull(repository);
+
+        // Effect 2: Location from configuration
+        Assert.Equal(keyDir, repository.Directory.FullName);
+
+        // Effect 3: No writing
+        Assert.Throws<InvalidOperationException>(() => repository.StoreElement(xElement, friendlyName: null));
+
+        // Effect 4: No key encryption
+        Assert.NotNull(options.XmlEncryptor);
+        Assert.Throws<InvalidOperationException>(() => options.XmlEncryptor.Encrypt(xElement));
+    }
+
+    private static void AssertNotReadOnly(KeyManagementOptions options, string keyDir)
+    {
+        // Missing effect 1: No key generation
+        Assert.True(options.AutoGenerateKeys);
+
+        var repository = options.XmlRepository;
+        if (repository is not null)
+        {
+            // Missing effect 2: Location from configuration
+            Assert.NotEqual(keyDir, (repository as FileSystemXmlRepository)?.Directory.FullName);
+
+
+            // Missing effect 3: No writing
+            repository.StoreElement(xElement, friendlyName: null);
+        }
+
+        var encryptor = options.XmlEncryptor;
+        if (encryptor is not null)
+        {
+            // Missing effect 4: No key encryption
+            options.XmlEncryptor.Encrypt(xElement);
+        }
+    }
+}

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/Internal/KeyManagementOptionsPostSetupTest.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/Internal/KeyManagementOptionsPostSetupTest.cs
@@ -81,16 +81,24 @@ public class KeyManagementOptionsPostSetupTest
 
         IPostConfigureOptions<KeyManagementOptions> setup = new KeyManagementOptionsPostSetup(config, NullLoggerFactory.Instance);
 
-        var options = new KeyManagementOptions()
+        var xmlDir = Directory.CreateTempSubdirectory();
+        try
         {
-            XmlRepository = new FileSystemXmlRepository(new DirectoryInfo("/testpath2"), NullLoggerFactory.Instance),
-        };
+            var options = new KeyManagementOptions()
+            {
+                XmlRepository = new FileSystemXmlRepository(xmlDir, NullLoggerFactory.Instance),
+            };
 
-        setup.PostConfigure(Options.DefaultName, options);
+            setup.PostConfigure(Options.DefaultName, options);
 
-        AssertNotReadOnly(options, keyDir);
+            AssertNotReadOnly(options, keyDir);
 
-        Assert.True(options.AutoGenerateKeys);
+            Assert.True(options.AutoGenerateKeys);
+        }
+        finally
+        {
+            xmlDir.Delete(recursive: true);
+        }
     }
 
     [Fact]

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/Internal/KeyManagementOptionsPostSetupTest.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/Internal/KeyManagementOptionsPostSetupTest.cs
@@ -175,7 +175,6 @@ public class KeyManagementOptionsPostSetupTest
             // Missing effect 2: Location from configuration
             Assert.NotEqual(keyDir, (repository as FileSystemXmlRepository)?.Directory.FullName);
 
-
             // Missing effect 3: No writing
             repository.StoreElement(xElement, friendlyName: null);
         }

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/Internal/KeyManagementOptionsPostSetupTest.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/Internal/KeyManagementOptionsPostSetupTest.cs
@@ -53,6 +53,25 @@ public class KeyManagementOptionsPostSetupTest
     }
 
     [Fact]
+    public void ConfigureReadOnly_EmptyDirPath()
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(
+        [
+            new KeyValuePair<string, string>(KeyManagementOptionsPostSetup.ReadOnlyDataProtectionKeyDirectoryKey, ""),
+        ]).Build();
+
+        IPostConfigureOptions<KeyManagementOptions> setup = new KeyManagementOptionsPostSetup(config, NullLoggerFactory.Instance);
+
+        var options = new KeyManagementOptions();
+
+        setup.PostConfigure(Options.DefaultName, options);
+
+        AssertNotReadOnly(options, keyDir);
+
+        Assert.True(options.AutoGenerateKeys);
+    }
+
+    [Fact]
     public void ConfigureReadOnly_ExplicitRepository()
     {
         var config = new ConfigurationBuilder().AddInMemoryCollection(

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/ServiceCollectionTests.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/ServiceCollectionTests.cs
@@ -105,4 +105,24 @@ public class ServiceCollectionTests
         Assert.NotNull(options.XmlEncryptor);
         Assert.Throws<InvalidOperationException>(() => options.XmlEncryptor.Encrypt(xElement));
     }
+
+    [Fact]
+    public void NoReadOnlyDataProtectionKeyDirectory()
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+
+        var services = new ServiceCollection()
+            .AddSingleton<IConfiguration>(config)
+            .AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance)
+            .AddDataProtection()
+            .Services
+            .BuildServiceProvider();
+
+        var options = services.GetRequiredService<IOptions<KeyManagementOptions>>().Value;
+
+        // Missing effect 1: No key generation
+        Assert.True(options.AutoGenerateKeys);
+
+        // KeyManagementOptionsPostSetupTest covers other missing effects
+    }
 }

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/ServiceCollectionTests.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/ServiceCollectionTests.cs
@@ -1,8 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Xml.Linq;
+using Microsoft.AspNetCore.DataProtection.Internal;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using Microsoft.AspNetCore.DataProtection.Repositories;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.DataProtection;
@@ -60,5 +66,43 @@ public class ServiceCollectionTests
 
             Assert.NotNull(services.GetService(descriptor.ServiceType));
         }
+    }
+
+    [Fact]
+    public void ReadOnlyDataProtectionKeyDirectory()
+    {
+        var keyDir = new DirectoryInfo("/testpath").FullName;
+
+        var config = new ConfigurationBuilder().AddInMemoryCollection(
+        [
+            new KeyValuePair<string, string>(KeyManagementOptionsPostSetup.ReadOnlyDataProtectionKeyDirectoryKey, keyDir),
+        ]).Build();
+
+        var services = new ServiceCollection()
+            .AddSingleton<IConfiguration>(config)
+            .AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance)
+            .AddDataProtection()
+            .Services
+            .BuildServiceProvider();
+
+        var options = services.GetRequiredService<IOptions<KeyManagementOptions>>().Value;
+
+        // Effect 1: No key generation
+        Assert.False(options.AutoGenerateKeys);
+
+        var repository = options.XmlRepository as FileSystemXmlRepository;
+        Assert.NotNull(repository);
+
+        // Effect 2: Location from configuration
+        Assert.Equal(keyDir, repository.Directory.FullName);
+
+        var xElement = new XElement("element");
+
+        // Effect 3: No writing
+        Assert.Throws<InvalidOperationException>(() => repository.StoreElement(xElement, friendlyName: null));
+
+        // Effect 4: No key encryption
+        Assert.NotNull(options.XmlEncryptor);
+        Assert.Throws<InvalidOperationException>(() => options.XmlEncryptor.Encrypt(xElement));
     }
 }


### PR DESCRIPTION
# Introduce a read-only mode for data protection keyring consumers

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

When multiple app instances consume the same keyring, they all try to rotate it, leading to races.  This change introduces an IConfiguration property (usually set as an env var) that puts data protection in a read-only mode.  The expectation is that writing will be done by a separate (i.e. non-app-instance) component.

Fixes #52915