### PR TITLE
Manually resolve ref and runtime packs instead of modifying the .NET SDK used in the build

### DIFF
--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -127,6 +127,7 @@
     <PropertyGroup>
       <SharedFxVersion>@(_ResolvedProductVersionInfo->'%(PackageVersion)')</SharedFxVersion>
       <_AppRefSubPath>$([System.IO.Path]::Combine('packs', 'Microsoft.AspNetCore.App.Ref', '$(SharedFxVersion)'))</_AppRefSubPath>
+      <_AppRefDestinationSubPath>$([System.IO.Path]::Combine('packs', 'Microsoft.AspNetCore.App', '$(SharedFxVersion)'))</_AppRefDestinationSubPath>
       <_AppRuntimeSubPath>$([System.IO.Path]::Combine('shared', 'Microsoft.AspNetCore.App', '$(SharedFxVersion)'))</_AppRuntimeSubPath>
       <_AppRefPath>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts', 'obj', 'TargetingPack.Layout', '$(Configuration)', '$(_AppRefSubPath)'))</_AppRefPath>
       <_AppRuntimePath>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts', 'obj', 'SharedFx.Layout', '$(Configuration)', '$(TargetRuntimeIdentifier)', '$(_AppRuntimeSubPath)'))</_AppRuntimePath>
@@ -150,10 +151,10 @@
     <ItemGroup Condition=" $(_AppRefPathExists) ">
       <HelixCorrelationPayload Include="$(_AppRefPath)"
           Condition=" $(IsWindowsHelixQueue) "
-          Destination="$(DotNetCliDestination)\$(_AppRefSubPath)" />
+          Destination="$(DotNetCliDestination)\$(_AppRefDestinationSubPath)" />
       <HelixCorrelationPayload Include="$(_AppRefPath)"
           Condition=" !$(IsWindowsHelixQueue) "
-          Destination="$(DotNetCliDestination)/$(_AppRefSubPath.Replace('\','/'))" />
+          Destination="$(DotNetCliDestination)/$(_AppRefDestinationSubPath.Replace('\','/'))" />
       <HelixCorrelationPayload Include="$(_AppRuntimePath)"
           Condition=" $(IsWindowsHelixQueue) "
           Destination="$(DotNetCliDestination)\$(_AppRuntimeSubPath)" />

--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -128,7 +128,6 @@
       <SharedFxVersion>@(_ResolvedProductVersionInfo->'%(PackageVersion)')</SharedFxVersion>
       <_AppRefSubPath>$([System.IO.Path]::Combine('packs', 'Microsoft.AspNetCore.App.Ref', '$(SharedFxVersion)'))</_AppRefSubPath>
       <_AppRuntimeSubPath>$([System.IO.Path]::Combine('shared', 'Microsoft.AspNetCore.App', '$(SharedFxVersion)'))</_AppRuntimeSubPath>
-      <_AppRuntimeDestinationSubPath>$([System.IO.Path]::Combine('shared', 'Microsoft.AspNetCore.App', '$(SharedFxVersion)'))</_AppRefDestinationSubPath>
       <_AppRefPath>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts', 'obj', 'TargetingPack.Layout', '$(Configuration)', '$(_AppRefSubPath)'))</_AppRefPath>
       <_AppRuntimePath>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts', 'obj', 'SharedFx.Layout', '$(Configuration)', '$(TargetRuntimeIdentifier)', '$(_AppRuntimeSubPath)'))</_AppRuntimePath>
 

--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -147,7 +147,7 @@
     <Error Text="Targeting path location '$(_AppRefPath)' does not exist and some tests are guaranteed to fail."
         Condition=" !$(_AppRefPathExists) AND '$(DoNotRequireSharedFxHelix)' != true " />
 
