### PR TITLE
Set ProducesDotNetReleaseShippingAssets property in Publishing.props

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <PublishingVersion>3</PublishingVersion>
+    <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
# Set ProducesDotNetReleaseShippingAssets property in Publishing.props

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Add a boolean property named `ProducesDotNetReleaseShippingAssets` in `Publishing.props` for repos that produce .NET shipping packages (packages that we ship with the release infra)
Based on this property we will select which packages to ship as part of .NET on release day.

**This is a infrastructure only change.** It will add extra metadata to the MergedManifest.xml produced during CI build.

Issue: https://github.com/dotnet/release/issues/822
