### PR TITLE
#54289 SPA proxy launch options

### DIFF
--- a/src/Middleware/Spa/SpaProxy/src/SpaDevelopmentServerOptions.cs
+++ b/src/Middleware/Spa/SpaProxy/src/SpaDevelopmentServerOptions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -6,15 +6,17 @@ using System;
 namespace Microsoft.AspNetCore.SpaProxy
 {
     internal class SpaDevelopmentServerOptions
-        {
-            public string ServerUrl { get; set; } = "";
+    {
+        public string ServerUrl { get; set; } = "";
 
-            public string LaunchCommand { get; set; } = "";
+        public string LaunchCommand { get; set; } = "";
 
-            public int MaxTimeoutInSeconds { get; set; }
+        public int MaxTimeoutInSeconds { get; set; }
 
-            public TimeSpan MaxTimeout => TimeSpan.FromSeconds(MaxTimeoutInSeconds);
+        public TimeSpan MaxTimeout => TimeSpan.FromSeconds(MaxTimeoutInSeconds);
 
-            public string WorkingDirectory { get; set; } = "";
-        }
+        public string WorkingDirectory { get; set; } = "";
+
+        public string WindowStyle { get; set; } = "";
+    }
 }

--- a/src/Middleware/Spa/SpaProxy/src/SpaDevelopmentServerOptions.cs
+++ b/src/Middleware/Spa/SpaProxy/src/SpaDevelopmentServerOptions.cs
@@ -17,6 +17,8 @@ namespace Microsoft.AspNetCore.SpaProxy
 
         public string WorkingDirectory { get; set; } = "";
 
+        public string StartStrategy { get; set; } = "";
+
         public string WindowStyle { get; set; } = "";
     }
 }

--- a/src/Middleware/Spa/SpaProxy/src/SpaDevelopmentServerStartStrategy.cs
+++ b/src/Middleware/Spa/SpaProxy/src/SpaDevelopmentServerStartStrategy.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.SpaProxy
+{
+    internal enum SpaDevelopmentServerStartStrategy
+    {
+        /// <summary>
+        /// Start another process, leave any existing process running
+        /// </summary>
+        ReLaunch,
+        /// <summary>
+        /// Kill any existing process before starting a new one
+        /// </summary>
+        Restart,
+        /// <summary>
+        /// If a process is running already, assume it is active and don't start another instance
+        /// </summary>
+        Wait
+    }
+}

--- a/src/Middleware/Spa/SpaProxy/src/SpaProxyLaunchManager.cs
+++ b/src/Middleware/Spa/SpaProxy/src/SpaProxyLaunchManager.cs
@@ -170,7 +170,7 @@ namespace Microsoft.AspNetCore.SpaProxy
                     // run the proxy manually.
                     CreateNoWindow = false,
                     UseShellExecute = true,
-                    WindowStyle = ProcessWindowStyle.Normal,
+                    WindowStyle = GetWindowStyle(_options.WindowStyle).GetValueOrDefault(ProcessWindowStyle.Normal),
                     WorkingDirectory = Path.Combine(AppContext.BaseDirectory, _options.WorkingDirectory)
                 };
                 _spaProcess = Process.Start(info);
@@ -344,6 +344,18 @@ rm {scriptPath};
         {
             Dispose(disposing: true);
             GC.SuppressFinalize(this);
+        }
+
+        private static ProcessWindowStyle? GetWindowStyle(string configuredStyle)
+        {
+            if (string.IsNullOrEmpty(configuredStyle))
+            {
+                return null;
+            }
+
+            return Enum.TryParse<ProcessWindowStyle>(configuredStyle, true, out var style)
+                ? style
+                : null;
         }
     }
 }

