### PR TITLE
Add IsComposing Property to KeyboardEventArgs Classes

### DIFF
--- a/src/Components/Web.JS/src/Rendering/Events/EventTypes.ts
+++ b/src/Components/Web.JS/src/Rendering/Events/EventTypes.ts
@@ -260,6 +260,7 @@ function parseKeyboardEvent(event: KeyboardEvent): KeyboardEventArgs {
     altKey: event.altKey,
     metaKey: event.metaKey,
     type: event.type,
+    isComposing: event.isComposing,
   };
 }
 

--- a/src/Components/Web.JS/src/Rendering/Events/EventTypes.ts
+++ b/src/Components/Web.JS/src/Rendering/Events/EventTypes.ts
@@ -412,6 +412,7 @@ interface KeyboardEventArgs {
   altKey: boolean;
   metaKey: boolean;
   type: string;
+  isComposing: boolean;
 }
 
 interface MouseEventArgs {

--- a/src/Components/Web/src/PublicAPI.Shipped.txt
+++ b/src/Components/Web/src/PublicAPI.Shipped.txt
@@ -365,6 +365,8 @@ Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.ShiftKey.get -> bool
 Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.ShiftKey.set -> void
 Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.Type.get -> string!
 Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.Type.set -> void
+Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.IsComposing.get -> bool
+Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.IsComposing.set -> void
 Microsoft.AspNetCore.Components.Web.MouseEventArgs
 Microsoft.AspNetCore.Components.Web.MouseEventArgs.AltKey.get -> bool
 Microsoft.AspNetCore.Components.Web.MouseEventArgs.AltKey.set -> void

--- a/src/Components/Web/src/PublicAPI.Shipped.txt
+++ b/src/Components/Web/src/PublicAPI.Shipped.txt
@@ -365,8 +365,6 @@ Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.ShiftKey.get -> bool
 Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.ShiftKey.set -> void
 Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.Type.get -> string!
 Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.Type.set -> void
-Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.IsComposing.get -> bool
-Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.IsComposing.set -> void
 Microsoft.AspNetCore.Components.Web.MouseEventArgs
 Microsoft.AspNetCore.Components.Web.MouseEventArgs.AltKey.get -> bool
 Microsoft.AspNetCore.Components.Web.MouseEventArgs.AltKey.set -> void

--- a/src/Components/Web/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Web/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.IsComposing.get -> bool
+Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.IsComposing.set -> void

--- a/src/Components/Web/src/Web/KeyboardEventArgs.cs
+++ b/src/Components/Web/src/Web/KeyboardEventArgs.cs
@@ -58,7 +58,7 @@ public class KeyboardEventArgs : EventArgs
     public string Type { get; set; } = default!;
 
     /// <summary>
-    /// true if the event is fired after a composition session, otherwise false.
+    /// true if the event is fired within a composition session, otherwise false.
     /// </summary>
     public bool IsComposing { get; set; }
 }

--- a/src/Components/Web/src/Web/KeyboardEventArgs.cs
+++ b/src/Components/Web/src/Web/KeyboardEventArgs.cs
@@ -56,4 +56,9 @@ public class KeyboardEventArgs : EventArgs
     /// Gets or sets the type of the event.
     /// </summary>
     public string Type { get; set; } = default!;
+
+    /// <summary>
+    /// true if the event is fired after a composition session, otherwise false.
+    /// </summary>
+    public bool IsComposing { get; set; }
 }

--- a/src/Components/Web/src/WebEventData/KeyboardEventArgsReader.cs
+++ b/src/Components/Web/src/WebEventData/KeyboardEventArgsReader.cs
@@ -18,6 +18,7 @@ internal static class KeyboardEventArgsReader
     private static readonly JsonEncodedText AltKey = JsonEncodedText.Encode("altKey");
     private static readonly JsonEncodedText MetaKey = JsonEncodedText.Encode("metaKey");
     private static readonly JsonEncodedText Type = JsonEncodedText.Encode("type");
+    private static readonly JsonEncodedText IsComposing = JsonEncodedText.Encode("isComposing");
 
     internal static KeyboardEventArgs Read(JsonElement jsonElement)
     {
@@ -59,6 +60,10 @@ internal static class KeyboardEventArgsReader
             else if (property.NameEquals(Type.EncodedUtf8Bytes))
             {
                 eventArgs.Type = property.Value.GetString()!;
+            }
+            else if (property.NameEquals(IsComposing.EncodedUtf8Bytes))
+            {
+                eventArgs.IsComposing = property.Value.GetBoolean();
             }
             else
             {

--- a/src/Components/Web/test/WebEventData/KeyboardEventArgsReaderTest.cs
+++ b/src/Components/Web/test/WebEventData/KeyboardEventArgsReaderTest.cs
@@ -22,7 +22,7 @@ public class KeyboardEventArgsReaderTest
             Repeat = true,
             ShiftKey = true,
             Type = "type1",
-            IsComposing = false,
+            IsComposing = true,
         };
 
         var jsonElement = GetJsonElement(args);

--- a/src/Components/Web/test/WebEventData/KeyboardEventArgsReaderTest.cs
+++ b/src/Components/Web/test/WebEventData/KeyboardEventArgsReaderTest.cs
@@ -22,6 +22,7 @@ public class KeyboardEventArgsReaderTest
             Repeat = true,
             ShiftKey = true,
             Type = "type1",
+            IsComposing = false,
         };
 
         var jsonElement = GetJsonElement(args);
@@ -39,6 +40,7 @@ public class KeyboardEventArgsReaderTest
         Assert.Equal(args.Repeat, result.Repeat);
         Assert.Equal(args.ShiftKey, result.ShiftKey);
         Assert.Equal(args.Type, result.Type);
+        Assert.Equal(args.IsComposing, result.IsComposing);
     }
 
     private static JsonElement GetJsonElement<T>(T args)


### PR DESCRIPTION
# Add IsComposing Property to KeyboardEventArgs Classes

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes: Add IsComposing Property to KeyboardEventArgs Classes

## Description

This pull request introduces the `IsComposing` property to the `KeyboardEventArgs` class and its related components within the ASP.NET Core framework. The changes include:

- **Implementation**: The `IsComposing` property has been added to track the composition state of keyboard events, which is crucial for handling international character input methods.
- **Updates**: Modifications have been made to the `EventTypes.ts`, `KeyboardEventArgs.cs`, and `KeyboardEventArgsReader.cs` files to support this new property.
- **Testing**: Unit tests have been updated to ensure the new property functions as expected and maintains the integrity of the event handling system.

These enhancements aim to improve the developer experience by providing more detailed keyboard event information, facilitating better internationalization support in web applications.

Fixes #54456
