### PR TITLE
Improve performance of UriHelper.GetDisplayUrl

### DIFF
--- a/src/Http/Http.Extensions/src/UriHelper.cs
+++ b/src/Http/Http.Extensions/src/UriHelper.cs
@@ -203,7 +203,7 @@ public static class UriHelper
     /// suitable only for display.</returns>
     public static string GetDisplayUrl(this HttpRequest request)
     {
-        return string.Concat((ReadOnlySpan<string?>)[request.Scheme, SchemeDelimiter, request.Host.Value, request.PathBase.Value, request.Path.Value, request.QueryString.Value]);
+        return string.Concat([request.Scheme, SchemeDelimiter, request.Host.Value, request.PathBase.Value, request.Path.Value, request.QueryString.Value]);
     }
 
     /// <summary>

--- a/src/Http/Http.Extensions/src/UriHelper.cs
+++ b/src/Http/Http.Extensions/src/UriHelper.cs
@@ -203,54 +203,7 @@ public static class UriHelper
     /// suitable only for display.</returns>
     public static string GetDisplayUrl(this HttpRequest request)
     {
-        var scheme = request.Scheme ?? string.Empty;
-        var host = request.Host.Value ?? string.Empty;
-        var pathBase = request.PathBase.Value ?? string.Empty;
-        var path = request.Path.Value ?? string.Empty;
-        var queryString = request.QueryString.Value ?? string.Empty;
-
-        var length = scheme.Length + SchemeDelimiter.Length + host.Length
-            + pathBase.Length + path.Length + queryString.Length;
-
-        return string.Create(
-            length,
-            (scheme, host, pathBase, path, queryString),
-            static (buffer, uriParts) =>
-            {
-                var (scheme, host, pathBase, path, queryString) = uriParts;
-
-                if (scheme.Length > 0)
-                {
-                    scheme.CopyTo(buffer);
-                    buffer = buffer.Slice(scheme.Length);
-                }
-
-                SchemeDelimiter.CopyTo(buffer);
-                buffer = buffer.Slice(SchemeDelimiter.Length);
-
-                if (host.Length > 0)
-                {
-                    host.CopyTo(buffer);
-                    buffer = buffer.Slice(host.Length);
-                }
-
-                if (pathBase.Length > 0)
-                {
-                    pathBase.CopyTo(buffer);
-                    buffer = buffer.Slice(pathBase.Length);
-                }
-
-                if (path.Length > 0)
-                {
-                    path.CopyTo(buffer);
-                    buffer = buffer.Slice(path.Length);
-                }
-
-                if (queryString.Length > 0)
-                {
-                    queryString.CopyTo(buffer);
-                }
-            });
+        return string.Concat((ReadOnlySpan<string?>)[request.Scheme, SchemeDelimiter, request.Host.Value, request.PathBase.Value, request.Path.Value, request.QueryString.Value]);
     }
 
     /// <summary>


### PR DESCRIPTION
Replaced `StringBuilder` concatenation with the more efficient `string.Create` method for creating new strings by concatenating `scheme`, `host`, `pathBase`, `path`, and `queryString`. This method reduces overhead by avoiding multiple string concatenations and allocating the correct buffer size for the new string. The `CopyTo` method is used in a callback function to copy each string to the new string, slicing the buffer to remove the copied part. The `SchemeDelimiter` is always copied to the new string, regardless of its length. This change enhances the performance of the code.

# Improve performance of UriHelper.GetDisplayUrl

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Summary

`UriHelper.GetDisplayUrl` uses a non-pooled `StringBuilder` that is instantiated on every invocation. Although optimized in size, it is a heap allocation with an intermediary buffer.

```csharp
public static string GetDisplayUrl(this HttpRequest request)
{
    var scheme = request.Scheme ?? string.Empty;
    var host = request.Host.Value ?? string.Empty;
    var pathBase = request.PathBase.Value ?? string.Empty;
    var path = request.Path.Value ?? string.Empty;
    var queryString = request.QueryString.Value ?? string.Empty;

    // PERF: Calculate string length to allocate correct buffer size for StringBuilder.
    var length = scheme.Length + SchemeDelimiter.Length + host.Length
        + pathBase.Length + path.Length + queryString.Length;

    return new StringBuilder(length)
        .Append(scheme)
        .Append(SchemeDelimiter)
        .Append(host)
        .Append(pathBase)
        .Append(path)
        .Append(queryString)
        .ToString();
}
```

