### PR TITLE
Use DisposeAsync in FileStreamResultExecutor

### DIFF
--- a/src/Mvc/Mvc.Core/src/Infrastructure/FileStreamResultExecutor.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/FileStreamResultExecutor.cs
@@ -28,7 +28,7 @@ public partial class FileStreamResultExecutor : FileResultExecutorBase, IActionR
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(result);
 
-        using (result.FileStream)
+        await using (result.FileStream)
         {
             Log.ExecutingFileResult(Logger, result);
 

--- a/src/Mvc/Mvc.Core/test/Infrastructure/FileStreamResultExecutorTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/FileStreamResultExecutorTest.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Mvc.Infrastructure;
+
+public class FileStreamResultExecutorTest
+{
+	[Fact]
+	public async Task ExecuteAsync_DisposesStreamAsync()
+	{
+		// Arrange
+		var executor = CreateExecutor();
+
+		var httpContext = new DefaultHttpContext();
+		var actionContext = new ActionContext() { HttpContext = httpContext };
+
+		var stream = new AsyncOnlyStream();
+		var result = new FileStreamResult(stream, "text/plain");
+
+		// Act
+		await executor.ExecuteAsync(actionContext, result);
+
+		// Assert
+		Assert.True(stream.DidDisposeAsync);
+	}
+
+	private static FileStreamResultExecutor CreateExecutor()
+	{
+		return new FileStreamResultExecutor(NullLoggerFactory.Instance);
+	}
+
+	private class AsyncOnlyStream : Stream
+	{
+		public override bool CanRead => true;
+
+		public override bool CanSeek => false;
+
+		public override bool CanWrite => false;
+
+		public override long Length => throw new NotImplementedException();
+
+		public override long Position { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+		public override void Flush() { }
+
+		public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException("Must use ReadAsync");
+
+		public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+			=> Task.FromResult(0);
+
+		public override long Seek(long offset, SeekOrigin origin) => throw new NotImplementedException();
+
+		public override void SetLength(long value) => throw new NotImplementedException();
+
+		public override void Write(byte[] buffer, int offset, int count) => throw new NotImplementedException();
+
+		protected override void Dispose(bool disposing) => throw new NotSupportedException("Must use DisposeAsync");
+
+		public bool DidDisposeAsync { get; private set; }
+
+		public override ValueTask DisposeAsync()
+		{
+			DidDisposeAsync = true;
+			return ValueTask.CompletedTask;
+		}
+	}
+}

--- a/src/Mvc/Mvc.Core/test/Infrastructure/FileStreamResultExecutorTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/FileStreamResultExecutorTest.cs
@@ -8,63 +8,63 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure;
 
 public class FileStreamResultExecutorTest
 {
-	[Fact]
-	public async Task ExecuteAsync_DisposesStreamAsync()
-	{
-		// Arrange
-		var executor = CreateExecutor();
+    [Fact]
+    public async Task ExecuteAsync_DisposesStreamAsync()
+    {
+        // Arrange
+        var executor = CreateExecutor();
 
-		var httpContext = new DefaultHttpContext();
-		var actionContext = new ActionContext() { HttpContext = httpContext };
+        var httpContext = new DefaultHttpContext();
+        var actionContext = new ActionContext() { HttpContext = httpContext };
 
-		var stream = new AsyncOnlyStream();
-		var result = new FileStreamResult(stream, "text/plain");
+        var stream = new AsyncOnlyStream();
+        var result = new FileStreamResult(stream, "text/plain");
 
-		// Act
-		await executor.ExecuteAsync(actionContext, result);
+        // Act
+        await executor.ExecuteAsync(actionContext, result);
 
-		// Assert
-		Assert.True(stream.DidDisposeAsync);
-	}
+        // Assert
+        Assert.True(stream.DidDisposeAsync);
+    }
 
-	private static FileStreamResultExecutor CreateExecutor()
-	{
-		return new FileStreamResultExecutor(NullLoggerFactory.Instance);
-	}
+    private static FileStreamResultExecutor CreateExecutor()
+    {
+        return new FileStreamResultExecutor(NullLoggerFactory.Instance);
+    }
 
-	private class AsyncOnlyStream : Stream
-	{
-		public override bool CanRead => true;
+    private class AsyncOnlyStream : Stream
+    {
+        public override bool CanRead => true;
 
-		public override bool CanSeek => false;
+        public override bool CanSeek => false;
 
-		public override bool CanWrite => false;
+        public override bool CanWrite => false;
 
-		public override long Length => throw new NotImplementedException();
+        public override long Length => throw new NotImplementedException();
 
-		public override long Position { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public override long Position { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
-		public override void Flush() { }
+        public override void Flush() { }
 
-		public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException("Must use ReadAsync");
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException("Must use ReadAsync");
 
-		public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-			=> Task.FromResult(0);
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => Task.FromResult(0);
 
-		public override long Seek(long offset, SeekOrigin origin) => throw new NotImplementedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotImplementedException();
 
-		public override void SetLength(long value) => throw new NotImplementedException();
+        public override void SetLength(long value) => throw new NotImplementedException();
 
-		public override void Write(byte[] buffer, int offset, int count) => throw new NotImplementedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotImplementedException();
 
-		protected override void Dispose(bool disposing) => throw new NotSupportedException("Must use DisposeAsync");
+        protected override void Dispose(bool disposing) => throw new NotSupportedException("Must use DisposeAsync");
 
-		public bool DidDisposeAsync { get; private set; }
+        public bool DidDisposeAsync { get; private set; }
 
-		public override ValueTask DisposeAsync()
-		{
-			DidDisposeAsync = true;
-			return ValueTask.CompletedTask;
-		}
-	}
+        public override ValueTask DisposeAsync()
+        {
+            DidDisposeAsync = true;
+            return ValueTask.CompletedTask;
+        }
+    }
 }

--- a/src/Shared/ResultsHelpers/FileResultHelper.cs
+++ b/src/Shared/ResultsHelpers/FileResultHelper.cs
@@ -30,7 +30,7 @@ internal static partial class FileResultHelper
     {
         const int BufferSize = 64 * 1024;
         var outputStream = context.Response.Body;
-        using (fileStream)
+        await using (fileStream)
         {
             try
             {


### PR DESCRIPTION
# Use DisposeAsync in FileStreamResultExecutor

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

Support file streams that require DisposeAsync

Fixes #55441