-    <!-- Grab only the portions of the .dotnet/ tree built in this run and have Helix zip that up. -->
+    <!-- Grab the ref pack and runtime pack that were just built and have Helix zip that up. -->
     <ItemGroup Condition=" $(_AppRefPathExists) ">
       <HelixCorrelationPayload Include="$(_AppRefPath)"
           Condition=" $(IsWindowsHelixQueue) "

--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -115,8 +115,7 @@
 
   <!--
     In inner (per-queue) builds, tell the Helix SDK to pack up our just-built App.Ref / App.Runtime layouts w/
-    the current versions. Warning: When using RunHelix.ps1, .dotnet/ folder may contain older App.Ref and
-    App.Runtime layouts.
+    the current versions.
   -->
   <Target Name="IncludeAspNetRuntime" BeforeTargets="Gather">
     <MSBuild Projects="$(RepoRoot)src\Framework\App.Runtime\src\Microsoft.AspNetCore.App.Runtime.csproj"

--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -129,8 +129,8 @@
       <SharedFxVersion>@(_ResolvedProductVersionInfo->'%(PackageVersion)')</SharedFxVersion>
       <_AppRefSubPath>$([System.IO.Path]::Combine('packs', 'Microsoft.AspNetCore.App.Ref', '$(SharedFxVersion)'))</_AppRefSubPath>
       <_AppRuntimeSubPath>$([System.IO.Path]::Combine('shared', 'Microsoft.AspNetCore.App', '$(SharedFxVersion)'))</_AppRuntimeSubPath>
-      <_AppRefPath>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', '.dotnet', '$(_AppRefSubPath)'))</_AppRefPath>
-      <_AppRuntimePath>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', '.dotnet', '$(_AppRuntimeSubPath)'))</_AppRuntimePath>
+      <_AppRefPath>$([MSBuild]::NormalizeDirectory('$(TargetingPackLayoutRoot)', '$(_AppRefSubPath)'))</_AppRefPath>
+      <_AppRuntimePath>$([MSBuild]::NormalizeDirectory('$(SharedFrameworkLayoutRoot)', '$(_AppRuntimeSubPath)'))</_AppRuntimePath>
 
       <!--
         Don't bother checking for App.Runtime layout because we want both and App.Ref project depends on the

--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -128,10 +128,8 @@
       <SharedFxVersion>@(_ResolvedProductVersionInfo->'%(PackageVersion)')</SharedFxVersion>
       <_AppRefSubPath>$([System.IO.Path]::Combine('packs', 'Microsoft.AspNetCore.App.Ref', '$(SharedFxVersion)'))</_AppRefSubPath>
       <_AppRuntimeSubPath>$([System.IO.Path]::Combine('shared', 'Microsoft.AspNetCore.App', '$(SharedFxVersion)'))</_AppRuntimeSubPath>
-      <TargetingPackLayoutRoot>$(ArtifactsObjDir)TargetingPack.Layout\$(Configuration)\</TargetingPackLayoutRoot>
-      <SharedFrameworkLayoutRoot>$(ArtifactsObjDir)SharedFx.Layout\$(Configuration)\$(TargetRuntimeIdentifier)\</SharedFrameworkLayoutRoot>
-      <_AppRefPath>$([MSBuild]::NormalizeDirectory('$(TargetingPackLayoutRoot)', '$(_AppRefSubPath)'))</_AppRefPath>
-      <_AppRuntimePath>$([MSBuild]::NormalizeDirectory('$(SharedFrameworkLayoutRoot)', '$(_AppRuntimeSubPath)'))</_AppRuntimePath>
+      <_AppRefPath>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts', 'obj', 'TargetingPack.Layout', '$(Configuration)', '$(_AppRefSubPath)'))</_AppRefPath>
+      <_AppRuntimePath>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts', 'obj', 'SharedFx.Layout', '$(Configuration)', '$(TargetRuntimeIdentifier)', '$(_AppRuntimeSubPath)'))</_AppRuntimePath>
 
       <!--
         Don't bother checking for App.Runtime layout because we want both and App.Ref project depends on the

