### PR TITLE
Always ref  request body and response schemas and fix nested types

### DIFF
--- a/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
@@ -53,7 +53,8 @@ internal static class JsonTypeInfoExtensions
     internal static string? GetSchemaReferenceId(this JsonTypeInfo jsonTypeInfo, bool isTopLevel = true)
     {
         var type = jsonTypeInfo.Type;
-        if (isTopLevel && OpenApiConstants.PrimitiveTypes.Contains(type))
+        var underlyingType = Nullable.GetUnderlyingType(type);
+        if (isTopLevel && OpenApiConstants.PrimitiveTypes.Contains(underlyingType ?? type))
         {
             return null;
         }

--- a/src/OpenApi/src/Schemas/OpenApiJsonSchema.Helpers.cs
+++ b/src/OpenApi/src/Schemas/OpenApiJsonSchema.Helpers.cs
@@ -313,6 +313,10 @@ internal sealed partial class OpenApiJsonSchema
                 schema.Enum = [ReadOpenApiAny(ref reader, out var constType)];
                 schema.Type = constType;
                 break;
+            case OpenApiSchemaKeywords.RefKeyword:
+                reader.Read();
+                schema.Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = reader.GetString() };
+                break;
             default:
                 reader.Skip();
                 break;

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -228,7 +228,7 @@ internal sealed class OpenApiDocumentService(
             .Select(responseFormat => responseFormat.MediaType);
         foreach (var contentType in apiResponseFormatContentTypes)
         {
-            var schema = apiResponseType.Type is { } type ? await _componentService.GetOrCreateSchemaAsync(type, null, cancellationToken) : new OpenApiSchema();
+            var schema = apiResponseType.Type is { } type ? await _componentService.GetOrCreateSchemaAsync(type, null, cancellationToken, captureSchemaByRef: true) : new OpenApiSchema();
             response.Content[contentType] = new OpenApiMediaType { Schema = schema };
         }
 
@@ -465,7 +465,7 @@ internal sealed class OpenApiDocumentService(
         foreach (var requestForm in supportedRequestFormats)
         {
             var contentType = requestForm.MediaType;
-            requestBody.Content[contentType] = new OpenApiMediaType { Schema = await _componentService.GetOrCreateSchemaAsync(bodyParameter.Type, bodyParameter, cancellationToken) };
+            requestBody.Content[contentType] = new OpenApiMediaType { Schema = await _componentService.GetOrCreateSchemaAsync(bodyParameter.Type, bodyParameter, cancellationToken, captureSchemaByRef: true) };
         }
 
         return requestBody;

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -93,6 +93,14 @@ internal sealed class OpenApiSchemaService(
             schema.ApplyPolymorphismOptions(context);
             if (context.PropertyInfo is { AttributeProvider: { } attributeProvider } jsonPropertyInfo)
             {
+                // Short-circuit STJ's handling of nested properties, which uses a reference to the
+                // properties type schema with a schema that uses a document level reference.
+                // For example, if the property is a `public NestedTyped Nested { get; set; }` property,
+                // "nested": "#/properties/nested" because "nested": "#/components/schemas/NestedType"
+                if (jsonPropertyInfo.PropertyType == jsonPropertyInfo.DeclaringType)
+                {
+                    return new JsonObject { [OpenApiSchemaKeywords.RefKeyword] = context.TypeInfo.GetSchemaReferenceId() };
+                }
                 schema.ApplyNullabilityContextInfo(jsonPropertyInfo);
                 if (attributeProvider.GetCustomAttributes(inherit: false).OfType<ValidationAttribute>() is { } validationAttributes)
                 {
@@ -112,7 +120,7 @@ internal sealed class OpenApiSchemaService(
         }
     };
 
-    internal async Task<OpenApiSchema> GetOrCreateSchemaAsync(Type type, ApiParameterDescription? parameterDescription = null, CancellationToken cancellationToken = default)
+    internal async Task<OpenApiSchema> GetOrCreateSchemaAsync(Type type, ApiParameterDescription? parameterDescription = null, CancellationToken cancellationToken = default, bool captureSchemaByRef = false)
     {
         var key = parameterDescription?.ParameterDescriptor is IParameterInfoParameterDescriptor parameterInfoDescription
             && parameterDescription.ModelMetadata.PropertyName is null
@@ -126,7 +134,7 @@ internal sealed class OpenApiSchemaService(
         Debug.Assert(deserializedSchema != null, "The schema should have been deserialized successfully and materialize a non-null value.");
         var schema = deserializedSchema.Schema;
         await ApplySchemaTransformersAsync(schema, type, parameterDescription, cancellationToken);
-        _schemaStore.PopulateSchemaIntoReferenceCache(schema);
+        _schemaStore.PopulateSchemaIntoReferenceCache(schema, captureSchemaByRef);
         return schema;
     }
 

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=responses.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=responses.verified.txt
@@ -59,20 +59,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "hypotenuse": {
-                      "type": "number",
-                      "format": "double"
-                    },
-                    "color": {
-                      "type": "string"
-                    },
-                    "sides": {
-                      "type": "integer",
-                      "format": "int32"
-                    }
-                  }
+                  "$ref": "#/components/schemas/Triangle"
                 }
               }
             }
@@ -91,25 +78,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "required": [
-                    "$type"
-                  ],
-                  "type": "object",
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/ShapeTriangle"
-                    },
-                    {
-                      "$ref": "#/components/schemas/ShapeSquare"
-                    }
-                  ],
-                  "discriminator": {
-                    "propertyName": "$type",
-                    "mapping": {
-                      "triangle": "#/components/schemas/ShapeTriangle",
-                      "square": "#/components/schemas/ShapeSquare"
-                    }
-                  }
+                  "$ref": "#/components/schemas/Shape"
                 }
               }
             }
