### PR TITLE
Increase the default number of IO queues on larger machines

### DIFF
--- a/src/Servers/Kestrel/Transport.Sockets/src/Internal/IOQueue.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Internal/IOQueue.cs
@@ -10,6 +10,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal;
 
 internal sealed class IOQueue : PipeScheduler, IThreadPoolWorkItem
 {
+    public static readonly int DefaultCount = DetermineDefaultCount();
+
     private readonly ConcurrentQueue<Work> _workItems = new ConcurrentQueue<Work>();
     private int _doingWork;
 
@@ -72,5 +74,20 @@ internal sealed class IOQueue : PipeScheduler, IThreadPoolWorkItem
             Callback = callback;
             State = state;
         }
+    }
+
+    private static int DetermineDefaultCount()
+    {
+        // Since each IOQueue schedules one work item to process its work, the number of IOQueues determines the maximum
+        // parallelism of processing work queued to IOQueues. The default number below is based on the processor count and tries
+        // to use a high-enough number for that to not be a significant limiting factor for throughput.
+
+        int processorCount = Environment.ProcessorCount;
+        if (OperatingSystem.IsWindows() || processorCount <= 32)
+        {
+            return Math.Min(processorCount, 16);
+        }
+
+        return (processorCount + 1) / 2;
     }
 }

--- a/src/Servers/Kestrel/Transport.Sockets/src/Internal/IOQueue.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Internal/IOQueue.cs
@@ -81,6 +81,9 @@ internal sealed class IOQueue : PipeScheduler, IThreadPoolWorkItem
         // Since each IOQueue schedules one work item to process its work, the number of IOQueues determines the maximum
         // parallelism of processing work queued to IOQueues. The default number below is based on the processor count and tries
         // to use a high-enough number for that to not be a significant limiting factor for throughput.
+        //
+        // On Windows, the default number is limited due to some other perf issues. Once those are fixed, the same heuristic
+        // could apply there as well.
 
         int processorCount = Environment.ProcessorCount;
         if (OperatingSystem.IsWindows() || processorCount <= 32)
@@ -88,6 +91,6 @@ internal sealed class IOQueue : PipeScheduler, IThreadPoolWorkItem
             return Math.Min(processorCount, 16);
         }
 
-        return (processorCount + 1) / 2;
+        return processorCount / 2;
     }
 }

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionFactoryOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionFactoryOptions.cs
@@ -33,9 +33,9 @@ public class SocketConnectionFactoryOptions
     /// The number of I/O queues used to process requests. Set to 0 to directly schedule I/O to the ThreadPool.
     /// </summary>
     /// <remarks>
-    /// Defaults to <see cref="Environment.ProcessorCount" /> rounded down and clamped between 1 and 16.
+    /// Defaults to a value based on and limited to <see cref="Environment.ProcessorCount" />.
     /// </remarks>
-    public int IOQueueCount { get; set; } = Math.Min(Environment.ProcessorCount, 16);
+    public int IOQueueCount { get; set; } = Internal.IOQueue.DefaultCount;
 
     /// <summary>
     /// Wait until there is data available to allocate a buffer. Setting this to false can increase throughput at the cost of increased memory usage.

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -28,9 +28,9 @@ public class SocketTransportOptions
     /// The number of I/O queues used to process requests. Set to 0 to directly schedule I/O to the ThreadPool.
     /// </summary>
     /// <remarks>
-    /// Defaults to <see cref="Environment.ProcessorCount" /> rounded down and clamped between 1 and 16.
+    /// Defaults to a value based on and limited to <see cref="Environment.ProcessorCount" />.
     /// </remarks>
-    public int IOQueueCount { get; set; } = Math.Min(Environment.ProcessorCount, 16);
+    public int IOQueueCount { get; set; } = Internal.IOQueue.DefaultCount;
 
     /// <summary>
     /// Wait until there is data available to allocate a buffer. Setting this to false can increase throughput at the cost of increased memory usage.


### PR DESCRIPTION
The number of IO queues is currently limited to 16. On machines with more processors, increasing the number of IO queues appears to improve throughput on some benchmarks.