### PR TITLE
Fix XML docs in EndpointFilterInvocationContext.cs

### DIFF
--- a/src/Http/Http.Abstractions/src/EndpointFilterInvocationContext.cs
+++ b/src/Http/Http.Abstractions/src/EndpointFilterInvocationContext.cs
@@ -31,8 +31,7 @@ public abstract class EndpointFilterInvocationContext
     public abstract T GetArgument<T>(int index);
 
     /// <summary>
-    /// Creates a strongly-typed implementation of a <see cref="EndpointFilterInvocationContext"/>
-    /// given the provided type parameters.
+    /// Creates the default implementation of a <see cref="EndpointFilterInvocationContext"/>.    
     /// </summary>
     public static EndpointFilterInvocationContext Create(HttpContext httpContext) =>
         new DefaultEndpointFilterInvocationContext(httpContext);


### PR DESCRIPTION
The `Create(HttpContext httpContext)` method overload doesn't actually take any generic parameters like the other variants, so it doesn't seem correct for the XML docs to say "strongly-typed implementation" or mention "the provided type parameters" (this is probably a copy-and-paste error because the same XML doc comment is used for all variants of the `Create()` method).