@@ -120,6 +89,27 @@
   },
   "components": {
     "schemas": {
+      "Shape": {
+        "required": [
+          "$type"
+        ],
+        "type": "object",
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/ShapeTriangle"
+          },
+          {
+            "$ref": "#/components/schemas/ShapeSquare"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "$type",
+          "mapping": {
+            "triangle": "#/components/schemas/ShapeTriangle",
+            "square": "#/components/schemas/ShapeSquare"
+          }
+        }
+      },
       "ShapeSquare": {
         "properties": {
           "$type": {
@@ -184,6 +174,22 @@
           "createdAt": {
             "type": "string",
             "format": "date-time"
+          }
+        }
+      },
+      "Triangle": {
+        "type": "object",
+        "properties": {
+          "hypotenuse": {
+            "type": "number",
+            "format": "double"
+          },
+          "color": {
+            "type": "string"
+          },
+          "sides": {
+            "type": "integer",
+            "format": "int32"
           }
         }
       }

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
@@ -303,25 +303,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "required": [
-                  "$type"
-                ],
-                "type": "object",
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ShapeTriangle"
-                  },
-                  {
-                    "$ref": "#/components/schemas/ShapeSquare"
-                  }
-                ],
-                "discriminator": {
-                  "propertyName": "$type",
-                  "mapping": {
-                    "triangle": "#/components/schemas/ShapeTriangle",
-                    "square": "#/components/schemas/ShapeSquare"
-                  }
-                }
+                "$ref": "#/components/schemas/Shape"
               }
             }
           },
@@ -343,29 +325,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "required": [
-                  "$type"
-                ],
-                "type": "object",
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/WeatherForecastBaseWeatherForecastWithCity"
-                  },
-                  {
-                    "$ref": "#/components/schemas/WeatherForecastBaseWeatherForecastWithTimeSeries"
-                  },
-                  {
-                    "$ref": "#/components/schemas/WeatherForecastBaseWeatherForecastWithLocalNews"
-                  }
-                ],
-                "discriminator": {
-                  "propertyName": "$type",
-                  "mapping": {
-                    "0": "#/components/schemas/WeatherForecastBaseWeatherForecastWithCity",
-                    "1": "#/components/schemas/WeatherForecastBaseWeatherForecastWithTimeSeries",
-                    "2": "#/components/schemas/WeatherForecastBaseWeatherForecastWithLocalNews"
-                  }
-                }
+                "$ref": "#/components/schemas/WeatherForecastBase"
               }
             }
           },
