### PR TITLE
Work around auth issues with new internal source changes

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -706,6 +706,7 @@ extends:
       # Source build
       - template: /eng/common/templates-official/job/source-build.yml@self
         parameters:
+          enableInternalSources: true
           platform:
             name: 'Managed'
             container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8'

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -419,25 +419,8 @@ jobs:
 
       - ${{ parameters.beforeBuild }}
 
-      - ${{ if eq(parameters.agentOs, 'Windows') }}:
-        - task: PowerShell@2
-          displayName: Setup Private Feeds Credentials
-          inputs:
-            filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-            arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-          env:
-            Token: $(dn-bot-dnceng-artifact-feeds-rw)
-      - ${{ if ne(parameters.agentOs, 'Windows') }}:
-        - task: Bash@3
-          displayName: Setup Private Feeds Credentials
-          inputs:
-            filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
-            arguments: $(Build.SourcesDirectory)/NuGet.config $Token
-          env:
-            Token: $(dn-bot-dnceng-artifact-feeds-rw)
-
-      # Call the NugetAuthenticate task to add creds for added feeds.
-      - task: NuGetAuthenticate@1
+      # - template: /eng/common/templates-official/steps/enable-internal-sources.yml@self
+      # - template: /eng/common/templates-official/steps/enable-internal-runtimes.yml@self
 
       # Add COMPlus_* environment variables to build steps.
       - ${{ if ne(parameters.steps, '')}}:


### PR DESCRIPTION
For some reason, the new SetupNugetSources does not play well with aspnetcore. No known reason at this point. Workaround this by removing SetupNugetSources and replacing with commented-out forms of the new templates. When issues the new templates/scripts have been resolved, will re-enable.