### PR TITLE
[release/8.0] Fix stale values from `[SupplyParameterFromQuery]`

### DIFF
--- a/src/Components/Components/src/Routing/QueryParameterValueSupplier.cs
+++ b/src/Components/Components/src/Routing/QueryParameterValueSupplier.cs
@@ -51,10 +51,4 @@ internal sealed class QueryParameterValueSupplier
 
         return default;
     }
-
-    public static bool CanSupplyValueForType(Type targetType)
-    {
-        var elementType = targetType.IsArray ? targetType.GetElementType()! : targetType;
-        return UrlValueConstraint.TryGetByTargetType(elementType, out _);
-    }
 }

--- a/src/Components/Components/src/Routing/SupplyParameterFromQueryValueProvider.cs
+++ b/src/Components/Components/src/Routing/SupplyParameterFromQueryValueProvider.cs
@@ -1,0 +1,152 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Microsoft.AspNetCore.Components.Routing;
+
+internal sealed class SupplyParameterFromQueryValueProvider(NavigationManager navigationManager) : ICascadingValueSupplier, IDisposable
+{
+    private QueryParameterValueSupplier? _queryParameterValueSupplier;
+
+    private HashSet<ComponentState>? _subscribers;
+    private HashSet<ComponentState>? _pendingSubscribers;
+
+    private string? _lastUri;
+    private bool _isSubscribedToLocationChanges;
+    private bool _queryChanged;
+
+    public bool IsFixed => false;
+
+    public bool CanSupplyValue(in CascadingParameterInfo parameterInfo)
+        => parameterInfo.Attribute is SupplyParameterFromQueryAttribute;
+
+    public object? GetCurrentValue(in CascadingParameterInfo parameterInfo)
+    {
+        TryUpdateUri();
+
+        var attribute = (SupplyParameterFromQueryAttribute)parameterInfo.Attribute; // Must be a valid cast because we check in CanSupplyValue
+        var queryParameterName = attribute.Name ?? parameterInfo.PropertyName;
+        return _queryParameterValueSupplier.GetQueryParameterValue(parameterInfo.PropertyType, queryParameterName);
+    }
+
+    public void Subscribe(ComponentState subscriber, in CascadingParameterInfo parameterInfo)
+    {
+        if (_pendingSubscribers?.Count > 0 || (TryUpdateUri() && _isSubscribedToLocationChanges))
+        {
+            // Renderer.RenderInExistingBatch triggers Unsubscribe via ProcessDisposalQueueInExistingBatch after subscribing with any new components,
+            // so this branch should be taken iff there's a pending OnLocationChanged event for the current Uri that we're already subscribed to.
+            _pendingSubscribers ??= new();
+            _pendingSubscribers.Add(subscriber);
+            return;
+        }
+
+        _subscribers ??= new();
+        _subscribers.Add(subscriber);
+        SubscribeToLocationChanges();
+    }
+
+    public void Unsubscribe(ComponentState subscriber, in CascadingParameterInfo parameterInfo)
+    {
+        // ICascadingValueSupplier is internal, and Subscribe should always precede Unsubscribe.
+        Debug.Assert(_subscribers is not null);
+        _subscribers.Remove(subscriber);
+        _pendingSubscribers?.Remove(subscriber);
+
+        if (_subscribers.Count == 0 && _pendingSubscribers is null or { Count: 0 })
+        {
+            UnsubscribeFromLocationChanges();
+        }
+    }
+
+    [MemberNotNull(nameof(_queryParameterValueSupplier))]
+    private bool TryUpdateUri()
+    {
+        _queryParameterValueSupplier ??= new();
+
+        // NavigationManager triggers Router.OnLocationChanged which calls GetCurrentValue before this class's OnLocationHandler
+        // gets a chance to run, so we have to compare strings rather than rely on OnLocationChanged always running before Uri updates.
+        if (navigationManager.Uri == _lastUri)
+        {
+            return false;
+        }
+
+        var query = GetQueryString(navigationManager.Uri);
+
+        if (!query.Span.SequenceEqual(GetQueryString(_lastUri).Span))
+        {
+           _queryChanged = true;
+           _queryParameterValueSupplier.ReadParametersFromQuery(query);
+        }
+
+        _lastUri = navigationManager.Uri;
+        return true;
+
+        static ReadOnlyMemory<char> GetQueryString(string? url)
+        {
+            var queryStartPos = url?.IndexOf('?') ?? -1;
+
+            if (queryStartPos < 0)
+            {
+                return default;
+            }
+
+            Debug.Assert(url is not null);
+            var queryEndPos = url.IndexOf('#', queryStartPos);
+            return url.AsMemory(queryStartPos..(queryEndPos < 0 ? url.Length : queryEndPos));
+        }
+    }
+
+    private void SubscribeToLocationChanges()
+    {
+        if (_isSubscribedToLocationChanges)
+        {
+            return;
+        }
+
+        _isSubscribedToLocationChanges = true;
+        navigationManager.LocationChanged += OnLocationChanged;
+    }
+
+    private void UnsubscribeFromLocationChanges()
+    {
+        if (!_isSubscribedToLocationChanges)
+        {
+            return;
+        }
+
+        _isSubscribedToLocationChanges = false;
+        navigationManager.LocationChanged -= OnLocationChanged;
+    }
+
+    private void OnLocationChanged(object? sender, LocationChangedEventArgs args)
+    {
+        Debug.Assert(_subscribers is not null);
+
+        TryUpdateUri();
+
+        if (_queryChanged)
+        {
+            foreach (var subscriber in _subscribers)
+            {
+                subscriber.NotifyCascadingValueChanged(ParameterViewLifetime.Unbound);
+            }
+
+            _queryChanged = false;
+        }
+
+        if (_pendingSubscribers is not null)
+        {
+            foreach (var subscriber in _pendingSubscribers)
+            {
+                _subscribers.Add(subscriber);
+            }
+
+            _pendingSubscribers.Clear();
+        }
+    }
+
+    public void Dispose() => UnsubscribeFromLocationChanges();
+}

