### PR TITLE
Fix version files missing from publishing

### DIFF
--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -347,7 +347,6 @@ stages:
                   /p:AssetManifestFileName=aspnetcore-win.xml
                   $(_BuildArgs)
                   $(_PublishArgs)
-                  /p:PublishInstallerBaseVersion=true
                   $(_InternalRuntimeDownloadArgs)
                   $(WindowsArm64InstallersLogArgs)
           displayName: Build ARM64 Installers

--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -81,8 +81,7 @@ variables:
   - group: Publish-Build-Assets
   # The following extra properties are not set when testing. Use with final build.[cmd,sh] of asset-producing jobs.
   - name: _PublishArgs
-    value: /p:GenerateChecksums=true
-           /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
+    value: /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
   - ${{ if ne(parameters.produceBinlogs, 'true') }}:
     # Do not log most Windows steps in official builds; this is the slowest job. Site extensions step always logs.
     - name: WindowsArm64LogArgs

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -81,8 +81,7 @@ variables:
   - group: Publish-Build-Assets
   # The following extra properties are not set when testing. Use with final build.[cmd,sh] of asset-producing jobs.
   - name: _PublishArgs
-    value: /p:GenerateChecksums=true
-           /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
+    value: /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
   - ${{ if ne(parameters.produceBinlogs, 'true') }}:
     # Do not log most Windows steps in official builds; this is the slowest job. Site extensions step always logs.
     - name: WindowsArm64LogArgs

--- a/eng/AfterSigning.targets
+++ b/eng/AfterSigning.targets
@@ -1,14 +1,13 @@
 <Project>
-  <PropertyGroup Condition="'$(GenerateChecksums)' == 'true'">
+  <PropertyGroup>
     <!-- $(InstallersOutputPath) is not defined. Root Directory.Build.props is not imported. -->
     <InstallersOutputPath>$(ArtifactsDir)installers\</InstallersOutputPath>
     <_SuppressSdkImports>false</_SuppressSdkImports>
   </PropertyGroup>
 
   <Target Name="PopulateGenerateChecksumItems"
-          Condition="'$(GenerateChecksums)' == 'true'"
           AfterTargets="Build"
-          BeforeTargets="GenerateChecksums" >
+          BeforeTargets="GenerateChecksums">
 
     <ItemGroup>
       <InstallerFiles Include="$(InstallersOutputPath)**\*.msi" />
@@ -25,6 +24,6 @@
 
   </Target>
 
-  <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" Condition="'$(GenerateChecksums)' == 'true'" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
 </Project>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -17,7 +17,7 @@
                                           '$(PostBuildSign)' != 'true' and
                                           '$(DotNetBuildRepo)' != 'true'">false</EnableDefaultPublishItems>
 
-    <PublishInstallerBaseVersion Condition="'$(PublishInstallerBaseVersion)' == '' and '$(EnableDefaultPublishItems)' == 'true'">true</PublishInstallerBaseVersion>
+    <PublishInstallerBaseVersion Condition="'$(OS)' == 'Windows_NT' or '$(DotNetBuildRepo)' == 'true'">true</PublishInstallerBaseVersion>
     <!-- This avoids creating VS.*.symbols.nupkg packages that are identical to the original package. -->
     <AutoGenerateSymbolPackages>false</AutoGenerateSymbolPackages>
   </PropertyGroup>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -33,7 +33,7 @@
     <_InstallersToPublish Include="$(ArtifactsDir)packages\**\*.jar" UploadPathSegment="jar" />
     <_InstallersToPublish Include="$(ArtifactsDir)packages\**\*.pom" UploadPathSegment="jar" />
     <!-- All builds produce npm assets - only publish them once -->
-    <_InstallersToPublish Include="$(ArtifactsDir)packages\**\*.tgz" UploadPathSegment="npm" Condition="'$(OS)' == 'Windows_NT'" />
+    <_InstallersToPublish Include="$(ArtifactsDir)packages\**\*.tgz" UploadPathSegment="npm" Condition="'$(OS)' == 'Windows_NT' or '$(DotNetBuildRepo)' == 'true'" />
     <_InstallersToPublish Include="$(ArtifactsDir)installers\**\*.deb" UploadPathSegment="Runtime" />
     <_InstallersToPublish Include="$(ArtifactsDir)installers\**\*.exe" UploadPathSegment="Runtime" />
     <_InstallersToPublish Include="$(ArtifactsDir)installers\**\*.msi" UploadPathSegment="Runtime" />


### PR DESCRIPTION
Regressed with https://github.com/dotnet/aspnetcore/commit/38b8d1c392ca3581a070ec380e3f64d9275b296e

Fixes sdk --> installer dependency flow: https://github.com/dotnet/installer/pull/19116

Also enables checksum generation in all builds so that the VMR gets them as well.