### PR TITLE
Revert "Skip some Razor build tests to observe effect on test runner"

### DIFF
--- a/src/Mvc/test/Mvc.FunctionalTests/RazorBuildTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RazorBuildTest.cs
@@ -4,7 +4,6 @@
 using System.Net;
 using System.Net.Http;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
@@ -84,7 +83,6 @@ public class RazorBuildTest : IClassFixture<MvcTestFixture<RazorBuildWebSite.Sta
     }
 
     [Fact]
-    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/56322", Queues = $"{HelixConstants.Debian12};{HelixConstants.Mariner}")]
     public async Task RazorViews_AreUpdatedOnChange()
     {
         // Arrange
@@ -122,7 +120,6 @@ public class RazorBuildTest : IClassFixture<MvcTestFixture<RazorBuildWebSite.Sta
     }
 
     [Fact]
-    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/56322", Queues = $"{HelixConstants.Debian12};{HelixConstants.Mariner}")]
     public async Task RazorPages_AreUpdatedOnChange()
     {
         // Arrange

--- a/src/Testing/src/xunit/HelixConstants.cs
+++ b/src/Testing/src/xunit/HelixConstants.cs
@@ -8,8 +8,6 @@ public static class HelixConstants
     public const string Windows10Arm64 = "Windows.10.Arm64v8.Open;";
     public const string DebianAmd64 = "Debian.11.Amd64.Open;";
     public const string DebianArm64 = "Debian.11.Arm64.Open;";
-    public const string Debian12 = "(Debian.12.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-amd64";
     public const string AlmaLinuxAmd64 = "(AlmaLinux.8.Amd64.Open)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:almalinux-8-helix-amd64;";
-    public const string Mariner = "(Mariner)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-helix-amd64";
     public const string NativeAotNotSupportedHelixQueues = "All.OSX;All.Linux;Windows.11.Amd64.Client.Open;Windows.11.Amd64.Client;Windows.Amd64.Server2022.Open;Windows.Amd64.Server2022;windows.11.arm64.open;windows.11.arm64";
 }


### PR DESCRIPTION
It didn't actually do anything because it's also necessary to use [ConditionalFact].

It's also unclear that the reasoning behind skipping those two tests was correct.

Fixes https://github.com/dotnet/aspnetcore/issues/56322 (as in, should close it, not that it fixes the underlying test issue)