### PR TITLE
Docs: changed to align with function behaviour.

### DIFF
--- a/src/Mvc/Mvc.ViewFeatures/src/Rendering/IHtmlHelperOfT.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Rendering/IHtmlHelperOfT.cs
@@ -188,9 +188,8 @@ public interface IHtmlHelper<TModel> : IHtmlHelper
     /// <summary>
     /// Returns an &lt;input&gt; element of type "hidden" for the specified <paramref name="expression"/>. Adds a
     /// "value" attribute to the element containing the first non-<c>null</c> value found in:
-    /// the <see cref="ActionContext.ModelState"/> entry with full name,
-    /// the <paramref name="expression"/> evaluated against <see cref="ViewDataDictionary.Model"/>, or
-    /// the <paramref name="htmlAttributes"/> dictionary entry with key "value".
+    /// the <see cref="ActionContext.ModelState"/> entry with full name or
+    /// the <paramref name="expression"/> evaluated against <see cref="ViewDataDictionary.Model"/>.
     /// See <see cref="NameFor"/> for more information about a "full name".
     /// </summary>
     /// <param name="expression">An expression to be evaluated against the current model.</param>


### PR DESCRIPTION
# Documentation change for Html.HiddenFor #49415 

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

 ## Summary of changes

Changed a sentence to indicate that htmlAttributes parameter is not used. 

## Description

This pull request deals with Issue https://github.com/dotnet/aspnetcore/issues/49415, which is related to how HtmlHelper.HiddenFor() works in .NET 6 and up. The issue arises when the Model's property is empty, and a value is given in the htmlAttributes parameter. The way it currently behaves is not in line with what is explained in the documentation. Therefore, the documentation has been updated accordingly. 

Please review, thanks!.

Fixes #49415  (documentation changed)
