### PR TITLE
Use span.Equals instead of string.Compare  in JumpTables

### DIFF
--- a/src/Http/Routing/src/Matching/LinearSearchJumpTable.cs
+++ b/src/Http/Routing/src/Matching/LinearSearchJumpTable.cs
@@ -30,17 +30,11 @@ internal sealed class LinearSearchJumpTable : JumpTable
         }
 
         var entries = _entries;
+        var pathSpan = path.AsSpan(segment.Start..(segment.Start + segment.Length));
         for (var i = 0; i < entries.Length; i++)
         {
             var text = entries[i].text;
-            if (segment.Length == text.Length &&
-                string.Compare(
-                    path,
-                    segment.Start,
-                    text,
-                    0,
-                    segment.Length,
-                    StringComparison.OrdinalIgnoreCase) == 0)
+            if (pathSpan.Equals(text, StringComparison.OrdinalIgnoreCase))
             {
                 return entries[i].destination;
             }

--- a/src/Http/Routing/src/Matching/LinearSearchJumpTable.cs
+++ b/src/Http/Routing/src/Matching/LinearSearchJumpTable.cs
@@ -30,7 +30,7 @@ internal sealed class LinearSearchJumpTable : JumpTable
         }
 
         var entries = _entries;
-        var pathSpan = path.AsSpan(segment.Start..(segment.Start + segment.Length));
+        var pathSpan = path.AsSpan(segment.Start, segment.Length);
         for (var i = 0; i < entries.Length; i++)
         {
             var text = entries[i].text;

--- a/src/Http/Routing/src/Matching/SingleEntryJumpTable.cs
+++ b/src/Http/Routing/src/Matching/SingleEntryJumpTable.cs
@@ -24,19 +24,14 @@ internal sealed class SingleEntryJumpTable : JumpTable
 
     public override int GetDestination(string path, PathSegment segment)
     {
-        if (segment.Length == 0)
+        var length = segment.Length;
+        if (length == 0)
         {
             return _exitDestination;
         }
 
-        if (segment.Length == _text.Length &&
-            string.Compare(
-                path,
-                segment.Start,
-                _text,
-                0,
-                segment.Length,
-                StringComparison.OrdinalIgnoreCase) == 0)
+        var pathSpan = path.AsSpan(segment.Start, length);
+        if (pathSpan.Equals(_text, StringComparison.OrdinalIgnoreCase))
         {
             return _destination;
         }


### PR DESCRIPTION
This is a performance improvement for `LinearSearchJumpTable` and `SingleEntryJumpTable` which is used heavily in routing.

## Description

Instead of relying on `string.Compare` returning `0`, we use `span.Equals`. The latter is much more optimized for example with vectorization.

Not sure if I must wrap with `#if NET???_OR_GREATER` - would appreciate direction.

```
// * Summary *

BenchmarkDotNet v0.13.12, Windows 11 (10.0.22621.3447/22H2/2022Update/SunValley2)
12th Gen Intel Core i7-1260P, 1 CPU, 16 logical and 12 physical cores
.NET SDK 8.0.202
  [Host]     : .NET 8.0.3 (8.0.324.11423), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.3 (8.0.324.11423), X64 RyuJIT AVX2


| Method       | Mean     | Error    | StdDev   | Median   |
|------------- |---------:|---------:|---------:|---------:|
| Compare_Hit  | 90.61 ns | 1.758 ns | 4.601 ns | 89.08 ns |
| Compare_Miss | 74.30 ns | 1.386 ns | 1.082 ns | 73.99 ns |
| Equals_Hit   | 44.69 ns | 1.351 ns | 3.897 ns | 42.87 ns |
| Equals_Miss  | 45.37 ns | 0.884 ns | 0.738 ns | 45.25 ns |
```

## Standalone benchmark code

```c#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

BenchmarkRunner.Run<Benchmarks>();

public class Benchmarks
{
    private readonly LinearSearchJumpTable_Compare _searchWithCompare;
    private readonly LinearSearchJumpTable_Equals _searchWithEquals;

    public Benchmarks()
    {
        var entries = new[]
        {
            ("Controller1", 1),
            ("Controller2", 2),
            ("Controller3", 3),
            ("Controller4", 4),
            ("Controller5", 5),
            ("Controller6", 6),
            ("Controller7", 7),
            ("Controller8", 8),
            ("Controller9", 9),
        };

        _searchWithCompare = new (-1, -1, entries);
        _searchWithEquals = new (-1, -1, entries);
    }

    [Benchmark]
    public int Compare_Hit()
    {
        return _searchWithCompare.GetDestination("controller9", new PathSegment(0, 11));
    }

    [Benchmark]
    public int Compare_Miss()
    {
        return _searchWithCompare.GetDestination("controllerZ", new PathSegment(0, 11));
    }

    [Benchmark]
    public int Equals_Hit()
    {
        return _searchWithEquals.GetDestination("controller9", new PathSegment(0, 11));
    }

    [Benchmark]
    public int Equals_Miss()
    {
        return _searchWithEquals.GetDestination("controllerZ", new PathSegment(0, 11));
    }
}

internal sealed class LinearSearchJumpTable_Compare
{
    private readonly int _defaultDestination;
    private readonly int _exitDestination;
    private readonly (string text, int destination)[] _entries;

    public LinearSearchJumpTable_Compare(
        int defaultDestination,
        int exitDestination,
        (string text, int destination)[] entries)
    {
        _defaultDestination = defaultDestination;
        _exitDestination = exitDestination;
        _entries = entries;
    }

    public int GetDestination(string path, PathSegment segment)
    {
        if (segment.Length == 0)
        {
            return _exitDestination;
        }

        var entries = _entries;
        for (var i = 0; i < entries.Length; i++)
        {
            var text = entries[i].text;
            if (segment.Length == text.Length &&
                string.Compare(
                    path,
                    segment.Start,
                    text,
                    0,
                    segment.Length,
                    StringComparison.OrdinalIgnoreCase) == 0)
            {
                return entries[i].destination;
            }
        }

        return _defaultDestination;
    }
}

internal sealed class LinearSearchJumpTable_Equals
{
    private readonly int _defaultDestination;
    private readonly int _exitDestination;
    private readonly (string text, int destination)[] _entries;

    public LinearSearchJumpTable_Equals(
        int defaultDestination,
        int exitDestination,
        (string text, int destination)[] entries)
    {
        _defaultDestination = defaultDestination;
        _exitDestination = exitDestination;
        _entries = entries;
    }

    public int GetDestination(string path, PathSegment segment)
    {
        if (segment.Length == 0)
        {
            return _exitDestination;
        }

        var entries = _entries;
        var pathSpan = path.AsSpan(segment.Start..(segment.Start + segment.Length));
        for (var i = 0; i < entries.Length; i++)
        {
            var text = entries[i].text;
            if (pathSpan.Equals(text, StringComparison.OrdinalIgnoreCase))
            {
                return entries[i].destination;
            }
        }

        return _defaultDestination;
    }
}

internal readonly struct PathSegment : IEquatable<PathSegment>
{
    public readonly int Start;
    public readonly int Length;

    public PathSegment(int start, int length)
    {
        Start = start;
        Length = length;
    }

    public override bool Equals(object? obj)
    {
        return obj is PathSegment segment ? Equals(segment) : false;
    }

    public bool Equals(PathSegment other)
    {
        return Start == other.Start && Length == other.Length;
    }

    public override int GetHashCode()
    {
        return Start;
    }

    public override string ToString()
    {
        return $"Segment({Start}:{Length})";
    }
}
```