### PR TITLE
Caching: SE.Redis update and fix naming inconsistency

### DIFF
--- a/eng/Baseline.Designer.props
+++ b/eng/Baseline.Designer.props
@@ -374,15 +374,15 @@
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.StackExchangeRedis' AND '$(TargetFramework)' == 'net462' ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[8.0.0, )" />
-    <BaselinePackageReference Include="StackExchange.Redis" Version="[2.6.122, )" />
+    <BaselinePackageReference Include="StackExchange.Redis" Version="[2.7.23, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.StackExchangeRedis' AND ('$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' OR '$(TargetFramework)' == 'net8.0') ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[8.0.0, )" />
-    <BaselinePackageReference Include="StackExchange.Redis" Version="[2.6.122, )" />
+    <BaselinePackageReference Include="StackExchange.Redis" Version="[2.7.23, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.StackExchangeRedis' AND '$(TargetFramework)' == 'netstandard2.0' ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[8.0.0, )" />
-    <BaselinePackageReference Include="StackExchange.Redis" Version="[2.6.122, )" />
+    <BaselinePackageReference Include="StackExchange.Redis" Version="[2.7.23, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore' ">

--- a/eng/Baseline.Designer.props
+++ b/eng/Baseline.Designer.props
@@ -374,15 +374,15 @@
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.StackExchangeRedis' AND '$(TargetFramework)' == 'net462' ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[8.0.0, )" />
-    <BaselinePackageReference Include="StackExchange.Redis" Version="[2.7.23, )" />
+    <BaselinePackageReference Include="StackExchange.Redis" Version="[2.6.122, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.StackExchangeRedis' AND ('$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' OR '$(TargetFramework)' == 'net8.0') ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[8.0.0, )" />
-    <BaselinePackageReference Include="StackExchange.Redis" Version="[2.7.23, )" />
+    <BaselinePackageReference Include="StackExchange.Redis" Version="[2.6.122, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.StackExchangeRedis' AND '$(TargetFramework)' == 'netstandard2.0' ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[8.0.0, )" />
-    <BaselinePackageReference Include="StackExchange.Redis" Version="[2.7.23, )" />
+    <BaselinePackageReference Include="StackExchange.Redis" Version="[2.6.122, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore' ">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -324,7 +324,7 @@
     <SeleniumWebDriverVersion>4.17.0</SeleniumWebDriverVersion>
     <SerilogExtensionsLoggingVersion>1.4.0</SerilogExtensionsLoggingVersion>
     <SerilogSinksFileVersion>4.0.0</SerilogSinksFileVersion>
-    <StackExchangeRedisVersion>2.6.122</StackExchangeRedisVersion>
+    <StackExchangeRedisVersion>2.7.23</StackExchangeRedisVersion>
     <SystemReactiveLinqVersion>5.0.0</SystemReactiveLinqVersion>
     <SwashbuckleAspNetCoreVersion>6.4.0</SwashbuckleAspNetCoreVersion>
     <XunitAbstractionsVersion>2.0.3</XunitAbstractionsVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -324,7 +324,7 @@
     <SeleniumWebDriverVersion>4.17.0</SeleniumWebDriverVersion>
     <SerilogExtensionsLoggingVersion>1.4.0</SerilogExtensionsLoggingVersion>
     <SerilogSinksFileVersion>4.0.0</SerilogSinksFileVersion>
-    <StackExchangeRedisVersion>2.7.23</StackExchangeRedisVersion>
+    <StackExchangeRedisVersion>2.7.27</StackExchangeRedisVersion>
     <SystemReactiveLinqVersion>5.0.0</SystemReactiveLinqVersion>
     <SwashbuckleAspNetCoreVersion>6.4.0</SwashbuckleAspNetCoreVersion>
     <XunitAbstractionsVersion>2.0.3</XunitAbstractionsVersion>

