### PR TITLE
FlyBy typo fix in FeatureCollectionExtensions.cs

### DIFF
--- a/src/Extensions/Features/src/FeatureCollectionExtensions.cs
+++ b/src/Extensions/Features/src/FeatureCollectionExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Http.Features;
 public static class FeatureCollectionExtensions
 {
     /// <summary>
-    /// Retrives the requested feature from the collection.
+    /// Retrieves the requested feature from the collection.
     /// Throws an <see cref="InvalidOperationException"/> if the feature is not present.
     /// </summary>
     /// <param name="featureCollection">The <see cref="IFeatureCollection"/>.</param>
@@ -27,7 +27,7 @@ public static class FeatureCollectionExtensions
     }
 
     /// <summary>
-    /// Retrives the requested feature from the collection.
+    /// Retrieves the requested feature from the collection.
     /// Throws an <see cref="InvalidOperationException"/> if the feature is not present.
     /// </summary>
     /// <param name="featureCollection">feature collection</param>

--- a/src/Extensions/Features/test/FeatureCollectionExtensionsTests.cs
+++ b/src/Extensions/Features/test/FeatureCollectionExtensionsTests.cs
@@ -17,15 +17,15 @@ public class FeatureCollectionExtensionsTests
         features.Set<IThing>(thing);
 
         // Act
-        var retrivedThing = features.GetRequiredFeature<IThing>();
+        var retrievedThing = features.GetRequiredFeature<IThing>();
 
         // Assert
-        Assert.NotNull(retrivedThing);
-        Assert.Equal(retrivedThing, thing);
+        Assert.NotNull(retrievedThing);
+        Assert.Equal(retrievedThing, thing);
     }
 
     [Fact]
-    public void ExceptionThrowned_WhenAskedForUnknownFeature()
+    public void ExceptionThrown_WhenAskedForUnknownFeature()
     {
         // Arrange
         var features = new FeatureCollection();


### PR DESCRIPTION
# Fixes a type on the XML code documentation FeatureCollectionExtensions.cs

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

This fixed just a simple typo in XML docs. 
