### PR TITLE
Quarantine the flakiest IIS tests

### DIFF
--- a/src/Servers/IIS/IIS/test/Common.LongTests/ShutdownTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.LongTests/ShutdownTests.cs
@@ -537,6 +537,7 @@ public class ShutdownTests : IISFunctionalTestBase
         await deploymentResult.HttpClient.RetryRequestAsync("/ProcessId", async r => await r.Content.ReadAsStringAsync() == processBefore);
     }
 
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/55937")]
     [ConditionalFact]
     public async Task OutOfProcessToInProcessHostingModelSwitchWorks()
     {

--- a/src/Servers/IIS/IIS/test/IIS.Tests/ClientDisconnectTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/ClientDisconnectTests.cs
@@ -225,6 +225,7 @@ public class ClientDisconnectTests : StrictTestServerTests
         }
     }
 
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/55936")]
     [ConditionalFact]
     public async Task ReaderThrowsResetExceptionOnInvalidBody()
     {


### PR DESCRIPTION
There's already a bulk retry for IIS tests, but these are still failing often enough to be irritating.

Part of #55936 and #55937