### PR TITLE
Increase logs and delays in CanLaunchPhotinoWebViewAndClickButton

### DIFF
--- a/src/Components/WebView/test/E2ETest/BasicBlazorHybridTest.cs
+++ b/src/Components/WebView/test/E2ETest/BasicBlazorHybridTest.cs
@@ -18,21 +18,21 @@ public class BasicBlazorHybridTest
         // Note: This test produces *a lot* of debug output to aid when debugging failures. The only output
         // that is necessary for the functioning of this test is the "Test passed" at the end of this method.
 
-        Console.WriteLine($"Current directory: {Environment.CurrentDirectory}");
-        Console.WriteLine($"Current assembly: {typeof(Program).Assembly.Location}");
+        Console.WriteLine($"[{DateTime.Now.ToLongTimeString()}] Current directory: {Environment.CurrentDirectory}");
+        Console.WriteLine($"[{DateTime.Now.ToLongTimeString()}] Current assembly: {typeof(Program).Assembly.Location}");
         var thisProgramDir = Path.GetDirectoryName(typeof(Program).Assembly.Location);
 
         // Add correct runtime sub-folder to PATH to ensure native files are discovered (this is supposed to happen automatically, but somehow it doesn't...)
         var newNativePath = Path.Combine(thisProgramDir, "runtimes", RuntimeInformation.RuntimeIdentifier, "native");
-        Console.WriteLine($"Adding new native path: {newNativePath}");
+        Console.WriteLine($"[{DateTime.Now.ToLongTimeString()}] Adding new native path: {newNativePath}");
         Environment.SetEnvironmentVariable("PATH", newNativePath + ";" + Environment.GetEnvironmentVariable("PATH"));
-        Console.WriteLine($"New PATH env var: {Environment.GetEnvironmentVariable("PATH")}");
+        Console.WriteLine($"[{DateTime.Now.ToLongTimeString()}] New PATH env var: {Environment.GetEnvironmentVariable("PATH")}");
 
         var thisAppFiles = Directory.GetFiles(thisProgramDir, "*", SearchOption.AllDirectories).ToArray();
-        Console.WriteLine($"Found {thisAppFiles.Length} files in this app:");
+        Console.WriteLine($"[{DateTime.Now.ToLongTimeString()}] Found {thisAppFiles.Length} files in this app:");
         foreach (var file in thisAppFiles)
         {
-            Console.WriteLine($"\t{file}");
+            Console.WriteLine($"[{DateTime.Now.ToLongTimeString()}] \t{file}");
         }
 
         var hostPage = "wwwroot/webviewtesthost.html";
@@ -41,7 +41,7 @@ public class BasicBlazorHybridTest
         serviceCollection.AddBlazorWebView();
         serviceCollection.AddSingleton<HttpClient>();
 
-        Console.WriteLine($"Creating BlazorWindow...");
+        Console.WriteLine($"[{DateTime.Now.ToLongTimeString()}] Creating BlazorWindow...");
         BlazorWindow mainWindow = null;
         try
         {
@@ -53,11 +53,11 @@ public class BasicBlazorHybridTest
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"Exception {ex.GetType().FullName} while creating window: {ex.Message}");
+            Console.WriteLine($"[{DateTime.Now.ToLongTimeString()}] Exception {ex.GetType().FullName} while creating window: {ex.Message}");
             Console.WriteLine(ex.StackTrace);
         }
 
-        Console.WriteLine($"Hooking exception handler...");
+        Console.WriteLine($"[{DateTime.Now.ToLongTimeString()}] Hooking exception handler...");
         AppDomain.CurrentDomain.UnhandledException += (sender, error) =>
         {
             Console.Write(
@@ -65,15 +65,15 @@ public class BasicBlazorHybridTest
                 error.ExceptionObject.ToString() + Environment.NewLine);
         };
 
-        Console.WriteLine($"Setting up root components...");
+        Console.WriteLine($"[{DateTime.Now.ToLongTimeString()}] Setting up root components...");
         mainWindow.RootComponents.Add<Pages.TestPage>("root");
 
-        Console.WriteLine($"Running window...");
+        Console.WriteLine($"[{DateTime.Now.ToLongTimeString()}] Running window...");
 
         const string NewControlDivValueMessage = "wvt:NewControlDivValue";
         var isWebViewReady = false;
 
-        Console.WriteLine($"RegisterWebMessageReceivedHandler...");
+        Console.WriteLine($"[{DateTime.Now.ToLongTimeString()}] RegisterWebMessageReceivedHandler...");
         mainWindow.PhotinoWindow.RegisterWebMessageReceivedHandler((s, msg) =>
         {
             if (!msg.StartsWith("__bwv:", StringComparison.Ordinal))
@@ -90,29 +90,33 @@ public class BasicBlazorHybridTest
         });
         var testPassed = false;
 
