### PR TITLE
Removing noReload argument from WebDriverExtensions.Nagivate

### DIFF
--- a/src/Components/test/E2ETest/Infrastructure/ServerTestBase.cs
+++ b/src/Components/test/E2ETest/Infrastructure/ServerTestBase.cs
@@ -26,9 +26,9 @@ public abstract class ServerTestBase<TServerFixture>
         _serverFixture = serverFixture;
     }
 
-    public void Navigate(string relativeUrl, bool noReload = false)
+    public void Navigate(string relativeUrl)
     {
-        Browser.Navigate(_serverFixture.RootUri, relativeUrl, noReload);
+        Browser.Navigate(_serverFixture.RootUri, relativeUrl);
     }
 
     protected override void InitializeAsyncCore()

--- a/src/Components/test/E2ETest/Infrastructure/WebDriverExtensions/BasicTestAppAuthenticationWebDriverExtensions.cs
+++ b/src/Components/test/E2ETest/Infrastructure/WebDriverExtensions/BasicTestAppAuthenticationWebDriverExtensions.cs
@@ -22,14 +22,14 @@ internal static class BasicTestAppAuthenticationWebDriverExtensions
             // original page, but this adds several seconds of delay
             var originalWindow = browser.CurrentWindowHandle;
             browser.SwitchTo().NewWindow(WindowType.Tab);
-            browser.Navigate(baseUri, baseRelativeUri, noReload: false);
+            browser.Navigate(baseUri, baseRelativeUri);
             browser.Exists(By.CssSelector("h1#authentication"));
             browser.Close();
             browser.SwitchTo().Window(originalWindow);
         }
         else
         {
-            browser.Navigate(baseUri, baseRelativeUri, noReload: false);
+            browser.Navigate(baseUri, baseRelativeUri);
             browser.Exists(By.CssSelector("h1#authentication"));
         }
     }

