### PR TITLE
http.sys accept loop - mitigate against break due to possible conflicting IO callbacks

### DIFF
--- a/src/Servers/HttpSys/src/AsyncAcceptContext.Log.cs
+++ b/src/Servers/HttpSys/src/AsyncAcceptContext.Log.cs
@@ -12,7 +12,7 @@ internal partial class AsyncAcceptContext
         [LoggerMessage(LoggerEventIds.AcceptSetResultFailed, LogLevel.Error, "Error attempting to set 'accept' outcome", EventName = "AcceptSetResultFailed")]
         public static partial void AcceptSetResultFailed(ILogger logger, Exception exception);
 
-        [LoggerMessage(LoggerEventIds.AcceptSetExpectationMismatch, LogLevel.Error, "Mismatch setting callback expectation {Value}", EventName = "AcceptSetExpectationMismatch")]
+        [LoggerMessage(LoggerEventIds.AcceptSetExpectationMismatch, LogLevel.Error, "Mismatch setting callback expectation - {Value}", EventName = "AcceptSetExpectationMismatch")]
         public static partial void AcceptSetExpectationMismatch(ILogger logger, int value);
 
         [LoggerMessage(LoggerEventIds.AcceptCancelExpectationMismatch, LogLevel.Error, "Mismatch canceling accept state - {Value}", EventName = "AcceptCancelExpectationMismatch")]

--- a/src/Servers/HttpSys/src/AsyncAcceptContext.Log.cs
+++ b/src/Servers/HttpSys/src/AsyncAcceptContext.Log.cs
@@ -12,13 +12,15 @@ internal partial class AsyncAcceptContext
         [LoggerMessage(LoggerEventIds.AcceptSetResultFailed, LogLevel.Error, "Error attempting to set 'accept' outcome", EventName = "AcceptSetResultFailed")]
         public static partial void AcceptSetResultFailed(ILogger logger, Exception exception);
 
-        [LoggerMessage(LoggerEventIds.AcceptSetExpectationMismatch, LogLevel.Error, "Mismatch setting callback expectation - {Value}", EventName = "AcceptSetExpectationMismatch")]
+        // note on "critical": these represent an unexpected IO callback state that needs investigation; see https://github.com/dotnet/aspnetcore/pull/54368/
+
+        [LoggerMessage(LoggerEventIds.AcceptSetExpectationMismatch, LogLevel.Critical, "Mismatch setting callback expectation - {Value}", EventName = "AcceptSetExpectationMismatch")]
         public static partial void AcceptSetExpectationMismatch(ILogger logger, int value);
 
-        [LoggerMessage(LoggerEventIds.AcceptCancelExpectationMismatch, LogLevel.Error, "Mismatch canceling accept state - {Value}", EventName = "AcceptCancelExpectationMismatch")]
+        [LoggerMessage(LoggerEventIds.AcceptCancelExpectationMismatch, LogLevel.Critical, "Mismatch canceling accept state - {Value}", EventName = "AcceptCancelExpectationMismatch")]
         public static partial void AcceptCancelExpectationMismatch(ILogger logger, int value);
 
-        [LoggerMessage(LoggerEventIds.AcceptObserveExpectationMismatch, LogLevel.Error, "Mismatch observing accept callback - {Value}", EventName = "AcceptObserveExpectationMismatch")]
+        [LoggerMessage(LoggerEventIds.AcceptObserveExpectationMismatch, LogLevel.Critical, "Mismatch observing accept callback - {Value}", EventName = "AcceptObserveExpectationMismatch")]
         public static partial void AcceptObserveExpectationMismatch(ILogger logger, int value);
     }
 }

