### PR TITLE
Set OpenAPI discriminators for JSON polymorphic types

### DIFF
--- a/src/OpenApi/sample/Program.cs
+++ b/src/OpenApi/sample/Program.cs
@@ -108,9 +108,9 @@ schemas.MapPost("/list-of-ints", (List<int> values) => values.Count);
 schemas.MapPost("/ienumerable-of-ints", (IEnumerable<int> values) => values.Count());
 schemas.MapGet("/dictionary-of-ints", () => new Dictionary<string, int> { { "one", 1 }, { "two", 2 } });
 schemas.MapGet("/frozen-dictionary-of-ints", () => ImmutableDictionary.CreateRange(new Dictionary<string, int> { { "one", 1 }, { "two", 2 } }));
-schemas.MapGet("/shape", (Shape shape) => { });
-schemas.MapGet("/weatherforecastbase", (WeatherForecastBase forecast) => { });
-schemas.MapGet("/person", (Person person) => { });
+schemas.MapPost("/shape", (Shape shape) => { });
+schemas.MapPost("/weatherforecastbase", (WeatherForecastBase forecast) => { });
+schemas.MapPost("/person", (Person person) => { });
 
 app.MapControllers();
 

--- a/src/OpenApi/sample/Program.cs
+++ b/src/OpenApi/sample/Program.cs
@@ -91,7 +91,7 @@ responses.MapGet("/200-only-xml", () => new TodoWithDueDate(1, "Test todo", fals
     .Produces<Todo>(contentType: "text/xml");
 
 responses.MapGet("/triangle", () => new Triangle { Color = "red", Sides = 3, Hypotenuse = 5.0 });
-responses.MapGet("/shape", () => new Shape { Color = "blue", Sides = 4 });
+responses.MapGet("/shape", Shape () => new Triangle { Color = "blue", Sides = 4 });
 
 schemas.MapGet("/typed-results", () => TypedResults.Ok(new Triangle { Color = "red", Sides = 3, Hypotenuse = 5.0 }));
 schemas.MapGet("/multiple-results", Results<Ok<Triangle>, NotFound<string>> () => Random.Shared.Next(0, 2) == 0
@@ -108,6 +108,9 @@ schemas.MapPost("/list-of-ints", (List<int> values) => values.Count);
 schemas.MapPost("/ienumerable-of-ints", (IEnumerable<int> values) => values.Count());
 schemas.MapGet("/dictionary-of-ints", () => new Dictionary<string, int> { { "one", 1 }, { "two", 2 } });
 schemas.MapGet("/frozen-dictionary-of-ints", () => ImmutableDictionary.CreateRange(new Dictionary<string, int> { { "one", 1 }, { "two", 2 } }));
+schemas.MapGet("/shape", (Shape shape) => { });
+schemas.MapGet("/weatherforecastbase", (WeatherForecastBase forecast) => { });
+schemas.MapGet("/person", (Person person) => { });
 
 app.MapControllers();
 

--- a/src/OpenApi/sample/Sample.csproj
+++ b/src/OpenApi/sample/Sample.csproj
@@ -22,7 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="../test/SharedTypes.cs" />
+    <Compile Include="../test/Shared/SharedTypes.cs" />
+    <Compile Include="../test/Shared/SharedTypes.Polymorphism.cs" />
   </ItemGroup>
 
   <!-- Required to generated trimmable Map-invocations. -->

--- a/src/OpenApi/src/Schemas/OpenApiJsonSchema.Helpers.cs
+++ b/src/OpenApi/src/Schemas/OpenApiJsonSchema.Helpers.cs
@@ -83,7 +83,11 @@ internal sealed partial class OpenApiJsonSchema
     }
 
     internal static IOpenApiAny? ReadOpenApiAny(ref Utf8JsonReader reader)
+        => ReadOpenApiAny(ref reader, out _);
+
+    internal static IOpenApiAny? ReadOpenApiAny(ref Utf8JsonReader reader, out string? type)
     {
+        type = null;
         if (reader.TokenType == JsonTokenType.Null)
         {
             return new OpenApiNull();
@@ -91,6 +95,7 @@ internal sealed partial class OpenApiJsonSchema
 
         if (reader.TokenType == JsonTokenType.True || reader.TokenType == JsonTokenType.False)
         {
+            type = "boolean";
             return new OpenApiBoolean(reader.GetBoolean());
         }
 
@@ -98,32 +103,38 @@ internal sealed partial class OpenApiJsonSchema
         {
             if (reader.TryGetInt32(out var intValue))
             {
+                type = "integer";
                 return new OpenApiInteger(intValue);
             }
 
             if (reader.TryGetInt64(out var longValue))
             {
+                type = "integer";
                 return new OpenApiLong(longValue);
             }
 
             if (reader.TryGetSingle(out var floatValue) && !float.IsInfinity(floatValue))
             {
+                type = "number";
                 return new OpenApiFloat(floatValue);
             }
 
             if (reader.TryGetDouble(out var doubleValue))
             {
+                type = "number";
                 return new OpenApiDouble(doubleValue);
             }
         }
 
         if (reader.TokenType == JsonTokenType.String)
         {
+            type = "string";
             return new OpenApiString(reader.GetString());
         }
 
         if (reader.TokenType == JsonTokenType.StartArray)
         {
+            type = "array";
             var array = new OpenApiArray();
             while (reader.TokenType != JsonTokenType.EndArray)
             {
@@ -135,6 +146,7 @@ internal sealed partial class OpenApiJsonSchema
 
         if (reader.TokenType == JsonTokenType.StartObject)
         {
+            type = "object";
             var obj = new OpenApiObject();
             reader.Read();
             while (reader.TokenType != JsonTokenType.EndObject)
@@ -293,6 +305,13 @@ internal sealed partial class OpenApiJsonSchema
             case OpenApiConstants.SchemaId:
                 reader.Read();
                 schema.Extensions.Add(OpenApiConstants.SchemaId, new OpenApiString(reader.GetString()));
+                break;
+            // OpenAPI does not support the `const` keyword in its schema implementation, so
+            // we map it to its closest approximation, an enum with a single value, here.
+            case OpenApiSchemaKeywords.ConstKeyword:
+                reader.Read();
+                schema.Enum = [ReadOpenApiAny(ref reader, out var constType)];
+                schema.Type = constType;
                 break;
             default:
                 reader.Skip();

--- a/src/OpenApi/src/Schemas/OpenApiSchemaKeywords.cs
+++ b/src/OpenApi/src/Schemas/OpenApiSchemaKeywords.cs
@@ -25,4 +25,5 @@ internal class OpenApiSchemaKeywords
     public const string MaxItemsKeyword = "maxItems";
     public const string RefKeyword = "$ref";
     public const string SchemaIdKeyword = "x-schema-id";
+    public const string ConstKeyword = "const";
 }

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -90,6 +90,7 @@ internal sealed class OpenApiSchemaService(
             }
             schema.ApplyPrimitiveTypesAndFormats(context);
             schema.ApplySchemaReferenceId(context);
+            schema.ApplyPolymorphismOptions(context);
             if (context.PropertyInfo is { AttributeProvider: { } attributeProvider } jsonPropertyInfo)
             {
                 schema.ApplyNullabilityContextInfo(jsonPropertyInfo);

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=responses.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=responses.verified.txt
@@ -59,7 +59,20 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "hypotenuse": {
+                      "type": "number",
+                      "format": "double"
+                    },
+                    "color": {
+                      "type": "string"
+                    },
+                    "sides": {
+                      "type": "integer",
+                      "format": "int32"
+                    }
+                  }
                 }
               }
             }
@@ -78,7 +91,25 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "required": [
+                    "$type"
+                  ],
+                  "type": "object",
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/ShapeTriangle"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ShapeSquare"
+                    }
+                  ],
+                  "discriminator": {
+                    "propertyName": "$type",
+                    "mapping": {
+                      "triangle": "#/components/schemas/ShapeTriangle",
+                      "square": "#/components/schemas/ShapeSquare"
+                    }
+                  }
                 }
               }
             }
