### PR TITLE
Add unit test to confirm change token is disposed during

### DIFF
--- a/src/Components/Endpoints/test/HotReloadServiceTests.cs
+++ b/src/Components/Endpoints/test/HotReloadServiceTests.cs
@@ -137,9 +137,9 @@ public class HotReloadServiceTests
         Assert.Empty(compositeEndpointDataSource.Endpoints);
     }
 
-    public class WrappedChangeTokenDisposable : IDisposable
+    private sealed class WrappedChangeTokenDisposable : IDisposable
     {
-        public bool IsDisposed { get; private set;}
+        public bool IsDisposed { get; private set; }
         private readonly IDisposable _innerDisposable;
 
         public WrappedChangeTokenDisposable(IDisposable innerDisposable)


### PR DESCRIPTION
Add unit test to confirm change token is disposed during razer hot reload.

During the unit test, the disposable change token is wrapped in an object that can
track and return dispose state. This is only used during this one unit test. 

