### PR TITLE
[Blazor] ChangeDetection.cs - typo in comments (EventCallBack => EventCallback)

### DIFF
--- a/src/Components/Components/src/ChangeDetection.cs
+++ b/src/Components/Components/src/ChangeDetection.cs
@@ -37,7 +37,7 @@ internal sealed class ChangeDetection
     // This logic assumes that no new System.TypeCode enum entries have been declared since 7.0, or at least that any new ones
     // represent immutable types. If System.TypeCode changes, review this logic to ensure it is still correct.
     // Supported immutable types : bool, byte, sbyte, short, ushort, int, uint, long, ulong, char, double,
-    //                             string, DateTime, decimal, Guid, Enum, EventCallBack, EventCallBack<>.
+    //                             string, DateTime, decimal, Guid, Enum, EventCallback, EventCallback<>.
     // For performance reasons, the following immutable types are not supported: IntPtr, UIntPtr, Type.
     private static bool IsKnownImmutableType(Type type)
         => Type.GetTypeCode(type) != TypeCode.Object


### PR DESCRIPTION
Just a tiny patch.