### PR TITLE
Improve E2E tests performance

### DIFF
--- a/src/Components/test/E2ETest/ServerExecutionTests/CircuitGracefulTerminationTests.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/CircuitGracefulTerminationTests.cs
@@ -33,7 +33,7 @@ public class CircuitGracefulTerminationTests : ServerTestBase<BasicTestAppServer
         // instance across tests (One of the tests closes the browser). For that reason we simply create
         // a new browser instance for every test in this class sos that there are no issues when running
         // them together.
-        await base.InitializeAsync(Guid.NewGuid().ToString());
+        await base.InitializeAsync(null);
     }
 
     protected override void InitializeAsyncCore()

--- a/src/Components/test/E2ETest/ServerExecutionTests/HotReloadTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/HotReloadTest.cs
@@ -24,7 +24,7 @@ public class HotReloadTest : ServerTestBase<BasicTestAppServerSiteFixture<HotRel
 
     public override async Task InitializeAsync()
     {
-        await base.InitializeAsync(Guid.NewGuid().ToString());
+        await base.InitializeAsync(null);
     }
 
     protected override void InitializeAsyncCore()

--- a/src/Components/test/E2ETest/ServerExecutionTests/ProtectedBrowserStorageUsageTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ProtectedBrowserStorageUsageTest.cs
@@ -26,7 +26,7 @@ public class ProtectedBrowserStorageUsageTest : ServerTestBase<ToggleExecutionMo
     {
         // Since browser storage needs to be reset in between tests, it's easiest for each
         // test to run in its own browser instance.
-        await base.InitializeAsync(Guid.NewGuid().ToString());
+        await base.InitializeAsync(null);
     }
 
     protected override void InitializeAsyncCore()

--- a/src/Components/test/E2ETest/Tests/BinaryHttpClientTest.cs
+++ b/src/Components/test/E2ETest/Tests/BinaryHttpClientTest.cs
@@ -39,7 +39,7 @@ public class BinaryHttpClientTest : BrowserTestBase,
         _appElement = Browser.MountTestComponent<BinaryHttpRequestsComponent>();
     }
 
-    public override Task InitializeAsync() => base.InitializeAsync(Guid.NewGuid().ToString());
+    public override Task InitializeAsync() => base.InitializeAsync(null);
 
     [Fact]
     public void CanSendAndReceiveBytes()

--- a/src/Components/test/E2ETest/Tests/BootResourceCachingTest.cs
+++ b/src/Components/test/E2ETest/Tests/BootResourceCachingTest.cs
@@ -32,7 +32,7 @@ public class BootResourceCachingTest
 
     public override Task InitializeAsync()
     {
-        return base.InitializeAsync(Guid.NewGuid().ToString());
+        return base.InitializeAsync(null);
     }
 
     [Fact]

--- a/src/Components/test/E2ETest/Tests/PerformanceTest.cs
+++ b/src/Components/test/E2ETest/Tests/PerformanceTest.cs
@@ -25,7 +25,7 @@ public class PerformanceTest
         Navigate("/");
     }
 
-    public override Task InitializeAsync() => base.InitializeAsync(Guid.NewGuid().ToString());
+    public override Task InitializeAsync() => base.InitializeAsync(null);
 
     [Fact]
     public void HasTitle()

--- a/src/Components/test/E2ETest/Tests/SignalRClientTest.cs
+++ b/src/Components/test/E2ETest/Tests/SignalRClientTest.cs
@@ -35,7 +35,7 @@ public class SignalRClientTest : ServerTestBase<BlazorWasmTestAppFixture<BasicTe
         Browser.Exists(By.Id("signalr-client"));
     }
 
-    public override Task InitializeAsync() => base.InitializeAsync(Guid.NewGuid().ToString());
+    public override Task InitializeAsync() => base.InitializeAsync(null);
 
     [Fact]
     public void SignalRClientWorksWithLongPolling()


### PR DESCRIPTION
Fixes #56004

Without this PR the chrome instances are referenced indefinitely until the test fixture is disposed.
The PR replaces GUIDs that were used to get a fresh browser by `null` to note that the Browser should not be reused instead. And then when the test class is disposed the Browser is disposed. This limits the number of dangling chrome instances which accumulate overtime and slow down the machine (each instance takes 10% of cpu continuously on my machine, even after the test)