### PR TITLE
Makes RemoteAuthenticationContext serialize correctly

### DIFF
--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Models/RemoteAuthenticationContext.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Models/RemoteAuthenticationContext.cs
@@ -10,6 +10,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 /// Represents the context during authentication operations.
 /// </summary>
 /// <typeparam name="TRemoteAuthenticationState"></typeparam>
+[DynamicallyAccessedMembers(JsonSerialized)]
 public class RemoteAuthenticationContext<[DynamicallyAccessedMembers(JsonSerialized)] TRemoteAuthenticationState> where TRemoteAuthenticationState : RemoteAuthenticationState
 {
     /// <summary>


### PR DESCRIPTION

# Makes RemoteAuthenticationContext serialize correctly

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

This PR ensures that `RemoteAuthenticationContext` property assignments are not optimized away when only used in serialization.

## Description
The entire context is serialized for `JSInterop` and the `State` and `InterativeRequest` properties are lost during serialization. This seems to be because the only usage is for serialization and the property assignments are compiled out.

I think this may be the root cause of #53131, which I've also seen in our production application. The lack of the `State` property after serialization causes issues with the logout callback.

The following code sample demonstrates this behaviour:
```cs
protected override void OnInitialized()
{
    base.OnInitialized();

    var currentContext = new RemoteAuthenticationContext<RemoteAuthenticationState>();
    currentContext.State = new RemoteAuthenticationState() { ReturnUrl = "/" };
    Console.WriteLine($"currentContext: {JsonSerializer.Serialize(currentContext)}");

    var proposedContext = new DemoRemoteAuthenticationContextWithAttribute<RemoteAuthenticationState>();
    proposedContext.State = new RemoteAuthenticationState() { ReturnUrl = "/" };
    Console.WriteLine($"proposedContext: {JsonSerializer.Serialize(proposedContext)}");
}

// explicit member types as LinkerFlags is internal
[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)]
public class DemoRemoteAuthenticationContextWithAttribute<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)] TRemoteAuthenticationState> where TRemoteAuthenticationState : RemoteAuthenticationState
{
    public string? Url { get; set; }

    public TRemoteAuthenticationState? State { get; set; }

    public InteractiveRequestOptions? InteractiveRequest { get; set; }
}
```

Which gives the following output in a browser:
```
currentContext: {}
proposedContext: {"Url":null,"State":{"ReturnUrl":"/"},"InteractiveRequest":null}
```

Fixes #53131
