### PR TITLE
Support resolving OpenApiPaths entries from document

### DIFF
--- a/src/Mvc/Mvc.ApiExplorer/src/Microsoft.AspNetCore.Mvc.ApiExplorer.csproj
+++ b/src/Mvc/Mvc.ApiExplorer/src/Microsoft.AspNetCore.Mvc.ApiExplorer.csproj
@@ -20,5 +20,6 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.AspNetCore.Mvc.ApiExplorer.Test" />
+    <InternalsVisibleTo Include="Microsoft.AspNetCore.OpenApi.Tests" />
   </ItemGroup>
 </Project>

--- a/src/OpenApi/sample/Program.cs
+++ b/src/OpenApi/sample/Program.cs
@@ -1,9 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Mvc;
-
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddOpenApi("v1");
@@ -18,13 +15,15 @@ if (app.Environment.IsDevelopment())
 }
 
 var v1 = app.MapGroup("v1")
-    .WithMetadata(new ApiExplorerSettingsAttribute { GroupName = "v1" });
+    .WithGroupName("v1");
 
 var v2 = app.MapGroup("v2")
-    .WithMetadata(new ApiExplorerSettingsAttribute { GroupName = "v2" });
+    .WithGroupName("v2");
 
 v1.MapPost("/todos", (Todo todo) => Results.Created($"/todos/{todo.Id}", todo));
 v1.MapGet("/todos/{id}", (int id) => new TodoWithDueDate(1, "Test todo", false, DateTime.Now.AddDays(1), DateTime.Now));
+
+v2.MapPost("/users", () => Results.Created("/users/1", new { Id = 1, Name = "Test user" }));
 
 app.Run();
 

--- a/src/OpenApi/src/Extensions/ApiDescriptionExtensions.cs
+++ b/src/OpenApi/src/Extensions/ApiDescriptionExtensions.cs
@@ -14,8 +14,8 @@ internal static class ApiDescriptionExtensions
     /// </summary>
     /// <param name="apiDescription">The ApiDescription to resolve an operation type from.</param>
     /// <returns>The <see cref="OperationType"/> associated with the given <paramref name="apiDescription"/>.</returns>
-    public static OperationType TopOperationType(this ApiDescription apiDescription) =>
-        apiDescription.HttpMethod switch
+    public static OperationType ToOperationType(this ApiDescription apiDescription) =>
+        apiDescription.HttpMethod?.ToUpperInvariant() switch
         {
             "GET" => OperationType.Get,
             "POST" => OperationType.Post,
@@ -25,7 +25,7 @@ internal static class ApiDescriptionExtensions
             "HEAD" => OperationType.Head,
             "OPTIONS" => OperationType.Options,
             "TRACE" => OperationType.Trace,
-            _ => OperationType.Get
+            _ => throw new InvalidOperationException($"Unsupported HTTP method: {apiDescription.HttpMethod}"),
         };
 
     /// <summary>
@@ -41,9 +41,9 @@ internal static class ApiDescriptionExtensions
         Debug.Assert(apiDescription.RelativePath != null, "Relative path cannot be null.");
         var strippedRoute = new StringBuilder();
         var routePattern = RoutePatternFactory.Parse(apiDescription.RelativePath);
-        strippedRoute.Append('/');
         for (var i = 0; i < routePattern.PathSegments.Count; i++)
         {
+            strippedRoute.Append('/');
             var segment = routePattern.PathSegments[i];
             foreach (var part in segment.Parts)
             {
@@ -58,10 +58,11 @@ internal static class ApiDescriptionExtensions
                     strippedRoute.Append('}');
                 }
             }
-            if (i != routePattern.PathSegments.Count - 1)
-            {
-                strippedRoute.Append('/');
-            }
+        }
+        // "" -> "/"
+        if (routePattern.PathSegments.Count == 0)
+        {
+            strippedRoute.Append('/');
         }
         return strippedRoute.ToString();
     }