--- a/src/Components/Components/src/SupplyParameterFromQueryProviderServiceCollectionExtensions.cs
+++ b/src/Components/Components/src/SupplyParameterFromQueryProviderServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -20,118 +19,7 @@ public static class SupplyParameterFromQueryProviderServiceCollectionExtensions
     /// <returns>The <see cref="IServiceCollection"/>.</returns>
     public static IServiceCollection AddSupplyValueFromQueryProvider(this IServiceCollection services)
     {
-        services.TryAddEnumerable(ServiceDescriptor.Scoped<ICascadingValueSupplier, SupplyValueFromQueryValueProvider>());
+        services.TryAddEnumerable(ServiceDescriptor.Scoped<ICascadingValueSupplier, SupplyParameterFromQueryValueProvider>());
         return services;
-    }
-
-    internal sealed class SupplyValueFromQueryValueProvider : ICascadingValueSupplier, IDisposable
-    {
-        private readonly QueryParameterValueSupplier _queryParameterValueSupplier = new();
-        private readonly NavigationManager _navigationManager;
-        private HashSet<ComponentState>? _subscribers;
-        private bool _isSubscribedToLocationChanges;
-        private bool _queryParametersMightHaveChanged = true;
-
-        public SupplyValueFromQueryValueProvider(NavigationManager navigationManager)
-        {
-            _navigationManager = navigationManager;
-        }
-
-        public bool IsFixed => false;
-
-        public bool CanSupplyValue(in CascadingParameterInfo parameterInfo)
-            => parameterInfo.Attribute is SupplyParameterFromQueryAttribute;
-
-        public object? GetCurrentValue(in CascadingParameterInfo parameterInfo)
-        {
-            if (_queryParametersMightHaveChanged)
-            {
-                _queryParametersMightHaveChanged = false;
-                UpdateQueryParameters();
-            }
-
-            var attribute = (SupplyParameterFromQueryAttribute)parameterInfo.Attribute; // Must be a valid cast because we check in CanSupplyValue
-            var queryParameterName = attribute.Name ?? parameterInfo.PropertyName;
-            return _queryParameterValueSupplier.GetQueryParameterValue(parameterInfo.PropertyType, queryParameterName);
-        }
-
-        public void Subscribe(ComponentState subscriber, in CascadingParameterInfo parameterInfo)
-        {
-            SubscribeToLocationChanges();
-
-            _subscribers ??= new();
-            _subscribers.Add(subscriber);
-        }
-
-        public void Unsubscribe(ComponentState subscriber, in CascadingParameterInfo parameterInfo)
-        {
-            _subscribers!.Remove(subscriber);
-
-            if (_subscribers.Count == 0)
-            {
-                UnsubscribeFromLocationChanges();
-            }
-        }
-
-        private void UpdateQueryParameters()
-        {
-            var query = GetQueryString(_navigationManager.Uri);
-
-            _queryParameterValueSupplier.ReadParametersFromQuery(query);
-
-            static ReadOnlyMemory<char> GetQueryString(string url)
-            {
-                var queryStartPos = url.IndexOf('?');
-
-                if (queryStartPos < 0)
-                {
-                    return default;
-                }
-
-                var queryEndPos = url.IndexOf('#', queryStartPos);
-                return url.AsMemory(queryStartPos..(queryEndPos < 0 ? url.Length : queryEndPos));
-            }
-        }
-
-        private void SubscribeToLocationChanges()
-        {
-            if (_isSubscribedToLocationChanges)
-            {
-                return;
-            }
-
-            _isSubscribedToLocationChanges = true;
-            _queryParametersMightHaveChanged = true;
-            _navigationManager.LocationChanged += OnLocationChanged;
-        }
-
-        private void UnsubscribeFromLocationChanges()
-        {
-            if (!_isSubscribedToLocationChanges)
-            {
-                return;
-            }
-
-            _isSubscribedToLocationChanges = false;
-            _navigationManager.LocationChanged -= OnLocationChanged;
-        }
-
-        private void OnLocationChanged(object? sender, LocationChangedEventArgs args)
-        {
-            _queryParametersMightHaveChanged = true;
-
-            if (_subscribers is not null)
-            {
-                foreach (var subscriber in _subscribers)
-                {
-                    subscriber.NotifyCascadingValueChanged(ParameterViewLifetime.Unbound);
-                }
-            }
-        }
-
-        public void Dispose()
-        {
-            UnsubscribeFromLocationChanges();
-        }
     }
 }

