### PR TITLE
Unquarantine CounterPageCanUseThreads. Fixes #53723

### DIFF
--- a/src/Components/test/E2ETest/Tests/ThreadingAppTest.cs
+++ b/src/Components/test/E2ETest/Tests/ThreadingAppTest.cs
@@ -66,7 +66,6 @@ public class ThreadingAppTest
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/53723")]
     public void CounterPageCanUseThreads()
     {
         // Navigate to "Counter"


### PR DESCRIPTION
This test was fixed in https://github.com/dotnet/aspnetcore/pull/54062 and has a 100% pass rate since then (2.5 weeks so far).