### PR TITLE
Fix time scale

### DIFF
--- a/src/SignalR/common/Http.Connections/src/HttpConnectionDispatcherOptions.cs
+++ b/src/SignalR/common/Http.Connections/src/HttpConnectionDispatcherOptions.cs
@@ -112,7 +112,6 @@ public class HttpConnectionDispatcherOptions
             ArgumentOutOfRangeException.ThrowIfEqual(value, TimeSpan.Zero);
 
             _transportSendTimeout = value;
-            TransportSendTimeoutTicks = value.Ticks;
         }
     }
 
@@ -133,7 +132,6 @@ public class HttpConnectionDispatcherOptions
     /// </remarks>
     public bool AllowStatefulReconnects { get; set; }
 
-    internal long TransportSendTimeoutTicks { get; private set; }
     internal bool TransportSendTimeoutEnabled => _transportSendTimeout != Timeout.InfiniteTimeSpan;
 
     // We initialize these lazily based on the state of the options specified here.

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -555,7 +555,7 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
                 await task.DefaultTimeout();
 
                 // We've been gone longer than the expiration time
-                connection.LastSeenTicks = Environment.TickCount64 - (long)disconnectTimeout.TotalMilliseconds - 1;
+                connection.LastSeenTicks = TimeSpan.FromMilliseconds(Environment.TickCount64) - disconnectTimeout - TimeSpan.FromTicks(1);
 
                 // The application is still running here because the poll is only killed
                 // by the heartbeat so we pretend to do a scan and this should force the application task to complete
@@ -1277,6 +1277,7 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
 
         using (StartVerifiableLog(expectedErrorsFilter: ExpectedErrors))
         {
+            var initialTime = TimeSpan.FromMilliseconds(Environment.TickCount64);
             var manager = CreateConnectionManager(LoggerFactory);
             var connection = manager.CreateConnection();
             connection.TransportType = HttpTransportType.LongPolling;
@@ -1287,16 +1288,23 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
             var builder = new ConnectionBuilder(services.BuildServiceProvider());
             builder.UseConnectionHandler<TestConnectionHandler>();
             var app = builder.Build();
-            var options = new HttpConnectionDispatcherOptions();
             // First poll completes immediately
+            var options = new HttpConnectionDispatcherOptions();
             await dispatcher.ExecuteAsync(context, options, app).DefaultTimeout();
             var sync = new SyncPoint();
             context.Response.Body = new BlockingStream(sync);
             var dispatcherTask = dispatcher.ExecuteAsync(context, options, app);
             await connection.Transport.Output.WriteAsync(new byte[] { 1 }).DefaultTimeout();
             await sync.WaitForSyncPoint().DefaultTimeout();
+
+            // Try cancel before cancellation should occur
+            connection.TryCancelSend(initialTime + options.TransportSendTimeout);
+            Assert.False(connection.SendingToken.IsCancellationRequested);
+
             // Cancel write to response body
-            connection.TryCancelSend(long.MaxValue);
+            connection.TryCancelSend(TimeSpan.FromMilliseconds(Environment.TickCount64) + options.TransportSendTimeout + TimeSpan.FromTicks(1));
+            Assert.True(connection.SendingToken.IsCancellationRequested);
+
             sync.Continue();
             await dispatcherTask.DefaultTimeout();
             // Connection should be removed on canceled write
@@ -1310,6 +1318,7 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
     {
         using (StartVerifiableLog())
         {
+            var initialTime = TimeSpan.FromMilliseconds(Environment.TickCount64);
             var manager = CreateConnectionManager(LoggerFactory);
             var connection = manager.CreateConnection();
             var dispatcher = CreateDispatcher(manager, LoggerFactory);
@@ -1326,8 +1335,15 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
             var dispatcherTask = dispatcher.ExecuteAsync(context, options, app);
             await connection.Transport.Output.WriteAsync(new byte[] { 1 }).DefaultTimeout();
             await sync.WaitForSyncPoint().DefaultTimeout();
+
+            // Try cancel before cancellation should occur
+            connection.TryCancelSend(initialTime + options.TransportSendTimeout);
+            Assert.False(connection.SendingToken.IsCancellationRequested);
+
             // Cancel write to response body
-            connection.TryCancelSend(long.MaxValue);
+            connection.TryCancelSend(TimeSpan.FromMilliseconds(Environment.TickCount64) + options.TransportSendTimeout + TimeSpan.FromTicks(1));
+            Assert.True(connection.SendingToken.IsCancellationRequested);
+
             sync.Continue();
             await dispatcherTask.DefaultTimeout();
             // Connection should be removed on canceled write
@@ -1346,6 +1362,7 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
         }
         using (StartVerifiableLog(expectedErrorsFilter: ExpectedErrors))
         {
+            var initialTime = TimeSpan.FromMilliseconds(Environment.TickCount64);
             var manager = CreateConnectionManager(LoggerFactory);
             var connection = manager.CreateConnection();
             var dispatcher = CreateDispatcher(manager, LoggerFactory);
@@ -1362,8 +1379,15 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
             var dispatcherTask = dispatcher.ExecuteAsync(context, options, app);
             await connection.Transport.Output.WriteAsync(new byte[] { 1 }).DefaultTimeout();
             await sync.WaitForSyncPoint().DefaultTimeout();
+
+            // Try cancel before cancellation should occur
+            connection.TryCancelSend(initialTime + options.TransportSendTimeout);
+            Assert.False(connection.SendingToken.IsCancellationRequested);
+
             // Cancel write to response body
-            connection.TryCancelSend(long.MaxValue);
+            connection.TryCancelSend(TimeSpan.FromMilliseconds(Environment.TickCount64) + options.TransportSendTimeout + TimeSpan.FromTicks(1));
+            Assert.True(connection.SendingToken.IsCancellationRequested);
+
             sync.Continue();
             await dispatcherTask.DefaultTimeout();
             // Connection should be removed on canceled write


### PR DESCRIPTION
We converted UtcNow.Ticks usage to Environment.TickCount64 usage. TickCount64 is in milliseconds and UtcNow.Ticks is in the 100-nanosecond scale. When we made this change we didn't convert TickCount64 to the same scale so comparisons were wrong.
