### PR TITLE
Don't publish version files in codesign jobs

### DIFF
--- a/.azure/pipelines/jobs/codesign-xplat.yml
+++ b/.azure/pipelines/jobs/codesign-xplat.yml
@@ -39,6 +39,7 @@ jobs:
         -projects $(Build.SourcesDirectory)/eng/empty.proj
         /p:AssetManifestFileName=aspnetcore-${{ parameters.inputName }}-signed.xml
         /p:DotNetSignType=$(_SignType)
+        /p:PublishInstallerBaseVersion=false
         $(_BuildArgs)
         $(_PublishArgs)
         $(_InternalRuntimeDownloadCodeSignArgs)

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -12,7 +12,8 @@
                                        '$(PostBuildSign)' != 'true' and
                                        '$(DotNetBuildRepo)' != 'true'">false</EnableDefaultArtifacts>
 
-    <PublishInstallerBaseVersion Condition="'$(OS)' == 'Windows_NT' or '$(DotNetBuildOrchestrator)' == 'true'">true</PublishInstallerBaseVersion>
+    <PublishInstallerBaseVersion Condition="'$(PublishInstallerBaseVersion)' == '' and 
+                                            ('$(OS)' == 'Windows_NT' or '$(DotNetBuildOrchestrator)' == 'true')">true</PublishInstallerBaseVersion>
     <!-- This avoids creating VS.*.symbols.nupkg packages that are identical to the original package. -->
     <AutoGenerateSymbolPackages>false</AutoGenerateSymbolPackages>
   </PropertyGroup>


### PR DESCRIPTION
We were always publishing the installer version files on Windows unconditionally - this broke official builds in `release/*` branches, because the CodeSign jobs run there, which sign Mac/Linux packages on Windows. We should only publish from the main Windows job that always runs. See https://dev.azure.com/dnceng/internal/_build/results?buildId=2442099&view=results for example failure