### PR TITLE
fixes minimal apis not returning traceid on problem details upon exceptions

### DIFF
--- a/src/Http/Http.Extensions/src/DefaultProblemDetailsWriter.cs
+++ b/src/Http/Http.Extensions/src/DefaultProblemDetailsWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http.Json;
 using Microsoft.Extensions.Options;
@@ -53,6 +54,10 @@ internal sealed partial class DefaultProblemDetailsWriter : IProblemDetailsWrite
     {
         var httpContext = context.HttpContext;
         ProblemDetailsDefaults.Apply(context.ProblemDetails, httpContext.Response.StatusCode);
+
+        var traceId = Activity.Current?.Id ?? httpContext.TraceIdentifier;
+        context.ProblemDetails.Extensions["traceId"] = traceId;
+
         _options.CustomizeProblemDetails?.Invoke(context);
 
         var problemDetailsType = context.ProblemDetails.GetType();

--- a/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
+++ b/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Http.Json;
 using System.Text.Json.Serialization;
 using Microsoft.CodeAnalysis;
 using JsonOptions = Microsoft.AspNetCore.Http.Json.JsonOptions;
+using System.Diagnostics;
 
 namespace Microsoft.AspNetCore.Http.Extensions.Tests;
 
@@ -26,6 +27,8 @@ public partial class DefaultProblemDetailsWriterTest
         var writer = GetWriter();
         var stream = new MemoryStream();
         var context = CreateContext(stream);
+
+        var expectedTraceId = Activity.Current?.Id ?? context.TraceIdentifier;
         var expectedProblem = new ProblemDetails()
         {
             Detail = "Custom Bad Request",
@@ -52,6 +55,7 @@ public partial class DefaultProblemDetailsWriterTest
         Assert.Equal(expectedProblem.Title, problemDetails.Title);
         Assert.Equal(expectedProblem.Detail, problemDetails.Detail);
         Assert.Equal(expectedProblem.Instance, problemDetails.Instance);
+        Assert.Equal(expectedTraceId, problemDetails.Extensions["traceId"].ToString());
     }
 
     [Fact]
@@ -61,6 +65,7 @@ public partial class DefaultProblemDetailsWriterTest
         var writer = GetWriter();
         var stream = new MemoryStream();
         var context = CreateContext(stream);
+        var expectedTraceId = Activity.Current?.Id ?? context.TraceIdentifier;
         var expectedProblem = new ProblemDetails()
         {
             Detail = "Custom Bad Request",
@@ -82,7 +87,7 @@ public partial class DefaultProblemDetailsWriterTest
         //Assert
         stream.Position = 0;
         var result = await JsonSerializer.DeserializeAsync<Dictionary<string, object>>(stream, JsonSerializerOptions.Default);
-        Assert.Equal(result.Keys, new(new() { { "type", 0 }, { "title", 1 }, { "status", 2 }, { "detail", 3 }, { "instance", 4 }, { "extensionKey", 5 } }));
+        Assert.Equal(result.Keys, new(new() { { "type", 0 }, { "title", 1 }, { "status", 2 }, { "detail", 3 }, { "instance", 4 }, { "extensionKey", 5 }, {"traceId", expectedTraceId } }));
     }
 
     [Fact]
@@ -92,6 +97,7 @@ public partial class DefaultProblemDetailsWriterTest
         var writer = GetWriter();
         var stream = new MemoryStream();
         var context = CreateContext(stream);
+        var expectedTraceId = Activity.Current?.Id ?? context.TraceIdentifier;
         var expectedProblem = new ValidationProblemDetails()
         {
             Detail = "Custom Bad Request",
@@ -113,7 +119,7 @@ public partial class DefaultProblemDetailsWriterTest
         //Assert
         stream.Position = 0;
         var result = await JsonSerializer.DeserializeAsync<Dictionary<string, object>>(stream, JsonSerializerOptions.Default);
-        Assert.Equal(result.Keys, new(new() { { "type", 0 }, { "title", 1 }, { "status", 2 }, { "detail", 3 }, { "instance", 4 }, { "errors", 5 } }));
+        Assert.Equal(result.Keys, new(new() { { "type", 0 }, { "title", 1 }, { "status", 2 }, { "detail", 3 }, { "instance", 4 }, { "errors", 5 }, {"traceId", expectedTraceId } }));
     }
 
     [Fact]
@@ -125,6 +131,7 @@ public partial class DefaultProblemDetailsWriterTest
         var context = CreateContext(stream);
         var originalProblemDetails = new ProblemDetails();
 
+        var expectedTraceId = Activity.Current?.Id ?? context.TraceIdentifier;
         var expectedProblem = new ProblemDetails()
         {
             Detail = "Custom Bad Request",
@@ -153,6 +160,7 @@ public partial class DefaultProblemDetailsWriterTest
         Assert.Equal(expectedProblem.Title, problemDetails.Title);
         Assert.Equal(expectedProblem.Detail, problemDetails.Detail);
         Assert.Equal(expectedProblem.Instance, problemDetails.Instance);
+        Assert.Equal(expectedTraceId, problemDetails.Extensions["traceId"].ToString());
     }
 
     [Fact]
@@ -165,6 +173,7 @@ public partial class DefaultProblemDetailsWriterTest
         var writer = GetWriter(jsonOptions: options);
         var stream = new MemoryStream();
         var context = CreateContext(stream);
+        var expectedTraceId = Activity.Current?.Id ?? context.TraceIdentifier;
         var expectedProblem = new ProblemDetails()
         {
             Detail = "Custom Bad Request",
@@ -191,6 +200,7 @@ public partial class DefaultProblemDetailsWriterTest
         Assert.Equal(expectedProblem.Title, problemDetails.Title);
         Assert.Equal(expectedProblem.Detail, problemDetails.Detail);
         Assert.Equal(expectedProblem.Instance, problemDetails.Instance);
+        Assert.Equal(expectedTraceId, problemDetails.Extensions["traceId"].ToString());
     }
 
     [Fact]
@@ -203,6 +213,7 @@ public partial class DefaultProblemDetailsWriterTest
         var writer = GetWriter(jsonOptions: options);
         var stream = new MemoryStream();
         var context = CreateContext(stream);
+        var expectedTraceId = Activity.Current?.Id ?? context.TraceIdentifier;
         var expectedProblem = new ProblemDetails()
         {
             Detail = "Custom Bad Request",
@@ -229,6 +240,7 @@ public partial class DefaultProblemDetailsWriterTest
         Assert.Equal(expectedProblem.Title, problemDetails.Title);
         Assert.Equal(expectedProblem.Detail, problemDetails.Detail);
         Assert.Equal(expectedProblem.Instance, problemDetails.Instance);
+        Assert.Equal(expectedTraceId, problemDetails.Extensions["traceId"].ToString());
     }
 
     [Fact]
@@ -238,6 +250,7 @@ public partial class DefaultProblemDetailsWriterTest
         var writer = GetWriter();
         var stream = new MemoryStream();
         var context = CreateContext(stream);
+        var expectedTraceId = Activity.Current?.Id ?? context.TraceIdentifier;
         var expectedProblem = new HttpValidationProblemDetails()
         {
             Detail = "Custom Bad Request",
@@ -267,6 +280,7 @@ public partial class DefaultProblemDetailsWriterTest
         Assert.Equal(expectedProblem.Detail, problemDetails.Detail);
         Assert.Equal(expectedProblem.Instance, problemDetails.Instance);
         Assert.Equal(expectedProblem.Errors, problemDetails.Errors);
+        Assert.Equal(expectedTraceId, problemDetails.Extensions["traceId"].ToString());
     }
 
     [Fact]
@@ -279,6 +293,7 @@ public partial class DefaultProblemDetailsWriterTest
         var writer = GetWriter(jsonOptions: options);
         var stream = new MemoryStream();
         var context = CreateContext(stream);
+        var expectedTraceId = Activity.Current?.Id ?? context.TraceIdentifier;
         var expectedProblem = new HttpValidationProblemDetails()
         {
             Detail = "Custom Bad Request",
@@ -308,6 +323,7 @@ public partial class DefaultProblemDetailsWriterTest
         Assert.Equal(expectedProblem.Detail, problemDetails.Detail);
         Assert.Equal(expectedProblem.Instance, problemDetails.Instance);
         Assert.Equal(expectedProblem.Errors, problemDetails.Errors);
+        Assert.Equal(expectedTraceId, problemDetails.Extensions["traceId"].ToString());
     }
 
     [Fact]
@@ -320,6 +336,7 @@ public partial class DefaultProblemDetailsWriterTest
         var writer = GetWriter(jsonOptions: options);
         var stream = new MemoryStream();
         var context = CreateContext(stream);
+        var expectedTraceId = Activity.Current?.Id ?? context.TraceIdentifier;
         var expectedProblem = new CustomProblemDetails()
         {
             Detail = "Custom Bad Request",
@@ -349,6 +366,7 @@ public partial class DefaultProblemDetailsWriterTest
         Assert.Equal(expectedProblem.Detail, problemDetails.Detail);
         Assert.Equal(expectedProblem.Instance, problemDetails.Instance);
         Assert.Equal(expectedProblem.ExtraProperty, problemDetails.ExtraProperty);
+        Assert.Equal(expectedTraceId, problemDetails.Extensions["traceId"].ToString());
     }
 
     [Fact]
@@ -361,6 +379,7 @@ public partial class DefaultProblemDetailsWriterTest
         var writer = GetWriter(jsonOptions: options);
         var stream = new MemoryStream();
         var context = CreateContext(stream);
+        var expectedTraceId = Activity.Current?.Id ?? context.TraceIdentifier;
         var expectedProblem = new CustomProblemDetails()
         {
             Detail = "Custom Bad Request",
@@ -390,6 +409,7 @@ public partial class DefaultProblemDetailsWriterTest
         Assert.Equal(expectedProblem.Detail, problemDetails.Detail);
         Assert.Equal(expectedProblem.Instance, problemDetails.Instance);
         Assert.Equal(expectedProblem.ExtraProperty, problemDetails.ExtraProperty);
+        Assert.Equal(expectedTraceId, problemDetails.Extensions["traceId"].ToString());
     }
 
     [Fact]
@@ -402,6 +422,7 @@ public partial class DefaultProblemDetailsWriterTest
         var writer = GetWriter(jsonOptions: options);
         var stream = new MemoryStream();
         var context = CreateContext(stream);
+        var expectedTraceId = Activity.Current?.Id ?? context.TraceIdentifier;
         var expectedProblem = new CustomProblemDetails()
         {
             Detail = "Custom Bad Request",
@@ -431,6 +452,7 @@ public partial class DefaultProblemDetailsWriterTest
         Assert.Equal(expectedProblem.Detail, problemDetails.Detail);
         Assert.Equal(expectedProblem.Instance, problemDetails.Instance);
         Assert.Equal(expectedProblem.ExtraProperty, problemDetails.ExtraProperty);
+        Assert.Equal(expectedTraceId, problemDetails.Extensions["traceId"].ToString());
     }
 
     [Fact]
@@ -441,6 +463,7 @@ public partial class DefaultProblemDetailsWriterTest
         var stream = new MemoryStream();
         var context = CreateContext(stream);
         var expectedProblem = new ProblemDetails();
+        var expectedTraceId = Activity.Current?.Id ?? context.TraceIdentifier;
         expectedProblem.Extensions["Extension1"] = "Extension1-Value";
         expectedProblem.Extensions["Extension2"] = "Extension2-Value";
 
@@ -467,6 +490,11 @@ public partial class DefaultProblemDetailsWriterTest
             {
                 Assert.Equal("Extension2", extension.Key);
                 Assert.Equal("Extension2-Value", extension.Value.ToString());
+            },
+            (extension) =>
+            {
+                Assert.Equal("traceId", extension.Key);
+                Assert.Equal(expectedTraceId, extension.Value.ToString());
             });
     }
 
