### PR TITLE
Bump Microsoft.OpenApi dependency version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -334,7 +334,7 @@
     <XUnitRunnerVisualStudioVersion>2.4.3</XUnitRunnerVisualStudioVersion>
     <MicrosoftDataSqlClientVersion>4.0.5</MicrosoftDataSqlClientVersion>
     <MicrosoftAspNetCoreAppVersion>6.0.0-preview.3.21167.1</MicrosoftAspNetCoreAppVersion>
-    <MicrosoftOpenApiVersion>1.4.3</MicrosoftOpenApiVersion>
+    <MicrosoftOpenApiVersion>1.6.13</MicrosoftOpenApiVersion>
     <!-- dotnet tool versions (see also auto-updated DotnetEfVersion property). -->
     <DotnetDumpVersion>6.0.322601</DotnetDumpVersion>
     <DotnetServeVersion>1.10.93</DotnetServeVersion>


### PR DESCRIPTION
Increment the version of the `Microsoft.OpenApi` dependency that we use in `Microsoft.AspNetCore.OpenApi` to fix https://github.com/dotnet/aspnetcore/issues/54189.