--- a/src/Caching/StackExchangeRedis/src/RedisCache.Log.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCache.Log.cs
@@ -13,7 +13,7 @@ public partial class RedisCache
         [LoggerMessage(1, LogLevel.Warning, "Could not determine the Redis server version. Falling back to use HMSET command instead of HSET.", EventName = "CouldNotDetermineServerVersion")]
         public static partial void CouldNotDetermineServerVersion(ILogger logger, Exception exception);
 
-        [LoggerMessage(2, LogLevel.Debug, "Unable to add library name suffix.", EventName = nameof(UnableToAddLibraryNameSuffix))]
+        [LoggerMessage(2, LogLevel.Debug, "Unable to add library name suffix.", EventName = "UnableToAddLibraryNameSuffix")]
         internal static partial void UnableToAddLibraryNameSuffix(ILogger logger, Exception exception);
     }
 }

--- a/src/Caching/StackExchangeRedis/src/RedisCache.Log.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCache.Log.cs
@@ -12,5 +12,8 @@ public partial class RedisCache
     {
         [LoggerMessage(1, LogLevel.Warning, "Could not determine the Redis server version. Falling back to use HMSET command instead of HSET.", EventName = "CouldNotDetermineServerVersion")]
         public static partial void CouldNotDetermineServerVersion(ILogger logger, Exception exception);
+
+        [LoggerMessage(2, LogLevel.Debug, "Unable to add library name suffix.", EventName = nameof(UnableToAddLibraryNameSuffix))]
+        internal static partial void UnableToAddLibraryNameSuffix(ILogger logger, Exception exception);
     }
 }

--- a/src/Caching/StackExchangeRedis/src/RedisCache.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCache.cs
@@ -257,7 +257,7 @@ public partial class RedisCache : IDistributedCache, IDisposable
                 IConnectionMultiplexer connection;
                 if (_options.ConnectionMultiplexerFactory is null)
                 {
-                    connection = ConnectionMultiplexer.Connect(_options.GetConfiguredOptions("asp.net DC"));
+                    connection = ConnectionMultiplexer.Connect(_options.GetConfiguredOptions());
                 }
                 else
                 {
@@ -301,7 +301,7 @@ public partial class RedisCache : IDistributedCache, IDisposable
                 IConnectionMultiplexer connection;
                 if (_options.ConnectionMultiplexerFactory is null)
                 {
-                    connection = await ConnectionMultiplexer.ConnectAsync(_options.GetConfiguredOptions("asp.net DC")).ConfigureAwait(false);
+                    connection = await ConnectionMultiplexer.ConnectAsync(_options.GetConfiguredOptions()).ConfigureAwait(false);
                 }
                 else
                 {
@@ -325,6 +325,7 @@ public partial class RedisCache : IDistributedCache, IDisposable
         WriteTimeTicks(ref _lastConnectTicks, DateTimeOffset.UtcNow);
         ValidateServerFeatures(connection);
         TryRegisterProfiler(connection);
+        TryAddSuffix(connection);
     }
 
     private void ValidateServerFeatures(IConnectionMultiplexer connection)
@@ -359,6 +360,19 @@ public partial class RedisCache : IDistributedCache, IDisposable
         if (_options.ProfilingSession is not null)
         {
             connection.RegisterProfiler(_options.ProfilingSession);
+        }
+    }
+
+    private static void TryAddSuffix(IConnectionMultiplexer connection)
+    {
+        try
+        {
+            connection.AddLibraryNameSuffix("aspnet");
+            connection.AddLibraryNameSuffix("DC");
+        }
+        catch (Exception ex)
+        {   // not critical
+            Debug.WriteLine(ex.Message);
         }
     }
 

--- a/src/Caching/StackExchangeRedis/src/RedisCache.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCache.cs
@@ -371,7 +371,8 @@ public partial class RedisCache : IDistributedCache, IDisposable
             connection.AddLibraryNameSuffix("DC");
         }
         catch (Exception ex)
-        {   // not critical
+        {
+            // not critical
             Debug.WriteLine(ex.Message);
         }
     }

