### PR TITLE
Infrastructure tweaks for unified build

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -200,6 +200,7 @@ stages:
         steps:
         - script: ./eng/build.cmd
                   -ci
+                  -prepareMachine
                   -arch x64
                   -all
                   $(_BuildArgs)
@@ -250,6 +251,7 @@ stages:
         # The sign settings have been configured to
         - script: ./eng/build.cmd
                   -ci
+                  -prepareMachine
                   -arch x64
                   -pack
                   -all
@@ -262,6 +264,7 @@ stages:
         # This is going to actually build x86 native assets.
         - script: ./eng/build.cmd
                   -ci
+                  -prepareMachine
                   -noBuildRepoTasks
                   -arch x86
                   -pack
@@ -277,6 +280,7 @@ stages:
         # Build the arm64 shared framework
         - script: ./eng/build.cmd
                   -ci
+                  -prepareMachine
                   -noBuildRepoTasks
                   -arch arm64
                   -sign
@@ -292,6 +296,7 @@ stages:
 
         - script: .\src\SiteExtensions\build.cmd
                   -ci
+                  -prepareMachine
                   -noBuildRepoTasks
                   -pack
                   -noBuildDeps
@@ -305,6 +310,7 @@ stages:
         # previous steps. Sign check is disabled because it is run in a separate step below, after installers are built.
         - script: ./eng/build.cmd
                   -ci
+                  -prepareMachine
                   -noBuildRepoTasks
                   -noBuildNative
                   -noBuild
@@ -317,6 +323,7 @@ stages:
         # Windows installers bundle x86/x64/arm64 assets
         - script: ./eng/build.cmd
                   -ci
+                  -prepareMachine
                   -noBuildRepoTasks
                   -sign
                   -buildInstallers
@@ -330,6 +337,7 @@ stages:
         # Windows installers bundle and sharedfx msi for arm64
         - script: ./eng/build.cmd
                   -ci
+                  -prepareMachine
                   -noBuildRepoTasks
                   -arch arm64
                   -sign
@@ -436,28 +444,28 @@ stages:
               $(_InternalRuntimeDownloadArgs)
           displayName: Run build.sh
         - script: ./eng/build.sh
-              --ci 
-              --nobl 
-              --arch x64 
-              --build-installers 
-              --no-build-deps 
+              --ci
+              --nobl
+              --arch x64
+              --build-installers
+              --no-build-deps
               --no-build-nodejs
-              -p:OnlyPackPlatformSpecificPackages=true 
-              -p:BuildRuntimeArchive=false 
+              -p:OnlyPackPlatformSpecificPackages=true
+              -p:BuildRuntimeArchive=false
               -p:LinuxInstallerType=deb
               $(_BuildArgs)
               $(_InternalRuntimeDownloadArgs)
           displayName: Build Debian installers
           target: debpkg
         - script: ./eng/build.sh
-              --ci 
-              --nobl 
-              --arch x64 
-              --build-installers 
-              --no-build-deps 
+              --ci
+              --nobl
+              --arch x64
+              --build-installers
+              --no-build-deps
               --no-build-nodejs
-              -p:OnlyPackPlatformSpecificPackages=true 
-              -p:BuildRuntimeArchive=false 
+              -p:OnlyPackPlatformSpecificPackages=true
+              -p:BuildRuntimeArchive=false
               -p:LinuxInstallerType=rpm
               -p:AssetManifestFileName=aspnetcore-Linux_x64.xml
               $(_BuildArgs)
@@ -525,14 +533,14 @@ stages:
               $(_InternalRuntimeDownloadArgs)
           displayName: Run build.sh
         - script: ./eng/build.sh
-              --ci 
-              --nobl 
-              --arch arm64 
-              --build-installers 
-              --no-build-deps 
+              --ci
+              --nobl
+              --arch arm64
+              --build-installers
+              --no-build-deps
               --no-build-nodejs
-              -p:OnlyPackPlatformSpecificPackages=true 
-              -p:BuildRuntimeArchive=false 
+              -p:OnlyPackPlatformSpecificPackages=true
+              -p:BuildRuntimeArchive=false
               -p:LinuxInstallerType=rpm
               -p:AssetManifestFileName=aspnetcore-Linux_arm64.xml
               $(_BuildArgs)
@@ -729,11 +737,11 @@ stages:
           timeoutInMinutes: 240
           steps:
           # Build the shared framework
-          - script: ./eng/build.cmd -ci -nobl -all -pack -arch x64
+          - script: ./eng/build.cmd -ci -prepareMachine -nobl -all -pack -arch x64
                     /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
             displayName: Build shared fx
           # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
-          - script: ./eng/build.cmd -ci -nobl -all -noBuildRepoTasks -noBuildNative -noBuild -test
+          - script: ./eng/build.cmd -ci -prepareMachine -nobl -all -noBuildRepoTasks -noBuildNative -noBuild -test
                     -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true
                     /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
             displayName: Run build.cmd helix target
