### PR TITLE
Add separate activities for Hub methods

### DIFF
--- a/src/SignalR/server/Core/src/HubConnectionContext.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContext.cs
@@ -59,6 +59,8 @@ public partial class HubConnectionContext
     // Tracks groups that the connection has been added to
     internal HashSet<string> GroupNames { get; } = new HashSet<string>();
 
+    internal Activity? OriginalActivity { get; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="HubConnectionContext"/> class.
     /// </summary>
@@ -73,6 +75,7 @@ public partial class HubConnectionContext
         _streamBufferCapacity = contextOptions.StreamBufferCapacity;
         _maxMessageSize = contextOptions.MaximumReceiveMessageSize;
         _statefulReconnectBufferSize = contextOptions.StatefulReconnectBufferSize;
+        OriginalActivity = contextOptions.OriginalActivity;
 
         _connectionContext = connectionContext;
         _logger = loggerFactory.CreateLogger(typeof(HubConnectionContext));

--- a/src/SignalR/server/Core/src/HubConnectionContext.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContext.cs
@@ -59,7 +59,7 @@ public partial class HubConnectionContext
     // Tracks groups that the connection has been added to
     internal HashSet<string> GroupNames { get; } = new HashSet<string>();
 
-    internal Activity? OriginalActivity { get; }
+    internal Activity? OriginalActivity { get; set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="HubConnectionContext"/> class.
@@ -75,7 +75,6 @@ public partial class HubConnectionContext
         _streamBufferCapacity = contextOptions.StreamBufferCapacity;
         _maxMessageSize = contextOptions.MaximumReceiveMessageSize;
         _statefulReconnectBufferSize = contextOptions.StatefulReconnectBufferSize;
-        OriginalActivity = contextOptions.OriginalActivity;
 
         _connectionContext = connectionContext;
         _logger = loggerFactory.CreateLogger(typeof(HubConnectionContext));

--- a/src/SignalR/server/Core/src/HubConnectionContextOptions.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContextOptions.cs
@@ -41,6 +41,4 @@ public class HubConnectionContextOptions
     /// Gets or sets the maximum bytes to buffer per connection when using stateful reconnect.
     /// </summary>
     internal long StatefulReconnectBufferSize { get; set; } = 100_000;
-
-    internal Activity? OriginalActivity { get; set; }
 }

--- a/src/SignalR/server/Core/src/HubConnectionContextOptions.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContextOptions.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+
 namespace Microsoft.AspNetCore.SignalR;
 
 /// <summary>
@@ -39,4 +41,6 @@ public class HubConnectionContextOptions
     /// Gets or sets the maximum bytes to buffer per connection when using stateful reconnect.
     /// </summary>
     internal long StatefulReconnectBufferSize { get; set; } = 100_000;
+
+    internal Activity? OriginalActivity { get; set; }
 }

--- a/src/SignalR/server/Core/src/HubConnectionContextOptions.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContextOptions.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
-
 namespace Microsoft.AspNetCore.SignalR;
 
 /// <summary>

--- a/src/SignalR/server/Core/src/HubConnectionHandler.cs
+++ b/src/SignalR/server/Core/src/HubConnectionHandler.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.SignalR.Internal;
@@ -125,7 +126,12 @@ public class HubConnectionHandler<THub> : ConnectionHandler where THub : Hub
             TimeProvider = TimeProvider,
             MaximumParallelInvocations = _maxParallelInvokes,
             StatefulReconnectBufferSize = _statefulReconnectBufferSize,
+            OriginalActivity = Activity.Current,
         };
+
+        // Get off the parent span.
+        // This is likely the Http Request span and we want Hub method invocations to not be collected under a long running span.
+        Activity.Current = null;
 
         Log.ConnectedStarting(_logger);
 

