### PR TITLE
Fixed LDAP nested group claims

### DIFF
--- a/src/Security/Authentication/Negotiate/src/Internal/LdapAdapter.cs
+++ b/src/Security/Authentication/Negotiate/src/Internal/LdapAdapter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Globalization;
 using System.DirectoryServices.Protocols;
 using System.Linq;
 using System.Security.Claims;
@@ -16,7 +17,7 @@ internal static partial class LdapAdapter
 {
     [GeneratedRegex(@"(?<![^\\]\\),")]
     internal static partial Regex DistinguishedNameSeparator();
-    
+
     public static async Task RetrieveClaimsAsync(LdapSettings settings, ClaimsIdentity identity, ILogger logger)
     {
         var user = identity.Name!;
@@ -28,19 +29,19 @@ internal static partial class LdapAdapter
             settings.ClaimsCache = new MemoryCache(new MemoryCacheOptions { SizeLimit = settings.ClaimsCacheSize });
         }
 
-        if (settings.ClaimsCache.TryGetValue<IEnumerable<string>>(user, out var cachedClaims) && cachedClaims is not null)
+        if (settings.ClaimsCache.TryGetValue< IEnumerable< KeyValuePair<string, string> > >(user, out var cachedClaims) && cachedClaims is not null)
         {
             foreach (var claim in cachedClaims)
             {
-                identity.AddClaim(new Claim(identity.RoleClaimType, claim));
+                identity.AddClaim(new Claim(claim.Key, claim.Value));
             }
 
             return;
         }
 
         var distinguishedName = settings.Domain.Split('.').Select(name => $"dc={name}").Aggregate((a, b) => $"{a},{b}");
-        var retrievedClaims = new List<string>();
-
+        var retrievedClaims = new List< KeyValuePair<string, string> >();
+        //sAMAccountName is always unique (at least within a forest)
         var filter = $"(&(objectClass=user)(sAMAccountName={userAccountName}))"; // This is using ldap search query language, it is looking on the server for someUser
         var searchRequest = new SearchRequest(distinguishedName, filter, SearchScope.Subtree);
 
@@ -62,27 +63,52 @@ internal static partial class LdapAdapter
             var userFound = searchResponse.Entries[0]; //Get the object that was found on ldap
             var memberof = userFound.Attributes["memberof"]; // You can access ldap Attributes with Attributes property
 
-            foreach (var group in memberof)
+            //Get the user SID
+            var userSID = userFound.Attributes["objectsid"];
+            if (userSID is not null)
             {
-                // Example distinguished name: CN=TestGroup,DC=KERB,DC=local
-                var groupDN = $"{Encoding.UTF8.GetString((byte[])group)}";
-                var groupCN = DistinguishedNameSeparator().Split(groupDN)[0].Substring("CN=".Length);
-
-                if (!settings.IgnoreNestedGroups)
+                if (userSID.Count == 1)
                 {
-                    GetNestedGroups(settings.LdapConnection, identity, distinguishedName, groupCN, logger, retrievedClaims, new HashSet<string>());
+                    string? usid = ParseSID((byte[])userSID[0]);
+                    if (usid is not null)
+                    {
+                        retrievedClaims.Add(new KeyValuePair<string, string>(ClaimTypes.Sid, usid.ToString()));
+                    }
                 }
-                else
+            }
+
+            HashSet<string> uniqueGroups = new HashSet<string>();
+            if (memberof is not null)
+            {
+                foreach (var group in memberof)
                 {
-                    retrievedClaims.Add(groupCN);
+                    // Example distinguished name: CN=TestGroup,DC=KERB,DC=local
+                    var groupDN = $"{Encoding.UTF8.GetString((byte[])group)}";
+                    var groupCN = DistinguishedNameSeparator().Split(groupDN)[0].Substring("CN=".Length);
+
+                    if (!settings.IgnoreNestedGroups)
+                    {
+                        GetNestedGroups(settings.LdapConnection, identity, distinguishedName, groupCN, logger, retrievedClaims, uniqueGroups);
+                    }
+                    else
+                    {
+                        retrievedClaims.Add(new KeyValuePair<string, string>(identity.RoleClaimType, groupCN));
+                        string? groupSID = GetGroupSID(settings.LdapConnection, distinguishedName, groupCN, logger);
+                        if (groupSID is not null)
+                        {
+                            retrievedClaims.Add(new KeyValuePair<string, string>(ClaimTypes.GroupSid, groupSID));
+                        }
+                    }
                 }
             }
 
             var entrySize = user.Length * 2; //Approximate the size of stored key in memory cache.
             foreach (var claim in retrievedClaims)
             {
-                identity.AddClaim(new Claim(identity.RoleClaimType, claim));
-                entrySize += claim.Length * 2; //Approximate the size of stored value in memory cache.
+                identity.AddClaim(new Claim(claim.Key, claim.Value));
+                //Approximate the size of stored value in memory cache.
+                entrySize += claim.Key.Length * 2;
+                entrySize += claim.Value.Length * 2;
             }
 
             settings.ClaimsCache.Set(user,
@@ -98,10 +124,8 @@ internal static partial class LdapAdapter
         }
     }
 
