### PR TITLE
Remove KeyManagementOptions copy constructor

### DIFF
--- a/src/DataProtection/DataProtection/src/KeyManagement/KeyManagementOptions.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/KeyManagementOptions.cs
@@ -27,29 +27,6 @@ public class KeyManagementOptions
     {
     }
 
-    // copy ctor
-    internal KeyManagementOptions(KeyManagementOptions other)
-    {
-        if (other != null)
-        {
-            AutoGenerateKeys = other.AutoGenerateKeys;
-            _newKeyLifetime = other._newKeyLifetime;
-            XmlEncryptor = other.XmlEncryptor;
-            XmlRepository = other.XmlRepository;
-            AuthenticatedEncryptorConfiguration = other.AuthenticatedEncryptorConfiguration;
-
-            foreach (var keyEscrowSink in other.KeyEscrowSinks)
-            {
-                KeyEscrowSinks.Add(keyEscrowSink);
-            }
-
-            foreach (var encryptorFactory in other.AuthenticatedEncryptorFactories)
-            {
-                AuthenticatedEncryptorFactories.Add(encryptorFactory);
-            }
-        }
-    }
-
     /// <summary>
     /// Specifies whether the data protection system should auto-generate keys.
     /// </summary>

--- a/src/DataProtection/DataProtection/src/KeyManagement/KeyRingProvider.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/KeyRingProvider.cs
@@ -19,7 +19,8 @@ internal sealed class KeyRingProvider : ICacheableKeyRingProvider, IKeyRingProvi
     private CacheableKeyRing? _cacheableKeyRing;
     private readonly object _cacheableKeyRingLockObj = new object();
     private readonly IDefaultKeyResolver _defaultKeyResolver;
-    private readonly KeyManagementOptions _keyManagementOptions;
+    private readonly bool _autoGenerateKeys;
+    private readonly TimeSpan _newKeyLifetime;
     private readonly IKeyManager _keyManager;
     private readonly ILogger _logger;
 
@@ -41,7 +42,9 @@ internal sealed class KeyRingProvider : ICacheableKeyRingProvider, IKeyRingProvi
         IDefaultKeyResolver defaultKeyResolver,
         ILoggerFactory loggerFactory)
     {
-        _keyManagementOptions = new KeyManagementOptions(keyManagementOptions.Value); // clone so new instance is immutable
+        var options = keyManagementOptions.Value ?? new();
+        _autoGenerateKeys = options.AutoGenerateKeys;
+        _newKeyLifetime = options.NewKeyLifetime;
         _keyManager = keyManager;
         CacheableKeyRingProvider = this;
         _defaultKeyResolver = defaultKeyResolver;
@@ -113,7 +116,7 @@ internal sealed class KeyRingProvider : ICacheableKeyRingProvider, IKeyRingProvi
 
         // We have been asked to generate a new key, but auto-generation of keys has been disabled.
         // We need to use the fallback key or fail.
-        if (!_keyManagementOptions.AutoGenerateKeys)
+        if (!_autoGenerateKeys)
         {
             var keyToUse = defaultKey ?? defaultKeyPolicy.FallbackKey;
             if (keyToUse == null)
@@ -135,7 +138,7 @@ internal sealed class KeyRingProvider : ICacheableKeyRingProvider, IKeyRingProvi
         {
             // The case where there's no default key is the easiest scenario, since it
             // means that we need to create a new key with immediate activation.
-            var newKey = _keyManager.CreateNewKey(activationDate: now, expirationDate: now + _keyManagementOptions.NewKeyLifetime);
+            var newKey = _keyManager.CreateNewKey(activationDate: now, expirationDate: now + _newKeyLifetime);
             return CreateCacheableKeyRingCore(now, keyJustAdded: newKey); // recursively call
         }
         else
@@ -143,7 +146,7 @@ internal sealed class KeyRingProvider : ICacheableKeyRingProvider, IKeyRingProvi
             // If there is a default key, then the new key we generate should become active upon
             // expiration of the default key. The new key lifetime is measured from the creation
             // date (now), not the activation date.
-            var newKey = _keyManager.CreateNewKey(activationDate: defaultKey.ExpirationDate, expirationDate: now + _keyManagementOptions.NewKeyLifetime);
+            var newKey = _keyManager.CreateNewKey(activationDate: defaultKey.ExpirationDate, expirationDate: now + _newKeyLifetime);
             return CreateCacheableKeyRingCore(now, keyJustAdded: newKey); // recursively call
         }
     }


### PR DESCRIPTION
There was only one caller and that caller only wanted two members.  Plus, it was subtly hiding the fact that it might be cloning a null object.