--- a/src/Servers/HttpSys/src/AsyncAcceptContext.Log.cs
+++ b/src/Servers/HttpSys/src/AsyncAcceptContext.Log.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Server.HttpSys;
+
+internal partial class AsyncAcceptContext
+{
+    private static partial class Log
+    {
+        [LoggerMessage(LoggerEventIds.AcceptSetResultFailed, LogLevel.Error, "Error attempting to set 'accept' outcome", EventName = "AcceptSetResultFailed")]
+        public static partial void AcceptSetResultFailed(ILogger logger, Exception exception);
+
+        [LoggerMessage(LoggerEventIds.AcceptSetExpectationMismatch, LogLevel.Error, "Mismatch setting callback expectation {Value}", EventName = "AcceptSetExpectationMismatch")]
+        public static partial void AcceptSetExpectationMismatch(ILogger logger, int value);
+
+        [LoggerMessage(LoggerEventIds.AcceptCancelExpectationMismatch, LogLevel.Error, "Mismatch canceling accept state - {Value}", EventName = "AcceptCancelExpectationMismatch")]
+        public static partial void AcceptCancelExpectationMismatch(ILogger logger, int value);
+
+        [LoggerMessage(LoggerEventIds.AcceptObserveExpectationMismatch, LogLevel.Error, "Mismatch observing accept callback - {Value}", EventName = "AcceptObserveExpectationMismatch")]
+        public static partial void AcceptObserveExpectationMismatch(ILogger logger, int value);
+    }
+}

--- a/src/Servers/HttpSys/src/AsyncAcceptContext.Log.cs
+++ b/src/Servers/HttpSys/src/AsyncAcceptContext.Log.cs
@@ -20,7 +20,7 @@ internal partial class AsyncAcceptContext
         [LoggerMessage(LoggerEventIds.AcceptCancelExpectationMismatch, LogLevel.Critical, "Mismatch canceling accept state - {Value}", EventName = "AcceptCancelExpectationMismatch")]
         public static partial void AcceptCancelExpectationMismatch(ILogger logger, int value);
 
-        [LoggerMessage(LoggerEventIds.AcceptObserveExpectationMismatch, LogLevel.Critical, "Mismatch observing accept callback - {Value}", EventName = "AcceptObserveExpectationMismatch")]
-        public static partial void AcceptObserveExpectationMismatch(ILogger logger, int value);
+        [LoggerMessage(LoggerEventIds.AcceptObserveExpectationMismatch, LogLevel.Critical, "Mismatch observing {Kind} accept callback - {Value}", EventName = "AcceptObserveExpectationMismatch")]
+        public static partial void AcceptObserveExpectationMismatch(ILogger logger, string kind, int value);
     }
 }

--- a/src/Servers/HttpSys/src/AsyncAcceptContext.cs
+++ b/src/Servers/HttpSys/src/AsyncAcceptContext.cs
@@ -3,14 +3,17 @@
 
 using System.Diagnostics;
 using System.Threading.Tasks.Sources;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.HttpSys;
 
-internal sealed unsafe class AsyncAcceptContext : IValueTaskSource<RequestContext>, IDisposable
+internal sealed unsafe partial class AsyncAcceptContext : IValueTaskSource<RequestContext>, IDisposable
 {
     private static readonly IOCompletionCallback IOCallback = IOWaitCallback;
     private readonly PreAllocatedOverlapped _preallocatedOverlapped;
     private readonly IRequestContextFactory _requestContextFactory;
+    private readonly ILogger _logger;
+    private int _expectedCompletionCount;
 
     private NativeOverlapped* _overlapped;
 
@@ -23,11 +26,12 @@ internal sealed unsafe class AsyncAcceptContext : IValueTaskSource<RequestContex
 
     private RequestContext? _requestContext;
 
-    internal AsyncAcceptContext(HttpSysListener server, IRequestContextFactory requestContextFactory)
+    internal AsyncAcceptContext(HttpSysListener server, IRequestContextFactory requestContextFactory, ILogger logger)
     {
         Server = server;
         _requestContextFactory = requestContextFactory;
         _preallocatedOverlapped = new(IOCallback, state: this, pinData: null);
+        _logger = logger;
     }
 
     internal HttpSysListener Server { get; }
@@ -54,11 +58,12 @@ internal sealed unsafe class AsyncAcceptContext : IValueTaskSource<RequestContex
     {
         try
         {
+            ObserveCompletion(); // expectation tracking
             if (errorCode != ErrorCodes.ERROR_SUCCESS &&
                 errorCode != ErrorCodes.ERROR_MORE_DATA)
             {
-                _mrvts.SetException(new HttpSysException((int)errorCode));
-                return;
+                // (keep all the error handling in one place)
+                throw new HttpSysException((int)errorCode);
             }
 
             Debug.Assert(_requestContext != null);
@@ -70,7 +75,14 @@ internal sealed unsafe class AsyncAcceptContext : IValueTaskSource<RequestContex
                 // we want to reuse the acceptContext object for future accepts.
                 _requestContext = null;
 
-                _mrvts.SetResult(requestContext);
+                try
+                {
+                    _mrvts.SetResult(requestContext);
+                }
+                catch (Exception ex)
+                {
+                    Log.AcceptSetResultFailed(_logger, ex);
+                }
             }
             else
             {
@@ -83,15 +95,23 @@ internal sealed unsafe class AsyncAcceptContext : IValueTaskSource<RequestContex
                 if (statusCode != ErrorCodes.ERROR_SUCCESS &&
                     statusCode != ErrorCodes.ERROR_IO_PENDING)
                 {
-                    // someother bad error, possible(?) return values are:
+                    // some other bad error, possible(?) return values are:
                     // ERROR_INVALID_HANDLE, ERROR_INSUFFICIENT_BUFFER, ERROR_OPERATION_ABORTED
-                    _mrvts.SetException(new HttpSysException((int)statusCode));
+                    // (keep all the error handling in one place)
+                    throw new HttpSysException((int)statusCode);
                 }
             }
         }
         catch (Exception exception)
         {
-            _mrvts.SetException(exception);
+            try
+            {
+                _mrvts.SetException(exception);
+            }
+            catch (Exception ex)
+            {
+                Log.AcceptSetResultFailed(_logger, ex);
+            }
         }
     }
 
