### PR TITLE
Don't pass nameof to ObjectDisposedException.ThrowIf

### DIFF
--- a/src/Http/Http/src/Internal/ReferenceReadStream.cs
+++ b/src/Http/Http/src/Internal/ReferenceReadStream.cs
@@ -147,6 +147,6 @@ internal sealed class ReferenceReadStream : Stream
 
     private void ThrowIfDisposed()
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(ReferenceReadStream));
+        ObjectDisposedException.ThrowIf(_disposed, typeof(ReferenceReadStream));
     }
 }

--- a/src/Http/WebUtilities/src/BufferedReadStream.cs
+++ b/src/Http/WebUtilities/src/BufferedReadStream.cs
@@ -418,6 +418,6 @@ public class BufferedReadStream : Stream
 
     private void CheckDisposed()
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(BufferedReadStream));
+        ObjectDisposedException.ThrowIf(_disposed, typeof(BufferedReadStream));
     }
 }

--- a/src/Http/WebUtilities/src/FileBufferingReadStream.cs
+++ b/src/Http/WebUtilities/src/FileBufferingReadStream.cs
@@ -497,6 +497,6 @@ public class FileBufferingReadStream : Stream
 
     private void ThrowIfDisposed()
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(FileBufferingReadStream));
+        ObjectDisposedException.ThrowIf(_disposed, typeof(FileBufferingReadStream));
     }
 }

--- a/src/Http/WebUtilities/src/FileBufferingWriteStream.cs
+++ b/src/Http/WebUtilities/src/FileBufferingWriteStream.cs
@@ -288,6 +288,6 @@ public sealed class FileBufferingWriteStream : Stream
 
     private void ThrowIfDisposed()
     {
-        ObjectDisposedException.ThrowIf(Disposed, nameof(FileBufferingWriteStream));
+        ObjectDisposedException.ThrowIf(Disposed, typeof(FileBufferingWriteStream));
     }
 }

--- a/src/Http/WebUtilities/src/HttpRequestStreamReader.cs
+++ b/src/Http/WebUtilities/src/HttpRequestStreamReader.cs
@@ -120,7 +120,7 @@ public class HttpRequestStreamReader : TextReader
     /// <inheritdoc />
     public override int Peek()
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(HttpRequestStreamReader));
+        ObjectDisposedException.ThrowIf(_disposed, typeof(HttpRequestStreamReader));
 
         if (_charBufferIndex == _charsRead)
         {
@@ -136,7 +136,7 @@ public class HttpRequestStreamReader : TextReader
     /// <inheritdoc />
     public override int Read()
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(HttpRequestStreamReader));
+        ObjectDisposedException.ThrowIf(_disposed, typeof(HttpRequestStreamReader));
 
         if (_charBufferIndex == _charsRead)
         {
@@ -172,7 +172,7 @@ public class HttpRequestStreamReader : TextReader
             throw new ArgumentNullException(nameof(buffer));
         }
 
-        ObjectDisposedException.ThrowIf(_disposed, nameof(HttpRequestStreamReader));
+        ObjectDisposedException.ThrowIf(_disposed, typeof(HttpRequestStreamReader));
 
         var count = buffer.Length;
         var charsRead = 0;
@@ -234,7 +234,7 @@ public class HttpRequestStreamReader : TextReader
     [SuppressMessage("ApiDesign", "RS0027:Public API with optional parameter(s) should have the most parameters amongst its public overloads.", Justification = "Required to maintain compatibility")]
     public override async ValueTask<int> ReadAsync(Memory<char> buffer, CancellationToken cancellationToken = default)
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(HttpRequestStreamReader));
+        ObjectDisposedException.ThrowIf(_disposed, typeof(HttpRequestStreamReader));
 
         if (_charBufferIndex == _charsRead && await ReadIntoBufferAsync() == 0)
         {
@@ -324,7 +324,7 @@ public class HttpRequestStreamReader : TextReader
     /// <inheritdoc />
     public override async Task<string?> ReadLineAsync()
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(HttpRequestStreamReader));
+        ObjectDisposedException.ThrowIf(_disposed, typeof(HttpRequestStreamReader));
 
         StringBuilder? sb = null;
         var consumeLineFeed = false;
