### PR TITLE
[release/8.0] [Blazor] Correctly encode non-ASCII characters in redirect URL

### DIFF
--- a/src/Components/Endpoints/src/DependencyInjection/HttpNavigationManager.cs
+++ b/src/Components/Endpoints/src/DependencyInjection/HttpNavigationManager.cs
@@ -11,7 +11,7 @@ internal sealed class HttpNavigationManager : NavigationManager, IHostEnvironmen
 
     protected override void NavigateToCore(string uri, NavigationOptions options)
     {
-        var absoluteUriString = ToAbsoluteUri(uri).ToString();
+        var absoluteUriString = ToAbsoluteUri(uri).AbsoluteUri;
         throw new NavigationException(absoluteUriString);
     }
 }

--- a/src/Components/Endpoints/test/RazorComponentResultTest.cs
+++ b/src/Components/Endpoints/test/RazorComponentResultTest.cs
@@ -516,7 +516,7 @@ public class RazorComponentResultTest
         protected override void NavigateToCore(string uri, NavigationOptions options)
         {
             // Equivalent to what RemoteNavigationManager would do
-            var absoluteUriString = ToAbsoluteUri(uri).ToString();
+            var absoluteUriString = ToAbsoluteUri(uri).AbsoluteUri;
             throw new NavigationException(absoluteUriString);
         }
     }

--- a/src/Components/Server/src/Circuits/RemoteNavigationManager.cs
+++ b/src/Components/Server/src/Circuits/RemoteNavigationManager.cs
@@ -87,7 +87,7 @@ internal sealed partial class RemoteNavigationManager : NavigationManager, IHost
 
         if (_jsRuntime == null)
         {
-            var absoluteUriString = ToAbsoluteUri(uri).ToString();
+            var absoluteUriString = ToAbsoluteUri(uri).AbsoluteUri;
             throw new NavigationException(absoluteUriString);
         }
 
