### PR TITLE
Allow retries in DefaultKeyResolver.CanCreateAuthenticatedEncryptor

### DIFF
--- a/src/DataProtection/DataProtection/src/KeyManagement/DefaultKeyResolver.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/DefaultKeyResolver.cs
@@ -87,7 +87,7 @@ internal sealed class DefaultKeyResolver : IDefaultKeyResolver
                     if (exceptions is null)
                     {
                         // The first failure doesn't count as a retry
-                        exceptions = new();
+                        exceptions = [];
                     }
                     else
                     {

--- a/src/DataProtection/DataProtection/src/KeyManagement/DefaultKeyResolver.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/DefaultKeyResolver.cs
@@ -103,6 +103,9 @@ internal sealed class DefaultKeyResolver : IDefaultKeyResolver
                 _logger.RetryingMethodOfKeyAfterFailure(key.KeyId, nameof(IKey.CreateEncryptor), ex);
             }
 
+            // Reset the descriptor to allow for a retry
+            (key as Key)?.ResetDescriptor();
+
             // Don't retry immediately
             Thread.Sleep(_decryptRetryDelay);
         }

--- a/src/DataProtection/DataProtection/src/KeyManagement/DefaultKeyResolver.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/DefaultKeyResolver.cs
@@ -109,7 +109,7 @@ internal sealed class DefaultKeyResolver : IDefaultKeyResolver
             // Reset the descriptor to allow for a retry
             (key as Key)?.ResetDescriptor();
 
-            // Don't retry immediately
+            // Don't retry immediately - allow a little time for the transient problem to clear
             Thread.Sleep(_decryptRetryDelay);
         }
     }

--- a/src/DataProtection/DataProtection/src/KeyManagement/DefaultKeyResolver.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/DefaultKeyResolver.cs
@@ -54,7 +54,7 @@ internal sealed class DefaultKeyResolver : IDefaultKeyResolver
     {
         _keyPropagationWindow = KeyManagementOptions.KeyPropagationWindow;
         _maxServerToServerClockSkew = KeyManagementOptions.MaxServerClockSkew;
-        _maxDecryptRetries = keyManagementOptions.Value.MaximumDefaultKeyResolverRetries;
+        _maxDecryptRetries = keyManagementOptions.Value.MaximumTotalDefaultKeyResolverRetries;
         _decryptRetryDelay = keyManagementOptions.Value.DefaultKeyResolverRetryDelay;
         _logger = loggerFactory.CreateLogger<DefaultKeyResolver>();
     }

--- a/src/DataProtection/DataProtection/src/KeyManagement/Key.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/Key.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Xml.Linq;
 using Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption;
 using Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel;
@@ -16,7 +17,13 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement;
 /// </summary>
 internal sealed class Key : IKey
 {
-    private readonly Lazy<IAuthenticatedEncryptorDescriptor> _lazyDescriptor;
+    private IAuthenticatedEncryptorDescriptor? _descriptor;
+
+    // If descriptor is available at construction time, these will remain null forever
+    private readonly object? _descriptorLock; // Protects _descriptor and _descriptorException
+    private readonly Func<IAuthenticatedEncryptorDescriptor>? _descriptorFactory; // May not be used
+    private Exception? _descriptorException;
+
     private readonly IEnumerable<IAuthenticatedEncryptorFactory> _encryptorFactories;
 
     private IAuthenticatedEncryptor? _encryptor;
@@ -36,8 +43,10 @@ internal sealed class Key : IKey
               creationDate,
               activationDate,
               expirationDate,
-              new Lazy<IAuthenticatedEncryptorDescriptor>(() => descriptor),
-              encryptorFactories)
+              encryptorFactories,
+              descriptor,
+              descriptorFactory: null,
+              descriptorException: null)
     {
     }
 
@@ -57,8 +66,29 @@ internal sealed class Key : IKey
               creationDate,
               activationDate,
               expirationDate,
