### PR TITLE
Add support for reference-based schemas in OpenAPI document

### DIFF
--- a/src/OpenApi/perf/Microbenchmarks/OpenApiSchemaComparerBenchmark.cs
+++ b/src/OpenApi/perf/Microbenchmarks/OpenApiSchemaComparerBenchmark.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using BenchmarkDotNet.Attributes;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.AspNetCore.OpenApi.Microbenchmarks;
+
+public class OpenApiSchemaComparerBenchmark
+{
+    [Params(1, 10, 100)]
+    public int ElementCount { get; set; }
+
+    private OpenApiSchema _schema;
+
+    [GlobalSetup(Target = nameof(OpenApiSchema_GetHashCode))]
+    public void OpenApiSchema_Setup()
+    {
+        _schema = new OpenApiSchema
+        {
+            AdditionalProperties = GenerateInnerSchema(),
+            AdditionalPropertiesAllowed = true,
+            AllOf = Enumerable.Range(0, ElementCount).Select(_ => GenerateInnerSchema()).ToList(),
+            AnyOf = Enumerable.Range(0, ElementCount).Select(_ => GenerateInnerSchema()).ToList(),
+            Deprecated = true,
+            Default = new OpenApiString("default"),
+            Description = "description",
+            Discriminator = new OpenApiDiscriminator(),
+            Example = new OpenApiString("example"),
+            ExclusiveMaximum = true,
+            ExclusiveMinimum = true,
+            Extensions = new Dictionary<string, IOpenApiExtension>
+            {
+                ["key"] = new OpenApiString("value")
+            },
+            ExternalDocs = new OpenApiExternalDocs(),
+            Enum = Enumerable.Range(0, ElementCount).Select(_ => (IOpenApiAny)new OpenApiString("enum")).ToList(),
+            OneOf = Enumerable.Range(0, ElementCount).Select(_ => GenerateInnerSchema()).ToList(),
+        };
+
+        static OpenApiSchema GenerateInnerSchema() => new OpenApiSchema
+        {
+            Properties = Enumerable.Range(0, 10).ToDictionary(i => i.ToString(CultureInfo.InvariantCulture), _ => new OpenApiSchema()),
+            Deprecated = true,
+            Default = new OpenApiString("default"),
+            Description = "description",
+            Example = new OpenApiString("example"),
+            Extensions = new Dictionary<string, IOpenApiExtension>
+            {
+                ["key"] = new OpenApiString("value")
+            },
+        };
+    }
+
+    [Benchmark]
+    public void OpenApiSchema_GetHashCode()
+    {
+        OpenApiSchemaComparer.Instance.GetHashCode(_schema);
+    }
+}

--- a/src/OpenApi/sample/Controllers/TestController.cs
+++ b/src/OpenApi/sample/Controllers/TestController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 
 [ApiController]
 [Route("[controller]")]
+[ApiExplorerSettings(GroupName = "controllers")]
 public class TestController : ControllerBase
 {
     [HttpGet]

--- a/src/OpenApi/sample/Program.cs
+++ b/src/OpenApi/sample/Program.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel;
+using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.OpenApi.Models;
 using Sample.Transformers;
@@ -24,8 +26,10 @@ builder.Services.AddOpenApi("v2", options => {
         return Task.CompletedTask;
     });
 });
+builder.Services.AddOpenApi("controllers");
 builder.Services.AddOpenApi("responses");
 builder.Services.AddOpenApi("forms");
+builder.Services.AddOpenApi("schemas-by-ref");
 
 var app = builder.Build();
 
@@ -37,6 +41,9 @@ if (app.Environment.IsDevelopment())
 
 var forms = app.MapGroup("forms")
     .WithGroupName("forms");
+
+var schemas = app.MapGroup("schemas-by-ref")
+    .WithGroupName("schemas-by-ref");
 
 if (app.Environment.IsDevelopment())
 {
@@ -83,6 +90,17 @@ responses.MapGet("/200-only-xml", () => new TodoWithDueDate(1, "Test todo", fals
 
 responses.MapGet("/triangle", () => new Triangle { Color = "red", Sides = 3, Hypotenuse = 5.0 });
 responses.MapGet("/shape", () => new Shape { Color = "blue", Sides = 4 });
+
+schemas.MapGet("/typed-results", () => TypedResults.Ok(new Triangle { Color = "red", Sides = 3, Hypotenuse = 5.0 }));
+schemas.MapGet("/multiple-results", Results<Ok<Triangle>, NotFound<string>> () => Random.Shared.Next(0, 2) == 0
+    ? TypedResults.Ok(new Triangle { Color = "red", Sides = 3, Hypotenuse = 5.0 })
+    : TypedResults.NotFound<string>("Item not found."));
+schemas.MapGet("/iresult-no-produces", () => Results.Ok(new Triangle { Color = "red", Sides = 3, Hypotenuse = 5.0 }));
+schemas.MapGet("/iresult-with-produces", () => Results.Ok(new Triangle { Color = "red", Sides = 3, Hypotenuse = 5.0 }))
+    .Produces<Triangle>(200, "text/xml");
+schemas.MapGet("/primitives", ([Description("The ID associated with the Todo item.")] int id, [Description("The number of Todos to fetch")] int size) => { });
+schemas.MapGet("/product", (Product product) => TypedResults.Ok(product));
+schemas.MapGet("/account", (Account account) => TypedResults.Ok(account));
 
 app.MapControllers();
 

--- a/src/OpenApi/sample/Program.cs
+++ b/src/OpenApi/sample/Program.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Frozen;
+using System.Collections.Immutable;
 using System.ComponentModel;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
@@ -101,6 +103,11 @@ schemas.MapGet("/iresult-with-produces", () => Results.Ok(new Triangle { Color =
 schemas.MapGet("/primitives", ([Description("The ID associated with the Todo item.")] int id, [Description("The number of Todos to fetch")] int size) => { });
 schemas.MapGet("/product", (Product product) => TypedResults.Ok(product));
 schemas.MapGet("/account", (Account account) => TypedResults.Ok(account));
+schemas.MapPost("/array-of-ints", (int[] values) => values.Sum());
+schemas.MapPost("/list-of-ints", (List<int> values) => values.Count);
+schemas.MapPost("/ienumerable-of-ints", (IEnumerable<int> values) => values.Count());
+schemas.MapGet("/dictionary-of-ints", () => new Dictionary<string, int> { { "one", 1 }, { "two", 2 } });
+schemas.MapGet("/frozen-dictionary-of-ints", () => ImmutableDictionary.CreateRange(new Dictionary<string, int> { { "one", 1 }, { "two", 2 } }));
 
 app.MapControllers();
 

--- a/src/OpenApi/src/Comparers/OpenApiAnyComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiAnyComparer.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Linq;
 using Microsoft.OpenApi.Any;
 
 namespace Microsoft.AspNetCore.OpenApi;
@@ -24,7 +25,25 @@ internal sealed class OpenApiAnyComparer : IEqualityComparer<IOpenApiAny>
             return true;
         }
 
-        return GetHashCode(x) == GetHashCode(y);
+        return x.AnyType == y.AnyType &&
+            (x switch
+            {
+                OpenApiNull _ => y is OpenApiNull,
+                OpenApiArray arrayX => y is OpenApiArray arrayY && arrayX.SequenceEqual(arrayY, Instance),
+                OpenApiObject objectX => y is OpenApiObject objectY && objectX.Keys.Count == objectY.Keys.Count && objectX.Keys.All(key => objectY.ContainsKey(key) && Equals(objectX[key], objectY[key])),
+                OpenApiBinary binaryX => y is OpenApiBinary binaryY && binaryX.Value.SequenceEqual(binaryY.Value),
+                OpenApiInteger integerX => y is OpenApiInteger integerY && integerX.Value == integerY.Value,
+                OpenApiLong longX => y is OpenApiLong longY && longX.Value == longY.Value,
+                OpenApiDouble doubleX => y is OpenApiDouble doubleY && doubleX.Value == doubleY.Value,
+                OpenApiFloat floatX => y is OpenApiFloat floatY && floatX.Value == floatY.Value,
+                OpenApiBoolean booleanX => y is OpenApiBoolean booleanY && booleanX.Value == booleanY.Value,
+                OpenApiString stringX => y is OpenApiString stringY && stringX.Value == stringY.Value,
+                OpenApiPassword passwordX => y is OpenApiPassword passwordY && passwordX.Value == passwordY.Value,
+                OpenApiByte byteX => y is OpenApiByte byteY && byteX.Value.SequenceEqual(byteY.Value),
+                OpenApiDate dateX => y is OpenApiDate dateY && dateX.Value == dateY.Value,
+                OpenApiDateTime dateTimeX => y is OpenApiDateTime dateTimeY && dateTimeX.Value == dateTimeY.Value,
+                _ => x.Equals(y)
+            });
     }
 
     public int GetHashCode(IOpenApiAny obj)
@@ -35,22 +54,8 @@ internal sealed class OpenApiAnyComparer : IEqualityComparer<IOpenApiAny>
         {
             hashCode.Add(primitive.PrimitiveType);
         }
-        if (obj is OpenApiArray array)
+        hashCode.Add<object?>(obj switch
         {
-            foreach (var item in array)
-            {
-                hashCode.Add(item, Instance);
-            }
-        }
-        if (obj is OpenApiObject openApiObject)
-        {
-            foreach (var item in openApiObject)
-            {
-                hashCode.Add(item.Key);
-                hashCode.Add(item.Value, Instance);
-            }
-        }
-        hashCode.Add<object?>(obj switch {
             OpenApiBinary binary => binary.Value,
             OpenApiInteger integer => integer.Value,
             OpenApiLong @long => @long.Value,

--- a/src/OpenApi/src/Comparers/OpenApiAnyComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiAnyComparer.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.OpenApi.Any;
+
+namespace Microsoft.AspNetCore.OpenApi;
+
+internal sealed class OpenApiAnyComparer : IEqualityComparer<IOpenApiAny>
+{
+    public static OpenApiAnyComparer Instance { get; } = new OpenApiAnyComparer();
+
+    public bool Equals(IOpenApiAny? x, IOpenApiAny? y)
+    {
+        if (x is null && y is null)
+        {
+            return true;
+        }
+        if (x is null || y is null)
+        {
+            return false;
+        }
+
+        return GetHashCode(x) == GetHashCode(y);
+    }
+
+    public int GetHashCode(IOpenApiAny obj)
+    {
+        var hashCode = new HashCode();
+        hashCode.Add(obj.AnyType);
+        if (obj is IOpenApiPrimitive primitive)
+        {
+            hashCode.Add(primitive.PrimitiveType);
+        }
+        if (obj is OpenApiArray array)
+        {
+            foreach (var item in array)
+            {
+                hashCode.Add(item, Instance);
+            }
+        }
+        if (obj is OpenApiObject openApiObject)
+        {
+            foreach (var item in openApiObject)
+            {
+                hashCode.Add(item.Key);
+                hashCode.Add(item.Value, Instance);
+            }
+        }
+        hashCode.Add<object?>(obj switch {
+            OpenApiBinary binary => binary.Value,
+            OpenApiInteger integer => integer.Value,
+            OpenApiLong @long => @long.Value,
+            OpenApiDouble @double => @double.Value,
+            OpenApiFloat @float => @float.Value,
+            OpenApiBoolean boolean => boolean.Value,
+            OpenApiString @string => @string.Value,
+            OpenApiPassword password => password.Value,
+            OpenApiByte @byte => @byte.Value,
+            OpenApiDate date => date.Value,
+            OpenApiDateTime dateTime => dateTime.Value,
+            _ => null
+        });
+
+        return hashCode.ToHashCode();
+    }
+}

--- a/src/OpenApi/src/Comparers/OpenApiAnyComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiAnyComparer.cs
@@ -54,9 +54,16 @@ internal sealed class OpenApiAnyComparer : IEqualityComparer<IOpenApiAny>
         {
             hashCode.Add(primitive.PrimitiveType);
         }
+        if (obj is OpenApiBinary binary)
+        {
+            hashCode.AddBytes(binary.Value);
+        }
+        if (obj is OpenApiByte bytes)
+        {
+            hashCode.AddBytes(bytes.Value);
+        }
         hashCode.Add<object?>(obj switch
         {
-            OpenApiBinary binary => binary.Value,
             OpenApiInteger integer => integer.Value,
             OpenApiLong @long => @long.Value,
             OpenApiDouble @double => @double.Value,
@@ -64,7 +71,6 @@ internal sealed class OpenApiAnyComparer : IEqualityComparer<IOpenApiAny>
             OpenApiBoolean boolean => boolean.Value,
             OpenApiString @string => @string.Value,
             OpenApiPassword password => password.Value,
-            OpenApiByte @byte => @byte.Value,
             OpenApiDate date => date.Value,
             OpenApiDateTime dateTime => dateTime.Value,
             _ => null

--- a/src/OpenApi/src/Comparers/OpenApiAnyComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiAnyComparer.cs
@@ -19,6 +19,10 @@ internal sealed class OpenApiAnyComparer : IEqualityComparer<IOpenApiAny>
         {
             return false;
         }
+        if (object.ReferenceEquals(x, y))
+        {
+            return true;
+        }
 
         return GetHashCode(x) == GetHashCode(y);
     }

--- a/src/OpenApi/src/Comparers/OpenApiDiscriminatorComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiDiscriminatorComparer.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Linq;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.AspNetCore.OpenApi;
@@ -24,18 +25,16 @@ internal sealed class OpenApiDiscriminatorComparer : IEqualityComparer<OpenApiDi
             return true;
         }
 
-        return GetHashCode(x) == GetHashCode(y);
+        return x.PropertyName == y.PropertyName &&
+            x.Mapping.Count == y.Mapping.Count &&
+            x.Mapping.Keys.All(key => y.Mapping.ContainsKey(key) && x.Mapping[key] == y.Mapping[key]);
     }
 
     public int GetHashCode(OpenApiDiscriminator obj)
     {
         var hashCode = new HashCode();
         hashCode.Add(obj.PropertyName);
-        foreach (var item in obj.Mapping)
-        {
-            hashCode.Add(item.Key);
-            hashCode.Add(item.Value);
-        }
+        hashCode.Add(obj.Mapping.Count);
         return hashCode.ToHashCode();
     }
 }

--- a/src/OpenApi/src/Comparers/OpenApiDiscriminatorComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiDiscriminatorComparer.cs
@@ -19,6 +19,10 @@ internal sealed class OpenApiDiscriminatorComparer : IEqualityComparer<OpenApiDi
         {
             return false;
         }
+        if (object.ReferenceEquals(x, y))
+        {
+            return true;
+        }
 
         return GetHashCode(x) == GetHashCode(y);
     }

--- a/src/OpenApi/src/Comparers/OpenApiDiscriminatorComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiDiscriminatorComparer.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.AspNetCore.OpenApi;
+
+internal sealed class OpenApiDiscriminatorComparer : IEqualityComparer<OpenApiDiscriminator>
+{
+    public static OpenApiDiscriminatorComparer Instance { get; } = new OpenApiDiscriminatorComparer();
+
+    public bool Equals(OpenApiDiscriminator? x, OpenApiDiscriminator? y)
+    {
+        if (x is null && y is null)
+        {
+            return true;
+        }
+        if (x is null || y is null)
+        {
+            return false;
+        }
+
+        return GetHashCode(x) == GetHashCode(y);
+    }
+
+    public int GetHashCode(OpenApiDiscriminator obj)
+    {
+        var hashCode = new HashCode();
+        hashCode.Add(obj.PropertyName);
+        foreach (var item in obj.Mapping)
+        {
+            hashCode.Add(item.Key);
+            hashCode.Add(item.Value);
+        }
+        return hashCode.ToHashCode();
+    }
+}

--- a/src/OpenApi/src/Comparers/OpenApiExternalDocsComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiExternalDocsComparer.cs
@@ -16,10 +16,13 @@ internal sealed class OpenApiExternalDocsComparer : IEqualityComparer<OpenApiExt
         {
             return true;
         }
-
         if (x is null || y is null)
         {
             return false;
+        }
+        if (object.ReferenceEquals(x, y))
+        {
+            return true;
         }
 
         return GetHashCode(x) == GetHashCode(y);

--- a/src/OpenApi/src/Comparers/OpenApiExternalDocsComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiExternalDocsComparer.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.OpenApi.Any;
+using System.Linq;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.AspNetCore.OpenApi;
@@ -25,7 +25,10 @@ internal sealed class OpenApiExternalDocsComparer : IEqualityComparer<OpenApiExt
             return true;
         }
 
-        return GetHashCode(x) == GetHashCode(y);
+        return x.Description == y.Description &&
+            x.Url == y.Url &&
+            x.Extensions.Count == y.Extensions.Count
+            && x.Extensions.Keys.All(k => y.Extensions.ContainsKey(k) && y.Extensions[k] == x.Extensions[k]);
     }
 
     public int GetHashCode(OpenApiExternalDocs obj)
@@ -33,18 +36,7 @@ internal sealed class OpenApiExternalDocsComparer : IEqualityComparer<OpenApiExt
         var hashCode = new HashCode();
         hashCode.Add(obj.Description);
         hashCode.Add(obj.Url);
-        foreach (var item in obj.Extensions)
-        {
-            hashCode.Add(item.Key, StringComparer.Ordinal);
-            if (item.Value is IOpenApiAny openApiAny)
-            {
-                hashCode.Add(openApiAny, OpenApiAnyComparer.Instance);
-            }
-            else
-            {
-                hashCode.Add(item.Value);
-            }
-        }
+        hashCode.Add(obj.Extensions.Count);
         return hashCode.ToHashCode();
     }
 }

--- a/src/OpenApi/src/Comparers/OpenApiExternalDocsComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiExternalDocsComparer.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.AspNetCore.OpenApi;
+
+internal sealed class OpenApiExternalDocsComparer : IEqualityComparer<OpenApiExternalDocs>
+{
+    public static OpenApiExternalDocsComparer Instance { get; } = new OpenApiExternalDocsComparer();
+
+    public bool Equals(OpenApiExternalDocs? x, OpenApiExternalDocs? y)
+    {
+        if (x is null && y is null)
+        {
+            return true;
+        }
+
+        if (x is null || y is null)
+        {
+            return false;
+        }
+
+        return GetHashCode(x) == GetHashCode(y);
+    }
+
+    public int GetHashCode(OpenApiExternalDocs obj)
+    {
+        var hashCode = new HashCode();
+        hashCode.Add(obj.Description);
+        hashCode.Add(obj.Url);
+        foreach (var item in obj.Extensions)
+        {
+            hashCode.Add(item.Key, StringComparer.Ordinal);
+            if (item.Value is IOpenApiAny openApiAny)
+            {
+                hashCode.Add(openApiAny, OpenApiAnyComparer.Instance);
+            }
+            else
+            {
+                hashCode.Add(item.Value);
+            }
+        }
+        return hashCode.ToHashCode();
+    }
+}

--- a/src/OpenApi/src/Comparers/OpenApiReferenceComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiReferenceComparer.cs
@@ -19,6 +19,10 @@ internal sealed class OpenApiReferenceComparer : IEqualityComparer<OpenApiRefere
         {
             return false;
         }
+        if (object.ReferenceEquals(x, y))
+        {
+            return true;
+        }
 
         return GetHashCode(x) == GetHashCode(y);
     }

--- a/src/OpenApi/src/Comparers/OpenApiReferenceComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiReferenceComparer.cs
@@ -24,20 +24,16 @@ internal sealed class OpenApiReferenceComparer : IEqualityComparer<OpenApiRefere
             return true;
         }
 
-        return GetHashCode(x) == GetHashCode(y);
+        return x.ExternalResource == y.ExternalResource &&
+            x.HostDocument?.HashCode == y.HostDocument?.HashCode &&
+            x.Id == y.Id &&
+            x.Type == y.Type;
     }
 
     public int GetHashCode(OpenApiReference obj)
     {
         var hashCode = new HashCode();
         hashCode.Add(obj.ExternalResource);
-        if (obj.HostDocument is not null)
-        {
-            // Microsoft.OpenApi provides a HashCode property for
-            // the OpenAPI document that we can use to uniquely identify
-            // the host document that is referenced here.
-            hashCode.Add(obj.HostDocument.HashCode);
-        };
         hashCode.Add(obj.Id);
         if (obj.Type is not null)
         {

--- a/src/OpenApi/src/Comparers/OpenApiReferenceComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiReferenceComparer.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.AspNetCore.OpenApi;
+
+internal sealed class OpenApiReferenceComparer : IEqualityComparer<OpenApiReference>
+{
+    public static OpenApiReferenceComparer Instance { get; } = new OpenApiReferenceComparer();
+
+    public bool Equals(OpenApiReference? x, OpenApiReference? y)
+    {
+        if (x is null && y is null)
+        {
+            return true;
+        }
+        if (x is null || y is null)
+        {
+            return false;
+        }
+
+        return GetHashCode(x) == GetHashCode(y);
+    }
+
+    public int GetHashCode(OpenApiReference obj)
+    {
+        var hashCode = new HashCode();
+        hashCode.Add(obj.ExternalResource);
+        if (obj.HostDocument is not null)
+        {
+            // Microsoft.OpenApi provides a HashCode property for
+            // the OpenAPI document that we can use to uniquely identify
+            // the host document that is referenced here.
+            hashCode.Add(obj.HostDocument.HashCode);
+        };
+        hashCode.Add(obj.Id);
+        if (obj.Type is not null)
+        {
+            hashCode.Add(obj.Type);
+        }
+        return hashCode.ToHashCode();
+    }
+}

--- a/src/OpenApi/src/Comparers/OpenApiSchemaComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiSchemaComparer.cs
@@ -1,0 +1,102 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.AspNetCore.OpenApi;
+
+internal sealed class OpenApiSchemaComparer : IEqualityComparer<OpenApiSchema>
+{
+    public static OpenApiSchemaComparer Instance { get; } = new OpenApiSchemaComparer();
+
+    public bool Equals(OpenApiSchema? x, OpenApiSchema? y)
+    {
+        if (x is null && y is null)
+        {
+            return true;
+        }
+        if (x is null || y is null)
+        {
+            return false;
+        }
+
+        return GetHashCode(x) == GetHashCode(y);
+    }
+
+    public int GetHashCode(OpenApiSchema obj)
+    {
+        var hashCode = new HashCode();
+        hashCode.Add(obj.AdditionalProperties, Instance);
+        hashCode.Add(obj.AdditionalPropertiesAllowed);
+        foreach (var item in obj.AllOf)
+        {
+            hashCode.Add(item, Instance);
+        }
+        foreach (var item in obj.AnyOf)
+        {
+            hashCode.Add(item, Instance);
+        }
+        hashCode.Add(obj.Deprecated);
+        hashCode.Add(obj.Default, OpenApiAnyComparer.Instance);
+        hashCode.Add(obj.Description);
+        hashCode.Add(obj.Discriminator, OpenApiDiscriminatorComparer.Instance);
+        hashCode.Add(obj.Example, OpenApiAnyComparer.Instance);
+        hashCode.Add(obj.ExclusiveMaximum);
+        hashCode.Add(obj.ExclusiveMinimum);
+        foreach ((var key, var value) in obj.Extensions)
+        {
+            hashCode.Add(key);
+            if (value is IOpenApiAny any)
+            {
+                hashCode.Add(any, OpenApiAnyComparer.Instance);
+            }
+            else
+            {
+                hashCode.Add(value);
+            }
+        }
+        hashCode.Add(obj.ExternalDocs, OpenApiExternalDocsComparer.Instance);
+        foreach (var item in obj.Enum)
+        {
+            hashCode.Add(item, OpenApiAnyComparer.Instance);
+        }
+        hashCode.Add(obj.Format);
+        hashCode.Add(obj.Items, Instance);
+        hashCode.Add(obj.Title);
+        hashCode.Add(obj.Type);
+        hashCode.Add(obj.Maximum);
+        hashCode.Add(obj.MaxItems);
+        hashCode.Add(obj.MaxLength);
+        hashCode.Add(obj.MaxProperties);
+        hashCode.Add(obj.Minimum);
+        hashCode.Add(obj.MinItems);
+        hashCode.Add(obj.MinLength);
+        hashCode.Add(obj.MinProperties);
+        hashCode.Add(obj.MultipleOf);
+        foreach (var item in obj.OneOf)
+        {
+            hashCode.Add(item, Instance);
+        }
+        hashCode.Add(obj.Not, Instance);
+        hashCode.Add(obj.Nullable);
+        hashCode.Add(obj.Pattern);
+        foreach ((var key, var value) in obj.Properties)
+        {
+            hashCode.Add(key);
+            hashCode.Add(value, Instance);
+        }
+        hashCode.Add(obj.ReadOnly);
+        foreach (var item in obj.Required.Order())
+        {
+            hashCode.Add(item);
+        }
+        hashCode.Add(obj.Reference, OpenApiReferenceComparer.Instance);
+        hashCode.Add(obj.UniqueItems);
+        hashCode.Add(obj.UnresolvedReference);
+        hashCode.Add(obj.WriteOnly);
+        hashCode.Add(obj.Xml, OpenApiXmlComparer.Instance);
+        return hashCode.ToHashCode();
+    }
+}

--- a/src/OpenApi/src/Comparers/OpenApiSchemaComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiSchemaComparer.cs
@@ -21,6 +21,10 @@ internal sealed class OpenApiSchemaComparer : IEqualityComparer<OpenApiSchema>
         {
             return false;
         }
+        if (object.ReferenceEquals(x, y))
+        {
+            return true;
+        }
 
         return GetHashCode(x) == GetHashCode(y);
     }

--- a/src/OpenApi/src/Comparers/OpenApiSchemaComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiSchemaComparer.cs
@@ -26,7 +26,46 @@ internal sealed class OpenApiSchemaComparer : IEqualityComparer<OpenApiSchema>
             return true;
         }
 
