### PR TITLE
Add missing registry keys for Microsoft.AspNetCore.App

### DIFF
--- a/src/Installers/Windows/SharedFramework/Product.wxs
+++ b/src/Installers/Windows/SharedFramework/Product.wxs
@@ -117,7 +117,7 @@
             </Component>
             <?endif?>
 
-            <Component Id="C_ProductCentralVersion" Win64="no">
+            <Component Id="C_ProductCentralVersion" Directory="TARGETDIR" Win64="no">
                 <RegistryKey Key="$(var.ProductVersionCentralKey)" Root="HKLM">
                     <RegistryValue Action="write" Name="$(var.PackageVersion)" Type="integer" Value="1" KeyPath="yes"/>
                 </RegistryKey>

--- a/src/Installers/Windows/SharedFramework/Product.wxs
+++ b/src/Installers/Windows/SharedFramework/Product.wxs
@@ -73,6 +73,12 @@
 
             <?define ProductVersionKey=SOFTWARE\Microsoft\ASP.NET Core\Shared Framework\v$(var.MajorVersion).$(var.MinorVersion)\$(var.PackageVersion)?>
 
+            <?ifdef ProductVersionCentralKey?>
+            <?undef ProductVersionCentralKey?>
+            <?endif?>
+
+            <?define ProductVersionCentralKey=SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\$(var.Platform)\sharedfx?>
+
             <Component Id="C_ProductVersion">
                 <?if $(var.Platform)=x64 ?>
                 <!-- Only install when actually on native architecture -->
@@ -109,6 +115,12 @@
                 </RegistryKey>
             </Component>
             <?endif?>
+
+            <Component Id="C_ProductCentralVersion">
+                <RegistryKey Key="$(var.ProductVersionCentralKey)" Root="HKLM">
+                    <RegistryValue Name="Version" Type="string" Value="$(var.Version)" />
+                </RegistryKey>
+            </Component>
         </DirectoryRef>
     </Fragment>
 </Wix>

--- a/src/Installers/Windows/SharedFramework/Product.wxs
+++ b/src/Installers/Windows/SharedFramework/Product.wxs
@@ -116,12 +116,12 @@
                 </RegistryKey>
             </Component>
             <?endif?>
-
-            <Component Id="C_ProductCentralVersion" Directory="TARGETDIR" Win64="no">
-                <RegistryKey Key="$(var.ProductVersionCentralKey)" Root="HKLM">
-                    <RegistryValue Action="write" Name="$(var.PackageVersion)" Type="integer" Value="1" KeyPath="yes"/>
-                </RegistryKey>
-            </Component>
         </DirectoryRef>
+
+        <Component Id="C_ProductCentralVersion" Directory="TARGETDIR" Win64="no">
+            <RegistryKey Key="$(var.ProductVersionCentralKey)" Root="HKLM">
+                <RegistryValue Action="write" Name="$(var.PackageVersion)" Type="integer" Value="1" KeyPath="yes"/>
+            </RegistryKey>
+        </Component>
     </Fragment>
 </Wix>

--- a/src/Installers/Windows/SharedFramework/Product.wxs
+++ b/src/Installers/Windows/SharedFramework/Product.wxs
@@ -60,7 +60,7 @@
             <ComponentRef Id="C_ProductVersion_NonNative" />
             <ComponentRef Id="C_ProductInstallDir_NonNative" />
             <?endif?>
-            <ComponentRef ID="C_ProductCentralVersion" />
+            <ComponentRef Id="C_ProductCentralVersion" />
         </ComponentGroup>
 
         <DirectoryRef Id="SharedFolder">

--- a/src/Installers/Windows/SharedFramework/Product.wxs
+++ b/src/Installers/Windows/SharedFramework/Product.wxs
@@ -60,6 +60,7 @@
             <ComponentRef Id="C_ProductVersion_NonNative" />
             <ComponentRef Id="C_ProductInstallDir_NonNative" />
             <?endif?>
+            <ComponentRef ID="C_ProductCentralVersion" />
         </ComponentGroup>
 
         <DirectoryRef Id="SharedFolder">

--- a/src/Installers/Windows/SharedFramework/Product.wxs
+++ b/src/Installers/Windows/SharedFramework/Product.wxs
@@ -119,7 +119,7 @@
 
             <Component Id="C_ProductCentralVersion" Win64="no">
                 <RegistryKey Key="$(var.ProductVersionCentralKey)" Root="HKLM">
-                    <RegistryValue Action="write" Name="$(var.Version)" Type="integer" Value="1" KeyPath="yes"/>
+                    <RegistryValue Action="write" Name="$(var.PackageVersion)" Type="integer" Value="1" KeyPath="yes"/>
                 </RegistryKey>
             </Component>
         </DirectoryRef>

--- a/src/Installers/Windows/SharedFramework/Product.wxs
+++ b/src/Installers/Windows/SharedFramework/Product.wxs
@@ -78,7 +78,7 @@
             <?undef ProductVersionCentralKey?>
             <?endif?>
 
-            <?define ProductVersionCentralKey=SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\$(var.Platform)\sharedfx?>
+            <?define ProductVersionCentralKey=SOFTWARE\dotnet\Setup\InstalledVersions\$(var.Platform)\sharedfx\Microsoft.AspNetCore.App?>
 
             <Component Id="C_ProductVersion">
                 <?if $(var.Platform)=x64 ?>
@@ -117,9 +117,9 @@
             </Component>
             <?endif?>
 
-            <Component Id="C_ProductCentralVersion">
+            <Component Id="C_ProductCentralVersion" Win64="no">
                 <RegistryKey Key="$(var.ProductVersionCentralKey)" Root="HKLM">
-                    <RegistryValue Name="Version" Type="string" Value="$(var.Version)" />
+                    <RegistryValue Action="write" Name="$(var.Version)" Type="integer" Value="1" KeyPath="yes"/>
                 </RegistryKey>
             </Component>
         </DirectoryRef>


### PR DESCRIPTION
Should fix https://github.com/dotnet/aspnetcore/issues/55368. If it works we should backport to 6.0 & 80

Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2442651&view=results