@@ -387,25 +347,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "required": [
-                  "discriminator"
-                ],
-                "type": "object",
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/PersonStudent"
-                  },
-                  {
-                    "$ref": "#/components/schemas/PersonTeacher"
-                  }
-                ],
-                "discriminator": {
-                  "propertyName": "discriminator",
-                  "mapping": {
-                    "student": "#/components/schemas/PersonStudent",
-                    "teacher": "#/components/schemas/PersonTeacher"
-                  }
-                }
+                "$ref": "#/components/schemas/Person"
               }
             }
           },
@@ -447,6 +389,27 @@
           "format": "int32"
         }
       },
+      "Person": {
+        "required": [
+          "discriminator"
+        ],
+        "type": "object",
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/PersonStudent"
+          },
+          {
+            "$ref": "#/components/schemas/PersonTeacher"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "discriminator",
+          "mapping": {
+            "student": "#/components/schemas/PersonStudent",
+            "teacher": "#/components/schemas/PersonTeacher"
+          }
+        }
+      },
       "PersonStudent": {
         "properties": {
           "discriminator": {
@@ -486,6 +449,27 @@
           },
           "name": {
             "type": "string"
+          }
+        }
+      },
+      "Shape": {
+        "required": [
+          "$type"
+        ],
+        "type": "object",
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/ShapeTriangle"
+          },
+          {
+            "$ref": "#/components/schemas/ShapeSquare"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "$type",
+          "mapping": {
+            "triangle": "#/components/schemas/ShapeTriangle",
+            "square": "#/components/schemas/ShapeSquare"
           }
         }
       },
@@ -544,6 +528,31 @@
           "sides": {
             "type": "integer",
             "format": "int32"
+          }
+        }
+      },
+      "WeatherForecastBase": {
+        "required": [
+          "$type"
+        ],
+        "type": "object",
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/WeatherForecastBaseWeatherForecastWithCity"
+          },
+          {
+            "$ref": "#/components/schemas/WeatherForecastBaseWeatherForecastWithTimeSeries"
+          },
+          {
+            "$ref": "#/components/schemas/WeatherForecastBaseWeatherForecastWithLocalNews"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "$type",
+          "mapping": {
+            "0": "#/components/schemas/WeatherForecastBaseWeatherForecastWithCity",
+            "1": "#/components/schemas/WeatherForecastBaseWeatherForecastWithTimeSeries",
+            "2": "#/components/schemas/WeatherForecastBaseWeatherForecastWithLocalNews"
           }
         }
       },

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v1.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v1.verified.txt
@@ -62,29 +62,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "required": [
-                  "id",
-                  "title",
-                  "completed",
-                  "createdAt"
-                ],
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "integer",
-                    "format": "int32"
-                  },
-                  "title": {
-                    "type": "string"
-                  },
-                  "completed": {
-                    "type": "boolean"
-                  },
-                  "createdAt": {
-                    "type": "string",
-                    "format": "date-time"
-                  }
-                }
+                "$ref": "#/components/schemas/Todo"
               }
             }
           },
@@ -128,34 +106,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "required": [
-                    "dueDate",
-                    "id",
-                    "title",
-                    "completed",
-                    "createdAt"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "dueDate": {
-                      "type": "string",
-                      "format": "date-time"
-                    },
-                    "id": {
-                      "type": "integer",
-                      "format": "int32"
-                    },
-                    "title": {
-                      "type": "string"
-                    },
-                    "completed": {
-                      "type": "boolean"
-                    },
-                    "createdAt": {
-                      "type": "string",
-                      "format": "date-time"
-                    }
-                  }
+                  "$ref": "#/components/schemas/TodoWithDueDate"
                 }
               }
             }