-        return GetHashCode(x) == GetHashCode(y);
+        return Instance.Equals(x.AdditionalProperties, y.AdditionalProperties) &&
+            x.AdditionalPropertiesAllowed == y.AdditionalPropertiesAllowed &&
+            x.AllOf.SequenceEqual(y.AllOf, Instance) &&
+            x.AnyOf.SequenceEqual(y.AnyOf, Instance) &&
+            x.Deprecated == y.Deprecated &&
+            OpenApiAnyComparer.Instance.Equals(x.Default, y.Default) &&
+            x.Description == y.Description &&
+            OpenApiDiscriminatorComparer.Instance.Equals(x.Discriminator, y.Discriminator) &&
+            OpenApiAnyComparer.Instance.Equals(x.Example, y.Example) &&
+            x.ExclusiveMaximum == y.ExclusiveMaximum &&
+            x.ExclusiveMinimum == y.ExclusiveMinimum &&
+            x.Extensions.Count == y.Extensions.Count
+            && x.Extensions.Keys.All(k => y.Extensions.ContainsKey(k) && x.Extensions[k] is IOpenApiAny anyX && y.Extensions[k] is IOpenApiAny anyY && OpenApiAnyComparer.Instance.Equals(anyX, anyY)) &&
+            OpenApiExternalDocsComparer.Instance.Equals(x.ExternalDocs, y.ExternalDocs) &&
+            x.Enum.SequenceEqual(y.Enum, OpenApiAnyComparer.Instance) &&
+            x.Format == y.Format &&
+            Instance.Equals(x.Items, y.Items) &&
+            x.Title == y.Title &&
+            x.Type == y.Type &&
+            x.Maximum == y.Maximum &&
+            x.MaxItems == y.MaxItems &&
+            x.MaxLength == y.MaxLength &&
+            x.MaxProperties == y.MaxProperties &&
+            x.Minimum == y.Minimum &&
+            x.MinItems == y.MinItems &&
+            x.MinLength == y.MinLength &&
+            x.MinProperties == y.MinProperties &&
+            x.MultipleOf == y.MultipleOf &&
+            x.OneOf.SequenceEqual(y.OneOf, Instance) &&
+            Instance.Equals(x.Not, y.Not) &&
+            x.Nullable == y.Nullable &&
+            x.Pattern == y.Pattern &&
+            x.Properties.Keys.All(k => y.Properties.ContainsKey(k) && Instance.Equals(x.Properties[k], y.Properties[k])) &&
+            x.ReadOnly == y.ReadOnly &&
+            x.Required.Order().SequenceEqual(y.Required.Order()) &&
+            OpenApiReferenceComparer.Instance.Equals(x.Reference, y.Reference) &&
+            x.UniqueItems == y.UniqueItems &&
+            x.UnresolvedReference == y.UnresolvedReference &&
+            x.WriteOnly == y.WriteOnly &&
+            OpenApiXmlComparer.Instance.Equals(x.Xml, y.Xml);
     }
 
     public int GetHashCode(OpenApiSchema obj)
@@ -34,14 +73,8 @@ internal sealed class OpenApiSchemaComparer : IEqualityComparer<OpenApiSchema>
         var hashCode = new HashCode();
         hashCode.Add(obj.AdditionalProperties, Instance);
         hashCode.Add(obj.AdditionalPropertiesAllowed);
-        foreach (var item in obj.AllOf)
-        {
-            hashCode.Add(item, Instance);
-        }
-        foreach (var item in obj.AnyOf)
-        {
-            hashCode.Add(item, Instance);
-        }
+        hashCode.Add(obj.AllOf.Count);
+        hashCode.Add(obj.AnyOf.Count);
         hashCode.Add(obj.Deprecated);
         hashCode.Add(obj.Default, OpenApiAnyComparer.Instance);
         hashCode.Add(obj.Description);
@@ -49,23 +82,9 @@ internal sealed class OpenApiSchemaComparer : IEqualityComparer<OpenApiSchema>
         hashCode.Add(obj.Example, OpenApiAnyComparer.Instance);
         hashCode.Add(obj.ExclusiveMaximum);
         hashCode.Add(obj.ExclusiveMinimum);
-        foreach ((var key, var value) in obj.Extensions)
-        {
-            hashCode.Add(key);
-            if (value is IOpenApiAny any)
-            {
-                hashCode.Add(any, OpenApiAnyComparer.Instance);
-            }
-            else
-            {
-                hashCode.Add(value);
-            }
-        }
+        hashCode.Add(obj.Extensions.Count);
         hashCode.Add(obj.ExternalDocs, OpenApiExternalDocsComparer.Instance);
-        foreach (var item in obj.Enum)
-        {
-            hashCode.Add(item, OpenApiAnyComparer.Instance);
-        }
+        hashCode.Add(obj.Enum.Count);
         hashCode.Add(obj.Format);
         hashCode.Add(obj.Items, Instance);
         hashCode.Add(obj.Title);
@@ -79,23 +98,13 @@ internal sealed class OpenApiSchemaComparer : IEqualityComparer<OpenApiSchema>
         hashCode.Add(obj.MinLength);
         hashCode.Add(obj.MinProperties);
         hashCode.Add(obj.MultipleOf);
-        foreach (var item in obj.OneOf)
-        {
-            hashCode.Add(item, Instance);
-        }
+        hashCode.Add(obj.OneOf.Count);
         hashCode.Add(obj.Not, Instance);
         hashCode.Add(obj.Nullable);
         hashCode.Add(obj.Pattern);
-        foreach ((var key, var value) in obj.Properties)
-        {
-            hashCode.Add(key);
-            hashCode.Add(value, Instance);
-        }
+        hashCode.Add(obj.Properties.Count);
         hashCode.Add(obj.ReadOnly);
-        foreach (var item in obj.Required.Order())
-        {
-            hashCode.Add(item);
-        }
+        hashCode.Add(obj.Required.Count);
         hashCode.Add(obj.Reference, OpenApiReferenceComparer.Instance);
         hashCode.Add(obj.UniqueItems);
         hashCode.Add(obj.UnresolvedReference);

--- a/src/OpenApi/src/Comparers/OpenApiTagComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiTagComparer.cs
@@ -23,6 +23,11 @@ internal sealed class OpenApiTagComparer : IEqualityComparer<OpenApiTag>
         {
             return false;
         }
+        if (object.ReferenceEquals(x, y))
+        {
+            return true;
+        }
+
         // Tag comparisons are case-sensitive by default. Although the OpenAPI specification
         // only outlines case sensitivity for property names, we extend this principle to
         // property values for tag names as well.

--- a/src/OpenApi/src/Comparers/OpenApiTagComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiTagComparer.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.OpenApi;
 /// This comparer is used to maintain a globally unique list of tags encountered
 /// in a particular OpenAPI document.
 /// </summary>
-internal class OpenApiTagComparer : IEqualityComparer<OpenApiTag>
+internal sealed class OpenApiTagComparer : IEqualityComparer<OpenApiTag>
 {
     public static OpenApiTagComparer Instance { get; } = new OpenApiTagComparer();
 

--- a/src/OpenApi/src/Comparers/OpenApiXmlComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiXmlComparer.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.OpenApi.Any;
+using System.Linq;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.AspNetCore.OpenApi;
@@ -25,7 +25,13 @@ internal sealed class OpenApiXmlComparer : IEqualityComparer<OpenApiXml>
             return true;
         }
 
-        return GetHashCode(x) == GetHashCode(y);
+        return x.Name == y.Name &&
+            x.Namespace == y.Namespace &&
+            x.Prefix == y.Prefix &&
+            x.Attribute == y.Attribute &&
+            x.Wrapped == y.Wrapped &&
+            x.Extensions.Count == y.Extensions.Count
+            && x.Extensions.Keys.All(k => y.Extensions.ContainsKey(k) && y.Extensions[k] == x.Extensions[k]);
     }
 
     public int GetHashCode(OpenApiXml obj)
@@ -36,17 +42,7 @@ internal sealed class OpenApiXmlComparer : IEqualityComparer<OpenApiXml>
         hashCode.Add(obj.Prefix);
         hashCode.Add(obj.Attribute);
         hashCode.Add(obj.Wrapped);
-        foreach (var item in obj.Extensions)
-        {
-            hashCode.Add(item.Key);
-            if (item.Value is IOpenApiAny any)
-            {
-                hashCode.Add(any, OpenApiAnyComparer.Instance);
-            }
-            {
-                hashCode.Add(item.Value);
-            }
-        }
+        hashCode.Add(obj.Extensions.Count);
         return hashCode.ToHashCode();
     }
 }

--- a/src/OpenApi/src/Comparers/OpenApiXmlComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiXmlComparer.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.AspNetCore.OpenApi;
+
+internal sealed class OpenApiXmlComparer : IEqualityComparer<OpenApiXml>
+{
+    public static OpenApiXmlComparer Instance { get; } = new OpenApiXmlComparer();
+
+    public bool Equals(OpenApiXml? x, OpenApiXml? y)
+    {
+        if (x is null && y is null)
+        {
+            return true;
+        }
+        if (x is null || y is null)
+        {
+            return false;
+        }
+
+        return GetHashCode(x) == GetHashCode(y);
+    }
+
+    public int GetHashCode([DisallowNull] OpenApiXml obj)
+    {
+        var hashCode = new HashCode();
+        hashCode.Add(obj.Name);
+        hashCode.Add(obj.Namespace);
+        hashCode.Add(obj.Prefix);
+        hashCode.Add(obj.Attribute);
+        hashCode.Add(obj.Wrapped);
+        foreach (var item in obj.Extensions)
+        {
+            hashCode.Add(item.Key);
+            if (item.Value is IOpenApiAny any)
+            {
+                hashCode.Add(any, OpenApiAnyComparer.Instance);
+            }
+            {
+                hashCode.Add(item.Value);
+            }
+        }
+        return hashCode.ToHashCode();
+    }
+}

--- a/src/OpenApi/src/Comparers/OpenApiXmlComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiXmlComparer.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 
@@ -21,11 +20,15 @@ internal sealed class OpenApiXmlComparer : IEqualityComparer<OpenApiXml>
         {
             return false;
         }
+        if (object.ReferenceEquals(x, y))
+        {
+            return true;
+        }
 
         return GetHashCode(x) == GetHashCode(y);
     }
 
-    public int GetHashCode([DisallowNull] OpenApiXml obj)
+    public int GetHashCode(OpenApiXml obj)
     {
         var hashCode = new HashCode();
         hashCode.Add(obj.Name);

--- a/src/OpenApi/src/Extensions/JsonObjectSchemaExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonObjectSchemaExtensions.cs
@@ -164,14 +164,15 @@ internal static class JsonObjectSchemaExtensions
     /// opposed to after the generated schemas have been mapped to OpenAPI schemas.
     /// </remarks>
     /// <param name="schema">The <see cref="JsonObject"/> produced by the underlying schema generator.</param>
-    /// <param name="type">The <see cref="Type"/> associated with the <see paramref="schema"/>.</param>
-    internal static void ApplyPrimitiveTypesAndFormats(this JsonObject schema, Type type)
+    /// <param name="context">The <see cref="JsonSchemaGenerationContext"/> associated with the <see paramref="schema"/>.</param>
+    internal static void ApplyPrimitiveTypesAndFormats(this JsonObject schema, JsonSchemaGenerationContext context)
     {
-        if (_simpleTypeToOpenApiSchema.TryGetValue(type, out var openApiSchema))
+        if (_simpleTypeToOpenApiSchema.TryGetValue(context.TypeInfo.Type, out var openApiSchema))
         {
             schema[OpenApiSchemaKeywords.NullableKeyword] = openApiSchema.Nullable || (schema[OpenApiSchemaKeywords.TypeKeyword] is JsonArray schemaType && schemaType.GetValues<string>().Contains("null"));
             schema[OpenApiSchemaKeywords.TypeKeyword] = openApiSchema.Type;
             schema[OpenApiSchemaKeywords.FormatKeyword] = openApiSchema.Format;
+            schema[OpenApiConstants.SchemaId] = context.TypeInfo.GetSchemaReferenceId();
         }
     }
 
@@ -323,5 +324,15 @@ internal static class JsonObjectSchemaExtensions
             schema[OpenApiSchemaKeywords.DiscriminatorKeyword] = polymorphismOptions.TypeDiscriminatorPropertyName;
             schema[OpenApiSchemaKeywords.DiscriminatorMappingKeyword] = mappings;
         }
+    }
+
+    /// <summary>
+    /// Set the x-schema-id property on the schema to the identifier associated with the type.
+    /// </summary>
+    /// <param name="schema">The <see cref="JsonObject"/> produced by the underlying schema generator.</param>
+    /// <param name="context">The <see cref="JsonSchemaGenerationContext"/> associated with the current type.</param>
+    internal static void ApplySchemaReferenceId(this JsonObject schema, JsonSchemaGenerationContext context)
+    {
+        schema[OpenApiConstants.SchemaId] = context.TypeInfo.GetSchemaReferenceId();
     }
 }

--- a/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
@@ -1,0 +1,121 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO.Pipelines;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.OpenApi;
+
+internal static class JsonTypeInfoExtensions
+{
+    private static readonly Dictionary<Type, string> _simpleTypeToName = new()
+    {
+        [typeof(bool)] = "boolean",
+        [typeof(byte)] = "byte",
+        [typeof(int)] = "int",
+        [typeof(uint)] = "uint",
+        [typeof(long)] = "long",
+        [typeof(ulong)] = "ulong",
+        [typeof(short)] = "short",
+        [typeof(ushort)] = "ushort",
+        [typeof(float)] = "float",
+        [typeof(double)] = "double",
+        [typeof(decimal)] = "decimal",
+        [typeof(DateTime)] = "DateTime",
+        [typeof(DateTimeOffset)] = "DateTimeOffset",
+        [typeof(Guid)] = "Guid",
+        [typeof(char)] = "char",
+        [typeof(Uri)] = "Uri",
+        [typeof(string)] = "string",
+        [typeof(IFormFile)] = "IFormFile",
+        [typeof(IFormFileCollection)] = "IFormFileCollection",
+        [typeof(PipeReader)] = "PipeReader",
+        [typeof(Stream)] = "Stream"
+    };
+
+    /// <summary>
+    /// The following method maps a JSON type to a schema reference ID that will eventually be used as the
+    /// schema reference name in the OpenAPI document. These schema reference names are considered URL fragments
+    /// in the context of JSON Schema's $ref keyword and must comply with the character restrictions of URL fragments.
+    /// In particular, the generated strings can contain alphanumeric characters and a subset of special symbols. This
+    /// means that certain symbols that appear commonly in .NET type names like ">" are not permitted in the
+    /// generated reference ID.
+    /// </summary>
+    /// <param name="jsonTypeInfo">The <see cref="JsonTypeInfo"/> associated with the target schema.</param>
+    /// <returns>The schema reference ID represented as a string name.</returns>
+    internal static string GetSchemaReferenceId(this JsonTypeInfo jsonTypeInfo)
+    {
+        var type = jsonTypeInfo.Type;
+        // Short-hand if the type we're generating a schema reference ID for is
+        // one of the simple types defined above.
+        if (_simpleTypeToName.TryGetValue(type, out var simpleName))
+        {
+            return simpleName;
+        }
+
+        if (jsonTypeInfo is JsonTypeInfo { Kind: JsonTypeInfoKind.Enumerable, ElementType: { } elementType })
+        {
+            var elementTypeInfo = jsonTypeInfo.Options.GetTypeInfo(elementType);
+            return $"ArrayOf{elementTypeInfo.GetSchemaReferenceId()}";
+        }
+
+        if (jsonTypeInfo is JsonTypeInfo { Kind: JsonTypeInfoKind.Dictionary, KeyType: { } keyType, ElementType: { } valueType })
+        {
+            var keyTypeInfo = jsonTypeInfo.Options.GetTypeInfo(keyType);
+            var valueTypeInfo = jsonTypeInfo.Options.GetTypeInfo(valueType);
+            return $"DictionaryOf{keyTypeInfo.GetSchemaReferenceId()}And{valueTypeInfo.GetSchemaReferenceId()}";
+        }
+
+        return type.GetSchemaReferenceId(jsonTypeInfo.Options);
+    }
+
+    internal static string GetSchemaReferenceId(this Type type, JsonSerializerOptions options)
+    {
+        // Check the simple types map first to account for the element types
+        // of enumerables that have been processed above.
+        if (_simpleTypeToName.TryGetValue(type, out var simpleName))
+        {
+            return simpleName;
+        }
+
+        // Although arrays are enumerable types they are not encoded correctly
+        // with JsonTypeInfoKind.Enumerable so we handle that here
+        if (type.IsArray && type.GetElementType() is { } elementType)
+        {
+            var elementTypeInfo = options.GetTypeInfo(elementType);
+            return $"ArrayOf{elementTypeInfo.GetSchemaReferenceId()}";
+        }
+
+        // Special handling for anonymous types
+        if (type.Name.StartsWith("<>f", StringComparison.Ordinal))
+        {
+            var typeName = "AnonymousType";
+            var anonymousTypeProperties = type.GetGenericArguments();
+            var propertyNames = string.Join("And", anonymousTypeProperties.Select(p => p.GetSchemaReferenceId(options)));
+            return $"{typeName}Of{propertyNames}";
+        }
+
+        if (type.IsGenericType)
+        {
+            // Nullable types are suffixed with `?` (e.g. `Todo?`)
+            if (type.GetGenericTypeDefinition() == typeof(Nullable<>)
+                && Nullable.GetUnderlyingType(type) is { } underlyingType)
+            {
+                return $"{underlyingType.GetSchemaReferenceId(options)}?";
+            }
+            // Special handling for generic types that are collections
+            // Generic types become a concatenation of the generic type name and the type arguments
+            else
+            {
+                var genericTypeName = type.Name[..type.Name.LastIndexOf('`')];
+                var genericArguments = type.GetGenericArguments();
+                var argumentNames = string.Join("And", genericArguments.Select(arg => arg.GetSchemaReferenceId(options)));
+                return $"{genericTypeName}Of{argumentNames}";
+            }
+        }
+        return type.Name;
+    }
+}

--- a/src/OpenApi/src/Microsoft.AspNetCore.OpenApi.csproj
+++ b/src/OpenApi/src/Microsoft.AspNetCore.OpenApi.csproj
@@ -28,7 +28,6 @@
     <Compile Include="$(SharedSourceRoot)PropertyAsParameterInfo.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)ParameterBindingMethodCache.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)TypeNameHelper\TypeNameHelper.cs" LinkBase="Shared" />
-    <Compile Include="$(SharedSourceRoot)\HashCode.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenApi/src/Microsoft.AspNetCore.OpenApi.csproj
+++ b/src/OpenApi/src/Microsoft.AspNetCore.OpenApi.csproj
@@ -28,6 +28,7 @@
     <Compile Include="$(SharedSourceRoot)PropertyAsParameterInfo.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)ParameterBindingMethodCache.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)TypeNameHelper\TypeNameHelper.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)\HashCode.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenApi/src/Schemas/OpenApiJsonSchema.Helpers.cs
+++ b/src/OpenApi/src/Schemas/OpenApiJsonSchema.Helpers.cs
@@ -7,6 +7,7 @@ using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
+using OpenApiConstants = Microsoft.AspNetCore.OpenApi.OpenApiConstants;
 
 internal sealed partial class OpenApiJsonSchema
 {
@@ -288,6 +289,10 @@ internal sealed partial class OpenApiJsonSchema
                 reader.Read();
                 var mappings = ReadDictionary<string>(ref reader);
                 schema.Discriminator.Mapping = mappings;
+                break;
+            case OpenApiConstants.SchemaId:
+                reader.Read();
+                schema.Extensions.Add(OpenApiConstants.SchemaId, new OpenApiString(reader.GetString()));
                 break;
             default:
                 reader.Skip();

--- a/src/OpenApi/src/Schemas/OpenApiSchemaKeywords.cs
+++ b/src/OpenApi/src/Schemas/OpenApiSchemaKeywords.cs
@@ -23,4 +23,5 @@ internal class OpenApiSchemaKeywords
     public const string MaximumKeyword = "maximum";
     public const string MinItemsKeyword = "minItems";
     public const string MaxItemsKeyword = "maxItems";
+    public const string RefKeyword = "$ref";
 }

--- a/src/OpenApi/src/Schemas/OpenApiSchemaKeywords.cs
+++ b/src/OpenApi/src/Schemas/OpenApiSchemaKeywords.cs
@@ -24,4 +24,5 @@ internal class OpenApiSchemaKeywords
     public const string MinItemsKeyword = "minItems";
     public const string MaxItemsKeyword = "maxItems";
     public const string RefKeyword = "$ref";
+    public const string SchemaIdKeyword = "x-schema-id";
 }

--- a/src/OpenApi/src/Services/OpenApiConstants.cs
+++ b/src/OpenApi/src/Services/OpenApiConstants.cs
@@ -11,6 +11,7 @@ internal static class OpenApiConstants
     internal const string DefaultOpenApiVersion = "1.0.0";
     internal const string DefaultOpenApiRoute = "/openapi/{documentName}.json";
     internal const string DescriptionId = "x-aspnetcore-id";
+    internal const string SchemaId = "x-schema-id";
     internal const string DefaultOpenApiResponseKey = "default";
     // Since there's a finite set of operation types that can be included in a given
     // OpenApiPaths, we can pre-allocate an array of these types and use a direct

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -79,10 +79,10 @@ internal sealed class OpenApiDocumentService(
             var transformer = _options.DocumentTransformers[i];
             await transformer.TransformAsync(document, documentTransformerContext, cancellationToken);
         }
-        // Remove `x-aspnetcore-id` extension from operations after all transformers have run.
-        await _scrubExtensionsTransformer.TransformAsync(document, documentTransformerContext, cancellationToken);
         // Move duplicated JSON schemas to the global components.schemas object and map references after all transformers have run.
         await _schemaReferenceTransformer.TransformAsync(document, documentTransformerContext, cancellationToken);
