### PR TITLE
Reduce helix-matrix timeout to 3 hours

### DIFF
--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -29,7 +29,7 @@ jobs:
     jobName: Helix_matrix_x64
     jobDisplayName: 'Tests: Helix full matrix x64'
     agentOs: Windows
-    timeoutInMinutes: 480
+    timeoutInMinutes: 180
     steps:
     # Build the shared framework
     - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -nobl -all -pack -arch x64


### PR DESCRIPTION
Average build time is 90 minutes