### PR TITLE
Fix CanUseFocusExtensionToFocusElementPreventScroll

### DIFF
--- a/src/Components/test/E2ETest/Tests/ComponentRenderingTestBase.cs
+++ b/src/Components/test/E2ETest/Tests/ComponentRenderingTestBase.cs
@@ -431,7 +431,7 @@ public abstract class ComponentRenderingTestBase : ServerTestBase<ToggleExecutio
     [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/46835")]
     public void CanUseFocusExtensionToFocusElementPreventScroll()
     {
-        Browser.Manage().Window.Size = new System.Drawing.Size(100, 300);
+        Browser.Manage().Window.Size = new System.Drawing.Size(600, 600);
         var appElement = Browser.MountTestComponent<ElementFocusComponent>();
 
         var buttonElement = Browser.Exists(By.Id("focus-button-prevented"));
@@ -451,7 +451,7 @@ public abstract class ComponentRenderingTestBase : ServerTestBase<ToggleExecutio
         var pageYOffsetAfter = getPageYOffset();
 
         //  Verify that not scrolled
-        Assert.Equal(pageYOffsetAfter, pageYOffsetBefore);
+        Assert.Equal(pageYOffsetBefore, pageYOffsetAfter);
 
         // A local helper that gets the ID of the focused element.
         string getFocusedElementId() => Browser.SwitchTo().ActiveElement().GetAttribute("id");


### PR DESCRIPTION
Fixes CanUseFocusExtensionToFocusElementPreventScroll

The issue was that the test window was so absurdly small that clicking the "focus without scrolling" button actually *did* cause scrolling, because the button itself was partially off-screen. Now the window is big enough to contain that button, clicking it correctly shows we don't scroll to the thing you're programmatically focusing (which is 10,000 pixels down from the button).

When merged, we can mark https://github.com/dotnet/aspnetcore/issues/46835 as `test-fixed`.