### PR TITLE
Use Convert.ToHexStringLower()

### DIFF
--- a/src/Antiforgery/src/Internal/BinaryBlob.cs
+++ b/src/Antiforgery/src/Internal/BinaryBlob.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
-using System.Text;
 
 namespace Microsoft.AspNetCore.Antiforgery;
 
@@ -45,18 +43,7 @@ internal sealed class BinaryBlob : IEquatable<BinaryBlob>
         }
     }
 
-    private string DebuggerString
-    {
-        get
-        {
-            var sb = new StringBuilder("0x", 2 + (_data.Length * 2));
-            for (var i = 0; i < _data.Length; i++)
-            {
-                sb.AppendFormat(CultureInfo.InvariantCulture, "{0:x2}", _data[i]);
-            }
-            return sb.ToString();
-        }
-    }
+    private string DebuggerString => $"0x{Convert.ToHexStringLower(_data)}";
 
     public override bool Equals(object? obj)
     {

--- a/src/Security/Authentication/Facebook/src/FacebookHandler.cs
+++ b/src/Security/Authentication/Facebook/src/FacebookHandler.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
 using System.Net.Http;
 using System.Security.Claims;
 using System.Security.Cryptography;
@@ -70,12 +69,7 @@ public class FacebookHandler : OAuthHandler<FacebookOptions>
         var key = Encoding.ASCII.GetBytes(Options.AppSecret);
         var tokenBytes = Encoding.ASCII.GetBytes(accessToken);
         var hash = HMACSHA256.HashData(key, tokenBytes);
-        var builder = new StringBuilder();
-        for (int i = 0; i < hash.Length; i++)
-        {
-            builder.Append(CultureInfo.InvariantCulture, $"{hash[i]:x2}");
-        }
-        return builder.ToString();
+        return Convert.ToHexStringLower(hash);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
# Use Convert.ToHexStringLower

Use `Convert.ToHexStringLower()` in two locations.

## Description

Use `Convert.ToHexStringLower()` instead of looping through the buffer to format with a `StringBuilder`.
