### PR TITLE
Condition RIDs on which target RIDs are available when doing a VMR build

### DIFF
--- a/src/Servers/IIS/IIS/test/testassets/TestTasks/TestTasks.csproj
+++ b/src/Servers/IIS/IIS/test/testassets/TestTasks/TestTasks.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(DotNetBuild)' == 'true'">$(TargetRuntimeIdentifier)</RuntimeIdentifiers>
 
     <!--
       This is used as a package by ASP.NET benchmarking infrastructure. It is meant for internal use only. See also

--- a/src/Servers/IIS/build/testsite.props
+++ b/src/Servers/IIS/build/testsite.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <RuntimeIdentifiers>$(RuntimeIdentifiers);win-x64;win-x86</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(DotNetBuild)' == 'true'">$(TargetRuntimeIdentifier)</RuntimeIdentifiers>
     <Platforms>x64;x86</Platforms>
     <IISExpressAppHostConfig>$(MSBuildThisFileDirectory)applicationhost.config</IISExpressAppHostConfig>
     <IISAppHostConfig>$(MSBuildThisFileDirectory)applicationhost.iis.config</IISAppHostConfig>

--- a/src/Servers/testassets/ServerComparison.TestSites/ServerComparison.TestSites.csproj
+++ b/src/Servers/testassets/ServerComparison.TestSites/ServerComparison.TestSites.csproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <RuntimeIdentifiers>win-x86;win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(DotNetBuild)' == 'true'">$(TargetRuntimeIdentifier)</RuntimeIdentifiers>
     <InProcessTestSite>true</InProcessTestSite>
   </PropertyGroup>
 


### PR DESCRIPTION
## Description

Limit which RIDs we try to restore for to avoid trying to restore CI versions (or official versions built outside of the VMR) of the apphost pack.

Contributes to https://github.com/dotnet/source-build/issues/3934