### PR TITLE
Fix code tags in docs

### DIFF
--- a/src/Security/Authorization/Core/src/AuthorizationServiceExtensions.cs
+++ b/src/Security/Authorization/Core/src/AuthorizationServiceExtensions.cs
@@ -22,7 +22,7 @@ public static class AuthorizationServiceExtensions
     /// <param name="requirement">The requirement to evaluate the policy against.</param>
     /// <returns>
     /// A flag indicating whether requirement evaluation has succeeded or failed.
-    /// This value is <value>true</value> when the user fulfills the policy, otherwise <value>false</value>.
+    /// This value is <c>true</c> when the user fulfills the policy, otherwise <c>false</c>.
     /// </returns>
     public static Task<AuthorizationResult> AuthorizeAsync(this IAuthorizationService service, ClaimsPrincipal user, object? resource, IAuthorizationRequirement requirement)
     {
@@ -41,7 +41,7 @@ public static class AuthorizationServiceExtensions
     /// <param name="policy">The policy to evaluate.</param>
     /// <returns>
     /// A flag indicating whether policy evaluation has succeeded or failed.
-    /// This value is <value>true</value> when the user fulfills the policy, otherwise <value>false</value>.
+    /// This value is <c>true</c> when the user fulfills the policy, otherwise <c>false</c>.
     /// </returns>
     public static Task<AuthorizationResult> AuthorizeAsync(this IAuthorizationService service, ClaimsPrincipal user, object? resource, AuthorizationPolicy policy)
     {
@@ -59,7 +59,7 @@ public static class AuthorizationServiceExtensions
     /// <param name="policy">The policy to evaluate.</param>
     /// <returns>
     /// A flag indicating whether policy evaluation has succeeded or failed.
-    /// This value is <value>true</value> when the user fulfills the policy, otherwise <value>false</value>.
+    /// This value is <c>true</c> when the user fulfills the policy, otherwise <c>false</c>.
     /// </returns>
     public static Task<AuthorizationResult> AuthorizeAsync(this IAuthorizationService service, ClaimsPrincipal user, AuthorizationPolicy policy)
     {
@@ -77,7 +77,7 @@ public static class AuthorizationServiceExtensions
     /// <param name="policyName">The name of the policy to evaluate.</param>
     /// <returns>
     /// A flag indicating whether policy evaluation has succeeded or failed.
-    /// This value is <value>true</value> when the user fulfills the policy, otherwise <value>false</value>.
+    /// This value is <c>true</c> when the user fulfills the policy, otherwise <c>false</c>.
     /// </returns>
     public static Task<AuthorizationResult> AuthorizeAsync(this IAuthorizationService service, ClaimsPrincipal user, string policyName)
     {

--- a/src/Security/Authorization/Core/src/DefaultAuthorizationService.cs
+++ b/src/Security/Authorization/Core/src/DefaultAuthorizationService.cs
@@ -57,7 +57,7 @@ public class DefaultAuthorizationService : IAuthorizationService
     /// <param name="requirements">The requirements to evaluate.</param>
     /// <returns>
     /// A flag indicating whether authorization has succeeded.
-    /// This value is <value>true</value> when the user fulfills the policy otherwise <value>false</value>.
+    /// This value is <c>true</c> when the user fulfills the policy, otherwise <c>false</c>.
     /// </returns>
     public virtual async Task<AuthorizationResult> AuthorizeAsync(ClaimsPrincipal user, object? resource, IEnumerable<IAuthorizationRequirement> requirements)
     {
@@ -94,7 +94,7 @@ public class DefaultAuthorizationService : IAuthorizationService
     /// <param name="policyName">The name of the policy to check against a specific context.</param>
     /// <returns>
     /// A flag indicating whether authorization has succeeded.
-    /// This value is <value>true</value> when the user fulfills the policy otherwise <value>false</value>.
+    /// This value is <c>true</c> when the user fulfills the policy otherwise <c>false</c>.
     /// </returns>
     public virtual async Task<AuthorizationResult> AuthorizeAsync(ClaimsPrincipal user, object? resource, string policyName)
     {

--- a/src/Security/Authorization/Core/src/IAuthorizationService.cs
+++ b/src/Security/Authorization/Core/src/IAuthorizationService.cs
@@ -23,7 +23,7 @@ public interface IAuthorizationService
     /// <param name="requirements">The requirements to evaluate.</param>
     /// <returns>
     /// A flag indicating whether authorization has succeeded.
-    /// This value is <value>true</value> when the user fulfills the policy; otherwise <value>false</value>.
+    /// This value is <c>true</c> when the user fulfills the policy; otherwise <c>false</c>.
     /// </returns>
     /// <remarks>
     /// Resource is an optional parameter and may be null. Please ensure that you check it is not
@@ -43,7 +43,7 @@ public interface IAuthorizationService
     /// <returns>
     /// A flag indicating whether authorization has succeeded.
     /// Returns a flag indicating whether the user, and optional resource has fulfilled the policy.
-    /// <value>true</value> when the policy has been fulfilled; otherwise <value>false</value>.
+    /// <c>true</c> when the policy has been fulfilled; otherwise <c>false</c>.
     /// </returns>
     /// <remarks>
     /// Resource is an optional parameter and may be null. Please ensure that you check it is not


### PR DESCRIPTION
`<value>` is reserved for property values and also didn't make the word render as code in the docs (see https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authorization.defaultauthorizationservice.authorizeasync?view=aspnetcore-8.0#microsoft-aspnetcore-authorization-defaultauthorizationservice-authorizeasync(system-security-claims-claimsprincipal-system-object-system-string)).
