### PR TITLE
[release/8.0] Update Swashbuckle.AspNetCore to 6.6.2

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -321,7 +321,7 @@
     <SerilogSinksFileVersion>4.0.0</SerilogSinksFileVersion>
     <StackExchangeRedisVersion>2.7.27</StackExchangeRedisVersion>
     <SystemReactiveLinqVersion>5.0.0</SystemReactiveLinqVersion>
-    <SwashbuckleAspNetCoreVersion>6.4.0</SwashbuckleAspNetCoreVersion>
+    <SwashbuckleAspNetCoreVersion>6.6.2</SwashbuckleAspNetCoreVersion>
     <XunitAbstractionsVersion>2.0.3</XunitAbstractionsVersion>
     <XunitAnalyzersVersion>1.0.0</XunitAnalyzersVersion>
     <XunitVersion>2.4.2</XunitVersion>

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/GrpcSwaggerServiceExtensionsTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/GrpcSwaggerServiceExtensionsTests.cs
@@ -46,7 +46,7 @@ public class GrpcSwaggerServiceExtensionsTests
 
         var path = swagger.Paths["/v1/greeter/{name}"];
         Assert.True(path.Operations.TryGetValue(OperationType.Get, out var operation));
-        Assert.Equal("Success", operation.Responses["200"].Description);
+        Assert.Equal("OK", operation.Responses["200"].Description);
         Assert.Equal("Error", operation.Responses["default"].Description);
     }
 


### PR DESCRIPTION
## Description

Update Swashbuckle.AspNetCore in .NET 8 templates to a version that has built-in support for .NET 8 so users creating applications from the template get a better experience when creating new applications targeting .NET 8.

## Customer Impact

Development on the Swashbuckle.AspNetCore repo has restarted after a haitus and Swashbuckle.AspNetCore 6.6.2 is the first release following this hiatus. The most impactful change here is that this release updates Swashbuckle to target the net8.0 TFM and fixes some long-standing bugs in the library.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

6.6.2 has already been independently consumed by developers in their own APIs. This change updates the templates to in .NET 8 to use this version.

## Verification

- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A


