### PR TITLE
Revert "[release/6.0] Update karma.local.conf.js (#53412)"

### DIFF
--- a/src/SignalR/clients/ts/FunctionalTests/scripts/karma.local.conf.js
+++ b/src/SignalR/clients/ts/FunctionalTests/scripts/karma.local.conf.js
@@ -1,5 +1,3 @@
-const os = require('os');
-
 try {
     // Karma configuration for a local run (the default)
     const createKarmaConfig = require("./karma.base.conf");
@@ -47,16 +45,8 @@ try {
     // We use the launchers themselves to figure out if the browser exists. It's a bit sneaky, but it works.
     tryAddBrowser("ChromeHeadlessNoSandbox", ChromeHeadlessBrowser.prototype);
     tryAddBrowser("ChromiumHeadlessIgnoreCert", ChromiumHeadlessBrowser.prototype);
-
-    if (os.platform() !== 'darwin') {
-      if (!tryAddBrowser("FirefoxHeadless", FirefoxHeadlessBrowser.prototype)) {
-        tryAddBrowser("FirefoxDeveloperHeadless", FirefoxDeveloperHeadlessBrowser.prototype);
-      }
-    } else {
-        // https://bugzilla.mozilla.org/show_bug.cgi?id=1871366
-        // https://bugzilla.mozilla.org/show_bug.cgi?id=1871447
-        // It looks like some Entitlements issue with Firefox and macOS, additionally, it seems 'firefox-bin' is being removed which is what the karma firefox launcher uses by default
-        tryAddBrowser("FirefoxHeadlessMac", FirefoxHeadlessBrowser.prototype);
+    if (!tryAddBrowser("FirefoxHeadless", FirefoxHeadlessBrowser.prototype)) {
+      tryAddBrowser("FirefoxDeveloperHeadless", FirefoxDeveloperHeadlessBrowser.prototype);
     }
 
     // We need to receive an argument from the caller, but globals don't seem to work, so we use an environment variable.
@@ -81,11 +71,6 @@ try {
 
           // Ignore cert errors to allow our test cert to work (NEVER do this outside of testing)
           flags: ["--allow-insecure-localhost", "--ignore-certificate-errors"]
-        },
-        FirefoxHeadlessMac: {
-          base: 'FirefoxHeadless',
-
-          command: '/Applications/FireFox.app/Contents/MacOS/firefox'
         }
       },
     });


### PR DESCRIPTION
This reverts commit 40f12e6726aa4fda0a4444244e947b9faf932008.

Looks like release/6.0 didn't need this backport.