### PR TITLE
Fix Kestrel HTTP/3 tests

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionContext.cs
@@ -183,7 +183,7 @@ internal partial class QuicConnectionContext : TransportMultiplexedConnection
             }
         }
 #if DEBUG
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not ConnectionResetException)
         {
             Debug.Fail($"Unexpected exception in {nameof(QuicConnectionContext)}.{nameof(AcceptAsync)}: {ex}");
             throw;


### PR DESCRIPTION
I noticed a couple of HTTP/3 tests were failing. However, the error is in unchanged logic and is odd.

Basically:
1. Accept connection inside try. There are multiple catches.
2. Catch expected error and rethrow.
3. Another catch then catches the exception thrown inside catch (!?!?)

```cs
try
{
    return await connection.AcceptAsync(); // ExpectedException is thrown.
}
catch (ExpectedException ex)
{
    throw new MyException("Blah", ex); // ExpectedException is caught and rethrown as MyException.
}
catch (Exception ex)
{
    Debug.Fail("Should never be here"); // MyException is caught here?!
    throw;
}
```

The rethrown `MyException` is being caught in the last catch and `Debug.Fail` is running. I didn't know try/catch worked like that.

Current `Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests.QuicConnectionContextTests.AcceptAsync_ClientClosesConnection_ServerNotified` result:

```
Assert.Throws() Failure
Expected: typeof(Microsoft.AspNetCore.Connections.ConnectionResetException)
Actual:   typeof(Microsoft.VisualStudio.TestPlatform.TestHost.DebugAssertException): Method Debug.Fail failed with 'Unexpected exception in QuicConnectionContext.AcceptAsync: Microsoft.AspNetCore.Connections.ConnectionResetException: Connection aborted by peer (256).
           ---> System.Net.Quic.QuicException: Connection aborted by peer (256).
             at System.Net.Quic.QuicConnection.HandleEventShutdownInitiatedByPeer(_SHUTDOWN_INITIATED_BY_PEER_e__Struct& data)
             at System.Net.Quic.QuicConnection.HandleConnectionEvent(QUIC_CONNECTION_EVENT& connectionEvent)
             at System.Net.Quic.QuicConnection.NativeCallback(QUIC_HANDLE* connection, Void* context, QUIC_CONNECTION_EVENT* connectionEvent)
          --- End of stack trace from previous location ---
             at System.Net.Quic.QuicConnection.AcceptInboundStreamAsync(CancellationToken cancellationToken)
             at Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal.QuicConnectionContext.AcceptAsync(CancellationToken cancellationToken) in C:\Development\Source\aspnetcore\src\Servers\Kestrel\Transport.Quic\src\Internal\QuicConnectionContext.cs:line 96
             --- End of inner exception stack trace ---
             at Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal.QuicConnectionContext.AcceptAsync(CancellationToken cancellationToken) in C:\Development\Source\aspnetcore\src\Servers\Kestrel\Transport.Quic\src\Internal\QuicConnectionContext.cs:line 144
          ', and was translated to Microsoft.VisualStudio.TestPlatform.TestHost.DebugAssertException to avoid terminating the process hosting the test.
---- Microsoft.VisualStudio.TestPlatform.TestHost.DebugAssertException : Method Debug.Fail failed with 'Unexpected exception in QuicConnectionContext.AcceptAsync: Microsoft.AspNetCore.Connections.ConnectionResetException: Connection aborted by peer (256).
 ---> System.Net.Quic.QuicException: Connection aborted by peer (256).
   at System.Net.Quic.QuicConnection.HandleEventShutdownInitiatedByPeer(_SHUTDOWN_INITIATED_BY_PEER_e__Struct& data)
   at System.Net.Quic.QuicConnection.HandleConnectionEvent(QUIC_CONNECTION_EVENT& connectionEvent)
   at System.Net.Quic.QuicConnection.NativeCallback(QUIC_HANDLE* connection, Void* context, QUIC_CONNECTION_EVENT* connectionEvent)
--- End of stack trace from previous location ---
   at System.Net.Quic.QuicConnection.AcceptInboundStreamAsync(CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal.QuicConnectionContext.AcceptAsync(CancellationToken cancellationToken) in C:\Development\Source\aspnetcore\src\Servers\Kestrel\Transport.Quic\src\Internal\QuicConnectionContext.cs:line 96
   --- End of inner exception stack trace ---
   at Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal.QuicConnectionContext.AcceptAsync(CancellationToken cancellationToken) in C:\Development\Source\aspnetcore\src\Servers\Kestrel\Transport.Quic\src\Internal\QuicConnectionContext.cs:line 144
', and was translated to Microsoft.VisualStudio.TestPlatform.TestHost.DebugAssertException to avoid terminating the process hosting the test.
```