### PR TITLE
Use exact runtime for non-servicing builds of Blazor DevServer

### DIFF
--- a/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
+++ b/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
@@ -36,8 +36,11 @@
 
   <Target Name="_CreateRuntimeConfig" BeforeTargets="CoreBuild">
     <PropertyGroup>
-      <_RuntimeConfigProperties>
-        AspNetCoreMajorMinorVersion=$(AspNetCoreMajorMinorVersion);
+      <_RuntimeConfigProperties Condition="'$(IsServicingBuild)' == 'true'">
+        FrameworkVersion=$(AspNetCoreMajorMinorVersion).0;
+      </_RuntimeConfigProperties>
+      <_RuntimeConfigProperties Condition="'$(IsServicingBuild)' != 'true'">
+        FrameworkVersion=$(SharedFxVersion);
       </_RuntimeConfigProperties>
 
       <_RuntimeConfigPath>$(OutputPath)blazor-devserver.runtimeconfig.json</_RuntimeConfigPath>

--- a/src/Components/WebAssembly/DevServer/src/blazor-devserver.runtimeconfig.json.in
+++ b/src/Components/WebAssembly/DevServer/src/blazor-devserver.runtimeconfig.json.in
@@ -3,7 +3,7 @@
     "tfm": "net9.0",
     "framework": {
       "name": "Microsoft.AspNetCore.App",
-      "version": "${AspNetCoreMajorMinorVersion}.0"
+      "version": "${FrameworkVersion}"
     },
     "rollForwardOnNoCandidateFx": 2
   }


### PR DESCRIPTION
The goal here is to unblock the sdk's aspnetcore dependency update (https://github.com/dotnet/sdk/pull/41509) which is currently failing with the following error from the smoke tests:

```
Microsoft.DotNet.SourceBuild.SmokeTests.WebScenarioTests.VerifyScenario
System.InvalidOperationException : Failed to execute /vmr/artifacts/bin/Microsoft.DotNet.SourceBuild.SmokeTests/Release/extracted-sdk/dotnet run --no-launch-profile /bl:/vmr/artifacts/TestResults/Release/WebScenarioTests_BlazorWasm_CSharp-run.binlog
Exit code: 150

You must install or update .NET to run this application.

App: /vmr/artifacts/bin/Microsoft.DotNet.SourceBuild.SmokeTests/Release/packages/microsoft.aspnetcore.components.webassembly.devserver/9.0.0-preview.6.24317.3/tools/blazor-devserver.dll
Architecture: x64
Framework: 'Microsoft.AspNetCore.App', version '9.0.0' (x64)
.NET location: /vmr/artifacts/bin/Microsoft.DotNet.SourceBuild.SmokeTests/Release/extracted-sdk/

The following frameworks were found:
  9.0.0-preview.6.24317.3 at [/vmr/artifacts/bin/Microsoft.DotNet.SourceBuild.SmokeTests/Release/extracted-sdk/shared/Microsoft.AspNetCore.App]

Learn more:
https://aka.ms/dotnet/app-launch-failed

To install missing framework, download:
https://aka.ms/dotnet-core-applaunch?framework=Microsoft.AspNetCore.App&framework_version=9.0.0&arch=x64&rid=centos.9-x64&os=centos.9
```


If this is the right approach, I'll make the same changes to #56181. I'm hoping that the sdk's aspnetcore dependency update for release/8.0 won't fail the same way since it's a servicing branch.