### PR TITLE
Ensure key creation time is no later than key activation time

### DIFF
--- a/src/DataProtection/DataProtection/src/KeyManagement/XmlKeyManager.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/XmlKeyManager.cs
@@ -135,9 +135,12 @@ public sealed class XmlKeyManager : IKeyManager, IInternalXmlKeyManager
     /// <inheritdoc />
     public IKey CreateNewKey(DateTimeOffset activationDate, DateTimeOffset expirationDate)
     {
+        // For an immediately-activated key, the caller's Now may be slightly before ours,
+        // so we'll compensate to ensure that activation is never before creation.
+        var now = DateTimeOffset.UtcNow;
         return _internalKeyManager.CreateNewKey(
             keyId: Guid.NewGuid(),
-            creationDate: DateTimeOffset.UtcNow,
+            creationDate: activationDate < now ? activationDate : now,
             activationDate: activationDate,
             expirationDate: expirationDate);
     }


### PR DESCRIPTION
It makes no functional difference, but it was causing confusion.