### PR TITLE
Move computation of ShouldGenerateNewKey to KeyRingProvider

### DIFF
--- a/src/DataProtection/DataProtection/src/KeyManagement/DefaultKeyResolver.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/DefaultKeyResolver.cs
@@ -71,7 +71,7 @@ internal sealed class DefaultKeyResolver : IDefaultKeyResolver
         }
     }
 
-    private IKey? FindDefaultKey(DateTimeOffset now, IEnumerable<IKey> allKeys, out IKey? fallbackKey, out bool callerShouldGenerateNewKey)
+    private IKey? FindDefaultKey(DateTimeOffset now, IEnumerable<IKey> allKeys, out IKey? fallbackKey)
     {
         // find the preferred default key (allowing for server-to-server clock skew)
         var preferredDefaultKey = (from key in allKeys
@@ -87,33 +87,12 @@ internal sealed class DefaultKeyResolver : IDefaultKeyResolver
             if (preferredDefaultKey.IsRevoked || preferredDefaultKey.IsExpired(now) || !CanCreateAuthenticatedEncryptor(preferredDefaultKey))
             {
                 _logger.KeyIsNoLongerUnderConsiderationAsDefault(preferredDefaultKey.KeyId);
-                preferredDefaultKey = null;
             }
-        }
-
-        // Only the key that has been most recently activated is eligible to be the preferred default,
-        // and only if it hasn't expired or been revoked. This is intentional: generating a new key is
-        // an implicit signal that we should stop using older keys (even if they're not revoked), so
-        // activating a new key should permanently mark all older keys as non-preferred.
-
-        if (preferredDefaultKey != null)
-        {
-            // Does *any* key in the key ring fulfill the requirement that its activation date is prior
-            // to the preferred default key's expiration date (allowing for skew) and that it will
-            // remain valid one propagation cycle from now? If so, the caller doesn't need to add a
-            // new key.
-            callerShouldGenerateNewKey = !allKeys.Any(key =>
-               key.ActivationDate <= (preferredDefaultKey.ExpirationDate + _maxServerToServerClockSkew)
-               && !key.IsExpired(now + _keyPropagationWindow)
-               && !key.IsRevoked);
-
-            if (callerShouldGenerateNewKey)
+            else
             {
-                _logger.DefaultKeyExpirationImminentAndRepository();
+                fallbackKey = null;
+                return preferredDefaultKey;
             }
-
-            fallbackKey = null;
-            return preferredDefaultKey;
         }
 
         // If we got this far, the caller must generate a key now.
@@ -121,25 +100,35 @@ internal sealed class DefaultKeyResolver : IDefaultKeyResolver
         // the caller is configured not to generate a new key. We should try to make sure the fallback
         // key has propagated to all callers (so its creation date should be before the previous
         // propagation period), and we cannot use revoked keys. The fallback key may be expired.
-        fallbackKey = (from key in (from key in allKeys
+
+        // Note that the two sort orders are opposite: we want the *newest* key that's old enough
+        // or the *oldest* key that's too new.
+
+        // Unlike for the preferred key, we don't choose a fallback key and then reject it if
+        // CanCreateAuthenticatedEncryptor is false.  We want to end up with *some* key, so we
+        // keep trying until we find one that works.
+        var unrevokedKeys = allKeys.Where(key => !key.IsRevoked);
+        fallbackKey = (from key in (from key in unrevokedKeys
                                     where key.CreationDate <= now - _keyPropagationWindow
                                     orderby key.CreationDate descending
-                                    select key).Concat(from key in allKeys
+                                    select key).Concat(from key in unrevokedKeys
+                                                       where key.CreationDate > now - _keyPropagationWindow
                                                        orderby key.CreationDate ascending
                                                        select key)
-                       where !key.IsRevoked && CanCreateAuthenticatedEncryptor(key)
+                       where CanCreateAuthenticatedEncryptor(key)
                        select key).FirstOrDefault();
 
         _logger.RepositoryContainsNoViableDefaultKey();
 
-        callerShouldGenerateNewKey = true;
         return null;
     }
 
     public DefaultKeyResolution ResolveDefaultKeyPolicy(DateTimeOffset now, IEnumerable<IKey> allKeys)
     {
         var retVal = default(DefaultKeyResolution);
-        retVal.DefaultKey = FindDefaultKey(now, allKeys, out retVal.FallbackKey, out retVal.ShouldGenerateNewKey);
+        var defaultKey = FindDefaultKey(now, allKeys, out retVal.FallbackKey);
+        retVal.DefaultKey = defaultKey;
+        retVal.ShouldGenerateNewKey = defaultKey is null;
         return retVal;
     }
 }

--- a/src/DataProtection/DataProtection/src/KeyManagement/DefaultKeyResolver.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/DefaultKeyResolver.cs
@@ -102,7 +102,7 @@ internal sealed class DefaultKeyResolver : IDefaultKeyResolver
         // propagation period), and we cannot use revoked keys. The fallback key may be expired.
 
         // Note that the two sort orders are opposite: we want the *newest* key that's old enough
-        // or the *oldest* key that's too new.
+        // (to have been propagated) or the *oldest* key that's too new.
 
         // Unlike for the preferred key, we don't choose a fallback key and then reject it if
         // CanCreateAuthenticatedEncryptor is false.  We want to end up with *some* key, so we

--- a/src/DataProtection/DataProtection/src/KeyManagement/Internal/DefaultKeyResolution.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/Internal/DefaultKeyResolution.cs
@@ -30,8 +30,12 @@ public struct DefaultKeyResolution
     public IKey? FallbackKey;
 
     /// <summary>
-    /// 'true' if a new key should be persisted to the keyring, 'false' otherwise.
+    /// True if the caller should generate and persist a new key to the keyring.
+    /// False if the caller should determine for itself whether to generate a new key.
     /// This value may be 'true' even if a valid default key was found.
     /// </summary>
+    /// <remarks>
+    /// Does not reflect the time to expiration of the default key, if there is one.
+    /// </remarks>
     public bool ShouldGenerateNewKey;
 }

