### PR TITLE
Return unsuccessful when trying to read form and request does not have body

### DIFF
--- a/src/Http/Routing/test/FunctionalTests/MinimalFormTests.cs
+++ b/src/Http/Routing/test/FunctionalTests/MinimalFormTests.cs
@@ -699,6 +699,63 @@ public class MinimalFormTests
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
+    [Fact]
+    public async Task MapPost_WithFormFile_MissingBody_ReturnsBadRequest()
+    {
+        using var host = new HostBuilder()
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder
+                    .Configure(app =>
+                    {
+                        app.UseRouting();
+                        app.UseEndpoints(b => b.MapPost("/", (IFormFile formFile) => "ok").DisableAntiforgery());
+                    })
+                    .UseTestServer();
+            })
+            .ConfigureServices(services => services.AddRouting())
+            .Build();
+
+        using var server = host.GetTestServer();
+
+        await host.StartAsync();
+        var client = server.CreateClient();
+
+        var response = await client.PostAsync("/", null);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task MapPost_WithFormFile_MissingContentType_ReturnsUnsupportedMediaType()
+    {
+        using var host = new HostBuilder()
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder
+                    .Configure(app =>
+                    {
+                        app.UseRouting();
+                        app.UseEndpoints(b => b.MapPost("/", (IFormFile formFile) => "ok").DisableAntiforgery());
+                    })
+                    .UseTestServer();
+            })
+            .ConfigureServices(services => services.AddRouting())
+            .Build();
+
+        using var server = host.GetTestServer();
+
+        await host.StartAsync();
+        var client = server.CreateClient();
+
+        var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Post, "/")
+        {
+            Content = new ByteArrayContent([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+        });
+
+        Assert.Equal(HttpStatusCode.UnsupportedMediaType, response.StatusCode);
+    }
+
     class Todo
     {
         public string Name { get; set; }

--- a/src/Shared/RequestDelegateCreationMessages.cs
+++ b/src/Shared/RequestDelegateCreationMessages.cs
@@ -53,4 +53,9 @@ internal static class RequestDelegateCreationLogging
     public const string FormDataMappingFailedEventName = "FormDataMappingFailed";
     public const string FormDataMappingFailedLogMessage = @"Failed to bind parameter ""{ParameterType} {ParameterName}"" from the request body as form.";
     public const string FormDataMappingFailedExceptionMessage = @"Failed to bind parameter ""{0} {1}"" from the request body as form.";
+
+    public const int UnexpectedRequestWithoutBodyEventId = 11;
+    public const string UnexpectedRequestWithoutBodyEventName = "UnexpectedRequestWithoutBody";
+    public const string UnexpectedRequestWithoutBodyLogMessage = @"Unexpected request without body, failed to bind parameter ""{ParameterType} {ParameterName}"" from the request body as form.";
+    public const string UnexpectedRequestWithoutBodyExceptionMessage = @"Unexpected request without body, failed to bind parameter ""{0} {1}"" from the request body as form.";
 }


### PR DESCRIPTION
# Return unsuccessful when trying to read form and request does not have body. Fixes #53630


<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

`TryReadFormAsync` returns unsuccessful, if `IHttpRequestBodyDetectionFeature.CanHaveBody` is false, while attempting to read form. Previously, when `IHttpRequestBodyDetectionFeature.CanHaveBody` was false, returned successful, which resulted that request without body and content type would result unwanted reading attempt of the (non-existing form) and throwing/returning 500 status

Fixes #53630 
