### PR TITLE
Improve doc in IAuthenticationHandler

### DIFF
--- a/src/Http/Authentication.Abstractions/src/IAuthenticationHandler.cs
+++ b/src/Http/Authentication.Abstractions/src/IAuthenticationHandler.cs
@@ -18,19 +18,19 @@ public interface IAuthenticationHandler
     Task InitializeAsync(AuthenticationScheme scheme, HttpContext context);
 
     /// <summary>
-    /// Authenticate the current request.
+    /// Authenticate the request associated with the <see cref="HttpContext"/> passed to the InitializeAsync method.
     /// </summary>
     /// <returns>The <see cref="AuthenticateResult"/> result.</returns>
     Task<AuthenticateResult> AuthenticateAsync();
 
     /// <summary>
-    /// Challenge the current request.
+    /// Challenge the request associated with the <see cref="HttpContext"/> passed to the InitializeAsync method.
     /// </summary>
     /// <param name="properties">The <see cref="AuthenticationProperties"/> that contains the extra meta-data arriving with the authentication.</param>
     Task ChallengeAsync(AuthenticationProperties? properties);
 
     /// <summary>
-    /// Forbid the current request.
+    /// Forbid the request associated with the <see cref="HttpContext"/> passed to the InitializeAsync method.
     /// </summary>
     /// <param name="properties">The <see cref="AuthenticationProperties"/> that contains the extra meta-data arriving with the authentication.</param>
     Task ForbidAsync(AuthenticationProperties? properties);

--- a/src/Http/Authentication.Abstractions/src/IAuthenticationHandler.cs
+++ b/src/Http/Authentication.Abstractions/src/IAuthenticationHandler.cs
@@ -14,23 +14,23 @@ public interface IAuthenticationHandler
     /// Initialize the authentication handler. The handler should initialize anything it needs from the request and scheme as part of this method.
     /// </summary>
     /// <param name="scheme">The <see cref="AuthenticationScheme"/> scheme.</param>
-    /// <param name="context">The <see cref="HttpContext"/> context.</param>
+    /// <param name="context">The <see cref="HttpContext"/> context for the current request.</param>
     Task InitializeAsync(AuthenticationScheme scheme, HttpContext context);
 
     /// <summary>
-    /// Authenticate the current request using the <see cref="HttpContext"/> passed to the <see cref="InitializeAsync"/> method.
+    /// Authenticate the current request.
     /// </summary>
     /// <returns>The <see cref="AuthenticateResult"/> result.</returns>
     Task<AuthenticateResult> AuthenticateAsync();
 
     /// <summary>
-    /// Challenge the current request using the <see cref="HttpContext"/> passed to the <see cref="InitializeAsync"/> method.
+    /// Challenge the current request.
     /// </summary>
     /// <param name="properties">The <see cref="AuthenticationProperties"/> that contains the extra meta-data arriving with the authentication.</param>
     Task ChallengeAsync(AuthenticationProperties? properties);
 
     /// <summary>
-    /// Forbid the current request using the <see cref="HttpContext"/> passed to the <see cref="InitializeAsync"/> method.
+    /// Forbid the current request.
     /// </summary>
     /// <param name="properties">The <see cref="AuthenticationProperties"/> that contains the extra meta-data arriving with the authentication.</param>
     Task ForbidAsync(AuthenticationProperties? properties);

--- a/src/Http/Authentication.Abstractions/src/IAuthenticationHandler.cs
+++ b/src/Http/Authentication.Abstractions/src/IAuthenticationHandler.cs
@@ -18,19 +18,19 @@ public interface IAuthenticationHandler
     Task InitializeAsync(AuthenticationScheme scheme, HttpContext context);
 
     /// <summary>
-    /// Authenticate the request associated with the <see cref="HttpContext"/> passed to the InitializeAsync method.
+    /// Authenticate the current request using the <see cref="HttpContext"/> passed to the <see cref="InitializeAsync"/> method.
     /// </summary>
     /// <returns>The <see cref="AuthenticateResult"/> result.</returns>
     Task<AuthenticateResult> AuthenticateAsync();
 
     /// <summary>
-    /// Challenge the request associated with the <see cref="HttpContext"/> passed to the InitializeAsync method.
+    /// Challenge the current request using the <see cref="HttpContext"/> passed to the <see cref="InitializeAsync"/> method.
     /// </summary>
     /// <param name="properties">The <see cref="AuthenticationProperties"/> that contains the extra meta-data arriving with the authentication.</param>
     Task ChallengeAsync(AuthenticationProperties? properties);
 
     /// <summary>
-    /// Forbid the request associated with the <see cref="HttpContext"/> passed to the InitializeAsync method.
+    /// Forbid the current request using the <see cref="HttpContext"/> passed to the <see cref="InitializeAsync"/> method.
     /// </summary>
     /// <param name="properties">The <see cref="AuthenticationProperties"/> that contains the extra meta-data arriving with the authentication.</param>
     Task ForbidAsync(AuthenticationProperties? properties);


### PR DESCRIPTION
# Clarify "current request" in method descriptions in IAuthenticationHandler

Clarified that the "current request" was passed to the InitializeAsync and thus stored within the instance somewhere.

## Description

I think the prior wording was confusing because the methods in question take no parameter, so it was unclear how the method determined the "current request".

No issue opened, as that would have doubled the work required for this small change.
