### PR TITLE
[Blazor] InputBase - SetCurrentValueAsync + SetCurrentValueAsStringAsync (fix for #44105)

### DIFF
--- a/src/Components/Web/src/Forms/InputCheckbox.cs
+++ b/src/Components/Web/src/Forms/InputCheckbox.cs
@@ -42,7 +42,7 @@ public class InputCheckbox : InputBase<bool>
         // It sends the "on" value when the checkbox is checked, and nothing otherwise.
         builder.AddAttribute(6, "value", bool.TrueString);
 
-        builder.AddAttribute(7, "onchange", EventCallback.Factory.CreateBinder<bool>(this, __value => CurrentValue = __value, CurrentValue));
+        builder.AddAttribute(7, "onchange", EventCallback.Factory.CreateBinder<bool>(this, SetCurrentValueAsync, CurrentValue));
         builder.SetUpdatesAttributeName("checked");
         builder.AddElementReferenceCapture(8, __inputReference => Element = __inputReference);
         builder.CloseElement();

--- a/src/Components/Web/src/Forms/InputDate.cs
+++ b/src/Components/Web/src/Forms/InputDate.cs
@@ -89,7 +89,7 @@ public class InputDate<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType
         builder.AddAttributeIfNotNullOrEmpty(3, "name", NameAttributeValue);
         builder.AddAttribute(4, "class", CssClass);
         builder.AddAttribute(5, "value", CurrentValueAsString);
-        builder.AddAttribute(6, "onchange", EventCallback.Factory.CreateBinder<string?>(this, __value => CurrentValueAsString = __value, CurrentValueAsString));
+        builder.AddAttribute(6, "onchange", EventCallback.Factory.CreateBinder<string?>(this, SetCurrentValueAsStringAsync, CurrentValueAsString));
         builder.SetUpdatesAttributeName("value");
         builder.AddElementReferenceCapture(7, __inputReference => Element = __inputReference);
         builder.CloseElement();

--- a/src/Components/Web/src/Forms/InputNumber.cs
+++ b/src/Components/Web/src/Forms/InputNumber.cs
@@ -58,7 +58,7 @@ public class InputNumber<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTy
         builder.AddAttributeIfNotNullOrEmpty(4, "name", NameAttributeValue);
         builder.AddAttributeIfNotNullOrEmpty(5, "class", CssClass);
         builder.AddAttribute(6, "value", CurrentValueAsString);
-        builder.AddAttribute(7, "onchange", EventCallback.Factory.CreateBinder<string?>(this, __value => CurrentValueAsString = __value, CurrentValueAsString));
+        builder.AddAttribute(7, "onchange", EventCallback.Factory.CreateBinder<string?>(this, SetCurrentValueAsStringAsync, CurrentValueAsString));
         builder.SetUpdatesAttributeName("value");
         builder.AddElementReferenceCapture(8, __inputReference => Element = __inputReference);
         builder.CloseElement();

--- a/src/Components/Web/src/Forms/InputRadioGroup.cs
+++ b/src/Components/Web/src/Forms/InputRadioGroup.cs
@@ -35,7 +35,7 @@ public class InputRadioGroup<[DynamicallyAccessedMembers(DynamicallyAccessedMemb
         // On the first render, we can instantiate the InputRadioContext
         if (_context is null)
         {
-            var changeEventCallback = EventCallback.Factory.CreateBinder<string?>(this, __value => CurrentValueAsString = __value, CurrentValueAsString);
+            var changeEventCallback = EventCallback.Factory.CreateBinder<string?>(this, SetCurrentValueAsStringAsync, CurrentValueAsString);
             _context = new InputRadioContext(this, CascadedContext, changeEventCallback);
         }
         else if (_context.ParentContext != CascadedContext)

--- a/src/Components/Web/src/Forms/InputSelect.cs
+++ b/src/Components/Web/src/Forms/InputSelect.cs
@@ -47,13 +47,13 @@ public class InputSelect<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTy
         if (_isMultipleSelect)
         {
             builder.AddAttribute(5, "value", BindConverter.FormatValue(CurrentValue)?.ToString());
-            builder.AddAttribute(6, "onchange", EventCallback.Factory.CreateBinder<string?[]?>(this, SetCurrentValueAsStringArray, default));
+            builder.AddAttribute(6, "onchange", EventCallback.Factory.CreateBinder<string?[]?>(this, SetCurrentValueAsStringArrayAsync, default));
             builder.SetUpdatesAttributeName("value");
         }
         else
         {
             builder.AddAttribute(7, "value", CurrentValueAsString);
-            builder.AddAttribute(8, "onchange", EventCallback.Factory.CreateBinder<string?>(this, __value => CurrentValueAsString = __value, default));
+            builder.AddAttribute(8, "onchange", EventCallback.Factory.CreateBinder<string?>(this, SetCurrentValueAsStringAsync, default));
             builder.SetUpdatesAttributeName("value");
         }
 
@@ -82,10 +82,10 @@ public class InputSelect<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTy
         return base.FormatValueAsString(value);
     }
 
-    private void SetCurrentValueAsStringArray(string?[]? value)
+    private Task SetCurrentValueAsStringArrayAsync(string?[]? value)
     {
-        CurrentValue = BindConverter.TryConvertTo<TValue>(value, CultureInfo.CurrentCulture, out var result)
+        return SetCurrentValueAsync(BindConverter.TryConvertTo<TValue>(value, CultureInfo.CurrentCulture, out var result)
             ? result
-            : default;
+            : default);
     }
 }

--- a/src/Components/Web/src/Forms/InputText.cs
+++ b/src/Components/Web/src/Forms/InputText.cs
@@ -36,7 +36,7 @@ public class InputText : InputBase<string?>
         builder.AddAttributeIfNotNullOrEmpty(2, "name", NameAttributeValue);
         builder.AddAttributeIfNotNullOrEmpty(3, "class", CssClass);
         builder.AddAttribute(4, "value", CurrentValueAsString);
-        builder.AddAttribute(5, "onchange", EventCallback.Factory.CreateBinder<string?>(this, __value => CurrentValueAsString = __value, CurrentValueAsString));
+        builder.AddAttribute(5, "onchange", EventCallback.Factory.CreateBinder<string?>(this, SetCurrentValueAsStringAsync, CurrentValueAsString));
         builder.SetUpdatesAttributeName("value");
         builder.AddElementReferenceCapture(6, __inputReference => Element = __inputReference);
         builder.CloseElement();

--- a/src/Components/Web/src/Forms/InputTextArea.cs
+++ b/src/Components/Web/src/Forms/InputTextArea.cs
@@ -36,7 +36,7 @@ public class InputTextArea : InputBase<string?>
         builder.AddAttributeIfNotNullOrEmpty(2, "name", NameAttributeValue);
         builder.AddAttributeIfNotNullOrEmpty(3, "class", CssClass);
         builder.AddAttribute(4, "value", CurrentValueAsString);
-        builder.AddAttribute(5, "onchange", EventCallback.Factory.CreateBinder<string?>(this, __value => CurrentValueAsString = __value, CurrentValueAsString));
+        builder.AddAttribute(5, "onchange", EventCallback.Factory.CreateBinder<string?>(this, SetCurrentValueAsStringAsync, CurrentValueAsString));
         builder.SetUpdatesAttributeName("value");
         builder.AddElementReferenceCapture(6, __inputReference => Element = __inputReference);
         builder.CloseElement();

--- a/src/Components/Web/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Web/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.AspNetCore.Components.Forms.InputBase<TValue>.SetCurrentValueAsStringAsync(string? value) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Components.Forms.InputBase<TValue>.SetCurrentValueAsync(TValue? value) -> System.Threading.Tasks.Task!

--- a/src/Components/Web/test/Forms/InputBaseTest.cs
+++ b/src/Components/Web/test/Forms/InputBaseTest.cs
@@ -290,7 +290,7 @@ public class InputBaseTest
         rootComponent.EditContext.OnValidationStateChanged += (sender, eventArgs) => { numValidationStateChanges++; };
 
         // Act
-        await inputComponent.SetCurrentValueAsStringAsync("1991/11/20");
+        await inputComponent.InvokeCurrentValueAsStringSetterAsync("1991/11/20");
 
         // Assert
         var receivedParsedValue = valueChangedArgs.Single();
@@ -320,14 +320,14 @@ public class InputBaseTest
         rootComponent.EditContext.OnValidationStateChanged += (sender, eventArgs) => { numValidationStateChanges++; };
 
         // Act/Assert 1: Transition to invalid
-        await inputComponent.SetCurrentValueAsStringAsync("1991/11/40");
+        await inputComponent.InvokeCurrentValueAsStringSetterAsync("1991/11/40");
         Assert.Empty(valueChangedArgs);
         Assert.True(rootComponent.EditContext.IsModified(fieldIdentifier));
         Assert.Equal(new[] { "Bad date value" }, rootComponent.EditContext.GetValidationMessages(fieldIdentifier));
         Assert.Equal(1, numValidationStateChanges);
 
         // Act/Assert 2: Transition to valid
-        await inputComponent.SetCurrentValueAsStringAsync("1991/11/20");
+        await inputComponent.InvokeCurrentValueAsStringSetterAsync("1991/11/20");
         var receivedParsedValue = valueChangedArgs.Single();
         Assert.Equal(1991, receivedParsedValue.Year);
         Assert.Equal(11, receivedParsedValue.Month);
@@ -351,7 +351,7 @@ public class InputBaseTest
         var inputComponent = await InputRenderer.RenderAndGetComponent(rootComponent);
 
         // Act + Assert 1 (Precondition): The test needs a validation message to be removed later.
-        await inputComponent.SetCurrentValueAsStringAsync("1991/11/40");
+        await inputComponent.InvokeCurrentValueAsStringSetterAsync("1991/11/40");
         Assert.Equal(new[] { "Bad date value" }, rootComponent.EditContext.GetValidationMessages(fieldIdentifier));
 
         // Act: Dispose the input component
@@ -562,7 +562,7 @@ public class InputBaseTest
             throw new NotImplementedException();
         }
 
