### PR TITLE
[release/8.0] Don't require latest runtime patch for Blazor DevServer

### DIFF
--- a/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
+++ b/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
@@ -37,7 +37,7 @@
   <Target Name="_CreateRuntimeConfig" BeforeTargets="CoreBuild">
     <PropertyGroup>
       <_RuntimeConfigProperties>
-        SharedFxVersion=$(SharedFxVersion);
+        AspNetCoreMajorMinorVersion=$(AspNetCoreMajorMinorVersion);
       </_RuntimeConfigProperties>
 
       <_RuntimeConfigPath>$(OutputPath)blazor-devserver.runtimeconfig.json</_RuntimeConfigPath>

--- a/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
+++ b/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
@@ -36,8 +36,11 @@
 
   <Target Name="_CreateRuntimeConfig" BeforeTargets="CoreBuild">
     <PropertyGroup>
-      <_RuntimeConfigProperties>
-        AspNetCoreMajorMinorVersion=$(AspNetCoreMajorMinorVersion);
+      <_RuntimeConfigProperties Condition="'$(IsServicingBuild)' == 'true'">
+        FrameworkVersion=$(AspNetCoreMajorMinorVersion).0;
+      </_RuntimeConfigProperties>
+      <_RuntimeConfigProperties Condition="'$(IsServicingBuild)' != 'true'">
+        FrameworkVersion=$(SharedFxVersion);
       </_RuntimeConfigProperties>
 
       <_RuntimeConfigPath>$(OutputPath)blazor-devserver.runtimeconfig.json</_RuntimeConfigPath>

--- a/src/Components/WebAssembly/DevServer/src/blazor-devserver.runtimeconfig.json.in
+++ b/src/Components/WebAssembly/DevServer/src/blazor-devserver.runtimeconfig.json.in
@@ -3,7 +3,7 @@
     "tfm": "net8.0",
     "framework": {
       "name": "Microsoft.AspNetCore.App",
-      "version": "${SharedFxVersion}"
+      "version": "${AspNetCoreMajorMinorVersion}.0"
     },
     "rollForwardOnNoCandidateFx": 2
   }

--- a/src/Components/WebAssembly/DevServer/src/blazor-devserver.runtimeconfig.json.in
+++ b/src/Components/WebAssembly/DevServer/src/blazor-devserver.runtimeconfig.json.in
@@ -3,7 +3,7 @@
     "tfm": "net8.0",
     "framework": {
       "name": "Microsoft.AspNetCore.App",
-      "version": "${AspNetCoreMajorMinorVersion}.0"
+      "version": "${FrameworkVersion}"
     },
     "rollForwardOnNoCandidateFx": 2
   }

--- a/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj
+++ b/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj
@@ -89,7 +89,7 @@
     <ProjectReference
       Include="..\testassets\Components.TestServer\Components.TestServer.csproj"
       Targets="Build;Publish"
-      Properties="BuildProjectReferences=false;TestTrimmedOrMultithreadingApps=true;PublishDir=$(MSBuildThisFileDirectory)$(OutputPath)trimmed-or-threading\Components.TestServer\;" />
+      Properties="BuildProjectReferences=false;TestTrimmedOrMultithreadingApps=true;PublishDir=$(MSBuildThisFileDirectory)$(OutputPath)trimmed\Components.TestServer\;" />
   </ItemGroup>
 
   <!-- Shared testing infrastructure for running E2E tests using selenium -->

