### PR TITLE
Introduce a logger provider that counts warnings and errors

### DIFF
--- a/src/DataProtection/DataProtection/src/DataProtectionServiceCollectionExtensions.cs
+++ b/src/DataProtection/DataProtection/src/DataProtectionServiceCollectionExtensions.cs
@@ -34,6 +34,7 @@ public static class DataProtectionServiceCollectionExtensions
         ArgumentNullThrowHelper.ThrowIfNull(services);
 
         services.TryAddSingleton<IActivator, TypeForwardingActivator>();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, MetricsLoggerProvider>());
         services.AddOptions();
         AddDataProtectionServices(services);
 

--- a/src/DataProtection/DataProtection/src/MetricsLoggerProvider.cs
+++ b/src/DataProtection/DataProtection/src/MetricsLoggerProvider.cs
@@ -1,0 +1,91 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Metrics;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Xml.Linq;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Win32;
+
+namespace Microsoft.AspNetCore.DataProtection;
+
+internal sealed class MetricsLoggerProvider : ILoggerProvider
+{
+    public const string MeterName = "Microsoft.AspNetCore.DataProtection";
+
+    private readonly Meter? _meter;
+
+    private readonly ILogger _logger;
+
+    public MetricsLoggerProvider()
+    {
+        _logger = NullLogger.Instance;
+    }
+
+    public MetricsLoggerProvider(IMeterFactory meterFactory)
+    {
+        _meter = meterFactory.Create(MeterName);
+
+        var errorCounter = _meter.CreateCounter<long>(
+            "errors",
+            unit: "{error}",
+            description: "Number of errors that have occurred.");
+        var warningCounter = _meter.CreateCounter<long>(
+            "warnings",
+            unit: "{warning}",
+            description: "Number of warnings that have occurred.");
+
+        _logger = new MetricsLogger(errorCounter, warningCounter);
+    }
+
+    ILogger ILoggerProvider.CreateLogger(string _categoryName) => _logger;
+
+    void IDisposable.Dispose() => _meter?.Dispose();
+
+    private sealed class MetricsLogger : ILogger
+    {
+        private readonly Counter<long> _errorCounter;
+        private readonly Counter<long> _warningCounter;
+
+        public MetricsLogger(Counter<long> errorCounter, Counter<long> warningCounter)
+        {
+            _errorCounter = errorCounter;
+            _warningCounter = warningCounter;
+        }
+
+        IDisposable? ILogger.BeginScope<TState>(TState state) => null;
+
+        bool ILogger.IsEnabled(LogLevel logLevel) => logLevel switch
+        {
+            LogLevel.Error => _errorCounter.Enabled,
+            LogLevel.Warning => _warningCounter.Enabled,
+            _ => false,
+        };
+
+        void ILogger.Log<TState>(LogLevel logLevel, EventId eventId, TState _state, Exception? _exception, Func<TState, Exception?, string> _formatter)
+        {
+            switch(logLevel)
+            {
+                case LogLevel.Error:
+                    if (_errorCounter.Enabled)
+                    {
+                        var tags = new TagList([new("id", eventId.Name ?? eventId.Id.ToString(CultureInfo.InvariantCulture))]);
+                        _errorCounter.Add(1, tags);
+                    }
+                    break;
+                case LogLevel.Warning:
+                    if (_warningCounter.Enabled)
+                    {
+                        var tags = new TagList([new("id", eventId.Name ?? eventId.Id.ToString(CultureInfo.InvariantCulture))]);
+                        _warningCounter.Add(1, tags);
+                    }
+                    break;
+            }
+        }
+    }
+}

--- a/src/DataProtection/DataProtection/src/MetricsLoggerProvider.cs
+++ b/src/DataProtection/DataProtection/src/MetricsLoggerProvider.cs
@@ -33,7 +33,7 @@ internal sealed class MetricsLoggerProvider : ILoggerProvider
         _meter = meterFactory.Create(MeterName);
 
         var counter = _meter.CreateCounter<long>(
-            "aspnetcore.dataprotection.log_messages",
+            "aspnetcore.data_protection.log_messages",
             unit: "{message}",
             description: "Number of messages that have been logged.");
 
@@ -88,8 +88,8 @@ internal sealed class MetricsLoggerProvider : ILoggerProvider
 
             var tags = new TagList(
             [
-                new("id", eventId.Name ?? eventId.Id.ToString(CultureInfo.InvariantCulture)),
-                new("level", levelName),
+                new("aspnetcore.data_protection.log_message_id", eventId.Name ?? eventId.Id.ToString(CultureInfo.InvariantCulture)),
+                new("aspnetcore.data_protection.log_level", levelName),
             ]);
             _counter.Add(1, tags);
         }

--- a/src/DataProtection/DataProtection/src/MetricsLoggerProvider.cs
+++ b/src/DataProtection/DataProtection/src/MetricsLoggerProvider.cs
@@ -35,7 +35,7 @@ internal sealed class MetricsLoggerProvider : ILoggerProvider
         var counter = _meter.CreateCounter<long>(
             "aspnetcore.data_protection.log_messages",
             unit: "{message}",
-            description: "Number of messages that have been logged.");
+            description: "Number of log records that have been logged.");
 
         _logger = new MetricsLogger(counter);
     }


### PR DESCRIPTION
...if an `IMeterFactory` is present (and does nothing otherwise).  This will provide insight into things like how often unknown key identifiers are encountered.

Part of #53654