### PR TITLE
Remove CheckStdoutWithLargeWrites_TestSink test from retry list

### DIFF
--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -10,7 +10,6 @@
     {"testName": {"contains": "CertificateChangedOnDisk_Symlink"}}, // depends on FS event timing
     {"testName": {"contains": "BlazorWebTemplate_IndividualAuth_LocalDb"}}, // randomly-generated string could contain forbidden substring
     {"testName": {"contains": "POST_ServerAbort_ClientReceivesAbort"}},
-    {"testName": {"contains": "CheckStdoutWithLargeWrites_TestSink" }},
     {"testAssembly": {"contains": "IIS"}},
     {"testAssembly": {"contains": "Template"}},
     {"failureMessage": {"contains":"(Site is started but no worker process found)"}},


### PR DESCRIPTION
Remove `CheckStdoutWithLargeWrites_TestSink` test from retry list since it's already included in `*IIS*` filter.

c.f. https://github.com/dotnet/aspnetcore/issues/52734