### PR TITLE
Enable trimming for OpenAPI package

### DIFF
--- a/eng/TrimmableProjects.props
+++ b/eng/TrimmableProjects.props
@@ -73,6 +73,7 @@
     <TrimmableProject Include="Microsoft.AspNetCore.HttpsPolicy" />
     <TrimmableProject Include="Microsoft.AspNetCore.Localization.Routing" />
     <TrimmableProject Include="Microsoft.AspNetCore.Localization" />
+    <TrimmableProject Include="Microsoft.AspNetCore.OpenApi" />
     <TrimmableProject Include="Microsoft.AspNetCore.OutputCaching" />
     <TrimmableProject Include="Microsoft.AspNetCore.RateLimiting" />
     <TrimmableProject Include="Microsoft.AspNetCore.RequestDecompression" />

--- a/eng/TrimmableProjects.props
+++ b/eng/TrimmableProjects.props
@@ -73,7 +73,6 @@
     <TrimmableProject Include="Microsoft.AspNetCore.HttpsPolicy" />
     <TrimmableProject Include="Microsoft.AspNetCore.Localization.Routing" />
     <TrimmableProject Include="Microsoft.AspNetCore.Localization" />
-    <TrimmableProject Include="Microsoft.AspNetCore.OpenApi" />
     <TrimmableProject Include="Microsoft.AspNetCore.OutputCaching" />
     <TrimmableProject Include="Microsoft.AspNetCore.RateLimiting" />
     <TrimmableProject Include="Microsoft.AspNetCore.RequestDecompression" />
@@ -108,5 +107,6 @@
     <TrimmableProject Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" />
     <TrimmableProject Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     <TrimmableProject Include="Microsoft.Extensions.Features" />
+    <TrimmableProject Include="Microsoft.AspNetCore.OpenApi" />
   </ItemGroup>
 </Project>

--- a/src/OpenApi/sample/Controllers/TestController.cs
+++ b/src/OpenApi/sample/Controllers/TestController.cs
@@ -27,7 +27,7 @@ public class TestController : ControllerBase
 
         [FromRoute]
         [MinLength(5)]
-        [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "Suppress trim-related warnings for MVC.")]
+        [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = "MinLengthAttribute works without reflection on string properties.")]
         public string? Name { get; set; }
     }
 

--- a/src/OpenApi/sample/Controllers/TestController.cs
+++ b/src/OpenApi/sample/Controllers/TestController.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Mvc;
 
 [ApiController]
@@ -26,6 +27,7 @@ public class TestController : ControllerBase
 
         [FromRoute]
         [MinLength(5)]
+        [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "Suppress trim-related warnings for MVC.")]
         public string? Name { get; set; }
     }
 

--- a/src/OpenApi/sample/Program.cs
+++ b/src/OpenApi/sample/Program.cs
@@ -7,7 +7,9 @@ using Sample.Transformers;
 
 var builder = WebApplication.CreateBuilder(args);
 
+#pragma warning disable IL2026 // MVC isn't trim-friendly yet
 builder.Services.AddControllers();
