### PR TITLE
Fix custom elements JS initializer not being included in build output

### DIFF
--- a/src/Components/CustomElements/src/Microsoft.AspNetCore.Components.CustomElements.csproj
+++ b/src/Components/CustomElements/src/Microsoft.AspNetCore.Components.CustomElements.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
@@ -18,7 +18,7 @@
     </ResolveStaticWebAssetsInputsDependsOn>
   </PropertyGroup>
 
-  <Target Name="IncludeCompileJsOutput" BeforeTargets="_ResolveJsModuleInputs">
+  <Target Name="IncludeCompileJsOutput" BeforeTargets="ResolveJSModuleStaticWebAssets">
     <ItemGroup>
       <_JsBuildOutput Include="$(InteropWorkingDir)dist\$(Configuration)\**" Exclude="$(InteropWorkingDir)dist\.gitignore" />
     </ItemGroup>

--- a/src/Components/test/E2ETest/Tests/CustomElementsTest.cs
+++ b/src/Components/test/E2ETest/Tests/CustomElementsTest.cs
@@ -55,7 +55,6 @@ public class CustomElementsTest : ServerTestBase<ToggleExecutionModeServerFixtur
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/54889")]
     public void CanUpdateSimpleParameters()
     {
         app.FindElement(By.Id("add-custom-element")).Click();
@@ -106,7 +105,6 @@ public class CustomElementsTest : ServerTestBase<ToggleExecutionModeServerFixtur
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/54889")]
     public void CanUpdateComplexParameters()
     {
         app.FindElement(By.Id("add-custom-element")).Click();


### PR DESCRIPTION
Fixes an issue where the `IncludeCompileJsOutput` target was running too late, so the custom elements JS initializer wasn't getting included correctly in the build output.

Fixes https://github.com/dotnet/aspnetcore/issues/54889