### PR TITLE
Handle JSON comments and trailing commas in user-jwts

### DIFF
--- a/src/Tools/dotnet-user-jwts/src/Commands/CreateCommand.cs
+++ b/src/Tools/dotnet-user-jwts/src/Commands/CreateCommand.cs
@@ -254,7 +254,7 @@ internal sealed class CreateCommand
                 reporter.Output(jwt.Token);
                 break;
             case "json":
-                reporter.Output(JsonSerializer.Serialize(jwt, new JsonSerializerOptions { WriteIndented = true }));
+                reporter.Output(JsonSerializer.Serialize(jwt, SerializerOptions.Default));
                 break;
             default:
                 reporter.Output(Resources.FormatCreateCommand_Confirmed(jwtToken.Id));

--- a/src/Tools/dotnet-user-jwts/src/Commands/CreateCommand.cs
+++ b/src/Tools/dotnet-user-jwts/src/Commands/CreateCommand.cs
@@ -254,7 +254,7 @@ internal sealed class CreateCommand
                 reporter.Output(jwt.Token);
                 break;
             case "json":
-                reporter.Output(JsonSerializer.Serialize(jwt, SerializerOptions.Default));
+                reporter.Output(JsonSerializer.Serialize(jwt, JwtSerializerOptions.Default));
                 break;
             default:
                 reporter.Output(Resources.FormatCreateCommand_Confirmed(jwtToken.Id));

--- a/src/Tools/dotnet-user-jwts/src/Commands/ListCommand.cs
+++ b/src/Tools/dotnet-user-jwts/src/Commands/ListCommand.cs
@@ -1,9 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json;
 using Microsoft.Extensions.CommandLineUtils;
 using Microsoft.Extensions.Tools.Internal;
-using System.Text.Json;
 
 namespace Microsoft.AspNetCore.Authentication.JwtBearer.Tools;
 
@@ -54,11 +54,11 @@ internal sealed class ListCommand
     {
         if (jwtStore.Jwts is { Count: > 0 } jwts)
         {
-            reporter.Output(JsonSerializer.Serialize(jwts, new JsonSerializerOptions { WriteIndented = true }));
+            reporter.Output(JsonSerializer.Serialize(jwts, SerializerOptions.Default));
         }
         else
         {
-            reporter.Output(JsonSerializer.Serialize(Array.Empty<Jwt>(), new JsonSerializerOptions { WriteIndented = true }));
+            reporter.Output(JsonSerializer.Serialize(Array.Empty<Jwt>(), SerializerOptions.Default));
         }
     }
 

--- a/src/Tools/dotnet-user-jwts/src/Commands/ListCommand.cs
+++ b/src/Tools/dotnet-user-jwts/src/Commands/ListCommand.cs
@@ -54,11 +54,11 @@ internal sealed class ListCommand
     {
         if (jwtStore.Jwts is { Count: > 0 } jwts)
         {
-            reporter.Output(JsonSerializer.Serialize(jwts, SerializerOptions.Default));
+            reporter.Output(JsonSerializer.Serialize(jwts, JwtSerializerOptions.Default));
         }
         else
         {
-            reporter.Output(JsonSerializer.Serialize(Array.Empty<Jwt>(), SerializerOptions.Default));
+            reporter.Output(JsonSerializer.Serialize(Array.Empty<Jwt>(), JwtSerializerOptions.Default));
         }
     }
 

--- a/src/Tools/dotnet-user-jwts/src/Helpers/DevJwtCliHelpers.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/DevJwtCliHelpers.cs
@@ -141,7 +141,7 @@ internal static class DevJwtCliHelpers
 
         static void PrintJwtJson(IReporter reporter, Jwt jwt, bool showAll, JwtSecurityToken fullToken)
         {
-            reporter.Output(JsonSerializer.Serialize(jwt, SerializerOptions.Default));
+            reporter.Output(JsonSerializer.Serialize(jwt, JwtSerializerOptions.Default));
         }
 
         static void PrintJwtDefault(IReporter reporter, Jwt jwt, bool showAll, JwtSecurityToken fullToken)