--- a/src/Middleware/Spa/SpaProxy/src/SpaProxyLaunchManager.cs
+++ b/src/Middleware/Spa/SpaProxy/src/SpaProxyLaunchManager.cs
@@ -71,21 +71,7 @@ namespace Microsoft.AspNetCore.SpaProxy
         {
             var httpClient = CreateHttpClient();
 
-            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-            using var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(timeout.Token, cancellationToken);
-            try
-            {
-                var response = await httpClient.GetAsync(_options.ServerUrl, cancellationTokenSource.Token);
-                var running = response.IsSuccessStatusCode;
-                return running;
-            }
-            catch (Exception exception) when (exception is HttpRequestException ||
-                  exception is TaskCanceledException ||
-                  exception is OperationCanceledException)
-            {
-                _logger.LogDebug(exception, "Failed to connect to the SPA Development proxy.");
-                return false;
-            }
+            return await ProbeSpaDevelopmentServerUrl(httpClient, cancellationToken);
         }
 
         private static HttpClient CreateHttpClient()

--- a/src/Middleware/Spa/SpaProxy/src/build/Microsoft.AspNetCore.SpaProxy.targets
+++ b/src/Middleware/Spa/SpaProxy/src/build/Microsoft.AspNetCore.SpaProxy.targets
@@ -14,6 +14,7 @@
       <_SpaProxyServerLaunchConfigLines Include="    &quot;WorkingDirectory&quot;: &quot;$(_SpaRootFullPath)&quot;," />
       <_SpaProxyServerLaunchConfigLines Include="    &quot;MaxTimeoutInSeconds&quot;: &quot;$(SpaProxyTimeoutInSeconds)&quot;" />
       <_SpaProxyServerLaunchConfigLines Include="    &quot;WindowStyle&quot;: &quot;$(SpaProxyWindowStyle)&quot;" />
+      <_SpaProxyServerLaunchConfigLines Include="    &quot;StartStrategy&quot;: &quot;$(SpaProxyStartStrategy)&quot;" />
       <_SpaProxyServerLaunchConfigLines Include="  }" />
       <_SpaProxyServerLaunchConfigLines Include="}" />
     </ItemGroup>

--- a/src/Middleware/Spa/SpaProxy/src/build/Microsoft.AspNetCore.SpaProxy.targets
+++ b/src/Middleware/Spa/SpaProxy/src/build/Microsoft.AspNetCore.SpaProxy.targets
@@ -13,6 +13,7 @@
       <_SpaProxyServerLaunchConfigLines Include="    &quot;LaunchCommand&quot;: &quot;$(SpaProxyLaunchCommand)&quot;," />
       <_SpaProxyServerLaunchConfigLines Include="    &quot;WorkingDirectory&quot;: &quot;$(_SpaRootFullPath)&quot;," />
       <_SpaProxyServerLaunchConfigLines Include="    &quot;MaxTimeoutInSeconds&quot;: &quot;$(SpaProxyTimeoutInSeconds)&quot;" />
+      <_SpaProxyServerLaunchConfigLines Include="    &quot;WindowStyle&quot;: &quot;$(SpaProxyWindowStyle)&quot;" />
       <_SpaProxyServerLaunchConfigLines Include="  }" />
       <_SpaProxyServerLaunchConfigLines Include="}" />
     </ItemGroup>


### PR DESCRIPTION
# SPA proxy launch options

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
    - Guidance would be appreciated here, there are no existing unit tests for the SPA proxy, I'm happy to create some, however i'd need guidance of the desired frameworks, style, etc.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Prevent duplicate launch of SPA proxy and allow configuration of SPA proxy window styles

## Description

The SPA proxy can launch twice if an instance takes longer than expected to launch, for example creating certificates, first-time compilation. This PR introduces backward compatible options to allow control of the launch behaviour, allowing users to configure what happens if the framework thinks the SPA proxy hasn't launched in time.

The SPA proxy process always launches with the `Normal` window style, which will place it in front of other processes as it launches. The changes include a backward compatible means to configure this, so that the window can open minimized so it does not interfere (or grab focus) when a user/developer is working on other tasks as the process launches.

There is also a minor refactor, removing duplication of some code.

### Referring back to [the contribution guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md), this PR:
- [x] is backward compatible, current behaviour will continue, unless users decide to change the configuration options
- [x] has changes for everyone, others could/would have been impacted by the duplicate-launch and focus-grabbing SPA process window
- [x] tweaks/fixes an existing feature, it does not introduce anything new - only a means of configuring the way in which a current feature behaves
- [x] does remove some duplication, otherwise this PR introduces more capability rather that simply refactoring things
- [x] Isn't too large, should not take too long to review

Fixes #54289
