### PR TITLE
Add APIs for OpenAPI document transformers

### DIFF
--- a/AspNetCore.sln
+++ b/AspNetCore.sln
@@ -1790,6 +1790,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Components.WasmRemoteAuthen
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample", "src\OpenApi\sample\Sample.csproj", "{6DEC24A8-A166-432F-8E3B-58FFCDA92F52}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNetCore.OpenApi.Microbenchmarks", "src\OpenApi\perf\Microsoft.AspNetCore.OpenApi.Microbenchmarks.csproj", "{CF082AD5-E513-4A27-A6C7-3767E04D6205}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -10807,6 +10809,22 @@ Global
 		{6DEC24A8-A166-432F-8E3B-58FFCDA92F52}.Release|x64.Build.0 = Release|Any CPU
 		{6DEC24A8-A166-432F-8E3B-58FFCDA92F52}.Release|x86.ActiveCfg = Release|Any CPU
 		{6DEC24A8-A166-432F-8E3B-58FFCDA92F52}.Release|x86.Build.0 = Release|Any CPU
+		{CF082AD5-E513-4A27-A6C7-3767E04D6205}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF082AD5-E513-4A27-A6C7-3767E04D6205}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CF082AD5-E513-4A27-A6C7-3767E04D6205}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{CF082AD5-E513-4A27-A6C7-3767E04D6205}.Debug|arm64.Build.0 = Debug|Any CPU
+		{CF082AD5-E513-4A27-A6C7-3767E04D6205}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CF082AD5-E513-4A27-A6C7-3767E04D6205}.Debug|x64.Build.0 = Debug|Any CPU
+		{CF082AD5-E513-4A27-A6C7-3767E04D6205}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CF082AD5-E513-4A27-A6C7-3767E04D6205}.Debug|x86.Build.0 = Debug|Any CPU
+		{CF082AD5-E513-4A27-A6C7-3767E04D6205}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CF082AD5-E513-4A27-A6C7-3767E04D6205}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CF082AD5-E513-4A27-A6C7-3767E04D6205}.Release|arm64.ActiveCfg = Release|Any CPU
+		{CF082AD5-E513-4A27-A6C7-3767E04D6205}.Release|arm64.Build.0 = Release|Any CPU
+		{CF082AD5-E513-4A27-A6C7-3767E04D6205}.Release|x64.ActiveCfg = Release|Any CPU
+		{CF082AD5-E513-4A27-A6C7-3767E04D6205}.Release|x64.Build.0 = Release|Any CPU
+		{CF082AD5-E513-4A27-A6C7-3767E04D6205}.Release|x86.ActiveCfg = Release|Any CPU
+		{CF082AD5-E513-4A27-A6C7-3767E04D6205}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -11691,6 +11709,7 @@ Global
 		{433F91E4-E39D-4EB0-B798-2998B3969A2C} = {6126DCE4-9692-4EE2-B240-C65743572995}
 		{8A021D6D-7935-4AB3-BB47-38D4FF9B0D13} = {6126DCE4-9692-4EE2-B240-C65743572995}
 		{6DEC24A8-A166-432F-8E3B-58FFCDA92F52} = {2299CCD8-8F9C-4F2B-A633-9BF4DA81022B}
+		{CF082AD5-E513-4A27-A6C7-3767E04D6205} = {2299CCD8-8F9C-4F2B-A633-9BF4DA81022B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3E8720B3-DBDD-498C-B383-2CC32A054E8F}

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -290,7 +290,7 @@
     <!-- 3rd party dependencies -->
     <AzureIdentityVersion>1.10.3</AzureIdentityVersion>
     <AngleSharpVersion>0.9.9</AngleSharpVersion>
-    <BenchmarkDotNetVersion>0.13.12</BenchmarkDotNetVersion>
+    <BenchmarkDotNetVersion>0.13.0</BenchmarkDotNetVersion>
     <CastleCoreVersion>4.2.1</CastleCoreVersion>
     <CommandLineParserVersion>2.3.0</CommandLineParserVersion>
     <FSharpCoreVersion>6.0.0</FSharpCoreVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -290,7 +290,7 @@
     <!-- 3rd party dependencies -->
     <AzureIdentityVersion>1.10.3</AzureIdentityVersion>
     <AngleSharpVersion>0.9.9</AngleSharpVersion>
-    <BenchmarkDotNetVersion>0.13.0</BenchmarkDotNetVersion>
+    <BenchmarkDotNetVersion>0.13.12</BenchmarkDotNetVersion>
     <CastleCoreVersion>4.2.1</CastleCoreVersion>
     <CommandLineParserVersion>2.3.0</CommandLineParserVersion>
     <FSharpCoreVersion>6.0.0</FSharpCoreVersion>

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/SharedTypes.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/SharedTypes.cs
@@ -12,8 +12,6 @@ using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using System.Diagnostics.CodeAnalysis;
-using Microsoft.Diagnostics.Runtime.Interop;
 
 namespace Microsoft.AspNetCore.Http.Generators.Tests;
 

--- a/src/OpenApi/OpenApi.slnf
+++ b/src/OpenApi/OpenApi.slnf
@@ -9,7 +9,8 @@
       "src\\Http\\Routing\\src\\Microsoft.AspNetCore.Routing.csproj",
       "src\\OpenApi\\src\\Microsoft.AspNetCore.OpenApi.csproj",
       "src\\OpenApi\\test\\Microsoft.AspNetCore.OpenApi.Tests.csproj",
-      "src\\OpenApi\\sample\\Sample.csproj"
+      "src\\OpenApi\\sample\\Sample.csproj",
+      "src\\OpenApi\\perf\\Microsoft.AspNetCore.OpenApi.Microbenchmarks.csproj"
     ]
   }
 }

--- a/src/OpenApi/perf/AssemblyInfo.cs
+++ b/src/OpenApi/perf/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+[assembly: BenchmarkDotNet.Attributes.AspNetCoreBenchmark]

--- a/src/OpenApi/perf/Microsoft.AspNetCore.OpenApi.Microbenchmarks.csproj
+++ b/src/OpenApi/perf/Microsoft.AspNetCore.OpenApi.Microbenchmarks.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <PreserveCompilationContext>true</PreserveCompilationContext>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="BenchmarkDotNet" />
+    <Reference Include="Microsoft.AspNetCore" />
+    <Reference Include="Microsoft.AspNetCore.OpenApi" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\test\Microsoft.AspNetCore.OpenApi.Tests.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="$(SharedSourceRoot)BenchmarkRunner\*.cs" />
+  </ItemGroup>
+
+</Project>

