### PR TITLE
Sleep in MultipleThreadsForceRefresh

### DIFF
--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/KeyManagement/KeyRingProviderTests.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/KeyManagement/KeyRingProviderTests.cs
@@ -807,6 +807,7 @@ public class KeyRingProviderTests
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/55227")]
     public async Task MultipleThreadsForceRefresh(bool failsToReadKeyRing)
     {
         const int taskCount = 10;


### PR DESCRIPTION
...to increase the likelihood of two threads racing to enter the critical section.

For #55227