### PR TITLE
Add internal pipeline for IdentityModel nightlies

### DIFF
--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -8,12 +8,6 @@ schedules:
     include:
     - main
   always: true
-- cron: "0 18 * * *"
-  branches:
-    include:
-    - main
-  always: true
-  displayName: IdentityModel test job
 - cron: "0 9 * * *"
   branches:
     include:
@@ -24,8 +18,6 @@ schedules:
 variables:
 - name: _UseHelixOpenQueues
   value: ${{ ne(variables['System.TeamProject'], 'internal') }}
-- name: _IsIdentityModelTestJob
-  value: ${{ eq(variables['Build.CronSchedule.DisplayName'], 'IdentityModel test job') }}
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-HelixApi-Access
 - template: /eng/common/templates/variables/pool-providers.yml
@@ -38,17 +30,14 @@ jobs:
     agentOs: Windows
     timeoutInMinutes: 300
     steps:
-    - ${{ if eq(variables['Build.CronSchedule.DisplayName'], 'IdentityModel test job') }}:
-      - script: echo "##vso[build.addbuildtag]identitymodel-test"
-        displayName: 'Set CI identitymodel-test tag'
     # Build the shared framework
     - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -nobl -all -pack -arch x64
-              /p:CrossgenOutput=false /p:IsIdentityModelTestJob=$(_IsIdentityModelTestJob) /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
+              /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Build shared fx
     # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
     - script: .\eng\build.cmd -ci -prepareMachine -nobl -all -noBuildRepoTasks -noBuildNative -noBuild -test
               -projects eng\helix\helix.proj /p:IsHelixJob=true
-              /p:CrossgenOutput=false /p:IsIdentityModelTestJob=$(_IsIdentityModelTestJob) /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
+              /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.cmd helix target
       env:
         HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues

--- a/.azure/pipelines/identitymodel-helix-matrix.yml
+++ b/.azure/pipelines/identitymodel-helix-matrix.yml
@@ -1,0 +1,76 @@
+# We only want to run IdentityModel matrix on main
+pr: none
+trigger: none
+schedules:
+# Cron timezone is UTC.
+- cron: "0 */12 * * *"
+  branches:
+    include:
+    - main
+    - release/8.0
+  always: true
+
+variables:
+- name: _UseHelixOpenQueues
+  value: false
+- group: DotNet-HelixApi-Access
+- template: /eng/common/templates/variables/pool-providers.yml
+
+jobs:
+- template: jobs/default-build.yml
+  parameters:
+    jobName: Helix_matrix_x64
+    jobDisplayName: 'Tests: IdentityModel nightlies helix full matrix x64'
+    agentOs: Windows
+    timeoutInMinutes: 300
+    steps:
+    - task: NuGetAuthenticate@1
+    - task: NuGetCommand@2
+      displayName: Install Microsoft.IdentityModel.Logging
+      inputs:
+        command: 'custom'
+        arguments: 'install Microsoft.IdentityModel.Logging
+                    -Source https://pkgs.dev.azure.com/dnceng/internal/_packaging/identitymodel-nightlies/nuget/v3/index.json 
+                    -DependencyVersion Highest -PreRelease'
+    - task: NuGetCommand@2
+      inputs:
+      displayName: Install Microsoft.IdentityModel.Protocols.OpenIdConnect
+        command: 'custom'
+        arguments: 'install Microsoft.IdentityModel.Protocols.OpenIdConnect
+                    -Source https://pkgs.dev.azure.com/dnceng/internal/_packaging/identitymodel-nightlies/nuget/v3/index.json 
+                    -DependencyVersion Highest -PreRelease'
+    - task: NuGetCommand@2
+      inputs:
+      displayName: Install Microsoft.IdentityModel.Protocols.WsFederation
+        command: 'custom'
+        arguments: 'install Microsoft.IdentityModel.Protocols.WsFederation
+                    -Source https://pkgs.dev.azure.com/dnceng/internal/_packaging/identitymodel-nightlies/nuget/v3/index.json 
+                    -DependencyVersion Highest -PreRelease'
+    - task: NuGetCommand@2
+      inputs:
+      displayName: System.IdentityModel.Tokens.Jwt
+        command: 'custom'
+        arguments: 'install System.IdentityModel.Tokens.Jwt
+                    -Source https://pkgs.dev.azure.com/dnceng/internal/_packaging/identitymodel-nightlies/nuget/v3/index.json 
+                    -DependencyVersion Highest -PreRelease'
+    - task: PowerShell@2
+      displayName: Add IdentityModel feel to NuGet.config
+      inputs:
+        filePath: $(Build.SourcesDirectory)/eng/scripts/SetupIdentitySources.ps1
+        arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config
+    # Build the shared framework
+    - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -nobl -all -pack -arch x64
+              /p:CrossgenOutput=false /p:IsIdentityModelTestJob=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
+      displayName: Build shared fx
+    # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
+    - script: .\eng\build.cmd -ci -prepareMachine -nobl -all -noBuildRepoTasks -noBuildNative -noBuild -test
+              -projects eng\helix\helix.proj /p:IsHelixJob=true
+              /p:CrossgenOutput=false /p:IsIdentityModelTestJob=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
+      displayName: Run build.cmd helix target
+      env:
+        HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
+    artifacts:
+    - name: Helix_logs
+      path: artifacts/log/
+      publishOnError: true

