### PR TITLE
[release/8.0] Fix duplicate error.type tags in metrics

### DIFF
--- a/src/Hosting/Hosting/src/Microsoft.AspNetCore.Hosting.csproj
+++ b/src/Hosting/Hosting/src/Microsoft.AspNetCore.Hosting.csproj
@@ -16,6 +16,7 @@
     <Compile Include="$(SharedSourceRoot)StackTrace\**\*.cs" />
     <Compile Include="$(SharedSourceRoot)ErrorPage\**\*.cs" />
     <Compile Include="$(SharedSourceRoot)StaticWebAssets\**\*.cs" LinkBase="StaticWebAssets" />
+    <Compile Include="$(SharedSourceRoot)Metrics\MetricsExtensions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Middleware/Diagnostics/src/DiagnosticsTelemetry.cs
+++ b/src/Middleware/Diagnostics/src/DiagnosticsTelemetry.cs
@@ -15,7 +15,9 @@ internal static class DiagnosticsTelemetry
 
         if (context.Features.Get<IHttpMetricsTagsFeature>() is { } tagsFeature)
         {
-            tagsFeature.Tags.Add(new KeyValuePair<string, object?>("error.type", ex.GetType().FullName));
+            // Multiple exception middleware could be registered that have already added the tag.
+            // We don't want to add a duplicate tag here because that breaks some metrics systems.
+            tagsFeature.TryAddTag("error.type", ex.GetType().FullName);
         }
     }
 }

--- a/src/Middleware/Diagnostics/src/Microsoft.AspNetCore.Diagnostics.csproj
+++ b/src/Middleware/Diagnostics/src/Microsoft.AspNetCore.Diagnostics.csproj
@@ -17,6 +17,7 @@
     <Compile Include="$(SharedSourceRoot)TypeNameHelper\*.cs" />
     <Compile Include="$(SharedSourceRoot)Reroute.cs" />
     <Compile Include="$(SharedSourceRoot)HttpExtensions.cs" />
+    <Compile Include="$(SharedSourceRoot)Metrics\MetricsExtensions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Middleware/Diagnostics/test/FunctionalTests/ExceptionHandlerSampleTest.cs
+++ b/src/Middleware/Diagnostics/test/FunctionalTests/ExceptionHandlerSampleTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net;

--- a/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerTest.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+using System.Net.Http;
 
 namespace Microsoft.AspNetCore.Diagnostics;
 
