### PR TITLE
Warn when [Authorize] is overridden by [AllowAnonymous] from "farther" away

### DIFF
--- a/src/Framework/AspNetCoreAnalyzers/samples/WebAppSample/WebAppSample.csproj
+++ b/src/Framework/AspNetCoreAnalyzers/samples/WebAppSample/WebAppSample.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
@@ -215,11 +215,11 @@ internal static class DiagnosticDescriptors
         isEnabledByDefault: true,
         helpLinkUri: "https://aka.ms/aspnet/analyzers");
 
-    internal static readonly DiagnosticDescriptor AuthorizeAttributeOverridden = new(
+    internal static readonly DiagnosticDescriptor OverriddenAuthorizeAttribute = new(
         "ASP0026",
-        new LocalizableResourceString(nameof(Resources.Analyzer_AuthorizeAttributeOverridden_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.Analyzer_AuthorizeAttributeOverridden_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        new LocalizableResourceString(nameof(Resources.Analyzer_OverriddenAuthorizeAttribute_Title), Resources.ResourceManager, typeof(Resources)),
+        new LocalizableResourceString(nameof(Resources.Analyzer_OverriddenAuthorizeAttribute_Message), Resources.ResourceManager, typeof(Resources)),
+        "Security",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         helpLinkUri: "https://aka.ms/aspnet/analyzers");

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
@@ -214,4 +214,13 @@ internal static class DiagnosticDescriptors
         DiagnosticSeverity.Info,
         isEnabledByDefault: true,
         helpLinkUri: "https://aka.ms/aspnet/analyzers");
+
+    internal static readonly DiagnosticDescriptor AuthorizeAttributeOverridden = new(
+        "ASP0026",
+        new LocalizableResourceString(nameof(Resources.Analyzer_AuthorizeAttributeOverridden_Title), Resources.ResourceManager, typeof(Resources)),
+        new LocalizableResourceString(nameof(Resources.Analyzer_AuthorizeAttributeOverridden_Message), Resources.ResourceManager, typeof(Resources)),
+        "Usage",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        helpLinkUri: "https://aka.ms/aspnet/analyzers");
 }

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Mvc/DetectOverriddenAuthorizeAttribute.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Mvc/DetectOverriddenAuthorizeAttribute.cs
@@ -1,0 +1,229 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.AspNetCore.App.Analyzers.Infrastructure;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.AspNetCore.Analyzers.Mvc;
+
+using WellKnownType = WellKnownTypeData.WellKnownType;
+
+public partial class MvcAnalyzer
+{
+    /// <summary>
+    /// This tries to detect [Authorize] attributes that are unwittingly overridden by [AllowAnonymous] attributes that are "farther" away from a controller.
+    /// </summary>
+    /// <remarks>
+    /// This might report the same [Authorize] attribute multiple times if it's on a shared base type, but we'd have to disable parallelization of the
+    /// entire MvcAnalyzer to avoid that. We assume that this scenario is rare enough and that overreporting is benign enough to not warrant the performance hit.
+    /// See AuthorizeOnControllerBaseWithMultipleChildren_AllowAnonymousOnControllerBaseBaseType_HasMultipleDiagnostics.
+    /// </remarks>
+    private static void DetectOverriddenAuthorizeAttributeOnController(SymbolAnalysisContext context, WellKnownTypes wellKnownTypes,
+        INamedTypeSymbol controllerSymbol, List<AttributeInfo> authorizeAttributes, out string? allowAnonClass)
+    {
+        Debug.Assert(authorizeAttributes.Count is 0);
+
+        var isCheckingBaseType = false;
+        allowAnonClass = null;
+
+        foreach (var currentClass in controllerSymbol.GetTypeHierarchy())
+        {
+            FindAuthorizeAndAllowAnonymous(wellKnownTypes, currentClass, isCheckingBaseType, authorizeAttributes, out var foundAllowAnonymous);
+            if (foundAllowAnonymous)
+            {
+                // Anything we find after this would be farther away, so we can short circuit.
+                ReportAuthorizeAttributeOverriddenDiagnosticsIfAny(context, authorizeAttributes, currentClass.Name);
+                // Keep track of the nearest class with [AllowAnonymous] for later reporting of method-level [Authorize] attributes.
+                allowAnonClass = currentClass.Name;
+                return;
+            }
+
+            isCheckingBaseType = true;
+        }
+    }
+
+    /// <summary>
+    /// This tries to detect [Authorize] attributes that are unwittingly overridden by [AllowAnonymous] attributes that are "farther" away from a controller action.
+    /// To do so, it first searches the action method and then the controller class. It repeats this process for each virtual method the action may override and for
+    /// each base class the controller may inherit from. Since it searches for the attributes closest to the action first, it short circuits as soon as [AllowAnonymous] is found.
+    /// If it has already detected a closer [Authorize] attribute, it reports a diagnostic at the [Authorize] attribute's location indicating that it will be overridden.
+    /// </summary>
+    private static void DetectOverriddenAuthorizeAttributeOnAction(SymbolAnalysisContext context, WellKnownTypes wellKnownTypes,
+        IMethodSymbol actionSymbol, List<AttributeInfo> authorizeAttributes, string? allowAnonClass)
+    {
+        Debug.Assert(authorizeAttributes.Count is 0);
+
+        bool foundAllowAnonymous;
+        var isCheckingBaseType = false;
+        var currentMethod = actionSymbol;
+
+        foreach (var currentClass in actionSymbol.ContainingType.GetTypeHierarchy())
+        {
+            if (currentMethod is not null && IsSameSymbol(currentMethod.ContainingType, currentClass))
+            {
+                FindAuthorizeAndAllowAnonymous(wellKnownTypes, currentMethod, isCheckingBaseType, authorizeAttributes, out foundAllowAnonymous);
+                if (foundAllowAnonymous)
+                {
+                    // [AllowAnonymous] was found on the action method. Anything we find after this would be farther away, so we don't need to report any
+                    // [Authorize] attributes unless we already found one on the very same method or an override.
+                    ReportAuthorizeAttributeOverriddenDiagnosticsIfAny(context, authorizeAttributes, currentMethod.ContainingType.Name, currentMethod.Name);
+                    return;
+                }
+
+                currentMethod = currentMethod.OverriddenMethod;
+
+                if (currentMethod is null)
+                {
+                    if (authorizeAttributes.Count is 0)
+                    {
+                        // We've already checked the Controller and any base classes for overridden attributes in DetectOverriddenAuthorizeAttributeOnController.
+                        // If there are no more base methods and are not tracking any unreported [Authorize] attributes that might be overridden by a class, we're done.
+                        return;
+                    }
+
+                    if (!isCheckingBaseType && allowAnonClass is not null)
+                    {
+                        // Don't use allowAnonClass once we start checking overrides to avoid false positives. But if we found [Authorize] directly on a non-virtual
+                        // action method, we can report it without rechecking the controller or its base types for [AllowAnonymous] if an allowAnonClass was passed in.
+                        ReportAuthorizeAttributeOverriddenDiagnosticsIfAny(context, authorizeAttributes, allowAnonClass);
+                        return;
+                    }
+                }
+            }
+
+            // We're mostly looking for [Authorize] on virtual methods and verifying they are not overridden by farther away [AllowAnonymous] attributes,
+            // but we still need to track [Authorize] attributes on classes in case there is a [AllowAnonymous] on a base method farther away.
+            FindAuthorizeAndAllowAnonymous(wellKnownTypes, currentClass, isCheckingBaseType, authorizeAttributes, out foundAllowAnonymous);
+            if (foundAllowAnonymous)
+            {
+                // We've already searched Controllers and their base types for overridden [Authorize] attribute locations, we don't need to report those again.
+                ReportAuthorizeAttributeOverriddenDiagnosticsIfAny(context, authorizeAttributes.Where(a => a.IsTargetingMethod), currentClass.Name);
+                return;
+            }
+
+            isCheckingBaseType = true;
+        }
+
+        Debug.Assert(currentMethod is null);
+    }
+
+    private static bool IsSameSymbol(ISymbol? x, ISymbol? y) => SymbolEqualityComparer.Default.Equals(x, y);
+
+    private static bool IsInheritableAttribute(WellKnownTypes wellKnownTypes, INamedTypeSymbol attribute)
+    {
+        // [AttributeUsage] is sealed but inheritable.
+        var attributeUsageAttributeType = wellKnownTypes.Get(WellKnownType.System_AttributeUsageAttribute);
+        var attributeUsage = attribute.GetAttributes(attributeUsageAttributeType, inherit: true).FirstOrDefault();
+
+        if (attributeUsage is not null)
+        {
+            foreach (var arg in attributeUsage.NamedArguments)
+            {
+                if (arg.Key == nameof(AttributeUsageAttribute.Inherited))
+                {
+                    return (bool)arg.Value.Value!;
+                }
+            }
+        }
+
+        // If [AttributeUsage] is not found or the Inherited property is not set, the default is true.
+        return true;
+    }
+
+    private static bool IsMatchingAttribute(WellKnownTypes wellKnownTypes, INamedTypeSymbol attribute,
+        INamedTypeSymbol commonAttribute, ITypeSymbol attributeInterface, bool mustBeInheritable)
+    {
+        // The "common" attribute is either [Authorize] or [AllowAnonymous] so we can skip the interface and inheritable checks.
+        if (IsSameSymbol(attribute, commonAttribute))
+        {
+            return true;
+        }
+
+        if (!attributeInterface.IsAssignableFrom(attribute))
+        {
+            return false;
+        }
+
+        return !mustBeInheritable || IsInheritableAttribute(wellKnownTypes, attribute);
+    }
+
+    private static void FindAuthorizeAndAllowAnonymous(WellKnownTypes wellKnownTypes, ISymbol symbol, bool isCheckingBaseType,
+        List<AttributeInfo> authorizeAttributes, out bool foundAllowAnonymous)
+    {
+        AttributeData? localAuthorizeAttribute = null;
+        List<AttributeData>? localAuthorizeAttributeOverflow = null;
+        foundAllowAnonymous = false;
+
+        foreach (var attribute in symbol.GetAttributes())
+        {
+            if (attribute.AttributeClass is null)
+            {
+                continue;
+            }
+
+            var authInterfaceType = wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Authorization_IAuthorizeData);
+            var authAttributeType = wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Authorization_AuthorizeAttribute);
+            if (IsMatchingAttribute(wellKnownTypes, attribute.AttributeClass, authAttributeType, authInterfaceType, isCheckingBaseType))
+            {
+                if (localAuthorizeAttribute is null)
+                {
+                    localAuthorizeAttribute = attribute;
+                }
+                else
+                {
+                    // This is ony allocated if there are multiple [Authorize] attributes on the same symbol which we assume is rare.
+                    localAuthorizeAttributeOverflow ??= [];
+                    localAuthorizeAttributeOverflow.Add(attribute);
+                }
+            }
+
+            var anonInterfaceType = wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Authorization_IAllowAnonymous);
+            var anonAttributeType = wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Authorization_AllowAnonymousAttribute);
+            if (IsMatchingAttribute(wellKnownTypes, attribute.AttributeClass, anonAttributeType, anonInterfaceType, isCheckingBaseType))
+            {
+                // If localAuthorizeAttribute is not null, [AllowAnonymous] came after [Authorize] on the same method or class. We assume
+                // this closer [AllowAnonymous] was intended to override the [Authorize] attribute which it always does regardless of order.
+                // [Authorize(...)] could still be useful for configuring the authentication scheme even if the endpoint allows anonymous requests.
+                localAuthorizeAttribute = null;
+                localAuthorizeAttributeOverflow?.Clear();
+                foundAllowAnonymous = true;
+            }
+        }
+
+        if (localAuthorizeAttribute is not null)
+        {
+            var isTargetingMethod = symbol is IMethodSymbol;
+            authorizeAttributes.Add(new(localAuthorizeAttribute, isTargetingMethod));
+            if (localAuthorizeAttributeOverflow is not null)
+            {
+                foreach (var extraAttribute in localAuthorizeAttributeOverflow)
+                {
+                    authorizeAttributes.Add(new(extraAttribute, isTargetingMethod));
+                }
+            }
+        }
+    }
+
+    private static void ReportAuthorizeAttributeOverriddenDiagnosticsIfAny(SymbolAnalysisContext context,
+        IEnumerable<AttributeInfo> authorizeAttributes, string allowAnonClass, string? allowAnonMethod = null)
+    {
+        string? allowAnonLocation = null;
+
+        foreach (var authorizeAttribute in authorizeAttributes)
+        {
+            allowAnonLocation ??= allowAnonMethod is null ? allowAnonClass : $"{allowAnonClass}.{allowAnonMethod}";
+            if (authorizeAttribute.AttributeData.ApplicationSyntaxReference is { } syntaxReference)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.AuthorizeAttributeOverridden,
+                    syntaxReference.GetSyntax(context.CancellationToken).GetLocation(),
+                    allowAnonLocation));
+            }
+        }
+    }
+}

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Mvc/MvcAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Mvc/MvcAnalyzer.cs
@@ -23,7 +23,7 @@ public partial class MvcAnalyzer : DiagnosticAnalyzer
 {
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(
         DiagnosticDescriptors.AmbiguousActionRoute,
-        DiagnosticDescriptors.AuthorizeAttributeOverridden
+        DiagnosticDescriptors.OverriddenAuthorizeAttribute
     );
 
     public override void Initialize(AnalysisContext context)

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Mvc/MvcAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Mvc/MvcAnalyzer.cs
@@ -22,7 +22,8 @@ using WellKnownType = WellKnownTypeData.WellKnownType;
 public partial class MvcAnalyzer : DiagnosticAnalyzer
 {
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(
-        DiagnosticDescriptors.AmbiguousActionRoute
+        DiagnosticDescriptors.AmbiguousActionRoute,
+        DiagnosticDescriptors.AuthorizeAttributeOverridden
     );
 
     public override void Initialize(AnalysisContext context)
@@ -36,17 +37,34 @@ public partial class MvcAnalyzer : DiagnosticAnalyzer
             var wellKnownTypes = WellKnownTypes.GetOrCreate(compilation);
             var routeUsageCache = RouteUsageCache.GetOrCreate(compilation);
 
-            var concurrentQueue = new ConcurrentQueue<List<ActionRoute>>();
+            var concurrentQueue = new ConcurrentQueue<(List<ActionRoute> ActionRoutes, List<AttributeInfo> AuthorizeAttributes)>();
 
             context.RegisterSymbolAction(context =>
             {
                 var namedTypeSymbol = (INamedTypeSymbol)context.Symbol;
+
+                // Visit Controllers
                 if (MvcDetector.IsController(namedTypeSymbol, wellKnownTypes))
                 {
                     // Pool and reuse lists for each block.
-                    if (!concurrentQueue.TryDequeue(out var actionRoutes))
+                    if (!concurrentQueue.TryDequeue(out var pooledItems))
                     {
-                        actionRoutes = new List<ActionRoute>();
+                        pooledItems.ActionRoutes = [];
+                        pooledItems.AuthorizeAttributes = [];
+                    }
+
+                    DetectOverriddenAuthorizeAttributeOnController(context, wellKnownTypes, namedTypeSymbol, pooledItems.AuthorizeAttributes, out var allowAnonClass);
+                    pooledItems.AuthorizeAttributes.Clear();
+
+                    // Visit Actions
+                    foreach (var member in namedTypeSymbol.GetMembers())
+                    {
+                        if (member is IMethodSymbol methodSymbol && MvcDetector.IsAction(methodSymbol, wellKnownTypes))
+                        {
+                            PopulateActionRoutes(context, wellKnownTypes, routeUsageCache, pooledItems.ActionRoutes, methodSymbol);
+                            DetectOverriddenAuthorizeAttributeOnAction(context, wellKnownTypes, methodSymbol, pooledItems.AuthorizeAttributes, allowAnonClass);
+                            pooledItems.AuthorizeAttributes.Clear();
+                        }
                     }
 
                     RoutePatternTree? controllerRoutePattern = null;
@@ -60,50 +78,41 @@ public partial class MvcAnalyzer : DiagnosticAnalyzer
                         }
                     }
 
-                    PopulateActionRoutes(context, wellKnownTypes, routeUsageCache, namedTypeSymbol, actionRoutes);
-
-                    DetectAmbiguousActionRoutes(context, wellKnownTypes, controllerRoutePattern, actionRoutes);
+                    DetectAmbiguousActionRoutes(context, wellKnownTypes, controllerRoutePattern, pooledItems.ActionRoutes);
 
                     // Return to the pool.
-                    actionRoutes.Clear();
-                    concurrentQueue.Enqueue(actionRoutes);
+                    pooledItems.ActionRoutes.Clear();
+                    concurrentQueue.Enqueue(pooledItems);
                 }
             }, SymbolKind.NamedType);
         });
     }
 