--- a/src/Tools/dotnet-user-jwts/src/Helpers/DevJwtCliHelpers.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/DevJwtCliHelpers.cs
@@ -4,9 +4,6 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Text.Json;
-using System.Text.Json.Nodes;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Configuration.UserSecrets;
 using Microsoft.Extensions.Tools.Internal;
 using Microsoft.IdentityModel.Tokens;
 
@@ -144,7 +141,7 @@ internal static class DevJwtCliHelpers
 
         static void PrintJwtJson(IReporter reporter, Jwt jwt, bool showAll, JwtSecurityToken fullToken)
         {
-            reporter.Output(JsonSerializer.Serialize(jwt, new JsonSerializerOptions { WriteIndented = true }));
+            reporter.Output(JsonSerializer.Serialize(jwt, SerializerOptions.Default));
         }
 
         static void PrintJwtDefault(IReporter reporter, Jwt jwt, bool showAll, JwtSecurityToken fullToken)

--- a/src/Tools/dotnet-user-jwts/src/Helpers/JwtAuthenticationSchemeSettings.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/JwtAuthenticationSchemeSettings.cs
@@ -16,7 +16,7 @@ internal sealed record JwtAuthenticationSchemeSettings(string SchemeName, List<s
     public void Save(string filePath)
     {
         using var reader = new FileStream(filePath, FileMode.Open, FileAccess.Read);
-        var config = JsonSerializer.Deserialize<JsonObject>(reader, SerializerOptions.Default);
+        var config = JsonSerializer.Deserialize<JsonObject>(reader, JwtSerializerOptions.Default);
         reader.Close();
 
         var settingsObject = new JsonObject
@@ -58,13 +58,13 @@ internal sealed record JwtAuthenticationSchemeSettings(string SchemeName, List<s
             streamOptions.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
         }
         using var writer = new FileStream(filePath, streamOptions);
-        JsonSerializer.Serialize(writer, config, SerializerOptions.Default);
+        JsonSerializer.Serialize(writer, config, JwtSerializerOptions.Default);
     }
 
     public static void RemoveScheme(string filePath, string name)
     {
         using var reader = new FileStream(filePath, FileMode.Open, FileAccess.Read);
-        var config = JsonSerializer.Deserialize<JsonObject>(reader, SerializerOptions.Default);
+        var config = JsonSerializer.Deserialize<JsonObject>(reader, JwtSerializerOptions.Default);
         reader.Close();
 
         if (config[AuthenticationKey] is JsonObject authentication &&
@@ -74,6 +74,6 @@ internal sealed record JwtAuthenticationSchemeSettings(string SchemeName, List<s
         }
 
         using var writer = new FileStream(filePath, FileMode.Create, FileAccess.Write);
-        JsonSerializer.Serialize(writer, config, SerializerOptions.Default);
+        JsonSerializer.Serialize(writer, config, JwtSerializerOptions.Default);
     }
 }

--- a/src/Tools/dotnet-user-jwts/src/Helpers/JwtAuthenticationSchemeSettings.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/JwtAuthenticationSchemeSettings.cs
@@ -13,8 +13,10 @@ internal sealed record JwtAuthenticationSchemeSettings(string SchemeName, List<s
     private const string AuthenticationKey = "Authentication";
     private const string SchemesKey = "Schemes";
 
-    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
     {
+        AllowTrailingCommas = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
         WriteIndented = true,
     };
 
@@ -69,7 +71,7 @@ internal sealed record JwtAuthenticationSchemeSettings(string SchemeName, List<s
     public static void RemoveScheme(string filePath, string name)
     {
         using var reader = new FileStream(filePath, FileMode.Open, FileAccess.Read);
-        var config = JsonSerializer.Deserialize<JsonObject>(reader);
+        var config = JsonSerializer.Deserialize<JsonObject>(reader, _jsonSerializerOptions);
         reader.Close();
 
         if (config[AuthenticationKey] is JsonObject authentication &&

--- a/src/Tools/dotnet-user-jwts/src/Helpers/JwtAuthenticationSchemeSettings.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/JwtAuthenticationSchemeSettings.cs
@@ -13,17 +13,10 @@ internal sealed record JwtAuthenticationSchemeSettings(string SchemeName, List<s
     private const string AuthenticationKey = "Authentication";
     private const string SchemesKey = "Schemes";
 
-    private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
-    {
-        AllowTrailingCommas = true,
-        ReadCommentHandling = JsonCommentHandling.Skip,
-        WriteIndented = true,
-    };
-
     public void Save(string filePath)
     {
         using var reader = new FileStream(filePath, FileMode.Open, FileAccess.Read);
-        var config = JsonSerializer.Deserialize<JsonObject>(reader, _jsonSerializerOptions);
+        var config = JsonSerializer.Deserialize<JsonObject>(reader, SerializerOptions.Default);
         reader.Close();
 
         var settingsObject = new JsonObject
@@ -65,13 +58,13 @@ internal sealed record JwtAuthenticationSchemeSettings(string SchemeName, List<s
             streamOptions.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
         }
         using var writer = new FileStream(filePath, streamOptions);
-        JsonSerializer.Serialize(writer, config, _jsonSerializerOptions);
+        JsonSerializer.Serialize(writer, config, SerializerOptions.Default);
     }
 
     public static void RemoveScheme(string filePath, string name)
     {
         using var reader = new FileStream(filePath, FileMode.Open, FileAccess.Read);
-        var config = JsonSerializer.Deserialize<JsonObject>(reader, _jsonSerializerOptions);
+        var config = JsonSerializer.Deserialize<JsonObject>(reader, SerializerOptions.Default);
         reader.Close();
 
         if (config[AuthenticationKey] is JsonObject authentication &&
@@ -81,6 +74,6 @@ internal sealed record JwtAuthenticationSchemeSettings(string SchemeName, List<s
         }
 
         using var writer = new FileStream(filePath, FileMode.Create, FileAccess.Write);
-        JsonSerializer.Serialize(writer, config, _jsonSerializerOptions);
+        JsonSerializer.Serialize(writer, config, SerializerOptions.Default);
     }
 }

--- a/src/Tools/dotnet-user-jwts/src/Helpers/JwtSerializerOptions.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/JwtSerializerOptions.cs
@@ -5,7 +5,7 @@ using System.Text.Json;
 
 namespace Microsoft.AspNetCore.Authentication.JwtBearer.Tools;
 
-internal static class SerializerOptions
+internal static class JwtSerializerOptions
 {
     public static JsonSerializerOptions Default { get; } = new()
     {

--- a/src/Tools/dotnet-user-jwts/src/Helpers/JwtStore.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/JwtStore.cs
@@ -9,13 +9,17 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer.Tools;
 
 public class JwtStore
 {
+    private static readonly JsonSerializerOptions _serializerOptions = new()
+    {
+        AllowTrailingCommas = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+    };
+
     private const string FileName = "user-jwts.json";
-    private readonly string _userSecretsId;
     private readonly string _filePath;
 
     public JwtStore(string userSecretsId, Program program = null)
     {
-        _userSecretsId = userSecretsId;
         _filePath = Path.Combine(Path.GetDirectoryName(PathHelper.GetSecretsPathFromSecretsId(userSecretsId)), FileName);
         Load();
 
@@ -35,7 +39,7 @@ public class JwtStore
             using var fileStream = new FileStream(_filePath, FileMode.Open, FileAccess.Read);
             if (fileStream.Length > 0)
             {
-                Jwts = JsonSerializer.Deserialize<IDictionary<string, Jwt>>(fileStream) ?? new Dictionary<string, Jwt>();
+                Jwts = JsonSerializer.Deserialize<IDictionary<string, Jwt>>(fileStream, _serializerOptions) ?? new Dictionary<string, Jwt>();
             }
         }
     }

--- a/src/Tools/dotnet-user-jwts/src/Helpers/JwtStore.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/JwtStore.cs
@@ -9,12 +9,6 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer.Tools;
 
 public class JwtStore
 {
-    private static readonly JsonSerializerOptions _serializerOptions = new()
-    {
-        AllowTrailingCommas = true,
-        ReadCommentHandling = JsonCommentHandling.Skip,
-    };
-
     private const string FileName = "user-jwts.json";
     private readonly string _filePath;
 
@@ -39,7 +33,7 @@ public class JwtStore
             using var fileStream = new FileStream(_filePath, FileMode.Open, FileAccess.Read);
             if (fileStream.Length > 0)
             {
-                Jwts = JsonSerializer.Deserialize<IDictionary<string, Jwt>>(fileStream, _serializerOptions) ?? new Dictionary<string, Jwt>();
+                Jwts = JsonSerializer.Deserialize<IDictionary<string, Jwt>>(fileStream, SerializerOptions.Default) ?? new Dictionary<string, Jwt>();
             }
         }
     }

--- a/src/Tools/dotnet-user-jwts/src/Helpers/JwtStore.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/JwtStore.cs
@@ -33,7 +33,7 @@ public class JwtStore
             using var fileStream = new FileStream(_filePath, FileMode.Open, FileAccess.Read);
             if (fileStream.Length > 0)
             {
-                Jwts = JsonSerializer.Deserialize<IDictionary<string, Jwt>>(fileStream, SerializerOptions.Default) ?? new Dictionary<string, Jwt>();
+                Jwts = JsonSerializer.Deserialize<IDictionary<string, Jwt>>(fileStream, JwtSerializerOptions.Default) ?? new Dictionary<string, Jwt>();
             }
         }
     }

--- a/src/Tools/dotnet-user-jwts/src/Helpers/SerializerOptions.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/SerializerOptions.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+
+namespace Microsoft.AspNetCore.Authentication.JwtBearer.Tools;
+
+internal static class SerializerOptions
+{
+    public static JsonSerializerOptions Default { get; } = new()
+    {
+        AllowTrailingCommas = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        WriteIndented = true,
+    };
+}

--- a/src/Tools/dotnet-user-jwts/src/Helpers/SigningKeysHandler.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/SigningKeysHandler.cs
@@ -29,12 +29,6 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer.Tools;
 //              }]
 internal static class SigningKeysHandler
 {
-    private static readonly JsonSerializerOptions _serializerOptions = new()
-    {
-        AllowTrailingCommas = true,
-        ReadCommentHandling = JsonCommentHandling.Skip,
-    };
-
     public static byte[] GetSigningKeyMaterial(string userSecretsId, string scheme, string issuer)
     {
         var projectConfiguration = new ConfigurationBuilder()
@@ -74,7 +68,7 @@ internal static class SigningKeysHandler
             using var secretsFileStream = new FileStream(secretsFilePath, FileMode.Open, FileAccess.Read);
             if (secretsFileStream.Length > 0)
             {
-                secrets = JsonSerializer.Deserialize<JsonObject>(secretsFileStream, _serializerOptions);
+                secrets = JsonSerializer.Deserialize<JsonObject>(secretsFileStream, SerializerOptions.Default);
             }
         }
 

--- a/src/Tools/dotnet-user-jwts/src/Helpers/SigningKeysHandler.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/SigningKeysHandler.cs
@@ -68,7 +68,7 @@ internal static class SigningKeysHandler
             using var secretsFileStream = new FileStream(secretsFilePath, FileMode.Open, FileAccess.Read);
             if (secretsFileStream.Length > 0)
             {
-                secrets = JsonSerializer.Deserialize<JsonObject>(secretsFileStream, SerializerOptions.Default);
+                secrets = JsonSerializer.Deserialize<JsonObject>(secretsFileStream, JwtSerializerOptions.Default);
             }
         }
 

--- a/src/Tools/dotnet-user-jwts/src/Helpers/SigningKeysHandler.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/SigningKeysHandler.cs
@@ -1,12 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Extensions.Configuration.UserSecrets;
-using Microsoft.Extensions.Configuration;
-using System.Text.Json.Nodes;
-using System.Text.Json;
 using System.Linq;
-using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.UserSecrets;
 
 namespace Microsoft.AspNetCore.Authentication.JwtBearer.Tools;
 
@@ -30,6 +29,12 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer.Tools;
 //              }]
 internal static class SigningKeysHandler
 {
+    private static readonly JsonSerializerOptions _serializerOptions = new()
+    {
+        AllowTrailingCommas = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+    };
+
     public static byte[] GetSigningKeyMaterial(string userSecretsId, string scheme, string issuer)
     {
         var projectConfiguration = new ConfigurationBuilder()
@@ -69,7 +74,7 @@ internal static class SigningKeysHandler
             using var secretsFileStream = new FileStream(secretsFilePath, FileMode.Open, FileAccess.Read);
             if (secretsFileStream.Length > 0)
             {
-                secrets = JsonSerializer.Deserialize<JsonObject>(secretsFileStream);
+                secrets = JsonSerializer.Deserialize<JsonObject>(secretsFileStream, _serializerOptions);
             }
         }
 

--- a/src/Tools/dotnet-user-jwts/test/UserJwtsTestFixture.cs
+++ b/src/Tools/dotnet-user-jwts/test/UserJwtsTestFixture.cs
@@ -1,18 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
 using Microsoft.Extensions.Configuration.UserSecrets;
 
 namespace Microsoft.AspNetCore.Authentication.JwtBearer.Tools.Tests;
 
-public class UserJwtsTestFixture : IDisposable
+public sealed class UserJwtsTestFixture : IDisposable
 {
-    private Stack<Action> _disposables = new Stack<Action>();
-    internal string TestSecretsId;
+    private readonly Stack<Action> _disposables = new();
+    internal string TestSecretsId { get; private set; }
 
     private const string ProjectTemplate = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>

--- a/src/Tools/dotnet-user-jwts/test/UserJwtsTests.cs
+++ b/src/Tools/dotnet-user-jwts/test/UserJwtsTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer.Tools.Tests;
 
 public class UserJwtsTests(UserJwtsTestFixture fixture, ITestOutputHelper output) : IClassFixture<UserJwtsTestFixture>
 {
-    private readonly TestConsole _console = new TestConsole(output);
+    private readonly TestConsole _console = new(output);
 
     [Fact]
     public void List_NoTokensForNewProject()
@@ -71,12 +71,10 @@ public class UserJwtsTests(UserJwtsTestFixture fixture, ITestOutputHelper output
 
         app.Run(new[] { "create", "--project", project });
         Assert.Contains("New JWT saved", _console.GetOutput());
-        var matches = Regex.Matches(_console.GetOutput(), "New JWT saved with ID '(.*?)'");
-        var id = matches.SingleOrDefault().Groups[1].Value;
 
         var appSettings = JsonSerializer.Deserialize<JsonObject>(File.ReadAllText(appsettings));
         Assert.Equal("dotnet-user-jwts", appSettings["Authentication"]["Schemes"]["Bearer"]["ValidIssuer"].GetValue<string>());
-        app.Run(new[] { "create", "--project", project, "--issuer", "new-issuer"  });
+        app.Run(["create", "--project", project, "--issuer", "new-issuer"]);
         appSettings = JsonSerializer.Deserialize<JsonObject>(File.ReadAllText(appsettings));
         Assert.Equal("new-issuer", appSettings["Authentication"]["Schemes"]["Bearer"]["ValidIssuer"].GetValue<string>());
     }
@@ -208,7 +206,7 @@ public class UserJwtsTests(UserJwtsTestFixture fixture, ITestOutputHelper output
         app.Run(new[] { "key", "--reset", "--force", "--project", project });
         Assert.Contains("New signing key created:", _console.GetOutput());
 
-        using FileStream openStream = File.OpenRead(secretsFilePath);
+        using var openStream = File.OpenRead(secretsFilePath);
         var secretsJson = await JsonSerializer.DeserializeAsync<JsonObject>(openStream);
         Assert.NotNull(secretsJson);
         Assert.True(secretsJson.ContainsKey(SigningKeysHandler.GetSigningKeyPropertyName(DevJwtsDefaults.Scheme)));
@@ -423,11 +421,39 @@ public class UserJwtsTests(UserJwtsTestFixture fixture, ITestOutputHelper output
   }
 }");
         var app = new Program(_console);
-        app.Run(new[] { "create", "--project", project});
+        app.Run(new[] { "create", "--project", project });
         var output = _console.GetOutput();
 
         Assert.Contains("New JWT saved", output);
-        using FileStream openStream = File.OpenRead(secretsFilePath);
+        using var openStream = File.OpenRead(secretsFilePath);
+        var secretsJson = await JsonSerializer.DeserializeAsync<JsonObject>(openStream);
+        Assert.NotNull(secretsJson);
+        var signingKey = Assert.Single(secretsJson[SigningKeysHandler.GetSigningKeyPropertyName(DevJwtsDefaults.Scheme)].AsArray());
+        Assert.Equal(32, signingKey["Length"].GetValue<int>());
+        Assert.True(Convert.TryFromBase64String(signingKey["Value"].GetValue<string>(), new byte[32], out var _));
+        Assert.True(secretsJson.TryGetPropertyValue("Foo", out var fooField));
+        Assert.Equal("baz", fooField["Bar"].GetValue<string>());
+    }
+
+    [Fact]
+    public async Task Create_GracefullyHandles_PrepopulatedSecrets_WithCommasAndComments()
+    {
+        var projectPath = fixture.CreateProject();
+        var project = Path.Combine(projectPath, "TestProject.csproj");
+        var secretsFilePath = PathHelper.GetSecretsPathFromSecretsId(fixture.TestSecretsId);
+        await File.WriteAllTextAsync(secretsFilePath,
+@"{
+  ""Foo"": {
+    ""Bar"": ""baz"",
+    //""Bar"": ""baz"",
+  }
+}");
+        var app = new Program(_console);
+        app.Run(["create", "--project", project]);
+        var output = _console.GetOutput();
+
+        Assert.Contains("New JWT saved", output);
+        using var openStream = File.OpenRead(secretsFilePath);
         var secretsJson = await JsonSerializer.DeserializeAsync<JsonObject>(openStream);
         Assert.NotNull(secretsJson);
         var signingKey = Assert.Single(secretsJson[SigningKeysHandler.GetSigningKeyPropertyName(DevJwtsDefaults.Scheme)].AsArray());
@@ -444,7 +470,7 @@ public class UserJwtsTests(UserJwtsTestFixture fixture, ITestOutputHelper output
         var project = Path.Combine(projectPath, "TestProject.csproj");
 
         var app = new Program(_console);
-        app.Run(new[] { "create", "--project", project});
+        app.Run(new[] { "create", "--project", project });
         var matches = Regex.Matches(_console.GetOutput(), "New JWT saved with ID '(.*?)'");
         var id = matches.SingleOrDefault().Groups[1].Value;
         app.Run(new[] { "print", id, "--project", project, "--show-all" });
@@ -466,7 +492,7 @@ public class UserJwtsTests(UserJwtsTestFixture fixture, ITestOutputHelper output
 
         Assert.Contains("New JWT saved", _console.GetOutput());
 
-        using FileStream openStream = File.OpenRead(secretsFilePath);
+        using var openStream = File.OpenRead(secretsFilePath);
         var secretsJson = await JsonSerializer.DeserializeAsync<JsonObject>(openStream);
         Assert.True(secretsJson.ContainsKey(SigningKeysHandler.GetSigningKeyPropertyName("test-scheme")));
         var signingKey = Assert.Single(secretsJson[SigningKeysHandler.GetSigningKeyPropertyName("test-scheme")].AsArray());
@@ -488,7 +514,7 @@ public class UserJwtsTests(UserJwtsTestFixture fixture, ITestOutputHelper output
 
         Assert.Contains("New JWT saved", _console.GetOutput());
 
-        using FileStream openStream = File.OpenRead(secretsFilePath);
+        using var openStream = File.OpenRead(secretsFilePath);
         var secretsJson = await JsonSerializer.DeserializeAsync<JsonObject>(openStream);
         Assert.True(secretsJson.ContainsKey(SigningKeysHandler.GetSigningKeyPropertyName("test-scheme")));
         var signingKeys = secretsJson[SigningKeysHandler.GetSigningKeyPropertyName("test-scheme")].AsArray();
@@ -510,7 +536,7 @@ public class UserJwtsTests(UserJwtsTestFixture fixture, ITestOutputHelper output
 
         Assert.Contains("New JWT saved", _console.GetOutput());
 
-        using FileStream openStream = File.OpenRead(secretsFilePath);
+        using var openStream = File.OpenRead(secretsFilePath);
         var secretsJson = await JsonSerializer.DeserializeAsync<JsonObject>(openStream);
         var signingKey1 = Assert.Single(secretsJson[SigningKeysHandler.GetSigningKeyPropertyName("test-scheme")].AsArray());
         Assert.Equal("test-issuer", signingKey1["Issuer"].GetValue<string>());
@@ -580,7 +606,7 @@ public class UserJwtsTests(UserJwtsTestFixture fixture, ITestOutputHelper output
         Directory.SetCurrentDirectory(projectPath);
 
         var app = new Program(_console);
-        app.Run(new[] { "create" });
+        app.Run(["create"]);
 
         Assert.DoesNotContain("No project found at `-p|--project` path or current directory.", _console.GetOutput());
         Assert.Contains("New JWT saved", _console.GetOutput());
@@ -593,7 +619,7 @@ public class UserJwtsTests(UserJwtsTestFixture fixture, ITestOutputHelper output
         Directory.SetCurrentDirectory(path.FullName);
 
         var app = new Program(_console);
-        app.Run(new[] { "create" });
+        app.Run(["create"]);
 
         Assert.Contains($"Could not find a MSBuild project file in '{Directory.GetCurrentDirectory()}'. Specify which project to use with the --project option.", _console.GetOutput());
         Assert.DoesNotContain(Resources.CreateCommand_NoAudience_Error, _console.GetOutput());
@@ -606,7 +632,7 @@ public class UserJwtsTests(UserJwtsTestFixture fixture, ITestOutputHelper output
         Directory.SetCurrentDirectory(path.FullName);
 
         var app = new Program(_console);
-        app.Run(new[] { "remove", "some-id" });
+        app.Run(["remove", "some-id"]);
 
         Assert.Contains($"Could not find a MSBuild project file in '{Directory.GetCurrentDirectory()}'. Specify which project to use with the --project option.", _console.GetOutput());
     }
@@ -618,7 +644,7 @@ public class UserJwtsTests(UserJwtsTestFixture fixture, ITestOutputHelper output
         Directory.SetCurrentDirectory(path.FullName);
 
         var app = new Program(_console);
-        app.Run(new[] { "clear" });
+        app.Run(["clear"]);
 
         Assert.Contains($"Could not find a MSBuild project file in '{Directory.GetCurrentDirectory()}'. Specify which project to use with the --project option.", _console.GetOutput());
     }
@@ -630,7 +656,7 @@ public class UserJwtsTests(UserJwtsTestFixture fixture, ITestOutputHelper output
         Directory.SetCurrentDirectory(path.FullName);
 
         var app = new Program(_console);
-        app.Run(new[] { "list" });
+        app.Run(["list"]);
 
         Assert.Contains($"Could not find a MSBuild project file in '{Directory.GetCurrentDirectory()}'. Specify which project to use with the --project option.", _console.GetOutput());
     }
@@ -669,7 +695,6 @@ public class UserJwtsTests(UserJwtsTestFixture fixture, ITestOutputHelper output
         var projectPath = fixture.CreateProject();
         var tempPath = Path.GetTempPath();
         var targetPath = Path.GetRelativePath(tempPath, projectPath);
-        var project = Path.Combine(projectPath, "TestProject.csproj");
         Directory.SetCurrentDirectory(tempPath);
 
         var app = new Program(_console);


### PR DESCRIPTION
# Handle JSON comments and trailing commas

Handle JSON comments and trailing commas in user secrets files.

## Description

Handle the presence of comments and trailing commas in JSON files processed by `user-jwts` so the JSON serializer doesn't throw exceptions when it encounters them.

Also fixes up some of the IDE suggestions found while making the change.

Fixes #54814
