### PR TITLE
QuickGrid: Add EventCallback<TGridItem> for clicking on a row.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19332,7 +19332,7 @@
     },
     "src/JSInterop/Microsoft.JSInterop.JS/src": {
       "name": "@microsoft/dotnet-js-interop",
-      "version": "9.0.0-ci",
+      "version": "8.0.0-dev",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^6.15.0",
@@ -19833,7 +19833,7 @@
     },
     "src/SignalR/clients/ts/signalr": {
       "name": "@microsoft/signalr",
-      "version": "9.0.0-ci",
+      "version": "5.0.0-dev",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -19845,7 +19845,7 @@
     },
     "src/SignalR/clients/ts/signalr-protocol-msgpack": {
       "name": "@microsoft/signalr-protocol-msgpack",
-      "version": "9.0.0-ci",
+      "version": "5.0.0-dev",
       "license": "MIT",
       "dependencies": {
         "@microsoft/signalr": "*",

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Unshipped.txt
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 #nullable enable
+Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.OnRowClicked.get -> Microsoft.AspNetCore.Components.EventCallback<TGridItem>
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.OverscanCount.get -> int
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.OverscanCount.set -> void

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Unshipped.txt
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.OnRowClicked.get -> Microsoft.AspNetCore.Components.EventCallback<TGridItem>
+Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.OnRowClicked.set -> void
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.OverscanCount.get -> int
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.OverscanCount.set -> void

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
@@ -65,10 +65,12 @@
 
     private void RenderRow(RenderTreeBuilder __builder, int rowIndex, TGridItem item)
     {
-        <tr @key="@(ItemKey(item))" aria-rowindex="@rowIndex">
+        <tr @key="@(ItemKey(item))" aria-rowindex="@rowIndex" @onclick="() => HandleRowClick(item)">
             @foreach (var col in _columns)
             {
-                <td class="@ColumnClass(col)" @key="@col">@{ col.CellContent(__builder, item); }</td>
+                <td class="@ColumnClass(col)" @key="@col">@{
+                        col.CellContent(__builder, item);
+                    }</td>
             }
         </tr>
     }

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
@@ -63,9 +63,10 @@
         }
     }
 
