### PR TITLE
Using SearchValues in ContentDispositionHeaderValue

### DIFF
--- a/src/Http/Headers/src/ContentDispositionHeaderValue.cs
+++ b/src/Http/Headers/src/ContentDispositionHeaderValue.cs
@@ -657,10 +657,9 @@ public class ContentDispositionHeaderValue
             }
 
             var toHexEscape = inputBytes.Slice(0, length);
-            while (toHexEscape.Length > 0)
+            for (int i = 0; i < toHexEscape.Length; i++)
             {
-                HexEscape(builder, toHexEscape[0]);
-                toHexEscape = toHexEscape.Slice(1);
+                HexEscape(builder, toHexEscape[i]);
             }
 
             inputBytes = inputBytes.Slice(length);

--- a/src/Http/Headers/src/ContentDispositionHeaderValue.cs
+++ b/src/Http/Headers/src/ContentDispositionHeaderValue.cs
@@ -623,14 +623,13 @@ public class ContentDispositionHeaderValue
         var maxInputBytes = Encoding.UTF8.GetMaxByteCount(input.Length);
         byte[]? bufferFromPool = null;
         Span<byte> inputBytes = maxInputBytes <= MaxStackAllocSizeBytes
-            ? stackalloc byte[MaxStackAllocSizeBytes]
+            ? stackalloc byte[maxInputBytes]
             : bufferFromPool = ArrayPool<byte>.Shared.Rent(maxInputBytes);
 
-        var maxInputAsciiCount = Encoding.ASCII.GetMaxCharCount(input.Length);
         char[]? charBufferFromPool = null;
-        Span<char> tempCharBuffer = maxInputAsciiCount <= MaxStackAllocSizeChars
-            ? stackalloc char[MaxStackAllocSizeChars]
-            : charBufferFromPool = ArrayPool<char>.Shared.Rent(maxInputAsciiCount);
+        Span<char> tempCharBuffer = input.Length <= MaxStackAllocSizeChars
+            ? stackalloc char[input.Length]
+            : charBufferFromPool = ArrayPool<char>.Shared.Rent(input.Length);
 
         var bytesWritten = Encoding.UTF8.GetBytes(input, inputBytes);
         inputBytes = inputBytes[..bytesWritten];

--- a/src/Http/Headers/src/ContentDispositionHeaderValue.cs
+++ b/src/Http/Headers/src/ContentDispositionHeaderValue.cs
@@ -29,6 +29,7 @@ public class ContentDispositionHeaderValue
     private const string ReadDateString = "read-date";
     private const string SizeString = "size";
     private const int MaxStackAllocSizeBytes = 256;
+    private const int MaxStackAllocSizeChars = MaxStackAllocSizeBytes / 2;
     private static readonly char[] QuestionMark = new char[] { '?' };
     private static readonly char[] SingleQuote = new char[] { '\'' };
     private static readonly char[] EscapeChars = new char[] { '\\', '"' };
@@ -627,9 +628,9 @@ public class ContentDispositionHeaderValue
 
         var maxInputAsciiCount = Encoding.ASCII.GetMaxCharCount(input.Length);
         char[]? charBufferFromPool = null;
-        Span<char> tempCharBuffer = maxInputAsciiCount <= MaxStackAllocSizeBytes
-            ? stackalloc char[MaxStackAllocSizeBytes]
-            : charBufferFromPool = ArrayPool<char>.Shared.Rent(maxInputBytes);
+        Span<char> tempCharBuffer = maxInputAsciiCount <= MaxStackAllocSizeChars
+            ? stackalloc char[MaxStackAllocSizeChars]
+            : charBufferFromPool = ArrayPool<char>.Shared.Rent(maxInputAsciiCount);
 
         var bytesWritten = Encoding.UTF8.GetBytes(input, inputBytes);
         inputBytes = inputBytes[..bytesWritten];

--- a/src/Http/Headers/src/ContentDispositionHeaderValue.cs
+++ b/src/Http/Headers/src/ContentDispositionHeaderValue.cs
@@ -640,7 +640,7 @@ public class ContentDispositionHeaderValue
                 length = remaining.Length;
             }
 