-        public async Task SetCurrentValueAsStringAsync(string value)
+        public async Task InvokeCurrentValueAsStringSetterAsync(string value)
         {
             // This is equivalent to the subclass writing to CurrentValueAsString
             // (e.g., from @bind), except to simplify the test code there's an InvokeAsync

--- a/src/Components/Web/test/Forms/InputDateTest.cs
+++ b/src/Components/Web/test/Forms/InputDateTest.cs
@@ -23,7 +23,7 @@ public class InputDateTest
         var inputComponent = await InputRenderer.RenderAndGetComponent(rootComponent);
 
         // Act
-        await inputComponent.SetCurrentValueAsStringAsync("invalidDate");
+        await inputComponent.InvokeCurrentValueAsStringSetterAsync("invalidDate");
 
         // Assert
         var validationMessages = rootComponent.EditContext.GetValidationMessages(fieldIdentifier);
@@ -56,7 +56,7 @@ public class InputDateTest
 
     private class TestInputDateComponent : InputDate<DateTime>
     {
-        public async Task SetCurrentValueAsStringAsync(string value)
+        public async Task InvokeCurrentValueAsStringSetterAsync(string value)
         {
             // This is equivalent to the subclass writing to CurrentValueAsString
             // (e.g., from @bind), except to simplify the test code there's an InvokeAsync

--- a/src/Components/Web/test/Forms/InputNumberTest.cs
+++ b/src/Components/Web/test/Forms/InputNumberTest.cs
@@ -23,7 +23,7 @@ public class InputNumberTest
         var inputComponent = await InputRenderer.RenderAndGetComponent(rootComponent);
 
         // Act
-        await inputComponent.SetCurrentValueAsStringAsync("notANumber");
+        await inputComponent.InvokeCurrentValueAsStringSetterAsync("notANumber");
 
         // Assert
         var validationMessages = rootComponent.EditContext.GetValidationMessages(fieldIdentifier);
@@ -56,7 +56,7 @@ public class InputNumberTest
 
     private class TestInputNumberComponent : InputNumber<int>
     {
-        public async Task SetCurrentValueAsStringAsync(string value)
+        public async Task InvokeCurrentValueAsStringSetterAsync(string value)
         {
             // This is equivalent to the subclass writing to CurrentValueAsString
             // (e.g., from @bind), except to simplify the test code there's an InvokeAsync

--- a/src/Components/Web/test/Forms/InputSelectTest.cs
+++ b/src/Components/Web/test/Forms/InputSelectTest.cs
@@ -181,7 +181,7 @@ public class InputSelectTest
         var inputSelectComponent = await InputRenderer.RenderAndGetComponent(rootComponent);
 
         // Act
-        await inputSelectComponent.SetCurrentValueAsStringAsync("invalidNumber");
+        await inputSelectComponent.InvokeCurrentValueAsStringSetterAsync("invalidNumber");
 
         // Assert
         var validationMessages = rootComponent.EditContext.GetValidationMessages(fieldIdentifier);
@@ -239,7 +239,7 @@ public class InputSelectTest
             get => base.CurrentValueAsString;
             set => base.CurrentValueAsString = value;
         }
-        public async Task SetCurrentValueAsStringAsync(string value)
+        public async Task InvokeCurrentValueAsStringSetterAsync(string value)
         {
             // This is equivalent to the subclass writing to CurrentValueAsString
             // (e.g., from @bind), except to simplify the test code there's an InvokeAsync

--- a/src/Components/test/E2ETest/Tests/FormsTest.cs
+++ b/src/Components/test/E2ETest/Tests/FormsTest.cs
@@ -907,6 +907,102 @@ public class FormsTest : ServerTestBase<ToggleExecutionModeServerFixture<Program
     }
 
     [Fact]
+    public void InputTextValueChangedExceptionDispatched()
+    {
+        var appElement = Browser.MountTestComponent<InputsWithFailingValueChangedHandler>();
+        var input = appElement.FindElement(By.Id("inputtext"));
+
+        // Observe that the exception in the value changed handler is dispatched to the error boundary
+        input.SendKeys("123\t");
+
+        Browser.Exists(By.Id("errorcontent"));
+    }
+
+    [Fact]
+    public void InputTextAreaValueChangedExceptionDispatched()
+    {
+        var appElement = Browser.MountTestComponent<InputsWithFailingValueChangedHandler>();
+        var input = appElement.FindElement(By.Id("inputtextarea"));
+
+        // Observe that the exception in the value changed handler is dispatched to the error boundary
+        input.SendKeys("123\t");
+
+        Browser.Exists(By.Id("errorcontent"));
+    }
+
+    [Fact]
+    public void InputCheckboxValueChangedExceptionDispatched()
+    {
+        var appElement = Browser.MountTestComponent<InputsWithFailingValueChangedHandler>();
+        var input = appElement.FindElement(By.Id("inputcheckbox"));
+
+        // Observe that the exception in the value changed handler is dispatched to the error boundary
+        input.Click();
+
+        Browser.Exists(By.Id("errorcontent"));
+    }
+
+    [Fact]
+    public void InputDateValueChangedExceptionDispatched()
+    {
+        var appElement = Browser.MountTestComponent<InputsWithFailingValueChangedHandler>();
+        var input = appElement.FindElement(By.Id("inputdate"));
+
+        // Observe that the exception in the value changed handler is dispatched to the error boundary
+        input.SendKeys("02\t");
+
+        Browser.Exists(By.Id("errorcontent"));
+    }
+
+    [Fact]
+    public void InputNumberValueChangedExceptionDispatched()
+    {
+        var appElement = Browser.MountTestComponent<InputsWithFailingValueChangedHandler>();
+        var input = appElement.FindElement(By.Id("inputnumber"));
+
+        // Observe that the exception in the value changed handler is dispatched to the error boundary
+        input.SendKeys("123\t");
+
+        Browser.Exists(By.Id("errorcontent"));
+    }
+
+    [Fact]
+    public void InputRadioGroupValueChangedExceptionDispatched()
+    {
+        var appElement = Browser.MountTestComponent<InputsWithFailingValueChangedHandler>();
+        var tuesday = appElement.FindElement(By.Id("inputradiogroup-tuesday"));
+
+        // Observe that the exception in the value changed handler is dispatched to the error boundary
+        tuesday.Click();
+
+        Browser.Exists(By.Id("errorcontent"));
+    }
+
+    [Fact]
+    public void InputSelectValueChangedExceptionDispatched()
+    {
+        var appElement = Browser.MountTestComponent<InputsWithFailingValueChangedHandler>();
+        var input = new SelectElement(appElement.FindElement(By.Id("inputselect")));
+
+        // Observe that the exception in the value changed handler is dispatched to the error boundary
+        input.SelectByValue("Wednesday");
+
+        Browser.Exists(By.Id("errorcontent"));
+    }
+
+    [Fact]
+    public void InputSelectMultipleValueChangedExceptionDispatched()
+    {
+        var appElement = Browser.MountTestComponent<InputsWithFailingValueChangedHandler>();
+        var input = new SelectElement(appElement.FindElement(By.Id("inputselectmultiple")));
+
+        // Observe that the exception in the value changed handler is dispatched to the error boundary
+        input.SelectByValue("Wednesday");
+
+        Browser.Exists(By.Id("errorcontent"));
+    }
+
+    [Fact]
     public void InputWithCustomParserPreservesInvalidValueWhenParsingFails()
     {
         var appElement = Browser.MountTestComponent<InputsWithMutatingSetters>();

--- a/src/Components/test/testassets/BasicTestApp/FormsTest/InputsWithFailingValueChangedHandler.razor
+++ b/src/Components/test/testassets/BasicTestApp/FormsTest/InputsWithFailingValueChangedHandler.razor
@@ -1,0 +1,52 @@
+﻿@using Microsoft.AspNetCore.Components.Forms
+
+<ErrorBoundary>
+	<ErrorContent>
+		<span id="errorcontent">ErrorContent</span>
+	</ErrorContent>
+	<ChildContent>
+		<EditForm Model="_model">
+			<InputText id="inputtext" @bind-Value:get="_model.Text" @bind-Value:set="HandleTextValueChanged" />
+			<InputTextArea id="inputtextarea" @bind-Value:get="_model.Text" @bind-Value:set="HandleTextValueChanged" />
+			<InputCheckbox id="inputcheckbox" @bind-Value:get="_model.Bool" @bind-Value:set="HandleBoolValueChanged" />
+			<InputDate id="inputdate" @bind-Value:get="_model.Date" @bind-Value:set="HandleDateValueChanged" />
+			<InputNumber id="inputnumber" @bind-Value:get="_model.Number" @bind-Value:set="HandleNumberValueChanged" />
+			<InputRadioGroup @bind-Value:get="@_model.DayOfWeek" @bind-Value:set="HandleDayOfWeekValueChanged">
+				<InputRadio Value="@DayOfWeek.Monday" id="inputradiogroup-monday" />
+				<InputRadio Value="@DayOfWeek.Tuesday" id="inputradiogroup-tuesday" />
+				<InputRadio Value="@DayOfWeek.Wednesday" id="inputradiogroup-wednesday" />
+			</InputRadioGroup>
+			<InputSelect id="inputselect" @bind-Value:get="@_model.DayOfWeek" @bind-Value:set="HandleDayOfWeekValueChanged">
+				<option value="@DayOfWeek.Monday">Monday</option>
+				<option value="@DayOfWeek.Tuesday">Tuesday</option>
+				<option value="@DayOfWeek.Wednesday">Wednesday</option>
+			</InputSelect>
+			<InputSelect id="inputselectmultiple" @bind-Value:get="@_model.DayOfWeekArray" @bind-Value:set="HandleDayOfWeekArrayValueChanged">
+				<option value="@DayOfWeek.Monday">Monday</option>
+				<option value="@DayOfWeek.Tuesday">Tuesday</option>
+				<option value="@DayOfWeek.Wednesday">Wednesday</option>
+			</InputSelect>
+		</EditForm>
+	</ChildContent>
+</ErrorBoundary>
+
+@code {
+	private Model _model = new();
+
+	private void HandleTextValueChanged(string value) => throw new Exception("This is a test exception");
+	private void HandleBoolValueChanged(bool value) => throw new Exception("This is a test exception");
+	private void HandleDateValueChanged(DateTime value) => throw new Exception("This is a test exception");
+	private void HandleNumberValueChanged(int value) => throw new Exception("This is a test exception");
+	private void HandleDayOfWeekValueChanged(DayOfWeek value) => throw new Exception("This is a test exception");
+	private void HandleDayOfWeekArrayValueChanged(DayOfWeek[] value) => throw new Exception("This is a test exception");
+
+	private class Model
+	{
+		public string Text { get; set; }
+		public bool Bool { get; set; }
+		public DateTime Date { get; set; }
+		public int Number { get; set; }
+		public DayOfWeek DayOfWeek { get; set; }
+		public DayOfWeek[] DayOfWeekArray { get; set; } = Array.Empty<DayOfWeek>();
+	}
+}

--- a/src/Components/test/testassets/BasicTestApp/Index.razor
+++ b/src/Components/test/testassets/BasicTestApp/Index.razor
@@ -49,7 +49,8 @@
         <option value="BasicTestApp.FormsTest.InputRangeComponent">Input range</option>
         <option value="BasicTestApp.FormsTest.InputsWithoutEditForm">Inputs without EditForm</option>
         <option value="BasicTestApp.FormsTest.InputsWithMutatingSetters">Inputs with mutating setters</option>
-        <option value="BasicTestApp.FormsTest.InputRadioParentImplementsIHandleEvent">Input Radio Parent Implements IHandleEvent</option>
+		<option value="BasicTestApp.FormsTest.InputRadioParentImplementsIHandleEvent">Input Radio Parent Implements IHandleEvent</option>
+		<option value="BasicTestApp.FormsTest.InputsWithFailingValueChangedHandler">Inputs with failing ValueChanged handler</option>
         <option value="BasicTestApp.NavigateOnSubmit">Navigate to submit</option>
         <option value="BasicTestApp.GlobalizationBindCases">Globalization Bind Cases</option>
         <option value="BasicTestApp.GracefulTermination">Graceful Termination</option>


### PR DESCRIPTION
# Proper Asynchronous Handling for `ValueChanged` Callback
Fixes #44105

## Description
* Failing E2E tests were introduced in the first commit (the tests demonstrate just one of the issues related to the original implementation).
* The fix was introduced in the second commit (tests passed).
* Backwards compatibility is preserved.
* New public APIs have been introduced:
  ```
  Microsoft.AspNetCore.Components.Forms.InputBase<TValue>.SetCurrentValueAsStringAsync(string? value) -> System.Threading.Tasks.Task!
  Microsoft.AspNetCore.Components.Forms.InputBase<TValue>.SetCurrentValueAsync(TValue? value) -> System.Threading.Tasks.Task!
  ```

I'm willing to continue collaborating on this PR if I receive a code review and further refinements are needed.

cc @jirikanda