### PR TITLE
Remove IIS launch profiles from templates

### DIFF
--- a/src/ProjectTemplates/Shared/BlazorTemplateTest.cs
+++ b/src/ProjectTemplates/Shared/BlazorTemplateTest.cs
@@ -62,10 +62,10 @@ public abstract class BlazorTemplateTest : LoggedTest
                                 || (!serverProject && auth is not null);
             var noHttps = args?.Contains(ArgConstants.NoHttps) ?? false;
             var expectedLaunchProfileNames = requiresHttps
-                ? new[] { "https", "IIS Express" }
+                ? new[] { "https" }
                 : noHttps
-                    ? new[] { "http", "IIS Express" }
-                    : new[] { "http", "https", "IIS Express" };
+                    ? new[] { "http" }
+                    : new[] { "http", "https" };
             await project.VerifyLaunchSettings(expectedLaunchProfileNames);
         }
 

--- a/src/ProjectTemplates/Shared/Project.cs
+++ b/src/ProjectTemplates/Shared/Project.cs
@@ -329,20 +329,6 @@ public class Project : IDisposable
 
             // Check there are no more launch profiles defined
             Assert.False(profilesEnumerator.MoveNext());
-
-            if (launchSettings.RootElement.TryGetProperty("iisSettings", out var iisSettings)
-                && iisSettings.TryGetProperty("iisExpress", out var iisExpressSettings))
-            {
-                var iisSslPort = iisExpressSettings.GetProperty("sslPort").GetInt32();
-                if (expectedLaunchProfileNames.Contains("https"))
-                {
-                    Assert.True(iisSslPort >= 44300 && iisSslPort <= 44399, $"IIS Express port was expected to be >= 44300 and <= 44399 but was {iisSslPort} in file {filePath}");
-                }
-                else
-                {
-                    Assert.Equal(0, iisSslPort);
-                }
-            }
         }
     }
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Properties/launchSettings.json
@@ -13,7 +13,11 @@
         "environmentVariables": {
           "ASPNETCORE_ENVIRONMENT": "Development"
         }
+      //#if (HasHttpsProfile)
       },
+      //#else
+      }
+      //#endif
       //#endif
       //#if (HasHttpsProfile)
       "https": {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Properties/launchSettings.json
@@ -28,5 +28,6 @@
           "ASPNETCORE_ENVIRONMENT": "Development"
         }
       }
+      //#endif
     }
   }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Properties/launchSettings.json
@@ -1,17 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/launchsettings.json",
-    "iisSettings": {
-      "windowsAuthentication": false,
-      "anonymousAuthentication": true,
-      "iisExpress": {
-        "applicationUrl": "http://localhost:8080",
-        //#if (HasHttpsProfile)
-        "sslPort": 44300
-        //#else
-        "sslPort": 0
-        //#endif
-      }
-    },
     "profiles": {
       //#if (HasHttpProfile)
       "http": {
@@ -36,17 +24,6 @@
         "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
         //#endif
         "applicationUrl": "https://localhost:5501;http://localhost:5500",
-        "environmentVariables": {
-          "ASPNETCORE_ENVIRONMENT": "Development"
-        }
-      },
-      //#endif
-      "IIS Express": {
-        "commandName": "IISExpress",
-        "launchBrowser": true,
-        //#if (UseWebAssembly)
-        "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
-        //#endif
         "environmentVariables": {
           "ASPNETCORE_ENVIRONMENT": "Development"
         }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Properties/launchSettings.json
@@ -24,5 +24,6 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
+    //#endif
   }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Properties/launchSettings.json
@@ -1,22 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/launchsettings.json",
-  "iisSettings": {
-    //#if (WindowsAuth)
-    "windowsAuthentication": true,
-    "anonymousAuthentication": false,
-    //#else
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    //#endif
-    "iisExpress": {
-      "applicationUrl": "http://localhost:8080",
-      //#if (HasHttpsProfile)
-      "sslPort": 44300
-      //#else
-      "sslPort": 0
-      //#endif
-    }
-  },
   "profiles": {
     //#if (HasHttpProfile)
     "http": {
@@ -37,15 +20,6 @@
       "launchBrowser": true,
       "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    //#endif
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Properties/launchSettings.json
@@ -11,7 +11,11 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
+    //#if (HasHttpsProfile)
     },
+    //#else
+    }
+    //#endif
     //#endif
     //#if (HasHttpsProfile)
     "https": {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/Properties/launchSettings.json
@@ -1,22 +1,5 @@
 ﻿{
   "$schema": "https://json.schemastore.org/launchsettings.json",
-  "iisSettings": {
-    //#if (WindowsAuth)
-    "windowsAuthentication": true,
-    "anonymousAuthentication": false,
-    //#else
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    //#endif
-    "iisExpress": {
-      "applicationUrl": "http://localhost:8080",
-      //#if (HasHttpsProfile)
-      "sslPort": 44300
-      //#else
-      "sslPort": 0
-      //#endif
-    }
-  },
   "profiles": {
     "http": {
       "commandName": "Project",
@@ -33,14 +16,6 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    //#endif
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/Properties/launchSettings.json
@@ -9,7 +9,11 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
+    //#if (HasHttpsProfile)
     },
+    //#else
+    }
+    //#endif
     //#if (HasHttpsProfile)
     "https": {
       "commandName": "Project",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/Properties/launchSettings.json
@@ -20,5 +20,6 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
+    //#endif
   }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-FSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-FSharp/Properties/launchSettings.json
@@ -1,17 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/launchsettings.json",
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:8080",
-      //#if (HasHttpsProfile)
-      "sslPort": 44300
-      //#else
-      "sslPort": 0
-      //#endif
-    }
-  },
   "profiles": {
     "http": {
       "commandName": "Project",
@@ -28,14 +16,6 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    //#endif
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-FSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-FSharp/Properties/launchSettings.json
@@ -9,7 +9,11 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
+    //#if (HasHttpsProfile)
     },
+    //#else
+    }
+    //#endif
     //#if (HasHttpsProfile)
     "https": {
       "commandName": "Project",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-FSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-FSharp/Properties/launchSettings.json
@@ -20,5 +20,6 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
+    //#endif
   }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Properties/launchSettings.json
@@ -10,7 +10,11 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
+    //#if (HasHttpsProfile)
     },
