### PR TITLE
Use the VMR commit hash in .version

### DIFF
--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -311,7 +311,8 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       Overwrite="true" />
 
     <ItemGroup>
-      <VersionLines Include="$(SourceRevisionId)" />
+      <VersionLines Include="$(DotNetGitCommitHash)" Condition="'$(DotNetGitCommitHash)' != ''" />
+      <VersionLines Include="$(SourceRevisionId)" Condition="'$(DotNetGitCommitHash)' == ''" />
       <VersionLines Include="$(SharedFxVersion)" />
     </ItemGroup>
 


### PR DESCRIPTION
This puts the VMR's commit hash, provided by the VMR as the property DotNetGitCommitHash, in the .version file.

Contributes to https://github.com/dotnet/source-build/issues/3643
