### PR TITLE
Covariant THub-Parameter

### DIFF
--- a/src/SignalR/server/Core/src/IHubContext`T.cs
+++ b/src/SignalR/server/Core/src/IHubContext`T.cs
@@ -6,7 +6,7 @@ namespace Microsoft.AspNetCore.SignalR;
 /// <summary>
 /// A context abstraction for a hub.
 /// </summary>
-public interface IHubContext<THub, T>
+public interface IHubContext<out THub, T>
     where THub : Hub<T>
     where T : class
 {


### PR DESCRIPTION
# Covariant THub-Parameter

Make generics version of `IHubContext` parameter covariant (analogous to the not generic version).

Fixes #50705