### PR TITLE
fix: remove double logging of BadHttpRequest errors

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -695,7 +695,6 @@ internal abstract partial class HttpProtocol : IHttpResponseControl
                 // This has to be caught here so StatusCode is set properly before disposing the HttpContext
                 // (DisposeContext logs StatusCode).
                 SetBadRequestState(ex);
-                ReportApplicationError(ex);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
# remove double logging of BadHttpRequest errors

## Description

`SetBadRequestState` already logs the error at debug level (where it belongs).
There is no reason to also log it as an application error (at error level), when it isn't an application error, but an IO error.

Fixes #23949
