### PR TITLE
Remove UsingToolNetFrameworkReferenceAssemblies

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -47,8 +47,6 @@
   <PropertyGroup Label="Arcade settings">
     <!-- Opt-in to Arcade tools for building VSIX projects. -->
     <UsingToolVSSDK>true</UsingToolVSSDK>
-    <!-- Only use Microsoft.NETFramework.ReferenceAssemblies on non-windows builds. Using this on Windows breaks MVC runtime compilation. -->
-    <UsingToolNetFrameworkReferenceAssemblies Condition="'$(OS)' != 'Windows_NT'">true</UsingToolNetFrameworkReferenceAssemblies>
     <!-- Disable XLIFF tasks -->
     <UsingToolXliff>false</UsingToolXliff>
   </PropertyGroup>


### PR DESCRIPTION
UsingToolNetFrameworkReferenceAssemblies got removed from Arcade a while ago as the SDK supports that natively.