### PR TITLE
Set default devcontainer to 8 cores

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -35,5 +35,8 @@
     "DOTNET_WATCH_SUPPRESS_LAUNCH_BROWSER": "true"
   },
   // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-  "remoteUser": "vscode"
+  "remoteUser": "vscode",
+  "hostRequirements": {
+    "cpus": 8
+  }
 }


### PR DESCRIPTION
Set the default devcontainer size to 8 cores to ensure there's enough disk space.

https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/configuring-dev-containers/setting-a-minimum-specification-for-codespace-machines#setting-a-minimum-machine-specification

An alternative would be to set the minimum disk size, currently both get you the same 8 core vm though.

Fixes #55272