+    //#else
+    }
+    //#endif
     //#endif
     //#if (HasHttpsProfile)
     "https": {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Properties/launchSettings.json
@@ -1,22 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/launchsettings.json",
-  "iisSettings": {
-    //#if (WindowsAuth)
-    "windowsAuthentication": true,
-    "anonymousAuthentication": false,
-    //#else
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    //#endif
-    "iisExpress": {
-      "applicationUrl": "http://localhost:8080",
-      //#if (HasHttpsProfile)
-      "sslPort": 44300
-      //#else
-      "sslPort": 0
-      //#endif
-    }
-  },
   "profiles": {
     //#if (HasHttpProfile)
     "http": {
@@ -35,14 +18,6 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    //#endif
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Properties/launchSettings.json
@@ -22,5 +22,6 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
+    //#endif
   }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Properties/launchSettings.json
@@ -10,7 +10,11 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
+    //#if (HasHttpsProfile)
     },
+    //#else
+    }
+    //#endif
     //#endif
     //#if (HasHttpsProfile)
     "https": {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Properties/launchSettings.json
@@ -1,22 +1,5 @@
 ﻿{
   "$schema": "https://json.schemastore.org/launchsettings.json",
-  "iisSettings": {
-    //#if (WindowsAuth)
-    "windowsAuthentication": true,
-    "anonymousAuthentication": false,
-    //#else
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    //#endif
-    "iisExpress": {
-      "applicationUrl": "http://localhost:8080",
-      //#if (HasHttpsProfile)
-      "sslPort": 44300
-      //#else
-      "sslPort": 0
-      //#endif
-    }
-  },
   "profiles": {
     //#if (HasHttpProfile)
     "http": {
@@ -35,14 +18,6 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    //#endif
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Properties/launchSettings.json
@@ -22,5 +22,6 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
+    //#endif
   }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/Properties/launchSettings.json
@@ -1,22 +1,5 @@
 ﻿{
   "$schema": "https://json.schemastore.org/launchsettings.json",
-  "iisSettings": {
-    //#if (WindowsAuth)
-    "windowsAuthentication": true,
-    "anonymousAuthentication": false,
-    //#else
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    //#endif
-    "iisExpress": {
-      "applicationUrl": "http://localhost:8080",
-      //#if (HasHttpsProfile)
-      "sslPort": 44300
-      //#else
-      "sslPort": 0
-      //#endif
-    }
-  },
   "profiles": {
     "http": {
       "commandName": "Project",
@@ -33,14 +16,6 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    //#endif
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/Properties/launchSettings.json
@@ -9,7 +9,11 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
+    //#if (HasHttpsProfile)
     },
+    //#else
+    }
+    //#endif
     //#if (HasHttpsProfile)
     "https": {
       "commandName": "Project",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/Properties/launchSettings.json
@@ -20,5 +20,6 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
+    //#endif
   }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Properties/launchSettings.json
@@ -1,22 +1,5 @@
 ﻿{
   "$schema": "https://json.schemastore.org/launchsettings.json",
-  "iisSettings": {
-    //#if (WindowsAuth)
-    "windowsAuthentication": true,
-    "anonymousAuthentication": false,
-    //#else
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    //#endif
-    "iisExpress": {
-      "applicationUrl": "http://localhost:8080",
-      //#if (HasHttpsProfile)
-      "sslPort": 44300
-      //#else
-      "sslPort": 0
-      //#endif
-    }
-  },
   "profiles": {
     //#if (HasHttpProfile)
     "http": {
@@ -37,15 +20,6 @@
       "launchBrowser": true,
       "launchUrl": "weatherforecast",
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    //#endif
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "launchUrl": "weatherforecast",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Properties/launchSettings.json
@@ -24,5 +24,6 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
+    //#endif
   }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Properties/launchSettings.json
@@ -11,7 +11,11 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
+    //#if (HasHttpsProfile)
     },
+    //#else
+    }
+    //#endif
     //#endif
     //#if (HasHttpsProfile)
     "https": {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/Properties/launchSettings.json
@@ -1,22 +1,5 @@
 ﻿{
   "$schema": "https://json.schemastore.org/launchsettings.json",
-  "iisSettings": {
-    //#if (WindowsAuth)
-    "windowsAuthentication": true,
-    "anonymousAuthentication": false,
-    //#else
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    //#endif
-    "iisExpress": {
-      "applicationUrl": "http://localhost:8080",
-      //#if (HasHttpsProfile)
-      "sslPort": 44300
-      //#else
-      "sslPort": 0
-      //#endif
-    }
-  },
   "profiles": {
     "http": {
       "commandName": "Project",
@@ -35,15 +18,6 @@
       "launchBrowser": true,
       "launchUrl": "weatherforecast",
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    //#endif
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "launchUrl": "weatherforecast",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/Properties/launchSettings.json
@@ -10,7 +10,11 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
+    //#if (HasHttpsProfile)
     },
+    //#else
+    }
+    //#endif
     //#if (HasHttpsProfile)
     "https": {
       "commandName": "Project",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/Properties/launchSettings.json
@@ -22,5 +22,6 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
+    //#endif
   }
 }

--- a/src/ProjectTemplates/test/Templates.Mvc.Tests/BlazorTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Mvc.Tests/BlazorTemplateTest.cs
@@ -57,8 +57,8 @@ public class BlazorTemplateTest : LoggedTest
         await project.RunDotNetNewAsync("blazor", args: args);
 
         var expectedLaunchProfileNames = args.Contains(ArgConstants.NoHttps)
-            ? new[] { "http", "IIS Express" }
-            : new[] { "http", "https", "IIS Express" };
+            ? new[] { "http" }
+            : new[] { "http", "https" };
         await project.VerifyLaunchSettings(expectedLaunchProfileNames);
 
         var projectFileContents = await ReadProjectFileAsync(project);

--- a/src/ProjectTemplates/test/Templates.Mvc.Tests/MvcTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Mvc.Tests/MvcTemplateTest.cs
@@ -59,8 +59,8 @@ public class MvcTemplateTest : LoggedTest
 
         var noHttps = args?.Contains(ArgConstants.NoHttps) ?? false;
         var expectedLaunchProfileNames = noHttps
-            ? new[] { "http", "IIS Express" }
-            : new[] { "http", "https", "IIS Express" };
+            ? new[] { "http" }
+            : new[] { "http", "https" };
         await project.VerifyLaunchSettings(expectedLaunchProfileNames);
 
         var projectExtension = languageOverride == "F#" ? "fsproj" : "csproj";
@@ -157,8 +157,8 @@ public class MvcTemplateTest : LoggedTest
         await project.RunDotNetNewAsync("mvc", auth: "Individual", useLocalDB: useLocalDB, args: args);
 
         var expectedLaunchProfileNames = noHttps
-            ? new[] { "http", "IIS Express" }
-            : new[] { "http", "https", "IIS Express" };
+            ? new[] { "http" }
+            : new[] { "http", "https" };
         await project.VerifyLaunchSettings(expectedLaunchProfileNames);
 
         var projectFileContents = project.ReadFile($"{project.ProjectName}.csproj");

--- a/src/ProjectTemplates/test/Templates.Mvc.Tests/MvcTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Mvc.Tests/MvcTemplateTest.cs
@@ -355,7 +355,7 @@ public class MvcTemplateTest : LoggedTest
         await project.RunDotNetNewAsync("mvc", auth: auth, args: args);
 
         // Identity Web auth requires https and thus ignores the --no-https option if passed so there should never be an 'http' profile
-        var expectedLaunchProfileNames = new[] { "https", "IIS Express" };
+        var expectedLaunchProfileNames = new[] { "https" };
         await project.VerifyLaunchSettings(expectedLaunchProfileNames);
 
         // Verify building in debug works

--- a/src/ProjectTemplates/test/Templates.Mvc.Tests/RazorPagesTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Mvc.Tests/RazorPagesTemplateTest.cs
@@ -54,8 +54,8 @@ public class RazorPagesTemplateTest : LoggedTest
         await project.RunDotNetNewAsync("razor", args: args);
 
         var expectedLaunchProfileNames = noHttps
-            ? new[] { "http", "IIS Express" }
-            : new[] { "http", "https", "IIS Express" };
+            ? new[] { "http" }
+            : new[] { "http", "https" };
         await project.VerifyLaunchSettings(expectedLaunchProfileNames);
 
         var projectFileContents = ReadFile(project.TemplateOutputDir, $"{project.ProjectName}.csproj");
@@ -148,8 +148,8 @@ public class RazorPagesTemplateTest : LoggedTest
 
         // Individual auth supports no https OK
         var expectedLaunchProfileNames = noHttps
-            ? new[] { "http", "IIS Express" }
-            : new[] { "http", "https", "IIS Express" };
+            ? new[] { "http" }
+            : new[] { "http", "https" };
         await project.VerifyLaunchSettings(expectedLaunchProfileNames);
 
         var projectFileContents = ReadFile(project.TemplateOutputDir, $"{project.ProjectName}.csproj");
@@ -293,7 +293,7 @@ public class RazorPagesTemplateTest : LoggedTest
         await project.RunDotNetNewAsync("razor", auth: auth, args: args);
 
         // Identity Web auth requires https and thus ignores the --no-https option if passed so there should never be an 'http' profile
-        var expectedLaunchProfileNames = new[] { "https", "IIS Express" };
+        var expectedLaunchProfileNames = new[] { "https" };
         await project.VerifyLaunchSettings(expectedLaunchProfileNames);
 
         // Verify building in debug works

--- a/src/ProjectTemplates/test/Templates.Mvc.Tests/WebApiTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Mvc.Tests/WebApiTemplateTest.cs
@@ -195,8 +195,8 @@ public class WebApiTemplateTest : LoggedTest
 
         var noHttps = args.Contains(ArgConstants.NoHttps);
         var expectedLaunchProfileNames = noHttps
-            ? new[] { "http", "IIS Express" }
-            : new[] { "http", "https", "IIS Express" };
+            ? new[] { "http" }
+            : new[] { "http", "https" };
         await project.VerifyLaunchSettings(expectedLaunchProfileNames);
 
         await project.RunDotNetBuildAsync();
@@ -220,10 +220,10 @@ public class WebApiTemplateTest : LoggedTest
                             || string.Equals(auth, "SingleOrg", StringComparison.OrdinalIgnoreCase);
         var noHttps = args?.Contains(ArgConstants.NoHttps) ?? false;
         var expectedLaunchProfileNames = requiresHttps
-            ? new[] { "https", "IIS Express" }
+            ? new[] { "https" }
             : noHttps
-                ? new[] { "http", "IIS Express" }
-                : new[] { "http", "https", "IIS Express" };
+                ? new[] { "http" }
+                : new[] { "http", "https" };
         await project.VerifyLaunchSettings(expectedLaunchProfileNames);
 
         // Avoid the F# compiler. See https://github.com/dotnet/aspnetcore/issues/14022

--- a/src/ProjectTemplates/test/Templates.Tests/EmptyWebTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Tests/EmptyWebTemplateTest.cs
@@ -79,8 +79,8 @@ public class EmptyWebTemplateTest : LoggedTest
 
         var noHttps = args?.Contains(ArgConstants.NoHttps) ?? false;
         var expectedLaunchProfileNames = noHttps
-            ? new[] { "http", "IIS Express" }
-            : new[] { "http", "https", "IIS Express" };
+            ? new[] { "http" }
+            : new[] { "http", "https" };
         await project.VerifyLaunchSettings(expectedLaunchProfileNames);
 
         // Avoid the F# compiler. See https://github.com/dotnet/aspnetcore/issues/14022


### PR DESCRIPTION
# Remove IIS launch profiles from templates

VS now supports showing the IIS Express launch option all the time (as of 17.11) and will auto-create the launch profile if one doesn't already exist so we no longer need to always seed the templates with IIS launch settings which are only applicable in VS anyway.

![image](https://github.com/dotnet/aspnetcore/assets/249088/29e5f076-b64c-46d9-8cc5-82980337e409)

Fixes #46501
Fixes #42818

FYI @sayedihashimi