### PR TITLE
PathString.StartsWithSegments: Clarify trailing slash behavior in doc comments

### DIFF
--- a/src/Http/Http.Abstractions/src/PathString.cs
+++ b/src/Http/Http.Abstractions/src/PathString.cs
@@ -212,6 +212,12 @@ public readonly struct PathString : IEquatable<PathString>
     /// </summary>
     /// <param name="other">The <see cref="PathString"/> to compare.</param>
     /// <returns>true if value matches the beginning of this string; otherwise, false.</returns>
+    /// <remarks>
+    /// When the <paramref name="other"/> parameter contains a trailing slash, the <see cref="PathString"/> being checked
+    /// must either exactly match or include a trailing slash. For instance, for a <see cref="PathString"/> of "/a/b",
+    /// this method will return <c>true</c> for "/a", but will return <c>false</c> for "/a/".
+    /// Whereas, a <see cref="PathString"/> of "/a//b/" will return <c>true</c> when compared with "/a/".
+    /// </remarks>
     public bool StartsWithSegments(PathString other)
     {
         return StartsWithSegments(other, StringComparison.OrdinalIgnoreCase);
@@ -224,6 +230,12 @@ public readonly struct PathString : IEquatable<PathString>
     /// <param name="other">The <see cref="PathString"/> to compare.</param>
     /// <param name="comparisonType">One of the enumeration values that determines how this <see cref="PathString"/> and value are compared.</param>
     /// <returns>true if value matches the beginning of this string; otherwise, false.</returns>
+    /// <remarks>
+    /// When the <paramref name="other"/> parameter contains a trailing slash, the <see cref="PathString"/> being checked
+    /// must either exactly match or include a trailing slash. For instance, for a <see cref="PathString"/> of "/a/b",
+    /// this method will return <c>true</c> for "/a", but will return <c>false</c> for "/a/".
+    /// Whereas, a <see cref="PathString"/> of "/a//b/" will return <c>true</c> when compared with "/a/".
+    /// </remarks>
     public bool StartsWithSegments(PathString other, StringComparison comparisonType)
     {
         var value1 = Value ?? string.Empty;
@@ -242,6 +254,12 @@ public readonly struct PathString : IEquatable<PathString>
     /// <param name="other">The <see cref="PathString"/> to compare.</param>
     /// <param name="remaining">The remaining segments after the match.</param>
     /// <returns>true if value matches the beginning of this string; otherwise, false.</returns>
+    /// <remarks>
+    /// When the <paramref name="other"/> parameter contains a trailing slash, the <see cref="PathString"/> being checked
+    /// must either exactly match or include a trailing slash. For instance, for a <see cref="PathString"/> of "/a/b",
+    /// this method will return <c>true</c> for "/a", but will return <c>false</c> for "/a/".
+    /// Whereas, a <see cref="PathString"/> of "/a//b/" will return <c>true</c> when compared with "/a/".
+    /// </remarks>
     public bool StartsWithSegments(PathString other, out PathString remaining)
     {
         return StartsWithSegments(other, StringComparison.OrdinalIgnoreCase, out remaining);
@@ -255,6 +273,12 @@ public readonly struct PathString : IEquatable<PathString>
     /// <param name="comparisonType">One of the enumeration values that determines how this <see cref="PathString"/> and value are compared.</param>
     /// <param name="remaining">The remaining segments after the match.</param>
     /// <returns>true if value matches the beginning of this string; otherwise, false.</returns>
+    /// <remarks>
+    /// When the <paramref name="other"/> parameter contains a trailing slash, the <see cref="PathString"/> being checked
+    /// must either exactly match or include a trailing slash. For instance, for a <see cref="PathString"/> of "/a/b",
+    /// this method will return <c>true</c> for "/a", but will return <c>false</c> for "/a/".
+    /// Whereas, a <see cref="PathString"/> of "/a//b/" will return <c>true</c> when compared with "/a/".
+    /// </remarks>
     public bool StartsWithSegments(PathString other, StringComparison comparisonType, out PathString remaining)
     {
         var value1 = Value ?? string.Empty;
@@ -279,6 +303,12 @@ public readonly struct PathString : IEquatable<PathString>
     /// <param name="matched">The matched segments with the original casing in the source value.</param>
     /// <param name="remaining">The remaining segments after the match.</param>
     /// <returns>true if value matches the beginning of this string; otherwise, false.</returns>
+    /// <remarks>
+    /// When the <paramref name="other"/> parameter contains a trailing slash, the <see cref="PathString"/> being checked
+    /// must either exactly match or include a trailing slash. For instance, for a <see cref="PathString"/> of "/a/b",
+    /// this method will return <c>true</c> for "/a", but will return <c>false</c> for "/a/".
+    /// Whereas, a <see cref="PathString"/> of "/a//b/" will return <c>true</c> when compared with "/a/".
+    /// </remarks>
     public bool StartsWithSegments(PathString other, out PathString matched, out PathString remaining)
     {
         return StartsWithSegments(other, StringComparison.OrdinalIgnoreCase, out matched, out remaining);
@@ -293,6 +323,12 @@ public readonly struct PathString : IEquatable<PathString>
     /// <param name="matched">The matched segments with the original casing in the source value.</param>
     /// <param name="remaining">The remaining segments after the match.</param>
     /// <returns>true if value matches the beginning of this string; otherwise, false.</returns>
+    /// <remarks>
+    /// When the <paramref name="other"/> parameter contains a trailing slash, the <see cref="PathString"/> being checked
+    /// must either exactly match or include a trailing slash. For instance, for a <see cref="PathString"/> of "/a/b",
+    /// this method will return <c>true</c> for "/a", but will return <c>false</c> for "/a/".
+    /// Whereas, a <see cref="PathString"/> of "/a//b/" will return <c>true</c> when compared with "/a/".
+    /// </remarks>
     public bool StartsWithSegments(PathString other, StringComparison comparisonType, out PathString matched, out PathString remaining)
     {
         var value1 = Value ?? string.Empty;

--- a/src/Http/Http.Abstractions/test/PathStringTests.cs
+++ b/src/Http/Http.Abstractions/test/PathStringTests.cs
@@ -127,12 +127,44 @@ public class PathStringTests
     }
 
     [Theory]
+    [InlineData("/a/", "/a/", true)]
+    [InlineData("/a/b", "/a/", false)]
+    [InlineData("/a/b/", "/a/", false)]
+    [InlineData("/a//b", "/a/", true)]
+    [InlineData("/a//b/", "/a/", true)]
+    public void StartsWithSegments_DoesMatchExactPathOrPathWithExtraTrailingSlash(string sourcePath, string testPath, bool expectedResult)
+    {
+        var source = new PathString(sourcePath);
+        var test = new PathString(testPath);
+
+        var result = source.StartsWithSegments(test);
+
+        Assert.Equal(expectedResult, result);
+    }
+
+    [Theory]
     [InlineData("/test/path", "/TEST", true)]
     [InlineData("/test/path", "/TEST/pa", false)]
     [InlineData("/TEST/PATH", "/test", true)]
     [InlineData("/TEST/path", "/test/pa", false)]
     [InlineData("/test/PATH/path/TEST", "/TEST/path/PATH", true)]
     public void StartsWithSegmentsWithRemainder_DoesACaseInsensitiveMatch(string sourcePath, string testPath, bool expectedResult)
+    {
+        var source = new PathString(sourcePath);
+        var test = new PathString(testPath);
+
+        var result = source.StartsWithSegments(test, out var remaining);
+
+        Assert.Equal(expectedResult, result);
+    }
+
+    [Theory]
+    [InlineData("/a/", "/a/", true)]
+    [InlineData("/a/b", "/a/", false)]
+    [InlineData("/a/b/", "/a/", false)]
+    [InlineData("/a//b", "/a/", true)]
+    [InlineData("/a//b/", "/a/", true)]
+    public void StartsWithSegmentsWithRemainder_DoesMatchExactPathOrPathWithExtraTrailingSlash(string sourcePath, string testPath, bool expectedResult)
     {
         var source = new PathString(sourcePath);
         var test = new PathString(testPath);
@@ -164,6 +196,27 @@ public class PathStringTests
     }
 
     [Theory]
+    [InlineData("/a/", "/a/", StringComparison.OrdinalIgnoreCase, true)]
+    [InlineData("/a/", "/a/", StringComparison.Ordinal, true)]
+    [InlineData("/a/b", "/a/", StringComparison.OrdinalIgnoreCase, false)]
+    [InlineData("/a/b", "/a/", StringComparison.Ordinal, false)]
+    [InlineData("/a/b/", "/a/", StringComparison.OrdinalIgnoreCase, false)]
+    [InlineData("/a/b/", "/a/", StringComparison.Ordinal, false)]
+    [InlineData("/a//b", "/a/", StringComparison.OrdinalIgnoreCase, true)]
+    [InlineData("/a//b", "/a/", StringComparison.Ordinal, true)]
+    [InlineData("/a//b/", "/a/", StringComparison.OrdinalIgnoreCase, true)]
+    [InlineData("/a//b/", "/a/", StringComparison.Ordinal, true)]
+    public void StartsWithSegments_DoesMatchExactPathOrPathWithExtraTrailingSlashUsingSpecifiedComparison(string sourcePath, string testPath, StringComparison comparison, bool expectedResult)
+    {
+        var source = new PathString(sourcePath);
+        var test = new PathString(testPath);
+
+        var result = source.StartsWithSegments(test, comparison);
+
+        Assert.Equal(expectedResult, result);
+    }
+
+    [Theory]
     [InlineData("/test/path", "/TEST", StringComparison.OrdinalIgnoreCase, true)]
     [InlineData("/test/path", "/TEST", StringComparison.Ordinal, false)]
     [InlineData("/test/path", "/TEST/pa", StringComparison.OrdinalIgnoreCase, false)]
@@ -175,6 +228,27 @@ public class PathStringTests
     [InlineData("/test/PATH/path/TEST", "/TEST/path/PATH", StringComparison.OrdinalIgnoreCase, true)]
     [InlineData("/test/PATH/path/TEST", "/TEST/path/PATH", StringComparison.Ordinal, false)]
     public void StartsWithSegmentsWithRemainder_DoesMatchUsingSpecifiedComparison(string sourcePath, string testPath, StringComparison comparison, bool expectedResult)
+    {
+        var source = new PathString(sourcePath);
+        var test = new PathString(testPath);
+
+        var result = source.StartsWithSegments(test, comparison, out var remaining);
+
+        Assert.Equal(expectedResult, result);
+    }
+
+    [Theory]
+    [InlineData("/a/", "/a/", StringComparison.OrdinalIgnoreCase, true)]
+    [InlineData("/a/", "/a/", StringComparison.Ordinal, true)]
+    [InlineData("/a/b", "/a/", StringComparison.OrdinalIgnoreCase, false)]
+    [InlineData("/a/b", "/a/", StringComparison.Ordinal, false)]
+    [InlineData("/a/b/", "/a/", StringComparison.OrdinalIgnoreCase, false)]
+    [InlineData("/a/b/", "/a/", StringComparison.Ordinal, false)]
+    [InlineData("/a//b", "/a/", StringComparison.OrdinalIgnoreCase, true)]
+    [InlineData("/a//b", "/a/", StringComparison.Ordinal, true)]
+    [InlineData("/a//b/", "/a/", StringComparison.OrdinalIgnoreCase, true)]
+    [InlineData("/a//b/", "/a/", StringComparison.Ordinal, true)]
+    public void StartsWithSegmentsWithRemainder_DoesMatchExactPathOrPathWithExtraTrailingSlashUsingSpecifiedComparison(string sourcePath, string testPath, StringComparison comparison, bool expectedResult)
     {
         var source = new PathString(sourcePath);
         var test = new PathString(testPath);


### PR DESCRIPTION
# PathString.StartsWithSegments: Clarify trailing slash behavior in doc comments

## Description

Adds remarks clarifying some unexpected behavior of trailing slashes with the `StartsWithSegments` methods on `PathString`.

**Remarks**

```
/// <remarks>
/// When the <paramref name="other"/> parameter contains a trailing slash, the <see cref="PathString"/> being checked
/// must either exactly match or include a trailing slash. For instance, for a <see cref="PathString"/> of "/a/b",
/// this method will return <c>true</c> for "/a", but will return <c>false</c> for "/a/".
/// Whereas, a <see cref="PathString"/> of "/a//b/" will return <c>true</c> when compared with "/a/".
/// </remarks>
```

Fixes #2713
