### PR TITLE
Fix shadow copy up to date check on startup (#52831)

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/Environment.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/Environment.cpp
@@ -231,7 +231,7 @@ bool Environment::CheckUpToDate(const std::wstring& source, const std::filesyste
             auto sourceInnerDirectory = std::filesystem::directory_entry(path);
             if (sourceInnerDirectory.path() != directoryToIgnore)
             {
-                CheckUpToDate(destination / path.path().filename(), path.path(), extension, directoryToIgnore);
+                CheckUpToDate(/* source */ path.path(), /* destination */ destination / path.path().filename(), extension, directoryToIgnore);
             }
         }
     }

--- a/src/Servers/IIS/IIS/test/IIS.ShadowCopy.Tests/ShadowCopyTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.ShadowCopy.Tests/ShadowCopyTests.cs
@@ -1,9 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.IO;
-using System.Threading.Tasks;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests.Utilities;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
@@ -135,6 +133,37 @@ public class ShadowCopyTests : IISFunctionalTestBase
         }
         var fileContents = File.ReadAllBytes(dllPath);
         File.WriteAllBytes(dllPath, fileContents);
+
+        await deploymentResult.AssertRecycledAsync();
+
+        response = await deploymentResult.HttpClient.GetAsync("Wow!");
+        Assert.True(response.IsSuccessStatusCode);
+    }
+
+    [ConditionalFact]
+    public async Task ShadowCopyDeleteFolderDuringShutdownWorks()
+    {
+        using var directory = TempDirectory.Create();
+        var deploymentParameters = Fixture.GetBaseDeploymentParameters();
+        deploymentParameters.HandlerSettings["enableShadowCopy"] = "true";
+        deploymentParameters.HandlerSettings["shadowCopyDirectory"] = directory.DirectoryPath;
+
+        var deploymentResult = await DeployAsync(deploymentParameters);
+        var deleteDirPath = Path.Combine(deploymentResult.ContentRoot, "wwwroot/deletethis");
+        Directory.CreateDirectory(deleteDirPath);
+        File.WriteAllText(Path.Combine(deleteDirPath, "file.dll"), "");
+
+        var response = await deploymentResult.HttpClient.GetAsync("Wow!");
+        Assert.True(response.IsSuccessStatusCode);
+
+        AddAppOffline(deploymentResult.ContentRoot);
+        await AssertAppOffline(deploymentResult);
+
+        // Delete folder + file after app is shut down
+        // Testing specific path on startup where we compare the app directory contents with the shadow copy directory
+        Directory.Delete(deleteDirPath, recursive: true);
+
+        RemoveAppOffline(deploymentResult.ContentRoot);
 
         await deploymentResult.AssertRecycledAsync();
 

--- a/src/Servers/IIS/IIS/test/IIS.ShadowCopy.Tests/ShadowCopyTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.ShadowCopy.Tests/ShadowCopyTests.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.AspNetCore.InternalTesting;
+using System;
+using System.IO;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests.Utilities;
 using Microsoft.AspNetCore.Testing;
 using Xunit;


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspnetcore/pull/52831

# Fix shadow copy up to date check on startup

## Description

If using shadow copy in ANCM and you shutdown the app (e.g. app_offline.htm) then delete a subfolder (with a dll), starting up the app can cause a crash that can only be resolved by adding back the deleted folder. Or resolved by deleting the shadow copy folder (either manually or with cleanShadowCopyDirectory setting turned on).

## Customer Impact

App permanently crashes on startup until moving app to a new directory, cleaning shadow copy folders, or readding removed file. This is a hard to diagnose issue as it's just a random crash with little info about what happened.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Code was obviously wrong once the issue was looked into, very simple fix. Added a test to verify.

## Verification

- [x] Automatic

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A