### PR TITLE
Skip some Razor build tests to observe effect on test runner

### DIFF
--- a/src/Mvc/test/Mvc.FunctionalTests/RazorBuildTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RazorBuildTest.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -83,6 +84,7 @@ public class RazorBuildTest : IClassFixture<MvcTestFixture<RazorBuildWebSite.Sta
     }
 
     [Fact]
+    [SkipOnHelix("test host process crashing")]
     public async Task RazorViews_AreUpdatedOnChange()
     {
         // Arrange
@@ -120,6 +122,7 @@ public class RazorBuildTest : IClassFixture<MvcTestFixture<RazorBuildWebSite.Sta
     }
 
     [Fact]
+    [SkipOnHelix("test host process crashing")]
     public async Task RazorPages_AreUpdatedOnChange()
     {
         // Arrange

--- a/src/Mvc/test/Mvc.FunctionalTests/RazorBuildTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RazorBuildTest.cs
@@ -4,6 +4,7 @@
 using System.Net;
 using System.Net.Http;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
@@ -80,6 +81,74 @@ public class RazorBuildTest : IClassFixture<MvcTestFixture<RazorBuildWebSite.Sta
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal("Hello from buildtime-compiled rzc view!", responseBody.Trim());
+    }
+
+    [Fact]
+    [SkipOnHelix(Queues = $"{HelixConstants.Debian12};{HelixConstants.Mariner}")]
+    public async Task RazorViews_AreUpdatedOnChange()
+    {
+        // Arrange
+        var expected1 = "Original content";
+        var path = "/Views/UpdateableViews/Index.cshtml";
+
+        // Act - 1
+        var body = await Client.GetStringAsync("/UpdateableViews");
+
+        // Assert - 1
+        Assert.Equal(expected1, body.Trim(), ignoreLineEndingDifferences: true);
+
+        // Act - 2
+        await UpdateFile(path, "@GetType().Assembly");
+        body = await Client.GetStringAsync("/UpdateableViews");
+
+        // Assert - 2
+        var actual2 = body.Trim();
+        Assert.NotEqual(expected1, actual2);
+
+        // Act - 3
+        // With all things being the same, expect a cached compilation
+        body = await Client.GetStringAsync("/UpdateableViews");
+
+        // Assert - 3
+        Assert.Equal(actual2, body.Trim(), ignoreLineEndingDifferences: true);
+
+        // Act - 4
+        // Trigger a change in ViewImports
+        await UpdateFile("/Views/UpdateableViews/_ViewImports.cshtml", "new content");
+        body = await Client.GetStringAsync("/UpdateableViews");
+
+        // Assert - 4
+        Assert.NotEqual(actual2, body.Trim());
+    }
+
+    [Fact]
+    [SkipOnHelix(Queues = $"{HelixConstants.Debian12};{HelixConstants.Mariner}")]
+    public async Task RazorPages_AreUpdatedOnChange()
+    {
+        // Arrange
+        var expected1 = "Original content";
+
+        // Act - 1
+        var body = await Client.GetStringAsync("/UpdateablePage");
+
+        // Assert - 1
+        Assert.Equal(expected1, body.Trim(), ignoreLineEndingDifferences: true);
+
+        // Act - 2
+        await UpdateRazorPages();
+        await UpdateFile("/Pages/UpdateablePage.cshtml", "@page" + Environment.NewLine + "@GetType().Assembly");
+        body = await Client.GetStringAsync("/UpdateablePage");
+
+        // Assert - 2
+        var actual2 = body.Trim();
+        Assert.NotEqual(expected1, actual2);
+
+        // Act - 3
+        // With all things being unchanged, we should get the cached page.
+        body = await Client.GetStringAsync("/UpdateablePage");
+
+        // Assert - 3
+        Assert.Equal(actual2, body.Trim(), ignoreLineEndingDifferences: true);
     }
 
     private async Task UpdateFile(string path, string content)

--- a/src/Mvc/test/Mvc.FunctionalTests/RazorBuildTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RazorBuildTest.cs
@@ -84,7 +84,7 @@ public class RazorBuildTest : IClassFixture<MvcTestFixture<RazorBuildWebSite.Sta
     }
 
     [Fact]
-    [SkipOnHelix(Queues = $"{HelixConstants.Debian12};{HelixConstants.Mariner}")]
+    [SkipOnHelix("https://github.dev/dotnet/aspnetcore/pull/56292", Queues = $"{HelixConstants.Debian12};{HelixConstants.Mariner}")]
     public async Task RazorViews_AreUpdatedOnChange()
     {
         // Arrange
@@ -122,7 +122,7 @@ public class RazorBuildTest : IClassFixture<MvcTestFixture<RazorBuildWebSite.Sta
     }
 
     [Fact]
-    [SkipOnHelix(Queues = $"{HelixConstants.Debian12};{HelixConstants.Mariner}")]
+    [SkipOnHelix("https://github.dev/dotnet/aspnetcore/pull/56292", Queues = $"{HelixConstants.Debian12};{HelixConstants.Mariner}")]
     public async Task RazorPages_AreUpdatedOnChange()
     {
         // Arrange

--- a/src/Mvc/test/Mvc.FunctionalTests/RazorBuildTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RazorBuildTest.cs
@@ -84,7 +84,7 @@ public class RazorBuildTest : IClassFixture<MvcTestFixture<RazorBuildWebSite.Sta
     }
 
     [Fact]
