### PR TITLE
Update Alpine versions

### DIFF
--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -2,7 +2,7 @@
   <!-- This file is shared between Helix.proj and .csproj files. -->
   <PropertyGroup>
     <HelixQueueAlmaLinux8>(AlmaLinux.8.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:almalinux-8-helix-amd64</HelixQueueAlmaLinux8>
-    <HelixQueueAlpine316>(Alpine.316.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.16-helix-amd64</HelixQueueAlpine316>
+    <HelixQueueAlpine318>(Alpine.318.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.18-helix-amd64</HelixQueueAlpine318>
     <HelixQueueDebian11>(Debian.11.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64</HelixQueueDebian11>
     <HelixQueueFedora38>(Fedora.38.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-38-helix</HelixQueueFedora38>
     <HelixQueueMariner>(Mariner)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-1.0-helix</HelixQueueMariner>
@@ -42,7 +42,7 @@
         <HelixAvailableTargetQueue Include="$(HelixQueueAlmaLinux8)" Platform="Linux" />
 
         <!-- Containers -->
-        <HelixAvailableTargetQueue Include="$(HelixQueueAlpine316)" Platform="Linux" />
+        <HelixAvailableTargetQueue Include="$(HelixQueueAlpine318)" Platform="Linux" />
         <HelixAvailableTargetQueue Include="$(HelixQueueDebian11)" Platform="Linux" />
         <HelixAvailableTargetQueue Include="$(HelixQueueFedora38)" Platform="Linux" />
         <HelixAvailableTargetQueue Include="$(HelixQueueMariner)" Platform="Linux" />

--- a/eng/targets/Helix.targets
+++ b/eng/targets/Helix.targets
@@ -17,7 +17,7 @@
   <PropertyGroup Condition="'$(TestDependsOnPlaywright)' == 'true'">
     <SkipHelixQueues>
       $(HelixQueueAlmaLinux8);
-      $(HelixQueueAlpine316);
+      $(HelixQueueAlpine318);
       $(HelixQueueDebian11);
       $(HelixQueueFedora38);
       $(HelixQueueMariner);


### PR DESCRIPTION
Alpine 3.16 will be EOL before we ship and 3.17 will be getting close. We can safely skip forward to Alpine 3.18 in `main`.

There are more similar changes to come after this one. After this PR merges, I'll try to batch up the changes.