+
     private void RenderRow(RenderTreeBuilder __builder, int rowIndex, TGridItem item)
     {
-        <tr @key="@(ItemKey(item))" aria-rowindex="@rowIndex" @onclick="() => HandleRowClick(item)">
+        <tr @key="@(ItemKey(item))" aria-rowindex="@rowIndex" @onclick="@(async () => await HandleRowClick(item))">
             @foreach (var col in _columns)
             {
                 <td class="@ColumnClass(col)" @key="@col">@{

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
@@ -6,14 +6,10 @@
 @typeparam TGridItem
 
 <CascadingValue TValue="InternalGridContext<TGridItem>" IsFixed="true" Value="@_internalGridContext">
-    @{
-        StartCollectingColumns();
-    }
+    @{StartCollectingColumns(); }
     @ChildContent
     <Defer>
-        @{
-            FinishCollectingColumns();
-        }
+        @{FinishCollectingColumns(); }
         <ColumnsCollectedNotifier TGridItem="TGridItem" />
 
         <table theme="@Theme" aria-rowcount="@(_ariaBodyRowCount + 1)" @ref="_tableReference" @onclosecolumnoptions="CloseColumnOptions" @attributes="AdditionalAttributes" class="@GridClass()">
@@ -26,12 +22,12 @@
                 @if (Virtualize)
                 {
                     <Virtualize @ref="@_virtualizeComponent"
-                                TItem="(int RowIndex, TGridItem Data)"
-                                ItemSize="@ItemSize"
-                                OverscanCount="@OverscanCount"
-                                ItemsProvider="@ProvideVirtualizedItems"
-                                ItemContent="@(item => builder => RenderRow(builder, item.RowIndex, item.Data))"
-                                Placeholder="@(placeholderContext => builder => RenderPlaceholderRow(builder, placeholderContext))" />
+                        TItem="(int RowIndex, TGridItem Data)"
+                        ItemSize="@ItemSize"
+                        OverscanCount="@OverscanCount"
+                        ItemsProvider="@ProvideVirtualizedItems"
+                        ItemContent="@(item => builder => RenderRow(builder, item.RowIndex, item.Data))"
+                        Placeholder="@(placeholderContext => builder => RenderPlaceholderRow(builder, placeholderContext))" />
                 }
                 else
                 {

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
@@ -2,12 +2,18 @@
 @using Microsoft.AspNetCore.Components.Rendering
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.AspNetCore.Components.Web.Virtualization
+
 @typeparam TGridItem
+
 <CascadingValue TValue="InternalGridContext<TGridItem>" IsFixed="true" Value="@_internalGridContext">
-    @{ StartCollectingColumns(); }
+    @{
+        StartCollectingColumns();
+    }
     @ChildContent
     <Defer>
-        @{ FinishCollectingColumns(); }
+        @{
+            FinishCollectingColumns();
+        }
         <ColumnsCollectedNotifier TGridItem="TGridItem" />
 
         <table theme="@Theme" aria-rowcount="@(_ariaBodyRowCount + 1)" @ref="_tableReference" @onclosecolumnoptions="CloseColumnOptions" @attributes="AdditionalAttributes" class="@GridClass()">
@@ -20,12 +26,12 @@
                 @if (Virtualize)
                 {
                     <Virtualize @ref="@_virtualizeComponent"
-                        TItem="(int RowIndex, TGridItem Data)"
-                        ItemSize="@ItemSize"
-                        OverscanCount="@OverscanCount"
-                        ItemsProvider="@ProvideVirtualizedItems"
-                        ItemContent="@(item => builder => RenderRow(builder, item.RowIndex, item.Data))"
-                        Placeholder="@(placeholderContext => builder => RenderPlaceholderRow(builder, placeholderContext))" />
+                                TItem="(int RowIndex, TGridItem Data)"
+                                ItemSize="@ItemSize"
+                                OverscanCount="@OverscanCount"
+                                ItemsProvider="@ProvideVirtualizedItems"
+                                ItemContent="@(item => builder => RenderRow(builder, item.RowIndex, item.Data))"
+                                Placeholder="@(placeholderContext => builder => RenderPlaceholderRow(builder, placeholderContext))" />
                 }
                 else
                 {
@@ -53,51 +59,78 @@
         {
             while (rowIndex++ < initialRowIndex + Pagination.ItemsPerPage)
             {
-                <tr>
-                    @foreach (var col in _columns)
-                    {
-                        <td class="@ColumnClass(col)" @key="@col"></td>
-                    }
-                </tr>
+                __builder.OpenElement(0, "tr");
+                foreach (var col in _columns)
+                {
+                    __builder.OpenElement(1, "td");
+                    __builder.AddAttribute(2, "class", ColumnClass(col));
+                    __builder.CloseElement();
+                }
+                __builder.CloseElement();
             }
         }
     }
 
-
     private void RenderRow(RenderTreeBuilder __builder, int rowIndex, TGridItem item)
     {
-        <tr @key="@(ItemKey(item))" aria-rowindex="@rowIndex" @onclick="@(async () => await HandleRowClick(item))">
-            @foreach (var col in _columns)
-            {
-                <td class="@ColumnClass(col)" @key="@col">@{
-                        col.CellContent(__builder, item);
-                    }</td>
-            }
-        </tr>
+        __builder.OpenElement(0, "tr");
+        __builder.AddAttribute(1, "key", ItemKey(item));
+        __builder.AddAttribute(2, "aria-rowindex", rowIndex);
+
+        if (OnRowClicked.HasDelegate)
+        {
+            __builder.AddAttribute(3, "onclick", EventCallback.Factory.Create(this, () => HandleRowClick(item)));
+        }
+
+        foreach (var col in _columns)
+        {
+            __builder.OpenElement(4, "td");
+            __builder.AddAttribute(5, "class", ColumnClass(col));
+            col.CellContent(__builder, item);
+            __builder.CloseElement();
+        }
+
+        __builder.CloseElement();
     }
 
     private void RenderPlaceholderRow(RenderTreeBuilder __builder, PlaceholderContext placeholderContext)
     {
-        <tr aria-rowindex="@(placeholderContext.Index + 1)">
-            @foreach (var col in _columns)
-            {
-                <td class="grid-cell-placeholder @ColumnClass(col)" @key="@col">@{ col.RenderPlaceholderContent(__builder, placeholderContext); }</td>
-            }
-        </tr>
+        __builder.OpenElement(0, "tr");
+        __builder.AddAttribute(1, "aria-rowindex", placeholderContext.Index + 1);
+        foreach (var col in _columns)
+        {
+            __builder.OpenElement(2, "td");
+            __builder.AddAttribute(3, "class", "grid-cell-placeholder " + ColumnClass(col));
+            col.RenderPlaceholderContent(__builder, placeholderContext);
+            __builder.CloseElement();
+        }
+        __builder.CloseElement();
     }
 
     private void RenderColumnHeaders(RenderTreeBuilder __builder)
     {
         foreach (var col in _columns)
         {
-            <th class="@ColumnHeaderClass(col)" aria-sort="@AriaSortValue(col)" @key="@col" scope="col">
-                <div class="col-header-content">@col.HeaderContent</div>
+            __builder.OpenElement(0, "th");
+            __builder.AddAttribute(1, "class", ColumnHeaderClass(col));
+            __builder.AddAttribute(2, "aria-sort", AriaSortValue(col));
+            __builder.AddAttribute(3, "key", col);
+            __builder.AddAttribute(4, "scope", "col");
 
-                @if (col == _displayOptionsForColumn)
-                {
-                    <div class="col-options">@col.ColumnOptions</div>
-                }
-            </th>
+            __builder.OpenElement(5, "div");
+            __builder.AddAttribute(6, "class", "col-header-content");
+            __builder.AddContent(7, col.HeaderContent);
+            __builder.CloseElement();
+
+            if (col == _displayOptionsForColumn)
+            {
+                __builder.OpenElement(8, "div");
+                __builder.AddAttribute(9, "class", "col-options");
+                __builder.AddContent(10, col.ColumnOptions);
+                __builder.CloseElement();
+            }
+
+            __builder.CloseElement();
         }
     }
 }

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
@@ -107,7 +107,7 @@ public partial class QuickGrid<TGridItem> : IAsyncDisposable
     /// <summary>
     /// Gets or sets the callback event that is triggered when a row in the grid is clicked.
     /// </summary>
-    [Parameter] public EventCallback<TGridItem> OnRowClicked { get; set; }
+    [Parameter] public EventCallback<TGridItem> OnRowClicked { get; private set; }
 
     [Inject] private IServiceProvider Services { get; set; } = default!;
     [Inject] private IJSRuntime JS { get; set; } = default!;

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
@@ -104,6 +104,11 @@ public partial class QuickGrid<TGridItem> : IAsyncDisposable
     /// </summary>
     [Parameter(CaptureUnmatchedValues = true)] public IReadOnlyDictionary<string, object>? AdditionalAttributes { get; set; }
 
+    /// <summary>
+    /// Gets or sets the callback event that is triggered when a row in the grid is clicked.
+    /// </summary>
+    [Parameter] public EventCallback<TGridItem> OnRowClicked { get; set; }
+
     [Inject] private IServiceProvider Services { get; set; } = default!;
     [Inject] private IJSRuntime JS { get; set; } = default!;
 
@@ -439,6 +444,10 @@ public partial class QuickGrid<TGridItem> : IAsyncDisposable
             // The JS side may routinely be gone already if the reason we're disposing is that
             // the client disconnected. This is not an error.
         }
+    }
+    private Task HandleRowClick(TGridItem item)
+    {
+        return OnRowClicked.InvokeAsync(item);
     }
 
     private void CloseColumnOptions()

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
@@ -107,7 +107,7 @@ public partial class QuickGrid<TGridItem> : IAsyncDisposable
     /// <summary>
     /// Gets or sets the callback event that is triggered when a row in the grid is clicked.
     /// </summary>
-    [Parameter] public EventCallback<TGridItem> OnRowClicked { get; private set; }
+    [Parameter] public EventCallback<TGridItem> OnRowClicked { get; set; }
 
     [Inject] private IServiceProvider Services { get; set; } = default!;
     [Inject] private IJSRuntime JS { get; set; } = default!;
@@ -445,9 +445,13 @@ public partial class QuickGrid<TGridItem> : IAsyncDisposable
             // the client disconnected. This is not an error.
         }
     }
