### PR TITLE
Resolve change token leak in Blazor hot reload

### DIFF
--- a/src/Components/Endpoints/src/Builder/RazorComponentEndpointDataSource.cs
+++ b/src/Components/Endpoints/src/Builder/RazorComponentEndpointDataSource.cs
@@ -28,7 +28,7 @@ internal class RazorComponentEndpointDataSource<[DynamicallyAccessedMembers(Comp
     private List<Endpoint>? _endpoints;
     private CancellationTokenSource _cancellationTokenSource;
     private IChangeToken _changeToken;
-    private IDisposable? _disposable;
+    private IDisposable? _disposable;                   // THREADING: protected by _lock
 
     // Internal for testing.
     internal ComponentApplicationBuilder Builder => _builder;
@@ -155,10 +155,13 @@ internal class RazorComponentEndpointDataSource<[DynamicallyAccessedMembers(Comp
  
     public void OnHotReloadClearCache(Type[]? types)
     {
-        if (_disposable != null)
+        lock (_lock)
         {
-            _disposable?.Dispose();
-            _disposable = null;
+            if (_disposable != null)
+            {
+                _disposable?.Dispose();
+                _disposable = null;
+            }
         }
     }
 

--- a/src/Components/Endpoints/src/Builder/RazorComponentEndpointDataSource.cs
+++ b/src/Components/Endpoints/src/Builder/RazorComponentEndpointDataSource.cs
@@ -28,6 +28,7 @@ internal class RazorComponentEndpointDataSource<[DynamicallyAccessedMembers(Comp
     private List<Endpoint>? _endpoints;
     private CancellationTokenSource _cancellationTokenSource;
     private IChangeToken _changeToken;
+    private IDisposable? _disposable;
 
     // Internal for testing.
     internal ComponentApplicationBuilder Builder => _builder;
@@ -141,7 +142,7 @@ internal class RazorComponentEndpointDataSource<[DynamicallyAccessedMembers(Comp
             oldCancellationTokenSource?.Cancel();
             if (_hotReloadService is { MetadataUpdateSupported : true })
             {
-                ChangeToken.OnChange(_hotReloadService.GetChangeToken, UpdateEndpoints);
+                _disposable = ChangeToken.OnChange(_hotReloadService.GetChangeToken, UpdateEndpoints);
             }
         }
     }
@@ -152,5 +153,11 @@ internal class RazorComponentEndpointDataSource<[DynamicallyAccessedMembers(Comp
         Debug.Assert(_changeToken != null);
         Debug.Assert(_endpoints != null);
         return _changeToken;
+    }
+
+    public void Dispose()
+    {
+        _disposable?.Dispose();
+        _disposable = null;
     }
 }

--- a/src/Components/Endpoints/src/Builder/RazorComponentEndpointDataSource.cs
+++ b/src/Components/Endpoints/src/Builder/RazorComponentEndpointDataSource.cs
@@ -140,8 +140,13 @@ internal class RazorComponentEndpointDataSource<[DynamicallyAccessedMembers(Comp
             _cancellationTokenSource = new CancellationTokenSource();
             _changeToken = new CancellationChangeToken(_cancellationTokenSource.Token);
             oldCancellationTokenSource?.Cancel();
+            oldCancellationTokenSource?.Dispose();
             if (_hotReloadService is { MetadataUpdateSupported : true })
             {
+                if (_disposable != null)
+                {
+                    _disposable?.Dispose();
+                }
                 _disposable = ChangeToken.OnChange(_hotReloadService.GetChangeToken, UpdateEndpoints);
             }
         }
@@ -155,6 +160,7 @@ internal class RazorComponentEndpointDataSource<[DynamicallyAccessedMembers(Comp
         return _changeToken;
     }
 
+    // NOTE: Safia, I don't think this will ever get called.
     public void Dispose()
     {
         _disposable?.Dispose();

--- a/src/Components/Endpoints/src/Builder/RazorComponentEndpointDataSource.cs
+++ b/src/Components/Endpoints/src/Builder/RazorComponentEndpointDataSource.cs
@@ -46,6 +46,7 @@ internal class RazorComponentEndpointDataSource<[DynamicallyAccessedMembers(Comp
         _renderModeEndpointProviders = renderModeEndpointProviders.ToArray();
         _factory = factory;
         _hotReloadService = hotReloadService;
+        HotReloadService.ClearCacheEvent += OnHotReloadClearCache;
         DefaultBuilder = new RazorComponentsEndpointConventionBuilder(
             _lock,
             builder,
@@ -149,6 +150,15 @@ internal class RazorComponentEndpointDataSource<[DynamicallyAccessedMembers(Comp
                 }
                 _disposable = ChangeToken.OnChange(_hotReloadService.GetChangeToken, UpdateEndpoints);
             }
+        }
+    }
+ 
+    public void OnHotReloadClearCache(Type[]? types)
+    {
+        if (_disposable != null)
+        {
+            _disposable?.Dispose();
+            _disposable = null;
         }
     }
 

--- a/src/Components/Endpoints/src/Builder/RazorComponentEndpointDataSource.cs
+++ b/src/Components/Endpoints/src/Builder/RazorComponentEndpointDataSource.cs
@@ -159,11 +159,4 @@ internal class RazorComponentEndpointDataSource<[DynamicallyAccessedMembers(Comp
         Debug.Assert(_endpoints != null);
         return _changeToken;
     }
-
-    // NOTE: Safia, I don't think this will ever get called.
-    public void Dispose()
-    {
-        _disposable?.Dispose();
-        _disposable = null;
-    }
 }

--- a/src/Components/Endpoints/src/Builder/RazorComponentEndpointDataSource.cs
+++ b/src/Components/Endpoints/src/Builder/RazorComponentEndpointDataSource.cs
@@ -144,10 +144,7 @@ internal class RazorComponentEndpointDataSource<[DynamicallyAccessedMembers(Comp
             oldCancellationTokenSource?.Dispose();
             if (_hotReloadService is { MetadataUpdateSupported : true })
             {
-                if (_disposable != null)
-                {
-                    _disposable?.Dispose();
-                }
+                _disposable?.Dispose();
                 _disposable = ChangeToken.OnChange(_hotReloadService.GetChangeToken, UpdateEndpoints);
             }
         }
@@ -157,11 +154,8 @@ internal class RazorComponentEndpointDataSource<[DynamicallyAccessedMembers(Comp
     {
         lock (_lock)
         {
-            if (_disposable != null)
-            {
-                _disposable?.Dispose();
-                _disposable = null;
-            }
+            _disposable?.Dispose();
+            _disposable = null;
         }
     }
 

--- a/src/Components/Endpoints/src/DependencyInjection/HotReloadService.cs
+++ b/src/Components/Endpoints/src/DependencyInjection/HotReloadService.cs
@@ -32,6 +32,7 @@ internal sealed class HotReloadService : IDisposable
     {
         var current = Interlocked.Exchange(ref _tokenSource, new CancellationTokenSource());
         current.Cancel();
+        current.Dispose();
     }
 
     public void Dispose()

--- a/src/Components/Endpoints/src/DependencyInjection/HotReloadService.cs
+++ b/src/Components/Endpoints/src/DependencyInjection/HotReloadService.cs
@@ -18,6 +18,7 @@ internal sealed class HotReloadService : IDisposable
 
     private CancellationTokenSource _tokenSource = new();
     private static event Action<Type[]?>? UpdateApplicationEvent;
+    internal static event Action<Type[]?>? ClearCacheEvent;
 
     public bool MetadataUpdateSupported { get; internal set; }
 
@@ -26,6 +27,11 @@ internal sealed class HotReloadService : IDisposable
     public static void UpdateApplication(Type[]? changedTypes)
     {
         UpdateApplicationEvent?.Invoke(changedTypes);
+    }
+    
+    public static void ClearCache(Type[]? types) 
+    { 
+        ClearCacheEvent?.Invoke(types);
     }
 
     private void NotifyUpdateApplication(Type[]? changedTypes)


### PR DESCRIPTION
Description
The blazor hotreload service and end point data source are leaking change token on each iteration. By the 15th or 20th iteration, dotnet watch begins to slow significantly and quickly starts failing to apply. 

There is a clear cache static method that is expected to be implemented by the hot reload extension model. This method was not being implemented for the blazor version of this service. This adds that callback and forwards it to the data source to dispose the last change token in a thread safe manner.  Also cleaned up a few other smaller missing dispose calls in this scenario. 

Note that I wouldn't normally expose a static event in this way, but these two classes already have this existing pattern. Also, they are both singleton instances that stay alive once created. So I am not unadvising the static event in a dispose method (there is no appropriate time to dispose of either)

Fixes #52757 Hot reload becomes very slow with dotnet watch and Blazor
https://github.com/dotnet/aspnetcore/issues/52757