--- a/src/DataProtection/DataProtection/src/KeyManagement/KeyRingProvider.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/KeyRingProvider.cs
@@ -66,10 +66,33 @@ internal sealed class KeyRingProvider : ICacheableKeyRingProvider, IKeyRingProvi
 
         // Fetch the current default key from the list of all keys
         var defaultKeyPolicy = _defaultKeyResolver.ResolveDefaultKeyPolicy(now, allKeys);
-        if (!defaultKeyPolicy.ShouldGenerateNewKey)
+        var defaultKey = defaultKeyPolicy.DefaultKey;
+
+        // Determine whether we need to generate a new key
+        bool shouldGenerateNewKey;
+        if (defaultKeyPolicy.ShouldGenerateNewKey || defaultKey == null)
         {
-            CryptoUtil.Assert(defaultKeyPolicy.DefaultKey != null, "Expected to see a default key.");
-            return CreateCacheableKeyRingCoreStep2(now, cacheExpirationToken, defaultKeyPolicy.DefaultKey, allKeys);
+            shouldGenerateNewKey = true;
+        }
+        else
+        {
+            // If we have a default key, we have to consider its expiration date.  We have to generate a replacement
+            // if it will expire within the propagation window starting now (so that all other consumers pick up the
+            // replacement before the current default key expires).  However, we also have to factor in the refresh
+            // period, since we need to ensure that key generation occurs during the refresh that *precedes* the
+            // propagation window ending at the expiration date.
+            var minExpirationDate = now + KeyManagementOptions.KeyRingRefreshPeriod + KeyManagementOptions.KeyPropagationWindow;
+            var defaultKeyExpirationDate = defaultKey.ExpirationDate;
+            shouldGenerateNewKey =
+                defaultKeyExpirationDate < minExpirationDate &&
+                    (_defaultKeyResolver.ResolveDefaultKeyPolicy(defaultKeyExpirationDate, allKeys).DefaultKey is not { } nextDefaultKey ||
+                    nextDefaultKey.ExpirationDate < minExpirationDate);
+        }
+
+        if (!shouldGenerateNewKey)
+        {
+            CryptoUtil.Assert(defaultKey != null, "Expected to see a default key.");
+            return CreateCacheableKeyRingCoreStep2(now, cacheExpirationToken, defaultKey, allKeys);
         }
 
         _logger.PolicyResolutionStatesThatANewKeyShouldBeAddedToTheKeyRing();