-    private static void GetNestedGroups(LdapConnection connection, ClaimsIdentity principal, string distinguishedName, string groupCN, ILogger logger, IList<string> retrievedClaims, HashSet<string> processedGroups)
+    private static void GetNestedGroups(LdapConnection connection, ClaimsIdentity principal, string distinguishedName, string groupCN, ILogger logger, IList< KeyValuePair<string, string> > retrievedClaims, HashSet<string> processedGroups)
     {
-        retrievedClaims.Add(groupCN);
-
         var filter = $"(&(objectClass=group)(sAMAccountName={groupCN}))"; // This is using ldap search query language, it is looking on the server for someUser
         var searchRequest = new SearchRequest(distinguishedName, filter, SearchScope.Subtree);
         var searchResponse = (SearchResponse)connection.SendRequest(searchRequest);
@@ -116,10 +140,51 @@ internal static partial class LdapAdapter
             var group = searchResponse.Entries[0]; // Get the object that was found on ldap
             var groupDN = group.DistinguishedName;
 
+            if (processedGroups.Contains(groupDN)) {
+                //No need to continue, this group was resolved before
+                return;
+            }
+
+            retrievedClaims.Add(new KeyValuePair<string, string>(principal.RoleClaimType, groupCN));
             processedGroups.Add(groupDN);
 
+            //Get the group SID
+            var groupSID = group.Attributes["objectsid"];
+            if (groupSID is not null)
+            {
+                if (groupSID.Count == 1)
+                {
+                    //For some reason it is sometimes string and sometimes byte[]
+                    //when it is returned as a string then every byte is converted to a char and simply put together as a string
+                    switch (groupSID[0])
+                    {
+                        case string groupSIDstr:
+                            ReadOnlySpan<char> groupSIDspn = groupSIDstr;
+                            Span<byte> lgroupSIDba = stackalloc byte[groupSIDspn.Length];
+                            for (int i = 0; i < groupSIDspn.Length; ++i)
+                            {
+                                byte[] bytes = BitConverter.GetBytes(groupSIDspn[i]);
+                                lgroupSIDba[i] = bytes[0];
+                            }
+                            string? lgsid = ParseSID(lgroupSIDba);
+                            if (lgsid is not null)
+                            {
+                                retrievedClaims.Add(new KeyValuePair<string, string>(ClaimTypes.GroupSid, lgsid));
+                            }
+                            break;
+                        case byte[] groupSIDba:
+                            string? gsid = ParseSID(groupSIDba);
+                            if (gsid is not null)
+                            {
+                                retrievedClaims.Add(new KeyValuePair<string, string>(ClaimTypes.GroupSid, gsid));
+                            }
+                            break;
+                    }
+                }
+            }
+
             var memberof = group.Attributes["memberof"]; // You can access ldap Attributes with Attributes property
-            if (memberof != null)
+            if (memberof is not null)
             {
                 foreach (var member in memberof)
                 {
@@ -129,12 +194,137 @@ internal static partial class LdapAdapter
                     if (processedGroups.Contains(nestedGroupDN))
                     {
                         // We need to keep track of already processed groups because circular references are possible with AD groups
-                        return;
+                        continue;
                     }
 
                     GetNestedGroups(connection, principal, distinguishedName, nestedGroupCN, logger, retrievedClaims, processedGroups);
                 }
             }
         }
