### PR TITLE
Remove comment about DotNet-Blob-Feed from ci.yml

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -77,7 +77,6 @@ variables:
            /p:OfficialBuildId=$(Build.BuildNumber)
            /p:SkipTestBuild=true
            /p:PostBuildSign=$(PostBuildSign)
-  # DotNet-Blob-Feed provides: dotnetfeed-storage-access-key-1
   # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
   - group: Publish-Build-Assets
   # The following extra properties are not set when testing. Use with final build.[cmd,sh] of asset-producing jobs.


### PR DESCRIPTION
Makes it easier to grep for remaining usages in the org.