--- a/src/OpenApi/src/Extensions/ApiDescriptionExtensions.cs
+++ b/src/OpenApi/src/Extensions/ApiDescriptionExtensions.cs
@@ -14,7 +14,7 @@ internal static class ApiDescriptionExtensions
     /// </summary>
     /// <param name="apiDescription">The ApiDescription to resolve an operation type from.</param>
     /// <returns>The <see cref="OperationType"/> associated with the given <paramref name="apiDescription"/>.</returns>
-    public static OperationType ToOperationType(this ApiDescription apiDescription) =>
+    public static OperationType GetOperationType(this ApiDescription apiDescription) =>
         apiDescription.HttpMethod?.ToUpperInvariant() switch
         {
             "GET" => OperationType.Get,
@@ -39,6 +39,11 @@ internal static class ApiDescriptionExtensions
     public static string MapRelativePathToItemPath(this ApiDescription apiDescription)
     {
         Debug.Assert(apiDescription.RelativePath != null, "Relative path cannot be null.");
+        // "" -> "/"
+        if (string.IsNullOrEmpty(apiDescription.RelativePath))
+        {
+            return "/";
+        }
         var strippedRoute = new StringBuilder();
         var routePattern = RoutePatternFactory.Parse(apiDescription.RelativePath);
         for (var i = 0; i < routePattern.PathSegments.Count; i++)
@@ -57,12 +62,11 @@ internal static class ApiDescriptionExtensions
                     strippedRoute.Append(parameterPart.Name);
                     strippedRoute.Append('}');
                 }
+                else if (part is RoutePatternSeparatorPart separatorPart)
+                {
+                    strippedRoute.Append(separatorPart.Content);
+                }
             }
-        }
-        // "" -> "/"
-        if (routePattern.PathSegments.Count == 0)
-        {
-            strippedRoute.Append('/');
         }
         return strippedRoute.ToString();
     }

--- a/src/OpenApi/src/Extensions/ApiDescriptionExtensions.cs
+++ b/src/OpenApi/src/Extensions/ApiDescriptionExtensions.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Text;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.OpenApi.Models;
+
+internal static class ApiDescriptionExtensions
+{
+    /// <summary>
+    /// Maps the HTTP method of the ApiDescription to the OpenAPI <see cref="OperationType"/> .
+    /// </summary>
+    /// <param name="apiDescription">The ApiDescription to resolve an operation type from.</param>
+    /// <returns>The <see cref="OperationType"/> associated with the given <paramref name="apiDescription"/>.</returns>
+    public static OperationType TopOperationType(this ApiDescription apiDescription) =>
+        apiDescription.HttpMethod switch
+        {
+            "GET" => OperationType.Get,
+            "POST" => OperationType.Post,
+            "PUT" => OperationType.Put,
+            "DELETE" => OperationType.Delete,
+            "PATCH" => OperationType.Patch,
+            "HEAD" => OperationType.Head,
+            "OPTIONS" => OperationType.Options,
+            "TRACE" => OperationType.Trace,
+            _ => OperationType.Get
+        };
+
+    /// <summary>
+    /// Maps the relative path included in the ApiDescription to the path
+    /// that should be included in the OpenApiDocument. This typically
+    /// consists of removing any constraints from route parameter parts
+    /// and retaining only the literals.
+    /// </summary>
+    /// <param name="apiDescription">The ApiDescription to resolve an item path from.</param>
+    /// <returns>The resolved item path for the given <paramref name="apiDescription"/>.</returns>
+    public static string MapRelativePathToItemPath(this ApiDescription apiDescription)
+    {
+        Debug.Assert(apiDescription.RelativePath != null, "Relative path cannot be null.");
+        var strippedRoute = new StringBuilder();
+        var routePattern = RoutePatternFactory.Parse(apiDescription.RelativePath);
+        strippedRoute.Append('/');
+        for (var i = 0; i < routePattern.PathSegments.Count; i++)
+        {
+            var segment = routePattern.PathSegments[i];
+            foreach (var part in segment.Parts)
+            {
+                if (part is RoutePatternLiteralPart literalPart)
+                {
+                    strippedRoute.Append(literalPart.Content);
+                }
+                else if (part is RoutePatternParameterPart parameterPart)
+                {
+                    strippedRoute.Append('{');
+                    strippedRoute.Append(parameterPart.Name);
+                    strippedRoute.Append('}');
+                }
+            }
+            if (i != routePattern.PathSegments.Count - 1)
+            {
+                strippedRoute.Append('/');
+            }
+        }
+        return strippedRoute.ToString();
+    }
+}

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -11,7 +11,7 @@ using Microsoft.OpenApi.Models;
 
 namespace Microsoft.AspNetCore.OpenApi;
 