--- a/src/Components/test/E2ETest/Tests/RemoteAuthenticationTest.cs
+++ b/src/Components/test/E2ETest/Tests/RemoteAuthenticationTest.cs
@@ -21,7 +21,7 @@ public class RemoteAuthenticationTest :
 {
     public readonly bool TestTrimmedApps = typeof(ToggleExecutionModeServerFixture<>).Assembly
         .GetCustomAttributes<AssemblyMetadataAttribute>()
-        .First(m => m.Key == "Microsoft.AspNetCore.E2ETesting.TestTrimmedOrMultithreadingApps")
+        .First(m => m.Key == "Microsoft.AspNetCore.E2ETesting.TestTrimmedApps")
         .Value == "true";
 
     public RemoteAuthenticationTest(
@@ -67,7 +67,7 @@ public class RemoteAuthenticationTest :
 
     private static string GetPublishedContentRoot(Assembly assembly)
     {
-        var contentRoot = Path.Combine(AppContext.BaseDirectory, "trimmed-or-threading", assembly.GetName().Name);
+        var contentRoot = Path.Combine(AppContext.BaseDirectory, "trimmed", assembly.GetName().Name);
 
         if (!Directory.Exists(contentRoot))
         {

--- a/src/Components/test/E2ETest/Tests/WebAssemblyPrerenderedTest.cs
+++ b/src/Components/test/E2ETest/Tests/WebAssemblyPrerenderedTest.cs
@@ -56,7 +56,7 @@ public class WebAssemblyPrerenderedTest : ServerTestBase<AspNetSiteServerFixture
 
     private static string GetPublishedContentRoot(Assembly assembly)
     {
-        var contentRoot = Path.Combine(AppContext.BaseDirectory, "trimmed-or-threading", assembly.GetName().Name);
+        var contentRoot = Path.Combine(AppContext.BaseDirectory, "trimmed", assembly.GetName().Name);
 
         if (!Directory.Exists(contentRoot))
         {


### PR DESCRIPTION
# Don't require latest runtime patch for Blazor DevServer

This fixes a failure to launch the Blazor DevServer when a project's Microsoft.AspNetCore.Components.WebAssembly.DevServer NuGet dependency has a new patch version than the aspnetcore runtime provided by the SDK.

## Description

This is a backport of DevServer changes from #56123 for release/8.0.

If you have not installed an SDK with the 8.0.6 runtimes, but you reference the 8.0.6 version of the Microsoft.AspNetCore.Components.WebAssembly.DevServer NuGet dependency, and try to `dotnet run` the project, you’ll see the following output:

```  
You must install or update .NET to run this application.

App: C:\.tools\.nuget\packages\microsoft.aspnetcore.components.webassembly.devserver\8.0.6\tools\blazor-devserver.dll
Architecture: x64
Framework: 'Microsoft.AspNetCore.App', version '8.0.6' (x64)
.NET location: C:\Program Files\dotnet\

The following frameworks were found:
  6.0.30 at [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  8.0.5 at [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]

Learn more:
https://aka.ms/dotnet/app-launch-failed

To install missing framework, download:
https://aka.ms/dotnet-core-applaunch?framework=Microsoft.AspNetCore.App&framework_version=8.0.6&arch=x64&rid=win-x64&os=win10

C:\Program Files\dotnet\dotnet.exe (process 12924) exited with code -2147450730 (0x80008096).
To automatically close the console when debugging stops, enable Tools->Options->Debugging->Automatically close the console when debugging stops.
Press any key to close this window . . .
  
```

You can work around this issue by installing the 8.0.301 SDK from [https://dotnet.microsoft.com/en-us/download/dotnet/8.0](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) that brings in the 8.0.6 runtime. Or you can downgrade the Microsoft.AspNetCore.Components.WebAssembly.DevServer NuGet dependency to 8.0.5.

However, it ought not be necessary for the NuGet dependency to exactly align with the runtime patch version. https://github.com/dotnet/runtime/issues/88204#issuecomment-1652259739 has more context.

Fixes #56119

## Customer Impact

If a customer tries to use an older SDK with a newer version of the Microsoft.AspNetCore.Components.WebAssembly.DevServer NuGet dependency, they'll see the following error in Visual Studio:

![Process with Id of {ID} is not running error](https://github.com/dotnet/aspnetcore/assets/54385/33823bf8-3f99-48ce-a302-8ffd77a4db6c)

Similar reports come into VS feedback and GitHub pretty regularly. VS does not seem to give any details other than the following in from the “Debug” output by default.

> The target process exited without raising a CoreCLR started event. Ensure that the target process is configured to use .NET Core. This may be expected if the target process did not run on .NET Core.  
> The program ‘\[720\] dotnet.exe’ has exited with code 2147516566 (0x80008096).  
> The program ‘\[720\] dotnet.exe: Program Trace’ has exited with code 0 (0x0).

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

It allows the dev server to work in environments where it would previously completely fail without easy-to-find debug info. The Blazor dev server is stable and only uses public API, so it does not require a specific runtime patch.

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A