@@ -482,6 +510,7 @@ public partial class DefaultProblemDetailsWriterTest
         var context = CreateContext(stream);
         var expectedProblem = new ProblemDetails();
         var customExtensionData = new CustomExtensionData("test");
+        var expectedTraceId = Activity.Current?.Id ?? context.TraceIdentifier;
         expectedProblem.Extensions["Extension"] = customExtensionData;
 
         var problemDetailsContext = new ProblemDetailsContext()
@@ -507,6 +536,11 @@ public partial class DefaultProblemDetailsWriterTest
                 var value = Assert.IsType<JsonElement>(extension.Value);
 
                 Assert.Equal(expectedExtension.GetProperty("data").GetString(), value.GetProperty("data").GetString());
+            },
+            (extension) =>
+            {
+                Assert.Equal("traceId", extension.Key);
+                Assert.Equal(expectedTraceId, extension.Value.ToString());
             });
     }
 
@@ -517,6 +551,7 @@ public partial class DefaultProblemDetailsWriterTest
         var writer = GetWriter();
         var stream = new MemoryStream();
         var context = CreateContext(stream, StatusCodes.Status500InternalServerError);
+        var expectedTraceId = Activity.Current?.Id ?? context.TraceIdentifier;
 
         //Act
         await writer.WriteAsync(new ProblemDetailsContext() { HttpContext = context });
