### PR TITLE
Comment out selenium/standalone-chrome container images.

### DIFF
--- a/src/Components/benchmarkapps/Wasm.Performance/dockerfile
+++ b/src/Components/benchmarkapps/Wasm.Performance/dockerfile
@@ -29,7 +29,18 @@ RUN .dotnet/dotnet publish -c Release --no-restore -o /app ./src/Components/benc
 RUN chmod +x /app/Wasm.Performance.Driver
 
 WORKDIR /app
-FROM selenium/standalone-chrome:124.0 as final
+# NOTE: This has been commented out because it is causing our builds to get a build warning
+#       because we are pulling this container image from docker.io. We should consider whether
+#       we need this code in our repo at all, and if not remove it.
+#       If we do need it then we need to get the container image imported into mcr.microsoft.com
+#
+#       I have opened up a PR to do this, however it is not certain we'll be allowed to do this
+#       and there is further legal/compliance work that needs to be done. In the meantime commenting
+#       this out should get our builds to green again whilst this issue is resolved.
+#
+#       PR: https://github.com/microsoft/mcr/pull/3232
+#
+# FROM selenium/standalone-chrome:124.0 as final
 COPY --from=build ./app ./
 COPY ./exec.sh ./
 

--- a/src/Components/benchmarkapps/Wasm.Performance/local.dockerfile
+++ b/src/Components/benchmarkapps/Wasm.Performance/local.dockerfile
@@ -1,4 +1,15 @@
-FROM selenium/standalone-chrome:latest as final
+# NOTE: This has been commented out because it is causing our builds to get a build warning
+#       because we are pulling this container image from docker.io. We should consider whether
+#       we need this code in our repo at all, and if not remove it.
+#       If we do need it then we need to get the container image imported into mcr.microsoft.com
+#
+#       I have opened up a PR to do this, however it is not certain we'll be allowed to do this
+#       and there is further legal/compliance work that needs to be done. In the meantime commenting
+#       this out should get our builds to green again whilst this issue is resolved.
+#
+#       PR: https://github.com/microsoft/mcr/pull/3232
+#
+# FROM selenium/standalone-chrome:latest as final
 
 ENV StressRunDuration=0
 


### PR DESCRIPTION
This PR comments out the use of `selenium/stable-chrome` for the benchmark projects. See comment in the source file with a link to the MCR pull request to try to eventually enable us to continue using them. It is possible that continuing to use these images will be too much of a compliance hurdle (unless anyone wants to commit to doing a source build of the images).