--- a/src/SignalR/server/Core/src/HubConnectionHandler.cs
+++ b/src/SignalR/server/Core/src/HubConnectionHandler.cs
@@ -126,16 +126,18 @@ public class HubConnectionHandler<THub> : ConnectionHandler where THub : Hub
             TimeProvider = TimeProvider,
             MaximumParallelInvocations = _maxParallelInvokes,
             StatefulReconnectBufferSize = _statefulReconnectBufferSize,
+        };
+
+        Log.ConnectedStarting(_logger);
+
+        var connectionContext = new HubConnectionContext(connection, contextOptions, _loggerFactory)
+        {
             OriginalActivity = Activity.Current,
         };
 
         // Get off the parent span.
         // This is likely the Http Request span and we want Hub method invocations to not be collected under a long running span.
         Activity.Current = null;
-
-        Log.ConnectedStarting(_logger);
-
-        var connectionContext = new HubConnectionContext(connection, contextOptions, _loggerFactory);
 
         var resolvedSupportedProtocols = (supportedProtocols as IReadOnlyList<string>) ?? supportedProtocols.ToList();
         if (!await connectionContext.HandshakeAsync(handshakeTimeout, resolvedSupportedProtocols, _protocolResolver, _userIdProvider, _enableDetailedErrors))

--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -7,7 +7,6 @@ using System.Reflection;
 using System.Security.Claims;
 using System.Threading.Channels;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Internal;
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Extensions.DependencyInjection;
@@ -783,10 +782,11 @@ internal sealed partial class DefaultHubDispatcher<THub> : HubDispatcher<THub> w
         if (serviceProvider.GetService<ActivitySource>() is ActivitySource activitySource
             && activitySource.HasListeners())
         {
+            var requestContext = Activity.Current?.Context;
             // Get off the parent span.
             // This is likely the Http Request span and we want Hub method invocations to not be collected under a long running span.
             Activity.Current = null;
-            var requestContext = serviceProvider.GetService<IHttpActivityFeature>()?.Activity.Context;
+
             var activity = activitySource.CreateActivity($"{typeof(THub).Name}/{methodName}", ActivityKind.Server, parentId: null,
                 links: requestContext.HasValue ? [new ActivityLink(requestContext.Value)] : null);
 

--- a/src/SignalR/server/Core/src/Internal/SignalRActivitySource.cs
+++ b/src/SignalR/server/Core/src/Internal/SignalRActivitySource.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Microsoft.AspNetCore.SignalR.Internal;
+
+// Internal for now so we don't need API review.
+// Just a wrapper for the ActivitySource
+// don't want to put ActivitySource directly in DI as hosting already does that and it could get overwritten.
+internal sealed class SignalRActivitySource
+{
+    public ActivitySource ActivitySource { get; } = new ActivitySource("Microsoft.AspNetCore.SignalR.Server");
+}

--- a/src/SignalR/server/Core/src/SignalRDependencyInjectionExtensions.cs
+++ b/src/SignalR/server/Core/src/SignalRDependencyInjectionExtensions.cs
@@ -31,6 +31,8 @@ public static class SignalRDependencyInjectionExtensions
         services.TryAddScoped(typeof(IHubActivator<>), typeof(DefaultHubActivator<>));
         services.AddAuthorization();
 
+        services.TryAddSingleton(new SignalRActivitySource());
+
         var builder = new SignalRServerBuilder(services);
         builder.AddJsonProtocol();
         return builder;

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -369,6 +370,14 @@ public class MethodHub : TestHub
         var sum = await Clients.Caller.InvokeAsync<int>("Sum", 1, cancellationToken: default);
         yield return sum;
     }
+
+    public void ActivityMethod()
+    {
+        var activitySource = new ActivitySource("test_custom");
+        var activity = activitySource.CreateActivity("inner", ActivityKind.Server);
+        activity.Start();
+        activity.Stop();
+    }
 }
 
 internal class SelfRef
@@ -704,6 +713,13 @@ public class StreamingHub : TestHub
     }
 
     public async Task<ChannelReader<string>> CounterChannelAsync(int count)