@@ -952,6 +953,138 @@ public class ExceptionHandlerTest
         // Act
         var response = await server.CreateClient().GetAsync("/path");
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+
+        await instrumentCollector.WaitForMeasurementsAsync(minCount: 1).DefaultTimeout();
+
+        // Assert
+        Assert.Collection(
+            instrumentCollector.GetMeasurementSnapshot(),
+            m =>
+            {
+                Assert.True(m.Value > 0);
+                Assert.Equal(404, (int)m.Tags["http.response.status_code"]);
+                Assert.Equal("System.Exception", (string)m.Tags["error.type"]);
+            });
+    }
+
+    [Fact]
+    public async Task UnhandledError_MultipleHandlers_ExceptionNameTagAddedOnce()
+    {
+        // Arrange
+        var meterFactory = new TestMeterFactory();
+        using var instrumentCollector = new MetricCollector<double>(meterFactory, "Microsoft.AspNetCore.Hosting", "http.server.request.duration");
+
+        using var host = new HostBuilder()
+            .ConfigureServices(s =>
+            {
+                s.AddSingleton<IMeterFactory>(meterFactory);
+            })
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder
+                .UseTestServer()
+                .Configure(app =>
+                {
+                    // Second error and handler
+                    app.UseExceptionHandler(new ExceptionHandlerOptions()
+                    {
+                        ExceptionHandler = httpContext =>
+                        {
+                            httpContext.Response.StatusCode = StatusCodes.Status500InternalServerError;
+                            return Task.CompletedTask;
+                        }
+                    });
+                    app.Use(async (context, next) =>
+                    {
+                        await next();
+                        throw new InvalidOperationException("Test exception2");
+                    });
+
+                    // First error and handler
+                    app.UseExceptionHandler(new ExceptionHandlerOptions()
+                    {
+                        ExceptionHandler = httpContext =>
+                        {
+                            httpContext.Response.StatusCode = StatusCodes.Status404NotFound;
+                            return Task.CompletedTask;
+                        }
+                    });
+                    app.Run(context =>
+                    {
+                        throw new Exception("Test exception1");
+                    });
+                });
+            }).Build();
+
+        await host.StartAsync();
+
+        var server = host.GetTestServer();
+
+        // Act
+        var response = await server.CreateClient().GetAsync("/path");
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+
+        await instrumentCollector.WaitForMeasurementsAsync(minCount: 1).DefaultTimeout();
+
+        // Assert
+        Assert.Collection(
+            instrumentCollector.GetMeasurementSnapshot(),
+            m =>
+            {
+                Assert.True(m.Value > 0);
+                Assert.Equal(500, (int)m.Tags["http.response.status_code"]);
+                Assert.Equal("System.Exception", (string)m.Tags["error.type"]);
+            });
+    }
+
+    [Fact]
+    public async Task UnhandledError_ErrorAfterHandler_ExceptionNameTagAddedOnce()
+    {
+        // Arrange
+        var meterFactory = new TestMeterFactory();
+        using var instrumentCollector = new MetricCollector<double>(meterFactory, "Microsoft.AspNetCore.Hosting", "http.server.request.duration");
+
+        using var host = new HostBuilder()
+            .ConfigureServices(s =>
+            {
+                s.AddSingleton<IMeterFactory>(meterFactory);
+            })
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder
+                .UseTestServer()
+                .Configure(app =>
+                {
+                    // Second error
+                    app.Use(async (context, next) =>
+                    {
+                        await next();
+
+                        throw new InvalidOperationException("Test exception2");
+                    });
+
+                    // First error and handler
+                    app.UseExceptionHandler(new ExceptionHandlerOptions()
+                    {
+                        ExceptionHandler = httpContext =>
+                        {
+                            httpContext.Response.StatusCode = StatusCodes.Status404NotFound;
+                            return httpContext.Response.WriteAsync("Custom handler");
+                        }
+                    });
+                    app.Run(context =>
+                    {
+                        throw new Exception("Test exception1");
+                    });
+                });
+            }).Build();
+
+        await host.StartAsync();
+
+        var server = host.GetTestServer();
+
+        // Act
+        await Assert.ThrowsAsync<HttpRequestException>(async () => await server.CreateClient().GetAsync("/path"));
 
         await instrumentCollector.WaitForMeasurementsAsync(minCount: 1).DefaultTimeout();
 

--- a/src/Middleware/Diagnostics/test/testassets/ExceptionHandlerSample/ExceptionHandlerSample.csproj
+++ b/src/Middleware/Diagnostics/test/testassets/ExceptionHandlerSample/ExceptionHandlerSample.csproj
@@ -10,5 +10,6 @@
     <Reference Include="Microsoft.AspNetCore.Server.IISIntegration" />
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel" />
     <Reference Include="Microsoft.AspNetCore.StaticFiles" />
+    <Reference Include="Microsoft.AspNetCore.WebSockets" />
   </ItemGroup>
 </Project>