-    private Task HandleRowClick(TGridItem item)
+
+    private async Task HandleRowClick(TGridItem item)
     {
-        return OnRowClicked.InvokeAsync(item);
+        if (OnRowClicked.HasDelegate)
+        {
+            await OnRowClicked.InvokeAsync(item);
+        }
     }
 
     private void CloseColumnOptions()

--- a/src/Components/test/E2ETest/Tests/QuickGridTest.cs
+++ b/src/Components/test/E2ETest/Tests/QuickGridTest.cs
@@ -125,7 +125,7 @@ public class QuickGridTest : ServerTestBase<ToggleExecutionModeServerFixture<Pro
     }
 
     [Fact]
-    public void QuickGrid_RowClick_DisplaysDetails()
+    public void QuickGridRowClickDisplaysDetails()
     {
         // Arrange
         var grid = app.FindElement(By.CssSelector("#grid > table"));

--- a/src/Components/test/E2ETest/Tests/QuickGridTest.cs
+++ b/src/Components/test/E2ETest/Tests/QuickGridTest.cs
@@ -135,7 +135,7 @@ public class QuickGridTest : ServerTestBase<ToggleExecutionModeServerFixture<Pro
         // Act
         firstRow.Click();
 
-        var wait = new WebDriverWait(Browser, TimeSpan.FromSeconds(5));
+        var wait = new WebDriverWait(Browser, TimeSpan.FromSeconds(1));
         var detailsAfterClick = wait.Until(driver =>
         {
             var elements = driver.FindElements(By.Id("personDetails"));

--- a/src/Components/test/E2ETest/Tests/QuickGridTest.cs
+++ b/src/Components/test/E2ETest/Tests/QuickGridTest.cs
@@ -6,8 +6,10 @@ using BasicTestApp.QuickGridTest;
 using Microsoft.AspNetCore.Components.E2ETest;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
+using Microsoft.AspNetCore.Components.QuickGrid;
 using Microsoft.AspNetCore.E2ETesting;
 using OpenQA.Selenium;
+using OpenQA.Selenium.Support.UI;
 using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Components.E2ETests.Tests;
@@ -120,5 +122,30 @@ public class QuickGridTest : ServerTestBase<ToggleExecutionModeServerFixture<Pro
         var grid = app.FindElement(By.CssSelector("#grid > table"));
         Assert.Equal("somevalue", grid.GetAttribute("custom-attrib"));
         Assert.Contains("custom-class-attrib", grid.GetAttribute("class")?.Split(" "));
+    }
+
+    [Fact]
+    public void QuickGrid_RowClick_DisplaysDetails()
+    {
+        // Arrange
+        var grid = app.FindElement(By.CssSelector("#grid > table"));
+        var firstRow = grid.FindElement(By.CssSelector("tbody > tr:nth-child(1)"));
+        var detailsBeforeClick = app.FindElements(By.Id("personDetails")).Count;
+
+        // Act
+        firstRow.Click();
+
+        var wait = new WebDriverWait(Browser, TimeSpan.FromSeconds(5));
+        var detailsAfterClick = wait.Until(driver =>
+        {
+            var elements = driver.FindElements(By.Id("personDetails"));
+            if (elements.Count > 0 && elements[0].Displayed){ return elements[0];}    
+            return null;
+        });
+
+        // Assert
+        Assert.Equal(0, detailsBeforeClick);
+        Assert.True(detailsAfterClick.Displayed, "Details panel should be displayed after a row is clicked.");
+        Assert.Contains("Details:", detailsAfterClick.Text);
     }
 }

--- a/src/Components/test/testassets/BasicTestApp/QuickGridTest/SampleQuickGridComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/QuickGridTest/SampleQuickGridComponent.razor
@@ -3,7 +3,7 @@
 <h3>Sample QuickGrid Component</h3>
 
 <div id="grid">
-    <QuickGrid Items="@FilteredPeople" Pagination="@pagination" custom-attrib="somevalue" class="custom-class-attrib" OnRowClicked=HandleRowClick>
+    <QuickGrid Items="@FilteredPeople" Pagination="@pagination" custom-attrib="somevalue" class="custom-class-attrib" OnRowClicked="@EventCallback.Factory.Create(this, (Person p) => HandleRowClick(p))">
         <PropertyColumn Property="@(p => p.PersonId)" Sortable="true" />
         <PropertyColumn Property="@(p => p.firstName)" Sortable="true">
             <ColumnOptions>
@@ -30,8 +30,8 @@
     record Person(int PersonId, string firstName, string lastName, DateOnly BirthDate);
     PaginationState pagination = new PaginationState { ItemsPerPage = 10 };
     string firstNameFilter;
-    Person selectedPerson = new Person(0, "", "", new DateOnly()); // Initialize with a default empty person
-    bool hasSelectedPerson = false; // Flag to track if a person is selected
+    Person selectedPerson = new Person(0, "", "", new DateOnly());
+    bool hasSelectedPerson = false;
 
     private Task HandleRowClick(Person person)
     {

--- a/src/Components/test/testassets/BasicTestApp/QuickGridTest/SampleQuickGridComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/QuickGridTest/SampleQuickGridComponent.razor
@@ -3,19 +3,26 @@
 <h3>Sample QuickGrid Component</h3>
 
 <div id="grid">
-    <QuickGrid Items="@FilteredPeople" Pagination="@pagination" custom-attrib="somevalue" class="custom-class-attrib">
+    <QuickGrid Items="@FilteredPeople" Pagination="@pagination" custom-attrib="somevalue" class="custom-class-attrib" OnRowClicked=HandleRowClick>
         <PropertyColumn Property="@(p => p.PersonId)" Sortable="true" />
         <PropertyColumn Property="@(p => p.firstName)" Sortable="true">
-                <ColumnOptions>
-                    <div class="search-box">
-                        <input type="search" autofocus @bind="firstNameFilter" @bind:event="oninput" placeholder="First name..." />
-                    </div>
-                </ColumnOptions>
-         </PropertyColumn>
+            <ColumnOptions>
+                <div class="search-box">
+                    <input type="search" autofocus @bind="firstNameFilter" @bind:event="oninput" placeholder="First name..." />
+                </div>
+            </ColumnOptions>
+        </PropertyColumn>
         <PropertyColumn Property="@(p => p.lastName)" Sortable="true" />
         <PropertyColumn Property="@(p => p.BirthDate)" Format="yyyy-MM-dd" Sortable="true" />
         <PropertyColumn Title="Age in years" Property="@(p => ComputeAge(p.BirthDate))" Sortable="true"/>
     </QuickGrid>
+    @if (hasSelectedPerson)
+    {
+        <div id="personDetails">
+            <strong>Details:</strong>
+            @selectedPerson.firstName @selectedPerson.lastName - @selectedPerson.BirthDate.ToString("yyyy-MM-dd")
+        </div>
+    }
 </div>
 <Paginator State="@pagination" />
 
@@ -23,6 +30,15 @@
     record Person(int PersonId, string firstName, string lastName, DateOnly BirthDate);
     PaginationState pagination = new PaginationState { ItemsPerPage = 10 };
     string firstNameFilter;
+    Person selectedPerson = new Person(0, "", "", new DateOnly()); // Initialize with a default empty person
+    bool hasSelectedPerson = false; // Flag to track if a person is selected
+
+    private Task HandleRowClick(Person person)
+    {
+        selectedPerson = person ?? throw new ArgumentNullException(nameof(person));
+        hasSelectedPerson = true;
+        return Task.CompletedTask;
+    }
 
     int ComputeAge(DateOnly birthDate)
         => DateTime.Now.Year - birthDate.Year - (birthDate.DayOfYear < DateTime.Now.DayOfYear ? 0 : 1);


### PR DESCRIPTION
# QuickGrid: Add EventCallback<TGridItem> for clicking on a row.

**Description:**
This pull request aims to enhance the QuickGrid component by adding the capability to handle row click events. This feature allows developers to perform specific actions when a user clicks on a row in the grid, such as navigating to a detailed view of the selected item.

**Changes made:** 
1) Introduced `EventCallback` Parameter
2) Updated the `RenderRow` method to include an `@onclick` event handler that triggers the `OnRowClicked` callback.
3) Modified the `SampleQuickGridComponent` to demonstrate the usage of the `OnRowClicked` event callback.
4) Added E2E test to validify the changes using `SampleQuickGridComponent` 

Fixes #44899
