### PR TITLE
Enable use of RestoreConfigFile property in source-build

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -40,6 +40,7 @@
       <_AdditionalRepoTaskBuildArgs />
       <_AdditionalRepoTaskBuildArgs Condition="'$(DotNetRuntimeSourceFeed)' != ''" >$(_AdditionalRepoTaskBuildArgs) --runtimesourcefeed $(DotNetRuntimeSourceFeed)</_AdditionalRepoTaskBuildArgs>
       <_AdditionalRepoTaskBuildArgs Condition="'$(DotNetRuntimeSourceFeedKey)' != ''" >$(_AdditionalRepoTaskBuildArgs) --runtimesourcefeedkey $(DotNetRuntimeSourceFeedKey)</_AdditionalRepoTaskBuildArgs>
+      <_AdditionalRepoTaskBuildArgs Condition="'$(RestoreConfigFile)' != ''" >$(_AdditionalRepoTaskBuildArgs) /p:RestoreConfigFile=$(RestoreConfigFile)</_AdditionalRepoTaskBuildArgs>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Contributes to: https://github.com/dotnet/source-build/issues/3170

Backport of changes in https://github.com/dotnet/installer/pull/18478

### Description

Source-build needs to use `RestoreConfigFile` property during build to avoid modifications of `NuGet.config` files in source tree. This change enables passing this property to the inner build.