### PR TITLE
Add HTML title attribute to "th" elements

### DIFF
--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
@@ -87,7 +87,7 @@
     {
         foreach (var col in _columns)
         {
-            <th class="@ColumnHeaderClass(col)" aria-sort="@AriaSortValue(col)" @key="@col" scope="col">
+            <th class="@ColumnHeaderClass(col)" aria-sort="@AriaSortValue(col)" @key="@col" scope="col" title="@col.Title">
                 <div class="col-header-content">@col.HeaderContent</div>
 
                 @if (col == _displayOptionsForColumn)


### PR DESCRIPTION
# Add HTML title attribute to "th" elements

Previously the `<th>` cells were rendered without allocating the column title in `QuickGrid.razor`.
This was listed as an issue in #55576, the desired functionality was to have abbreviated column headers with the ability to hover 
to see the full title.

**Changes made:**
1) Rendered column headers with the `title` value.

Fixes #55576