-              new Lazy<IAuthenticatedEncryptorDescriptor>(GetLazyDescriptorDelegate(keyManager, keyElement)),
-              encryptorFactories)
+              encryptorFactories,
+              descriptor: null,
+              descriptorFactory: GetLazyDescriptorDelegate(keyManager, keyElement),
+              descriptorException: null)
+    {
+    }
+
+    // internal for testing
+    internal Key(
+        Guid keyId,
+        DateTimeOffset creationDate,
+        DateTimeOffset activationDate,
+        DateTimeOffset expirationDate,
+        IEnumerable<IAuthenticatedEncryptorFactory> encryptorFactories,
+        Func<IAuthenticatedEncryptorDescriptor>? descriptorFactory)
+        : this(keyId,
+              creationDate,
+              activationDate,
+              expirationDate,
+              encryptorFactories,
+              descriptor: null,
+              descriptorFactory: descriptorFactory,
+              descriptorException: null)
     {
     }
 
@@ -67,15 +97,20 @@ internal sealed class Key : IKey
         DateTimeOffset creationDate,
         DateTimeOffset activationDate,
         DateTimeOffset expirationDate,
-        Lazy<IAuthenticatedEncryptorDescriptor> lazyDescriptor,
-        IEnumerable<IAuthenticatedEncryptorFactory> encryptorFactories)
+        IEnumerable<IAuthenticatedEncryptorFactory> encryptorFactories,
+        IAuthenticatedEncryptorDescriptor? descriptor,
+        Func<IAuthenticatedEncryptorDescriptor>? descriptorFactory,
+        Exception? descriptorException)
     {
         KeyId = keyId;
         CreationDate = creationDate;
         ActivationDate = activationDate;
         ExpirationDate = expirationDate;
-        _lazyDescriptor = lazyDescriptor;
         _encryptorFactories = encryptorFactories;
+        _descriptor = descriptor;
+        _descriptorFactory = descriptorFactory;
+        _descriptorException = descriptorException;
+        _descriptorLock = descriptor is null ? new() : null;
     }
 
     public DateTimeOffset ActivationDate { get; }
@@ -92,7 +127,56 @@ internal sealed class Key : IKey
     {
         get
         {
-            return _lazyDescriptor.Value;
+            // We could check for _descriptorException here, but there's no reason to optimize that case
+            // (i.e. by avoiding taking the lock)
+
+            if (_descriptor is not null) // Can only become less null, so losing a race here doesn't matter
+            {
+                Debug.Assert(_descriptorException is null); // Mutually exclusive with _descriptor
+                return _descriptor;
+            }
+
+            lock (_descriptorLock!)
+            {
+                if (_descriptorException is not null)
+                {
+                    throw _descriptorException;
+                }
+
+                if (_descriptor is not null)
+                {
+                    return _descriptor;
+                }
+
+                Debug.Assert(_descriptorFactory is not null, "Key constructed without either descriptor or descriptor factory");
+
+                try
+                {
+                    _descriptor = _descriptorFactory();
+                    return _descriptor;
+                }
+                catch (Exception ex)
+                {
+                    _descriptorException = ex;
+                    throw;
+                }
+            }
+        }
+    }
+
+    internal void ResetDescriptor()
+    {
+        if (_descriptor is not null)
+        {
+            Debug.Fail("ResetDescriptor called with descriptor available");
+            Debug.Assert(_descriptorException is null); // Mutually exclusive with _descriptor
+            return;
+        }
+
+        lock (_descriptorLock!)
+        {
+            _descriptor = null;
+            _descriptorException = null;
         }
     }
 
@@ -121,13 +205,16 @@ internal sealed class Key : IKey
 
     internal Key Clone()
     {
+        // Note that we don't reuse _descriptorLock
         return new Key(
             keyId: KeyId,
             creationDate: CreationDate,
             activationDate: ActivationDate,
             expirationDate: ExpirationDate,
-            lazyDescriptor: _lazyDescriptor,
-            encryptorFactories: _encryptorFactories)
+            encryptorFactories: _encryptorFactories,
+            descriptor: _descriptor,
+            descriptorFactory: _descriptorFactory,
+            descriptorException: _descriptorException)
         {
             IsRevoked = IsRevoked,
         };

