### PR TITLE
Improve documentation for CookiePolicyMiddleware and CookieOptions

### DIFF
--- a/src/Http/Http.Features/src/CookieOptions.cs
+++ b/src/Http/Http.Features/src/CookieOptions.cs
@@ -9,10 +9,11 @@ namespace Microsoft.AspNetCore.Http;
 /// Options used to create a new cookie.
 /// </summary>
 /// <remarks>
-/// When using the <see cref="CookieOptions"/> to configure cookies, it's important to note that these options govern the behavior
-/// of individual cookies. Reusing the same <see cref="CookieOptions"/> instance across multiple cookies can lead to unintended
-/// consequences, such as modifications affecting multiple cookies. It's recommended to instantiate a new <see cref="CookieOptions"/>
-/// object for each cookie to ensure that the configuration is applied independently.
+/// A <see cref="CookieOptions"/> instance is intended to govern the behavior of an individual cookie.
+/// Reusing the same <see cref="CookieOptions"/> instance across multiple cookies can lead to unintended
+/// consequences, such as modifications affecting multiple cookies. We recommend instantiating a new
+/// <see cref="CookieOptions"/> object for each cookie to ensure that the configuration is applied
+/// independently.
 /// </remarks>
 public class CookieOptions
 {

--- a/src/Http/Http.Features/src/CookieOptions.cs
+++ b/src/Http/Http.Features/src/CookieOptions.cs
@@ -8,6 +8,12 @@ namespace Microsoft.AspNetCore.Http;
 /// <summary>
 /// Options used to create a new cookie.
 /// </summary>
+/// <remarks>
+/// When using the <see cref="CookieOptions"/> to configure cookies, it's important to note that these options govern the behavior
+/// of individual cookies. Reusing the same <see cref="CookieOptions"/> instance across multiple cookies can lead to unintended
+/// consequences, such as modifications affecting multiple cookies. It's recommended to instantiate a new <see cref="CookieOptions"/>
+/// object for each cookie to ensure that the configuration is applied independently.
+/// </remarks>
 public class CookieOptions
 {
     private List<string>? _extensions;

--- a/src/Security/CookiePolicy/src/CookiePolicyMiddleware.cs
+++ b/src/Security/CookiePolicy/src/CookiePolicyMiddleware.cs
@@ -13,6 +13,12 @@ namespace Microsoft.AspNetCore.CookiePolicy;
 /// <summary>
 /// Initializes a new instance of <see cref="CookiePolicyMiddleware"/>.
 /// </summary>
+/// <remarks>
+/// When using the <see cref="CookieOptions"/> to configure cookies, it's important to note that these options govern the behavior
+/// of individual cookies. Reusing the same <see cref="CookieOptions"/> instance across multiple cookies can lead to unintended
+/// consequences, such as modifications affecting multiple cookies. It's recommended to instantiate a new <see cref="CookieOptions"/>
+/// object for each cookie to ensure that the configuration is applied independently.
+/// </remarks>
 public class CookiePolicyMiddleware
 {
     private readonly RequestDelegate _next;

--- a/src/Security/CookiePolicy/src/CookiePolicyMiddleware.cs
+++ b/src/Security/CookiePolicy/src/CookiePolicyMiddleware.cs
@@ -14,10 +14,12 @@ namespace Microsoft.AspNetCore.CookiePolicy;
 /// Initializes a new instance of <see cref="CookiePolicyMiddleware"/>.
 /// </summary>
 /// <remarks>
-/// When using the <see cref="CookieOptions"/> to configure cookies, it's important to note that these options govern the behavior
-/// of individual cookies. Reusing the same <see cref="CookieOptions"/> instance across multiple cookies can lead to unintended
-/// consequences, such as modifications affecting multiple cookies. It's recommended to instantiate a new <see cref="CookieOptions"/>
-/// object for each cookie to ensure that the configuration is applied independently.
+/// When using <see cref="CookieOptions"/> to configure cookies, note that a
+/// <see cref="CookieOptions"/> instance is intended to govern the behavior of an individual cookie.
+/// Reusing the same <see cref="CookieOptions"/> instance across multiple cookies can lead to unintended
+/// consequences, such as modifications affecting multiple cookies. We recommend instantiating a new
+/// <see cref="CookieOptions"/> object for each cookie to ensure that the configuration is applied
+/// independently.
 /// </remarks>
 public class CookiePolicyMiddleware
 {


### PR DESCRIPTION
# Improve documentation for CookiePolicyMiddleware and CookieOptions

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Summary of the changes (Less than 80 chars)

Added more detail in the doc. to warn developers of the recommended usage to avoid potential issues related to reusing CookieOptions instances.

## Description

This pull request deals with Issue https://github.com/dotnet/aspnetcore/issues/53875 which is related to CookiePolicyMiddleware that's set up with UseCookiePolicy directly modifies the CookieOptions that's passed in to IResponseCookies.Append. This can lead to bugs where the modifications "bleed" over to unintended cookies if the CookieOptions is reused for multiple cookies, for example if it's stored in a static field in a controller.

Therefore, the documentation has been updated accordingly.

Fixes #53875  (documentation changed)
