### PR TITLE
[Blazor] Fix WASM perf benchmarks

### DIFF
--- a/src/Components/benchmarkapps/Wasm.Performance/dockerfile
+++ b/src/Components/benchmarkapps/Wasm.Performance/dockerfile
@@ -24,6 +24,7 @@ RUN git init \
     && git remote add origin https://github.com/aspnet/aspnetcore
 
 RUN ./restore.sh
+RUN npm run build
 RUN .dotnet/dotnet publish -c Release --no-restore -o /app ./src/Components/benchmarkapps/Wasm.Performance/Driver/Wasm.Performance.Driver.csproj
 RUN chmod +x /app/Wasm.Performance.Driver
 


### PR DESCRIPTION
# Fix WASM perf benchmarks

Updates `Wasm.Performance/dockerfile` to run `npm run build` before building the `Wasm.Performance.Driver` project. Changes were verified manually.

Fixes #54230