@@ -764,7 +772,7 @@ stages:
     - ${{ if eq(variables.enableSourceIndex, 'true') }}:
       - template: /eng/common/templates/job/source-index-stage1.yml
         parameters:
-          sourceIndexBuildCommand: ./eng/build.cmd -Configuration Release -ci -noBuildJava -binaryLog /p:OnlyPackPlatformSpecificPackages=true
+          sourceIndexBuildCommand: ./eng/build.cmd -Configuration Release -ci -prepareMachine -noBuildJava -binaryLog /p:OnlyPackPlatformSpecificPackages=true
           binlogPath: artifacts/log/Release/Build.binlog
           presteps:
           - task: NodeTool@0

--- a/.azure/pipelines/devBuilds.yml
+++ b/.azure/pipelines/devBuilds.yml
@@ -24,6 +24,7 @@ stages:
       steps:
       - script: ./eng/build.cmd
                 -ci
+                -prepareMachine
                 -arch x64
                 /bl:$(Build.SourcesDirectory)/artifacts/log/build.components.x64.binlog
         displayName: Build x64
@@ -46,6 +47,7 @@ stages:
       steps:
       - script: ./eng/build.cmd
                 -ci
+                -prepareMachine
                 -arch x64
                 /bl:$(Build.SourcesDirectory)/artifacts/log/build.servers.x64.binlog
         displayName: Build x64
@@ -68,6 +70,7 @@ stages:
       steps:
       - script: ./eng/build.cmd
                 -ci
+                -prepareMachine
                 -arch x64
                 /bl:$(Build.SourcesDirectory)/artifacts/log/build.projectTemplates.x64.binlog
         displayName: Build x64
@@ -90,6 +93,7 @@ stages:
       steps:
       - script: ./eng/build.cmd
                 -ci
+                -prepareMachine
                 -arch x64
                 /bl:$(Build.SourcesDirectory)/artifacts/log/build.all.x64.binlog
         displayName: Build x64

--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -32,11 +32,11 @@ jobs:
     timeoutInMinutes: 480
     steps:
     # Build the shared framework
-    - script: ./eng/build.cmd -ci -nobl -all -pack -arch x64
+    - script: ./eng/build.cmd -ci -prepareMachine -nobl -all -pack -arch x64
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Build shared fx
     # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
-    - script: .\eng\build.cmd -ci -nobl -all -noBuildRepoTasks -noBuildNative -noBuild -test
+    - script: .\eng\build.cmd -ci -prepareMachine -nobl -all -noBuildRepoTasks -noBuildNative -noBuild -test
               -projects eng\helix\helix.proj /p:IsHelixJob=true
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.cmd helix target

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -256,7 +256,7 @@ jobs:
                 ${{ step.env }}
     - ${{ if eq(parameters.steps, '')}}:
       - ${{ if eq(parameters.agentOs, 'Windows') }}:
-        - script: $(BuildDirectory)\build.cmd -ci -nobl -Configuration $(BuildConfiguration) $(BuildScriptArgs)
+        - script: $(BuildDirectory)\build.cmd -ci -prepareMachine -nobl -Configuration $(BuildConfiguration) $(BuildScriptArgs)
             /p:DotNetSignType=$(_SignType)
           displayName: Run build.cmd
           env:

--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -53,11 +53,11 @@ jobs:
     timeoutInMinutes: 120
     steps:
     # Build the shared framework
-    - script: ./eng/build.cmd -ci -nobl -all -noBuildJava -pack -arch x64
+    - script: ./eng/build.cmd -ci -prepareMachine -nobl -all -noBuildJava -pack -arch x64
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Build shared fx
     # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
-    - script: ./eng/build.cmd -ci -nobl -all -noBuildRepoTasks -noBuildNative -noBuild -noBuildJava -test
+    - script: ./eng/build.cmd -ci -prepareMachine -nobl -all -noBuildRepoTasks -noBuildNative -noBuild -noBuildJava -test
               -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:RunQuarantinedTests=true /p:IsHelixJob=true
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.cmd helix target
@@ -80,9 +80,9 @@ jobs:
     isAzDOTestingJob: true
     enablePublishTestResults: false
     steps:
-    - script: ./eng/build.cmd -ci -nobl -all -noBuildJava -pack
+    - script: ./eng/build.cmd -ci -prepareMachine -nobl -all -noBuildJava -pack
       displayName: Build
-    - script: ./eng/build.cmd -ci -nobl -all -noBuildRepoTasks -noBuildNative -NoBuild -noBuildJava -test
+    - script: ./eng/build.cmd -ci -prepareMachine -nobl -all -noBuildRepoTasks -noBuildNative -NoBuild -noBuildJava -test
               /p:RunQuarantinedTests=true /p:SkipHelixReadyTests=true
       displayName: Run Quarantined Tests
       continueOnError: true

