### PR TITLE
Add entry for freebsd-arm64

### DIFF
--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -113,6 +113,7 @@ and are generated based on the last package release.
     <LatestPackageReference Include="Microsoft.NETCore.App.Runtime.linux-musl-arm" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Runtime.linux-musl-arm64" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Runtime.freebsd-x64" />
+    <LatestPackageReference Include="Microsoft.NETCore.App.Runtime.freebsd-arm64" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Runtime.$(TargetRuntimeIdentifier)" Condition=" '$(PortableBuild)' == 'false' " />
 
     <!-- Crossgen2 compiler -->
@@ -129,6 +130,7 @@ and are generated based on the last package release.
     <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.win-arm" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.win-arm64" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.freebsd-x64" />
+    <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.freebsd-arm64" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.$(TargetRuntimeIdentifier)" Condition=" '$(PortableBuild)' == 'false' " />
   </ItemGroup>
 


### PR DESCRIPTION
## Description
This PR add similar entry for FreeBSD arm64 platform, similar to x64 one, as SDK is buildable on both now.

The SDK is now available to FreeBSD users via FreeBSD's ports system and package manager.
It remains a community supported platform.