--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -128,6 +128,8 @@
       <SharedFxVersion>@(_ResolvedProductVersionInfo->'%(PackageVersion)')</SharedFxVersion>
       <_AppRefSubPath>$([System.IO.Path]::Combine('packs', 'Microsoft.AspNetCore.App.Ref', '$(SharedFxVersion)'))</_AppRefSubPath>
       <_AppRuntimeSubPath>$([System.IO.Path]::Combine('shared', 'Microsoft.AspNetCore.App', '$(SharedFxVersion)'))</_AppRuntimeSubPath>
+      <TargetingPackLayoutRoot>$(ArtifactsObjDir)TargetingPack.Layout\$(Configuration)\</TargetingPackLayoutRoot>
+      <SharedFrameworkLayoutRoot>$(ArtifactsObjDir)SharedFx.Layout\$(Configuration)\$(TargetRuntimeIdentifier)\</SharedFrameworkLayoutRoot>
       <_AppRefPath>$([MSBuild]::NormalizeDirectory('$(TargetingPackLayoutRoot)', '$(_AppRefSubPath)'))</_AppRefPath>
       <_AppRuntimePath>$([MSBuild]::NormalizeDirectory('$(SharedFrameworkLayoutRoot)', '$(_AppRuntimeSubPath)'))</_AppRuntimePath>
 

--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -127,8 +127,8 @@
     <PropertyGroup>
       <SharedFxVersion>@(_ResolvedProductVersionInfo->'%(PackageVersion)')</SharedFxVersion>
       <_AppRefSubPath>$([System.IO.Path]::Combine('packs', 'Microsoft.AspNetCore.App.Ref', '$(SharedFxVersion)'))</_AppRefSubPath>
-      <_AppRefDestinationSubPath>$([System.IO.Path]::Combine('packs', 'Microsoft.AspNetCore.App', '$(SharedFxVersion)'))</_AppRefDestinationSubPath>
       <_AppRuntimeSubPath>$([System.IO.Path]::Combine('shared', 'Microsoft.AspNetCore.App', '$(SharedFxVersion)'))</_AppRuntimeSubPath>
+      <_AppRuntimeDestinationSubPath>$([System.IO.Path]::Combine('shared', 'Microsoft.AspNetCore.App', '$(SharedFxVersion)'))</_AppRefDestinationSubPath>
       <_AppRefPath>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts', 'obj', 'TargetingPack.Layout', '$(Configuration)', '$(_AppRefSubPath)'))</_AppRefPath>
       <_AppRuntimePath>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts', 'obj', 'SharedFx.Layout', '$(Configuration)', '$(TargetRuntimeIdentifier)', '$(_AppRuntimeSubPath)'))</_AppRuntimePath>
 
@@ -151,10 +151,10 @@
     <ItemGroup Condition=" $(_AppRefPathExists) ">
       <HelixCorrelationPayload Include="$(_AppRefPath)"
           Condition=" $(IsWindowsHelixQueue) "
-          Destination="$(DotNetCliDestination)\$(_AppRefDestinationSubPath)" />
+          Destination="$(DotNetCliDestination)\$(_AppRefSubPath)" />
       <HelixCorrelationPayload Include="$(_AppRefPath)"
           Condition=" !$(IsWindowsHelixQueue) "
-          Destination="$(DotNetCliDestination)/$(_AppRefDestinationSubPath.Replace('\','/'))" />
+          Destination="$(DotNetCliDestination)/$(_AppRefSubPath.Replace('\','/'))" />
       <HelixCorrelationPayload Include="$(_AppRuntimePath)"
           Condition=" $(IsWindowsHelixQueue) "
           Destination="$(DotNetCliDestination)\$(_AppRuntimeSubPath)" />

