### PR TITLE
[Blazor] Fix `@key` not being respected for interactive WebAssembly components after publish

### DIFF
--- a/src/Components/WebAssembly/WebAssembly/src/Services/DefaultWebAssemblyJSRuntime.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Services/DefaultWebAssemblyJSRuntime.cs
@@ -106,6 +106,7 @@ internal sealed partial class DefaultWebAssemblyJSRuntime : WebAssemblyJSRuntime
 
     [DynamicDependency(JsonSerialized, typeof(RootComponentOperation))]
     [DynamicDependency(JsonSerialized, typeof(RootComponentOperationBatch))]
+    [DynamicDependency(JsonSerialized, typeof(ComponentMarkerKey))]
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The correct members will be preserved by the above DynamicDependency")]
     internal static RootComponentOperationBatch DeserializeOperations(string operationsJson)
     {


### PR DESCRIPTION
## [Blazor] Fix `@key` not being respected for interactive WebAssembly components after publish

Fixes an issue where the members of `ComponentMarkerKey` were not being correctly preserved after publish, causing each interactive WebAssembly component to effectively have an empty key.

Fixes #53289