+        Console.WriteLine($"[{DateTime.Now.ToLongTimeString()}] Attaching WindowCreated handler...");
         mainWindow.PhotinoWindow.WindowCreated += (s, e) =>
         {
+            Console.WriteLine($"[{DateTime.Now.ToLongTimeString()}] In WindowCreated event...");
             Task.Run(async () =>
             {
+                Console.WriteLine($"[{DateTime.Now.ToLongTimeString()}] In async test task...");
+
                 try
                 {
                     // This is the actual test logic here (wait for WebView, click button, verify updates, etc.)
 
                     // 1. Wait for WebView ready
-                    Console.WriteLine($"Waiting for WebView ready...");
+                    Console.WriteLine($"[{DateTime.Now.ToLongTimeString()}] Waiting for WebView ready...");
                     var isWebViewReadyRetriesLeft = 20;
                     while (!isWebViewReady)
                     {
-                        Console.WriteLine($"WebView not ready yet, waiting 1sec...");
+                        Console.WriteLine($"[{DateTime.Now.ToLongTimeString()}] WebView not ready yet, waiting 1sec...");
                         await Task.Delay(1000);
                         isWebViewReadyRetriesLeft--;
                         if (isWebViewReadyRetriesLeft == 0)
                         {
-                            Console.WriteLine($"WebView never became ready, failing the test...");
+                            Console.WriteLine($"[{DateTime.Now.ToLongTimeString()}] WebView never became ready, failing the test...");
                             return;
                         }
                     }
-                    Console.WriteLine($"WebView is ready!");
+                    Console.WriteLine($"[{DateTime.Now.ToLongTimeString()}] WebView is ready!");
 
                     // 2. Check TestPage starting state
                     if (!await WaitForControlDiv(mainWindow.PhotinoWindow, controlValueToWaitFor: "0"))
@@ -130,7 +134,7 @@ public class BasicBlazorHybridTest
                     }
 
                     // 5. If we get here, it all worked!
-                    Console.WriteLine($"All tests passed!");
+                    Console.WriteLine($"[{DateTime.Now.ToLongTimeString()}] All tests passed!");
                     testPassed = true;
                 }
                 catch (Exception ex)
@@ -153,16 +157,16 @@ public class BasicBlazorHybridTest
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"Exception while running window: {ex}");
+            Console.WriteLine($"[{DateTime.Now.ToLongTimeString()}] Exception while running window: {ex}");
         }
 
         // This line is what's required for the test to be considered as passed. The xUnit test in WebViewManagerE2ETests checks
         // that this reports success and that decides if the test is pass/fail.
-        Console.WriteLine($"Test passed? {testPassed}");
+        Console.WriteLine($"[{DateTime.Now.ToLongTimeString()}] Test passed? {testPassed}");
     }
 
     const int MaxWaitTimes = 30;
-    const int WaitTimeInMS = 250;
+    const int WaitTimeInMS = 1000;
 
     public async Task<bool> WaitForControlDiv(PhotinoWindow photinoWindow, string controlValueToWaitFor)
     {
@@ -172,20 +176,20 @@ public class BasicBlazorHybridTest
             // Tell WebView to report the current controlDiv value (this is inside the loop because
             // it's possible for this to execute before the WebView has finished processing previous
             // C#-generated events, such as WebView button clicks).
-            Console.WriteLine($"Asking WebView for current controlDiv value...");
+            Console.WriteLine($"[{DateTime.Now.ToLongTimeString()}] Asking WebView for current controlDiv value...");
             photinoWindow.SendWebMessage($"wvt:GetControlDivValue");
 
             // And wait for the value to appear
             if (_latestControlDivValue == controlValueToWaitFor)
             {
-                Console.WriteLine($"WebView reported the expected controlDiv value of {controlValueToWaitFor}!");
+                Console.WriteLine($"[{DateTime.Now.ToLongTimeString()}] WebView reported the expected controlDiv value of {controlValueToWaitFor}!");
                 return true;
             }
-            Console.WriteLine($"Waiting for controlDiv to have value '{controlValueToWaitFor}', but it's still '{_latestControlDivValue}', so waiting {WaitTimeInMS}ms.");
+            Console.WriteLine($"[{DateTime.Now.ToLongTimeString()}] Waiting for controlDiv to have value '{controlValueToWaitFor}', but it's still '{_latestControlDivValue}', so waiting {WaitTimeInMS}ms.");
             await Task.Delay(WaitTimeInMS);
         }
 
-        Console.WriteLine($"Waited {MaxWaitTimes * WaitTimeInMS}ms but couldn't get controlDiv to have value '{controlValueToWaitFor}' (last value is '{_latestControlDivValue}').");
+        Console.WriteLine($"[{DateTime.Now.ToLongTimeString()}] Waited {MaxWaitTimes * WaitTimeInMS}ms but couldn't get controlDiv to have value '{controlValueToWaitFor}' (last value is '{_latestControlDivValue}').");
         return false;
     }
 }

--- a/src/Components/WebView/test/E2ETest/WebViewManagerE2ETests.cs
+++ b/src/Components/WebView/test/E2ETest/WebViewManagerE2ETests.cs
@@ -3,10 +3,11 @@
 
 using System.Diagnostics;
 using Microsoft.AspNetCore.Testing;
+using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Components.WebViewE2E.Test;
 
-public class WebViewManagerE2ETests
+public class WebViewManagerE2ETests(ITestOutputHelper output)
 {
     // Skips:
     // - Ubuntu is skipped due to this error:
@@ -39,7 +40,9 @@ public class WebViewManagerE2ETests
 
         var testProgramOutput = photinoProcess.StandardOutput.ReadToEnd();
 
-        await photinoProcess.WaitForExitAsync().TimeoutAfter(TimeSpan.FromSeconds(30));
+        await photinoProcess.WaitForExitAsync().TimeoutAfter(TimeSpan.FromSeconds(60));
+
+        output.WriteLine(testProgramOutput);
 
         // The test app reports its own results by calling Console.WriteLine(), so here we only need to verify that
         // the test internally believes it passed (and we trust it!).


### PR DESCRIPTION
Really not sure what's causing the failure, especially because it fails so rarely. It seems unlikely it's a product bug (in Blazor code), so it seems more likely it's a problem with either the test infrastructure (e.g. slow machines?), or something to do with WebView2.

So if this passes on CI, then I suggest we merge this change and see what happens. And if it fails again in the future then we try additional things, such as a full retry within the test (e.g. if certain parts fail to even load, retry the whole test from scratch).

Fixes #54017
