### PR TITLE
Include a warning about port spoofing in xml

### DIFF
--- a/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Builder;
 
@@ -28,8 +29,10 @@ public static class RoutingEndpointConventionBuilderExtensions
     ///
     /// To prevent host and port spoofing, use one of the following approaches:
     ///
-    /// - Use <see cref="HttpContext.Connection"/> (<see cref="ConnectionInfo.LocalPort"/>) where the ports are checked.
-    /// - Employ <see href="https://learn.microsoft.com/aspnet/core/fundamentals/servers/kestrel/host-filtering">Host filtering</see>.
+    /// <list type="bullet">
+    ///   <item>Use <see cref="HttpContext.Connection"/> (<see cref="ConnectionInfo.LocalPort"/>) where the ports are checked.</item>
+    ///   <item>Employ <see href="https://learn.microsoft.com/aspnet/core/fundamentals/servers/kestrel/host-filtering">Host filtering</see>.</item>
+    /// </list>
     /// </remarks>
     public static TBuilder RequireHost<TBuilder>(this TBuilder builder, params string[] hosts) where TBuilder : IEndpointConventionBuilder
     {

--- a/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
@@ -23,13 +23,13 @@ public static class RoutingEndpointConventionBuilderExtensions
     /// </param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
     /// <remarks>
-    /// API that relies on the <see href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host">Host header</see>, such as
+    /// API that relies on the <see href="https://developer.mozilla.org/docs/Web/HTTP/Headers/Host">Host header</see>, such as
     /// <see cref="HttpRequest.Host"/> and <see cref="RequireHost"/>, are subject to potential spoofing by clients.
     ///
     /// To prevent host and port spoofing, use one of the following approaches:
     ///
     /// - Use <see cref="HttpContext.Connection"/> (<see cref="ConnectionInfo.LocalPort"/>) where the ports are checked.
-    /// - Employ <see href="https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/host-filtering?view=aspnetcore-7.0">Host filtering</see>.
+    /// - Employ <see href="https://learn.microsoft.com/aspnet/core/fundamentals/servers/kestrel/host-filtering">Host filtering</see>.
     /// </remarks>
     public static TBuilder RequireHost<TBuilder>(this TBuilder builder, params string[] hosts) where TBuilder : IEndpointConventionBuilder
     {

--- a/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
@@ -23,7 +23,7 @@ public static class RoutingEndpointConventionBuilderExtensions
     /// </param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
     /// <remarks>
-    /// API that relies on the <see href="https://developer.mozilla.org/docs/Web/HTTP/Headers/Host">Host header</see>, such as
+    /// APIs that rely on the <see href="https://developer.mozilla.org/docs/Web/HTTP/Headers/Host">Host header</see>, such as
     /// <see cref="HttpRequest.Host"/> and <see cref="RequireHost"/>, are subject to potential spoofing by clients.
     ///
     /// To prevent host and port spoofing, use one of the following approaches:

--- a/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
@@ -24,7 +24,7 @@ public static class RoutingEndpointConventionBuilderExtensions
     /// <returns>A reference to this instance after the operation has completed.</returns>
     /// <remarks>
     /// APIs that rely on the <see href="https://developer.mozilla.org/docs/Web/HTTP/Headers/Host">Host header</see>, such as
-    /// <see cref="HttpRequest.Host"/> and <see cref="RequireHost"/>, are subject to potential spoofing by clients.
+    /// <see cref="HttpRequest.Host"/> and <see cref="RequireHost"/>, are vulnerable to potential spoofing by clients.
     ///
     /// To prevent host and port spoofing, use one of the following approaches:
     ///

--- a/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
@@ -27,12 +27,7 @@ public static class RoutingEndpointConventionBuilderExtensions
     /// APIs that rely on the <see href="https://developer.mozilla.org/docs/Web/HTTP/Headers/Host">Host header</see>, such as
     /// <see cref="HttpRequest.Host"/> and <see cref="RequireHost"/>, are vulnerable to potential spoofing by clients.
     ///
-    /// To prevent host and port spoofing, use one of the following approaches:
-    ///
-    /// <list type="bullet">
-    ///   <item>Use <see cref="HttpContext.Connection"/> (<see cref="ConnectionInfo.LocalPort"/>) where the ports are checked.</item>
-    ///   <item>Employ <see href="https://learn.microsoft.com/aspnet/core/fundamentals/servers/kestrel/host-filtering">Host filtering</see>.</item>
-    /// </list>
+    /// To prevent host and port spoofing, use <see href="https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.connections.features.itlshandshakefeature.hostname">ITlsHandshakeFeature.HostName</see> to verify the server name used during the TLS handshake, and <see cref="HttpContext.Connection"/> (<see cref="ConnectionInfo.LocalPort"/>) to verify the local port the connection was accepted on.
     /// </remarks>
     public static TBuilder RequireHost<TBuilder>(this TBuilder builder, params string[] hosts) where TBuilder : IEndpointConventionBuilder
     {

--- a/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
@@ -24,10 +24,19 @@ public static class RoutingEndpointConventionBuilderExtensions
     /// </param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
     /// <remarks>
-    /// APIs that rely on the <see href="https://developer.mozilla.org/docs/Web/HTTP/Headers/Host">Host header</see>, such as
-    /// <see cref="HttpRequest.Host"/> and <see cref="RequireHost"/>, are vulnerable to potential spoofing by clients.
+    /// APIs that depend on the <see href="https://developer.mozilla.org/docs/Web/HTTP/Headers/Host">Host header</see>, including
+    /// <see cref="HttpRequest.Host"/> and <see cref="RequireHost"/>, are vulnerable to client spoofing.
     ///
-    /// To prevent host and port spoofing, use <see href="https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.connections.features.itlshandshakefeature.hostname">ITlsHandshakeFeature.HostName</see> to verify the server name used during the TLS handshake, and <see cref="HttpContext.Connection"/> (<see cref="ConnectionInfo.LocalPort"/>) to verify the local port the connection was accepted on.
+   /// To safeguard against host and port spoofing:
+    /// <list type="bullet">
+    /// <item><description>
+    /// Verify the server name used during the TLS handshake using <see href="https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.connections.features.itlshandshakefeature.hostname">ITlsHandshakeFeature.HostName</see>.
+    /// </description></item>
+    /// <item><description>
+    /// Verify the local port where the connection was accepted using <see cref="HttpContext.Connection"/> (specifically <see cref="ConnectionInfo.LocalPort"/>).
+    /// </description></item>
+    /// </list>
+    /// </remarks>
     /// </remarks>
     public static TBuilder RequireHost<TBuilder>(this TBuilder builder, params string[] hosts) where TBuilder : IEndpointConventionBuilder
     {

--- a/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
@@ -22,6 +22,15 @@ public static class RoutingEndpointConventionBuilderExtensions
     /// An empty collection means any host will be accepted.
     /// </param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
+    /// <remarks>
+    /// API that relies on the <see href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host">Host header</see>, such as
+    /// <see cref="HttpRequest.Host"/> and <see cref="RequireHost"/>, are subject to potential spoofing by clients.
+    ///
+    /// To prevent host and port spoofing, use one of the following approaches:
+    ///
+    /// - Use <see cref="HttpContext.Connection"/> (<see cref="ConnectionInfo.LocalPort"/>) where the ports are checked.
+    /// - Employ <see href="https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/host-filtering?view=aspnetcore-7.0">Host filtering</see>.
+    /// </remarks>
     public static TBuilder RequireHost<TBuilder>(this TBuilder builder, params string[] hosts) where TBuilder : IEndpointConventionBuilder
     {
         ArgumentNullException.ThrowIfNull(builder);


### PR DESCRIPTION
# Include a warning about port spoofing in xml

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Summary of the changes

Added remark which describes the warning as per https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks?view=aspnetcore-7.0#require-host

## Description

Update API remarks for RoutingEndpointConventionBuilderExtensions.RequireHost to warn about host spoofing

Fixes #48818  (documentation changed)