+        // Remove `x-aspnetcore-id` and `x-schema-id` extensions from operations after all transformers have run.
+        await _scrubExtensionsTransformer.TransformAsync(document, documentTransformerContext, cancellationToken);
     }
 
     // Note: Internal for testing.

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -34,6 +34,7 @@ internal sealed class OpenApiDocumentService(
     private readonly OpenApiOptions _options = optionsMonitor.Get(documentName);
     private readonly OpenApiSchemaService _componentService = serviceProvider.GetRequiredKeyedService<OpenApiSchemaService>(documentName);
     private readonly IOpenApiDocumentTransformer _scrubExtensionsTransformer = new ScrubExtensionsTransformer();
+    private readonly IOpenApiDocumentTransformer _schemaReferenceTransformer = new OpenApiSchemaReferenceTransformer();
 
     private static readonly OpenApiEncoding _defaultFormEncoding = new OpenApiEncoding { Style = ParameterStyle.Form, Explode = true };
 
@@ -80,6 +81,8 @@ internal sealed class OpenApiDocumentService(
         }
         // Remove `x-aspnetcore-id` extension from operations after all transformers have run.
         await _scrubExtensionsTransformer.TransformAsync(document, documentTransformerContext, cancellationToken);
+        // Move duplicated JSON schemas to the global components.schemas object and map references after all transformers have run.
+        await _schemaReferenceTransformer.TransformAsync(document, documentTransformerContext, cancellationToken);
     }
 
     // Note: Internal for testing.

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Concurrent;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -44,7 +43,7 @@ internal sealed class OpenApiDocumentService(
     /// are unique within the lifetime of an application and serve as helpful associators between
     /// operations, API descriptions, and their respective transformer contexts.
     /// </summary>
-    private readonly ConcurrentDictionary<string, OpenApiOperationTransformerContext> _operationTransformerContextCache = new();
+    private readonly Dictionary<string, OpenApiOperationTransformerContext> _operationTransformerContextCache = new();
     private static readonly ApiResponseType _defaultApiResponseType = new ApiResponseType { StatusCode = StatusCodes.Status200OK };
 
     internal bool TryGetCachedOperationTransformerContext(string descriptionId, [NotNullWhen(true)] out OpenApiOperationTransformerContext? context)

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -102,6 +102,7 @@ internal sealed class OpenApiSchemaService(
         Debug.Assert(deserializedSchema != null, "The schema should have been deserialized successfully and materialize a non-null value.");
         var schema = deserializedSchema.Schema;
         await ApplySchemaTransformersAsync(schema, type, parameterDescription, cancellationToken);
+        _schemaStore.PopulateSchemaIntoReferenceCache(schema);
         return schema;
     }
 

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -76,7 +76,8 @@ internal sealed class OpenApiSchemaService(
                     [OpenApiSchemaKeywords.FormatKeyword] = "binary"
                 };
             }
-            schema.ApplyPrimitiveTypesAndFormats(type);
+            schema.ApplyPrimitiveTypesAndFormats(context);
+            schema.ApplySchemaReferenceId(context);
             if (context.GetCustomAttributes(typeof(ValidationAttribute)) is { } validationAttributes)
             {
                 schema.ApplyValidationAttributes(validationAttributes);

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaStore.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaStore.cs
@@ -49,7 +49,7 @@ internal sealed class OpenApiSchemaStore
         },
     };
 
-    private readonly Dictionary<OpenApiSchema, string?> _schemasWithReference = new(OpenApiSchemaComparer.Instance);
+    public readonly Dictionary<OpenApiSchema, string?> SchemasByReference = new(OpenApiSchemaComparer.Instance);
     private readonly Dictionary<string, int> _referenceIdCounter = new();
 
     /// <summary>
@@ -115,7 +115,7 @@ internal sealed class OpenApiSchemaStore
 
     private void AddOrUpdateSchemaByReference(OpenApiSchema schema)
     {
-        if (_schemasWithReference.TryGetValue(schema, out var referenceId))
+        if (SchemasByReference.TryGetValue(schema, out var referenceId))
         {
             // If we've already used this reference ID else where in the document, increment a counter value to the reference
             // ID to avoid name collisions. These collisions are most likely to occur when the same .NET type produces a different
@@ -151,18 +151,18 @@ internal sealed class OpenApiSchemaStore
                 {
                     counter++;
                     _referenceIdCounter[targetReferenceId] = counter;
-                    _schemasWithReference[schema] = $"{targetReferenceId}{counter}";
+                    SchemasByReference[schema] = $"{targetReferenceId}{counter}";
                 }
                 else
                 {
                     _referenceIdCounter[targetReferenceId] = 1;
-                    _schemasWithReference[schema] = targetReferenceId;
+                    SchemasByReference[schema] = targetReferenceId;
                 }
             }
         }
         else
         {
-            _schemasWithReference[schema] = null;
+            SchemasByReference[schema] = null;
         }
     }
 
@@ -176,6 +176,4 @@ internal sealed class OpenApiSchemaStore
 
         throw new InvalidOperationException("The schema reference ID must be set on the schema.");
     }
-
-    public Dictionary<OpenApiSchema, string?> SchemasByReference => _schemasWithReference;
 }

--- a/src/OpenApi/src/Transformers/Implementations/OpenApiSchemaReferenceTransformer.cs
+++ b/src/OpenApi/src/Transformers/Implementations/OpenApiSchemaReferenceTransformer.cs
@@ -1,0 +1,137 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.AspNetCore.OpenApi;
+
+/// <summary>
+/// Document transformer to support mapping duplicate JSON schema instances
+/// into JSON schema references across the document.
+/// </summary>
+internal sealed class OpenApiSchemaReferenceTransformer : IOpenApiDocumentTransformer
+{
+    public Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken)
+    {
+        var schemaStore = context.ApplicationServices.GetRequiredKeyedService<OpenApiSchemaStore>(context.DocumentName);
+        var schemasByReference = schemaStore.SchemasByReference;
+
+        foreach (var pathItem in document.Paths.Values)
+        {
+            for (var i = 0; i < OpenApiConstants.OperationTypes.Length; i++)
+            {
+                var operationType = OpenApiConstants.OperationTypes[i];
+                if (pathItem.Operations.TryGetValue(operationType, out var operation))
+                {
+                    if (operation.Parameters is not null)
+                    {
+                        foreach (var parameter in operation.Parameters)
+                        {
+                            parameter.Schema = ResolveReferenceForSchema(parameter.Schema, schemasByReference);
+                        }
+                    }
+
+                    if (operation.RequestBody is not null)
+                    {
+                        foreach (var content in operation.RequestBody.Content)
+                        {
+                            content.Value.Schema = ResolveReferenceForSchema(content.Value.Schema, schemasByReference);
+                        }
+                    }
+
+                    if (operation.Responses is not null)
+                    {
+                        foreach (var response in operation.Responses.Values)
+                        {
+                            if (response.Content is not null)
+                            {
+                                foreach (var content in response.Content)
+                                {
+                                    content.Value.Schema = ResolveReferenceForSchema(content.Value.Schema, schemasByReference);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        document.Components ??= new OpenApiComponents();
+        document.Components.Schemas ??= new Dictionary<string, OpenApiSchema>();
+
+        foreach (var (schema, referenceId) in schemasByReference.OrderBy(kvp => kvp.Value))
+        {
+            if (referenceId is not null)
+            {
+                document.Components.Schemas[referenceId] = ResolveReferenceForSchema(schema, schemasByReference, skipResolution: true);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    internal static OpenApiSchema? ResolveReferenceForSchema(OpenApiSchema? schema, ConcurrentDictionary<OpenApiSchema, string?> schemasByReference, bool skipResolution = false)
+    {
+        if (schema is null)
+        {
+            return schema;
+        }
+
+        if (!skipResolution && schemasByReference.TryGetValue(schema, out var referenceId) && referenceId is not null)
+        {
+            return new OpenApiSchema { Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = referenceId } };
+        }
+
+        if (schema.AllOf != null)
+        {
+            for (var i = 0; i < schema.AllOf.Count; i++)
+            {
+                schema.AllOf[i] = ResolveReferenceForSchema(schema.AllOf[i], schemasByReference);
+            }
+        }
+
+        if (schema.OneOf != null)
+        {
+            for (var i = 0; i < schema.OneOf.Count; i++)
+            {
+                schema.OneOf[i] = ResolveReferenceForSchema(schema.OneOf[i], schemasByReference);
+            }
+        }
+
+        if (schema.AnyOf != null)
+        {
+            for (var i = 0; i < schema.AnyOf.Count; i++)
+            {
+                schema.AnyOf[i] = ResolveReferenceForSchema(schema.AnyOf[i], schemasByReference);
+            }
+        }
+
+        if (schema.AdditionalProperties is not null)
+        {
+            schema.AdditionalProperties = ResolveReferenceForSchema(schema.AdditionalProperties, schemasByReference);
+        }
+
+        if (schema.Items is not null)
+        {
+            schema.Items = ResolveReferenceForSchema(schema.Items, schemasByReference);
+        }
+
+        if (schema.Properties != null)
+        {
+            foreach (var property in schema.Properties)
+            {
+                schema.Properties[property.Key] = ResolveReferenceForSchema(property.Value, schemasByReference);
+            }
+        }
+
+        if (schema.Not is not null)
+        {
+            schema.Not = ResolveReferenceForSchema(schema.Not, schemasByReference);
+        }
+
+        return schema;
+    }
+}

--- a/src/OpenApi/src/Transformers/Implementations/OpenApiSchemaReferenceTransformer.cs
+++ b/src/OpenApi/src/Transformers/Implementations/OpenApiSchemaReferenceTransformer.cs
@@ -73,6 +73,12 @@ internal sealed class OpenApiSchemaReferenceTransformer : IOpenApiDocumentTransf
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Resolves the provided schema into a reference if it is found in the schemas-by-reference cache.
+    /// </summary>
+    /// <param name="schema">The inline schema to replace with a reference.</param>
+    /// <param name="schemasByReference">A cache of schemas and their associated reference IDs.</param>
+    /// <param name="skipResolution">When <see langword="true" />, will skip resolving references for the top-most schema provided.</param>
     internal static OpenApiSchema? ResolveReferenceForSchema(OpenApiSchema? schema, ConcurrentDictionary<OpenApiSchema, string?> schemasByReference, bool skipResolution = false)
     {
         if (schema is null)
@@ -85,7 +91,7 @@ internal sealed class OpenApiSchemaReferenceTransformer : IOpenApiDocumentTransf
             return new OpenApiSchema { Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = referenceId } };
         }
 
-        if (schema.AllOf != null)
+        if (schema.AllOf is not null)
         {
             for (var i = 0; i < schema.AllOf.Count; i++)
             {
@@ -93,7 +99,7 @@ internal sealed class OpenApiSchemaReferenceTransformer : IOpenApiDocumentTransf
             }
         }
 
-        if (schema.OneOf != null)
+        if (schema.OneOf is not null)
         {
             for (var i = 0; i < schema.OneOf.Count; i++)
             {
@@ -101,7 +107,7 @@ internal sealed class OpenApiSchemaReferenceTransformer : IOpenApiDocumentTransf
             }
         }
 
-        if (schema.AnyOf != null)
+        if (schema.AnyOf is not null)
         {
             for (var i = 0; i < schema.AnyOf.Count; i++)
             {
@@ -119,7 +125,7 @@ internal sealed class OpenApiSchemaReferenceTransformer : IOpenApiDocumentTransf
             schema.Items = ResolveReferenceForSchema(schema.Items, schemasByReference);
         }
 
-        if (schema.Properties != null)
+        if (schema.Properties is not null)
         {
             foreach (var property in schema.Properties)
             {

--- a/src/OpenApi/src/Transformers/Implementations/ScrubExtensionsTransformer.cs
+++ b/src/OpenApi/src/Transformers/Implementations/ScrubExtensionsTransformer.cs
@@ -24,8 +24,101 @@ internal sealed class ScrubExtensionsTransformer : IOpenApiDocumentTransformer
                 }
 
                 operation.Extensions.Remove(OpenApiConstants.DescriptionId);
+
+                if (operation.Parameters is not null)
+                {
+                    foreach (var parameter in operation.Parameters)
+                    {
+                        ScrubSchemaIdExtension(parameter.Schema);
+                    }
+                }
+
+                if (operation.RequestBody is not null)
+                {
+                    foreach (var content in operation.RequestBody.Content)
+                    {
+                        ScrubSchemaIdExtension(content.Value.Schema);
+                    }
+                }
+
+                if (operation.Responses is not null)
+                {
+                    foreach (var response in operation.Responses.Values)
+                    {
+                        if (response.Content is not null)
+                        {
+                            foreach (var content in response.Content)
+                            {
+                                ScrubSchemaIdExtension(content.Value.Schema);
+                            }
+                        }
+                    }
+                }
             }
         }
+
+        foreach (var schema in document.Components.Schemas.Values)
+        {
+            ScrubSchemaIdExtension(schema);
+        }
+
         return Task.CompletedTask;
+    }
+
+    internal static void ScrubSchemaIdExtension(OpenApiSchema? schema)
+    {
+        if (schema is null)
+        {
+            return;
+        }
+
+        if (schema.AllOf is not null)
+        {
+            for (var i = 0; i < schema.AllOf.Count; i++)
+            {
+                ScrubSchemaIdExtension(schema.AllOf[i]);
+            }
+        }
+
+        if (schema.OneOf is not null)
+        {
+            for (var i = 0; i < schema.OneOf.Count; i++)
+            {
+                ScrubSchemaIdExtension(schema.OneOf[i]);
+            }
+        }
+
+        if (schema.AnyOf is not null)
+        {
+            for (var i = 0; i < schema.AnyOf.Count; i++)
+            {
+                ScrubSchemaIdExtension(schema.AnyOf[i]);
+            }
+        }
+
+        if (schema.AdditionalProperties is not null)
+        {
+            ScrubSchemaIdExtension(schema.AdditionalProperties);
+        }
+
+        if (schema.Items is not null)
+        {
+            ScrubSchemaIdExtension(schema.Items);
+        }
+
+        if (schema.Properties is not null)
+        {
+            foreach (var property in schema.Properties)
+            {
+                ScrubSchemaIdExtension(schema.Properties[property.Key]);
+            }
+        }
+
+        if (schema.Not is not null)
+        {
+            ScrubSchemaIdExtension(schema.Not);
+        }
+
+        schema.Extensions.Remove(OpenApiConstants.SchemaId);
     }
 }

--- a/src/OpenApi/test/Comparers/OpenApiAnyComparerTests.cs
+++ b/src/OpenApi/test/Comparers/OpenApiAnyComparerTests.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi.Any;
+
+public class OpenApiAnyComparerTests
+{
+    public static object[][] Data => [
+        [new OpenApiNull(), new OpenApiNull(), true],
+        [new OpenApiNull(), new OpenApiBoolean(true), false],
+        [new OpenApiBoolean(true), new OpenApiBoolean(true), true],
+        [new OpenApiBoolean(true), new OpenApiBoolean(false), false],
+        [new OpenApiInteger(1), new OpenApiInteger(1), true],
+        [new OpenApiInteger(1), new OpenApiInteger(2), false],
+        [new OpenApiLong(1), new OpenApiLong(1), true],
+        [new OpenApiLong(1), new OpenApiLong(2), false],
+        [new OpenApiFloat(1.1f), new OpenApiFloat(1.1f), true],
+        [new OpenApiFloat(1.1f), new OpenApiFloat(1.2f), false],
+        [new OpenApiDouble(1.1), new OpenApiDouble(1.1), true],
+        [new OpenApiDouble(1.1), new OpenApiDouble(1.2), false],
+        [new OpenApiString("value"), new OpenApiString("value"), true],
+        [new OpenApiString("value"), new OpenApiString("value2"), false],
+        [new OpenApiObject(), new OpenApiObject(), true],
+        [new OpenApiObject(), new OpenApiObject { ["key"] = new OpenApiString("value") }, false],
+        [new OpenApiObject { ["key"] = new OpenApiString("value") }, new OpenApiObject { ["key"] = new OpenApiString("value") }, true],
+        [new OpenApiObject { ["key"] = new OpenApiString("value") }, new OpenApiObject { ["key"] = new OpenApiString("value2") }, false],
+        [new OpenApiObject { ["key2"] = new OpenApiString("value") }, new OpenApiObject { ["key"] = new OpenApiString("value") }, false],
+        [new OpenApiDate(DateTime.Today), new OpenApiDate(DateTime.Today), true],
+        [new OpenApiDate(DateTime.Today), new OpenApiDate(DateTime.Today.AddDays(1)), false],
+        [new OpenApiPassword("password"), new OpenApiPassword("password"), true],
+        [new OpenApiPassword("password"), new OpenApiPassword("password2"), false],
+        [new OpenApiArray { new OpenApiString("value") }, new OpenApiArray { new OpenApiString("value") }, true],
+        [new OpenApiArray { new OpenApiString("value") }, new OpenApiArray { new OpenApiString("value2") }, false],
+        [new OpenApiArray { new OpenApiString("value2"), new OpenApiString("value") }, new OpenApiArray { new OpenApiString("value"), new OpenApiString("value2") }, false],
+        [new OpenApiArray { new OpenApiString("value"), new OpenApiString("value") }, new OpenApiArray { new OpenApiString("value"), new OpenApiString("value") }, true]
+    ];
+
+    [Theory]
+    [MemberData(nameof(Data))]
+    public void ProducesCorrectHashCodeForAny(IOpenApiAny any, IOpenApiAny anotherAny, bool isEqual)
+    {
+        // Act
+        var hash = OpenApiAnyComparer.Instance.GetHashCode(any);
+        var anotherHash = OpenApiAnyComparer.Instance.GetHashCode(anotherAny);
+
+        // Assert
+        Assert.Equal(isEqual, hash.Equals(anotherHash));
+    }
+}

--- a/src/OpenApi/test/Comparers/OpenApiAnyComparerTests.cs
+++ b/src/OpenApi/test/Comparers/OpenApiAnyComparerTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.OpenApi.Any;
 
@@ -9,10 +10,15 @@ public class OpenApiAnyComparerTests
     public static object[][] Data => [
         [new OpenApiNull(), new OpenApiNull(), true],
         [new OpenApiNull(), new OpenApiBoolean(true), false],
+        [new OpenApiByte(1), new OpenApiByte(1), true],
+        [new OpenApiByte(1), new OpenApiByte(2), false],
+        [new OpenApiBinary(Encoding.UTF8.GetBytes("test")), new OpenApiBinary(Encoding.UTF8.GetBytes("test")), true],
+        [new OpenApiBinary(Encoding.UTF8.GetBytes("test2")), new OpenApiBinary(Encoding.UTF8.GetBytes("test")), false],
         [new OpenApiBoolean(true), new OpenApiBoolean(true), true],
         [new OpenApiBoolean(true), new OpenApiBoolean(false), false],
         [new OpenApiInteger(1), new OpenApiInteger(1), true],
         [new OpenApiInteger(1), new OpenApiInteger(2), false],
+        [new OpenApiInteger(1), new OpenApiLong(1), false],
         [new OpenApiLong(1), new OpenApiLong(1), true],
         [new OpenApiLong(1), new OpenApiLong(2), false],
         [new OpenApiFloat(1.1f), new OpenApiFloat(1.1f), true],
@@ -38,13 +44,6 @@ public class OpenApiAnyComparerTests
 
     [Theory]
     [MemberData(nameof(Data))]
-    public void ProducesCorrectHashCodeForAny(IOpenApiAny any, IOpenApiAny anotherAny, bool isEqual)
-    {
-        // Act
-        var hash = OpenApiAnyComparer.Instance.GetHashCode(any);
-        var anotherHash = OpenApiAnyComparer.Instance.GetHashCode(anotherAny);
-
-        // Assert
-        Assert.Equal(isEqual, hash.Equals(anotherHash));
-    }
+    public void ProducesCorrectEqualityForOpenApiAny(IOpenApiAny any, IOpenApiAny anotherAny, bool isEqual)
+        => Assert.Equal(isEqual, OpenApiAnyComparer.Instance.Equals(any, anotherAny));
 }

--- a/src/OpenApi/test/Comparers/OpenApiDiscriminatorComparerTests.cs
+++ b/src/OpenApi/test/Comparers/OpenApiDiscriminatorComparerTests.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi.Models;
+
+public class OpenApiDiscriminatorComparerTests
+{
+    public static object[][] Data => [
+        [new OpenApiDiscriminator(), new OpenApiDiscriminator(), true],
+        [new OpenApiDiscriminator { PropertyName = "prop" }, new OpenApiDiscriminator(), false],
+        [new OpenApiDiscriminator { PropertyName = "prop" }, new OpenApiDiscriminator { PropertyName = "prop" }, true],
+        [new OpenApiDiscriminator { PropertyName = "prop2" }, new OpenApiDiscriminator { PropertyName = "prop" }, false],
+        [new OpenApiDiscriminator { PropertyName = "prop", Mapping = { ["key"] = "discriminatorValue" } }, new OpenApiDiscriminator { PropertyName = "prop", Mapping = { ["key"] = "discriminatorValue" } }, true],
+        [new OpenApiDiscriminator { PropertyName = "prop", Mapping = { ["key"] = "discriminatorValue" } }, new OpenApiDiscriminator { PropertyName = "prop2", Mapping = { ["key"] = "discriminatorValue" } }, false],
+        [new OpenApiDiscriminator { PropertyName = "prop", Mapping = { ["key"] = "discriminatorValue" } }, new OpenApiDiscriminator { PropertyName = "prop", Mapping = { ["key"] = "discriminatorValue2" } }, false]
+    ];
+
+    [Theory]
+    [MemberData(nameof(Data))]
+    public void ProducesCorrectHashCodeForDiscriminator(OpenApiDiscriminator discriminator, OpenApiDiscriminator anotherDiscriminator, bool isEqual)
+    {
+        // Act
+        var hash = OpenApiDiscriminatorComparer.Instance.GetHashCode(discriminator);
+        var anotherHash = OpenApiDiscriminatorComparer.Instance.GetHashCode(anotherDiscriminator);
+
+        // Assert
+        Assert.Equal(isEqual, hash.Equals(anotherHash));
+    }
+}

--- a/src/OpenApi/test/Comparers/OpenApiDiscriminatorComparerTests.cs
+++ b/src/OpenApi/test/Comparers/OpenApiDiscriminatorComparerTests.cs
@@ -18,13 +18,6 @@ public class OpenApiDiscriminatorComparerTests
 
     [Theory]
     [MemberData(nameof(Data))]
-    public void ProducesCorrectHashCodeForDiscriminator(OpenApiDiscriminator discriminator, OpenApiDiscriminator anotherDiscriminator, bool isEqual)
-    {
-        // Act
-        var hash = OpenApiDiscriminatorComparer.Instance.GetHashCode(discriminator);
-        var anotherHash = OpenApiDiscriminatorComparer.Instance.GetHashCode(anotherDiscriminator);
-
-        // Assert
-        Assert.Equal(isEqual, hash.Equals(anotherHash));
-    }
+    public void ProducesCorrectEqualityForOpenApiDiscriminator(OpenApiDiscriminator discriminator, OpenApiDiscriminator anotherDiscriminator, bool isEqual)
+        => Assert.Equal(isEqual, OpenApiDiscriminatorComparer.Instance.Equals(discriminator, anotherDiscriminator));
 }

--- a/src/OpenApi/test/Comparers/OpenApiExternalDocsComparerTests.cs
+++ b/src/OpenApi/test/Comparers/OpenApiExternalDocsComparerTests.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+
+public class OpenApiExternalDocsComparerTests
+{
+    public static object[][] Data => [
+        [new OpenApiExternalDocs(), new OpenApiExternalDocs(), true],
+        [new OpenApiExternalDocs(), new OpenApiExternalDocs { Description = "description" }, false],
+        [new OpenApiExternalDocs { Description = "description" }, new OpenApiExternalDocs { Description = "description" }, true],
+        [new OpenApiExternalDocs { Description = "description" }, new OpenApiExternalDocs { Description = "description", Url = new Uri("http://localhost") }, false],
+        [new OpenApiExternalDocs { Description = "description", Url = new Uri("http://localhost") }, new OpenApiExternalDocs { Description = "description", Url = new Uri("http://localhost") }, true],
+    ];
+
+    [Theory]
+    [MemberData(nameof(Data))]
+    public void ProducesCorrectHashCodeForAny(OpenApiExternalDocs externalDocs, OpenApiExternalDocs anotherExternalDocs, bool isEqual)
+    {
+        // Act
+        var hash = OpenApiExternalDocsComparer.Instance.GetHashCode(externalDocs);
+        var anotherHash = OpenApiExternalDocsComparer.Instance.GetHashCode(anotherExternalDocs);
+
+        // Assert
+        Assert.Equal(isEqual, hash.Equals(anotherHash));
+    }
+}

--- a/src/OpenApi/test/Comparers/OpenApiExternalDocsComparerTests.cs
+++ b/src/OpenApi/test/Comparers/OpenApiExternalDocsComparerTests.cs
@@ -13,17 +13,11 @@ public class OpenApiExternalDocsComparerTests
         [new OpenApiExternalDocs { Description = "description" }, new OpenApiExternalDocs { Description = "description" }, true],
         [new OpenApiExternalDocs { Description = "description" }, new OpenApiExternalDocs { Description = "description", Url = new Uri("http://localhost") }, false],
         [new OpenApiExternalDocs { Description = "description", Url = new Uri("http://localhost") }, new OpenApiExternalDocs { Description = "description", Url = new Uri("http://localhost") }, true],
+        [new OpenApiExternalDocs { Description = "description", Url = new Uri("http://localhost") }, new OpenApiExternalDocs { Description = "description", Url = new Uri("http://localhost") }, true],
     ];
 
     [Theory]
     [MemberData(nameof(Data))]
-    public void ProducesCorrectHashCodeForAny(OpenApiExternalDocs externalDocs, OpenApiExternalDocs anotherExternalDocs, bool isEqual)
-    {
-        // Act
-        var hash = OpenApiExternalDocsComparer.Instance.GetHashCode(externalDocs);
-        var anotherHash = OpenApiExternalDocsComparer.Instance.GetHashCode(anotherExternalDocs);
-
-        // Assert
-        Assert.Equal(isEqual, hash.Equals(anotherHash));
-    }
+    public void ProducesCorrectEqualityForOpenApiExternalDocs(OpenApiExternalDocs externalDocs, OpenApiExternalDocs anotherExternalDocs, bool isEqual)
+        => Assert.Equal(isEqual, OpenApiExternalDocsComparer.Instance.Equals(externalDocs, anotherExternalDocs));
 }

--- a/src/OpenApi/test/Comparers/OpenApiReferenceComparerTests.cs
+++ b/src/OpenApi/test/Comparers/OpenApiReferenceComparerTests.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi.Models;
+
+public class OpenApiReferenceComparerTests
+{
+    public static object[][] Data => [
+        [new OpenApiReference(), new OpenApiReference(), true],
+        [new OpenApiReference(), new OpenApiReference { Id = "id" }, false],
+        [new OpenApiReference { Id = "id" }, new OpenApiReference { Id = "id" }, true],
+        [new OpenApiReference { Id = "id" }, new OpenApiReference { Id = "id", Type = ReferenceType.Schema }, false],
+        [new OpenApiReference { Id = "id", Type = ReferenceType.Schema }, new OpenApiReference { Id = "id", Type = ReferenceType.Schema }, true],
+        [new OpenApiReference { Id = "id", Type = ReferenceType.Schema }, new OpenApiReference { Id = "id", Type = ReferenceType.Response }, false],
+        [new OpenApiReference { Id = "id", Type = ReferenceType.Response, ExternalResource = "http://localhost/pet.json" }, new OpenApiReference { Id = "id", Type = ReferenceType.Response, ExternalResource = "http://localhost/pet.json" }, true],
+        [new OpenApiReference { Id = "id", Type = ReferenceType.Response, ExternalResource = "http://localhost/pet.json" }, new OpenApiReference { Id = "id", Type = ReferenceType.Response, ExternalResource = "http://localhost/pet2.json" }, false],
+        [new OpenApiReference { Id = "id", Type = ReferenceType.Response, ExternalResource = "http://localhost/pet.json", HostDocument = new OpenApiDocument() }, new OpenApiReference { Id = "id", Type = ReferenceType.Response, ExternalResource = "http://localhost/pet.json", HostDocument = new OpenApiDocument() }, true],
+        [new OpenApiReference { Id = "id", Type = ReferenceType.Response, ExternalResource = "http://localhost/pet.json", HostDocument = new OpenApiDocument { Info = new() { Title = "Test" }} }, new OpenApiReference { Id = "id", Type = ReferenceType.Response, ExternalResource = "http://localhost/pet2.json", HostDocument = new OpenApiDocument() }, false]
+    ];
+
+    [Theory]
+    [MemberData(nameof(Data))]
+    public void ProducesCorrectHashCodeForReference(OpenApiReference reference, OpenApiReference anotherReference, bool isEqual)
+    {
+        // Act
+        var hash = OpenApiReferenceComparer.Instance.GetHashCode(reference);
+        var anotherHash = OpenApiReferenceComparer.Instance.GetHashCode(anotherReference);
+
+        // Assert
+        Assert.Equal(isEqual, hash.Equals(anotherHash));
+    }
+}

--- a/src/OpenApi/test/Comparers/OpenApiReferenceComparerTests.cs
+++ b/src/OpenApi/test/Comparers/OpenApiReferenceComparerTests.cs
@@ -21,13 +21,6 @@ public class OpenApiReferenceComparerTests
 
     [Theory]
     [MemberData(nameof(Data))]
-    public void ProducesCorrectHashCodeForReference(OpenApiReference reference, OpenApiReference anotherReference, bool isEqual)
-    {
-        // Act
-        var hash = OpenApiReferenceComparer.Instance.GetHashCode(reference);
-        var anotherHash = OpenApiReferenceComparer.Instance.GetHashCode(anotherReference);
-
-        // Assert
-        Assert.Equal(isEqual, hash.Equals(anotherHash));
-    }
+    public void ProducesCorrectEqualityForOpenApiReference(OpenApiReference reference, OpenApiReference anotherReference, bool isEqual)
+        => Assert.Equal(isEqual, OpenApiReferenceComparer.Instance.Equals(reference, anotherReference));
 }

--- a/src/OpenApi/test/Comparers/OpenApiSchemaComparerTests.cs
+++ b/src/OpenApi/test/Comparers/OpenApiSchemaComparerTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.OpenApi;
-using Microsoft.Diagnostics.Runtime.Interop;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
@@ -96,13 +95,6 @@ public class OpenApiSchemaComparerTests
 
     [Theory]
     [MemberData(nameof(SinglePropertyData))]
-    public void SinglePropertyProducesCorrectHashCode(OpenApiSchema schema, OpenApiSchema anotherSchema, bool isEqual)
-    {
-        // Act
-        var hash = OpenApiSchemaComparer.Instance.GetHashCode(schema);
-        var anotherHash = OpenApiSchemaComparer.Instance.GetHashCode(anotherSchema);
-
-        // Assert
-        Assert.Equal(isEqual, hash.Equals(anotherHash));
-    }
+    public void ProducesCorrectEqualityForOpenApiSchema(OpenApiSchema schema, OpenApiSchema anotherSchema, bool isEqual)
+        => Assert.Equal(isEqual, OpenApiSchemaComparer.Instance.Equals(schema, anotherSchema));
 }