@@ -99,6 +119,36 @@ internal sealed unsafe class AsyncAcceptContext : IValueTaskSource<RequestContex
     {
         var acceptContext = (AsyncAcceptContext)ThreadPoolBoundHandle.GetNativeOverlappedState(nativeOverlapped)!;
         acceptContext.IOCompleted(errorCode, numBytes);
+    }
+
+    private void SetExpectCompletion() // we anticipate a completion *might* occur
+    {
+        // note this is intentionally a "reset and check" rather than Increment, so that we don't spam
+        // the logs forever if a glitch occurs
+        var value = Interlocked.Exchange(ref _expectedCompletionCount, 1); // should have been 0
+        if (value != 0)
+        {
+            Log.AcceptSetExpectationMismatch(_logger, value);
+            Debug.Assert(false, nameof(SetExpectCompletion)); // fail hard in debug
+        }
+    }
+    private void CancelExpectCompletion() // due to error-code etc, we no longer anticipate a completion
+    {
+        var value = Interlocked.Decrement(ref _expectedCompletionCount); // should have been 1, so now 0
+        if (value != 0)
+        {
+            Log.AcceptCancelExpectationMismatch(_logger, value);
+            Debug.Assert(false, nameof(CancelExpectCompletion)); // fail hard in debug
+        }
+    }
+    private void ObserveCompletion() // a completion was invoked
+    {
+        var value = Interlocked.Decrement(ref _expectedCompletionCount); // should have been 1, so now 0
+        if (value != 0)
+        {
+            Log.AcceptObserveExpectationMismatch(_logger, value);
+            Debug.Assert(false, nameof(ObserveCompletion)); // fail hard in debug
+        }
     }
 
     private uint QueueBeginGetContext()
@@ -111,6 +161,7 @@ internal sealed unsafe class AsyncAcceptContext : IValueTaskSource<RequestContex
 
             retry = false;
             uint bytesTransferred = 0;
+            SetExpectCompletion(); // track this *before*, because of timing vs IOCP (could even be effectively synchronous)
             statusCode = HttpApi.HttpReceiveHttpRequest(
                 Server.RequestQueue.Handle,
                 _requestContext.RequestId,
@@ -122,35 +173,44 @@ internal sealed unsafe class AsyncAcceptContext : IValueTaskSource<RequestContex
                 &bytesTransferred,
                 _overlapped);
 
