### PR TITLE
Bump update-dotnet-sdk to v3.1.2

### DIFF
--- a/.github/workflows/update-sdk.yml
+++ b/.github/workflows/update-sdk.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: martincostello/update-dotnet-sdk@b3d5ca8064ec275f7a1d0b9640d28a57ab94090b
+    - uses: martincostello/update-dotnet-sdk@65c5f402b15326dd12d7b1dac63abdbb53ed695c # v3.1.2
       with:
         quality: 'daily'
         repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Bump update-dotnet-sdk to [v3.1.2](https://github.com/martincostello/update-dotnet-sdk/releases/tag/v3.1.2) ([diff](https://github.com/martincostello/update-dotnet-sdk/compare/b3d5ca8064ec275f7a1d0b9640d28a57ab94090b...65c5f402b15326dd12d7b1dac63abdbb53ed695c)) to fix existing pull requests not being closed when a new pull request to update the .NET SDK is opened.

See https://github.com/dotnet/aspnetcore/pull/53525#issuecomment-1904473366.

/cc @wtgodbe
