### PR TITLE
Update helix OS versions

### DIFF
--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -1,12 +1,12 @@
 <Project>
   <!-- This file is shared between Helix.proj and .csproj files. -->
   <PropertyGroup>
-    <HelixQueueAlmaLinux8>(AlmaLinux.8.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:almalinux-8-helix-amd64</HelixQueueAlmaLinux8>
-    <HelixQueueAlpine318>(Alpine.318.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.18-helix-amd64</HelixQueueAlpine318>
-    <HelixQueueDebian11>(Debian.11.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64</HelixQueueDebian11>
-    <HelixQueueFedora38>(Fedora.38.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-38-helix</HelixQueueFedora38>
-    <HelixQueueMariner>(Mariner)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-1.0-helix</HelixQueueMariner>
-    <HelixQueueArmDebian12>(Debian.12.Arm64.Open)ubuntu.2004.armarch.open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-arm64v8</HelixQueueArmDebian12>
+    <HelixQueueAlmaLinux8>(AlmaLinux.8.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:almalinux-8-helix-amd64</HelixQueueAlmaLinux8>
+    <HelixQueueAlpine318>(Alpine.318.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.18-helix-amd64</HelixQueueAlpine318>
+    <HelixQueueDebian12>(Debian.12.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-amd64</HelixQueueDebian12>
+    <HelixQueueFedora39>(Fedora.39.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-39-helix</HelixQueueFedora39>
+    <HelixQueueMariner>(Mariner)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-helix</HelixQueueMariner>
+    <HelixQueueArmDebian12>(Debian.12.Arm64.Open)ubuntu.2204.armarch.open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-arm64v8</HelixQueueArmDebian12>
 
     <!-- Do not attempt to override global property. -->
     <RunQuarantinedTests Condition=" '$(RunQuarantinedTests)' == '' ">false</RunQuarantinedTests>
@@ -43,8 +43,8 @@
 
         <!-- Containers -->
         <HelixAvailableTargetQueue Include="$(HelixQueueAlpine318)" Platform="Linux" />
-        <HelixAvailableTargetQueue Include="$(HelixQueueDebian11)" Platform="Linux" />
-        <HelixAvailableTargetQueue Include="$(HelixQueueFedora38)" Platform="Linux" />
+        <HelixAvailableTargetQueue Include="$(HelixQueueDebian12)" Platform="Linux" />
+        <HelixAvailableTargetQueue Include="$(HelixQueueFedora39)" Platform="Linux" />
         <HelixAvailableTargetQueue Include="$(HelixQueueMariner)" Platform="Linux" />
         <HelixAvailableTargetQueue Include="$(HelixQueueArmDebian12)" Platform="Linux" />
 

--- a/eng/targets/Helix.targets
+++ b/eng/targets/Helix.targets
@@ -18,8 +18,8 @@
     <SkipHelixQueues>
       $(HelixQueueAlmaLinux8);
       $(HelixQueueAlpine318);
-      $(HelixQueueDebian11);
-      $(HelixQueueFedora38);
+      $(HelixQueueDebian12);
+      $(HelixQueueFedora39);
       $(HelixQueueMariner);
       Ubuntu.2004.Amd64.Open;
     </SkipHelixQueues>


### PR DESCRIPTION
Update OS versions.

- Mariner 1.0 is EOL.
- Debian 11 will be EOL in 7/2024
- We are using Ubuntu 22.04 as our container host, generally.
- Fedora doesn't need to change, but Fedora 38 will likely be EOL when we ship .NET 9.

Related: https://github.com/dotnet/core/pull/9231