### PR TITLE
Handle parameters in Accepts mediatypes in DefaultProblemDetailsWriter

### DIFF
--- a/src/Http/Http.Extensions/src/DefaultProblemDetailsWriter.cs
+++ b/src/Http/Http.Extensions/src/DefaultProblemDetailsWriter.cs
@@ -39,8 +39,12 @@ internal sealed partial class DefaultProblemDetailsWriter : IProblemDetailsWrite
         {
             var acceptHeaderValue = acceptHeader[i];
 
-            if (_jsonMediaType.IsSubsetOf(acceptHeaderValue) ||
+            /*if (_jsonMediaType.IsSubsetOf(acceptHeaderValue) ||
                 _problemDetailsJsonMediaType.IsSubsetOf(acceptHeaderValue))
+            {
+                return true;
+            }*/
+            if(acceptHeaderValue.IsSubsetOf(_jsonMediaType) || acceptHeaderValue.IsSubsetOf(_problemDetailsJsonMediaType))
             {
                 return true;
             }

--- a/src/Http/Http.Extensions/src/DefaultProblemDetailsWriter.cs
+++ b/src/Http/Http.Extensions/src/DefaultProblemDetailsWriter.cs
@@ -37,7 +37,8 @@ internal sealed partial class DefaultProblemDetailsWriter : IProblemDetailsWrite
         for (var i = 0; i < acceptHeader.Count; i++)
         {
             var acceptHeaderValue = acceptHeader[i];
-            // One of the media types needs to be checked if it's a subset of the accepted header value
+            // Check to see if the Accepted header values support `application/json` or `application/problem+json`
+            // with  support for argument parameters. Support handling `*/*` and `application/*` as Accepts header values.
             // Application/json is a subset of */* but */* is not a subset of application/json
             if (acceptHeaderValue.IsSubsetOf(_jsonMediaType) || acceptHeaderValue.IsSubsetOf(_problemDetailsJsonMediaType) || _jsonMediaType.IsSubsetOf(acceptHeaderValue))
             {

--- a/src/Http/Http.Extensions/src/DefaultProblemDetailsWriter.cs
+++ b/src/Http/Http.Extensions/src/DefaultProblemDetailsWriter.cs
@@ -34,13 +34,12 @@ internal sealed partial class DefaultProblemDetailsWriter : IProblemDetailsWrite
         {
             return true;
         }
-    
         for (var i = 0; i < acceptHeader.Count; i++)
         {
             var acceptHeaderValue = acceptHeader[i];
-            //One of the media types needs to be checked if it's a subset of the accepted header value
-            //Application/json is a subset of */* but */* is not a subset of application/json
-            if(acceptHeaderValue.IsSubsetOf(_jsonMediaType) || acceptHeaderValue.IsSubsetOf(_problemDetailsJsonMediaType) || _jsonMediaType.IsSubsetOf(acceptHeaderValue))
+            // One of the media types needs to be checked if it's a subset of the accepted header value
+            // Application/json is a subset of */* but */* is not a subset of application/json
+            if (acceptHeaderValue.IsSubsetOf(_jsonMediaType) || acceptHeaderValue.IsSubsetOf(_problemDetailsJsonMediaType) || _jsonMediaType.IsSubsetOf(acceptHeaderValue))
             {
                 return true;
             }

--- a/src/Http/Http.Extensions/src/DefaultProblemDetailsWriter.cs
+++ b/src/Http/Http.Extensions/src/DefaultProblemDetailsWriter.cs
@@ -34,17 +34,13 @@ internal sealed partial class DefaultProblemDetailsWriter : IProblemDetailsWrite
         {
             return true;
         }
-
+    
         for (var i = 0; i < acceptHeader.Count; i++)
         {
             var acceptHeaderValue = acceptHeader[i];
-
-            /*if (_jsonMediaType.IsSubsetOf(acceptHeaderValue) ||
-                _problemDetailsJsonMediaType.IsSubsetOf(acceptHeaderValue))
-            {
-                return true;
-            }*/
-            if(acceptHeaderValue.IsSubsetOf(_jsonMediaType) || acceptHeaderValue.IsSubsetOf(_problemDetailsJsonMediaType))
+            //One of the media types needs to be checked if it's a subset of the accepted header value
+            //Application/json is a subset of */* but */* is not a subset of application/json
+            if(acceptHeaderValue.IsSubsetOf(_jsonMediaType) || acceptHeaderValue.IsSubsetOf(_problemDetailsJsonMediaType) || _jsonMediaType.IsSubsetOf(acceptHeaderValue))
             {
                 return true;
             }

--- a/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
+++ b/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
@@ -600,6 +600,8 @@ public partial class DefaultProblemDetailsWriterTest
     [InlineData("application/*")]
     [InlineData("application/json")]
     [InlineData("application/problem+json")]
+    [InlineData("application/json; charset=utf-8")]
+    [InlineData("application/json; v=1.0")]
     public void CanWrite_ReturnsTrue_WhenJsonAccepted(string contentType)
     {
         // Arrange


### PR DESCRIPTION
Address #52577

Fixed issue where DefaultProblemDetailWriter doesn't handle media type subsets. Added test cases including media type subsets. The corresponds with Issue#52577 tagged help wanted. 


