### PR TITLE
Use built-in OpenAPI support in templates

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/Microsoft.DotNet.Web.ProjectTemplates.csproj
+++ b/src/ProjectTemplates/Web.ProjectTemplates/Microsoft.DotNet.Web.ProjectTemplates.csproj
@@ -26,7 +26,6 @@
       MicrosoftNETCoreAppRuntimeVersion=$(MicrosoftNETCoreAppRuntimeVersion);
       SystemNetHttpJsonVersion=$(SystemNetHttpJsonVersion);
       MicrosoftGraphVersion=$(MicrosoftGraphVersion);
-      SwashbuckleAspNetCoreVersion=$(SwashbuckleAspNetCoreVersion);
     </GeneratedContentProperties>
   </PropertyGroup>
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/WebApi-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/WebApi-CSharp.csproj.in
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="${MicrosoftAspNetCoreAuthenticationJwtBearerVersion}" Condition="'$(OrganizationalAuth)' == 'True' OR '$(IndividualB2CAuth)' == 'True'" NoWarn="NU1605" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="${MicrosoftAspNetCoreAuthenticationNegotiateVersion}" Condition="'$(WindowsAuth)' == 'True'" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="${MicrosoftAspNetCoreAuthenticationOpenIdConnectVersion}" Condition="'$(OrganizationalAuth)' == 'True' OR '$(IndividualB2CAuth)' == 'True'" NoWarn="NU1605" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="${MicrosoftAspNetCoreOpenApiVersion}" Condition="'$(EnableOpenAPI)' == 'True' />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="${MicrosoftAspNetCoreOpenApiVersion}" Condition="'$(EnableOpenAPI)' == 'True'" />
     <PackageReference Include="Microsoft.Identity.Web" Version="${MicrosoftIdentityWebVersion}" Condition="'$(OrganizationalAuth)' == 'True' OR '$(IndividualB2CAuth)' == 'True'"/>
     <PackageReference Include="Microsoft.Identity.Web.GraphServiceClient" Version="${MicrosoftIdentityWebGraphServiceClientVersion}" Condition=" '$(GenerateGraph)' == 'True' " />
     <PackageReference Include="Microsoft.Identity.Web.DownstreamApi" Version="${MicrosoftIdentityWebDownstreamApiVersion}" Condition="'$(OrganizationalAuth)' == 'True' OR '$(IndividualB2CAuth)' == 'True'"/>

--- a/src/ProjectTemplates/Web.ProjectTemplates/WebApi-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/WebApi-CSharp.csproj.in
@@ -14,11 +14,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="${MicrosoftAspNetCoreAuthenticationJwtBearerVersion}" Condition="'$(OrganizationalAuth)' == 'True' OR '$(IndividualB2CAuth)' == 'True'" NoWarn="NU1605" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="${MicrosoftAspNetCoreAuthenticationNegotiateVersion}" Condition="'$(WindowsAuth)' == 'True'" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="${MicrosoftAspNetCoreAuthenticationOpenIdConnectVersion}" Condition="'$(OrganizationalAuth)' == 'True' OR '$(IndividualB2CAuth)' == 'True'" NoWarn="NU1605" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="${MicrosoftAspNetCoreOpenApiVersion}" Condition="'$(EnableOpenAPI)' == 'True' AND '$(UsingMinimalAPIs)' == 'True'" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="${MicrosoftAspNetCoreOpenApiVersion}" Condition="'$(EnableOpenAPI)' == 'True' />
     <PackageReference Include="Microsoft.Identity.Web" Version="${MicrosoftIdentityWebVersion}" Condition="'$(OrganizationalAuth)' == 'True' OR '$(IndividualB2CAuth)' == 'True'"/>
     <PackageReference Include="Microsoft.Identity.Web.GraphServiceClient" Version="${MicrosoftIdentityWebGraphServiceClientVersion}" Condition=" '$(GenerateGraph)' == 'True' " />
     <PackageReference Include="Microsoft.Identity.Web.DownstreamApi" Version="${MicrosoftIdentityWebDownstreamApiVersion}" Condition="'$(OrganizationalAuth)' == 'True' OR '$(IndividualB2CAuth)' == 'True'"/>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="${SwashbuckleAspNetCoreVersion}" Condition="'$(EnableOpenAPI)' == 'True'" />
   </ItemGroup>
 
   <!--#endif -->

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.Main.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.Main.cs
@@ -59,9 +59,8 @@ public class Program
         builder.Services.AddControllers();
         #endif
         #if (EnableOpenAPI)