+    {
+        await Task.Yield();
+        return CounterChannel(count);
+    }
+
+    [HubMethodName("RenamedCounterChannel")]
+    public async Task<ChannelReader<string>> CounterChannelAsync2(int count)
     {
         await Task.Yield();
         return CounterChannel(count);

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
@@ -371,11 +371,9 @@ public class MethodHub : TestHub
         yield return sum;
     }
 
-    public void ActivityMethod()
+    public void ActivityMethod(TestActivitySource testActivitySource)
     {
-        var activitySource = new ActivitySource("test_custom");
-        var activity = activitySource.CreateActivity("inner", ActivityKind.Server);
-        activity.Start();
+        var activity = testActivitySource.ActivitySource.StartActivity("inner", ActivityKind.Server);
         activity.Stop();
     }
 }
@@ -388,6 +386,11 @@ internal class SelfRef
     }
 
     public SelfRef Self { get; set; }
+}
+
+public class TestActivitySource
+{
+    public ActivitySource ActivitySource { get; set; }
 }
 
 public abstract class TestHub : Hub

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.Activity.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.Activity.cs
@@ -1,0 +1,377 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.AspNetCore.SignalR.Internal;
+using Microsoft.AspNetCore.SignalR.Protocol;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Testing;
+using Moq;
+
+namespace Microsoft.AspNetCore.SignalR.Tests;
+
+public partial class HubConnectionHandlerTests
+{
+    [Fact]
+    public async Task HubMethodInvokesCreateActivities()
+    {
+        using (StartVerifiableLog())
+        {
+            var activities = new List<Activity>();
+            var testSource = new ActivitySource("test_source");
+            var hubMethodTestSource = new TestActivitySource() { ActivitySource = new ActivitySource("test_custom") };
+
+            var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(builder =>
+            {
+                builder.AddSingleton(hubMethodTestSource);
+
+                // Provided by hosting layer normally
+                builder.AddSingleton(testSource);
+            }, LoggerFactory);
+            var signalrSource = serviceProvider.GetRequiredService<SignalRActivitySource>().ActivitySource;
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = activitySource => (ReferenceEquals(activitySource, testSource))
+                    || ReferenceEquals(activitySource, hubMethodTestSource.ActivitySource) || ReferenceEquals(activitySource, signalrSource),
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+                ActivityStarted = activities.Add
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var mockHttpRequestActivity = new Activity("HttpRequest");
+            mockHttpRequestActivity.Start();
+            Activity.Current = mockHttpRequestActivity;
+
+            var connectionHandler = serviceProvider.GetService<HubConnectionHandler<MethodHub>>();
+
+            using (var client = new TestClient())
+            {
+                var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+
+                var activity = Assert.Single(activities);
+                AssertHubMethodActivity<MethodHub>(activity, nameof(MethodHub.OnConnectedAsync), mockHttpRequestActivity);
+
+                await client.SendInvocationAsync(nameof(MethodHub.Echo), "test").DefaultTimeout();
+
+                var completionMessage = Assert.IsType<CompletionMessage>(await client.ReadAsync().DefaultTimeout());
+                var res = (string)completionMessage.Result;
+                Assert.Equal("test", res);
+
+                Assert.Equal(2, activities.Count);
+                AssertHubMethodActivity<MethodHub>(activities[1], nameof(MethodHub.Echo), mockHttpRequestActivity);
+
+                await client.SendInvocationAsync("RenamedMethod").DefaultTimeout();
+                Assert.IsType<CompletionMessage>(await client.ReadAsync().DefaultTimeout());
+
+                Assert.Equal(3, activities.Count);
+                AssertHubMethodActivity<MethodHub>(activities[2], "RenamedMethod", mockHttpRequestActivity);
+
+                await client.SendInvocationAsync(nameof(MethodHub.ActivityMethod)).DefaultTimeout();
+                Assert.IsType<CompletionMessage>(await client.ReadAsync().DefaultTimeout());
+
+                Assert.Equal(5, activities.Count);
+                AssertHubMethodActivity<MethodHub>(activities[3], nameof(MethodHub.ActivityMethod), mockHttpRequestActivity);
+                Assert.NotNull(activities[4].Parent);
+                Assert.Equal("inner", activities[4].OperationName);
+                Assert.Equal(activities[3], activities[4].Parent);
+
+                client.Dispose();
+
+                await connectionHandlerTask;
+            }
+
+            Assert.Equal(6, activities.Count);
+            AssertHubMethodActivity<MethodHub>(activities[5], nameof(MethodHub.OnDisconnectedAsync), mockHttpRequestActivity);
+        }
+    }
+
+    [Fact]
+    public async Task StreamingHubMethodCreatesActivities()
+    {
+        using (StartVerifiableLog())
+        {
+            var activities = new List<Activity>();
+            var testSource = new ActivitySource("test_source");
+
+            var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(builder =>
+            {
+                // Provided by hosting layer normally
+                builder.AddSingleton(testSource);
+            }, LoggerFactory);
+            var signalrSource = serviceProvider.GetRequiredService<SignalRActivitySource>().ActivitySource;
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = activitySource => (ReferenceEquals(activitySource, testSource))
+                    || ReferenceEquals(activitySource, signalrSource),
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+                ActivityStarted = activities.Add
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var mockHttpRequestActivity = new Activity("HttpRequest");
+            mockHttpRequestActivity.Start();
+            Activity.Current = mockHttpRequestActivity;
+
+            var connectionHandler = serviceProvider.GetService<HubConnectionHandler<StreamingHub>>();
+            Mock<IInvocationBinder> invocationBinder = new Mock<IInvocationBinder>();
+            invocationBinder.Setup(b => b.GetStreamItemType(It.IsAny<string>())).Returns(typeof(int));
+
+            using (var client = new TestClient(invocationBinder: invocationBinder.Object))
+            {
+                var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+
+                var activity = Assert.Single(activities);
+                AssertHubMethodActivity<StreamingHub>(activity, nameof(StreamingHub.OnConnectedAsync), mockHttpRequestActivity);
+
+                _ = await client.StreamAsync(nameof(StreamingHub.CounterChannel), 3).DefaultTimeout();
+
+                Assert.Equal(2, activities.Count);
+                AssertHubMethodActivity<StreamingHub>(activities[1], nameof(StreamingHub.CounterChannel), mockHttpRequestActivity);
+
+                _ = await client.StreamAsync("RenamedCounterChannel", 3).DefaultTimeout();
+
+                Assert.Equal(3, activities.Count);
+                AssertHubMethodActivity<StreamingHub>(activities[2], "RenamedCounterChannel", mockHttpRequestActivity);
+
+                client.Dispose();
+
+                await connectionHandlerTask;
+            }
+
+            Assert.Equal(4, activities.Count);
+            AssertHubMethodActivity<StreamingHub>(activities[3], nameof(StreamingHub.OnDisconnectedAsync), mockHttpRequestActivity);
+        }
+    }
+
+    [Fact]
+    public async Task ExceptionInOnConnectedAsyncSetsActivityErrorState()
+    {
+        bool ExpectedErrors(WriteContext writeContext)
+        {
+            return writeContext.LoggerName == "Microsoft.AspNetCore.SignalR.HubConnectionHandler" &&
+                   writeContext.EventId.Name == "ErrorDispatchingHubEvent";
+        }
+
+        using (StartVerifiableLog(ExpectedErrors))
+        {
+            var activities = new List<Activity>();
+            var testSource = new ActivitySource("test_source");
+
+            var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(builder =>
+            {
+                // Provided by hosting layer normally
+                builder.AddSingleton(testSource);
+            }, LoggerFactory);
+            var signalrSource = serviceProvider.GetRequiredService<SignalRActivitySource>().ActivitySource;
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = activitySource => (ReferenceEquals(activitySource, testSource))
+                    || ReferenceEquals(activitySource, signalrSource),
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+                ActivityStarted = activities.Add
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var mockHttpRequestActivity = new Activity("HttpRequest");
+            mockHttpRequestActivity.Start();
+            Activity.Current = mockHttpRequestActivity;
+
+            var connectionHandler = serviceProvider.GetService<HubConnectionHandler<OnConnectedThrowsHub>>();
+
+            using (var client = new TestClient())
+            {
+                var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+
+                var activity = Assert.Single(activities);
+                AssertHubMethodActivity<OnConnectedThrowsHub>(activity, nameof(OnConnectedThrowsHub.OnConnectedAsync),
+                    mockHttpRequestActivity, exceptionType: typeof(InvalidOperationException));
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ExceptionInOnDisconnectedAsyncSetsActivityErrorState()
+    {
+        bool ExpectedErrors(WriteContext writeContext)
+        {
+            return writeContext.LoggerName == "Microsoft.AspNetCore.SignalR.HubConnectionHandler" &&
+                   writeContext.EventId.Name == "ErrorDispatchingHubEvent";
+        }
+
+        using (StartVerifiableLog(ExpectedErrors))
+        {
+            var activities = new List<Activity>();
+            var testSource = new ActivitySource("test_source");
+
+            var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(builder =>
+            {
+                // Provided by hosting layer normally
+                builder.AddSingleton(testSource);
+            }, LoggerFactory);
+            var signalrSource = serviceProvider.GetRequiredService<SignalRActivitySource>().ActivitySource;
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = activitySource => (ReferenceEquals(activitySource, testSource))
+                    || ReferenceEquals(activitySource, signalrSource),
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+                ActivityStarted = activities.Add
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var mockHttpRequestActivity = new Activity("HttpRequest");
+            mockHttpRequestActivity.Start();
+            Activity.Current = mockHttpRequestActivity;
+
+            var connectionHandler = serviceProvider.GetService<HubConnectionHandler<OnDisconnectedThrowsHub>>();
+
+            using (var client = new TestClient())
+            {
+                var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+                client.Dispose();
+
+                await connectionHandlerTask.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+            }
+
+            Assert.Equal(2, activities.Count);
+            var activity = activities[1];
+            AssertHubMethodActivity<OnDisconnectedThrowsHub>(activity, nameof(OnDisconnectedThrowsHub.OnDisconnectedAsync),
+                mockHttpRequestActivity, exceptionType: typeof(InvalidOperationException));
+        }
+    }
+
+    [Fact]
+    public async Task ExceptionInStreamingMethodSetsActivityErrorState()
+    {
+        bool ExpectedErrors(WriteContext writeContext)
+        {
+            return writeContext.LoggerName == "Microsoft.AspNetCore.SignalR.Internal.DefaultHubDispatcher" &&
+                   writeContext.EventId.Name == "FailedStreaming";
+        }
+
+        using (StartVerifiableLog(ExpectedErrors))
+        {
+            var activities = new List<Activity>();
+            var testSource = new ActivitySource("test_source");
+
+            var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(builder =>
+            {
+                // Provided by hosting layer normally
+                builder.AddSingleton(testSource);
+            }, LoggerFactory);
+            var signalrSource = serviceProvider.GetRequiredService<SignalRActivitySource>().ActivitySource;
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = activitySource => (ReferenceEquals(activitySource, testSource))
+                    || ReferenceEquals(activitySource, signalrSource),
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+                ActivityStarted = activities.Add
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var mockHttpRequestActivity = new Activity("HttpRequest");
+            mockHttpRequestActivity.Start();
+            Activity.Current = mockHttpRequestActivity;
+
+            var connectionHandler = serviceProvider.GetService<HubConnectionHandler<StreamingHub>>();
+
+            using (var client = new TestClient())
+            {
+                var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+
+                _ = await client.StreamAsync(nameof(StreamingHub.ExceptionAsyncEnumerable)).DefaultTimeout();
+
+                Assert.Equal(2, activities.Count);
+                var activity = activities[1];
+                AssertHubMethodActivity<StreamingHub>(activity, nameof(StreamingHub.ExceptionAsyncEnumerable),
+                    mockHttpRequestActivity, exceptionType: typeof(Exception));
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ExceptionInHubMethodSetsActivityErrorState()
+    {
+        bool ExpectedErrors(WriteContext writeContext)
+        {
+            return writeContext.LoggerName == "Microsoft.AspNetCore.SignalR.Internal.DefaultHubDispatcher" &&
+                   writeContext.EventId.Name == "FailedInvokingHubMethod";
+        }
+
+        using (StartVerifiableLog(ExpectedErrors))
+        {
+            var activities = new List<Activity>();
+            var testSource = new ActivitySource("test_source");
+
+            var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(builder =>
+            {
+                // Provided by hosting layer normally
+                builder.AddSingleton(testSource);
+            }, LoggerFactory);
+            var signalrSource = serviceProvider.GetRequiredService<SignalRActivitySource>().ActivitySource;
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = activitySource => (ReferenceEquals(activitySource, testSource))
+                    || ReferenceEquals(activitySource, signalrSource),
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+                ActivityStarted = activities.Add
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var mockHttpRequestActivity = new Activity("HttpRequest");
+            mockHttpRequestActivity.Start();
+            Activity.Current = mockHttpRequestActivity;
+
+            var connectionHandler = serviceProvider.GetService<HubConnectionHandler<MethodHub>>();
+
+            using (var client = new TestClient())
+            {
+                var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+
+                _ = await client.InvokeAsync(nameof(MethodHub.MethodThatThrows)).DefaultTimeout();
+
+                Assert.Equal(2, activities.Count);
+                var activity = activities[1];
+                AssertHubMethodActivity<MethodHub>(activity, nameof(MethodHub.MethodThatThrows),
+                    mockHttpRequestActivity, exceptionType: typeof(InvalidOperationException));
+            }
+        }
+    }
+
+    private static void AssertHubMethodActivity<THub>(Activity activity, string methodName, Activity httpActivity, Type exceptionType = null)
+    {
+        Assert.Null(activity.Parent);
+        Assert.True(activity.IsStopped);
+        Assert.Equal($"{typeof(THub).FullName}/{methodName}", activity.OperationName);
+
+        var tags = activity.Tags.ToArray();
+        if (exceptionType is not null)
+        {
+            Assert.Equal(ActivityStatusCode.Error, activity.Status);
+            Assert.Equal(4, tags.Length);
+            Assert.Equal("error.type", tags[3].Key);
+            Assert.Equal(exceptionType.FullName, tags[3].Value);
+        }
+        else
+        {
+            Assert.Equal(ActivityStatusCode.Unset, activity.Status);
+            Assert.Equal(3, tags.Length);
+        }
+
+        Assert.Equal("rpc.method", tags[0].Key);
+        Assert.Equal(methodName, tags[0].Value);
+        Assert.Equal("rpc.system", tags[1].Key);
+        Assert.Equal("signalr", tags[1].Value);
+        Assert.Equal("rpc.service", tags[2].Key);
+        Assert.Equal(typeof(THub).FullName, tags[2].Value);
+
+        // Linked to original http request span
+        Assert.Equal(httpActivity.SpanId, Assert.Single(activity.Links).Context.SpanId);
+    }
+}

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -17,9 +17,9 @@ using Microsoft.AspNetCore.Connections.Abstractions;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Connections.Features;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.SignalR.Internal;
 using Microsoft.AspNetCore.SignalR.Protocol;
-using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
@@ -29,7 +29,6 @@ using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
-using Microsoft.AspNetCore.Http.Features;
 
 namespace Microsoft.AspNetCore.SignalR.Tests;
 
@@ -5328,155 +5327,6 @@ public partial class HubConnectionHandlerTests : VerifiableLoggedTest
 
             Assert.Null(state.DisconnectedException);
         }
-    }
-
-    [Fact]
-    public async Task HubMethodInvokesCreateActivities()
-    {
-        using (StartVerifiableLog())
-        {
-            var activities = new List<Activity>();
-            var testSource = new ActivitySource("test_source");
-            using var listener = new ActivityListener
-            {
-                ShouldListenTo = activitySource => (ReferenceEquals(activitySource, testSource))
-                    || activitySource.Name == "test_custom" || activitySource.Name == "Microsoft.AspNetCore.SignalR.Server",
-                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
-                ActivityStarted = activities.Add
-            };
-            ActivitySource.AddActivityListener(listener);
-
-            var mockHttpRequestActivity = new Activity("HttpRequest");
-            mockHttpRequestActivity.Start();
-            Activity.Current = mockHttpRequestActivity;
-
-            var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(builder =>
-            {
-                // Provided by hosting layer normally
-                builder.AddSingleton(testSource);
-            }, LoggerFactory);
-            var connectionHandler = serviceProvider.GetService<HubConnectionHandler<MethodHub>>();
-
-            using (var client = new TestClient())
-            {
-                var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
-
-                var activity = Assert.Single(activities);
-                AssertHubMethodActivity<MethodHub>(activity, nameof(MethodHub.OnConnectedAsync), mockHttpRequestActivity);
-
-                await client.SendInvocationAsync(nameof(MethodHub.Echo), "test").DefaultTimeout();
-
-                var completionMessage = Assert.IsType<CompletionMessage>(await client.ReadAsync().DefaultTimeout());
-                var res = (string)completionMessage.Result;
-                Assert.Equal("test", res);
-
-                Assert.Equal(2, activities.Count);
-                AssertHubMethodActivity<MethodHub>(activities[1], nameof(MethodHub.Echo), mockHttpRequestActivity);
-
-                await client.SendInvocationAsync("RenamedMethod").DefaultTimeout();
-                Assert.IsType<CompletionMessage>(await client.ReadAsync().DefaultTimeout());
-
-                Assert.Equal(3, activities.Count);
-                AssertHubMethodActivity<MethodHub>(activities[2], "RenamedMethod", mockHttpRequestActivity);
-
-                await client.SendInvocationAsync(nameof(MethodHub.ActivityMethod)).DefaultTimeout();
-                Assert.IsType<CompletionMessage>(await client.ReadAsync().DefaultTimeout());
-
-                Assert.Equal(5, activities.Count);
-                AssertHubMethodActivity<MethodHub>(activities[3], nameof(MethodHub.ActivityMethod), mockHttpRequestActivity);
-                Assert.NotNull(activities[4].Parent);
-                Assert.Equal("inner", activities[4].OperationName);
-                Assert.Equal(activities[3], activities[4].Parent);
-
-                client.Dispose();
-
-                await connectionHandlerTask;
-            }
-
-            Assert.Equal(6, activities.Count);
-            AssertHubMethodActivity<MethodHub>(activities[5], nameof(MethodHub.OnDisconnectedAsync), mockHttpRequestActivity);
-        }
-    }
-
-    [Fact]
-    public async Task StreamingHubMethodCreatesActivities()
-    {
-        using (StartVerifiableLog())
-        {
-            var activities = new List<Activity>();
-            var testSource = new ActivitySource("test_source");
-            using var listener = new ActivityListener
-            {
-                ShouldListenTo = activitySource => (ReferenceEquals(activitySource, testSource)
-                || activitySource.Name == "Microsoft.AspNetCore.SignalR.Server"),
-                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
-                ActivityStarted = activities.Add
-            };
-            ActivitySource.AddActivityListener(listener);
-
-            var mockHttpRequestActivity = new Activity("HttpRequest");
-            mockHttpRequestActivity.Start();
-            Activity.Current = mockHttpRequestActivity;
-
-            var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(builder =>
-            {
-                // Provided by hosting layer normally
-                builder.AddSingleton(testSource);
-            }, LoggerFactory);
-            var connectionHandler = serviceProvider.GetService<HubConnectionHandler<StreamingHub>>();
-            Mock<IInvocationBinder> invocationBinder = new Mock<IInvocationBinder>();
-            invocationBinder.Setup(b => b.GetStreamItemType(It.IsAny<string>())).Returns(typeof(int));
-
-            using (var client = new TestClient(invocationBinder: invocationBinder.Object))
-            {
-                var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
-
-                var activity = Assert.Single(activities);
-                AssertHubMethodActivity<StreamingHub>(activity, nameof(StreamingHub.OnConnectedAsync), mockHttpRequestActivity);
-
-                _ = await client.StreamAsync(nameof(StreamingHub.CounterChannel), 3).DefaultTimeout();
-
-                Assert.Equal(2, activities.Count);
-                AssertHubMethodActivity<StreamingHub>(activities[1], nameof(StreamingHub.CounterChannel), mockHttpRequestActivity);
-
-                _ = await client.StreamAsync("RenamedCounterChannel", 3).DefaultTimeout();
-
-                Assert.Equal(3, activities.Count);
-                AssertHubMethodActivity<StreamingHub>(activities[2], "RenamedCounterChannel", mockHttpRequestActivity);
-
-                client.Dispose();
-
-                await connectionHandlerTask;
-            }
-
-            Assert.Equal(4, activities.Count);
-            AssertHubMethodActivity<StreamingHub>(activities[3], nameof(StreamingHub.OnDisconnectedAsync), mockHttpRequestActivity);
-        }
-    }
-
-    private static void AssertHubMethodActivity<THub>(Activity activity, string methodName, Activity httpActivity)
-    {
-        Assert.Null(activity.Parent);
-        Assert.True(activity.IsStopped);
-        Assert.Equal($"{typeof(THub).FullName}/{methodName}", activity.OperationName);
-        Assert.Collection(activity.Tags,
-            one =>
-            {
-                Assert.Equal("rpc.method", one.Key);
-                Assert.Equal(methodName, one.Value);
-            },
-            two =>
-            {
-                Assert.Equal("rpc.system", two.Key);
-                Assert.Equal("signalr", two.Value);
-            },
-            three =>
-            {
-                Assert.Equal("rpc.service", three.Key);
-                Assert.Equal(typeof(THub).FullName, three.Value);
-            });
-        // Linked to original http request span
-        Assert.Equal(httpActivity.SpanId, Assert.Single(activity.Links).Context.SpanId);
     }
 
 #pragma warning disable CA2252 // This API requires opting into preview features

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -5407,7 +5407,8 @@ public partial class HubConnectionHandlerTests : VerifiableLoggedTest
             var testSource = new ActivitySource("test_source");
             using var listener = new ActivityListener
             {
-                ShouldListenTo = activitySource => (ReferenceEquals(activitySource, testSource)),
+                ShouldListenTo = activitySource => (ReferenceEquals(activitySource, testSource)
+                || activitySource.Name == "Microsoft.AspNetCore.SignalR.Server"),
                 Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
                 ActivityStarted = activities.Add
             };


### PR DESCRIPTION
First part of https://github.com/dotnet/aspnetcore/issues/51557

Follows conventions from https://github.com/open-telemetry/semantic-conventions/blob/main/docs/rpc/rpc-spans.md

Haven't added `server.address` yet since it looks like we'd need to copy a chunk of code from Kestrel to do it properly:
https://github.com/dotnet/aspnetcore/blob/027c60168383421750f01e427e4f749d0684bc02/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelMetrics.cs#L308

----------------

**Hub methods are separate spans:**

![image](https://github.com/dotnet/aspnetcore/assets/7574801/be186f9f-b480-427e-9a27-e2ee4134023e)

-----------

**Streaming has events:**

![image](https://github.com/dotnet/aspnetcore/assets/7574801/c5d75a8e-4327-4110-adfe-2b432934083b)
