### PR TITLE
[Infrastructure] Add `CheckStdoutWithLargeWrites_TestSink` to the retry list

### DIFF
--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -10,6 +10,7 @@
     {"testName": {"contains": "CertificateChangedOnDisk_Symlink"}}, // depends on FS event timing
     {"testName": {"contains": "BlazorWebTemplate_IndividualAuth_LocalDb"}}, // randomly-generated string could contain forbidden substring
     {"testName": {"contains": "POST_ServerAbort_ClientReceivesAbort"}},
+    {"testName": {"contains": "CheckStdoutWithLargeWrites_TestSink" }},
     {"testAssembly": {"contains": "IIS"}},
     {"testAssembly": {"contains": "Template"}},
     {"failureMessage": {"contains":"(Site is started but no worker process found)"}},


### PR DESCRIPTION
Add `Microsoft.AspNetCore.Server.IIS.NewShim.FunctionalTests.StartupTests.CheckStdoutWithLargeWrites_TestSink` to the retry list test.

Related failure https://dev.azure.com/dnceng-public/public/_build/results?buildId=565480&view=ms.vss-test-web.build-test-results-tab&runId=13513250&resultId=111825&paneView=dotnet-dnceng.dnceng-build-release-tasks.helix-test-information-tab