### PR TITLE
Fix Java discovery in helix-matrix pipeline

### DIFF
--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -32,7 +32,7 @@ jobs:
     timeoutInMinutes: 480
     steps:
     # Build the shared framework
-    - script: ./eng/build.cmd -ci -prepareMachine -nobl -all -pack -arch x64
+    - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -nobl -all -pack -arch x64
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Build shared fx
     # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.


### PR DESCRIPTION
After #54421 got merged, the "Build shared fx" step of our helix-matrix pipeline started failing with [errors finding the JDK](https://dev.azure.com/dnceng-public/public/_build/results?buildId=608157&view=logs&j=8c9dd6ae-5017-5a70-997c-c2386fed4e85&t=08f03346-66e4-5e90-efbd-e93e009e9dd6).

![image](https://github.com/dotnet/aspnetcore/assets/54385/1096d652-5c65-4239-b735-0a08045f8db4)

I saw that #54421 added an `NativeToolsOnMachine` param to build.ps1 which it uses in ci.yml, so I did the same in helix-matrix.yml. Hopefully next we can make the pipeline green.

Test helix-matrix run: https://dev.azure.com/dnceng-public/public/_build/results?buildId=609177&view=results