### PR TITLE
Remove triggers for release/7.0

### DIFF
--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -18,7 +18,6 @@ schedules:
   branches:
     include:
     - release/6.0
-    - release/7.0
     - release/8.0
   always: false
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -84,18 +84,6 @@ updates:
     allow:
       - dependency-type: "all"
     commit-message:
-      prefix: "[release/7.0] "
-      include: scope
-    labels:
-      - area-infrastructure
-    target-branch: "release/7.0"
-  - package-ecosystem: "gitsubmodule"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    allow:
-      - dependency-type: "all"
-    commit-message:
       prefix: "[release/8.0] "
       include: scope
     labels:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -597,21 +597,6 @@ configuration:
       - isAction:
           action: Opened
       - targetsBranch:
-          branch: release/7.0
-      then:
-      - addMilestone:
-          milestone: 7.0.x
-      - addReply:
-          reply: >-
-            Hi @${issueAuthor}. If this is not a tell-mode PR, please make sure to follow the instructions laid out in the [servicing process](https://aka.ms/aspnet/servicing) document.
-
-            Otherwise, please add `tell-mode` label.
-      description: Add release/7.0 targeting PRs to the servicing project
-    - if:
-      - payloadType: Pull_Request
-      - isAction:
-          action: Opened
-      - targetsBranch:
           branch: release/6.0
       then:
       - addMilestone:


### PR DESCRIPTION
release/7.0 is officially out of support, so we don't need to build it or have automation for it anymore.