--- a/.azure/pipelines/identitymodel-helix-matrix.yml
+++ b/.azure/pipelines/identitymodel-helix-matrix.yml
@@ -19,7 +19,7 @@ variables:
 jobs:
 - template: jobs/default-build.yml
   parameters:
-    jobName: Helix_matrix_x64
+    jobName: IdentityModel_helix_matrix_x64
     jobDisplayName: 'Tests: IdentityModel nightlies helix full matrix x64'
     agentOs: Windows
     timeoutInMinutes: 300

--- a/eng/scripts/SetupIdentitySources.ps1
+++ b/eng/scripts/SetupIdentitySources.ps1
@@ -1,0 +1,45 @@
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory = $true)][string]$ConfigFile
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version 2.0
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+# Add source entry to PackageSources
+function AddPackageSource($sources, $SourceName, $SourceEndPoint) {
+    $packageSource = $sources.SelectSingleNode("add[@key='$SourceName']")
+    
+    if ($packageSource -eq $null)
+    {
+        $packageSource = $doc.CreateElement("add")
+        $packageSource.SetAttribute("key", $SourceName)
+        $packageSource.SetAttribute("value", $SourceEndPoint)
+        $sources.AppendChild($packageSource) | Out-Null
+    }
+    else {
+        Write-Host "Package source $SourceName already present."
+    }
+}
+
+if (!(Test-Path $ConfigFile -PathType Leaf)) {
+  Write-PipelineTelemetryError -Category 'Build' -Message "eng/scripts/SetupIdentitySources.ps1 returned a non-zero exit code. Couldn't find the NuGet config file: $ConfigFile"
+  ExitWithExitCode 1
+}
+
+# Load NuGet.config
+$doc = New-Object System.Xml.XmlDocument
+$filename = (Get-Item $ConfigFile).FullName
+$doc.Load($filename)
+
+# Get reference to <PackageSources> or create one if none exist already
+$sources = $doc.DocumentElement.SelectSingleNode("packageSources")
+if ($sources -eq $null) {
+    $sources = $doc.CreateElement("packageSources")
+    $doc.DocumentElement.AppendChild($sources) | Out-Null
+}
+
+AddPackageSource -Sources $sources -SourceName "identitymodel-nightlies" -SourceEndPoint "https://pkgs.dev.azure.com/dnceng/internal/_packaging/identitymodel-nightlies/nuget/v3/index.json"
+
+$doc.Save($filename)


### PR DESCRIPTION
Plan is to use https://dev.azure.com/dnceng/internal/_build?definitionId=928 (which is currently disabled) as the test pipeline for running our tests against the latest nightlies from the IdentityModel team. Won't be able to test this until the PR is merged as we'll have to re-direct that pipeline to point to `Identitymodel-helix-matrix.yml`, but this PR is essentially purely additive, so it shouldn't break anything to merge it then iterate.