### PR TITLE
Use SearchValues throughout dotnet/aspnetcore (part 2)

### DIFF
--- a/src/Http/Http/test/RequestCookiesCollectionTests.cs
+++ b/src/Http/Http/test/RequestCookiesCollectionTests.cs
@@ -37,11 +37,12 @@ public class RequestCookiesCollectionTests
     [InlineData("er=dd,err=cc,errr=bb", new[] { "dd", "cc", "bb" })]
     [InlineData("errorcookie=dd,:(\"sa;", new[] { "dd" })]
     [InlineData("s;", null)]
+    [InlineData("er=;,err=,errr=\\,errrr=\"", null)]
     public void ParseInvalidCookies(string cookieToParse, string[] expectedCookieValues)
     {
         var cookies = RequestCookieCollection.Parse(new StringValues(new[] { cookieToParse }));
 
-        if(expectedCookieValues == null)
+        if (expectedCookieValues == null)
         {
             Assert.Equal(0, cookies.Count);
             return;
@@ -52,6 +53,23 @@ public class RequestCookiesCollectionTests
         {
             var value = expectedCookieValues[i];
             Assert.Equal(value, cookies.ElementAt(i).Value);
+        }
+    }
+
+    [Fact]
+    public void AllExpectedCookieValueCharsPresent()
+    {
+        foreach (var c in Enumerable.Range(0x00, 0xFF).Select(x => (char)x))
+        {
+            var cookies = RequestCookieCollection.Parse(new StringValues(new[] { $"something={c}" }));
+            if (c < 0x21 || c > 0x7E || c == '\\' || c == ',' || c == ';' || c == '\"')
+            {
+                Assert.Equal(0, cookies.Count);
+            }
+            else
+            {
+                Assert.Equal(c.ToString(), cookies.Single().Value);
+            }
         }
     }
 }

--- a/src/Http/Shared/CookieHeaderParserShared.cs
+++ b/src/Http/Shared/CookieHeaderParserShared.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using Microsoft.Extensions.Primitives;
@@ -9,6 +10,11 @@ namespace Microsoft.Net.Http.Headers;
 
 internal static class CookieHeaderParserShared
 {
+    // cookie-octet      = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
+    //                     ; US-ASCII characters excluding CTLs, whitespace DQUOTE, comma, semicolon, and backslash
+    private static readonly SearchValues<char> CookieValueChar =
+        SearchValues.Create("!#$%&'()*+-./0123456789:<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~");
+
     public static bool TryParseValues(StringValues values, IDictionary<string, string> store, bool supportsMultipleValues)
     {
         // If a parser returns an empty list, it means there was no value, but that's valid (e.g. "Accept: "). The caller
@@ -192,15 +198,14 @@ internal static class CookieHeaderParserShared
             offset++;
         }
 
-        while (offset < input.Length)
+        var delta = input.AsSpan(offset).IndexOfAnyExcept(CookieValueChar);
+        if (delta == -1)
         {
-            var c = input[offset];
-            if (!IsCookieValueChar(c))
-            {
-                break;
-            }
-
-            offset++;
+            offset = input.Length;
+        }
+        else
+        {
+            offset += delta;
         }
 
         if (inQuotes)
@@ -231,16 +236,5 @@ internal static class CookieHeaderParserShared
         }
         offset++;
         return true;
-    }
-
-    // cookie-octet      = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
-    //                     ; US-ASCII characters excluding CTLs, whitespace DQUOTE, comma, semicolon, and backslash
-    private static bool IsCookieValueChar(char c)
-    {
-        if (c < 0x21 || c > 0x7E)
-        {
-            return false;
-        }
-        return !(c == '"' || c == ',' || c == ';' || c == '\\');
     }
 }

--- a/src/Http/Shared/CookieHeaderParserShared.cs
+++ b/src/Http/Shared/CookieHeaderParserShared.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Net.Http.Headers;
 internal static class CookieHeaderParserShared
 {
     // cookie-octet      = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
-    //                     ; US-ASCII characters excluding CTLs, whitespace DQUOTE, comma, semicolon, and backslash
+    //                     ; US-ASCII characters excluding CTLs, whitespace, DQUOTE, comma, semicolon, and backslash
     private static readonly SearchValues<char> CookieValueChar =
         SearchValues.Create("!#$%&'()*+-./0123456789:<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~");
 

--- a/src/Http/Shared/CookieHeaderParserShared.cs
+++ b/src/Http/Shared/CookieHeaderParserShared.cs
@@ -199,7 +199,7 @@ internal static class CookieHeaderParserShared
         }
 
         var delta = input.AsSpan(offset).IndexOfAnyExcept(CookieValueChar);
-        if (delta == -1)
+        if (delta < 0)
         {
             offset = input.Length;
         }


### PR DESCRIPTION
# Use SearchValues throughout dotnet/aspnetcore

Using SearchValues in cookie header parser to find the end of the cookie value.

## Description

- Replacing the loop to search for invalid vales in CookieHeaderParserShared with SearchValues (one of the tasks in https://github.com/dotnet/aspnetcore/issues/46484 )
- Covering tests for all allowed values.

For the performance comparison, I used the existing `RequestCookieCollectionBenchmarks`:

```
BenchmarkDotNet=v0.13.0, OS=Windows 10.0.22631
12th Gen Intel Core i7-1255U, 1 CPU, 12 logical and 10 physical cores
.NET SDK=9.0.100-preview.3.24161.2
  [Host]     : .NET 9.0.0 (9.0.24.17301), X64 RyuJIT
  Job-XWCXZR : .NET 9.0.0 (9.0.24.16003), X64 RyuJIT

Server=True  Toolchain=.NET Core 9.0  InvocationCount=1
RunStrategy=Throughput  UnrollFactor=1
```

Before:

|              Method |     Mean |    Error |   StdDev |     Op/s | Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------- |---------:|---------:|---------:|---------:|------:|------:|------:|----------:|
| Parse_TypicalCookie | 13.11 us | 1.670 us | 4.845 us | 76,275.9 |     - |     - |     - |      1 KB |

After:

|              Method |     Mean |     Error |    StdDev |      Op/s | Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------- |---------:|----------:|----------:|----------:|------:|------:|------:|----------:|
| Parse_TypicalCookie | 6.914 us | 0.2298 us | 0.6444 us | 144,628.1 |     - |     - |     - |     952 B |


If the approach is agreed, I would continue to extend this PR covering further tasks mentioned in the linked issue. At that point I will mark the PR as draft until those are done. Although I can do independent PRs as well, please indicate the preference.