-    private static void PopulateActionRoutes(SymbolAnalysisContext context, WellKnownTypes wellKnownTypes, RouteUsageCache routeUsageCache, INamedTypeSymbol namedTypeSymbol, List<ActionRoute> actionRoutes)
+    private static void PopulateActionRoutes(SymbolAnalysisContext context, WellKnownTypes wellKnownTypes, RouteUsageCache routeUsageCache, List<ActionRoute> actionRoutes, IMethodSymbol methodSymbol)
     {
-        foreach (var member in namedTypeSymbol.GetMembers())
+        // [Route("xxx")] attributes don't have a HTTP method and instead use the HTTP methods of other attributes.
+        // For example, [HttpGet] + [HttpPost] + [Route("xxx")] means the route "xxx" is combined with the HTTP methods.
+        var unroutedHttpMethods = GetUnroutedMethodHttpMethods(wellKnownTypes, methodSymbol);
+
+        foreach (var attribute in methodSymbol.GetAttributes())
         {
-            if (member is IMethodSymbol methodSymbol &&
-                MvcDetector.IsAction(methodSymbol, wellKnownTypes))
+            if (attribute.AttributeClass is null || !wellKnownTypes.IsType(attribute.AttributeClass, RouteAttributeTypes, out var match))
             {
-                // [Route("xxx")] attributes don't have a HTTP method and instead use the HTTP methods of other attributes.
-                // For example, [HttpGet] + [HttpPost] + [Route("xxx")] means the route "xxx" is combined with the HTTP methods.
-                var unroutedHttpMethods = GetUnroutedMethodHttpMethods(wellKnownTypes, methodSymbol);
-
-                foreach (var attribute in methodSymbol.GetAttributes())
-                {
-                    if (attribute.AttributeClass is null || !wellKnownTypes.IsType(attribute.AttributeClass, RouteAttributeTypes, out var match))
-                    {
-                        continue;
-                    }
-
-                    var routeUsage = GetRouteUsageModel(attribute, routeUsageCache, context.CancellationToken);
-                    if (routeUsage is null)
-                    {
-                        continue;
-                    }
-
-                    // [Route] uses unrouted HTTP verb attributes for its HTTP methods.
-                    var methods = match.Value is WellKnownType.Microsoft_AspNetCore_Mvc_RouteAttribute
-                        ? unroutedHttpMethods
-                        : ImmutableArray.Create(GetHttpMethod(match.Value)!);
-
-                    actionRoutes.Add(new ActionRoute(methodSymbol, routeUsage, methods));
-                }
+                continue;
             }
+
+            var routeUsage = GetRouteUsageModel(attribute, routeUsageCache, context.CancellationToken);
+            if (routeUsage is null)
+            {
+                continue;
+            }
+
+            // [Route] uses unrouted HTTP verb attributes for its HTTP methods.
+            var methods = match.Value is WellKnownType.Microsoft_AspNetCore_Mvc_RouteAttribute
+                ? unroutedHttpMethods
+                : ImmutableArray.Create(GetHttpMethod(match.Value)!);
+
+            actionRoutes.Add(new ActionRoute(methodSymbol, routeUsage, methods));
         }
     }
 
