### PR TITLE
Fixup `HybridCache` public API

### DIFF
--- a/src/Caching/Hybrid/src/HybridCacheBuilderExtensions.cs
+++ b/src/Caching/Hybrid/src/HybridCacheBuilderExtensions.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Caching.Hybrid;
 
-namespace Microsoft.Extensions.Caching.Hybrid;
+namespace Microsoft.Extensions.DependencyInjection;
 
 /// <summary>
 /// Configuration extension methods for <see cref="IHybridCacheBuilder"/> / <see cref="HybridCache"/>.
@@ -14,7 +14,7 @@ public static class HybridCacheBuilderExtensions
     /// <summary>
     /// Serialize values of type <typeparamref name="T"/> with the specified serializer from <paramref name="serializer"/>.
     /// </summary>
-    public static IHybridCacheBuilder WithSerializer<T>(this IHybridCacheBuilder builder, IHybridCacheSerializer<T> serializer)
+    public static IHybridCacheBuilder AddSerializer<T>(this IHybridCacheBuilder builder, IHybridCacheSerializer<T> serializer)
     {
         builder.Services.AddSingleton<IHybridCacheSerializer<T>>(serializer);
         return builder;
@@ -23,7 +23,7 @@ public static class HybridCacheBuilderExtensions
     /// <summary>
     /// Serialize values of type <typeparamref name="T"/> with the serializer of type <typeparamref name="TImplementation"/>.
     /// </summary>
-    public static IHybridCacheBuilder WithSerializer<T,
+    public static IHybridCacheBuilder AddSerializer<T,
 #if NET5_0_OR_GREATER
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
 #endif
@@ -37,7 +37,7 @@ public static class HybridCacheBuilderExtensions
     /// <summary>
     /// Add <paramref name="factory"/> as an additional serializer factory, which can provide serializers for multiple types.
     /// </summary>
-    public static IHybridCacheBuilder WithSerializerFactory(this IHybridCacheBuilder builder, IHybridCacheSerializerFactory factory)
+    public static IHybridCacheBuilder AddSerializerFactory(this IHybridCacheBuilder builder, IHybridCacheSerializerFactory factory)
     {
         builder.Services.AddSingleton<IHybridCacheSerializerFactory>(factory);
         return builder;
@@ -46,7 +46,7 @@ public static class HybridCacheBuilderExtensions
     /// <summary>
     /// Add a factory of type <typeparamref name="TImplementation"/> as an additional serializer factory, which can provide serializers for multiple types.
     /// </summary>
-    public static IHybridCacheBuilder WithSerializerFactory<
+    public static IHybridCacheBuilder AddSerializerFactory<
 #if NET5_0_OR_GREATER
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
 #endif

--- a/src/Caching/Hybrid/src/HybridCacheServiceExtensions.cs
+++ b/src/Caching/Hybrid/src/HybridCacheServiceExtensions.cs
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.Caching.Hybrid.Internal;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
-namespace Microsoft.Extensions.Caching.Hybrid;
+namespace Microsoft.Extensions.DependencyInjection;
 
 /// <summary>
 /// Configuration extension methods for <see cref="HybridCache"/>.

--- a/src/Caching/Hybrid/src/Internal/DefaultHybridCache.cs
+++ b/src/Caching/Hybrid/src/Internal/DefaultHybridCache.cs
@@ -144,13 +144,13 @@ internal sealed partial class DefaultHybridCache : HybridCache
         return stampede.JoinAsync(token);
     }
 
-    public override ValueTask RemoveKeyAsync(string key, CancellationToken token = default)
+    public override ValueTask RemoveAsync(string key, CancellationToken token = default)
     {
         _localCache.Remove(key);
         return _backendCache is null ? default : new(_backendCache.RemoveAsync(key, token));
     }
 
-    public override ValueTask RemoveTagAsync(string tag, CancellationToken token = default)
+    public override ValueTask RemoveByTagAsync(string tag, CancellationToken token = default)
         => default; // tags not yet implemented
 
     public override ValueTask SetAsync<T>(string key, T value, HybridCacheEntryOptions? options = null, IReadOnlyCollection<string>? tags = null, CancellationToken token = default)

--- a/src/Caching/Hybrid/src/PublicAPI.Unshipped.txt
+++ b/src/Caching/Hybrid/src/PublicAPI.Unshipped.txt
@@ -1,7 +1,7 @@
 #nullable enable
 abstract Microsoft.Extensions.Caching.Hybrid.HybridCache.GetOrCreateAsync<TState, T>(string! key, TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<T>>! factory, Microsoft.Extensions.Caching.Hybrid.HybridCacheEntryOptions? options = null, System.Collections.Generic.IReadOnlyCollection<string!>? tags = null, System.Threading.CancellationToken token = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<T>
-abstract Microsoft.Extensions.Caching.Hybrid.HybridCache.RemoveKeyAsync(string! key, System.Threading.CancellationToken token = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
-abstract Microsoft.Extensions.Caching.Hybrid.HybridCache.RemoveTagAsync(string! tag, System.Threading.CancellationToken token = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+abstract Microsoft.Extensions.Caching.Hybrid.HybridCache.RemoveAsync(string! key, System.Threading.CancellationToken token = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+abstract Microsoft.Extensions.Caching.Hybrid.HybridCache.RemoveByTagAsync(string! tag, System.Threading.CancellationToken token = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
 abstract Microsoft.Extensions.Caching.Hybrid.HybridCache.SetAsync<T>(string! key, T value, Microsoft.Extensions.Caching.Hybrid.HybridCacheEntryOptions? options = null, System.Collections.Generic.IReadOnlyCollection<string!>? tags = null, System.Threading.CancellationToken token = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
 Microsoft.Extensions.Caching.Distributed.IBufferDistributedCache
 Microsoft.Extensions.Caching.Distributed.IBufferDistributedCache.Set(string! key, System.Buffers.ReadOnlySequence<byte> value, Microsoft.Extensions.Caching.Distributed.DistributedCacheEntryOptions! options) -> void
@@ -11,7 +11,6 @@ Microsoft.Extensions.Caching.Distributed.IBufferDistributedCache.TryGetAsync(str
 Microsoft.Extensions.Caching.Hybrid.HybridCache
 Microsoft.Extensions.Caching.Hybrid.HybridCache.GetOrCreateAsync<T>(string! key, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<T>>! factory, Microsoft.Extensions.Caching.Hybrid.HybridCacheEntryOptions? options = null, System.Collections.Generic.IReadOnlyCollection<string!>? tags = null, System.Threading.CancellationToken token = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<T>
 Microsoft.Extensions.Caching.Hybrid.HybridCache.HybridCache() -> void
-Microsoft.Extensions.Caching.Hybrid.HybridCacheBuilderExtensions
 Microsoft.Extensions.Caching.Hybrid.HybridCacheEntryFlags
 Microsoft.Extensions.Caching.Hybrid.HybridCacheEntryFlags.DisableCompression = 32 -> Microsoft.Extensions.Caching.Hybrid.HybridCacheEntryFlags
 Microsoft.Extensions.Caching.Hybrid.HybridCacheEntryFlags.DisableDistributedCache = Microsoft.Extensions.Caching.Hybrid.HybridCacheEntryFlags.DisableDistributedCacheRead | Microsoft.Extensions.Caching.Hybrid.HybridCacheEntryFlags.DisableDistributedCacheWrite -> Microsoft.Extensions.Caching.Hybrid.HybridCacheEntryFlags
@@ -42,7 +41,6 @@ Microsoft.Extensions.Caching.Hybrid.HybridCacheOptions.MaximumPayloadBytes.get -
 Microsoft.Extensions.Caching.Hybrid.HybridCacheOptions.MaximumPayloadBytes.set -> void
 Microsoft.Extensions.Caching.Hybrid.HybridCacheOptions.ReportTagMetrics.get -> bool
 Microsoft.Extensions.Caching.Hybrid.HybridCacheOptions.ReportTagMetrics.set -> void
-Microsoft.Extensions.Caching.Hybrid.HybridCacheServiceExtensions
 Microsoft.Extensions.Caching.Hybrid.IHybridCacheBuilder
 Microsoft.Extensions.Caching.Hybrid.IHybridCacheBuilder.Services.get -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 Microsoft.Extensions.Caching.Hybrid.IHybridCacheSerializer<T>
@@ -50,11 +48,13 @@ Microsoft.Extensions.Caching.Hybrid.IHybridCacheSerializer<T>.Deserialize(System
 Microsoft.Extensions.Caching.Hybrid.IHybridCacheSerializer<T>.Serialize(T value, System.Buffers.IBufferWriter<byte>! target) -> void
 Microsoft.Extensions.Caching.Hybrid.IHybridCacheSerializerFactory
 Microsoft.Extensions.Caching.Hybrid.IHybridCacheSerializerFactory.TryCreateSerializer<T>(out Microsoft.Extensions.Caching.Hybrid.IHybridCacheSerializer<T>? serializer) -> bool
-static Microsoft.Extensions.Caching.Hybrid.HybridCacheBuilderExtensions.WithSerializer<T, TImplementation>(this Microsoft.Extensions.Caching.Hybrid.IHybridCacheBuilder! builder) -> Microsoft.Extensions.Caching.Hybrid.IHybridCacheBuilder!
-static Microsoft.Extensions.Caching.Hybrid.HybridCacheBuilderExtensions.WithSerializer<T>(this Microsoft.Extensions.Caching.Hybrid.IHybridCacheBuilder! builder, Microsoft.Extensions.Caching.Hybrid.IHybridCacheSerializer<T>! serializer) -> Microsoft.Extensions.Caching.Hybrid.IHybridCacheBuilder!
-static Microsoft.Extensions.Caching.Hybrid.HybridCacheBuilderExtensions.WithSerializerFactory(this Microsoft.Extensions.Caching.Hybrid.IHybridCacheBuilder! builder, Microsoft.Extensions.Caching.Hybrid.IHybridCacheSerializerFactory! factory) -> Microsoft.Extensions.Caching.Hybrid.IHybridCacheBuilder!
-static Microsoft.Extensions.Caching.Hybrid.HybridCacheBuilderExtensions.WithSerializerFactory<TImplementation>(this Microsoft.Extensions.Caching.Hybrid.IHybridCacheBuilder! builder) -> Microsoft.Extensions.Caching.Hybrid.IHybridCacheBuilder!
-static Microsoft.Extensions.Caching.Hybrid.HybridCacheServiceExtensions.AddHybridCache(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.Caching.Hybrid.IHybridCacheBuilder!
-static Microsoft.Extensions.Caching.Hybrid.HybridCacheServiceExtensions.AddHybridCache(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<Microsoft.Extensions.Caching.Hybrid.HybridCacheOptions!>! setupAction) -> Microsoft.Extensions.Caching.Hybrid.IHybridCacheBuilder!
-virtual Microsoft.Extensions.Caching.Hybrid.HybridCache.RemoveKeysAsync(System.Collections.Generic.IEnumerable<string!>! keys, System.Threading.CancellationToken token = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
-virtual Microsoft.Extensions.Caching.Hybrid.HybridCache.RemoveTagsAsync(System.Collections.Generic.IEnumerable<string!>! tags, System.Threading.CancellationToken token = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+Microsoft.Extensions.DependencyInjection.HybridCacheBuilderExtensions
+Microsoft.Extensions.DependencyInjection.HybridCacheServiceExtensions
+static Microsoft.Extensions.DependencyInjection.HybridCacheBuilderExtensions.AddSerializer<T, TImplementation>(this Microsoft.Extensions.Caching.Hybrid.IHybridCacheBuilder! builder) -> Microsoft.Extensions.Caching.Hybrid.IHybridCacheBuilder!
+static Microsoft.Extensions.DependencyInjection.HybridCacheBuilderExtensions.AddSerializer<T>(this Microsoft.Extensions.Caching.Hybrid.IHybridCacheBuilder! builder, Microsoft.Extensions.Caching.Hybrid.IHybridCacheSerializer<T>! serializer) -> Microsoft.Extensions.Caching.Hybrid.IHybridCacheBuilder!
+static Microsoft.Extensions.DependencyInjection.HybridCacheBuilderExtensions.AddSerializerFactory(this Microsoft.Extensions.Caching.Hybrid.IHybridCacheBuilder! builder, Microsoft.Extensions.Caching.Hybrid.IHybridCacheSerializerFactory! factory) -> Microsoft.Extensions.Caching.Hybrid.IHybridCacheBuilder!
+static Microsoft.Extensions.DependencyInjection.HybridCacheBuilderExtensions.AddSerializerFactory<TImplementation>(this Microsoft.Extensions.Caching.Hybrid.IHybridCacheBuilder! builder) -> Microsoft.Extensions.Caching.Hybrid.IHybridCacheBuilder!
+static Microsoft.Extensions.DependencyInjection.HybridCacheServiceExtensions.AddHybridCache(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.Caching.Hybrid.IHybridCacheBuilder!
+static Microsoft.Extensions.DependencyInjection.HybridCacheServiceExtensions.AddHybridCache(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<Microsoft.Extensions.Caching.Hybrid.HybridCacheOptions!>! setupAction) -> Microsoft.Extensions.Caching.Hybrid.IHybridCacheBuilder!
+virtual Microsoft.Extensions.Caching.Hybrid.HybridCache.RemoveAsync(System.Collections.Generic.IEnumerable<string!>! keys, System.Threading.CancellationToken token = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+virtual Microsoft.Extensions.Caching.Hybrid.HybridCache.RemoveByTagAsync(System.Collections.Generic.IEnumerable<string!>! tags, System.Threading.CancellationToken token = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask

--- a/src/Caching/Hybrid/src/Runtime/HybridCache.cs
+++ b/src/Caching/Hybrid/src/Runtime/HybridCache.cs
@@ -67,19 +67,21 @@ public abstract class HybridCache
     /// <summary>
     /// Asynchronously removes the value associated with the key if it exists.
     /// </summary>
-    public abstract ValueTask RemoveKeyAsync(string key, CancellationToken token = default);
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Not ambiguous in context")]
+    public abstract ValueTask RemoveAsync(string key, CancellationToken token = default);
 
     /// <summary>
     /// Asynchronously removes the value associated with the key if it exists.
     /// </summary>
     /// <remarks>Implementors should treat <c>null</c> as empty</remarks>
-    public virtual ValueTask RemoveKeysAsync(IEnumerable<string> keys, CancellationToken token = default)
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Not ambiguous in context")]
+    public virtual ValueTask RemoveAsync(IEnumerable<string> keys, CancellationToken token = default)
     {
         return keys switch
         {
             // for consistency with GetOrCreate/Set: interpret null as "none"
             null or ICollection<string> { Count: 0 } => default,
-            ICollection<string> { Count: 1 } => RemoveTagAsync(keys.Single(), token),
+            ICollection<string> { Count: 1 } => RemoveByTagAsync(keys.Single(), token),
             _ => ForEachAsync(this, keys, token),
         };
 
@@ -88,7 +90,7 @@ public abstract class HybridCache
         {
             foreach (var key in keys)
             {
-                await @this.RemoveKeyAsync(key, token).ConfigureAwait(false);
+                await @this.RemoveAsync(key, token).ConfigureAwait(false);
             }
         }
     }
@@ -97,13 +99,14 @@ public abstract class HybridCache
     /// Asynchronously removes all values associated with the specified tags.
     /// </summary>
     /// <remarks>Implementors should treat <c>null</c> as empty</remarks>
-    public virtual ValueTask RemoveTagsAsync(IEnumerable<string> tags, CancellationToken token = default)
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Not ambiguous in context")]
+    public virtual ValueTask RemoveByTagAsync(IEnumerable<string> tags, CancellationToken token = default)
     {
         return tags switch
         {
             // for consistency with GetOrCreate/Set: interpret null as "none"
             null or ICollection<string> { Count: 0 } => default,
-            ICollection<string> { Count: 1 } => RemoveTagAsync(tags.Single(), token),
+            ICollection<string> { Count: 1 } => RemoveByTagAsync(tags.Single(), token),
             _ => ForEachAsync(this, tags, token),
         };
 
@@ -112,7 +115,7 @@ public abstract class HybridCache
         {
             foreach (var key in keys)
             {
-                await @this.RemoveTagAsync(key, token).ConfigureAwait(false);
+                await @this.RemoveByTagAsync(key, token).ConfigureAwait(false);
             }
         }
     }
@@ -120,5 +123,6 @@ public abstract class HybridCache
     /// <summary>
     /// Asynchronously removes all values associated with the specified tag.
     /// </summary>
-    public abstract ValueTask RemoveTagAsync(string tag, CancellationToken token = default);
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Not ambiguous in context")]
+    public abstract ValueTask RemoveByTagAsync(string tag, CancellationToken token = default);
 }

--- a/src/Caching/Hybrid/test/BufferReleaseTests.cs
+++ b/src/Caching/Hybrid/test/BufferReleaseTests.cs
@@ -53,7 +53,7 @@ public class BufferReleaseTests // note that buffer ref-counting is only enabled
         Assert.NotSame(first, second);
 
         Assert.Equal(1, cacheItem.RefCount);
-        await cache.RemoveKeyAsync(key);
+        await cache.RemoveAsync(key);
         var third = await cache.GetOrCreateAsync(key, _ => GetAsync(), _noUnderlying);
         Assert.Null(third);
 
@@ -138,7 +138,7 @@ public class BufferReleaseTests // note that buffer ref-counting is only enabled
         Assert.NotSame(first, second);
 
         Assert.Equal(1, cacheItem.RefCount);
-        await cache.RemoveKeyAsync(key);
+        await cache.RemoveAsync(key);
         var third = await cache.GetOrCreateAsync(key, _ => GetAsync(), _noUnderlying);
         Assert.Null(third);
         Assert.Null(await cache.BackendCache.GetAsync(key)); // should be gone from L2 too
@@ -196,7 +196,7 @@ public class BufferReleaseTests // note that buffer ref-counting is only enabled
         Assert.NotSame(first, second);
 
         Assert.Equal(1, cacheItem.RefCount);
-        await cache.RemoveKeyAsync(key);
+        await cache.RemoveAsync(key);
         var third = await cache.GetOrCreateAsync(key, _ => GetAsync(), _noUnderlying);
         Assert.Null(third);
         Assert.Null(await cache.BackendCache.GetAsync(key)); // should be gone from L2 too

--- a/src/Caching/Hybrid/test/L2Tests.cs
+++ b/src/Caching/Hybrid/test/L2Tests.cs
@@ -81,7 +81,7 @@ public class L2Tests(ITestOutputHelper Log)
         Assert.Equal(8, backend.OpCount); // SET
 
         Log.WriteLine("Removing key...");
-        await cache.RemoveKeyAsync(Me());
+        await cache.RemoveAsync(Me());
         Assert.Equal(9, backend.OpCount); // DEL
 
         Log.WriteLine("Fetching new...");
@@ -136,7 +136,7 @@ public class L2Tests(ITestOutputHelper Log)
         Assert.Equal(8, backend.OpCount); // SET
 
         Log.WriteLine("Removing key...");
-        await cache.RemoveKeyAsync(Me());
+        await cache.RemoveAsync(Me());
         Assert.Equal(9, backend.OpCount); // DEL
 
         Log.WriteLine("Fetching new...");

--- a/src/Caching/Hybrid/test/ServiceConstructionTests.cs
+++ b/src/Caching/Hybrid/test/ServiceConstructionTests.cs
@@ -120,7 +120,7 @@ public class ServiceConstructionTests
     public void CustomSerializerConfiguration()
     {
         var services = new ServiceCollection();
-        services.AddHybridCache().WithSerializer<Customer, CustomerSerializer>();
+        services.AddHybridCache().AddSerializer<Customer, CustomerSerializer>();
         using var provider = services.BuildServiceProvider();
         var cache = Assert.IsType<DefaultHybridCache>(provider.GetRequiredService<HybridCache>());
 
@@ -132,7 +132,7 @@ public class ServiceConstructionTests
     public void CustomSerializerFactoryConfiguration()
     {
         var services = new ServiceCollection();
-        services.AddHybridCache().WithSerializerFactory<CustomFactory>();
+        services.AddHybridCache().AddSerializerFactory<CustomFactory>();
         using var provider = services.BuildServiceProvider();
         var cache = Assert.IsType<DefaultHybridCache>(provider.GetRequiredService<HybridCache>());
 


### PR DESCRIPTION
# Fixup `HybridCache` public API

1. apply approved API changes per https://github.com/dotnet/aspnetcore/issues/55332
2. fix incorrect namespace of service extension types to the standard DI dumping ground (as per the previously approved API, https://github.com/dotnet/aspnetcore/issues/54647)
3. fix misapplication of serializer APIs; approved naming was `AddSerializer`, not `WithSerializer` (in https://github.com/dotnet/aspnetcore/issues/54647)

/cc @amcasey 