### PR TITLE
Use JSON source generator in WebApplicationFactory

### DIFF
--- a/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
+++ b/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Reflection;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.TestHost;
@@ -21,7 +22,7 @@ namespace Microsoft.AspNetCore.Mvc.Testing;
 /// </summary>
 /// <typeparam name="TEntryPoint">A type in the entry point assembly of the application.
 /// Typically the Startup or Program classes can be used.</typeparam>
-public class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDisposable where TEntryPoint : class
+public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDisposable where TEntryPoint : class
 {
     private bool _disposed;
     private bool _disposedAsync;
@@ -235,7 +236,7 @@ public class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDisposable 
 
     private static string? GetContentRootFromFile(string file)
     {
-        var data = JsonSerializer.Deserialize<IDictionary<string, string>>(File.ReadAllBytes(file))!;
+        var data = JsonSerializer.Deserialize(File.ReadAllBytes(file), CustomJsonSerializerContext.Default.IDictionaryStringString)!;
         var key = typeof(TEntryPoint).Assembly.GetName().FullName;
 
         // If the `ContentRoot` is not provided in the app manifest, then return null
@@ -247,6 +248,9 @@ public class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDisposable 
 
         return (contentRoot == "~") ? AppContext.BaseDirectory : contentRoot;
     }
+
+    [JsonSerializable(typeof(IDictionary<string, string>))]
+    private sealed partial class CustomJsonSerializerContext : JsonSerializerContext;
 
     private string? GetContentRootFromAssembly()
     {


### PR DESCRIPTION
# Use JSON source generator in WebApplicationFactory

Use JSON source generator to deserialize dictionary.

## Description

Use JSON source generator to deserialize JSON to prevent `InvalidOperationException` in a test project with `JsonSerializerIsReflectionEnabledByDefault=false`.

I wasn't sure how to test this without having to add an entirely new test project - happy to add something if someone can give a suggestion on how to go about that in a way that would be acceptable to the team.

Fixes #55586
