### PR TITLE
Fix up nullability and primitive type handing in schema generation

### DIFF
--- a/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
@@ -24,8 +24,6 @@ namespace Microsoft.AspNetCore.OpenApi;
 /// </summary>
 internal static class JsonNodeSchemaExtensions
 {
-    private static readonly NullabilityInfoContext _nullabilityInfoContext = new();
-
     private static readonly Dictionary<Type, OpenApiSchema> _simpleTypeToOpenApiSchema = new()
     {
         [typeof(bool)] = new() { Type = "boolean" },
@@ -365,7 +363,8 @@ internal static class JsonNodeSchemaExtensions
             return;
         }
 
-        var nullabilityInfo = _nullabilityInfoContext.Create(parameterInfo);
+        var nullabilityInfoContext = new NullabilityInfoContext();
+        var nullabilityInfo = nullabilityInfoContext.Create(parameterInfo);
         if (nullabilityInfo.WriteState == NullabilityState.Nullable)
         {
             schema[OpenApiSchemaKeywords.NullableKeyword] = true;
@@ -376,16 +375,10 @@ internal static class JsonNodeSchemaExtensions
     /// Support applying nullability status for reference types provided as a property or field.
     /// </summary>
     /// <param name="schema">The <see cref="JsonNode"/> produced by the underlying schema generator.</param>
-    /// <param name="attributeProvider">The <see cref="PropertyInfo" /> or <see cref="FieldInfo"/> associated with the schema.</param>
-    internal static void ApplyNullabilityContextInfo(this JsonNode schema, ICustomAttributeProvider attributeProvider)
+    /// <param name="propertyInfo">The <see cref="JsonPropertyInfo" /> associated with the schema.</param>
+    internal static void ApplyNullabilityContextInfo(this JsonNode schema, JsonPropertyInfo propertyInfo)
     {
-        var nullabilityInfo = attributeProvider switch
-        {
-            PropertyInfo propertyInfo => !propertyInfo.PropertyType.IsValueType ? _nullabilityInfoContext.Create(propertyInfo) : null,
-            FieldInfo fieldInfo => !fieldInfo.FieldType.IsValueType ? _nullabilityInfoContext.Create(fieldInfo) : null,
-            _ => null
-        };
-        if (nullabilityInfo is { WriteState: NullabilityState.Nullable } or { ReadState: NullabilityState.Nullable })
+        if (propertyInfo.IsGetNullable || propertyInfo.IsSetNullable)
         {
             schema[OpenApiSchemaKeywords.NullableKeyword] = true;
         }

--- a/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
@@ -24,9 +24,6 @@ namespace Microsoft.AspNetCore.OpenApi;
 /// </summary>
 internal static class JsonNodeSchemaExtensions
 {
-    private static readonly bool _isNullabilityInfoContextSupported =
-        AppContext.TryGetSwitch("System.Reflection.NullabilityInfoContext.IsSupported", out bool isSupported) ? isSupported : true;
-
     private static readonly Dictionary<Type, OpenApiSchema> _simpleTypeToOpenApiSchema = new()
     {
         [typeof(bool)] = new() { Type = "boolean" },
@@ -364,7 +361,7 @@ internal static class JsonNodeSchemaExtensions
     /// <param name="parameterInfo">The <see cref="ParameterInfo" /> associated with the schema.</param>
     internal static void ApplyNullabilityContextInfo(this JsonNode schema, ParameterInfo parameterInfo)
     {
-        if (parameterInfo.ParameterType.IsValueType || !_isNullabilityInfoContextSupported)
+        if (parameterInfo.ParameterType.IsValueType)
         {
             return;
         }
@@ -384,6 +381,8 @@ internal static class JsonNodeSchemaExtensions
     /// <param name="propertyInfo">The <see cref="JsonPropertyInfo" /> associated with the schema.</param>
     internal static void ApplyNullabilityContextInfo(this JsonNode schema, JsonPropertyInfo propertyInfo)
     {
+        // Avoid setting explicit nullability annotations for `object` types so they continue to match on the catch
+        // all schema (no type, no format, no constraints).
         if (propertyInfo.PropertyType != typeof(object) && (propertyInfo.IsGetNullable || propertyInfo.IsSetNullable))
         {
             schema[OpenApiSchemaKeywords.NullableKeyword] = true;

--- a/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
@@ -23,7 +23,8 @@ internal static class JsonTypeInfoExtensions
         typeof(ulong),
         typeof(short),
         typeof(ushort),
-        typeof(char)
+        typeof(char),
+        typeof(object)
     ];
     private static readonly Dictionary<Type, string> _simpleTypeToName = new()
     {

--- a/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
@@ -11,38 +11,6 @@ namespace Microsoft.AspNetCore.OpenApi;
 
 internal static class JsonTypeInfoExtensions
 {
-    private static readonly List<Type> _exemptPrimitives =
-    [
-        typeof(bool),
-        typeof(byte),
-        typeof(sbyte),
-        typeof(byte[]),
-        typeof(string),
-        typeof(int),
-        typeof(uint),
-        typeof(nint),
-        typeof(nuint),
-        typeof(Int128),
-        typeof(UInt128),
-        typeof(long),
-        typeof(ulong),
-        typeof(float),
-        typeof(double),
-        typeof(decimal),
-        typeof(Half),
-        typeof(ulong),
-        typeof(short),
-        typeof(ushort),
-        typeof(char),
-        typeof(object),
-        typeof(DateTime),
-        typeof(DateTimeOffset),
-        typeof(TimeOnly),
-        typeof(DateOnly),
-        typeof(Guid),
-        typeof(Uri),
-        typeof(Version)
-    ];
     private static readonly Dictionary<Type, string> _simpleTypeToName = new()
     {
         [typeof(bool)] = "boolean",
@@ -85,7 +53,7 @@ internal static class JsonTypeInfoExtensions
     internal static string? GetSchemaReferenceId(this JsonTypeInfo jsonTypeInfo, bool isTopLevel = true)
     {
         var type = jsonTypeInfo.Type;
-        if (isTopLevel && _exemptPrimitives.Contains(type))
+        if (isTopLevel && OpenApiConstants.PrimitiveTypes.Contains(type))
         {
             return null;
         }

--- a/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
@@ -14,17 +14,34 @@ internal static class JsonTypeInfoExtensions
     private static readonly List<Type> _exemptPrimitives =
     [
         typeof(bool),
+        typeof(byte),
+        typeof(sbyte),
+        typeof(byte[]),
         typeof(string),
         typeof(int),
+        typeof(uint),
+        typeof(nint),
+        typeof(nuint),
+        typeof(Int128),
+        typeof(UInt128),
         typeof(long),
+        typeof(ulong),
         typeof(float),
         typeof(double),
         typeof(decimal),
+        typeof(Half),
         typeof(ulong),
         typeof(short),
         typeof(ushort),
         typeof(char),
-        typeof(object)
+        typeof(object),
+        typeof(DateTime),
+        typeof(DateTimeOffset),
+        typeof(TimeOnly),
+        typeof(DateOnly),
+        typeof(Guid),
+        typeof(Uri),
+        typeof(Version)
     ];
     private static readonly Dictionary<Type, string> _simpleTypeToName = new()
     {

--- a/src/OpenApi/src/Services/OpenApiConstants.cs
+++ b/src/OpenApi/src/Services/OpenApiConstants.cs
@@ -27,4 +27,39 @@ internal static class OpenApiConstants
         OperationType.Patch,
         OperationType.Trace
     ];
+    // Represents primitive types that should never be represented as
+    // a schema reference and always inlined.
+    internal static readonly List<Type> PrimitiveTypes =
+    [
+        typeof(bool),
+        typeof(byte),
+        typeof(sbyte),
+        typeof(byte[]),
+        typeof(string),
+        typeof(int),
+        typeof(uint),
+        typeof(nint),
+        typeof(nuint),
+        typeof(Int128),
+        typeof(UInt128),
+        typeof(long),
+        typeof(ulong),
+        typeof(float),
+        typeof(double),
+        typeof(decimal),
+        typeof(Half),
+        typeof(ulong),
+        typeof(short),
+        typeof(ushort),
+        typeof(char),
+        typeof(object),
+        typeof(DateTime),
+        typeof(DateTimeOffset),
+        typeof(TimeOnly),
+        typeof(DateOnly),
+        typeof(TimeSpan),
+        typeof(Guid),
+        typeof(Uri),
+        typeof(Version)
+    ];
 }

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -83,9 +83,9 @@ internal sealed class OpenApiSchemaService(
             }
             schema.ApplyPrimitiveTypesAndFormats(context);
             schema.ApplySchemaReferenceId(context);
-            if (context.PropertyInfo is { AttributeProvider: { } attributeProvider })
+            if (context.PropertyInfo is { AttributeProvider: { } attributeProvider } jsonPropertyInfo)
             {
-                schema.ApplyNullabilityContextInfo(attributeProvider);
+                schema.ApplyNullabilityContextInfo(jsonPropertyInfo);
                 if (attributeProvider.GetCustomAttributes(inherit: false).OfType<ValidationAttribute>() is { } validationAttributes)
                 {
                     schema.ApplyValidationAttributes(validationAttributes);

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -81,6 +81,13 @@ internal sealed class OpenApiSchemaService(
                     }
                 };
             }
+            // STJ uses `true` in place of an empty object to represent a schema that matches
+            // anything. We override this default behavior here to match the style traditionally
+            // expected in OpenAPI documents.
+            if (type == typeof(object))
+            {
+                schema = new JsonObject();
+            }
             schema.ApplyPrimitiveTypesAndFormats(context);
             schema.ApplySchemaReferenceId(context);
             if (context.PropertyInfo is { AttributeProvider: { } attributeProvider } jsonPropertyInfo)

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaStore.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaStore.cs
@@ -144,9 +144,8 @@ internal sealed class OpenApiSchemaStore
             // }
             // In this case, although the reference ID  based on the .NET type we would use is `string`, the
             // two schemas are distinct.
-            if (referenceId == null)
+            if (referenceId == null && GetSchemaReferenceId(schema) is { } targetReferenceId)
             {
-                var targetReferenceId = GetSchemaReferenceId(schema);
                 if (_referenceIdCounter.TryGetValue(targetReferenceId, out var counter))
                 {
                     counter++;
@@ -166,7 +165,7 @@ internal sealed class OpenApiSchemaStore
         }
     }
 
-    private static string GetSchemaReferenceId(OpenApiSchema schema)
+    private static string? GetSchemaReferenceId(OpenApiSchema schema)
     {
         if (schema.Extensions.TryGetValue(OpenApiConstants.SchemaId, out var referenceIdAny)
             && referenceIdAny is OpenApiString { Value: string referenceId })
@@ -174,6 +173,6 @@ internal sealed class OpenApiSchemaStore
             return referenceId;
         }
 
-        throw new InvalidOperationException("The schema reference ID must be set on the schema.");
+        return null;
     }
 }

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=controllers.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=controllers.verified.txt
@@ -25,7 +25,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/string2"
+              "minLength": 5,
+              "type": "string"
             }
           }
         ],
@@ -35,17 +36,17 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/string"
+                  "type": "string"
                 }
               },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/string"
+                  "type": "string"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/string"
+                  "type": "string"
                 }
               }
             }