--- a/src/OpenApi/perf/TransformersBenchmark.cs
+++ b/src/OpenApi/perf/TransformersBenchmark.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.OpenApi.Microbenchmarks;
 public class TransformersBenchmark : OpenApiDocumentServiceTestBase
 {
     [Params(10, 100, 1000)]
-    public int InvocationCount { get; set; }
+    public int TransformerCount { get; set; }
 
     private readonly IEndpointRouteBuilder _builder = CreateBuilder();
     private readonly OpenApiOptions _options = new OpenApiOptions();
@@ -31,7 +31,7 @@ public class TransformersBenchmark : OpenApiDocumentServiceTestBase
     public void OperationTransformerAsDelegate_Setup()
     {
         _builder.MapGet("/", () => { });
-        for (var i = 0; i <= 1000; i++)
+        for (var i = 0; i <= TransformerCount; i++)
         {
             _options.UseOperationTransformer((operation, context, token) =>
             {
@@ -46,7 +46,7 @@ public class TransformersBenchmark : OpenApiDocumentServiceTestBase
     public void ActivatedDocumentTransformer_Setup()
     {
         _builder.MapGet("/", () => { });
-        for (var i = 0; i <= 1000; i++)
+        for (var i = 0; i <= TransformerCount; i++)
         {
             _options.UseTransformer<ActivatedTransformer>();
         }
@@ -57,7 +57,7 @@ public class TransformersBenchmark : OpenApiDocumentServiceTestBase
     public void DocumentTransformerAsDelegate_Delegate()
     {
         _builder.MapGet("/", () => { });
-        for (var i = 0; i <= 1000; i++)
+        for (var i = 0; i <= TransformerCount; i++)
         {
             _options.UseTransformer((document, context, token) =>
             {
@@ -71,28 +71,19 @@ public class TransformersBenchmark : OpenApiDocumentServiceTestBase
     [Benchmark]
     public async Task OperationTransformerAsDelegate()
     {
-        for (var i = 0; i <= InvocationCount; i++)
-        {
-            await _documentService.GetOpenApiDocumentAsync();
-        }
+        await _documentService.GetOpenApiDocumentAsync();
     }
 
     [Benchmark]
     public async Task ActivatedDocumentTransformer()
     {
-        for (var i = 0; i <= InvocationCount; i++)
-        {
-            await _documentService.GetOpenApiDocumentAsync();
-        }
+        await _documentService.GetOpenApiDocumentAsync();
     }
 
     [Benchmark]
     public async Task DocumentTransformerAsDelegate()
     {
-        for (var i = 0; i <= InvocationCount; i++)
-        {
-            await _documentService.GetOpenApiDocumentAsync();
-        }
+        await _documentService.GetOpenApiDocumentAsync();
     }
 
     private class ActivatedTransformer : IOpenApiDocumentTransformer

--- a/src/OpenApi/perf/TransformersBenchmark.cs
+++ b/src/OpenApi/perf/TransformersBenchmark.cs
@@ -1,0 +1,100 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection.Metadata;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.AspNetCore.OpenApi.Microbenchmarks;
+
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+public class TransformersBenchmark : OpenApiDocumentServiceTestBase
+{
+    [Params(10, 100, 1000)]
+    public int InvocationCount { get; set; }
+
+    private readonly IEndpointRouteBuilder _builder = CreateBuilder();
+    private readonly OpenApiOptions _options = new OpenApiOptions();
+    private OpenApiDocumentService _documentService;
+
+    [GlobalSetup(Target = nameof(OperationTransformerAsDelegate))]
+    public void OperationTransformerAsDelegate_Setup()
+    {
+        _builder.MapGet("/", () => { });
+        for (var i = 0; i <= 1000; i++)
+        {
+            _options.UseOperationTransformer((operation, context, token) =>
+            {
+                operation.Description = "New Description";
+                return Task.CompletedTask;
+            });
+        }
+        _documentService = CreateDocumentService(_builder, _options);
+    }
+
+    [GlobalSetup(Target = nameof(ActivatedDocumentTransformer))]
+    public void ActivatedDocumentTransformer_Setup()
+    {
+        _builder.MapGet("/", () => { });
+        for (var i = 0; i <= 1000; i++)
+        {
+            _options.UseTransformer<ActivatedTransformer>();
+        }
+        _documentService = CreateDocumentService(_builder, _options);
+    }
+
+    [GlobalSetup(Target = nameof(DocumentTransformerAsDelegate))]
+    public void DocumentTransformerAsDelegate_Delegate()
+    {
+        _builder.MapGet("/", () => { });
+        for (var i = 0; i <= 1000; i++)
+        {
+            _options.UseTransformer((document, context, token) =>
+            {
+                document.Info.Description = "New Description";
+                return Task.CompletedTask;
+            });
+        }
+        _documentService = CreateDocumentService(_builder, _options);
+    }
+
+    [Benchmark]
+    public async Task OperationTransformerAsDelegate()
+    {
+        for (var i = 0; i < InvocationCount; i++)
+        {
+            await _documentService.GetOpenApiDocumentAsync();
+        }
+    }
+
+    [Benchmark]
+    public async Task ActivatedDocumentTransformer()
+    {
+        for (var i = 0; i < InvocationCount; i++)
+        {
+            await _documentService.GetOpenApiDocumentAsync();
+        }
+    }
+
+    [Benchmark]
+    public async Task DocumentTransformerAsDelegate()
+    {
+        for (var i = 0; i < InvocationCount; i++)
+        {
+            await _documentService.GetOpenApiDocumentAsync();
+        }
+    }
+
+    private class ActivatedTransformer : IOpenApiDocumentTransformer
+    {
+        public Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken)
+        {
+            document.Info.Description = "Info Description";
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/OpenApi/perf/TransformersBenchmark.cs
+++ b/src/OpenApi/perf/TransformersBenchmark.cs
@@ -10,6 +10,12 @@ using Microsoft.OpenApi.Models;
 
 namespace Microsoft.AspNetCore.OpenApi.Microbenchmarks;
 
+/// <summary>
+/// The following benchmarks are used to assess the memory and performance
+/// impact of different types of transformers. In particular, we want to
+/// measure the impact of (a) context-object creation and caching and (b)
+/// enumerator usage when processing operations in a given document.
+/// </summary>
 [MemoryDiagnoser]
 [EventPipeProfiler(EventPipeProfile.GcVerbose)]
 public class TransformersBenchmark : OpenApiDocumentServiceTestBase

--- a/src/OpenApi/perf/TransformersBenchmark.cs
+++ b/src/OpenApi/perf/TransformersBenchmark.cs
@@ -1,9 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Reflection.Metadata;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Diagnosers;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.OpenApi.Models;
@@ -16,8 +14,6 @@ namespace Microsoft.AspNetCore.OpenApi.Microbenchmarks;
 /// measure the impact of (a) context-object creation and caching and (b)
 /// enumerator usage when processing operations in a given document.
 /// </summary>
-[MemoryDiagnoser]
-[EventPipeProfiler(EventPipeProfile.GcVerbose)]
 public class TransformersBenchmark : OpenApiDocumentServiceTestBase
 {
     [Params(10, 100, 1000)]

--- a/src/OpenApi/perf/TransformersBenchmark.cs
+++ b/src/OpenApi/perf/TransformersBenchmark.cs
@@ -71,7 +71,7 @@ public class TransformersBenchmark : OpenApiDocumentServiceTestBase
     [Benchmark]
     public async Task OperationTransformerAsDelegate()
     {
-        for (var i = 0; i < InvocationCount; i++)
+        for (var i = 0; i <= InvocationCount; i++)
         {
             await _documentService.GetOpenApiDocumentAsync();
         }
@@ -80,7 +80,7 @@ public class TransformersBenchmark : OpenApiDocumentServiceTestBase
     [Benchmark]
     public async Task ActivatedDocumentTransformer()
     {
-        for (var i = 0; i < InvocationCount; i++)
+        for (var i = 0; i <= InvocationCount; i++)
         {
             await _documentService.GetOpenApiDocumentAsync();
         }
@@ -89,7 +89,7 @@ public class TransformersBenchmark : OpenApiDocumentServiceTestBase
     [Benchmark]
     public async Task DocumentTransformerAsDelegate()
     {
-        for (var i = 0; i < InvocationCount; i++)
+        for (var i = 0; i <= InvocationCount; i++)
         {
             await _documentService.GetOpenApiDocumentAsync();
         }

--- a/src/OpenApi/sample/Program.cs
+++ b/src/OpenApi/sample/Program.cs
@@ -1,10 +1,24 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.OpenApi.Models;
+
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddOpenApi("v1");
-builder.Services.AddOpenApi("v2");
+builder.Services.AddAuthentication().AddJwtBearer();
+
+builder.Services.AddOpenApi("v1", options =>
+{
+    options.AddHeader("X-Version", "1.0");
+    options.UseTransformer<BearerSecuritySchemeTransformer>();
+});
+builder.Services.AddOpenApi("v2", options => {
+    options.UseTransformer(new AddContactTransformer());
+    options.UseTransformer((document, context, token) => {
+        document.Info.License = new OpenApiLicense { Name = "MIT" };
+        return Task.CompletedTask;
+    });
+});
 
 var app = builder.Build();
 

--- a/src/OpenApi/sample/Program.cs
+++ b/src/OpenApi/sample/Program.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.OpenApi.Models;
+using Sample.Transformers;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/src/OpenApi/sample/Sample.csproj
+++ b/src/OpenApi/sample/Sample.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore" />
+    <Reference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <Reference Include="Microsoft.AspNetCore.Hosting" />
     <Reference Include="Microsoft.AspNetCore.OpenApi" />
     <Reference Include="Microsoft.AspNetCore.Http" />

--- a/src/OpenApi/sample/Transformers/AddBearerSecuritySchemeTransformer.cs
+++ b/src/OpenApi/sample/Transformers/AddBearerSecuritySchemeTransformer.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi.Models;
+
+public sealed class BearerSecuritySchemeTransformer(IAuthenticationSchemeProvider authenticationSchemeProvider) : IOpenApiDocumentTransformer
+{
+    public async Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken)
+    {
+        var authenticationSchemes = (authenticationSchemeProvider is not null)
+                ? await authenticationSchemeProvider.GetAllSchemesAsync()
+                : [];
+        var requirements = authenticationSchemes
+                .Where(authScheme => authScheme.Name == "Bearer")
+                .ToDictionary(
+                    (authScheme) => authScheme.Name,
+                    (authScheme) => new OpenApiSecurityScheme
+                    {
+                        Type = SecuritySchemeType.Http,
+                        Scheme = "bearer", // "bearer" refers to the header name here
+                        In = ParameterLocation.Header,
+                        BearerFormat = "Json Web Token"
+                    });
+        document.Components ??= new OpenApiComponents();
+        document.Components.SecuritySchemes = requirements;
+    }
+}

--- a/src/OpenApi/sample/Transformers/AddBearerSecuritySchemeTransformer.cs
+++ b/src/OpenApi/sample/Transformers/AddBearerSecuritySchemeTransformer.cs
@@ -5,25 +5,27 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.OpenApi.Models;
 
+namespace Sample.Transformers;
+
 public sealed class BearerSecuritySchemeTransformer(IAuthenticationSchemeProvider authenticationSchemeProvider) : IOpenApiDocumentTransformer
 {
     public async Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken)
     {
-        var authenticationSchemes = (authenticationSchemeProvider is not null)
-                ? await authenticationSchemeProvider.GetAllSchemesAsync()
-                : [];
-        var requirements = authenticationSchemes
-                .Where(authScheme => authScheme.Name == "Bearer")
-                .ToDictionary(
-                    (authScheme) => authScheme.Name,
-                    (authScheme) => new OpenApiSecurityScheme
-                    {
-                        Type = SecuritySchemeType.Http,
-                        Scheme = "bearer", // "bearer" refers to the header name here
-                        In = ParameterLocation.Header,
-                        BearerFormat = "Json Web Token"
-                    });
-        document.Components ??= new OpenApiComponents();
-        document.Components.SecuritySchemes = requirements;
+        var authenticationSchemes = await authenticationSchemeProvider.GetAllSchemesAsync();
+        if (authenticationSchemes.Any(authScheme => authScheme.Name == "Bearer"))
+        {
+            var requirements = new Dictionary<string, OpenApiSecurityScheme>
+            {
+                ["Bearer"] = new OpenApiSecurityScheme
+                {
+                    Type = SecuritySchemeType.Http,
+                    Scheme = "bearer", // "bearer" refers to the header name here
+                    In = ParameterLocation.Header,
+                    BearerFormat = "Json Web Token"
+                }
+            };
+            document.Components ??= new OpenApiComponents();
+            document.Components.SecuritySchemes = requirements;
+        }
     }
 }

--- a/src/OpenApi/sample/Transformers/AddContactTransformer.cs
+++ b/src/OpenApi/sample/Transformers/AddContactTransformer.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi.Models;
+
+public sealed class AddContactTransformer : IOpenApiDocumentTransformer
+{
+    public Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken)
+    {
+        document.Info.Contact = new OpenApiContact
+        {
+            Name = "OpenAPI Enthusiast",
+            Email = "iloveopenapi@example.com"
+        };
+        return Task.CompletedTask;
+    }
+}

--- a/src/OpenApi/sample/Transformers/AddContactTransformer.cs
+++ b/src/OpenApi/sample/Transformers/AddContactTransformer.cs
@@ -4,6 +4,8 @@
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.OpenApi.Models;
 
+namespace Sample.Transformers;
+
 public sealed class AddContactTransformer : IOpenApiDocumentTransformer
 {
     public Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken)

--- a/src/OpenApi/sample/Transformers/OperationTransformers.cs
+++ b/src/OpenApi/sample/Transformers/OperationTransformers.cs
@@ -6,6 +6,8 @@ using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Extensions;
 
+namespace Sample.Transformers;
+
 public static class OperationTransformers
 {
     public static OpenApiOptions AddHeader(this OpenApiOptions options, string headerName, string defaultValue)

--- a/src/OpenApi/sample/Transformers/OperationTransformers.cs
+++ b/src/OpenApi/sample/Transformers/OperationTransformers.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Any;
+
+public static class OperationTransformers
+{
+    public static OpenApiOptions AddHeader(this OpenApiOptions options, string headerName, string defaultValue)
+    {
+        return options.UseOperationTransformer((operation, context, cancellationToken) =>
+        {
+            operation.Parameters.Add(new OpenApiParameter
+            {
+                Name = headerName,
+                In = ParameterLocation.Header,
+                Schema = new OpenApiSchema
+                {
+                    Type = "string",
+                    Default = new OpenApiString(defaultValue)
+                }
+            });
+            return Task.CompletedTask;
+        });
+    }
+}

--- a/src/OpenApi/sample/Transformers/OperationTransformers.cs
+++ b/src/OpenApi/sample/Transformers/OperationTransformers.cs
@@ -4,6 +4,7 @@
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Extensions;
 
 public static class OperationTransformers
 {
@@ -11,15 +12,13 @@ public static class OperationTransformers
     {
         return options.UseOperationTransformer((operation, context, cancellationToken) =>
         {
+            var schema = OpenApiTypeMapper.MapTypeToOpenApiPrimitiveType(typeof(string));
+            schema.Default = new OpenApiString(defaultValue);
             operation.Parameters.Add(new OpenApiParameter
             {
                 Name = headerName,
                 In = ParameterLocation.Header,
-                Schema = new OpenApiSchema
-                {
-                    Type = "string",
-                    Default = new OpenApiString(defaultValue)
-                }
+                Schema = schema
             });
             return Task.CompletedTask;
         });

--- a/src/OpenApi/src/Extensions/OpenApiEndpointRouteBuilderExtensions.cs
+++ b/src/OpenApi/src/Extensions/OpenApiEndpointRouteBuilderExtensions.cs
@@ -43,7 +43,7 @@ public static class OpenApiEndpointRouteBuilderExtensions
                 }
                 else
                 {
-                    var document = await documentService.GetOpenApiDocumentAsync();
+                    var document = await documentService.GetOpenApiDocumentAsync(context.RequestAborted);
                     var documentOptions = options.Get(documentName);
                     using var output = MemoryBufferWriter.Get();
                     using var writer = Utf8BufferTextWriter.Get(output);

--- a/src/OpenApi/src/Microsoft.AspNetCore.OpenApi.csproj
+++ b/src/OpenApi/src/Microsoft.AspNetCore.OpenApi.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.AspNetCore.OpenApi.Tests" />
+    <InternalsVisibleTo Include="Microsoft.AspNetCore.OpenApi.Microbenchmarks" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenApi/src/PublicAPI.Unshipped.txt
+++ b/src/OpenApi/src/PublicAPI.Unshipped.txt
@@ -1,5 +1,8 @@
 #nullable enable
 Microsoft.AspNetCore.Builder.OpenApiEndpointRouteBuilderExtensions
+Microsoft.AspNetCore.OpenApi.IOpenApiDocumentTransformer.TransformAsync(Microsoft.OpenApi.Models.OpenApiDocument! document, Microsoft.AspNetCore.OpenApi.OpenApiDocumentTransformerContext! context, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.OpenApi.OpenApiOperationTransformerContext.Description.get -> Microsoft.AspNetCore.Mvc.ApiExplorer.ApiDescription!
+Microsoft.AspNetCore.OpenApi.OpenApiOperationTransformerContext.Description.init -> void
 Microsoft.AspNetCore.OpenApi.OpenApiOptions
 Microsoft.AspNetCore.OpenApi.OpenApiOptions.DocumentName.get -> string!
 Microsoft.AspNetCore.OpenApi.OpenApiOptions.OpenApiOptions() -> void
@@ -7,9 +10,28 @@ Microsoft.AspNetCore.OpenApi.OpenApiOptions.OpenApiVersion.get -> Microsoft.Open
 Microsoft.AspNetCore.OpenApi.OpenApiOptions.OpenApiVersion.set -> void
 Microsoft.AspNetCore.OpenApi.OpenApiOptions.ShouldInclude.get -> System.Func<Microsoft.AspNetCore.Mvc.ApiExplorer.ApiDescription!, bool>!
 Microsoft.AspNetCore.OpenApi.OpenApiOptions.ShouldInclude.set -> void
+Microsoft.AspNetCore.OpenApi.OpenApiOptions.UseOperationTransformer(System.Func<Microsoft.OpenApi.Models.OpenApiOperation!, Microsoft.AspNetCore.OpenApi.OpenApiOperationTransformerContext!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! transformer) -> Microsoft.AspNetCore.OpenApi.OpenApiOptions!
+Microsoft.AspNetCore.OpenApi.OpenApiOptions.UseTransformer(Microsoft.AspNetCore.OpenApi.IOpenApiDocumentTransformer! transformer) -> Microsoft.AspNetCore.OpenApi.OpenApiOptions!
+Microsoft.AspNetCore.OpenApi.OpenApiOptions.UseTransformer(System.Func<Microsoft.OpenApi.Models.OpenApiDocument!, Microsoft.AspNetCore.OpenApi.OpenApiDocumentTransformerContext!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! transformer) -> Microsoft.AspNetCore.OpenApi.OpenApiOptions!
+Microsoft.AspNetCore.OpenApi.OpenApiOptions.UseTransformer<TTransformerType>() -> Microsoft.AspNetCore.OpenApi.OpenApiOptions!
 Microsoft.Extensions.DependencyInjection.OpenApiServiceCollectionExtensions
 static Microsoft.AspNetCore.Builder.OpenApiEndpointRouteBuilderExtensions.MapOpenApi(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints, string! pattern = "/openapi/{documentName}.json") -> Microsoft.AspNetCore.Builder.IEndpointConventionBuilder!
 static Microsoft.Extensions.DependencyInjection.OpenApiServiceCollectionExtensions.AddOpenApi(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Microsoft.Extensions.DependencyInjection.OpenApiServiceCollectionExtensions.AddOpenApi(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, string! documentName) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Microsoft.Extensions.DependencyInjection.OpenApiServiceCollectionExtensions.AddOpenApi(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, string! documentName, System.Action<Microsoft.AspNetCore.OpenApi.OpenApiOptions!>! configureOptions) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Microsoft.Extensions.DependencyInjection.OpenApiServiceCollectionExtensions.AddOpenApi(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<Microsoft.AspNetCore.OpenApi.OpenApiOptions!>! configureOptions) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+Microsoft.AspNetCore.OpenApi.IOpenApiDocumentTransformer
+Microsoft.AspNetCore.OpenApi.OpenApiDocumentTransformerContext
+Microsoft.AspNetCore.OpenApi.OpenApiDocumentTransformerContext.ApplicationServices.get -> System.IServiceProvider!
+Microsoft.AspNetCore.OpenApi.OpenApiDocumentTransformerContext.ApplicationServices.init -> void
+Microsoft.AspNetCore.OpenApi.OpenApiDocumentTransformerContext.DescriptionGroups.get -> System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Mvc.ApiExplorer.ApiDescriptionGroup!>!
+Microsoft.AspNetCore.OpenApi.OpenApiDocumentTransformerContext.DescriptionGroups.init -> void
+Microsoft.AspNetCore.OpenApi.OpenApiDocumentTransformerContext.DocumentName.get -> string!
+Microsoft.AspNetCore.OpenApi.OpenApiDocumentTransformerContext.DocumentName.init -> void
+Microsoft.AspNetCore.OpenApi.OpenApiDocumentTransformerContext.OpenApiDocumentTransformerContext() -> void
+Microsoft.AspNetCore.OpenApi.OpenApiOperationTransformerContext
+Microsoft.AspNetCore.OpenApi.OpenApiOperationTransformerContext.ApplicationServices.get -> System.IServiceProvider!
+Microsoft.AspNetCore.OpenApi.OpenApiOperationTransformerContext.ApplicationServices.init -> void
+Microsoft.AspNetCore.OpenApi.OpenApiOperationTransformerContext.DocumentName.get -> string!
+Microsoft.AspNetCore.OpenApi.OpenApiOperationTransformerContext.DocumentName.init -> void
+Microsoft.AspNetCore.OpenApi.OpenApiOperationTransformerContext.OpenApiOperationTransformerContext() -> void

--- a/src/OpenApi/src/Services/OpenApiConstants.cs
+++ b/src/OpenApi/src/Services/OpenApiConstants.cs
@@ -8,4 +8,5 @@ internal static class OpenApiConstants
     internal const string DefaultDocumentName = "v1";
     internal const string DefaultOpenApiVersion = "1.0.0";
     internal const string DefaultOpenApiRoute = "/openapi/{documentName}.json";
+    internal const string DescriptionId = "x-aspnetcore-id";
 }

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -70,25 +70,7 @@ internal sealed class OpenApiDocumentService(
         for (var i = 0; i < _options.DocumentTransformers.Count; i++)
         {
             var transformer = _options.DocumentTransformers[i];
-            try
-            {
-                await transformer.TransformAsync(document, documentTransformerContext, cancellationToken);
-            }
-            finally
-            {
-                if (transformer is IDisposable disposable)
-                {
-                    disposable.Dispose();
-                }
-                if (transformer is IAsyncDisposable asyncDisposable)
-                {
-                    await asyncDisposable.DisposeAsync();
-                }
-                if (transformer is TypeBasedOpenApiDocumentTransformer typedTransformer)
-                {
-                    await typedTransformer.DisposeAsync();
-                }
-            }
+            await transformer.TransformAsync(document, documentTransformerContext, cancellationToken);
         }
     }
 

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -70,7 +70,25 @@ internal sealed class OpenApiDocumentService(
         for (var i = 0; i < _options.DocumentTransformers.Count; i++)
         {
             var transformer = _options.DocumentTransformers[i];
-            await transformer.TransformAsync(document, documentTransformerContext, cancellationToken);
+            try
+            {
+                await transformer.TransformAsync(document, documentTransformerContext, cancellationToken);
+            }
+            finally
+            {
+                if (transformer is IDisposable disposable)
+                {
+                    disposable.Dispose();
+                }
+                if (transformer is IAsyncDisposable asyncDisposable)
+                {
+                    await asyncDisposable.DisposeAsync();
+                }
+                if (transformer is TypeBasedOpenApiDocumentTransformer typedTransformer)
+                {
+                    await typedTransformer.DisposeAsync();
+                }
+            }
         }
     }
 

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -33,15 +33,7 @@ internal sealed class OpenApiDocumentService(
     private readonly ConcurrentDictionary<string, OpenApiOperationTransformerContext> _operationTransformerContextCache = new();
 
     internal bool TryGetCachedOperationTransformerContext(string descriptionId, [NotNullWhen(true)] out OpenApiOperationTransformerContext? context)
-    {
-        context = null;
-        if (_operationTransformerContextCache.TryGetValue(descriptionId, out var cachedContext))
-        {
-            context = cachedContext;
-            return true;
-        }
-        return false;
-    }
+        => _operationTransformerContextCache.TryGetValue(descriptionId, out context);
 
     public async Task<OpenApiDocument> GetOpenApiDocumentAsync(CancellationToken cancellationToken = default)
     {

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -66,21 +66,11 @@ internal sealed class OpenApiDocumentService(
             ApplicationServices = serviceProvider,
             DescriptionGroups = apiDescriptionGroupCollectionProvider.ApiDescriptionGroups.Items,
         };
+        // Use index-based for loop to avoid allocating an enumerator with a foreach.
         for (var i = 0; i < _options.DocumentTransformers.Count; i++)
         {
             var transformer = _options.DocumentTransformers[i];
-            // Delayed initialization for DI-activated transformers
-            // until the first time they are used when we have access
-            // to the target service provider.
-            if (transformer is TypeBasedOpenApiDocumentTransformer activatedTransformer)
-            {
-                activatedTransformer.Initialize(serviceProvider);
-                await activatedTransformer.TransformAsync(document, documentTransformerContext, cancellationToken);
-            }
-            else
-            {
-                await transformer.TransformAsync(document, documentTransformerContext, cancellationToken);
-            }
+            await transformer.TransformAsync(document, documentTransformerContext, cancellationToken);
         }
     }
 

--- a/src/OpenApi/src/Services/OpenApiOptions.cs
+++ b/src/OpenApi/src/Services/OpenApiOptions.cs
@@ -58,6 +58,8 @@ public sealed class OpenApiOptions
     /// <returns>The <see cref="OpenApiOptions"/> instance for further customization.</returns>
     public OpenApiOptions UseTransformer(IOpenApiDocumentTransformer transformer)
     {
+        ArgumentNullException.ThrowIfNull(transformer, nameof(transformer));
+
         DocumentTransformers.Add(transformer);
         return this;
     }
@@ -69,6 +71,8 @@ public sealed class OpenApiOptions
     /// <returns>The <see cref="OpenApiOptions"/> instance for further customization.</returns>
     public OpenApiOptions UseTransformer(Func<OpenApiDocument, OpenApiDocumentTransformerContext, CancellationToken, Task> transformer)
     {
+        ArgumentNullException.ThrowIfNull(transformer, nameof(transformer));
+
         DocumentTransformers.Add(new DelegateOpenApiDocumentTransformer(transformer));
         return this;
     }
@@ -80,6 +84,8 @@ public sealed class OpenApiOptions
     /// <returns>The <see cref="OpenApiOptions"/> instance for further customization.</returns>
     public OpenApiOptions UseOperationTransformer(Func<OpenApiOperation, OpenApiOperationTransformerContext, CancellationToken, Task> transformer)
     {
+        ArgumentNullException.ThrowIfNull(transformer, nameof(transformer));
+
         DocumentTransformers.Add(new DelegateOpenApiDocumentTransformer(transformer));
         return this;
     }

--- a/src/OpenApi/src/Services/OpenApiOptions.cs
+++ b/src/OpenApi/src/Services/OpenApiOptions.cs
@@ -1,8 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.OpenApi;
+using Microsoft.OpenApi.Models;
 
 namespace Microsoft.AspNetCore.OpenApi;
 
@@ -11,6 +13,8 @@ namespace Microsoft.AspNetCore.OpenApi;
 /// </summary>
 public sealed class OpenApiOptions
 {
+    internal readonly List<IOpenApiDocumentTransformer> DocumentTransformers = [];
+
     /// <summary>
     /// Initializes a new instance of the <see cref="OpenApiOptions"/> class
     /// with the default <see cref="ShouldInclude"/> predicate.
@@ -34,4 +38,49 @@ public sealed class OpenApiOptions
     /// A delegate to determine whether a given <see cref="ApiDescription"/> should be included in the given OpenAPI document.
     /// </summary>
     public Func<ApiDescription, bool> ShouldInclude { get; set; }
+
+    /// <summary>
+    /// Registers a new document transformer on the current <see cref="OpenApiOptions"/> instance.
+    /// </summary>
+    /// <typeparam name="TTransformerType">The type of the <see cref="IOpenApiDocumentTransformer"/> to instantiate.</typeparam>
+    /// <returns>The <see cref="OpenApiOptions"/> instance for further customization.</returns>
+    public OpenApiOptions UseTransformer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TTransformerType>()
+        where TTransformerType : IOpenApiDocumentTransformer
+    {
+        DocumentTransformers.Add(new ActivatedOpenApiDocumentTransformer(typeof(TTransformerType)));
+        return this;
+    }
+
+    /// <summary>
+    /// Registers a given instance of <see cref="IOpenApiDocumentTransformer"/> on the current <see cref="OpenApiOptions"/> instance.
+    /// </summary>
+    /// <param name="transformer">The <see cref="IOpenApiDocumentTransformer"/> instance to use.</param>
+    /// <returns>The <see cref="OpenApiOptions"/> instance for further customization.</returns>
+    public OpenApiOptions UseTransformer(IOpenApiDocumentTransformer transformer)
+    {
+        DocumentTransformers.Add(transformer);
+        return this;
+    }
+
+    /// <summary>
+    /// Registers a given delegate as a document transformer on the current <see cref="OpenApiOptions"/> instance.
+    /// </summary>
+    /// <param name="transformer">The delegate representing the document transformer.</param>
+    /// <returns>The <see cref="OpenApiOptions"/> instance for further customization.</returns>
+    public OpenApiOptions UseTransformer(Func<OpenApiDocument, OpenApiDocumentTransformerContext, CancellationToken, Task> transformer)
+    {
+        DocumentTransformers.Add(new DelegateOpenApiDocumentTransformer(transformer));
+        return this;
+    }
+
+    /// <summary>
+    /// Registers a given delegate as an operation transformer on the current <see cref="OpenApiOptions"/> instance.
+    /// </summary>
+    /// <param name="transformer">The delegate representing the operation transformer.</param>
+    /// <returns>The <see cref="OpenApiOptions"/> instance for further customization.</returns>
+    public OpenApiOptions UseOperationTransformer(Func<OpenApiOperation, OpenApiOperationTransformerContext, CancellationToken, Task> transformer)
+    {
+        DocumentTransformers.Add(new DelegateOpenApiDocumentTransformer(transformer));
+        return this;
+    }
 }

--- a/src/OpenApi/src/Services/OpenApiOptions.cs
+++ b/src/OpenApi/src/Services/OpenApiOptions.cs
@@ -47,7 +47,7 @@ public sealed class OpenApiOptions
     public OpenApiOptions UseTransformer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TTransformerType>()
         where TTransformerType : IOpenApiDocumentTransformer
     {
-        DocumentTransformers.Add(new ActivatedOpenApiDocumentTransformer(typeof(TTransformerType)));
+        DocumentTransformers.Add(new TypeBasedOpenApiDocumentTransformer(typeof(TTransformerType)));
         return this;
     }
 

--- a/src/OpenApi/src/Transformers/ActivatedOpenApiDocumentTransformer.cs
+++ b/src/OpenApi/src/Transformers/ActivatedOpenApiDocumentTransformer.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.AspNetCore.OpenApi;
+
+internal sealed class ActivatedOpenApiDocumentTransformer(Type transformerType) : IOpenApiDocumentTransformer
+{
+    internal IOpenApiDocumentTransformer? Transformer { get; set; }
+
+    internal void Initialize(IServiceProvider serviceProvider)
+    {
+        Transformer ??= ActivatorUtilities.CreateInstance(serviceProvider, transformerType) as IOpenApiDocumentTransformer;
+    }
+
+    public Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken)
+    {
+        Debug.Assert(Transformer != null, "Transformer should have been initialized.");
+        return Transformer.TransformAsync(document, context, cancellationToken);
+    }
+}

--- a/src/OpenApi/src/Transformers/DelegateOpenApiDocumentTransformer.cs
+++ b/src/OpenApi/src/Transformers/DelegateOpenApiDocumentTransformer.cs
@@ -36,9 +36,22 @@ internal sealed class DelegateOpenApiDocumentTransformer : IOpenApiDocumentTrans
             {
                 foreach (var operation in pathItem.Operations.Values)
                 {
-                    var descriptionId = ((OpenApiString)operation.Extensions[OpenApiConstants.DescriptionId]).Value;
-                    var operationContext = documentService.OperationTransformerContextCache[descriptionId];
-                    await _operationTransformer(operation, operationContext, cancellationToken);
+                    if (operation.Extensions.TryGetValue(OpenApiConstants.DescriptionId, out var descriptionIdExtension) &&
+                        descriptionIdExtension is OpenApiString { Value: var descriptionId } &&
+                        documentService.OperationTransformerContextCache.TryGetValue(descriptionId, out var operationContext))
+                    {
+                        await _operationTransformer(operation, operationContext, cancellationToken);
+                    }
+                    else
+                    {
+                        // If the cached operation transformer context was not found, throw an exception.
+                        // This can occur if the `x-aspnetcore-id` extension attribute was removed by the
+                        // user in another operation transformer or if the lookup for operation transformer
+                        // context resulted in a cache miss. As an alternative here, we could just to implement
+                        // the "slow-path" and look up the ApiDescription associated with the OpenApiOperation
+                        // using the OperationType and given path, but we'll avoid this for now.
+                        throw new InvalidOperationException("Cached operation transformer context not found.");
+                    }
                 }
             }
         }

--- a/src/OpenApi/src/Transformers/DelegateOpenApiDocumentTransformer.cs
+++ b/src/OpenApi/src/Transformers/DelegateOpenApiDocumentTransformer.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.AspNetCore.OpenApi;
+
+internal sealed class DelegateOpenApiDocumentTransformer : IOpenApiDocumentTransformer
+{
+    private readonly Func<OpenApiDocument, OpenApiDocumentTransformerContext, CancellationToken, Task>? _documentTransformer;
+    private readonly Func<OpenApiOperation, OpenApiOperationTransformerContext, CancellationToken, Task>? _operationTransformer;
+
+    public DelegateOpenApiDocumentTransformer(Func<OpenApiDocument, OpenApiDocumentTransformerContext, CancellationToken, Task> transformer)
+    {
+        _documentTransformer = transformer;
+    }
+
+    public DelegateOpenApiDocumentTransformer(Func<OpenApiOperation, OpenApiOperationTransformerContext, CancellationToken, Task> transformer)
+    {
+        _operationTransformer = transformer;
+    }
+
+    public async Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken)
+    {
+        if (_documentTransformer != null)
+        {
+            await _documentTransformer(document, context, cancellationToken);
+        }
+
+        if (_operationTransformer != null)
+        {
+            var documentService = context.ApplicationServices.GetRequiredKeyedService<OpenApiDocumentService>(context.DocumentName);
+            foreach (var pathItem in document.Paths.Values)
+            {
+                foreach (var operation in pathItem.Operations.Values)
+                {
+                    var descriptionId = ((OpenApiString)operation.Extensions[OpenApiConstants.DescriptionId]).Value;
+                    var operationContext = documentService.OperationTransformerContextCache[descriptionId];
+                    await _operationTransformer(operation, operationContext, cancellationToken);
+                }
+            }
+        }
+    }
+}

--- a/src/OpenApi/src/Transformers/DelegateOpenApiDocumentTransformer.cs
+++ b/src/OpenApi/src/Transformers/DelegateOpenApiDocumentTransformer.cs
@@ -38,7 +38,7 @@ internal sealed class DelegateOpenApiDocumentTransformer : IOpenApiDocumentTrans
                 {
                     if (operation.Extensions.TryGetValue(OpenApiConstants.DescriptionId, out var descriptionIdExtension) &&
                         descriptionIdExtension is OpenApiString { Value: var descriptionId } &&
-                        documentService.OperationTransformerContextCache.TryGetValue(descriptionId, out var operationContext))
+                        documentService.TryGetCachedOperationTransformerContext(descriptionId, out var operationContext))
                     {
                         await _operationTransformer(operation, operationContext, cancellationToken);
                     }
@@ -50,7 +50,7 @@ internal sealed class DelegateOpenApiDocumentTransformer : IOpenApiDocumentTrans
                         // context resulted in a cache miss. As an alternative here, we could just to implement
                         // the "slow-path" and look up the ApiDescription associated with the OpenApiOperation
                         // using the OperationType and given path, but we'll avoid this for now.
-                        throw new InvalidOperationException("Cached operation transformer context not found.");
+                        throw new InvalidOperationException("Cached operation transformer context not found. Please ensure that the operation contains the `x-aspnetcore-id` extension attribute.");
                     }
                 }
             }

--- a/src/OpenApi/src/Transformers/IOpenApiDocumentTransformer.cs
+++ b/src/OpenApi/src/Transformers/IOpenApiDocumentTransformer.cs
@@ -14,7 +14,7 @@ public interface IOpenApiDocumentTransformer
     /// Transforms the specified OpenAPI document.
     /// </summary>
     /// <param name="document">The <see cref="OpenApiDocument"/> to modify.</param>
-    /// <param name="context">The <see cref="OpenApiDocumentTransformerContext"/> associated with the <see paramref="document"/> .</param>
+    /// <param name="context">The <see cref="OpenApiDocumentTransformerContext"/> associated with the <see paramref="document"/>.</param>
     /// <param name="cancellationToken">The cancellation token to use.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
     public Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken);

--- a/src/OpenApi/src/Transformers/IOpenApiDocumentTransformer.cs
+++ b/src/OpenApi/src/Transformers/IOpenApiDocumentTransformer.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.AspNetCore.OpenApi;
+
+/// <summary>
+/// Represents a transformer that can be used to modify an OpenAPI document.
+/// </summary>
+public interface IOpenApiDocumentTransformer
+{
+    /// <summary>
+    /// Transforms the specified OpenAPI document.
+    /// </summary>
+    /// <param name="document">The <see cref="OpenApiDocument"/> to modify.</param>
+    /// <param name="context">The <see cref="OpenApiDocumentTransformerContext"/> associated with the <see paramref="document"/> .</param>
+    /// <param name="cancellationToken">The cancellation token to use.</param>
+    /// <returns>The task object representing the asynchronous operation.</returns>
+    public Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken);
+}

--- a/src/OpenApi/src/Transformers/OpenApiDocumentTransformerContext.cs
+++ b/src/OpenApi/src/Transformers/OpenApiDocumentTransformerContext.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+
+namespace Microsoft.AspNetCore.OpenApi;
+
+/// <summary>
+/// Represents the context in which an OpenAPI document transformer is executed.
+/// </summary>
+public sealed class OpenApiDocumentTransformerContext
+{
+    /// <summary>
+    /// Gets the name of the associated OpenAPI document.
+    /// </summary>
+    public required string DocumentName { get; init; }
+
+    /// <summary>
+    /// Gets the API description groups associated with current document.
+    /// </summary>
+    public required IReadOnlyList<ApiDescriptionGroup> DescriptionGroups { get; init; }
+
+    /// <summary>
+    /// Gets the application services associated with current document.
+    /// </summary>
+    public required IServiceProvider ApplicationServices { get; init; }
+}

--- a/src/OpenApi/src/Transformers/OpenApiOperationTransformerContext.cs
+++ b/src/OpenApi/src/Transformers/OpenApiOperationTransformerContext.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+
+namespace Microsoft.AspNetCore.OpenApi;
+
+/// <summary>
+/// Represents the context in which an OpenAPI operation transformer is executed.
+/// </summary>
+public sealed class OpenApiOperationTransformerContext
+{
+    /// <summary>
+    /// Gets the name of the associated OpenAPI document.
+    /// </summary>
+    public required string DocumentName { get; init; }
+
+    /// <summary>
+    /// Gets the API description associated with current document.
+    /// </summary>
+    public required ApiDescription Description { get; init; }
+
+    /// <summary>
+    /// Gets the application services associated with current document.
+    /// </summary>
+    public required IServiceProvider ApplicationServices { get; init; }
+}

--- a/src/OpenApi/src/Transformers/OpenApiOperationTransformerContext.cs
+++ b/src/OpenApi/src/Transformers/OpenApiOperationTransformerContext.cs
@@ -16,7 +16,7 @@ public sealed class OpenApiOperationTransformerContext
     public required string DocumentName { get; init; }
 
     /// <summary>
-    /// Gets the API description associated with current document.
+    /// Gets the API description associated with target operation.
     /// </summary>
     public required ApiDescription Description { get; init; }
 

--- a/src/OpenApi/src/Transformers/OpenApiOperationTransformerContext.cs
+++ b/src/OpenApi/src/Transformers/OpenApiOperationTransformerContext.cs
@@ -21,7 +21,7 @@ public sealed class OpenApiOperationTransformerContext
     public required ApiDescription Description { get; init; }
 
     /// <summary>
-    /// Gets the application services associated with current document.
+    /// Gets the application services associated with the current document the target operation is in.
     /// </summary>
     public required IServiceProvider ApplicationServices { get; init; }
 }

--- a/src/OpenApi/src/Transformers/TypeBasedOpenApiDocumentTransformer.cs
+++ b/src/OpenApi/src/Transformers/TypeBasedOpenApiDocumentTransformer.cs
@@ -7,13 +7,14 @@ using Microsoft.OpenApi.Models;
 
 namespace Microsoft.AspNetCore.OpenApi;
 
-internal sealed class ActivatedOpenApiDocumentTransformer(Type transformerType) : IOpenApiDocumentTransformer
+internal sealed class TypeBasedOpenApiDocumentTransformer(Type transformerType) : IOpenApiDocumentTransformer
 {
     internal IOpenApiDocumentTransformer? Transformer { get; set; }
 
     internal void Initialize(IServiceProvider serviceProvider)
     {
-        Transformer ??= ActivatorUtilities.CreateInstance(serviceProvider, transformerType) as IOpenApiDocumentTransformer;
+        Debug.Assert(typeof(IOpenApiDocumentTransformer).IsAssignableFrom(transformerType), "Type should implement IOpenApiDocumentTransformer.");
+        Transformer ??= (IOpenApiDocumentTransformer)ActivatorUtilities.CreateInstance(serviceProvider, transformerType);
     }
 
     public Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken)

--- a/src/OpenApi/src/Transformers/TypeBasedOpenApiDocumentTransformer.cs
+++ b/src/OpenApi/src/Transformers/TypeBasedOpenApiDocumentTransformer.cs
@@ -10,25 +10,25 @@ namespace Microsoft.AspNetCore.OpenApi;
 internal sealed class TypeBasedOpenApiDocumentTransformer(Type transformerType) : IOpenApiDocumentTransformer
 {
     private readonly ObjectFactory _transformerFactory = ActivatorUtilities.CreateFactory(transformerType, []);
-    private IOpenApiDocumentTransformer? _transformer;
 
-    public ValueTask DisposeAsync()
+    public async Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken)
     {
-        if (_transformer is IAsyncDisposable asyncDisposable)
+        var transformer = _transformerFactory.Invoke(context.ApplicationServices, []) as IOpenApiDocumentTransformer;
+        Debug.Assert(transformer != null, $"The type {transformerType} does not implement {nameof(IOpenApiDocumentTransformer)}.");
+        try
         {
-            return asyncDisposable.DisposeAsync();
+            await transformer.TransformAsync(document, context, cancellationToken);
         }
-        if (_transformer is IDisposable disposable)
+        finally
         {
-            disposable.Dispose();
+            if (transformer is IAsyncDisposable asyncDisposable)
+            {
+                await asyncDisposable.DisposeAsync();
+            }
+            else if (transformer is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
         }
-        return ValueTask.CompletedTask;
-    }
-
-    public Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken)
-    {
-        _transformer = _transformerFactory.Invoke(context.ApplicationServices, []) as IOpenApiDocumentTransformer;
-        Debug.Assert(_transformer != null, $"The type {transformerType} does not implement {nameof(IOpenApiDocumentTransformer)}.");
-        return _transformer.TransformAsync(document, context, cancellationToken);
     }
 }

--- a/src/OpenApi/src/Transformers/TypeBasedOpenApiDocumentTransformer.cs
+++ b/src/OpenApi/src/Transformers/TypeBasedOpenApiDocumentTransformer.cs
@@ -10,10 +10,25 @@ namespace Microsoft.AspNetCore.OpenApi;
 internal sealed class TypeBasedOpenApiDocumentTransformer(Type transformerType) : IOpenApiDocumentTransformer
 {
     private readonly ObjectFactory _transformerFactory = ActivatorUtilities.CreateFactory(transformerType, []);
+    private IOpenApiDocumentTransformer? _transformer;
+
+    public ValueTask DisposeAsync()
+    {
+        if (_transformer is IAsyncDisposable asyncDisposable)
+        {
+            return asyncDisposable.DisposeAsync();
+        }
+        if (_transformer is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+        return ValueTask.CompletedTask;
+    }
+
     public Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken)
     {
-        var transformer = _transformerFactory.Invoke(context.ApplicationServices, []) as IOpenApiDocumentTransformer;
-        Debug.Assert(transformer != null, $"The type {transformerType} does not implement {nameof(IOpenApiDocumentTransformer)}.");
-        return transformer.TransformAsync(document, context, cancellationToken);
+        _transformer = _transformerFactory.Invoke(context.ApplicationServices, []) as IOpenApiDocumentTransformer;
+        Debug.Assert(_transformer != null, $"The type {transformerType} does not implement {nameof(IOpenApiDocumentTransformer)}.");
+        return _transformer.TransformAsync(document, context, cancellationToken);
     }
 }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests.csproj
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests.csproj
@@ -18,4 +18,8 @@
     <Reference Include="Microsoft.AspNetCore.OpenApi" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.AspNetCore.OpenApi.Microbenchmarks" />
+  </ItemGroup>
+
 </Project>

--- a/src/OpenApi/test/Services/OpenApiDocumentServiceTests.Info.cs
+++ b/src/OpenApi/test/Services/OpenApiDocumentServiceTests.Info.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.OpenApi;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting.Internal;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -21,7 +22,8 @@ public partial class OpenApiDocumentServiceTests
             "v1",
             new Mock<IApiDescriptionGroupCollectionProvider>().Object,
             hostEnvironment,
-            new Mock<IOptionsMonitor<OpenApiOptions>>().Object);
+            new Mock<IOptionsMonitor<OpenApiOptions>>().Object,
+            new Mock<IServiceProvider>().Object);
 
         // Act
         var info = docService.GetOpenApiInfo();
@@ -42,7 +44,8 @@ public partial class OpenApiDocumentServiceTests
             "v2",
             new Mock<IApiDescriptionGroupCollectionProvider>().Object,
             hostEnvironment,
-            new Mock<IOptionsMonitor<OpenApiOptions>>().Object);
+            new Mock<IOptionsMonitor<OpenApiOptions>>().Object,
+            new Mock<IServiceProvider>().Object);
 
         // Act
         var info = docService.GetOpenApiInfo();

--- a/src/OpenApi/test/Transformers/DocumentTransformerTests.cs
+++ b/src/OpenApi/test/Transformers/DocumentTransformerTests.cs
@@ -123,46 +123,6 @@ public class DocumentTransformerTests : OpenApiDocumentServiceTestBase
     }
 
     [Fact]
-    public async Task DocumentTransformer_SupportsDisposableInstanceTransformer()
-    {
-        var builder = CreateBuilder();
-
-        builder.MapGet("/todo", () => { });
-        builder.MapGet("/user", () => { });
-
-        var options = new OpenApiOptions();
-        var transformer = new DisposableTransformer();
-        options.UseTransformer(transformer);
-
-        Assert.False(transformer.Disposed);
-        await VerifyOpenApiDocument(builder, options, document =>
-        {
-            Assert.Equal("Info Description", document.Info.Description);
-        });
-        Assert.True(transformer.Disposed);
-    }
-
-    [Fact]
-    public async Task DocumentTransformer_SupportsAsyncDisposableInstanceTransformer()
-    {
-        var builder = CreateBuilder();
-
-        builder.MapGet("/todo", () => { });
-        builder.MapGet("/user", () => { });
-
-        var options = new OpenApiOptions();
-        var transformer = new AsyncDisposableTransformer();
-        options.UseTransformer(transformer);
-
-        Assert.False(transformer.Disposed);
-        await VerifyOpenApiDocument(builder, options, document =>
-        {
-            Assert.Equal("Info Description", document.Info.Description);
-        });
-        Assert.True(transformer.Disposed);
-    }
-
-    [Fact]
     public async Task DocumentTransformer_SupportsDisposableActivatedTransformer()
     {
         var builder = CreateBuilder();

--- a/src/OpenApi/test/Transformers/OpenApiOptionsTests.cs
+++ b/src/OpenApi/test/Transformers/OpenApiOptionsTests.cs
@@ -21,8 +21,8 @@ public class OpenApiOptionsTests
         var result = options.UseTransformer(transformer);
 
         // Assert
-        Assert.Single(options.DocumentTransformers);
-        Assert.IsType<DelegateOpenApiDocumentTransformer>(options.DocumentTransformers[0]);
+        var insertedTransformer = Assert.Single(options.DocumentTransformers);
+        Assert.IsType<DelegateOpenApiDocumentTransformer>(insertedTransformer);
         Assert.IsType<OpenApiOptions>(result);
     }
 
@@ -37,8 +37,8 @@ public class OpenApiOptionsTests
         var result = options.UseTransformer(transformer);
 
         // Assert
-        Assert.Single(options.DocumentTransformers);
-        Assert.Same(transformer, options.DocumentTransformers[0]);
+        var insertedTransformer = Assert.Single(options.DocumentTransformers);
+        Assert.Same(transformer, insertedTransformer);
         Assert.IsType<OpenApiOptions>(result);
     }
 
@@ -52,8 +52,8 @@ public class OpenApiOptionsTests
         var result = options.UseTransformer<TestOpenApiDocumentTransformer>();
 
         // Assert
-        Assert.Single(options.DocumentTransformers);
-        Assert.IsType<ActivatedOpenApiDocumentTransformer>(options.DocumentTransformers[0]);
+        var insertedTransformer = Assert.Single(options.DocumentTransformers);
+        Assert.IsType<TypeBasedOpenApiDocumentTransformer>(insertedTransformer);
         Assert.IsType<OpenApiOptions>(result);
     }
 
@@ -72,8 +72,8 @@ public class OpenApiOptionsTests
         var result = options.UseOperationTransformer(transformer);
 
         // Assert
-        Assert.Single(options.DocumentTransformers);
-        Assert.IsType<DelegateOpenApiDocumentTransformer>(options.DocumentTransformers[0]);
+        var insertedTransformer = Assert.Single(options.DocumentTransformers);
+        Assert.IsType<DelegateOpenApiDocumentTransformer>(insertedTransformer);
         Assert.IsType<OpenApiOptions>(result);
     }
 