-internal class OpenApiDocumentService(
+internal sealed class OpenApiDocumentService(
     [ServiceKey] string documentName,
     IApiDescriptionGroupCollectionProvider apiDescriptionGroupCollectionProvider,
     IHostEnvironment hostEnvironment,
@@ -67,7 +67,7 @@ internal class OpenApiDocumentService(
         var operations = new Dictionary<OperationType, OpenApiOperation>();
         foreach (var description in descriptions)
         {
-            operations[description.TopOperationType()] = new OpenApiOperation();
+            operations[description.ToOperationType()] = new OpenApiOperation();
         }
         return operations;
     }

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -15,9 +15,9 @@ internal sealed class OpenApiDocumentService(
     [ServiceKey] string documentName,
     IApiDescriptionGroupCollectionProvider apiDescriptionGroupCollectionProvider,
     IHostEnvironment hostEnvironment,
-    IOptionsSnapshot<OpenApiOptions> optionsSnapshot)
+    IOptionsMonitor<OpenApiOptions> optionsMonitor)
 {
-    private readonly OpenApiOptions _options = optionsSnapshot.Get(documentName);
+    private readonly OpenApiOptions _options = optionsMonitor.Get(documentName);
 
     public Task<OpenApiDocument> GetOpenApiDocumentAsync()
     {

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -29,6 +29,7 @@ internal sealed class OpenApiDocumentService(
         return Task.FromResult(document);
     }
 
+    // Note: Internal for testing.
     internal OpenApiInfo GetOpenApiInfo()
     {
         return new OpenApiInfo
@@ -47,7 +48,7 @@ internal sealed class OpenApiDocumentService(
     /// the object to support filtering each
     /// description instance into its appropriate document.
     /// </remarks>
-    internal OpenApiPaths GetOpenApiPaths()
+    private OpenApiPaths GetOpenApiPaths()
     {
         var descriptionsByPath = apiDescriptionGroupCollectionProvider.ApiDescriptionGroups.Items
             .SelectMany(group => group.Items)
@@ -62,12 +63,12 @@ internal sealed class OpenApiDocumentService(
         return paths;
     }
 
-    internal static Dictionary<OperationType, OpenApiOperation> GetOperations(IGrouping<string?, ApiDescription> descriptions)
+    private static Dictionary<OperationType, OpenApiOperation> GetOperations(IGrouping<string?, ApiDescription> descriptions)
     {
         var operations = new Dictionary<OperationType, OpenApiOperation>();
         foreach (var description in descriptions)
         {
-            operations[description.ToOperationType()] = new OpenApiOperation();
+            operations[description.GetOperationType()] = new OpenApiOperation();
         }
         return operations;
     }

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -1,23 +1,74 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.AspNetCore.OpenApi;
 
-internal sealed class OpenApiDocumentService(IHostEnvironment hostEnvironment)
+internal class OpenApiDocumentService(
+    [ServiceKey] string documentName,
+    IApiDescriptionGroupCollectionProvider apiDescriptionGroupCollectionProvider,
+    IHostEnvironment hostEnvironment,
+    IOptionsSnapshot<OpenApiOptions> optionsSnapshot)
 {
+    private readonly OpenApiOptions _options = optionsSnapshot.Get(documentName);
+
     public Task<OpenApiDocument> GetOpenApiDocumentAsync()
     {
         var document = new OpenApiDocument
         {
-            Info = new OpenApiInfo
-            {
-                Title = hostEnvironment.ApplicationName,
-                Version = OpenApiConstants.DefaultOpenApiVersion
-            }
+            Info = GetOpenApiInfo(),
+            Paths = GetOpenApiPaths()
         };
         return Task.FromResult(document);
+    }
+
+    internal OpenApiInfo GetOpenApiInfo()
+    {
+        return new OpenApiInfo
+        {
+            Title = $"{hostEnvironment.ApplicationName} | {documentName}",
+            Version = OpenApiConstants.DefaultOpenApiVersion
+        };
+    }
+
+    /// <summary>
+    /// Gets the OpenApiPaths for the document based on the ApiDescriptions.
+    /// </summary>
+    /// <remarks>
+    /// At this point in the construction of the OpenAPI document, we run
+    /// each API description through the `ShouldInclude` delegate defined in
+    /// the object to support filtering each
+    /// description instance into its appropriate document.
+    /// </remarks>
+    internal OpenApiPaths GetOpenApiPaths()
+    {
+        var descriptionsByPath = apiDescriptionGroupCollectionProvider.ApiDescriptionGroups.Items
+            .SelectMany(group => group.Items)
+            .Where(_options.ShouldInclude)
+            .GroupBy(apiDescription => apiDescription.MapRelativePathToItemPath());
+        var paths = new OpenApiPaths();
+        foreach (var descriptions in descriptionsByPath)
+        {
+            Debug.Assert(descriptions.Key != null, "Relative path mapped to OpenApiPath key cannot be null.");
+            paths.Add(descriptions.Key, new OpenApiPathItem { Operations = GetOperations(descriptions) });
+        }
+        return paths;
+    }
+
+    internal static Dictionary<OperationType, OpenApiOperation> GetOperations(IGrouping<string?, ApiDescription> descriptions)
+    {
+        var operations = new Dictionary<OperationType, OpenApiOperation>();
+        foreach (var description in descriptions)
+        {
+            operations[description.TopOperationType()] = new OpenApiOperation();
+        }
+        return operations;
     }
 }

--- a/src/OpenApi/test/Extensions/ApiDescriptionExtensionsTests.cs
+++ b/src/OpenApi/test/Extensions/ApiDescriptionExtensionsTests.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+
+public class ApiDescriptionExtensionsTests
+{
+    [Theory]
+    [InlineData("api/todos", "/api/todos")]
+    [InlineData("api/todos/{id}", "/api/todos/{id}")]
+    [InlineData("api/todos/{id:int:min(10)}", "/api/todos/{id}")]
+    [InlineData("{a}/{b}/{c=19}", "/{a}/{b}/{c}")]
+    [InlineData("{a}/{b}/{c?}", "/{a}/{b}/{c}")]
+    [InlineData("{a:int}/{b}/{c:int}", "/{a}/{b}/{c}")]
+    public void MapRelativePathToItemPath_ReturnsItemPathForApiDescription(string relativePath, string expectedItemPath)
+    {
+        // Arrange
+        var apiDescription = new ApiDescription
+        {
+            RelativePath = relativePath
+        };
+
+        // Act
+        var itemPath = apiDescription.MapRelativePathToItemPath();
+
+        // Assert
+        Assert.Equal(expectedItemPath, itemPath);
+    }
+}

--- a/src/OpenApi/test/Extensions/ApiDescriptionExtensionsTests.cs
+++ b/src/OpenApi/test/Extensions/ApiDescriptionExtensionsTests.cs
@@ -15,6 +15,7 @@ public class ApiDescriptionExtensionsTests
     [InlineData("{a:int}/{b}/{c:int}", "/{a}/{b}/{c}")]
     [InlineData("", "/")]
     [InlineData("api", "/api")]
+    [InlineData("{p1}/{p2}.{p3?}", "/{p1}/{p2}.{p3}")]
     public void MapRelativePathToItemPath_ReturnsItemPathForApiDescription(string relativePath, string expectedItemPath)
     {
         // Arrange
@@ -49,23 +50,25 @@ public class ApiDescriptionExtensionsTests
         };
 
         // Act
-        var operationType = apiDescription.ToOperationType();
+        var operationType = apiDescription.GetOperationType();
 
         // Assert
         Assert.Equal(expectedOperationType, operationType);
     }
 
-    [Fact]
-    public void ToOperationType_ThrowsForUnknownApiDescription()
+    [Theory]
+    [InlineData("UNKNOWN")]
+    [InlineData("unknown")]
+    public void ToOperationType_ThrowsForUnknownHttpMethod(string methodName)
     {
         // Arrange
         var apiDescription = new ApiDescription
         {
-            HttpMethod = "UNKNOWN"
+            HttpMethod = methodName
         };
 
         // Act & Assert
-        var exception = Assert.Throws<InvalidOperationException>(() => apiDescription.ToOperationType());
-        Assert.Equal("Unsupported HTTP method: UNKNOWN", exception.Message);
+        var exception = Assert.Throws<InvalidOperationException>(() => apiDescription.GetOperationType());
+        Assert.Equal($"Unsupported HTTP method: {methodName}", exception.Message);
     }
 }

--- a/src/OpenApi/test/Extensions/ApiDescriptionExtensionsTests.cs
+++ b/src/OpenApi/test/Extensions/ApiDescriptionExtensionsTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.OpenApi.Models;
 
 public class ApiDescriptionExtensionsTests
 {
@@ -12,6 +13,8 @@ public class ApiDescriptionExtensionsTests
     [InlineData("{a}/{b}/{c=19}", "/{a}/{b}/{c}")]
     [InlineData("{a}/{b}/{c?}", "/{a}/{b}/{c}")]
     [InlineData("{a:int}/{b}/{c:int}", "/{a}/{b}/{c}")]
+    [InlineData("", "/")]
+    [InlineData("api", "/api")]
     public void MapRelativePathToItemPath_ReturnsItemPathForApiDescription(string relativePath, string expectedItemPath)
     {
         // Arrange
@@ -25,5 +28,44 @@ public class ApiDescriptionExtensionsTests
 
         // Assert
         Assert.Equal(expectedItemPath, itemPath);
+    }
+
+    [Theory]
+    [InlineData("GET", OperationType.Get)]
+    [InlineData("POST", OperationType.Post)]
+    [InlineData("PUT", OperationType.Put)]
+    [InlineData("DELETE", OperationType.Delete)]
+    [InlineData("PATCH", OperationType.Patch)]
+    [InlineData("HEAD", OperationType.Head)]
+    [InlineData("OPTIONS", OperationType.Options)]
+    [InlineData("TRACE", OperationType.Trace)]
+    [InlineData("gEt", OperationType.Get)]
+    public void ToOperationType_ReturnsOperationTypeForApiDescription(string httpMethod, OperationType expectedOperationType)
+    {
+        // Arrange
+        var apiDescription = new ApiDescription
+        {
+            HttpMethod = httpMethod
+        };
+
+        // Act
+        var operationType = apiDescription.ToOperationType();
+
+        // Assert
+        Assert.Equal(expectedOperationType, operationType);
+    }
+
+    [Fact]
+    public void ToOperationType_ThrowsForUnknownApiDescription()
+    {
+        // Arrange
+        var apiDescription = new ApiDescription
+        {
+            HttpMethod = "UNKNOWN"
+        };
+
+        // Act & Assert
+        var exception = Assert.Throws<InvalidOperationException>(() => apiDescription.ToOperationType());
+        Assert.Equal("Unsupported HTTP method: UNKNOWN", exception.Message);
     }
 }

--- a/src/OpenApi/test/Extensions/OpenApiServiceCollectionExtensionsTests.cs
+++ b/src/OpenApi/test/Extensions/OpenApiServiceCollectionExtensionsTests.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.Extensions.ApiDescriptions;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/OpenApi/test/Services/OpenApiDocumentServiceTests.Info.cs
+++ b/src/OpenApi/test/Services/OpenApiDocumentServiceTests.Info.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.Extensions.Hosting.Internal;
+using Microsoft.Extensions.Options;
+using Moq;
+
+public partial class OpenApiDocumentServiceTests
+{
+    [Fact]
+    public void GetOpenApiInfo_RespectsHostEnvironmentName()
+    {
+        // Arrange
+        var hostEnvironment = new HostingEnvironment
+        {
+            ApplicationName = "TestApplication"
+        };
+        var docService = new OpenApiDocumentService(
+            "v1",
+            new Mock<IApiDescriptionGroupCollectionProvider>().Object,
+            hostEnvironment,
+            new Mock<IOptionsSnapshot<OpenApiOptions>>().Object);
+
+        // Act
+        var info = docService.GetOpenApiInfo();
+
+        // Assert
+        Assert.Equal("TestApplication | v1", info.Title);
+    }
+}

--- a/src/OpenApi/test/Services/OpenApiDocumentServiceTests.Info.cs
+++ b/src/OpenApi/test/Services/OpenApiDocumentServiceTests.Info.cs
@@ -21,12 +21,33 @@ public partial class OpenApiDocumentServiceTests
             "v1",
             new Mock<IApiDescriptionGroupCollectionProvider>().Object,
             hostEnvironment,
-            new Mock<IOptionsSnapshot<OpenApiOptions>>().Object);
+            new Mock<IOptionsMonitor<OpenApiOptions>>().Object);
 
         // Act
         var info = docService.GetOpenApiInfo();
 
         // Assert
         Assert.Equal("TestApplication | v1", info.Title);
+    }
+
+    [Fact]
+    public void GetOpenApiInfo_RespectsDocumentName()
+    {
+        // Arrange
+        var hostEnvironment = new HostingEnvironment
+        {
+            ApplicationName = "TestApplication"
+        };
+        var docService = new OpenApiDocumentService(
+            "v2",
+            new Mock<IApiDescriptionGroupCollectionProvider>().Object,
+            hostEnvironment,
+            new Mock<IOptionsMonitor<OpenApiOptions>>().Object);
+
+        // Act
+        var info = docService.GetOpenApiInfo();
+
+        // Assert
+        Assert.Equal("TestApplication | v2", info.Title);
     }
 }