@@ -359,7 +359,7 @@ public class HttpRequestStreamReader : TextReader
     /// <inheritdoc />
     public override string? ReadLine()
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(HttpRequestStreamReader));
+        ObjectDisposedException.ThrowIf(_disposed, typeof(HttpRequestStreamReader));
 
         StringBuilder? sb = null;
         var consumeLineFeed = false;

--- a/src/Http/WebUtilities/src/HttpResponseStreamWriter.cs
+++ b/src/Http/WebUtilities/src/HttpResponseStreamWriter.cs
@@ -105,7 +105,7 @@ public class HttpResponseStreamWriter : TextWriter
     /// <inheritdoc/>
     public override void Write(char value)
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(HttpResponseStreamWriter));
+        ObjectDisposedException.ThrowIf(_disposed, typeof(HttpResponseStreamWriter));
 
         if (_charBufferCount == _charBufferSize)
         {
@@ -119,7 +119,7 @@ public class HttpResponseStreamWriter : TextWriter
     /// <inheritdoc/>
     public override void Write(char[] values, int index, int count)
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(HttpResponseStreamWriter));
+        ObjectDisposedException.ThrowIf(_disposed, typeof(HttpResponseStreamWriter));
 
         if (values == null)
         {
@@ -140,7 +140,7 @@ public class HttpResponseStreamWriter : TextWriter
     /// <inheritdoc/>
     public override void Write(ReadOnlySpan<char> value)
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(HttpResponseStreamWriter));
+        ObjectDisposedException.ThrowIf(_disposed, typeof(HttpResponseStreamWriter));
 
         var remaining = value.Length;
         while (remaining > 0)
@@ -160,7 +160,7 @@ public class HttpResponseStreamWriter : TextWriter
     /// <inheritdoc/>
     public override void Write(string? value)
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(HttpResponseStreamWriter));
+        ObjectDisposedException.ThrowIf(_disposed, typeof(HttpResponseStreamWriter));
 
         if (value == null)
         {
@@ -183,7 +183,7 @@ public class HttpResponseStreamWriter : TextWriter
     /// <inheritdoc/>
     public override void WriteLine(ReadOnlySpan<char> value)
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(HttpResponseStreamWriter));
+        ObjectDisposedException.ThrowIf(_disposed, typeof(HttpResponseStreamWriter));
 
         Write(value);
         Write(NewLine);
@@ -505,7 +505,7 @@ public class HttpResponseStreamWriter : TextWriter
     /// <inheritdoc/>
     public override void Flush()
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(HttpResponseStreamWriter));
+        ObjectDisposedException.ThrowIf(_disposed, typeof(HttpResponseStreamWriter));
 
         FlushInternal(flushEncoder: true);
     }

--- a/src/Http/WebUtilities/src/PagedByteBuffer.cs
+++ b/src/Http/WebUtilities/src/PagedByteBuffer.cs
@@ -136,6 +136,6 @@ internal sealed class PagedByteBuffer : IDisposable
 
     private void ThrowIfDisposed()
     {
-        ObjectDisposedException.ThrowIf(Disposed, nameof(PagedByteBuffer));
+        ObjectDisposedException.ThrowIf(Disposed, typeof(PagedByteBuffer));
     }
 }

--- a/src/Middleware/Spa/SpaServices.Extensions/test/ListLoggerFactory.cs
+++ b/src/Middleware/Spa/SpaServices.Extensions/test/ListLoggerFactory.cs
@@ -46,7 +46,7 @@ public class ListLoggerFactory : ILoggerFactory
 
     private void CheckDisposed()
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(ListLoggerFactory));
+        ObjectDisposedException.ThrowIf(_disposed, typeof(ListLoggerFactory));
     }
 
     public void AddProvider(ILoggerProvider provider)

--- a/src/Servers/IIS/IIS/src/Core/WrappingStream.cs
+++ b/src/Servers/IIS/IIS/src/Core/WrappingStream.cs
@@ -15,7 +15,7 @@ internal sealed class WrappingStream : Stream
 
     public void SetInnerStream(Stream inner)
     {
-        ObjectDisposedException.ThrowIf(_disposed, nameof(WrappingStream));
+        ObjectDisposedException.ThrowIf(_disposed, typeof(WrappingStream));
 
         _inner = inner;
     }


### PR DESCRIPTION
...pass typeof.  (Really, we should probably pass `this`, but this change is more conservative and mostly equivalent.)

Fixes #54143