### PR TITLE
Enable building native projects for windows arm64

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -114,7 +114,7 @@
                         Include="$(RepoRoot)src\Installers\Rpm\**\*.*proj" />
       </ItemGroup>
 
-      <ItemGroup Condition=" '$(TargetOsName)' == 'win' AND ('$(TargetArchitecture)' == 'x86' OR '$(TargetArchitecture)' == 'x64') ">
+      <ItemGroup Condition=" '$(TargetOsName)' == 'win' AND ('$(TargetArchitecture)' == 'x86' OR '$(TargetArchitecture)' == 'x64' OR '$(TargetArchitecture)' == 'arm64') ">
         <NativeProjects Include="$(RepoRoot)src\**\*.vcxproj" Exclude="@(ProjectToExclude)" AdditionalProperties="Platform=x64" />
         <NativeProjects Include="$(RepoRoot)src\**\*.vcxproj" Exclude="@(ProjectToExclude)" AdditionalProperties="Platform=Win32" />
         <NativeProjects Include="$(RepoRoot)src\**\*.vcxproj" Exclude="@(ProjectToExclude)" AdditionalProperties="Platform=arm64" />

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -52,7 +52,7 @@ Run publishing.
 Debug or Release
 
 .PARAMETER Architecture
-The CPU architecture to build for (x64, x86, arm). Default=x64
+The CPU architecture to build for (x64, x86, arm64). Default=x64
 
 .PARAMETER Projects
 A list of projects to build. Globbing patterns are supported, such as "$(pwd)/**/*.csproj"
@@ -66,7 +66,7 @@ You can also use -NoBuildManaged to suppress this project type.
 
 .PARAMETER BuildNative
 Build native projects (C++).
-This is the default for x64 and x86 builds but useful when you want to build _only_ native projects.
+This is the default but useful when you want to build _only_ native projects.
 You can use -NoBuildNative to suppress this project type.
 
 .PARAMETER BuildNodeJS
@@ -150,7 +150,7 @@ param(
     [ValidateSet('Debug', 'Release')]
     $Configuration,
 
-    [ValidateSet('x64', 'x86', 'arm', 'arm64')]
+    [ValidateSet('x64', 'x86', 'arm64')]
     $Architecture = 'x64',
 
     # A list of projects which should be built.
@@ -316,8 +316,7 @@ if ($BuildNodeJS) { $dotnetBuildArguments += "/p:BuildNodeJS=true" }
 # Don't bother with two builds if just one will build everything. Ignore super-weird cases like
 # "-Projects ... -NoBuildJava -NoBuildManaged -NoBuildNodeJS". An empty `./build.ps1` command will build both
 # managed and native projects.
-$performDesktopBuild = ($BuildInstallers -and $Architecture -ne "arm") -or `
-    ($BuildNative -and -not $Architecture.StartsWith("arm", [System.StringComparison]::OrdinalIgnoreCase))
+$performDesktopBuild = $BuildInstallers -or $BuildNative
 $performDotnetBuild = $BuildJava -or $BuildManaged -or $BuildNodeJS -or `
     ($All -and -not ($NoBuildJava -and $NoBuildManaged -and $NoBuildNodeJS)) -or `
     ($Projects -and -not ($BuildInstallers -or $specifiedBuildNative))

--- a/eng/scripts/RunHelix.ps1
+++ b/eng/scripts/RunHelix.ps1
@@ -19,7 +19,7 @@
 .PARAMETER RunQuarantinedTests
     By default quarantined tests are not run. Set this to $true to run only the quarantined tests.
 .PARAMETER TargetArchitecture
-    The CPU architecture to build for (x64, x86, arm). Default=x64
+    The CPU architecture to build for (x64, x86, arm64). Default=x64
 .PARAMETER MSBuildArguments
     Additional MSBuild arguments to be passed through.
 #>
@@ -31,7 +31,7 @@ param(
     [string]$HelixQueues = "Windows.10.Amd64.Server20H2.Open",
     [switch]$RunQuarantinedTests,
 
-    [ValidateSet('x64', 'x86', 'arm', 'arm64')]
+    [ValidateSet('x64', 'x86', 'arm64')]
     [string]$TargetArchitecture = "x64",
 
     # Capture the rest


### PR DESCRIPTION
Fixes building aspnetcore for windows arm64 in the VMR.

## Description

Right now the native projects are only built when targetting x86/x64 architectures. This causes an issue in the VMR because we're building windows arm64 in a separate job and aspnetcore fails because of the missing native assets.

The desktop msbuild build for the native projects was disabled for arm64, enable it to match the other architectures.