### PR TITLE
Added InternalServerError and InternalServerError<TValue> to TypedResults

### DIFF
--- a/src/Http/Http.Results/src/InternalServerError.cs
+++ b/src/Http/Http.Results/src/InternalServerError.cs
@@ -1,0 +1,53 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Http.HttpResults;
+
+/// <summary>
+/// An <see cref="IResult"/> that on execution will write an object to the response
+/// with Internal Server Error (500) status code.
+/// </summary>
+public sealed class InternalServerError : IResult, IEndpointMetadataProvider, IStatusCodeHttpResult
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InternalServerError"/> class with the values
+    /// provided.
+    /// </summary>
+    internal InternalServerError()
+    {
+    }
+
+    /// <summary>
+    /// Gets the HTTP status code: <see cref="StatusCodes.Status500InternalServerError"/>
+    /// </summary>
+    public int StatusCode => StatusCodes.Status500InternalServerError;
+
+    int? IStatusCodeHttpResult.StatusCode => StatusCode;
+
+    /// <inheritdoc/>
+    public Task ExecuteAsync(HttpContext httpContext)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        // Creating the logger with a string to preserve the category after the refactoring.
+        var loggerFactory = httpContext.RequestServices.GetRequiredService<ILoggerFactory>();
+        var logger = loggerFactory.CreateLogger("Microsoft.AspNetCore.Http.Result.InternalServerErrorObjectResult");
+
+        HttpResultsHelper.Log.WritingResultAsStatusCode(logger, StatusCode);
+        httpContext.Response.StatusCode = StatusCode;
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(method);
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(StatusCodes.Status500InternalServerError, typeof(void)));
+    }
+}

--- a/src/Http/Http.Results/src/InternalServerError.cs
+++ b/src/Http/Http.Results/src/InternalServerError.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-using System.Runtime.ExceptionServices;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.Extensions.DependencyInjection;
@@ -22,20 +21,6 @@ public sealed class InternalServerError : IResult, IEndpointMetadataProvider, IS
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="InternalServerError"/> class with the values
-    /// </summary>
-    /// <param name="exception">The exception to be thrown.</param>
-    internal InternalServerError(ExceptionDispatchInfo exception)
-    {
-        Exception = exception;
-    }
-
-    /// <summary>
-    /// Gets the exception to be thrown.
-    /// </summary>
-    public ExceptionDispatchInfo? Exception { get; }
-
-    /// <summary>
     /// Gets the HTTP status code: <see cref="StatusCodes.Status500InternalServerError"/>
     /// </summary>
     public int StatusCode => StatusCodes.Status500InternalServerError;
@@ -45,7 +30,6 @@ public sealed class InternalServerError : IResult, IEndpointMetadataProvider, IS
     /// <inheritdoc/>
     public Task ExecuteAsync(HttpContext httpContext)
     {
-        Exception?.Throw();
         ArgumentNullException.ThrowIfNull(httpContext);
 
         // Creating the logger with a string to preserve the category after the refactoring.

--- a/src/Http/Http.Results/src/InternalServerError.cs
+++ b/src/Http/Http.Results/src/InternalServerError.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,6 +22,20 @@ public sealed class InternalServerError : IResult, IEndpointMetadataProvider, IS
     }
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="InternalServerError"/> class with the values
+    /// </summary>
+    /// <param name="exception">The exception to be thrown.</param>
+    internal InternalServerError(ExceptionDispatchInfo exception)
+    {
+        Exception = exception;
+    }
+
+    /// <summary>
+    /// Gets the exception to be thrown.
+    /// </summary>
+    public ExceptionDispatchInfo? Exception { get; }
+
+    /// <summary>
     /// Gets the HTTP status code: <see cref="StatusCodes.Status500InternalServerError"/>
     /// </summary>
     public int StatusCode => StatusCodes.Status500InternalServerError;