--- a/.azure/pipelines/quarantined-tests.yml
+++ b/.azure/pipelines/quarantined-tests.yml
@@ -27,11 +27,11 @@ jobs:
     timeoutInMinutes: 480
     steps:
     # Build the shared framework
-    - script: ./eng/build.cmd -ci -nobl -all -noBuildJava -pack -arch x64
+    - script: ./eng/build.cmd -ci -prepareMachine -nobl -all -noBuildJava -pack -arch x64
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Build shared fx
     # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
-    - script: ./eng/build.cmd -ci -nobl -all -noBuildRepoTasks -noBuildNative -noBuild -noBuildJava -test
+    - script: ./eng/build.cmd -ci -prepareMachine -nobl -all -noBuildRepoTasks -noBuildNative -noBuild -noBuildJava -test
               -projects eng\helix\helix.proj /p:RunQuarantinedTests=true /p:IsHelixJob=true
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.cmd helix target

--- a/.azure/pipelines/richnav.yml
+++ b/.azure/pipelines/richnav.yml
@@ -33,6 +33,7 @@ stages:
       steps:
       - script: ./eng/build.cmd
                 -ci
+                -prepareMachine
                 -arch x64
                 -buildNative
                 /p:EnableRichCodeNavigation=false
@@ -41,6 +42,7 @@ stages:
 
       - script: ./eng/build.cmd
                 -ci
+                -prepareMachine
                 -arch x64
                 -all
                 -noBuildNative
@@ -52,6 +54,7 @@ stages:
       # This is going to actually build x86 native assets.
       - script: ./eng/build.cmd
                 -ci
+                -prepareMachine
                 -arch x86
                 -all
                 -noBuildJava
@@ -65,6 +68,7 @@ stages:
       # Build the arm64 shared framework
       - script: ./eng/build.cmd
                 -ci
+                -prepareMachine
                 -arch arm64
                 -noBuildJava
                 -noBuildNodeJS

--- a/.azure/pipelines/stress.yml
+++ b/.azure/pipelines/stress.yml
@@ -26,7 +26,7 @@ jobs:
     agentOs: Windows
     isAzDOTestingJob: true
     steps:
-    - script: .\src\Servers\Kestrel\stress\build.cmd -ci -c Release
+    - script: .\src\Servers\Kestrel\stress\build.cmd -ci -prepareMachine -c Release
       displayName: Build Repo
     - script: .\.dotnet\dotnet.exe run --project .\src\Servers\Kestrel\stress\HttpStress.csproj -c Release -aspnetlog
       displayName: Run stress

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -12,6 +12,9 @@ build projects, run tests, and generate code.
 .PARAMETER CI
 Sets up CI specific settings and variables.
 
+.PARAMETER PrepareMachine
+In CI, Turns on machine preparation/clean up code that changes the machine state (e.g. kills build processes).
+
 .PARAMETER Restore
 Run restore.
 
@@ -124,6 +127,7 @@ Online version: https://github.com/dotnet/aspnetcore/blob/main/docs/BuildFromSou
 [CmdletBinding(PositionalBinding = $false, DefaultParameterSetName='Groups')]
 param(
     [switch]$CI,
+    [switch]$PrepareMachine,
 
     # Build lifecycle options
     [switch]$Restore,
@@ -209,7 +213,7 @@ if ($Projects) {
     }
 }
 # When adding new sub-group build flags, add them to this check.
-elseif (-not ($All -or $BuildNative -or $BuildManaged -or $BuildNodeJS -or $BuildInstallers -or $BuildJava)) {
+elseif (-not ($All -or $BuildNative -or $BuildManaged -or $BuildNodeJS -or $BuildInstallers -or $BuildJava -or $OnlyBuildRepoTasks)) {
     Write-Warning "No default group of projects was specified, so building the managed and native projects and their dependencies. Run ``build.cmd -help`` for more details."
 
     # The goal of this is to pick a sensible default for `build.cmd` with zero arguments.
@@ -478,10 +482,6 @@ finally {
     if ($DumpProcesses -or $ci) {
         Stop-Job -Name DumpProcesses
         Remove-Job -Name DumpProcesses
-    }
-
-    if ($ci) {
-        & "$PSScriptRoot/scripts/KillProcesses.ps1"
     }
 }
 


### PR DESCRIPTION
- Use arcade standard prepareMachine to decide whether to kill running processes. Unified build invokes eng/build.ps1 with -ci, as would a user running the build locally. It should not blanket kill the host processes. Pass -prepareMachine in YML files
- if OnlyBuildRepoTasks is passed, don't write a warning that nothing will get built.
