### PR TITLE
[release/8.0] Fix casing of ProblemDetails for RFC compliance

### DIFF
--- a/src/Http/Http.Abstractions/src/ProblemDetails/HttpValidationProblemDetails.cs
+++ b/src/Http/Http.Abstractions/src/ProblemDetails/HttpValidationProblemDetails.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Microsoft.AspNetCore.Http;
@@ -36,5 +37,6 @@ public class HttpValidationProblemDetails : ProblemDetails
     /// <summary>
     /// Gets the validation errors associated with this instance of <see cref="HttpValidationProblemDetails"/>.
     /// </summary>
+    [JsonPropertyName("errors")]
     public IDictionary<string, string[]> Errors { get; set; } = new Dictionary<string, string[]>(StringComparer.Ordinal);
 }

--- a/src/Http/Http.Abstractions/src/ProblemDetails/ProblemDetails.cs
+++ b/src/Http/Http.Abstractions/src/ProblemDetails/ProblemDetails.cs
@@ -18,6 +18,7 @@ public class ProblemDetails
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyOrder(-5)]
+    [JsonPropertyName("type")]
     public string? Type { get; set; }
 
     /// <summary>
@@ -27,6 +28,7 @@ public class ProblemDetails
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyOrder(-4)]
+    [JsonPropertyName("title")]
     public string? Title { get; set; }
 
     /// <summary>
@@ -34,6 +36,7 @@ public class ProblemDetails
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyOrder(-3)]
+    [JsonPropertyName("status")]
     public int? Status { get; set; }
 
     /// <summary>
@@ -41,6 +44,7 @@ public class ProblemDetails
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyOrder(-2)]
+    [JsonPropertyName("detail")]
     public string? Detail { get; set; }
 
     /// <summary>
@@ -48,6 +52,7 @@ public class ProblemDetails
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyOrder(-1)]
+    [JsonPropertyName("instance")]
     public string? Instance { get; set; }
 
     /// <summary>

--- a/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
+++ b/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
@@ -55,6 +55,36 @@ public partial class DefaultProblemDetailsWriterTest
     }
 
     [Fact]
+    public async Task WriteAsync_Works_ProperCasing()
+    {
+        // Arrange
+        var writer = GetWriter();
+        var stream = new MemoryStream();
+        var context = CreateContext(stream);
+        var expectedProblem = new ProblemDetails()
+        {
+            Detail = "Custom Bad Request",
+            Instance = "Custom Bad Request",
+            Status = StatusCodes.Status400BadRequest,
+            Type = "https://tools.ietf.org/html/rfc9110#section-15.5.1-custom",
+            Title = "Custom Bad Request",
+        };
+        var problemDetailsContext = new ProblemDetailsContext()
+        {
+            HttpContext = context,
+            ProblemDetails = expectedProblem
+        };
+
+        //Act
+        await writer.WriteAsync(problemDetailsContext);
+
+        //Assert
+        stream.Position = 0;
+        var result = await JsonSerializer.DeserializeAsync<Dictionary<string, object>>(stream, SerializerOptions);
+        Assert.Equal(result.Keys, new(new() { { "type", 0 }, { "title", 1 }, { "status", 2}, { "detail", 3 }, { "instance", 4 } }));
+    }
+
+    [Fact]
     public async Task WriteAsync_Works_WhenReplacingProblemDetailsUsingSetter()
     {
         // Arrange

--- a/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
+++ b/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
@@ -68,6 +68,7 @@ public partial class DefaultProblemDetailsWriterTest
             Status = StatusCodes.Status400BadRequest,
             Type = "https://tools.ietf.org/html/rfc9110#section-15.5.1-custom",
             Title = "Custom Bad Request",
+            Extensions = new Dictionary<string, object>() { { "extensionKey", 1 } }
         };
         var problemDetailsContext = new ProblemDetailsContext()
         {
@@ -80,8 +81,39 @@ public partial class DefaultProblemDetailsWriterTest
 
         //Assert
         stream.Position = 0;
-        var result = await JsonSerializer.DeserializeAsync<Dictionary<string, object>>(stream, SerializerOptions);
-        Assert.Equal(result.Keys, new(new() { { "type", 0 }, { "title", 1 }, { "status", 2}, { "detail", 3 }, { "instance", 4 } }));
+        var result = await JsonSerializer.DeserializeAsync<Dictionary<string, object>>(stream, JsonSerializerOptions.Default);
+        Assert.Equal(result.Keys, new(new() { { "type", 0 }, { "title", 1 }, { "status", 2 }, { "detail", 3 }, { "instance", 4 }, { "extensionKey", 5 } }));
+    }
+
+    [Fact]
+    public async Task WriteAsync_Works_ProperCasing_ValidationProblemDetails()
+    {
+        // Arrange
+        var writer = GetWriter();
+        var stream = new MemoryStream();
+        var context = CreateContext(stream);
+        var expectedProblem = new ValidationProblemDetails()
+        {
+            Detail = "Custom Bad Request",
+            Instance = "Custom Bad Request",
+            Status = StatusCodes.Status400BadRequest,
+            Type = "https://tools.ietf.org/html/rfc9110#section-15.5.1-custom",
+            Title = "Custom Bad Request",
+            Errors = new Dictionary<string, string[]>() { { "name", ["Name is invalid."] } }
+        };
+        var problemDetailsContext = new ProblemDetailsContext()
+        {
+            HttpContext = context,
+            ProblemDetails = expectedProblem
+        };
+
+        //Act
+        await writer.WriteAsync(problemDetailsContext);
+
+        //Assert
+        stream.Position = 0;
+        var result = await JsonSerializer.DeserializeAsync<Dictionary<string, object>>(stream, JsonSerializerOptions.Default);
+        Assert.Equal(result.Keys, new(new() { { "type", 0 }, { "title", 1 }, { "status", 2 }, { "detail", 3 }, { "instance", 4 }, { "errors", 5 } }));
     }
 
     [Fact]