@@ -30,6 +45,7 @@ public sealed class InternalServerError : IResult, IEndpointMetadataProvider, IS
     /// <inheritdoc/>
     public Task ExecuteAsync(HttpContext httpContext)
     {
+        Exception?.Throw();
         ArgumentNullException.ThrowIfNull(httpContext);
 
         // Creating the logger with a string to preserve the category after the refactoring.

--- a/src/Http/Http.Results/src/InternalServerErrorOfT.cs
+++ b/src/Http/Http.Results/src/InternalServerErrorOfT.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Http.HttpResults;
+
+/// <summary>
+/// An <see cref="IResult"/> that on execution will write an object to the response
+/// with Internal Server Error (500) status code.
+/// </summary>
+/// <typeparam name="TValue">The type of error object that will be JSON serialized to the response body.</typeparam>
+public sealed class InternalServerError<TValue> : IResult, IEndpointMetadataProvider, IStatusCodeHttpResult, IValueHttpResult, IValueHttpResult<TValue>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InternalServerError"/> class with the values
+    /// provided.
+    /// </summary>
+    /// <param name="error">The error content to format in the entity body.</param>
+    internal InternalServerError(TValue? error)
+    {
+        Value = error;
+        HttpResultsHelper.ApplyProblemDetailsDefaultsIfNeeded(Value, StatusCode);
+    }
+
+    /// <summary>
+    /// Gets the object result.
+    /// </summary>
+    public TValue? Value { get; }
+
+    object? IValueHttpResult.Value => Value;
+
+    /// <summary>
+    /// Gets the HTTP status code: <see cref="StatusCodes.Status500InternalServerError"/>
+    /// </summary>
+    public int StatusCode => StatusCodes.Status500InternalServerError;
+
+    int? IStatusCodeHttpResult.StatusCode => StatusCode;
+
+    /// <inheritdoc/>
+    public Task ExecuteAsync(HttpContext httpContext)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        // Creating the logger with a string to preserve the category after the refactoring.
+        var loggerFactory = httpContext.RequestServices.GetRequiredService<ILoggerFactory>();
+        var logger = loggerFactory.CreateLogger("Microsoft.AspNetCore.Http.Result.InternalServerErrorObjectResult");
+
+        HttpResultsHelper.Log.WritingResultAsStatusCode(logger, StatusCode);
+        httpContext.Response.StatusCode = StatusCode;
+
+        return HttpResultsHelper.WriteResultAsJsonAsync(
+                httpContext,
+                logger: logger,
+                Value);
+    }
+
+    /// <inheritdoc/>
+    static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(method);
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(StatusCodes.Status500InternalServerError, typeof(TValue), new[] { "application/json" }));
+    }
+}

--- a/src/Http/Http.Results/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Results/src/PublicAPI.Unshipped.txt
@@ -1,6 +1,5 @@
 #nullable enable
 Microsoft.AspNetCore.Http.HttpResults.InternalServerError
-Microsoft.AspNetCore.Http.HttpResults.InternalServerError.Exception.get -> System.Runtime.ExceptionServices.ExceptionDispatchInfo?
 Microsoft.AspNetCore.Http.HttpResults.InternalServerError.ExecuteAsync(Microsoft.AspNetCore.Http.HttpContext! httpContext) -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Http.HttpResults.InternalServerError.StatusCode.get -> int
 Microsoft.AspNetCore.Http.HttpResults.InternalServerError<TValue>
