### PR TITLE
Fix Build From Source example

### DIFF
--- a/docs/BuildFromSource.md
+++ b/docs/BuildFromSource.md
@@ -59,10 +59,20 @@ The steps you follow next depend on your preferred development environment:
     ./restore.cmd
     ```
 
-1. You'll typically focus on one project in the repo. You can use the `startvs.cmd` command to launch Visual Studio in a particular project area. For example, to launch Visual Studio in the `src/Http` project:
+1. After the `restore` script finishes, activate the locally installed .NET by running the following command.
 
     ```powershell
-    cd src\Http
+    # Windows - note the leading period followed by a space
+    . ./activate.ps1
+    ```
+
+1. You'll typically focus on one project in the repo. You can use the `startvs.cmd` command to launch Visual Studio in a particular project area. For example, to launch Visual Studio in the `src/Http` project, after you have built it with `./build.cmd`:
+
+    > :bulb: The `build.cmd` script will be local to the directory of the project you opened. For example, the script located in the `src/Http` directory. If you want to build the whole tree, use the `build.cmd` that is located in the `eng` directory.
+
+    ```powershell
+    cd src/Http
+    ./build.cmd
     ./startvs.cmd
     ```
 

--- a/docs/BuildFromSource.md
+++ b/docs/BuildFromSource.md
@@ -59,13 +59,6 @@ The steps you follow next depend on your preferred development environment:
     ./restore.cmd
     ```
 
-1. After the `restore` script finishes, activate the locally installed .NET by running the following command.
-
-    ```powershell
-    # Windows - note the leading period followed by a space
-    . ./activate.ps1
-    ```
-
 1. You'll typically focus on one project in the repo. You can use the `startvs.cmd` command to launch Visual Studio in a particular project area. For example, to launch Visual Studio in the `src/Http` project, after you have built it with `./build.cmd`:
 
     > :bulb: The `build.cmd` script will be local to the directory of the project you opened. For example, the script located in the `src/Http` directory. If you want to build the whole tree, use the `build.cmd` that is located in the `eng` directory.

--- a/docs/BuildFromSource.md
+++ b/docs/BuildFromSource.md
@@ -59,10 +59,10 @@ The steps you follow next depend on your preferred development environment:
     ./restore.cmd
     ```
 
-1. You'll typically focus on one project in the repo. You can use the `startvs.cmd` command to launch Visual Studio in a particular project area. For example, to launch Visual Studio in the `Components` project:
+1. You'll typically focus on one project in the repo. You can use the `startvs.cmd` command to launch Visual Studio in a particular project area. For example, to launch Visual Studio in the `src/Http` project:
 
     ```powershell
-    cd src\Components
+    cd src\Http
     ./startvs.cmd
     ```
 


### PR DESCRIPTION
The current example does not contain the specified startvs.cmd and requires more steps.
This PR uses `src/Http` as an example, which also makes it consistent with the Vs Code example.