### PR TITLE
Improve usage of `Type.GetType` when activating types in data protection

### DIFF
--- a/src/DataProtection/DataProtection/src/Internal/DefaultTypeNameResolver.cs
+++ b/src/DataProtection/DataProtection/src/Internal/DefaultTypeNameResolver.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.AspNetCore.DataProtection.Internal;
+
+internal sealed class DefaultTypeNameResolver : ITypeNameResolver
+{
+    public static readonly DefaultTypeNameResolver Instance = new();
+
+    private DefaultTypeNameResolver()
+    {
+    }
+
+    [UnconditionalSuppressMessage("Trimmer", "IL2057", Justification = "Type.GetType is only used to resolve statically known types that are referenced by DataProtection assembly.")]
+    public bool TryResolveType(string typeName, [NotNullWhen(true)] out Type? type)
+    {
+        try
+        {
+            // Some exceptions are thrown regardless of the value of throwOnError.
+            // For example, if the type is found but cannot be loaded,
+            // a System.TypeLoadException is thrown even if throwOnError is false.
+            type = Type.GetType(typeName, throwOnError: false);
+            return type != null;
+        }
+        catch
+        {
+            type = null;
+            return false;
+        }
+    }
+}

--- a/src/DataProtection/DataProtection/src/Internal/ITypeNameResolver.cs
+++ b/src/DataProtection/DataProtection/src/Internal/ITypeNameResolver.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.AspNetCore.DataProtection.Internal;
+
+internal interface ITypeNameResolver
+{
+    bool TryResolveType(string typeName, [NotNullWhen(true)] out Type? type);
+}

--- a/src/DataProtection/DataProtection/src/KeyManagement/XmlKeyManager.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/XmlKeyManager.cs
@@ -465,7 +465,6 @@ public sealed class XmlKeyManager : IKeyManager, IInternalXmlKeyManager
         }
     }
 
-    [UnconditionalSuppressMessage("Trimmer", "IL2057", Justification = "Type.GetType result is only useful with types that are referenced by DataProtection assembly.")]
     private IAuthenticatedEncryptorDescriptorDeserializer CreateDeserializer(string descriptorDeserializerTypeName)
     {
         var resolvedTypeName = TypeForwardingActivator.TryForwardTypeName(descriptorDeserializerTypeName, out var forwardedTypeName)

--- a/src/DataProtection/DataProtection/src/TypeExtensions.cs
+++ b/src/DataProtection/DataProtection/src/TypeExtensions.cs
@@ -44,6 +44,7 @@ internal static class TypeExtensions
     public static bool MatchType(string resolvedTypeName, ITypeNameResolver typeNameResolver, Type matchType)
     {
         // Before attempting to resolve the name to a type, check if it starts with the full name of the type.
+        // Use StartsWith to ignore potential assembly version differences.
         if (matchType.FullName != null && resolvedTypeName.StartsWith(matchType.FullName, StringComparison.Ordinal))
         {
             return typeNameResolver.TryResolveType(resolvedTypeName, out var resolvedType) && resolvedType == matchType;

--- a/src/DataProtection/DataProtection/src/TypeExtensions.cs
+++ b/src/DataProtection/DataProtection/src/TypeExtensions.cs
@@ -41,7 +41,7 @@ internal static class TypeExtensions
         }
     }
 
-    public static bool MatchType(string resolvedTypeName, ITypeNameResolver typeNameResolver, Type matchType)
+    public static bool MatchName(this Type matchType, string resolvedTypeName, ITypeNameResolver typeNameResolver)
     {
         // Before attempting to resolve the name to a type, check if it starts with the full name of the type.
         // Use StartsWith to ignore potential assembly version differences.

--- a/src/DataProtection/DataProtection/src/TypeExtensions.cs
+++ b/src/DataProtection/DataProtection/src/TypeExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.DataProtection.Internal;
 
 namespace Microsoft.AspNetCore.DataProtection;
 
@@ -38,5 +39,16 @@ internal static class TypeExtensions
         {
             throw new InvalidOperationException($"Unable to load type '{typeName}'. If the app is published with trimming then this type may have been trimmed. Ensure the type's assembly is excluded from trimming.", ex);
         }
+    }
+
+    public static bool MatchType(string resolvedTypeName, ITypeNameResolver typeNameResolver, Type matchType)
+    {
+        // Before attempting to resolve the name to a type, check if it starts with the full name of the type.
+        if (matchType.FullName != null && resolvedTypeName.StartsWith(matchType.FullName, StringComparison.Ordinal))
+        {
+            return typeNameResolver.TryResolveType(resolvedTypeName, out var resolvedType) && resolvedType == matchType;
+        }
+
+        return false;
     }
 }