## Motivation and goals

This method is frequently used in hot paths like redirect and rewrite rules.

From the benchmarks below, we can see that, compared to the current implementation using a `StringBuilder` with enough capacity, string interpolation is around 3 times better in terms of duration and around 4 times in memory used.

`String.Create` is even more performant.

# Benchmarks

```ini

BenchmarkDotNet v0.13.12, Windows 11 (10.0.22631.3593/23H2/2023Update/SunValley3)
13th Gen Intel Core i9-13900K, 1 CPU, 32 logical and 24 physical cores
.NET SDK 9.0.100-preview.4.24267.66
  [Host]     : .NET 9.0.0 (9.0.24.26619), X64 RyuJIT AVX2
  DefaultJob : .NET 9.0.0 (9.0.24.26619), X64 RyuJIT AVX2


```
| Method               | scheme | host             | basePath   | path                | query                | Mean      | Ratio | Gen0   | Allocated | Alloc Ratio |
|--------------------- |------- |----------------- |----------- |-------------------- |--------------------- |----------:|------:|-------:|----------:|------------:|
| **StringBuilder**        | **http**   | **cname.domain.tld** | ****           | **/**                   | ****                     | **67.161 ns** |  **1.00** | **0.0288** |     **544 B** |        **1.00** |
| String_Interpolation | http   | cname.domain.tld |            | /                   |                      | 24.606 ns |  0.37 | 0.0038 |      72 B |        0.13 |
| String_Concat        | http   | cname.domain.tld |            | /                   |                      | 23.160 ns |  0.34 | 0.0038 |      72 B |        0.13 |
| String_Create        | http   | cname.domain.tld |            | /                   |                      |  9.903 ns |  0.15 | 0.0038 |      72 B |        0.13 |
|                      |        |                  |            |                     |                      |           |       |        |           |             |
| **StringBuilder**        | **http**   | **cname.domain.tld** | ****           | **/**                   | **?para(...)alue3 [42]** | **92.873 ns** |  **1.00** | **0.0446** |     **840 B** |        **1.00** |
| String_Interpolation | http   | cname.domain.tld |            | /                   | ?para(...)alue3 [42] | 26.817 ns |  0.29 | 0.0085 |     160 B |        0.19 |
| String_Concat        | http   | cname.domain.tld |            | /                   | ?para(...)alue3 [42] | 25.303 ns |  0.27 | 0.0085 |     160 B |        0.19 |
| String_Create        | http   | cname.domain.tld |            | /                   | ?para(...)alue3 [42] | 11.978 ns |  0.13 | 0.0085 |     160 B |        0.19 |
|                      |        |                  |            |                     |                      |           |       |        |           |             |
| **StringBuilder**        | **http**   | **cname.domain.tld** | ****           | **/path/one/two/three** | ****                     | **74.314 ns** |  **1.00** | **0.0314** |     **592 B** |        **1.00** |
| String_Interpolation | http   | cname.domain.tld |            | /path/one/two/three |                      | 23.582 ns |  0.32 | 0.0059 |     112 B |        0.19 |
| String_Concat        | http   | cname.domain.tld |            | /path/one/two/three |                      | 35.836 ns |  0.48 | 0.0059 |     112 B |        0.19 |
| String_Create        | http   | cname.domain.tld |            | /path/one/two/three |                      |  9.352 ns |  0.13 | 0.0059 |     112 B |        0.19 |
|                      |        |                  |            |                     |                      |           |       |        |           |             |
| **StringBuilder**        | **http**   | **cname.domain.tld** | ****           | **/path/one/two/three** | **?para(...)alue3 [42]** | **93.593 ns** |  **1.00** | **0.0467** |     **880 B** |        **1.00** |
| String_Interpolation | http   | cname.domain.tld |            | /path/one/two/three | ?para(...)alue3 [42] | 28.930 ns |  0.31 | 0.0102 |     192 B |        0.22 |
| String_Concat        | http   | cname.domain.tld |            | /path/one/two/three | ?para(...)alue3 [42] | 41.730 ns |  0.45 | 0.0102 |     192 B |        0.22 |
| String_Create        | http   | cname.domain.tld |            | /path/one/two/three | ?para(...)alue3 [42] | 13.065 ns |  0.14 | 0.0102 |     192 B |        0.22 |
|                      |        |                  |            |                     |                      |           |       |        |           |             |
| **StringBuilder**        | **http**   | **cname.domain.tld** | **/base-path** | **/**                   | ****                     | **71.984 ns** |  **1.00** | **0.0305** |     **576 B** |        **1.00** |
| String_Interpolation | http   | cname.domain.tld | /base-path | /                   |                      | 23.342 ns |  0.32 | 0.0051 |      96 B |        0.17 |
| String_Concat        | http   | cname.domain.tld | /base-path | /                   |                      | 20.272 ns |  0.28 | 0.0051 |      96 B |        0.17 |
| String_Create        | http   | cname.domain.tld | /base-path | /                   |                      | 10.282 ns |  0.14 | 0.0051 |      96 B |        0.17 |
|                      |        |                  |            |                     |                      |           |       |        |           |             |
| **StringBuilder**        | **http**   | **cname.domain.tld** | **/base-path** | **/**                   | **?para(...)alue3 [42]** | **93.702 ns** |  **1.00** | **0.0459** |     **864 B** |        **1.00** |
| String_Interpolation | http   | cname.domain.tld | /base-path | /                   | ?para(...)alue3 [42] | 28.924 ns |  0.31 | 0.0093 |     176 B |        0.20 |
| String_Concat        | http   | cname.domain.tld | /base-path | /                   | ?para(...)alue3 [42] | 25.931 ns |  0.28 | 0.0093 |     176 B |        0.20 |
| String_Create        | http   | cname.domain.tld | /base-path | /                   | ?para(...)alue3 [42] | 13.951 ns |  0.15 | 0.0093 |     176 B |        0.20 |
|                      |        |                  |            |                     |                      |           |       |        |           |             |
| **StringBuilder**        | **http**   | **cname.domain.tld** | **/base-path** | **/path/one/two/three** | ****                     | **75.755 ns** |  **1.00** | **0.0327** |     **616 B** |        **1.00** |
| String_Interpolation | http   | cname.domain.tld | /base-path | /path/one/two/three |                      | 24.781 ns |  0.33 | 0.0068 |     128 B |        0.21 |
| String_Concat        | http   | cname.domain.tld | /base-path | /path/one/two/three |                      | 36.724 ns |  0.48 | 0.0068 |     128 B |        0.21 |
| String_Create        | http   | cname.domain.tld | /base-path | /path/one/two/three |                      | 11.092 ns |  0.15 | 0.0068 |     128 B |        0.21 |
|                      |        |                  |            |                     |                      |           |       |        |           |             |
| **StringBuilder**        | **http**   | **cname.domain.tld** | **/base-path** | **/path/one/two/three** | **?para(...)alue3 [42]** | **89.961 ns** |  **1.00** | **0.0479** |     **904 B** |        **1.00** |
| String_Interpolation | http   | cname.domain.tld | /base-path | /path/one/two/three | ?para(...)alue3 [42] | 31.002 ns |  0.34 | 0.0114 |     216 B |        0.24 |
| String_Concat        | http   | cname.domain.tld | /base-path | /path/one/two/three | ?para(...)alue3 [42] | 41.576 ns |  0.46 | 0.0114 |     216 B |        0.24 |
| String_Create        | http   | cname.domain.tld | /base-path | /path/one/two/three | ?para(...)alue3 [42] | 14.374 ns |  0.16 | 0.0115 |     216 B |        0.24 |