@@ -179,4 +188,5 @@ public partial class MvcAnalyzer : DiagnosticAnalyzer
     }
 
     private record struct ActionRoute(IMethodSymbol ActionSymbol, RouteUsageModel RouteUsageModel, ImmutableArray<string> HttpMethods);
+    private record struct AttributeInfo(AttributeData AttributeData, bool IsTargetingMethod);
 }

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Resources.resx
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Resources.resx
@@ -315,4 +315,10 @@
   <data name="Analyzer_UseAddAuthorizationBuilder_Title" xml:space="preserve">
     <value>Use AddAuthorizationBuilder</value>
   </data>
+  <data name="Analyzer_AuthorizeAttributeOverridden_Message" xml:space="preserve">
+    <value>This [Authorize] attribute is overridden by an [AllowAnonymous] attribute from farther away on '{0}'</value>
+  </data>
+  <data name="Analyzer_AuthorizeAttributeOverridden_Title" xml:space="preserve">
+    <value>[Authorize] overridden by [AllowAnonymous] from farther away</value>
+  </data>
 </root>

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Resources.resx
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Resources.resx
@@ -315,10 +315,10 @@
   <data name="Analyzer_UseAddAuthorizationBuilder_Title" xml:space="preserve">
     <value>Use AddAuthorizationBuilder</value>
   </data>