@@ -80,7 +103,7 @@ internal sealed class KeyRingProvider : ICacheableKeyRingProvider, IKeyRingProvi
         // new keys endlessly, eventually falling back to the one we just added if all else fails.
         if (keyJustAdded != null)
         {
-            var keyToUse = defaultKeyPolicy.DefaultKey ?? defaultKeyPolicy.FallbackKey ?? keyJustAdded;
+            var keyToUse = defaultKey ?? defaultKeyPolicy.FallbackKey ?? keyJustAdded;
             return CreateCacheableKeyRingCoreStep2(now, cacheExpirationToken, keyToUse, allKeys);
         }
 
@@ -90,7 +113,7 @@ internal sealed class KeyRingProvider : ICacheableKeyRingProvider, IKeyRingProvi
         // We need to use the fallback key or fail.
         if (!_keyManagementOptions.AutoGenerateKeys)
         {
-            var keyToUse = defaultKeyPolicy.DefaultKey ?? defaultKeyPolicy.FallbackKey;
+            var keyToUse = defaultKey ?? defaultKeyPolicy.FallbackKey;
             if (keyToUse == null)
             {
                 _logger.KeyRingDoesNotContainValidDefaultKey();
@@ -103,7 +126,7 @@ internal sealed class KeyRingProvider : ICacheableKeyRingProvider, IKeyRingProvi
             }
         }
 
-        if (defaultKeyPolicy.DefaultKey == null)
+        if (defaultKey == null)
         {
             // The case where there's no default key is the easiest scenario, since it
             // means that we need to create a new key with immediate activation.
@@ -115,7 +138,7 @@ internal sealed class KeyRingProvider : ICacheableKeyRingProvider, IKeyRingProvi
             // If there is a default key, then the new key we generate should become active upon
             // expiration of the default key. The new key lifetime is measured from the creation
             // date (now), not the activation date.
-            var newKey = _keyManager.CreateNewKey(activationDate: defaultKeyPolicy.DefaultKey.ExpirationDate, expirationDate: now + _keyManagementOptions.NewKeyLifetime);
+            var newKey = _keyManager.CreateNewKey(activationDate: defaultKey.ExpirationDate, expirationDate: now + _keyManagementOptions.NewKeyLifetime);
             return CreateCacheableKeyRingCore(now, keyJustAdded: newKey); // recursively call
         }
     }

--- a/src/DataProtection/DataProtection/src/KeyManagement/KeyRingProvider.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/KeyRingProvider.cs
@@ -128,6 +128,9 @@ internal sealed class KeyRingProvider : ICacheableKeyRingProvider, IKeyRingProvi
             }
         }
 
