### PR TITLE
Add test coverage for generic types

### DIFF
--- a/src/OpenApi/src/Schemas/OpenApiJsonSchema.Helpers.cs
+++ b/src/OpenApi/src/Schemas/OpenApiJsonSchema.Helpers.cs
@@ -289,6 +289,9 @@ internal sealed partial class OpenApiJsonSchema
                 var mappings = ReadDictionary<string>(ref reader);
                 schema.Discriminator.Mapping = mappings;
                 break;
+            default:
+                reader.Skip();
+                break;
         }
     }
 }

--- a/src/OpenApi/src/Schemas/OpenApiJsonSchema.Helpers.cs
+++ b/src/OpenApi/src/Schemas/OpenApiJsonSchema.Helpers.cs
@@ -265,6 +265,11 @@ internal sealed partial class OpenApiJsonSchema
                 var props = ReadDictionary<OpenApiJsonSchema>(ref reader);
                 schema.Properties = props?.ToDictionary(p => p.Key, p => p.Value.Schema);
                 break;
+            case OpenApiSchemaKeywords.AdditionalPropertiesKeyword:
+                reader.Read();
+                var additionalPropsConverter = (JsonConverter<OpenApiJsonSchema>)options.GetTypeInfo(typeof(OpenApiJsonSchema)).Converter;
+                schema.AdditionalProperties = additionalPropsConverter.Read(ref reader, typeof(OpenApiJsonSchema), options)?.Schema;
+                break;
             case OpenApiSchemaKeywords.AnyOfKeyword:
                 reader.Read();
                 schema.Type = "object";

--- a/src/OpenApi/src/Schemas/OpenApiSchemaKeywords.cs
+++ b/src/OpenApi/src/Schemas/OpenApiSchemaKeywords.cs
@@ -7,6 +7,7 @@ internal class OpenApiSchemaKeywords
     public const string FormatKeyword = "format";
     public const string ItemsKeyword = "items";
     public const string PropertiesKeyword = "properties";
+    public const string AdditionalPropertiesKeyword = "additionalProperties";
     public const string RequiredKeyword = "required";
     public const string AnyOfKeyword = "anyOf";
     public const string EnumKeyword = "enum";

--- a/src/OpenApi/test/Services/OpenApiComponentService/OpenApiComponentService.ResponseSchemas.cs
+++ b/src/OpenApi/test/Services/OpenApiComponentService/OpenApiComponentService.ResponseSchemas.cs
@@ -393,4 +393,81 @@ public partial class OpenApiComponentServiceTests : OpenApiDocumentServiceTestBa
                 });
         });
     }
+
+    [Fact]
+    public async Task GetOpenApiResponse_HandlesGenericType()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapGet("/", () => TypedResults.Ok<PaginatedItems<Todo>>(new(0, 1, 5, 50, [new Todo(1, "Test Title", true, DateTime.Now), new Todo(2, "Test Title 2", false, DateTime.Now)])));
+
+        // Assert that the response schema is correctly generated. For now, generics are inlined
+        // in the generated OpenAPI schema since OpenAPI supports generics via dynamic references as of
+        // OpenAPI 3.1.0.
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths["/"].Operations[OperationType.Get];
+            var responses = Assert.Single(operation.Responses);
+            var response = responses.Value;
+            Assert.True(response.Content.TryGetValue("application/json", out var mediaType));
+            Assert.Equal("object", mediaType.Schema.Type);
+            Assert.Collection(mediaType.Schema.Properties,
+                property =>
+                {
+                    Assert.Equal("pageIndex", property.Key);
+                    Assert.Equal("integer", property.Value.Type);
+                    Assert.Equal("int32", property.Value.Format);
+                },
+                property =>
+                {
+                    Assert.Equal("pageSize", property.Key);
+                    Assert.Equal("integer", property.Value.Type);
+                    Assert.Equal("int32", property.Value.Format);
+                },
+                property =>
+                {
+                    Assert.Equal("totalItems", property.Key);
+                    Assert.Equal("integer", property.Value.Type);
+                    Assert.Equal("int64", property.Value.Format);
+                },
+                property =>
+                {
+                    Assert.Equal("totalPages", property.Key);
+                    Assert.Equal("integer", property.Value.Type);
+                    Assert.Equal("int32", property.Value.Format);
+                },
+                property =>
+                {
+                    Assert.Equal("items", property.Key);
+                    Assert.Equal("array", property.Value.Type);
+                    Assert.NotNull(property.Value.Items);
+                    Assert.Equal("object", property.Value.Items.Type);
+                    Assert.Collection(property.Value.Items.Properties,
+                        property =>
+                        {
+                            Assert.Equal("id", property.Key);
+                            Assert.Equal("integer", property.Value.Type);
+                            Assert.Equal("int32", property.Value.Format);
+                        },
+                        property =>
+                        {
+                            Assert.Equal("title", property.Key);
+                            Assert.Equal("string", property.Value.Type);
+                        },
+                        property =>
+                        {
+                            Assert.Equal("completed", property.Key);
+                            Assert.Equal("boolean", property.Value.Type);
+                        },
+                        property =>
+                        {
+                            Assert.Equal("createdAt", property.Key);
+                            Assert.Equal("string", property.Value.Type);
+                            Assert.Equal("date-time", property.Value.Format);
+                        });
+                });
+        });
+    }
 }

--- a/src/OpenApi/test/SharedTypes.cs
+++ b/src/OpenApi/test/SharedTypes.cs
@@ -63,3 +63,12 @@ internal class Proposal
     public required Proposal ProposalElement { get; set; }
     public required Stream Stream { get; set; }
 }
+
+internal class PaginatedItems<T>(int pageIndex, int pageSize, long totalItems, int totalPages, IEnumerable<T> items) where T : class
+{
+    public int PageIndex { get; set; } = pageIndex;
+    public int PageSize { get; set; } = pageSize;
+    public long TotalItems { get; set; } = totalItems;
+    public int TotalPages { get; set; } = totalPages;
+    public IEnumerable<T> Items { get; set; } = items;
+}


### PR DESCRIPTION
Added a test case to cover the common scenario of generic types used to represent paginated data.

Also closes https://github.com/dotnet/aspnetcore/issues/55883.