-        // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-        builder.Services.AddEndpointsApiExplorer();
-        builder.Services.AddSwaggerGen();
+        // Learn more about configuring OpenAPI at https://aka.ms/aspnetcore/openapi
+        builder.Services.AddOpenApi();
         #endif
         #if (WindowsAuth)
 
@@ -81,8 +80,7 @@ public class Program
         #if (EnableOpenAPI)
         if (app.Environment.IsDevelopment())
         {
-            app.UseSwagger();
-            app.UseSwaggerUI();
+            app.MapOpenApi();
         }
         #endif
         #if (HasHttpsProfile)
@@ -165,12 +163,10 @@ public class Program
         #if (EnableOpenAPI && !NoAuth)
         })
         .WithName("GetWeatherForecast")
-        .WithOpenApi()
         .RequireAuthorization();
         #elif (EnableOpenAPI && NoAuth)
         })
-        .WithName("GetWeatherForecast")
-        .WithOpenApi();
+        .WithName("GetWeatherForecast");
         #elif (!EnableOpenAPI && !NoAuth)
         })
         .RequireAuthorization();

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.Main.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.Main.cs
@@ -59,7 +59,7 @@ public class Program
         builder.Services.AddControllers();
         #endif
         #if (EnableOpenAPI)
-        // Learn more about configuring OpenAPI at https://aka.ms/aspnetcore/openapi
+        // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
         builder.Services.AddOpenApi();
         #endif
         #if (WindowsAuth)

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.OrgOrIndividualB2CAuth.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.OrgOrIndividualB2CAuth.cs
@@ -42,7 +42,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 builder.Services.AddAuthorization();
 
 #if (EnableOpenAPI)
-// Learn more about configuring OpenAPI at https://aka.ms/aspnetcore/openapi
+// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
 #endif
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.OrgOrIndividualB2CAuth.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.OrgOrIndividualB2CAuth.cs
@@ -42,9 +42,8 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 builder.Services.AddAuthorization();
 
 #if (EnableOpenAPI)
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+// Learn more about configuring OpenAPI at https://aka.ms/aspnetcore/openapi
+builder.Services.AddOpenApi();
 #endif
 
 var app = builder.Build();
@@ -53,8 +52,7 @@ var app = builder.Build();
 #if (EnableOpenAPI)
 if (app.Environment.IsDevelopment())
 {
-    app.UseSwagger();
-    app.UseSwaggerUI();
+    app.MapOpenApi();
 }
 #endif
 #if (HasHttpsProfile)

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.WindowsOrNoAuth.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.WindowsOrNoAuth.cs
@@ -6,7 +6,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 #if (EnableOpenAPI)
-// Learn more about configuring OpenAPI at https://aka.ms/aspnetcore/openapi
+// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
 #endif
 #if (WindowsAuth)

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.WindowsOrNoAuth.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.WindowsOrNoAuth.cs
@@ -6,9 +6,8 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 #if (EnableOpenAPI)
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+// Learn more about configuring OpenAPI at https://aka.ms/aspnetcore/openapi
+builder.Services.AddOpenApi();
 #endif
 #if (WindowsAuth)
 builder.Services.AddAuthentication(NegotiateDefaults.AuthenticationScheme)
@@ -27,8 +26,7 @@ var app = builder.Build();
 #if (EnableOpenAPI)
 if (app.Environment.IsDevelopment())
 {
-    app.UseSwagger();
-    app.UseSwaggerUI();
+    app.MapOpenApi();
 }
 #endif
 #if (HasHttpsProfile)
@@ -54,8 +52,7 @@ app.MapGet("/weatherforecast", () =>
     return forecast;
 #if (EnableOpenAPI)
 })
-.WithName("GetWeatherForecast")
-.WithOpenApi();
+.WithName("GetWeatherForecast");
 #else
 });
 #endif

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.cs
@@ -46,9 +46,8 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 
 builder.Services.AddControllers();
 #if (EnableOpenAPI)
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+// Learn more about configuring OpenAPI at https://aka.ms/aspnetcore/openapi
+builder.Services.AddOpenApi();
 #endif
 #if (WindowsAuth)
 