+        // We're going to generate a new key.  You'd think we could just take for granted what effect
+        // this would have on the final result, but the key resolver is an extension point, so we have
+        // to give it a chance to weigh in - hence the recursive call, triggering re-resolution.
         if (defaultKey == null)
         {
             // The case where there's no default key is the easiest scenario, since it

--- a/src/DataProtection/DataProtection/src/KeyManagement/KeyRingProvider.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/KeyRingProvider.cs
@@ -68,10 +68,12 @@ internal sealed class KeyRingProvider : ICacheableKeyRingProvider, IKeyRingProvi
         var defaultKeyPolicy = _defaultKeyResolver.ResolveDefaultKeyPolicy(now, allKeys);
         var defaultKey = defaultKeyPolicy.DefaultKey;
 
-        // We shouldn't call CreateKey more than once, else we risk stack diving. This code path shouldn't
-        // get hit unless there was an ineligible key with an activation date slightly later than the one we
-        // just added. If this does happen, then we'll just use whatever key we can instead of creating
-        // new keys endlessly, eventually falling back to the one we just added if all else fails.
+        // We shouldn't call CreateKey more than once, else we risk stack diving. Thus, we don't even
+        // check defaultKeyPolicy.ShouldGenerateNewKey.  However, this code path shouldn't get hit
+        // with ShouldGenerateNewKey true unless there was an ineligible key with an activation date
+        // slightly later than the one we just added. If this does happen, then we'll just use whatever
+        // key we can instead of creating new keys endlessly, eventually falling back to the one we just
+        // added if all else fails.
         if (keyJustAdded != null)
         {
             var keyToUse = defaultKey ?? defaultKeyPolicy.FallbackKey ?? keyJustAdded;

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/KeyManagement/DefaultKeyResolverTests.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/KeyManagement/DefaultKeyResolverTests.cs
@@ -74,7 +74,7 @@ public class DefaultKeyResolverTests
     }
 
     [Fact]
-    public void ResolveDefaultKeyPolicy_ValidExistingKey_NoSuccessor_ReturnsExistingKey_SignalsGenerateNewKey()
+    public void ResolveDefaultKeyPolicy_ValidExistingKey_NoSuccessor_ReturnsExistingKey_DoesNotSignalGenerateNewKey()
     {
         // Arrange
         var resolver = CreateDefaultKeyResolver();
@@ -85,11 +85,11 @@ public class DefaultKeyResolverTests
 
         // Assert
         Assert.Same(key1, resolution.DefaultKey);
-        Assert.True(resolution.ShouldGenerateNewKey);
+        Assert.False(resolution.ShouldGenerateNewKey); // Does not reflect pending expiration
     }
 
     [Fact]
-    public void ResolveDefaultKeyPolicy_ValidExistingKey_NoLegitimateSuccessor_ReturnsExistingKey_SignalsGenerateNewKey()
+    public void ResolveDefaultKeyPolicy_ValidExistingKey_NoLegitimateSuccessor_ReturnsExistingKey_DoesNotSignalGenerateNewKey()
     {
         // Arrange
         var resolver = CreateDefaultKeyResolver();
@@ -102,7 +102,7 @@ public class DefaultKeyResolverTests
 
         // Assert
         Assert.Same(key1, resolution.DefaultKey);
-        Assert.True(resolution.ShouldGenerateNewKey);
+        Assert.False(resolution.ShouldGenerateNewKey); // Does not reflect pending expiration
     }
 
     [Fact]

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/KeyManagement/KeyRingProviderTests.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/KeyManagement/KeyRingProviderTests.cs
@@ -438,16 +438,12 @@ public class KeyRingProviderTests
 
         if (expectGeneration)
         {
-            var expectedCallSequenceCount = expectedCallSequence.Count; // Snap count before adding CreateNewKey
             expectedCallSequence.Add("CreateNewKey");
-            // Repeat all the calls that led up to CreateNewKey
-            for (int i = 0; i < expectedCallSequenceCount; i++)
+            // Repeat the initial calls, but not the second resolution
+            for (int i = 0; i < 3; i++)
             {
                 expectedCallSequence.Add(expectedCallSequence[i]);
             }
-
-            // We can't just duplicate the entries from resolveDefaultKeyPolicyReturnValues because
-            // the allKeys argument now includes the generated key
 
             resolveDefaultKeyPolicyReturnValues.Add(
                 Tuple.Create(now, (IEnumerable<IKey>)allKeysAfterGeneration, new DefaultKeyResolution()
@@ -456,16 +452,7 @@ public class KeyRingProviderTests
                     ShouldGenerateNewKey = false // Let the key ring provider decide
                 }));
 
-            if (expectSecondResolution)
-            {
-                resolveDefaultKeyPolicyReturnValues.Add(
-                    Tuple.Create(expiration1, (IEnumerable<IKey>)allKeysAfterGeneration, new DefaultKeyResolution()
-                    {
-                        DefaultKey = key2ValidWhenKey1Expires ? key2 : null,
-                        FallbackKey = key2ValidWhenKey1Expires ? null : key2,
-                        ShouldGenerateNewKey = !key2ValidWhenKey1Expires
-                    }));
-            }
+            // We don't repeat the second resolution because the key ring provider should not need to resolve again
         }
 
         var keyRingProvider = SetupCreateCacheableKeyRingTestAndCreateKeyManager(

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/KeyManagement/KeyRingProviderTests.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/KeyManagement/KeyRingProviderTests.cs
@@ -71,11 +71,16 @@ public class KeyRingProviderTests
             createNewKeyCallbacks: null,
             resolveDefaultKeyPolicyReturnValues: new[]
             {
-                        Tuple.Create((DateTimeOffset)now, (IEnumerable<IKey>)allKeys, new DefaultKeyResolution()
-                        {
-                            DefaultKey = key1,
-                            ShouldGenerateNewKey = false
-                        })
+                Tuple.Create((DateTimeOffset)now, (IEnumerable<IKey>)allKeys, new DefaultKeyResolution()
+                {
+                    DefaultKey = key1,
+                    ShouldGenerateNewKey = false
+                }),
+                Tuple.Create(key1.ExpirationDate, (IEnumerable<IKey>)allKeys, new DefaultKeyResolution()
+                {
+                    DefaultKey = key2,
+                    ShouldGenerateNewKey = false
+                }),
             });
 
         // Act
