### PR TITLE
Update dependencies from https://github.com/dotnet/efcore build 20240301.3

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,37 +9,37 @@
 -->
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="dotnet-ef" Version="9.0.0-preview.2.24113.1">
+    <Dependency Name="dotnet-ef" Version="9.0.0-preview.3.24151.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>42e6cfbd0c5b431a89b1923e7b73296705cf7ddf</Sha>
+      <Sha>5d3dfe13139f5c0c27223797d5263ae71a50002f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0-preview.2.24113.1">
+    <Dependency Name="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0-preview.3.24151.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>42e6cfbd0c5b431a89b1923e7b73296705cf7ddf</Sha>
+      <Sha>5d3dfe13139f5c0c27223797d5263ae71a50002f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.EntityFrameworkCore.Relational" Version="9.0.0-preview.2.24113.1">
+    <Dependency Name="Microsoft.EntityFrameworkCore.Relational" Version="9.0.0-preview.3.24151.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>42e6cfbd0c5b431a89b1923e7b73296705cf7ddf</Sha>
+      <Sha>5d3dfe13139f5c0c27223797d5263ae71a50002f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0-preview.2.24113.1">
+    <Dependency Name="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0-preview.3.24151.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>42e6cfbd0c5b431a89b1923e7b73296705cf7ddf</Sha>
+      <Sha>5d3dfe13139f5c0c27223797d5263ae71a50002f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0-preview.2.24113.1">
+    <Dependency Name="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0-preview.3.24151.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>42e6cfbd0c5b431a89b1923e7b73296705cf7ddf</Sha>
+      <Sha>5d3dfe13139f5c0c27223797d5263ae71a50002f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.EntityFrameworkCore.Tools" Version="9.0.0-preview.2.24113.1">
+    <Dependency Name="Microsoft.EntityFrameworkCore.Tools" Version="9.0.0-preview.3.24151.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>42e6cfbd0c5b431a89b1923e7b73296705cf7ddf</Sha>
+      <Sha>5d3dfe13139f5c0c27223797d5263ae71a50002f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.EntityFrameworkCore" Version="9.0.0-preview.2.24113.1">
+    <Dependency Name="Microsoft.EntityFrameworkCore" Version="9.0.0-preview.3.24151.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>42e6cfbd0c5b431a89b1923e7b73296705cf7ddf</Sha>
+      <Sha>5d3dfe13139f5c0c27223797d5263ae71a50002f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.EntityFrameworkCore.Design" Version="9.0.0-preview.2.24113.1">
+    <Dependency Name="Microsoft.EntityFrameworkCore.Design" Version="9.0.0-preview.3.24151.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>42e6cfbd0c5b431a89b1923e7b73296705cf7ddf</Sha>
+      <Sha>5d3dfe13139f5c0c27223797d5263ae71a50002f</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Caching.Abstractions" Version="9.0.0-preview.2.24114.1">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -141,14 +141,14 @@
     <MicrosoftExtensionsDiagnosticsTestingVersion>9.0.0-preview.2.24123.2</MicrosoftExtensionsDiagnosticsTestingVersion>
     <MicrosoftExtensionsTimeProviderTestingVersion>9.0.0-preview.2.24123.2</MicrosoftExtensionsTimeProviderTestingVersion>
     <!-- Packages from dotnet/efcore -->
-    <dotnetefVersion>9.0.0-preview.2.24113.1</dotnetefVersion>
-    <MicrosoftEntityFrameworkCoreInMemoryVersion>9.0.0-preview.2.24113.1</MicrosoftEntityFrameworkCoreInMemoryVersion>
-    <MicrosoftEntityFrameworkCoreRelationalVersion>9.0.0-preview.2.24113.1</MicrosoftEntityFrameworkCoreRelationalVersion>
-    <MicrosoftEntityFrameworkCoreSqliteVersion>9.0.0-preview.2.24113.1</MicrosoftEntityFrameworkCoreSqliteVersion>
-    <MicrosoftEntityFrameworkCoreSqlServerVersion>9.0.0-preview.2.24113.1</MicrosoftEntityFrameworkCoreSqlServerVersion>
-    <MicrosoftEntityFrameworkCoreToolsVersion>9.0.0-preview.2.24113.1</MicrosoftEntityFrameworkCoreToolsVersion>
-    <MicrosoftEntityFrameworkCoreVersion>9.0.0-preview.2.24113.1</MicrosoftEntityFrameworkCoreVersion>
-    <MicrosoftEntityFrameworkCoreDesignVersion>9.0.0-preview.2.24113.1</MicrosoftEntityFrameworkCoreDesignVersion>
+    <dotnetefVersion>9.0.0-preview.3.24151.3</dotnetefVersion>
+    <MicrosoftEntityFrameworkCoreInMemoryVersion>9.0.0-preview.3.24151.3</MicrosoftEntityFrameworkCoreInMemoryVersion>
+    <MicrosoftEntityFrameworkCoreRelationalVersion>9.0.0-preview.3.24151.3</MicrosoftEntityFrameworkCoreRelationalVersion>
+    <MicrosoftEntityFrameworkCoreSqliteVersion>9.0.0-preview.3.24151.3</MicrosoftEntityFrameworkCoreSqliteVersion>
+    <MicrosoftEntityFrameworkCoreSqlServerVersion>9.0.0-preview.3.24151.3</MicrosoftEntityFrameworkCoreSqlServerVersion>
+    <MicrosoftEntityFrameworkCoreToolsVersion>9.0.0-preview.3.24151.3</MicrosoftEntityFrameworkCoreToolsVersion>
+    <MicrosoftEntityFrameworkCoreVersion>9.0.0-preview.3.24151.3</MicrosoftEntityFrameworkCoreVersion>
+    <MicrosoftEntityFrameworkCoreDesignVersion>9.0.0-preview.3.24151.3</MicrosoftEntityFrameworkCoreDesignVersion>
     <!-- Packages from dotnet/roslyn -->
     <MicrosoftCodeAnalysisCommonVersion>4.8.0-3.23518.7</MicrosoftCodeAnalysisCommonVersion>
     <MicrosoftCodeAnalysisExternalAccessAspNetCoreVersion>4.8.0-3.23518.7</MicrosoftCodeAnalysisExternalAccessAspNetCoreVersion>


### PR DESCRIPTION
Split out from https://github.com/dotnet/aspnetcore/pull/54055 to get the latest efcore without runtime.

dotnet-ef , Microsoft.EntityFrameworkCore , Microsoft.EntityFrameworkCore.Design , Microsoft.EntityFrameworkCore.InMemory , Microsoft.EntityFrameworkCore.Relational , Microsoft.EntityFrameworkCore.Sqlite , Microsoft.EntityFrameworkCore.SqlServer , Microsoft.EntityFrameworkCore.Tools
 From Version 9.0.0-preview.2.24113.1 -> To Version 9.0.0-preview.3.24151.3
