### PR TITLE
Skip Templates.Mvc.Tests in Helix on Debian12 and Mariner

### DIFF
--- a/src/ProjectTemplates/test/Templates.Mvc.Tests/Templates.Mvc.Tests.csproj
+++ b/src/ProjectTemplates/test/Templates.Mvc.Tests/Templates.Mvc.Tests.csproj
@@ -20,6 +20,14 @@
     <RestoreFolderName>Mvc</RestoreFolderName>
     <TestDependsOnAspNetPackages>true</TestDependsOnAspNetPackages>
     <HelixTimeout>02:30:00</HelixTimeout>
+
+    <!-- These tests fail in Helix in Debian and Mariner due to error -901 -->
+    <!-- Disabling on those OSes until a better fix can be identified -->
+    <SkipHelixQueues>
+      $(HelixQueueDebian12);
+      $(HelixQueueMariner);
+      $(SkipHelixQueues)
+    </SkipHelixQueues>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
These tests have been failing on Debian and Mariner for months. This has continued through many build ops rotations without progress.

To bring the build closer to a stable state, skipping them on those OSes until a better fix can be identified.