-            if ((statusCode == ErrorCodes.ERROR_CONNECTION_INVALID
-                || statusCode == ErrorCodes.ERROR_INVALID_PARAMETER)
-                && _requestContext.RequestId != 0)
+            switch (statusCode)
             {
-                // ERROR_CONNECTION_INVALID:
-                // The client reset the connection between the time we got the MORE_DATA error and when we called HttpReceiveHttpRequest
-                // with the new buffer. We can clear the request id and move on to the next request.
-                //
-                // ERROR_INVALID_PARAMETER: Historical check from HttpListener.
-                // https://referencesource.microsoft.com/#System/net/System/Net/_ListenerAsyncResult.cs,137
-                // we might get this if somebody stole our RequestId,
-                // set RequestId to 0 and start all over again with the buffer we just allocated
-                // BUGBUG: how can someone steal our request ID?  seems really bad and in need of fix.
-                _requestContext.RequestId = 0;
-                retry = true;
-            }
-            else if (statusCode == ErrorCodes.ERROR_MORE_DATA)
-            {
-                // the buffer was not big enough to fit the headers, we need
-                // to read the RequestId returned, allocate a new buffer of the required size
-                //  (uint)backingBuffer.Length - AlignmentPadding
-                AllocateNativeRequest(bytesTransferred);
-                retry = true;
-            }
-            else if (statusCode == ErrorCodes.ERROR_SUCCESS
-                && HttpSysListener.SkipIOCPCallbackOnSuccess)
-            {
-                // IO operation completed synchronously - callback won't be called to signal completion.
-                IOCompleted(statusCode, bytesTransferred);
+                case (ErrorCodes.ERROR_CONNECTION_INVALID or ErrorCodes.ERROR_INVALID_PARAMETER) when _requestContext.RequestId != 0:
+                    // ERROR_CONNECTION_INVALID:
+                    // The client reset the connection between the time we got the MORE_DATA error and when we called HttpReceiveHttpRequest
+                    // with the new buffer. We can clear the request id and move on to the next request.
+                    //
+                    // ERROR_INVALID_PARAMETER: Historical check from HttpListener.
+                    // https://referencesource.microsoft.com/#System/net/System/Net/_ListenerAsyncResult.cs,137
+                    // we might get this if somebody stole our RequestId,
+                    // set RequestId to 0 and start all over again with the buffer we just allocated
+                    // BUGBUG: how can someone steal our request ID?  seems really bad and in need of fix.
+                    CancelExpectCompletion();
+                    _requestContext.RequestId = 0;
+                    retry = true;
+                    break;
+                case ErrorCodes.ERROR_MORE_DATA:
+                    // the buffer was not big enough to fit the headers, we need
+                    // to read the RequestId returned, allocate a new buffer of the required size
+                    //  (uint)backingBuffer.Length - AlignmentPadding
+                    CancelExpectCompletion(); // we'll "expect" again when we retry
+                    AllocateNativeRequest(bytesTransferred);
+                    retry = true;
+                    break;
+                case ErrorCodes.ERROR_SUCCESS:
+                    if (HttpSysListener.SkipIOCPCallbackOnSuccess)
+                    {
+                        // IO operation completed synchronously - callback won't be called to signal completion.
+                        IOCompleted(statusCode, bytesTransferred); // marks completion
+                    }
+                    // else: callback fired by IOCP (at some point), which marks completion
+                    break;
+                case ErrorCodes.ERROR_IO_PENDING:
+                    break; // no change to state - callback will occur at some point
+                default:
+                    // fault code, not expecting an IOCP callback
+                    CancelExpectCompletion();
+                    break;
             }
         }
         while (retry);

--- a/src/Servers/HttpSys/src/LoggerEventIds.cs
+++ b/src/Servers/HttpSys/src/LoggerEventIds.cs
@@ -54,4 +54,8 @@ internal static class LoggerEventIds
     public const int RequestValidationFailed = 47;
     public const int CreateDisconnectTokenError = 48;
     public const int RequestAborted = 49;
+    public const int AcceptSetResultFailed = 50;
+    public const int AcceptSetExpectationMismatch = 51;
+    public const int AcceptCancelExpectationMismatch = 52;
+    public const int AcceptObserveExpectationMismatch = 53;
 }