@@ -8,8 +7,6 @@ Microsoft.AspNetCore.Http.HttpResults.InternalServerError<TValue>.ExecuteAsync(M
 Microsoft.AspNetCore.Http.HttpResults.InternalServerError<TValue>.StatusCode.get -> int
 Microsoft.AspNetCore.Http.HttpResults.InternalServerError<TValue>.Value.get -> TValue?
 static Microsoft.AspNetCore.Http.Results.InternalServerError() -> Microsoft.AspNetCore.Http.IResult!
-static Microsoft.AspNetCore.Http.Results.InternalServerError(System.Runtime.ExceptionServices.ExceptionDispatchInfo! exception) -> Microsoft.AspNetCore.Http.IResult!
 static Microsoft.AspNetCore.Http.Results.InternalServerError<TValue>(TValue? error) -> Microsoft.AspNetCore.Http.IResult!
 static Microsoft.AspNetCore.Http.TypedResults.InternalServerError() -> Microsoft.AspNetCore.Http.HttpResults.InternalServerError!
-static Microsoft.AspNetCore.Http.TypedResults.InternalServerError(System.Runtime.ExceptionServices.ExceptionDispatchInfo! exception) -> Microsoft.AspNetCore.Http.HttpResults.InternalServerError!
 static Microsoft.AspNetCore.Http.TypedResults.InternalServerError<TValue>(TValue? error) -> Microsoft.AspNetCore.Http.HttpResults.InternalServerError<TValue>!

--- a/src/Http/Http.Results/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Results/src/PublicAPI.Unshipped.txt
@@ -1,12 +1,15 @@
 #nullable enable
 Microsoft.AspNetCore.Http.HttpResults.InternalServerError
+Microsoft.AspNetCore.Http.HttpResults.InternalServerError.Exception.get -> System.Runtime.ExceptionServices.ExceptionDispatchInfo?
 Microsoft.AspNetCore.Http.HttpResults.InternalServerError.ExecuteAsync(Microsoft.AspNetCore.Http.HttpContext! httpContext) -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Http.HttpResults.InternalServerError.StatusCode.get -> int
 Microsoft.AspNetCore.Http.HttpResults.InternalServerError<TValue>
 Microsoft.AspNetCore.Http.HttpResults.InternalServerError<TValue>.ExecuteAsync(Microsoft.AspNetCore.Http.HttpContext! httpContext) -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Http.HttpResults.InternalServerError<TValue>.StatusCode.get -> int
 Microsoft.AspNetCore.Http.HttpResults.InternalServerError<TValue>.Value.get -> TValue?
-static Microsoft.AspNetCore.Http.Results.InternalServerError(object? error = null) -> Microsoft.AspNetCore.Http.IResult!
+static Microsoft.AspNetCore.Http.Results.InternalServerError() -> Microsoft.AspNetCore.Http.IResult!
+static Microsoft.AspNetCore.Http.Results.InternalServerError(System.Runtime.ExceptionServices.ExceptionDispatchInfo! exception) -> Microsoft.AspNetCore.Http.IResult!
 static Microsoft.AspNetCore.Http.Results.InternalServerError<TValue>(TValue? error) -> Microsoft.AspNetCore.Http.IResult!
 static Microsoft.AspNetCore.Http.TypedResults.InternalServerError() -> Microsoft.AspNetCore.Http.HttpResults.InternalServerError!
+static Microsoft.AspNetCore.Http.TypedResults.InternalServerError(System.Runtime.ExceptionServices.ExceptionDispatchInfo! exception) -> Microsoft.AspNetCore.Http.HttpResults.InternalServerError!
 static Microsoft.AspNetCore.Http.TypedResults.InternalServerError<TValue>(TValue? error) -> Microsoft.AspNetCore.Http.HttpResults.InternalServerError<TValue>!

--- a/src/Http/Http.Results/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Results/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,10 @@
 #nullable enable
+Microsoft.AspNetCore.Http.HttpResults.InternalServerError
+Microsoft.AspNetCore.Http.HttpResults.InternalServerError.ExecuteAsync(Microsoft.AspNetCore.Http.HttpContext! httpContext) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Http.HttpResults.InternalServerError.StatusCode.get -> int
+Microsoft.AspNetCore.Http.HttpResults.InternalServerError<TValue>
+Microsoft.AspNetCore.Http.HttpResults.InternalServerError<TValue>.ExecuteAsync(Microsoft.AspNetCore.Http.HttpContext! httpContext) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Http.HttpResults.InternalServerError<TValue>.StatusCode.get -> int
+Microsoft.AspNetCore.Http.HttpResults.InternalServerError<TValue>.Value.get -> TValue?
+static Microsoft.AspNetCore.Http.TypedResults.InternalServerError() -> Microsoft.AspNetCore.Http.HttpResults.InternalServerError!
+static Microsoft.AspNetCore.Http.TypedResults.InternalServerError<TValue>(TValue? error) -> Microsoft.AspNetCore.Http.HttpResults.InternalServerError<TValue>!

--- a/src/Http/Http.Results/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Results/src/PublicAPI.Unshipped.txt
@@ -6,5 +6,7 @@ Microsoft.AspNetCore.Http.HttpResults.InternalServerError<TValue>
 Microsoft.AspNetCore.Http.HttpResults.InternalServerError<TValue>.ExecuteAsync(Microsoft.AspNetCore.Http.HttpContext! httpContext) -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Http.HttpResults.InternalServerError<TValue>.StatusCode.get -> int
 Microsoft.AspNetCore.Http.HttpResults.InternalServerError<TValue>.Value.get -> TValue?
+static Microsoft.AspNetCore.Http.Results.InternalServerError(object? error = null) -> Microsoft.AspNetCore.Http.IResult!
+static Microsoft.AspNetCore.Http.Results.InternalServerError<TValue>(TValue? error) -> Microsoft.AspNetCore.Http.IResult!
 static Microsoft.AspNetCore.Http.TypedResults.InternalServerError() -> Microsoft.AspNetCore.Http.HttpResults.InternalServerError!
 static Microsoft.AspNetCore.Http.TypedResults.InternalServerError<TValue>(TValue? error) -> Microsoft.AspNetCore.Http.HttpResults.InternalServerError<TValue>!

--- a/src/Http/Http.Results/src/Results.cs
+++ b/src/Http/Http.Results/src/Results.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Pipelines;
+using System.Runtime.ExceptionServices;
 using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
@@ -693,10 +694,9 @@ public static partial class Results
     /// <summary>
     /// Produces a <see cref="StatusCodes.Status500InternalServerError"/> response.
     /// </summary>
-    /// <param name="error">An error object to be included in the HTTP response body.</param>
     /// <returns>The created <see cref="IResult"/> for the response.</returns>
-    public static IResult InternalServerError(object? error = null)
-        => InternalServerError<object>(error);
+    public static IResult InternalServerError()
+        => InternalServerError<object>(null);
 
     /// <summary>
     /// Produces a <see cref="StatusCodes.Status500InternalServerError"/> response.
@@ -705,6 +705,14 @@ public static partial class Results
     /// <returns>The created <see cref="IResult"/> for the response.</returns>
     public static IResult InternalServerError<TValue>(TValue? error)
         => error is null ? TypedResults.InternalServerError() : TypedResults.InternalServerError(error);
+
+    /// <summary>
+    /// Produces a <see cref="StatusCodes.Status500InternalServerError"/> response.
+    /// </summary>
+    /// <param name="exception">The exception to be thrown.</param>
+    /// <returns>The created <see cref="IResult"/> for the response.</returns>
+    public static IResult InternalServerError(ExceptionDispatchInfo exception)
+        => TypedResults.InternalServerError(exception);
 
     /// <summary>
     /// Produces a <see cref="ProblemDetails"/> response.

--- a/src/Http/Http.Results/src/Results.cs
+++ b/src/Http/Http.Results/src/Results.cs
@@ -691,6 +691,22 @@ public static partial class Results
         => error is null ? TypedResults.UnprocessableEntity() : TypedResults.UnprocessableEntity(error);
 
     /// <summary>
+    /// Produces a <see cref="StatusCodes.Status500InternalServerError"/> response.
+    /// </summary>
+    /// <param name="error">An error object to be included in the HTTP response body.</param>
+    /// <returns>The created <see cref="IResult"/> for the response.</returns>
+    public static IResult InternalServerError(object? error = null)
+        => InternalServerError<object>(error);
+
+    /// <summary>
+    /// Produces a <see cref="StatusCodes.Status500InternalServerError"/> response.
+    /// </summary>
+    /// <param name="error">An error object to be included in the HTTP response body.</param>
+    /// <returns>The created <see cref="IResult"/> for the response.</returns>
+    public static IResult InternalServerError<TValue>(TValue? error)
+        => error is null ? TypedResults.InternalServerError() : TypedResults.InternalServerError(error);
+
+    /// <summary>
     /// Produces a <see cref="ProblemDetails"/> response.
     /// </summary>
     /// <param name="statusCode">The value for <see cref="ProblemDetails.Status" />.</param>

--- a/src/Http/Http.Results/src/Results.cs
+++ b/src/Http/Http.Results/src/Results.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Pipelines;
-using System.Runtime.ExceptionServices;
 using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
@@ -705,14 +704,6 @@ public static partial class Results
     /// <returns>The created <see cref="IResult"/> for the response.</returns>
     public static IResult InternalServerError<TValue>(TValue? error)
         => error is null ? TypedResults.InternalServerError() : TypedResults.InternalServerError(error);
-
-    /// <summary>
-    /// Produces a <see cref="StatusCodes.Status500InternalServerError"/> response.
-    /// </summary>
-    /// <param name="exception">The exception to be thrown.</param>
-    /// <returns>The created <see cref="IResult"/> for the response.</returns>
-    public static IResult InternalServerError(ExceptionDispatchInfo exception)
-        => TypedResults.InternalServerError(exception);
 
     /// <summary>
     /// Produces a <see cref="ProblemDetails"/> response.

--- a/src/Http/Http.Results/src/ResultsCache.cs
+++ b/src/Http/Http.Results/src/ResultsCache.cs
@@ -14,4 +14,5 @@ internal static partial class ResultsCache
     public static NoContent NoContent { get; } = new();
     public static Ok Ok { get; } = new();
     public static UnprocessableEntity UnprocessableEntity { get; } = new();
+    public static InternalServerError InternalServerError { get; } = new();
 }

