### PR TITLE
Address feedback on PR #54675

### DIFF
--- a/src/DataProtection/DataProtection/src/Error.cs
+++ b/src/DataProtection/DataProtection/src/Error.cs
@@ -98,8 +98,8 @@ internal static class Error
         return new InvalidOperationException(message);
     }
 
-    public static InvalidOperationException KeyRingProvider_RefreshFailedOnOtherThread()
+    public static InvalidOperationException KeyRingProvider_RefreshFailedOnOtherThread(Exception? inner)
     {
-        return new InvalidOperationException(Resources.KeyRingProvider_RefreshFailedOnOtherThread);
+        return new InvalidOperationException(Resources.KeyRingProvider_RefreshFailedOnOtherThread, inner);
     }
 }

--- a/src/DataProtection/DataProtection/src/Resources.resx
+++ b/src/DataProtection/DataProtection/src/Resources.resx
@@ -191,7 +191,7 @@
     <value>The key ring's default data protection key {0:B} has been revoked.</value>
   </data>
   <data name="KeyRingProvider_RefreshFailedOnOtherThread" xml:space="preserve">
-    <value>Another thread failed to refresh the key ring.</value>
+    <value>Another thread failed to refresh the key ring. Refer to the inner exception for more information.</value>
   </data>
   <data name="LifetimeMustNotBeNegative" xml:space="preserve">
     <value>{0} must not be negative.</value>


### PR DESCRIPTION
- Take locks earlier since they're going to be taken anyway
- Observe exceptions on background tasks
- Rethrow task exceptions in the standard way
- Remove redundant Volatiles
- Attach an inner exception on losing threads