--- a/src/Caching/StackExchangeRedis/src/RedisCache.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCache.cs
@@ -257,14 +257,7 @@ public partial class RedisCache : IDistributedCache, IDisposable
                 IConnectionMultiplexer connection;
                 if (_options.ConnectionMultiplexerFactory is null)
                 {
-                    if (_options.ConfigurationOptions is not null)
-                    {
-                        connection = ConnectionMultiplexer.Connect(_options.ConfigurationOptions);
-                    }
-                    else
-                    {
-                        connection = ConnectionMultiplexer.Connect(_options.Configuration!);
-                    }
+                    connection = ConnectionMultiplexer.Connect(_options.GetConfiguredOptions("asp.net DC"));
                 }
                 else
                 {

--- a/src/Caching/StackExchangeRedis/src/RedisCache.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCache.cs
@@ -363,7 +363,7 @@ public partial class RedisCache : IDistributedCache, IDisposable
         }
     }
 
-    private static void TryAddSuffix(IConnectionMultiplexer connection)
+    private void TryAddSuffix(IConnectionMultiplexer connection)
     {
         try
         {
@@ -372,8 +372,7 @@ public partial class RedisCache : IDistributedCache, IDisposable
         }
         catch (Exception ex)
         {
-            // not critical
-            Debug.WriteLine(ex.Message);
+            Log.UnableToAddLibraryNameSuffix(_logger, ex);;
         }
     }
 

--- a/src/Caching/StackExchangeRedis/src/RedisCacheOptions.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCacheOptions.cs
@@ -59,18 +59,13 @@ public class RedisCacheOptions : IOptions<RedisCacheOptions>
         set => _useForceReconnect = value;
     }
 
-    internal ConfigurationOptions GetConfiguredOptions(string libSuffix)
+    internal ConfigurationOptions GetConfiguredOptions()
     {
-        var options = ConfigurationOptions?.Clone() ?? ConfigurationOptions.Parse(Configuration!);
+        var options = ConfigurationOptions ?? ConfigurationOptions.Parse(Configuration!);
 
         // we don't want an initially unavailable server to prevent DI creating the service itself
         options.AbortOnConnectFail = false;
 
-        if (!string.IsNullOrWhiteSpace(libSuffix))
-        {
-            var provider = DefaultOptionsProvider.GetProvider(options.EndPoints);
-            options.LibraryName = $"{provider.LibraryName} {libSuffix}";
-        }
         return options;
     }
 }

--- a/src/Middleware/Microsoft.AspNetCore.OutputCaching.StackExchangeRedis/src/RedisOutputCacheOptions.cs
+++ b/src/Middleware/Microsoft.AspNetCore.OutputCaching.StackExchangeRedis/src/RedisOutputCacheOptions.cs
@@ -54,18 +54,13 @@ public sealed class RedisOutputCacheOptions
         set => _useForceReconnect = value;
     }
 
-    internal ConfigurationOptions GetConfiguredOptions(string libSuffix)
+    internal ConfigurationOptions GetConfiguredOptions()
     {
-        var options = ConfigurationOptions?.Clone() ?? ConfigurationOptions.Parse(Configuration!);
+        var options = ConfigurationOptions ?? ConfigurationOptions.Parse(Configuration!);
 
         // we don't want an initially unavailable server to prevent DI creating the service itself
         options.AbortOnConnectFail = false;
 
-        if (!string.IsNullOrWhiteSpace(libSuffix))
-        {
-            var provider = DefaultOptionsProvider.GetProvider(options.EndPoints);
-            options.LibraryName = $"{provider.LibraryName} {libSuffix}";
-        }
         return options;
     }
 }

--- a/src/Middleware/Microsoft.AspNetCore.OutputCaching.StackExchangeRedis/src/RedisOutputCacheStore.Log.cs
+++ b/src/Middleware/Microsoft.AspNetCore.OutputCaching.StackExchangeRedis/src/RedisOutputCacheStore.Log.cs
@@ -15,6 +15,6 @@ internal partial class RedisOutputCacheStore
     [LoggerMessage(2, LogLevel.Error, "Fatal error occurred executing redis output-cache GC loop.", EventName = "RedisOutputCacheGCFatalError")]
     internal static partial void RedisOutputCacheGCFatalError(ILogger logger, Exception exception);
 
