### PR TITLE
[release/8.0] Bump to macos-12 build image

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -107,7 +107,7 @@ jobs:
       # See https://github.com/dotnet/arcade/blob/master/Documentation/ChoosingAMachinePool.md
       pool:
         ${{ if eq(parameters.agentOs, 'macOS') }}:
-          vmImage: macOS-11
+          vmImage: macOS-12
         ${{ if eq(parameters.agentOs, 'Linux') }}:
           ${{ if eq(parameters.useHostedUbuntu, true) }}:
             vmImage: ubuntu-20.04
@@ -329,7 +329,7 @@ jobs:
       pool:
         ${{ if eq(parameters.agentOs, 'macOS') }}:
           name: Azure Pipelines
-          image: macOS-11
+          image: macOS-12
           os: macOS
         ${{ if eq(parameters.agentOs, 'Linux') }}:
           name: $(DncEngInternalBuildPool)

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -167,8 +167,8 @@ jobs:
         - script: df -h
           displayName: Disk size
       - ${{ if eq(parameters.agentOs, 'macOS') }}:
-        - script: sudo xcode-select -s /Applications/Xcode_12.5.1.app/Contents/Developer
-          displayName: Use XCode 12.5.1
+        - script: sudo xcode-select -s /Applications/Xcode_14.2.0.app/Contents/Developer
+          displayName: Use XCode 14.2.0
       - checkout: self
         clean: true
       - ${{ if and(eq(parameters.agentOs, 'Windows'), eq(parameters.isAzDOTestingJob, true)) }}:
@@ -393,8 +393,8 @@ jobs:
         - script: df -h
           displayName: Disk size
       - ${{ if eq(parameters.agentOs, 'macOS') }}:
-        - script: sudo xcode-select -s /Applications/Xcode_12.5.1.app/Contents/Developer
-          displayName: Use XCode 12.5.1
+        - script: sudo xcode-select -s /Applications/Xcode_14.2.0.app/Contents/Developer
+          displayName: Use XCode 14.2.0
       - checkout: self
         clean: true
       - ${{ if and(eq(parameters.agentOs, 'Windows'), eq(parameters.isAzDOTestingJob, true)) }}:


### PR DESCRIPTION
AzDO will remove macos-11 in about two weeks: https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#recent-updates

Essentially backports https://github.com/dotnet/aspnetcore/pull/53145