+#pragma warning restore IL2026
 builder.Services.AddAuthentication().AddJwtBearer();
 
 builder.Services.AddOpenApi("v1", options =>
@@ -44,8 +46,15 @@ if (app.Environment.IsDevelopment())
 forms.MapPost("/form-file", (IFormFile resume) => Results.Ok(resume.FileName));
 forms.MapPost("/form-files", (IFormFileCollection files) => Results.Ok(files.Count));
 forms.MapPost("/form-file-multiple", (IFormFile resume, IFormFileCollection files) => Results.Ok(files.Count + resume.FileName));
+// Disable warnings because RDG does not support complex form binding yet.
+#pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+#pragma warning disable IL3050 // Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+#pragma warning disable RDG003 // Unable to resolve parameter
 forms.MapPost("/form-todo", ([FromForm] Todo todo) => Results.Ok(todo));
 forms.MapPost("/forms-pocos-and-files", ([FromForm] Todo todo, IFormFile file) => Results.Ok(new { Todo = todo, File = file.FileName }));
+#pragma warning restore RDG003 // Unable to resolve parameter
+#pragma warning restore IL3050 // Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+#pragma warning restore IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 
 var v1 = app.MapGroup("v1")
     .WithGroupName("v1");

--- a/src/OpenApi/sample/Sample.csproj
+++ b/src/OpenApi/sample/Sample.csproj
@@ -4,6 +4,11 @@
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <IsTrimmable>true</IsTrimmable>
+    <!-- Required to generated trimmable Map-invocations. -->
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
+    <InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.AspNetCore.Http.Generated</InterceptorsPreviewNamespaces>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,6 +25,11 @@
 
   <ItemGroup>
     <Compile Include="../test/SharedTypes.cs" />
+  </ItemGroup>
+
+  <!-- Required to generated trimmable Map-invocations. -->
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenApi/sample/Sample.csproj
+++ b/src/OpenApi/sample/Sample.csproj
@@ -6,9 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <IsTrimmable>true</IsTrimmable>
     <!-- Required to generated trimmable Map-invocations. -->
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
-    <InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.AspNetCore.Http.Generated</InterceptorsPreviewNamespaces>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenApi/sample/Sample.csproj
+++ b/src/OpenApi/sample/Sample.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <IsTrimmable>true</IsTrimmable>
     <!-- Required to generated trimmable Map-invocations. -->
     <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
     <IsAotCompatible>true</IsAotCompatible>

--- a/src/OpenApi/src/Extensions/JsonObjectSchemaExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonObjectSchemaExtensions.cs
@@ -4,7 +4,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.Linq;
-using System.Reflection;
 using System.Text.Json.Nodes;
 using JsonSchemaMapper;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
@@ -248,14 +247,10 @@ internal static class JsonObjectSchemaExtensions
         // based on our model binding heuristics. In that case, to access the validation attributes that the
         // model binder will respect we will need to get the property from the container type and map the
         // attributes on it to the schema.
-        if (parameterDescription.ModelMetadata.PropertyName is { } propertyName)
+        if (parameterDescription.ModelMetadata is { PropertyName: { }, ContainerType: { }, HasValidators: true, ValidatorMetadata: { } validations })
         {
-            var property = parameterDescription.ModelMetadata.ContainerType?.GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance);
-            if (property is not null)
-            {
-                var attributes = property.GetCustomAttributes(true).OfType<ValidationAttribute>();
-                schema.ApplyValidationAttributes(attributes);
-            }
+            var attributes = validations.OfType<ValidationAttribute>();
+            schema.ApplyValidationAttributes(attributes);
         }
         // Route constraints are only defined on parameters that are sourced from the path. Since
         // they are encoded in the route template, and not in the type information based to the underlying