--- a/src/OpenApi/test/Comparers/OpenApiSchemaComparerTests.cs
+++ b/src/OpenApi/test/Comparers/OpenApiSchemaComparerTests.cs
@@ -1,0 +1,108 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.Diagnostics.Runtime.Interop;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.Models;
+
+public class OpenApiSchemaComparerTests
+{
+    public static object[][] SinglePropertyData => [
+        [new OpenApiSchema { Title = "Title" }, new OpenApiSchema { Title = "Title" }, true],
+        [new OpenApiSchema { Title = "Title" }, new OpenApiSchema { Title = "Another Title" }, false],
+        [new OpenApiSchema { Type = "string" }, new OpenApiSchema { Type = "string" }, true],
+        [new OpenApiSchema { Type = "string" }, new OpenApiSchema { Type = "integer" }, false],
+        [new OpenApiSchema { Format = "int32" }, new OpenApiSchema { Format = "int32" }, true],
+        [new OpenApiSchema { Format = "int32" }, new OpenApiSchema { Format = "int64" }, false],
+        [new OpenApiSchema { Maximum = 10 }, new OpenApiSchema { Maximum = 10 }, true],
+        [new OpenApiSchema { Maximum = 10 }, new OpenApiSchema { Maximum = 20 }, false],
+        [new OpenApiSchema { Minimum = 10 }, new OpenApiSchema { Minimum = 10 }, true],
+        [new OpenApiSchema { Minimum = 10 }, new OpenApiSchema { Minimum = 20 }, false],
+        [new OpenApiSchema { ExclusiveMaximum = true }, new OpenApiSchema { ExclusiveMaximum = true }, true],
+        [new OpenApiSchema { ExclusiveMaximum = true }, new OpenApiSchema { ExclusiveMaximum = false }, false],
+        [new OpenApiSchema { ExclusiveMinimum = true }, new OpenApiSchema { ExclusiveMinimum = true }, true],
+        [new OpenApiSchema { ExclusiveMinimum = true }, new OpenApiSchema { ExclusiveMinimum = false }, false],
+        [new OpenApiSchema { MaxLength = 10 }, new OpenApiSchema { MaxLength = 10 }, true],
+        [new OpenApiSchema { MaxLength = 10 }, new OpenApiSchema { MaxLength = 20 }, false],
+        [new OpenApiSchema { MinLength = 10 }, new OpenApiSchema { MinLength = 10 }, true],
+        [new OpenApiSchema { MinLength = 10 }, new OpenApiSchema { MinLength = 20 }, false],
+        [new OpenApiSchema { Pattern = "pattern" }, new OpenApiSchema { Pattern = "pattern" }, true],
+        [new OpenApiSchema { Pattern = "pattern" }, new OpenApiSchema { Pattern = "another pattern" }, false],
+        [new OpenApiSchema { MaxItems = 10 }, new OpenApiSchema { MaxItems = 10 }, true],
+        [new OpenApiSchema { MaxItems = 10 }, new OpenApiSchema { MaxItems = 20 }, false],
+        [new OpenApiSchema { MinItems = 10 }, new OpenApiSchema { MinItems = 10 }, true],
+        [new OpenApiSchema { MinItems = 10 }, new OpenApiSchema { MinItems = 20 }, false],
+        [new OpenApiSchema { UniqueItems = true }, new OpenApiSchema { UniqueItems = true }, true],
+        [new OpenApiSchema { UniqueItems = true }, new OpenApiSchema { UniqueItems = false }, false],
+        [new OpenApiSchema { MaxProperties = 10 }, new OpenApiSchema { MaxProperties = 10 }, true],
+        [new OpenApiSchema { MaxProperties = 10 }, new OpenApiSchema { MaxProperties = 20 }, false],
+        [new OpenApiSchema { MinProperties = 10 }, new OpenApiSchema { MinProperties = 10 }, true],
+        [new OpenApiSchema { MinProperties = 10 }, new OpenApiSchema { MinProperties = 20 }, false],
+        [new OpenApiSchema { Required = new HashSet<string>() { "required" } }, new OpenApiSchema { Required = new HashSet<string> { "required" } }, true],
+        [new OpenApiSchema { Required = new HashSet<string>() { "name", "age" } }, new OpenApiSchema { Required = new HashSet<string> { "age", "name" } }, true],
+        [new OpenApiSchema { Required = new HashSet<string>() { "required" } }, new OpenApiSchema { Required = new HashSet<string> { "another required" } }, false],
+        [new OpenApiSchema { Enum = [new OpenApiString("value")] }, new OpenApiSchema { Enum = [new OpenApiString("value")] }, true],
+        [new OpenApiSchema { Enum = [new OpenApiString("value")] }, new OpenApiSchema { Enum = [new OpenApiString("value2" )] }, false],
+        [new OpenApiSchema { Enum = [new OpenApiString("value"), new OpenApiString("value2")] }, new OpenApiSchema { Enum = [new OpenApiString("value2" ), new OpenApiString("value" )] }, false],
+        [new OpenApiSchema { Items = new OpenApiSchema { Type = "string" } }, new OpenApiSchema { Items = new OpenApiSchema { Type = "string" } }, true],
+        [new OpenApiSchema { Items = new OpenApiSchema { Type = "string" } }, new OpenApiSchema { Items = new OpenApiSchema { Type = "integer" } }, false],
+        [new OpenApiSchema { Properties = new Dictionary<string, OpenApiSchema> { ["name"] = new OpenApiSchema { Type = "string" } } }, new OpenApiSchema { Properties = new Dictionary<string, OpenApiSchema> { ["name"] = new OpenApiSchema { Type = "string" } } }, true],
+        [new OpenApiSchema { Properties = new Dictionary<string, OpenApiSchema> { ["name"] = new OpenApiSchema { Type = "string" } } }, new OpenApiSchema { Properties = new Dictionary<string, OpenApiSchema> { ["name"] = new OpenApiSchema { Type = "integer" } } }, false],
+        [new OpenApiSchema { AdditionalProperties = new OpenApiSchema { Type = "string" } }, new OpenApiSchema { AdditionalProperties = new OpenApiSchema { Type = "string" } }, true],
+        [new OpenApiSchema { AdditionalProperties = new OpenApiSchema { Type = "string" } }, new OpenApiSchema { AdditionalProperties = new OpenApiSchema { Type = "integer" } }, false],
+        [new OpenApiSchema { Description = "Description" }, new OpenApiSchema { Description = "Description" }, true],
+        [new OpenApiSchema { Description = "Description" }, new OpenApiSchema { Description = "Another Description" }, false],
+        [new OpenApiSchema { Deprecated = true }, new OpenApiSchema { Deprecated = true }, true],
+        [new OpenApiSchema { Deprecated = true }, new OpenApiSchema { Deprecated = false }, false],
+        [new OpenApiSchema { ExternalDocs = new OpenApiExternalDocs { Description = "Description" } }, new OpenApiSchema { ExternalDocs = new OpenApiExternalDocs { Description = "Description" } }, true],
+        [new OpenApiSchema { ExternalDocs = new OpenApiExternalDocs { Description = "Description" } }, new OpenApiSchema { ExternalDocs = new OpenApiExternalDocs { Description = "Another Description" } }, false],
+        [new OpenApiSchema { UnresolvedReference = true }, new OpenApiSchema { UnresolvedReference = true }, true],
+        [new OpenApiSchema { UnresolvedReference = true }, new OpenApiSchema { UnresolvedReference = false }, false],
+        [new OpenApiSchema { Reference = new OpenApiReference { Id = "Id", Type = ReferenceType.Schema } }, new OpenApiSchema { Reference = new OpenApiReference { Id = "Id", Type = ReferenceType.Schema } }, true],
+        [new OpenApiSchema { Reference = new OpenApiReference { Id = "Id", Type = ReferenceType.Schema } }, new OpenApiSchema { Reference = new OpenApiReference { Id = "Another Id", Type = ReferenceType.Schema } }, false],
+        [new OpenApiSchema { Extensions = new Dictionary<string, IOpenApiExtension> { ["key"] = new OpenApiString("value") } }, new OpenApiSchema { Extensions = new Dictionary<string, IOpenApiExtension> { ["key"] = new OpenApiString("value") } }, true],
+        [new OpenApiSchema { Extensions = new Dictionary<string, IOpenApiExtension> { ["key"] = new OpenApiString("value") } }, new OpenApiSchema { Extensions = new Dictionary<string, IOpenApiExtension> { ["key"] = new OpenApiString("another value") } }, false],
+        [new OpenApiSchema { Extensions = new Dictionary<string, IOpenApiExtension> { ["key"] = new OpenApiString("value") } }, new OpenApiSchema { Extensions = new Dictionary<string, IOpenApiExtension> { ["key2"] = new OpenApiString("value") } }, false],
+        [new OpenApiSchema { Xml = new OpenApiXml { Name = "Name" } }, new OpenApiSchema { Xml = new OpenApiXml { Name = "Name" } }, true],
+        [new OpenApiSchema { Xml = new OpenApiXml { Name = "Name" } }, new OpenApiSchema { Xml = new OpenApiXml { Name = "Another Name" } }, false],
+        [new OpenApiSchema { Nullable = true }, new OpenApiSchema { Nullable = true }, true],
+        [new OpenApiSchema { Nullable = true }, new OpenApiSchema { Nullable = false }, false],
+        [new OpenApiSchema { ReadOnly = true }, new OpenApiSchema { ReadOnly = true }, true],
+        [new OpenApiSchema { ReadOnly = true }, new OpenApiSchema { ReadOnly = false }, false],
+        [new OpenApiSchema { WriteOnly = true }, new OpenApiSchema { WriteOnly = true }, true],
+        [new OpenApiSchema { WriteOnly = true }, new OpenApiSchema { WriteOnly = false }, false],
+        [new OpenApiSchema { Discriminator = new OpenApiDiscriminator { PropertyName = "PropertyName" } }, new OpenApiSchema { Discriminator = new OpenApiDiscriminator { PropertyName = "PropertyName" } }, true],
+        [new OpenApiSchema { Discriminator = new OpenApiDiscriminator { PropertyName = "PropertyName" } }, new OpenApiSchema { Discriminator = new OpenApiDiscriminator { PropertyName = "AnotherPropertyName" } }, false],
+        [new OpenApiSchema { Example = new OpenApiString("example") }, new OpenApiSchema { Example = new OpenApiString("example") }, true],
+        [new OpenApiSchema { Example = new OpenApiString("example") }, new OpenApiSchema { Example = new OpenApiString("another example") }, false],
+        [new OpenApiSchema { Example = new OpenApiInteger(2) }, new OpenApiSchema { Example = new OpenApiString("another example") }, false],
+        [new OpenApiSchema { AdditionalPropertiesAllowed = true }, new OpenApiSchema { AdditionalPropertiesAllowed = true }, true],
+        [new OpenApiSchema { AdditionalPropertiesAllowed = true }, new OpenApiSchema { AdditionalPropertiesAllowed = false }, false],
+        [new OpenApiSchema { Not = new OpenApiSchema { Type = "string" } }, new OpenApiSchema { Not = new OpenApiSchema { Type = "string" } }, true],
+        [new OpenApiSchema { Not = new OpenApiSchema { Type = "string" } }, new OpenApiSchema { Not = new OpenApiSchema { Type = "integer" } }, false],
+        [new OpenApiSchema { AnyOf = [new OpenApiSchema { Type = "string" }] }, new OpenApiSchema { AnyOf = [new OpenApiSchema { Type = "string" }] }, true],
+        [new OpenApiSchema { AnyOf = [new OpenApiSchema { Type = "string" }] }, new OpenApiSchema { AnyOf = [new OpenApiSchema { Type = "integer" }] }, false],
+        [new OpenApiSchema { AllOf = [new OpenApiSchema { Type = "string" }] }, new OpenApiSchema { AllOf = [new OpenApiSchema { Type = "string" }] }, true],
+        [new OpenApiSchema { AllOf = [new OpenApiSchema { Type = "string" }] }, new OpenApiSchema { AllOf = [new OpenApiSchema { Type = "integer" }] }, false],
+        [new OpenApiSchema { OneOf = [new OpenApiSchema { Type = "string" }] }, new OpenApiSchema { OneOf = [new OpenApiSchema { Type = "string" }] }, true],
+        [new OpenApiSchema { OneOf = [new OpenApiSchema { Type = "string" }] }, new OpenApiSchema { OneOf = [new OpenApiSchema { Type = "integer" }] }, false],
+        [new OpenApiSchema { MultipleOf = 10 }, new OpenApiSchema { MultipleOf = 10 }, true],
+        [new OpenApiSchema { MultipleOf = 10 }, new OpenApiSchema { MultipleOf = 20 }, false],
+        [new OpenApiSchema { Default = new OpenApiString("default") }, new OpenApiSchema { Default = new OpenApiString("default") }, true],
+        [new OpenApiSchema { Default = new OpenApiString("default") }, new OpenApiSchema { Default = new OpenApiString("another default") }, false],
+    ];
+
+    [Theory]
+    [MemberData(nameof(SinglePropertyData))]
+    public void SinglePropertyProducesCorrectHashCode(OpenApiSchema schema, OpenApiSchema anotherSchema, bool isEqual)
+    {
+        // Act
+        var hash = OpenApiSchemaComparer.Instance.GetHashCode(schema);
+        var anotherHash = OpenApiSchemaComparer.Instance.GetHashCode(anotherSchema);
+
+        // Assert
+        Assert.Equal(isEqual, hash.Equals(anotherHash));
+    }
+}

--- a/src/OpenApi/test/Comparers/OpenApiSchemaComparerTests.cs
+++ b/src/OpenApi/test/Comparers/OpenApiSchemaComparerTests.cs
@@ -97,4 +97,211 @@ public class OpenApiSchemaComparerTests
     [MemberData(nameof(SinglePropertyData))]
     public void ProducesCorrectEqualityForOpenApiSchema(OpenApiSchema schema, OpenApiSchema anotherSchema, bool isEqual)
         => Assert.Equal(isEqual, OpenApiSchemaComparer.Instance.Equals(schema, anotherSchema));
+
+    [Fact]
+    public void ValidatePropertiesOnOpenApiSchema()
+    {
+        var propertyNames = typeof(OpenApiSchema).GetProperties().Select(property => property.Name).ToList();
+        var originalSchema = new OpenApiSchema
+        {
+            AdditionalProperties = new OpenApiSchema(),
+            AdditionalPropertiesAllowed = true,
+            AllOf = [new OpenApiSchema()],
+            AnyOf = [new OpenApiSchema()],
+            Deprecated = true,
+            Default = new OpenApiString("default"),
+            Description = "description",
+            Discriminator = new OpenApiDiscriminator(),
+            Example = new OpenApiString("example"),
+            ExclusiveMaximum = true,
+            ExclusiveMinimum = true,
+            Extensions = new Dictionary<string, IOpenApiExtension>
+            {
+                ["key"] = new OpenApiString("value")
+            },
+            ExternalDocs = new OpenApiExternalDocs(),
+            Enum = [new OpenApiString("test")],
+            Format = "object",
+            Items = new OpenApiSchema(),
+            Maximum = 10,
+            MaxItems = 10,
+            MaxLength = 10,
+            MaxProperties = 10,
+            Minimum = 10,
+            MinItems = 10,
+            MinLength = 10,
+            MinProperties = 10,
+            MultipleOf = 10,
+            OneOf = [new OpenApiSchema()],
+            Not = new OpenApiSchema(),
+            Nullable = false,
+            Pattern = "pattern",
+            Properties = new Dictionary<string, OpenApiSchema> { ["name"] = new OpenApiSchema() },
+            ReadOnly = true,
+            Required = new HashSet<string> { "required" },
+            Reference = new OpenApiReference { Id = "Id", Type = ReferenceType.Schema },
+            UniqueItems = false,
+            UnresolvedReference = true,
+            WriteOnly = true,
+            Xml = new OpenApiXml { Name = "Name" },
+        };
+
+        OpenApiSchema modifiedSchema = new(originalSchema) { AdditionalProperties = new OpenApiSchema { Type = "string" } };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.AdditionalProperties)));
+
+        modifiedSchema = new(originalSchema) { AdditionalPropertiesAllowed = false };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.AdditionalPropertiesAllowed)));
+
+        modifiedSchema = new(originalSchema) { AllOf = [new OpenApiSchema { Type = "string" }] };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.AllOf)));
+
+        modifiedSchema = new(originalSchema) { AnyOf = [new OpenApiSchema { Type = "string" }] };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.AnyOf)));
+
+        modifiedSchema = new(originalSchema) { Deprecated = false };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.Deprecated)));
+
+        modifiedSchema = new(originalSchema) { Default = new OpenApiString("another default") };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.Default)));
+
+        modifiedSchema = new(originalSchema) { Description = "another description" };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.Description)));
+
+        modifiedSchema = new(originalSchema) { Discriminator = new OpenApiDiscriminator { PropertyName = "PropertyName" } };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.Discriminator)));
+
+        modifiedSchema = new(originalSchema) { Example = new OpenApiString("another example") };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.Example)));
+
+        modifiedSchema = new(originalSchema) { ExclusiveMaximum = false };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.ExclusiveMaximum)));
+
+        modifiedSchema = new(originalSchema) { ExclusiveMinimum = false };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.ExclusiveMinimum)));
+
+        modifiedSchema = new(originalSchema) { Extensions = new Dictionary<string, IOpenApiExtension> { ["key"] = new OpenApiString("another value") } };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.Extensions)));
+
+        modifiedSchema = new(originalSchema) { ExternalDocs = new OpenApiExternalDocs { Description = "another description" } };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.ExternalDocs)));
+
+        modifiedSchema = new(originalSchema) { Enum = [new OpenApiString("another test")] };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.Enum)));
+
+        modifiedSchema = new(originalSchema) { Format = "string" };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.Format)));
+
+        modifiedSchema = new(originalSchema) { Items = new OpenApiSchema { Type = "string" } };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.Items)));
+
+        modifiedSchema = new(originalSchema) { Maximum = 20 };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.Maximum)));
+
+        modifiedSchema = new(originalSchema) { MaxItems = 20 };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.MaxItems)));
+
+        modifiedSchema = new(originalSchema) { MaxLength = 20 };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.MaxLength)));
+
+        modifiedSchema = new(originalSchema) { MaxProperties = 20 };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.MaxProperties)));
+
+        modifiedSchema = new(originalSchema) { Minimum = 20 };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.Minimum)));
+
+        modifiedSchema = new(originalSchema) { MinItems = 20 };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.MinItems)));
+
+        modifiedSchema = new(originalSchema) { MinLength = 20 };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.MinLength)));
+
+        modifiedSchema = new(originalSchema) { MinProperties = 20 };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.MinProperties)));
+
+        modifiedSchema = new(originalSchema) { MultipleOf = 20 };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.MultipleOf)));
+
+        modifiedSchema = new(originalSchema) { OneOf = [new OpenApiSchema { Type = "string" }] };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.OneOf)));
+
+        modifiedSchema = new(originalSchema) { Not = new OpenApiSchema { Type = "string" } };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.Not)));
+
+        modifiedSchema = new(originalSchema) { Nullable = true };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.Nullable)));
+
+        modifiedSchema = new(originalSchema) { Pattern = "another pattern" };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.Pattern)));
+
+        modifiedSchema = new(originalSchema) { Properties = new Dictionary<string, OpenApiSchema> { ["name"] = new OpenApiSchema { Type = "integer" } } };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.Properties)));
+
+        modifiedSchema = new(originalSchema) { ReadOnly = false };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.ReadOnly)));
+
+        modifiedSchema = new(originalSchema) { Required = new HashSet<string> { "another required" } };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.Required)));
+
+        modifiedSchema = new(originalSchema) { Reference = new OpenApiReference { Id = "Another Id", Type = ReferenceType.Schema } };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.Reference)));
+
+        modifiedSchema = new(originalSchema) { Title = "Another Title" };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.Title)));
+
+        modifiedSchema = new(originalSchema) { Type = "integer" };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.Type)));
+
+        modifiedSchema = new(originalSchema) { UniqueItems = true };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.UniqueItems)));
+
+        modifiedSchema = new(originalSchema) { UnresolvedReference = false };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.UnresolvedReference)));
+
+        modifiedSchema = new(originalSchema) { WriteOnly = false };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.WriteOnly)));
+
+        modifiedSchema = new(originalSchema) { Xml = new OpenApiXml { Name = "Another Name" } };
+        Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
+        Assert.True(propertyNames.Remove(nameof(OpenApiSchema.Xml)));
+
+        Assert.Empty(propertyNames);
+    }
 }

