### PR TITLE
[Blazor] Fix WebAssembly trimming issue

### DIFF
--- a/src/Components/Shared/src/ResourceCollectionProvider.cs
+++ b/src/Components/Shared/src/ResourceCollectionProvider.cs
@@ -7,6 +7,8 @@ using Microsoft.JSInterop;
 
 namespace Microsoft.AspNetCore.Components;
 
+using static Microsoft.AspNetCore.Internal.LinkerFlags;
+
 internal class ResourceCollectionProvider
 {
     private const string ResourceCollectionUrlKey = "__ResourceCollectionUrl";
@@ -52,6 +54,8 @@ internal class ResourceCollectionProvider
         _resourceCollection = resourceCollection;
     }
 
+    [DynamicDependency(JsonSerialized, typeof(ResourceAsset))]
+    [DynamicDependency(JsonSerialized, typeof(ResourceAssetProperty))]
     private async Task<ResourceAssetCollection> LoadResourceCollection()
     {
         if (_url == null)


### PR DESCRIPTION
Fixes a problem where members of `ResourceAsset` and `ResourceAssetProperty` were getting trimmed away after publish, causing WebAssembly startup to fail.