### PR TITLE
[Blazor] Updated Blazor Server reconnect UI

### DIFF
--- a/src/Components/Components.slnf
+++ b/src/Components/Components.slnf
@@ -75,6 +75,7 @@
       "src\\Hosting\\Abstractions\\src\\Microsoft.AspNetCore.Hosting.Abstractions.csproj",
       "src\\Hosting\\Hosting\\src\\Microsoft.AspNetCore.Hosting.csproj",
       "src\\Hosting\\Server.Abstractions\\src\\Microsoft.AspNetCore.Hosting.Server.Abstractions.csproj",
+      "src\\Hosting\\TestHost\\src\\Microsoft.AspNetCore.TestHost.csproj",
       "src\\Html.Abstractions\\src\\Microsoft.AspNetCore.Html.Abstractions.csproj",
       "src\\Http\\Authentication.Abstractions\\src\\Microsoft.AspNetCore.Authentication.Abstractions.csproj",
       "src\\Http\\Authentication.Core\\src\\Microsoft.AspNetCore.Authentication.Core.csproj",

--- a/src/Components/Web.JS/src/Platform/Circuits/CircuitManager.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/CircuitManager.ts
@@ -89,7 +89,6 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
     this._connection = await this.startConnection();
 
     if (this._connection.state !== HubConnectionState.Connected) {
-      this.setCircuitStatus('disconnected');
       return false;
     }
 
@@ -103,11 +102,8 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
     );
 
     if (!this._circuitId) {
-      this.setCircuitStatus('disconnected');
       return false;
     }