--- a/src/Http/Http.Results/src/TypedResults.cs
+++ b/src/Http/Http.Results/src/TypedResults.cs
@@ -735,6 +735,20 @@ public static class TypedResults
     public static UnprocessableEntity<TValue> UnprocessableEntity<TValue>(TValue? error) => new(error);
 
     /// <summary>
+    /// Produces a <see cref="StatusCodes.Status500InternalServerError"/> response.
+    /// </summary>
+    /// <returns>The created <see cref="HttpResults.InternalServerError"/> for the response.</returns>
+    public static InternalServerError InternalServerError() => ResultsCache.InternalServerError;
+
+    /// <summary>
+    /// Produces a <see cref="StatusCodes.Status500InternalServerError"/> response.
+    /// </summary>
+    /// <typeparam name="TValue">The type of error object that will be JSON serialized to the response body.</typeparam>
+    /// <param name="error">The value to be included in the HTTP response body.</param>
+    /// <returns>The created <see cref="HttpResults.InternalServerError{TValue}"/> for the response.</returns>
+    public static InternalServerError<TValue> InternalServerError<TValue>(TValue? error) => new(error);
+
+    /// <summary>
     /// Produces a <see cref="ProblemDetails"/> response.
     /// </summary>
     /// <param name="statusCode">The value for <see cref="ProblemDetails.Status" />.</param>

--- a/src/Http/Http.Results/src/TypedResults.cs
+++ b/src/Http/Http.Results/src/TypedResults.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Pipelines;
+using System.Runtime.ExceptionServices;
 using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
@@ -747,6 +748,13 @@ public static class TypedResults
     /// <param name="error">The value to be included in the HTTP response body.</param>
     /// <returns>The created <see cref="HttpResults.InternalServerError{TValue}"/> for the response.</returns>
     public static InternalServerError<TValue> InternalServerError<TValue>(TValue? error) => new(error);