@@ -65,10 +66,12 @@
                 "type": "object",
                 "properties": {
                   "Title": {
-                    "$ref": "#/components/schemas/string2"
+                    "minLength": 5,
+                    "type": "string"
                   },
                   "Description": {
-                    "$ref": "#/components/schemas/string2"
+                    "minLength": 5,
+                    "type": "string"
                   },
                   "IsCompleted": {
                     "type": "boolean"
@@ -92,17 +95,7 @@
       }
     }
   },
-  "components": {
-    "schemas": {
-      "string": {
-        "type": "string"
-      },
-      "string2": {
-        "minLength": 5,
-        "type": "string"
-      }
-    }
-  },
+  "components": { },
   "tags": [
     {
       "name": "Test"

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=forms.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=forms.verified.txt
@@ -200,9 +200,6 @@
   },
   "components": {
     "schemas": {
-      "boolean": {
-        "type": "boolean"
-      },
       "DateTime": {
         "type": "string",
         "format": "date-time"
@@ -217,13 +214,6 @@
           "$ref": "#/components/schemas/IFormFile"
         }
       },
-      "int": {
-        "type": "integer",
-        "format": "int32"
-      },
-      "string": {
-        "type": "string"
-      },
       "Todo": {
         "required": [
           "id",
@@ -234,13 +224,14 @@
         "type": "object",
         "properties": {
           "id": {
-            "$ref": "#/components/schemas/int"
+            "type": "integer",
+            "format": "int32"
           },
           "title": {
-            "$ref": "#/components/schemas/string"
+            "type": "string"
           },
           "completed": {
-            "$ref": "#/components/schemas/boolean"
+            "type": "boolean"
           },
           "createdAt": {
             "$ref": "#/components/schemas/DateTime"

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=forms.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=forms.verified.txt
@@ -200,10 +200,6 @@
   },
   "components": {
     "schemas": {
-      "DateTime": {
-        "type": "string",
-        "format": "date-time"
-      },
       "IFormFile": {
         "type": "string",
         "format": "binary"
@@ -234,7 +230,8 @@
             "type": "boolean"
           },
           "createdAt": {
-            "$ref": "#/components/schemas/DateTime"
+            "type": "string",
+            "format": "date-time"
           }
         }
       }

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=responses.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=responses.verified.txt
@@ -89,10 +89,6 @@
   },
   "components": {
     "schemas": {
-      "DateTime": {
-        "type": "string",
-        "format": "date-time"
-      },
       "Todo": {
         "required": [
           "id",
@@ -113,7 +109,8 @@
             "type": "boolean"
           },
           "createdAt": {
-            "$ref": "#/components/schemas/DateTime"
+            "type": "string",
+            "format": "date-time"
           }
         }
       }

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=responses.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=responses.verified.txt
@@ -89,19 +89,9 @@
   },
   "components": {
     "schemas": {
-      "boolean": {
-        "type": "boolean"
-      },
       "DateTime": {
         "type": "string",
         "format": "date-time"
-      },
-      "int": {
-        "type": "integer",
-        "format": "int32"
-      },
-      "string": {
-        "type": "string"
       },
       "Todo": {
         "required": [
@@ -113,13 +103,14 @@
         "type": "object",
         "properties": {
           "id": {
-            "$ref": "#/components/schemas/int"
+            "type": "integer",
+            "format": "int32"
           },
           "title": {
-            "$ref": "#/components/schemas/string"
+            "type": "string"
           },
           "completed": {
-            "$ref": "#/components/schemas/boolean"
+            "type": "boolean"
           },
           "createdAt": {
             "$ref": "#/components/schemas/DateTime"

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
@@ -45,7 +45,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/string"
+                  "type": "string"
                 }
               }
             }
@@ -96,7 +96,8 @@
             "description": "The ID associated with the Todo item.",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/int"
+              "type": "integer",
+              "format": "int32"
             }
           },
           {
@@ -105,7 +106,8 @@
             "description": "The number of Todos to fetch",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/int"
+              "type": "integer",
+              "format": "int32"
             }
           }
         ],
@@ -195,7 +197,8 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/int"
+                  "type": "integer",
+                  "format": "int32"
                 }
               }
             }
