### PR TITLE
fix: added missing webtransport check before establishing a session

### DIFF
--- a/src/Servers/Kestrel/Core/src/CoreStrings.resx
+++ b/src/Servers/Kestrel/Core/src/CoreStrings.resx
@@ -666,10 +666,10 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
     <value>Error initializing outbound control stream.</value>
   </data>
   <data name="Http3WebTransportStatusMismatch" xml:space="preserve">
-    <value>HTTP/3 webtransport negotiation mismatch. Currently client has it '{clientStatus}' and server has it '{serverStatus}'</value>
+    <value>HTTP/3 webtransport negotiation mismatch. Client support: '{clientStatus}'. Server support: '{serverStatus}'.</value>
   </data>
   <data name="Http3DatagramStatusMismatch" xml:space="preserve">
-    <value>HTTP/3 datagrams negotiation mismatch. Currently client has it '{clientStatus}' and server has it '{serverStatus}'</value>
+    <value>HTTP/3 datagrams negotiation mismatch. Client support: '{clientStatus}'. Server support: '{serverStatus}'.</value>
   </data>
   <data name="Http3MethodMustBeConnectWhenUsingProtocolPseudoHeader" xml:space="preserve">
     <value>Method must be CONNECT when using the :protocol pseudo-header.</value>

--- a/src/Servers/Kestrel/Core/src/CoreStrings.resx
+++ b/src/Servers/Kestrel/Core/src/CoreStrings.resx
@@ -665,6 +665,9 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
   <data name="Http3ControlStreamErrorInitializingOutbound" xml:space="preserve">
     <value>Error initializing outbound control stream.</value>
   </data>
+  <data name="Http3WebTransportStatusMismatch" xml:space="preserve">
+    <value>HTTP/3 webtransport negotiation mismatch. Currently client has it '{clientStatus}' and server has it '{serverStatus}'</value>
+  </data>
   <data name="Http3DatagramStatusMismatch" xml:space="preserve">
     <value>HTTP/3 datagrams negotiation mismatch. Currently client has it '{clientStatus}' and server has it '{serverStatus}'</value>
   </data>

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -834,6 +834,11 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
                 throw new Http3StreamErrorException(CoreStrings.Http3MissingAuthorityOrPathPseudoHeaders, Http3ErrorCode.ProtocolError);
             }
 
+            if (_context.ClientPeerSettings.EnableWebTransport != _context.ServerPeerSettings.EnableWebTransport)
+            {
+                throw new Http3StreamErrorException(CoreStrings.FormatHttp3WebTransportStatusMismatch(_context.ClientPeerSettings.EnableWebTransport == 1, _context.ServerPeerSettings.EnableWebTransport == 1), Http3ErrorCode.SettingsError);
+            }
+
             if (_context.ClientPeerSettings.H3Datagram != _context.ServerPeerSettings.H3Datagram)
             {
                 throw new Http3StreamErrorException(CoreStrings.FormatHttp3DatagramStatusMismatch(_context.ClientPeerSettings.H3Datagram == 1, _context.ServerPeerSettings.H3Datagram == 1), Http3ErrorCode.SettingsError);


### PR DESCRIPTION
# Add missing webtransport check before establishing a session

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Once Kestrel wants to establish a new webtransport session it also should check both client and server enable webtransport settings.