--- a/eng/tools/GenerateFiles/Directory.Build.targets.in
+++ b/eng/tools/GenerateFiles/Directory.Build.targets.in
@@ -121,7 +121,8 @@
     <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
   </PropertyGroup>
 
-  <Target Name="ResolveLiveBuiltAspnetCoreKnownFramework" Condition="$(UpdateAspNetCoreKnownFramework)" AfterTargets="ResolveFrameworkReferences">
+  <!-- When building and running locally, manually resolve the just-built frameworks. On Helix, let the SDK resolve the packs itself (they're laid out on top of the .NET SDK in the work items) -->
+  <Target Name="ResolveLiveBuiltAspnetCoreKnownFramework" Condition="$(UpdateAspNetCoreKnownFramework) and '$(HELIX_CORRELATION_PAYLOAD)' == ''" AfterTargets="ResolveFrameworkReferences">
     <Error Text="Requested Microsoft.AspNetCore.App v${MicrosoftAspNetCoreAppRefVersion} ref pack does not exist."
         Condition="!Exists('$(TargetingPackLayoutRoot)packs\Microsoft.AspNetCore.App.Ref\${MicrosoftAspNetCoreAppRefVersion}\data\FrameworkList.xml') " />
     <ItemGroup>

--- a/eng/tools/GenerateFiles/Directory.Build.targets.in
+++ b/eng/tools/GenerateFiles/Directory.Build.targets.in
@@ -115,13 +115,13 @@
     </KnownFrameworkReference>
   </ItemGroup>
 
-  <PropertyGroup Condition="$(UpdateAspNetCoreKnownFramework)">
+  <!-- When building and running locally, manually resolve the just-built frameworks. On Helix, let the SDK resolve the packs itself (they're laid out on top of the .NET SDK in the work items) -->
+  <PropertyGroup Condition="$(UpdateAspNetCoreKnownFramework) and '$(HELIX_CORRELATION_PAYLOAD)' == ''">
     <EnableTargetingPackDownload>false</EnableTargetingPackDownload>
     <EnableRuntimePackDownload>false</EnableRuntimePackDownload>
     <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
   </PropertyGroup>
 
-  <!-- When building and running locally, manually resolve the just-built frameworks. On Helix, let the SDK resolve the packs itself (they're laid out on top of the .NET SDK in the work items) -->
   <Target Name="ResolveLiveBuiltAspnetCoreKnownFramework" Condition="$(UpdateAspNetCoreKnownFramework) and '$(HELIX_CORRELATION_PAYLOAD)' == ''" AfterTargets="ResolveFrameworkReferences">
     <Error Text="Requested Microsoft.AspNetCore.App v${MicrosoftAspNetCoreAppRefVersion} ref pack does not exist."
         Condition="!Exists('$(TargetingPackLayoutRoot)packs\Microsoft.AspNetCore.App.Ref\${MicrosoftAspNetCoreAppRefVersion}\data\FrameworkList.xml') " />

--- a/eng/tools/GenerateFiles/Directory.Build.targets.in
+++ b/eng/tools/GenerateFiles/Directory.Build.targets.in
@@ -121,7 +121,7 @@
     <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
   </PropertyGroup>
 
-  <Target Name="ResolveLiveBuiltAspnetCoreKnownFramework" Condition="$(UpdateAspNetCoreKnownFramework)">
+  <Target Name="ResolveLiveBuiltAspnetCoreKnownFramework" Condition="$(UpdateAspNetCoreKnownFramework)" AfterTargets="ResolveFrameworkReferences">
     <Error Text="Requested Microsoft.AspNetCore.App v${MicrosoftAspNetCoreAppRefVersion} ref pack does not exist."
         Condition="!Exists('$(TargetingPackLayoutRoot)packs\Microsoft.AspNetCore.App.Ref\${MicrosoftAspNetCoreAppRefVersion}\data\FrameworkList.xml') " />
     <ItemGroup>

--- a/eng/tools/GenerateFiles/Directory.Build.targets.in
+++ b/eng/tools/GenerateFiles/Directory.Build.targets.in
@@ -115,35 +115,27 @@
     </KnownFrameworkReference>
   </ItemGroup>
 
-  <!-- Warn if the "just-built" ASP.NET Core shared framework does not exist. -->
-  <Target Name="WarnAboutMissingSharedFramework"
-      BeforeTargets="Restore;Build;Rebuild;RunTests;Test;VSTest;Pack"
-      Condition=" $(UpdateAspNetCoreKnownFramework) ">
-    <PropertyGroup>
-      <!--
-        Property (already normalized) from Arcade SDK's RepoLayout.props. This covers all projects using the
-        Arcade SDK. Ignore $(LocalDotNetRoot) because that is set in root Directory.Build.props (where Arcade SDK
-        is imported) and therefore doesn't cover additional projects.
-      -->
-      <_DotNetRoot Condition=" '$(DotNetRoot)' != '' ">$(DotNetRoot)</_DotNetRoot>
-      <!--
-        Environment variable from eng/common/tools.ps1 scripts. This covers tests and assets that do not use the
-        Arcade SDK but are run from our build.* scripts.
-      -->
-      <_DotNetRoot Condition=" '$(_DotNetRoot)' == '' AND
-          '$(DOTNET_INSTALL_DIR)' != '' ">$([MSBuild]::NormalizeDirectory('$(DOTNET_INSTALL_DIR)'))</_DotNetRoot>
-      <!--
-        Environment variable from root activate.* and Helix runtest.* scripts. This covers tests and assets on
-        Helix agents and when run locally using 'msbuild' after activation.
-      -->
-      <_DotNetRoot Condition=" '$(_DotNetRoot)' == '' AND
-          '$(DOTNET_ROOT)' != '' ">$([MSBuild]::NormalizeDirectory('$(DOTNET_ROOT)'))</_DotNetRoot>
-    </PropertyGroup>
+  <PropertyGroup Condition="$(UpdateAspNetCoreKnownFramework)">
+    <EnableTargetingPackDownload>false</EnableTargetingPackDownload>
+    <EnableRuntimePackDownload>false</EnableRuntimePackDownload>
+    <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
+  </PropertyGroup>
 
-    <Error Text="Unable to determine dotnet root location." Condition=" '$(_DotNetRoot)' == '' " />
-    <Error Text="Dotnet root location '$(_DotNetRoot)' does not exist." Condition=" !EXISTS('$(_DotNetRoot)') " />
-    <Warning Text="Requested Microsoft.AspNetCore.App v${MicrosoftAspNetCoreAppRuntimeVersion} does not exist."
-        Condition=" !EXISTS('$(_DotNetRoot)shared\Microsoft.AspNetCore.App\${MicrosoftAspNetCoreAppRuntimeVersion}') " />
+  <Target Name="ResolveLiveBuiltAspnetCoreKnownFramework" Condition="$(UpdateAspNetCoreKnownFramework)">
+    <Error Text="Requested Microsoft.AspNetCore.App v${MicrosoftAspNetCoreAppRefVersion} ref pack does not exist."
+        Condition="!Exists('$(TargetingPackLayoutRoot)packs\Microsoft.AspNetCore.App.Ref\${MicrosoftAspNetCoreAppRefVersion}\data\FrameworkList.xml') " />
+    <ItemGroup>
+      <ResolvedTargetingPack Path="$(TargetingPackLayoutRoot)packs\Microsoft.AspNetCore.App.Ref\${MicrosoftAspNetCoreAppRefVersion}"
+                             NugetPackageVersion="${MicrosoftAspNetCoreAppRefVersion}"
+                             PackageDirectory="$(TargetingPackLayoutRoot)packs\Microsoft.AspNetCore.App.Ref\${MicrosoftAspNetCoreAppRefVersion}"
+                             Condition="'%(ResolvedTargetingPack.RuntimeFrameworkName)' == 'Microsoft.AspNetCore.App'" />
+      <ResolvedRuntimePack PackageDirectory="$(SharedFrameworkLayoutRoot)shared\Microsoft.AspNetCore.App\${MicrosoftAspNetCoreAppRuntimeVersion}"
+                           Condition="'%(ResolvedRuntimePack.RuntimeFrameworkName)' == 'Microsoft.AspNetCore.App'" />
+      <ResolvedFrameworkReference TargetingPackPath="$(TargetingPackLayoutRoot)packs\Microsoft.AspNetCore.App.Ref\${MicrosoftAspNetCoreAppRefVersion}"
+                                  TargetingPackVersion="${MicrosoftAspNetCoreAppRefVersion}"
+                                  RuntimePackPath="$(SharedFrameworkLayoutRoot)shared\Microsoft.AspNetCore.App\${MicrosoftAspNetCoreAppRuntimeVersion}"
+                                  Condition="'%(Identity)' == 'Microsoft.AspNetCore.App'" />
+    </ItemGroup>
   </Target>
 
   <!--

--- a/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
@@ -93,7 +93,6 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   <PropertyGroup>
     <TargetingPackSubPath>packs\Microsoft.AspNetCore.App.Ref\$(PackageVersion)\</TargetingPackSubPath>
     <LayoutTargetDir>$(TargetingPackLayoutRoot)$(TargetingPackSubPath)</LayoutTargetDir>
-    <LocalInstallationOutputPath>$(LocalDotNetRoot)$(TargetingPackSubPath)</LocalInstallationOutputPath>
 
     <ArchiveOutputFileName>aspnetcore-targeting-pack-$(PackageVersion)-$(TargetRuntimeIdentifier)</ArchiveOutputFileName>
     <ArchiveOutputPath>$(InstallersOutputPath)$(ArchiveOutputFileName)$(ArchiveExtension)</ArchiveOutputPath>

--- a/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
@@ -107,7 +107,6 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       GenerateFrameworkListFile;
       _ResolveTargetingPackContent;
       _BatchCopyToLayoutTargetDir;
-      _InstallTargetingPackIntoLocalDotNet;
       _CreateTargetingPackArchive;
     </BuildDependsOn>
     <ResolveTargetingPackContentDependsOn>
@@ -242,25 +241,6 @@ This package is an internal implementation of the .NET Core SDK and is not meant
           DestinationFiles="@(RefPackContent->'$(LayoutTargetDir)%(PackagePath)%(RecursiveDir)%(FileName)%(Extension)')"
           UseHardlinksIfPossible="true" />
     <Message Importance="High" Text="$(MSBuildProjectName) -> $(LayoutTargetDir)" />
-  </Target>
-
-  <Target Name="_CleanLocalDotNet" BeforeTargets="_InstallTargetingPackIntoLocalDotNet">
-    <ItemGroup>
-      <_ExtraDotNetFiles Include="$(LocalInstallationOutputPath)**\*.*"
-          Exclude="@(RefPackContent->'$(LocalInstallationOutputPath)%(PackagePath)%(RecursiveDir)%(FileName)%(Extension)')" />
-    </ItemGroup>
-    <Delete Files="@(_ExtraDotNetFiles)" />
-  </Target>
-
-  <!-- Workaround https://github.com/dotnet/sdk/issues/2910 by copying targeting pack into local installation. -->
-  <Target Name="_InstallTargetingPackIntoLocalDotNet"
-          Condition="'$(DotNetBuildFromSource)' != 'true'"
-          Inputs="@(RefPackContent)"
-          Outputs="@(RefPackContent->'$(LocalInstallationOutputPath)%(PackagePath)%(RecursiveDir)%(FileName)%(Extension)')">
-    <Copy SourceFiles="@(RefPackContent)"
-          DestinationFiles="@(RefPackContent->'$(LocalInstallationOutputPath)%(PackagePath)%(RecursiveDir)%(FileName)%(Extension)')"
-          UseHardlinksIfPossible="true" />
-    <Message Importance="High" Text="$(MSBuildProjectName) -> $(LocalInstallationOutputPath)" />
   </Target>
 
   <Target Name="_CreateTargetingPackArchive"

--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -202,7 +202,6 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       _GenerateRuntimeListFile;
       _ResolveRuntimePackContent;
       _ResolveSharedFrameworkContent;
-      _InstallFrameworkIntoLocalDotNet;
       _DownloadAndExtractDotNetRuntime;
       _BatchCopyToSharedFrameworkLayout;
       _BatchCopyToRedistLayout;
@@ -682,30 +681,6 @@ This package is an internal implementation of the .NET Core SDK and is not meant
 
     <Copy SourceFiles="@(AspnetCompositesByName->'$(CompositeTargetDir)%(Filename)%(Extension)')"
           DestinationFolder="$(LayoutAspnetPath)" />
-  </Target>
-
-  <Target Name="_CleanLocalDotNet" BeforeTargets="_InstallFrameworkIntoLocalDotNet">
-    <ItemGroup>
-      <_ExtraDotNetFiles Include="$(LocalInstallationOutputPath)**\*.*"
-          Exclude="@(RefPackContent->'$(LocalInstallationOutputPath)%(FileName)%(Extension)')" />
-    </ItemGroup>
-    <Delete Files="@(_ExtraDotNetFiles)" />
-  </Target>
-
-  <!--
-    Required to workaround https://github.com/dotnet/core-setup/issues/4809. This copies the shared framework
-    into the $reporoot/.dotnet folder so tests can run against the shared framework. This workaround is not
-    needed in source build.
-  -->
-  <Target Name="_InstallFrameworkIntoLocalDotNet"
-          Condition="'$(DotNetBuildFromSource)' != 'true'"
-          Inputs="@(SharedFxContent)"
-          Outputs="@(SharedFxContent->'$(LocalInstallationOutputPath)%(FileName)%(Extension)')">
-
-    <Copy SourceFiles="@(SharedFxContent)"
-          DestinationFiles="@(SharedFxContent->'$(LocalInstallationOutputPath)%(FileName)%(Extension)')"
-          UseHardlinksIfPossible="true" />
-    <Message Importance="High" Text="$(MSbuildProjectFile) -> $(LocalInstallationOutputPath)" />
   </Target>
 
   <Target Name="_CreateRedistCompositeArchive"

--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -172,7 +172,6 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <SharedRuntimeSubPath>shared\$(SharedFxName)\$(SharedFxVersion)\</SharedRuntimeSubPath>
     <SharedFxLayoutTargetDir>$(SharedFrameworkLayoutRoot)$(SharedRuntimeSubPath)</SharedFxLayoutTargetDir>
     <RedistLayoutTargetDir>$(RedistSharedFrameworkLayoutRoot)$(SharedRuntimeSubPath)</RedistLayoutTargetDir>
-    <LocalInstallationOutputPath>$(LocalDotNetRoot)$(SharedRuntimeSubPath)</LocalInstallationOutputPath>
 
     <RuntimeListFileName>RuntimeList.xml</RuntimeListFileName>
     <RuntimeListOutputPath>$(BaseIntermediateOutputPath)$(RuntimeListFileName)</RuntimeListOutputPath>


### PR DESCRIPTION
# Manually resolve ref and runtime packs instead of modifying the .NET SDK used in the build

## Description

Instead of modifying the SDK used in the build to include the just-built ref and runtime packs, use the same SDK features we use in dotnet/runtime to manually resolve the packs in their layout folders. This removes the need to modify the sdk to build tests.

Fixes https://github.com/dotnet/aspnetcore/pull/54084#discussion_r1493057506


TODO: I might need to modify the testing setup to resolve things correctly, we'll see what CI says.