### PR TITLE
Add mapping for .mjs files

### DIFF
--- a/src/Components/WebAssembly/Server/src/ComponentsWebAssemblyApplicationBuilderExtensions.cs
+++ b/src/Components/WebAssembly/Server/src/ComponentsWebAssemblyApplicationBuilderExtensions.cs
@@ -94,6 +94,7 @@ public static class ComponentsWebAssemblyApplicationBuilderExtensions
         AddMapping(contentTypeProvider, ".br", MediaTypeNames.Application.Octet);
         AddMapping(contentTypeProvider, ".dat", MediaTypeNames.Application.Octet);
         AddMapping(contentTypeProvider, ".blat", MediaTypeNames.Application.Octet);
+        AddMapping(contentTypeProvider, ".mjs", MediaTypeNames.Text.JavaScript);
 
         options.ContentTypeProvider = contentTypeProvider;
 


### PR DESCRIPTION
Newer emscripten produces `dotnet.native.worker.mjs` instead of `.js`.
Context: https://github.com/dotnet/runtime/pull/100334#pullrequestreview-2115161601
