### PR TITLE
Fix generating XML doc comments for query parameters in gRPC JSON transcoding

### DIFF
--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Proto/xmldoc.proto
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Proto/xmldoc.proto
@@ -35,6 +35,12 @@ service XmlDoc {
       delete: "/v1/greeter/{name}"
     };
   }
+  // QueryGet!
+  rpc QueryGet (StringRequestWithDetail) returns (StringReply) {
+    option (google.api.http) = {
+      get: "/v1/greeter/query/{name}"
+    };
+  }
 }
 
 // StringRequest!

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/XmlComments/XmlDocumentationIntegrationTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/XmlComments/XmlDocumentationIntegrationTests.cs
@@ -109,6 +109,29 @@ public class XmlDocumentationIntegrationTests
     }
 
     [Fact]
+    public void Parameters_QueryParameters_ProtoFieldDocs()
+    {
+        // Arrange & Act
+        var swagger = OpenApiTestHelpers.GetOpenApiDocument<XmlDocService>(_testOutputHelper);
+
+        // Assert
+        var path = swagger.Paths["/v1/greeter/query/{name}"];
+        Assert.Collection(path.Operations[OperationType.Get].Parameters,
+            p =>
+            {
+                Assert.Equal(ParameterLocation.Path, p.In);
+                Assert.Equal("name", p.Name);
+                Assert.Equal("Name field!", p.Description);
+            },
+            p =>
+            {
+                Assert.Equal(ParameterLocation.Query, p.In);
+                Assert.Equal("detail.age", p.Name);
+                Assert.Equal("Age field!", p.Description);
+            });
+    }
+
+    [Fact]
     public void Message_UseProtoDocs()
     {
         // Arrange & Act


### PR DESCRIPTION
Fix query parameters in gRPC JSON transcoding not setting the parameter description value.