### PR TITLE
Use ArgumentOutOfRangeException Throw methods in SendFileResponseExtensions..CheckRange

### DIFF
--- a/src/Http/Http.Extensions/src/SendFileResponseExtensions.cs
+++ b/src/Http/Http.Extensions/src/SendFileResponseExtensions.cs
@@ -124,14 +124,11 @@ public static class SendFileResponseExtensions
 
     private static void CheckRange(long offset, long? count, long fileLength)
     {
-        if (offset < 0 || offset > fileLength)
+        ArgumentOutOfRangeException.ThrowIfLessThan(offset, 0);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(offset, fileLength);
+        if (count is {} countValue)
         {
-            throw new ArgumentOutOfRangeException(nameof(offset), offset, string.Empty);
-        }
-        if (count.HasValue &&
-            (count.GetValueOrDefault() < 0 || count.GetValueOrDefault() > fileLength - offset))
-        {
-            throw new ArgumentOutOfRangeException(nameof(count), count, string.Empty);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(countValue, countValue, nameof(count));
         }
     }
 }

--- a/src/Http/Http.Extensions/src/SendFileResponseExtensions.cs
+++ b/src/Http/Http.Extensions/src/SendFileResponseExtensions.cs
@@ -128,6 +128,7 @@ public static class SendFileResponseExtensions
         ArgumentOutOfRangeException.ThrowIfGreaterThan(offset, fileLength);
         if (count is {} countValue)
         {
+            ArgumentOutOfRangeException.ThrowIfLessThan(countValue, 0, nameof(count));
             ArgumentOutOfRangeException.ThrowIfGreaterThan(countValue, fileLength - offset, nameof(count));
         }
     }

--- a/src/Http/Http.Extensions/src/SendFileResponseExtensions.cs
+++ b/src/Http/Http.Extensions/src/SendFileResponseExtensions.cs
@@ -128,7 +128,7 @@ public static class SendFileResponseExtensions
         ArgumentOutOfRangeException.ThrowIfGreaterThan(offset, fileLength);
         if (count is {} countValue)
         {
-            ArgumentOutOfRangeException.ThrowIfGreaterThan(countValue, countValue, nameof(count));
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(countValue, fileLength - offset, nameof(count));
         }
     }
 }


### PR DESCRIPTION
To allow inlining by the JIT.

# Use ArgumentOutOfRangeException Throw methods in SendFileResponseExtensions..CheckRange to allow inlining by the JIT

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Methods that throw exceptions are not inlinable by the JIT.

This PR uses the recently introduced **throw** methods in the `ArgumentOutOfRangeException` to allow the logic to be fully inlined in non-error situations to increase performance of static file responses.