### PR TITLE
Remove incorrect suppressions from AwaitableInfo

### DIFF
--- a/src/Shared/ObjectMethodExecutor/AwaitableInfo.cs
+++ b/src/Shared/ObjectMethodExecutor/AwaitableInfo.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Extensions.Internal;
 
 internal readonly struct AwaitableInfo
 {
+    internal const string RequiresUnreferencedCodeMessage = "Uses unbounded reflection to determine awaitability of types.";
+
     private const BindingFlags Everything = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance;
     private static readonly MethodInfo INotifyCompletion_OnCompleted = typeof(INotifyCompletion).GetMethod(nameof(INotifyCompletion.OnCompleted), Everything, new[] { typeof(Action) })!;
     private static readonly MethodInfo ICriticalNotifyCompletion_UnsafeOnCompleted = typeof(ICriticalNotifyCompletion).GetMethod(nameof(ICriticalNotifyCompletion.UnsafeOnCompleted), Everything, new[] { typeof(Action) })!;
@@ -41,8 +43,7 @@ internal readonly struct AwaitableInfo
         GetAwaiterMethod = getAwaiterMethod;
     }
 
-    [UnconditionalSuppressMessage("Trimmer", "IL2070", Justification = "Reflecting over the async Task types contract")]
-    [UnconditionalSuppressMessage("Trimmer", "IL2075", Justification = "Reflecting over the async Task types contract")]
+    [RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
     public static bool IsTypeAwaitable(
         Type type,
         out AwaitableInfo awaitableInfo)

--- a/src/Shared/ObjectMethodExecutor/CoercedAwaitableInfo.cs
+++ b/src/Shared/ObjectMethodExecutor/CoercedAwaitableInfo.cs
@@ -29,6 +29,7 @@ internal readonly struct CoercedAwaitableInfo
         AwaitableInfo = coercedAwaitableInfo;
     }
 
+    [RequiresUnreferencedCode(AwaitableInfo.RequiresUnreferencedCodeMessage)]
     [RequiresDynamicCode("Dynamically generates calls to FSharpAsync.")]
     public static bool IsTypeAwaitable(
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)] Type type,

--- a/src/Shared/ObjectMethodExecutor/ObjectMethodExecutorFSharpSupport.cs
+++ b/src/Shared/ObjectMethodExecutor/ObjectMethodExecutorFSharpSupport.cs
@@ -54,7 +54,7 @@ internal static class ObjectMethodExecutorFSharpSupport
     /// by the coercer expression, if it was possible to build a coercer; otherwise, <see langword="null"/>.
     /// </param>
     /// <returns><see langword="true"/> if it was possible to build a coercer; otherwise, <see langword="false"/>.</returns>
-    [UnconditionalSuppressMessage("Trimmer", "IL2060", Justification = "Reflecting over the async FSharpAsync<> contract.")]
+    [RequiresUnreferencedCode("Reflecting over the async FSharpAsync<> contract.")]
     public static bool TryBuildCoercerFromFSharpAsyncToAwaitable(
         Type possibleFSharpAsyncType,
         out Expression coerceToAwaitableExpression,
@@ -127,7 +127,7 @@ internal static class ObjectMethodExecutorFSharpSupport
     /// otherwise, <see langword="null"/>.
     /// </param>
     /// <returns><see langword="true"/> if it was possible to build a coercer; otherwise, <see langword="false"/>.</returns>
-    [UnconditionalSuppressMessage("Trimmer", "IL2060", Justification = "Reflecting over FSharp.Core.Unit.")]
+    [RequiresUnreferencedCode("Reflecting over FSharp.Core.Unit.")]
     public static bool TryBuildCoercerFromUnitAwaitableToVoidAwaitable(
         Type genericAwaitableType,
         out Expression coercerExpression,
@@ -168,12 +168,15 @@ internal static class ObjectMethodExecutorFSharpSupport
         }
     }
 
+    [RequiresUnreferencedCode("Reflecting over the async FSharpAsync<> contract.")]
     private static bool IsFSharpAsyncOpenGenericType(Type possibleFSharpAsyncType) =>
         IsCoerceableFSharpType(possibleFSharpAsyncType, FSharpAsyncGenericTypeName);
 
+    [RequiresUnreferencedCode("Reflecting over the async FSharpAsync<> contract.")]
     private static bool IsFSharpUnit(Type possibleFSharpUnitType) =>
         IsCoerceableFSharpType(possibleFSharpUnitType, FSharpUnitTypeName);
 
+    [RequiresUnreferencedCode("Reflecting over the async FSharpAsync<> contract.")]
     private static bool IsCoerceableFSharpType(Type possibleFSharpType, string coerceableFSharpTypeName)
     {
         var typeFullName = possibleFSharpType?.FullName;
@@ -199,9 +202,7 @@ internal static class ObjectMethodExecutorFSharpSupport
         }
     }
 
-    [UnconditionalSuppressMessage("Trimmer", "IL2026", Justification = "Reflecting over the async FSharpAsync<> contract")]
-    [UnconditionalSuppressMessage("Trimmer", "IL2055", Justification = "Reflecting over the async FSharpAsync<> contract")]
-    [UnconditionalSuppressMessage("Trimmer", "IL2072", Justification = "Reflecting over the async FSharpAsync<> contract")]
+    [RequiresUnreferencedCode("Reflecting over the async FSharpAsync<> contract.")]
     private static bool TryPopulateFSharpValueCaches(Type possibleFSharpType)
     {
         var assembly = possibleFSharpType.Assembly;


### PR DESCRIPTION
These warning suppressions are not correct. The reflection usage in these methods isn't compatible with trimming. Marking the methods correctly with RequiresUnreferencedCode.

See https://github.com/dotnet/runtime/issues/103258 for more info.