--- a/src/OpenApi/test/Transformers/OpenApiOptionsTests.cs
+++ b/src/OpenApi/test/Transformers/OpenApiOptionsTests.cs
@@ -1,0 +1,87 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi.Models;
+
+public class OpenApiOptionsTests
+{
+    [Fact]
+    public void UseTransformer_WithDocumentTransformerDelegate()
+    {
+        // Arrange
+        var options = new OpenApiOptions();
+        var transformer = new Func<OpenApiDocument, OpenApiDocumentTransformerContext, CancellationToken, Task>((document, context, cancellationToken) =>
+        {
+            document.Info.Title = "New Title";
+            return Task.CompletedTask;
+        });
+
+        // Act
+        var result = options.UseTransformer(transformer);
+
+        // Assert
+        Assert.Single(options.DocumentTransformers);
+        Assert.IsType<DelegateOpenApiDocumentTransformer>(options.DocumentTransformers[0]);
+        Assert.IsType<OpenApiOptions>(result);
+    }
+
+    [Fact]
+    public void UseTransformer_WithDocumentTransformerInstance()
+    {
+        // Arrange
+        var options = new OpenApiOptions();
+        var transformer = new TestOpenApiDocumentTransformer();
+
+        // Act
+        var result = options.UseTransformer(transformer);
+
+        // Assert
+        Assert.Single(options.DocumentTransformers);
+        Assert.Same(transformer, options.DocumentTransformers[0]);
+        Assert.IsType<OpenApiOptions>(result);
+    }
+
+    [Fact]
+    public void UseTransformer_WithDocumentTransformerType()
+    {
+        // Arrange
+        var options = new OpenApiOptions();
+
+        // Act
+        var result = options.UseTransformer<TestOpenApiDocumentTransformer>();
+
+        // Assert
+        Assert.Single(options.DocumentTransformers);
+        Assert.IsType<ActivatedOpenApiDocumentTransformer>(options.DocumentTransformers[0]);
+        Assert.IsType<OpenApiOptions>(result);
+    }
+
+    [Fact]
+    public void UseTransformer_WithOperationTransformerDelegate()
+    {
+        // Arrange
+        var options = new OpenApiOptions();
+        var transformer = new Func<OpenApiOperation, OpenApiOperationTransformerContext, CancellationToken, Task>((operation, context, cancellationToken) =>
+        {
+            operation.Description = "New Description";
+            return Task.CompletedTask;
+        });
+
+        // Act
+        var result = options.UseOperationTransformer(transformer);
+
+        // Assert
+        Assert.Single(options.DocumentTransformers);
+        Assert.IsType<DelegateOpenApiDocumentTransformer>(options.DocumentTransformers[0]);
+        Assert.IsType<OpenApiOptions>(result);
+    }
+
+    private class TestOpenApiDocumentTransformer : IOpenApiDocumentTransformer
+    {
+        public Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/OpenApi/test/Transformers/OperationTransformerTests.cs
+++ b/src/OpenApi/test/Transformers/OperationTransformerTests.cs
@@ -123,4 +123,26 @@ public class OperationTransformerTests : OpenApiDocumentServiceTestBase
                 });
         });
     }