+
+    /// <summary>
+    /// Produces a <see cref="StatusCodes.Status500InternalServerError"/> response.
+    /// </summary>
+    /// <param name="exception">The exception to be thrown</param>
+    /// <returns>The created <see cref="HttpResults.InternalServerError"/> for the response.</returns>
+    public static InternalServerError InternalServerError(ExceptionDispatchInfo exception) => new(exception);
 
     /// <summary>
     /// Produces a <see cref="ProblemDetails"/> response.

--- a/src/Http/Http.Results/src/TypedResults.cs
+++ b/src/Http/Http.Results/src/TypedResults.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Pipelines;
-using System.Runtime.ExceptionServices;
 using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
@@ -748,13 +747,6 @@ public static class TypedResults
     /// <param name="error">The value to be included in the HTTP response body.</param>
     /// <returns>The created <see cref="HttpResults.InternalServerError{TValue}"/> for the response.</returns>
     public static InternalServerError<TValue> InternalServerError<TValue>(TValue? error) => new(error);
-
-    /// <summary>
-    /// Produces a <see cref="StatusCodes.Status500InternalServerError"/> response.
-    /// </summary>
-    /// <param name="exception">The exception to be thrown</param>
-    /// <returns>The created <see cref="HttpResults.InternalServerError"/> for the response.</returns>
-    public static InternalServerError InternalServerError(ExceptionDispatchInfo exception) => new(exception);
 
     /// <summary>
     /// Produces a <see cref="ProblemDetails"/> response.

--- a/src/Http/Http.Results/test/InternalServerErrorOfTResultTests.cs
+++ b/src/Http/Http.Results/test/InternalServerErrorOfTResultTests.cs
@@ -1,0 +1,185 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Http.HttpResults;
+
+using System.Reflection;
+using System.Text;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Newtonsoft.Json.Linq;
+
+public class InternalServerErrorOfTResultTests
+{
+    [Fact]
+    public void InternalServerErrorObjectResult_SetsStatusCodeAndValue()
+    {
+        // Arrange & Act
+        var obj = new object();
+        var internalServerErrorObjectResult = new InternalServerError<object>(obj);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status500InternalServerError, internalServerErrorObjectResult.StatusCode);
+        Assert.Equal(obj, internalServerErrorObjectResult.Value);
+    }
+
+    [Fact]
+    public void InternalServerErrorObjectResult_ProblemDetails_SetsStatusCodeAndValue()
+    {
+        // Arrange & Act
+        var obj = new HttpValidationProblemDetails();
+        var result = new InternalServerError<HttpValidationProblemDetails>(obj);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
+        Assert.Equal(StatusCodes.Status500InternalServerError, obj.Status);
+        Assert.Equal(obj, result.Value);
+    }
+
+    [Fact]
+    public async Task InternalServerErrorObjectResult_ExecuteAsync_SetsStatusCode()
+    {
+        // Arrange
+        var result = new InternalServerError<string>("Hello");
+        var httpContext = new DefaultHttpContext()
+        {
+            RequestServices = CreateServices(),
+        };
+
+        // Act
+        await result.ExecuteAsync(httpContext);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status500InternalServerError, httpContext.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task InternalServerErrorObjectResult_ExecuteResultAsync_FormatsData()
+    {
+        // Arrange
+        var result = new InternalServerError<string>("Hello");
+        var stream = new MemoryStream();
+        var httpContext = new DefaultHttpContext()
+        {
+            RequestServices = CreateServices(),
+            Response =
+                {
+                    Body = stream,
+                },
+        };
+
+        // Act
+        await result.ExecuteAsync(httpContext);
+
+        // Assert
+        Assert.Equal("\"Hello\"", Encoding.UTF8.GetString(stream.ToArray()));
+    }
+
+    [Fact]
+    public async Task InternalServerErrorObjectResult_ExecuteResultAsync_UsesStatusCodeFromResultTypeForProblemDetails()
+    {
+        // Arrange
+        var details = new ProblemDetails { Status = StatusCodes.Status422UnprocessableEntity, };
+        var result = new InternalServerError<ProblemDetails>(details);
+
+        var httpContext = new DefaultHttpContext()
+        {
+            RequestServices = CreateServices(),
+        };
+
+        // Act
+        await result.ExecuteAsync(httpContext);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status422UnprocessableEntity, details.Status.Value);
+        Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
+        Assert.Equal(StatusCodes.Status500InternalServerError, httpContext.Response.StatusCode);
+    }
+
+    [Fact]
+    public void PopulateMetadata_AddsResponseTypeMetadata()
+    {
+        // Arrange
+        InternalServerError<Todo> MyApi() { throw new NotImplementedException(); }
+        var metadata = new List<object>();
+        var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
+
+        // Act
+        PopulateMetadata<InternalServerError<Todo>>(((Delegate)MyApi).GetMethodInfo(), builder);
+
+        // Assert
+        var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
+        Assert.Equal(StatusCodes.Status500InternalServerError, producesResponseTypeMetadata.StatusCode);
+        Assert.Equal(typeof(Todo), producesResponseTypeMetadata.Type);
+        Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/json");
+    }
+
+    [Fact]
+    public void ExecuteAsync_ThrowsArgumentNullException_WhenHttpContextIsNull()
+    {
+        // Arrange
+        var result = new InternalServerError<object>(null);
+        HttpContext httpContext = null;
+
+        // Act & Assert
+        Assert.ThrowsAsync<ArgumentNullException>("httpContext", () => result.ExecuteAsync(httpContext));
+    }
+
+    [Fact]
+    public void PopulateMetadata_ThrowsArgumentNullException_WhenMethodOrBuilderAreNull()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>("method", () => PopulateMetadata<InternalServerError<object>>(null, new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0)));
+        Assert.Throws<ArgumentNullException>("builder", () => PopulateMetadata<InternalServerError<object>>(((Delegate)PopulateMetadata_ThrowsArgumentNullException_WhenMethodOrBuilderAreNull).GetMethodInfo(), null));
+    }
+
+    [Fact]
+    public void InternalServerErrorObjectResult_Implements_IStatusCodeHttpResult_Correctly()
+    {
+        // Act & Assert
+        var result = Assert.IsAssignableFrom<IStatusCodeHttpResult>(new InternalServerError<string>(null));
+        Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
+    }
+
+    [Fact]
+    public void InternalServerErrorObjectResult_Implements_IValueHttpResult_Correctly()
+    {
+        // Arrange
+        var value = "Foo";
+
+        // Act & Assert
+        var result = Assert.IsAssignableFrom<IValueHttpResult>(new InternalServerError<string>(value));
+        Assert.IsType<string>(result.Value);
+        Assert.Equal(value, result.Value);
+    }
+
+    [Fact]
+    public void InternalServerErrorObjectResult_Implements_IValueHttpResultOfT_Correctly()
+    {
+        // Arrange & Act
+        var value = "Foo";
+
+        // Assert
+        var result = Assert.IsAssignableFrom<IValueHttpResult<string>>(new InternalServerError<string>(value));
+        Assert.IsType<string>(result.Value);
+        Assert.Equal(value, result.Value);
+    }
+
+    private static void PopulateMetadata<TResult>(MethodInfo method, EndpointBuilder builder)
+        where TResult : IEndpointMetadataProvider => TResult.PopulateMetadata(method, builder);
+
+    private record Todo(int Id, string Title);
+
+    private static IServiceProvider CreateServices()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ILoggerFactory, NullLoggerFactory>();
+        return services.BuildServiceProvider();
+    }
+}

