### PR TITLE
[release/6.0] Don't build Node components in SourceBuild

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -759,7 +759,7 @@ extends:
           platform:
             name: 'Managed'
             container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7'
-            buildScript: './eng/build.sh $(_PublishArgs) --no-build-repo-tasks $(_InternalRuntimeDownloadArgs)'
+            buildScript: './eng/build.sh $(_PublishArgs) --no-build-repo-tasks --no-build-nodejs $(_InternalRuntimeDownloadArgs)'
             skipPublishValidation: true
             jobProperties:
               timeoutInMinutes: 120


### PR DESCRIPTION
Switching to 1ES put us on a pool where Node is available - we didn't used to have to pass this arg to skip the node build, but now we do.