### PR TITLE
Fix AntiforgeryMiddlewareTest for non-US date formats

### DIFF
--- a/src/Mvc/test/Mvc.FunctionalTests/AntiforgeryMiddlewareTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/AntiforgeryMiddlewareTest.cs
@@ -44,7 +44,7 @@ public class AntiforgeryMiddlewareTest
             new("__RequestVerificationToken", tokens.RequestToken),
             new("name", "Test task"),
             new("isComplete", "false"),
-            new("dueDate", DateTime.Today.AddDays(1).ToString(CultureInfo.InvariantCulture)),
+            new("dueDate", DateTime.Today.AddDays(1).ToString(CultureInfo.CurrentCulture)),
         };
         request.Content = new FormUrlEncodedContent(nameValueCollection);
         var result = await client.SendAsync(request);
@@ -85,7 +85,7 @@ public class AntiforgeryMiddlewareTest
         {
             new("name", "Test task"),
             new("isComplete", "false"),
-            new("dueDate", DateTime.Today.AddDays(1).ToString(CultureInfo.InvariantCulture)),
+            new("dueDate", DateTime.Today.AddDays(1).ToString(CultureInfo.CurrentCulture)),
         };
         request.Content = new FormUrlEncodedContent(nameValueCollection);
         var result = await client.SendAsync(request);
@@ -128,7 +128,7 @@ public class AntiforgeryMiddlewareTest
             new("__RequestVerificationToken", tokens.RequestToken),
             new("name", "Test task"),
             new("isComplete", "false"),
-            new("dueDate", DateTime.Today.AddDays(1).ToString(CultureInfo.InvariantCulture)),
+            new("dueDate", DateTime.Today.AddDays(1).ToString(CultureInfo.CurrentCulture)),
         };
         request.Content = new FormUrlEncodedContent(nameValueCollection);
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await client.SendAsync(request));
@@ -160,7 +160,7 @@ public class AntiforgeryMiddlewareTest
             new("__RequestVerificationToken", tokens.RequestToken),
             new("name", "Test task"),
             new("isComplete", "false"),
-            new("dueDate", DateTime.Today.AddDays(1).ToString(CultureInfo.InvariantCulture)),
+            new("dueDate", DateTime.Today.AddDays(1).ToString(CultureInfo.CurrentCulture)),
         };
         request.Content = new FormUrlEncodedContent(nameValueCollection);
         var result = await client.SendAsync(request);
@@ -192,7 +192,7 @@ public class AntiforgeryMiddlewareTest
             new("__RequestVerificationToken", tokens.RequestToken),
             new("name", "Test task"),
             new("isComplete", "false"),
-            new("dueDate", DateTime.Today.AddDays(1).ToString(CultureInfo.InvariantCulture)),
+            new("dueDate", DateTime.Today.AddDays(1).ToString(CultureInfo.CurrentCulture)),
         };
         request.Content = new FormUrlEncodedContent(nameValueCollection);
         var result = await client.SendAsync(request);


### PR DESCRIPTION
# Fix AntiforgeryMiddlewareTest for non-US date formats

Fix tests failing with HTTP 400 if machine uses a non-US date format.

## Description

Use `CultureInfo.CurrentCulture` to match MVC's default `DateTime` binding behaviour to fix tests when running on a machine that doesn't use invariant/en-US date formatting, such as en-GB.

Otherwise the line below throws when binding the posted form as the format is invariant but MVC tries to bind it with the current culture.

https://github.com/dotnet/aspnetcore/blob/dad78b3671b250c671e8711e49f53b6ddf21d5e0/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DateTimeModelBinder.cs#L67

I figured this was the simpler change than reconfiguring MVC in all the tests to use invariant binding by default.

See https://github.com/dotnet/aspnetcore/pull/55595#issuecomment-2118693018.
