### PR TITLE
Date only and time only is not supported in blazor change detection for parameters

### DIFF
--- a/src/Components/Components/src/ChangeDetection.cs
+++ b/src/Components/Components/src/ChangeDetection.cs
@@ -7,7 +7,7 @@ namespace Microsoft.AspNetCore.Components;
 
 internal sealed class ChangeDetection
 {
-    private static ConcurrentDictionary<Type, bool> _immutableNonObjectTypesCache = new();
+    private static readonly ConcurrentDictionary<Type, bool> _immutableNonObjectTypesCache = new();
     public static bool MayHaveChanged<T1, T2>(T1 oldValue, T2 newValue)
     {
         var oldIsNotNull = oldValue != null;

--- a/src/Components/Components/src/ChangeDetection.cs
+++ b/src/Components/Components/src/ChangeDetection.cs
@@ -8,6 +8,7 @@ namespace Microsoft.AspNetCore.Components;
 internal sealed class ChangeDetection
 {
     private static readonly ConcurrentDictionary<Type, bool> _immutableNonObjectTypesCache = new();
+
     public static bool MayHaveChanged<T1, T2>(T1 oldValue, T2 newValue)
     {
         var oldIsNotNull = oldValue != null;

--- a/src/Components/Components/src/ChangeDetection.cs
+++ b/src/Components/Components/src/ChangeDetection.cs
@@ -2,12 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
+using Microsoft.AspNetCore.Components.HotReload;
 
 namespace Microsoft.AspNetCore.Components;
 
 internal sealed class ChangeDetection
 {
-    private static readonly ConcurrentDictionary<Type, bool> _immutableNonObjectTypesCache = new();
+    private static readonly ConcurrentDictionary<Type, bool> _immutableObjectTypesCache = new();
+
+    static ChangeDetection()
+    {
+        if (HotReloadManager.Default.MetadataUpdateSupported)
+        {
+            HotReloadManager.Default.OnDeltaApplied += _immutableObjectTypesCache.Clear;
+        }
+    }
 
     public static bool MayHaveChanged<T1, T2>(T1 oldValue, T2 newValue)
     {
@@ -34,10 +43,6 @@ internal sealed class ChangeDetection
         return false;
     }
 
-    // The contents of this list need to trade off false negatives against computation
-    // time. So we don't want a huge list of types to check (or would have to move to
-    // a hashtable lookup, which is differently expensive). It's better not to include
-    // uncommon types here even if they are known to be immutable.
     // This logic assumes that no new System.TypeCode enum entries have been declared since 7.0, or at least that any new ones
     // represent immutable types. If System.TypeCode changes, review this logic to ensure it is still correct.
     // Supported immutable types : bool, byte, sbyte, short, ushort, int, uint, long, ulong, char, double,
@@ -45,24 +50,11 @@ internal sealed class ChangeDetection
     // For performance reasons, the following immutable types are not supported: IntPtr, UIntPtr, Type.
     private static bool IsKnownImmutableType(Type type)
         => Type.GetTypeCode(type) != TypeCode.Object
-        || _immutableNonObjectTypesCache.GetOrAdd(type, IsImmutableNonObjectCore);
+        || _immutableObjectTypesCache.GetOrAdd(type, IsImmutableObjectTypeCore);
 
-    private static bool IsImmutableNonObjectCore(Type type)
+    private static bool IsImmutableObjectTypeCore(Type type)
         => type == typeof(Guid)
         || type == typeof(DateOnly)
         || type == typeof(TimeOnly)
         || typeof(IEventCallback).IsAssignableFrom(type);
-
-    public static event Action? OnHotReload;
-
-    public static void ClearImmutableTypeCache()
-    {
-        _immutableNonObjectTypesCache.Clear();
-    }
-
-    public static void HotReloadHandler()
-    {
-        ClearImmutableTypeCache();
-        OnHotReload?.Invoke();
-    }
 }

--- a/src/Components/Components/test/RenderTreeDiffBuilderTest.cs
+++ b/src/Components/Components/test/RenderTreeDiffBuilderTest.cs
@@ -1736,6 +1736,9 @@ public class RenderTreeDiffBuilderTest : IDisposable
         // Arrange: Populate old and new with equivalent content
         RenderFragment fragmentWillNotChange = builder => throw new NotImplementedException();
         var dateTimeWillNotChange = DateTime.Now;
+        var dateOnlyWillNotChange = DateOnly.FromDateTime(dateTimeWillNotChange);
+        var timeOnlyWillNotChange = TimeOnly.FromDateTime(dateTimeWillNotChange);
+
         foreach (var tree in new[] { oldTree, newTree })
         {
             tree.OpenComponent<CaptureSetParametersComponent>(0);
@@ -1758,6 +1761,8 @@ public class RenderTreeDiffBuilderTest : IDisposable
             tree.AddComponentParameter(1, "MyEnum", StringComparison.OrdinalIgnoreCase);
             tree.AddComponentParameter(1, "MyEventCallback", EventCallback.Empty);
             tree.AddComponentParameter(1, "MyEventCallbackOfT", EventCallback<int>.Empty);
+            tree.AddComponentParameter(1, "MyDateOnly", dateOnlyWillNotChange);
+            tree.AddComponentParameter(1, "MyTimeOnly", timeOnlyWillNotChange);
             tree.CloseComponent();
         }
 


### PR DESCRIPTION
# Add DateOnly and TimeOnly support in Blazor change detection

**Summary of the changes (Less than 80 chars)**
Add DateOnly and TimeOnly as known immutable types in Blazor change detection.

## Description

Updated the `ChangeDetection` class to include `DateOnly` and `TimeOnly` in the `IsKnownImmutableType` method. Introduced a caching mechanism to store immutability checks results using a `ConcurrentDictionary<T, U>` for performance optimization. Added support for hot reload to clear the cache when a hot reload event occurs.

Fixes #49021