### PR TITLE
Remove internal args from public build

### DIFF
--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -50,31 +50,6 @@ variables:
     value: true
 - name: _UseHelixOpenQueues
   value: ${{ ne(variables['System.TeamProject'], 'internal') }}
-- ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
-  - name: _BuildArgs
-    value: /p:TeamName=$(_TeamName)
-           /p:OfficialBuildId=$(Build.BuildNumber)
-           /p:SkipTestBuild=true
-           /p:PostBuildSign=$(PostBuildSign)
-  # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
-  - group: Publish-Build-Assets
-  # The following extra properties are not set when testing. Use with final build.[cmd,sh] of asset-producing jobs.
-  - name: _PublishArgs
-    value: /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
-  - ${{ if ne(parameters.produceBinlogs, 'true') }}:
-    # Do not log most Windows steps in official builds; this is the slowest job. Site extensions step always logs.
-    - name: WindowsArm64LogArgs
-      value: -ExcludeCIBinaryLog
-    - name: Windows64LogArgs
-      value: -ExcludeCIBinaryLog
-    - name: Windows86LogArgs
-      value: -ExcludeCIBinaryLog
-    - name: WindowsSignLogArgs
-      value: -ExcludeCIBinaryLog
-    - name: WindowsInstallersLogArgs
-      value: -ExcludeCIBinaryLog
-    - name: WindowsArm64InstallersLogArgs
-      value: -ExcludeCIBinaryLog
 - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
   - name: _BuildArgs
     value: '/p:SkipTestBuild=true /p:PostBuildSign=$(PostBuildSign)'


### PR DESCRIPTION
These args used to be conditioned under `if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'))` - they never should have been in `ci-public` in the first place