-    [LoggerMessage(3, LogLevel.Debug, "Unable to add library name suffix.", EventName = nameof(UnableToAddLibraryNameSuffix))]
+    [LoggerMessage(3, LogLevel.Debug, "Unable to add library name suffix.", EventName = "UnableToAddLibraryNameSuffix")]
     internal static partial void UnableToAddLibraryNameSuffix(ILogger logger, Exception exception);
 }

--- a/src/Middleware/Microsoft.AspNetCore.OutputCaching.StackExchangeRedis/src/RedisOutputCacheStore.Log.cs
+++ b/src/Middleware/Microsoft.AspNetCore.OutputCaching.StackExchangeRedis/src/RedisOutputCacheStore.Log.cs
@@ -14,4 +14,7 @@ internal partial class RedisOutputCacheStore
 
     [LoggerMessage(2, LogLevel.Error, "Fatal error occurred executing redis output-cache GC loop.", EventName = "RedisOutputCacheGCFatalError")]
     internal static partial void RedisOutputCacheGCFatalError(ILogger logger, Exception exception);
+
+    [LoggerMessage(3, LogLevel.Debug, "Unable to add library name suffix.", EventName = nameof(UnableToAddLibraryNameSuffix))]
+    internal static partial void UnableToAddLibraryNameSuffix(ILogger logger, Exception exception);
 }

--- a/src/Middleware/Microsoft.AspNetCore.OutputCaching.StackExchangeRedis/src/RedisOutputCacheStore.cs
+++ b/src/Middleware/Microsoft.AspNetCore.OutputCaching.StackExchangeRedis/src/RedisOutputCacheStore.cs
@@ -332,7 +332,7 @@ internal partial class RedisOutputCacheStore : IOutputCacheStore, IOutputCacheBu
                 IConnectionMultiplexer connection;
                 if (_options.ConnectionMultiplexerFactory is null)
                 {
-                    connection = await ConnectionMultiplexer.ConnectAsync(_options.GetConfiguredOptions("asp.net OC")).ConfigureAwait(false);
+                    connection = await ConnectionMultiplexer.ConnectAsync(_options.GetConfiguredOptions()).ConfigureAwait(false);
                 }
                 else
                 {
@@ -415,6 +415,7 @@ internal partial class RedisOutputCacheStore : IOutputCacheStore, IOutputCacheBu
         WriteTimeTicks(ref _lastConnectTicks, DateTimeOffset.UtcNow);
         ValidateServerFeatures(connection);
         TryRegisterProfiler(connection);
+        TryAddSuffix(connection);
     }
 
     private void ValidateServerFeatures(IConnectionMultiplexer connection)
@@ -448,6 +449,19 @@ internal partial class RedisOutputCacheStore : IOutputCacheStore, IOutputCacheBu
         if (_options.ProfilingSession is not null)
         {
             connection.RegisterProfiler(_options.ProfilingSession);
+        }
+    }
+
+    private static void TryAddSuffix(IConnectionMultiplexer connection)
+    {
+        try
+        {
+            connection.AddLibraryNameSuffix("aspnet");
+            connection.AddLibraryNameSuffix("OC");
+        }
+        catch (Exception ex)
+        {   // not critical
+            Debug.WriteLine(ex.Message);
         }
     }
 

--- a/src/Middleware/Microsoft.AspNetCore.OutputCaching.StackExchangeRedis/src/RedisOutputCacheStore.cs
+++ b/src/Middleware/Microsoft.AspNetCore.OutputCaching.StackExchangeRedis/src/RedisOutputCacheStore.cs
@@ -460,7 +460,8 @@ internal partial class RedisOutputCacheStore : IOutputCacheStore, IOutputCacheBu
             connection.AddLibraryNameSuffix("OC");
         }
         catch (Exception ex)
