### PR TITLE
Avoid O(N) string[] allocations for N header values in GetCommaSeparatedValues

### DIFF
--- a/src/Http/Http.Abstractions/perf/Microbenchmarks/GetHeaderSplitBenchmark.cs
+++ b/src/Http/Http.Abstractions/perf/Microbenchmarks/GetHeaderSplitBenchmark.cs
@@ -27,7 +27,7 @@ public class GetHeaderSplitBenchmark
     public void SplitSingleHeader()
     {
         var values = ParsingHelpers.GetHeaderSplit(_dictionary, "singleValue");
-        if (values.Count != 1)
+        if (values.Length != 1)
         {
             throw new Exception();
         }
@@ -37,7 +37,7 @@ public class GetHeaderSplitBenchmark
     public void SplitSingleQuotedHeader()
     {
         var values = ParsingHelpers.GetHeaderSplit(_dictionary, "singleValueQuoted");
-        if (values.Count != 1)
+        if (values.Length != 1)
         {
             throw new Exception();
         }
@@ -47,7 +47,7 @@ public class GetHeaderSplitBenchmark
     public void SplitDoubleHeader()
     {
         var values = ParsingHelpers.GetHeaderSplit(_dictionary, "doubleValue");
-        if (values.Count != 2)
+        if (values.Length != 2)
         {
             throw new Exception();
         }
@@ -57,7 +57,7 @@ public class GetHeaderSplitBenchmark
     public void SplitManyHeaders()
     {
         var values = ParsingHelpers.GetHeaderSplit(_dictionary, "manyValue");
-        if (values.Count != 6)
+        if (values.Length != 6)
         {
             throw new Exception();
         }

--- a/src/Http/Http.Abstractions/src/Extensions/HeaderDictionaryExtensions.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/HeaderDictionaryExtensions.cs
@@ -43,7 +43,7 @@ public static class HeaderDictionaryExtensions
     {
         // GetHeaderSplit will return only non-null elements of the given IHeaderDictionary.
 #pragma warning disable CS8619 // Nullability of reference types in value doesn't match target type.
-        return ParsingHelpers.GetHeaderSplit(headers, key).ToArray();
+        return ParsingHelpers.GetHeaderSplit(headers, key);
 #pragma warning restore CS8619 // Nullability of reference types in value doesn't match target type.
     }
 

--- a/src/Http/Http.Abstractions/src/Internal/ParsingHelpers.cs
+++ b/src/Http/Http.Abstractions/src/Internal/ParsingHelpers.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
-using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Http;
@@ -19,8 +18,7 @@ internal static class ParsingHelpers
     {
         var values = GetHeaderUnmodified(headers, key);
 
-        FourStrings stackBuffer = default;
-        ValueListBuilder<string> strings = new(stackBuffer);
+        ValueListBuilder<string> strings = new([null!, null!, null!, null!]);
 
         foreach (var segment in new HeaderSegmentCollection(values))
         {
@@ -134,13 +132,5 @@ internal static class ParsingHelpers
 
         var existing = GetHeaderUnmodified(headers, key);
         SetHeaderUnmodified(headers, key, StringValues.Concat(existing, values));
-    }
-
-    [InlineArray(4)]
-    private struct FourStrings
-    {
-#pragma warning disable IDE0044, IDE0051 // Add readonly modifier, Remove unused private members
-        private string _item0;
-#pragma warning restore IDE0044, IDE0051
     }
 }

--- a/src/Http/Http.Abstractions/src/Microsoft.AspNetCore.Http.Abstractions.csproj
+++ b/src/Http/Http.Abstractions/src/Microsoft.AspNetCore.Http.Abstractions.csproj
@@ -31,6 +31,7 @@ Microsoft.AspNetCore.Http.HttpResponse</Description>
     <Compile Include="$(SharedSourceRoot)Debugger\DebuggerHelpers.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)Debugger\DictionaryItemDebugView.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)Debugger\DictionaryDebugView.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)ValueStringBuilder\ValueListBuilder.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Shared/ValueStringBuilder/ValueListBuilder.cs
+++ b/src/Shared/ValueStringBuilder/ValueListBuilder.cs
@@ -1,0 +1,101 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+// Copied from https://github.com/dotnet/runtime/blob/a9ed4168626c14b4d74db0d8c205c69e56fc45ed/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ValueListBuilder.cs
+// with unused members removed.
+
+namespace System.Collections.Generic;
+
+internal ref partial struct ValueListBuilder<T>
+{
+    private Span<T> _span;
+    private T[]? _arrayFromPool;
+    private int _pos;
+
+    public ValueListBuilder(Span<T> initialSpan)
+    {
+        _span = initialSpan;
+        _arrayFromPool = null;
+        _pos = 0;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Add(T item)
+    {
+        int pos = _pos;
+
+        // Workaround for https://github.com/dotnet/runtime/issues/72004
+        Span<T> span = _span;
+        if ((uint)pos < (uint)span.Length)
+        {
+            span[pos] = item;
+            _pos = pos + 1;
+        }
+        else
+        {
+            AddWithResize(item);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void AddWithResize(T item)
+    {
+        Debug.Assert(_pos == _span.Length);
+        int pos = _pos;
+        Grow(1);
+        _span[pos] = item;
+        _pos = pos + 1;
+    }
+
+    public ReadOnlySpan<T> AsSpan() => _span.Slice(0, _pos);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Dispose()
+    {
+        T[]? toReturn = _arrayFromPool;
+        if (toReturn != null)
+        {
+            _arrayFromPool = null;
+            ArrayPool<T>.Shared.Return(toReturn);
+        }
+    }
+
+    // Note that consuming implementations depend on the list only growing if it's absolutely
+    // required.  If the list is already large enough to hold the additional items be added,
+    // it must not grow. The list is used in a number of places where the reference is checked
+    // and it's expected to match the initial reference provided to the constructor if that
+    // span was sufficiently large.
+    private void Grow(int additionalCapacityRequired = 1)
+    {
+        const int ArrayMaxLength = 0x7FFFFFC7; // same as Array.MaxLength
+
+        // Double the size of the span.  If it's currently empty, default to size 4,
+        // although it'll be increased in Rent to the pool's minimum bucket size.
+        int nextCapacity = Math.Max(_span.Length != 0 ? _span.Length * 2 : 4, _span.Length + additionalCapacityRequired);
+
+        // If the computed doubled capacity exceeds the possible length of an array, then we
+        // want to downgrade to either the maximum array length if that's large enough to hold
+        // an additional item, or the current length + 1 if it's larger than the max length, in
+        // which case it'll result in an OOM when calling Rent below.  In the exceedingly rare
+        // case where _span.Length is already int.MaxValue (in which case it couldn't be a managed
+        // array), just use that same value again and let it OOM in Rent as well.
+        if ((uint)nextCapacity > ArrayMaxLength)
+        {
+            nextCapacity = Math.Max(Math.Max(_span.Length + 1, ArrayMaxLength), _span.Length);
+        }
+
+        T[] array = ArrayPool<T>.Shared.Rent(nextCapacity);
+        _span.CopyTo(array);
+
+        T[]? toReturn = _arrayFromPool;
+        _span = _arrayFromPool = array;
+        if (toReturn != null)
+        {
+            ArrayPool<T>.Shared.Return(toReturn);
+        }
+    }
+}


### PR DESCRIPTION
Reduce allocation in HeaderDictionaryExtensions.GetCommaSeparatedValues

## Description

The method parses the header value, adding each segment as a string into a StringValues. It does so one at a time, such that each addition requires allocating a new array one element larger than the previous, for O(N) allocations and O(N^2) work.  The only consumer of that also doesn't actually use StringValues: it immediately ToArray's it.  So this just builds up the array directly, starting with stack memory for the first four elements and growing into array pool buffers if more is needed, then producing a single array of the right size at the end.