### PR TITLE
[release/6.0] Create ci-public.yml

### DIFF
--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -1,0 +1,869 @@
+#
+# See https://docs.microsoft.com/en-us/vsts/pipelines/yaml-schema for details on this file.
+#
+
+# Configure which branches trigger builds
+trigger:
+  batch: true
+  branches:
+    include:
+    - main
+    - release/*
+    - internal/release/*
+
+# Run PR validation on all branches
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - '*'
+
+schedules:
+- cron: 0 9 * * 1
+  displayName: "Run CodeQL3000 weekly, Monday at 2:00 AM PDT"
+  branches:
+    include:
+    - release/2.1
+    - release/6.0
+    - release/7.0
+    - main
+  always: true
+
+parameters:
+# Parameter below is ignored in public builds.
+#
+# Choose whether to run the CodeQL3000 tasks.
+# Manual builds align w/ official builds unless this parameter is true.
+- name: runCodeQL3000
+  default: false
+  displayName: Run CodeQL3000 tasks
+  type: boolean
+
+variables:
+- name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
+  value: true
+- name: _TeamName
+  value:  AspNetCore
+- name: _DotNetPublishToBlobFeed
+  value: true
+- name: _PublishUsingPipelines
+  value: true
+- name: _DotNetArtifactsCategory
+  value: .NETCORE
+- name: _DotNetValidationArtifactsCategory
+  value: .NETCORE
+- name: PostBuildSign
+  value: true
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - name: _BuildArgs
+    value: /p:TeamName=$(_TeamName)
+           /p:OfficialBuildId=$(Build.BuildNumber)
+           /p:SkipTestBuild=true
+           /p:PostBuildSign=$(PostBuildSign)
+  # DotNet-Blob-Feed provides: dotnetfeed-storage-access-key-1
+  # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
+  - group: DotNet-Blob-Feed
+  - group: Publish-Build-Assets
+  # The following extra properties are not set when testing. Use with final build.[cmd,sh] of asset-producing jobs.
+  - name: _PublishArgs
+    value: /p:Publish=true
+           /p:GenerateChecksums=true
+           /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
+           /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+           /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
+           /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
+           /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
+  # Do not log most Windows steps in official builds; this is the slowest job. Site extensions step always logs.
+  - name: WindowsArm64LogArgs
+    value: -ExcludeCIBinaryLog
+  - name: Windows64LogArgs
+    value: -ExcludeCIBinaryLog
+  - name: Windows86LogArgs
+    value: -ExcludeCIBinaryLog
+  - name: WindowsSignLogArgs
+    value: -ExcludeCIBinaryLog
+  - name: WindowsInstallersLogArgs
+    value: -ExcludeCIBinaryLog
+  - name: WindowsArm64InstallersLogArgs
+    value: -ExcludeCIBinaryLog
+- ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+  - name: _BuildArgs
+    value: '/p:SkipTestBuild=true /p:PostBuildSign=$(PostBuildSign)'
+  - name: _PublishArgs
+    value: ''
+  # Write binary logs for all main Windows build steps except the x86 one in public and PR builds.
+  - name: WindowsArm64LogArgs
+    value: /bl:artifacts/log/Release/Build.arm64.binlog
+  - name: Windows64LogArgs
+    value: /bl:artifacts/log/Release/Build.x64.binlog
+  - name: Windows86LogArgs
+    value: -ExcludeCIBinaryLog
+  - name: WindowsSignLogArgs
+    value: /bl:artifacts/log/Release/Build.CodeSign.binlog
+  - name: WindowsInstallersLogArgs
+    value: /bl:artifacts/log/Release/Build.Installers.binlog
+  - name: WindowsArm64InstallersLogArgs
+    value: /bl:artifacts/log/Release/Build.Installers.Arm64.binlog
+- ${{ if ne(variables['System.TeamProject'], 'internal') }}:
+  - name: _UseHelixOpenQueues
+    value: 'true'
+  - name: _SignType
+    value: ''
+  - name: _InternalRuntimeDownloadArgs
+    value: ''
+  - name: _InternalRuntimeDownloadCodeSignArgs
+    value: ''
+- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+  - group: DotNetBuilds storage account read tokens
+  - name: _InternalRuntimeDownloadArgs
+    value: -RuntimeSourceFeed https://dotnetbuilds.blob.core.windows.net/internal
+           -RuntimeSourceFeedKey $(dotnetbuilds-internal-container-read-token-base64)
+           /p:DotNetAssetRootAccessTokenSuffix='$(dotnetbuilds-internal-container-read-token-base64)'
+  # The code signing doesn't use the aspnet build scripts, so the msbuild parameters have to be passed directly. This
+  # is awkward but necessary because the eng/common/ build scripts don't add the msbuild properties automatically.
+  - name: _InternalRuntimeDownloadCodeSignArgs
+    value: $(_InternalRuntimeDownloadArgs)
+           /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal
+           /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
+  - group: DotNet-HelixApi-Access
+  - name: _UseHelixOpenQueues
+    value: 'false'
+  - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+    - name: _SignType
+      value: real
+  - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
+    - name: _SignType
+      value: test
+- name: runCodeQL3000
+  value: ${{ or(eq(variables['Build.Reason'], 'Schedule'), and(eq(variables['Build.Reason'], 'Manual'), eq(parameters.runCodeQL3000, 'true'))) }}
+
+stages:
+- stage: build
+  displayName: Build
+  jobs:
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), eq(variables.runCodeQL3000, 'true')) }}:
+    - template: jobs/default-build.yml
+      parameters:
+        jobName: build
+        jobDisplayName: Build and run CodeQL3000
+        agentOs: Windows
+        codeSign: false
+        # Component governance and SBOM creation are not needed here. Disable what Arcade would inject.
+        disableComponentGovernance: true
+        enableSbom: false
+        variables:
+        # Security analysis is included in normal runs. Disable its auto-injection.
+        - skipNugetSecurityAnalysis: true
+        # Do not let CodeQL3000 Extension gate scan frequency.
+        - Codeql.Cadence: 0
+        # Enable CodeQL3000 unconditionally so it may be run on any branch.
+        - Codeql.Enabled: true
+        # Ignore the small amount of infrastructure Python code in this repo.
+        - Codeql.Language: cpp,csharp,java,javascript
+        - Codeql.ExcludePathPatterns: submodules
+        # Ignore test and infrastructure code.
+        - Codeql.SourceRoot: src
+        # CodeQL3000 needs this plumbed along as a variable to enable TSA.
+        - Codeql.TSAEnabled: ${{ eq(variables['Build.Reason'], 'Schedule') }}
+        # Default expects tsaoptions.json under SourceRoot.
+        - Codeql.TSAOptionsPath: '$(Build.SourcesDirectory)/.config/tsaoptions.json'
+        beforeBuild:
+        - task: CodeQL3000Init@0
+          displayName: CodeQL Initialize
+        - script: "echo ##vso[build.addbuildtag]CodeQL3000"
+          displayName: 'Set CI CodeQL3000 tag'
+          condition: ne(variables.CODEQL_DIST,'')
+        steps:
+        - script: ./eng/build.cmd
+                  -ci
+                  -arch x64
+                  -all
+                  $(_BuildArgs)
+                  $(_InternalRuntimeDownloadArgs)
+                  /p:UseSharedCompilation=false
+          displayName: Build x64
+        afterBuild:
+        - task: CodeQL3000Finalize@0
+          displayName: CodeQL Finalize
+        artifacts:
+        - name: Build_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+
+  - ${{ else }}: # regular build
+    # Code check
+    - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), in(variables['Build.Reason'], 'Manual')) }}:
+      - template: jobs/default-build.yml
+        parameters:
+          jobName: Code_check
+          jobDisplayName: Code check
+          agentOs: Windows
+          steps:
+          - powershell: ./eng/scripts/CodeCheck.ps1 -ci $(_InternalRuntimeDownloadArgs)
+            displayName: Run eng/scripts/CodeCheck.ps1
+          artifacts:
+          - name: Code_Check_Logs
+            path: artifacts/log/
+            publishOnError: true
+            includeForks: true
+
+    # Build Windows (x64/x86)
+    - template: jobs/default-build.yml
+      parameters:
+        codeSign: true
+        jobName: Windows_build
+        jobDisplayName: "Build: Windows x64/x86"
+        agentOs: Windows
+        steps:
+        - script: "echo ##vso[build.addbuildtag]daily-build"
+          condition: and(notin(variables['Build.Reason'], 'PullRequest'), notin(variables['DotNetFinalVersionKind'], 'release', 'prerelease'))
+          displayName: 'Set CI tags'
+        - script: "echo ##vso[build.addbuildtag]release-candidate"
+          condition: and(notin(variables['Build.Reason'], 'PullRequest'), in(variables['DotNetFinalVersionKind'], 'release', 'prerelease'))
+          displayName: 'Set CI tags'
+
+        # !!! NOTE !!! Some of these steps have disabled code signing.
+        # This is intentional to workaround https://github.com/dotnet/arcade/issues/1957 which always re-submits for code-signing, even
+        # if they have already been signed. This results in slower builds due to re-submitting the same .nupkg many times for signing.
+        # The sign settings have been configured to
+        - script: ./eng/build.cmd
+                  -ci
+                  -arch x64
+                  -pack
+                  -all
+                  $(_BuildArgs)
+                  $(_InternalRuntimeDownloadArgs)
+                  $(Windows64LogArgs)
+          displayName: Build x64
+
+        # Build the x86 shared framework
+        # This is going to actually build x86 native assets.
+        - script: ./eng/build.cmd
+                  -ci
+                  -noBuildRepoTasks
+                  -arch x86
+                  -pack
+                  -all
+                  -noBuildJava
+                  -noBuildNative
+                  /p:OnlyPackPlatformSpecificPackages=true
+                  $(_BuildArgs)
+                  $(_InternalRuntimeDownloadArgs)
+                  $(Windows86LogArgs)
+          displayName: Build x86
+
+        - script: .\src\SiteExtensions\build.cmd
+                  -ci
+                  -noBuildRepoTasks
+                  -pack
+                  -noBuildDeps
+                  -noBuildNative
+                  $(_BuildArgs)
+                  $(_InternalRuntimeDownloadArgs)
+          condition: ne(variables['Build.Reason'], 'PullRequest')
+          displayName: Build SiteExtension
+
+        # This runs code-signing on all packages, zips, and jar files as defined in build/CodeSign.targets. If
+        # https://github.com/dotnet/arcade/issues/1957 is resolved, consider running code-signing inline with the other
+        # previous steps. Sign check is disabled because it is run in a separate step below, after installers are built.
+        - script: ./eng/build.cmd
+                  -ci
+                  -noBuildRepoTasks
+                  -noBuildNative
+                  -noBuild
+                  -noRestore
+                  -sign
+                  /p:DotNetSignType=$(_SignType)
+                  $(_BuildArgs)
+                  $(WindowsSignLogArgs)
+          displayName: Code sign packages
+
+        # Windows installers bundle both x86 and x64 assets
+        - script: ./eng/build.cmd
+                  -ci
+                  -noBuildRepoTasks
+                  -sign
+                  -buildInstallers
+                  -noBuildNative
+                  /p:DotNetSignType=$(_SignType)
+                  /p:AssetManifestFileName=aspnetcore-win-x64-x86.xml
+                  $(_BuildArgs)
+                  $(_PublishArgs)
+                  $(_InternalRuntimeDownloadArgs)
+                  /p:PublishInstallerBaseVersion=true
+                  $(WindowsInstallersLogArgs)
+          displayName: Build Installers
+
+        # A few files must also go to the VS package feed.
+        - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['PostBuildSign'], 'true')) }}:
+          - task: NuGetCommand@2
+            displayName: Push Visual Studio packages
+            inputs:
+              command: push
+              packagesToPush: 'artifacts/packages/**/VS.Redist.Common.AspNetCore.*.nupkg'
+              nuGetFeedType: external
+              publishFeedCredentials: 'DevDiv - VS package feed'
+
+        artifacts:
+        - name: Windows_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Windows_Packages
+          path: artifacts/packages/
+
+    # Build Windows ARM
+    - template: jobs/default-build.yml
+      parameters:
+        codeSign: true
+        jobName: Windows_arm_build
+        jobDisplayName: "Build: Windows ARM"
+        agentOs: Windows
+        buildArgs:
+          -arch arm
+          -sign
+          -pack
+          -noBuildNodeJS
+          -noBuildJava
+          /p:DotNetSignType=$(_SignType)
+          /p:OnlyPackPlatformSpecificPackages=true
+          /p:AssetManifestFileName=aspnetcore-win-arm.xml
+          $(_BuildArgs)
+          $(_PublishArgs)
+          $(_InternalRuntimeDownloadArgs)
+        installNodeJs: false
+        installJdk: false
+        artifacts:
+        - name: Windows_arm_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Windows_arm_Packages
+          path: artifacts/packages/
+
+    # Build Windows ARM64
+    - template: jobs/default-build.yml
+      parameters:
+        codeSign: true
+        jobName: Windows_arm64_build
+        jobDisplayName: "Build: Windows ARM64"
+        agentOs: Windows
+        installNodeJs: false
+        installJdk: false
+        artifacts:
+        - name: Windows_arm64_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Windows_arm64_Packages
+          path: artifacts/packages/
+        - name: Windows_arm64_Installers
+          path: artifacts/installers/
+        steps:
+        - script: ./eng/build.cmd
+                -ci
+                -arch arm64
+                -sign
+                -pack
+                -noBuildJava
+                -noBuildNative
+                -noBuildNodeJS
+                /p:DotNetSignType=$(_SignType)
+                /p:OnlyPackPlatformSpecificPackages=true
+                $(_BuildArgs)
+                $(_InternalRuntimeDownloadArgs)
+                $(WindowsArm64LogArgs)
+          displayName: Build ARM64
+
+        # Windows installers bundle for arm64
+        - script: ./eng/build.cmd
+                -ci
+                -noBuildRepoTasks
+                -arch arm64
+                -sign
+                -buildInstallers
+                -noBuildNative
+                -noBuildNodeJS
+                /p:DotNetSignType=$(_SignType)
+                /p:AssetManifestFileName=aspnetcore-win-arm64.xml
+                $(_BuildArgs)
+                $(_PublishArgs)
+                $(_InternalRuntimeDownloadArgs)
+                $(WindowsArm64InstallersLogArgs)
+          displayName: Build Arm64 Installers
+
+        # A few files must also go to the VS package feed.
+        - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['PostBuildSign'], 'true')) }}:
+          - task: NuGetCommand@2
+            displayName: Push Visual Studio packages
+            inputs:
+              command: push
+              packagesToPush: 'artifacts/packages/**/VS.Redist.Common.AspNetCore.*.nupkg'
+              nuGetFeedType: external
+              publishFeedCredentials: 'DevDiv - VS package feed'
+
+
+    # Build MacOS arm64
+    - template: jobs/default-build.yml
+      parameters:
+        jobName: MacOs_arm64_build
+        jobDisplayName: "Build: macOS arm64"
+        agentOs: macOs
+        buildArgs:
+          --arch arm64
+          --pack
+          --all
+          --no-build-nodejs
+          --no-build-java
+          -p:OnlyPackPlatformSpecificPackages=true
+          -p:AssetManifestFileName=aspnetcore-MacOS_arm64.xml
+          $(_BuildArgs)
+          $(_PublishArgs)
+          $(_InternalRuntimeDownloadArgs)
+        installNodeJs: false
+        installJdk: false
+        artifacts:
+        - name: MacOS_arm64_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: MacOS_arm64_Packages
+          path: artifacts/packages/
+
+    - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+      - template: jobs/codesign-xplat.yml
+        parameters:
+          inputName: MacOS_arm64
+
+    # Build MacOS x64
+    - template: jobs/default-build.yml
+      parameters:
+        jobName: MacOs_x64_build
+        jobDisplayName: "Build: macOS x64"
+        agentOs: macOs
+        buildArgs:
+          --pack
+          --all
+          --no-build-nodejs
+          --no-build-java
+          -p:OnlyPackPlatformSpecificPackages=true
+          -p:AssetManifestFileName=aspnetcore-MacOS_x64.xml
+          $(_BuildArgs)
+          $(_PublishArgs)
+          $(_InternalRuntimeDownloadArgs)
+        installNodeJs: false
+        installJdk: false
+        artifacts:
+        - name: MacOS_x64_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: MacOS_x64_Packages
+          path: artifacts/packages/
+
+    - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+      - template: jobs/codesign-xplat.yml
+        parameters:
+          inputName: MacOS_x64
+
+    # Build Linux x64
+    - template: jobs/default-build.yml
+      parameters:
+        jobName: Linux_x64_build
+        jobDisplayName: "Build: Linux x64"
+        agentOs: Linux
+        useHostedUbuntu: false
+        steps:
+        - script: ./eng/build.sh
+              --ci
+              --arch x64
+              --pack
+              --all
+              --no-build-nodejs
+              --no-build-java
+              -p:OnlyPackPlatformSpecificPackages=true
+              $(_BuildArgs)
+              $(_InternalRuntimeDownloadArgs)
+          displayName: Run build.sh
+        - script: |
+            git clean -xfd src/**/obj/
+            ./dockerbuild.sh bionic \
+              --ci \
+              --nobl \
+              --arch x64 \
+              --build-installers \
+              --no-build-deps \
+              --no-build-nodejs \
+              -p:OnlyPackPlatformSpecificPackages=true \
+              -p:BuildRuntimeArchive=false \
+              -p:LinuxInstallerType=deb \
+              $(_BuildArgs) \
+              $(_InternalRuntimeDownloadArgs)
+          displayName: Build Debian installers
+        - script: |
+            git clean -xfd src/**/obj/
+            ./dockerbuild.sh rhel \
+              --ci \
+              --nobl \
+              --arch x64 \
+              --build-installers \
+              --no-build-deps \
+              --no-build-nodejs \
+              -p:OnlyPackPlatformSpecificPackages=true \
+              -p:BuildRuntimeArchive=false \
+              -p:LinuxInstallerType=rpm \
+              -p:AssetManifestFileName=aspnetcore-Linux_x64.xml \
+              $(_BuildArgs) \
+              $(_PublishArgs) \
+              $(_InternalRuntimeDownloadArgs)
+          displayName: Build RPM installers
+        installNodeJs: false
+        installJdk: false
+        artifacts:
+        - name: Linux_x64_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Linux_x64_Packages
+          path: artifacts/packages/
+
+    - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+      - template: jobs/codesign-xplat.yml
+        parameters:
+          inputName: Linux_x64
+
+    # Build Linux ARM
+    - template: jobs/default-build.yml
+      parameters:
+        jobName: Linux_arm_build
+        jobDisplayName: "Build: Linux ARM"
+        agentOs: Linux
+        buildArgs:
+          --arch arm
+          --pack
+          --all
+          --no-build-nodejs
+          --no-build-java
+          -p:OnlyPackPlatformSpecificPackages=true
+          -p:AssetManifestFileName=aspnetcore-Linux_arm.xml
+          $(_BuildArgs)
+          $(_PublishArgs)
+          $(_InternalRuntimeDownloadArgs)
+        installNodeJs: false
+        installJdk: false
+        artifacts:
+        - name: Linux_arm_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Linux_arm_Packages
+          path: artifacts/packages/
+
+    - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+      - template: jobs/codesign-xplat.yml
+        parameters:
+          inputName: Linux_arm
+
+    # Build Linux ARM64
+    - template: jobs/default-build.yml
+      parameters:
+        jobName: Linux_arm64_build
+        jobDisplayName: "Build: Linux ARM64"
+        agentOs: Linux
+        steps:
+        - script: ./eng/build.sh
+              --ci
+              --arch arm64
+              --pack
+              --all
+              --no-build-nodejs
+              --no-build-java
+              -p:OnlyPackPlatformSpecificPackages=true
+              $(_BuildArgs)
+              $(_InternalRuntimeDownloadArgs)
+          displayName: Run build.sh
+        - script: git clean -xfd src/**/obj/;
+            ./dockerbuild.sh rhel --ci --nobl --arch arm64 --build-installers --no-build-deps --no-build-nodejs
+            -p:OnlyPackPlatformSpecificPackages=true -p:BuildRuntimeArchive=false -p:LinuxInstallerType=rpm
+            -p:AssetManifestFileName=aspnetcore-Linux_arm64.xml
+            $(_BuildArgs)
+            $(_PublishArgs)
+            $(_InternalRuntimeDownloadArgs)
+          displayName: Build RPM installers
+        installNodeJs: false
+        installJdk: false
+        artifacts:
+        - name: Linux_arm64_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Linux_arm64_Packages
+          path: artifacts/packages/
+
+    - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+      - template: jobs/codesign-xplat.yml
+        parameters:
+          inputName: Linux_arm64
+
+    # Build Linux Musl x64
+    - template: jobs/default-build.yml
+      parameters:
+        jobName: Linux_musl_x64_build
+        jobDisplayName: "Build: Linux Musl x64"
+        agentOs: Linux
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14-WithNode
+        buildArgs:
+          --arch x64
+          --os-name linux-musl
+          --pack
+          --all
+          --no-build-nodejs
+          --no-build-java
+          -p:OnlyPackPlatformSpecificPackages=true
+          -p:AssetManifestFileName=aspnetcore-Linux_musl_x64.xml
+          $(_BuildArgs)
+          $(_PublishArgs)
+          $(_InternalRuntimeDownloadArgs)
+        installNodeJs: false
+        installJdk: false
+        disableComponentGovernance: true
+        artifacts:
+        - name: Linux_musl_x64_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Linux_musl_x64_Packages
+          path: artifacts/packages/
+
+    - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+      - template: jobs/codesign-xplat.yml
+        parameters:
+          inputName: Linux_musl_x64
+
+    # Build Linux Musl ARM
+    - template: jobs/default-build.yml
+      parameters:
+        jobName: Linux_musl_arm_build
+        jobDisplayName: "Build: Linux Musl ARM"
+        agentOs: Linux
+        useHostedUbuntu: false
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm-alpine
+        buildArgs:
+          --arch arm
+          --os-name linux-musl
+          --pack
+          --all
+          --no-build-nodejs
+          --no-build-java
+          -p:OnlyPackPlatformSpecificPackages=true
+          -p:AssetManifestFileName=aspnetcore-Linux_musl_arm.xml
+          $(_BuildArgs)
+          $(_PublishArgs)
+          $(_InternalRuntimeDownloadArgs)
+        installNodeJs: false
+        installJdk: false
+        artifacts:
+        - name: Linux_musl_arm_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Linux_musl_arm_Packages
+          path: artifacts/packages/
+
+    - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+      - template: jobs/codesign-xplat.yml
+        parameters:
+          inputName: Linux_musl_arm
+
+    # Build Linux Musl ARM64
+    - template: jobs/default-build.yml
+      parameters:
+        jobName: Linux_musl_arm64_build
+        jobDisplayName: "Build: Linux Musl ARM64"
+        agentOs: Linux
+        useHostedUbuntu: false
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm64-alpine
+        buildArgs:
+          --arch arm64
+          --os-name linux-musl
+          --pack
+          --all
+          --no-build-nodejs
+          --no-build-java
+          -p:OnlyPackPlatformSpecificPackages=true
+          -p:AssetManifestFileName=aspnetcore-Linux_musl_arm64.xml
+          $(_BuildArgs)
+          $(_PublishArgs)
+          $(_InternalRuntimeDownloadArgs)
+        installNodeJs: false
+        installJdk: false
+        artifacts:
+        - name: Linux_musl_arm64_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Linux_musl_arm64_Packages
+          path: artifacts/packages/
+
+    - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+      - template: jobs/codesign-xplat.yml
+        parameters:
+          inputName: Linux_musl_arm64
+
+    - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), in(variables['Build.Reason'], 'Manual')) }}:
+      # Test jobs
+      - template: jobs/default-build.yml
+        parameters:
+          condition: ne(variables['SkipTests'], 'true')
+          jobName: Windows_Test
+          jobDisplayName: "Test: Windows Server x64"
+          agentOs: Windows
+          isTestingJob: true
+          # Just uploading artifacts/logs/ files can take 15 minutes. Doubling the cancel timeout for this job.
+          cancelTimeoutInMinutes: 30
+          buildArgs: -all -pack -test /p:SkipHelixReadyTests=true /p:SkipIISNewHandlerTests=true /p:SkipIISTests=true
+                     /p:SkipIISExpressTests=true /p:SkipIISNewShimTests=true /p:RunTemplateTests=false
+                     /p:SkipComponentsE2ETests=true
+                     $(_InternalRuntimeDownloadArgs)
+          beforeBuild:
+          - powershell: "& ./src/Servers/IIS/tools/UpdateIISExpressCertificate.ps1; & ./src/Servers/IIS/tools/update_schema.ps1"
+            displayName: Setup IISExpress test certificates and schema
+          artifacts:
+          - name: Windows_Test_Logs
+            path: artifacts/log/
+            publishOnError: true
+            includeForks: true
+          - name: Windows_Test_Results
+            path: artifacts/TestResults/
+            publishOnError: true
+            includeForks: true
+
+      - template: jobs/default-build.yml
+        parameters:
+          condition: ne(variables['SkipTests'], 'true')
+          jobName: MacOS_Test
+          jobDisplayName: "Test: macOS"
+          agentOs: macOS
+          timeoutInMinutes: 240
+          isTestingJob: true
+          buildArgs: --all --test "/p:RunTemplateTests=false /p:SkipComponentsE2ETests=true /p:SkipHelixReadyTests=true" $(_InternalRuntimeDownloadArgs)
+          beforeBuild:
+          - bash: "./eng/scripts/install-nginx-mac.sh"
+            displayName: Installing Nginx
+          artifacts:
+          - name: MacOS_Test_Logs
+            path: artifacts/log/
+            publishOnError: true
+            includeForks: true
+          - name: MacOS_Test_Results
+            path: artifacts/TestResults/
+            publishOnError: true
+            includeForks: true
+
+      - template: jobs/default-build.yml
+        parameters:
+          condition: ne(variables['SkipTests'], 'true')
+          jobName: Linux_Test
+          jobDisplayName: "Test: Ubuntu x64"
+          agentOs: Linux
+          isTestingJob: true
+          useHostedUbuntu: false
+          buildArgs: --all --test "/p:RunTemplateTests=false /p:SkipComponentsE2ETests=true /p:SkipHelixReadyTests=true" $(_InternalRuntimeDownloadArgs)
+          beforeBuild:
+          - bash: "./eng/scripts/install-nginx-linux.sh"
+            displayName: Installing Nginx
+          - bash: "echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p"
+            displayName: Increase inotify limit
+          artifacts:
+          - name: Linux_Test_Logs
+            path: artifacts/log/
+            publishOnError: true
+            includeForks: true
+          - name: Linux_Test_Results
+            path: artifacts/TestResults/
+            publishOnError: true
+            includeForks: true
+
+      # Helix x64
+      - template: jobs/default-build.yml
+        parameters:
+          jobName: Helix_x64
+          jobDisplayName: 'Tests: Helix x64'
+          agentOs: Windows
+          timeoutInMinutes: 240
+          steps:
+          # Build the shared framework
+          - script: ./eng/build.cmd -ci -nobl -all -pack -arch x64
+                    /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
+            displayName: Build shared fx
+          - script: ./eng/build.cmd -ci -nobl -noBuildRepoTasks -restore -noBuild -noBuildNative -projects src/Grpc/**/*.csproj
+                    /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
+            displayName: Restore interop projects
+          - script: ./eng/build.cmd -ci -nobl -noBuildRepoTasks -noRestore -test -all -noBuildNative -projects eng\helix\helix.proj
+                    /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildInteropProjects=true /p:RunTemplateTests=true /p:SkipComponentsE2ETests=true
+                    /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
+            displayName: Run build.cmd helix target
+            env:
+              HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
+
+          artifacts:
+          - name: Helix_logs
+            path: artifacts/log/
+            publishOnError: true
+            includeForks: true
+
+    # Source build
+    - template: /eng/common/templates/job/source-build.yml
+      parameters:
+        platform:
+          name: 'Managed'
+          container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7'
+          buildScript: './eng/build.sh $(_PublishArgs) --no-build-repo-tasks $(_InternalRuntimeDownloadArgs)'
+          skipPublishValidation: true
+          jobProperties:
+            timeoutInMinutes: 120
+
+    # Publish to the BAR
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - template: /eng/common/templates/job/publish-build-assets.yml
+        parameters:
+          dependsOn:
+            - Windows_build
+            - Windows_arm_build
+            - Windows_arm64_build
+            - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+              - CodeSign_Xplat_MacOS_arm64
+              - CodeSign_Xplat_MacOS_x64
+              - CodeSign_Xplat_Linux_x64
+              - CodeSign_Xplat_Linux_arm
+              - CodeSign_Xplat_Linux_arm64
+              - CodeSign_Xplat_Linux_musl_x64
+              - CodeSign_Xplat_Linux_musl_arm
+              - CodeSign_Xplat_Linux_musl_arm64
+            - ${{ if eq(variables['PostBuildSign'], 'true') }}:
+              - MacOs_arm64_build
+              - MacOs_x64_build
+              - Linux_x64_build
+              - Linux_arm_build
+              - Linux_arm64_build
+              - Linux_musl_x64_build
+              - Linux_musl_arm_build
+              - Linux_musl_arm64_build
+            # In addition to the dependencies above, ensure the build was successful overall.
+            - Source_Build_Managed
+          pool:
+            name: NetCore1ESPool-Svc-Internal
+            demands: ImageOverride -equals 1es-windows-2019
+          publishUsingPipelines: ${{ variables._PublishUsingPipelines }}
+          enablePublishBuildArtifacts: true # publish artifacts/log files
+
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables.runCodeQL3000, 'true')) }}:
+  - template: /eng/common/templates/post-build/post-build.yml
+    parameters:
+      publishingInfraVersion: 3
+      enableSymbolValidation: false
+      enableSigningValidation: false
+      enableNugetValidation: false
+      publishInstallersAndChecksums: true


### PR DESCRIPTION
In preparation of the move to 1ES templates - we need to bifurcate our top-level .yml file into a public & an internal file. This needs to be done in all active branches at the same time, before we update https://dev.azure.com/dnceng-public/public/_build?definitionId=83 to point to the new `ci-public.yml`