### PR TITLE
Cache request values when hosting metrics are enabled

### DIFF
--- a/src/Hosting/Hosting/src/Internal/HostingApplication.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplication.cs
@@ -162,7 +162,7 @@ internal sealed class HostingApplication : IHttpApplication<HostingApplication.C
             HasDiagnosticListener = false;
             MetricsEnabled = false;
             EventLogEnabled = false;
-            MetricsTagsFeature?.TagsList.Clear();
+            MetricsTagsFeature?.Reset();
         }
     }
 }

--- a/src/Hosting/Hosting/src/Internal/HostingMetrics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingMetrics.cs
@@ -33,18 +33,18 @@ internal sealed class HostingMetrics : IDisposable
     }
 
     // Note: Calling code checks whether counter is enabled.
-    public void RequestStart(bool isHttps, string scheme, string method, HostString host)
+    public void RequestStart(string scheme, string method)
     {
         // Tags must match request end.
         var tags = new TagList();
-        InitializeRequestTags(ref tags, isHttps, scheme, method, host);
+        InitializeRequestTags(ref tags, scheme, method);
         _activeRequestsCounter.Add(1, tags);
     }
 
-    public void RequestEnd(string protocol, bool isHttps, string scheme, string method, HostString host, string? route, int statusCode, bool unhandledRequest, Exception? exception, List<KeyValuePair<string, object?>>? customTags, long startTimestamp, long currentTimestamp)
+    public void RequestEnd(string protocol, string scheme, string method, string? route, int statusCode, bool unhandledRequest, Exception? exception, List<KeyValuePair<string, object?>>? customTags, long startTimestamp, long currentTimestamp)
     {
         var tags = new TagList();
-        InitializeRequestTags(ref tags, isHttps, scheme, method, host);
+        InitializeRequestTags(ref tags, scheme, method);
 
         // Tags must match request start.
         if (_activeRequestsCounter.Enabled)
@@ -100,30 +100,10 @@ internal sealed class HostingMetrics : IDisposable
 
     public bool IsEnabled() => _activeRequestsCounter.Enabled || _requestDuration.Enabled;
 
-    private static void InitializeRequestTags(ref TagList tags, bool isHttps, string scheme, string method, HostString host)
+    private static void InitializeRequestTags(ref TagList tags, string scheme, string method)
     {
         tags.Add("url.scheme", scheme);
         tags.Add("http.request.method", ResolveHttpMethod(method));
-
-        _ = isHttps;
-        _ = host;
-        // TODO: Support configuration for enabling host header annotations
-        /*
-        if (host.HasValue)
-        {
-            tags.Add("server.address", host.Host);
-
-            // Port is parsed each time it's accessed. Store part in local variable.
-            if (host.Port is { } port)
-            {
-                // Add port tag when not the default value for the current scheme
-                if ((isHttps && port != 443) || (!isHttps && port != 80))
-                {
-                    tags.Add("server.port", port);
-                }
-            }
-        }
-        */
     }
 
     private static readonly object[] BoxedStatusCodes = new object[512];

--- a/src/Hosting/Hosting/src/Internal/HttpMetricsTagsFeature.cs
+++ b/src/Hosting/Hosting/src/Internal/HttpMetricsTagsFeature.cs
@@ -10,4 +10,19 @@ internal sealed class HttpMetricsTagsFeature : IHttpMetricsTagsFeature
     ICollection<KeyValuePair<string, object?>> IHttpMetricsTagsFeature.Tags => TagsList;
 
     public List<KeyValuePair<string, object?>> TagsList { get; } = new List<KeyValuePair<string, object?>>();
+
+    // Cache request values when request starts. These are used when writing metrics when the request ends.
+    // This ensures that the tags match between the start and end of the request.
+    public string? Method { get; set; }
+    public string? Scheme { get; set; }
+    public string? Protocol { get; set; }
+
+    public void Reset()
+    {
+        TagsList.Clear();
+
+        Method = null;
+        Scheme = null;
+        Protocol = null;
+    }
 }

--- a/src/Hosting/Hosting/src/Internal/HttpMetricsTagsFeature.cs
+++ b/src/Hosting/Hosting/src/Internal/HttpMetricsTagsFeature.cs
@@ -12,7 +12,7 @@ internal sealed class HttpMetricsTagsFeature : IHttpMetricsTagsFeature
     public List<KeyValuePair<string, object?>> TagsList { get; } = new List<KeyValuePair<string, object?>>();
 
     // Cache request values when request starts. These are used when writing metrics when the request ends.