--- a/src/OpenApi/test/Comparers/OpenApiXmlComparerTests.cs
+++ b/src/OpenApi/test/Comparers/OpenApiXmlComparerTests.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi.Models;
+
+public class OpenApiXmlComparerTests
+{
+    public static object[][] Data => [
+        [new OpenApiXml(), new OpenApiXml(), true],
+        [new OpenApiXml(), new OpenApiXml { Name = "name" }, false],
+        [new OpenApiXml { Name = "name" }, new OpenApiXml { Name = "name" }, true],
+        [new OpenApiXml { Name = "name" }, new OpenApiXml { Name = "name", Namespace = new Uri("http://localhost.com/namespace") }, false],
+        [new OpenApiXml { Name = "name", Namespace = new Uri("http://localhost.com/namespace") }, new OpenApiXml { Name = "name", Namespace = new Uri("http://localhost.com/namespace") }, true],
+        [new OpenApiXml { Name = "name", Namespace = new Uri("http://localhost.com/namespace") }, new OpenApiXml { Name = "name", Namespace = new Uri("http://localhost.com/namespace2") }, false],
+        [new OpenApiXml { Name = "name", Namespace = new Uri("http://localhost.com/namespace"), Prefix = "prefix" }, new OpenApiXml { Name = "name", Namespace = new Uri("http://localhost.com/namespace"), Prefix = "prefix" }, true],
+        [new OpenApiXml { Name = "name", Namespace = new Uri("http://localhost.com/namespace"), Prefix = "prefix" }, new OpenApiXml { Name = "name", Namespace = new Uri("http://localhost.com/namespace"), Prefix = "prefix2" }, false]
+    ];
+
+    [Theory]
+    [MemberData(nameof(Data))]
+    public void ProducesCorrectHashCodeForXml(OpenApiXml xml, OpenApiXml anotherXml, bool isEqual)
+    {
+        // Act
+        var hash = OpenApiXmlComparer.Instance.GetHashCode(xml);
+        var anotherHash = OpenApiXmlComparer.Instance.GetHashCode(anotherXml);
+
+        // Assert
+        Assert.Equal(isEqual, hash.Equals(anotherHash));
+    }
+}

--- a/src/OpenApi/test/Comparers/OpenApiXmlComparerTests.cs
+++ b/src/OpenApi/test/Comparers/OpenApiXmlComparerTests.cs
@@ -19,13 +19,6 @@ public class OpenApiXmlComparerTests
 
     [Theory]
     [MemberData(nameof(Data))]
-    public void ProducesCorrectHashCodeForXml(OpenApiXml xml, OpenApiXml anotherXml, bool isEqual)
-    {
-        // Act
-        var hash = OpenApiXmlComparer.Instance.GetHashCode(xml);
-        var anotherHash = OpenApiXmlComparer.Instance.GetHashCode(anotherXml);
-
-        // Assert
-        Assert.Equal(isEqual, hash.Equals(anotherHash));
-    }
+    public void ProducesCorrectEqualityForOpenApiXml(OpenApiXml xml, OpenApiXml anotherXml, bool isEqual)
+        => Assert.Equal(isEqual, OpenApiXmlComparer.Instance.Equals(xml, anotherXml));
 }

--- a/src/OpenApi/test/Extensions/JsonTypeInfoExtensionsTests.cs
+++ b/src/OpenApi/test/Extensions/JsonTypeInfoExtensionsTests.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO.Pipelines;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OpenApi;
+
+public class JsonTypeInfoExtensionsTests
+{
+    private delegate void TestDelegate(int x, int y);
+
+    private class Container
+    {
+        internal delegate void ContainedTestDelegate(int x, int y);
+    }
+
+    /// <summary>
+    /// This data is used to test the <see cref="TypeExtensions.GetSchemaReferenceId"/> method
+    /// which is used to generate reference IDs for OpenAPI schemas in the OpenAPI document.
+    /// <remarks>
+    /// Some things of note:
+    /// - For generic types, we generate the reference ID by appending the type arguments to the type name.
+    /// Our implementation currently supports versions of OpenAPI up to v3.0 which do not include support for
+    /// generic types in schemas. This means that generic types must be resolved to their concrete types before
+    /// being encoded in teh OpenAPI document.
+    /// - Array-like types (List, IEnumerable, etc.) are represented as "ArrayOf" followed by the type name of the
+    /// element type.
+    /// - Dictionary-list types are represented as "DictionaryOf" followed by the key type and the value type.
+    /// - Supported primitive types are mapped to their corresponding names (string, char, Uri, etc.).
+    /// </remarks>
+    /// </summary>
+    public static IEnumerable<object[]> GetSchemaReferenceId_Data =>
+    [
+        [typeof(Todo), "Todo"],
+        [typeof(IEnumerable<Todo>), "ArrayOfTodo"],
+        [typeof(List<Todo>), "ArrayOfTodo"],
+        [typeof(TodoWithDueDate), "TodoWithDueDate"],
+        [typeof(IEnumerable<TodoWithDueDate>), "ArrayOfTodoWithDueDate"],
+        [(new { Id = 1 }).GetType(), "AnonymousTypeOfint"],
+        [(new { Id = 1, Name = "Todo" }).GetType(), "AnonymousTypeOfintAndstring"],
+        [typeof(IFormFile), "IFormFile"],
+        [typeof(IFormFileCollection), "IFormFileCollection"],
+        [typeof(Stream), "Stream"],
+        [typeof(PipeReader), "PipeReader"],
+        [typeof(Results<Ok<TodoWithDueDate>, Ok<Todo>>), "ResultsOfOkOfTodoWithDueDateAndOkOfTodo"],
+        [typeof(Ok<Todo>), "OkOfTodo"],
+        [typeof(NotFound<TodoWithDueDate>), "NotFoundOfTodoWithDueDate"],
+        [typeof(TestDelegate), "TestDelegate"],
+        [typeof(Container.ContainedTestDelegate), "ContainedTestDelegate"],
+        [typeof(List<int>), "ArrayOfint"],
+        [typeof(List<List<int>>), "ArrayOfArrayOfint"],
+        [typeof(int[]), "ArrayOfint"],
+        [typeof(ValidationProblemDetails), "ValidationProblemDetails"],
+        [typeof(ProblemDetails), "ProblemDetails"],
+        [typeof(Dictionary<string, string[]>), "DictionaryOfstringAndArrayOfstring"],
+        [typeof(Dictionary<string, List<string[]>>), "DictionaryOfstringAndArrayOfArrayOfstring"],
+    ];
+
+    [Theory]
+    [MemberData(nameof(GetSchemaReferenceId_Data))]
+    public void GetSchemaReferenceId_Works(Type type, string referenceId)
+    {
+        var jsonTypeInfo = JsonSerializerOptions.Default.GetTypeInfo(type);
+        Assert.Equal(referenceId, jsonTypeInfo.GetSchemaReferenceId());
+    }
+}

--- a/src/OpenApi/test/Extensions/JsonTypeInfoExtensionsTests.cs
+++ b/src/OpenApi/test/Extensions/JsonTypeInfoExtensionsTests.cs
@@ -57,6 +57,7 @@ public class JsonTypeInfoExtensionsTests
         [typeof(ProblemDetails), "ProblemDetails"],
         [typeof(Dictionary<string, string[]>), "DictionaryOfstringAndArrayOfstring"],
         [typeof(Dictionary<string, List<string[]>>), "DictionaryOfstringAndArrayOfArrayOfstring"],
+        [typeof(Dictionary<string, IEnumerable<string[]>>), "DictionaryOfstringAndArrayOfArrayOfstring"],
     ];
 
     [Theory]

--- a/src/OpenApi/test/Integration/OpenApiDocumentIntegrationTests.cs
+++ b/src/OpenApi/test/Integration/OpenApiDocumentIntegrationTests.cs
@@ -14,8 +14,10 @@ public sealed class OpenApiDocumentIntegrationTests(SampleAppFixture fixture) : 
     [Theory]
     [InlineData("v1")]
     [InlineData("v2")]
+    [InlineData("controllers")]
     [InlineData("responses")]
     [InlineData("forms")]
+    [InlineData("schemas-by-ref")]
     public async Task VerifyOpenApiDocument(string documentName)
     {
         var documentService = fixture.Services.GetRequiredKeyedService<OpenApiDocumentService>(documentName);

--- a/src/OpenApi/test/Integration/OpenApiDocumentIntegrationTests.cs
+++ b/src/OpenApi/test/Integration/OpenApiDocumentIntegrationTests.cs
@@ -24,9 +24,6 @@ public sealed class OpenApiDocumentIntegrationTests(SampleAppFixture fixture) : 
             .UseDirectory(SkipOnHelixAttribute.OnHelix()
                 ? Path.Combine(Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT"), "Integration", "snapshots")
                 : "snapshots")
-            // Temporarily auto-verify snapshots in feature branch
-            // until we are able to create stable reference IDs.
-            .AutoVerify()
             .UseParameters(documentName);
     }
 

--- a/src/OpenApi/test/Integration/OpenApiDocumentIntegrationTests.cs
+++ b/src/OpenApi/test/Integration/OpenApiDocumentIntegrationTests.cs
@@ -24,6 +24,9 @@ public sealed class OpenApiDocumentIntegrationTests(SampleAppFixture fixture) : 
             .UseDirectory(SkipOnHelixAttribute.OnHelix()
                 ? Path.Combine(Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT"), "Integration", "snapshots")
                 : "snapshots")
+            // Temporarily auto-verify snapshots in feature branch
+            // until we are able to create stable reference IDs.
+            .AutoVerify()
             .UseParameters(documentName);
     }
 

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=controllers.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=controllers.verified.txt
@@ -1,0 +1,111 @@
+﻿{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Sample | controllers",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/getbyidandname/{id}/{name}": {
+      "get": {
+        "tags": [
+          "Test"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "Name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/string2"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/string"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forms": {
+      "post": {
+        "tags": [
+          "Test"
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "Title": {
+                    "$ref": "#/components/schemas/string2"
+                  },
+                  "Description": {
+                    "$ref": "#/components/schemas/string2"
+                  },
+                  "IsCompleted": {
+                    "type": "boolean"
+                  }
+                }
+              },
+              "encoding": {
+                "application/x-www-form-urlencoded": {
+                  "style": "form",
+                  "explode": true
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "string": {
+        "type": "string"
+      },
+      "string2": {
+        "minLength": 5,
+        "type": "string"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Test"
+    }
+  ]
+}

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=forms.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=forms.verified.txt
@@ -17,8 +17,7 @@
                 "type": "object",
                 "properties": {
                   "resume": {
-                    "type": "string",
-                    "format": "binary"
+                    "$ref": "#/components/schemas/b5c4d621-6147-4b3c-9183-797cc94b0b90"
                   }
                 }
               },
@@ -51,11 +50,7 @@
                 "type": "object",
                 "properties": {
                   "files": {
-                    "type": "array",
-                    "items": {
-                      "type": "string",
-                      "format": "binary"
-                    }
+                    "$ref": "#/components/schemas/43abe0ce-2064-47ee-a04e-92b9e339e2d0"
                   }
                 }
               },
@@ -91,8 +86,7 @@
                     "type": "object",
                     "properties": {
                       "resume": {
-                        "type": "string",
-                        "format": "binary"
+                        "$ref": "#/components/schemas/b5c4d621-6147-4b3c-9183-797cc94b0b90"
                       }
                     }
                   },
@@ -100,11 +94,7 @@
                     "type": "object",
                     "properties": {
                       "files": {
-                        "type": "array",
-                        "items": {
-                          "type": "string",
-                          "format": "binary"
-                        }
+                        "$ref": "#/components/schemas/43abe0ce-2064-47ee-a04e-92b9e339e2d0"
                       }
                     }
                   }
@@ -136,29 +126,7 @@
           "content": {
             "multipart/form-data": {
               "schema": {
-                "required": [
-                  "id",
-                  "title",
-                  "completed",
-                  "createdAt"
-                ],
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "integer",
-                    "format": "int32"
-                  },
-                  "title": {
-                    "type": "string"
-                  },
-                  "completed": {
-                    "type": "boolean"
-                  },
-                  "createdAt": {
-                    "type": "string",
-                    "format": "date-time"
-                  }
-                }
+                "$ref": "#/components/schemas/69541eec-e82b-4392-8324-c696248e07c0"
               },
               "encoding": {
                 "multipart/form-data": {
@@ -169,29 +137,7 @@
             },
             "application/x-www-form-urlencoded": {
               "schema": {
-                "required": [
-                  "id",
-                  "title",
-                  "completed",
-                  "createdAt"
-                ],
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "integer",
-                    "format": "int32"
-                  },
-                  "title": {
-                    "type": "string"
-                  },
-                  "completed": {
-                    "type": "boolean"
-                  },
-                  "createdAt": {
-                    "type": "string",
-                    "format": "date-time"
-                  }
-                }
+                "$ref": "#/components/schemas/69541eec-e82b-4392-8324-c696248e07c0"
               },
               "encoding": {
                 "application/x-www-form-urlencoded": {
@@ -222,36 +168,13 @@
                 "type": "object",
                 "allOf": [
                   {
-                    "required": [
-                      "id",
-                      "title",
-                      "completed",
-                      "createdAt"
-                    ],
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "integer",
-                        "format": "int32"
-                      },
-                      "title": {
-                        "type": "string"
-                      },
-                      "completed": {
-                        "type": "boolean"
-                      },
-                      "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                      }
-                    }
+                    "$ref": "#/components/schemas/69541eec-e82b-4392-8324-c696248e07c0"
                   },
                   {
                     "type": "object",
                     "properties": {
                       "file": {
-                        "type": "string",
-                        "format": "binary"
+                        "$ref": "#/components/schemas/b5c4d621-6147-4b3c-9183-797cc94b0b90"
                       }
                     }
                   }
@@ -285,8 +208,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "$ref": "#/components/schemas/395e233d-7ba6-45e8-8d53-07aad3af95c5"
             }
           },
           {
@@ -294,8 +216,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "minLength": 5,
-              "type": "string"
+              "$ref": "#/components/schemas/41b5b17c-34e3-4b89-822f-7c899d59eba1"
             }
           }
         ],
@@ -305,17 +226,17 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/d62756ca-447d-4421-b74e-0cc897ceba2c"
                 }
               },
               "application/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/d62756ca-447d-4421-b74e-0cc897ceba2c"
                 }
               },
               "text/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/d62756ca-447d-4421-b74e-0cc897ceba2c"
                 }
               }
             }
@@ -335,15 +256,13 @@
                 "type": "object",
                 "properties": {
                   "Title": {
-                    "minLength": 5,
-                    "type": "string"
+                    "$ref": "#/components/schemas/41b5b17c-34e3-4b89-822f-7c899d59eba1"
                   },
                   "Description": {
-                    "minLength": 5,
-                    "type": "string"
+                    "$ref": "#/components/schemas/41b5b17c-34e3-4b89-822f-7c899d59eba1"
                   },
                   "IsCompleted": {
-                    "type": "boolean"
+                    "$ref": "#/components/schemas/94f0c04a-6ff5-41d5-b397-755acf944974"
                   }
                 }
               },
@@ -361,6 +280,61 @@
             "description": "OK"
           }
         }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "395e233d-7ba6-45e8-8d53-07aad3af95c5": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "41b5b17c-34e3-4b89-822f-7c899d59eba1": {
+        "minLength": 5,
+        "type": "string"
+      },
+      "43abe0ce-2064-47ee-a04e-92b9e339e2d0": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/b5c4d621-6147-4b3c-9183-797cc94b0b90"
+        }
+      },
+      "69541eec-e82b-4392-8324-c696248e07c0": {
+        "required": [
+          "id",
+          "title",
+          "completed",
+          "createdAt"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/395e233d-7ba6-45e8-8d53-07aad3af95c5"
+          },
+          "title": {
+            "$ref": "#/components/schemas/d62756ca-447d-4421-b74e-0cc897ceba2c"
+          },
+          "completed": {
+            "$ref": "#/components/schemas/94f0c04a-6ff5-41d5-b397-755acf944974"
+          },
+          "createdAt": {
+            "$ref": "#/components/schemas/c4406a75-b67c-4349-a3c2-a6e9db4dbd3f"
+          }
+        }
+      },
+      "94f0c04a-6ff5-41d5-b397-755acf944974": {
+        "type": "boolean"
+      },
+      "b5c4d621-6147-4b3c-9183-797cc94b0b90": {
+        "type": "string",
+        "format": "binary"
+      },
+      "c4406a75-b67c-4349-a3c2-a6e9db4dbd3f": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "d62756ca-447d-4421-b74e-0cc897ceba2c": {
+        "type": "string"
       }
     }
   },

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=forms.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=forms.verified.txt
@@ -196,91 +196,6 @@
           }
         }
       }
-    },
-    "/getbyidandname/{id}/{name}": {
-      "get": {
-        "tags": [
-          "Test"
-        ],
-        "parameters": [
-          {
-            "name": "Id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/int"
-            }
-          },
-          {
-            "name": "Name",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/string1"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/string"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/string"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/forms": {
-      "post": {
-        "tags": [
-          "Test"
-        ],
-        "requestBody": {
-          "content": {
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "Title": {
-                    "$ref": "#/components/schemas/string1"
-                  },
-                  "Description": {
-                    "$ref": "#/components/schemas/string1"
-                  },
-                  "IsCompleted": {
-                    "$ref": "#/components/schemas/boolean"
-                  }
-                }
-              },
-              "encoding": {
-                "application/x-www-form-urlencoded": {
-                  "style": "form",
-                  "explode": true
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
     }
   },
   "components": {
@@ -307,10 +222,6 @@
         "format": "int32"
       },
       "string": {
-        "type": "string"
-      },
-      "string1": {
-        "minLength": 5,
         "type": "string"
       },
       "Todo": {
@@ -341,9 +252,6 @@
   "tags": [
     {
       "name": "Sample"
-    },
-    {
-      "name": "Test"
     }
   ]
 }

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=forms.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=forms.verified.txt
@@ -17,7 +17,7 @@
                 "type": "object",
                 "properties": {
                   "resume": {
-                    "$ref": "#/components/schemas/a3557adb-bc64-4243-ad54-f48dcead08cf"
+                    "$ref": "#/components/schemas/IFormFile"
                   }
                 }
               },
@@ -50,7 +50,7 @@
                 "type": "object",
                 "properties": {
                   "files": {
-                    "$ref": "#/components/schemas/2a130426-7885-4e3e-a9d0-cc25e749c2c4"
+                    "$ref": "#/components/schemas/IFormFileCollection"
                   }
                 }
               },
@@ -86,7 +86,7 @@
                     "type": "object",
                     "properties": {
                       "resume": {
-                        "$ref": "#/components/schemas/a3557adb-bc64-4243-ad54-f48dcead08cf"
+                        "$ref": "#/components/schemas/IFormFile"
                       }
                     }
                   },
@@ -94,7 +94,7 @@
                     "type": "object",
                     "properties": {
                       "files": {
-                        "$ref": "#/components/schemas/2a130426-7885-4e3e-a9d0-cc25e749c2c4"
+                        "$ref": "#/components/schemas/IFormFileCollection"
                       }
                     }
                   }
@@ -126,7 +126,7 @@
           "content": {
             "multipart/form-data": {
               "schema": {
-                "$ref": "#/components/schemas/64d9d265-681d-406c-9ed4-45b24cba246e"
+                "$ref": "#/components/schemas/Todo"
               },
               "encoding": {
                 "multipart/form-data": {
@@ -137,7 +137,7 @@
             },
             "application/x-www-form-urlencoded": {
               "schema": {
-                "$ref": "#/components/schemas/64d9d265-681d-406c-9ed4-45b24cba246e"
+                "$ref": "#/components/schemas/Todo"
               },
               "encoding": {
                 "application/x-www-form-urlencoded": {
@@ -168,13 +168,13 @@
                 "type": "object",
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/64d9d265-681d-406c-9ed4-45b24cba246e"
+                    "$ref": "#/components/schemas/Todo"
                   },
                   {
                     "type": "object",
                     "properties": {
                       "file": {
-                        "$ref": "#/components/schemas/a3557adb-bc64-4243-ad54-f48dcead08cf"
+                        "$ref": "#/components/schemas/IFormFile"
                       }
                     }
                   }
@@ -208,7 +208,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/ebd68d78-03c3-4749-b0df-5378b1fc903a"
+              "$ref": "#/components/schemas/int"
             }
           },
           {
@@ -216,7 +216,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/59fe5d7e-ccb3-4651-882b-1d5995a4d0f4"
+              "$ref": "#/components/schemas/string1"
             }
           }
         ],
@@ -226,17 +226,17 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/9f4fb524-da71-49bb-9611-5c2734b4597c"
+                  "$ref": "#/components/schemas/string"
                 }
               },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/9f4fb524-da71-49bb-9611-5c2734b4597c"
+                  "$ref": "#/components/schemas/string"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/9f4fb524-da71-49bb-9611-5c2734b4597c"
+                  "$ref": "#/components/schemas/string"
                 }
               }
             }
@@ -256,13 +256,13 @@
                 "type": "object",
                 "properties": {
                   "Title": {
-                    "$ref": "#/components/schemas/59fe5d7e-ccb3-4651-882b-1d5995a4d0f4"
+                    "$ref": "#/components/schemas/string1"
                   },
                   "Description": {
-                    "$ref": "#/components/schemas/59fe5d7e-ccb3-4651-882b-1d5995a4d0f4"
+                    "$ref": "#/components/schemas/string1"
                   },
                   "IsCompleted": {
-                    "$ref": "#/components/schemas/649e6d0e-0974-4050-85ab-1549ad6aa913"
+                    "$ref": "#/components/schemas/boolean"
                   }
                 }
               },