-  <data name="Analyzer_AuthorizeAttributeOverridden_Message" xml:space="preserve">
-    <value>This [Authorize] attribute is overridden by an [AllowAnonymous] attribute from farther away on '{0}'</value>
+  <data name="Analyzer_OverriddenAuthorizeAttribute_Message" xml:space="preserve">
+    <value>This [Authorize] attribute is overridden by an [AllowAnonymous] attribute from farther away on '{0}'. See https://aka.ms/aspnetcore-warnings/ASP0026 for more details.</value>
   </data>
-  <data name="Analyzer_AuthorizeAttributeOverridden_Title" xml:space="preserve">
+  <data name="Analyzer_OverriddenAuthorizeAttribute_Title" xml:space="preserve">
     <value>[Authorize] overridden by [AllowAnonymous] from farther away</value>
   </data>
 </root>

--- a/src/Framework/AspNetCoreAnalyzers/test/Mvc/AuthorizeAttributeOverriddenTest.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/Mvc/AuthorizeAttributeOverriddenTest.cs
@@ -1,0 +1,602 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis.Testing;
+using VerifyCS = Microsoft.AspNetCore.Analyzers.Verifiers.CSharpAnalyzerVerifier<Microsoft.AspNetCore.Analyzers.Mvc.MvcAnalyzer>;
+
+namespace Microsoft.AspNetCore.Analyzers.Mvc;
+
+public partial class AuthorizeAttributeOverriddenTest
+{
+    private const string CommonPrefix = """
+using System;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+
+WebApplication.Create().Run();
+
+""";
+
+    [Fact]
+    public async Task AuthorizeOnAction_AllowAnonymousOnController_HasDiagnostics()
+    {
+        var source = $$"""
+{{CommonPrefix}}
+[AllowAnonymous]
+public class MyController
+{
+    [{|#0:Authorize|}]
+    public object Get() => new();
+}
+""";
+
+        await VerifyCS.VerifyAnalyzerAsync(source,
+            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyController").WithLocation(0)
+        );
+    }
+
+    [Fact]
+    public async Task AllowAnonymousOnAction_AuthorizeOnController_NoDiagnostics()
+    {
+        var source = $$"""
+{{CommonPrefix}}
+[Authorize]
+public class MyController
+{
+    [AllowAnonymous]
+    public object Get() => new();
+}
+""";
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task AuthorizeOnAction_AllowAnonymousOnControllerBase_HasDiagnostics()
+    {
+        var source = $$"""
+{{CommonPrefix}}
+[AllowAnonymous]
+public class MyControllerBase
+{
+}
+
+public class MyController : MyControllerBase
+{
+    [{|#0:Authorize|}]
+    public object Get() => new();
+}
+""";
+
+        await VerifyCS.VerifyAnalyzerAsync(source,
+            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBase").WithLocation(0)
+        );
+    }
+
+    [Fact]
+    public async Task AuthorizeOnActionControllerAndAction_AllowAnonymousOnControllerBase_HasMultipleDiagnostics()
+    {
+        // The closest Authorize attribute to the action reported if multiple could be considered overridden.
+        var source = $$"""
+{{CommonPrefix}}
+[AllowAnonymous]
+[{|#0:Authorize|}]
+public class MyControllerBase
+{
+}
+
+[{|#1:Authorize|}]
+public class MyController : MyControllerBase
+{
+    [{|#2:Authorize|}]
+    public object Get() => new();
+}
+""";
+
+        await VerifyCS.VerifyAnalyzerAsync(source,
+            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBase").WithLocation(0),
+            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBase").WithLocation(1),
+            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBase").WithLocation(2)
+        );
+    }
+
+    [Fact]
+    public async Task AuthorizeOnController_AllowAnonymousOnControllerBase_HasDiagnostics()
+    {
+        var source = $$"""
+{{CommonPrefix}}
+[AllowAnonymous]
+public class MyControllerBase
+{
+}
+
+[{|#0:Authorize|}]
+public class MyController : MyControllerBase
+{
+    public object Get() => new();
+}
+""";
+
+        await VerifyCS.VerifyAnalyzerAsync(source,
+            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBase").WithLocation(0)
+        );
+    }
+
+    [Fact]
+    public async Task AuthorizeOnControllerWithMultipleActions_AllowAnonymousOnControllerBase_HasSingleDiagnostic()
+    {
+        var source = $$"""
+{{CommonPrefix}}
+[AllowAnonymous]
+public class MyControllerBase
+{
+}
+
+[{|#0:Authorize|}]
+public class MyController : MyControllerBase
+{
+    public object Get() => new();
+    public object AnotherGet() => new();
+}
+""";
+
+        await VerifyCS.VerifyAnalyzerAsync(source,
+            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBase").WithLocation(0)
+        );
+    }
+
+    [Fact]
+    public async Task AuthorizeOnControllerBaseWithMultipleChildren_AllowAnonymousOnControllerBaseBaseType_HasMultipleDiagnostics()
+    {
+        var source = $$"""
+{{CommonPrefix}}
+[AllowAnonymous]
+public class MyControllerBaseBase
+{
+}
+
+[{|#0:Authorize|}]
+public class MyControllerBase : MyControllerBaseBase
+{
+}
+
+public class MyController : MyControllerBase
+{
+    public object Get() => new();
+    public object AnotherGet() => new();
+}
+
+public class MyOtherController : MyControllerBase
+{
+    public object Get() => new();
+    public object AnotherGet() => new();
+}
+""";
+
+        // This is not ideal. If someone comes along and fixes it to be a single diagnostic, feel free to update this test to end with
+        // "HasSingleDiagnostic" instead of "HasMultipleDiagnostics". I think fixing it will require disabling parallelization of the
+        // entire MvcAnalyzer which I don't think is a good tradeoff. I assume that this scenario is rare enough and that overreporting
+        // is benign enough to not warrant the performance hit.
+        await VerifyCS.VerifyAnalyzerAsync(source,
+            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBaseBase").WithLocation(0),
+            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBaseBase").WithLocation(0)
+        );
+    }
+
+    [Fact]
+    public async Task CustomAuthorizeOnAction_CustomAllowAnonymousOnController_HasDiagnostics()
+    {
+        var source = $$"""
+{{CommonPrefix}}
+[MyAllowAnonymous]
+public class MyController
+{
+    [{|#0:MyAuthorize|}]
+    public object Get() => new();
+}
+
+public class MyAuthorizeAttribute : Attribute, IAuthorizeData
+{
+    public string? Policy { get; set; }
+    public string? Roles { get; set; }
+    public string? AuthenticationSchemes { get; set; }
+}
+
+public class MyAllowAnonymousAttribute : Attribute, IAllowAnonymous
+{
+}
+""";
+
+        await VerifyCS.VerifyAnalyzerAsync(source,
+            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyController").WithLocation(0)
+        );
+    }
+
+    [Fact]
+    public async Task AuthorizeOnAction_NonInheritableAllowAnonymousOnController_NoDiagnostics()
+    {
+        var source = $$"""
+{{CommonPrefix}}
+[MyAllowAnonymous]
+public class MyControllerBase
+{
+}
+
+public class MyController : MyControllerBase
+{
+    [Authorize]
+    public object Get() => new();
+}
+
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+public class MyAllowAnonymousAttribute : Attribute, IAllowAnonymous
+{
+}
+""";
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task CustomAuthorizeCombinedWithAllowAnonymousOnAction_AllowAnonymousOnController_NoDiagnostics()
+    {
+        var source = $$"""
+{{CommonPrefix}}
+[AllowAnonymous]
+public class MyController
+{
+    [MyAuthorize]
+    public object Get() => new();
+}
+
+public class MyAuthorizeAttribute : Attribute, IAuthorizeData, IAllowAnonymous
+{
+    public string? Policy { get; set; }
+    public string? Roles { get; set; }
+    public string? AuthenticationSchemes { get; set; }
+}
+""";
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task AuthorizeBeforeAllowAnonymousOnAction_AllowAnonymousOnController_NoDiagnostics()
+    {
+        var source = $$"""
+{{CommonPrefix}}
+[AllowAnonymous]
+public class MyController
+{
+    [Authorize(AuthenticationSchemes = "foo")]
+    [AllowAnonymous]
+    public object Get() => new();
+}
+""";
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task AuthorizeAfterAllowAnonymousOnAction_NoAttributeOnController_HasDiagnostics()
+    {
+        var source = $$"""
+{{CommonPrefix}}
+public class MyController
+{
+    [AllowAnonymous]
+    [{|#0:Authorize|}]
+    public object Get() => new();
+}
+""";
+
+        await VerifyCS.VerifyAnalyzerAsync(source,
+            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyController.Get").WithLocation(0)
+        );
+    }
+
+    [Fact]
+    public async Task NoAttributeOnAction_AuthorizeBeforeAllowAnonymousOnController_NoDiagnostics()
+    {
+        var source = $$"""
+{{CommonPrefix}}
+[Authorize(AuthenticationSchemes = "foo")]
+[AllowAnonymous]
+public class MyController
+{
+    public object Get() => new();
+}
+""";
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task NoAttributeOnAction_AuthorizeAfterAllowAnonymousOnController_HasDiagnostics()
+    {
+        var source = $$"""
+{{CommonPrefix}}
+[AllowAnonymous]
+[{|#0:Authorize|}]
+public class MyController
+{
+    public object Get() => new();
+}
+""";
+
+        await VerifyCS.VerifyAnalyzerAsync(source,
+            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyController").WithLocation(0)
+        );
+    }
+
+    [Fact]
+    public async Task AuthorizeOnAction_AllowAnonymousOnBaseMethod_HasDiagnostics()
+    {
+        var source = $$"""
+{{CommonPrefix}}
+public class MyControllerBase
+{
+    [AllowAnonymous]
+    public virtual object Get() => new();
+}
+
+public class MyController : MyControllerBase
+{
+    [{|#0:Authorize|}]
+    public override object Get() => new();
+}
+""";
+
+        await VerifyCS.VerifyAnalyzerAsync(source,
+            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBase.Get").WithLocation(0)
+        );
+    }
+
+    [Fact]
+    public async Task AllowAnonymousOnVirtualBaseActionWithNoOverride_AuthorizeOnController_NoDiagnostics()
+    {
+        var source = $$"""
+{{CommonPrefix}}
+public class MyControllerBase
+{
+    [AllowAnonymous]
+    public virtual object Get() => new();
+}
+
+[Authorize]
+public class MyController : MyControllerBase
+{
+}
+""";
+
+        // I suspect [AllowAnonymous] on a specific action that never needs auth despite the child controller
+        // configuring auth is a fairly common pattern. However, if the action is explicitly overridden,
+        // you need to reapply [AllowAnonymous] on the override to silence the warning and clarify your intent.
+        // Making people do this when there isn't even an override is a bit onerous.
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task AllowAnonymousOnVirtualBaseActionAndOverride_AuthorizeOnController_NoDiagnostics()
+    {
+        var source = $$"""
+{{CommonPrefix}}
+public class MyControllerBase
+{
+    [AllowAnonymous]
+    public virtual object Get() => new();
+}
+
+[Authorize]
+public class MyController : MyControllerBase
+{
+    [AllowAnonymous]
+    public override object Get() => new();
+    public object AnotherGet() => new();
+}
+""";
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task AllowAnonymousOnVirtualBaseBaseActionButNotOverride_AuthorizeOnControllerBase_HasDiagnostics()
+    {
+        var source = $$"""
+{{CommonPrefix}}
+public class MyControllerBaseBase
+{
+    [AllowAnonymous]
+    public virtual object Get() => new();
+}
+
+[{|#0:Authorize|}]
+public class MyControllerBase : MyControllerBaseBase
+{
+}
+
+public class MyController : MyControllerBase
+{
+    public override object Get() => new();
+    public object AnotherGet() => new();
+}
+""";
+
+        await VerifyCS.VerifyAnalyzerAsync(source,
+            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBaseBase.Get").WithLocation(0)
+        );
+    }
+
+    [Fact]
+    public async Task AllowAnonymousOnVirtualBaseActionButNotOverride_AuthorizeOnController_HasDiagnostics()
+    {
+        var source = $$"""
+{{CommonPrefix}}
+public class MyControllerBase
+{
+    [AllowAnonymous]
+    public virtual object Get() => new();
+}
+
+[{|#0:Authorize|}]
+public class MyController : MyControllerBase
+{
+    public override object Get() => new();
+    public object AnotherGet() => new();
+}
+""";
+
+        await VerifyCS.VerifyAnalyzerAsync(source,
+            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBase.Get").WithLocation(0)
+        );
+    }
+
+    [Fact]
+    public async Task AllowAnonymousOnBaseBaseController_AuthorizeOnControllerBase_HasSingleDiagnostic()
+    {
+        var source = $$"""
+{{CommonPrefix}}
+[AllowAnonymous]
+public class MyControllerBaseBase
+{
+    public virtual object Get() => new();
+}
+
+[{|#0:Authorize|}]
+public class MyControllerBase : MyControllerBaseBase
+{
+}
+
+public class MyController : MyControllerBase
+{
+    public override object Get() => new();
+    public object AnotherGet() => new();
+}
+""";
+
+        await VerifyCS.VerifyAnalyzerAsync(source,
+            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBaseBase").WithLocation(0)
+        );
+    }
+
+    [Fact]
+    public async Task AllowAnonymousOnControllerBaseBaseType_AuthorizeOnControllerBaseAndAction_HasDiagnostics()
+    {
+        var source = $$"""
+{{CommonPrefix}}
+[AllowAnonymous]
+public class MyControllerBaseBase
+{
+    [{|#2:Authorize|}]
+    public virtual object Get() => new();
+}
+
+[{|#0:Authorize|}]
+public class MyControllerBase : MyControllerBaseBase
+{
+    [{|#1:Authorize|}]
+    public override object Get() => new();
+}
+
+public class MyController : MyControllerBase
+{
+    public override object Get() => new();
+    public object AnotherGet() => new();
+}
+""";
+
+        await VerifyCS.VerifyAnalyzerAsync(source,
+            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBaseBase").WithLocation(0),
+            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBaseBase").WithLocation(1),
+            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBaseBase").WithLocation(2)
+        );
+    }
+
+    [Fact]
+    public async Task AllowAnonymousOnBaseBaseType_AuthorizeOnControllerBaseAndAction_HasDiagnostics()
+    {
+        var source = $$"""
+{{CommonPrefix}}
+[Authorize]
+public class MyControllerBaseBase
+{
+    [AllowAnonymous]
+    public virtual object Get() => new();
+}
+
+[{|#0:Authorize|}]
+public class MyControllerBase : MyControllerBaseBase
+{
+    [{|#1:Authorize|}]
+    public override object Get() => new();
+}
+
+public class MyController : MyControllerBase
+{
+    public override object Get() => new();
+    public object AnotherGet() => new();
+}
+""";
+
+        await VerifyCS.VerifyAnalyzerAsync(source,
+            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBaseBase.Get").WithLocation(0),
+            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBaseBase.Get").WithLocation(1)
+        );
+    }
+
+    [Fact]
+    public async Task MultipleControllers_WithMultipleActions_HasDiagnostics()
+    {
+        // Copied from https://github.com/dotnet/aspnetcore/issues/43550#issuecomment-1940287150
+        var source = $$"""
+{{CommonPrefix}}
+[AllowAnonymous]
+public class OAuthControllerAnon : ControllerBase
+{
+}
+
+[Authorize]
+public class OAuthControllerAuthz : ControllerBase
+{
+}
+
+[{|#0:Authorize|}] // BUG
+public class OAuthControllerInherited : OAuthControllerAnon
+{
+}
+
+public class OAuthControllerInherited2 : OAuthControllerAnon
+{
+    [{|#1:Authorize|}] // BUG
+    public IActionResult Privacy()
+    {
+        return null;
+    }
+}
+
+[AllowAnonymous]
+[{|#2:Authorize|}] // BUG
+public class OAuthControllerMultiple : ControllerBase
+{
+}
+
+[AllowAnonymous]
+public class OAuthControllerInherited3 : ControllerBase
+{
+    [{|#3:Authorize|}] // BUG
+    public IActionResult Privacy()
+    {
+        return null;
+    }
+}
+""";
+
+        await VerifyCS.VerifyAnalyzerAsync(source,
+            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("OAuthControllerAnon").WithLocation(0),
+            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("OAuthControllerAnon").WithLocation(1),
+            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("OAuthControllerMultiple").WithLocation(2),
+            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("OAuthControllerInherited3").WithLocation(3)
+        );
+    }
+}

--- a/src/Framework/AspNetCoreAnalyzers/test/Mvc/DetectOverriddenAuthorizeAttributeTest.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/Mvc/DetectOverriddenAuthorizeAttributeTest.cs
@@ -6,7 +6,7 @@ using VerifyCS = Microsoft.AspNetCore.Analyzers.Verifiers.CSharpAnalyzerVerifier
 
 namespace Microsoft.AspNetCore.Analyzers.Mvc;
 
-public partial class AuthorizeAttributeOverriddenTest
+public partial class DetectOverriddenAuthorizeAttributeTest
 {
     private const string CommonPrefix = """
 using System;
@@ -32,7 +32,7 @@ public class MyController
 """;
 
         await VerifyCS.VerifyAnalyzerAsync(source,
-            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyController").WithLocation(0)
+            new DiagnosticResult(DiagnosticDescriptors.OverriddenAuthorizeAttribute).WithArguments("MyController").WithLocation(0)
         );
     }
 
@@ -70,7 +70,7 @@ public class MyController : MyControllerBase
 """;
 
         await VerifyCS.VerifyAnalyzerAsync(source,
-            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBase").WithLocation(0)
+            new DiagnosticResult(DiagnosticDescriptors.OverriddenAuthorizeAttribute).WithArguments("MyControllerBase").WithLocation(0)
         );
     }
 
@@ -95,9 +95,9 @@ public class MyController : MyControllerBase
 """;
 
         await VerifyCS.VerifyAnalyzerAsync(source,
-            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBase").WithLocation(0),
-            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBase").WithLocation(1),
-            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBase").WithLocation(2)
+            new DiagnosticResult(DiagnosticDescriptors.OverriddenAuthorizeAttribute).WithArguments("MyControllerBase").WithLocation(0),
+            new DiagnosticResult(DiagnosticDescriptors.OverriddenAuthorizeAttribute).WithArguments("MyControllerBase").WithLocation(1),
+            new DiagnosticResult(DiagnosticDescriptors.OverriddenAuthorizeAttribute).WithArguments("MyControllerBase").WithLocation(2)
         );
     }
 
@@ -119,7 +119,7 @@ public class MyController : MyControllerBase
 """;
 
         await VerifyCS.VerifyAnalyzerAsync(source,
-            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBase").WithLocation(0)
+            new DiagnosticResult(DiagnosticDescriptors.OverriddenAuthorizeAttribute).WithArguments("MyControllerBase").WithLocation(0)
         );
     }
 
@@ -142,7 +142,7 @@ public class MyController : MyControllerBase
 """;
 
         await VerifyCS.VerifyAnalyzerAsync(source,
-            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBase").WithLocation(0)
+            new DiagnosticResult(DiagnosticDescriptors.OverriddenAuthorizeAttribute).WithArguments("MyControllerBase").WithLocation(0)
         );
     }
 
@@ -179,8 +179,8 @@ public class MyOtherController : MyControllerBase
         // entire MvcAnalyzer which I don't think is a good tradeoff. I assume that this scenario is rare enough and that overreporting
         // is benign enough to not warrant the performance hit.
         await VerifyCS.VerifyAnalyzerAsync(source,
-            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBaseBase").WithLocation(0),
-            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBaseBase").WithLocation(0)
+            new DiagnosticResult(DiagnosticDescriptors.OverriddenAuthorizeAttribute).WithArguments("MyControllerBaseBase").WithLocation(0),
+            new DiagnosticResult(DiagnosticDescriptors.OverriddenAuthorizeAttribute).WithArguments("MyControllerBaseBase").WithLocation(0)
         );
     }
 
@@ -209,7 +209,7 @@ public class MyAllowAnonymousAttribute : Attribute, IAllowAnonymous
 """;
 
         await VerifyCS.VerifyAnalyzerAsync(source,
-            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyController").WithLocation(0)
+            new DiagnosticResult(DiagnosticDescriptors.OverriddenAuthorizeAttribute).WithArguments("MyController").WithLocation(0)
         );
     }
 
@@ -292,7 +292,7 @@ public class MyController
 """;
 
         await VerifyCS.VerifyAnalyzerAsync(source,
-            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyController.Get").WithLocation(0)
+            new DiagnosticResult(DiagnosticDescriptors.OverriddenAuthorizeAttribute).WithArguments("MyController.Get").WithLocation(0)
         );
     }
 
@@ -326,7 +326,7 @@ public class MyController
 """;
 
         await VerifyCS.VerifyAnalyzerAsync(source,
-            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyController").WithLocation(0)
+            new DiagnosticResult(DiagnosticDescriptors.OverriddenAuthorizeAttribute).WithArguments("MyController").WithLocation(0)
         );
     }
 
@@ -349,7 +349,7 @@ public class MyController : MyControllerBase
 """;
 
         await VerifyCS.VerifyAnalyzerAsync(source,
-            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBase.Get").WithLocation(0)
+            new DiagnosticResult(DiagnosticDescriptors.OverriddenAuthorizeAttribute).WithArguments("MyControllerBase.Get").WithLocation(0)
         );
     }
 
@@ -424,7 +424,7 @@ public class MyController : MyControllerBase
 """;
 
         await VerifyCS.VerifyAnalyzerAsync(source,
-            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBaseBase.Get").WithLocation(0)
+            new DiagnosticResult(DiagnosticDescriptors.OverriddenAuthorizeAttribute).WithArguments("MyControllerBaseBase.Get").WithLocation(0)
         );
     }
 
@@ -448,7 +448,7 @@ public class MyController : MyControllerBase
 """;
 
         await VerifyCS.VerifyAnalyzerAsync(source,
-            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBase.Get").WithLocation(0)
+            new DiagnosticResult(DiagnosticDescriptors.OverriddenAuthorizeAttribute).WithArguments("MyControllerBase.Get").WithLocation(0)
         );
     }
 
@@ -476,7 +476,7 @@ public class MyController : MyControllerBase
 """;
 
         await VerifyCS.VerifyAnalyzerAsync(source,
-            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBaseBase").WithLocation(0)
+            new DiagnosticResult(DiagnosticDescriptors.OverriddenAuthorizeAttribute).WithArguments("MyControllerBaseBase").WithLocation(0)
         );
     }
 
@@ -507,9 +507,9 @@ public class MyController : MyControllerBase
 """;
 
         await VerifyCS.VerifyAnalyzerAsync(source,
-            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBaseBase").WithLocation(0),
-            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBaseBase").WithLocation(1),
-            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBaseBase").WithLocation(2)
+            new DiagnosticResult(DiagnosticDescriptors.OverriddenAuthorizeAttribute).WithArguments("MyControllerBaseBase").WithLocation(0),
+            new DiagnosticResult(DiagnosticDescriptors.OverriddenAuthorizeAttribute).WithArguments("MyControllerBaseBase").WithLocation(1),
+            new DiagnosticResult(DiagnosticDescriptors.OverriddenAuthorizeAttribute).WithArguments("MyControllerBaseBase").WithLocation(2)
         );
     }
 