--- a/src/OpenApi/test/Services/OpenApiDocumentServiceTests.Paths.cs
+++ b/src/OpenApi/test/Services/OpenApiDocumentServiceTests.Paths.cs
@@ -1,0 +1,158 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.OpenApi.Models;
+
+public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBase
+{
+    [Fact]
+    public async Task GetOpenApiPaths_ReturnsPaths()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapGet("/api/todos", () => { });
+        builder.MapGet("/api/users", () => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            Assert.Collection(document.Paths.OrderBy(p => p.Key),
+                path =>
+                {
+                    Assert.Equal("/api/todos", path.Key);
+                    Assert.Collection(path.Value.Operations.OrderBy(o => o.Key),
+                        operation =>
+                        {
+                            Assert.Equal(OperationType.Get, operation.Key);
+                        });
+                },
+                path =>
+                {
+                    Assert.Equal("/api/users", path.Key);
+                    Assert.Collection(path.Value.Operations.OrderBy(o => o.Key),
+                        operation =>
+                        {
+                            Assert.Equal(OperationType.Get, operation.Key);
+                        });
+                });
+        });
+    }
+
+    [Fact]
+    public async Task GetOpenApiPaths_RespectsShouldInclude()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapGet("/api/todos", () => { }).WithMetadata(new EndpointGroupNameAttribute("v1"));
+        builder.MapGet("/api/users", () => { }).WithMetadata(new EndpointGroupNameAttribute("v2"));
+
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            Assert.Collection(document.Paths.OrderBy(p => p.Key),
+                path =>
+                {
+                    Assert.Equal("/api/todos", path.Key);
+                }
+            );
+        });
+    }
+
+    [Fact]
+    public async Task GetOpenApiPaths_RespectsSamePaths()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapGet("/api/todos", () => { });
+        builder.MapPost("/api/todos", () => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            Assert.Collection(document.Paths.OrderBy(p => p.Key),
+                path =>
+                {
+                    Assert.Equal("/api/todos", path.Key);
+                    Assert.Collection(path.Value.Operations.OrderBy(o => o.Key),
+                        operation =>
+                        {
+                            Assert.Equal(OperationType.Get, operation.Key);
+                        },
+                        operation =>
+                        {
+                            Assert.Equal(OperationType.Post, operation.Key);
+                        });
+                }
+            );
+        });
+    }
+
+    [Fact]
+    public async Task GetOpenApiPaths_HandlesRouteParameters()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapGet("/api/todos/{id}", () => { });
+        builder.MapPost("/api/todos/{id}", () => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            Assert.Collection(document.Paths.OrderBy(p => p.Key),
+                path =>
+                {
+                    Assert.Equal("/api/todos/{id}", path.Key);
+                    Assert.Collection(path.Value.Operations.OrderBy(o => o.Key),
+                        operation =>
+                        {
+                            Assert.Equal(OperationType.Get, operation.Key);
+                        },
+                        operation =>
+                        {
+                            Assert.Equal(OperationType.Post, operation.Key);
+                        });
+                }
+            );
+        });
+    }
+
+    [Fact]
+    public async Task GetOpenApiPaths_HandlesRouteConstraints()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapGet("/api/todos/{id:int}", () => { });
+        builder.MapPost("/api/todos/{id:int}", () => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            Assert.Collection(document.Paths.OrderBy(p => p.Key),
+                path =>
+                {
+                    Assert.Equal("/api/todos/{id}", path.Key);
+                    Assert.Collection(path.Value.Operations.OrderBy(o => o.Key),
+                        operation =>
+                        {
+                            Assert.Equal(OperationType.Get, operation.Key);
+                        },
+                        operation =>
+                        {
+                            Assert.Equal(OperationType.Post, operation.Key);
+                        });
+                }
+            );
+        });
+    }
+}