@@ -528,12 +563,14 @@ public partial class DefaultProblemDetailsWriterTest
         Assert.Equal(StatusCodes.Status500InternalServerError, problemDetails.Status);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", problemDetails.Type);
         Assert.Equal("An error occurred while processing your request.", problemDetails.Title);
+        Assert.Equal(expectedTraceId, problemDetails.Extensions["traceId"].ToString());
     }
 
     [Fact]
     public async Task WriteAsync_Applies_CustomConfiguration()
     {
         // Arrange
+        const string expectedTraceId = "new-traceId-Value";
         var options = new ProblemDetailsOptions()
         {
             CustomizeProblemDetails = (context) =>
@@ -541,6 +578,7 @@ public partial class DefaultProblemDetailsWriterTest
                 context.ProblemDetails.Status = StatusCodes.Status406NotAcceptable;
                 context.ProblemDetails.Title = "Custom Title";
                 context.ProblemDetails.Extensions["new-extension"] = new { TraceId = Guid.NewGuid() };
+                context.ProblemDetails.Extensions["traceId"] = expectedTraceId;
             }
         };
         var writer = GetWriter(options);
@@ -562,6 +600,7 @@ public partial class DefaultProblemDetailsWriterTest
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.5.1", problemDetails.Type);
         Assert.Equal("Custom Title", problemDetails.Title);
         Assert.Contains("new-extension", problemDetails.Extensions);
+        Assert.Equal(expectedTraceId, problemDetails.Extensions["traceId"].ToString());
     }
 
     [Theory]

--- a/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
+++ b/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
@@ -1,18 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
-using System.Text.Json.Serialization.Metadata;
-using Microsoft.AspNetCore.Http.Json;
-using System.Text.Json.Serialization;
-using Microsoft.CodeAnalysis;
 using JsonOptions = Microsoft.AspNetCore.Http.Json.JsonOptions;
-using System.Diagnostics;
 
 namespace Microsoft.AspNetCore.Http.Extensions.Tests;
 


### PR DESCRIPTION
I took liberty to remove an if condition that was in the previous code for Controllers:
https://github.com/dotnet/aspnetcore/blob/b3b8dffff4d092058b2d8942268b498cbfdb14ec/src/Mvc/Mvc.Core/src/Infrastructure/DefaultProblemDetailsFactory.cs#L92-L96

Since they don't represent any threat, because the received `HttpContext` can never be null, and the `TraceIdentifier` is always filled by Kestrel. Should not represent any threats.

closes #54325