@@ -540,13 +540,13 @@ public class MyController : MyControllerBase
 """;
 
         await VerifyCS.VerifyAnalyzerAsync(source,
-            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBaseBase.Get").WithLocation(0),
-            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("MyControllerBaseBase.Get").WithLocation(1)
+            new DiagnosticResult(DiagnosticDescriptors.OverriddenAuthorizeAttribute).WithArguments("MyControllerBaseBase.Get").WithLocation(0),
+            new DiagnosticResult(DiagnosticDescriptors.OverriddenAuthorizeAttribute).WithArguments("MyControllerBaseBase.Get").WithLocation(1)
         );
     }
 
     [Fact]
-    public async Task MultipleControllers_WithMultipleActions_HasDiagnostics()
+    public async Task AttributesOnMultipleActions_AttributesOnMultipleControllers_HasDiagnostics()
     {
         // Copied from https://github.com/dotnet/aspnetcore/issues/43550#issuecomment-1940287150
         var source = $$"""
@@ -593,10 +593,10 @@ public class OAuthControllerInherited3 : ControllerBase
 """;
 
         await VerifyCS.VerifyAnalyzerAsync(source,
-            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("OAuthControllerAnon").WithLocation(0),
-            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("OAuthControllerAnon").WithLocation(1),
-            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("OAuthControllerMultiple").WithLocation(2),
-            new DiagnosticResult(DiagnosticDescriptors.AuthorizeAttributeOverridden).WithArguments("OAuthControllerInherited3").WithLocation(3)
+            new DiagnosticResult(DiagnosticDescriptors.OverriddenAuthorizeAttribute).WithArguments("OAuthControllerAnon").WithLocation(0),
+            new DiagnosticResult(DiagnosticDescriptors.OverriddenAuthorizeAttribute).WithArguments("OAuthControllerAnon").WithLocation(1),
+            new DiagnosticResult(DiagnosticDescriptors.OverriddenAuthorizeAttribute).WithArguments("OAuthControllerMultiple").WithLocation(2),
+            new DiagnosticResult(DiagnosticDescriptors.OverriddenAuthorizeAttribute).WithArguments("OAuthControllerInherited3").WithLocation(3)
         );
     }
 }

--- a/src/Shared/Roslyn/CodeAnalysisExtensions.cs
+++ b/src/Shared/Roslyn/CodeAnalysisExtensions.cs
@@ -141,7 +141,7 @@ internal static class CodeAnalysisExtensions
         return false;
     }
 
-    private static IEnumerable<ITypeSymbol> GetTypeHierarchy(this ITypeSymbol? typeSymbol)
+    public static IEnumerable<ITypeSymbol> GetTypeHierarchy(this ITypeSymbol? typeSymbol)
     {
         while (typeSymbol != null)
         {

--- a/src/Shared/RoslynUtils/WellKnownTypeData.cs
+++ b/src/Shared/RoslynUtils/WellKnownTypeData.cs
@@ -113,11 +113,14 @@ internal static class WellKnownTypeData
         Microsoft_Extensions_DependencyInjection_PolicyServiceCollectionExtensions,
         Microsoft_Extensions_DependencyInjection_FromKeyedServicesAttribute,
         Microsoft_AspNetCore_Authorization_AuthorizationOptions,
-        Microsoft_Extensions_DependencyInjection_IServiceCollection
+        Microsoft_Extensions_DependencyInjection_IServiceCollection,
+        Microsoft_AspNetCore_Authorization_IAllowAnonymous,
+        Microsoft_AspNetCore_Authorization_IAuthorizeData,
+        System_AttributeUsageAttribute,
     }
 
-    public static string[] WellKnownTypeNames = new[]
-    {
+    public static string[] WellKnownTypeNames =
+    [
         "Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder",
         "Microsoft.AspNetCore.Http.IHeaderDictionary",
         "Microsoft.AspNetCore.Http.Metadata.IEndpointMetadataProvider",
@@ -225,5 +228,8 @@ internal static class WellKnownTypeData
         "Microsoft.Extensions.DependencyInjection.FromKeyedServicesAttribute",
         "Microsoft.AspNetCore.Authorization.AuthorizationOptions",
         "Microsoft.Extensions.DependencyInjection.IServiceCollection",
-    };
+        "Microsoft.AspNetCore.Authorization.IAllowAnonymous",
+        "Microsoft.AspNetCore.Authorization.IAuthorizeData",
+        "System.AttributeUsageAttribute",
+    ];
 }


### PR DESCRIPTION
This PR adds analyzer that warns when `[Authorize]` is overridden by `[AllowAnymous]` from farther away. A lot of people don't realize that the relative order of `[Authorize]` and `[AllowAnonymous]` does not matter, and incorrectly assume that if they put `[Authorize]` closer to an MVC action than `[AllowAnonymous]`, that it will still force authorization.

At first, I wanted to make this work and change the runtime to ignore `[AllowAnonymous]` if we observe an `[Authorize]` attribute that’s closer or at least log a warning. I tried this, but after seeing some of [our](https://github.com/dotnet/aspnetcore/blob/7033ec7f402fa4b7df2bf72a5e3dff1df6831f57/src/Mvc/test/Mvc.FunctionalTests/AuthMiddlewareUsingRequireAuthTest.cs#L24) [test](https://github.com/dotnet/aspnetcore/blob/7033ec7f402fa4b7df2bf72a5e3dff1df6831f57/src/Mvc/test/Mvc.FunctionalTests/RazorPagesWithBasePathTest.cs#L117) [cases](https://github.com/dotnet/aspnetcore/blob/7033ec7f402fa4b7df2bf72a5e3dff1df6831f57/src/Mvc/test/Mvc.FunctionalTests/RazorPagesWithEndpointRoutingTest.cs#L30) that started failing, I question if even logging a warning when there’s `IAuthorizeData` metadata after `IAllowAnonymous` metadata because it’s just so common to add `[Authorize]` using something like the `app.MapControllers().RequireAuthorization()` or `options.Conventions.AuthorizeFolder()`. Both those examples would result false positives if there any individual endpoints with `[AllowAnonymous]` because the `[Authorize]` attribute gets added last programmatically. I think this kind of thing is very common in real-world applications where certain endpoints like a login page never need authorization.

I now think we should stick solely with this analyzer that looks at the attributes on MVC controllers actions and base types in .NET 9. While this might not catch everything a runtime change would, I think the vast majority of the cases the analyzer would miss are false positives because they involve adding an authorization requirement programmatically which is an advanced scenario. Plus, the analyzer can catch some things that cannot be reliably caught at runtime, like `[Authorize]` coming after `[AllowAnonymous]` in the same attribute list since the order of attributes using reflection is undefined.

```csharp
[AllowAnonymous]
public class OAuthControllerAnon : ControllerBase
{
}

[Authorize]
public class OAuthControllerAuthz : ControllerBase
{
}

[Authorize] // BUG
public class OAuthControllerInherited : OAuthControllerAnon
{
}

public class OAuthControllerInherited2 : OAuthControllerAnon
{
    [Authorize] // BUG
    public IActionResult Privacy()
    {
        return null;
    }
}

[AllowAnonymous]
[Authorize] // BUG
public class OAuthControllerMultiple : ControllerBase
{
}

[AllowAnonymous]
public class OAuthControllerInherited3 : ControllerBase
{
    [Authorize] // BUG
    public IActionResult Privacy()
    {
        return null;
    }
}
```

I’ve considered suggesting a code fix, but I’m leaning against it. The two main possibilities would be to recommend removing either the `[AllowAnonymous]` attribute or the `[Authorize]` attribute, but I don’t think we should assume intent. And even if the intent was for the endpoint to allow anonymous access, removing something like `[Authorize(AuthenticationSchemes = “Cookies”)]` could easily be breaking since the authorization middleware would no longer know which authentication scheme to try to authenticate with. This can matter even if authentication isn’t required to access the endpoint, because the behavior of the endpoint could change given an authenticated user.

API Proposal: #56310

Fixes #43550