### PR TITLE
Include ContentLength when enumerating HttpHeaders

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
@@ -8670,6 +8670,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     return true;
                 }
             }
+
+            private static int GetNext(long bits, bool hasContentLength)
+            {
+                return bits != 0
+                    ? BitOperations.TrailingZeroCount(bits)
+                    : hasContentLength
+                        ? 49
+                        : -1;
+            }
         }
     }
 
@@ -15495,6 +15504,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     _next = _collection._contentLength.HasValue ? 38 : -1;
                     return true;
                 }
+            }
+
+            private static int GetNext(long bits, bool hasContentLength)
+            {
+                return bits != 0
+                    ? BitOperations.TrailingZeroCount(bits)
+                    : hasContentLength
+                        ? 38
+                        : -1;
             }
         }
     }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
@@ -8671,6 +8671,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
             }
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private static int GetNext(long bits, bool hasContentLength)
             {
                 return bits != 0
@@ -15506,6 +15507,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
             }
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private static int GetNext(long bits, bool hasContentLength)
             {
                 return bits != 0

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
@@ -244,7 +244,7 @@ internal sealed partial class HttpRequestHeaders : HttpHeaders
         {
             _collection = collection;
             _currentBits = collection._bits;
-            _next = _currentBits != 0 ? BitOperations.TrailingZeroCount(_currentBits) : -1;
+            _next = GetNext(_currentBits, collection.ContentLength.HasValue);
             _current = default;
             _hasUnknown = collection.MaybeUnknown != null;
             _unknownEnumerator = _hasUnknown
@@ -263,6 +263,7 @@ internal sealed partial class HttpRequestHeaders : HttpHeaders
         public void Reset()
         {
             _currentBits = _collection._bits;
+            _next = GetNext(_currentBits, _collection.ContentLength.HasValue);
             _next = _currentBits != 0 ? BitOperations.TrailingZeroCount(_currentBits) : -1;
         }
     }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
@@ -264,7 +264,6 @@ internal sealed partial class HttpRequestHeaders : HttpHeaders
         {
             _currentBits = _collection._bits;
             _next = GetNext(_currentBits, _collection.ContentLength.HasValue);
-            _next = _currentBits != 0 ? BitOperations.TrailingZeroCount(_currentBits) : -1;
         }
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
@@ -4,7 +4,6 @@
 using System.Buffers.Text;
 using System.Collections;
 using System.Globalization;
-using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponseHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponseHeaders.cs
@@ -5,7 +5,6 @@ using System.Buffers;
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Pipelines;
-using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.Extensions.Primitives;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponseHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponseHeaders.cs
@@ -152,7 +152,7 @@ internal sealed partial class HttpResponseHeaders : HttpHeaders
         {
             _collection = collection;
             _currentBits = collection._bits;
-            _next = _currentBits != 0 ? BitOperations.TrailingZeroCount(_currentBits) : -1;
+            _next = GetNext(_currentBits, collection.ContentLength.HasValue);
             _current = default;
             _currentKnownType = default;
             _hasUnknown = collection.MaybeUnknown != null;
@@ -174,7 +174,7 @@ internal sealed partial class HttpResponseHeaders : HttpHeaders
         public void Reset()
         {
             _currentBits = _collection._bits;
-            _next = _currentBits != 0 ? BitOperations.TrailingZeroCount(_currentBits) : -1;
+            _next = GetNext(_currentBits, _collection.ContentLength.HasValue);
         }
     }
 }

--- a/src/Servers/Kestrel/Core/test/HttpRequestHeadersTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpRequestHeadersTests.cs
@@ -831,6 +831,18 @@ public class HttpRequestHeadersTests
         Assert.Equal(0, count);
     }
 
+    [Fact]
+    public void ContentLengthEnumerableWithoutOtherKnownHeader()
+    {
+        IHeaderDictionary headers = new HttpRequestHeaders();
+        headers["content-length"] = "1024";
+        Assert.Single(headers);
+        headers["unknown"] = "value";
+        Assert.Equal(2, headers.Count()); // NB: enumerable count, not property
+        headers["host"] = "myhost";
+        Assert.Equal(3, headers.Count()); // NB: enumerable count, not property
+    }
+
     private static (string PrevHeaderValue, string NextHeaderValue) GetHeaderValues(HttpRequestHeaders headers, string prevName, string nextName, string prevValue, string nextValue)
     {
         headers.Reset();

--- a/src/Servers/Kestrel/Core/test/HttpResponseHeadersTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpResponseHeadersTests.cs
@@ -392,6 +392,18 @@ public class HttpResponseHeadersTests
         Assert.Null(headers.ContentLength);
     }
 
+    [Fact]
+    public void ContentLengthEnumerableWithoutOtherKnownHeader()
+    {
+        IHeaderDictionary headers = new HttpResponseHeaders();
+        headers["content-length"] = "1024";
+        Assert.Single(headers);
+        headers["unknown"] = "value";
+        Assert.Equal(2, headers.Count()); // NB: enumerable count, not property
+        headers["host"] = "myhost";
+        Assert.Equal(3, headers.Count()); // NB: enumerable count, not property
+    }
+
     private static long ParseLong(string value)
     {
         return long.Parse(value, NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite, CultureInfo.InvariantCulture);

--- a/src/Servers/Kestrel/shared/KnownHeaders.cs
+++ b/src/Servers/Kestrel/shared/KnownHeaders.cs
@@ -1430,6 +1430,7 @@ $@"        private void Clear(long bitsToClear)
                 }}
             }}{(loop.ClassName.Contains("Trailers") ? "" : $@"
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private static int GetNext(long bits, bool hasContentLength)
             {{
                 return bits != 0

--- a/src/Servers/Kestrel/shared/KnownHeaders.cs
+++ b/src/Servers/Kestrel/shared/KnownHeaders.cs
@@ -1428,7 +1428,16 @@ $@"        private void Clear(long bitsToClear)
                     {(!loop.ClassName.Contains("Trailers") ? $@"_next = _collection._contentLength.HasValue ? {loop.Headers.Length - 1} : -1;" : "_next = -1;")}
                     return true;
                 }}
-            }}
+            }}{(loop.ClassName.Contains("Trailers") ? "" : $@"
+
+            private static int GetNext(long bits, bool hasContentLength)
+            {{
+                return bits != 0
+                    ? BitOperations.TrailingZeroCount(bits)
+                    : hasContentLength
+                        ? {loop.Headers.Length - 1}
+                        : -1;
+            }}")}
         }}
     }}
 ")}}}";


### PR DESCRIPTION
...even if no bits are set.

Fixes #54557