### PR TITLE
Fix command to add build tag

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -174,7 +174,7 @@ extends:
           agentOs: Windows
           steps:
           - ${{ if notIn(variables['Build.Reason'], 'PullRequest') }}:
-            - script: "echo ##vso[build.addbuildtag]daily-build"
+            - script: echo "##vso[build.addbuildtag]daily-build"
               displayName: 'Set CI daily-build tag'
 
           # !!! NOTE !!! Some of these steps have disabled code signing.

--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -40,7 +40,7 @@ jobs:
     timeoutInMinutes: 300
     steps:
     - ${{ if eq(variables['Build.CronSchedule.DisplayName'], 'IdentityModel test job') }}:
-      - script: "echo ##vso[build.addbuildtag]identitymodel-test"
+      - script: echo "##vso[build.addbuildtag]identitymodel-test"
         displayName: 'Set CI identitymodel-test tag'
     # Build the shared framework
     - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -nobl -all -pack -arch x64


### PR DESCRIPTION
Mirrors changes in https://github.com/dotnet/arcade/pull/14687. The approach we use works on Windows but not Mac/Linux. We only set tags on Windows today, so we haven't been broken, but we should use the correct universal behavior in case somebody copy/pastes this code somewhere else at a later date.