### PR TITLE
[release/8.0] Skip SpotBugs for now

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -137,6 +137,8 @@ extends:
         name: NetCore1ESPool-Svc-Internal
         image: 1es-windows-2022-pt
         os: windows
+      spotBugs:
+        enabled: false
     containers:
       alpine319WithNode:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode


### PR DESCRIPTION
We're seeing failures in the task that don't seem to be related to our code: 

https://dev.azure.com/dnceng/internal/_build/results?buildId=2420337&view=logs&j=1b89928a-2219-5ef9-602f-f95beb3da4dc&t=cdd6bd84-dd5b-50f2-87a2-2385b3bec8b9&l=75

> ##[error]The following classes needed for analysis were missing:
##[error]  okhttp3.CookieJar
##[error]  okhttp3.Callback
##[error]  okhttp3.WebSocketListener
##[error]  org.msgpack.value.ValueType
##[error]  org.msgpack.core.MessageFormat
