### PR TITLE
Fix static analysis HRESULT / bool conversion warnings

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/WebConfigConfigurationSource.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/WebConfigConfigurationSource.cpp
@@ -12,7 +12,7 @@ std::shared_ptr<ConfigurationSection> WebConfigConfigurationSource::GetSection(c
     const CComBSTR applicationConfigPath = m_application.GetAppConfigPath();
 
     IAppHostElement* sectionElement;
-    if (LOG_IF_FAILED(m_manager->GetAdminSection(bstrAspNetCoreSection, applicationConfigPath, &sectionElement)))
+    if (FAILED_LOG(m_manager->GetAdminSection(bstrAspNetCoreSection, applicationConfigPath, &sectionElement)))
     {
         return nullptr;
     }

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -73,7 +73,7 @@ IN_PROCESS_APPLICATION::StopClr()
     // Signal shutdown
     if (m_pShutdownEvent != nullptr)
     {
-        LOG_IF_FAILED(SetEvent(m_pShutdownEvent));
+        LOG_LAST_ERROR_IF(!SetEvent(m_pShutdownEvent));
     }
 
     // Need to wait for either the app to be initialized, the worker thread to exit, or the shutdown timeout.


### PR DESCRIPTION
The `LOG_IF_FAILED` macro takes an `HRESULT` input and returns an `HRESULT`. It shouldn't be used in an `if` statement to detect failure: use the `FAILED_LOG` macro instead. Additionally, it shouldn't be passed a `BOOL`: use the `LOG_LAST_ERROR_IF` macro instead (and invert the condition if needed).

This follows the pattern for other uses of the `FAILED_LOG` and `LOG_LAST_ERROR_IF` macros throughout the project. See e.g.:

https://github.com/dotnet/aspnetcore/blob/649d2cf1de14fb98408f99a1ac831ac450f7861f/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/WebConfigConfigurationSection.cpp#L12-L15

https://github.com/dotnet/aspnetcore/blob/649d2cf1de14fb98408f99a1ac831ac450f7861f/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationinfo.cpp#L190

Resolves two cpp/hresult-boolean-conversion CodeQL warnings we're seeing on our backend.