### PR TITLE
[release/8.0] [Blazor] Fix `@key` not being respected for interactive WebAssembly components after publish

### DIFF
--- a/src/Components/WebAssembly/WebAssembly/src/Services/DefaultWebAssemblyJSRuntime.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Services/DefaultWebAssemblyJSRuntime.cs
@@ -106,6 +106,7 @@ internal sealed partial class DefaultWebAssemblyJSRuntime : WebAssemblyJSRuntime
 
     [DynamicDependency(JsonSerialized, typeof(RootComponentOperation))]
     [DynamicDependency(JsonSerialized, typeof(RootComponentOperationBatch))]
+    [DynamicDependency(JsonSerialized, typeof(ComponentMarkerKey))]
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The correct members will be preserved by the above DynamicDependency")]
     internal static RootComponentOperationBatch DeserializeOperations(string operationsJson)
     {


### PR DESCRIPTION
## Fix `@key` not being respected for interactive WebAssembly components after publish

Backport of #53746

Fixes an issue where, after publishing a Blazor Web App, components with the `InteractiveWebAssembly` render mode could not receive parameter updates from SSR updates. If the component received any changed parameters, it would always get destroyed and re-initialized regardless of whether a matching `@key` was present.

## Description

The problem was that members of `ComponentMarkerKey` were getting trimmed away after publish. The fix adds new trimming attributes to preserve the members of `ComponentMarkerKey`.

Fixes #53289

## Customer Impact

Without this fix, customers will not be able to preserve component instances between enhanced page updates if any component parameters change. This includes enhanced navigations (navigating from one internal page to another), and enhanced form posts. Because this is a problem specific to publishing, customers may not realize this bug exists in their app until it's deployed.

## Regression?

- [ ] Yes
- [X] No

This bug is specific to apps utilizing static server rendering, which is a new feature in .NET 8.

## Risk

- [ ] High
- [ ] Medium
- [X] Low

The fix is trivial and very unlikely to negatively impact other functionality.

## Verification

- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A