--- a/src/Components/test/E2ETest/Infrastructure/WebDriverExtensions/WebDriverExtensions.cs
+++ b/src/Components/test/E2ETest/Infrastructure/WebDriverExtensions/WebDriverExtensions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest;
 
 internal static class WebDriverExtensions
 {
-    public static void Navigate(this IWebDriver browser, Uri baseUri, string relativeUrl, bool noReload)
+    public static void Navigate(this IWebDriver browser, Uri baseUri, string relativeUrl)
     {
         var absoluteUrl = new Uri(baseUri, relativeUrl);
 

--- a/src/Components/test/E2ETest/ServerExecutionTests/CircuitContextTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/CircuitContextTest.cs
@@ -24,7 +24,7 @@ public class CircuitContextTest : ServerTestBase<BasicTestAppServerSiteFixture<S
 
     protected override void InitializeAsyncCore()
     {
-        Navigate(ServerPathBase, noReload: false);
+        Navigate(ServerPathBase);
         Browser.MountTestComponent<CircuitContextComponent>();
         Browser.Equal("Circuit Context", () => Browser.Exists(By.TagName("h1")).Text);
     }

--- a/src/Components/test/E2ETest/ServerExecutionTests/CircuitGracefulTerminationTests.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/CircuitGracefulTerminationTests.cs
@@ -38,7 +38,7 @@ public class CircuitGracefulTerminationTests : ServerTestBase<BasicTestAppServer
 
     protected override void InitializeAsyncCore()
     {
-        Navigate(ServerPathBase, noReload: false);
+        Navigate(ServerPathBase);
         Browser.MountTestComponent<GracefulTermination>();
         Browser.Equal("Graceful Termination", () => Browser.Exists(By.TagName("h1")).Text);
 

--- a/src/Components/test/E2ETest/ServerExecutionTests/HotReloadTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/HotReloadTest.cs
@@ -29,7 +29,7 @@ public class HotReloadTest : ServerTestBase<BasicTestAppServerSiteFixture<HotRel
 
     protected override void InitializeAsyncCore()
     {
-        Navigate(ServerPathBase, noReload: false);
+        Navigate(ServerPathBase;
         Browser.MountTestComponent<RenderOnHotReload>();
     }
 

--- a/src/Components/test/E2ETest/ServerExecutionTests/HotReloadTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/HotReloadTest.cs
@@ -29,7 +29,7 @@ public class HotReloadTest : ServerTestBase<BasicTestAppServerSiteFixture<HotRel
 
     protected override void InitializeAsyncCore()
     {
-        Navigate(ServerPathBase;
+        Navigate(ServerPathBase);
         Browser.MountTestComponent<RenderOnHotReload>();
     }
 

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerInteropTestDefaultExceptionsBehavior.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerInteropTestDefaultExceptionsBehavior.cs
@@ -24,7 +24,7 @@ public class ServerInteropTestDefaultExceptionsBehavior : ServerTestBase<BasicTe
 
     protected override void InitializeAsyncCore()
     {
-        Navigate(ServerPathBase, noReload: true);
+        Navigate(ServerPathBase);
         Browser.MountTestComponent<InteropComponent>();
     }
 

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerInteropTestJsInvocationsTimeoutsBehavior.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerInteropTestJsInvocationsTimeoutsBehavior.cs
@@ -23,7 +23,7 @@ public class ServerInteropTestJsInvocationsTimeoutsBehavior : ServerTestBase<Bas
 
     protected override void InitializeAsyncCore()
     {
-        Navigate(ServerPathBase, noReload: true);
+        Navigate(ServerPathBase);
         Browser.MountTestComponent<LongRunningInterop>();
     }
 

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerReconnectionTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerReconnectionTest.cs
@@ -23,7 +23,7 @@ public class ServerReconnectionTest : ServerTestBase<BasicTestAppServerSiteFixtu
 
     protected override void InitializeAsyncCore()
     {
-        Navigate(ServerPathBase, noReload: false);
+        Navigate(ServerPathBase);
         Browser.MountTestComponent<ReconnectionComponent>();
         Browser.Exists(By.Id("count"));
     }

--- a/src/Components/test/E2ETest/Tests/BinaryHttpClientTest.cs
+++ b/src/Components/test/E2ETest/Tests/BinaryHttpClientTest.cs
@@ -35,7 +35,7 @@ public class BinaryHttpClientTest : BrowserTestBase,
 
     protected override void InitializeAsyncCore()
     {
-        Browser.Navigate(_devHostServerFixture.RootUri, "/subdir", noReload: true);
+        Browser.Navigate(_devHostServerFixture.RootUri, "/subdir");
         _appElement = Browser.MountTestComponent<BinaryHttpRequestsComponent>();
     }
 

--- a/src/Components/test/E2ETest/Tests/BindTest.cs
+++ b/src/Components/test/E2ETest/Tests/BindTest.cs
@@ -26,7 +26,7 @@ public class BindTest : ServerTestBase<ToggleExecutionModeServerFixture<Program>
     protected override void InitializeAsyncCore()
     {
         // On WebAssembly, page reloads are expensive so skip if possible
-        Navigate(ServerPathBase, noReload: _serverFixture.ExecutionMode == ExecutionMode.Client);
+        Navigate(ServerPathBase);
         Browser.MountTestComponent<BindCasesComponent>();
         Browser.Exists(By.Id("bind-cases"));
     }

--- a/src/Components/test/E2ETest/Tests/CascadingValueTest.cs
+++ b/src/Components/test/E2ETest/Tests/CascadingValueTest.cs
@@ -22,7 +22,7 @@ public class CascadingValueTest : ServerTestBase<ToggleExecutionModeServerFixtur
 
     protected override void InitializeAsyncCore()
     {
-        Navigate(ServerPathBase, noReload: _serverFixture.ExecutionMode == ExecutionMode.Client);
+        Navigate(ServerPathBase);
         Browser.MountTestComponent<BasicTestApp.CascadingValueTest.CascadingValueSupplier>();
     }
 

--- a/src/Components/test/E2ETest/Tests/CircuitTests.cs
+++ b/src/Components/test/E2ETest/Tests/CircuitTests.cs
@@ -24,7 +24,7 @@ public class CircuitTests : ServerTestBase<BasicTestAppServerSiteFixture<ServerS
 
     protected override void InitializeAsyncCore()
     {
-        Navigate(ServerPathBase, noReload: false);
+        Navigate(ServerPathBase);
     }
 
     [Theory]

--- a/src/Components/test/E2ETest/Tests/ComponentRenderingTestBase.cs
+++ b/src/Components/test/E2ETest/Tests/ComponentRenderingTestBase.cs
@@ -27,7 +27,7 @@ public abstract class ComponentRenderingTestBase : ServerTestBase<ToggleExecutio
 
     protected override void InitializeAsyncCore()
     {
-        Navigate(ServerPathBase, noReload: _serverFixture.ExecutionMode == ExecutionMode.Client);
+        Navigate(ServerPathBase);
     }
 
     [Fact]

--- a/src/Components/test/E2ETest/Tests/CustomElementsTest.cs
+++ b/src/Components/test/E2ETest/Tests/CustomElementsTest.cs
@@ -32,7 +32,7 @@ public class CustomElementsTest : ServerTestBase<ToggleExecutionModeServerFixtur
 
     protected override void InitializeAsyncCore()
     {
-        Navigate(ServerPathBase, noReload: false);
+        Navigate(ServerPathBase);
         app = Browser.MountTestComponent<CustomElementsComponent>();
     }
 

--- a/src/Components/test/E2ETest/Tests/DynamicComponentRenderingTest.cs
+++ b/src/Components/test/E2ETest/Tests/DynamicComponentRenderingTest.cs
@@ -27,7 +27,7 @@ public class DynamicComponentRenderingTest : ServerTestBase<ToggleExecutionModeS
 
     protected override void InitializeAsyncCore()
     {
-        Navigate(ServerPathBase, noReload: _serverFixture.ExecutionMode == ExecutionMode.Client);
+        Navigate(ServerPathBase);
         app = Browser.MountTestComponent<DynamicComponentRendering>();
         testCasePicker = new SelectElement(app.FindElement(By.Id("dynamic-component-case-picker")));
     }

--- a/src/Components/test/E2ETest/Tests/ErrorBoundaryTest.cs
+++ b/src/Components/test/E2ETest/Tests/ErrorBoundaryTest.cs
@@ -21,7 +21,7 @@ public class ErrorBoundaryTest : ServerTestBase<ToggleExecutionModeServerFixture
     protected override void InitializeAsyncCore()
     {
         // Many of these tests trigger fatal exceptions, so we always have to reload
-        Navigate(ServerPathBase, noReload: false);
+        Navigate(ServerPathBase);
         Browser.MountTestComponent<ErrorBoundaryContainer>();
     }
 

--- a/src/Components/test/E2ETest/Tests/ErrorNotificationTest.cs
+++ b/src/Components/test/E2ETest/Tests/ErrorNotificationTest.cs
@@ -25,7 +25,7 @@ public class ErrorNotificationTest : ServerTestBase<ToggleExecutionModeServerFix
     protected override void InitializeAsyncCore()
     {
         // On WebAssembly, page reloads are expensive so skip if possible
-        Navigate(ServerPathBase, noReload: _serverFixture.ExecutionMode == ExecutionMode.Client);
+        Navigate(ServerPathBase);
         Browser.MountTestComponent<ErrorComponent>();
         Browser.Exists(By.Id("blazor-error-ui"));
         Browser.Exists(By.Id("throw-simple-exception"));

--- a/src/Components/test/E2ETest/Tests/EventBubblingTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventBubblingTest.cs
@@ -28,7 +28,7 @@ public class EventBubblingTest : ServerTestBase<ToggleExecutionModeServerFixture
 
     protected override void InitializeAsyncCore()
     {
-        Navigate(ServerPathBase, noReload: _serverFixture.ExecutionMode == ExecutionMode.Client);
+        Navigate(ServerPathBase);
         Browser.MountTestComponent<EventBubblingComponent>();
         Browser.Exists(By.Id("event-bubbling"));
     }

--- a/src/Components/test/E2ETest/Tests/EventCallbackTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventCallbackTest.cs
@@ -23,7 +23,7 @@ public class EventCallbackTest : ServerTestBase<ToggleExecutionModeServerFixture
     protected override void InitializeAsyncCore()
     {
         // On WebAssembly, page reloads are expensive so skip if possible
-        Navigate(ServerPathBase, noReload: _serverFixture.ExecutionMode == ExecutionMode.Client);
+        Navigate(ServerPathBase);
         Browser.MountTestComponent<BasicTestApp.EventCallbackTest.EventCallbackCases>();
     }
 

--- a/src/Components/test/E2ETest/Tests/EventCustomArgsTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventCustomArgsTest.cs
@@ -24,7 +24,7 @@ public class EventCustomArgsTest : ServerTestBase<ToggleExecutionModeServerFixtu
     protected override void InitializeAsyncCore()
     {
         // Always do a full page reload because these tests need to start with no custom event registrations
-        Navigate(ServerPathBase, noReload: false);
+        Navigate(ServerPathBase);
         Browser.MountTestComponent<EventCustomArgsComponent>();
     }
 

--- a/src/Components/test/E2ETest/Tests/EventTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventTest.cs
@@ -26,7 +26,7 @@ public class EventTest : ServerTestBase<ToggleExecutionModeServerFixture<Program
 
     protected override void InitializeAsyncCore()
     {
-        Navigate(ServerPathBase, noReload: true);
+        Navigate(ServerPathBase);
     }
 
     [Fact]

--- a/src/Components/test/E2ETest/Tests/FormsInputDateTest.cs
+++ b/src/Components/test/E2ETest/Tests/FormsInputDateTest.cs
@@ -30,7 +30,7 @@ public class FormsInputDateTest : ServerTestBase<ToggleExecutionModeServerFixtur
 
     protected override void InitializeAsyncCore()
     {
-        Navigate(ServerPathBase, noReload: _serverFixture.ExecutionMode == ExecutionMode.Client);
+        Navigate(ServerPathBase);
     }
 
     [Fact]

--- a/src/Components/test/E2ETest/Tests/FormsTest.cs
+++ b/src/Components/test/E2ETest/Tests/FormsTest.cs
@@ -25,7 +25,7 @@ public class FormsTest : ServerTestBase<ToggleExecutionModeServerFixture<Program
     protected override void InitializeAsyncCore()
     {
         // On WebAssembly, page reloads are expensive so skip if possible
-        Navigate(ServerPathBase, noReload: _serverFixture.ExecutionMode == ExecutionMode.Client);
+        Navigate(ServerPathBase);
     }
 
     protected virtual IWebElement MountSimpleValidationComponent()

--- a/src/Components/test/E2ETest/Tests/HeadModificationTest.cs
+++ b/src/Components/test/E2ETest/Tests/HeadModificationTest.cs
@@ -22,7 +22,7 @@ public class HeadModificationTest : ServerTestBase<ToggleExecutionModeServerFixt
 
     protected override void InitializeAsyncCore()
     {
-        Navigate(ServerPathBase, noReload: _serverFixture.ExecutionMode == ExecutionMode.Client);
+        Navigate(ServerPathBase);
     }
 
     [Fact]

--- a/src/Components/test/E2ETest/Tests/HostedInAlternativeBasePathTest.cs
+++ b/src/Components/test/E2ETest/Tests/HostedInAlternativeBasePathTest.cs
@@ -24,7 +24,7 @@ public class HostedInAlternativeBasePathTest : ServerTestBase<AspNetSiteServerFi
 
     protected override void InitializeAsyncCore()
     {
-        Navigate("/app/", noReload: true);
+        Navigate("/app/");
         WaitUntilLoaded();
     }
 

--- a/src/Components/test/E2ETest/Tests/HostedInAspNetTest.cs
+++ b/src/Components/test/E2ETest/Tests/HostedInAspNetTest.cs
@@ -23,7 +23,7 @@ public class HostedInAspNetTest : ServerTestBase<AspNetSiteServerFixture>
 
     protected override void InitializeAsyncCore()
     {
-        Navigate("/", noReload: true);
+        Navigate("/");
         WaitUntilLoaded();
     }
 

--- a/src/Components/test/E2ETest/Tests/HttpClientTest.cs
+++ b/src/Components/test/E2ETest/Tests/HttpClientTest.cs
@@ -37,7 +37,7 @@ public class HttpClientTest : ServerTestBase<BlazorWasmTestAppFixture<BasicTestA
     {
         base.InitializeAsyncCore();
 
-        Browser.Navigate(_serverFixture.RootUri, "/subdir", noReload: true);
+        Browser.Navigate(_serverFixture.RootUri, "/subdir");
         _appElement = Browser.MountTestComponent<HttpRequestsComponent>();
     }
 

--- a/src/Components/test/E2ETest/Tests/InputActionsTest.cs
+++ b/src/Components/test/E2ETest/Tests/InputActionsTest.cs
@@ -24,7 +24,7 @@ public class InputFocusTest : ServerTestBase<ToggleExecutionModeServerFixture<Pr
     protected override void InitializeAsyncCore()
     {
         // On WebAssembly, page reloads are expensive so skip if possible
-        Navigate(ServerPathBase, noReload: _serverFixture.ExecutionMode == ExecutionMode.Client);
+        Navigate(ServerPathBase);
     }
 
     protected virtual IWebElement MountInputActionsComponent()

--- a/src/Components/test/E2ETest/Tests/InputFileTest.cs
+++ b/src/Components/test/E2ETest/Tests/InputFileTest.cs
@@ -31,7 +31,7 @@ public class InputFileTest : ServerTestBase<ToggleExecutionModeServerFixture<Pro
         _tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(_tempDirectory);
 
-        Navigate(ServerPathBase, noReload: _serverFixture.ExecutionMode == ExecutionMode.Client);
+        Navigate(ServerPathBase);
         Browser.MountTestComponent<InputFileComponent>();
     }
 

--- a/src/Components/test/E2ETest/Tests/InteropTest.cs
+++ b/src/Components/test/E2ETest/Tests/InteropTest.cs
@@ -23,7 +23,7 @@ public class InteropTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
 
     protected override void InitializeAsyncCore()
     {
-        Navigate(ServerPathBase, noReload: true);
+        Navigate(ServerPathBase);
         Browser.MountTestComponent<InteropComponent>();
     }
 

--- a/src/Components/test/E2ETest/Tests/JSRootComponentsTest.cs
+++ b/src/Components/test/E2ETest/Tests/JSRootComponentsTest.cs
@@ -25,7 +25,7 @@ public class JSRootComponentsTest : ServerTestBase<ToggleExecutionModeServerFixt
 
     protected override void InitializeAsyncCore()
     {
-        Navigate(ServerPathBase, noReload: false);
+        Navigate(ServerPathBase);
         app = Browser.MountTestComponent<JavaScriptRootComponents>();
     }
 

--- a/src/Components/test/E2ETest/Tests/JsonSerializationTest.cs
+++ b/src/Components/test/E2ETest/Tests/JsonSerializationTest.cs
@@ -22,7 +22,7 @@ public class JsonSerializationTest : ServerTestBase<ToggleExecutionModeServerFix
 
     protected override void InitializeAsyncCore()
     {
-        Navigate(ServerPathBase, noReload: _serverFixture.ExecutionMode == ExecutionMode.Client);
+        Navigate(ServerPathBase);
         Browser.MountTestComponent<JsonSerializationCases>();
         Browser.Exists(By.Id("json-serialization-cases"));
     }

--- a/src/Components/test/E2ETest/Tests/KeyTest.cs
+++ b/src/Components/test/E2ETest/Tests/KeyTest.cs
@@ -25,7 +25,7 @@ public class KeyTest : ServerTestBase<ToggleExecutionModeServerFixture<Program>>
     protected override void InitializeAsyncCore()
     {
         // On WebAssembly, page reloads are expensive so skip if possible
-        Navigate(ServerPathBase, noReload: _serverFixture.ExecutionMode == ExecutionMode.Client);
+        Navigate(ServerPathBase);
     }
 
     [Fact]

--- a/src/Components/test/E2ETest/Tests/MultipleHostedAppTest.cs
+++ b/src/Components/test/E2ETest/Tests/MultipleHostedAppTest.cs
@@ -24,7 +24,7 @@ public class MultipleHostedAppTest : ServerTestBase<AspNetSiteServerFixture>
 
     protected override void InitializeAsyncCore()
     {
-        Navigate("/", noReload: true);
+        Navigate("/");
         WaitUntilLoaded();
     }
 

--- a/src/Components/test/E2ETest/Tests/PerformanceTest.cs
+++ b/src/Components/test/E2ETest/Tests/PerformanceTest.cs
@@ -22,7 +22,7 @@ public class PerformanceTest
 
     protected override void InitializeAsyncCore()
     {
-        Navigate("/", noReload: true);
+        Navigate("/");
     }
 
     public override Task InitializeAsync() => base.InitializeAsync(Guid.NewGuid().ToString());

--- a/src/Components/test/E2ETest/Tests/PropertyInjectionTest.cs
+++ b/src/Components/test/E2ETest/Tests/PropertyInjectionTest.cs
@@ -24,7 +24,7 @@ public class PropertyInjectionTest : ServerTestBase<ToggleExecutionModeServerFix
 
     protected override void InitializeAsyncCore()
     {
-        Navigate(ServerPathBase, noReload: false);
+        Navigate(ServerPathBase);
         Browser.MountTestComponent<PropertyInjectionComponent>();
     }
 

--- a/src/Components/test/E2ETest/Tests/ProtectedBrowserStorageInjectionTest.cs
+++ b/src/Components/test/E2ETest/Tests/ProtectedBrowserStorageInjectionTest.cs
@@ -23,7 +23,7 @@ public class ProtectedBrowserStorageInjectionTest : ServerTestBase<ToggleExecuti
 
     protected override void InitializeAsyncCore()
     {
-        Navigate(ServerPathBase, noReload: _serverFixture.ExecutionMode == ExecutionMode.Client);
+        Navigate(ServerPathBase);
         Browser.MountTestComponent<ProtectedBrowserStorageInjectionComponent>();
     }
 

--- a/src/Components/test/E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/E2ETest/Tests/RoutingTest.cs
@@ -28,7 +28,7 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
 
     protected override void InitializeAsyncCore()
     {
-        Navigate(ServerPathBase, noReload: false);
+        Navigate(ServerPathBase);
         Browser.WaitUntilTestSelectorReady();
     }
 
@@ -859,7 +859,7 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
         // Add a navigation lock that blocks internal navigations
         Browser.FindElement(By.Id("add-navigation-lock")).Click();
         Browser.FindElement(By.CssSelector("#navigation-lock-0 > input.block-internal-navigation")).Click();
-        
+
         var uriBeforeBlockedNavigation = Browser.FindElement(By.Id("test-info")).Text;
         var relativeCanceledUri = "/mycanceledtestpath";
         var expectedCanceledAbsoluteUri = $"{_serverFixture.RootUri}subdir{relativeCanceledUri}";
@@ -955,7 +955,7 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
         // Add a navigation lock that blocks internal navigations
         Browser.FindElement(By.Id("add-navigation-lock")).Click();
         Browser.FindElement(By.CssSelector("#navigation-lock-0 > input.block-internal-navigation")).Click();
-        
+
         var uriBeforeBlockedNavigation = Browser.FindElement(By.Id("test-info")).Text;
         var expectedCanceledRelativeUri = $"/subdir/some-path-0";
 
@@ -1000,7 +1000,7 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
         // Add a navigation lock that blocks internal navigations
         Browser.FindElement(By.Id("add-navigation-lock")).Click();
         Browser.FindElement(By.CssSelector("#navigation-lock-0 > input.block-internal-navigation")).Click();
-        
+
         var uriBeforeBlockedNavigation = Browser.FindElement(By.Id("test-info")).Text;
 
         var expectedCanceledAbsoluteUri = $"{_serverFixture.RootUri}subdir/some-path-0";
@@ -1182,7 +1182,7 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
         // Add a navigation lock that blocks internal navigations
         Browser.FindElement(By.Id("add-navigation-lock")).Click();
         Browser.FindElement(By.CssSelector("#navigation-lock-0 > input.block-internal-navigation")).Click();
-        
+
         var uriBeforeBlockedNavigation = Browser.FindElement(By.Id("test-info")).Text;
 
         Browser.FindElement(By.Id("programmatic-navigation")).Click();
@@ -1211,7 +1211,7 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
         // Add a navigation lock that blocks internal navigations
         Browser.FindElement(By.Id("add-navigation-lock")).Click();
         Browser.FindElement(By.CssSelector("#navigation-lock-0 > input.block-internal-navigation")).Click();
-        
+
         var uriBeforeBlockedNavigation = Browser.FindElement(By.Id("test-info")).Text;
 
         Browser.FindElement(By.Id("internal-link-navigation")).Click();

--- a/src/Components/test/E2ETest/Tests/SectionsTest.cs
+++ b/src/Components/test/E2ETest/Tests/SectionsTest.cs
@@ -26,7 +26,7 @@ public class SectionsTest : ServerTestBase<ToggleExecutionModeServerFixture<Prog
 
     protected override void InitializeAsyncCore()
     {
-        Navigate(ServerPathBase, noReload: _serverFixture.ExecutionMode == ExecutionMode.Client);
+        Navigate(ServerPathBase);
         _appElement = Browser.MountTestComponent<BasicTestApp.SectionsTest.ParentComponentWithTwoChildren>();
     }
 
@@ -256,7 +256,7 @@ public class SectionsTest : ServerTestBase<ToggleExecutionModeServerFixture<Prog
     [Fact]
     public void SectionOutletGetsDisposed_NoContentsRendered()
     {
-        // Render Counter and TextComponent SectionContents with same Name      
+        // Render Counter and TextComponent SectionContents with same Name
         _appElement.FindElement(By.Id("counter-render-section-content")).Click();
         _appElement.FindElement(By.Id("text-render-section-content")).Click();
 

--- a/src/Components/test/E2ETest/Tests/SectionsWithCascadingParametersTest.cs
+++ b/src/Components/test/E2ETest/Tests/SectionsWithCascadingParametersTest.cs
@@ -24,7 +24,7 @@ public class SectionsWithCascadingParametersTest : ServerTestBase<ToggleExecutio
 
     protected override void InitializeAsyncCore()
     {
-        Navigate(ServerPathBase, noReload: _serverFixture.ExecutionMode == ExecutionMode.Client);
+        Navigate(ServerPathBase);
         Browser.MountTestComponent<BasicTestApp.SectionsTest.SectionsWithCascadingParameters>();
     }
 

--- a/src/Components/test/E2ETest/Tests/SectionsWithErrorBoundaryTest.cs
+++ b/src/Components/test/E2ETest/Tests/SectionsWithErrorBoundaryTest.cs
@@ -24,7 +24,7 @@ public class SectionsWithErrorBoundaryTest : ServerTestBase<ToggleExecutionModeS
 
     protected override void InitializeAsyncCore()
     {
-        Navigate(ServerPathBase, noReload: _serverFixture.ExecutionMode == ExecutionMode.Client);
+        Navigate(ServerPathBase);
         Browser.MountTestComponent<BasicTestApp.SectionsTest.SectionsWithErrorBoundary>();
     }
 

--- a/src/Components/test/E2ETest/Tests/StandaloneAppTest.cs
+++ b/src/Components/test/E2ETest/Tests/StandaloneAppTest.cs
@@ -22,7 +22,7 @@ public class StandaloneAppTest
 
     protected override void InitializeAsyncCore()
     {
-        Navigate("/", noReload: true);
+        Navigate("/");
         WaitUntilLoaded();
     }
 

--- a/src/Components/test/E2ETest/Tests/StartupErrorNotificationTest.cs
+++ b/src/Components/test/E2ETest/Tests/StartupErrorNotificationTest.cs
@@ -28,7 +28,7 @@ public class StartupErrorNotificationTest : ServerTestBase<BlazorWasmTestAppFixt
     {
         var url = $"{ServerPathBase}?error={(errorIsAsync ? "async" : "sync")}";
 
-        Navigate(url, noReload: true);
+        Navigate(url);
         var errorUiElem = Browser.Exists(By.Id("blazor-error-ui"), TimeSpan.FromSeconds(10));
         Assert.NotNull(errorUiElem);
 

--- a/src/Components/test/E2ETest/Tests/SvgTest.cs
+++ b/src/Components/test/E2ETest/Tests/SvgTest.cs
@@ -23,7 +23,7 @@ public class SvgTest : ServerTestBase<ToggleExecutionModeServerFixture<Program>>
 
     protected override void InitializeAsyncCore()
     {
-        Navigate(ServerPathBase, noReload: _serverFixture.ExecutionMode == ExecutionMode.Client);
+        Navigate(ServerPathBase);
     }
 
     [Fact]

--- a/src/Components/test/E2ETest/Tests/ThreadingAppHostedTest.cs
+++ b/src/Components/test/E2ETest/Tests/ThreadingAppHostedTest.cs
@@ -28,7 +28,7 @@ public class ThreadingHostedAppTest
 
     protected override void InitializeAsyncCore()
     {
-        Navigate("/", noReload: true);
+        Navigate("/");
         WaitUntilLoaded();
     }
 

--- a/src/Components/test/E2ETest/Tests/ThreadingAppTest.cs
+++ b/src/Components/test/E2ETest/Tests/ThreadingAppTest.cs
@@ -23,7 +23,7 @@ public class ThreadingAppTest
 
     protected override void InitializeAsyncCore()
     {
-        Navigate("/", noReload: true);
+        Navigate("/");
         WaitUntilLoaded();
     }
 

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -25,7 +25,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
 
     protected override void InitializeAsyncCore()
     {
-        Navigate(ServerPathBase, noReload: _serverFixture.ExecutionMode == ExecutionMode.Client);
+        Navigate(ServerPathBase);
     }
 
     [Fact]

--- a/src/Components/test/E2ETest/Tests/WebAssemblyConfigurationHostedTest.cs
+++ b/src/Components/test/E2ETest/Tests/WebAssemblyConfigurationHostedTest.cs
@@ -26,7 +26,7 @@ public class WebAssemblyConfigurationHostedTest : ServerTestBase<BasicTestAppSer
     {
         base.InitializeAsyncCore();
 
-        Navigate(ServerPathBase, noReload: false);
+        Navigate(ServerPathBase);
         _appElement = Browser.MountTestComponent<ConfigurationComponent>();
     }
 

--- a/src/Components/test/E2ETest/Tests/WebAssemblyConfigurationTest.cs
+++ b/src/Components/test/E2ETest/Tests/WebAssemblyConfigurationTest.cs
@@ -27,7 +27,7 @@ public class WebAssemblyConfigurationTest : ServerTestBase<BlazorWasmTestAppFixt
     {
         base.InitializeAsyncCore();
 
-        Navigate(ServerPathBase, noReload: false);
+        Navigate(ServerPathBase);
         _appElement = Browser.MountTestComponent<ConfigurationComponent>();
     }
 

--- a/src/Components/test/E2ETest/Tests/WebAssemblyConfigureRuntimeTest.cs
+++ b/src/Components/test/E2ETest/Tests/WebAssemblyConfigureRuntimeTest.cs
@@ -25,7 +25,7 @@ public class WebAssemblyConfigureRuntimeTest : ServerTestBase<BlazorWasmTestAppF
     {
         base.InitializeAsyncCore();
 
-        Navigate(ServerPathBase, noReload: false);
+        Navigate(ServerPathBase);
         Browser.MountTestComponent<ConfigureRuntime>();
     }
 

--- a/src/Components/test/E2ETest/Tests/WebAssemblyGlobalizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/WebAssemblyGlobalizationTest.cs
@@ -24,7 +24,7 @@ public class WebAssemblyGlobalizationTest : GlobalizationTest<ToggleExecutionMod
 
     protected override void SetCulture(string culture)
     {
-        Navigate($"{ServerPathBase}/?culture={culture}", noReload: false);
+        Navigate($"{ServerPathBase}/?culture={culture}");
 
         // That should have triggered a page load, so wait for the main test selector to come up.
         Browser.MountTestComponent<GlobalizationBindCases>();

--- a/src/Components/test/E2ETest/Tests/WebAssemblyICUShardingTest.cs
+++ b/src/Components/test/E2ETest/Tests/WebAssemblyICUShardingTest.cs
@@ -106,7 +106,7 @@ public class WebAssemblyICUShardingTest : ServerTestBase<ToggleExecutionModeServ
     {
         // Arrange
         // This verifies that we complain if the app programtically configures a language.
-        Navigate($"{ServerPathBase}/?culture=fr&dotNetCulture=es", noReload: false);
+        Navigate($"{ServerPathBase}/?culture=fr&dotNetCulture=es");
 
         var errorUi = Browser.Exists(By.Id("blazor-error-ui"));
         Browser.Equal("block", () => errorUi.GetCssValue("display"));
@@ -119,6 +119,6 @@ public class WebAssemblyICUShardingTest : ServerTestBase<ToggleExecutionModeServ
 
     private void Initialize(CultureInfo culture)
     {
-        Navigate($"{ServerPathBase}/?culture={culture}", noReload: false);
+        Navigate($"{ServerPathBase}/?culture={culture}");
     }
 }

--- a/src/Components/test/E2ETest/Tests/WebAssemblyLazyLoadTest.cs
+++ b/src/Components/test/E2ETest/Tests/WebAssemblyLazyLoadTest.cs
@@ -28,7 +28,7 @@ public class WebAssemblyLazyLoadTest : ServerTestBase<ToggleExecutionModeServerF
 
     protected override void InitializeAsyncCore()
     {
-        Navigate(ServerPathBase, noReload: false);
+        Navigate(ServerPathBase);
         Browser.MountTestComponent<TestRouterWithLazyAssembly>();
         Browser.Exists(By.Id("blazor-error-ui"));
 

--- a/src/Components/test/E2ETest/Tests/WebAssemblyLocalizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/WebAssemblyLocalizationTest.cs
@@ -25,7 +25,7 @@ public class WebAssemblyLocalizationTest : ServerTestBase<ToggleExecutionModeSer
     [InlineData("fr-FR", "Bonjour!")]
     public void CanSetCultureAndReadLocalizedResources(string culture, string message)
     {
-        Navigate($"{ServerPathBase}/?culture={culture}", noReload: false);
+        Navigate($"{ServerPathBase}/?culture={culture}");
 
         Browser.MountTestComponent<LocalizedText>();
 

--- a/src/Components/test/E2ETest/Tests/WebAssemblyLoggingTest.cs
+++ b/src/Components/test/E2ETest/Tests/WebAssemblyLoggingTest.cs
@@ -22,7 +22,7 @@ public class WebAssemblyLoggingTest : ServerTestBase<ToggleExecutionModeServerFi
 
     protected override void InitializeAsyncCore()
     {
-        Navigate(ServerPathBase, noReload: false);
+        Navigate(ServerPathBase);
         Browser.MountTestComponent<ErrorComponent>();
         Browser.Exists(By.Id("blazor-error-ui"));
 

--- a/src/Components/test/E2ETest/Tests/WebAssemblyPrerenderedTest.cs
+++ b/src/Components/test/E2ETest/Tests/WebAssemblyPrerenderedTest.cs
@@ -35,7 +35,7 @@ public class WebAssemblyPrerenderedTest : ServerTestBase<AspNetSiteServerFixture
     [Fact]
     public void CanPrerenderAndAddHeadOutletRootComponent()
     {
-        Navigate("/", noReload: true);
+        Navigate("/");
 
         // Verify that the title is updated during prerendering
         Browser.Equal("Current count: 0", () => Browser.Title);


### PR DESCRIPTION
**Removing noReload Argument from WebDriverExtensions.Navigate**

**Summary of Changes:**
This pull request addresses the removal of the noReload argument from the WebDriverExtensions.Navigate method. The removal was initiated in https://github.com/dotnet/aspnetcore/pull/35414, but the argument persisted. This PR rectifies this by eliminating the argument and adjusting all references throughout the tests accordingly.

**Description:**

1. The following actions were undertaken:
2. Removal of the noReload argument from the WebDriverExtensions.Navigate method.
3. Elimination of the noReload argument from ServerTestBase.Navigate.
4. Modification of all instances where ServerTestBase.Navigate was referenced to exclude the noReload variable.

**Fixes:**
This resolves issue #46810 by completely removing the noReload argument and updating all previous instances where it was utilized.