--- a/src/Http/Http.Results/test/InternalServerErrorResultTests.cs
+++ b/src/Http/Http.Results/test/InternalServerErrorResultTests.cs
@@ -1,0 +1,98 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Http.HttpResults;
+
+using System.Reflection;
+using System.Text;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+public class InternalServerErrorResultTests
+{
+    [Fact]
+    public void InternalServerErrorObjectResult_SetsStatusCode()
+    {
+        // Arrange & Act
+        var internalServerErrorResult = new InternalServerError();
+
+        // Assert
+        Assert.Equal(StatusCodes.Status500InternalServerError, internalServerErrorResult.StatusCode);
+    }
+
+    [Fact]
+    public async Task InternalServerErrorObjectResult_ExecuteAsync_SetsStatusCode()
+    {
+        // Arrange
+        var result = new InternalServerError();
+        var httpContext = new DefaultHttpContext()
+        {
+            RequestServices = CreateServices(),
+        };
+
+        // Act
+        await result.ExecuteAsync(httpContext);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status500InternalServerError, httpContext.Response.StatusCode);
+    }
+
+    [Fact]
+    public void PopulateMetadata_AddsResponseTypeMetadata()
+    {
+        // Arrange
+        InternalServerError MyApi() { throw new NotImplementedException(); }
+        var metadata = new List<object>();
+        var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
+
+        // Act
+        PopulateMetadata<InternalServerError>(((Delegate)MyApi).GetMethodInfo(), builder);
+
+        // Assert
+        var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
+        Assert.Equal(StatusCodes.Status500InternalServerError, producesResponseTypeMetadata.StatusCode);
+        Assert.Equal(typeof(void), producesResponseTypeMetadata.Type);
+    }
+
+    [Fact]
+    public void ExecuteAsync_ThrowsArgumentNullException_WhenHttpContextIsNull()
+    {
+        // Arrange
+        var result = new InternalServerError();
+        HttpContext httpContext = null;
+
+        // Act & Assert
+        Assert.ThrowsAsync<ArgumentNullException>("httpContext", () => result.ExecuteAsync(httpContext));
+    }
+
+    [Fact]
+    public void PopulateMetadata_ThrowsArgumentNullException_WhenMethodOrBuilderAreNull()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>("method", () => PopulateMetadata<InternalServerError>(null, new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0)));
+        Assert.Throws<ArgumentNullException>("builder", () => PopulateMetadata<InternalServerError>(((Delegate)PopulateMetadata_ThrowsArgumentNullException_WhenMethodOrBuilderAreNull).GetMethodInfo(), null));
+    }
+
+    [Fact]
+    public void InternalServerErrorObjectResult_Implements_IStatusCodeHttpResult_Correctly()
+    {
+        // Act & Assert
+        var result = Assert.IsAssignableFrom<IStatusCodeHttpResult>(new InternalServerError());
+        Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
+    }
+
+    private static void PopulateMetadata<TResult>(MethodInfo method, EndpointBuilder builder)
+        where TResult : IEndpointMetadataProvider => TResult.PopulateMetadata(method, builder);
+
+    private static IServiceProvider CreateServices()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ILoggerFactory, NullLoggerFactory>();
+        return services.BuildServiceProvider();
+    }
+}