+    }
+
+    private static string? GetGroupSID(LdapConnection connection, string distinguishedName, string groupCN, ILogger logger)
+    {
+        var filter = $"(&(objectClass=group)(sAMAccountName={groupCN}))"; // This is using ldap search query language, it is looking on the server for someUser
+        var searchRequest = new SearchRequest(distinguishedName, filter, SearchScope.Subtree);
+        var searchResponse = (SearchResponse)connection.SendRequest(searchRequest);
+
+        if (searchResponse.Entries.Count > 0)
+        {
+            if (searchResponse.Entries.Count > 1 && logger.IsEnabled(LogLevel.Warning))
+            {
+                logger.LogWarning($"More than one response received for query: {filter} with distinguished name: {distinguishedName}");
+            }
+
+            var group = searchResponse.Entries[0]; // Get the object that was found on ldap
+            var groupSID = group.Attributes["objectsid"];
+            if (groupSID is not null)
+            {
+                if (groupSID.Count == 1)
+                {
+                    if (groupSID[0] is string)
+                    {
+                        ReadOnlySpan<char> groupSIDspn = (string)groupSID[0];
+                        Span<byte> groupSIDba = stackalloc byte[groupSIDspn.Length];
+                        for (int i = 0; i < groupSIDspn.Length; ++i)
+                        {
+                            byte[] bytes = BitConverter.GetBytes(groupSIDspn[i]);
+                            groupSIDba[i] = bytes[0];
+                        }
+                        return ParseSID(groupSIDba);
+                    }
+                    else if (groupSID[0] is byte[])
+                    {
+                        return ParseSID((byte[])groupSID[0]);
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    //Straight from SID.cs of the .NET runtime library
+    internal const int MaxSubAuthorities = 15;
+    internal const long MaxIdentifierAuthority = 0xFFFFFFFFFFFF;
+    private const int MinBinaryLength = 1 + 1 + 6; // Revision (1) + subauth count (1) + identifier authority (6)
+    private const byte Revision = 1;
+    internal enum IdentifierAuthority : long
+    {
+        NullAuthority = 0,
+        WorldAuthority = 1,
+        LocalAuthority = 2,
+        CreatorAuthority = 3,
+        NonUniqueAuthority = 4,
+        NTAuthority = 5,
+        SiteServerAuthority = 6,
+        InternetSiteAuthority = 7,
+        ExchangeAuthority = 8,
+        ResourceManagerAuthority = 9,
+    }
+
+    private static string? ParseSID(ReadOnlySpan<byte> binaryForm)
+    {
+        //See SID.cs of the .NET runtime library
+        if (binaryForm.Length < MinBinaryLength)
+        {
+            return null;
+        }
+        if (binaryForm[0] != Revision)
+        {
+            return null;
+        }
+        int subAuthoritiesLength = binaryForm[1];
+        if (subAuthoritiesLength > MaxSubAuthorities)
+        {
+            return null;
+        }
+        int totalLength = 1 + 1 + 6 + 4 * subAuthoritiesLength;
+        if (binaryForm.Length < totalLength)
+        {
+            return null;
+        }
+        Span<int> subAuthorities = stackalloc int[subAuthoritiesLength];
+        IdentifierAuthority authority = (IdentifierAuthority)(
+            (((long)binaryForm[2]) << 40) +
+            (((long)binaryForm[3]) << 32) +
+            (((long)binaryForm[4]) << 24) +
+            (((long)binaryForm[5]) << 16) +
+            (((long)binaryForm[6]) << 8) +
+            (((long)binaryForm[7]))
+        );
+
+        for (int i = 0; i < subAuthoritiesLength; i++)
+        {
+            subAuthorities[i] =
+                (int)(
+                (((uint)binaryForm[8 + 4 * i + 0]) << 0) +
+                (((uint)binaryForm[8 + 4 * i + 1]) << 8) +
+                (((uint)binaryForm[8 + 4 * i + 2]) << 16) +
+                (((uint)binaryForm[8 + 4 * i + 3]) << 24)
+            );
+        }
+
+        if (authority < 0 || (long)authority > MaxIdentifierAuthority)
+        {
+            return null;
+        }
+
+        Span<char> result = stackalloc char[189];
+        result[0] = 'S';
+        result[1] = '-';
+        result[2] = '1';
+        result[3] = '-';
+        int length = 4;
+        ((ulong)authority).TryFormat(result.Slice(length), out int written, provider: CultureInfo.InvariantCulture);
+        length += written;
+        //Might need a check against a stack overflow, but this is directly taken from SID.cs of the .NET runtime library
+        for (int index = 0; index < subAuthorities.Length; index++)
+        {
+            result[length] = '-';
+            length += 1;
+            ((uint)subAuthorities[index]).TryFormat(result.Slice(length), out written, provider: CultureInfo.InvariantCulture);
+            length += written;
+        }
+        return result.Slice(0, length).ToString();
     }
 }

--- a/src/Security/Authentication/Negotiate/src/Internal/LdapAdapter.cs
+++ b/src/Security/Authentication/Negotiate/src/Internal/LdapAdapter.cs
@@ -230,27 +230,26 @@ internal static partial class LdapAdapter
             {
                 if (groupSID.Count == 1)
                 {
-                    if (groupSID[0] is string)
+                    switch (groupSID[0])
                     {
-                        string groupSIDstr = (string)groupSID[0];
-                        // The maximum permitted size of a SID is 1 + 1 + 6 + 4 * MaxSubAuthorities
-                        // and to avoid unsafe dynamic stackalloc allocations a max static allocation and
-                        // slice method will be used here. The maximum size will be rounded up to the
-                        // next power of two to increase allocation speed.
-                        int allocSize = (int)BitOperations.RoundUpToPowerOf2((uint)(1 + 1 + 6 + 4 * MaxSubAuthorities));
-                        if (groupSIDstr.Length <= allocSize)
-                        {
-                            Span<byte> lgroupSIDba = stackalloc byte[allocSize];
-                            for (int i = 0; i < groupSIDstr.Length; ++i)
+                        case string groupSIDstr:
+                            // The maximum permitted size of a SID is 1 + 1 + 6 + 4 * MaxSubAuthorities
+                            // and to avoid unsafe dynamic stackalloc allocations a max static allocation and
+                            // slice method will be used here. The maximum size will be rounded up to the
+                            // next power of two to increase allocation speed.
+                            int allocSize = (int)BitOperations.RoundUpToPowerOf2((uint)(1 + 1 + 6 + 4 * MaxSubAuthorities));
+                            if (groupSIDstr.Length <= allocSize)
                             {
-                                lgroupSIDba[i] = Convert.ToByte(groupSIDstr[i]);
+                                Span<byte> lgroupSIDba = stackalloc byte[allocSize];
+                                for (int i = 0; i < groupSIDstr.Length; ++i)
+                                {
+                                    lgroupSIDba[i] = Convert.ToByte(groupSIDstr[i]);
+                                }
+                                return ParseSID(lgroupSIDba.Slice(0, groupSIDstr.Length));
                             }
-                            return ParseSID(lgroupSIDba.Slice(0, groupSIDstr.Length));
-                        }
-                    }
-                    else if (groupSID[0] is byte[])
-                    {
-                        return ParseSID((byte[])groupSID[0]);
+                            break;
+                        case byte[] groupSIDba:
+                            return ParseSID(groupSIDba);
                     }
                 }
             }

--- a/src/Security/Authentication/Negotiate/src/Internal/LdapAdapter.cs
+++ b/src/Security/Authentication/Negotiate/src/Internal/LdapAdapter.cs
@@ -29,7 +29,7 @@ internal static partial class LdapAdapter
             settings.ClaimsCache = new MemoryCache(new MemoryCacheOptions { SizeLimit = settings.ClaimsCacheSize });
         }
 
-        if (settings.ClaimsCache.TryGetValue< IEnumerable< KeyValuePair<string, string> > >(user, out var cachedClaims) && cachedClaims is not null)
+        if (settings.ClaimsCache.TryGetValue<IEnumerable<KeyValuePair<string, string>>>(user, out var cachedClaims) && cachedClaims is not null)
         {
             foreach (var claim in cachedClaims)
             {

--- a/src/Security/Authentication/Negotiate/src/Internal/LdapAdapter.cs
+++ b/src/Security/Authentication/Negotiate/src/Internal/LdapAdapter.cs
@@ -69,7 +69,7 @@ internal static partial class LdapAdapter
             {
                 if (userSID.Count == 1)
                 {
-                    string? usid = ParseSID((byte[])userSID[0]);
+                    var usid = ParseSID((byte[])userSID[0]);
                     if (usid is not null)
                     {
                         retrievedClaims.Add(new KeyValuePair<string, string>(ClaimTypes.Sid, usid.ToString()));

--- a/src/Security/Authentication/Negotiate/src/Internal/LdapAdapter.cs
+++ b/src/Security/Authentication/Negotiate/src/Internal/LdapAdapter.cs
@@ -77,7 +77,7 @@ internal static partial class LdapAdapter
                 }
             }
 
-            HashSet<string> uniqueGroups = new HashSet<string>();
+            var uniqueGroups = new HashSet<string>();
             if (memberof is not null)
             {
                 foreach (var group in memberof)
@@ -93,7 +93,7 @@ internal static partial class LdapAdapter
                     else
                     {
                         retrievedClaims.Add(new KeyValuePair<string, string>(identity.RoleClaimType, groupCN));
-                        string? groupSID = GetGroupSID(settings.LdapConnection, distinguishedName, groupCN, logger);
+                        var groupSID = GetGroupSID(settings.LdapConnection, distinguishedName, groupCN, logger);
                         if (groupSID is not null)
                         {
                             retrievedClaims.Add(new KeyValuePair<string, string>(ClaimTypes.GroupSid, groupSID));
@@ -124,7 +124,7 @@ internal static partial class LdapAdapter
         }
     }
 
-    private static void GetNestedGroups(LdapConnection connection, ClaimsIdentity principal, string distinguishedName, string groupCN, ILogger logger, IList< KeyValuePair<string, string> > retrievedClaims, HashSet<string> processedGroups)
+    private static void GetNestedGroups(LdapConnection connection, ClaimsIdentity principal, string distinguishedName, string groupCN, ILogger logger, IList<KeyValuePair<string, string>> retrievedClaims, HashSet<string> processedGroups)
     {
         var filter = $"(&(objectClass=group)(sAMAccountName={groupCN}))"; // This is using ldap search query language, it is looking on the server for someUser
         var searchRequest = new SearchRequest(distinguishedName, filter, SearchScope.Subtree);
@@ -166,14 +166,14 @@ internal static partial class LdapAdapter
                                 byte[] bytes = BitConverter.GetBytes(groupSIDspn[i]);
                                 lgroupSIDba[i] = bytes[0];
                             }
-                            string? lgsid = ParseSID(lgroupSIDba);
+                            var lgsid = ParseSID(lgroupSIDba);
                             if (lgsid is not null)
                             {
                                 retrievedClaims.Add(new KeyValuePair<string, string>(ClaimTypes.GroupSid, lgsid));
                             }
                             break;
                         case byte[] groupSIDba:
-                            string? gsid = ParseSID(groupSIDba);
+                            var gsid = ParseSID(groupSIDba);
                             if (gsid is not null)
                             {
                                 retrievedClaims.Add(new KeyValuePair<string, string>(ClaimTypes.GroupSid, gsid));
@@ -240,10 +240,11 @@ internal static partial class LdapAdapter
                 }
             }
         }
+        
         return null;
     }
 
-    //Straight from SID.cs of the .NET runtime library
+    // Straight from SID.cs of the .NET runtime library
     internal const int MaxSubAuthorities = 15;
     internal const long MaxIdentifierAuthority = 0xFFFFFFFFFFFF;
     private const int MinBinaryLength = 1 + 1 + 6; // Revision (1) + subauth count (1) + identifier authority (6)

--- a/src/Security/Authentication/Negotiate/src/Internal/LdapAdapter.cs
+++ b/src/Security/Authentication/Negotiate/src/Internal/LdapAdapter.cs
@@ -108,7 +108,6 @@ internal static partial class LdapAdapter
             {
                 identity.AddClaim(new Claim(claim.Key, claim.Value));
                 // Approximate the size of stored value in memory cache.
-                entrySize += claim.Key.Length * 2;
                 entrySize += claim.Value.Length * 2;
             }
 

--- a/src/Security/Authentication/Negotiate/src/LdapSettings.cs
+++ b/src/Security/Authentication/Negotiate/src/LdapSettings.cs
@@ -16,6 +16,14 @@ public class LdapSettings
     /// This is mainly used on Linux.
     /// </summary>
     public bool EnableLdapClaimResolution { get; set; }
+    
+    /// <summary>
+    /// Configure whether the SID claims should be resolved when 
+    /// EnableLdapClaimResolution is true and the LDAP connection 
+    /// is used to resolve claims.
+    /// This is mainly used on Linux.
+    /// </summary>
+    public bool EnableLdapSIDClaimResolution { get; set; }
 
     /// <summary>
     /// The domain to use for the LDAP connection. This is a mandatory setting.

--- a/src/Security/Authentication/Negotiate/src/PublicAPI.Shipped.txt
+++ b/src/Security/Authentication/Negotiate/src/PublicAPI.Shipped.txt
@@ -24,6 +24,8 @@ Microsoft.AspNetCore.Authentication.Negotiate.LdapSettings.Domain.get -> string!
 Microsoft.AspNetCore.Authentication.Negotiate.LdapSettings.Domain.set -> void
 Microsoft.AspNetCore.Authentication.Negotiate.LdapSettings.EnableLdapClaimResolution.get -> bool
 Microsoft.AspNetCore.Authentication.Negotiate.LdapSettings.EnableLdapClaimResolution.set -> void
+Microsoft.AspNetCore.Authentication.Negotiate.LdapSettings.EnableLdapSIDClaimResolution.get -> bool
+Microsoft.AspNetCore.Authentication.Negotiate.LdapSettings.EnableLdapSIDClaimResolution.set -> void
 Microsoft.AspNetCore.Authentication.Negotiate.LdapSettings.IgnoreNestedGroups.get -> bool
 Microsoft.AspNetCore.Authentication.Negotiate.LdapSettings.IgnoreNestedGroups.set -> void
 Microsoft.AspNetCore.Authentication.Negotiate.LdapSettings.LdapConnection.get -> System.DirectoryServices.Protocols.LdapConnection?

--- a/src/Security/Authentication/Negotiate/test/Negotiate.Test/NegotiateHandlerTests.cs
+++ b/src/Security/Authentication/Negotiate/test/Negotiate.Test/NegotiateHandlerTests.cs
@@ -209,7 +209,7 @@ public class NegotiateHandlerTests
     {
         var claimsCache = new MemoryCache(new MemoryCacheOptions());
         var claimsList = new List<KeyValuePair<string, string>>();
-        claimsList.Add(new KeyValuePair<string, string>(ClaimTypes.X500DistinguishedName, "CN=Domain Admins,CN=Users,DC=domain,DC=net"));
+        claimsList.Add(new KeyValuePair<string, string>("http://schemas.microsoft.com/ws/2008/06/identity/claims/role", "CN=Domain Admins,CN=Users,DC=domain,DC=net"));
         claimsCache.Set("name", claimsList);
         NegotiateOptions negotiateOptions = null;
         using var host = await CreateHostAsync(options =>

--- a/src/Security/Authentication/Negotiate/test/Negotiate.Test/NegotiateHandlerTests.cs
+++ b/src/Security/Authentication/Negotiate/test/Negotiate.Test/NegotiateHandlerTests.cs
@@ -208,7 +208,9 @@ public class NegotiateHandlerTests
     public async Task RBACClaimsRetrievedFromCacheAfterKerberosCompleted()
     {
         var claimsCache = new MemoryCache(new MemoryCacheOptions());
-        claimsCache.Set("name", new string[] { "CN=Domain Admins,CN=Users,DC=domain,DC=net" });
+        var claimsList = List< KeyValuePair<string, string> >();
+        claimsList.Add(new KeyValuePair<string, string>(ClaimTypes.X500DistinguishedName, "CN=Domain Admins,CN=Users,DC=domain,DC=net"));
+        claimsCache.Set("name", claimsList);
         NegotiateOptions negotiateOptions = null;
         using var host = await CreateHostAsync(options =>
             {

--- a/src/Security/Authentication/Negotiate/test/Negotiate.Test/NegotiateHandlerTests.cs
+++ b/src/Security/Authentication/Negotiate/test/Negotiate.Test/NegotiateHandlerTests.cs
@@ -208,7 +208,7 @@ public class NegotiateHandlerTests
     public async Task RBACClaimsRetrievedFromCacheAfterKerberosCompleted()
     {
         var claimsCache = new MemoryCache(new MemoryCacheOptions());
-        var claimsList = List< KeyValuePair<string, string> >();
+        var claimsList = List<KeyValuePair<string, string>>();
         claimsList.Add(new KeyValuePair<string, string>(ClaimTypes.X500DistinguishedName, "CN=Domain Admins,CN=Users,DC=domain,DC=net"));
         claimsCache.Set("name", claimsList);
         NegotiateOptions negotiateOptions = null;

--- a/src/Security/Authentication/Negotiate/test/Negotiate.Test/NegotiateHandlerTests.cs
+++ b/src/Security/Authentication/Negotiate/test/Negotiate.Test/NegotiateHandlerTests.cs
@@ -208,7 +208,7 @@ public class NegotiateHandlerTests
     public async Task RBACClaimsRetrievedFromCacheAfterKerberosCompleted()
     {
         var claimsCache = new MemoryCache(new MemoryCacheOptions());
-        var claimsList = List<KeyValuePair<string, string>>();
+        var claimsList = new List<KeyValuePair<string, string>>();
         claimsList.Add(new KeyValuePair<string, string>(ClaimTypes.X500DistinguishedName, "CN=Domain Admins,CN=Users,DC=domain,DC=net"));
         claimsCache.Set("name", claimsList);
         NegotiateOptions negotiateOptions = null;


### PR DESCRIPTION
# Fixed LDAP based claims
Claims retrieved from LDAP return unique group memberships with SIDs.

## Description
Fix:
- Returning group names as claim only once (unique) instead of multiple times when resolving nested groups
- Handling users without an explicit group membership without null exception (happens when a user is only an implicit group member without "memberof" attributes in LDAP)

Added:
- Adds user and group SIDs as claims which is the default on windows. This should enable writing more portable code.

Todo:
- For some reason the SID of builtin groups is returned as string. Only used empirical results on local machine (using a samba ad and not a windows server) to check how to interpret the string but should investigate the cause.

The code for the SID parsing is derived from SID.cs of the .NET runtime library, because SID parsing is not available on Linux.

Fixes #55705 