### PR TITLE
Add support for OpenAPI schema transformers

### DIFF
--- a/src/OpenApi/src/PublicAPI.Unshipped.txt
+++ b/src/OpenApi/src/PublicAPI.Unshipped.txt
@@ -11,9 +11,20 @@ Microsoft.AspNetCore.OpenApi.OpenApiOptions.OpenApiVersion.set -> void
 Microsoft.AspNetCore.OpenApi.OpenApiOptions.ShouldInclude.get -> System.Func<Microsoft.AspNetCore.Mvc.ApiExplorer.ApiDescription!, bool>!
 Microsoft.AspNetCore.OpenApi.OpenApiOptions.ShouldInclude.set -> void
 Microsoft.AspNetCore.OpenApi.OpenApiOptions.UseOperationTransformer(System.Func<Microsoft.OpenApi.Models.OpenApiOperation!, Microsoft.AspNetCore.OpenApi.OpenApiOperationTransformerContext!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! transformer) -> Microsoft.AspNetCore.OpenApi.OpenApiOptions!
+Microsoft.AspNetCore.OpenApi.OpenApiOptions.UseSchemaTransformer(System.Func<Microsoft.OpenApi.Models.OpenApiSchema!, Microsoft.AspNetCore.OpenApi.OpenApiSchemaTransformerContext!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! transformer) -> Microsoft.AspNetCore.OpenApi.OpenApiOptions!
 Microsoft.AspNetCore.OpenApi.OpenApiOptions.UseTransformer(Microsoft.AspNetCore.OpenApi.IOpenApiDocumentTransformer! transformer) -> Microsoft.AspNetCore.OpenApi.OpenApiOptions!
 Microsoft.AspNetCore.OpenApi.OpenApiOptions.UseTransformer(System.Func<Microsoft.OpenApi.Models.OpenApiDocument!, Microsoft.AspNetCore.OpenApi.OpenApiDocumentTransformerContext!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! transformer) -> Microsoft.AspNetCore.OpenApi.OpenApiOptions!
 Microsoft.AspNetCore.OpenApi.OpenApiOptions.UseTransformer<TTransformerType>() -> Microsoft.AspNetCore.OpenApi.OpenApiOptions!
