### PR TITLE
Update build.gradle okhttp dependency 

### DIFF
--- a/src/SignalR/clients/java/signalr/core/build.gradle
+++ b/src/SignalR/clients/java/signalr/core/build.gradle
@@ -7,7 +7,7 @@ group 'com.microsoft.signalr'
 
 dependencies {
     implementation 'com.google.code.gson:gson:2.8.9'
-    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     api 'io.reactivex.rxjava3:rxjava:3.0.11'
     implementation 'org.slf4j:slf4j-api:1.7.25'
 }


### PR DESCRIPTION
Updated okhttp version to 4.12 because when using this library on android and building in release mode with the latest android gradle plugin, we get errors from the R8 shrinker saying that some classes are missing. here is the generated list from the R8 shrinker:
```
# Please add these rules to your existing keep rules in order to suppress warnings.
#-dontwarn org.bouncycastle.jsse.BCSSLParameters
#-dontwarn org.bouncycastle.jsse.BCSSLSocket
#-dontwarn org.bouncycastle.jsse.provider.BouncyCastleJsseProvider
#-dontwarn org.conscrypt.Conscrypt$Version
#-dontwarn org.conscrypt.Conscrypt
#-dontwarn org.conscrypt.ConscryptHostnameVerifier
#-dontwarn org.openjsse.javax.net.ssl.SSLParameters
#-dontwarn org.openjsse.javax.net.ssl.SSLSocket
#-dontwarn org.openjsse.net.ssl.OpenJSSE
```

# Updating okhttp version

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

See above