### PR TITLE
[Blazor] Prevent error boundaries from handling exceptions of type `NavigationException`

### DIFF
--- a/src/Components/Components/src/RenderTree/Renderer.cs
+++ b/src/Components/Components/src/RenderTree/Renderer.cs
@@ -1066,6 +1066,15 @@ public abstract partial class Renderer : IDisposable, IAsyncDisposable
         // already on the sync context (and if not, we have a bug we want to know about).
         Dispatcher.AssertAccess();
 
+        // We don't allow NavigationException instances to be caught by error boundaries.
+        // These are special exceptions whose purpose is to be as invisible as possible to
+        // user code and bubble all the way up to get handled by the framework as a redirect.
+        if (error is NavigationException)
+        {
+            HandleException(error);
+            return;
+        }
+
         // Find the closest error boundary, if any
         var candidate = errorSourceOrNull;
         while (candidate is not null)

--- a/src/Components/test/E2ETest/ServerRenderingTests/RedirectionTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/RedirectionTest.cs
@@ -205,6 +205,22 @@ public class RedirectionTest : ServerTestBase<BasicTestAppServerSiteFixture<Razo
     // response to something like a 200 that the 'fetch' is allowed to read (embedding the
     // destination URL).
 
+    [Fact]
+    public void RedirectEnhancedGetToInternalWithErrorBoundary()
+    {
+        // This test verifies that redirection works even if an ErrorBoundary wraps
+        // a component throwing a NavigationException.
+
+        Browser.Exists(By.LinkText("Enhanced GET with redirect inside error boundary")).Click();
+        Browser.Equal("Scroll to hash", () => _originalH1Element.Text);
+        Assert.EndsWith("/subdir/nav/scroll-to-hash?foo=%F0%9F%99%82", Browser.Url);
+
+        // See that 'back' takes you to the place from before the redirection
+        Browser.Navigate().Back();
+        Browser.Equal("Redirections", () => _originalH1Element.Text);
+        Assert.EndsWith("/subdir/redirect", Browser.Url);
+    }
+
     private void AssertElementRemoved(IWebElement element)
     {
         Browser.True(() =>

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Redirections/RedirectErrorBoundaryGet.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Redirections/RedirectErrorBoundaryGet.razor
@@ -1,0 +1,14 @@
+﻿@page "/redirect/error-boundary/get"
+
+<h1>Redirect in error boundary GET</h1>
+
+<ErrorBoundary>
+    <ChildContent>
+        <RedirectGet />
+    </ChildContent>
+    <ErrorContent>
+        <p>
+            Error caught by error boundary: @context.Message
+        </p>
+    </ErrorContent>
+</ErrorBoundary>

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Redirections/RedirectHome.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Redirections/RedirectHome.razor
@@ -90,3 +90,8 @@
         </form>
     </li>
 </ul>
+
+<h2>Redirect inside error boundary</h2>
+<ul>
+    <li><a href="redirect/error-boundary/get">Enhanced GET with redirect inside error boundary</a></li>
+</ul>


### PR DESCRIPTION
# Prevent error boundaries from handling exceptions of type `NavigationException`

Fixes an issue where error boundaries may handle `NavigationException` instances and treat them as uncaught errors rather than signals to redirect.

## Description

This PR fixes the issue by ignoring error boundaries if the exception getting dispatched is a `NavigatonException`.

Fixes #52777
