### PR TITLE
updating Microsoft.Data.SqlClient to cover CVE warning

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -331,7 +331,7 @@
     <XunitExtensibilityCoreVersion>$(XunitVersion)</XunitExtensibilityCoreVersion>
     <XunitExtensibilityExecutionVersion>$(XunitVersion)</XunitExtensibilityExecutionVersion>
     <XUnitRunnerVisualStudioVersion>2.4.3</XUnitRunnerVisualStudioVersion>
-    <MicrosoftDataSqlClientVersion>4.0.1</MicrosoftDataSqlClientVersion>
+    <MicrosoftDataSqlClientVersion>4.0.5</MicrosoftDataSqlClientVersion>
     <MicrosoftAspNetCoreAppVersion>6.0.0-preview.3.21167.1</MicrosoftAspNetCoreAppVersion>
     <MicrosoftOpenApiVersion>1.4.3</MicrosoftOpenApiVersion>
     <!-- dotnet tool versions (see also auto-updated DotnetEfVersion property). -->


### PR DESCRIPTION
Build ops; current CI is generating:

```
2024-01-23T20:12:02.4087726Z _________________________________________________________________________________________________________________________________________________
2024-01-23T20:12:02.4088166Z |Security Alerts                                                                                                                                |
2024-01-23T20:12:02.4088585Z |_______________________________________________________________________________________________________________________________________________|
2024-01-23T20:12:02.4088956Z |Alert title                             |Affected component                      |Severity                      |Due date                      |
2024-01-23T20:12:02.4089268Z |________________________________________|________________________________________|______________________________|______________________________|
2024-01-23T20:12:02.4089996Z |CVE-2024-0056                           |Microsoft.Data.SqlClient 4.0.1          |High                          |2024-02-16T09:15:40.1351132Z  |
2024-01-23T20:12:02.4090343Z |________________________________________|________________________________________|______________________________|______________________________|
```

Trying to resolve; note that "current" is 5.1.4, am tempted to jump major, but let's see if small bump works, first (major only to net9, minor should be safer to backport)