### PR TITLE
Only enable SwaggerUI in development

### DIFF
--- a/src/Grpc/JsonTranscoding/test/testassets/Sandbox/Startup.cs
+++ b/src/Grpc/JsonTranscoding/test/testassets/Sandbox/Startup.cs
@@ -30,10 +30,13 @@ public class Startup
 
         #region Secret
         app.UseSwagger();
-        app.UseSwaggerUI(c =>
+        if (env.IsDevelopment())
         {
-            c.SwaggerEndpoint("/swagger/v1/swagger.json", "My API V1");
-        });
+            app.UseSwaggerUI(c =>
+            {
+                c.SwaggerEndpoint("/swagger/v1/swagger.json", "My API V1");
+            });
+        }
         #endregion
 
         app.UseRouting();


### PR DESCRIPTION
Follow recommended guidance around only enabling Swagger UI in development environments.