@@ -285,20 +285,35 @@
   },
   "components": {
     "schemas": {
-      "2a130426-7885-4e3e-a9d0-cc25e749c2c4": {
+      "boolean": {
+        "type": "boolean"
+      },
+      "DateTime": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "IFormFile": {
+        "type": "string",
+        "format": "binary"
+      },
+      "IFormFileCollection": {
         "type": "array",
         "items": {
-          "$ref": "#/components/schemas/a3557adb-bc64-4243-ad54-f48dcead08cf"
+          "$ref": "#/components/schemas/IFormFile"
         }
       },
-      "59fe5d7e-ccb3-4651-882b-1d5995a4d0f4": {
+      "int": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "string": {
+        "type": "string"
+      },
+      "string1": {
         "minLength": 5,
         "type": "string"
       },
-      "649e6d0e-0974-4050-85ab-1549ad6aa913": {
-        "type": "boolean"
-      },
-      "64d9d265-681d-406c-9ed4-45b24cba246e": {
+      "Todo": {
         "required": [
           "id",
           "title",
@@ -308,33 +323,18 @@
         "type": "object",
         "properties": {
           "id": {
-            "$ref": "#/components/schemas/ebd68d78-03c3-4749-b0df-5378b1fc903a"
+            "$ref": "#/components/schemas/int"
           },
           "title": {
-            "$ref": "#/components/schemas/9f4fb524-da71-49bb-9611-5c2734b4597c"
+            "$ref": "#/components/schemas/string"
           },
           "completed": {
-            "$ref": "#/components/schemas/649e6d0e-0974-4050-85ab-1549ad6aa913"
+            "$ref": "#/components/schemas/boolean"
           },
           "createdAt": {
-            "$ref": "#/components/schemas/ff0058d0-c4f1-4595-93ce-138cef4d0ffc"
+            "$ref": "#/components/schemas/DateTime"
           }
         }
-      },
-      "9f4fb524-da71-49bb-9611-5c2734b4597c": {
-        "type": "string"
-      },
-      "a3557adb-bc64-4243-ad54-f48dcead08cf": {
-        "type": "string",
-        "format": "binary"
-      },
-      "ebd68d78-03c3-4749-b0df-5378b1fc903a": {
-        "type": "integer",
-        "format": "int32"
-      },
-      "ff0058d0-c4f1-4595-93ce-138cef4d0ffc": {
-        "type": "string",
-        "format": "date-time"
       }
     }
   },

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=forms.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=forms.verified.txt
@@ -17,7 +17,7 @@
                 "type": "object",
                 "properties": {
                   "resume": {
-                    "$ref": "#/components/schemas/b5c4d621-6147-4b3c-9183-797cc94b0b90"
+                    "$ref": "#/components/schemas/a3557adb-bc64-4243-ad54-f48dcead08cf"
                   }
                 }
               },
@@ -50,7 +50,7 @@
                 "type": "object",
                 "properties": {
                   "files": {
-                    "$ref": "#/components/schemas/43abe0ce-2064-47ee-a04e-92b9e339e2d0"
+                    "$ref": "#/components/schemas/2a130426-7885-4e3e-a9d0-cc25e749c2c4"
                   }
                 }
               },
@@ -86,7 +86,7 @@
                     "type": "object",
                     "properties": {
                       "resume": {
-                        "$ref": "#/components/schemas/b5c4d621-6147-4b3c-9183-797cc94b0b90"
+                        "$ref": "#/components/schemas/a3557adb-bc64-4243-ad54-f48dcead08cf"
                       }
                     }
                   },
@@ -94,7 +94,7 @@
                     "type": "object",
                     "properties": {
                       "files": {
-                        "$ref": "#/components/schemas/43abe0ce-2064-47ee-a04e-92b9e339e2d0"
+                        "$ref": "#/components/schemas/2a130426-7885-4e3e-a9d0-cc25e749c2c4"
                       }
                     }
                   }
@@ -126,7 +126,7 @@
           "content": {
             "multipart/form-data": {
               "schema": {
-                "$ref": "#/components/schemas/69541eec-e82b-4392-8324-c696248e07c0"
+                "$ref": "#/components/schemas/64d9d265-681d-406c-9ed4-45b24cba246e"
               },
               "encoding": {
                 "multipart/form-data": {
@@ -137,7 +137,7 @@
             },
             "application/x-www-form-urlencoded": {
               "schema": {
-                "$ref": "#/components/schemas/69541eec-e82b-4392-8324-c696248e07c0"
+                "$ref": "#/components/schemas/64d9d265-681d-406c-9ed4-45b24cba246e"
               },
               "encoding": {
                 "application/x-www-form-urlencoded": {
@@ -168,13 +168,13 @@
                 "type": "object",
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/69541eec-e82b-4392-8324-c696248e07c0"
+                    "$ref": "#/components/schemas/64d9d265-681d-406c-9ed4-45b24cba246e"
                   },
                   {
                     "type": "object",
                     "properties": {
                       "file": {
-                        "$ref": "#/components/schemas/b5c4d621-6147-4b3c-9183-797cc94b0b90"
+                        "$ref": "#/components/schemas/a3557adb-bc64-4243-ad54-f48dcead08cf"
                       }
                     }
                   }
@@ -208,7 +208,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/395e233d-7ba6-45e8-8d53-07aad3af95c5"
+              "$ref": "#/components/schemas/ebd68d78-03c3-4749-b0df-5378b1fc903a"
             }
           },
           {
@@ -216,7 +216,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/41b5b17c-34e3-4b89-822f-7c899d59eba1"
+              "$ref": "#/components/schemas/59fe5d7e-ccb3-4651-882b-1d5995a4d0f4"
             }
           }
         ],
@@ -226,17 +226,17 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/d62756ca-447d-4421-b74e-0cc897ceba2c"
+                  "$ref": "#/components/schemas/9f4fb524-da71-49bb-9611-5c2734b4597c"
                 }
               },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/d62756ca-447d-4421-b74e-0cc897ceba2c"
+                  "$ref": "#/components/schemas/9f4fb524-da71-49bb-9611-5c2734b4597c"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/d62756ca-447d-4421-b74e-0cc897ceba2c"
+                  "$ref": "#/components/schemas/9f4fb524-da71-49bb-9611-5c2734b4597c"
                 }
               }
             }
@@ -256,13 +256,13 @@
                 "type": "object",
                 "properties": {
                   "Title": {
-                    "$ref": "#/components/schemas/41b5b17c-34e3-4b89-822f-7c899d59eba1"
+                    "$ref": "#/components/schemas/59fe5d7e-ccb3-4651-882b-1d5995a4d0f4"
                   },
                   "Description": {
-                    "$ref": "#/components/schemas/41b5b17c-34e3-4b89-822f-7c899d59eba1"
+                    "$ref": "#/components/schemas/59fe5d7e-ccb3-4651-882b-1d5995a4d0f4"
                   },
                   "IsCompleted": {
-                    "$ref": "#/components/schemas/94f0c04a-6ff5-41d5-b397-755acf944974"
+                    "$ref": "#/components/schemas/649e6d0e-0974-4050-85ab-1549ad6aa913"
                   }
                 }
               },
@@ -285,21 +285,20 @@
   },
   "components": {
     "schemas": {
-      "395e233d-7ba6-45e8-8d53-07aad3af95c5": {
-        "type": "integer",
-        "format": "int32"
+      "2a130426-7885-4e3e-a9d0-cc25e749c2c4": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/a3557adb-bc64-4243-ad54-f48dcead08cf"
+        }
       },
-      "41b5b17c-34e3-4b89-822f-7c899d59eba1": {
+      "59fe5d7e-ccb3-4651-882b-1d5995a4d0f4": {
         "minLength": 5,
         "type": "string"
       },
-      "43abe0ce-2064-47ee-a04e-92b9e339e2d0": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/b5c4d621-6147-4b3c-9183-797cc94b0b90"
-        }
+      "649e6d0e-0974-4050-85ab-1549ad6aa913": {
+        "type": "boolean"
       },
-      "69541eec-e82b-4392-8324-c696248e07c0": {
+      "64d9d265-681d-406c-9ed4-45b24cba246e": {
         "required": [
           "id",
           "title",
@@ -309,32 +308,33 @@
         "type": "object",
         "properties": {
           "id": {
-            "$ref": "#/components/schemas/395e233d-7ba6-45e8-8d53-07aad3af95c5"
+            "$ref": "#/components/schemas/ebd68d78-03c3-4749-b0df-5378b1fc903a"
           },
           "title": {
-            "$ref": "#/components/schemas/d62756ca-447d-4421-b74e-0cc897ceba2c"
+            "$ref": "#/components/schemas/9f4fb524-da71-49bb-9611-5c2734b4597c"
           },
           "completed": {
-            "$ref": "#/components/schemas/94f0c04a-6ff5-41d5-b397-755acf944974"
+            "$ref": "#/components/schemas/649e6d0e-0974-4050-85ab-1549ad6aa913"
           },
           "createdAt": {
-            "$ref": "#/components/schemas/c4406a75-b67c-4349-a3c2-a6e9db4dbd3f"
+            "$ref": "#/components/schemas/ff0058d0-c4f1-4595-93ce-138cef4d0ffc"
           }
         }
       },
-      "94f0c04a-6ff5-41d5-b397-755acf944974": {
-        "type": "boolean"
+      "9f4fb524-da71-49bb-9611-5c2734b4597c": {
+        "type": "string"
       },
-      "b5c4d621-6147-4b3c-9183-797cc94b0b90": {
+      "a3557adb-bc64-4243-ad54-f48dcead08cf": {
         "type": "string",
         "format": "binary"
       },
-      "c4406a75-b67c-4349-a3c2-a6e9db4dbd3f": {
+      "ebd68d78-03c3-4749-b0df-5378b1fc903a": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "ff0058d0-c4f1-4595-93ce-138cef4d0ffc": {
         "type": "string",
         "format": "date-time"
-      },
-      "d62756ca-447d-4421-b74e-0cc897ceba2c": {
-        "type": "string"
       }
     }
   },

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=responses.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=responses.verified.txt
@@ -16,56 +16,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "required": [
-                    "id",
-                    "title",
-                    "completed",
-                    "createdAt"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "integer",
-                      "format": "int32"
-                    },
-                    "title": {
-                      "type": "string"
-                    },
-                    "completed": {
-                      "type": "boolean"
-                    },
-                    "createdAt": {
-                      "type": "string",
-                      "format": "date-time"
-                    }
-                  }
+                  "$ref": "#/components/schemas/cb67bf5c-0a17-455a-acb9-4324f99bcf05"
                 }
               },
               "text/xml": {
                 "schema": {
-                  "required": [
-                    "id",
-                    "title",
-                    "completed",
-                    "createdAt"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "integer",
-                      "format": "int32"
-                    },
-                    "title": {
-                      "type": "string"
-                    },
-                    "completed": {
-                      "type": "boolean"
-                    },
-                    "createdAt": {
-                      "type": "string",
-                      "format": "date-time"
-                    }
-                  }
+                  "$ref": "#/components/schemas/cb67bf5c-0a17-455a-acb9-4324f99bcf05"
                 }
               }
             }
@@ -84,29 +40,7 @@
             "content": {
               "text/xml": {
                 "schema": {
-                  "required": [
-                    "id",
-                    "title",
-                    "completed",
-                    "createdAt"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "integer",
-                      "format": "int32"
-                    },
-                    "title": {
-                      "type": "string"
-                    },
-                    "completed": {
-                      "type": "boolean"
-                    },
-                    "createdAt": {
-                      "type": "string",
-                      "format": "date-time"
-                    }
-                  }
+                  "$ref": "#/components/schemas/cb67bf5c-0a17-455a-acb9-4324f99bcf05"
                 }
               }
             }
@@ -186,8 +120,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "$ref": "#/components/schemas/39e70582-872d-45e8-b883-3a021018394a"
             }
           },
           {
@@ -195,8 +128,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "minLength": 5,
-              "type": "string"
+              "$ref": "#/components/schemas/cd7ce4a8-6fcf-4809-96a3-bc50d89c8c6f"
             }
           }
         ],
@@ -206,17 +138,17 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/74741e12-6b04-4edc-b754-502097062da4"
                 }
               },
               "application/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/74741e12-6b04-4edc-b754-502097062da4"
                 }
               },
               "text/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/74741e12-6b04-4edc-b754-502097062da4"
                 }
               }
             }
@@ -236,15 +168,13 @@
                 "type": "object",
                 "properties": {
                   "Title": {
-                    "minLength": 5,
-                    "type": "string"
+                    "$ref": "#/components/schemas/cd7ce4a8-6fcf-4809-96a3-bc50d89c8c6f"
                   },
                   "Description": {
-                    "minLength": 5,
-                    "type": "string"
+                    "$ref": "#/components/schemas/cd7ce4a8-6fcf-4809-96a3-bc50d89c8c6f"
                   },
                   "IsCompleted": {
-                    "type": "boolean"
+                    "$ref": "#/components/schemas/aa370fa4-9eb6-4ae7-9e62-3b994cdc809d"
                   }
                 }
               },
@@ -262,6 +192,51 @@
             "description": "OK"
           }
         }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "39e70582-872d-45e8-b883-3a021018394a": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "74741e12-6b04-4edc-b754-502097062da4": {
+        "type": "string"
+      },
+      "aa370fa4-9eb6-4ae7-9e62-3b994cdc809d": {
+        "type": "boolean"
+      },
+      "b0b73dc2-38d9-4a4e-8611-ea29ce2b6a43": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "cb67bf5c-0a17-455a-acb9-4324f99bcf05": {
+        "required": [
+          "id",
+          "title",
+          "completed",
+          "createdAt"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/39e70582-872d-45e8-b883-3a021018394a"
+          },
+          "title": {
+            "$ref": "#/components/schemas/74741e12-6b04-4edc-b754-502097062da4"
+          },
+          "completed": {
+            "$ref": "#/components/schemas/aa370fa4-9eb6-4ae7-9e62-3b994cdc809d"
+          },
+          "createdAt": {
+            "$ref": "#/components/schemas/b0b73dc2-38d9-4a4e-8611-ea29ce2b6a43"
+          }
+        }
+      },
+      "cd7ce4a8-6fcf-4809-96a3-bc50d89c8c6f": {
+        "minLength": 5,
+        "type": "string"
       }
     }
   },

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=responses.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=responses.verified.txt
@@ -16,12 +16,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/37898816-ec65-4bb1-a098-3ff86636df9a"
+                  "$ref": "#/components/schemas/Todo"
                 }
               },
               "text/xml": {
                 "schema": {
-                  "$ref": "#/components/schemas/37898816-ec65-4bb1-a098-3ff86636df9a"
+                  "$ref": "#/components/schemas/Todo"
                 }
               }
             }
@@ -40,7 +40,7 @@
             "content": {
               "text/xml": {
                 "schema": {
-                  "$ref": "#/components/schemas/37898816-ec65-4bb1-a098-3ff86636df9a"
+                  "$ref": "#/components/schemas/Todo"
                 }
               }
             }
@@ -120,7 +120,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/418e62b5-c70b-45ce-90d8-d0f996477bf3"
+              "$ref": "#/components/schemas/int"
             }
           },
           {
@@ -128,7 +128,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/cfbf5f45-19c8-4966-abe3-fe450b7bbd85"
+              "$ref": "#/components/schemas/string1"
             }
           }
         ],
@@ -138,17 +138,17 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/55e8699a-a482-4daa-b66e-5251d7dd5867"
+                  "$ref": "#/components/schemas/string"
                 }
               },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/55e8699a-a482-4daa-b66e-5251d7dd5867"
+                  "$ref": "#/components/schemas/string"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/55e8699a-a482-4daa-b66e-5251d7dd5867"
+                  "$ref": "#/components/schemas/string"
                 }
               }
             }
@@ -168,13 +168,13 @@
                 "type": "object",
                 "properties": {
                   "Title": {
-                    "$ref": "#/components/schemas/cfbf5f45-19c8-4966-abe3-fe450b7bbd85"
+                    "$ref": "#/components/schemas/string1"
                   },
                   "Description": {
-                    "$ref": "#/components/schemas/cfbf5f45-19c8-4966-abe3-fe450b7bbd85"
+                    "$ref": "#/components/schemas/string1"
                   },
                   "IsCompleted": {
-                    "$ref": "#/components/schemas/25c6fa13-0f52-45c8-b965-c671fc24db07"
+                    "$ref": "#/components/schemas/boolean"
                   }
                 }
               },
@@ -197,10 +197,25 @@
   },
   "components": {
     "schemas": {
-      "25c6fa13-0f52-45c8-b965-c671fc24db07": {
+      "boolean": {
         "type": "boolean"
       },
-      "37898816-ec65-4bb1-a098-3ff86636df9a": {
+      "DateTime": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "int": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "string": {
+        "type": "string"
+      },
+      "string1": {
+        "minLength": 5,
+        "type": "string"
+      },
+      "Todo": {
         "required": [
           "id",
           "title",
@@ -210,33 +225,18 @@
         "type": "object",
         "properties": {
           "id": {
-            "$ref": "#/components/schemas/418e62b5-c70b-45ce-90d8-d0f996477bf3"
+            "$ref": "#/components/schemas/int"
           },
           "title": {
-            "$ref": "#/components/schemas/55e8699a-a482-4daa-b66e-5251d7dd5867"
+            "$ref": "#/components/schemas/string"
           },
           "completed": {
-            "$ref": "#/components/schemas/25c6fa13-0f52-45c8-b965-c671fc24db07"
+            "$ref": "#/components/schemas/boolean"
           },
           "createdAt": {
-            "$ref": "#/components/schemas/5ed0503d-2416-4dfc-b7f5-823376cd0b31"
+            "$ref": "#/components/schemas/DateTime"
           }
         }
-      },
-      "418e62b5-c70b-45ce-90d8-d0f996477bf3": {
-        "type": "integer",
-        "format": "int32"
-      },
-      "55e8699a-a482-4daa-b66e-5251d7dd5867": {
-        "type": "string"
-      },
-      "5ed0503d-2416-4dfc-b7f5-823376cd0b31": {
-        "type": "string",
-        "format": "date-time"
-      },
-      "cfbf5f45-19c8-4966-abe3-fe450b7bbd85": {
-        "minLength": 5,
-        "type": "string"
       }
     }
   },

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=responses.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=responses.verified.txt
@@ -16,12 +16,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/cb67bf5c-0a17-455a-acb9-4324f99bcf05"
+                  "$ref": "#/components/schemas/37898816-ec65-4bb1-a098-3ff86636df9a"
                 }
               },
               "text/xml": {
                 "schema": {
-                  "$ref": "#/components/schemas/cb67bf5c-0a17-455a-acb9-4324f99bcf05"
+                  "$ref": "#/components/schemas/37898816-ec65-4bb1-a098-3ff86636df9a"
                 }
               }
             }
@@ -40,7 +40,7 @@
             "content": {
               "text/xml": {
                 "schema": {
-                  "$ref": "#/components/schemas/cb67bf5c-0a17-455a-acb9-4324f99bcf05"
+                  "$ref": "#/components/schemas/37898816-ec65-4bb1-a098-3ff86636df9a"
                 }
               }
             }
@@ -120,7 +120,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/39e70582-872d-45e8-b883-3a021018394a"
+              "$ref": "#/components/schemas/418e62b5-c70b-45ce-90d8-d0f996477bf3"
             }
           },
           {
@@ -128,7 +128,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/cd7ce4a8-6fcf-4809-96a3-bc50d89c8c6f"
+              "$ref": "#/components/schemas/cfbf5f45-19c8-4966-abe3-fe450b7bbd85"
             }
           }
         ],
@@ -138,17 +138,17 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/74741e12-6b04-4edc-b754-502097062da4"
+                  "$ref": "#/components/schemas/55e8699a-a482-4daa-b66e-5251d7dd5867"
                 }
               },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/74741e12-6b04-4edc-b754-502097062da4"
+                  "$ref": "#/components/schemas/55e8699a-a482-4daa-b66e-5251d7dd5867"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/74741e12-6b04-4edc-b754-502097062da4"
+                  "$ref": "#/components/schemas/55e8699a-a482-4daa-b66e-5251d7dd5867"
                 }
               }
             }
@@ -168,13 +168,13 @@
                 "type": "object",
                 "properties": {
                   "Title": {
-                    "$ref": "#/components/schemas/cd7ce4a8-6fcf-4809-96a3-bc50d89c8c6f"
+                    "$ref": "#/components/schemas/cfbf5f45-19c8-4966-abe3-fe450b7bbd85"
                   },
                   "Description": {
-                    "$ref": "#/components/schemas/cd7ce4a8-6fcf-4809-96a3-bc50d89c8c6f"
+                    "$ref": "#/components/schemas/cfbf5f45-19c8-4966-abe3-fe450b7bbd85"
                   },
                   "IsCompleted": {
-                    "$ref": "#/components/schemas/aa370fa4-9eb6-4ae7-9e62-3b994cdc809d"
+                    "$ref": "#/components/schemas/25c6fa13-0f52-45c8-b965-c671fc24db07"
                   }
                 }
               },
@@ -197,21 +197,10 @@
   },
   "components": {
     "schemas": {
-      "39e70582-872d-45e8-b883-3a021018394a": {
-        "type": "integer",
-        "format": "int32"
-      },
-      "74741e12-6b04-4edc-b754-502097062da4": {
-        "type": "string"
-      },
-      "aa370fa4-9eb6-4ae7-9e62-3b994cdc809d": {
+      "25c6fa13-0f52-45c8-b965-c671fc24db07": {
         "type": "boolean"
       },
-      "b0b73dc2-38d9-4a4e-8611-ea29ce2b6a43": {
-        "type": "string",
-        "format": "date-time"
-      },
-      "cb67bf5c-0a17-455a-acb9-4324f99bcf05": {
+      "37898816-ec65-4bb1-a098-3ff86636df9a": {
         "required": [
           "id",
           "title",
@@ -221,20 +210,31 @@
         "type": "object",
         "properties": {
           "id": {
-            "$ref": "#/components/schemas/39e70582-872d-45e8-b883-3a021018394a"
+            "$ref": "#/components/schemas/418e62b5-c70b-45ce-90d8-d0f996477bf3"
           },
           "title": {
-            "$ref": "#/components/schemas/74741e12-6b04-4edc-b754-502097062da4"
+            "$ref": "#/components/schemas/55e8699a-a482-4daa-b66e-5251d7dd5867"
           },
           "completed": {
-            "$ref": "#/components/schemas/aa370fa4-9eb6-4ae7-9e62-3b994cdc809d"
+            "$ref": "#/components/schemas/25c6fa13-0f52-45c8-b965-c671fc24db07"
           },
           "createdAt": {
-            "$ref": "#/components/schemas/b0b73dc2-38d9-4a4e-8611-ea29ce2b6a43"
+            "$ref": "#/components/schemas/5ed0503d-2416-4dfc-b7f5-823376cd0b31"
           }
         }
       },
-      "cd7ce4a8-6fcf-4809-96a3-bc50d89c8c6f": {
+      "418e62b5-c70b-45ce-90d8-d0f996477bf3": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "55e8699a-a482-4daa-b66e-5251d7dd5867": {
+        "type": "string"
+      },
+      "5ed0503d-2416-4dfc-b7f5-823376cd0b31": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "cfbf5f45-19c8-4966-abe3-fe450b7bbd85": {
         "minLength": 5,
         "type": "string"
       }

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=responses.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=responses.verified.txt
@@ -108,91 +108,6 @@
           }
         }
       }
-    },
-    "/getbyidandname/{id}/{name}": {
-      "get": {
-        "tags": [
-          "Test"
-        ],
-        "parameters": [
-          {
-            "name": "Id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/int"
-            }
-          },
-          {
-            "name": "Name",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/string1"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/string"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/string"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/forms": {
-      "post": {
-        "tags": [
-          "Test"
-        ],
-        "requestBody": {
-          "content": {
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "Title": {
-                    "$ref": "#/components/schemas/string1"
-                  },
-                  "Description": {
-                    "$ref": "#/components/schemas/string1"
-                  },
-                  "IsCompleted": {
-                    "$ref": "#/components/schemas/boolean"
-                  }
-                }
-              },
-              "encoding": {
-                "application/x-www-form-urlencoded": {
-                  "style": "form",
-                  "explode": true
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
     }
   },
   "components": {
@@ -209,10 +124,6 @@
         "format": "int32"
       },
       "string": {
-        "type": "string"
-      },
-      "string1": {
-        "minLength": 5,
         "type": "string"
       },
       "Todo": {
@@ -243,9 +154,6 @@
   "tags": [
     {
       "name": "Sample"
-    },
-    {
-      "name": "Test"
     }
   ]
 }

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
@@ -175,6 +175,121 @@
           }
         }
       }
+    },
+    "/schemas-by-ref/array-of-ints": {
+      "post": {
+        "tags": [
+          "Sample"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ArrayOfint"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/int"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/schemas-by-ref/list-of-ints": {
+      "post": {
+        "tags": [
+          "Sample"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ArrayOfint"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/int"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/schemas-by-ref/ienumerable-of-ints": {
+      "post": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/int"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/schemas-by-ref/dictionary-of-ints": {
+      "get": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DictionaryOfstringAndint"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/schemas-by-ref/frozen-dictionary-of-ints": {
+      "get": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DictionaryOfstringAndint"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -188,6 +303,18 @@
           "name": {
             "$ref": "#/components/schemas/string"
           }
+        }
+      },
+      "ArrayOfint": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/int"
+        }
+      },
+      "DictionaryOfstringAndint": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/int"
         }
       },
       "int": {

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
@@ -1,0 +1,221 @@
+﻿{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Sample | schemas-by-ref",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/schemas-by-ref/typed-results": {
+      "get": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Triangle"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/schemas-by-ref/multiple-results": {
+      "get": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Triangle"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/schemas-by-ref/iresult-no-produces": {
+      "get": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/schemas-by-ref/iresult-with-produces": {
+      "get": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Triangle"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/schemas-by-ref/primitives": {
+      "get": {
+        "tags": [
+          "Sample"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "description": "The ID associated with the Todo item.",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "description": "The number of Todos to fetch",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/schemas-by-ref/product": {
+      "get": {
+        "tags": [
+          "Sample"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Product"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Product"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/schemas-by-ref/account": {
+      "get": {
+        "tags": [
+          "Sample"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Account"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Account"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Account": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/int"
+          },
+          "name": {
+            "$ref": "#/components/schemas/string"
+          }
+        }
+      },
+      "int": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "Product": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/int"
+          },
+          "name": {
+            "$ref": "#/components/schemas/string"
+          }
+        }
+      },
+      "string": {
+        "type": "string"
+      },
+      "Triangle": {
+        "type": "object"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Sample"
+    }
+  ]
+}

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v1.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v1.verified.txt
@@ -16,7 +16,7 @@
             "in": "query",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/f428dfbe-8f3f-4fde-9522-c7417768e8fb"
+              "$ref": "#/components/schemas/ArrayOfGuid"
             }
           },
           {
@@ -34,7 +34,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/f428dfbe-8f3f-4fde-9522-c7417768e8fb"
+                  "$ref": "#/components/schemas/ArrayOfGuid"
                 }
               }
             }
@@ -71,16 +71,16 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "$ref": "#/components/schemas/ef4eaa9c-faba-4fe1-9772-27214c624406"
+                    "$ref": "#/components/schemas/int"
                   },
                   "title": {
-                    "$ref": "#/components/schemas/57a98a68-509a-4f81-bb7d-219ba669527e"
+                    "$ref": "#/components/schemas/string"
                   },
                   "completed": {
-                    "$ref": "#/components/schemas/5ca5a67f-8fa3-428b-913c-c9537cfad6f5"
+                    "$ref": "#/components/schemas/boolean"
                   },
                   "createdAt": {
-                    "$ref": "#/components/schemas/8c37f379-9055-41e8-8abb-5bb69f85117c"
+                    "$ref": "#/components/schemas/DateTime"
                   }
                 }
               }
@@ -107,7 +107,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/ef4eaa9c-faba-4fe1-9772-27214c624406"
+              "$ref": "#/components/schemas/int"
             }
           },
           {
@@ -135,19 +135,19 @@
                   "type": "object",
                   "properties": {
                     "dueDate": {
-                      "$ref": "#/components/schemas/8c37f379-9055-41e8-8abb-5bb69f85117c"
+                      "$ref": "#/components/schemas/DateTime"
                     },
                     "id": {
-                      "$ref": "#/components/schemas/ef4eaa9c-faba-4fe1-9772-27214c624406"
+                      "$ref": "#/components/schemas/int"
                     },
                     "title": {
-                      "$ref": "#/components/schemas/57a98a68-509a-4f81-bb7d-219ba669527e"
+                      "$ref": "#/components/schemas/string"
                     },
                     "completed": {
-                      "$ref": "#/components/schemas/5ca5a67f-8fa3-428b-913c-c9537cfad6f5"
+                      "$ref": "#/components/schemas/boolean"
                     },
                     "createdAt": {
-                      "$ref": "#/components/schemas/8c37f379-9055-41e8-8abb-5bb69f85117c"
+                      "$ref": "#/components/schemas/DateTime"
                     }
                   }
                 }
