### PR TITLE
[release/8.0] [Blazor] Fix hot reload memory leak

### DIFF
--- a/src/Components/Endpoints/src/DependencyInjection/HotReloadService.cs
+++ b/src/Components/Endpoints/src/DependencyInjection/HotReloadService.cs
@@ -18,6 +18,7 @@ internal sealed class HotReloadService : IDisposable
 
     private CancellationTokenSource _tokenSource = new();
     private static event Action<Type[]?>? UpdateApplicationEvent;
+    internal static event Action<Type[]?>? ClearCacheEvent;
 
     public bool MetadataUpdateSupported { get; internal set; }
 
@@ -27,11 +28,17 @@ internal sealed class HotReloadService : IDisposable
     {
         UpdateApplicationEvent?.Invoke(changedTypes);
     }
+    
+    public static void ClearCache(Type[]? types) 
+    { 
+        ClearCacheEvent?.Invoke(types);
+    }
 
     private void NotifyUpdateApplication(Type[]? changedTypes)
     {
         var current = Interlocked.Exchange(ref _tokenSource, new CancellationTokenSource());
         current.Cancel();
+        current.Dispose();
     }
 
     public void Dispose()

--- a/src/Components/Endpoints/test/HotReloadServiceTests.cs
+++ b/src/Components/Endpoints/test/HotReloadServiceTests.cs
@@ -137,6 +137,52 @@ public class HotReloadServiceTests
         Assert.Empty(compositeEndpointDataSource.Endpoints);
     }
 
+    private sealed class WrappedChangeTokenDisposable : IDisposable
+    {
+        public bool IsDisposed { get; private set; }
+        private readonly IDisposable _innerDisposable;
+
+        public WrappedChangeTokenDisposable(IDisposable innerDisposable)
+        { 
+            _innerDisposable = innerDisposable;
+        }
+
+        public void Dispose()
+        { 
+             IsDisposed = true;
+             _innerDisposable.Dispose();
+        }
+    }
+
+    [Fact]
+    public void ConfirmChangeTokenDisposedHotReload()
+    {
+        // Arrange
+        var builder = CreateBuilder(typeof(ServerComponent));
+        var services = CreateServices(typeof(MockEndpointProvider));
+        var endpointDataSource = CreateDataSource<App>(builder, services);
+
+        WrappedChangeTokenDisposable wrappedChangeTokenDisposable = null;
+
+        endpointDataSource.SetDisposableChangeTokenAction = (IDisposable disposableChangeToken) => {
+            wrappedChangeTokenDisposable = new WrappedChangeTokenDisposable(disposableChangeToken); 
+            return wrappedChangeTokenDisposable;
+        };
+
+        var endpoint = Assert.IsType<RouteEndpoint>(Assert.Single(endpointDataSource.Endpoints));
+        Assert.Equal("/server", endpoint.RoutePattern.RawText);
+        Assert.DoesNotContain(endpoint.Metadata, (element) => element is TestMetadata);
+
+        // Make a modification and then perform a hot reload.
+        endpointDataSource.Conventions.Add(builder =>
+            builder.Metadata.Add(new TestMetadata()));
+        HotReloadService.UpdateApplication(null);
+        HotReloadService.ClearCache(null);
+
+        // Confirm the change token is disposed after ClearCache
+        Assert.True(wrappedChangeTokenDisposable.IsDisposed);
+    }
+
     private class TestMetadata { }
 
     private ComponentApplicationBuilder CreateBuilder(params Type[] types)


### PR DESCRIPTION
# Fix hot reload memory leak

Fixes an issue where a memory leak caused hot reload edits in Blazor Web apps to take an increasing amount of time over the course of a hot reload session.

Backport of #53750 and #53827

## Description

There is a static `ClearCache` method that is expected to be implemented by the hot reload extension model. This method was not being implemented for Blazor's `HotReloadService`. This PR adds that callback and forwards it to the data source to dispose the last change token in a thread safe manner. The PR also cleans up a few other smaller missing `Dispose` calls for this scenario.

Fixes #52757

## Customer Impact

Without this fix, if customers make more than 15 or 20 hot reload edits in a single hot reload session for their Blazor Web app, hot reload edits grind to a halt until the application gets restarted. We've received significant customer feedback that this impacts their workflow.

## Regression?

- [ ] Yes
- [X] No

This bug is specific to Blazor Web apps, which are new in .NET 8.

## Risk

- [ ] High
- [ ] Medium
- [X] Low

The only changes introduced are those that allow the correct disposal of hot reload state, and functionality is otherwise unchanged. The fix was verified both locally and with automated tests.

## Verification

- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A