### PR TITLE
[Infrastructure] Update the dependency management script to automatically install vsts-npm-auth and provision a PAT

### DIFF
--- a/eng/scripts/update-npm-dependencies.ps1
+++ b/eng/scripts/update-npm-dependencies.ps1
@@ -17,6 +17,14 @@ if (-not $WhatIf) {
     Remove-Item .\package-lock.json
 }
 
+Write-Host "Provisioning a token for the NPM registry. You might be prompted to authenticate."
+Write-Host "If this command fails because it can't find vsts-npm-auth. Run 'npm install -g vsts-npm-auth' and try again."
+if (-not $WhatIf) {
+    # This command provisions a PAT token for the VSTS NPM registry that lasts for 15 minutes, which is more than enough time to run npm install
+    # and ensure any missing package is mirrored.
+    vsts-npm-auth.cmd -E 15 -F -C .\.npmrc
+}
+
 Write-Host "Running npm install"
 if (-not $WhatIf) {
     npm install --prefer-online --include optional

--- a/eng/scripts/update-npm-dependencies.ps1
+++ b/eng/scripts/update-npm-dependencies.ps1
@@ -17,12 +17,22 @@ if (-not $WhatIf) {
     Remove-Item .\package-lock.json
 }
 
+try {
+    Get-Command vsts-npm-auth -CommandType ExternalScript
+    Write-Host "vsts-npm-auth is already installed"
+}
+catch {
+    Write-Host "Installing vsts-npm-auth"
+    if (-not $WhatIf) {
+        npm install -g vsts-npm-auth
+    }
+}
+
 Write-Host "Provisioning a token for the NPM registry. You might be prompted to authenticate."
-Write-Host "If this command fails because it can't find vsts-npm-auth. Run 'npm install -g vsts-npm-auth' and try again."
 if (-not $WhatIf) {
     # This command provisions a PAT token for the VSTS NPM registry that lasts for 15 minutes, which is more than enough time to run npm install
     # and ensure any missing package is mirrored.
-    vsts-npm-auth.cmd -E 15 -F -C .\.npmrc
+    vsts-npm-auth -E 15 -F -C .\.npmrc
 }
 
 Write-Host "Running npm install"


### PR DESCRIPTION
* The PAT is needed to mirror any missing package into the the AzDo feed.
* The step we automated had to be done manually which is worse, since we didn't provide explicit guidance.
* This change automates this step and ensures we allocate a short-lived token on the machine (15 min) as opposed to 90 days which is the default.