### PR TITLE
Fix duplicate route detection of actions with route parameters

### DIFF
--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Mvc/DetectAmbiguousActionRoutes.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Mvc/DetectAmbiguousActionRoutes.cs
@@ -76,7 +76,7 @@ public partial class MvcAnalyzer
                     {
                         for (var k = 0; k < parameterNode.ParameterParts.Length; k++)
                         {
-                            if (parameterNode.ParameterParts[j] is RoutePatternNameParameterPartNode namePartNode)
+                            if (parameterNode.ParameterParts[k] is RoutePatternNameParameterPartNode namePartNode)
                             {
                                 if (!namePartNode.ParameterNameToken.IsMissing)
                                 {

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Mvc/DetectAmbiguousActionRoutes.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Mvc/DetectAmbiguousActionRoutes.cs
@@ -20,7 +20,7 @@ public partial class MvcAnalyzer
 {
     private static void DetectAmbiguousActionRoutes(SymbolAnalysisContext context, WellKnownTypes wellKnownTypes, RoutePatternTree? controllerRoutePattern, List<ActionRoute> actionRoutes)
     {
-        var controllerHasActionReplacement = controllerRoutePattern != null ? HasActionReplacementToken(controllerRoutePattern) : false;
+        var controllerHasActionToken = controllerRoutePattern != null ? HasActionToken(controllerRoutePattern) : false;
 
         // Ambiguous action route detection is conservative in what it detects to avoid false positives.
         //
@@ -33,7 +33,7 @@ public partial class MvcAnalyzer
         {
             // Group action routes together. When multiple match in a group, then report action routes to diagnostics.
             var groupedByParent = actionRoutes
-                .GroupBy(ar => new ActionRouteGroupKey(ar.ActionSymbol, ar.RouteUsageModel.RoutePattern, ar.HttpMethods, controllerHasActionReplacement, wellKnownTypes));
+                .GroupBy(ar => new ActionRouteGroupKey(ar.ActionSymbol, ar.RouteUsageModel.RoutePattern, ar.HttpMethods, controllerHasActionToken, wellKnownTypes));
 
             foreach (var ambiguousGroup in groupedByParent.Where(g => g.Count() >= 2))
             {
@@ -48,7 +48,12 @@ public partial class MvcAnalyzer
         }
     }
 
-    private static bool HasActionReplacementToken(RoutePatternTree routePattern)
+    /// <summary>
+    /// Search route pattern for:
+    /// 1. Action replacement tokens, [action]
+    /// 2. Action parameter tokens, {action}
+    /// </summary>
+    private static bool HasActionToken(RoutePatternTree routePattern)
     {
         for (var i = 0; i < routePattern.Root.Parts.Length; i++)
         {
@@ -67,6 +72,23 @@ public partial class MvcAnalyzer
                             }
                         }
                     }
+                    else if (segment.Children[j] is RoutePatternParameterNode parameterNode)
+                    {
+                        for (var k = 0; k < parameterNode.ParameterParts.Length; k++)
+                        {
+                            if (parameterNode.ParameterParts[j] is RoutePatternNameParameterPartNode namePartNode)
+                            {
+                                if (!namePartNode.ParameterNameToken.IsMissing)
+                                {
+                                    var name = namePartNode.ParameterNameToken.Value!.ToString();
+                                    if (string.Equals(name, "action", StringComparison.OrdinalIgnoreCase))
+                                    {
+                                        return true;
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -80,10 +102,10 @@ public partial class MvcAnalyzer
         public RoutePatternTree RoutePattern { get; }
         public ImmutableArray<string> HttpMethods { get; }
         public string ActionName { get; }
-        public bool HasActionReplacement { get; }
+        public bool HasActionToken { get; }
         private readonly WellKnownTypes _wellKnownTypes;
 
-        public ActionRouteGroupKey(IMethodSymbol actionSymbol, RoutePatternTree routePattern, ImmutableArray<string> httpMethods, bool controllerHasActionReplacement, WellKnownTypes wellKnownTypes)
+        public ActionRouteGroupKey(IMethodSymbol actionSymbol, RoutePatternTree routePattern, ImmutableArray<string> httpMethods, bool controllerHasActionToken, WellKnownTypes wellKnownTypes)
         {
             Debug.Assert(!httpMethods.IsDefault);
 
@@ -92,7 +114,7 @@ public partial class MvcAnalyzer
             HttpMethods = httpMethods;
             _wellKnownTypes = wellKnownTypes;
             ActionName = GetActionName(ActionSymbol, _wellKnownTypes);
-            HasActionReplacement = controllerHasActionReplacement || HasActionReplacementToken(RoutePattern);
+            HasActionToken = controllerHasActionToken || HasActionToken(RoutePattern);
         }
 
         private static string GetActionName(IMethodSymbol actionSymbol, WellKnownTypes wellKnownTypes)
@@ -118,7 +140,7 @@ public partial class MvcAnalyzer
         {
             return
                 AmbiguousRoutePatternComparer.Instance.Equals(RoutePattern, other.RoutePattern) &&
-                (!HasActionReplacement || string.Equals(ActionName, other.ActionName, StringComparison.OrdinalIgnoreCase)) &&
+                (!HasActionToken || string.Equals(ActionName, other.ActionName, StringComparison.OrdinalIgnoreCase)) &&
                 HasMatchingHttpMethods(HttpMethods, other.HttpMethods) &&
                 CanMatchActions(_wellKnownTypes, ActionSymbol, other.ActionSymbol);
         }

--- a/src/Framework/AspNetCoreAnalyzers/test/Mvc/DetectAmbiguousActionRoutesTest.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/Mvc/DetectAmbiguousActionRoutesTest.cs
@@ -39,6 +39,34 @@ internal class Program
         // Act & Assert
         await VerifyCS.VerifyAnalyzerAsync(source, expectedDiagnostics);
     }
+/*
+    [Fact]
+    public async Task ActionRouteToken_DifferentActionNames_NoDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+public class WeatherForecastController : ControllerBase
+{
+    [Route(""{action}"")]
+    public object Get() => new object();
+
+    [Route(""{action}"")]
+    public object Get1() => new object();
+}
+internal class Program
+{
+    static void Main(string[] args)
+    {
+    }
+}
+";
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+*/
 
     [Fact]
     public async Task ActionReplacementToken_DifferentActionNames_NoDiagnostics()
@@ -298,6 +326,284 @@ public abstract class MyControllerBase : ControllerBase
     public abstract object Get(string s);
 }
 [Route(""[controller]/[action]"")]
+public class WeatherForecastController : MyControllerBase
+{
+    [Route(""{i}"")]
+    public object Get(int i) => new object();
+
+    [Route(""{s}"")]
+    public override object Get(string s) => new object();
+}
+internal class Program
+{
+    static void Main(string[] args)
+    {
+    }
+}
+";
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task ActionRouteToken_DifferentActionNames_NoDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+public class WeatherForecastController : ControllerBase
+{
+    [Route(""{action}"")]
+    public object Get() => new object();
+
+    [Route(""{action}"")]
+    public object Get1() => new object();
+}
+internal class Program
+{
+    static void Main(string[] args)
+    {
+    }
+}
+";
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task ActionRouteToken_SameActionName_HasDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+public class WeatherForecastController : ControllerBase
+{
+    [Route({|#0:""{action}""|})]
+    public object Get() => new object();
+
+    [Route({|#1:""{action}""|})]
+    public object Get(int i) => new object();
+}
+internal class Program
+{
+    static void Main(string[] args)
+    {
+    }
+}
+";
+
+        var expectedDiagnostics = new[] {
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousActionRoute).WithArguments("[action]").WithLocation(0),
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousActionRoute).WithArguments("[action]").WithLocation(1)
+        };
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source, expectedDiagnostics);
+    }
+
+    [Fact]
+    public async Task ActionRouteToken_ActionNameAttribute_HasDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+public class WeatherForecastController : ControllerBase
+{
+    [Route({|#0:""{action}""|})]
+    public object Get() => new object();
+
+    [Route({|#1:""{action}""|})]
+    [ActionName(""get"")]
+    public object Get1(int i) => new object();
+}
+internal class Program
+{
+    static void Main(string[] args)
+    {
+    }
+}
+";
+
+        var expectedDiagnostics = new[] {
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousActionRoute).WithArguments("[action]").WithLocation(0),
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousActionRoute).WithArguments("[action]").WithLocation(1)
+        };
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source, expectedDiagnostics);
+    }
+
+    [Fact]
+    public async Task ActionRouteToken_ActionNameAttributeNullValue_NoDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+public class WeatherForecastController : ControllerBase
+{
+    [Route({|#0:""{action}""|})]
+    public object Get() => new object();
+
+    [Route({|#1:""{action}""|})]
+    [ActionName(null)]
+    public object Get1(int i) => new object();
+}
+internal class Program
+{
+    static void Main(string[] args)
+    {
+    }
+}
+";
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task ActionRouteToken_OnController_NoDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+[Route(""{controller}/{action}"")]
+public class WeatherForecastController : ControllerBase
+{
+    [Route(""{i}"")]
+    public object Get(int i) => new object();
+
+    [Route(""{i}"")]
+    public object Get1(int i) => new object();
+}
+internal class Program
+{
+    static void Main(string[] args)
+    {
+    }
+}
+";
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task ActionRouteToken_OnBaseController_NoDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+[Route(""{controller}/{action}"")]
+public class MyControllerBase : ControllerBase
+{
+}
+public class WeatherForecastController : MyControllerBase
+{
+    [Route(""{i}"")]
+    public object Get(int i) => new object();
+
+    [Route(""{i}"")]
+    public object Get1(int i) => new object();
+}
+internal class Program
+{
+    static void Main(string[] args)
+    {
+    }
+}
+";
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task ActionRouteToken_OnBaseControllerButOverridden_HasDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+[Route(""{controller}/{action}"")]
+public class MyControllerBase : ControllerBase
+{
+}
+[Route(""api"")]
+public class WeatherForecastController : MyControllerBase
+{
+    [Route({|#0:""{i}""|})]
+    public object Get(int i) => new object();
+
+    [Route({|#1:""{i}""|})]
+    public object Get1(int i) => new object();
+}
+internal class Program
+{
+    static void Main(string[] args)
+    {
+    }
+}
+";
+
+        var expectedDiagnostics = new[] {
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousActionRoute).WithArguments("{i}").WithLocation(0),
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousActionRoute).WithArguments("{i}").WithLocation(1)
+        };
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source, expectedDiagnostics);
+    }
+
+    [Fact]
+    public async Task ActionRouteToken_OnController_ActionName_NoDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+[Route(""{controller}/{action}"")]
+public class WeatherForecastController : ControllerBase
+{
+    [Route(""{i}"")]
+    public object Get(int i) => new object();
+
+    [Route(""{s}"")]
+    [ActionName(name: ""getWithString"")]
+    public object Get(string s) => new object();
+}
+internal class Program
+{
+    static void Main(string[] args)
+    {
+    }
+}
+";
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task ActionRouteToken_OnController_ActionNameOnBase_NoDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+public abstract class MyControllerBase : ControllerBase
+{
+    [ActionName(name: ""getWithString"")]
+    public abstract object Get(string s);
+}
+[Route(""{controller}/{action}"")]
 public class WeatherForecastController : MyControllerBase
 {
     [Route(""{i}"")]

--- a/src/Framework/AspNetCoreAnalyzers/test/Mvc/DetectAmbiguousActionRoutesTest.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/Mvc/DetectAmbiguousActionRoutesTest.cs
@@ -39,34 +39,6 @@ internal class Program
         // Act & Assert
         await VerifyCS.VerifyAnalyzerAsync(source, expectedDiagnostics);
     }
-/*
-    [Fact]
-    public async Task ActionRouteToken_DifferentActionNames_NoDiagnostics()
-    {
-        // Arrange
-        var source = @"
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Mvc;
-public class WeatherForecastController : ControllerBase
-{
-    [Route(""{action}"")]
-    public object Get() => new object();
-
-    [Route(""{action}"")]
-    public object Get1() => new object();
-}
-internal class Program
-{
-    static void Main(string[] args)
-    {
-    }
-}
-";
-
-        // Act & Assert
-        await VerifyCS.VerifyAnalyzerAsync(source);
-    }
-*/
 
     [Fact]
     public async Task ActionReplacementToken_DifferentActionNames_NoDiagnostics()
@@ -397,8 +369,8 @@ internal class Program
 ";
 
         var expectedDiagnostics = new[] {
-            new DiagnosticResult(DiagnosticDescriptors.AmbiguousActionRoute).WithArguments("[action]").WithLocation(0),
-            new DiagnosticResult(DiagnosticDescriptors.AmbiguousActionRoute).WithArguments("[action]").WithLocation(1)
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousActionRoute).WithArguments("{action}").WithLocation(0),
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousActionRoute).WithArguments("{action}").WithLocation(1)
         };
 
         // Act & Assert
@@ -430,8 +402,8 @@ internal class Program
 ";
 
         var expectedDiagnostics = new[] {
-            new DiagnosticResult(DiagnosticDescriptors.AmbiguousActionRoute).WithArguments("[action]").WithLocation(0),
-            new DiagnosticResult(DiagnosticDescriptors.AmbiguousActionRoute).WithArguments("[action]").WithLocation(1)
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousActionRoute).WithArguments("{action}").WithLocation(0),
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousActionRoute).WithArguments("{action}").WithLocation(1)
         };
 
         // Act & Assert


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/49777

A previous fix handled the situation where `[action]` replacement tokens in a route could cause false positives. Using a replacement token for `[action]` is recommended by our docs, but `{action}` can do the same thing.

This PR fixes `{action}` route tokens in the route analyzer.

Example:
```cs
[Route("api/[controller]")]
[ApiController]
public class MyController : ControllerBase
{
    [HttpGet("{action}")]
    public IActionResult GetTime() => Ok(DateTime.Now.ToString("HH:mm:ss"));
    
    [HttpGet("{action}")]
    public IActionResult GetDate() => Ok(DateTime.Now.ToString("yyyy-MM-dd"));
}
```