@@ -171,6 +122,61 @@
         "items": {
           "type": "string",
           "format": "uuid"
+        }
+      },
+      "Todo": {
+        "required": [
+          "id",
+          "title",
+          "completed",
+          "createdAt"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "title": {
+            "type": "string"
+          },
+          "completed": {
+            "type": "boolean"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "TodoWithDueDate": {
+        "required": [
+          "dueDate",
+          "id",
+          "title",
+          "completed",
+          "createdAt"
+        ],
+        "type": "object",
+        "properties": {
+          "dueDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "title": {
+            "type": "string"
+          },
+          "completed": {
+            "type": "boolean"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       }
     },

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v2.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v2.verified.txt
@@ -23,10 +23,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
+                  "$ref": "#/components/schemas/ArrayOfstring"
                 }
               }
             }
@@ -45,7 +42,16 @@
       }
     }
   },
-  "components": { },
+  "components": {
+    "schemas": {
+      "ArrayOfstring": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    }
+  },
   "tags": [
     {
       "name": "users"

--- a/src/OpenApi/test/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Responses.cs
+++ b/src/OpenApi/test/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Responses.cs
@@ -231,7 +231,7 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
             Assert.Empty(response.Value.Description);
             var mediaTypeEntry = Assert.Single(response.Value.Content);
             Assert.Equal("application/json", mediaTypeEntry.Key);
-            var schema = mediaTypeEntry.Value.Schema;
+            var schema = mediaTypeEntry.Value.Schema.GetEffective(document);
             Assert.Equal("object", schema.Type);
             Assert.Collection(schema.Properties, property =>
             {
@@ -264,7 +264,8 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
             Assert.NotNull(defaultResponse);
             Assert.Empty(defaultResponse.Description);
             var defaultContent = Assert.Single(defaultResponse.Content.Values);
-            Assert.Collection(defaultContent.Schema.Properties,
+            var defaultSchema = defaultContent.Schema.GetEffective(document);
+            Assert.Collection(defaultSchema.Properties,
             property =>
             {
                 Assert.Equal("code", property.Key);
@@ -281,7 +282,7 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
             Assert.Equal("OK", okResponse.Description);
             var okContent = Assert.Single(okResponse.Content);
             Assert.Equal("application/json", okContent.Key);
-            var schema = okContent.Value.Schema;
+            var schema = okContent.Value.Schema.GetEffective(document);
             Assert.Equal("object", schema.Type);
             Assert.Collection(schema.Properties, property =>
             {

--- a/src/OpenApi/test/Services/OpenApiSchemaService/OpenApiSchemaService.PolymorphicSchemas.cs
+++ b/src/OpenApi/test/Services/OpenApiSchemaService/OpenApiSchemaService.PolymorphicSchemas.cs
@@ -23,7 +23,7 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             Assert.NotNull(operation.RequestBody);
             var requestBody = operation.RequestBody.Content;
             Assert.True(requestBody.TryGetValue("application/json", out var mediaType));
-            var schema = mediaType.Schema;
+            var schema = mediaType.Schema.GetEffective(document);
             // Assert discriminator mappings have been configured correctly
             Assert.Equal("$type", schema.Discriminator.PropertyName);
             Assert.Contains(schema.Discriminator.PropertyName, schema.Required);
@@ -60,7 +60,7 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             Assert.NotNull(operation.RequestBody);
             var requestBody = operation.RequestBody.Content;
             Assert.True(requestBody.TryGetValue("application/json", out var mediaType));
-            var schema = mediaType.Schema;
+            var schema = mediaType.Schema.GetEffective(document);
             // Assert discriminator mappings have been configured correctly
             Assert.Equal("$type", schema.Discriminator.PropertyName);
             Assert.Contains(schema.Discriminator.PropertyName, schema.Required);
@@ -105,7 +105,7 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             Assert.NotNull(operation.RequestBody);
             var requestBody = operation.RequestBody.Content;
             Assert.True(requestBody.TryGetValue("application/json", out var mediaType));
-            var schema = mediaType.Schema;
+            var schema = mediaType.Schema.GetEffective(document);
             // Assert discriminator mappings have been configured correctly
             Assert.Equal("discriminator", schema.Discriminator.PropertyName);
             Assert.Contains(schema.Discriminator.PropertyName, schema.Required);
@@ -144,7 +144,7 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             Assert.NotNull(operation.RequestBody);
             var requestBody = operation.RequestBody.Content;
             Assert.True(requestBody.TryGetValue("application/json", out var mediaType));
-            var schema = mediaType.Schema;
+            var schema = mediaType.Schema.GetEffective(document);
             // Assert discriminator mappings have been configured correctly
             Assert.Equal("$type", schema.Discriminator.PropertyName);
             Assert.Collection(schema.Discriminator.Mapping,

--- a/src/OpenApi/test/Services/OpenApiSchemaService/OpenApiSchemaService.RequestBodySchemas.cs
+++ b/src/OpenApi/test/Services/OpenApiSchemaService/OpenApiSchemaService.RequestBodySchemas.cs
@@ -30,8 +30,9 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             var content = Assert.Single(requestBody.Content);
             Assert.Equal("application/json", content.Key);
             Assert.NotNull(content.Value.Schema);
-            Assert.Equal("object", content.Value.Schema.Type);
-            Assert.Collection(content.Value.Schema.Properties,
+            var schema = content.Value.Schema.GetEffective(document);
+            Assert.Equal("object", schema.Type);
+            Assert.Collection(schema.Properties,
                 property =>
                 {
                     Assert.Equal("id", property.Key);
@@ -76,8 +77,9 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             var content = Assert.Single(requestBody.Content);
             Assert.Equal("application/json", content.Key);
             Assert.NotNull(content.Value.Schema);
-            Assert.Equal("object", content.Value.Schema.Type);
-            Assert.Collection(content.Value.Schema.Properties,
+            var effectiveSchema = content.Value.Schema.GetEffective(document);
+            Assert.Equal("object", effectiveSchema.Type);
+            Assert.Collection(effectiveSchema.Properties,
                 property =>
                 {
                     Assert.Equal("id", property.Key);
@@ -148,7 +150,7 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             var operation = document.Paths["/required-properties"].Operations[OperationType.Post];
             var requestBody = operation.RequestBody;
             var content = Assert.Single(requestBody.Content);
-            var schema = content.Value.Schema;
+            var schema = content.Value.Schema.GetEffective(document);
             Assert.Collection(schema.Required,
                 property => Assert.Equal("title", property),
                 property => Assert.Equal("completed", property));
@@ -175,7 +177,7 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
                 var operation = document.Paths[$"/{path}"].Operations[OperationType.Post];
                 var requestBody = operation.RequestBody;
 
-                var effectiveSchema = requestBody.Content["application/octet-stream"].Schema;
+                var effectiveSchema = requestBody.Content["application/octet-stream"].Schema.GetEffective(document);
 
                 Assert.Equal("string", effectiveSchema.Type);
                 Assert.Equal("binary", effectiveSchema.Format);
@@ -198,15 +200,18 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             var operation = document.Paths[$"/proposal"].Operations[OperationType.Post];
             var requestBody = operation.RequestBody;
             var schema = requestBody.Content["application/json"].Schema;
-            Assert.Collection(schema.Properties,
+            Assert.Equal("Proposal", schema.Reference.Id);
+            var effectiveSchema = schema.GetEffective(document);
+            Assert.Collection(effectiveSchema.Properties,
                 property => {
                     Assert.Equal("proposalElement", property.Key);
-                    // Todo: Assert that refs are used correctly.
+                    Assert.Equal("Proposal", property.Value.Reference.Id);
                 },
                 property => {
                     Assert.Equal("stream", property.Key);
-                    Assert.Equal("string", property.Value.Type);
-                    Assert.Equal("binary", property.Value.Format);
+                    var targetSchema = property.Value.GetEffective(document);
+                    Assert.Equal("string", targetSchema.Type);
+                    Assert.Equal("binary", targetSchema.Format);
                 });
         });
     }
@@ -290,9 +295,10 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             Assert.NotNull(operation.RequestBody);
             var requestBody = operation.RequestBody.Content;
             Assert.True(requestBody.TryGetValue("application/json", out var mediaType));
-            Assert.Equal("object", mediaType.Schema.Type);
-            Assert.Empty(mediaType.Schema.AnyOf);
-            Assert.Collection(mediaType.Schema.Properties,
+            var schema = mediaType.Schema.GetEffective(document);
+            Assert.Equal("object", schema.Type);
+            Assert.Empty(schema.AnyOf);
+            Assert.Collection(schema.Properties,
                 property =>
                 {
                     Assert.Equal("length", property.Key);
@@ -329,8 +335,9 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             Assert.NotNull(operation.RequestBody);
             var requestBody = operation.RequestBody.Content;
             Assert.True(requestBody.TryGetValue("application/json", out var mediaType));
-            Assert.Equal("object", mediaType.Schema.Type);
-            Assert.Collection(mediaType.Schema.Properties,
+            var schema = mediaType.Schema.GetEffective(document);
+            Assert.Equal("object", schema.Type);
+            Assert.Collection(schema.Properties,
                 property =>
                 {
                     Assert.Equal("id", property.Key);
@@ -393,7 +400,7 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             var operation = document.Paths["/api"].Operations[OperationType.Post];
             var requestBody = operation.RequestBody;
             var content = Assert.Single(requestBody.Content);
-            var schema = content.Value.Schema;
+            var schema = content.Value.Schema.GetEffective(document);
             Assert.Collection(schema.Properties,
                 property =>
                 {
@@ -430,6 +437,37 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
         });
     }
 
+    [Fact]
+    public async Task SupportsNestedTypes()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPost("/api", (NestedType type) => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths["/api"].Operations[OperationType.Post];
+            var requestBody = operation.RequestBody;
+            var content = Assert.Single(requestBody.Content);
+            Assert.Equal("NestedType", content.Value.Schema.Reference.Id);
+            var schema = content.Value.Schema.GetEffective(document);
+            Assert.Collection(schema.Properties,
+                property =>
+                {
+                    Assert.Equal("name", property.Key);
+                    Assert.Equal("string", property.Value.Type);
+                },
+                property =>
+                {
+                    Assert.Equal("nested", property.Key);
+                    Assert.Equal("NestedType", property.Value.Reference.Id);
+                });
+        });
+    }
+
     private class DescriptionTodo
     {
         [Description("The unique identifier for a todo item.")]
@@ -455,4 +493,10 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
         public Uri? NullableUri { get; set; }
     }
 #nullable restore
+
+    private class NestedType
+    {
+        public string Name { get; set; }
+        public NestedType Nested { get; set; }
+    }
 }

--- a/src/OpenApi/test/Services/OpenApiSchemaService/OpenApiSchemaService.ResponseSchemas.cs
+++ b/src/OpenApi/test/Services/OpenApiSchemaService/OpenApiSchemaService.ResponseSchemas.cs
@@ -65,8 +65,9 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             var responses = Assert.Single(operation.Responses);
             var response = responses.Value;
             Assert.True(response.Content.TryGetValue("application/json", out var mediaType));
-            Assert.Equal("object", mediaType.Schema.Type);
-            Assert.Collection(mediaType.Schema.Properties,
+            var schema = mediaType.Schema.GetEffective(document);
+            Assert.Equal("object", schema.Type);
+            Assert.Collection(schema.Properties,
                 property =>
                 {
                     Assert.Equal("id", property.Key);
@@ -111,8 +112,9 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             var content = Assert.Single(response.Content);
             Assert.Equal("application/json", content.Key);
             Assert.NotNull(content.Value.Schema);
-            Assert.Equal("object", content.Value.Schema.Type);
-            Assert.Collection(content.Value.Schema.Properties,
+            var schema = content.Value.Schema.GetEffective(document);
+            Assert.Equal("object", schema.Type);
+            Assert.Collection(schema.Properties,
                 property =>
                 {
                     Assert.Equal("id", property.Key);
@@ -156,8 +158,9 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             var responses = Assert.Single(operation.Responses);
             var response = responses.Value;
             Assert.True(response.Content.TryGetValue("application/json", out var mediaType));
-            Assert.Equal("object", mediaType.Schema.Type);
-            Assert.Collection(mediaType.Schema.Properties,
+            var schema = mediaType.Schema.GetEffective(document);
+            Assert.Equal("object", schema.Type);
+            Assert.Collection(schema.Properties,
                 property =>
                 {
                     Assert.Equal("id", property.Key);
@@ -198,7 +201,7 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             var operation = document.Paths["/required-properties"].Operations[OperationType.Post];
             var response = operation.Responses["200"];
             var content = Assert.Single(response.Content);
-            var schema = content.Value.Schema;
+            var schema = content.Value.Schema.GetEffective(document);
             Assert.Collection(schema.Required,
                 property => Assert.Equal("title", property),
                 property => Assert.Equal("completed", property));
@@ -221,8 +224,9 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             var responses = Assert.Single(operation.Responses);
             var response = responses.Value;
             Assert.True(response.Content.TryGetValue("application/json", out var mediaType));
-            Assert.Equal("object", mediaType.Schema.Type);
-            Assert.Collection(mediaType.Schema.Properties,
+            var schema = mediaType.Schema.GetEffective(document);
+            Assert.Equal("object", schema.Type);
+            Assert.Collection(schema.Properties,
                 property =>
                 {
                     Assert.Equal("dueDate", property.Key);
@@ -276,8 +280,9 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             var responses = Assert.Single(operation.Responses);
             var response = responses.Value;
             Assert.True(response.Content.TryGetValue("application/json", out var mediaType));
-            Assert.Equal("object", mediaType.Schema.Type);
-            Assert.Collection(mediaType.Schema.Properties,
+            var schema = mediaType.Schema.GetEffective(document);
+            Assert.Equal("object", schema.Type);
+            Assert.Collection(schema.Properties,
                 property =>
                 {
                     Assert.Equal("isSuccessful", property.Key);
@@ -341,9 +346,10 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             var responses = Assert.Single(operation.Responses);
             var response = responses.Value;
             Assert.True(response.Content.TryGetValue("application/json", out var mediaType));
-            Assert.Equal("object", mediaType.Schema.Type);
-            Assert.Empty(mediaType.Schema.AnyOf);
-            Assert.Collection(mediaType.Schema.Properties,
+            var schema = mediaType.Schema.GetEffective(document);
+            Assert.Equal("object", schema.Type);
+            Assert.Empty(schema.AnyOf);
+            Assert.Collection(schema.Properties,
                 property =>
                 {
                     Assert.Equal("length", property.Key);
@@ -380,8 +386,9 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             var responses = Assert.Single(operation.Responses);
             var response = responses.Value;
             Assert.True(response.Content.TryGetValue("application/json", out var mediaType));
-            Assert.Equal("object", mediaType.Schema.Type);
-            Assert.Collection(mediaType.Schema.Properties,
+            var schema = mediaType.Schema.GetEffective(document);
+            Assert.Equal("object", schema.Type);
+            Assert.Collection(schema.Properties,
                 property =>
                 {
                     Assert.Equal("id", property.Key);
@@ -440,10 +447,12 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             var responses = Assert.Single(operation.Responses);
             var response = responses.Value;
             Assert.True(response.Content.TryGetValue("application/json", out var mediaType));
-            Assert.Equal("array", mediaType.Schema.Type);
-            Assert.NotNull(mediaType.Schema.Items);
-            Assert.Equal("object", mediaType.Schema.Items.Type);
-            Assert.Collection(mediaType.Schema.Items.Properties,
+            var schema = mediaType.Schema.GetEffective(document);
+            Assert.Equal("array", schema.Type);
+            Assert.NotNull(schema.Items);
+            var effectiveItemsSchema = schema.Items.GetEffective(document);
+            Assert.Equal("object", effectiveItemsSchema.Type);
+            Assert.Collection(effectiveItemsSchema.Properties,
                 property =>
                 {
                     Assert.Equal("id", property.Key);
@@ -487,8 +496,9 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             var responses = Assert.Single(operation.Responses);
             var response = responses.Value;
             Assert.True(response.Content.TryGetValue("application/json", out var mediaType));
-            Assert.Equal("object", mediaType.Schema.Type);
-            Assert.Collection(mediaType.Schema.Properties,
+            var schema = mediaType.Schema.GetEffective(document);
+            Assert.Equal("object", schema.Type);
+            Assert.Collection(schema.Properties,
                 property =>
                 {
                     Assert.Equal("pageIndex", property.Key);
@@ -565,20 +575,18 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             var responses = Assert.Single(operation.Responses);
             var response = responses.Value;
             Assert.True(response.Content.TryGetValue("application/problem+json", out var mediaType));
-            Assert.Equal("object", mediaType.Schema.Type);
-            // `string` schemas appear multiple times in this document so they should
-            // all resolve to reference IDs, hence the use of `GetEffective` to resolve the
-            // final schema.
-            Assert.Collection(mediaType.Schema.Properties,
+            var schema = mediaType.Schema.GetEffective(document);
+            Assert.Equal("object", schema.Type);
+            Assert.Collection(schema.Properties,
                 property =>
                 {
                     Assert.Equal("type", property.Key);
-                    Assert.Equal("string", property.Value.GetEffective(document).Type);
+                    Assert.Equal("string", property.Value.Type);
                 },
                 property =>
                 {
                     Assert.Equal("title", property.Key);
-                    Assert.Equal("string", property.Value.GetEffective(document).Type);
+                    Assert.Equal("string", property.Value.Type);
                 },
                 property =>
                 {
@@ -589,12 +597,12 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
                 property =>
                 {
                     Assert.Equal("detail", property.Key);
-                    Assert.Equal("string", property.Value.GetEffective(document).Type);
+                    Assert.Equal("string", property.Value.Type);
                 },
                 property =>
                 {
                     Assert.Equal("instance", property.Key);
-                    Assert.Equal("string", property.Value.GetEffective(document).Type);
+                    Assert.Equal("string", property.Value.Type);
                 },
                 property =>
                 {
@@ -625,8 +633,9 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             var responses = Assert.Single(operation.Responses);
             var response = responses.Value;
             Assert.True(response.Content.TryGetValue("application/json", out var mediaType));
-            Assert.Equal("object", mediaType.Schema.Type);
-            Assert.Collection(mediaType.Schema.Properties,
+            var schema = mediaType.Schema.GetEffective(document);
+            Assert.Equal("object", schema.Type);
+            Assert.Collection(schema.Properties,
                 property =>
                 {
                     Assert.Equal("object", property.Key);

--- a/src/OpenApi/test/Transformers/SchemaTransformerTests.cs
+++ b/src/OpenApi/test/Transformers/SchemaTransformerTests.cs
@@ -107,7 +107,7 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
         await VerifyOpenApiDocument(builder, options, document =>
         {
             var operation = Assert.Single(document.Paths.Values).Operations.Values.Single();
-            var schema = operation.RequestBody.Content["application/json"].Schema;
+            var schema = operation.RequestBody.Content["application/json"].Schema.GetEffective(document);
             Assert.Equal("2", ((OpenApiString)schema.Extensions["x-my-extension"]).Value);
         });
     }
@@ -164,10 +164,10 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
         {
             var path = Assert.Single(document.Paths.Values);
             var postOperation = path.Operations[OperationType.Post];
-            var requestSchema = postOperation.RequestBody.Content["application/json"].Schema;
+            var requestSchema = postOperation.RequestBody.Content["application/json"].Schema.GetEffective(document);
             Assert.Equal("todo", ((OpenApiString)requestSchema.Extensions["x-my-extension"]).Value);
             var getOperation = path.Operations[OperationType.Get];
-            var responseSchema = getOperation.Responses["200"].Content["application/json"].Schema;
+            var responseSchema = getOperation.Responses["200"].Content["application/json"].Schema.GetEffective(document);
             Assert.False(responseSchema.Extensions.TryGetValue("x-my-extension", out var _));
         });
     }


### PR DESCRIPTION
- Always capture top-level request body and response schemas by ref to react to feedback in https://github.com/dotnet/aspnetcore/issues/56318
- Fix handling of nested types in properties
- Fix handling of nullable primitive in `GetSchemaReferenceId`