### PR TITLE
[Blazor/Web.JS] Add Circuit Handler Notification on Circuit Disconnect

### DIFF
--- a/src/Components/Web.JS/src/Platform/Circuits/CircuitManager.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/CircuitManager.ts
@@ -204,7 +204,17 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
   }
 
   public async disconnect(): Promise<void> {
+    if (!this._circuitId || this.isDisposedOrDisposing()) {
+      return;
+    }
+
     await this._connection?.stop();
+
+    for (const handler of this._options.circuitHandlers) {
+      if (handler.onCircuitClosed) {
+        handler.onCircuitClosed();
+      }
+    }
   }
 
   public async reconnect(): Promise<boolean> {


### PR DESCRIPTION
# Add Circuit Handler Notification on Circuit Disconnect
- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description
Fixes #54807

This PR addresses the missing `onCircuitClosed()` call when a circuit is disconnected. Circuit handlers are now notified when a circuit is closed due to normal disconnect (calling `disconnect()`) or when an unhandled error has occurred _after_ the circuit has established a connection.

Unhandled errors can currently occur in two scenarios:
- Starting a new connection failed (`startConnection()`)
- Receiving the `JS.Error` message from the server

To prevent disconnect notifications to the circuit handlers before a connection has been established, the `!this._circuitId` check was added (`_circuitId` is only set _after_ `startConnection()` was successful).

### Additional Remarks
The comment in the related issue mentioned to refactor `disposeCore()` and call it in that case. However, I think handlers might also be interested in case of forced disconnects. Because the notification takes place in the `disconnect()` function, external/normal disconnection will now also properly notify the circuit handlers. Currently, this is only called by `Blazor._internal.forceCloseConnection()` if assigned in `startServerCore()` ([Boot.Server.Common.ts:84](https://github.com/dotnet/aspnetcore/blob/63c8031b6a6af5009b3c5bb4291fcc4c32b06b10/src/Components/Web.JS/src/Boot.Server.Common.ts#L84)). With this change, circuit handlers can always expect to receive an `onCircuitClosed()` invocation on disconnect if the circuit was opened beforehand (i.e., `onCircuitOpened()` was called).
