### PR TITLE
Pass -publish parameters

### DIFF
--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -81,8 +81,7 @@ variables:
   - group: Publish-Build-Assets
   # The following extra properties are not set when testing. Use with final build.[cmd,sh] of asset-producing jobs.
   - name: _PublishArgs
-    value: /p:Publish=true
-           /p:GenerateChecksums=true
+    value: /p:GenerateChecksums=true
            /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
   - ${{ if ne(parameters.produceBinlogs, 'true') }}:
     # Do not log most Windows steps in official builds; this is the slowest job. Site extensions step always logs.
@@ -343,6 +342,7 @@ stages:
                   -sign
                   -buildInstallers
                   -noBuildNative
+                  -publish
                   /p:DotNetSignType=$(_SignType)
                   /p:AssetManifestFileName=aspnetcore-win.xml
                   $(_BuildArgs)
@@ -378,6 +378,7 @@ stages:
           --pack
           --all
           --no-build-java
+          --publish
           -p:OnlyPackPlatformSpecificPackages=true
           -p:AssetManifestFileName=aspnetcore-MacOS_arm64.xml
           $(_BuildArgs)
@@ -407,6 +408,7 @@ stages:
           --pack
           --all
           --no-build-java
+          --publish
           -p:OnlyPackPlatformSpecificPackages=true
           -p:AssetManifestFileName=aspnetcore-MacOS_x64.xml
           $(_BuildArgs)
@@ -464,6 +466,7 @@ stages:
               --build-installers
               --no-build-deps
               --no-build-nodejs
+              --publish
               -p:OnlyPackPlatformSpecificPackages=true
               -p:BuildRuntimeArchive=false
               -p:LinuxInstallerType=rpm
@@ -497,6 +500,7 @@ stages:
           --pack
           --all
           --no-build-java
+          --publish
           -p:OnlyPackPlatformSpecificPackages=true
           -p:AssetManifestFileName=aspnetcore-Linux_arm.xml
           $(_BuildArgs)
@@ -539,6 +543,7 @@ stages:
               --build-installers
               --no-build-deps
               --no-build-nodejs
+              --publish
               -p:OnlyPackPlatformSpecificPackages=true
               -p:BuildRuntimeArchive=false
               -p:LinuxInstallerType=rpm
@@ -574,6 +579,7 @@ stages:
           --pack
           --all
           --no-build-java
+          --publish
           -p:OnlyPackPlatformSpecificPackages=true
           -p:AssetManifestFileName=aspnetcore-Linux_musl_x64.xml
           $(_BuildArgs)
@@ -608,6 +614,7 @@ stages:
           --pack
           --all
           --no-build-java
+          --publish
           -p:OnlyPackPlatformSpecificPackages=true
           -p:AssetManifestFileName=aspnetcore-Linux_musl_arm.xml
           $(_BuildArgs)
@@ -640,6 +647,7 @@ stages:
           --pack
           --all
           --no-build-java
+          --publish
           -p:OnlyPackPlatformSpecificPackages=true
           -p:AssetManifestFileName=aspnetcore-Linux_musl_arm64.xml
           $(_BuildArgs)
@@ -761,7 +769,7 @@ stages:
         platform:
           name: 'Managed'
           container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8'
-          buildScript: './eng/build.sh $(_PublishArgs) --no-build-repo-tasks $(_InternalRuntimeDownloadArgs)'
+          buildScript: './eng/build.sh --publish --no-build-repo-tasks $(_PublishArgs) $(_InternalRuntimeDownloadArgs)'
           skipPublishValidation: true
           jobProperties:
             timeoutInMinutes: 120

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -81,8 +81,7 @@ variables:
   - group: Publish-Build-Assets
   # The following extra properties are not set when testing. Use with final build.[cmd,sh] of asset-producing jobs.
   - name: _PublishArgs
-    value: /p:Publish=true
-           /p:GenerateChecksums=true
+    value: /p:GenerateChecksums=true
            /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
   - ${{ if ne(parameters.produceBinlogs, 'true') }}:
     # Do not log most Windows steps in official builds; this is the slowest job. Site extensions step always logs.
@@ -345,6 +344,7 @@ stages:
                   -sign
                   -buildInstallers
                   -noBuildNative
+                  -publish
                   /p:DotNetSignType=$(_SignType)
                   /p:AssetManifestFileName=aspnetcore-win.xml
                   $(_BuildArgs)
@@ -380,6 +380,7 @@ stages:
           --pack
           --all
           --no-build-java
