### PR TITLE
Fix SetLockoutEnabledAsync comments

### DIFF
--- a/src/Identity/Extensions.Core/src/UserManager.cs
+++ b/src/Identity/Extensions.Core/src/UserManager.cs
@@ -1735,11 +1735,11 @@ public class UserManager<TUser> : IDisposable where TUser : class
     }
 
     /// <summary>
-    /// Sets a flag indicating whether the specified <paramref name="user"/> is locked out,
+    /// Sets a flag indicating whether the specified <paramref name="user"/> can be locked out,
     /// as an asynchronous operation.
     /// </summary>
     /// <param name="user">The user whose locked out status should be set.</param>
-    /// <param name="enabled">Flag indicating whether the user is locked out or not.</param>
+    /// <param name="enabled">Flag indicating whether the user can be locked out or not.</param>
     /// <returns>
     /// The <see cref="Task"/> that represents the asynchronous operation, the <see cref="IdentityResult"/> of the operation
     /// </returns>


### PR DESCRIPTION

# Fix SetLockoutEnabledAsync comments

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

SetLockoutEnabledAsync sets the flag indicating if a user can be locked out, the comment insinuated that this is the actual locked out flag.

Fixes #56061