@@ -87,7 +92,7 @@ public class KeyRingProviderTests
         Assert.True(CacheableKeyRing.IsValid(cacheableKeyRing, now));
         expirationCts.Cancel();
         Assert.False(CacheableKeyRing.IsValid(cacheableKeyRing, now));
-        Assert.Equal(new[] { "GetCacheExpirationToken", "GetAllKeys", "ResolveDefaultKeyPolicy" }, callSequence);
+        Assert.Equal(new[] { "GetCacheExpirationToken", "GetAllKeys", "ResolveDefaultKeyPolicy", "ResolveDefaultKeyPolicy" }, callSequence);
     }
 
     [Fact]
@@ -346,6 +351,194 @@ public class KeyRingProviderTests
         expirationCts.Cancel();
         Assert.False(CacheableKeyRing.IsValid(cacheableKeyRing, now));
         Assert.Equal(new[] { "GetCacheExpirationToken", "GetAllKeys", "ResolveDefaultKeyPolicy" }, callSequence);
+    }
+
+    // The interesting time offsets are:
+    //   0. now
+    //   1. 24 hours from now, after a single refresh period
+    //   2. 48 hours from now, after a single propagation cycle
+    //   3. 72 hours from now, after a single refresh period and a single propagation cycle
+    // Therefore, we test at:
+    //   A. 12 hours from now, between (0) and (1)
+    //   B. 36 hours from now, between (1) and (2)
+    //   C. 60 hours from now, between (2) and (3)
+    //   D. 84 hours from now, after (3)
+    [Theory]
+    [InlineData(12, 12, true, true)]
+    [InlineData(12, 36, true, true)]
+    [InlineData(12, 60, true, true)]
+    [InlineData(12, 84, true, false)]
+    [InlineData(36, 12, true, true)]
+    [InlineData(36, 36, true, true)]
+    [InlineData(36, 60, true, true)]
+    [InlineData(36, 84, true, false)]
+    [InlineData(60, 12, true, true)]
+    [InlineData(60, 36, true, true)]
+    [InlineData(60, 60, true, true)]
+    [InlineData(60, 84, true, false)]
+    [InlineData(84, 12, false, false)]
+    [InlineData(84, 36, false, false)]
+    [InlineData(84, 60, false, false)]
+    [InlineData(84, 84, false, false)]
+    public void CreateCacheableKeyRing_UnactivatedKeyAvailable(int hoursToExpiration1, int hoursToExpiration2, bool expectSecondResolution, bool expectGeneration)
+    {
+        // Arrange
+        var actualCallSequence = new List<string>();
+
+        DateTimeOffset now = StringToDateTime("2016-02-01 00:00:00Z");
+
+        // Key1 is active, but Key2 is not
+        DateTimeOffset activation1 = now - TimeSpan.FromHours(1);
+        DateTimeOffset activation2 = now + TimeSpan.FromHours(1);
+
+        DateTimeOffset expiration1 = now + TimeSpan.FromHours(hoursToExpiration1);
+        DateTimeOffset expiration2 = now + TimeSpan.FromHours(hoursToExpiration2);
+
+        // Some basic timeline constraints - if these fail, it's a test issue
+        Assert.True(activation1 < now); // Key1 is active
+        Assert.True(now < activation2); // Key2 is not yet active
+        Assert.True(now < expiration1); // Key1 is not expired (also implies activation1 < expiration1)
+        Assert.True(activation2 < expiration2); // Key2 is not well-formed (also implies Key2 is unexpired, now < expiration2)
+        Assert.True(activation2 < expiration1); // Key1 and Key2 have overlapping activation periods - the alternative is covered in other tests
+        // Specifically do not require that expiration1 < expiration2
+
+        var key1 = CreateKey(activation1, expiration1);
+        var key2 = CreateKey(activation2, expiration2);
+
+        var generatedKey = CreateKey(expiration1, now + TimeSpan.FromDays(90));
+
+        var key2ValidWhenKey1Expires = expiration1 < expiration2;
+
+        var allKeys = new[] { key1, key2 };
+        var allKeysAfterGeneration = new[] { key1, key2, generatedKey };
+
+        var expectedCallSequence = new List<string> { "GetCacheExpirationToken", "GetAllKeys", "ResolveDefaultKeyPolicy" };
+
+        var resolveDefaultKeyPolicyReturnValues = new List<Tuple<DateTimeOffset, IEnumerable<IKey>, DefaultKeyResolution>>()
+        {
+            Tuple.Create(now, (IEnumerable<IKey>)allKeys, new DefaultKeyResolution()
+            {
+                DefaultKey = key1,
+                ShouldGenerateNewKey = false // Let the key ring provider decide
+            }),
+        };
+
+        if (expectSecondResolution)
+        {
+            expectedCallSequence.Add("ResolveDefaultKeyPolicy");
+
+            resolveDefaultKeyPolicyReturnValues.Add(
+                Tuple.Create(expiration1, (IEnumerable<IKey>)allKeys, new DefaultKeyResolution()
+                {
+                    DefaultKey = key2ValidWhenKey1Expires ? key2 : null,
+                    FallbackKey = key2ValidWhenKey1Expires ? null : key2,
+                    ShouldGenerateNewKey = !key2ValidWhenKey1Expires
+                }));
+        }
+
+        if (expectGeneration)
+        {
+            var expectedCallSequenceCount = expectedCallSequence.Count; // Snap count before adding CreateNewKey
+            expectedCallSequence.Add("CreateNewKey");
+            // Repeat all the calls that led up to CreateNewKey
+            for (int i = 0; i < expectedCallSequenceCount; i++)
+            {
+                expectedCallSequence.Add(expectedCallSequence[i]);
+            }
+
+            // We can't just duplicate the entries from resolveDefaultKeyPolicyReturnValues because
+            // the allKeys argument now includes the generated key
+
+            resolveDefaultKeyPolicyReturnValues.Add(
+                Tuple.Create(now, (IEnumerable<IKey>)allKeysAfterGeneration, new DefaultKeyResolution()
+                {
+                    DefaultKey = key1,
+                    ShouldGenerateNewKey = false // Let the key ring provider decide
+                }));
+
+            if (expectSecondResolution)
+            {
+                resolveDefaultKeyPolicyReturnValues.Add(
+                    Tuple.Create(expiration1, (IEnumerable<IKey>)allKeysAfterGeneration, new DefaultKeyResolution()
+                    {
+                        DefaultKey = key2ValidWhenKey1Expires ? key2 : null,
+                        FallbackKey = key2ValidWhenKey1Expires ? null : key2,
+                        ShouldGenerateNewKey = !key2ValidWhenKey1Expires
+                    }));
+            }
+        }
+
+        var keyRingProvider = SetupCreateCacheableKeyRingTestAndCreateKeyManager(
+            callSequence: actualCallSequence,
+            getCacheExpirationTokenReturnValues: new[] { CancellationToken.None, CancellationToken.None },
+            getAllKeysReturnValues: new[] { allKeys, allKeysAfterGeneration },
+            createNewKeyCallbacks: new[] {
+                Tuple.Create(expiration1, now + TimeSpan.FromDays(90), CreateKey())
+            },
+            resolveDefaultKeyPolicyReturnValues: resolveDefaultKeyPolicyReturnValues);
+
+        // Act
+        var cacheableKeyRing = keyRingProvider.GetCacheableKeyRing(now);
+
+        // Assert
+        Assert.Equal(key1.KeyId, cacheableKeyRing.KeyRing.DefaultKeyId);
+        Assert.Equal(expectedCallSequence, actualCallSequence);
+    }
+
+    [Fact]
+    public void CreateCacheableKeyRing_ForceKeyGeneration()
+    {
+        // Arrange
+        var actualCallSequence = new List<string>();
+
+        DateTimeOffset now = StringToDateTime("2016-02-01 00:00:00Z");
+
+        // Key is activate and not close to expiration
+        DateTimeOffset activation = now - TimeSpan.FromDays(30);
+        DateTimeOffset expiration = now + TimeSpan.FromDays(30);
+
+        var key = CreateKey(activation, expiration);
+        var generatedKey = CreateKey(expiration, now + TimeSpan.FromDays(90));
+
+        var allKeysBefore = new[] { key };
+        var allKeysAfter = new[] { key, generatedKey };
+
+        var keyRingProvider = SetupCreateCacheableKeyRingTestAndCreateKeyManager(
+            callSequence: actualCallSequence,
+            getCacheExpirationTokenReturnValues: new[] { CancellationToken.None, CancellationToken.None },
+            getAllKeysReturnValues: new[] { allKeysBefore, allKeysAfter },
+            createNewKeyCallbacks: new[] {
+                Tuple.Create(expiration, now + TimeSpan.FromDays(90), generatedKey)
+            },
+            resolveDefaultKeyPolicyReturnValues: new[] {
+                Tuple.Create(now, (IEnumerable<IKey>)allKeysBefore, new DefaultKeyResolution()
+                {
+                    DefaultKey = key,
+                    ShouldGenerateNewKey = true, // Force re-generation
+                }),
+                Tuple.Create(now, (IEnumerable<IKey>)allKeysAfter, new DefaultKeyResolution()
+                {
+                    DefaultKey = key,
+                    ShouldGenerateNewKey = true, // Force re-generation
+                }),
+            });
+
+        // Act
+        var cacheableKeyRing = keyRingProvider.GetCacheableKeyRing(now);
+
+        // Assert
+        Assert.Equal(key.KeyId, cacheableKeyRing.KeyRing.DefaultKeyId);
+        string[] expectedCallSequence =
+        [
+            "GetCacheExpirationToken",
+            "GetAllKeys",
+            "ResolveDefaultKeyPolicy",
+            "CreateNewKey",
+            "GetCacheExpirationToken",
+            "GetAllKeys",
+            "ResolveDefaultKeyPolicy",
+        ];
+        Assert.Equal(expectedCallSequence, actualCallSequence);
     }
 
     [Fact]
