### PR TITLE
Don't require latest runtime patch for Blazor DevServer

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -334,7 +334,6 @@
     <XunitExtensibilityExecutionVersion>$(XunitVersion)</XunitExtensibilityExecutionVersion>
     <XUnitRunnerVisualStudioVersion>2.4.3</XUnitRunnerVisualStudioVersion>
     <MicrosoftDataSqlClientVersion>4.0.5</MicrosoftDataSqlClientVersion>
-    <MicrosoftAspNetCoreAppVersion>6.0.0-preview.3.21167.1</MicrosoftAspNetCoreAppVersion>
     <MicrosoftOpenApiVersion>1.6.13</MicrosoftOpenApiVersion>
     <MicrosoftOpenApiReadersVersion>1.6.13</MicrosoftOpenApiReadersVersion>
     <!-- dotnet tool versions (see also auto-updated DotnetEfVersion property). -->

--- a/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
+++ b/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
@@ -37,7 +37,7 @@
   <Target Name="_CreateRuntimeConfig" BeforeTargets="CoreBuild">
     <PropertyGroup>
       <_RuntimeConfigProperties>
-        SharedFxVersion=$(SharedFxVersion);
+        AspNetCoreMajorMinorVersion=$(AspNetCoreMajorMinorVersion);
       </_RuntimeConfigProperties>
 
       <_RuntimeConfigPath>$(OutputPath)blazor-devserver.runtimeconfig.json</_RuntimeConfigPath>

--- a/src/Components/WebAssembly/DevServer/src/blazor-devserver.runtimeconfig.json.in
+++ b/src/Components/WebAssembly/DevServer/src/blazor-devserver.runtimeconfig.json.in
@@ -3,7 +3,7 @@
     "tfm": "net9.0",
     "framework": {
       "name": "Microsoft.AspNetCore.App",
-      "version": "${SharedFxVersion}"
+      "version": "${AspNetCoreMajorMinorVersion}.0"
     },
     "rollForwardOnNoCandidateFx": 2
   }

--- a/src/Middleware/ConcurrencyLimiter/sample/ConcurrencyLimiterSample.csproj
+++ b/src/Middleware/ConcurrencyLimiter/sample/ConcurrencyLimiterSample.csproj
@@ -9,9 +9,4 @@
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel" />
     <Reference Include="Microsoft.Extensions.Configuration.CommandLine" />
   </ItemGroup>
-
-  <!-- Benchmarks server uses shared Fx but needs refs to OOB packages. -->
-  <ItemGroup Condition="'$(BenchmarksTargetFramework)' != ''">
-    <PackageReference Include="Microsoft.AspNetCore.ConcurrencyLimiter" Version="$(MicrosoftAspNetCoreAppVersion)" />
-  </ItemGroup>
 </Project>

--- a/src/Mvc/perf/benchmarkapps/BasicApi/BasicApi.csproj
+++ b/src/Mvc/perf/benchmarkapps/BasicApi/BasicApi.csproj
@@ -30,11 +30,4 @@
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel" />
     <Reference Include="Microsoft.Extensions.Configuration.CommandLine" />
   </ItemGroup>
-
-  <!-- These references are used when building on the Benchmarks Server. -->
-  <ItemGroup Condition="'$(BenchmarksTargetFramework)' != ''">
-    <!-- Special-case the JwtBearer package because assembly no longer ships in Microsoft.AspNetCore.App. -->
-    <!-- Cannot use <Reference> because it's unsupported when building an isolated project. -->
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCoreAppVersion)" />
-  </ItemGroup>
 </Project>

--- a/src/ProjectTemplates/GenerateContent.targets
+++ b/src/ProjectTemplates/GenerateContent.targets
@@ -4,12 +4,6 @@
 
     <!-- Use for incremental builds. When versions or dependencies of templates change, this file is updated and causes a re-build. -->
     <_GenerateContentPropertiesHashFile>$(IntermediateOutputPath)$(MSBuildProjectName).content.g.cache</_GenerateContentPropertiesHashFile>
