### PR TITLE
Unquarantine ComponentLifecycleMethodThrowsExceptionTerminatesTheCircuit and ComponentLifecycleMethodThrowsExceptionTerminatesTheCircuit

### DIFF
--- a/src/Components/test/E2ETest/Tests/CircuitTests.cs
+++ b/src/Components/test/E2ETest/Tests/CircuitTests.cs
@@ -35,7 +35,6 @@ public class CircuitTests : ServerTestBase<BasicTestAppServerSiteFixture<ServerS
     [InlineData("render-throw")]
     [InlineData("afterrender-sync-throw")]
     [InlineData("afterrender-async-throw")]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/46836")]
     public void ComponentLifecycleMethodThrowsExceptionTerminatesTheCircuit(string id)
     {
         Browser.MountTestComponent<ReliabilityComponent>();
@@ -54,7 +53,6 @@ public class CircuitTests : ServerTestBase<BasicTestAppServerSiteFixture<ServerS
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/46836")]
     public void ComponentDisposeMethodThrowsExceptionTerminatesTheCircuit()
     {
         Browser.MountTestComponent<ReliabilityComponent>();


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/46836

Both of these tests have a 100% pass rate as far back as the history goes (30 days). It's completely plausible that the issue that made them break was a point-in-time issue with the runners over a year ago.