+
+    [Fact]
+    public async Task OperationTransformer_ThrowsExceptionIfDescriptionIdNotFound()
+    {
+        var builder = CreateBuilder();
+
+        builder.MapGet("/todo", () => { });
+
+        var options = new OpenApiOptions();
+        options.UseOperationTransformer((operation, context, cancellationToken) =>
+        {
+            operation.Extensions.Remove("x-aspnetcore-id");
+            return Task.CompletedTask;
+        });
+        options.UseOperationTransformer((operation, context, cancellationToken) =>
+        {
+            return Task.CompletedTask;
+        });
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => VerifyOpenApiDocument(builder, options, _ => { }));
+        Assert.Equal("Cached operation transformer context not found.", exception.Message);
+    }
 }

--- a/src/OpenApi/test/Transformers/OperationTransformerTests.cs
+++ b/src/OpenApi/test/Transformers/OperationTransformerTests.cs
@@ -143,6 +143,6 @@ public class OperationTransformerTests : OpenApiDocumentServiceTestBase
         });
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => VerifyOpenApiDocument(builder, options, _ => { }));
-        Assert.Equal("Cached operation transformer context not found.", exception.Message);
+        Assert.Equal("Cached operation transformer context not found. Please ensure that the operation contains the `x-aspnetcore-id` extension attribute.", exception.Message);
     }
 }