-            for (int i = 0; i < length;)
+            for (var i = 0; i < length;)
             {
                 Rune.DecodeFromUtf16(remaining.Slice(i), out Rune rune, out var runeLength);
                 EncodeToUtf8Hex(rune, builder);

--- a/src/Http/Headers/src/ContentDispositionHeaderValue.cs
+++ b/src/Http/Headers/src/ContentDispositionHeaderValue.cs
@@ -683,9 +683,7 @@ public class ContentDispositionHeaderValue
 
     private static void HexEscape(StringBuilder builder, byte b)
     {
-        builder.Append('%');
-        builder.Append(HexUpperChars[(b & 0xf0) >> 4]);
-        builder.Append(HexUpperChars[b & 0xf]);
+        builder.Append(CultureInfo.InvariantCulture, $"%{HexUpperChars[(b & 0xf0) >> 4]}{HexUpperChars[b & 0xf]}");
     }
 
     // Attempt to decode using RFC 5987 encoding.

--- a/src/Http/Headers/src/ContentDispositionHeaderValue.cs
+++ b/src/Http/Headers/src/ContentDispositionHeaderValue.cs
@@ -656,10 +656,9 @@ public class ContentDispositionHeaderValue
                 length = inputBytes.Length;
             }
 
-            var toHexEscape = inputBytes.Slice(0, length);
-            for (int i = 0; i < toHexEscape.Length; i++)
+            for (int i = 0; i < length; i++)
             {
-                HexEscape(builder, toHexEscape[i]);
+                HexEscape(builder, inputBytes[i]);
             }
 
             inputBytes = inputBytes.Slice(length);

--- a/src/Http/Headers/src/ContentDispositionHeaderValue.cs
+++ b/src/Http/Headers/src/ContentDispositionHeaderValue.cs
@@ -623,12 +623,12 @@ public class ContentDispositionHeaderValue
         var maxInputBytes = Encoding.UTF8.GetMaxByteCount(input.Length);
         byte[]? bufferFromPool = null;
         Span<byte> inputBytes = maxInputBytes <= MaxStackAllocSizeBytes
-            ? stackalloc byte[maxInputBytes]
+            ? stackalloc byte[MaxStackAllocSizeBytes]
             : bufferFromPool = ArrayPool<byte>.Shared.Rent(maxInputBytes);
 
         char[]? charBufferFromPool = null;
         Span<char> tempCharBuffer = input.Length <= MaxStackAllocSizeChars
-            ? stackalloc char[input.Length]
+            ? stackalloc char[MaxStackAllocSizeChars]
             : charBufferFromPool = ArrayPool<char>.Shared.Rent(input.Length);
 
         var bytesWritten = Encoding.UTF8.GetBytes(input, inputBytes);

--- a/src/Http/Headers/test/ContentDispositionHeaderValueTest.cs
+++ b/src/Http/Headers/test/ContentDispositionHeaderValueTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using System.Text;
 
 namespace Microsoft.Net.Http.Headers;
 
@@ -210,6 +211,45 @@ public class ContentDispositionHeaderValueTest
 
         contentDisposition.Parameters.Remove(contentDisposition.Parameters.First());
         Assert.Null(contentDisposition.FileNameStar.Value);
+    }
+
+    [Fact]
+    public void NonValidAscii_WhenNeedsEncoding_UsesHex()
+    {
+        var contentDisposition = new ContentDispositionHeaderValue("inline");
+        contentDisposition.FileNameStar = "a\u0080b";
+        Assert.Equal($"UTF-8\'\'a%C2%80b", contentDisposition.Parameters.First().Value); //%C2 added because the value in UTF-8 is encoded on 2 bytes.
+    }
+
+    [Fact]
+    public void FileNameStar_WhenNeedsEncoding_UsesHex()
+    {
+        var contentDisposition = new ContentDispositionHeaderValue("inline");
+        foreach (byte b in Enumerable.Range(0, 128))
+        {
+            contentDisposition.FileNameStar = $"a{(char)b}b";
+            if (b <= 0x20
+                || b == '"'
+                || b == '%'
+                || (b >= 0x27 && b <= 0x2A)
+                || b == ','
+                || b == '/'
+                || (b >= 0x3A && b <= 0x40)
+                || (b >= 0x5B && b <= 0x5D)
+                || (b >= 0x61 && b <= 0x5D)
+                || b == '{'
+                || b == '}'
+                || b >= 0x7F)
+            {
+                var hexC = Convert.ToHexString([b]);
+                Assert.Equal($"UTF-8\'\'a%{hexC}b", contentDisposition.Parameters.First().Value);
+            }
+            else
+            {
+                Assert.Equal($"UTF-8\'\'a{(char)b}b", contentDisposition.Parameters.First().Value);
+            }
+            contentDisposition.Parameters.Remove(contentDisposition.Parameters.First());
+        }
     }
 
     [Fact]

