### PR TITLE
Change nullability annotation of HostString.Value to explictly allow null

### DIFF
--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonTranscodingServerCallContext.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonTranscodingServerCallContext.cs
@@ -61,7 +61,7 @@ internal sealed class JsonTranscodingServerCallContext : ServerCallContext, ISer
 
     protected override string MethodCore => _method.FullName;
 
-    protected override string HostCore => HttpContext.Request.Host.Value;
+    protected override string HostCore => HttpContext.Request.Host.Value ?? string.Empty;
 
     protected override string PeerCore
     {

--- a/src/Http/Http.Abstractions/src/HostString.cs
+++ b/src/Http/Http.Abstractions/src/HostString.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Microsoft.AspNetCore.Http.Abstractions;
 using Microsoft.Extensions.Primitives;
@@ -25,14 +26,14 @@ public readonly struct HostString : IEquatable<HostString>
 
     private static readonly IdnMapping s_idnMapping = new();
 
-    private readonly string _value;
+    private readonly string? _value;
 
     /// <summary>
     /// Creates a new HostString without modification. The value should be Unicode rather than punycode, and may have a port.
     /// IPv4 and IPv6 addresses are also allowed, and also may have ports.
     /// </summary>
     /// <param name="value"></param>
-    public HostString(string value)
+    public HostString(string? value)
     {
         _value = value;
     }
@@ -67,7 +68,7 @@ public readonly struct HostString : IEquatable<HostString>
     /// <summary>
     /// Returns the original value from the constructor.
     /// </summary>
-    public string Value
+    public string? Value
     {
         get { return _value; }
     }
@@ -75,6 +76,8 @@ public readonly struct HostString : IEquatable<HostString>
     /// <summary>
     /// Returns true if the host is set.
     /// </summary>
+    [MemberNotNullWhen(true, nameof(_value))]
+    [MemberNotNullWhen(true, nameof(Value))]
     public bool HasValue
     {
         get { return !string.IsNullOrEmpty(_value); }

--- a/src/Http/Http.Abstractions/src/PublicAPI.Shipped.txt
+++ b/src/Http/Http.Abstractions/src/PublicAPI.Shipped.txt
@@ -274,10 +274,10 @@ Microsoft.AspNetCore.Http.HostString.HasValue.get -> bool
 Microsoft.AspNetCore.Http.HostString.Host.get -> string!
 Microsoft.AspNetCore.Http.HostString.HostString() -> void
 Microsoft.AspNetCore.Http.HostString.HostString(string! host, int port) -> void
-Microsoft.AspNetCore.Http.HostString.HostString(string! value) -> void
+Microsoft.AspNetCore.Http.HostString.HostString(string? value) -> void
 Microsoft.AspNetCore.Http.HostString.Port.get -> int?
 Microsoft.AspNetCore.Http.HostString.ToUriComponent() -> string!
-Microsoft.AspNetCore.Http.HostString.Value.get -> string!
+Microsoft.AspNetCore.Http.HostString.Value.get -> string?
 Microsoft.AspNetCore.Http.HttpContext
 Microsoft.AspNetCore.Http.HttpContext.HttpContext() -> void
 Microsoft.AspNetCore.Http.HttpMethods

--- a/src/Http/Http.Abstractions/src/PublicAPI.Shipped.txt
+++ b/src/Http/Http.Abstractions/src/PublicAPI.Shipped.txt
@@ -274,10 +274,10 @@ Microsoft.AspNetCore.Http.HostString.HasValue.get -> bool
 Microsoft.AspNetCore.Http.HostString.Host.get -> string!
 Microsoft.AspNetCore.Http.HostString.HostString() -> void
 Microsoft.AspNetCore.Http.HostString.HostString(string! host, int port) -> void
-Microsoft.AspNetCore.Http.HostString.HostString(string? value) -> void
+Microsoft.AspNetCore.Http.HostString.HostString(string! value) -> void
 Microsoft.AspNetCore.Http.HostString.Port.get -> int?
 Microsoft.AspNetCore.Http.HostString.ToUriComponent() -> string!
-Microsoft.AspNetCore.Http.HostString.Value.get -> string?
+Microsoft.AspNetCore.Http.HostString.Value.get -> string!
 Microsoft.AspNetCore.Http.HttpContext
 Microsoft.AspNetCore.Http.HttpContext.HttpContext() -> void
 Microsoft.AspNetCore.Http.HttpMethods

--- a/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 #nullable enable
+*REMOVED*Microsoft.AspNetCore.Http.HostString.HostString(string! value) -> void
+Microsoft.AspNetCore.Http.HostString.HostString(string? value) -> void
+*REMOVED*Microsoft.AspNetCore.Http.HostString.Value.get -> string!
+Microsoft.AspNetCore.Http.HostString.Value.get -> string?

--- a/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.AspNetCore.Http.HostString.HostString(string? value) -> void
+Microsoft.AspNetCore.Http.HostString.Value.get -> string?

--- a/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 #nullable enable
-Microsoft.AspNetCore.Http.HostString.HostString(string? value) -> void
-Microsoft.AspNetCore.Http.HostString.Value.get -> string?

--- a/src/Http/Http.Abstractions/test/HostStringTest.cs
+++ b/src/Http/Http.Abstractions/test/HostStringTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.InternalTesting;
@@ -18,6 +18,7 @@ public class HostStringTests
     }
 
     [Theory]
+    [InlineData(null, "")]
     [InlineData("localhost", "localhost")]
     [InlineData("1.2.3.4", "1.2.3.4")]
     [InlineData("[2001:db8:a0b:12f0::1]", "[2001:db8:a0b:12f0::1]")]

--- a/src/Middleware/Rewrite/src/RedirectToNonWwwRule.cs
+++ b/src/Middleware/Rewrite/src/RedirectToNonWwwRule.cs
@@ -43,7 +43,7 @@ internal sealed class RedirectToNonWwwRule : IRule
             return;
         }
 
-        if (!request.Host.Value.StartsWith(WwwDot, StringComparison.OrdinalIgnoreCase))
+        if (!request.Host.HasValue || !request.Host.Value.StartsWith(WwwDot, StringComparison.OrdinalIgnoreCase))
         {
             context.Result = RuleResult.ContinueRules;
             return;

--- a/src/Middleware/Rewrite/src/RedirectToWwwRule.cs
+++ b/src/Middleware/Rewrite/src/RedirectToWwwRule.cs
@@ -43,7 +43,7 @@ internal sealed class RedirectToWwwRule : IRule
             return;
         }
 
-        if (req.Host.Value.StartsWith(WwwDot, StringComparison.OrdinalIgnoreCase))
+        if (req.Host.HasValue && req.Host.Value.StartsWith(WwwDot, StringComparison.OrdinalIgnoreCase))
         {
             context.Result = RuleResult.ContinueRules;
             return;


### PR DESCRIPTION
# Change nullability annotation of HostString.Value to explictly allow null

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Change nullability annotation of HostString.Value to explictly allow null.

## Description

Fixes #53567