@@ -224,7 +227,8 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/int"
+                  "type": "integer",
+                  "format": "int32"
                 }
               }
             }
@@ -243,7 +247,8 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/int"
+                  "type": "integer",
+                  "format": "int32"
                 }
               }
             }
@@ -296,42 +301,39 @@
         "type": "object",
         "properties": {
           "id": {
-            "$ref": "#/components/schemas/int"
+            "type": "integer",
+            "format": "int32"
           },
           "name": {
-            "$ref": "#/components/schemas/string"
+            "type": "string"
           }
         }
       },
       "ArrayOfint": {
         "type": "array",
         "items": {
-          "$ref": "#/components/schemas/int"
+          "type": "integer",
+          "format": "int32"
         }
       },
       "DictionaryOfstringAndint": {
         "type": "object",
         "additionalProperties": {
-          "$ref": "#/components/schemas/int"
+          "type": "integer",
+          "format": "int32"
         }
-      },
-      "int": {
-        "type": "integer",
-        "format": "int32"
       },
       "Product": {
         "type": "object",
         "properties": {
           "id": {
-            "$ref": "#/components/schemas/int"
+            "type": "integer",
+            "format": "int32"
           },
           "name": {
-            "$ref": "#/components/schemas/string"
+            "type": "string"
           }
         }
-      },
-      "string": {
-        "type": "string"
       },
       "Triangle": {
         "type": "object"

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v1.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v1.verified.txt
@@ -71,13 +71,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "$ref": "#/components/schemas/int"
+                    "type": "integer",
+                    "format": "int32"
                   },
                   "title": {
-                    "$ref": "#/components/schemas/string"
+                    "type": "string"
                   },
                   "completed": {
-                    "$ref": "#/components/schemas/boolean"
+                    "type": "boolean"
                   },
                   "createdAt": {
                     "$ref": "#/components/schemas/DateTime"
@@ -107,7 +108,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/int"
+              "type": "integer",
+              "format": "int32"
             }
           },
           {
@@ -138,13 +140,14 @@
                       "$ref": "#/components/schemas/DateTime"
                     },
                     "id": {
-                      "$ref": "#/components/schemas/int"
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "title": {
-                      "$ref": "#/components/schemas/string"
+                      "type": "string"
                     },
                     "completed": {
-                      "$ref": "#/components/schemas/boolean"
+                      "type": "boolean"
                     },
                     "createdAt": {
                       "$ref": "#/components/schemas/DateTime"
@@ -166,9 +169,6 @@
           "$ref": "#/components/schemas/Guid"
         }
       },
