### PR TITLE
Bump update-dotnet-sdk action

### DIFF
--- a/.github/workflows/update-sdk.yml
+++ b/.github/workflows/update-sdk.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: martincostello/update-dotnet-sdk@9d42ad9bcbd97a74394c7273c9c616b4bf136b53 # v3.1.3
+    - uses: martincostello/update-dotnet-sdk@67d6e2b14939c06978a7f80444157296c3defe14 # v3.2.3
       with:
         quality: 'daily'
         repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Bump update-dotnet-sdk action

Bump the martincostello/update-dotnet-sdk action to v3.2.3.

## Description

Bump the [martincostello/update-dotnet-sdk](https://github.com/martincostello/update-dotnet-sdk) action to [v3.2.3](https://github.com/martincostello/update-dotnet-sdk/releases/tag/v3.2.3) to handle upcoming changes from the merging of the installer and sdk repos.

See https://github.com/dotnet/sdk/pull/41316.