@@ -168,7 +168,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/ef4eaa9c-faba-4fe1-9772-27214c624406"
+              "$ref": "#/components/schemas/int"
             }
           },
           {
@@ -176,7 +176,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/6c9029e9-73e8-4c85-9ba0-dcac0aeac2d3"
+              "$ref": "#/components/schemas/string1"
             }
           },
           {
@@ -194,17 +194,17 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/57a98a68-509a-4f81-bb7d-219ba669527e"
+                  "$ref": "#/components/schemas/string"
                 }
               },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/57a98a68-509a-4f81-bb7d-219ba669527e"
+                  "$ref": "#/components/schemas/string"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/57a98a68-509a-4f81-bb7d-219ba669527e"
+                  "$ref": "#/components/schemas/string"
                 }
               }
             }
@@ -234,13 +234,13 @@
                 "type": "object",
                 "properties": {
                   "Title": {
-                    "$ref": "#/components/schemas/6c9029e9-73e8-4c85-9ba0-dcac0aeac2d3"
+                    "$ref": "#/components/schemas/string1"
                   },
                   "Description": {
-                    "$ref": "#/components/schemas/6c9029e9-73e8-4c85-9ba0-dcac0aeac2d3"
+                    "$ref": "#/components/schemas/string1"
                   },
                   "IsCompleted": {
-                    "$ref": "#/components/schemas/5ca5a67f-8fa3-428b-913c-c9537cfad6f5"
+                    "$ref": "#/components/schemas/boolean"
                   }
                 }
               },
@@ -263,33 +263,33 @@
   },
   "components": {
     "schemas": {
-      "57a98a68-509a-4f81-bb7d-219ba669527e": {
-        "type": "string"
+      "ArrayOfGuid": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Guid"
+        }
       },
-      "5ca5a67f-8fa3-428b-913c-c9537cfad6f5": {
+      "boolean": {
         "type": "boolean"
       },
-      "6c9029e9-73e8-4c85-9ba0-dcac0aeac2d3": {
-        "minLength": 5,
-        "type": "string"
-      },
-      "766ab270-8249-4cc2-b011-89d948b951c9": {
-        "type": "string",
-        "format": "uuid"
-      },
-      "8c37f379-9055-41e8-8abb-5bb69f85117c": {
+      "DateTime": {
         "type": "string",
         "format": "date-time"
       },
-      "ef4eaa9c-faba-4fe1-9772-27214c624406": {
+      "Guid": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "int": {
         "type": "integer",
         "format": "int32"
       },
-      "f428dfbe-8f3f-4fde-9522-c7417768e8fb": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/766ab270-8249-4cc2-b011-89d948b951c9"
-        }
+      "string": {
+        "type": "string"
+      },
+      "string1": {
+        "minLength": 5,
+        "type": "string"
       }
     },
     "securitySchemes": {

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v1.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v1.verified.txt
@@ -16,11 +16,7 @@
             "in": "query",
             "required": true,
             "schema": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "format": "uuid"
-              }
+              "$ref": "#/components/schemas/bf441cfa-dc1c-404c-93e8-e047179b836a"
             }
           },
           {
@@ -38,11 +34,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "format": "uuid"
-                  }
+                  "$ref": "#/components/schemas/bf441cfa-dc1c-404c-93e8-e047179b836a"
                 }
               }
             }
@@ -79,18 +71,16 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "integer",
-                    "format": "int32"
+                    "$ref": "#/components/schemas/727d67af-5131-4af1-b143-3bf3aa18bd79"
                   },
                   "title": {
-                    "type": "string"
+                    "$ref": "#/components/schemas/f0608843-1a0c-47dd-add2-f785048742fa"
                   },
                   "completed": {
-                    "type": "boolean"
+                    "$ref": "#/components/schemas/1a86c17b-a912-4967-8b2c-90cf219288a9"
                   },
                   "createdAt": {
-                    "type": "string",
-                    "format": "date-time"
+                    "$ref": "#/components/schemas/35c7234b-f326-4638-a6ce-d78344728101"
                   }
                 }
               }
@@ -117,8 +107,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "$ref": "#/components/schemas/727d67af-5131-4af1-b143-3bf3aa18bd79"
             }
           },
           {
@@ -146,22 +135,19 @@
                   "type": "object",
                   "properties": {
                     "dueDate": {
-                      "type": "string",
-                      "format": "date-time"
+                      "$ref": "#/components/schemas/35c7234b-f326-4638-a6ce-d78344728101"
                     },
                     "id": {
-                      "type": "integer",
-                      "format": "int32"
+                      "$ref": "#/components/schemas/727d67af-5131-4af1-b143-3bf3aa18bd79"
                     },
                     "title": {
-                      "type": "string"
+                      "$ref": "#/components/schemas/f0608843-1a0c-47dd-add2-f785048742fa"
                     },
                     "completed": {
-                      "type": "boolean"
+                      "$ref": "#/components/schemas/1a86c17b-a912-4967-8b2c-90cf219288a9"
                     },
                     "createdAt": {
-                      "type": "string",
-                      "format": "date-time"
+                      "$ref": "#/components/schemas/35c7234b-f326-4638-a6ce-d78344728101"
                     }
                   }
                 }
@@ -182,8 +168,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "$ref": "#/components/schemas/727d67af-5131-4af1-b143-3bf3aa18bd79"
             }
           },
           {
@@ -191,8 +176,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "minLength": 5,
-              "type": "string"
+              "$ref": "#/components/schemas/5b328dbb-e2cb-49f9-98d2-3f3233f5abd2"
             }
           },
           {
@@ -210,17 +194,17 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/f0608843-1a0c-47dd-add2-f785048742fa"
                 }
               },
               "application/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/f0608843-1a0c-47dd-add2-f785048742fa"
                 }
               },
               "text/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/f0608843-1a0c-47dd-add2-f785048742fa"
                 }
               }
             }
@@ -250,15 +234,13 @@
                 "type": "object",
                 "properties": {
                   "Title": {
-                    "minLength": 5,
-                    "type": "string"
+                    "$ref": "#/components/schemas/5b328dbb-e2cb-49f9-98d2-3f3233f5abd2"
                   },
                   "Description": {
-                    "minLength": 5,
-                    "type": "string"
+                    "$ref": "#/components/schemas/5b328dbb-e2cb-49f9-98d2-3f3233f5abd2"
                   },
                   "IsCompleted": {
-                    "type": "boolean"
+                    "$ref": "#/components/schemas/1a86c17b-a912-4967-8b2c-90cf219288a9"
                   }
                 }
               },
@@ -280,6 +262,36 @@
     }
   },
   "components": {
+    "schemas": {
+      "09854117-8d70-4256-b885-9ac9711a4754": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "1a86c17b-a912-4967-8b2c-90cf219288a9": {
+        "type": "boolean"
+      },
+      "35c7234b-f326-4638-a6ce-d78344728101": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "5b328dbb-e2cb-49f9-98d2-3f3233f5abd2": {
+        "minLength": 5,
+        "type": "string"
+      },
+      "727d67af-5131-4af1-b143-3bf3aa18bd79": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "bf441cfa-dc1c-404c-93e8-e047179b836a": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/09854117-8d70-4256-b885-9ac9711a4754"
+        }
+      },
+      "f0608843-1a0c-47dd-add2-f785048742fa": {
+        "type": "string"
+      }
+    },
     "securitySchemes": {
       "Bearer": {
         "type": "http",

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v1.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v1.verified.txt
@@ -156,109 +156,6 @@
           }
         }
       }
-    },
-    "/getbyidandname/{id}/{name}": {
-      "get": {
-        "tags": [
-          "Test"
-        ],
-        "parameters": [
-          {
-            "name": "Id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/int"
-            }
-          },
-          {
-            "name": "Name",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/string1"
-            }
-          },
-          {
-            "name": "X-Version",
-            "in": "header",
-            "schema": {
-              "type": "string",
-              "default": "1.0"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/string"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/string"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/forms": {
-      "post": {
-        "tags": [
-          "Test"
-        ],
-        "parameters": [
-          {
-            "name": "X-Version",
-            "in": "header",
-            "schema": {
-              "type": "string",
-              "default": "1.0"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "Title": {
-                    "$ref": "#/components/schemas/string1"
-                  },
-                  "Description": {
-                    "$ref": "#/components/schemas/string1"
-                  },
-                  "IsCompleted": {
-                    "$ref": "#/components/schemas/boolean"
-                  }
-                }
-              },
-              "encoding": {
-                "application/x-www-form-urlencoded": {
-                  "style": "form",
-                  "explode": true
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
     }
   },
   "components": {
@@ -286,10 +183,6 @@
       },
       "string": {
         "type": "string"
-      },
-      "string1": {
-        "minLength": 5,
-        "type": "string"
       }
     },
     "securitySchemes": {
@@ -303,9 +196,6 @@
   "tags": [
     {
       "name": "Sample"
-    },
-    {
-      "name": "Test"
     }
   ]
 }

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v1.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v1.verified.txt
@@ -16,7 +16,7 @@
             "in": "query",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/bf441cfa-dc1c-404c-93e8-e047179b836a"
+              "$ref": "#/components/schemas/f428dfbe-8f3f-4fde-9522-c7417768e8fb"
             }
           },
           {
@@ -34,7 +34,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/bf441cfa-dc1c-404c-93e8-e047179b836a"
+                  "$ref": "#/components/schemas/f428dfbe-8f3f-4fde-9522-c7417768e8fb"
                 }
               }
             }
@@ -71,16 +71,16 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "$ref": "#/components/schemas/727d67af-5131-4af1-b143-3bf3aa18bd79"
+                    "$ref": "#/components/schemas/ef4eaa9c-faba-4fe1-9772-27214c624406"
                   },
                   "title": {
-                    "$ref": "#/components/schemas/f0608843-1a0c-47dd-add2-f785048742fa"
+                    "$ref": "#/components/schemas/57a98a68-509a-4f81-bb7d-219ba669527e"
                   },
                   "completed": {
-                    "$ref": "#/components/schemas/1a86c17b-a912-4967-8b2c-90cf219288a9"
+                    "$ref": "#/components/schemas/5ca5a67f-8fa3-428b-913c-c9537cfad6f5"
                   },
                   "createdAt": {
-                    "$ref": "#/components/schemas/35c7234b-f326-4638-a6ce-d78344728101"
+                    "$ref": "#/components/schemas/8c37f379-9055-41e8-8abb-5bb69f85117c"
                   }
                 }
               }
@@ -107,7 +107,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/727d67af-5131-4af1-b143-3bf3aa18bd79"
+              "$ref": "#/components/schemas/ef4eaa9c-faba-4fe1-9772-27214c624406"
             }
           },
           {
@@ -135,19 +135,19 @@
                   "type": "object",
                   "properties": {
                     "dueDate": {
-                      "$ref": "#/components/schemas/35c7234b-f326-4638-a6ce-d78344728101"
+                      "$ref": "#/components/schemas/8c37f379-9055-41e8-8abb-5bb69f85117c"
                     },
                     "id": {
-                      "$ref": "#/components/schemas/727d67af-5131-4af1-b143-3bf3aa18bd79"
+                      "$ref": "#/components/schemas/ef4eaa9c-faba-4fe1-9772-27214c624406"
                     },
                     "title": {
-                      "$ref": "#/components/schemas/f0608843-1a0c-47dd-add2-f785048742fa"
+                      "$ref": "#/components/schemas/57a98a68-509a-4f81-bb7d-219ba669527e"
                     },
                     "completed": {
-                      "$ref": "#/components/schemas/1a86c17b-a912-4967-8b2c-90cf219288a9"
+                      "$ref": "#/components/schemas/5ca5a67f-8fa3-428b-913c-c9537cfad6f5"
                     },
                     "createdAt": {
-                      "$ref": "#/components/schemas/35c7234b-f326-4638-a6ce-d78344728101"
+                      "$ref": "#/components/schemas/8c37f379-9055-41e8-8abb-5bb69f85117c"
                     }
                   }
                 }
@@ -168,7 +168,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/727d67af-5131-4af1-b143-3bf3aa18bd79"
+              "$ref": "#/components/schemas/ef4eaa9c-faba-4fe1-9772-27214c624406"
             }
           },
           {
@@ -176,7 +176,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/5b328dbb-e2cb-49f9-98d2-3f3233f5abd2"
+              "$ref": "#/components/schemas/6c9029e9-73e8-4c85-9ba0-dcac0aeac2d3"
             }
           },
           {
@@ -194,17 +194,17 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/f0608843-1a0c-47dd-add2-f785048742fa"
+                  "$ref": "#/components/schemas/57a98a68-509a-4f81-bb7d-219ba669527e"
                 }
               },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/f0608843-1a0c-47dd-add2-f785048742fa"
+                  "$ref": "#/components/schemas/57a98a68-509a-4f81-bb7d-219ba669527e"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/f0608843-1a0c-47dd-add2-f785048742fa"
+                  "$ref": "#/components/schemas/57a98a68-509a-4f81-bb7d-219ba669527e"
                 }
               }
             }
@@ -234,13 +234,13 @@
                 "type": "object",
                 "properties": {
                   "Title": {
-                    "$ref": "#/components/schemas/5b328dbb-e2cb-49f9-98d2-3f3233f5abd2"
+                    "$ref": "#/components/schemas/6c9029e9-73e8-4c85-9ba0-dcac0aeac2d3"
                   },
                   "Description": {
-                    "$ref": "#/components/schemas/5b328dbb-e2cb-49f9-98d2-3f3233f5abd2"
+                    "$ref": "#/components/schemas/6c9029e9-73e8-4c85-9ba0-dcac0aeac2d3"
                   },
                   "IsCompleted": {
-                    "$ref": "#/components/schemas/1a86c17b-a912-4967-8b2c-90cf219288a9"
+                    "$ref": "#/components/schemas/5ca5a67f-8fa3-428b-913c-c9537cfad6f5"
                   }
                 }
               },
@@ -263,33 +263,33 @@
   },
   "components": {
     "schemas": {
-      "09854117-8d70-4256-b885-9ac9711a4754": {
-        "type": "string",
-        "format": "uuid"
+      "57a98a68-509a-4f81-bb7d-219ba669527e": {
+        "type": "string"
       },
-      "1a86c17b-a912-4967-8b2c-90cf219288a9": {
+      "5ca5a67f-8fa3-428b-913c-c9537cfad6f5": {
         "type": "boolean"
       },
-      "35c7234b-f326-4638-a6ce-d78344728101": {
-        "type": "string",
-        "format": "date-time"
-      },
-      "5b328dbb-e2cb-49f9-98d2-3f3233f5abd2": {
+      "6c9029e9-73e8-4c85-9ba0-dcac0aeac2d3": {
         "minLength": 5,
         "type": "string"
       },
-      "727d67af-5131-4af1-b143-3bf3aa18bd79": {
+      "766ab270-8249-4cc2-b011-89d948b951c9": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "8c37f379-9055-41e8-8abb-5bb69f85117c": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "ef4eaa9c-faba-4fe1-9772-27214c624406": {
         "type": "integer",
         "format": "int32"
       },
-      "bf441cfa-dc1c-404c-93e8-e047179b836a": {
+      "f428dfbe-8f3f-4fde-9522-c7417768e8fb": {
         "type": "array",
         "items": {
-          "$ref": "#/components/schemas/09854117-8d70-4256-b885-9ac9711a4754"
+          "$ref": "#/components/schemas/766ab270-8249-4cc2-b011-89d948b951c9"
         }
-      },
-      "f0608843-1a0c-47dd-add2-f785048742fa": {
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v2.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v2.verified.txt
@@ -25,7 +25,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/47ba0817-b436-4155-b6b2-f276bbe04270"
+                    "$ref": "#/components/schemas/e59233cc-7558-4372-b87f-069434e1261e"
                   }
                 }
               }
@@ -64,7 +64,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/54217b56-3bf2-46ff-b14c-1b8309df8fde"
+              "$ref": "#/components/schemas/2dbc5935-d1cb-4ccd-9723-bd899adfe81b"
             }
           }
         ],
@@ -74,17 +74,17 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/47ba0817-b436-4155-b6b2-f276bbe04270"
+                  "$ref": "#/components/schemas/e59233cc-7558-4372-b87f-069434e1261e"
                 }
               },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/47ba0817-b436-4155-b6b2-f276bbe04270"
+                  "$ref": "#/components/schemas/e59233cc-7558-4372-b87f-069434e1261e"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/47ba0817-b436-4155-b6b2-f276bbe04270"
+                  "$ref": "#/components/schemas/e59233cc-7558-4372-b87f-069434e1261e"
                 }
               }
             }
@@ -104,10 +104,10 @@
                 "type": "object",
                 "properties": {
                   "Title": {
-                    "$ref": "#/components/schemas/54217b56-3bf2-46ff-b14c-1b8309df8fde"
+                    "$ref": "#/components/schemas/2dbc5935-d1cb-4ccd-9723-bd899adfe81b"
                   },
                   "Description": {
-                    "$ref": "#/components/schemas/54217b56-3bf2-46ff-b14c-1b8309df8fde"
+                    "$ref": "#/components/schemas/2dbc5935-d1cb-4ccd-9723-bd899adfe81b"
                   },
                   "IsCompleted": {
                     "type": "boolean"
@@ -133,11 +133,11 @@
   },
   "components": {
     "schemas": {
-      "47ba0817-b436-4155-b6b2-f276bbe04270": {
+      "2dbc5935-d1cb-4ccd-9723-bd899adfe81b": {
+        "minLength": 5,
         "type": "string"
       },
-      "54217b56-3bf2-46ff-b14c-1b8309df8fde": {
-        "minLength": 5,
+      "e59233cc-7558-4372-b87f-069434e1261e": {
         "type": "string"
       }
     }

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v2.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v2.verified.txt
@@ -25,7 +25,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/e59233cc-7558-4372-b87f-069434e1261e"
+                    "$ref": "#/components/schemas/string"
                   }
                 }
               }
@@ -64,7 +64,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/2dbc5935-d1cb-4ccd-9723-bd899adfe81b"
+              "$ref": "#/components/schemas/string1"
             }
           }
         ],
@@ -74,17 +74,17 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/e59233cc-7558-4372-b87f-069434e1261e"
+                  "$ref": "#/components/schemas/string"
                 }
               },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/e59233cc-7558-4372-b87f-069434e1261e"
+                  "$ref": "#/components/schemas/string"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/e59233cc-7558-4372-b87f-069434e1261e"
+                  "$ref": "#/components/schemas/string"
                 }
               }
             }
@@ -104,10 +104,10 @@
                 "type": "object",
                 "properties": {
                   "Title": {
-                    "$ref": "#/components/schemas/2dbc5935-d1cb-4ccd-9723-bd899adfe81b"
+                    "$ref": "#/components/schemas/string1"
                   },
                   "Description": {
-                    "$ref": "#/components/schemas/2dbc5935-d1cb-4ccd-9723-bd899adfe81b"
+                    "$ref": "#/components/schemas/string1"
                   },
                   "IsCompleted": {
                     "type": "boolean"
@@ -133,11 +133,11 @@
   },
   "components": {
     "schemas": {
-      "2dbc5935-d1cb-4ccd-9723-bd899adfe81b": {
-        "minLength": 5,
+      "string": {
         "type": "string"
       },
-      "e59233cc-7558-4372-b87f-069434e1261e": {
+      "string1": {
+        "minLength": 5,
         "type": "string"
       }
     }

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v2.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v2.verified.txt
@@ -25,7 +25,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "$ref": "#/components/schemas/47ba0817-b436-4155-b6b2-f276bbe04270"
                   }
                 }
               }
@@ -64,8 +64,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "minLength": 5,
-              "type": "string"
+              "$ref": "#/components/schemas/54217b56-3bf2-46ff-b14c-1b8309df8fde"
             }
           }
         ],
@@ -75,17 +74,17 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/47ba0817-b436-4155-b6b2-f276bbe04270"
                 }
               },
               "application/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/47ba0817-b436-4155-b6b2-f276bbe04270"
                 }
               },
               "text/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/47ba0817-b436-4155-b6b2-f276bbe04270"
                 }
               }
             }
@@ -105,12 +104,10 @@
                 "type": "object",
                 "properties": {
                   "Title": {
-                    "minLength": 5,
-                    "type": "string"
+                    "$ref": "#/components/schemas/54217b56-3bf2-46ff-b14c-1b8309df8fde"
                   },
                   "Description": {
-                    "minLength": 5,
-                    "type": "string"
+                    "$ref": "#/components/schemas/54217b56-3bf2-46ff-b14c-1b8309df8fde"
                   },
                   "IsCompleted": {
                     "type": "boolean"
@@ -131,6 +128,17 @@
             "description": "OK"
           }
         }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "47ba0817-b436-4155-b6b2-f276bbe04270": {
+        "type": "string"
+      },
+      "54217b56-3bf2-46ff-b14c-1b8309df8fde": {
+        "minLength": 5,
+        "type": "string"
       }
     }
   },

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v2.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v2.verified.txt
@@ -25,7 +25,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/string"
+                    "type": "string"
                   }
                 }
               }
@@ -43,114 +43,15 @@
           }
         }
       }
