### PR TITLE
Added retry for CheckInvalidHostingModelParameter

### DIFF
--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -10,6 +10,7 @@
     {"testName": {"contains": "CertificateChangedOnDisk_Symlink"}}, // depends on FS event timing
     {"testName": {"contains": "POST_ServerAbort_ClientReceivesAbort"}},
     {"testName": {"contains": "Microsoft.AspNetCore.Components.WebViewE2E.Test.WebViewManagerE2ETests.CanLaunchPhotinoWebViewAndClickButton"}},
+    {"testName": {"contains": "Microsoft.AspNetCore.Server.IIS.NewShim.FunctionalTests.StartupTests.CheckInvalidHostingModelParameter"}},
     {"testAssembly": {"contains": "IIS"}},
     {"testAssembly": {"contains": "Template"}},
     {"failureMessage": {"contains":"(Site is started but no worker process found)"}},


### PR DESCRIPTION
```
  Failed Microsoft.AspNetCore.Server.IIS.NewShim.FunctionalTests.StartupTests.CheckInvalidHostingModelParameter [3 s]
  Error Message:
   No entries matched by 'Could not load configuration. Exception message:
Unknown hosting model 'bogus'. Please specify either hostingModel="inprocess" or hostingModel="outofprocess" in the web.config file.'
Expected: True
Actual:   False
```

https://github.com/dotnet/aspnetcore/issues/54785