+Microsoft.AspNetCore.OpenApi.OpenApiSchemaTransformerContext
+Microsoft.AspNetCore.OpenApi.OpenApiSchemaTransformerContext.ApplicationServices.get -> System.IServiceProvider!
+Microsoft.AspNetCore.OpenApi.OpenApiSchemaTransformerContext.ApplicationServices.init -> void
+Microsoft.AspNetCore.OpenApi.OpenApiSchemaTransformerContext.DocumentName.get -> string!
+Microsoft.AspNetCore.OpenApi.OpenApiSchemaTransformerContext.DocumentName.init -> void
+Microsoft.AspNetCore.OpenApi.OpenApiSchemaTransformerContext.OpenApiSchemaTransformerContext() -> void
+Microsoft.AspNetCore.OpenApi.OpenApiSchemaTransformerContext.ParameterDescription.get -> Microsoft.AspNetCore.Mvc.ApiExplorer.ApiParameterDescription?
+Microsoft.AspNetCore.OpenApi.OpenApiSchemaTransformerContext.ParameterDescription.init -> void
+Microsoft.AspNetCore.OpenApi.OpenApiSchemaTransformerContext.Type.get -> System.Type!
+Microsoft.AspNetCore.OpenApi.OpenApiSchemaTransformerContext.Type.init -> void
 Microsoft.Extensions.DependencyInjection.OpenApiServiceCollectionExtensions
 static Microsoft.AspNetCore.Builder.OpenApiEndpointRouteBuilderExtensions.MapOpenApi(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints, string! pattern = "/openapi/{documentName}.json") -> Microsoft.AspNetCore.Builder.IEndpointConventionBuilder!
 static Microsoft.Extensions.DependencyInjection.OpenApiServiceCollectionExtensions.AddOpenApi(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -99,7 +99,7 @@ internal sealed class OpenApiDocumentService(
     /// the object to support filtering each
     /// description instance into its appropriate document.
     /// </remarks>
-    private async Task<OpenApiPaths> GetOpenApiPathsAsync(HashSet<OpenApiTag> capturedTags, CancellationToken cancellationToken = default)
+    private async Task<OpenApiPaths> GetOpenApiPathsAsync(HashSet<OpenApiTag> capturedTags, CancellationToken cancellationToken)
     {
         var descriptionsByPath = apiDescriptionGroupCollectionProvider.ApiDescriptionGroups.Items
             .SelectMany(group => group.Items)
@@ -114,7 +114,7 @@ internal sealed class OpenApiDocumentService(
         return paths;
     }
 
-    private async Task<Dictionary<OperationType, OpenApiOperation>> GetOperationsAsync(IGrouping<string?, ApiDescription> descriptions, HashSet<OpenApiTag> capturedTags, CancellationToken cancellationToken = default)
+    private async Task<Dictionary<OperationType, OpenApiOperation>> GetOperationsAsync(IGrouping<string?, ApiDescription> descriptions, HashSet<OpenApiTag> capturedTags, CancellationToken cancellationToken)
     {
         var operations = new Dictionary<OperationType, OpenApiOperation>();
         foreach (var description in descriptions)
@@ -132,7 +132,7 @@ internal sealed class OpenApiDocumentService(
         return operations;
     }
 
-    private async Task<OpenApiOperation> GetOperationAsync(ApiDescription description, HashSet<OpenApiTag> capturedTags, CancellationToken cancellationToken = default)
+    private async Task<OpenApiOperation> GetOperationAsync(ApiDescription description, HashSet<OpenApiTag> capturedTags, CancellationToken cancellationToken)
     {
         var tags = GetTags(description);
         if (tags != null)
@@ -177,7 +177,7 @@ internal sealed class OpenApiDocumentService(
         return [new OpenApiTag { Name = description.ActionDescriptor.RouteValues["controller"] }];
     }
 
-    private async Task<OpenApiResponses> GetResponsesAsync(ApiDescription description, CancellationToken cancellationToken = default)
+    private async Task<OpenApiResponses> GetResponsesAsync(ApiDescription description, CancellationToken cancellationToken)
     {
         // OpenAPI requires that each operation have a response, usually a successful one.
         // if there are no response types defined, we assume a successful 200 OK response
@@ -205,7 +205,7 @@ internal sealed class OpenApiDocumentService(
         return responses;
     }
 
-    private async Task<OpenApiResponse> GetResponseAsync(ApiDescription apiDescription, int statusCode, ApiResponseType apiResponseType, CancellationToken cancellationToken = default)
+    private async Task<OpenApiResponse> GetResponseAsync(ApiDescription apiDescription, int statusCode, ApiResponseType apiResponseType, CancellationToken cancellationToken)
     {
         var description = ReasonPhrases.GetReasonPhrase(statusCode);
         var response = new OpenApiResponse
@@ -240,7 +240,7 @@ internal sealed class OpenApiDocumentService(
         return response;
     }
 
-    private async Task<List<OpenApiParameter>?> GetParametersAsync(ApiDescription description, CancellationToken cancellationToken = default)
+    private async Task<List<OpenApiParameter>?> GetParametersAsync(ApiDescription description, CancellationToken cancellationToken)
     {
         List<OpenApiParameter>? parameters = null;
         foreach (var parameter in description.ParameterDescriptions)
@@ -273,7 +273,7 @@ internal sealed class OpenApiDocumentService(
         return parameters;
     }
 
-    private async Task<OpenApiRequestBody?> GetRequestBodyAsync(ApiDescription description, CancellationToken cancellationToken = default)
+    private async Task<OpenApiRequestBody?> GetRequestBodyAsync(ApiDescription description, CancellationToken cancellationToken)
     {
         // Only one parameter can be bound from the body in each request.
         if (description.TryGetBodyParameter(out var bodyParameter))
@@ -290,7 +290,7 @@ internal sealed class OpenApiDocumentService(
         return null;
     }
 
-    private async Task<OpenApiRequestBody> GetFormRequestBody(IList<ApiRequestFormat> supportedRequestFormats, IEnumerable<ApiParameterDescription> formParameters, CancellationToken cancellationToken = default)
+    private async Task<OpenApiRequestBody> GetFormRequestBody(IList<ApiRequestFormat> supportedRequestFormats, IEnumerable<ApiParameterDescription> formParameters, CancellationToken cancellationToken)
     {
         if (supportedRequestFormats.Count == 0)
         {
@@ -415,7 +415,7 @@ internal sealed class OpenApiDocumentService(
         return requestBody;
     }
 
-    private async Task<OpenApiRequestBody> GetJsonRequestBody(IList<ApiRequestFormat> supportedRequestFormats, ApiParameterDescription bodyParameter, CancellationToken cancellationToken = default)
+    private async Task<OpenApiRequestBody> GetJsonRequestBody(IList<ApiRequestFormat> supportedRequestFormats, ApiParameterDescription bodyParameter, CancellationToken cancellationToken)
     {
         if (supportedRequestFormats.Count == 0)
         {

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -55,7 +55,7 @@ internal sealed class OpenApiDocumentService(
         var document = new OpenApiDocument
         {
             Info = GetOpenApiInfo(),
-            Paths = GetOpenApiPaths(capturedTags),
+            Paths = await GetOpenApiPathsAsync(capturedTags, cancellationToken),
             Tags = [.. capturedTags]
         };
         await ApplyTransformersAsync(document, cancellationToken);
@@ -99,7 +99,7 @@ internal sealed class OpenApiDocumentService(
     /// the object to support filtering each
     /// description instance into its appropriate document.
     /// </remarks>
-    private OpenApiPaths GetOpenApiPaths(HashSet<OpenApiTag> capturedTags)
+    private async Task<OpenApiPaths> GetOpenApiPathsAsync(HashSet<OpenApiTag> capturedTags, CancellationToken cancellationToken = default)
     {
         var descriptionsByPath = apiDescriptionGroupCollectionProvider.ApiDescriptionGroups.Items
             .SelectMany(group => group.Items)
@@ -109,17 +109,17 @@ internal sealed class OpenApiDocumentService(
         foreach (var descriptions in descriptionsByPath)
         {
             Debug.Assert(descriptions.Key != null, "Relative path mapped to OpenApiPath key cannot be null.");
-            paths.Add(descriptions.Key, new OpenApiPathItem { Operations = GetOperations(descriptions, capturedTags) });
+            paths.Add(descriptions.Key, new OpenApiPathItem { Operations = await GetOperationsAsync(descriptions, capturedTags, cancellationToken) });
         }
         return paths;
     }
 
-    private Dictionary<OperationType, OpenApiOperation> GetOperations(IGrouping<string?, ApiDescription> descriptions, HashSet<OpenApiTag> capturedTags)
+    private async Task<Dictionary<OperationType, OpenApiOperation>> GetOperationsAsync(IGrouping<string?, ApiDescription> descriptions, HashSet<OpenApiTag> capturedTags, CancellationToken cancellationToken = default)
     {
         var operations = new Dictionary<OperationType, OpenApiOperation>();
         foreach (var description in descriptions)
         {
-            var operation = GetOperation(description, capturedTags);
+            var operation = await GetOperationAsync(description, capturedTags, cancellationToken);
             operation.Extensions.Add(OpenApiConstants.DescriptionId, new OpenApiString(description.ActionDescriptor.Id));
             _operationTransformerContextCache.TryAdd(description.ActionDescriptor.Id, new OpenApiOperationTransformerContext
             {
@@ -132,7 +132,7 @@ internal sealed class OpenApiDocumentService(
         return operations;
     }
 
-    private OpenApiOperation GetOperation(ApiDescription description, HashSet<OpenApiTag> capturedTags)
+    private async Task<OpenApiOperation> GetOperationAsync(ApiDescription description, HashSet<OpenApiTag> capturedTags, CancellationToken cancellationToken = default)
     {
         var tags = GetTags(description);
         if (tags != null)
@@ -147,9 +147,9 @@ internal sealed class OpenApiDocumentService(
             OperationId = GetOperationId(description),
             Summary = GetSummary(description),
             Description = GetDescription(description),
-            Responses = GetResponses(description),
-            Parameters = GetParameters(description),
-            RequestBody = GetRequestBody(description),
+            Responses = await GetResponsesAsync(description, cancellationToken),
+            Parameters = await GetParametersAsync(description, cancellationToken),
+            RequestBody = await GetRequestBodyAsync(description, cancellationToken),
             Tags = tags,
         };
         return operation;
@@ -177,7 +177,7 @@ internal sealed class OpenApiDocumentService(
         return [new OpenApiTag { Name = description.ActionDescriptor.RouteValues["controller"] }];
     }
 
-    private OpenApiResponses GetResponses(ApiDescription description)
+    private async Task<OpenApiResponses> GetResponsesAsync(ApiDescription description, CancellationToken cancellationToken = default)
     {
         // OpenAPI requires that each operation have a response, usually a successful one.
         // if there are no response types defined, we assume a successful 200 OK response
@@ -186,7 +186,7 @@ internal sealed class OpenApiDocumentService(
         {
             return new OpenApiResponses
             {
-                ["200"] = GetResponse(description, StatusCodes.Status200OK, _defaultApiResponseType)
+                ["200"] = await GetResponseAsync(description, StatusCodes.Status200OK, _defaultApiResponseType, cancellationToken)
             };
         }
 
@@ -200,12 +200,12 @@ internal sealed class OpenApiDocumentService(
             var responseKey = responseType.IsDefaultResponse
                 ? OpenApiConstants.DefaultOpenApiResponseKey
                 : responseType.StatusCode.ToString(CultureInfo.InvariantCulture);
-            responses.Add(responseKey, GetResponse(description, responseType.StatusCode, responseType));
+            responses.Add(responseKey, await GetResponseAsync(description, responseType.StatusCode, responseType, cancellationToken));
         }
         return responses;
     }
 
-    private OpenApiResponse GetResponse(ApiDescription apiDescription, int statusCode, ApiResponseType apiResponseType)
+    private async Task<OpenApiResponse> GetResponseAsync(ApiDescription apiDescription, int statusCode, ApiResponseType apiResponseType, CancellationToken cancellationToken = default)
     {
         var description = ReasonPhrases.GetReasonPhrase(statusCode);
         var response = new OpenApiResponse
@@ -222,7 +222,7 @@ internal sealed class OpenApiDocumentService(
             .Select(responseFormat => responseFormat.MediaType);
         foreach (var contentType in apiResponseFormatContentTypes)
         {
-            var schema = apiResponseType.Type is { } type ? _componentService.GetOrCreateSchema(type) : new OpenApiSchema();
+            var schema = apiResponseType.Type is { } type ? await _componentService.GetOrCreateSchemaAsync(type, null, cancellationToken) : new OpenApiSchema();
             response.Content[contentType] = new OpenApiMediaType { Schema = schema };
         }
 
@@ -240,7 +240,7 @@ internal sealed class OpenApiDocumentService(
         return response;
     }
 
-    private List<OpenApiParameter>? GetParameters(ApiDescription description)
+    private async Task<List<OpenApiParameter>?> GetParametersAsync(ApiDescription description, CancellationToken cancellationToken = default)
     {
         List<OpenApiParameter>? parameters = null;
         foreach (var parameter in description.ParameterDescriptions)
@@ -265,7 +265,7 @@ internal sealed class OpenApiDocumentService(
                 // Per the OpenAPI specification, parameters that are sourced from the path
                 // are always required, regardless of the requiredness status of the parameter.
                 Required = parameter.Source == BindingSource.Path || parameter.IsRequired,
-                Schema = _componentService.GetOrCreateSchema(parameter.Type, parameter),
+                Schema = await _componentService.GetOrCreateSchemaAsync(parameter.Type, parameter, cancellationToken),
             };
             parameters ??= [];
             parameters.Add(openApiParameter);
@@ -273,24 +273,24 @@ internal sealed class OpenApiDocumentService(
         return parameters;
     }
 
-    private OpenApiRequestBody? GetRequestBody(ApiDescription description)
+    private async Task<OpenApiRequestBody?> GetRequestBodyAsync(ApiDescription description, CancellationToken cancellationToken = default)
     {
         // Only one parameter can be bound from the body in each request.
         if (description.TryGetBodyParameter(out var bodyParameter))
         {
-            return GetJsonRequestBody(description.SupportedRequestFormats, bodyParameter);
+            return await GetJsonRequestBody(description.SupportedRequestFormats, bodyParameter, cancellationToken);
         }
         // If there are no body parameters, check for form parameters.
         // Note: Form parameters and body parameters cannot exist simultaneously
         // in the same endpoint.
         if (description.TryGetFormParameters(out var formParameters))
         {
-            return GetFormRequestBody(description.SupportedRequestFormats, formParameters);
+            return await GetFormRequestBody(description.SupportedRequestFormats, formParameters, cancellationToken);
         }
         return null;
     }
 
-    private OpenApiRequestBody GetFormRequestBody(IList<ApiRequestFormat> supportedRequestFormats, IEnumerable<ApiParameterDescription> formParameters)
+    private async Task<OpenApiRequestBody> GetFormRequestBody(IList<ApiRequestFormat> supportedRequestFormats, IEnumerable<ApiParameterDescription> formParameters, CancellationToken cancellationToken = default)
     {
         if (supportedRequestFormats.Count == 0)
         {
@@ -325,7 +325,7 @@ internal sealed class OpenApiDocumentService(
             if (parameter.All(parameter => parameter.ModelMetadata.ContainerType is null))
             {
                 var description = parameter.Single();
-                var parameterSchema = _componentService.GetOrCreateSchema(description.Type);
+                var parameterSchema = await _componentService.GetOrCreateSchemaAsync(description.Type, null, cancellationToken);
                 // Form files are keyed by their parameter name so we must capture the parameter name
                 // as a property in the schema.
                 if (description.Type == typeof(IFormFile) || description.Type == typeof(IFormFileCollection))
@@ -388,7 +388,7 @@ internal sealed class OpenApiDocumentService(
                     var propertySchema = new OpenApiSchema { Type = "object", Properties = new Dictionary<string, OpenApiSchema>() };
                     foreach (var description in parameter)
                     {
-                        propertySchema.Properties[description.Name] = _componentService.GetOrCreateSchema(description.Type);
+                        propertySchema.Properties[description.Name] = await _componentService.GetOrCreateSchemaAsync(description.Type, null, cancellationToken);
                     }
                     schema.AllOf.Add(propertySchema);
                 }
@@ -396,7 +396,7 @@ internal sealed class OpenApiDocumentService(
                 {
                     foreach (var description in parameter)
                     {
-                        schema.Properties[description.Name] = _componentService.GetOrCreateSchema(description.Type);
+                        schema.Properties[description.Name] = await _componentService.GetOrCreateSchemaAsync(description.Type, null, cancellationToken);
                     }
                 }
             }
@@ -415,7 +415,7 @@ internal sealed class OpenApiDocumentService(
         return requestBody;
     }
 
-    private OpenApiRequestBody GetJsonRequestBody(IList<ApiRequestFormat> supportedRequestFormats, ApiParameterDescription bodyParameter)
+    private async Task<OpenApiRequestBody> GetJsonRequestBody(IList<ApiRequestFormat> supportedRequestFormats, ApiParameterDescription bodyParameter, CancellationToken cancellationToken = default)
     {
         if (supportedRequestFormats.Count == 0)
         {
@@ -442,7 +442,7 @@ internal sealed class OpenApiDocumentService(
         foreach (var requestForm in supportedRequestFormats)
         {
             var contentType = requestForm.MediaType;
-            requestBody.Content[contentType] = new OpenApiMediaType { Schema = _componentService.GetOrCreateSchema(bodyParameter.Type) };
+            requestBody.Content[contentType] = new OpenApiMediaType { Schema = await _componentService.GetOrCreateSchemaAsync(bodyParameter.Type, bodyParameter, cancellationToken) };
         }
 
         return requestBody;

--- a/src/OpenApi/src/Services/OpenApiOptions.cs
+++ b/src/OpenApi/src/Services/OpenApiOptions.cs
@@ -14,6 +14,7 @@ namespace Microsoft.AspNetCore.OpenApi;
 public sealed class OpenApiOptions
 {
     internal readonly List<IOpenApiDocumentTransformer> DocumentTransformers = [];
+    internal readonly List<Func<OpenApiSchema, OpenApiSchemaTransformerContext, CancellationToken, Task>> SchemaTransformers = [];
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OpenApiOptions"/> class
@@ -87,6 +88,19 @@ public sealed class OpenApiOptions
         ArgumentNullException.ThrowIfNull(transformer, nameof(transformer));
 
         DocumentTransformers.Add(new DelegateOpenApiDocumentTransformer(transformer));
+        return this;
+    }
+
+    /// <summary>
+    /// Registers a given delegate as an schema transformer on the current <see cref="OpenApiOptions"/> instance.
+    /// </summary>
+    /// <param name="transformer">The delegate representing the schema transformer.</param>
+    /// <returns>The <see cref="OpenApiOptions"/> instance for further customization.</returns>
+    public OpenApiOptions UseSchemaTransformer(Func<OpenApiSchema, OpenApiSchemaTransformerContext, CancellationToken, Task> transformer)
+    {
+        ArgumentNullException.ThrowIfNull(transformer, nameof(transformer));
+
+        SchemaTransformers.Add(transformer);
         return this;
     }
 }

--- a/src/OpenApi/src/Services/OpenApiOptions.cs
+++ b/src/OpenApi/src/Services/OpenApiOptions.cs
@@ -92,7 +92,7 @@ public sealed class OpenApiOptions
     }
 
     /// <summary>
-    /// Registers a given delegate as an schema transformer on the current <see cref="OpenApiOptions"/> instance.
+    /// Registers a given delegate as a schema transformer on the current <see cref="OpenApiOptions"/> instance.
     /// </summary>
     /// <param name="transformer">The delegate representing the schema transformer.</param>
     /// <returns>The <see cref="OpenApiOptions"/> instance for further customization.</returns>

--- a/src/OpenApi/src/Transformers/OpenApiSchemaTransformerContext.cs
+++ b/src/OpenApi/src/Transformers/OpenApiSchemaTransformerContext.cs
@@ -19,11 +19,10 @@ public sealed class OpenApiSchemaTransformerContext
     /// <summary>
     /// Gets the <see cref="Type" /> associated with the current <see cref="OpenApiSchema"/>
     /// </summary>
-    /// <value></value>
     public required Type Type { get; init; }
 
     /// <summary>
-    /// Gets the <see cref="ApiParameterDescription"/>  associated with target schema.
+    /// Gets the <see cref="ApiParameterDescription"/> associated with the target schema.
     /// Null when processing an OpenAPI schema for a response type.
     /// </summary>
     public required ApiParameterDescription? ParameterDescription { get; init; }

--- a/src/OpenApi/src/Transformers/OpenApiSchemaTransformerContext.cs
+++ b/src/OpenApi/src/Transformers/OpenApiSchemaTransformerContext.cs
@@ -17,7 +17,7 @@ public sealed class OpenApiSchemaTransformerContext
     public required string DocumentName { get; init; }
 
     /// <summary>
-    /// Gets the <see cref="Type" /> associated with the current <see cref="OpenApiSchema"/>
+    /// Gets the <see cref="Type" /> associated with the current <see cref="OpenApiSchema"/>.
     /// </summary>
     public required Type Type { get; init; }
 

--- a/src/OpenApi/src/Transformers/OpenApiSchemaTransformerContext.cs
+++ b/src/OpenApi/src/Transformers/OpenApiSchemaTransformerContext.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.AspNetCore.OpenApi;
+
+/// <summary>
+/// Represents the context in which an OpenAPI schema transformer is executed.
+/// </summary>
+public sealed class OpenApiSchemaTransformerContext
+{
+    /// <summary>
+    /// Gets the name of the associated OpenAPI document.
+    /// </summary>
+    public required string DocumentName { get; init; }
+
+    /// <summary>
+    /// Gets the <see cref="Type" /> associated with the current <see cref="OpenApiSchema"/>
+    /// </summary>
+    /// <value></value>
+    public required Type Type { get; init; }
+
+    /// <summary>
+    /// Gets the <see cref="ApiParameterDescription"/>  associated with target schema.
+    /// Null when processing an OpenAPI schema for a response type.
+    /// </summary>
+    public required ApiParameterDescription? ParameterDescription { get; init; }
+
+    /// <summary>
+    /// Gets the application services associated with the current document the target schema is in.
+    /// </summary>
+    public required IServiceProvider ApplicationServices { get; init; }
+}

--- a/src/OpenApi/test/Services/OpenApiDocumentServiceTestsBase.cs
+++ b/src/OpenApi/test/Services/OpenApiDocumentServiceTestsBase.cs
@@ -21,13 +21,13 @@ using static Microsoft.AspNetCore.OpenApi.Tests.OpenApiOperationGeneratorTests;
 
 public abstract class OpenApiDocumentServiceTestBase
 {
-    public static async Task VerifyOpenApiDocument(IEndpointRouteBuilder builder, Action<OpenApiDocument> verifyOpenApiDocument)
-        => await VerifyOpenApiDocument(builder, new OpenApiOptions(), verifyOpenApiDocument);
+    public static async Task VerifyOpenApiDocument(IEndpointRouteBuilder builder, Action<OpenApiDocument> verifyOpenApiDocument, CancellationToken cancellationToken = default)
+        => await VerifyOpenApiDocument(builder, new OpenApiOptions(), verifyOpenApiDocument, cancellationToken);
 
-    public static async Task VerifyOpenApiDocument(IEndpointRouteBuilder builder, OpenApiOptions openApiOptions, Action<OpenApiDocument> verifyOpenApiDocument)
+    public static async Task VerifyOpenApiDocument(IEndpointRouteBuilder builder, OpenApiOptions openApiOptions, Action<OpenApiDocument> verifyOpenApiDocument, CancellationToken cancellationToken = default)
     {
         var documentService = CreateDocumentService(builder, openApiOptions);
-        var document = await documentService.GetOpenApiDocumentAsync();
+        var document = await documentService.GetOpenApiDocumentAsync(cancellationToken);
         verifyOpenApiDocument(document);
     }
 

--- a/src/OpenApi/test/Services/OpenApiDocumentServiceTestsBase.cs
+++ b/src/OpenApi/test/Services/OpenApiDocumentServiceTestsBase.cs
@@ -73,6 +73,8 @@ public abstract class OpenApiDocumentServiceTestBase
         var openApiOptions = new Mock<IOptionsMonitor<OpenApiOptions>>();
         openApiOptions.Setup(o => o.Get(It.IsAny<string>())).Returns(new OpenApiOptions());
 
+        var schemaService = new OpenApiSchemaService("Test", Options.Create(new Microsoft.AspNetCore.Http.Json.JsonOptions()), builder.ServiceProvider, openApiOptions.Object);
+        ((TestServiceProvider)builder.ServiceProvider).TestSchemaService = schemaService;
         var documentService = new OpenApiDocumentService("Test", apiDescriptionGroupCollectionProvider, hostEnvironment, openApiOptions.Object, builder.ServiceProvider);
         ((TestServiceProvider)builder.ServiceProvider).TestDocumentService = documentService;
 
@@ -97,6 +99,8 @@ public abstract class OpenApiDocumentServiceTestBase
 
         var apiDescriptionGroupCollectionProvider = CreateApiDescriptionGroupCollectionProvider(context.Results);
 
+        var schemaService = new OpenApiSchemaService("Test", Options.Create(new Microsoft.AspNetCore.Http.Json.JsonOptions()), builder.ServiceProvider, options.Object);
+        ((TestServiceProvider)builder.ServiceProvider).TestSchemaService = schemaService;
         var documentService = new OpenApiDocumentService("Test", apiDescriptionGroupCollectionProvider, hostEnvironment, options.Object, builder.ServiceProvider);
         ((TestServiceProvider)builder.ServiceProvider).TestDocumentService = documentService;
 
@@ -214,33 +218,27 @@ public abstract class OpenApiDocumentServiceTestBase
         private IKeyedServiceProvider _serviceProvider;
         internal OpenApiDocumentService TestDocumentService { get; set; }
         internal OpenApiSchemaStore TestSchemaStoreService { get; } = new OpenApiSchemaStore();
-        private OpenApiSchemaService _testSchemaService;
+        internal OpenApiSchemaService TestSchemaService { get; set; }
 
         public void SetInternalServiceProvider(IServiceCollection serviceCollection)
         {
             serviceCollection.AddKeyedSingleton<OpenApiSchemaStore>("Test");
+            serviceCollection.Configure<OpenApiOptions>("Test", options =>
+            {
+                options.DocumentName = "Test";
+            });
             _serviceProvider = serviceCollection.BuildServiceProvider();
-            _testSchemaService = new OpenApiSchemaService(
-                "Test",
-                Options.Create(new Microsoft.AspNetCore.Http.Json.JsonOptions()),
-                _serviceProvider
-            );
         }
 
         public object GetKeyedService(Type serviceType, object serviceKey)
         {
-
             if (serviceType == typeof(OpenApiDocumentService))
             {
                 return TestDocumentService;
             }
             if (serviceType == typeof(OpenApiSchemaService))
             {
-                return _testSchemaService;
-            }
-            if (serviceType == typeof(OpenApiSchemaService))
-            {
-                return _testSchemaService;
+                return TestSchemaService;
             }
             if (serviceType == typeof(OpenApiSchemaStore))
             {
@@ -258,12 +256,11 @@ public abstract class OpenApiDocumentServiceTestBase
             }
             if (serviceType == typeof(OpenApiSchemaService))
             {
-                return _testSchemaService;
+                return TestSchemaService;
             }
-
-            if (serviceType == typeof(OpenApiSchemaService))
+            if (serviceType == typeof(OpenApiSchemaStore))
             {
-                return _testSchemaService;
+                return TestSchemaStoreService;
             }
 
             return _serviceProvider.GetRequiredKeyedService(serviceType, serviceKey);

--- a/src/OpenApi/test/Transformers/SchemaTransformerTests.cs
+++ b/src/OpenApi/test/Transformers/SchemaTransformerTests.cs
@@ -1,0 +1,134 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+
+public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
+{
+    [Fact]
+    public async Task SchemaTransformer_CanAccessTypeAndParameterDescriptionForParameter()
+    {
+        var builder = CreateBuilder();
+
+        builder.MapPost("/todo", (Todo todo) => { });
+
+        var options = new OpenApiOptions();
+        options.UseSchemaTransformer((schema, context, cancellationToken) =>
+        {
+            Assert.Equal(typeof(Todo), context.Type);
+            Assert.Equal("todo", context.ParameterDescription.Name);
+            return Task.CompletedTask;
+        });
+
+        await VerifyOpenApiDocument(builder, document => { });
+    }
+
+    [Fact]
+    public async Task SchemaTransformer_CanAccessTypeForResponse()
+    {
+        var builder = CreateBuilder();
+
+        builder.MapGet("/todo", () => new Todo(1, "Item1", false, DateTime.Now));
+
+        var options = new OpenApiOptions();
+        options.UseSchemaTransformer((schema, context, cancellationToken) =>
+        {
+            Assert.Equal(typeof(Todo), context.Type);
+            Assert.Null(context.ParameterDescription);
+            return Task.CompletedTask;
+        });
+
+        await VerifyOpenApiDocument(builder, document => { });
+    }
+
+    [Fact]
+    public async Task SchemaTransformer_RunsInRegisteredOrder()
+    {
+        var builder = CreateBuilder();
+
+        builder.MapPost("/todo", (Todo todo) => { });
+
+        var options = new OpenApiOptions();
+        options.UseSchemaTransformer((schema, context, cancellationToken) =>
+        {
+            schema.Extensions["x-my-extension"] = new OpenApiString("1");
+            return Task.CompletedTask;
+        });
+        options.UseSchemaTransformer((schema, context, cancellationToken) =>
+        {
+            Assert.Equal("1", ((OpenApiString)schema.Extensions["x-my-extension"]).Value);
+            schema.Extensions["x-my-extension"] = new OpenApiString("2");
+            return Task.CompletedTask;
+        });
+
+        await VerifyOpenApiDocument(builder, options, document =>
+        {
+            var operation = Assert.Single(document.Paths.Values).Operations.Values.Single();
+            var schema = operation.RequestBody.Content["application/json"].Schema;
+            Assert.Equal("2", ((OpenApiString)schema.Extensions["x-my-extension"]).Value);
+        });
+    }
+
+    [Fact]
+    public async Task SchemaTransformer_OnTypeModifiesBothRequestAndResponse()
+    {
+        var builder = CreateBuilder();
+
+        builder.MapPost("/todo", (Todo todo) => { });
+        builder.MapGet("/todo", () => new Todo(1, "Item1", false, DateTime.Now));
+
+        var options = new OpenApiOptions();
+        options.UseSchemaTransformer((schema, context, cancellationToken) =>
+        {
+            if (context.Type == typeof(Todo))
+            {
+                schema.Extensions["x-my-extension"] = new OpenApiString("1");
+            }
+            return Task.CompletedTask;
+        });
+
+        await VerifyOpenApiDocument(builder, options, document =>
+        {
+            var path = Assert.Single(document.Paths.Values);
+            var postOperation = path.Operations[OperationType.Post];
+            var requestSchema = postOperation.RequestBody.Content["application/json"].Schema;
+            Assert.Equal("1", ((OpenApiString)requestSchema.Extensions["x-my-extension"]).Value);
+            var getOperation = path.Operations[OperationType.Get];
+            var responseSchema = getOperation.Responses["200"].Content["application/json"].Schema;
+            Assert.Equal("1", ((OpenApiString)responseSchema.Extensions["x-my-extension"]).Value);
+        });
+    }
+
+    [Fact]
+    public async Task SchemaTransformer_WithDescriptionOnlyModifiesParameter()
+    {
+        var builder = CreateBuilder();
+
+        builder.MapPost("/todo", (Todo todo) => { });
+        builder.MapGet("/todo", () => new Todo(1, "Item1", false, DateTime.Now));
+
+        var options = new OpenApiOptions();
+        options.UseSchemaTransformer((schema, context, cancellationToken) =>
+        {
+            if (context.Type == typeof(Todo) && context.ParameterDescription is not null)
+            {
+                schema.Extensions["x-my-extension"] = new OpenApiString(context.ParameterDescription.Name);
+            }
+            return Task.CompletedTask;
+        });
+
+        await VerifyOpenApiDocument(builder, options, document =>
+        {
+            var path = Assert.Single(document.Paths.Values);
+            var postOperation = path.Operations[OperationType.Post];
+            var requestSchema = postOperation.RequestBody.Content["application/json"].Schema;
+            Assert.Equal("todo", ((OpenApiString)requestSchema.Extensions["x-my-extension"]).Value);
+            var getOperation = path.Operations[OperationType.Get];
+            var responseSchema = getOperation.Responses["200"].Content["application/json"].Schema;
+            Assert.False(responseSchema.Extensions.TryGetValue("x-my-extension", out var _));
+        });
+    }
+}


### PR DESCRIPTION
This PR adds support for the OpenAPI schema transformers API to the built-in generator.

Schema Transformer:

* [`src/OpenApi/src/Services/OpenApiOptions.cs`](diffhunk://#diff-1e67d8ed05b45af61307238fa24b706d89fc8c6ddba73bac108af00c26b46dbeR17): Added a new `UseSchemaTransformer` method that allows users to register a delegate as a schema transformer. This method adds the provided transformer delegate to the `SchemaTransformers` list. [[1]](diffhunk://#diff-1e67d8ed05b45af61307238fa24b706d89fc8c6ddba73bac108af00c26b46dbeR17) [[2]](diffhunk://#diff-1e67d8ed05b45af61307238fa24b706d89fc8c6ddba73bac108af00c26b46dbeR93-R105)
* [`src/OpenApi/perf/Microbenchmarks/TransformersBenchmark.cs`](diffhunk://#diff-9fc86114a6c135b21594047b7df9782e874098915df63e3f61ef2f483a91b79cR68-R89): A new `SchemaTransformer_Setup` method has been added. This method sets up a new schema transformer that adds an extension to the schema based on the context. A new benchmark method, `SchemaTransformer`, has also been added. [[1]](diffhunk://#diff-9fc86114a6c135b21594047b7df9782e874098915df63e3f61ef2f483a91b79cR68-R89) [[2]](diffhunk://#diff-9fc86114a6c135b21594047b7df9782e874098915df63e3f61ef2f483a91b79cR108-R113)

|            Method | TransformerCount |     Mean |    Error |   StdDev |     Op/s |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------ |----------------- |---------:|---------:|---------:|---------:|-------:|------:|------:|----------:|
| SchemaTransformer |               10 | 10.01 us | 0.096 us | 0.085 us | 99,938.4 | 0.1221 |     - |     - |     20 KB |
| SchemaTransformer |              100 | 13.01 us | 0.141 us | 0.110 us | 76,890.6 | 0.1831 |     - |     - |     25 KB |
| SchemaTransformer |             1000 | 40.00 us | 0.289 us | 0.242 us | 25,002.0 | 0.4883 |     - |     - |     82 KB |

Additional Changes:

* [`src/OpenApi/src/PublicAPI.Unshipped.txt`](diffhunk://#diff-8d0a0675439c09083194d712f368bc9905ed7e2a7595b37f668f2a4d2c79416dR14-R27): Added new entries related to the `OpenApiSchemaTransformerContext` class and the `UseSchemaTransformer` method in the `OpenApiOptions` class.
* [`src/OpenApi/perf/Microbenchmarks/TransformersBenchmark.cs`](diffhunk://#diff-9fc86114a6c135b21594047b7df9782e874098915df63e3f61ef2f483a91b79cR7): Imported the `Microsoft.OpenApi.Any` namespace.