### PR TITLE
Fix inheritdoc tag for ObjectPool.Create()

### DIFF
--- a/src/ObjectPool/src/ObjectPool.cs
+++ b/src/ObjectPool/src/ObjectPool.cs
@@ -27,7 +27,7 @@ public abstract class ObjectPool<T> where T : class
 /// </summary>
 public static class ObjectPool
 {
-    /// <inheritdoc />
+    /// <inheritdoc cref="ObjectPoolProvider.Create{T}(IPooledObjectPolicy{T})" />
     public static ObjectPool<T> Create<T>(IPooledObjectPolicy<T>? policy = null) where T : class, new()
     {
         var provider = new DefaultObjectPoolProvider();


### PR DESCRIPTION
This inheritdoc tag caused the following warning in the dotnet/dotnet-api-doc repo:

"Inheritdoc should not be used on static object if cref is not specified"

Contributes to https://github.com/dotnet/dotnet-api-docs/issues/9343.