--- a/src/Http/Http.Results/test/ResultsTests.cs
+++ b/src/Http/Http.Results/test/ResultsTests.cs
@@ -1677,7 +1677,6 @@ public partial class ResultsTests
         (() => Results.Forbid(null, null), typeof(ForbidHttpResult)),
         (() => Results.InternalServerError(), typeof(InternalServerError)),
         (() => Results.InternalServerError<object>(new()), typeof(InternalServerError<object>)),
-        (() => Results.InternalServerError(ExceptionDispatchInfo.Capture(new ArgumentException("Test"))), typeof(InternalServerError)),
         (() => Results.Json(new(), (JsonSerializerOptions)null, null, null), typeof(JsonHttpResult<object>)),
         (() => Results.NoContent(), typeof(NoContent)),
         (() => Results.NotFound(null), typeof(NotFound)),

--- a/src/Http/Http.Results/test/ResultsTests.cs
+++ b/src/Http/Http.Results/test/ResultsTests.cs
@@ -397,6 +397,44 @@ public partial class ResultsTests
         Assert.Equal(authenticationSchemes ?? new ReadOnlyCollection<string>(new List<string>()), result.AuthenticationSchemes);
     }
 
+    [Fact]
+    public void InternalServerError_WithValue_ResultHasCorrectValues()
+    {
+        // Arrange
+        object value = new { };
+
+        // Act
+        var result = Results.InternalServerError(value) as InternalServerError<object>;
+
+        // Assert
+        Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
+        Assert.Equal(value, result.Value);
+    }
+
+    [Fact]
+    public void InternalServerErrorOfT_WithValue_ResultHasCorrectValues()
+    {
+        // Arrange
+        var value = new Todo(1);
+
+        // Act
+        var result = Results.InternalServerError(value) as InternalServerError<Todo>;
+
+        // Assert
+        Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
+        Assert.Equal(value, result.Value);
+    }
+
+    [Fact]
+    public void InternalServerError_WithNoArgs_ResultHasCorrectValues()
+    {
+        // Act
+        var result = Results.InternalServerError() as InternalServerError;
+
+        // Assert
+        Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
+    }
+
     [Theory]
     [MemberData(nameof(ChallengeForbidSignInOut_ResultHasCorrectValues_Data))]
     public void SignOut_ResultHasCorrectValues(AuthenticationProperties properties, IList<string> authenticationSchemes)
@@ -1636,6 +1674,8 @@ public partial class ResultsTests
         (() => Results.File(Path.Join(Path.DirectorySeparatorChar.ToString(), "rooted", "path"), null, null, null, null, false), typeof(PhysicalFileHttpResult)),
         (() => Results.File("path", null, null, null, null, false), typeof(VirtualFileHttpResult)),
         (() => Results.Forbid(null, null), typeof(ForbidHttpResult)),
+        (() => Results.InternalServerError(null), typeof(InternalServerError)),
+        (() => Results.InternalServerError(new()), typeof(InternalServerError<object>)),
         (() => Results.Json(new(), (JsonSerializerOptions)null, null, null), typeof(JsonHttpResult<object>)),
         (() => Results.NoContent(), typeof(NoContent)),
         (() => Results.NotFound(null), typeof(NotFound)),

--- a/src/Http/Http.Results/test/ResultsTests.cs
+++ b/src/Http/Http.Results/test/ResultsTests.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using System.IO.Pipelines;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
@@ -1674,8 +1675,9 @@ public partial class ResultsTests
         (() => Results.File(Path.Join(Path.DirectorySeparatorChar.ToString(), "rooted", "path"), null, null, null, null, false), typeof(PhysicalFileHttpResult)),
         (() => Results.File("path", null, null, null, null, false), typeof(VirtualFileHttpResult)),
         (() => Results.Forbid(null, null), typeof(ForbidHttpResult)),
-        (() => Results.InternalServerError(null), typeof(InternalServerError)),
-        (() => Results.InternalServerError(new()), typeof(InternalServerError<object>)),
+        (() => Results.InternalServerError(), typeof(InternalServerError)),
+        (() => Results.InternalServerError<object>(new()), typeof(InternalServerError<object>)),
+        (() => Results.InternalServerError(ExceptionDispatchInfo.Capture(new ArgumentException("Test"))), typeof(InternalServerError)),
         (() => Results.Json(new(), (JsonSerializerOptions)null, null, null), typeof(JsonHttpResult<object>)),
         (() => Results.NoContent(), typeof(NoContent)),
         (() => Results.NotFound(null), typeof(NotFound)),