@@ -68,8 +67,7 @@ var app = builder.Build();
 #if (EnableOpenAPI)
 if (app.Environment.IsDevelopment())
 {
-    app.UseSwagger();
-    app.UseSwaggerUI();
+    app.MapOpenApi();
 }
 #endif
 #if (HasHttpsProfile)

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.cs
@@ -46,7 +46,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 
 builder.Services.AddControllers();
 #if (EnableOpenAPI)
-// Learn more about configuring OpenAPI at https://aka.ms/aspnetcore/openapi
+// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
 #endif
 #if (WindowsAuth)

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Properties/launchSettings.json
@@ -23,11 +23,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      //#if (EnableOpenAPI)
-      "launchUrl": "swagger",
-      //#else
       "launchUrl": "weatherforecast",
-      //#endif
       "applicationUrl": "http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -39,11 +35,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      //#if (EnableOpenAPI)
-      "launchUrl": "swagger",
-      //#else
       "launchUrl": "weatherforecast",
-      //#endif
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -53,11 +45,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      //#if (EnableOpenAPI)
-      "launchUrl": "swagger",
-      //#else
       "launchUrl": "weatherforecast",
-      //#endif
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/ProjectTemplates/test/Templates.Mvc.Tests/WebApiTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Mvc.Tests/WebApiTemplateTest.cs
@@ -171,7 +171,7 @@ public class WebApiTemplateTest : LoggedTest
             aspNetProcess.Process.HasExited,
             ErrorMessages.GetFailedProcessMessageOrEmpty("Run built project", project, aspNetProcess.Process));
 
-        await aspNetProcess.AssertNotFound("swagger");
+        await aspNetProcess.AssertNotFound("openapi/v1.json");
     }
 
     [ConditionalTheory]
@@ -206,7 +206,7 @@ public class WebApiTemplateTest : LoggedTest
             aspNetProcess.Process.HasExited,
             ErrorMessages.GetFailedProcessMessageOrEmpty("Run built project", project, aspNetProcess.Process));
 
-        await aspNetProcess.AssertNotFound("swagger");
+        await aspNetProcess.AssertNotFound("openapi/v1.json");
     }
 
     private async Task<Project> PublishAndBuildWebApiTemplate(string languageOverride, string auth, string[] args = null)
@@ -260,7 +260,7 @@ public class WebApiTemplateTest : LoggedTest
                 ErrorMessages.GetFailedProcessMessageOrEmpty("Run built project", project, aspNetProcess.Process));
 
             await aspNetProcess.AssertOk("weatherforecast");
-            await aspNetProcess.AssertOk("swagger");
+            await aspNetProcess.AssertOk("openapi/v1.json");
             await aspNetProcess.AssertNotFound("/");
         }
 
@@ -271,8 +271,6 @@ public class WebApiTemplateTest : LoggedTest
                 ErrorMessages.GetFailedProcessMessageOrEmpty("Run published project", project, aspNetProcess.Process));
 
             await aspNetProcess.AssertOk("weatherforecast");
-            // Swagger is only available in Development
-            await aspNetProcess.AssertNotFound("swagger");
             await aspNetProcess.AssertNotFound("/");
         }
     }

--- a/src/ProjectTemplates/test/Templates.Mvc.Tests/WebApiTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Mvc.Tests/WebApiTemplateTest.cs
@@ -271,6 +271,8 @@ public class WebApiTemplateTest : LoggedTest
                 ErrorMessages.GetFailedProcessMessageOrEmpty("Run published project", project, aspNetProcess.Process));
 
             await aspNetProcess.AssertOk("weatherforecast");
+            // OpenAPI endpoint is only enabled in Development
+            await aspNetProcess.AssertNotFound("openapi/v1.json");
             await aspNetProcess.AssertNotFound("/");
         }
     }


### PR DESCRIPTION
Part of #46349.

- Update templates to use new APIs in `Microsoft.AspNetCore.OpenApi` for document generation when `EnableOpenApi=true`
- Remove `WithOpenApi` calls on endpoints
- Update `launchUrl` for projects were `EnableOpenApi=true`