### PR TITLE
Exclude tests from CodeQL

### DIFF
--- a/.CodeQL.yml
+++ b/.CodeQL.yml
@@ -1,0 +1,9 @@
+# This file configures CodeQL runs and TSA bug autofiling. For more information, see:
+# https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/troubleshooting/bugs/generated-library-code
+# (Access restricted to Microsoft employees only.)
+
+path_classifiers:
+  refs:
+    # The test/ directories don't contain shipping implementations of code, so they should
+    # be excluded from analysis. 
+    - src/**/test/*

--- a/.azure/pipelines/signalr-daily-tests.yml
+++ b/.azure/pipelines/signalr-daily-tests.yml
@@ -26,6 +26,10 @@ extends:
         name: NetCore1ESPool-Svc-Internal
         image: 1es-windows-2022-pt
         os: windows
+      codeql:
+        compiled:
+          enabled: false
+          justificationForDisabling: 'This is a test-only pipeline. The same product code is already scanned in the main pipeline (aspnetcore-ci)'
     stages:
     - stage: build
       displayName: Build


### PR DESCRIPTION
We only need to run CodeQL against source code, we can skip the tests (for now).