### PR TITLE
Test fixes

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -314,7 +314,7 @@
     <NewtonsoftJsonBsonVersion>1.0.2</NewtonsoftJsonBsonVersion>
     <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     <NSwagApiDescriptionClientVersion>13.0.4</NSwagApiDescriptionClientVersion>
-    <PhotinoNETVersion>2.6.0</PhotinoNETVersion>
+    <PhotinoNETVersion>2.5.2</PhotinoNETVersion>
     <MicrosoftPlaywrightVersion>1.28.0</MicrosoftPlaywrightVersion>
     <PollyExtensionsHttpVersion>3.0.0</PollyExtensionsHttpVersion>
     <PollyVersion>7.2.4</PollyVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -314,7 +314,7 @@
     <NewtonsoftJsonBsonVersion>1.0.2</NewtonsoftJsonBsonVersion>
     <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     <NSwagApiDescriptionClientVersion>13.0.4</NSwagApiDescriptionClientVersion>
-    <PhotinoNETVersion>2.4.0</PhotinoNETVersion>
+    <PhotinoNETVersion>2.6.0</PhotinoNETVersion>
     <MicrosoftPlaywrightVersion>1.28.0</MicrosoftPlaywrightVersion>
     <PollyExtensionsHttpVersion>3.0.0</PollyExtensionsHttpVersion>
     <PollyVersion>7.2.4</PollyVersion>

--- a/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
@@ -1469,7 +1469,7 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
     [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/54757")]
     public void EnhancedFormThatCallsNavigationManagerRefreshDoesNotPushHistoryEntry()
     {
-        GoTo("about:blank");
+        Navigate("about:blank");
 
         var startUrl = Browser.Url;
         GoTo("forms/form-that-calls-navigation-manager-refresh");
@@ -1492,7 +1492,7 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
     [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/54757")]
     public void EnhancedFormThatCallsNavigationManagerRefreshDoesNotPushHistoryEntry_Streaming()
     {
-        GoTo("about:blank");
+        Navigate("about:blank");
 
         var startUrl = Browser.Url;
         GoTo("forms/form-that-calls-navigation-manager-refresh-streaming");

--- a/src/Components/test/E2ETest/Tests/ThreadingAppHostedTest.cs
+++ b/src/Components/test/E2ETest/Tests/ThreadingAppHostedTest.cs
@@ -11,7 +11,7 @@ using Xunit.Abstractions;
 namespace Microsoft.AspNetCore.Components.E2ETest.Tests;
 
 public class ThreadingHostedAppTest
-    : ServerTestBase<ThreadingHostedAppTest.ThreadingAppServerSiteFixture>, IDisposable
+    : ServerTestBase<ThreadingHostedAppTest.ThreadingAppServerSiteFixture>
 {
     public class ThreadingAppServerSiteFixture : AspNetSiteServerFixture
     {
@@ -109,12 +109,5 @@ public class ThreadingHostedAppTest
     {
         var app = Browser.Exists(By.TagName("app"));
         Browser.NotEqual("Loading...", () => app.Text);
-    }
-
-    public void Dispose()
-    {
-        // Make the tests run faster by navigating back to the home page when we are done
-        // If we don't, then the next test will reload the whole page before it starts
-        Browser.Exists(By.LinkText("Home")).Click();
     }
 }

--- a/src/Components/test/E2ETest/Tests/ThreadingAppTest.cs
+++ b/src/Components/test/E2ETest/Tests/ThreadingAppTest.cs
@@ -11,7 +11,7 @@ using Xunit.Abstractions;
 namespace Microsoft.AspNetCore.Components.E2ETest.Tests;
 
 public class ThreadingAppTest
-    : ServerTestBase<BlazorWasmTestAppFixture<ThreadingApp.Program>>, IDisposable
+    : ServerTestBase<BlazorWasmTestAppFixture<ThreadingApp.Program>>
 {
     public ThreadingAppTest(
         BrowserFixture browserFixture,
@@ -126,12 +126,5 @@ public class ThreadingAppTest
     {
         var app = Browser.Exists(By.TagName("app"));
         Browser.NotEqual("Loading...", () => app.Text);
-    }
-
-    public void Dispose()
-    {
-        // Make the tests run faster by navigating back to the home page when we are done
-        // If we don't, then the next test will reload the whole page before it starts
-        Browser.Exists(By.LinkText("Home")).Click();
     }
 }


### PR DESCRIPTION
These changes should fix the tests quarantined in #54757 and #54754

### About our WebView E2E tests and Photino

We still have no clear understanding of why the Photino tests sometimes fail in CI. The change I've made here, updating the Photino dependency to 2.5.2, might help but I have no evidence that it will.

Overall my opinion about the Photino tests is that we don't know at all that our tests' way of integrating with Photino is really valid. We've built on Photino.NET and *not* Photino.Blazor because our goal is to prove that WebViewManager etc actually works, so we don't want to build on the 3rd-party logic in Photino.Blazor that itself uses WebViewManager. However, our repo's `PhotinoWebViewManager` differs subtly from [the on in Photino.Blazor](https://github.com/tryphotino/photino.Blazor/blob/master/Photino.Blazor/PhotinoWebViewManager.cs), in that their `SendMessage` works using a simple message pump to serialize the calls, whereas ours does not. I don't know if this is the root cause of our instability, but I don't really think it is, because whatever the problem is I can't repro it locally with or without that change. So it seems more likely that there's a different issue when running in CI. From the captured logs, it seems that in CI, sometimes the Photino window just closes immediately without reporting any errors.

I also notice that our `Microsoft.AspNetCore.Components.WebView.Photino` `BlazorWebView` class is not even disposable, which means the `PhotinoWebViewManager` can never get disposed, and hence the underlying `WebViewManager` can never get disposed. That can't be right (not that it should affect the test). I tried changing all this so disposal was threaded through all these references, but this leads to deadlock since our test app's `Program.Main` can't be async (it breaks Photino completely - it just opens a blank window and is unable to put a WebView2 inside it for some reason), and we can't block on the `DisposeAsync` call either - that deadlocks.

So altogether I'm unconvinced that our test-only Photino integration is really valid. It's possible that if someone was to dig into the real end-to-end going right through Photino's unmanaged code, they would find that we are doing something wrong, but that's not something we're likely to do in reality. If we can't make the E2E test reliable, I'd be more inclined to either:

 * Replace our `Microsoft.AspNetCore.Components.WebView.Photino` with Photino.Blazor
 * Or if that still isn't reliable, come up with a completely different kind of E2E test for WebView that doesn't involve Photino