-
-    <!-- The version of the shared framework. This is used in tests to ensure they run against the shared framework version we just built. -->
-    <GeneratedContentProperties>
-      $(GeneratedContentProperties);
-      MicrosoftAspNetCoreAppVersion=$(SharedFxVersion);
-    </GeneratedContentProperties>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SiteExtensions/Sdk/SiteExtension.targets
+++ b/src/SiteExtensions/Sdk/SiteExtension.targets
@@ -85,7 +85,6 @@
               HostingStartupPackageName=%(_HostingStartupPackageReference.Identity);
               HostingStartupVersion=%(_HostingStartupPackageReference.Version);
               RuntimeFrameworkVersion=$(HostingStartupRuntimeFrameworkVersion);
-              MicrosoftAspNetCoreAppVersion=$(SharedFxVersion);
               UseAppHost=false;
               NoBuild=false;
               RestoreAdditionalProjectSources=$(_RsRestoreSources)" />
@@ -97,7 +96,6 @@
               HostingStartupPackageName=%(_HostingStartupPackageReference.Identity);
               HostingStartupVersion=%(_HostingStartupPackageReference.Version);
               RuntimeFrameworkVersion=$(HostingStartupRuntimeFrameworkVersion);
-              MicrosoftAspNetCoreAppVersion=$(SharedFxVersion);
               UseAppHost=false;
               NoBuild=false;
               IncludeMainProjectInDepsFile=false" />


### PR DESCRIPTION
If you have not installed an SDK with the 8.0.6 runtimes, but you reference the 8.0.6 version of the Microsoft.AspNetCore.Components.WebAssembly.DevServer NuGet dependency, you’ll see the following error:

![Process with Id of {ID} is not running error](https://github.com/dotnet/aspnetcore/assets/54385/33823bf8-3f99-48ce-a302-8ffd77a4db6c)

Similar reports come into VS feedback and GitHub pretty regularly with every patch. VS does not seem to give any details other than the following in from the “Debug” output by default.

> The target process exited without raising a CoreCLR started event. Ensure that the target process is configured to use .NET Core. This may be expected if the target process did not run on .NET Core.  
> The program ‘\[720\] dotnet.exe’ has exited with code 2147516566 (0x80008096).  
> The program ‘\[720\] dotnet.exe: Program Trace’ has exited with code 0 (0x0).

If you try to `dotnet run` the project, you’ll see the following output:

```  
You must install or update .NET to run this application.

App: C:\.tools\.nuget\packages\microsoft.aspnetcore.components.webassembly.devserver\8.0.6\tools\blazor-devserver.dll
Architecture: x64
Framework: 'Microsoft.AspNetCore.App', version '8.0.6' (x64)
.NET location: C:\Program Files\dotnet\

The following frameworks were found:
  6.0.30 at [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  8.0.5 at [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]

Learn more:
https://aka.ms/dotnet/app-launch-failed

To install missing framework, download:
https://aka.ms/dotnet-core-applaunch?framework=Microsoft.AspNetCore.App&framework_version=8.0.6&arch=x64&rid=win-x64&os=win10

C:\Program Files\dotnet\dotnet.exe (process 12924) exited with code -2147450730 (0x80008096).
To automatically close the console when debugging stops, enable Tools->Options->Debugging->Automatically close the console when debugging stops.
Press any key to close this window . . .
  
```

You can work around this issue by installing the 8.0.301 SDK from [https://dotnet.microsoft.com/en-us/download/dotnet/8.0](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) that brings in the 8.0.6 runtime. Or you can downgrade the Microsoft.AspNetCore.Components.WebAssembly.DevServer NuGet dependency to 8.0.5.

However, it ought not be necessary for the NuGet dependency to exactly align with the runtime patch version. https://github.com/dotnet/runtime/issues/88204#issuecomment-1652259739 has more context.

I think we should consider backporting at least the first commit to `release/8.0`. The second commit deletes `MicrosoftAspNetCoreAppVersion` which was out of date and apparently not used for anything important. @sebastienros I found [this reference](
https://github.com/aspnet/Benchmarks/blob/454ac306183e71b710622b6b0aad88b7ecc3ca8a/build/job-variables.yml#L13-L14) to BasicApi.csproj in one of our benchmark jobs, but the path is incorrect (it doesn't include the "perf/" directory), so I deleted the outdated PackageReference that was intended to assist with benchmarking. We could put it back but use `SharedFxVersion` or something similar if we need it.

Fixes #56119