+          --publish
           -p:OnlyPackPlatformSpecificPackages=true
           -p:AssetManifestFileName=aspnetcore-MacOS_arm64.xml
           $(_BuildArgs)
@@ -409,6 +410,7 @@ stages:
           --pack
           --all
           --no-build-java
+          --publish
           -p:OnlyPackPlatformSpecificPackages=true
           -p:AssetManifestFileName=aspnetcore-MacOS_x64.xml
           $(_BuildArgs)
@@ -466,6 +468,7 @@ stages:
               --build-installers
               --no-build-deps
               --no-build-nodejs
+              --publish
               -p:OnlyPackPlatformSpecificPackages=true
               -p:BuildRuntimeArchive=false
               -p:LinuxInstallerType=rpm
@@ -499,6 +502,7 @@ stages:
           --pack
           --all
           --no-build-java
+          --publish
           -p:OnlyPackPlatformSpecificPackages=true
           -p:AssetManifestFileName=aspnetcore-Linux_arm.xml
           $(_BuildArgs)
@@ -541,6 +545,7 @@ stages:
               --build-installers
               --no-build-deps
               --no-build-nodejs
+              --publish
               -p:OnlyPackPlatformSpecificPackages=true
               -p:BuildRuntimeArchive=false
               -p:LinuxInstallerType=rpm
@@ -576,6 +581,7 @@ stages:
           --pack
           --all
           --no-build-java
+          --publish
           -p:OnlyPackPlatformSpecificPackages=true
           -p:AssetManifestFileName=aspnetcore-Linux_musl_x64.xml
           $(_BuildArgs)
@@ -610,6 +616,7 @@ stages:
           --pack
           --all
           --no-build-java
+          --publish
           -p:OnlyPackPlatformSpecificPackages=true
           -p:AssetManifestFileName=aspnetcore-Linux_musl_arm.xml
           $(_BuildArgs)
@@ -642,6 +649,7 @@ stages:
           --pack
           --all
           --no-build-java
+          --publish
           -p:OnlyPackPlatformSpecificPackages=true
           -p:AssetManifestFileName=aspnetcore-Linux_musl_arm64.xml
           $(_BuildArgs)
@@ -763,7 +771,7 @@ stages:
         platform:
           name: 'Managed'
           container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8'
-          buildScript: './eng/build.sh $(_PublishArgs) --no-build-repo-tasks $(_InternalRuntimeDownloadArgs)'
+          buildScript: './eng/build.sh --publish --no-build-repo-tasks $(_PublishArgs) $(_InternalRuntimeDownloadArgs)'
           skipPublishValidation: true
           jobProperties:
             timeoutInMinutes: 120

--- a/.azure/pipelines/jobs/codesign-xplat.yml
+++ b/.azure/pipelines/jobs/codesign-xplat.yml
@@ -29,6 +29,7 @@ jobs:
         flattenFolders: true
     - powershell: .\eng\common\build.ps1
         -ci
+        -nativeToolsOnMachine
         -nobl
         -msbuildEngine dotnet
         -restore

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -45,6 +45,9 @@ Run tests.
 .PARAMETER Sign
 Run code signing.
 
+.PARAMETER Publish
+Run publishing.
+
 .PARAMETER Configuration
 Debug or Release
 
@@ -141,6 +144,7 @@ param(
     [switch]$Pack, # Produce packages
     [switch]$Test, # Run tests
     [switch]$Sign, # Code sign
+    [switch]$Publish, # Run arcade publishing
 
     [Alias('c')]
     [ValidateSet('Debug', 'Release')]
@@ -262,6 +266,7 @@ if (-not $RunBuild) { $MSBuildArguments += "/p:NoBuild=true" }
 $MSBuildArguments += "/p:Pack=$Pack"
 $MSBuildArguments += "/p:Test=$Test"
 $MSBuildArguments += "/p:Sign=$Sign"
+$MSBuildArguments += "/p:Publish=$Publish"
 
 $MSBuildArguments += "/p:TargetArchitecture=$Architecture"
 $MSBuildArguments += "/p:TargetOsName=win"


### PR DESCRIPTION
https://github.com/dotnet/aspnetcore/pull/54422/files introduced new build script switches for -publish and -no-publish to be compatible with VMR workflows. The aspnetcore CI jobs were passing /p:Publish=true instead of using such a switch. The default value for the new switch if not passed is false, so essentially this turned off publishing for much of aspnetcore. Fix this by not using the msbuild property. Instead, pass the switch. This matches standard arcade repo patterns.

# {PR title}

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

{Detail}

Fixes #{bug number} (in this specific format)