--- a/src/Mvc/Mvc.Core/src/ValidationProblemDetails.cs
+++ b/src/Mvc/Mvc.Core/src/ValidationProblemDetails.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Core;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
@@ -81,5 +82,6 @@ public class ValidationProblemDetails : HttpValidationProblemDetails
     /// <summary>
     /// Gets the validation errors associated with this instance of <see cref="HttpValidationProblemDetails"/>.
     /// </summary>
+    [JsonPropertyName("errors")]
     public new IDictionary<string, string[]> Errors { get { return base.Errors; } set { base.Errors = value; } }
 }


### PR DESCRIPTION
Backport of #53789 to release/8.0

/cc @captainsafia

This PR ensures that property keys that are used in `ProblemDetails` and `ValidationProblemDetails` are always in camel-case, regardless of the serialization options in the application as a whole, to provide compliance with the RFC 7807 spec.

## Description

In .NET 8, we merged a PR to remove the custom converters used for `ProblemDetails` and `ValidationProbleemDetails` in feature of the `IgnoreWhenNull` attributes that were provided in the box by System.Text.Json.

At the same time, we removed the pre-defined type names that existed on the properties of these types.

As it turns out, this was a bad move. The RFC for problem details is particular about property keys being all lower-case ([ref](https://www.rfc-editor.org/rfc/rfc7807#section-3.1)) regardless of what serialization options the rest of the system might be using by default.

This means that are implementation is no longer RFC-compliant. Fixing this by bring backing the explicit type names.

Fixes https://github.com/dotnet/aspnetcore/issues/53639

## Customer Impact

This change breaks the contract provided by the Problem Details specifications. Clients that expect to receive problem details messages that comply with the spec will break if they deserialize with the assumption that our property keys are encoded correctly.

Although there are workarounds to this issue, they involve large amounts of code and we should really provide a correct implementation of the ProblemDetails spec.

## Regression?

- [X] Yes
- [ ] No

This is a regression from the .NET 7 experience.

## Risk

- [ ] High
- [X] Medium
- [ ] Low

Although the change is localized to the `ProblemDetails` codepaths in MVC/Minimal APIs, this change is technically introducing a behavioral breaking change in a servicing release. Users who took a dependency on the broken behavior in .NET 8 will be impacted.

## Verification

- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A