-      "boolean": {
-        "type": "boolean"
-      },
       "DateTime": {
         "type": "string",
         "format": "date-time"
@@ -176,13 +176,6 @@
       "Guid": {
         "type": "string",
         "format": "uuid"
-      },
-      "int": {
-        "type": "integer",
-        "format": "int32"
-      },
-      "string": {
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v1.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v1.verified.txt
@@ -81,7 +81,8 @@
                     "type": "boolean"
                   },
                   "createdAt": {
-                    "$ref": "#/components/schemas/DateTime"
+                    "type": "string",
+                    "format": "date-time"
                   }
                 }
               }
@@ -137,7 +138,8 @@
                   "type": "object",
                   "properties": {
                     "dueDate": {
-                      "$ref": "#/components/schemas/DateTime"
+                      "type": "string",
+                      "format": "date-time"
                     },
                     "id": {
                       "type": "integer",
@@ -150,7 +152,8 @@
                       "type": "boolean"
                     },
                     "createdAt": {
-                      "$ref": "#/components/schemas/DateTime"
+                      "type": "string",
+                      "format": "date-time"
                     }
                   }
                 }
@@ -166,16 +169,9 @@
       "ArrayOfGuid": {
         "type": "array",
         "items": {
-          "$ref": "#/components/schemas/Guid"
+          "type": "string",
+          "format": "uuid"
         }
-      },
-      "DateTime": {
-        "type": "string",
-        "format": "date-time"
-      },
-      "Guid": {
-        "type": "string",
-        "format": "uuid"
       }
     },
     "securitySchemes": {

--- a/src/OpenApi/test/Transformers/Implementations/OpenApiSchemaReferenceTransformerTests.cs
+++ b/src/OpenApi/test/Transformers/Implementations/OpenApiSchemaReferenceTransformerTests.cs
@@ -289,13 +289,8 @@ public class OpenApiSchemaReferenceTransformerTests : OpenApiDocumentServiceTest
             Assert.False(responseSchema.Extensions.TryGetValue("x-my-extension", out var _));
             // Schemas are distinct because of applied transformer so no reference is used.
             Assert.Null(responseSchema.Reference);
-
-            // References are only created for `DateTime` type
-            Assert.Collection(document.Components.Schemas.Keys,
-                key =>
-                {
-                    Assert.Equal("DateTime", key);
-                });
+            // No schemas get componentized here
+            Assert.Empty(document.Components.Schemas);
         });
     }
 }

