### PR TITLE
Match arguments and property names in UserLoginInfo

### DIFF
--- a/src/Identity/Extensions.Core/src/PublicAPI.Unshipped.txt
+++ b/src/Identity/Extensions.Core/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+*REMOVED*Microsoft.AspNetCore.Identity.UserLoginInfo.UserLoginInfo(string! loginProvider, string! providerKey, string? displayName) -> void
+Microsoft.AspNetCore.Identity.UserLoginInfo.UserLoginInfo(string! loginProvider, string! providerKey, string? providerDisplayName) -> void

--- a/src/Identity/Extensions.Core/src/UserLoginInfo.cs
+++ b/src/Identity/Extensions.Core/src/UserLoginInfo.cs
@@ -13,12 +13,12 @@ public class UserLoginInfo
     /// </summary>
     /// <param name="loginProvider">The provider associated with this login information.</param>
     /// <param name="providerKey">The unique identifier for this user provided by the login provider.</param>
-    /// <param name="displayName">The display name for the login provider.</param>
-    public UserLoginInfo(string loginProvider, string providerKey, string? displayName)
+    /// <param name="providerDisplayName">The display name for the login provider.</param>
+    public UserLoginInfo(string loginProvider, string providerKey, string? providerDisplayName)
     {
         LoginProvider = loginProvider;
         ProviderKey = providerKey;
-        ProviderDisplayName = displayName;
+        ProviderDisplayName = providerDisplayName;
     }
 
     /// <summary>


### PR DESCRIPTION
Without matching names, since there is no default constructor, System.Text.Json deserialization fails and requires a custom converter.

/cc @eiriktsarpalis