-    [SkipOnHelix("https://github.dev/dotnet/aspnetcore/pull/56292", Queues = $"{HelixConstants.Debian12};{HelixConstants.Mariner}")]
+    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/56322", Queues = $"{HelixConstants.Debian12};{HelixConstants.Mariner}")]
     public async Task RazorViews_AreUpdatedOnChange()
     {
         // Arrange
@@ -122,7 +122,7 @@ public class RazorBuildTest : IClassFixture<MvcTestFixture<RazorBuildWebSite.Sta
     }
 
     [Fact]
-    [SkipOnHelix("https://github.dev/dotnet/aspnetcore/pull/56292", Queues = $"{HelixConstants.Debian12};{HelixConstants.Mariner}")]
+    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/56322", Queues = $"{HelixConstants.Debian12};{HelixConstants.Mariner}")]
     public async Task RazorPages_AreUpdatedOnChange()
     {
         // Arrange

--- a/src/Mvc/test/Mvc.FunctionalTests/RazorBuildTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RazorBuildTest.cs
@@ -5,7 +5,6 @@ using System.Net;
 using System.Net.Http;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation;
-using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -81,74 +80,6 @@ public class RazorBuildTest : IClassFixture<MvcTestFixture<RazorBuildWebSite.Sta
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal("Hello from buildtime-compiled rzc view!", responseBody.Trim());
-    }
-
-    [Fact]
-    [SkipOnHelix("test host process crashing")]
-    public async Task RazorViews_AreUpdatedOnChange()
-    {
-        // Arrange
-        var expected1 = "Original content";
-        var path = "/Views/UpdateableViews/Index.cshtml";
-
-        // Act - 1
-        var body = await Client.GetStringAsync("/UpdateableViews");
-
-        // Assert - 1
-        Assert.Equal(expected1, body.Trim(), ignoreLineEndingDifferences: true);
-
-        // Act - 2
-        await UpdateFile(path, "@GetType().Assembly");
-        body = await Client.GetStringAsync("/UpdateableViews");
-
-        // Assert - 2
-        var actual2 = body.Trim();
-        Assert.NotEqual(expected1, actual2);
-
-        // Act - 3
-        // With all things being the same, expect a cached compilation
-        body = await Client.GetStringAsync("/UpdateableViews");
-
-        // Assert - 3
-        Assert.Equal(actual2, body.Trim(), ignoreLineEndingDifferences: true);
-
-        // Act - 4
-        // Trigger a change in ViewImports
-        await UpdateFile("/Views/UpdateableViews/_ViewImports.cshtml", "new content");
-        body = await Client.GetStringAsync("/UpdateableViews");
-
-        // Assert - 4
-        Assert.NotEqual(actual2, body.Trim());
-    }
-
-    [Fact]
-    [SkipOnHelix("test host process crashing")]
-    public async Task RazorPages_AreUpdatedOnChange()
-    {
-        // Arrange
-        var expected1 = "Original content";
-
-        // Act - 1
-        var body = await Client.GetStringAsync("/UpdateablePage");
-
-        // Assert - 1
-        Assert.Equal(expected1, body.Trim(), ignoreLineEndingDifferences: true);
-
-        // Act - 2
-        await UpdateRazorPages();
-        await UpdateFile("/Pages/UpdateablePage.cshtml", "@page" + Environment.NewLine + "@GetType().Assembly");
-        body = await Client.GetStringAsync("/UpdateablePage");
-
-        // Assert - 2
-        var actual2 = body.Trim();
-        Assert.NotEqual(expected1, actual2);
-
-        // Act - 3
-        // With all things being unchanged, we should get the cached page.
-        body = await Client.GetStringAsync("/UpdateablePage");
-
-        // Assert - 3
-        Assert.Equal(actual2, body.Trim(), ignoreLineEndingDifferences: true);
     }
 
     private async Task UpdateFile(string path, string content)

--- a/src/Testing/src/xunit/HelixConstants.cs
+++ b/src/Testing/src/xunit/HelixConstants.cs
@@ -8,6 +8,8 @@ public static class HelixConstants
     public const string Windows10Arm64 = "Windows.10.Arm64v8.Open;";
     public const string DebianAmd64 = "Debian.11.Amd64.Open;";
     public const string DebianArm64 = "Debian.11.Arm64.Open;";
+    public const string Debian12 = "(Debian.12.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-amd64";
     public const string AlmaLinuxAmd64 = "(AlmaLinux.8.Amd64.Open)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:almalinux-8-helix-amd64;";
+    public const string Mariner = "(Mariner)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-helix-amd64";
     public const string NativeAotNotSupportedHelixQueues = "All.OSX;All.Linux;Windows.11.Amd64.Client.Open;Windows.11.Amd64.Client;Windows.Amd64.Server2022.Open;Windows.Amd64.Server2022;windows.11.arm64.open;windows.11.arm64";
 }


### PR DESCRIPTION
On several builds, the test `RazorPages_AreUpdatedOnChange` has been the very last one before `The active test run was aborted. Reason: Test host process crashed`.

Checking to see whether skipping that test (and a similar one) results in a different outcome.