### PR TITLE
Update InternalServerError.cs

### DIFF
--- a/src/Http/Http.Results/src/InternalServerError.cs
+++ b/src/Http/Http.Results/src/InternalServerError.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.Reflection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Metadata;


### PR DESCRIPTION
The license header was missing which caused unified-build to fail.

>     D:\a\_work\1\vmr\src\aspnetcore\src\Http\Http.Results\src\InternalServerError.cs(1,1): error IDE0073: A source file is missing a required header. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0073) [D:\a\_work\1\vmr\src\aspnetcore\src\Http\Http.Results\src\Microsoft.AspNetCore.Http.Results.csproj]