### PR TITLE
Disable async key ring update in Mvc.FunctionalTests

### DIFF
--- a/src/Mvc/test/Mvc.FunctionalTests/Infrastructure/MvcTestFixture.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/Infrastructure/MvcTestFixture.cs
@@ -17,6 +17,7 @@ public class MvcTestFixture<TStartup> : WebApplicationFactory<TStartup>
 {
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
+        AppContext.SetSwitch("Microsoft.AspNetCore.DataProtection.KeyManagement.DisableAsyncKeyRingUpdate", true);
         builder
             .UseRequestCulture<TStartup>("en-GB", "en-US")
             .UseEnvironment("Production")


### PR DESCRIPTION
I _think_ this is right place to set the app context switch to get it to apply to all tests.