### PR TITLE
[Infrastructure] Avoid building node JS assets multiple times

### DIFF
--- a/.azure/pipelines/richnav.yml
+++ b/.azure/pipelines/richnav.yml
@@ -55,6 +55,7 @@ stages:
                 -arch x86
                 -all
                 -noBuildJava
+                -noBuildNodeJS
                 -noBuildNative
                 -noBuildRepoTasks
                 $(_BuildArgs)
@@ -66,6 +67,7 @@ stages:
                 -ci
                 -arch arm64
                 -noBuildJava
+                -noBuildNodeJS
                 -noBuildNative
                 -noBuildRepoTasks
                 $(_BuildArgs)


### PR DESCRIPTION
This pipeline is broken as a result of the last change in main

https://dev.azure.com/dnceng-public/public/_build/results?buildId=569485&view=results

Triggered an internal build to ensure it fixed it

https://dev.azure.com/dnceng-public/public/_build/results?buildId=569540&view=logs&j=1b89928a-2219-5ef9-602f-f95beb3da4dc&t=1b89928a-2219-5ef9-602f-f95beb3da4dc