--- a/src/Http/Http.Results/test/TypedResultsTests.cs
+++ b/src/Http/Http.Results/test/TypedResultsTests.cs
@@ -1422,6 +1422,30 @@ public partial class TypedResultsTests
         Assert.Equal(StatusCodes.Status422UnprocessableEntity, result.StatusCode);
     }
 
+    // [Fact]
+    // public void InternalServerError_WithValue_ResultHasCorrectValues()
+    // {
+    //     // Arrange
+    //     var value = new { };
+
+    //     // Act
+    //     var result = TypedResults.InternalServerError(value);
+
+    //     // Assert
+    //     Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
+    //     Assert.Equal(value, result.Value);
+    // }
+
+    // [Fact]
+    // public void InternalServerError_WithNoArgs_ResultHasCorrectValues()
+    // {
+    //     // Act
+    //     var result = TypedResults.InternalServerError();
+
+    //     // Assert
+    //     Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
+    // }
+
     [JsonSerializable(typeof(object))]
     private partial class ObjectJsonContext : JsonSerializerContext
     { }

--- a/src/Http/Http.Results/test/TypedResultsTests.cs
+++ b/src/Http/Http.Results/test/TypedResultsTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.ObjectModel;
 using System.IO.Pipelines;
+using System.Runtime.ExceptionServices;
 using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
@@ -12,6 +13,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Net.Http.Headers;
+using Xunit.Sdk;
 
 namespace Microsoft.AspNetCore.Http.HttpResults;
 
@@ -1422,29 +1424,47 @@ public partial class TypedResultsTests
         Assert.Equal(StatusCodes.Status422UnprocessableEntity, result.StatusCode);
     }
 
-    // [Fact]
-    // public void InternalServerError_WithValue_ResultHasCorrectValues()
-    // {
-    //     // Arrange
-    //     var value = new { };
+    [Fact]
+    public void InternalServerError_WithValue_ResultHasCorrectValues()
+    {
+        // Arrange
+        var value = new { };
 
-    //     // Act
-    //     var result = TypedResults.InternalServerError(value);
+        // Act
+        var result = TypedResults.InternalServerError(value);
 
-    //     // Assert
-    //     Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
-    //     Assert.Equal(value, result.Value);
-    // }
+        // Assert
+        Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
+        Assert.Equal(value, result.Value);
+    }
 
-    // [Fact]
-    // public void InternalServerError_WithNoArgs_ResultHasCorrectValues()
-    // {
-    //     // Act
-    //     var result = TypedResults.InternalServerError();
+    [Fact]
+    public void InternalServerError_WithNoArgs_ResultHasCorrectValues()
+    {
+        // Act
+        var result = TypedResults.InternalServerError();
 
-    //     // Assert
-    //     Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
-    // }
+        // Assert
+        Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
+    }
+
+    [Fact]
+    public async void InternalServerError_WithException_ThrowsException()
+    {
+        // Arrange
+        var exceptionMessage = "Test exception";
+        ArgumentException exception = new(exceptionMessage);
+        var exceptionInfo = ExceptionDispatchInfo.Capture(exception);
+
+        // Act
+        var result = TypedResults.InternalServerError(exceptionInfo);
+        var exResult = await Record.ExceptionAsync(() => result.ExecuteAsync(null));
+
+        // Assert
+        Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
+        Assert.IsType<ArgumentException>(exResult);
+        Assert.Equal(exceptionMessage, exResult.Message);
+    }
 
     [JsonSerializable(typeof(object))]
     private partial class ObjectJsonContext : JsonSerializerContext

--- a/src/Http/Http.Results/test/TypedResultsTests.cs
+++ b/src/Http/Http.Results/test/TypedResultsTests.cs
@@ -1448,24 +1448,6 @@ public partial class TypedResultsTests
         Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
     }
 
-    [Fact]
-    public async void InternalServerError_WithException_ThrowsException()
-    {
-        // Arrange
-        var exceptionMessage = "Test exception";
-        ArgumentException exception = new(exceptionMessage);
-        var exceptionInfo = ExceptionDispatchInfo.Capture(exception);
-
-        // Act
-        var result = TypedResults.InternalServerError(exceptionInfo);
-        var exResult = await Record.ExceptionAsync(() => result.ExecuteAsync(null));
-
-        // Assert
-        Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
-        Assert.IsType<ArgumentException>(exResult);
-        Assert.Equal(exceptionMessage, exResult.Message);
-    }
-
     [JsonSerializable(typeof(object))]
     private partial class ObjectJsonContext : JsonSerializerContext
     { }


### PR DESCRIPTION

# Extending TypedResults with InternalServerError

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description
Added ``InternalServerError`` and ``InternalServerError<TValue>`` to ``TypedResults``.

Fixes #53073 