-    // This ensures that the tags match between the start and end of the request.
+    // This ensures that the tags match between the start and end of the request. Important for up/down counters.
     public string? Method { get; set; }
     public string? Scheme { get; set; }
     public string? Protocol { get; set; }

--- a/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
@@ -208,6 +208,7 @@ public class HostingApplicationDiagnosticsTests
         context.HttpContext.Request.Protocol = "HTTP/2";
         context.HttpContext.Request.Method = "PUT";
         context.HttpContext.Request.Scheme = "https";
+        context.HttpContext.Features.GetRequiredFeature<IHttpMetricsTagsFeature>().Tags.Add(new KeyValuePair<string, object>("custom.tag", "custom.value"));
 
         hostingApplication.DisposeContext(context, null);
 
@@ -225,6 +226,11 @@ public class HostingApplicationDiagnosticsTests
                 Assert.Equal("http", m.Tags["url.scheme"]);
                 Assert.Equal("POST", m.Tags["http.request.method"]);
             });
+
+        Assert.Empty(context.MetricsTagsFeature.TagsList);
+        Assert.Null(context.MetricsTagsFeature.Scheme);
+        Assert.Null(context.MetricsTagsFeature.Method);
+        Assert.Null(context.MetricsTagsFeature.Protocol);
     }
 
     [Fact]

--- a/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
@@ -175,6 +175,59 @@ public class HostingApplicationDiagnosticsTests
     }
 
     [Fact]
+    public void Metrics_RequestChanges_OriginalValuesUsed()
+    {
+        // Arrange
+        var hostingEventSource = new HostingEventSource(Guid.NewGuid().ToString());
+
+        var testMeterFactory = new TestMeterFactory();
+        using var activeRequestsCollector = new MetricCollector<long>(testMeterFactory, HostingMetrics.MeterName, "http.server.active_requests");
+        using var requestDurationCollector = new MetricCollector<double>(testMeterFactory, HostingMetrics.MeterName, "http.server.request.duration");
+
+        // Act
+        var hostingApplication = CreateApplication(out var features, eventSource: hostingEventSource, meterFactory: testMeterFactory, configure: c =>
+        {
+            c.Request.Protocol = "1.1";
+            c.Request.Scheme = "http";
+            c.Request.Method = "POST";
+            c.Request.Host = new HostString("localhost");
+            c.Request.Path = "/hello";
+            c.Request.ContentType = "text/plain";
+            c.Request.ContentLength = 1024;
+        });
+        var context = hostingApplication.CreateContext(features);
+
+        Assert.Collection(activeRequestsCollector.GetMeasurementSnapshot(),
+            m =>
+            {
+                Assert.Equal(1, m.Value);
+                Assert.Equal("http", m.Tags["url.scheme"]);
+                Assert.Equal("POST", m.Tags["http.request.method"]);
+            });
+
+        context.HttpContext.Request.Protocol = "HTTP/2";
+        context.HttpContext.Request.Method = "PUT";
+        context.HttpContext.Request.Scheme = "https";
+
+        hostingApplication.DisposeContext(context, null);
+
+        // Assert
+        Assert.Collection(activeRequestsCollector.GetMeasurementSnapshot(),
+            m =>
+            {
+                Assert.Equal(1, m.Value);
+                Assert.Equal("http", m.Tags["url.scheme"]);
+                Assert.Equal("POST", m.Tags["http.request.method"]);
+            },
+            m =>
+            {
+                Assert.Equal(-1, m.Value);
+                Assert.Equal("http", m.Tags["url.scheme"]);
+                Assert.Equal("POST", m.Tags["http.request.method"]);
+            });
+    }
+
+    [Fact]
     public void DisposeContextDoesNotThrowWhenContextScopeIsNull()
     {
         // Arrange


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/55280

Hosting metrics use data on `HttpContext` when writing tag values. For example, the HTTP method of a request is metadata when writing metrics.

However, the context is mutable, which means that someone can modify the values used by hosting metrics during the request pipeline. This has the worst impact on the active requests counter, which depends on tags being the same for the start and the end of the request. If tags don't match then you end up with two dimensions, one going up and the other going down:

```
http.server.active_requests{ http_request_method="GET", url_scheme="http"} = 100
http.server.active_requests{ http_request_method="GET", url_scheme="https"} = -100
```

Fix is to stash the initial values on the context (this PR puts them on the metrics tags feature which is on the context) when the request starts and then use the stashed values at the end of the request.

There is slightly more memory used per request when metrics are enabled (3 additional fields), and no impact when metrics are disabled.