### PR TITLE
Revert "Use the VMR commit hash in .version (#54461)"

### DIFF
--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -311,8 +311,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       Overwrite="true" />
 
     <ItemGroup>
-      <VersionLines Include="$(DotNetGitCommitHash)" Condition="'$(DotNetGitCommitHash)' != ''" />
-      <VersionLines Include="$(SourceRevisionId)" Condition="'$(DotNetGitCommitHash)' == ''" />
+      <VersionLines Include="$(SourceRevisionId)" />
       <VersionLines Include="$(SharedFxVersion)" />
     </ItemGroup>
 


### PR DESCRIPTION
This reverts commit 818d0e3ca1374a38b0d87bd57a1952115e1f9af5.

Over at https://github.com/dotnet/installer/pull/18941, we decied that we wanted to go in a different (and simpler!) direction. We will make sure `SourceRevisionId` is defined/used correctly everywhere.