-        {   // not critical
+        {
+            // not critical
             Debug.WriteLine(ex.Message);
         }
     }

--- a/src/Middleware/Microsoft.AspNetCore.OutputCaching.StackExchangeRedis/src/RedisOutputCacheStore.cs
+++ b/src/Middleware/Microsoft.AspNetCore.OutputCaching.StackExchangeRedis/src/RedisOutputCacheStore.cs
@@ -452,7 +452,7 @@ internal partial class RedisOutputCacheStore : IOutputCacheStore, IOutputCacheBu
         }
     }
 
-    private static void TryAddSuffix(IConnectionMultiplexer connection)
+    private void TryAddSuffix(IConnectionMultiplexer connection)
     {
         try
         {
@@ -461,8 +461,7 @@ internal partial class RedisOutputCacheStore : IOutputCacheStore, IOutputCacheBu
         }
         catch (Exception ex)
         {
-            // not critical
-            Debug.WriteLine(ex.Message);
+            UnableToAddLibraryNameSuffix(_logger, ex);
         }
     }
 

--- a/src/Middleware/Microsoft.AspNetCore.OutputCaching.StackExchangeRedis/test/RedisConnectionFixture.cs
+++ b/src/Middleware/Microsoft.AspNetCore.OutputCaching.StackExchangeRedis/test/RedisConnectionFixture.cs
@@ -13,8 +13,9 @@ public class RedisConnectionFixture : IDisposable
         var options = new RedisOutputCacheOptions
         {
             Configuration = "127.0.0.1:6379", // TODO: CI test config here
-        }.GetConfiguredOptions("CI test");
+        }.GetConfiguredOptions();
         _muxer = ConnectionMultiplexer.Connect(options);
+        _muxer.AddLibraryNameSuffix("test");
     }
 
     public IDatabase Database => _muxer.GetDatabase();

--- a/src/SignalR/server/StackExchangeRedis/src/RedisHubLifetimeManager.cs
+++ b/src/SignalR/server/StackExchangeRedis/src/RedisHubLifetimeManager.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.SignalR.StackExchangeRedis.Internal;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using StackExchange.Redis;
+using RedisProtocol = Microsoft.AspNetCore.SignalR.StackExchangeRedis.Internal.RedisProtocol; // to disambiguate from StackExchange.Redis.RedisProtocol
 
 namespace Microsoft.AspNetCore.SignalR.StackExchangeRedis;
 

--- a/src/SignalR/server/StackExchangeRedis/test/TestConnectionMultiplexer.cs
+++ b/src/SignalR/server/StackExchangeRedis/test/TestConnectionMultiplexer.cs
@@ -1,19 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
 using System.Net;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 using StackExchange.Redis;
 using StackExchange.Redis.Maintenance;
 using StackExchange.Redis.Profiling;
-using Xunit;
 
 namespace Microsoft.AspNetCore.SignalR.Tests;
 
@@ -237,6 +230,8 @@ public class TestConnectionMultiplexer : IConnectionMultiplexer
     }
 
     public ValueTask DisposeAsync() => default;
+
+    public void AddLibraryNameSuffix(string suffix) { } // don't need to implement
 }
 
 public class TestRedisServer


### PR DESCRIPTION
Resolve redis cache naming inconsistencies

The cache intent is included in the connection metadata ... or should be.

- rev SE.Redis; among other fixes, this resolves an issue with some client identifier strings being ignored at the server
- consistently apply identifier in cache setup
  - this was applied in async connect, but not sync connect
  - this was not applied if the factory callback was used (Aspire uses this)
- avoid cloning the configuration options (breaks key-rotation scenarios)
- adds (opt-in) RESP3 support (via lib-rev), and assorted lib fixes

manual test evidence (from running tests with a pause in):

``` txt
> redis-cli client list
...
id=348 ... resp=2 lib-name=SE.Redis-aspnet-DC lib-ver=2.7.27.49176
id=345 ... resp=2 lib-name=SE.Redis-aspnet-DC lib-ver=2.7.27.49176
```