@@ -128,7 +128,7 @@ internal sealed partial class RemoteNavigationManager : NavigationManager, IHost
     {
         if (_jsRuntime == null)
         {
-            var absoluteUriString = ToAbsoluteUri(Uri).ToString();
+            var absoluteUriString = ToAbsoluteUri(Uri).AbsoluteUri;
             throw new NavigationException(absoluteUriString);
         }
 

--- a/src/Components/test/E2ETest/ServerRenderingTests/RedirectionTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/RedirectionTest.cs
@@ -39,7 +39,7 @@ public class RedirectionTest : ServerTestBase<BasicTestAppServerSiteFixture<Razo
         AssertElementRemoved(_originalH1Element);
         Browser.Equal("Scroll to hash", () => Browser.Exists(By.TagName("h1")).Text);
         Browser.True(() => Browser.GetScrollY() > 500);
-        Assert.EndsWith("/subdir/nav/scroll-to-hash#some-content", Browser.Url);
+        Assert.EndsWith("/subdir/nav/scroll-to-hash?foo=%F0%9F%99%82#some-content", Browser.Url);
 
         // See that 'back' takes you to the place from before the redirection
         Browser.Navigate().Back();
@@ -61,7 +61,7 @@ public class RedirectionTest : ServerTestBase<BasicTestAppServerSiteFixture<Razo
         AssertElementRemoved(_originalH1Element);
         Browser.Equal("Scroll to hash", () => Browser.Exists(By.TagName("h1")).Text);
         Browser.True(() => Browser.GetScrollY() > 500);
-        Assert.EndsWith("/subdir/nav/scroll-to-hash#some-content", Browser.Url);
+        Assert.EndsWith("/subdir/nav/scroll-to-hash?foo=%F0%9F%99%82#some-content", Browser.Url);
 
         // See that 'back' takes you to the place from before the redirection
         Browser.Navigate().Back();
@@ -87,7 +87,7 @@ public class RedirectionTest : ServerTestBase<BasicTestAppServerSiteFixture<Razo
 
         Browser.Exists(By.LinkText("Enhanced GET with internal redirection")).Click();
         Browser.Equal("Scroll to hash", () => _originalH1Element.Text);
-        Assert.EndsWith("/subdir/nav/scroll-to-hash", Browser.Url);
+        Assert.EndsWith("/subdir/nav/scroll-to-hash?foo=%F0%9F%99%82", Browser.Url);
 
         // See that 'back' takes you to the place from before the redirection
         Browser.Navigate().Back();
@@ -108,7 +108,7 @@ public class RedirectionTest : ServerTestBase<BasicTestAppServerSiteFixture<Razo
         // See above for why enhanced nav doesn't support preserving the hash
         Browser.Exists(By.CssSelector("#form-enhanced-internal button")).Click();
         Browser.Equal("Scroll to hash", () => _originalH1Element.Text);
-        Assert.EndsWith("/subdir/nav/scroll-to-hash", Browser.Url);
+        Assert.EndsWith("/subdir/nav/scroll-to-hash?foo=%F0%9F%99%82", Browser.Url);
 
         // See that 'back' takes you to the place from before the redirection
         Browser.Navigate().Back();
@@ -129,7 +129,7 @@ public class RedirectionTest : ServerTestBase<BasicTestAppServerSiteFixture<Razo
         // See above for why enhanced nav doesn't support preserving the hash
         Browser.Exists(By.LinkText("Streaming enhanced GET with internal redirection")).Click();
         Browser.Equal("Scroll to hash", () => _originalH1Element.Text);
-        Assert.EndsWith("/subdir/nav/scroll-to-hash", Browser.Url);
+        Assert.EndsWith("/subdir/nav/scroll-to-hash?foo=%F0%9F%99%82", Browser.Url);
 
         // See that 'back' takes you to the place from before the redirection
         Browser.Navigate().Back();
@@ -150,7 +150,7 @@ public class RedirectionTest : ServerTestBase<BasicTestAppServerSiteFixture<Razo
         // See above for why enhanced nav doesn't support preserving the hash
         Browser.Exists(By.CssSelector("#form-streaming-enhanced-internal button")).Click();
         Browser.Equal("Scroll to hash", () => _originalH1Element.Text);
-        Assert.EndsWith("/subdir/nav/scroll-to-hash", Browser.Url);
+        Assert.EndsWith("/subdir/nav/scroll-to-hash?foo=%F0%9F%99%82", Browser.Url);
 
         // See that 'back' takes you to the place from before the redirection
         Browser.Navigate().Back();

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Redirections/RedirectGet.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Redirections/RedirectGet.razor
@@ -10,6 +10,6 @@
     protected override async Task OnInitializedAsync()
     {
         await Task.Delay(500);
-        Nav.NavigateTo(External ? "https://microsoft.com" : "nav/scroll-to-hash#some-content");
+        Nav.NavigateTo(External ? "https://microsoft.com?foo=🙂" : "nav/scroll-to-hash?foo=🙂#some-content");
     }
 }

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Redirections/RedirectPost.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Redirections/RedirectPost.razor
@@ -12,6 +12,6 @@
     private async Task DoRedirectionAsync()
     {
         await Task.Delay(500);
-        Nav.NavigateTo(External ? "https://microsoft.com" : "nav/scroll-to-hash#some-content");
+        Nav.NavigateTo(External ? "https://microsoft.com?foo=🙂" : "nav/scroll-to-hash?foo=🙂#some-content");
     }
 }

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Redirections/RedirectStreamingGet.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Redirections/RedirectStreamingGet.razor
@@ -11,6 +11,6 @@
     protected override async Task OnInitializedAsync()
     {
         await Task.Delay(500);
-        Nav.NavigateTo(External ? "https://microsoft.com" : "nav/scroll-to-hash#some-content");
+        Nav.NavigateTo(External ? "https://microsoft.com?foo=🙂" : "nav/scroll-to-hash?foo=🙂#some-content");
     }
 }

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Redirections/RedirectStreamingPost.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Redirections/RedirectStreamingPost.razor
@@ -13,6 +13,6 @@
     private async Task DoRedirectionAsync()
     {
         await Task.Delay(500);
-        Nav.NavigateTo(External ? "https://microsoft.com" : "nav/scroll-to-hash#some-content");
+        Nav.NavigateTo(External ? "https://microsoft.com?foo=🙂" : "nav/scroll-to-hash?foo=🙂#some-content");
     }
 }


### PR DESCRIPTION
# Correctly encode non-ASCII characters in redirect URL

Backport of #53623

Encodes non-ASCII characters included in redirect URLs.

## Description

The culprit was the use of [`Uri.ToString()`](https://github.com/dotnet/runtime/blob/2558ff925b907633332c2f5160c15d153f29f2db/src/libraries/System.Private.Uri/src/System/Uri.cs#L1556), which decodes URL-encoded characters. This PR replaces the relevant occurrences of `Uri.ToString()` with `Uri.AbsoluteUri`, which does not perform any decoding.

Fixes #52438

## Customer Impact

Customers who redirect to a URL with a non-ASCII character from within a Blazor component may be met with an unhandled exception that prevents the page from loading. Unlike Razor Pages, where a workaround exists to manually encode the non-ASCII characters, there is no known workaround in Blazor.

## Regression?

- [ ] Yes
- [X] No

This bug has existed since the ability to redirect from a Razor component was introduced in .NET 8.

## Risk

- [ ] High
- [ ] Medium
- [X] Low

The fix is clear, and existing redirection tests have been updated to include non-ASCII characters in the URL to verify the change.

## Verification

- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A