### PR TITLE
Fix `MouseOverAndMouseOut_CanTrigger`

### DIFF
--- a/src/Components/test/E2ETest/Tests/EventTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventTest.cs
@@ -73,7 +73,7 @@ public class EventTest : ServerTestBase<ToggleExecutionModeServerFixture<Program
         var output = Browser.Exists(By.Id("output"));
         Assert.Equal(string.Empty, output.Text);
 
-        var other = Browser.Exists(By.Id("other"));
+        var other = Browser.Exists(By.Id("mouseover_label"));
 
         // Mouse over the button and then back off
         var actions = new Actions(Browser)
@@ -154,8 +154,6 @@ public class EventTest : ServerTestBase<ToggleExecutionModeServerFixture<Program
 
         var output = Browser.Exists(By.Id("output"));
         Assert.Equal(string.Empty, output.Text);
-
-        var other = Browser.Exists(By.Id("other"));
 
         // Mousedown
         var actions = new Actions(Browser).ClickAndHold(input);

--- a/src/Components/test/testassets/BasicTestApp/MouseEventComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/MouseEventComponent.razor
@@ -7,7 +7,8 @@
         Output: <span id="output">@message</span>
     </p>
     <p>
-        Mouseover: <input id="mouseover_input" type="text" @onmouseover="OnMouseEvent" @onmouseout="OnMouseEvent" />
+        @* We use the label here as a target for the "mouseout" event *@
+        <span id="mouseover_label">Mouseover:</span> <input id="mouseover_input" type="text" @onmouseover="OnMouseEvent" @onmouseout="OnMouseEvent" />
     </p>
     <p>
         Mouseenter: <input id="mouseenter_input" type="text" @onmouseenter="OnMouseEvent" @onmouseleave="OnMouseEvent" />


### PR DESCRIPTION
# Fix `MouseOverAndMouseOut_CanTrigger`

I wasn't able to reproduce the issue locally, but I think I have a pretty good guess where the flakiness came from.

The test utilizes the `OpenQA.Selenium.Interactions.Actions` API to simulate moving the mouse in and out of a text box to cause the `mouseover` and `mouseout` events to trigger. However, the "out" movement was performed by moving the mouse to an element _all the way at the bottom of the page_, which means pathing directly over another text input that listens to the `pointerenter` and `pointerleave` events:
```text
OpenQA.Selenium.BrowserAssertFailedException : Xunit.Sdk.EqualException: Assert.Equal() Failure
Expected: mouseover,mouseout,
Actual:   mouseover,pointerenter,mouseout,pointerleave,
```

The fix works by instead moving the cursor to a `<span>` element right next to the original text input to minimize the chance that the mouse hovers over unrelated elements.

Marks #53724 as `test-fixed`