--- a/src/OpenApi/src/Extensions/OpenApiEndpointConventionBuilderExtensions.cs
+++ b/src/OpenApi/src/Extensions/OpenApiEndpointConventionBuilderExtensions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Builder;
 /// </summary>
 public static class OpenApiEndpointConventionBuilderExtensions
 {
-    private const string TrimWarningMessage = "Calls Microsoft.AspNetCore.OpenApi.OpenApiGenerator.GetOpenApiOperation(MethodInfo, EndpointMetadataCollection, RoutePattern) which uses dynamic analysis.";
+    private const string TrimWarningMessage = "Calls Microsoft.AspNetCore.OpenApi.OpenApiGenerator.GetOpenApiOperation(MethodInfo, EndpointMetadataCollection, RoutePattern) which uses dynamic analysis. Use IServiceCollection.AddOpenApi() to generate OpenAPI metadata at startup for all endpoints,";
 
     /// <summary>
     /// Adds an OpenAPI annotation to <see cref="Endpoint.Metadata" /> associated

--- a/src/OpenApi/src/Extensions/OpenApiEndpointConventionBuilderExtensions.cs
+++ b/src/OpenApi/src/Extensions/OpenApiEndpointConventionBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using Microsoft.AspNetCore.Http;
@@ -17,12 +18,16 @@ namespace Microsoft.AspNetCore.Builder;
 /// </summary>
 public static class OpenApiEndpointConventionBuilderExtensions
 {
+    private const string TrimWarningMessage = "Calls Microsoft.AspNetCore.OpenApi.OpenApiGenerator.GetOpenApiOperation(MethodInfo, EndpointMetadataCollection, RoutePattern) which uses dynamic analysis.";
+
     /// <summary>
     /// Adds an OpenAPI annotation to <see cref="Endpoint.Metadata" /> associated
     /// with the current endpoint.
     /// </summary>
     /// <param name="builder">The <see cref="IEndpointConventionBuilder"/>.</param>
     /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+    [RequiresDynamicCode(TrimWarningMessage)]
+    [RequiresUnreferencedCode(TrimWarningMessage)]
     public static TBuilder WithOpenApi<TBuilder>(this TBuilder builder) where TBuilder : IEndpointConventionBuilder
     {
         builder.Finally(builder => AddAndConfigureOperationForEndpoint(builder));
@@ -36,6 +41,8 @@ public static class OpenApiEndpointConventionBuilderExtensions
     /// <param name="builder">The <see cref="IEndpointConventionBuilder"/>.</param>
     /// <param name="configureOperation">An <see cref="Func{T, TResult}"/> that returns a new OpenAPI annotation given a generated operation.</param>
     /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+    [RequiresDynamicCode(TrimWarningMessage)]
+    [RequiresUnreferencedCode(TrimWarningMessage)]
     public static TBuilder WithOpenApi<TBuilder>(this TBuilder builder, Func<OpenApiOperation, OpenApiOperation> configureOperation)
         where TBuilder : IEndpointConventionBuilder
     {
@@ -43,6 +50,8 @@ public static class OpenApiEndpointConventionBuilderExtensions
         return builder;
     }
 
+    [RequiresDynamicCode(TrimWarningMessage)]
+    [RequiresUnreferencedCode(TrimWarningMessage)]
     private static void AddAndConfigureOperationForEndpoint(EndpointBuilder endpointBuilder, Func<OpenApiOperation, OpenApiOperation>? configure = null)
     {
         foreach (var item in endpointBuilder.Metadata)

--- a/src/OpenApi/src/Extensions/OpenApiServiceCollectionExtensions.cs
+++ b/src/OpenApi/src/Extensions/OpenApiServiceCollectionExtensions.cs
@@ -1,8 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.Http.Json;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.Extensions.ApiDescriptions;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -67,6 +70,8 @@ public static class OpenApiServiceCollectionExtensions
         services.AddSingleton<IDocumentProvider, OpenApiDocumentProvider>();
         // Required to resolve document names for build-time generation
         services.AddSingleton(new NamedService<OpenApiDocumentService>(documentName));
+        // Required to support JSON serializations
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<JsonOptions>, OpenApiSchemaJsonOptions>());
         return services;
     }
 }

--- a/src/OpenApi/src/Microsoft.AspNetCore.OpenApi.csproj
+++ b/src/OpenApi/src/Microsoft.AspNetCore.OpenApi.csproj
@@ -7,7 +7,7 @@
     <!-- Needed to support compiling Utf8BufferTextWriter implementation shared with SignalR -->
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Description>Provides APIs for annotating route handler endpoints in ASP.NET Core with OpenAPI annotations.</Description>
-    <IsTrimmable>true</IsTrimmable>
+    <IsAotCompatible>true</IsAotCompatible>
     <!-- Required to generated native AoT friendly `MapOpenApi` endpoint. -->
     <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
     <InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.AspNetCore.Http.Generated</InterceptorsPreviewNamespaces>

--- a/src/OpenApi/src/Microsoft.AspNetCore.OpenApi.csproj
+++ b/src/OpenApi/src/Microsoft.AspNetCore.OpenApi.csproj
@@ -7,6 +7,10 @@
     <!-- Needed to support compiling Utf8BufferTextWriter implementation shared with SignalR -->
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Description>Provides APIs for annotating route handler endpoints in ASP.NET Core with OpenAPI annotations.</Description>
+    <IsTrimmable>true</IsTrimmable>
+    <!-- Required to generated native AoT friendly `MapOpenApi` endpoint. -->
+    <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
+    <InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.AspNetCore.Http.Generated</InterceptorsPreviewNamespaces>
   </PropertyGroup>
 
   <ItemGroup>
@@ -34,6 +38,11 @@
   <ItemGroup>
     <Compile Include="$(RepoRoot)/src/SignalR/common/Shared/Utf8BufferTextWriter.cs" LinkBase="Shared" />
     <Compile Include="$(RepoRoot)/src/SignalR/common/Shared/MemoryBufferWriter.cs" LinkBase="Shared" />
+  </ItemGroup>
+
+  <!-- Required to generated native AoT friendly `MapOpenApi` endpoint. -->
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenApi/src/Schemas/OpenApiJsonSchemaContext.cs
+++ b/src/OpenApi/src/Schemas/OpenApiJsonSchemaContext.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.AspNetCore.OpenApi;
+
+[JsonSerializable(typeof(OpenApiJsonSchema))]
+[JsonSerializable(typeof(string))]
+internal sealed partial class OpenApiJsonSchemaContext : JsonSerializerContext { }

--- a/src/OpenApi/src/Schemas/OpenApiSchemaJsonOptions.cs
+++ b/src/OpenApi/src/Schemas/OpenApiSchemaJsonOptions.cs
@@ -10,7 +10,7 @@ internal sealed class OpenApiSchemaJsonOptions : IConfigureOptions<JsonOptions>
 {
     public void Configure(JsonOptions options)
     {
-        // Put our resolver in front of the reflection-based one.
+        // Put our resolver in front of the reflection-based one. See ProblemDetailsJsonOptionsSetup for more info.
         options.SerializerOptions.TypeInfoResolverChain.Insert(0, OpenApiJsonSchemaContext.Default);
     }
 }

--- a/src/OpenApi/src/Schemas/OpenApiSchemaJsonOptions.cs
+++ b/src/OpenApi/src/Schemas/OpenApiSchemaJsonOptions.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Http.Json;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.OpenApi;
+
+internal sealed class OpenApiSchemaJsonOptions : IConfigureOptions<JsonOptions>
+{
+    public void Configure(JsonOptions options)
+    {
+        // Put our resolver in front of the reflection-based one.
+        options.SerializerOptions.TypeInfoResolverChain.Insert(0, OpenApiJsonSchemaContext.Default);
+    }
+}

--- a/src/OpenApi/src/Services/OpenApiComponentService.cs
+++ b/src/OpenApi/src/Services/OpenApiComponentService.cs
@@ -80,7 +80,8 @@ internal sealed class OpenApiComponentService(IOptions<JsonOptions> jsonOptions)
         {
             schemaAsJsonObject.ApplyParameterInfo(parameterDescription);
         }
-        return JsonSerializer.Deserialize<OpenApiJsonSchema>(schemaAsJsonObject)?.Schema ?? new OpenApiSchema();
+        var deserializedSchema = JsonSerializer.Deserialize(schemaAsJsonObject, OpenApiJsonSchemaContext.Default.OpenApiJsonSchema);
+        return deserializedSchema != null ? deserializedSchema.Schema : new OpenApiSchema();
     }
 
     private JsonObject CreateSchema((Type Type, ParameterInfo? ParameterInfo) key)

