### PR TITLE
Fix components-e2e logging issues

### DIFF
--- a/.azure/pipelines/components-e2e-tests.yml
+++ b/.azure/pipelines/components-e2e-tests.yml
@@ -52,11 +52,13 @@ jobs:
     - script: .dotnet/dotnet build ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-restore
       displayName: Build
     - script: .dotnet/dotnet test ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-build --filter 'Quarantined!=true|Quarantined=false'
+                 -p:VsTestUseMSBuildOutput=false
                  --logger:"trx%3BLogFileName=Microsoft.AspNetCore.Components.E2ETests.trx"
                  --logger:"html%3BLogFileName=Microsoft.AspNetCore.Components.E2ETests.html"
                  --results-directory $(Build.SourcesDirectory)/artifacts/TestResults/$(BuildConfiguration)/Unquarantined
       displayName: Run E2E tests
     - script: .dotnet/dotnet test ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-build --filter 'Quarantined=true' -p:RunQuarantinedTests=true
+                 -p:VsTestUseMSBuildOutput=false
                  --logger:"trx%3BLogFileName=Microsoft.AspNetCore.Components.E2ETests.trx"
                  --logger:"html%3BLogFileName=Microsoft.AspNetCore.Components.E2ETests.html"
                  --results-directory $(Build.SourcesDirectory)/artifacts/TestResults/$(BuildConfiguration)/Quarantined


### PR DESCRIPTION
Since https://github.com/dotnet/aspnetcore/pull/54483 was merged, logs for the `components-e2e` pipeline has increased to 600MB+ in size on successful runs. Furthermore, there have been multiple recent failures in that pipeline with the following stack trace:

```text
/home/vsts/work/1/s/.dotnet/sdk/9.0.100-preview.3.24161.2/Microsoft.TestPlatform.targets(46,5): error MSB4018: The "VSTestTask2" task failed unexpectedly. [/home/vsts/work/1/s/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj]
/home/vsts/work/1/s/.dotnet/sdk/9.0.100-preview.3.24161.2/Microsoft.TestPlatform.targets(46,5): error MSB4018: System.IndexOutOfRangeException: Index was outside the bounds of the array. [/home/vsts/work/1/s/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj]
/home/vsts/work/1/s/.dotnet/sdk/9.0.100-preview.3.24161.2/Microsoft.TestPlatform.targets(46,5): error MSB4018:    at Microsoft.TestPlatform.Build.Tasks.VSTestTask2.LogEventsFromTextOutput(String singleLine, MessageImportance messageImportance) in /_/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask2.cs:line 67 [/home/vsts/work/1/s/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj]
/home/vsts/work/1/s/.dotnet/sdk/9.0.100-preview.3.24161.2/Microsoft.TestPlatform.targets(46,5): error MSB4018:    at Microsoft.Build.Utilities.ToolTask.LogMessagesFromStandardErrorOrOutput(Queue dataQueue, ManualResetEvent dataAvailableSignal, MessageImportance messageImportance, StandardOutputOrErrorQueueType queueType) [/home/vsts/work/1/s/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj]
/home/vsts/work/1/s/.dotnet/sdk/9.0.100-preview.3.24161.2/Microsoft.TestPlatform.targets(46,5): error MSB4018:    at Microsoft.Build.Utilities.ToolTask.HandleToolNotifications(Process proc) [/home/vsts/work/1/s/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj]
/home/vsts/work/1/s/.dotnet/sdk/9.0.100-preview.3.24161.2/Microsoft.TestPlatform.targets(46,5): error MSB4018:    at Microsoft.Build.Utilities.ToolTask.ExecuteTool(String pathToTool, String responseFileCommands, String commandLineCommands) [/home/vsts/work/1/s/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj]
/home/vsts/work/1/s/.dotnet/sdk/9.0.100-preview.3.24161.2/Microsoft.TestPlatform.targets(46,5): error MSB4018:    at Microsoft.Build.Utilities.ToolTask.Execute() [/home/vsts/work/1/s/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj]
/home/vsts/work/1/s/.dotnet/sdk/9.0.100-preview.3.24161.2/Microsoft.TestPlatform.targets(46,5): error MSB4018:    at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute() [/home/vsts/work/1/s/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj]
/home/vsts/work/1/s/.dotnet/sdk/9.0.100-preview.3.24161.2/Microsoft.TestPlatform.targets(46,5): error MSB4018:    at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(ITaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask) [/home/vsts/work/1/s/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj]
```

Disabling the new TerminalLogger (which is [on by default in .NET 9](https://github.com/microsoft/vstest/issues/4843#:~:text=enabled%20by%20default%20for%20most%20dotnet%20workloads%2C%20including%20dotnet%20test)) seems to have resolved both the log size and test pipeline failure issues.