### PR TITLE
Add entry to aspnetcore to propagate EFCore into the VMR

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -12,6 +12,7 @@
     <Dependency Name="dotnet-ef" Version="9.0.0-preview.4.24205.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
       <Sha>45448efb1da8914489739bc4116f7a8f6c9374a2</Sha>
+      <SourceBuildTarball RepoName="efcore" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0-preview.4.24205.3">
       <Uri>https://github.com/dotnet/efcore</Uri>


### PR DESCRIPTION
## Description

Adds the entry to the dependency to enable the VMR tooling to propagate efcore into the VMR.

Contributes to https://github.com/dotnet/installer/pull/19313