--- a/src/OpenApi/src/Services/OpenApiGenerator.cs
+++ b/src/OpenApi/src/Services/OpenApiGenerator.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -25,6 +26,8 @@ namespace Microsoft.AspNetCore.OpenApi;
 /// <summary>
 /// Defines a set of methods for generating OpenAPI definitions for endpoints.
 /// </summary>
+[RequiresUnreferencedCode("OpenApiGenerator performs reflection to generate OpenAPI descriptors. This cannot be statically analyzed.")]
+[RequiresDynamicCode("OpenApiGenerator performs reflection to generate OpenAPI descriptors. This cannot be statically analyzed.")]
 internal sealed class OpenApiGenerator
 {
     private readonly IHostEnvironment? _environment;

--- a/src/OpenApi/src/Transformers/TypeBasedOpenApiDocumentTransformer.cs
+++ b/src/OpenApi/src/Transformers/TypeBasedOpenApiDocumentTransformer.cs
@@ -8,14 +8,22 @@ using Microsoft.OpenApi.Models;
 
 namespace Microsoft.AspNetCore.OpenApi;
 
-internal sealed class TypeBasedOpenApiDocumentTransformer([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type transformerType) : IOpenApiDocumentTransformer
+internal sealed class TypeBasedOpenApiDocumentTransformer : IOpenApiDocumentTransformer
 {
-    private readonly ObjectFactory _transformerFactory = ActivatorUtilities.CreateFactory(transformerType, []);
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+    private readonly Type _transformerType;
+    private readonly ObjectFactory _transformerFactory;
+
+    internal TypeBasedOpenApiDocumentTransformer([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type transformerType)
+    {
+        _transformerType = transformerType;
+        _transformerFactory = ActivatorUtilities.CreateFactory(_transformerType, []);
+    }
 
     public async Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken)
     {
         var transformer = _transformerFactory.Invoke(context.ApplicationServices, []) as IOpenApiDocumentTransformer;
-        Debug.Assert(transformer != null, $"The type {transformerType} does not implement {nameof(IOpenApiDocumentTransformer)}.");
+        Debug.Assert(transformer != null, $"The type {_transformerType} does not implement {nameof(IOpenApiDocumentTransformer)}.");
         try
         {
             await transformer.TransformAsync(document, context, cancellationToken);

--- a/src/OpenApi/src/Transformers/TypeBasedOpenApiDocumentTransformer.cs
+++ b/src/OpenApi/src/Transformers/TypeBasedOpenApiDocumentTransformer.cs
@@ -2,12 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.AspNetCore.OpenApi;
 
-internal sealed class TypeBasedOpenApiDocumentTransformer(Type transformerType) : IOpenApiDocumentTransformer
+internal sealed class TypeBasedOpenApiDocumentTransformer([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type transformerType) : IOpenApiDocumentTransformer
 {
     private readonly ObjectFactory _transformerFactory = ActivatorUtilities.CreateFactory(transformerType, []);
 

--- a/src/OpenApi/test/Extensions/OpenApiEndpointRouteBuilderExtensionsTests.cs
+++ b/src/OpenApi/test/Extensions/OpenApiEndpointRouteBuilderExtensionsTests.cs
@@ -3,6 +3,8 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging;
 using Microsoft.AspNetCore.Routing;
 using static Microsoft.AspNetCore.OpenApi.Tests.OpenApiOperationGeneratorTests;
 using Microsoft.AspNetCore.Builder;
@@ -164,6 +166,7 @@ public class OpenApiEndpointRouteBuilderExtensionsTests : OpenApiDocumentService
             .AddSingleton<IServiceProviderIsService>(serviceProviderIsService)
             .AddSingleton<IHostEnvironment>(hostEnvironment)
             .AddSingleton(CreateApiDescriptionGroupCollectionProvider())
+            .AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance)
             .AddOpenApi(documentName)
             .BuildServiceProvider();
         return serviceProvider;


### PR DESCRIPTION
Part of https://github.com/dotnet/aspnetcore/issues/54598.

- Use RDG to source generate the `MapOpenApi` endpoint
- Use STJ source generation for (de)serialization
- Add RUC/RDC attributes where required
- Fix bug where RDG would emit code for complex form bound parameters