### PR TITLE
Don't use diagnostics memory pool in GracefulTurnsAbortiveIfRequestsDoNotFinish

### DIFF
--- a/src/Servers/Kestrel/test/FunctionalTests/Http2/ShutdownTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/Http2/ShutdownTests.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.Server.Kestrel.FunctionalTests;
 using Microsoft.AspNetCore.InternalTesting;
 using Moq;
 using Xunit;
+using System.Buffers;
 
 #if SOCKETS
 namespace Microsoft.AspNetCore.Server.Kestrel.Sockets.FunctionalTests.Http2;
@@ -173,11 +174,9 @@ public class ShutdownTests : TestApplicationErrorLoggerLoggedTest
         var requestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var requestUnblocked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        var memoryPoolFactory = new DiagnosticMemoryPoolFactory(allowLateReturn: true);
-
         var testContext = new TestServiceContext(LoggerFactory)
         {
-            MemoryPoolFactory = memoryPoolFactory.Create
+            MemoryPoolFactory = () => new PinnedBlockMemoryPool()
         };
 
         ThrowOnUngracefulShutdown = false;

--- a/src/Servers/Kestrel/test/FunctionalTests/Http2/ShutdownTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/Http2/ShutdownTests.cs
@@ -1,23 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
+using System.Buffers;
 using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
-using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.FunctionalTests;
-using Microsoft.AspNetCore.InternalTesting;
-using Moq;
-using Xunit;
-using System.Buffers;
 
 #if SOCKETS
 namespace Microsoft.AspNetCore.Server.Kestrel.Sockets.FunctionalTests.Http2;

--- a/src/Servers/Kestrel/test/FunctionalTests/Http2/ShutdownTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/Http2/ShutdownTests.cs
@@ -219,7 +219,5 @@ public class ShutdownTests : TestApplicationErrorLoggerLoggedTest
         Assert.Contains(LogMessages, m => m.Message.Contains("is closed. The last processed stream ID was 1."));
         Assert.Contains(LogMessages, m => m.Message.Contains("Some connections failed to close gracefully during server shutdown."));
         Assert.DoesNotContain(LogMessages, m => m.Message.Contains("Request finished in"));
-
-        await memoryPoolFactory.WhenAllBlocksReturned(TestConstants.DefaultTimeout);
     }
 }


### PR DESCRIPTION
Addresses flaky test https://github.com/dotnet/aspnetcore/issues/39986

Abortive cancellation has undefined behavior and diagnostics memory pool throws errors in those (e.g. attempting to read memory after server and pool have shutdown). Use normal memory pool directly.