--- a/src/Components/Endpoints/test/RazorComponentsServiceCollectionExtensionsTest.cs
+++ b/src/Components/Endpoints/test/RazorComponentsServiceCollectionExtensionsTest.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms.Mapping;
+using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.FileProviders;
@@ -90,7 +91,7 @@ public class RazorComponentsServiceCollectionExtensionsTest
                 [typeof(ICascadingValueSupplier)] = new[]
                 {
                     typeof(SupplyParameterFromFormValueProvider),
-                    typeof(SupplyParameterFromQueryProviderServiceCollectionExtensions.SupplyValueFromQueryValueProvider),
+                    typeof(SupplyParameterFromQueryValueProvider),
                 }
             };
         }

--- a/src/Components/test/testassets/BasicTestApp/RouterTest/WithQueryGuidParameter.razor
+++ b/src/Components/test/testassets/BasicTestApp/RouterTest/WithQueryGuidParameter.razor
@@ -1,0 +1,30 @@
+﻿@page "/WithQueryGuidParameter"
+
+<p>GuidValue: <strong id="value-QueryGuid">@GuidValue</strong></p>
+<p>StringValue: <strong id="value-StringValue">@StringValue</strong></p>
+
+<p>OnParametersSet count: <strong id="param-set-count">@onParametersSetCount</strong></p>
+
+<p>
+    Links:
+    <a href="WithQueryGuidParameter?l=8b7ae9ee-de22-4dd0-8fa1-b31e66abcc79">With GuidValue</a> |
+    <a href="WithQueryParameters/Abc?l=50&l=100&l=-20">Another page with LongValues</a> |
+    <a href="WithQueryParameters/Abc?stringvalue=B">Another page with StringValue</a> |
+</p>
+
+@code
+{
+    private int onParametersSetCount;
+
+    // Use "l" as the query parameter name to test that it doesn't cause problems with
+    // WithQueryParameters.LongValues which is also called "l".
+    // https://github.com/dotnet/aspnetcore/issues/52483
+    [SupplyParameterFromQuery(Name = "l")] public Guid GuidValue { get ; set; }
+
+    [SupplyParameterFromQuery] public string StringValue { get ; set; }
+
+    protected override void OnParametersSet()
+    {
+        onParametersSetCount++;
+    }
+}

--- a/src/Components/test/testassets/BasicTestApp/RouterTest/WithQueryParameters.razor
+++ b/src/Components/test/testassets/BasicTestApp/RouterTest/WithQueryParameters.razor
@@ -15,6 +15,8 @@
     Links:
     <a href="WithQueryParameters/@FirstName?intvalue=123">With IntValue</a> |
     <a href="WithQueryParameters/@FirstName?l=50&l=100&l=-20&intvalue=123">With IntValue and LongValues</a> |
+    <a href="WithQueryGuidParameter?l=8b7ae9ee-de22-4dd0-8fa1-b31e66abcc79">Another page with GuidValue</a> |
+    <a href="WithQueryGuidParameter?stringvalue=A">Another page with StringValue</a> |
 </p>
 
 @code


### PR DESCRIPTION
# Fix stale values from `[SupplyParameterFromQuery]`

Backport of #53443

Fixes an issue where parameters supplied from query values may receive out-of-date values.

## Description

This PR fixes the issue by checking if the URI has changed when a query parameter value gets requested, rather than relying on the `LocationChanged` event, which might execute after the router requests query parameter values.

Fixes #52483
Fixes #53055

## Customer Impact

Customers can't rely on the query parameter value being up to date in the `OnInitialized{Async}` or `OnParametersSet{Async}()` component lifecycle events. The current workaround is to parse the current URL manually, which defeats the purpose of `[SupplyParameterFromQuery]`. This is a breaking change from .NET 7, and we've received notable customer feedback that this is impactful.

## Regression?

- [X] Yes
- [ ] No

Regressed from .NET 7.

## Risk

- [ ] High
- [ ] Medium
- [X] Low

We've introduced new regression tests to ensure that the bug was actually fixed. Other existing functionality is well-tested, so we can be reasonably confident this change doesn't introduce a new regression. The diff is large only because the code was moved from one place to another.

## Verification

- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A