### PR TITLE
Fix Incorrect usage of the `ObjectDisposedException.ThrowIf`

### DIFF
--- a/src/Http/Http/src/Internal/ReferenceReadStream.cs
+++ b/src/Http/Http/src/Internal/ReferenceReadStream.cs
@@ -147,6 +147,6 @@ internal sealed class ReferenceReadStream : Stream
 
     private void ThrowIfDisposed()
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(ReferenceReadStream));
+        ObjectDisposedException.ThrowIf(_disposed, this);
     }
 }

--- a/src/Http/WebUtilities/src/BufferedReadStream.cs
+++ b/src/Http/WebUtilities/src/BufferedReadStream.cs
@@ -418,6 +418,6 @@ public class BufferedReadStream : Stream
 
     private void CheckDisposed()
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(BufferedReadStream));
+        ObjectDisposedException.ThrowIf(_disposed, this);
     }
 }

--- a/src/Http/WebUtilities/src/FileBufferingReadStream.cs
+++ b/src/Http/WebUtilities/src/FileBufferingReadStream.cs
@@ -497,6 +497,6 @@ public class FileBufferingReadStream : Stream
 
     private void ThrowIfDisposed()
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(FileBufferingReadStream));
+        ObjectDisposedException.ThrowIf(_disposed, this);
     }
 }

--- a/src/Http/WebUtilities/src/FileBufferingWriteStream.cs
+++ b/src/Http/WebUtilities/src/FileBufferingWriteStream.cs
@@ -288,6 +288,6 @@ public sealed class FileBufferingWriteStream : Stream
 
     private void ThrowIfDisposed()
     {
-        ObjectDisposedException.ThrowIf(Disposed, nameof(FileBufferingWriteStream));
+        ObjectDisposedException.ThrowIf(Disposed, this);
     }
 }

--- a/src/Http/WebUtilities/src/HttpRequestStreamReader.cs
+++ b/src/Http/WebUtilities/src/HttpRequestStreamReader.cs
@@ -120,7 +120,7 @@ public class HttpRequestStreamReader : TextReader
     /// <inheritdoc />
     public override int Peek()
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(HttpRequestStreamReader));
+        ThrowIfDisposed();
 
         if (_charBufferIndex == _charsRead)
         {
@@ -136,7 +136,7 @@ public class HttpRequestStreamReader : TextReader
     /// <inheritdoc />
     public override int Read()
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(HttpRequestStreamReader));
+        ThrowIfDisposed();
 
         if (_charBufferIndex == _charsRead)
         {
@@ -172,7 +172,7 @@ public class HttpRequestStreamReader : TextReader
             throw new ArgumentNullException(nameof(buffer));
         }
 
-        ObjectDisposedException.ThrowIf(_disposed, nameof(HttpRequestStreamReader));
+        ThrowIfDisposed();
 
         var count = buffer.Length;
         var charsRead = 0;
@@ -234,7 +234,7 @@ public class HttpRequestStreamReader : TextReader
     [SuppressMessage("ApiDesign", "RS0027:Public API with optional parameter(s) should have the most parameters amongst its public overloads.", Justification = "Required to maintain compatibility")]
     public override async ValueTask<int> ReadAsync(Memory<char> buffer, CancellationToken cancellationToken = default)
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(HttpRequestStreamReader));
+        ThrowIfDisposed();
 
         if (_charBufferIndex == _charsRead && await ReadIntoBufferAsync() == 0)
         {
@@ -324,7 +324,7 @@ public class HttpRequestStreamReader : TextReader
     /// <inheritdoc />
     public override async Task<string?> ReadLineAsync()
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(HttpRequestStreamReader));
+        ThrowIfDisposed();
 
         StringBuilder? sb = null;
         var consumeLineFeed = false;
@@ -359,7 +359,7 @@ public class HttpRequestStreamReader : TextReader
     /// <inheritdoc />
     public override string? ReadLine()
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(HttpRequestStreamReader));
+        ThrowIfDisposed();
 
         StringBuilder? sb = null;
         var consumeLineFeed = false;
@@ -544,5 +544,10 @@ public class HttpRequestStreamReader : TextReader
 
         public bool Completed { get; }
         public string? Result { get; }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
     }
 }

--- a/src/Http/WebUtilities/src/HttpResponseStreamWriter.cs
+++ b/src/Http/WebUtilities/src/HttpResponseStreamWriter.cs
@@ -105,7 +105,7 @@ public class HttpResponseStreamWriter : TextWriter
     /// <inheritdoc/>
     public override void Write(char value)
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(HttpResponseStreamWriter));
+        ThrowIfDisposed();
 
         if (_charBufferCount == _charBufferSize)
         {
@@ -119,7 +119,7 @@ public class HttpResponseStreamWriter : TextWriter
     /// <inheritdoc/>
     public override void Write(char[] values, int index, int count)
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(HttpResponseStreamWriter));
+        ThrowIfDisposed();
 
         if (values == null)
         {
@@ -140,7 +140,7 @@ public class HttpResponseStreamWriter : TextWriter
     /// <inheritdoc/>
     public override void Write(ReadOnlySpan<char> value)
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(HttpResponseStreamWriter));
+        ThrowIfDisposed();
 
         var remaining = value.Length;
         while (remaining > 0)
@@ -160,7 +160,7 @@ public class HttpResponseStreamWriter : TextWriter
     /// <inheritdoc/>
     public override void Write(string? value)
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(HttpResponseStreamWriter));
+        ThrowIfDisposed();
 
         if (value == null)
         {
@@ -183,7 +183,7 @@ public class HttpResponseStreamWriter : TextWriter
     /// <inheritdoc/>
     public override void WriteLine(ReadOnlySpan<char> value)
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(HttpResponseStreamWriter));
+        ThrowIfDisposed();
 
         Write(value);
         Write(NewLine);
@@ -505,7 +505,7 @@ public class HttpResponseStreamWriter : TextWriter
     /// <inheritdoc/>
     public override void Flush()
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(HttpResponseStreamWriter));
+        ThrowIfDisposed();
 
         FlushInternal(flushEncoder: true);
     }
@@ -672,5 +672,10 @@ public class HttpResponseStreamWriter : TextWriter
     private static Task GetObjectDisposedTask()
     {
         return Task.FromException(new ObjectDisposedException(nameof(HttpResponseStreamWriter)));
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
     }
 }

--- a/src/Http/WebUtilities/src/PagedByteBuffer.cs
+++ b/src/Http/WebUtilities/src/PagedByteBuffer.cs
@@ -136,6 +136,6 @@ internal sealed class PagedByteBuffer : IDisposable
 
     private void ThrowIfDisposed()
     {
-        ObjectDisposedException.ThrowIf(Disposed, nameof(PagedByteBuffer));
+        ObjectDisposedException.ThrowIf(Disposed, this);
     }
 }

--- a/src/Servers/IIS/IIS/src/Core/WrappingStream.cs
+++ b/src/Servers/IIS/IIS/src/Core/WrappingStream.cs
@@ -15,7 +15,7 @@ internal sealed class WrappingStream : Stream
 
     public void SetInnerStream(Stream inner)
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(WrappingStream));
+        ObjectDisposedException.ThrowIf(_disposed, this);
 
         _inner = inner;
     }


### PR DESCRIPTION
# Fix Incorrect usage of the ObjectDisposedException.ThrowIf

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

Updated the usages to pass an instance so correct error is reported. Arguably no tests/docs needed for the change so none was added. 

Fixes #54143 

