### PR TITLE
Unquarantine `HeartbeatLoopRunsWithSpecifiedInterval`

### DIFF
--- a/src/Servers/Kestrel/Core/test/HeartbeatTests.cs
+++ b/src/Servers/Kestrel/Core/test/HeartbeatTests.cs
@@ -20,7 +20,6 @@ public class HeartbeatTests : LoggedTest
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/55297")]
     public async void HeartbeatLoopRunsWithSpecifiedInterval()
     {
         var heartbeatCallCount = 0;


### PR DESCRIPTION
Unquarantining since it's been more than 30 days since this test failed.

Fixes https://github.com/dotnet/aspnetcore/issues/55297