--- a/src/OpenApi/test/Transformers/OperationTransformerTests.cs
+++ b/src/OpenApi/test/Transformers/OperationTransformerTests.cs
@@ -1,0 +1,126 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.OpenApi;
+
+public class OperationTransformerTests : OpenApiDocumentServiceTestBase
+{
+    [Fact]
+    public async Task OperationTransformer_CanAccessApiDescription()
+    {
+        var builder = CreateBuilder();
+
+        builder.MapGet("/todo", () => { });
+        builder.MapGet("/user", () => { });
+
+        var options = new OpenApiOptions();
+        options.UseOperationTransformer((operation, context, cancellationToken) =>
+        {
+            var apiDescription = context.Description;
+            operation.Description = apiDescription.RelativePath;
+            return Task.CompletedTask;
+        });
+
+        await VerifyOpenApiDocument(builder, options, document =>
+        {
+            Assert.Collection(document.Paths.OrderBy(p => p.Key),
+                path =>
+                {
+                    Assert.Equal("/todo", path.Key);
+                    var operation = Assert.Single(path.Value.Operations.Values);
+                    Assert.Equal("todo", operation.Description);
+                },
+                path =>
+                {
+                    Assert.Equal("/user", path.Key);
+                    var operation = Assert.Single(path.Value.Operations.Values);
+                    Assert.Equal("user", operation.Description);
+                });
+        });
+    }
+
+    [Fact]
+    public async Task OperationTransformer_RunsInRegisteredOrder()
+    {
+        var builder = CreateBuilder();
+
+        builder.MapGet("/todo", () => { });
+        builder.MapGet("/user", () => { });
+
+        var options = new OpenApiOptions();
+        options.UseOperationTransformer((operation, context, cancellationToken) =>
+        {
+            operation.Description = "1";
+            return Task.CompletedTask;
+        });
+        options.UseOperationTransformer((operation, context, cancellationToken) =>
+        {
+            Assert.Equal("1", operation.Description);
+            operation.Description = "2";
+            return Task.CompletedTask;
+        });
+        options.UseOperationTransformer((operation, context, cancellationToken) =>
+        {
+            Assert.Equal("2", operation.Description);
+            operation.Description = "3";
+            return Task.CompletedTask;
+        });
+
+        await VerifyOpenApiDocument(builder, options, document =>
+        {
+            Assert.Collection(document.Paths.OrderBy(p => p.Key),
+                path =>
+                {
+                    Assert.Equal("/todo", path.Key);
+                    var operation = Assert.Single(path.Value.Operations.Values);
+                    Assert.Equal("3", operation.Description);
+                },
+                path =>
+                {
+                    Assert.Equal("/user", path.Key);
+                    var operation = Assert.Single(path.Value.Operations.Values);
+                    Assert.Equal("3", operation.Description);
+                });
+        });
+    }
+
+    [Fact]
+    public async Task OperationTransformer_CanMutateOperationViaDocumentTransformer()
+    {
+        var builder = CreateBuilder();
+
+        builder.MapGet("/todo", () => { });
+        builder.MapGet("/user", () => { });
+
+        var options = new OpenApiOptions();
+        options.UseTransformer((document, context, cancellationToken) =>
+        {
+            foreach (var pathItem in document.Paths.Values)
+            {
+                foreach (var operation in pathItem.Operations.Values)
+                {
+                    operation.Description = "3";
+                }
+            }
+            return Task.CompletedTask;
+        });
+
+        await VerifyOpenApiDocument(builder, options, document =>
+        {
+            Assert.Collection(document.Paths.OrderBy(p => p.Key),
+                path =>
+                {
+                    Assert.Equal("/todo", path.Key);
+                    var operation = Assert.Single(path.Value.Operations.Values);
+                    Assert.Equal("3", operation.Description);
+                },
+                path =>
+                {
+                    Assert.Equal("/user", path.Key);
+                    var operation = Assert.Single(path.Value.Operations.Values);
+                    Assert.Equal("3", operation.Description);
+                });
+        });
+    }
+}


### PR DESCRIPTION
This PR adds support for document and operation transformers to OpenAPI feature branch. I've not included schema transformers in this delta since schema-related changes are not in.