### PR TITLE
[Blazor] Avoid validating antiforgery for non form data content types

### DIFF
--- a/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
+++ b/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
@@ -163,7 +163,6 @@ internal partial class RazorComponentEndpointInvoker : IRazorComponentEndpointIn
             // want to run the form handling logic against the error page.
             context.Features.Get<IExceptionHandlerFeature>() == null;
 
-
         if (processPost)
         {
             if (!context.Request.HasFormContentType)

--- a/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
+++ b/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
@@ -168,7 +168,7 @@ internal partial class RazorComponentEndpointInvoker : IRazorComponentEndpointIn
             if (!context.Request.HasFormContentType)
             {
                 context.Response.StatusCode = StatusCodes.Status400BadRequest;
-                if (context.RequestServices.GetService<IHostEnvironment>()?.IsDevelopment() == true)
+                if (EndpointHtmlRenderer.ShouldShowDetailedErrors(context))
                 {
                     await context.Response.WriteAsync("The request has an incorrect Content-type.");
                 }

--- a/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
+++ b/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
@@ -12,7 +12,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Components.Endpoints;
@@ -165,7 +164,9 @@ internal partial class RazorComponentEndpointInvoker : IRazorComponentEndpointIn
 
         if (processPost)
         {
-            if (!context.Request.HasFormContentType)
+            // We can't use request.HasFormContentType here because it will throw. We should revisit that.
+            if (!string.Equals(context.Request.ContentType, "application/x-www-form-urlencoded", StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(context.Request.ContentType, "multipart/form-data", StringComparison.OrdinalIgnoreCase))
             {
                 context.Response.StatusCode = StatusCodes.Status400BadRequest;
                 if (EndpointHtmlRenderer.ShouldShowDetailedErrors(context))

--- a/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
+++ b/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
@@ -163,11 +163,22 @@ internal partial class RazorComponentEndpointInvoker : IRazorComponentEndpointIn
             // want to run the form handling logic against the error page.
             context.Features.Get<IExceptionHandlerFeature>() == null;
 
+
         if (processPost)
         {
-            var valid = false;
+            if (!context.Request.HasFormContentType)
+            {
+                context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                if (context.RequestServices.GetService<IHostEnvironment>()?.IsDevelopment() == true)
+                {
+                    await context.Response.WriteAsync("The request has an incorrect Content-type.");
+                }
+                return RequestValidationState.InvalidPostRequest;
+            }
+
             // Respect the token validation done by the middleware _if_ it has been set, otherwise
             // run the validation here.
+            var valid = false;
             if (context.Features.Get<IAntiforgeryValidationFeature>() is { } antiForgeryValidationFeature)
             {
                 if (!antiForgeryValidationFeature.IsValid)

--- a/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
+++ b/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
@@ -216,7 +216,7 @@ internal partial class RazorComponentEndpointInvoker : IRazorComponentEndpointIn
             {
                 context.Response.StatusCode = StatusCodes.Status400BadRequest;
 
-                if (context.RequestServices.GetService<IHostEnvironment>()?.IsDevelopment() == true)
+                if (EndpointHtmlRenderer.ShouldShowDetailedErrors(context))
                 {
                     await context.Response.WriteAsync("A valid antiforgery token was not provided with the request. Add an antiforgery token, or disable antiforgery validation for this endpoint.");
                 }

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Streaming.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Streaming.cs
@@ -194,13 +194,19 @@ internal partial class EndpointHtmlRenderer
         return depth;
     }
 
+    internal static bool ShouldShowDetailedErrors(HttpContext httpContext)
+    {
+        var env = httpContext.RequestServices.GetRequiredService<IWebHostEnvironment>();
+        var options = httpContext.RequestServices.GetRequiredService<IOptions<RazorComponentsServiceOptions>>();
+        var showDetailedErrors = env.IsDevelopment() || options.Value.DetailedErrors;
+        return showDetailedErrors;
+    }
+
     private static void HandleExceptionAfterResponseStarted(HttpContext httpContext, TextWriter writer, Exception exception)
     {
         // We already started the response so we have no choice but to return a 200 with HTML and will
         // have to communicate the error information within that
-        var env = httpContext.RequestServices.GetRequiredService<IWebHostEnvironment>();
-        var options = httpContext.RequestServices.GetRequiredService<IOptions<RazorComponentsServiceOptions>>();
-        var showDetailedErrors = env.IsDevelopment() || options.Value.DetailedErrors;
+        var showDetailedErrors = ShouldShowDetailedErrors(httpContext);
         var message = showDetailedErrors
             ? exception.ToString()
             : "There was an unhandled exception on the current request. For more details turn on detailed exceptions by setting 'DetailedErrors: true' in 'appSettings.Development.json'";

--- a/src/Components/Endpoints/test/RazorComponentEndpointInvokerTest.cs
+++ b/src/Components/Endpoints/test/RazorComponentEndpointInvokerTest.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Microsoft.AspNetCore.Components.Endpoints.Tests;
+public class RazorComponentEndpointInvokerTest
+{
+    [Fact]
+    public async Task Invoker_RejectsPostRequestsWithNonFormDataContentTypesAsync()
+    {
+        // Arrange
+        var services = new ServiceCollection().AddRazorComponents()
+                        .Services.AddAntiforgery()
+                        .AddSingleton<IConfiguration>(new ConfigurationBuilder().Build())
+                        .AddSingleton<IWebHostEnvironment>(new TestWebHostEnvironment())
+                        .BuildServiceProvider();
+
+        var invoker = new RazorComponentEndpointInvoker(
+            new EndpointHtmlRenderer(
+                services,
+                NullLoggerFactory.Instance),
+            NullLogger<RazorComponentEndpointInvoker>.Instance);
+
+        var context = new DefaultHttpContext();
+        context.SetEndpoint(new RouteEndpoint(
+            ctx => Task.CompletedTask,
+            RoutePatternFactory.Parse("/"),
+            0,
+            new EndpointMetadataCollection(
+                // These don't matter
+                new ComponentTypeMetadata(typeof(AuthorizeView)),
+                new RootComponentMetadata(typeof(AuthorizeView))),
+            "test"));
+        context.Request.Method = "POST";
+        context.Request.ContentType = "application/json";
+        context.RequestServices = services;
+
+        // Act
+        await invoker.Render(context);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, context.Response.StatusCode);
+    }
+
+    private class TestWebHostEnvironment : IWebHostEnvironment
+    {
+        public string WebRootPath { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public IFileProvider WebRootFileProvider { get => new NullFileProvider(); set => throw new NotImplementedException(); }
+        public string EnvironmentName { get => "Development"; set => throw new NotImplementedException(); }
+        public string ApplicationName { get => "Test"; set => throw new NotImplementedException(); }
+        public string ContentRootPath { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public IFileProvider ContentRootFileProvider { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+    }
+}


### PR DESCRIPTION
Sends bad request if content-type is not valid (like application/json)

Fixes https://github.com/dotnet/aspnetcore/issues/55582