### PR TITLE
Fix flaky CanRenderComponentWithPersistedState test variations

### DIFF
--- a/src/Components/test/testassets/BasicTestApp/wwwroot/JSInitializers/Modern/BasicTestApp.lib.module.js
+++ b/src/Components/test/testassets/BasicTestApp/wwwroot/JSInitializers/Modern/BasicTestApp.lib.module.js
@@ -30,7 +30,6 @@ export function beforeServerStart(options) {
     return new Promise((resolve, reject) => {
         options.circuitHandlers.push({
             onCircuitOpened: () => {
-                debugger;
                 appendElement('modern-circuit-opened', 'Modern "circuitOpened"');
             },
             onCircuitClosed: () => appendElement('modern-circuit-closed', 'Modern "circuitClosed"')

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/App.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/App.razor
@@ -18,24 +18,41 @@
     <script src="_framework/blazor.web.js" autostart="false" suppress-error="BL9992"></script>
     <script src="_content/TestContentPackage/counterInterop.js"></script>
     <script>
-        const enableClassicInitializers = sessionStorage.getItem('enable-classic-initializers') === 'true';
-        const suppressEnhancedNavigation = sessionStorage.getItem('suppress-enhanced-navigation') === 'true';
-        const blockLoadBootResource = sessionStorage.getItem('block-load-boot-resource') === 'true';
-        sessionStorage.removeItem('suppress-enhanced-navigation');
-        sessionStorage.removeItem('block-load-boot-resource');
-        sessionStorage.removeItem('enable-classic-initializers');
-
-        let loadBootResourceUnblocked = null;
-        if (blockLoadBootResource) {
-            loadBootResourceUnblocked = new Promise(resolve => {
-                window.unblockLoadBootResource = resolve;
-            });
+        function appendHiddenParagraph(id) {
+            const paragraph = document.createElement('p');
+            paragraph.id = id;
+            paragraph.style = 'display: none;';
+            document.body.appendChild(paragraph);
         }
 
-        let maxParallelResourceDownloadCount = 0;
-        let currentParallelResourceDownloadCount = 0;
-
         function callBlazorStart() {
+            const enableClassicInitializers = sessionStorage.getItem('enable-classic-initializers') === 'true';
+            const suppressEnhancedNavigation = sessionStorage.getItem('suppress-enhanced-navigation') === 'true';
+            const blockLoadBootResource = sessionStorage.getItem('block-load-boot-resource') === 'true';
+            sessionStorage.removeItem('suppress-enhanced-navigation');
+            sessionStorage.removeItem('block-load-boot-resource');
+            sessionStorage.removeItem('enable-classic-initializers');
+
+            let loadBootResourceUnblocked = null;
+            if (blockLoadBootResource) {
+                loadBootResourceUnblocked = new Promise(resolve => {
+                    window.unblockLoadBootResource = () => {
+                        var origSetItem = localStorage.setItem;
+                        localStorage.setItem = function (key) {
+                            origSetItem.apply(this, arguments);
+                            if (key.startsWith('blazor-resource-hash:')) {
+                                localStorage.setItem = origSetItem;
+                                appendHiddenParagraph('unblocked-wasm');
+                            }
+                        };
+                        resolve();
+                    }
+                });
+            }
+
+            let maxParallelResourceDownloadCount = 0;
+            let currentParallelResourceDownloadCount = 0;
+
             Blazor.start({
                 ssr: {
                     disableDomPreservation: suppressEnhancedNavigation,
@@ -71,12 +88,7 @@
                         }
                     },
                 },
-            }).then(() => {
-                const startedParagraph = document.createElement('p');
-                startedParagraph.id = 'blazor-started';
-                startedParagraph.style = 'display: none;';
-                document.body.appendChild(startedParagraph);
-            });
+            }).then(() => appendHiddenParagraph('blazor-started'));
         }
 
         if (location.search.indexOf('suppress-autostart') < 0) {

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/PersistentState/PageWithoutComponents.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/PersistentState/PageWithoutComponents.razor
@@ -4,7 +4,7 @@
 
 <a id="page-with-components-link" href=@($"persistent-state/page-with-components?render-mode={RenderMode}&streaming-id={StreamingId}")>Go to page with components</a>
 
-<a id="page-with-components-link-and-state" href=@($"persistent-state/page-with-components?render-mode={RenderMode}&streaming-id={StreamingId}&server-state=other")>Go to page with components</a>
+<a id="page-with-components-link-and-state" href=@($"persistent-state/page-with-components?render-mode={RenderMode}&streaming-id={StreamingId}&server-state=other")>Go to page with components and state</a>
 
 
 @code {

--- a/src/Components/test/testassets/TestContentPackage/PersistentComponents/NonStreamingComponentWithPersistentState.razor
+++ b/src/Components/test/testassets/TestContentPackage/PersistentComponents/NonStreamingComponentWithPersistentState.razor
@@ -1,6 +1,6 @@
 ﻿<p>Non streaming component with persistent state</p>
 
-<p>This component demonstrates state persistence in the absence of streaming rendering. When the component renders it will try to restore the state and if present display that it succeded in doing so and the restored value. If the state is not present, it will indicate it didn't find it and display a "fresh" value.</p>
+<p>This component demonstrates state persistence in the absence of streaming rendering. When the component renders it will try to restore the state and if present display that it succeeded in doing so and the restored value. If the state is not present, it will indicate it didn't find it and display a "fresh" value.</p>
 
 <p id="interactive">Interactive: @(!RunningOnServer)</p>
 <p id="interactive-runtime">Interactive runtime: @_interactiveRuntime</p>


### PR DESCRIPTION
- Verify wasm resources are fully loaded before refreshing

Fixes #50810