@@ -613,10 +806,11 @@ public class KeyRingProviderTests
             .Returns<DateTimeOffset, IEnumerable<IKey>>((now, allKeys) =>
             {
                 callSequence.Add("ResolveDefaultKeyPolicy");
-                resolveDefaultKeyPolicyReturnValuesEnumerator.MoveNext();
-                Assert.Equal(resolveDefaultKeyPolicyReturnValuesEnumerator.Current.Item1, now);
-                Assert.Equal(resolveDefaultKeyPolicyReturnValuesEnumerator.Current.Item2, allKeys);
-                return resolveDefaultKeyPolicyReturnValuesEnumerator.Current.Item3;
+                Assert.True(resolveDefaultKeyPolicyReturnValuesEnumerator.MoveNext());
+                var current = resolveDefaultKeyPolicyReturnValuesEnumerator.Current;
+                Assert.Equal(current.Item1, now);
+                Assert.Equal(current.Item2, allKeys);
+                return current.Item3;
             });
 
         return CreateKeyRingProvider(mockKeyManager.Object, mockDefaultKeyResolver.Object, keyManagementOptions);
@@ -674,10 +868,18 @@ public class KeyRingProviderTests
 
     private static IKey CreateKey(string activationDate, string expirationDate, bool isRevoked = false)
     {
+        return CreateKey(
+            DateTimeOffset.ParseExact(activationDate, "u", CultureInfo.InvariantCulture),
+            DateTimeOffset.ParseExact(expirationDate, "u", CultureInfo.InvariantCulture),
+            isRevoked);
+    }
+
+    private static IKey CreateKey(DateTimeOffset activationDate, DateTimeOffset expirationDate, bool isRevoked = false)
+    {
         var mockKey = new Mock<IKey>();
         mockKey.Setup(o => o.KeyId).Returns(Guid.NewGuid());
-        mockKey.Setup(o => o.ActivationDate).Returns(DateTimeOffset.ParseExact(activationDate, "u", CultureInfo.InvariantCulture));
-        mockKey.Setup(o => o.ExpirationDate).Returns(DateTimeOffset.ParseExact(expirationDate, "u", CultureInfo.InvariantCulture));
+        mockKey.Setup(o => o.ActivationDate).Returns(activationDate);
+        mockKey.Setup(o => o.ExpirationDate).Returns(expirationDate);
         mockKey.Setup(o => o.IsRevoked).Returns(isRevoked);
         mockKey.Setup(o => o.Descriptor).Returns(new Mock<IAuthenticatedEncryptorDescriptor>().Object);
         mockKey.Setup(o => o.CreateEncryptor()).Returns(new Mock<IAuthenticatedEncryptor>().Object);


### PR DESCRIPTION
It used to be the case that part of IDefaultKeyResolver.ResolveDefaultKeyPolicy's job was to determine whether the current default key was close enough to expiration that a new one ought to be generated.  This didn't make sense as the definition of "too close" depended upon the refresh period and propagation time of the ICacheableKeyRingProvider.  That is, the IDefaultKeyResolver had to make assumptions about how often it would be polled for changed.

The old logic was also very subtle and, as far as I was able to determine, slightly incorrect.  Formerly, the presence of any key activated prior to the current default key's expiration date and not expiring during the next propagation cycle was considered an acceptable replacement.  Several things seem strange about this:

1. The logic for finding a successor key is not the same as the logic for finding a preferred key (e.g. CanCreateAuthenticatedEncryptor is not checked)
2. The propagation window is counted forward from the current time, rather than backward from the expiration time
3. It's not immediately clear what happens if the successor key is unexpired at the end of the propagation window but expired before the default key's expiration time (maybe that's impossible or maybe that would be caught next refresh?)
4. As mentioned above, it doesn't seem like the resolver should know about the refresh period or make assumptions about how often it's called

Now, the ICacheableKeyRingProvider is responsible for determining whether the returned default key is close enough to expiration that a new key should be generated.  It checks whether the current time is within one propagation cycle of the expiration time, padding by an extra refresh period to account for the fact that we don't know where in the refresh cycle expiration will fall (i.e. so that we never generate a new key _less_ than a full propagation cycle ahead of when it's needed).

Part of #53654