### PR TITLE
Bump helix-matrix timeout up to 5 hours

### DIFF
--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -29,7 +29,7 @@ jobs:
     jobName: Helix_matrix_x64
     jobDisplayName: 'Tests: Helix full matrix x64'
     agentOs: Windows
-    timeoutInMinutes: 180
+    timeoutInMinutes: 300
     steps:
     # Build the shared framework
     - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -nobl -all -pack -arch x64


### PR DESCRIPTION
We occasionally get spikes to around 3-4 hours