### PR TITLE
[Blazor] Port interactive server root component fix to `main`

### DIFF
--- a/src/Components/Server/src/DependencyInjection/ComponentServiceCollectionExtensions.cs
+++ b/src/Components/Server/src/DependencyInjection/ComponentServiceCollectionExtensions.cs
@@ -61,12 +61,12 @@ public static class ComponentServiceCollectionExtensions
         // user's configuration. So even if the user has multiple independent server-side
         // Components entrypoints, this lot is the same and repeated registrations are a no-op.
         services.TryAddSingleton<ICircuitFactory, CircuitFactory>();
-        services.TryAddSingleton<IServerComponentDeserializer, ServerComponentDeserializer>();
         services.TryAddSingleton<ICircuitHandleRegistry, CircuitHandleRegistry>();
         services.TryAddSingleton<RootComponentTypeCache>();
         services.TryAddSingleton<ComponentParameterDeserializer>();
         services.TryAddSingleton<ComponentParametersTypeCache>();
         services.TryAddSingleton<CircuitIdFactory>();
+        services.TryAddScoped<IServerComponentDeserializer, ServerComponentDeserializer>();
         services.TryAddScoped<IErrorBoundaryLogger, RemoteErrorBoundaryLogger>();
         services.TryAddScoped<AntiforgeryStateProvider, DefaultAntiforgeryStateProvider>();
 

--- a/src/Components/test/E2ETest/ServerRenderingTests/InteractivityTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/InteractivityTest.cs
@@ -1146,6 +1146,55 @@ public class InteractivityTest : ServerTestBase<BasicTestAppServerSiteFixture<Ra
         Browser.Equal("True", () => Browser.FindElement(By.Id("has-circuit-context")).Text);
     }
 
+    [Fact]
+    public void InteractiveServerRootComponents_CanBecomeInteractive_WithoutInterferingWithOtherCircuits()
+    {
+        // Start by setting up 2 tabs with interactive server components.
+        SetUpPageWithOneInteractiveServerComponent();
+
+        var firstWindow = Browser.CurrentWindowHandle;
+        Browser.SwitchTo().NewWindow(WindowType.Tab);
+        var secondWindow = Browser.CurrentWindowHandle;
+
+        SetUpPageWithOneInteractiveServerComponent();
+
+        // Start streaming in the second tab.
+        Browser.Click(By.Id("start-streaming-link"));
+        Browser.Equal("Streaming", () => Browser.FindElement(By.Id("status")).Text);
+
+        // Add an interactive server component while streaming.
+        // This will update the existing component, but the new component
+        // won't become interactive until streaming ends.
+        Browser.Click(By.Id(AddServerPrerenderedId));
+        Browser.Equal("False", () => Browser.FindElement(By.Id($"is-interactive-1")).Text);
+
+        // Add an interactive server component in the first tab.
+        // This component will become interactive immediately because the response
+        // that rendered the component will have completed quickly.
+        Browser.SwitchTo().Window(firstWindow);
+        Browser.Click(By.Id(AddServerPrerenderedId));
+        Browser.Equal("True", () => Browser.FindElement(By.Id($"is-interactive-1")).Text);
+
+        // Stop streaming in the second tab.
+        // This will activate the pending component for interactivity.
+        // This check verifies that a circuit can activate components from its most
+        // recent response, even if that response isn't the most recent between all
+        // circuits.
+        Browser.SwitchTo().Window(secondWindow);
+        Browser.Click(By.Id("stop-streaming-link"));
+        Browser.Equal("True", () => Browser.FindElement(By.Id($"is-interactive-1")).Text);
+
+        void SetUpPageWithOneInteractiveServerComponent()
+        {
+            Navigate($"{ServerPathBase}/streaming-interactivity");
+
+            Browser.Equal("Not streaming", () => Browser.FindElement(By.Id("status")).Text);
+
+            Browser.Click(By.Id(AddServerPrerenderedId));
+            Browser.Equal("True", () => Browser.FindElement(By.Id($"is-interactive-0")).Text);
+        }
+    }
+
     private void BlockWebAssemblyResourceLoad()
     {
         // Force a WebAssembly resource cache miss so that we can fall back to using server interactivity


### PR DESCRIPTION
Ports an internal interactive server root component activation fix to `main`