--- a/src/DataProtection/DataProtection/src/KeyManagement/Key.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/Key.cs
@@ -130,7 +130,7 @@ internal sealed class Key : IKey
             // We could check for _descriptorException here, but there's no reason to optimize that case
             // (i.e. by avoiding taking the lock)
 
-            if (_descriptor is not null) // Can only become less null, so losing a race here doesn't matter
+            if (_descriptor is not null) // Can only go from null to non-null, so losing a race here doesn't matter
             {
                 Debug.Assert(_descriptorException is null); // Mutually exclusive with _descriptor
                 return _descriptor;

--- a/src/DataProtection/DataProtection/src/KeyManagement/KeyManagementOptions.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/KeyManagementOptions.cs
@@ -95,6 +95,25 @@ public class KeyManagementOptions
     }
 
     /// <summary>
+    /// During each default key resolution, if a key decryption attempt fails,
+    /// it can be retried, as long as the total number of retries across all keys
+    /// does not exceed this value.
+    /// </summary>
+    /// <remarks>
+    /// Settable for testing.
+    /// </remarks>
+    internal int MaximumDefaultKeyResolverRetries { get; set; } = 10;
+
+    /// <summary>
+    /// Wait this long before each default key resolution decryption retry.
+    /// <seealso cref="MaximumDefaultKeyResolverRetries"/>
+    /// </summary>
+    /// <remarks>
+    /// Settable for testing.
+    /// </remarks>
+    internal TimeSpan DefaultKeyResolverRetryDelay { get; set; } = TimeSpan.FromMilliseconds(200);
+
+    /// <summary>
     /// Controls the lifetime (number of days before expiration)
     /// for newly-generated keys.
     /// </summary>

--- a/src/DataProtection/DataProtection/src/KeyManagement/KeyManagementOptions.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/KeyManagementOptions.cs
@@ -102,11 +102,11 @@ public class KeyManagementOptions
     /// <remarks>
     /// Settable for testing.
     /// </remarks>
-    internal int MaximumDefaultKeyResolverRetries { get; set; } = 10;
+    internal int MaximumTotalDefaultKeyResolverRetries { get; set; } = 10;
 
     /// <summary>
     /// Wait this long before each default key resolution decryption retry.
-    /// <seealso cref="MaximumDefaultKeyResolverRetries"/>
+    /// <seealso cref="MaximumTotalDefaultKeyResolverRetries"/>
     /// </summary>
     /// <remarks>
     /// Settable for testing.

--- a/src/DataProtection/DataProtection/src/LoggingExtensions.cs
+++ b/src/DataProtection/DataProtection/src/LoggingExtensions.cs
@@ -73,7 +73,7 @@ internal static partial class LoggingExtensions
     [LoggerMessage(11, LogLevel.Debug, "Using managed symmetric algorithm '{FullName}'.", EventName = "UsingManagedSymmetricAlgorithm")]
     public static partial void UsingManagedSymmetricAlgorithm(this ILogger logger, string fullName);
 
-    [LoggerMessage(12, LogLevel.Warning, "Key {KeyId:B} is ineligible to be the default key because its {MethodName} method failed.", EventName = "KeyIsIneligibleToBeTheDefaultKeyBecauseItsMethodFailed")]
+    [LoggerMessage(12, LogLevel.Warning, "Key {KeyId:B} is ineligible to be the default key because its {MethodName} method failed after the maximum number of retries.", EventName = "KeyIsIneligibleToBeTheDefaultKeyBecauseItsMethodFailed")]
     public static partial void KeyIsIneligibleToBeTheDefaultKeyBecauseItsMethodFailed(this ILogger logger, Guid keyId, string methodName, Exception exception);
 
     [LoggerMessage(13, LogLevel.Debug, "Considering key {KeyId:B} with expiration date {ExpirationDate:u} as default key.", EventName = "ConsideringKeyWithExpirationDateAsDefaultKey")]