--- a/src/OpenApi/test/Services/OpenApiDocumentServiceTests.Paths.cs
+++ b/src/OpenApi/test/Services/OpenApiDocumentServiceTests.Paths.cs
@@ -133,7 +133,6 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
                         {
                             Assert.Equal(OperationType.Patch, operation.Key);
                         });
-
                 }
             );
         });

--- a/src/OpenApi/test/Services/OpenApiDocumentServiceTestsBase.cs
+++ b/src/OpenApi/test/Services/OpenApiDocumentServiceTestsBase.cs
@@ -21,7 +21,7 @@ public abstract class OpenApiDocumentServiceTestBase
         {
             ApplicationName = nameof(OpenApiDocumentServiceTests)
         };
-        var options = new Mock<IOptionsSnapshot<OpenApiOptions>>();
+        var options = new Mock<IOptionsMonitor<OpenApiOptions>>();
         options.Setup(o => o.Get(It.IsAny<string>())).Returns(new OpenApiOptions());
 
         var provider = CreateEndpointMetadataApiDescriptionProvider(endpointDataSource);

--- a/src/OpenApi/test/Services/OpenApiDocumentServiceTestsBase.cs
+++ b/src/OpenApi/test/Services/OpenApiDocumentServiceTestsBase.cs
@@ -1,0 +1,87 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Options;
+using Microsoft.OpenApi.Models;
+using Moq;
+using static Microsoft.AspNetCore.OpenApi.Tests.OpenApiOperationGeneratorTests;
+
+public abstract class OpenApiDocumentServiceTestBase
+{
+    public static async Task VerifyOpenApiDocument(IEndpointRouteBuilder builder, Action<OpenApiDocument> verifyOpenApiDocument)
+    {
+        var context = new ApiDescriptionProviderContext([]);
+
+        var endpointDataSource = builder.DataSources.OfType<EndpointDataSource>().Single();
+        var hostEnvironment = new HostEnvironment
+        {
+            ApplicationName = nameof(OpenApiDocumentServiceTests)
+        };
+        var options = new Mock<IOptionsSnapshot<OpenApiOptions>>();
+        options.Setup(o => o.Get(It.IsAny<string>())).Returns(new OpenApiOptions());
+
+        var provider = CreateEndpointMetadataApiDescriptionProvider(endpointDataSource);
+        provider.OnProvidersExecuting(context);
+        provider.OnProvidersExecuted(context);
+
+        var apiDescriptionGroupCollectionProvider = CreateApiDescriptionGroupCollectionProvider(context.Results);
+
+        var documentService = new OpenApiDocumentService("Test", apiDescriptionGroupCollectionProvider, hostEnvironment, options.Object);
+        var document = await documentService.GetOpenApiDocumentAsync();
+        verifyOpenApiDocument(document);
+    }
+
+    public static IApiDescriptionGroupCollectionProvider CreateApiDescriptionGroupCollectionProvider(IList<ApiDescription> apiDescriptions = null)
+    {
+        var apiDescriptionGroup = new ApiDescriptionGroup("testGroupName", (apiDescriptions ?? Array.Empty<ApiDescription>()).AsReadOnly());
+        var apiDescriptionGroupCollection = new ApiDescriptionGroupCollection([apiDescriptionGroup], 1);
+        var apiDescriptionGroupCollectionProvider = new Mock<IApiDescriptionGroupCollectionProvider>();
+        apiDescriptionGroupCollectionProvider.Setup(p => p.ApiDescriptionGroups).Returns(apiDescriptionGroupCollection);
+        return apiDescriptionGroupCollectionProvider.Object;
+    }
+
+    private static EndpointMetadataApiDescriptionProvider CreateEndpointMetadataApiDescriptionProvider(EndpointDataSource endpointDataSource) => new EndpointMetadataApiDescriptionProvider(
+        endpointDataSource,
+        new HostEnvironment { ApplicationName = nameof(OpenApiDocumentServiceTests) },
+        new DefaultParameterPolicyFactory(Options.Create(new RouteOptions()), new TestServiceProvider()),
+        new ServiceProviderIsService());
+
+    internal static TestEndpointRouteBuilder CreateBuilder() =>
+        new TestEndpointRouteBuilder(new ApplicationBuilder(TestServiceProvider.Instance));
+
+    internal class TestEndpointRouteBuilder : IEndpointRouteBuilder
+    {
+        public TestEndpointRouteBuilder(IApplicationBuilder applicationBuilder)
+        {
+            ApplicationBuilder = applicationBuilder ?? throw new ArgumentNullException(nameof(applicationBuilder));
+            DataSources = new List<EndpointDataSource>();
+        }
+
+        public IApplicationBuilder ApplicationBuilder { get; }
+
+        public IApplicationBuilder CreateApplicationBuilder() => ApplicationBuilder.New();
+
+        public ICollection<EndpointDataSource> DataSources { get; }
+
+        public IServiceProvider ServiceProvider => ApplicationBuilder.ApplicationServices;
+    }
+
+    private class TestServiceProvider : IServiceProvider
+    {
+        public static TestServiceProvider Instance { get; } = new TestServiceProvider();
+
+        public object GetService(Type serviceType)
+        {
+            if (serviceType == typeof(IOptions<RouteHandlerOptions>))
+            {
+                return Options.Create(new RouteHandlerOptions());
+            }
+
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for generating the `OpenApiPaths` from a given set of ApiDescriptions.