### PR TITLE
Unquarantine `ClosingTheBrowserWindow_GracefullyDisconnects_TheCurrentCircuit`

### DIFF
--- a/src/Components/test/E2ETest/ServerExecutionTests/CircuitGracefulTerminationTests.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/CircuitGracefulTerminationTests.cs
@@ -62,7 +62,6 @@ public class CircuitGracefulTerminationTests : ServerTestBase<BasicTestAppServer
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/44185")]
     public async Task ClosingTheBrowserWindow_GracefullyDisconnects_TheCurrentCircuit()
     {
         // Arrange & Act

--- a/src/Components/test/E2ETest/ServerExecutionTests/CircuitGracefulTerminationTests.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/CircuitGracefulTerminationTests.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.E2ETesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Testing;
-using Microsoft.AspNetCore.InternalTesting;
 using OpenQA.Selenium;
 using TestServer;
 using Xunit.Abstractions;


### PR DESCRIPTION
## Unquarantine `ClosingTheBrowserWindow_GracefullyDisconnects_TheCurrentCircuit`

This test hasn't failed in at least 30 days, so I believe it should be safe to unquarantine it.

There's nothing wrong with the test in particular - the flakiness came from the fact that Blazor relies on the `unload` event, which is [deprecated and known to have reliability problems](https://developer.mozilla.org/docs/Web/API/Window/unload_event#usage_notes).

If we decide that it's not worth unquarantining this test given the possibility of potential future flakiness, then we should backlog the issue tracking fixing this test (#44185) because the real fix would be addressing #39409, which has been closed.

Fixes #44185