--- a/src/Http/Headers/test/ContentDispositionHeaderValueTest.cs
+++ b/src/Http/Headers/test/ContentDispositionHeaderValueTest.cs
@@ -222,6 +222,14 @@ public class ContentDispositionHeaderValueTest
     }
 
     [Fact]
+    public void LongValidAscii_FullyProcessedWithout()
+    {
+        var contentDisposition = new ContentDispositionHeaderValue("inline");
+        contentDisposition.FileNameStar = new string('a', 400); // 400 is larger to the max stackallow size
+        Assert.Equal($"UTF-8\'\'{new string('a', 400)}", contentDisposition.Parameters.First().Value);
+    }
+
+    [Fact]
     public void FileNameStar_WhenNeedsEncoding_UsesHex()
     {
         var contentDisposition = new ContentDispositionHeaderValue("inline");

--- a/src/Http/Http/perf/Microbenchmarks/ContentDispositionHeaderValueBenchmarks.cs
+++ b/src/Http/Http/perf/Microbenchmarks/ContentDispositionHeaderValueBenchmarks.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using BenchmarkDotNet.Attributes;
+using Microsoft.Net.Http.Headers;
+
+namespace Microsoft.AspNetCore.Http;
+
+public class ContentDispositionHeaderValueBenchmarks
+{
+    private readonly ContentDispositionHeaderValue _contentDisposition = new ContentDispositionHeaderValue("inline");
+
+    [Benchmark]
+    public void FileNameStarEncoding() => _contentDisposition.FileNameStar = "My TypicalFilename 2024 04 09 08:00:00.dat";
+
+    [Benchmark]
+    public void FileNameStarNoEncoding() => _contentDisposition.FileNameStar = "My_TypicalFilename_2024_04_09-08_00_00.dat";
+
+}


### PR DESCRIPTION
# Using SearchValues in ContentDispositionHeaderValue

Task of https://github.com/dotnet/aspnetcore/issues/46484

## Description

Updating the current Encode5987 method to use SearchValues and IndexOfAny method during the encode of the FileNameStar property. Adding unit tests and a benchmark to measure the before-after performance.

Compared to the .NET runtime [implementation](https://source.dot.net/#System.Net.Http/System/Net/Http/Headers/HeaderUtilities.cs,696f2b0de2ccd5de) a second `Span<char>` is pooled because `ValueStringBuilder` used by the .NET runtime is internal, hence `Encoding.ASCII.GetChars` needs a way to reference the chars passed to the `StringBuilder`

## Performance Comparison:

BenchmarkDotNet=v0.13.0, OS=Windows 10.0.22631
12th Gen Intel Core i7-1255U, 1 CPU, 12 logical and 10 physical cores
.NET SDK=9.0.100-preview.4.24201.1
  [Host]     : .NET 9.0.0 (9.0.24.20403), X64 RyuJIT
  Job-SUANLL : .NET 9.0.0 (9.0.24.18101), X64 RyuJIT

Server=True  Toolchain=.NET Core 9.0  RunStrategy=Throughput

BEFORE:

|                 Method |     Mean |   Error |  StdDev |        Op/s |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------- |---------:|--------:|--------:|------------:|-------:|------:|------:|----------:|
|   FileNameStarEncoding | 213.8 ns | 1.79 ns | 1.68 ns | 4,676,383.4 | 0.0052 |     - |     - |     496 B |
| FileNameStarNoEncoding | 201.0 ns | 1.32 ns | 1.23 ns | 4,975,577.6 | 0.0050 |     - |     - |     464 B |

AFTER **UPDATED: 2024/04/13 corresponding to commit [With custom utf8 and hex encoding combined](https://github.com/dotnet/aspnetcore/pull/55039/commits/2eadb693477f2556fc50787575bc325b3b22c6de)**:

|                 Method |      Mean |    Error |   StdDev |         Op/s |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------- |----------:|---------:|---------:|-------------:|-------:|------:|------:|----------:|
|   FileNameStarEncoding | 213.61 ns | 1.828 ns | 1.710 ns |  4,681,410.7 | 0.0052 |     - |     - |     496 B |
| FileNameStarNoEncoding |  87.12 ns | 0.962 ns | 0.853 ns | 11,478,216.6 | 0.0039 |     - |     - |     368 B |


Fixes #46484
