### PR TITLE
removing pure comment

### DIFF
--- a/src/SignalR/clients/ts/signalr/src/Utils.ts
+++ b/src/SignalR/clients/ts/signalr/src/Utils.ts
@@ -236,8 +236,7 @@ export function constructUserAgent(version: string, os: string, runtime: string,
     return userAgent;
 }
 
-// eslint-disable-next-line spaced-comment
-/*#__PURE__*/ function getOsName(): string {
+function getOsName(): string {
     if (Platform.isNode) {
         switch (process.platform) {
             case "win32":
@@ -254,8 +253,7 @@ export function constructUserAgent(version: string, os: string, runtime: string,
     }
 }
 
-// eslint-disable-next-line spaced-comment
-/*#__PURE__*/ function getRuntimeVersion(): string | undefined {
+function getRuntimeVersion(): string | undefined {
     if (Platform.isNode) {
         return process.versions.node;
     }


### PR DESCRIPTION
# Remove Pure comment to prevent warning when building with rollup


- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.



## Description
there is a warning that happens when you build a package with rollup or vite.

```
node_modules/@microsoft/signalr/dist/esm/Utils.js (189:0): A comment

"/*#__PURE__*/"

in "node_modules/@microsoft/signalr/dist/esm/Utils.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.
node_modules/@microsoft/signalr/dist/esm/Utils.js (207:0): A comment

"/*#__PURE__*/"

in "node_modules/@microsoft/signalr/dist/esm/Utils.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.
````
Rollup expects the `"/*#__PURE__*/"` annotations on function calls or constructor invocation, not on module function declaration.

> Comments containing @__PURE__ or #__PURE__ mark a specific function call or constructor invocation as side effect free. That means that Rollup will tree-shake i.e. remove the call unless the return value is used in some code that is not tree-shaken. These annotations need to immediately precede the call invocation to take effect. The following code will be completely tree-shaken unless this option is set to false, in which case it will remain unchanged.

https://rollupjs.org/configuration-options/#pure

You can reproduce the issue with the [Rollup REPL](https://rollupjs.org/repl/?version=4.5.0&shareable=JTdCJTIyZXhhbXBsZSUyMiUzQSUyMiUyMiUyQyUyMm1vZHVsZXMlMjIlM0ElNUIlN0IlMjJjb2RlJTIyJTNBJTIyJTJGJTJGJTIwZXNsaW50LWRpc2FibGUtbmV4dC1saW5lJTIwc3BhY2VkLWNvbW1lbnQlNUNuJTJGKiUyM19fUFVSRV9fKiUyRiUyMGZ1bmN0aW9uJTIwZ2V0T3NOYW1lKCklMjAlN0IlNUNuJTIwJTIwJTIwJTIwaWYlMjAoUGxhdGZvcm0uaXNOb2RlKSUyMCU3QiU1Q24lMjAlMjAlMjAlMjAlMjAlMjAlMjAlMjBzd2l0Y2glMjAocHJvY2Vzcy5wbGF0Zm9ybSklMjAlN0IlNUNuJTIwJTIwJTIwJTIwJTIwJTIwJTIwJTIwJTIwJTIwJTIwJTIwY2FzZSUyMCU1QyUyMndpbjMyJTVDJTIyJTNBJTVDbiUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMHJldHVybiUyMCU1QyUyMldpbmRvd3MlMjBOVCU1QyUyMiUzQiU1Q24lMjAlMjAlMjAlMjAlMjAlMjAlMjAlMjAlMjAlMjAlMjAlMjBjYXNlJTIwJTVDJTIyZGFyd2luJTVDJTIyJTNBJTVDbiUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMHJldHVybiUyMCU1QyUyMm1hY09TJTVDJTIyJTNCJTVDbiUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMGNhc2UlMjAlNUMlMjJsaW51eCU1QyUyMiUzQSU1Q24lMjAlMjAlMjAlMjAlMjAlMjAlMjAlMjAlMjAlMjAlMjAlMjAlMjAlMjAlMjAlMjByZXR1cm4lMjAlNUMlMjJMaW51eCU1QyUyMiUzQiU1Q24lMjAlMjAlMjAlMjAlMjAlMjAlMjAlMjAlMjAlMjAlMjAlMjBkZWZhdWx0JTNBJTVDbiUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMHJldHVybiUyMHByb2Nlc3MucGxhdGZvcm0lM0IlNUNuJTIwJTIwJTIwJTIwJTIwJTIwJTIwJTIwJTdEJTVDbiUyMCUyMCUyMCUyMCU3RCU1Q24lMjAlMjAlMjAlMjBlbHNlJTIwJTdCJTVDbiUyMCUyMCUyMCUyMCUyMCUyMCUyMCUyMHJldHVybiUyMCU1QyUyMiU1QyUyMiUzQiU1Q24lMjAlMjAlMjAlMjAlN0QlNUNuJTdEJTIyJTJDJTIyaXNFbnRyeSUyMiUzQXRydWUlMkMlMjJuYW1lJTIyJTNBJTIybWFpbi5qcyUyMiU3RCU1RCUyQyUyMm9wdGlvbnMlMjIlM0ElN0IlN0QlN0Q=)


Fixes #55286 