--- a/src/DataProtection/DataProtection/src/LoggingExtensions.cs
+++ b/src/DataProtection/DataProtection/src/LoggingExtensions.cs
@@ -252,4 +252,7 @@ internal static partial class LoggingExtensions
 
     [LoggerMessage(72, LogLevel.Error, "The key ring's default data protection key {KeyId:B} has been revoked.", EventName = "KeyRingDefaultKeyIsRevoked")]
     public static partial void KeyRingDefaultKeyIsRevoked(this ILogger logger, Guid keyId);
+
+    [LoggerMessage(73, LogLevel.Debug, "Key {KeyId:B} method {MethodName} failed. Retrying.", EventName = "RetryingMethodOfKeyAfterFailure")]
+    public static partial void RetryingMethodOfKeyAfterFailure(this ILogger logger, Guid keyId, string methodName, Exception exception);
 }

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/KeyManagement/DefaultKeyResolverTests.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/KeyManagement/DefaultKeyResolverTests.cs
@@ -335,7 +335,7 @@ public class DefaultKeyResolverTests
         // Arrange
         var options = Options.Create(new KeyManagementOptions()
         {
-            MaximumDefaultKeyResolverRetries = maxRetries,
+            MaximumTotalDefaultKeyResolverRetries = maxRetries,
             DefaultKeyResolverRetryDelay = TimeSpan.Zero,
         });
 
@@ -412,7 +412,7 @@ public class DefaultKeyResolverTests
         // Arrange
         var options = Options.Create(new KeyManagementOptions()
         {
-            MaximumDefaultKeyResolverRetries = 3,
+            MaximumTotalDefaultKeyResolverRetries = 3,
             DefaultKeyResolverRetryDelay = TimeSpan.Zero,
         });
 

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/KeyManagement/DefaultKeyResolverTests.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/KeyManagement/DefaultKeyResolverTests.cs
@@ -326,13 +326,16 @@ public class DefaultKeyResolverTests
         Assert.Equal(0, descriptorFactoryCalls); // Not retried
     }
 
-    [Fact]
-    public void CreateEncryptor_FirstAttemptIsNotARetry()
+    [Theory]
+    [InlineData(0)] // Retries disabled (as by appcontext switch)
+    [InlineData(1)]
+    [InlineData(10)]
+    public void CreateEncryptor_FirstAttemptIsNotARetry(int maxRetries)
     {
         // Arrange
         var options = Options.Create(new KeyManagementOptions()
         {
-            MaximumDefaultKeyResolverRetries = 3,
+            MaximumDefaultKeyResolverRetries = maxRetries,
             DefaultKeyResolverRetryDelay = TimeSpan.Zero,
         });
 
@@ -400,7 +403,7 @@ public class DefaultKeyResolverTests
         Assert.True(resolution.ShouldGenerateNewKey);
 
         Assert.Equal(1, descriptorFactoryCalls1); // 1 try
-        Assert.Equal(4, descriptorFactoryCalls2); // 1 try plus max (3) retries
+        Assert.Equal(1 + maxRetries, descriptorFactoryCalls2); // 1 try plus max retries
     }
 
     [Fact]


### PR DESCRIPTION
This code is trying to ensure that the selected key can be decrypted (i.e. is usable).  It may fail if, for example, Azure KeyVault is unreachable due to connectivity issues.  If it fails, there's a log message and then an immediately-activated key will be generated.  An immediately-activated key can cause problems for sessions making requests to multiple app instances and those problems won't obviously be connected to the (almost silent) failure in CanCreateAuthenticatedEncryptor.  Rather than effectively swallowing such errors, we should allow some retries.

Part of #36157