## StringBuilder

This benchmark uses the same implementation as `UriHelper.GetDisplayUrl`.

## String_Interpolation

This benchmark uses string interpolation to build the URL.

## String_Concat

This benchmark uses the new in **.NET 9.0** `String.Concat(ReadOnlySpan<string?> values)` to build the URL.

## String_Create

This benchmark uses `String.Create` and spans to build the URL.

## Code

```csharp
[MemoryDiagnoser]
[HideColumns("Error", "StdDev", "Median", "RatioSD")]
public class DisplayUrlBenchmark
{
    private static readonly string SchemeDelimiter = Uri.SchemeDelimiter;

    private static readonly string[] schemes = ["http"];
    private static readonly string[] hosts = ["cname.domain.tld"];
    private static readonly string[] basePaths = [null, "/base-path",];
    private static readonly string[] paths = ["/", "/path/one/two/three",];
    private static readonly string[] queries = [null, "?param1=value1&param2=value2&param3=value3",];

    public IEnumerable<object[]> Data()
    {
        foreach (var scheme in schemes)
        {
            foreach (var host in hosts)
            {
                foreach (var basePath in basePaths)
                {
                    foreach (var path in paths)
                    {
                        foreach (var query in queries)
                        {
                            yield return new object[] { scheme, new HostString(host), new PathString(basePath), new PathString(path), new QueryString(query), };
                        }
                    }
                }
            }
        }
    }

    [Benchmark(Baseline = true)]
    [ArgumentsSource(nameof(Data))]
    public string StringBuilder(string scheme, HostString host, PathString basePath, PathString path, QueryString query)
    {
        var schemeValue = scheme ?? string.Empty;
        var hostValue = host.Value ?? string.Empty;
        var basePathValue = basePath.Value ?? string.Empty;
        var pathValue = path.Value ?? string.Empty;
        var queryValue = query.Value ?? string.Empty;

        var length =
            +schemeValue.Length
            + SchemeDelimiter
            + hostValue.Length
            + basePathValue.Length
            + pathValue.Length
            + queryValue.Length;

        return new StringBuilder(length)
                .Append(schemeValue)
                .Append(SchemeDelimiter)
                .Append(hostValue)
                .Append(basePathValue)
                .Append(pathValue)
                .Append(queryValue)
                .ToString();
    }

    [Benchmark]
    [ArgumentsSource(nameof(Data))]
    public string String_Interpolation(string scheme, HostString host, PathString basePath, PathString path, QueryString query)
    {
        return $"{scheme}://{host.Value}{basePath.Value}{path.Value}{query.Value}";
    }

    [Benchmark]
    [ArgumentsSource(nameof(Data))]
    public string String_Concat(string scheme, HostString host, PathString basePath, PathString path, QueryString query)
    {
        return string.Concat((ReadOnlySpan<string>)[scheme, "://", host.Value, basePath.Value, path, query.Value]);
    }

    [Benchmark]
    [ArgumentsSource(nameof(Data))]
    public string String_Create(string scheme, HostString host, PathString basePath, PathString path, QueryString query)
    {
        var schemeValue = scheme ?? string.Empty;
        var hostValue = host.Value ?? string.Empty;
        var basePathValue = basePath.Value ?? string.Empty;
        var pathValue = path.Value ?? string.Empty;
        var queryValue = query.Value ?? string.Empty;

        var length =
            +schemeValue.Length
            + SchemeDelimiter.Length
            + hostValue.Length
            + basePathValue.Length
            + pathValue.Length
            + queryValue.Length;

        return string.Create(
            length,
            (schemeValue, hostValue, basePathValue, pathValue, queryValue),
            static (buffer, uriParts) =>
            {
                var (scheme, host, basePath, path, query) = uriParts;

                if (scheme.Length > 0)
                {
                    scheme.CopyTo(buffer);
                    buffer = buffer.Slice(scheme.Length);
                }

                SchemeDelimiter.CopyTo(buffer);
                buffer = buffer.Slice(SchemeDelimiter.Length);

                if (host.Length > 0)
                {
                    host.CopyTo(buffer);
                    buffer = buffer.Slice(host.Length);
                }

                if (basePath.Length > 0)
                {
                    basePath.CopyTo(buffer);
                    buffer = buffer.Slice(basePath.Length);
                }

                if (path.Length > 0)
                {
                    path.CopyTo(buffer);
                    buffer = buffer.Slice(path.Length);
                }

                if (query.Length > 0)
                {
                    query.CopyTo(buffer);
                }
            });
    }
}
```


{Detail}

Fixes #28906