--- a/src/OpenApi/test/Transformers/Implementations/OpenApiSchemaReferenceTransformerTests.cs
+++ b/src/OpenApi/test/Transformers/Implementations/OpenApiSchemaReferenceTransformerTests.cs
@@ -201,14 +201,10 @@ public class OpenApiSchemaReferenceTransformerTests : OpenApiDocumentServiceTest
             Assert.Equal("string", requestBodySchema.AllOf[0].Properties["resume"].Type);
             Assert.Equal("binary", requestBodySchema.AllOf[0].Properties["resume"].Format);
 
-            // String parameter `name` should use reference ID shared by string properties in the
-            // Todo object.
+            // string parameter is not resolved to a top-level reference.
             Assert.Equal("object", requestBodySchema2.AllOf[0].Type);
-            var nameParameterReference = requestBodySchema2.AllOf[0].Properties["name"].Reference.Id;
-            var todoTitleReference = requestBodySchema.AllOf[1].GetEffective(document).Properties["title"].Reference.Id;
-            var todoTitleReference2 = requestBodySchema2.AllOf[1].GetEffective(document).Properties["title"].Reference.Id;
-            Assert.Equal(nameParameterReference, todoTitleReference);
-            Assert.Equal(nameParameterReference, todoTitleReference2);
+            Assert.Null(requestBodySchema.AllOf[1].GetEffective(document).Properties["title"].Reference);
+            Assert.Null(requestBodySchema2.AllOf[1].GetEffective(document).Properties["title"].Reference);
         });
     }
 
