### PR TITLE
Add .NET 9 nightly NuGet feed and remove .NET 7

### DIFF
--- a/docs/DailyBuilds.md
+++ b/docs/DailyBuilds.md
@@ -7,19 +7,6 @@ If you want to download the latest daily build and use it in a project, then you
 * Obtain the latest [build of the .NET Core SDK](https://github.com/dotnet/installer#table).
 * Add a NuGet.Config to your project directory with the following content:
 
-## .NET 7
-
-  ```xml
-  <?xml version="1.0" encoding="utf-8"?>
-  <configuration>
-      <packageSources>
-          <clear />
-          <add key="aspnetcore" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
-          <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
-      </packageSources>
-  </configuration>
-  ```
-  
 ## .NET 8
 
   ```xml
@@ -27,7 +14,20 @@ If you want to download the latest daily build and use it in a project, then you
   <configuration>
       <packageSources>
           <clear />
-          <add key="aspnetcore" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
+          <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
+          <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
+      </packageSources>
+  </configuration>
+  ```
+
+## .NET 9
+
+  ```xml
+  <?xml version="1.0" encoding="utf-8"?>
+  <configuration>
+      <packageSources>
+          <clear />
+          <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
           <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
       </packageSources>
   </configuration>


### PR DESCRIPTION
Just added a new section for .NET 9 and removed .NET 7 to keep docs updated with the latest versions.
