### PR TITLE
Don't auto-label wtgodbe's PRs

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -734,15 +734,6 @@ configuration:
       description: Remove pending-ci-rerun label when CI rerun requested
     - if:
       - payloadType: Pull_Request
-      - isActivitySender:
-          user: wtgodbe
-          issueAuthor: False
-      then:
-      - addLabel:
-          label: area-infrastructure
-      description: Add area-infrastructure to wtgodbe's PRs
-    - if:
-      - payloadType: Pull_Request
       - labelAdded:
           label: breaking-change
       then:


### PR DESCRIPTION
This action is supposed to auto-label my PRs, but after the conversion it auto-labels any PR that I take action on. Our other policies mostly cover what this one was trying to do anyways, so let's just delete it.