### PR TITLE
UnixCertificateManager: implement IsTrusted.

### DIFF
--- a/src/Shared/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/UnixCertificateManager.cs
@@ -18,7 +18,12 @@ internal sealed class UnixCertificateManager : CertificateManager
     {
     }
 
-    public override bool IsTrusted(X509Certificate2 certificate) => false;
+    public override bool IsTrusted(X509Certificate2 certificate)
+    {
+        using X509Chain chain = new X509Chain();
+        chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+        return chain.Build(certificate);
+    }
 
     protected override X509Certificate2 SaveCertificateCore(X509Certificate2 certificate, StoreName storeName, StoreLocation storeLocation)
     {

--- a/src/Shared/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/UnixCertificateManager.cs
@@ -21,6 +21,8 @@ internal sealed class UnixCertificateManager : CertificateManager
     public override bool IsTrusted(X509Certificate2 certificate)
     {
         using X509Chain chain = new X509Chain();
+        // This is just a heuristic for whether or not we should prompt the user to re-run with `--trust`
+        // so we don't need to check revocation (which doesn't really make sense for dev certs anyway)
         chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
         return chain.Build(certificate);
     }


### PR DESCRIPTION
Consider the certificate trusted when .NET trusts it.

@davidfowl ptal.