### PR TITLE
Ability to run E2E tests on WebAssembly multithreaded runtime

### DIFF
--- a/src/Components/test/E2ETest/Infrastructure/ServerFixtures/BlazorWasmTestAppFixture.cs
+++ b/src/Components/test/E2ETest/Infrastructure/ServerFixtures/BlazorWasmTestAppFixture.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using TestServer;
 using DevHostServerProgram = Microsoft.AspNetCore.Components.WebAssembly.DevServer.Server.Program;
 
 namespace Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
@@ -58,6 +59,11 @@ public class BlazorWasmTestAppFixture<TProgram> : WebHostServerFixture
         {
             args.Add("--environment");
             args.Add(Environment);
+        }
+
+        if (WebAssemblyTestHelper.MultithreadingIsEnabled())
+        {
+            args.Add("--apply-cop-headers");
         }
 
         return DevHostServerProgram.BuildWebHost(args.ToArray());

--- a/src/Components/test/testassets/Components.TestServer/AuthenticationStartup.cs
+++ b/src/Components/test/testassets/Components.TestServer/AuthenticationStartup.cs
@@ -52,6 +52,7 @@ public class AuthenticationStartupBase
         // Mount the server-side Blazor app on /subdir
         app.Map("/subdir", app =>
         {
+            WebAssemblyTestHelper.ServeCoopHeadersIfWebAssemblyThreadingEnabled(app);
             app.UseBlazorFrameworkFiles();
             app.UseStaticFiles();
 

--- a/src/Components/test/testassets/Components.TestServer/ClientStartup.cs
+++ b/src/Components/test/testassets/Components.TestServer/ClientStartup.cs
@@ -34,6 +34,7 @@ public class ClientStartup
         app.Map("/subdir", app =>
         {
             // Add it before to ensure it takes priority over files in wwwroot
+            WebAssemblyTestHelper.ServeCoopHeadersIfWebAssemblyThreadingEnabled(app);
             app.UseBlazorFrameworkFiles();
             app.UseStaticFiles();
 

--- a/src/Components/test/testassets/Components.TestServer/CorsStartup.cs
+++ b/src/Components/test/testassets/Components.TestServer/CorsStartup.cs
@@ -49,6 +49,7 @@ public class CorsStartup
         // Mount the server-side Blazor app on /subdir
         app.Map("/subdir", app =>
         {
+            WebAssemblyTestHelper.ServeCoopHeadersIfWebAssemblyThreadingEnabled(app);
             app.UseBlazorFrameworkFiles();
             app.UseStaticFiles();
 

--- a/src/Components/test/testassets/Components.TestServer/HotReloadStartup.cs
+++ b/src/Components/test/testassets/Components.TestServer/HotReloadStartup.cs
@@ -33,6 +33,7 @@ public class HotReloadStartup
             app.UseDeveloperExceptionPage();
         }
 
+        WebAssemblyTestHelper.ServeCoopHeadersIfWebAssemblyThreadingEnabled(app);
         app.UseBlazorFrameworkFiles();
         app.UseStaticFiles();
         app.UseRouting();

--- a/src/Components/test/testassets/Components.TestServer/InternationalizationStartup.cs
+++ b/src/Components/test/testassets/Components.TestServer/InternationalizationStartup.cs
@@ -34,6 +34,7 @@ public class InternationalizationStartup
         // Mount the server-side Blazor app on /subdir
         app.Map("/subdir", app =>
         {
+            WebAssemblyTestHelper.ServeCoopHeadersIfWebAssemblyThreadingEnabled(app);
             app.UseBlazorFrameworkFiles();
             app.UseStaticFiles();
 

--- a/src/Components/test/testassets/Components.TestServer/MultipleComponents.cs
+++ b/src/Components/test/testassets/Components.TestServer/MultipleComponents.cs
@@ -39,6 +39,7 @@ public class MultipleComponents
 
         app.Map("/Client/multiple-components", app =>
         {
+            WebAssemblyTestHelper.ServeCoopHeadersIfWebAssemblyThreadingEnabled(app);
             app.UseBlazorFrameworkFiles();
             app.UseStaticFiles();
             app.UseRouting();

--- a/src/Components/test/testassets/Components.TestServer/Program.cs
+++ b/src/Components/test/testassets/Components.TestServer/Program.cs
@@ -54,14 +54,21 @@ public class Program
         var contentRoot = typeof(Program).Assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
             .Single(a => a.Key == "Microsoft.AspNetCore.InternalTesting.BasicTestApp.ContentRoot")
             .Value;
+        var finalArgs = new List<string>();
+        finalArgs.AddRange(args);
+        finalArgs.AddRange(
+        [
+            "--contentroot", contentRoot,
+            "--pathbase", "/subdir",
+            "--applicationpath", typeof(BasicTestApp.Program).Assembly.Location,
+        ]);
 
-        var finalArgs = args.Concat(new[]
+        if (WebAssemblyTestHelper.MultithreadingIsEnabled())
         {
-                "--contentroot", contentRoot,
-                "--pathbase", "/subdir",
-                "--applicationpath", typeof(BasicTestApp.Program).Assembly.Location,
-            }).ToArray();
-        var host = DevServerProgram.BuildWebHost(finalArgs);
+            finalArgs.Add("--apply-cop-headers");
+        }
+
+        var host = DevServerProgram.BuildWebHost(finalArgs.ToArray());
         return (host, "/subdir");
     }
 

--- a/src/Components/test/testassets/Components.TestServer/RazorComponentEndpointsStartup.cs
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponentEndpointsStartup.cs
@@ -57,6 +57,8 @@ public class RazorComponentEndpointsStartup<TRootComponent>
 
         app.Map("/subdir", app =>
         {
+            WebAssemblyTestHelper.ServeCoopHeadersIfWebAssemblyThreadingEnabled(app);
+
             if (!env.IsDevelopment())
             {
                 app.UseExceptionHandler("/Error", createScopeForErrors: true);

--- a/src/Components/test/testassets/Components.TestServer/SaveState.cs
+++ b/src/Components/test/testassets/Components.TestServer/SaveState.cs
@@ -37,6 +37,7 @@ public class SaveState
             app.UseDeveloperExceptionPage();
         }
 
+        WebAssemblyTestHelper.ServeCoopHeadersIfWebAssemblyThreadingEnabled(app);
         app.UseBlazorFrameworkFiles();
         app.UseStaticFiles();
         app.UseRouting();

--- a/src/Components/test/testassets/Components.TestServer/StartupWithMapFallbackToClientSideBlazor.cs
+++ b/src/Components/test/testassets/Components.TestServer/StartupWithMapFallbackToClientSideBlazor.cs
@@ -33,6 +33,7 @@ public class StartupWithMapFallbackToClientSideBlazor
         // The client-side files middleware needs to be here because the base href in hardcoded to /subdir/
         app.Map("/subdir", subApp =>
         {
+            WebAssemblyTestHelper.ServeCoopHeadersIfWebAssemblyThreadingEnabled(app);
             subApp.UseBlazorFrameworkFiles();
             subApp.UseStaticFiles();
 

--- a/src/Components/test/testassets/Components.TestServer/WebAssemblyTestHelper.cs
+++ b/src/Components/test/testassets/Components.TestServer/WebAssemblyTestHelper.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+
+namespace TestServer;
+
+public static class WebAssemblyTestHelper
+{
+    public static bool MultithreadingIsEnabled()
+    {
+        var entrypointAssembly = Assembly.GetExecutingAssembly();
+        var attribute = entrypointAssembly.GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(x => x.Key.Equals("Microsoft.AspNetCore.InternalTesting.RunWebAssemblyE2ETestsWithMultithreading", StringComparison.Ordinal));
+        return attribute is not null && bool.Parse(attribute.Value);
+    }
+
+    public static void ServeCoopHeadersIfWebAssemblyThreadingEnabled(IApplicationBuilder app)
+    {
+        if (MultithreadingIsEnabled())
+        {
+            app.Use(async (ctx, next) =>
+            {
+                // Browser multi-threaded runtime requires cross-origin policy headers to enable SharedArrayBuffer.
+                ctx.Response.Headers.Append("Cross-Origin-Embedder-Policy", "require-corp");
+                ctx.Response.Headers.Append("Cross-Origin-Opener-Policy", "same-origin");
+                await next(ctx);
+            });
+        }
+    }
+}

--- a/src/Components/test/testassets/Directory.Build.props
+++ b/src/Components/test/testassets/Directory.Build.props
@@ -10,7 +10,7 @@
       headers if and only if this flag is set. Note that until https://github.com/dotnet/runtime/issues/98502
       is fixed, you will have to delete artifacts\obj directories after changing this flag.
     -->
-    <WasmEnableThreads>true</WasmEnableThreads>
+    <!--<WasmEnableThreads>true</WasmEnableThreads>-->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/test/testassets/Directory.Build.props
+++ b/src/Components/test/testassets/Directory.Build.props
@@ -3,5 +3,20 @@
 
   <PropertyGroup>
     <EnableTypeScriptNuGetTarget>true</EnableTypeScriptNuGetTarget>
+
+    <!--
+      This controls whether the WebAssembly E2E tests run with the multithreaded runtime or not.
+      It also implicitly sets an assembly metadata attribute so the test servers will serve the COOP
+      headers if and only if this flag is set. Note that until https://github.com/dotnet/runtime/issues/98502
+      is fixed, you will have to delete artifacts\obj directories after changing this flag.
+    -->
+    <WasmEnableThreads>true</WasmEnableThreads>
   </PropertyGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition="'$(WasmEnableThreads)' == 'true'">
+      <_Parameter1>Microsoft.AspNetCore.InternalTesting.RunWebAssemblyE2ETestsWithMultithreading</_Parameter1>
+      <_Parameter2>true</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/53435

Provides an easy way to have all the E2E tests run on the WebAssembly multithreaded runtime by setting a single MSBuild property in `src/Components/test/testassets/Directory.Build.props`.

```xml
  <PropertyGroup>
    <!--
      This controls whether the WebAssembly E2E tests run with the multithreaded runtime or not.
      It also implicitly sets an assembly metadata attribute so the test servers will serve the COOP
      headers if and only if this flag is set. Note that until https://github.com/dotnet/runtime/issues/98502
      is fixed, you will have to delete artifacts\obj directories after changing this flag.
    -->
    <!--<WasmEnableThreads>true</WasmEnableThreads>-->
  </PropertyGroup>
```

It's commented out because we don't actually want to enable this by default, because:

1. This is not the common case
2. Currently, many of the E2E tests will fail until we implement https://github.com/dotnet/aspnetcore/issues/54365

The purpose of this PR is to simplify collaboration around implementing proper support for WebAssembly multithreading.