### PR TITLE
Use 11.x version of JDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -24,7 +24,7 @@
     "xcopy-msbuild": "17.1.0"
   },
   "native-tools": {
-    "jdk": "11.0.23"
+    "jdk": "11"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.24272.5",


### PR DESCRIPTION
Should allow us to roll forward to the latest available rather than demanding a specific version. Follow-up to https://github.com/dotnet/aspnetcore/pull/56210.