### PR TITLE
Pass through CancellationToken when writing OpenAPI response

### DIFF
--- a/src/OpenApi/src/Extensions/OpenApiEndpointRouteBuilderExtensions.cs
+++ b/src/OpenApi/src/Extensions/OpenApiEndpointRouteBuilderExtensions.cs
@@ -50,8 +50,8 @@ public static class OpenApiEndpointRouteBuilderExtensions
                     try
                     {
                         document.Serialize(new OpenApiJsonWriter(writer), documentOptions.OpenApiVersion);
-                        await context.Response.BodyWriter.WriteAsync(output.ToArray());
-                        await context.Response.BodyWriter.FlushAsync();
+                        await context.Response.BodyWriter.WriteAsync(output.ToArray(), context.RequestAborted);
+                        await context.Response.BodyWriter.FlushAsync(context.RequestAborted);
                     }
                     finally
                     {


### PR DESCRIPTION
# Pass through CancellationToken when writing OpenAPI response

Pass through the request's CancellationToken when writing the OpenAPI response.

## Description

Happened to notice it wasn't being used, so added it for consistency.
