### PR TITLE
Fixed source generator endpoint delegate handling for nullable scenarios

### DIFF
--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Endpoint.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Endpoint.cs
@@ -108,7 +108,7 @@ internal class Endpoint
 
     public static bool SignatureEquals(Endpoint a, Endpoint b)
     {
-        if (!string.Equals(a.Response?.WrappedResponseType, b.Response?.WrappedResponseType, StringComparison.Ordinal) ||
+        if (!string.Equals(a.Response?.WrappedResponseTypeDisplayName, b.Response?.WrappedResponseTypeDisplayName, StringComparison.Ordinal) ||
             !a.HttpMethod.Equals(b.HttpMethod, StringComparison.Ordinal) ||
             a.Parameters.Length != b.Parameters.Length)
         {
@@ -129,7 +129,7 @@ internal class Endpoint
     public static int GetSignatureHashCode(Endpoint endpoint)
     {
         var hashCode = new HashCode();
-        hashCode.Add(endpoint.Response?.WrappedResponseType);
+        hashCode.Add(endpoint.Response?.WrappedResponseTypeDisplayName);
         hashCode.Add(endpoint.HttpMethod);
 
         foreach (var parameter in endpoint.Parameters)

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointResponse.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointResponse.cs
@@ -14,7 +14,8 @@ using WellKnownType = WellKnownTypeData.WellKnownType;
 internal class EndpointResponse
 {
     public ITypeSymbol? ResponseType { get; set; }
-    public string WrappedResponseType { get; set; }
+    public ITypeSymbol WrappedResponseType { get; set; }
+    public string WrappedResponseTypeDisplayName { get; set; }
     public string? ContentType { get; set; }
     public bool IsAwaitable { get; set; }
     public bool HasNoResponse { get; set; }
@@ -27,7 +28,8 @@ internal class EndpointResponse
     {
         WellKnownTypes = wellKnownTypes;
         ResponseType = UnwrapResponseType(method, out bool isAwaitable, out bool awaitableIsVoid);
-        WrappedResponseType = method.ReturnType.ToDisplayString(EmitterConstants.DisplayFormat);
+        WrappedResponseType = method.ReturnType;
+        WrappedResponseTypeDisplayName = method.ReturnType.ToDisplayString(EmitterConstants.DisplayFormat);
         IsAwaitable = isAwaitable;
         HasNoResponse = method.ReturnsVoid || awaitableIsVoid;
         IsIResult = GetIsIResult();
@@ -100,7 +102,8 @@ internal class EndpointResponse
     {
         return obj is EndpointResponse otherEndpointResponse &&
             SymbolEqualityComparer.Default.Equals(otherEndpointResponse.ResponseType, ResponseType) &&
-            otherEndpointResponse.WrappedResponseType.Equals(WrappedResponseType, StringComparison.Ordinal) &&
+            SymbolEqualityComparer.Default.Equals(otherEndpointResponse.WrappedResponseType, WrappedResponseType) &&
+            otherEndpointResponse.WrappedResponseTypeDisplayName.Equals(WrappedResponseTypeDisplayName, StringComparison.Ordinal) &&
             otherEndpointResponse.IsAwaitable == IsAwaitable &&
             otherEndpointResponse.HasNoResponse == HasNoResponse &&
             otherEndpointResponse.IsIResult == IsIResult &&
@@ -108,5 +111,5 @@ internal class EndpointResponse
     }
 
     public override int GetHashCode() =>
-        HashCode.Combine(SymbolEqualityComparer.Default.GetHashCode(ResponseType), WrappedResponseType, IsAwaitable, HasNoResponse, IsIResult, ContentType);
+        HashCode.Combine(SymbolEqualityComparer.Default.GetHashCode(ResponseType), SymbolEqualityComparer.Default.GetHashCode(WrappedResponseType), WrappedResponseTypeDisplayName, IsAwaitable, HasNoResponse, IsIResult, ContentType);
 }

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/StaticRouteHandlerModel.Emitter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/StaticRouteHandlerModel.Emitter.cs
@@ -22,7 +22,7 @@ internal static class StaticRouteHandlerModelEmitter
         // IResult (int arg0, Todo arg1) => throw null!
         if (endpoint.Parameters.Length == 0)
         {
-            return endpoint.Response == null || (endpoint.Response.HasNoResponse && !endpoint.Response.IsAwaitable) ? "void ()" : $"{endpoint.Response.WrappedResponseType} ()";
+            return endpoint.Response == null || (endpoint.Response.HasNoResponse && !endpoint.Response.IsAwaitable) ? "void ()" : $"{endpoint.Response.WrappedResponseTypeDisplayName} ()";
         }
         var parameterTypeList = string.Join(", ", endpoint.Parameters.Select((p, i) => $"{EmitUnwrappedParameterType(p)} arg{i}{(p.HasDefaultValue ? $"= {p.DefaultValue}" : string.Empty)}"));
 
@@ -30,7 +30,7 @@ internal static class StaticRouteHandlerModelEmitter
         {
             return $"void ({parameterTypeList})";
         }
-        return $"{endpoint.Response.WrappedResponseType} ({parameterTypeList})";
+        return $"{endpoint.Response.WrappedResponseTypeDisplayName} ({parameterTypeList})";
     }
 
     private static string EmitUnwrappedParameterType(EndpointParameter p)
@@ -88,7 +88,7 @@ internal static class StaticRouteHandlerModelEmitter
         {
             codeWriter.WriteLine($"var task = handler({endpoint.EmitArgumentList()});");
         }
-        if (endpoint.Response.IsAwaitable && endpoint.Response.ResponseType?.NullableAnnotation == NullableAnnotation.Annotated)
+        if (endpoint.Response.IsAwaitable && endpoint.Response.WrappedResponseType.NullableAnnotation == NullableAnnotation.Annotated)
         {
             codeWriter.WriteLine("if (task == null)");
             codeWriter.StartBlock();
@@ -380,7 +380,7 @@ internal static class StaticRouteHandlerModelEmitter
         else if (endpoint.Response?.IsAwaitable == true)
         {
             codeWriter.WriteLine($"var task = handler({endpoint.EmitFilteredArgumentList()});");
-            if (endpoint.Response?.ResponseType?.NullableAnnotation == NullableAnnotation.Annotated)
+            if (endpoint.Response?.WrappedResponseType.NullableAnnotation == NullableAnnotation.Annotated)
             {
                 codeWriter.WriteLine("if (task == null)");
                 codeWriter.StartBlock();

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/CompileTimeCreationTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/CompileTimeCreationTests.cs
@@ -464,8 +464,8 @@ app.MapGet("/", {innerSource});
     public async Task AwaitableRequestDelegateThrowsNullReferenceExceptionOnUnannotatedNullDelegate(string innerSource)
     {
         var source = $"""
-                      app.MapGet("/", {innerSource});
-                      """;
+app.MapGet("/", {innerSource});
+""";
         var (_, compilation) = await RunGeneratorAsync(source);
         var endpoint = GetEndpointFromCompilation(compilation);
 

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/CompileTimeCreationTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/CompileTimeCreationTests.cs
@@ -427,7 +427,7 @@ app.MapGet("/", () => "Hello world!");
         Assert.Equal("JsonSerializerOptions instance must specify a TypeInfoResolver setting before being marked as read-only.", exception.Message);
     }
 
-    public static IEnumerable<object[]> NullResult
+    public static IEnumerable<object[]> NullResultWithNullAnnotation
     {
         get
         {
@@ -435,7 +435,7 @@ app.MapGet("/", () => "Hello world!");
             {
                 new object[] { "IResult? () => null", "The IResult returned by the Delegate must not be null." },
                 new object[] { "Task<IResult?>? () => null", "The Task returned by the Delegate must not be null." },
-                new object[] { "Task<bool?>? () => null", "The Task returned by the Delegate must not be null." },
+                new object[] { "Task<bool>? () => null", "The Task returned by the Delegate must not be null." },
                 new object[] { "Task<IResult?> () => Task.FromResult<IResult?>(null)", "The IResult returned by the Delegate must not be null." },
                 new object[] { "ValueTask<IResult?> () => ValueTask.FromResult<IResult?>(null)", "The IResult returned by the Delegate must not be null." },
             };
@@ -443,7 +443,7 @@ app.MapGet("/", () => "Hello world!");
     }
 
     [Theory]
-    [MemberData(nameof(NullResult))]
+    [MemberData(nameof(NullResultWithNullAnnotation))]
     public async Task RequestDelegateThrowsInvalidOperationExceptionOnNullDelegate(string innerSource, string message)
     {
         var source = $"""
@@ -456,6 +456,21 @@ app.MapGet("/", {innerSource});
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await endpoint.RequestDelegate(httpContext));
 
         Assert.Equal(message, exception.Message);
+    }
+
+    [Theory]
+    [InlineData("Task<bool> () => null!")]
+    [InlineData("Task<bool?> () => null!")]
+    public async Task AwaitableRequestDelegateThrowsNullReferenceExceptionOnUnannotatedNullDelegate(string innerSource)
+    {
+        var source = $"""
+                      app.MapGet("/", {innerSource});
+                      """;
+        var (_, compilation) = await RunGeneratorAsync(source);
+        var endpoint = GetEndpointFromCompilation(compilation);
+
+        var httpContext = CreateHttpContext();
+        _ = await Assert.ThrowsAsync<NullReferenceException>(async () => await endpoint.RequestDelegate(httpContext));
     }
 
     [Theory]

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/CompileTimeCreationTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/CompileTimeCreationTests.cs
@@ -435,7 +435,7 @@ app.MapGet("/", () => "Hello world!");
             {
                 new object[] { "IResult? () => null", "The IResult returned by the Delegate must not be null." },
                 new object[] { "Task<IResult?>? () => null", "The Task returned by the Delegate must not be null." },
-                new object[] { "Task<bool>? () => null", "The Task returned by the Delegate must not be null." },
+                new object[] { "Task<bool?>? () => null", "The Task returned by the Delegate must not be null." },
                 new object[] { "Task<IResult?> () => Task.FromResult<IResult?>(null)", "The IResult returned by the Delegate must not be null." },
                 new object[] { "ValueTask<IResult?> () => ValueTask.FromResult<IResult?>(null)", "The IResult returned by the Delegate must not be null." },
             };


### PR DESCRIPTION
Fixed source generator endpoint delegate handling for nullable scenarios by storing the `WrappedResponseType` and using it to check for nullability.

Fixes #54172