--- a/src/Middleware/Diagnostics/test/testassets/ExceptionHandlerSample/StartupWithWebSocket.cs
+++ b/src/Middleware/Diagnostics/test/testassets/ExceptionHandlerSample/StartupWithWebSocket.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Text;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http.Metadata;
+
+namespace ExceptionHandlerSample;
+
+// Note that this class isn't used in tests as TestServer doesn't have the right behavior to test web sockets
+// in the way we need. But leaving here so it can be used in Program.cs when starting the app manually.
+public class StartupWithWebSocket
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+    }
+
+    public void Configure(IApplicationBuilder app)
+    {
+        app.UseExceptionHandler(options => { }); // Exception handling middleware introduces duplicate tag
+        app.UseWebSockets();
+
+        app.Use(async (HttpContext context, Func<Task> next) =>
+        {
+            try
+            {
+                if (context.WebSockets.IsWebSocketRequest)
+                {
+                    using var ws = await context.WebSockets.AcceptWebSocketAsync();
+                    await ws.SendAsync(new ArraySegment<byte>(Encoding.UTF8.GetBytes("Hello")), System.Net.WebSockets.WebSocketMessageType.Text, true, context.RequestAborted);
+                    await ws.CloseAsync(System.Net.WebSockets.WebSocketCloseStatus.NormalClosure, "done", context.RequestAborted);
+                    throw new InvalidOperationException("Throw after websocket request completion to produce the bug");
+                }
+                else
+                {
+                    await context.Response.WriteAsync($"Not a web socket request. PID: {Process.GetCurrentProcess().Id}");
+                }
+            }
+            catch (Exception ex)
+            {
+                _ = ex;
+                throw;
+            }
+        });
+    }
+}
+

--- a/src/Shared/Metrics/MetricsExtensions.cs
+++ b/src/Shared/Metrics/MetricsExtensions.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Microsoft.AspNetCore.Http;
+
+internal static class MetricsExtensions
+{
+    public static bool TryAddTag(this IHttpMetricsTagsFeature feature, string name, object? value)
+    {
+        var tags = feature.Tags;
+
+        // Tags is internally represented as a List<T>.
+        // Prefer looping through the list to avoid allocating an enumerator.
+        if (tags is List<KeyValuePair<string, object?>> list)
+        {
+            foreach (var tag in list)
+            {
+                if (tag.Key == name)
+                {
+                    return false;
+                }
+            }
+        }
+        else
+        {
+            foreach (var tag in tags)
+            {
+                if (tag.Key == name)
+                {
+                    return false;
+                }
+            }
+        }
+
+        tags.Add(new KeyValuePair<string, object?>(name, value));
+        return true;
+    }
+
+    public static bool TryAddTag(this ref TagList tags, string name, object? value)
+    {
+        for (var i = 0; i < tags.Count; i++)
+        {
+            if (tags[i].Key == name)
+            {
+                return false;
+            }
+        }
+
+        tags.Add(new KeyValuePair<string, object?>(name, value));
+        return true;
+    }
+}


### PR DESCRIPTION
# Fix duplicate error.type tags in metrics

## Description

ASP.NET Core has a prominent metric - `http.request.server.duration` - that reports information about HTTP request duration along with important metadata. One piece of metadata is whether an error occurred during the request. This is the `error.type` tag. 

The `error.type` tag can be reported from multiple places, and it's possible to get duplicate tag values in rare situations. Duplicate metrics tags can break some telemetry tooling.

`error.type` can be added by exception middleware and it can be added in hosting if there is an unhandled exception. That means there can be duplicates if:

* Exception handling middleware handles an exception (tag added in middleware) and then there is an unhandled exception afterwards (tag added in hosting)
* Two configured exception handling middleware instances. An error is thrown and is handled (tag added in middleware 1) and then afterwards another error is thrown and handled by the second middleware (tag added in middleware 2).

Fix by conditionally adding `error.type` to tag collection only if it isn't present, aka first value wins.

Fixes https://github.com/dotnet/aspnetcore/issues/55159

## Customer Impact

Reported by customer at https://github.com/dotnet/aspnetcore/issues/55159. Prometheus (popular OSS telemetry database) can't handle duplicates and fails to load new metrics.

There is also https://github.com/open-telemetry/opentelemetry-dotnet/issues/5199 which appears to be from the same issue and has 6 +1 votes.

A workaround is to not use the ASP.NET Core error middleware, but it is a very popular feature, and it's not obvious that it is the fix.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

The fix is simple: don't add `error.type` tag to metrics collection if it is already present.

## Verification

- [x] Manual (required)
- [x] Automated

Before:
![image](https://github.com/dotnet/aspnetcore/assets/303201/de6adf3f-85b1-4fc4-87a0-d9570a748692)

After:
![image](https://github.com/dotnet/aspnetcore/assets/303201/56634916-99c3-4194-8adb-c32bb05fa83e)

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A