### PR TITLE
Don't output secret value from user-secrets set

### DIFF
--- a/src/Tools/dotnet-user-secrets/src/Internal/SetCommand.cs
+++ b/src/Tools/dotnet-user-secrets/src/Internal/SetCommand.cs
@@ -99,7 +99,7 @@ Examples:
         {
             context.SecretStore.Set(_keyName, _keyValue);
             context.SecretStore.Save();
-            context.Reporter.Output(Resources.FormatMessage_Saved_Secret(_keyName, _keyValue));
+            context.Reporter.Output(Resources.FormatMessage_Saved_Secret(_keyName));
         }
     }
 }

--- a/src/Tools/dotnet-user-secrets/src/Resources.resx
+++ b/src/Tools/dotnet-user-secrets/src/Resources.resx
@@ -149,7 +149,7 @@ Use the '--help' flag to see info.</value>
     <value>Project file path {project}.</value>
   </data>
   <data name="Message_Saved_Secret" xml:space="preserve">
-    <value>Successfully saved {key} = {value} to the secret store.</value>
+    <value>Successfully saved {key} to the secret store.</value>
   </data>
   <data name="Message_Saved_Secrets" xml:space="preserve">
     <value>Successfully saved {number} secrets to the secret store.</value>

--- a/src/Tools/dotnet-user-secrets/test/SecretManagerTests.cs
+++ b/src/Tools/dotnet-user-secrets/test/SecretManagerTests.cs
@@ -299,7 +299,7 @@ public class SecretManagerTests : IClassFixture<UserSecretsTestFixture>
         foreach (var keyValue in secrets)
         {
             Assert.Contains(
-                string.Format(CultureInfo.InvariantCulture, "Successfully saved {0} to the secret store.", keyValue.Key, keyValue.Value),
+                string.Format(CultureInfo.InvariantCulture, "Successfully saved {0} to the secret store.", keyValue.Key),
                 _console.GetOutput());
         }
 

--- a/src/Tools/dotnet-user-secrets/test/SecretManagerTests.cs
+++ b/src/Tools/dotnet-user-secrets/test/SecretManagerTests.cs
@@ -112,7 +112,7 @@ public class SecretManagerTests : IClassFixture<UserSecretsTestFixture>
         foreach (var keyValue in secrets)
         {
             Assert.Contains(
-                string.Format(CultureInfo.InvariantCulture, "Successfully saved {0} = {1} to the secret store.", keyValue.Key, keyValue.Value),
+                string.Format(CultureInfo.InvariantCulture, "Successfully saved {0} to the secret store.", keyValue.Key),
                 _console.GetOutput());
         }
 
@@ -154,9 +154,9 @@ public class SecretManagerTests : IClassFixture<UserSecretsTestFixture>
         var secretManager = CreateProgram();
 
         secretManager.RunInternal("set", "secret1", "value1", "-p", projectPath, "--verbose");
-        Assert.Contains("Successfully saved secret1 = value1 to the secret store.", _console.GetOutput());
+        Assert.Contains("Successfully saved secret1 to the secret store.", _console.GetOutput());
         secretManager.RunInternal("set", "secret1", "value2", "-p", projectPath, "--verbose");
-        Assert.Contains("Successfully saved secret1 = value2 to the secret store.", _console.GetOutput());
+        Assert.Contains("Successfully saved secret1 to the secret store.", _console.GetOutput());
 
         _console.ClearOutput();
 
@@ -174,7 +174,7 @@ public class SecretManagerTests : IClassFixture<UserSecretsTestFixture>
         secretManager.RunInternal("-v", "set", "secret1", "value1", "-p", projectPath);
         Assert.Contains(string.Format(CultureInfo.InvariantCulture, "Project file path {0}.", Path.Combine(projectPath, "TestProject.csproj")), _console.GetOutput());
         Assert.Contains(string.Format(CultureInfo.InvariantCulture, "Secrets file path {0}.", PathHelper.GetSecretsPathFromSecretsId(secretId)), _console.GetOutput());
-        Assert.Contains("Successfully saved secret1 = value1 to the secret store.", _console.GetOutput());
+        Assert.Contains("Successfully saved secret1 to the secret store.", _console.GetOutput());
         _console.ClearOutput();
 
         secretManager.RunInternal("-v", "list", "-p", projectPath);
@@ -299,7 +299,7 @@ public class SecretManagerTests : IClassFixture<UserSecretsTestFixture>
         foreach (var keyValue in secrets)
         {
             Assert.Contains(
-                string.Format(CultureInfo.InvariantCulture, "Successfully saved {0} = {1} to the secret store.", keyValue.Key, keyValue.Value),
+                string.Format(CultureInfo.InvariantCulture, "Successfully saved {0} to the secret store.", keyValue.Key, keyValue.Value),
                 _console.GetOutput());
         }
 


### PR DESCRIPTION
Writing the secret value back to stdout when you call `dotnet user-secrets set {key} {value}` is not all that helpful. While this is fine in most cases, it's good security hygiene to not write secrets if you don't have to. Developers can always call ` dotnet user-secrets list` if they want to double check any values.