### PR TITLE
[DO NOT MERGE] Add a dummy test

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionContextTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionContextTests.cs
@@ -304,11 +304,13 @@ public class QuicConnectionContextTests : TestApplicationErrorLoggerLoggedTest
                 Assert.Fail("How did we get here?");
             }
         }
+#if DEBUG
         catch (Exception)
         {
             Logger.LogInformation("Exception");
             Assert.Fail("Repro succeeded");
         }
+#endif
         finally
         {
             Logger.LogInformation("Finally");


### PR DESCRIPTION
...to confirm that CI catches https://github.com/dotnet/runtime/issues/101772.

The test should fail whether or not the runtime issue is observed.  We're looking for it to fail with "repro succeeded", rather than "repro failed".