--- a/src/DataProtection/DataProtection/src/XmlEncryption/XmlEncryptionExtensions.cs
+++ b/src/DataProtection/DataProtection/src/XmlEncryption/XmlEncryptionExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.DataProtection.XmlEncryption;
 internal static unsafe class XmlEncryptionExtensions
 {
     // Used for testing edge case assembly loading errors
-    internal static Func<string, Type?> _getType = name => Type.GetType(name, throwOnError: false);
+    internal static Func<string, Type?> _getType = GetType;
 
     public static XElement DecryptElement(this XElement element, IActivator activator)
     {
@@ -70,7 +70,6 @@ internal static unsafe class XmlEncryptionExtensions
         return doc.Root!;
     }
 
-    [UnconditionalSuppressMessage("Trimmer", "IL2057", Justification = "Type.GetType result is only useful with types that are referenced by DataProtection assembly.")]
     private static IXmlDecryptor CreateDecryptor(IActivator activator, string decryptorTypeName)
     {
         if (!TryGetDecryptorType(decryptorTypeName, out var type))
@@ -114,6 +113,9 @@ internal static unsafe class XmlEncryptionExtensions
             return false;
         }
     }
+
+    [UnconditionalSuppressMessage("Trimmer", "IL2057", Justification = "Type.GetType result is only useful with types that are referenced by DataProtection assembly.")]
+    private static Type? GetType(string typeName) => Type.GetType(typeName, throwOnError: false);
 
     public static XElement? EncryptIfNecessary(this IXmlEncryptor encryptor, XElement element)
     {

--- a/src/DataProtection/DataProtection/src/XmlEncryption/XmlEncryptionExtensions.cs
+++ b/src/DataProtection/DataProtection/src/XmlEncryption/XmlEncryptionExtensions.cs
@@ -104,6 +104,9 @@ internal static unsafe class XmlEncryptionExtensions
             : decryptorTypeName;
         try
         {
+            // Some exceptions are thrown regardless of the value of throwOnError.
+            // For example, if the type is found but cannot be loaded,
+            // a System.TypeLoadException is thrown even if throwOnError is false.
             type = _getType(resolvedTypeName);
             return type is not null;
         }

--- a/src/DataProtection/DataProtection/src/XmlEncryption/XmlEncryptionExtensions.cs
+++ b/src/DataProtection/DataProtection/src/XmlEncryption/XmlEncryptionExtensions.cs
@@ -16,6 +16,9 @@ namespace Microsoft.AspNetCore.DataProtection.XmlEncryption;
 
 internal static unsafe class XmlEncryptionExtensions
 {
+    // Used for testing edge case assembly loading errors
+    internal static Func<string, Type> _getType = name => Type.GetType(name, throwOnError: false);
+
     public static XElement DecryptElement(this XElement element, IActivator activator)
     {
         // If no decryption necessary, return original element.
@@ -73,7 +76,7 @@ internal static unsafe class XmlEncryptionExtensions
         var resolvedTypeName = TypeForwardingActivator.TryForwardTypeName(decryptorTypeName, out var forwardedTypeName)
             ? forwardedTypeName
             : decryptorTypeName;
-        var type = Type.GetType(resolvedTypeName, throwOnError: false);
+        var type = _getType(resolvedTypeName);
 
         if (type == typeof(DpapiNGXmlDecryptor))
         {

--- a/src/DataProtection/DataProtection/src/XmlEncryption/XmlEncryptionExtensions.cs
+++ b/src/DataProtection/DataProtection/src/XmlEncryption/XmlEncryptionExtensions.cs
@@ -69,24 +69,28 @@ internal static unsafe class XmlEncryptionExtensions
 
     private static IXmlDecryptor CreateDecryptor(IActivator activator, string decryptorTypeName)
     {
-        var resolvedTypeName = TypeForwardingActivator.TryForwardTypeName(decryptorTypeName, out var forwardedTypeName)
+        // typeNameToMatch will be used for matching against known types but not passed to the activator.
+        // The activator will do its own forwarding.
+        var typeNameToMatch = TypeForwardingActivator.TryForwardTypeName(decryptorTypeName, out var forwardedTypeName)
             ? forwardedTypeName
             : decryptorTypeName;
+
+        // Note: ITypeNameResolver is only implemented on the activator in tests. In production, it's always DefaultTypeNameResolver.
         var typeNameResolver = activator as ITypeNameResolver ?? DefaultTypeNameResolver.Instance;
 
-        if (TypeExtensions.MatchType(resolvedTypeName, typeNameResolver, typeof(DpapiNGXmlDecryptor)))
+        if (typeof(DpapiNGXmlDecryptor).MatchName(typeNameToMatch, typeNameResolver))
         {
             return activator.CreateInstance<DpapiNGXmlDecryptor>(decryptorTypeName);
         }
-        else if (TypeExtensions.MatchType(resolvedTypeName, typeNameResolver, typeof(DpapiXmlDecryptor)))
+        else if (typeof(DpapiXmlDecryptor).MatchName(typeNameToMatch, typeNameResolver))
         {
             return activator.CreateInstance<DpapiXmlDecryptor>(decryptorTypeName);
         }
-        else if (TypeExtensions.MatchType(resolvedTypeName, typeNameResolver, typeof(EncryptedXmlDecryptor)))
+        else if (typeof(EncryptedXmlDecryptor).MatchName(typeNameToMatch, typeNameResolver))
         {
             return activator.CreateInstance<EncryptedXmlDecryptor>(decryptorTypeName);
         }
-        else if (TypeExtensions.MatchType(resolvedTypeName, typeNameResolver, typeof(NullXmlDecryptor)))
+        else if (typeof(NullXmlDecryptor).MatchName(typeNameToMatch, typeNameResolver))
         {
             return activator.CreateInstance<NullXmlDecryptor>(decryptorTypeName);
         }

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/XmlEncryption/XmlEncryptionExtensionsTests.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/XmlEncryption/XmlEncryptionExtensionsTests.cs
@@ -108,7 +108,7 @@ public class XmlEncryptionExtensionsTests
 
         // Assert
         XmlAssert.Equal("<value />", retVal);
-        mockTypeNameResolver.Verify(o => o.TryResolveType(forwardedTypeName, out resolvedType), Times.Once());
+        mockTypeNameResolver.Verify(o => o.TryResolveType(It.IsAny<string>(), out resolvedType), Times.Once());
     }
 
     [Fact]

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/XmlEncryption/XmlEncryptionExtensionsTests.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/XmlEncryption/XmlEncryptionExtensionsTests.cs
@@ -83,6 +83,7 @@ public class XmlEncryptionExtensionsTests
     {
         // Arrange
         var decryptorTypeName = typeof(NullXmlDecryptor).AssemblyQualifiedName;
+        TypeForwardingActivator.TryForwardTypeName(decryptorTypeName, out var forwardedTypeName);
 
         var original = XElement.Parse(@$"
                 <x:encryptedSecret decryptorType='{decryptorTypeName}' xmlns:x='http://schemas.asp.net/2015/03/dataProtection'>
@@ -95,7 +96,7 @@ public class XmlEncryptionExtensionsTests
         mockActivator.Setup(o => o.CreateInstance(typeof(NullXmlDecryptor), decryptorTypeName)).Returns(new NullXmlDecryptor());
         var mockTypeNameResolver = mockActivator.As<ITypeNameResolver>();
         var resolvedType = typeof(NullXmlDecryptor);
-        mockTypeNameResolver.Setup(mockTypeNameResolver => mockTypeNameResolver.TryResolveType(It.IsAny<string>(), out resolvedType)).Returns(true);
+        mockTypeNameResolver.Setup(mockTypeNameResolver => mockTypeNameResolver.TryResolveType(forwardedTypeName, out resolvedType)).Returns(true);
 
         var serviceCollection = new ServiceCollection();
         serviceCollection.AddSingleton<IActivator>(mockActivator.Object);
@@ -107,7 +108,7 @@ public class XmlEncryptionExtensionsTests
 
         // Assert
         XmlAssert.Equal("<value />", retVal);
-        mockTypeNameResolver.Verify(o => o.TryResolveType(It.IsAny<string>(), out resolvedType), Times.Once());
+        mockTypeNameResolver.Verify(o => o.TryResolveType(forwardedTypeName, out resolvedType), Times.Once());
     }
 
     [Fact]
@@ -126,7 +127,7 @@ public class XmlEncryptionExtensionsTests
         var mockActivator = new Mock<IActivator>();
         mockActivator.Setup(o => o.CreateInstance(typeof(IXmlDecryptor), decryptorTypeName)).Returns(new NullXmlDecryptor());
         var mockTypeNameResolver = mockActivator.As<ITypeNameResolver>();
-        var resolvedType = typeof(NullXmlDecryptor);
+        Type resolvedType = null;
         mockTypeNameResolver.Setup(mockTypeNameResolver => mockTypeNameResolver.TryResolveType(It.IsAny<string>(), out resolvedType)).Returns(false);
 
         var serviceCollection = new ServiceCollection();


### PR DESCRIPTION
Fixes #54253
Fixes #48910

There are some documented cases where `Type.GetType(<name>, throwOnError: false)` can still throw:

>  The `throwOnError` parameter specifies what happens when the type is not found, and also suppresses certain other exception conditions, as described in the Exceptions section. Some exceptions are thrown regardless of the value of `throwOnError`. For example, if the type is found but cannot be loaded, a `System.TypeLoadException` is thrown even if `throwOnError` is `false`.

This happens in the case where a `decryptorType` of previous version of an assembly has been used and prevents a custom `IActivator` implementation from doing proper forwarding.

This PR handles this case by catching errors from `Type.GetType` and letting the activator handle it instead.

Another way of solving this could be to make `TypeForwardingActivator` `public` and expose a way to register other namespaces to forward. Today, the [`DecryptorTypeForwardingActivator`](https://github.com/Azure/azure-sdk-for-net/blob/55d99db1548b45c52f63c89ac1671a00bf486842/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/src/DecryptorTypeForwardingActivator.cs) type in `Azure.Extensions.AspNetCore.DataProtection.Keys` is more or less an outdated copy of the `TypeForwardingActivator` in this repo.

// @JamesNK @amcasey 