### PR TITLE
Stop retrying template tests

### DIFF
--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -12,6 +12,7 @@
     {"testName": {"contains": "CanLaunchPhotinoWebViewAndClickButton"}},
     {"testName": {"contains": "CheckInvalidHostingModelParameter"}},
     {"testAssembly": {"contains": "IIS"}},
+    {"testAssembly": {"contains": "Template"}},
     {"failureMessage": {"contains":"(Site is started but no worker process found)"}},
     {"failureMessage": {"contains": "network disconnected"}}
   ],

--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -12,7 +12,6 @@
     {"testName": {"contains": "CanLaunchPhotinoWebViewAndClickButton"}},
     {"testName": {"contains": "CheckInvalidHostingModelParameter"}},
     {"testAssembly": {"contains": "IIS"}},
-    {"testAssembly": {"contains": "Template"}},
     {"failureMessage": {"contains":"(Site is started but no worker process found)"}},
     {"failureMessage": {"contains": "network disconnected"}}
   ],

--- a/src/ProjectTemplates/test/Templates.Mvc.Tests/Templates.Mvc.Tests.csproj
+++ b/src/ProjectTemplates/test/Templates.Mvc.Tests/Templates.Mvc.Tests.csproj
@@ -20,6 +20,7 @@
     <RestoreFolderName>Mvc</RestoreFolderName>
     <TestDependsOnAspNetPackages>true</TestDependsOnAspNetPackages>
     <HelixTimeout>01:50:00</HelixTimeout>
+    <TestDependsOnPlaywright>true</TestDependsOnPlaywright>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is to see whether we can get better error info from Helix by avoiding a timeout by not retrying.

Not currently planning to actually merge this.