### PR TITLE
Add missing TimeProvider registration

### DIFF
--- a/src/Identity/Core/src/IdentityBuilderExtensions.cs
+++ b/src/Identity/Core/src/IdentityBuilderExtensions.cs
@@ -44,6 +44,7 @@ public static class IdentityBuilderExtensions
         builder.Services.AddScoped(typeof(ISecurityStampValidator), typeof(SecurityStampValidator<>).MakeGenericType(builder.UserType));
         builder.Services.AddScoped(typeof(ITwoFactorSecurityStampValidator), typeof(TwoFactorSecurityStampValidator<>).MakeGenericType(builder.UserType));
         builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<SecurityStampValidatorOptions>, PostConfigureSecurityStampValidatorOptions>());
+        builder.Services.TryAddSingleton(TimeProvider.System);
     }
 
     /// <summary>

--- a/src/Identity/Core/src/IdentityBuilderExtensions.cs
+++ b/src/Identity/Core/src/IdentityBuilderExtensions.cs
@@ -44,7 +44,6 @@ public static class IdentityBuilderExtensions
         builder.Services.AddScoped(typeof(ISecurityStampValidator), typeof(SecurityStampValidator<>).MakeGenericType(builder.UserType));
         builder.Services.AddScoped(typeof(ITwoFactorSecurityStampValidator), typeof(TwoFactorSecurityStampValidator<>).MakeGenericType(builder.UserType));
         builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<SecurityStampValidatorOptions>, PostConfigureSecurityStampValidatorOptions>());
-        builder.Services.TryAddSingleton(TimeProvider.System);
     }
 
     /// <summary>
@@ -107,12 +106,14 @@ public static class IdentityBuilderExtensions
     // Set TimeProvider from DI on all options instances, if not already set by tests.
     private sealed class PostConfigureSecurityStampValidatorOptions : IPostConfigureOptions<SecurityStampValidatorOptions>
     {
-        public PostConfigureSecurityStampValidatorOptions(TimeProvider timeProvider)
+        public PostConfigureSecurityStampValidatorOptions(TimeProvider? timeProvider = null)
         {
+            // We could assign this to "timeProvider ?? TimeProvider.System", but
+            // SecurityStampValidator already has system clock fallback logic.
             TimeProvider = timeProvider;
         }
 
-        private TimeProvider TimeProvider { get; }
+        private TimeProvider? TimeProvider { get; }
 
         public void PostConfigure(string? name, SecurityStampValidatorOptions options)
         {

--- a/src/Identity/Core/src/IdentityServiceCollectionExtensions.cs
+++ b/src/Identity/Core/src/IdentityServiceCollectionExtensions.cs
@@ -171,12 +171,14 @@ public static class IdentityServiceCollectionExtensions
 
     private sealed class PostConfigureSecurityStampValidatorOptions : IPostConfigureOptions<SecurityStampValidatorOptions>
     {
-        public PostConfigureSecurityStampValidatorOptions(TimeProvider timeProvider)
+        public PostConfigureSecurityStampValidatorOptions(TimeProvider? timeProvider = null)
         {
+            // We could assign this to "timeProvider ?? TimeProvider.System", but
+            // SecurityStampValidator already has system clock fallback logic.
             TimeProvider = timeProvider;
         }
 
-        private TimeProvider TimeProvider { get; }
+        private TimeProvider? TimeProvider { get; }
 
         public void PostConfigure(string? name, SecurityStampValidatorOptions options)
         {

--- a/src/Identity/test/Identity.Test/IdentityBuilderTest.cs
+++ b/src/Identity/test/Identity.Test/IdentityBuilderTest.cs
@@ -197,7 +197,26 @@ public class IdentityBuilderTest
     }
 
     [Fact]
-    public void EnsureDefaultSignInManagerDependencies()
+    public void EnsureDefaultSignInManagerDependenciesForIdentity()
+    {
+        var services = new ServiceCollection()
+            .AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddLogging()
+            .AddIdentity<PocoUser, PocoRole>()
+            .AddUserStore<NoopUserStore>()
+            .AddRoleStore<NoopRoleStore>()
+            .AddSignInManager<MySignInManager>();
+
+        var provider = services.BuildServiceProvider();
+
+        Assert.IsType<MySignInManager>(provider.GetRequiredService<SignInManager<PocoUser>>());
+        Assert.IsType<SecurityStampValidator<PocoUser>>(provider.GetRequiredService<ISecurityStampValidator>());
+        Assert.IsType<TwoFactorSecurityStampValidator<PocoUser>>(provider.GetRequiredService<ITwoFactorSecurityStampValidator>());
+        Assert.NotNull(provider.GetService<IOptions<SecurityStampValidatorOptions>>());
+    }
+
+    [Fact]
+    public void EnsureDefaultSignInManagerDependenciesForIdentityCore()
     {
         var services = new ServiceCollection()
             .AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());

--- a/src/Identity/test/Identity.Test/IdentityBuilderTest.cs
+++ b/src/Identity/test/Identity.Test/IdentityBuilderTest.cs
@@ -197,6 +197,27 @@ public class IdentityBuilderTest
     }
 
     [Fact]
+    public void EnsureDefaultSignInManagerDependencies()
+    {
+        var services = new ServiceCollection()
+            .AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddLogging()
+            .AddIdentityCore<PocoUser>()
+            .AddRoles<PocoRole>()
+            .AddUserStore<NoopUserStore>()
+            .AddRoleStore<NoopRoleStore>()
+            .AddSignInManager<MySignInManager>();
+
+        var provider = services.BuildServiceProvider();
+
+        Assert.IsType<MySignInManager>(provider.GetRequiredService<SignInManager<PocoUser>>());
+        Assert.IsType<SecurityStampValidator<PocoUser>>(provider.GetRequiredService<ISecurityStampValidator>());
+        Assert.IsType<TwoFactorSecurityStampValidator<PocoUser>>(provider.GetRequiredService<ITwoFactorSecurityStampValidator>());
+        Assert.NotNull(provider.GetService<IOptions<SecurityStampValidatorOptions>>());
+        Assert.NotNull(provider.GetService<TimeProvider>());
+    }
+
+    [Fact]
     public void EnsureDefaultTokenProviders()
     {
         var services = new ServiceCollection()

--- a/src/Identity/test/Identity.Test/IdentityBuilderTest.cs
+++ b/src/Identity/test/Identity.Test/IdentityBuilderTest.cs
@@ -214,7 +214,6 @@ public class IdentityBuilderTest
         Assert.IsType<SecurityStampValidator<PocoUser>>(provider.GetRequiredService<ISecurityStampValidator>());
         Assert.IsType<TwoFactorSecurityStampValidator<PocoUser>>(provider.GetRequiredService<ITwoFactorSecurityStampValidator>());
         Assert.NotNull(provider.GetService<IOptions<SecurityStampValidatorOptions>>());
-        Assert.NotNull(provider.GetService<TimeProvider>());
     }
 
     [Fact]


### PR DESCRIPTION
# Add missing TimeProvider registration

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Add missing `TimeProvider` registration

`AddSignInManager()` method on `IdentityBuilder` adds dependencies that use `TimeProvider` but does not register an implementation for it within service collection. That results in `InvalidOperationException` being thrown on application startup for invalid service descriptor, because of missing `TimeProvider` implementation.

Fixes #53938

I haven't been able to locate unit tests that would cover specifically that identity builder methods. Any guidance for that would be welcomed if there is a need to add test coverage for the change.
