### PR TITLE
Run tests against latest IdentityModel once per day in Helix-Matrix

### DIFF
--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -8,6 +8,12 @@ schedules:
     include:
     - main
   always: true
+- cron: "0 18 * * *"
+  branches:
+    include:
+    - main
+  always: true
+  displayName: IdentityModel test job
 - cron: "0 9 * * *"
   branches:
     include:
@@ -19,6 +25,8 @@ schedules:
 variables:
 - name: _UseHelixOpenQueues
   value: ${{ ne(variables['System.TeamProject'], 'internal') }}
+- name: _IsIdentityModelTestJob
+  value: ${{ eq(variables['Build.CronSchedule.DisplayName'], 'IdentityModel test job') }}
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-HelixApi-Access
 - template: /eng/common/templates/variables/pool-providers.yml
@@ -31,14 +39,17 @@ jobs:
     agentOs: Windows
     timeoutInMinutes: 300
     steps:
+    - ${{ if eq(variables['Build.CronSchedule.DisplayName'], 'IdentityModel test job') }}:
+      - script: "echo ##vso[build.addbuildtag]identitymodel-test"
+        displayName: 'Set CI identitymodel-test tag'
     # Build the shared framework
     - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -nobl -all -pack -arch x64
-              /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
+              /p:CrossgenOutput=false /p:IsIdentityModelTestJob=$(_IsIdentityModelTestJob) /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Build shared fx
     # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
     - script: .\eng\build.cmd -ci -prepareMachine -nobl -all -noBuildRepoTasks -noBuildNative -noBuild -test
               -projects eng\helix\helix.proj /p:IsHelixJob=true
-              /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
+              /p:CrossgenOutput=false /p:IsIdentityModelTestJob=$(_IsIdentityModelTestJob) /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.cmd helix target
       env:
         HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,7 +11,8 @@
     <AspNetCorePatchVersion>0</AspNetCorePatchVersion>
     <PreReleaseVersionIteration>4</PreReleaseVersionIteration>
     <ValidateBaseline>true</ValidateBaseline>
-    <IdentityModelVersion>7.4.1</IdentityModelVersion>
+    <IdentityModelVersion Condition="'$(IsIdentityModelTestJob)' != 'true'">7.4.1</IdentityModelVersion>
+    <IdentityModelVersion Condition="'$(IsIdentityModelTestJob)' == 'true'">7.*</IdentityModelVersion>
     <!--
         When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages
     -->


### PR DESCRIPTION
Part of https://github.com/dotnet/aspnetcore/issues/54180. Adds tagged runs of `aspnetcore-helix-matrix` against the latest available IdentityModel packages once per day.