### PR TITLE
Replace "instanceof" due to DOM realm mixin when Blazor is IFRAME-d

### DIFF
--- a/src/Components/Web.JS/src/Rendering/BrowserRenderer.ts
+++ b/src/Components/Web.JS/src/Rendering/BrowserRenderer.ts
@@ -65,10 +65,10 @@ export class BrowserRenderer {
     if (elementsToClearOnRootComponentRender.delete(element)) {
       emptyLogicalElement(element);
 
-      if (element instanceof Comment) {
+      if (Object.prototype.toString.call(element) === "[object Comment]") {
         // We sanitize start comments by removing all the information from it now that we don't need it anymore
         // as it adds noise to the DOM.
-        element.textContent = '!';
+        (element as unknown as Comment).textContent = '!';
       }
     }
 

--- a/src/Components/Web.JS/src/Rendering/LogicalElements.ts
+++ b/src/Components/Web.JS/src/Rendering/LogicalElements.ts
@@ -152,7 +152,7 @@ export function insertLogicalChild(child: Node, parent: LogicalElement, childInd
   // If the child is a component comment with logical children, its children
   // need to be inserted into the parent node
   let nodeToInsert = child;
-  if (child instanceof Comment) {
+  if (Object.prototype.toString.call(child) === "[object Comment]") {
     const existingGranchildren = getLogicalChildrenArray(childAsLogicalElement);
     if (existingGranchildren?.length > 0) {
       const lastNodeToInsert = findLastDomNodeInRange(childAsLogicalElement);
@@ -196,7 +196,7 @@ export function removeLogicalChild(parent: LogicalElement, childIndex: number): 
   const childToRemove = childrenArray.splice(childIndex, 1)[0];
 
   // If it's a logical container, also remove its descendants
-  if (childToRemove instanceof Comment) {
+  if (Object.prototype.toString.call(childToRemove) === "[object Comment]") {
     const grandchildrenArray = getLogicalChildrenArray(childToRemove);
     if (grandchildrenArray) {
       while (grandchildrenArray.length > 0) {
@@ -307,8 +307,8 @@ export function permuteLogicalChildren(parent: LogicalElement, permutationList: 
 export function getClosestDomElement(logicalElement: LogicalElement): Element | (LogicalElement & DocumentFragment) {
   if (logicalElement instanceof Element || logicalElement instanceof DocumentFragment) {
     return logicalElement;
-  } else if (logicalElement instanceof Comment) {
-    return logicalElement.parentNode! as Element;
+  } else if (Object.prototype.toString.call(logicalElement) === "[object Comment]") {
+    return (logicalElement as unknown as Comment).parentNode! as Element;
   } else {
     throw new Error('Not a valid logical element');
   }
@@ -331,7 +331,7 @@ function appendDomNode(child: Node, parent: LogicalElement) {
   // It does not update the logical children array of anything
   if (parent instanceof Element || parent instanceof DocumentFragment) {
     parent.appendChild(child);
-  } else if (parent instanceof Comment) {
+  } else if (Object.prototype.toString.call(parent) === "[object Comment]") {
     const parentLogicalNextSibling = getLogicalNextSibling(parent) as any as Node;
     if (parentLogicalNextSibling) {
       // Since the parent has a logical next-sibling, its appended child goes right before that


### PR DESCRIPTION
When the Blazor page is in an IFRAME in Chrome (or Edge), the Comments (and potentially other HTML elements) in the frame fail the instanceof test because they're instances of frame's parent's Comment.

Replacing instanceof with this prototype check fixes the issue.

Issue is documented here: https://github.com/dotnet/aspnetcore/issues/55107

Fixes #55107 