@@ -89,6 +120,48 @@
   },
   "components": {
     "schemas": {
+      "ShapeSquare": {
+        "properties": {
+          "$type": {
+            "enum": [
+              "square"
+            ],
+            "type": "string"
+          },
+          "area": {
+            "type": "number",
+            "format": "double"
+          },
+          "color": {
+            "type": "string"
+          },
+          "sides": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "ShapeTriangle": {
+        "properties": {
+          "$type": {
+            "enum": [
+              "triangle"
+            ],
+            "type": "string"
+          },
+          "hypotenuse": {
+            "type": "number",
+            "format": "double"
+          },
+          "color": {
+            "type": "string"
+          },
+          "sides": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
       "Todo": {
         "required": [
           "id",

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
@@ -295,7 +295,7 @@
       }
     },
     "/schemas-by-ref/shape": {
-      "get": {
+      "post": {
         "tags": [
           "Sample"
         ],
@@ -335,7 +335,7 @@
       }
     },
     "/schemas-by-ref/weatherforecastbase": {
-      "get": {
+      "post": {
         "tags": [
           "Sample"
         ],
@@ -379,7 +379,7 @@
       }
     },
     "/schemas-by-ref/person": {
-      "get": {
+      "post": {
         "tags": [
           "Sample"
         ],

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
@@ -293,6 +293,130 @@
           }
         }
       }
+    },
+    "/schemas-by-ref/shape": {
+      "get": {
+        "tags": [
+          "Sample"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "$type"
+                ],
+                "type": "object",
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/ShapeTriangle"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ShapeSquare"
+                  }
+                ],
+                "discriminator": {
+                  "propertyName": "$type",
+                  "mapping": {
+                    "triangle": "#/components/schemas/ShapeTriangle",
+                    "square": "#/components/schemas/ShapeSquare"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/schemas-by-ref/weatherforecastbase": {
+      "get": {
+        "tags": [
+          "Sample"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "$type"
+                ],
+                "type": "object",
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/WeatherForecastBaseWeatherForecastWithCity"
+                  },
+                  {
+                    "$ref": "#/components/schemas/WeatherForecastBaseWeatherForecastWithTimeSeries"
+                  },
+                  {
+                    "$ref": "#/components/schemas/WeatherForecastBaseWeatherForecastWithLocalNews"
+                  }
+                ],
+                "discriminator": {
+                  "propertyName": "$type",
+                  "mapping": {
+                    "0": "#/components/schemas/WeatherForecastBaseWeatherForecastWithCity",
+                    "1": "#/components/schemas/WeatherForecastBaseWeatherForecastWithTimeSeries",
+                    "2": "#/components/schemas/WeatherForecastBaseWeatherForecastWithLocalNews"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/schemas-by-ref/person": {
+      "get": {
+        "tags": [
+          "Sample"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "discriminator"
+                ],
+                "type": "object",
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/PersonStudent"
+                  },
+                  {
+                    "$ref": "#/components/schemas/PersonTeacher"
+                  }
+                ],
+                "discriminator": {
+                  "propertyName": "discriminator",
+                  "mapping": {
+                    "student": "#/components/schemas/PersonStudent",
+                    "teacher": "#/components/schemas/PersonTeacher"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -323,6 +447,36 @@
           "format": "int32"
         }
       },
+      "PersonStudent": {
+        "properties": {
+          "discriminator": {
+            "enum": [
+              "student"
+            ],
+            "type": "string"
+          },
+          "gpa": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "PersonTeacher": {
+        "required": [
+          "subject"
+        ],
+        "properties": {
+          "discriminator": {
+            "enum": [
+              "teacher"
+            ],
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          }
+        }
+      },
       "Product": {
         "type": "object",
         "properties": {
@@ -335,8 +489,119 @@
           }
         }
       },
+      "ShapeSquare": {
+        "properties": {
+          "$type": {
+            "enum": [
+              "square"
+            ],
+            "type": "string"
+          },
+          "area": {
+            "type": "number",
+            "format": "double"
+          },
+          "color": {
+            "type": "string"
+          },
+          "sides": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "ShapeTriangle": {
+        "properties": {
+          "$type": {
+            "enum": [
+              "triangle"
+            ],
+            "type": "string"
+          },
+          "hypotenuse": {
+            "type": "number",
+            "format": "double"
+          },
+          "color": {
+            "type": "string"
+          },
+          "sides": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
       "Triangle": {
-        "type": "object"
+        "type": "object",
+        "properties": {
+          "hypotenuse": {
+            "type": "number",
+            "format": "double"
+          },
+          "color": {
+            "type": "string"
+          },
+          "sides": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "WeatherForecastBaseWeatherForecastWithCity": {
+        "required": [
+          "city"
+        ],
+        "properties": {
+          "$type": {
+            "enum": [
+              0
+            ],
+            "type": "integer"
+          },
+          "city": {
+            "type": "string"
+          }
+        }
+      },
+      "WeatherForecastBaseWeatherForecastWithLocalNews": {
+        "required": [
+          "news"
+        ],
+        "properties": {
+          "$type": {
+            "enum": [
+              2
+            ],
+            "type": "integer"
+          },
+          "news": {
+            "type": "string"
+          }
+        }
+      },
+      "WeatherForecastBaseWeatherForecastWithTimeSeries": {
+        "required": [
+          "summary"
+        ],
+        "properties": {
+          "$type": {
+            "enum": [
+              1
+            ],
+            "type": "integer"
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "temperatureC": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "summary": {
+            "type": "string"
+          }
+        }
       }
     }
   },

--- a/src/OpenApi/test/Services/OpenApiSchemaService/OpenApiSchemaService.ParameterSchemas.cs
+++ b/src/OpenApi/test/Services/OpenApiSchemaService/OpenApiSchemaService.ParameterSchemas.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 
-public partial class OpenApiComponentServiceTests : OpenApiDocumentServiceTestBase
+public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
 {
 #nullable enable
     public static object?[][] RouteParametersWithPrimitiveTypes =>

--- a/src/OpenApi/test/Services/OpenApiSchemaService/OpenApiSchemaService.PolymorphicSchemas.cs
+++ b/src/OpenApi/test/Services/OpenApiSchemaService/OpenApiSchemaService.PolymorphicSchemas.cs
@@ -1,0 +1,177 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+
+public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
+{
+    [Fact]
+    public async Task HandlesPolymorphicTypeWithMappingsAndStringDiscriminator()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPost("/api", (Shape shape) => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths["/api"].Operations[OperationType.Post];
+            Assert.NotNull(operation.RequestBody);
+            var requestBody = operation.RequestBody.Content;
+            Assert.True(requestBody.TryGetValue("application/json", out var mediaType));
+            var schema = mediaType.Schema;
+            // Assert discriminator mappings have been configured correctly
+            Assert.Equal("$type", schema.Discriminator.PropertyName);
+            Assert.Contains(schema.Discriminator.PropertyName, schema.Required);
+            Assert.Collection(schema.Discriminator.Mapping,
+                item => Assert.Equal("triangle", item.Key),
+                item => Assert.Equal("square", item.Key)
+            );
+            Assert.Collection(schema.Discriminator.Mapping,
+                item => Assert.Equal("#/components/schemas/ShapeTriangle", item.Value),
+                item => Assert.Equal("#/components/schemas/ShapeSquare", item.Value)
+            );
+            // Assert the schemas with the discriminator have been inserted into the components
+            Assert.True(document.Components.Schemas.TryGetValue("ShapeTriangle", out var triangleSchema));
+            Assert.Contains(schema.Discriminator.PropertyName, triangleSchema.Properties.Keys);
+            Assert.Equal("triangle", ((OpenApiString)triangleSchema.Properties[schema.Discriminator.PropertyName].Enum.First()).Value);
+            Assert.True(document.Components.Schemas.TryGetValue("ShapeSquare", out var squareSchema));
+            Assert.Equal("square", ((OpenApiString)squareSchema.Properties[schema.Discriminator.PropertyName].Enum.First()).Value);
+        });
+    }
+
+    [Fact]
+    public async Task HandlesPolymorphicTypeWithMappingsAndIntegerDiscriminator()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPost("/api", (WeatherForecastBase forecast) => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths["/api"].Operations[OperationType.Post];
+            Assert.NotNull(operation.RequestBody);
+            var requestBody = operation.RequestBody.Content;
+            Assert.True(requestBody.TryGetValue("application/json", out var mediaType));
+            var schema = mediaType.Schema;
+            // Assert discriminator mappings have been configured correctly
+            Assert.Equal("$type", schema.Discriminator.PropertyName);
+            Assert.Contains(schema.Discriminator.PropertyName, schema.Required);
+            Assert.Collection(schema.Discriminator.Mapping,
+                item => Assert.Equal("0", item.Key),
+                item => Assert.Equal("1", item.Key),
+                item => Assert.Equal("2", item.Key)
+            );
+            Assert.Collection(schema.Discriminator.Mapping,
+                item => Assert.Equal("#/components/schemas/WeatherForecastBaseWeatherForecastWithCity", item.Value),
+                item => Assert.Equal("#/components/schemas/WeatherForecastBaseWeatherForecastWithTimeSeries", item.Value),
+                item => Assert.Equal("#/components/schemas/WeatherForecastBaseWeatherForecastWithLocalNews", item.Value)
+            );
+            // Assert schema with discriminator = 0 has been inserted into the components
+            Assert.True(document.Components.Schemas.TryGetValue("WeatherForecastBaseWeatherForecastWithCity", out var citySchema));
+            Assert.Contains(schema.Discriminator.PropertyName, citySchema.Properties.Keys);
+            Assert.Equal(0, ((OpenApiInteger)citySchema.Properties[schema.Discriminator.PropertyName].Enum.First()).Value);
+            // Assert schema with discriminator = 1 has been inserted into the components
+            Assert.True(document.Components.Schemas.TryGetValue("WeatherForecastBaseWeatherForecastWithTimeSeries", out var timeSeriesSchema));
+            Assert.Contains(schema.Discriminator.PropertyName, timeSeriesSchema.Properties.Keys);
+            Assert.Equal(1, ((OpenApiInteger)timeSeriesSchema.Properties[schema.Discriminator.PropertyName].Enum.First()).Value);
+            // Assert schema with discriminator = 2 has been inserted into the components
+            Assert.True(document.Components.Schemas.TryGetValue("WeatherForecastBaseWeatherForecastWithLocalNews", out var newsSchema));
+            Assert.Contains(schema.Discriminator.PropertyName, newsSchema.Properties.Keys);
+            Assert.Equal(2, ((OpenApiInteger)newsSchema.Properties[schema.Discriminator.PropertyName].Enum.First()).Value);
+        });
+    }
+
+    [Fact]
+    public async Task HandlesPolymorphicTypesWithCustomPropertyName()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPost("/api", (Person person) => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths["/api"].Operations[OperationType.Post];
+            Assert.NotNull(operation.RequestBody);
+            var requestBody = operation.RequestBody.Content;
+            Assert.True(requestBody.TryGetValue("application/json", out var mediaType));
+            var schema = mediaType.Schema;
+            // Assert discriminator mappings have been configured correctly
+            Assert.Equal("discriminator", schema.Discriminator.PropertyName);
+            Assert.Contains(schema.Discriminator.PropertyName, schema.Required);
+            Assert.Collection(schema.Discriminator.Mapping,
+                item => Assert.Equal("student", item.Key),
+                item => Assert.Equal("teacher", item.Key)
+            );
+            Assert.Collection(schema.Discriminator.Mapping,
+                item => Assert.Equal("#/components/schemas/PersonStudent", item.Value),
+                item => Assert.Equal("#/components/schemas/PersonTeacher", item.Value)
+            );
+            // Assert schema with discriminator = 0 has been inserted into the components
+            Assert.True(document.Components.Schemas.TryGetValue("PersonStudent", out var citySchema));
+            Assert.Contains(schema.Discriminator.PropertyName, citySchema.Properties.Keys);
+            Assert.Equal("student", ((OpenApiString)citySchema.Properties[schema.Discriminator.PropertyName].Enum.First()).Value);
+            // Assert schema with discriminator = 1 has been inserted into the components
+            Assert.True(document.Components.Schemas.TryGetValue("PersonTeacher", out var timeSeriesSchema));
+            Assert.Contains(schema.Discriminator.PropertyName, timeSeriesSchema.Properties.Keys);
+            Assert.Equal("teacher", ((OpenApiString)timeSeriesSchema.Properties[schema.Discriminator.PropertyName].Enum.First()).Value);
+        });
+    }
+
+    [Fact]
+    public async Task HandlesPolymorphicTypesWithNonAbstractBaseClass()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPost("/api", (Color color) => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths["/api"].Operations[OperationType.Post];
+            Assert.NotNull(operation.RequestBody);
+            var requestBody = operation.RequestBody.Content;
+            Assert.True(requestBody.TryGetValue("application/json", out var mediaType));
+            var schema = mediaType.Schema;
+            // Assert discriminator mappings have been configured correctly
+            Assert.Equal("$type", schema.Discriminator.PropertyName);
+            Assert.Collection(schema.Discriminator.Mapping,
+                item => Assert.Equal("paint", item.Key),
+                item => Assert.Equal("fabric", item.Key)
+            );
+            Assert.Collection(schema.Discriminator.Mapping,
+                item => Assert.Equal("#/components/schemas/ColorPaintColor", item.Value),
+                item => Assert.Equal("#/components/schemas/ColorFabricColor", item.Value)
+            );
+            // Note that our implementation diverges from the OpenAPI specification here. OpenAPI
+            // requires that derived types in a polymorphic schema _always_ have a discriminator
+            // property associated with them. STJ permits the discriminator to be omitted from the
+            // if the base type is a non-abstract class and falls back to serializing to this base
+            // type. This is a known limitation of the current implementation.
+            Assert.Collection(schema.AnyOf,
+                schema => Assert.Equal("ColorPaintColor", schema.Reference.Id),
+                schema => Assert.Equal("ColorFabricColor", schema.Reference.Id),
+                schema => Assert.Equal("ColorColor", schema.Reference.Id));
+            // Assert schema with discriminator = "paint" has been inserted into the components
+            Assert.True(document.Components.Schemas.TryGetValue("ColorPaintColor", out var paintSchema));
+            Assert.Contains(schema.Discriminator.PropertyName, paintSchema.Properties.Keys);
+            Assert.Equal("paint", ((OpenApiString)paintSchema.Properties[schema.Discriminator.PropertyName].Enum.First()).Value);
+            // Assert schema with discriminator = "fabric" has been inserted into the components
+            Assert.True(document.Components.Schemas.TryGetValue("ColorFabricColor", out var fabricSchema));
+            Assert.Contains(schema.Discriminator.PropertyName, fabricSchema.Properties.Keys);
+            Assert.Equal("fabric", ((OpenApiString)fabricSchema.Properties[schema.Discriminator.PropertyName].Enum.First()).Value);
+        });
+    }
+}

--- a/src/OpenApi/test/Services/OpenApiSchemaService/OpenApiSchemaService.RequestBodySchemas.cs
+++ b/src/OpenApi/test/Services/OpenApiSchemaService/OpenApiSchemaService.RequestBodySchemas.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 
-public partial class OpenApiComponentServiceTests : OpenApiDocumentServiceTestBase
+public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
 {
     [Fact]
     public async Task GetOpenApiRequestBody_GeneratesSchemaForPoco()

--- a/src/OpenApi/test/Services/OpenApiSchemaService/OpenApiSchemaService.ResponseSchemas.cs
+++ b/src/OpenApi/test/Services/OpenApiSchemaService/OpenApiSchemaService.ResponseSchemas.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 
-public partial class OpenApiComponentServiceTests : OpenApiDocumentServiceTestBase
+public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
 {
     public static object[][] ResponsesWithPrimitiveTypes =>
     [

--- a/src/OpenApi/test/Shared/SharedTypes.Polymorphism.cs
+++ b/src/OpenApi/test/Shared/SharedTypes.Polymorphism.cs
@@ -1,0 +1,74 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+
+[JsonDerivedType(typeof(Triangle), typeDiscriminator: "triangle")]
+[JsonDerivedType(typeof(Square), typeDiscriminator: "square")]
+internal abstract class Shape
+{
+    public string Color { get; set; } = string.Empty;
+    public int Sides { get; set; }
+}
+
+internal class Triangle : Shape
+{
+    public double Hypotenuse { get; set; }
+}
+internal class Square : Shape
+{
+    public double Area { get; set; }
+}
+
+[JsonDerivedType(typeof(WeatherForecastWithCity), 0)]
+[JsonDerivedType(typeof(WeatherForecastWithTimeSeries), 1)]
+[JsonDerivedType(typeof(WeatherForecastWithLocalNews), 2)]
+internal abstract class WeatherForecastBase { }
+
+internal class WeatherForecastWithCity : WeatherForecastBase
+{
+    public required string City { get; set; }
+}
+
+internal class WeatherForecastWithTimeSeries : WeatherForecastBase
+{
+    public DateTimeOffset Date { get; set; }
+    public int TemperatureC { get; set; }
+    public required string Summary { get; set; }
+}
+
+internal class WeatherForecastWithLocalNews : WeatherForecastBase
+{
+    public required string News { get; set; }
+}
+
+[JsonDerivedType(typeof(Student), typeDiscriminator: "student")]
+[JsonDerivedType(typeof(Teacher), typeDiscriminator: "teacher")]
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "discriminator")]
+internal abstract class Person { }
+
+internal class Student : Person
+{
+    public decimal GPA { get; set; }
+}
+
+internal class Teacher : Person
+{
+    public required string Subject { get; set; }
+}
+
+[JsonDerivedType(typeof(PaintColor), typeDiscriminator: "paint")]
+[JsonDerivedType(typeof(FabricColor), typeDiscriminator: "fabric")]
+internal class Color
+{
+    public required string HexCode { get; set; }
+}
+
+internal class PaintColor : Color
+{
+    public bool IsMatte { get; set; }
+}
+internal class FabricColor : Color
+{
+    public required string Dye { get; set; }
+}

--- a/src/OpenApi/test/Shared/SharedTypes.cs
+++ b/src/OpenApi/test/Shared/SharedTypes.cs
@@ -20,23 +20,6 @@ internal record ResumeUpload(string Name, string Description, IFormFile Resume);
 
 internal record Result<T>(bool IsSuccessful, T Value, Error Error);
 
-[JsonDerivedType(typeof(Triangle), typeDiscriminator: "triangle")]
-[JsonDerivedType(typeof(Square), typeDiscriminator: "square")]
-internal class Shape
-{
-    internal string Color { get; set; } = string.Empty;
-    internal int Sides { get; set; }
-}
-
-internal class Triangle : Shape
-{
-    internal double Hypotenuse { get; set; }
-}
-internal class Square : Shape
-{
-    internal double Area { get; set; }
-}
-
 internal class Vehicle
 {
     public int Wheels { get; set; }


### PR DESCRIPTION
This PR adds support for mapping types annotated with STJ's `JsonDerivedType` annotations to OpenAPI schemas that configure the `discriminator` property accurately.

There are 3 components to this implementation:

- `ApplyPolymorphismOptions` sets the `discriminator.propertyName` and`discriminator.mapping` values in schema in accordance with the OpenAPI spec.
- `PopulateSchemaIntoReferenceCache` is updated to support generating reference IDs for derived types that capture the base type's schema ID.
- Changes to `OpenApiJsonSchema` to support mapping the `const: "some-string-here"` format that STJ uses to represent discriminator values to an enum that OpenAPI supports.

There's a notable divergence from the OpenAPI spec in this implementation that is documented in the `HandlesPolymorphicTypesWithNonAbstractBaseClass` test case. The OpenAPI spec requires that all derived types in a polymorphic schema must contain a type discriminator. STJ supports serializing to the base type (as long as it's a non-abstract class) when no discriminator is provided. We'll revisit this in a future PR in the event there are APIs in STJ for evaluating the base type a derived type is being generated in the context of (see https://github.com/dotnet/runtime/issues/104046).