-
-    this.setCircuitStatus('connected');
 
     for (const handler of this._options.circuitHandlers) {
       if (handler.onCircuitOpened){
@@ -119,8 +115,6 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
   }
 
   private async startConnection(): Promise<HubConnection> {
-    this.setCircuitStatus('connecting');
-
     const hubProtocol = new MessagePackHubProtocol();
     (hubProtocol as unknown as { name: string }).name = 'blazorpack';
 
@@ -164,7 +158,6 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
     connection.on('JS.EndLocationChanging', Blazor._internal.navigationManager.endLocationChanging);
     connection.onclose(error => {
       this._interopMethodsForReconnection = detachWebRendererInterop(WebRendererId.Server);
-      this.setCircuitStatus('disconnected');
 
       if (!this._disposed && !this._renderingFailed) {
         this._options.reconnectionHandler!.onConnectionDown(this._options.reconnectionOptions, error);
@@ -179,7 +172,6 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
     try {
       await connection.start();
     } catch (ex: any) {
-      this.setCircuitStatus('disconnected');
       this.unhandledError(ex as Error);
 
       if (ex.errorType === 'FailedToNegotiateWithServerError') {
@@ -232,11 +224,9 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
     }
 
     if (!await this._connection!.invoke<boolean>('ConnectCircuit', this._circuitId)) {
-      this.setCircuitStatus('disconnected');
       return false;
     }
 
-    this.setCircuitStatus('connected');
     this._options.reconnectionHandler!.onConnectionUp();
 
     return true;
@@ -305,10 +295,6 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
     // Disconnect on errors.
     // Trying to call methods on the connection after its been closed will throw.
     this.disconnect();
-  }
-
-  private setCircuitStatus(status: 'connecting' | 'connected' | 'disconnected') {
-    document.documentElement.style.setProperty('--blazor-circuit-status', status);
   }
 
   private getDisconnectFormData(): FormData {

--- a/src/Components/Web.JS/src/Platform/Circuits/CircuitStartOptions.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/CircuitStartOptions.ts
@@ -28,11 +28,6 @@ export function resolveOptions(userOptions?: Partial<CircuitStartOptions>): Circ
   // The spread operator can't be used for a deep merge, so do the same for subproperties
   if (userOptions && userOptions.reconnectionOptions) {
     result.reconnectionOptions = { ...defaultOptions.reconnectionOptions, ...userOptions.reconnectionOptions };
-
-    if (typeof(result.reconnectionOptions.retryIntervalMilliseconds) !== 'function' && result.reconnectionOptions.maxRetries === undefined) {
-      // For backwards compatibility, use default max retry count when a non-function retry interval is specified
-      result.reconnectionOptions.maxRetries = 8;
-    }
   }
 
   return result;
@@ -80,6 +75,7 @@ const defaultOptions: CircuitStartOptions = {
   initializers: undefined!,
   circuitHandlers: [],
   reconnectionOptions: {
+    maxRetries: 30,
     retryIntervalMilliseconds: computeDefaultRetryInterval,
     dialogId: 'components-reconnect-modal',
   },

--- a/src/Components/Web.JS/src/Platform/Circuits/CircuitStartOptions.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/CircuitStartOptions.ts
@@ -35,7 +35,8 @@ export function resolveOptions(userOptions?: Partial<CircuitStartOptions>): Circ
 
 export interface ReconnectionOptions {
   maxRetries: number;
-  retryIntervalMilliseconds: number;
+  retryIntervalMilliseconds?: number;
+  exponentialBackoffFactor?: number;
   dialogId: string;
 }
 
@@ -57,7 +58,8 @@ const defaultOptions: CircuitStartOptions = {
   circuitHandlers: [],
   reconnectionOptions: {
     maxRetries: 8,
-    retryIntervalMilliseconds: 20000,
+    // retryIntervalMilliseconds: 20000,
+    exponentialBackoffFactor: 2,
     dialogId: 'components-reconnect-modal',
   },
 };

--- a/src/Components/Web.JS/src/Platform/Circuits/CircuitStartOptions.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/CircuitStartOptions.ts
@@ -35,8 +35,7 @@ export function resolveOptions(userOptions?: Partial<CircuitStartOptions>): Circ
 
 export interface ReconnectionOptions {
   maxRetries: number;
-  retryIntervalMilliseconds?: number;
-  exponentialBackoffFactor?: number;
+  retryIntervalMilliseconds: number | ((attempt: number) => number);
   dialogId: string;
 }
 
@@ -50,6 +49,8 @@ export interface ReconnectionHandler {
   onConnectionUp(): void;
 }
 
+// eslint-disable-next-line array-element-newline, array-bracket-newline
+const defaultRetryIntervalsSeconds = [1, 3, 5, 10, 15, 30];
 const defaultOptions: CircuitStartOptions = {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   configureSignalR: (_) => { },
@@ -58,8 +59,7 @@ const defaultOptions: CircuitStartOptions = {
   circuitHandlers: [],
   reconnectionOptions: {
     maxRetries: 8,
-    // retryIntervalMilliseconds: 20000,
-    exponentialBackoffFactor: 2,
+    retryIntervalMilliseconds: (attempt) => 1000 * (defaultRetryIntervalsSeconds[attempt - 1] ?? defaultRetryIntervalsSeconds.at(-1)),
     dialogId: 'components-reconnect-modal',
   },
 };

--- a/src/Components/Web.JS/src/Platform/Circuits/DefaultReconnectDisplay.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/DefaultReconnectDisplay.ts
@@ -101,13 +101,14 @@ export class DefaultReconnectDisplay implements ReconnectDisplay {
 
   static readonly Css = `
     .${this.ReconnectOverlayClassName} {
-      position: absolute;
+      position: fixed;
       top: 0;
       bottom: 0;
       left: 0;
       right: 0;
       z-index: 10000;
       display: none;
+      overflow: hidden;
       animation: components-reconnect-fade-in;
     }
 

--- a/src/Components/Web.JS/src/Platform/Circuits/DefaultReconnectDisplay.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/DefaultReconnectDisplay.ts
@@ -94,9 +94,9 @@ export class DefaultReconnectDisplay implements ReconnectDisplay {
   }
 
   rejected(): void {
-    this.reloadButton.style.display = 'block';
-    this.rejoiningAnimation.style.display = 'none';
-    this.status.innerHTML = 'Unable to rejoin.<br />Please reload the page to restore functionality.';
+    // We have been able to reach the server, but the circuit is no longer available.
+    // We'll reload the page so the user can continue using the app as quickly as possible.
+    location.reload();
   }
 
   static readonly Css = `

--- a/src/Components/Web.JS/src/Platform/Circuits/DefaultReconnectDisplay.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/DefaultReconnectDisplay.ts
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { ReconnectDisplay } from './ReconnectDisplay';
-import { Logger, LogLevel } from '../Logging/Logger';
-import { Blazor } from '../../GlobalExports';
 
 export class DefaultReconnectDisplay implements ReconnectDisplay {
   static readonly ReconnectOverlayClassName = 'components-reconnect-overlay';
@@ -12,11 +10,9 @@ export class DefaultReconnectDisplay implements ReconnectDisplay {
 
   static readonly ReconnectVisibleClassName = 'components-reconnect-visible';
 
-  static readonly RippleGroupClassName = 'components-ripple-group';
+  static readonly RejoiningAnimationClassName = 'components-rejoining-animation';
 
-  static readonly RippleCount = 2;
-
-  static readonly ShowCheckInternetDelayMilliseconds = 5000;
+  static readonly AnimationRippleCount = 2;
 
   style: HTMLStyleElement;
 
@@ -24,11 +20,13 @@ export class DefaultReconnectDisplay implements ReconnectDisplay {
 
   dialog: HTMLDivElement;
 
-  checkInternetElement: HTMLParagraphElement;
+  rejoiningAnimation: HTMLDivElement;
 
-  showCheckInternetTimeout?: number;
+  reloadButton: HTMLButtonElement;
 
-  constructor(dialogId: string, private readonly maxRetries: number, private readonly document: Document, private readonly logger: Logger) {
+  status: HTMLParagraphElement;
+
+  constructor(dialogId: string, private readonly document: Document) {
     this.style = this.document.createElement('style');
     this.style.innerHTML = DefaultReconnectDisplay.Css;
 
@@ -39,29 +37,25 @@ export class DefaultReconnectDisplay implements ReconnectDisplay {
     this.dialog = this.document.createElement('div');
     this.dialog.className = DefaultReconnectDisplay.ReconnectDialogClassName;
 
-    const rippleGroup = document.createElement('div');
-    rippleGroup.className = DefaultReconnectDisplay.RippleGroupClassName;
+    this.rejoiningAnimation = document.createElement('div');
+    this.rejoiningAnimation.className = DefaultReconnectDisplay.RejoiningAnimationClassName;
 
-    for (let i = 0; i < DefaultReconnectDisplay.RippleCount; i++) {
+    for (let i = 0; i < DefaultReconnectDisplay.AnimationRippleCount; i++) {
       const ripple = document.createElement('div');
-      rippleGroup.appendChild(ripple);
+      this.rejoiningAnimation.appendChild(ripple);
     }
 
-    const rejoiningMessage = document.createElement('p');
-    rejoiningMessage.innerHTML = 'Rejoining the server...';
+    this.status = document.createElement('p');
+    this.status.innerHTML = '';
 
-    this.checkInternetElement = document.createElement('p');
-    this.checkInternetElement.innerHTML = 'Check your internet connection';
+    this.reloadButton = document.createElement('button');
+    this.reloadButton.addEventListener('click', () => location.reload());
+    this.reloadButton.style.display = 'none';
+    this.reloadButton.innerHTML = 'Reload';
 
-    const reloadButton = document.createElement('button');
-    reloadButton.setAttribute('onclick', 'location.reload()');
-    reloadButton.style.display = 'none';
-    reloadButton.innerHTML = 'Reload';
-
-    this.dialog.appendChild(rippleGroup);
-    this.dialog.appendChild(rejoiningMessage);
-    this.dialog.appendChild(this.checkInternetElement);
-    this.dialog.appendChild(reloadButton);
+    this.dialog.appendChild(this.rejoiningAnimation);
+    this.dialog.appendChild(this.status);
+    this.dialog.appendChild(this.reloadButton);
 
     this.overlay.appendChild(this.dialog);
   }
@@ -75,29 +69,34 @@ export class DefaultReconnectDisplay implements ReconnectDisplay {
       this.document.body.appendChild(this.style);
     }
 
+    this.overlay.style.display = 'block';
     this.overlay.classList.add(DefaultReconnectDisplay.ReconnectVisibleClassName);
-    this.checkInternetElement.style.display = 'none';
-    clearTimeout(this.showCheckInternetTimeout);
-    this.showCheckInternetTimeout = setTimeout(() => {
-      this.checkInternetElement.style.display = 'block';
-    }, DefaultReconnectDisplay.ShowCheckInternetDelayMilliseconds) as unknown as number;
   }
 
-  update(currentAttempt: number): void {
-    // TODO
+  update(currentAttempt: number, secondsToNextAttempt: number): void {
+    if (currentAttempt === 1 || secondsToNextAttempt === 0) {
+      this.status.innerHTML = 'Rejoining the server...';
+    } else {
+      const unitText = secondsToNextAttempt === 1 ? 'second' : 'seconds';
+      this.status.innerHTML = `Rejoin failed... trying again in ${secondsToNextAttempt} ${unitText}`;
+    }
   }
 
   hide(): void {
+    this.overlay.style.display = 'none';
     this.overlay.classList.remove(DefaultReconnectDisplay.ReconnectVisibleClassName);
-    clearTimeout(this.showCheckInternetTimeout);
   }
 
   failed(): void {
-    location.reload();
+    this.reloadButton.style.display = 'block';
+    this.rejoiningAnimation.style.display = 'none';
+    this.status.innerHTML = 'Failed to rejoin.<br />Please reload the page to attempt reconnection.';
   }
 
   rejected(): void {
-    location.reload();
+    this.reloadButton.style.display = 'block';
+    this.rejoiningAnimation.style.display = 'none';
+    this.status.innerHTML = 'Unable to rejoin.<br />Please reload the page to restore functionality.';
   }
 
   static readonly Css = `
@@ -130,6 +129,7 @@ export class DefaultReconnectDisplay implements ReconnectDisplay {
 
     .${this.ReconnectOverlayClassName} p {
       margin: 0;
+      text-align: center;
     }
 
     .${this.ReconnectOverlayClassName} button {
@@ -166,26 +166,26 @@ export class DefaultReconnectDisplay implements ReconnectDisplay {
       z-index: 10001;
     }
 
-    .${this.RippleGroupClassName} {
+    .${this.RejoiningAnimationClassName} {
       display: block;
       position: relative;
       width: 80px;
       height: 80px;
     }
 
-    .${this.RippleGroupClassName} div {
+    .${this.RejoiningAnimationClassName} div {
       position: absolute;
       border: 3px solid #0087ff;
       opacity: 1;
       border-radius: 50%;
-      animation: ${this.RippleGroupClassName} 1.5s cubic-bezier(0, 0.2, 0.8, 1) infinite;
+      animation: ${this.RejoiningAnimationClassName} 1.5s cubic-bezier(0, 0.2, 0.8, 1) infinite;
     }
 
-    .${this.RippleGroupClassName} div:nth-child(2) {
+    .${this.RejoiningAnimationClassName} div:nth-child(2) {
       animation-delay: -0.5s;
     }
 
-    @keyframes ${this.RippleGroupClassName} {
+    @keyframes ${this.RejoiningAnimationClassName} {
       0% {
         top: 40px;
         left: 40px;
@@ -239,164 +239,4 @@ export class DefaultReconnectDisplay implements ReconnectDisplay {
       }
     }
   `;
-}
-
-export class DefaultReconnectDisplayOld implements ReconnectDisplay {
-  modal: HTMLDivElement;
-
-  message: HTMLHeadingElement;
-
-  button: HTMLButtonElement;
-
-  reloadParagraph: HTMLParagraphElement;
-
-  loader: HTMLDivElement;
-
-  constructor(dialogId: string, private readonly maxRetries: number, private readonly document: Document, private readonly logger: Logger) {
-    this.modal = this.document.createElement('div');
-    this.modal.id = dialogId;
-    this.maxRetries = maxRetries;
-
-    const modalStyles = [
-      'position: fixed',
-      'top: 0',
-      'right: 0',
-      'bottom: 0',
-      'left: 0',
-      'z-index: 1050',
-      'display: none',
-      'overflow: hidden',
-      'background-color: #fff',
-      'opacity: 0.8',
-      'text-align: center',
-      'font-weight: bold',
-      'transition: visibility 0s linear 500ms',
-    ];
-
-    this.modal.style.cssText = modalStyles.join(';');
-
-    this.message = this.document.createElement('h5') as HTMLHeadingElement;
-    this.message.style.cssText = 'margin-top: 20px';
-
-    this.button = this.document.createElement('button') as HTMLButtonElement;
-    this.button.style.cssText = 'margin:5px auto 5px';
-    this.button.textContent = 'Retry';
-
-    const link = this.document.createElement('a');
-    link.addEventListener('click', () => location.reload());
-    link.textContent = 'reload';
-
-    this.reloadParagraph = this.document.createElement('p') as HTMLParagraphElement;
-    this.reloadParagraph.textContent = 'Alternatively, ';
-    this.reloadParagraph.appendChild(link);
-
-    this.modal.appendChild(this.message);
-    this.modal.appendChild(this.button);
-    this.modal.appendChild(this.reloadParagraph);
-
-    this.loader = this.getLoader();
-
-    this.message.after(this.loader);
-
-    this.button.addEventListener('click', async () => {
-      this.show();
-
-      try {
-        // reconnect will asynchronously return:
-        // - true to mean success
-        // - false to mean we reached the server, but it rejected the connection (e.g., unknown circuit ID)
-        // - exception to mean we didn't reach the server (this can be sync or async)
-        const successful = await Blazor.reconnect!();
-        if (!successful) {
-          this.rejected();
-        }
-      } catch (err: unknown) {
-        // We got an exception, server is currently unavailable
-        this.logger.log(LogLevel.Error, err as Error);
-        this.failed();
-      }
-    });
-  }
-
-  show(): void {
-    if (!this.document.contains(this.modal)) {
-      this.document.body.appendChild(this.modal);
-    }
-    this.modal.style.display = 'block';
-    this.loader.style.display = 'inline-block';
-    this.button.style.display = 'none';
-    this.reloadParagraph.style.display = 'none';
-    this.message.textContent = 'Attempting to reconnect to the server...';
-
-    // The visibility property has a transition so it takes effect after a delay.
-    // This is to prevent it appearing momentarily when navigating away. For the
-    // transition to take effect, we have to apply the visibility asynchronously.
-    this.modal.style.visibility = 'hidden';
-    setTimeout(() => {
-      this.modal.style.visibility = 'visible';
-    }, 0);
-  }
-
-  update(currentAttempt: number): void {
-    this.message.textContent = `Attempting to reconnect to the server: ${currentAttempt} of ${this.maxRetries}`;
-  }
-
-  hide(): void {
-    this.modal.style.display = 'none';
-  }
-
-  failed(): void {
-    this.button.style.display = 'block';
-    this.reloadParagraph.style.display = 'none';
-    this.loader.style.display = 'none';
-
-    const errorDescription = this.document.createTextNode('Reconnection failed. Try ');
-
-    const link = this.document.createElement('a');
-    link.textContent = 'reloading';
-    link.setAttribute('href', '');
-    link.addEventListener('click', () => location.reload());
-
-    const errorInstructions = this.document.createTextNode(' the page if you\'re unable to reconnect.');
-
-    this.message.replaceChildren(errorDescription, link, errorInstructions);
-  }
-
-  rejected(): void {
-    this.button.style.display = 'none';
-    this.reloadParagraph.style.display = 'none';
-    this.loader.style.display = 'none';
-
-    const errorDescription = this.document.createTextNode('Could not reconnect to the server. ');
-
-    const link = this.document.createElement('a');
-    link.textContent = 'Reload';
-    link.setAttribute('href', '');
-    link.addEventListener('click', () => location.reload());
-
-    const errorInstructions = this.document.createTextNode(' the page to restore functionality.');
-
-    this.message.replaceChildren(errorDescription, link, errorInstructions);
-  }
-
-  private getLoader(): HTMLDivElement {
-    const loader = this.document.createElement('div');
-
-    const loaderStyles = [
-      'border: 0.3em solid #f3f3f3',
-      'border-top: 0.3em solid #3498db',
-      'border-radius: 50%',
-      'width: 2em',
-      'height: 2em',
-      'display: inline-block',
-    ];
-
-    loader.style.cssText = loaderStyles.join(';');
-    loader.animate([{ transform: 'rotate(0deg)' }, { transform: 'rotate(360deg)' }], {
-      duration: 2000,
-      iterations: Infinity,
-    });
-
-    return loader;
-  }
 }

--- a/src/Components/Web.JS/src/Platform/Circuits/DefaultReconnectionHandler.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/DefaultReconnectionHandler.ts
@@ -28,7 +28,7 @@ export class DefaultReconnectionHandler implements ReconnectionHandler {
       const modal = document.getElementById(options.dialogId);
       this._reconnectionDisplay = modal
         ? new UserSpecifiedDisplay(modal, document, options.maxRetries)
-        : new DefaultReconnectDisplay(options.dialogId, document);
+        : new DefaultReconnectDisplay(options.dialogId, document, this._logger);
     }
 
     if (!this._currentReconnectionProcess) {

--- a/src/Components/Web.JS/src/Platform/Circuits/DefaultReconnectionHandler.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/DefaultReconnectionHandler.ts
@@ -137,7 +137,7 @@ class ReconnectionProcess {
         return;
       }
 
-      const nextTimeout = intervalMs - (deltaTime - simulatedTime);
+      const nextTimeout = Math.min(totalTimeMs, intervalMs - (deltaTime - simulatedTime));
       callback(totalTimeMs);
       setTimeout(step, nextTimeout);
     }

--- a/src/Components/Web.JS/src/Platform/Circuits/DefaultReconnectionHandler.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/DefaultReconnectionHandler.ts
@@ -27,7 +27,7 @@ export class DefaultReconnectionHandler implements ReconnectionHandler {
     if (!this._reconnectionDisplay) {
       const modal = document.getElementById(options.dialogId);
       this._reconnectionDisplay = modal
-        ? new UserSpecifiedDisplay(modal, options.maxRetries, document)
+        ? new UserSpecifiedDisplay(modal, document, options.maxRetries)
         : new DefaultReconnectDisplay(options.dialogId, document);
     }
 
@@ -63,12 +63,10 @@ class ReconnectionProcess {
   }
 
   async attemptPeriodicReconnection(options: ReconnectionOptions) {
-    for (let i = 0; i < options.maxRetries; i++) {
-      const currentAttempt = i + 1;
-
+    for (let i = 0; options.maxRetries === undefined || i < options.maxRetries; i++) {
       let retryInterval: number;
       if (typeof(options.retryIntervalMilliseconds) === 'function') {
-        const computedRetryInterval = options.retryIntervalMilliseconds(currentAttempt);
+        const computedRetryInterval = options.retryIntervalMilliseconds(i);
         if (computedRetryInterval === null || computedRetryInterval === undefined) {
           break;
         }
@@ -80,7 +78,7 @@ class ReconnectionProcess {
       }
 
       await this.runTimer(retryInterval, /* intervalMs */ 1000, remainingMs => {
-        this.reconnectDisplay.update(currentAttempt, Math.round(remainingMs / 1000));
+        this.reconnectDisplay.update(i + 1, Math.round(remainingMs / 1000));
       });
 
       if (this.isDisposed) {

--- a/src/Components/Web.JS/src/Platform/Circuits/DefaultReconnectionHandler.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/DefaultReconnectionHandler.ts
@@ -47,10 +47,6 @@ export class DefaultReconnectionHandler implements ReconnectionHandler {
 class ReconnectionProcess {
   static readonly MaximumFirstRetryInterval = 3000;
 
-  static readonly DefaultRetryInterval = 10000;
-
-  static readonly MinimumBackoffRetryInterval = 2000;
-
   readonly reconnectDisplay: ReconnectDisplay;
 
   isDisposed = false;
@@ -79,7 +75,7 @@ class ReconnectionProcess {
           : options.retryIntervalMilliseconds;
       }
 
-      await this.runTimer(retryInterval, 1000, remainingMs => {
+      await this.runTimer(retryInterval, /* intervalMs */ 1000, remainingMs => {
         this.reconnectDisplay.update(currentAttempt, Math.round(remainingMs / 1000));
       });
 
@@ -129,7 +125,8 @@ class ReconnectionProcess {
 
       // Get the number of steps that should have passed have since the last
       // call to "step". We expect this to be 1 in most cases, but it may
-      // be higher if the browser tab sleeps, for example.
+      // be higher if something causes the timeout to get significantly
+      // delayed (e.g., the browser sleeps the tab).
       const simulatedSteps = Math.max(1, Math.floor(deltaTime / intervalMs));
       const simulatedTime = intervalMs * simulatedSteps;
 

--- a/src/Components/Web.JS/src/Platform/Circuits/DefaultReconnectionHandler.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/DefaultReconnectionHandler.ts
@@ -120,7 +120,7 @@ class ReconnectionProcess {
 
     const step = () => {
       if (this.isDisposed) {
-        // Stop invoking the callback
+        // Stop invoking the callback after disposal.
         resolveTimerPromise();
         return;
       }

--- a/src/Components/Web.JS/src/Platform/Circuits/ReconnectDisplay.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/ReconnectDisplay.ts
@@ -3,7 +3,7 @@
 
 export interface ReconnectDisplay {
   show(): void;
-  update(currentAttempt: number): void;
+  update(currentAttempt: number, secondsToNextAttempt: number): void;
   hide(): void;
   failed(): void;
   rejected(): void;

--- a/src/Components/Web.JS/src/Platform/Circuits/UserSpecifiedDisplay.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/UserSpecifiedDisplay.ts
@@ -15,13 +15,17 @@ export class UserSpecifiedDisplay implements ReconnectDisplay {
 
   static readonly CurrentAttemptId = 'components-reconnect-current-attempt';
 
-  constructor(private dialog: HTMLElement, private readonly maxRetries: number, private readonly document: Document) {
+  static readonly SecondsToNextAttemptId = 'components-seconds-to-next-attempt';
+
+  constructor(private dialog: HTMLElement, private readonly document: Document, maxRetries?: number) {
     this.document = document;
 
-    const maxRetriesElement = this.document.getElementById(UserSpecifiedDisplay.MaxRetriesId);
+    if (maxRetries !== undefined) {
+      const maxRetriesElement = this.document.getElementById(UserSpecifiedDisplay.MaxRetriesId);
 
-    if (maxRetriesElement) {
-      maxRetriesElement.innerText = this.maxRetries.toString();
+      if (maxRetriesElement) {
+        maxRetriesElement.innerText = maxRetries.toString();
+      }
     }
   }
 
@@ -30,11 +34,17 @@ export class UserSpecifiedDisplay implements ReconnectDisplay {
     this.dialog.classList.add(UserSpecifiedDisplay.ShowClassName);
   }
 
-  update(currentAttempt: number): void {
+  update(currentAttempt: number, secondsToNextAttempt: number): void {
     const currentAttemptElement = this.document.getElementById(UserSpecifiedDisplay.CurrentAttemptId);
 
     if (currentAttemptElement) {
       currentAttemptElement.innerText = currentAttempt.toString();
+    }
+
+    const secondsToNextAttemptElement = this.document.getElementById(UserSpecifiedDisplay.SecondsToNextAttemptId);
+
+    if (secondsToNextAttemptElement) {
+      secondsToNextAttemptElement.innerText = secondsToNextAttempt.toString();
     }
   }
 

--- a/src/Components/test/testassets/Components.TestServer/Pages/_ServerHost.cshtml
+++ b/src/Components/test/testassets/Components.TestServer/Pages/_ServerHost.cshtml
@@ -50,7 +50,16 @@
         }
     </script>
     
-    <script src="_framework/blazor.server.js"></script>
+    <script src="_framework/blazor.server.js" autostart="false"></script>
+    <script>
+        Blazor.start({
+            reconnectionOptions: {
+                // It's easier to test the reconnection logic if we wait a bit
+                // before attempting to reconnect
+                retryIntervalMilliseconds: 5000,
+            },
+        });
+    </script>
     <script src="js/jsRootComponentInitializers.js"></script>
 
     <!-- Used by ExternalContentPackage -->

--- a/src/Components/test/testassets/Components.TestServer/Pages/_ServerHost.cshtml
+++ b/src/Components/test/testassets/Components.TestServer/Pages/_ServerHost.cshtml
@@ -49,14 +49,14 @@
             document.body.append(element);
         }
     </script>
-    
+
     <script src="_framework/blazor.server.js" autostart="false"></script>
     <script>
         Blazor.start({
             reconnectionOptions: {
                 // It's easier to test the reconnection logic if we wait a bit
                 // before attempting to reconnect
-                retryIntervalMilliseconds: 5000,
+                retryIntervalMilliseconds: Array.prototype.at.bind([5000, 5000, 5000, 10000, 30000]),
             },
         });
     </script>

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/App.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/App.razor
@@ -95,6 +95,8 @@
                 },
                 circuit: {
                     reconnectionOptions: {
+                        // It's easier to test the reconnection logic if we wait a bit
+                        // before attempting to reconnect
                         retryIntervalMilliseconds: 5000,
                     },
                 },

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/App.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/App.razor
@@ -93,6 +93,11 @@
                         }
                     },
                 },
+                circuit: {
+                    reconnectionOptions: {
+                        retryIntervalMilliseconds: 5000,
+                    },
+                },
             }).then(() => appendHiddenParagraph('blazor-started'));
         }
 


### PR DESCRIPTION
# Updated Blazor Server reconnect UI

Improves the default Blazor Server reconnect experience according to common customer feedback.

## Description

Makes the following improvements to the Blazor Server reconnect UI:
* Rather than waiting three seconds before attempting reconnection, then waiting an additional default of 20 seconds between successive attempts, the new default settings use a configurable exponential backoff strategy:
  * Retry as quickly as possible for the first 10 attempts
  * Retry every 5 seconds for the next 10 attempts
  * Retry every 30 seconds until reaching the user-configured max retry count
  * **Note**: Customers can configure their own retry interval calculation function to override the default behavior
* When the user navigates back to the disconnected app from another app or browser tab, a reconnect attempt is immediately made
* If the server can be reached, but reconnection fails because server disposed the circuit, a refresh occurs automatically
* The default reconnect UI shows the number of seconds until the next reconnect attempt instead of the number of attempts remaining
* The styling of the default reconnect UI has been modernized

Fixes #55721

## Customer Impact

Customers of apps built using Blazor Server often complain about the reconnection experience, which has motivated Blazor developers to open issues like #32113 suggesting improvements to reduce the amount of time the customer spends looking at the reconnect UI. This PR addresses many of those common concerns by performing reconnection attempts more aggressively. Unless apps have overridden the default reconnection options, they will automatically get thew new reconnect behavior by upgrading to .NET 9. In addition, the default reconnect UI styling has been updated. Styling changes will not affect apps that have overridden the default reconnect UI.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

This change only affects the reconnection experience when using Blazor Server or Server interactivity in a Blazor Web App. We have existing automated tests verifying core reconnect functionality. It's possible that some customers may have been relying on the previous defaults, but they'll still be able to override the new defaults if desired.

## Verification

- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A