-    },
-    "/getbyidandname/{id}/{name}": {
-      "get": {
-        "tags": [
-          "Test"
-        ],
-        "parameters": [
-          {
-            "name": "Id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            }
-          },
-          {
-            "name": "Name",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/string1"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/string"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/string"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/forms": {
-      "post": {
-        "tags": [
-          "Test"
-        ],
-        "requestBody": {
-          "content": {
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "Title": {
-                    "$ref": "#/components/schemas/string1"
-                  },
-                  "Description": {
-                    "$ref": "#/components/schemas/string1"
-                  },
-                  "IsCompleted": {
-                    "type": "boolean"
-                  }
-                }
-              },
-              "encoding": {
-                "application/x-www-form-urlencoded": {
-                  "style": "form",
-                  "explode": true
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
     }
   },
-  "components": {
-    "schemas": {
-      "string": {
-        "type": "string"
-      },
-      "string1": {
-        "minLength": 5,
-        "type": "string"
-      }
-    }
-  },
+  "components": { },
   "tags": [
     {
       "name": "users"
     },
     {
       "name": "Sample"
-    },
-    {
-      "name": "Test"
     }
   ]
 }

--- a/src/OpenApi/test/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.RequestBody.cs
+++ b/src/OpenApi/test/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.RequestBody.cs
@@ -195,7 +195,7 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
                 {
                     Assert.NotNull(allOfItem.Properties);
                     Assert.Contains("formFile1", allOfItem.Properties);
-                    var formFile1Property = allOfItem.Properties["formFile1"];
+                    var formFile1Property = allOfItem.Properties["formFile1"].GetEffective(document);
                     Assert.Equal("string", formFile1Property.Type);
                     Assert.Equal("binary", formFile1Property.Format);
                 },
@@ -203,7 +203,7 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
                 {
                     Assert.NotNull(allOfItem.Properties);
                     Assert.Contains("formFile2", allOfItem.Properties);
-                    var formFile2Property = allOfItem.Properties["formFile2"];
+                    var formFile2Property = allOfItem.Properties["formFile2"].GetEffective(document);
                     Assert.Equal("string", formFile2Property.Type);
                     Assert.Equal("binary", formFile2Property.Format);
                 });
@@ -536,12 +536,12 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
                         Assert.Collection(allOfItem.Properties, property =>
                             {
                                 Assert.Equal("id", property.Key);
-                                Assert.Equal("integer", property.Value.Type);
+                                Assert.Equal("integer", property.Value.GetEffective(document).Type);
                             },
                             property =>
                             {
                                 Assert.Equal("title", property.Key);
-                                Assert.Equal("string", property.Value.Type);
+                                Assert.Equal("string", property.Value.GetEffective(document).Type);
                             },
                             property =>
                             {
@@ -561,12 +561,12 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
                             property =>
                             {
                                 Assert.Equal("code", property.Key);
-                                Assert.Equal("integer", property.Value.Type);
+                                Assert.Equal("integer", property.Value.GetEffective(document).Type);
                             },
                             property =>
                             {
                                 Assert.Equal("message", property.Key);
-                                Assert.Equal("string", property.Value.Type);
+                                Assert.Equal("string", property.Value.GetEffective(document).Type);
                             });
                     });
             }
@@ -601,12 +601,12 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
                         Assert.Collection(allOfItem.Properties, property =>
                             {
                                 Assert.Equal("Id", property.Key);
-                                Assert.Equal("integer", property.Value.Type);
+                                Assert.Equal("integer", property.Value.GetEffective(document).Type);
                             },
                             property =>
                             {
                                 Assert.Equal("Title", property.Key);
-                                Assert.Equal("string", property.Value.Type);
+                                Assert.Equal("string", property.Value.GetEffective(document).Type);
                             },
                             property =>
                             {
@@ -626,12 +626,12 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
                             property =>
                             {
                                 Assert.Equal("Code", property.Key);
-                                Assert.Equal("integer", property.Value.Type);
+                                Assert.Equal("integer", property.Value.GetEffective(document).Type);
                             },
                             property =>
                             {
                                 Assert.Equal("Message", property.Key);
-                                Assert.Equal("string", property.Value.Type);
+                                Assert.Equal("string", property.Value.GetEffective(document).Type);
                             });
                     });
             }
@@ -701,18 +701,18 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
                 property =>
                 {
                     Assert.Equal("Name", property.Key);
-                    Assert.Equal("string", property.Value.Type);
+                    Assert.Equal("string", property.Value.GetEffective(document).Type);
                 },
                 property =>
                 {
                     Assert.Equal("Description", property.Key);
-                    Assert.Equal("string", property.Value.Type);
+                    Assert.Equal("string", property.Value.GetEffective(document).Type);
                 },
                 property =>
                 {
                     Assert.Equal("Resume", property.Key);
-                    Assert.Equal("string", property.Value.Type);
-                    Assert.Equal("binary", property.Value.Format);
+                    Assert.Equal("string", property.Value.GetEffective(document).Type);
+                    Assert.Equal("binary", property.Value.GetEffective(document).Format);
                 });
         });
     }
@@ -744,12 +744,12 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
                     property =>
                     {
                         Assert.Equal("name", property.Key);
-                        Assert.Equal("string", property.Value.Type);
+                        Assert.Equal("string", property.Value.GetEffective(document).Type);
                     },
                     property =>
                     {
                         Assert.Equal("description", property.Key);
-                        Assert.Equal("string", property.Value.Type);
+                        Assert.Equal("string", property.Value.GetEffective(document).Type);
                     },
                     property =>
                     {
@@ -1005,8 +1005,8 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
                 var content = Assert.Single(operation.RequestBody.Content);
                 Assert.Equal("application/octet-stream", content.Key);
                 Assert.NotNull(content.Value.Schema);
-                Assert.Equal("string", content.Value.Schema.Type);
-                Assert.Equal("binary", content.Value.Schema.Format);
+                Assert.Equal("string", content.Value.Schema.GetEffective(document).Type);
+                Assert.Equal("binary", content.Value.Schema.GetEffective(document).Format);
             }
         });
     }

--- a/src/OpenApi/test/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Responses.cs
+++ b/src/OpenApi/test/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Responses.cs
@@ -264,14 +264,16 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
             Assert.NotNull(defaultResponse);
             Assert.Empty(defaultResponse.Description);
             var defaultContent = Assert.Single(defaultResponse.Content.Values);
-            Assert.Collection(defaultContent.Schema.Properties, property =>
+            Assert.Collection(defaultContent.Schema.Properties,
+            property =>
             {
                 Assert.Equal("code", property.Key);
-                Assert.Equal("integer", property.Value.Type);
-            }, property =>
+                Assert.Equal("integer", property.Value.GetEffective(document).Type);
+            },
+            property =>
             {
                 Assert.Equal("message", property.Key);
-                Assert.Equal("string", property.Value.Type);
+                Assert.Equal("string", property.Value.GetEffective(document).Type);
             });
             // Generates the 200 status code response with the `Todo` response type.
             var okResponse = operation.Responses["200"];
@@ -284,11 +286,11 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
             Assert.Collection(schema.Properties, property =>
             {
                 Assert.Equal("id", property.Key);
-                Assert.Equal("integer", property.Value.Type);
+                Assert.Equal("integer", property.Value.GetEffective(document).Type);
             }, property =>
             {
                 Assert.Equal("title", property.Key);
-                Assert.Equal("string", property.Value.Type);
+                Assert.Equal("string", property.Value.GetEffective(document).Type);
             }, property =>
             {
                 Assert.Equal("completed", property.Key);

--- a/src/OpenApi/test/Services/OpenApiSchemaService/OpenApiComponentService.RequestBodySchemas.cs
+++ b/src/OpenApi/test/Services/OpenApiSchemaService/OpenApiComponentService.RequestBodySchemas.cs
@@ -174,15 +174,11 @@ public partial class OpenApiComponentServiceTests : OpenApiDocumentServiceTestBa
                 var operation = document.Paths[$"/{path}"].Operations[OperationType.Post];
                 var requestBody = operation.RequestBody;
 
-                var effectiveSchema = requestBody.Content["application/octet-stream"].Schema.GetEffective(document);
+                var effectiveSchema = requestBody.Content["application/octet-stream"].Schema;
 
                 Assert.Equal("string", effectiveSchema.Type);
                 Assert.Equal("binary", effectiveSchema.Format);
             }
-
-            var schema = Assert.Single(document.Components.Schemas);
-            Assert.Equal("string", schema.Value.Type);
-            Assert.Equal("binary", schema.Value.Format);
         });
     }
 

--- a/src/OpenApi/test/Services/OpenApiSchemaService/OpenApiComponentService.ResponseSchemas.cs
+++ b/src/OpenApi/test/Services/OpenApiSchemaService/OpenApiComponentService.ResponseSchemas.cs
@@ -225,8 +225,11 @@ public partial class OpenApiComponentServiceTests : OpenApiDocumentServiceTestBa
                 property =>
                 {
                     Assert.Equal("dueDate", property.Key);
-                    Assert.Equal("string", property.Value.Type);
-                    Assert.Equal("date-time", property.Value.Format);
+                    // DateTime schema appears twice in the document so we expect
+                    // this to map to a reference ID.
+                    var dateTimeSchema = property.Value.GetEffective(document);
+                    Assert.Equal("string", dateTimeSchema.Type);
+                    Assert.Equal("date-time", dateTimeSchema.Format);
                 },
                 property =>
                 {
@@ -247,8 +250,11 @@ public partial class OpenApiComponentServiceTests : OpenApiDocumentServiceTestBa
                 property =>
                 {
                     Assert.Equal("createdAt", property.Key);
-                    Assert.Equal("string", property.Value.Type);
-                    Assert.Equal("date-time", property.Value.Format);
+                    // DateTime schema appears twice in the document so we expect
+                    // this to map to a reference ID.
+                    var dateTimeSchema = property.Value.GetEffective(document);
+                    Assert.Equal("string", dateTimeSchema.Type);
+                    Assert.Equal("date-time", dateTimeSchema.Format);
                 });
         });
     }
@@ -485,14 +491,14 @@ public partial class OpenApiComponentServiceTests : OpenApiDocumentServiceTestBa
                 property =>
                 {
                     Assert.Equal("pageIndex", property.Key);
-                    Assert.Equal("integer", property.Value.Type);
-                    Assert.Equal("int32", property.Value.Format);
+                    Assert.Equal("integer", property.Value.GetEffective(document).Type);
+                    Assert.Equal("int32", property.Value.GetEffective(document).Format);
                 },
                 property =>
                 {
                     Assert.Equal("pageSize", property.Key);
-                    Assert.Equal("integer", property.Value.Type);
-                    Assert.Equal("int32", property.Value.Format);
+                    Assert.Equal("integer", property.Value.GetEffective(document).Type);
+                    Assert.Equal("int32", property.Value.GetEffective(document).Format);
                 },
                 property =>
                 {
@@ -503,8 +509,8 @@ public partial class OpenApiComponentServiceTests : OpenApiDocumentServiceTestBa
                 property =>
                 {
                     Assert.Equal("totalPages", property.Key);
-                    Assert.Equal("integer", property.Value.Type);
-                    Assert.Equal("int32", property.Value.Format);
+                    Assert.Equal("integer", property.Value.GetEffective(document).Type);
+                    Assert.Equal("int32", property.Value.GetEffective(document).Format);
                 },
                 property =>
                 {
@@ -516,8 +522,8 @@ public partial class OpenApiComponentServiceTests : OpenApiDocumentServiceTestBa
                         property =>
                         {
                             Assert.Equal("id", property.Key);
-                            Assert.Equal("integer", property.Value.Type);
-                            Assert.Equal("int32", property.Value.Format);
+                            Assert.Equal("integer", property.Value.GetEffective(document).Type);
+                            Assert.Equal("int32", property.Value.GetEffective(document).Format);
                         },
                         property =>
                         {
@@ -559,16 +565,19 @@ public partial class OpenApiComponentServiceTests : OpenApiDocumentServiceTestBa
             var response = responses.Value;
             Assert.True(response.Content.TryGetValue("application/problem+json", out var mediaType));
             Assert.Equal("object", mediaType.Schema.Type);
+            // `string` schemas appear multiple times in this document so they should
+            // all resolve to reference IDs, hence the use of `GetEffective` to resolve the
+            // final schema.
             Assert.Collection(mediaType.Schema.Properties,
                 property =>
                 {
                     Assert.Equal("type", property.Key);
-                    Assert.Equal("string", property.Value.Type);
+                    Assert.Equal("string", property.Value.GetEffective(document).Type);
                 },
                 property =>
                 {
                     Assert.Equal("title", property.Key);
-                    Assert.Equal("string", property.Value.Type);
+                    Assert.Equal("string", property.Value.GetEffective(document).Type);
                 },
                 property =>
                 {
@@ -579,12 +588,12 @@ public partial class OpenApiComponentServiceTests : OpenApiDocumentServiceTestBa
                 property =>
                 {
                     Assert.Equal("detail", property.Key);
-                    Assert.Equal("string", property.Value.Type);
+                    Assert.Equal("string", property.Value.GetEffective(document).Type);
                 },
                 property =>
                 {
                     Assert.Equal("instance", property.Key);
-                    Assert.Equal("string", property.Value.Type);
+                    Assert.Equal("string", property.Value.GetEffective(document).Type);
                 },
                 property =>
                 {
@@ -593,7 +602,7 @@ public partial class OpenApiComponentServiceTests : OpenApiDocumentServiceTestBa
                     // The errors object is a dictionary of string[]. Use `additionalProperties`
                     // to indicate that the payload can be arbitrary keys with string[] values.
                     Assert.Equal("array", property.Value.AdditionalProperties.Type);
-                    Assert.Equal("string", property.Value.AdditionalProperties.Items.Type);
+                    Assert.Equal("string", property.Value.AdditionalProperties.Items.GetEffective(document).Type);
                 });
         });
     }

--- a/src/OpenApi/test/SharedTypes.cs
+++ b/src/OpenApi/test/SharedTypes.cs
@@ -101,3 +101,15 @@ internal class ProjectBoard
     public required bool IsPrivate { get; set; }
 }
 #nullable restore
+
+internal class Account
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+internal class Product
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}

--- a/src/OpenApi/test/Transformers/Implementations/OpenApiSchemaReferenceTransformerTests.cs
+++ b/src/OpenApi/test/Transformers/Implementations/OpenApiSchemaReferenceTransformerTests.cs
@@ -1,0 +1,262 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.OpenApi.Models;
+
+public class OpenApiSchemaReferenceTransformerTests : OpenApiDocumentServiceTestBase
+{
+    [Fact]
+    public async Task IdenticalParameterTypesAreStoredWithSchemaReference()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPost("/api", (IFormFile value) => { });
+        builder.MapPost("/api-2", (IFormFile value) => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths["/api"].Operations[OperationType.Post];
+            var parameter = operation.RequestBody.Content["multipart/form-data"];
+            var schema = parameter.Schema;
+
+            var operation2 = document.Paths["/api-2"].Operations[OperationType.Post];
+            var parameter2 = operation2.RequestBody.Content["multipart/form-data"];
+            var schema2 = parameter2.Schema;
+
+            // {
+            //   "$ref": "#/components/schemas/IFormFileValue"
+            // }
+            // {
+            //   "components": {
+            //     "schemas": {
+            //       "IFormFileValue": {
+            //         "type": "object",
+            //         "properties": {
+            //           "value": {
+            //             "$ref": "#/components/schemas/IFormFile"
+            //           }
+            //         }
+            //       },
+            //       "IFormFile": {
+            //         "type": "string",
+            //         "format": "binary"
+            //       }
+            //     }
+            //   }
+            Assert.Equal(schema.Reference, schema2.Reference);
+
+            var effectiveSchema = schema.GetEffective(document);
+            Assert.Equal("object", effectiveSchema.Type);
+            Assert.Equal(1, effectiveSchema.Properties.Count);
+            var effectivePropertySchema = effectiveSchema.Properties["value"].GetEffective(document);
+            Assert.Equal("string", effectivePropertySchema.Type);
+            Assert.Equal("binary", effectivePropertySchema.Format);
+        });
+    }
+
+    [Fact]
+    public async Task TodoInRequestBodyAndResponseUsesSchemaReference()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPost("/api", (Todo todo) => TypedResults.Ok(todo));
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths["/api"].Operations[OperationType.Post];
+            var requestBody = operation.RequestBody.Content["application/json"];
+            var requestBodySchema = requestBody.Schema;
+
+            var response = operation.Responses["200"];
+            var responseContent = response.Content["application/json"];
+            var responseSchema = responseContent.Schema;
+
+            // {
+            //   "$ref": "#/components/schemas/Todo"
+            // }
+            // {
+            //   "components": {
+            //     "schemas": {
+            //       "Todo": {
+            //         "type": "object",
+            //         "properties": {
+            //           "id": {
+            //             "type": "integer"
+            //           },
+            //           ...
+            //         }
+            //       }
+            //     }
+            //   }
+            Assert.Equal(requestBodySchema.Reference.Id, responseSchema.Reference.Id);
+
+            var effectiveSchema = requestBodySchema.GetEffective(document);
+            Assert.Equal("object", effectiveSchema.Type);
+            Assert.Equal(4, effectiveSchema.Properties.Count);
+            var effectiveIdSchema = effectiveSchema.Properties["id"].GetEffective(document);
+            Assert.Equal("integer", effectiveIdSchema.Type);
+            var effectiveTitleSchema = effectiveSchema.Properties["title"].GetEffective(document);
+            Assert.Equal("string", effectiveTitleSchema.Type);
+            var effectiveCompletedSchema = effectiveSchema.Properties["completed"].GetEffective(document);
+            Assert.Equal("boolean", effectiveCompletedSchema.Type);
+            var effectiveCreatedAtSchema = effectiveSchema.Properties["createdAt"].GetEffective(document);
+            Assert.Equal("string", effectiveCreatedAtSchema.Type);
+        });
+    }
+
+    [Fact]
+    public async Task SameTypeInDictionaryAndListTypesUsesReferenceIds()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPost("/api", (Todo[] todo) => { });
+        builder.MapPost("/api-2", (Dictionary<string, Todo> todo) => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths["/api"].Operations[OperationType.Post];
+            var requestBody = operation.RequestBody.Content["application/json"];
+            var requestBodySchema = requestBody.Schema;
+
+            var operation2 = document.Paths["/api-2"].Operations[OperationType.Post];
+            var requestBody2 = operation2.RequestBody.Content["application/json"];
+            var requestBodySchema2 = requestBody2.Schema;
+
+            // {
+            //   "type": "array",
+            //   "items": {
+            //     "$ref": "#/components/schemas/Todo"
+            //   }
+            // }
+            // {
+            //   "type": "object",
+            //   "additionalProperties": {
+            //     "$ref": "#/components/schemas/Todo"
+            //   }
+            // }
+            // {
+            //   "components": {
+            //     "schemas": {
+            //       "Todo": {
+            //         "type": "object",
+            //         "properties": {
+            //           "id": {
+            //             "type": "integer"
+            //           },
+            //           ...
+            //         }
+            //       }
+            //     }
+            //   }
+            // }
+
+            // Parent types of schemas are different
+            Assert.Equal("array", requestBodySchema.Type);
+            Assert.Equal("object", requestBodySchema2.Type);
+            // Values of the list and dictionary point to the same reference ID
+            Assert.Equal(requestBodySchema.Items.Reference.Id, requestBodySchema2.AdditionalProperties.Reference.Id);
+        });
+    }
+
+    [Fact]
+    public async Task SameTypeInAllOfReferenceGetsHandledCorrectly()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPost("/api", (IFormFile resume, [FromForm] Todo todo) => { });
+        builder.MapPost("/api-2", ([FromForm] string name, [FromForm] Todo todo2) => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths["/api"].Operations[OperationType.Post];
+            var requestBody = operation.RequestBody.Content["multipart/form-data"];
+            var requestBodySchema = requestBody.Schema;
+
+            var operation2 = document.Paths["/api-2"].Operations[OperationType.Post];
+            var requestBody2 = operation2.RequestBody.Content["multipart/form-data"];
+            var requestBodySchema2 = requestBody2.Schema;
+
+            // Todo parameter (second parameter) in allOf for each operation should point to the same reference ID.
+            Assert.Equal(requestBodySchema.AllOf[1].Reference.Id, requestBodySchema2.AllOf[1].Reference.Id);
+
+            // IFormFile parameter should use inline schema since it only appears once in the application.
+            Assert.Equal("object", requestBodySchema.AllOf[0].Type);
+            Assert.Equal("string", requestBodySchema.AllOf[0].Properties["resume"].Type);
+            Assert.Equal("binary", requestBodySchema.AllOf[0].Properties["resume"].Format);
+
+            // String parameter `name` should use reference ID shared by string properties in the
+            // Todo object.
+            Assert.Equal("object", requestBodySchema2.AllOf[0].Type);
+            var nameParameterReference = requestBodySchema2.AllOf[0].Properties["name"].Reference.Id;
+            var todoTitleReference = requestBodySchema.AllOf[1].GetEffective(document).Properties["title"].Reference.Id;
+            var todoTitleReference2 = requestBodySchema2.AllOf[1].GetEffective(document).Properties["title"].Reference.Id;
+            Assert.Equal(nameParameterReference, todoTitleReference);
+            Assert.Equal(nameParameterReference, todoTitleReference2);
+        });
+    }
+
+    [Fact]
+    public async Task DifferentTypesWithSameSchemaMapToSameReferenceId()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPost("/api", (IEnumerable<Todo> todo) => { });
+        builder.MapPost("/api-2", (Todo[] todo) => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths["/api"].Operations[OperationType.Post];
+            var requestBody = operation.RequestBody.Content["application/json"];
+            var requestBodySchema = requestBody.Schema;
+
+            var operation2 = document.Paths["/api-2"].Operations[OperationType.Post];
+            var requestBody2 = operation2.RequestBody.Content["application/json"];
+            var requestBodySchema2 = requestBody2.Schema;
+
+            // {
+            //  "$ref": "#/components/schemas/TodoArray"
+            // }
+            // {
+            //  "$ref": "#/components/schemas/TodoArray"
+            // }
+            // {
+            //   "components": {
+            //     "schemas": {
+            //       "TodoArray": {
+            //         "type": "array",
+            //         "items": {
+            //           "$ref": "#/components/schemas/Todo"
+            //         }
+            //       }
+            //     }
+            //   }
+            // }
+
+            // Both list types should point to the same reference ID
+            Assert.Equal(requestBodySchema.Reference.Id, requestBodySchema2.Reference.Id);
+            // The referenced schema has an array type
+            Assert.Equal("array", requestBodySchema.GetEffective(document).Type);
+            // The items in the array are mapped to the Todo reference
+            Assert.NotNull(requestBodySchema.GetEffective(document).Items.Reference.Id);
+            Assert.Equal(4, requestBodySchema.GetEffective(document).Items.GetEffective(document).Properties.Count);
+        });
+    }
+}

--- a/src/OpenApi/test/Transformers/SchemaTransformerTests.cs
+++ b/src/OpenApi/test/Transformers/SchemaTransformerTests.cs
@@ -134,10 +134,10 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
         {
             var path = Assert.Single(document.Paths.Values);
             var postOperation = path.Operations[OperationType.Post];
-            var requestSchema = postOperation.RequestBody.Content["application/json"].Schema;
+            var requestSchema = postOperation.RequestBody.Content["application/json"].Schema.GetEffective(document);
             Assert.Equal("1", ((OpenApiString)requestSchema.Extensions["x-my-extension"]).Value);
             var getOperation = path.Operations[OperationType.Get];
-            var responseSchema = getOperation.Responses["200"].Content["application/json"].Schema;
+            var responseSchema = getOperation.Responses["200"].Content["application/json"].Schema.GetEffective(document);
             Assert.Equal("1", ((OpenApiString)responseSchema.Extensions["x-my-extension"]).Value);
         });
     }


### PR DESCRIPTION
Note: this PR targets a feature branch.

This pull request adds support for generating reference IDs for JSON schemas that are duplicated across the OpenAPI document. This implementation consists of three components:

- A collection of `IEqualityComparer` implementations that allow us to compare whether two `OpenApiSchema` instances are equivalent
- An `IOpenApiDocumentTransformer` implementation that walks the schemas in the OpenAPI document model and replaces inline schemas with reference ID-based schemas where applicable
- Additional logic to the schema store to support storing OpenAPI schemas alongside their reference IDs
	- Note: this PR generates a random GUID for each schema reference ID. Human-readable schema reference IDs will come in a follow-up PR.

In this implementation, references are generated based on the equality of the generated schemas, not the .NET type they are associated with. With this strategy, we avoid leaking details of .NET type system to the OpenAPI document. For example, types that map to the same JSON schema (like `IEnumerable<Todo>` and `Todo[]`) will use the same reference ID. This strategy also allows us to account for transformations made to the OpenAPI schema via transformers in the final document.