--- a/src/Servers/HttpSys/src/MessagePump.cs
+++ b/src/Servers/HttpSys/src/MessagePump.cs
@@ -162,7 +162,7 @@ internal sealed partial class MessagePump : IServer, IServerDelegationFeature
         Debug.Assert(RequestContextFactory != null);
 
         // Allocate and accept context per loop and reuse it for all accepts
-        var acceptContext = new AsyncAcceptContext(Listener, RequestContextFactory);
+        var acceptContext = new AsyncAcceptContext(Listener, RequestContextFactory, _logger);
 
         var loop = new AcceptLoop(acceptContext, this);
 

--- a/src/Servers/HttpSys/test/FunctionalTests/Listener/Utilities.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Listener/Utilities.cs
@@ -107,7 +107,7 @@ internal static class Utilities
     internal static async Task<RequestContext> AcceptAsync(this HttpSysListener server, TimeSpan timeout)
     {
         var factory = new TestRequestContextFactory(server);
-        using var acceptContext = new AsyncAcceptContext(server, factory);
+        using var acceptContext = new AsyncAcceptContext(server, factory, server.Logger);
 
         async Task<RequestContext> AcceptAsync()
         {


### PR DESCRIPTION
Context: #54251 

> System.InvalidOperationException: NativeOverlapped cannot be reused for multiple operations after .NET 6 to .NET 8 upgrade

This manifests as a fatal exception in the http.sys "accept" loop, which can either:

1. fault in purely managed code, stopping the message pump (`MessagePump.ExecuteAsync`)
2. fault during an IOCP callback, potentially killing the process

The underlying cause *appears* (hypothesis only) to be a duplicate callback, perhaps similar/related to the "large certificate" scenario (and mitigations) that impacted win8, and in particular [this check](https://github.com/dotnet/aspnetcore/blob/32b772a470e3c7dc147d3d124c32199bb3e7b6bc/src/Servers/HttpSys/src/AsyncAcceptContext.cs#L150-L153) somehow running both a sync and IOCP version of `IOCompleted` - this would break our expectations of a single caller into `IOCompleted`.

`IOCompleted` is intended to set the outcome of a value-task source; some unguarded `SetResult`/`SetException` (especially the final catch-all handler) mean that faults can indeed propagate, but this should not IMO be considered the main issue; rather, this is a symptom (albeit a fatal symptom) of being in an unexpected state, i.e. that we *attempted* to set the result while it wasn't actively pending.

To investigate and mitigate, this PR:

1. strengthens the `SetResult` / `SetException` aspects of `IOCompleted`, so that any fault becomes transient rather than fatal
2. adds logging of any such failure
3. adds tracking of what completions we're *expecting* at any point
4. logs any deviations from those expectations

This should a: help resolve the critical failures, and b: improve our understanding via logging if it *does* recur.

The use of `PreAllocatedOverlapped` on a reused `AsyncAcceptContext` means that we do not have the ability to change the IOCP callback state per call, which makes it impossible to do a reliable assert, but if we can prove the hypothesis, one additional mitigation option might be to *remove* the use of `PreAllocatedOverlapped`, using `public System.Threading.NativeOverlapped* AllocateNativeOverlapped (System.Threading.IOCompletionCallback callback, object? state, object? pinData)` per-accept rather than `public System.Threading.NativeOverlapped* AllocateNativeOverlapped (System.Threading.PreAllocatedOverlapped preAllocated)`, with a different `state` per usage; this will have *some* additional overhead, but would allow stronger correctness guarantees. This would be an area to investigate if a: the logging shows that this is indeed what is happening, and b: we are unable to mitigate in other ways (similar to `HttpSysListener.SkipIOCPCallbackOnSuccess`).

Suggested additional testing here should include "large client certificates" (or just "large headers"?) to see if we can force the same failure mode, although this could be ambitious.

Historic context: [prior to net6](https://github.com/dotnet/aspnetcore/commit/5d4dac2f9fbbbf110af57bd0594d62aba3650d3c), there was a separate `AsyncAcceptContext` and `TaskCompletionSource<>` per accept; the use of TCS (with `TrySet...`) means any double-set would have not been observed, and the separate `AsyncAcceptContext` means that each IOCP callback **could not** ever get confused and try triggering the wrong state.
