### PR TITLE
Fix exit code propagation when building inside the VMR

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -345,6 +345,10 @@ Remove-Item variable:global:_DotNetInstallDir -ea Ignore
 Remove-Item variable:global:_ToolsetBuildProj -ea Ignore
 Remove-Item variable:global:_MSBuildExe -ea Ignore
 
+# tools.ps1 expects the remaining arguments to be available via the $properties string array variable
+# TODO: Remove when https://github.com/dotnet/source-build/issues/4337 is implemented.
+[string[]] $properties = $MSBuildArguments
+
 # Import Arcade
 . "$PSScriptRoot/common/tools.ps1"
 

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -338,6 +338,10 @@ if [ "$(uname)" = "Darwin" ]; then
     ulimit -n 10000
 fi
 
+# tools.sh expects the remaining arguments to be available via the $properties string array variable
+# TODO: Remove when https://github.com/dotnet/source-build/issues/4337 is implemented.
+properties=$msbuild_args
+
 # Import Arcade
 . "$DIR/common/tools.sh"
 


### PR DESCRIPTION
Tested with https://github.com/dotnet/dotnet/pull/90
Fixes https://github.com/dotnet/source-build/issues/4277