@@ -294,24 +290,12 @@ public class OpenApiSchemaReferenceTransformerTests : OpenApiDocumentServiceTest
             // Schemas are distinct because of applied transformer so no reference is used.
             Assert.Null(responseSchema.Reference);
 
-            // References are still created for common types within the complex object (boolean, int, etc.)
+            // References are only created for `DateTime` type
             Assert.Collection(document.Components.Schemas.Keys,
-            key =>
-            {
-                Assert.Equal("boolean", key);
-            },
-            key =>
-            {
-                Assert.Equal("DateTime", key);
-            },
-            key =>
-            {
-                Assert.Equal("int", key);
-            },
-            key =>
-            {
-                Assert.Equal("string", key);
-            });
+                key =>
+                {
+                    Assert.Equal("DateTime", key);
+                });
         });
     }
 }


### PR DESCRIPTION
- Use `IsGetNullable` and `IsSetNullable` properties to set nullability status for properties
- Use per-instance `NullabilityInfoContext` instead of shared static instance
- Avoid allocating schemas for select primitive types
- Avoid including special `?` character in reference ID for nullable schemas
- Massage representation of `object` schemas to close https://github.com/dotnet/aspnetcore/issues/56351

Addresses feedback from https://github.com/dotnet/aspnetcore/pull/56330#discussion_r1649371307 and https://github.com/dotnet/aspnetcore/issues/56318