### PR TITLE
Amortise HTTP Result Content-Type arrays

### DIFF
--- a/src/Http/Http.Abstractions/src/Microsoft.AspNetCore.Http.Abstractions.csproj
+++ b/src/Http/Http.Abstractions/src/Microsoft.AspNetCore.Http.Abstractions.csproj
@@ -37,6 +37,7 @@ Microsoft.AspNetCore.Http.HttpResponse</Description>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.AspNetCore.Http.Abstractions.Microbenchmarks" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.Http.Extensions" />
+    <InternalsVisibleTo Include="Microsoft.AspNetCore.Http.Results" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Http/Http.Results/src/AcceptedAtRouteOfT.cs
+++ b/src/Http/Http.Results/src/AcceptedAtRouteOfT.cs
@@ -122,6 +122,6 @@ public sealed class AcceptedAtRoute<TValue> : IResult, IEndpointMetadataProvider
         ArgumentNullException.ThrowIfNull(method);
         ArgumentNullException.ThrowIfNull(builder);
 
-        builder.Metadata.Add(new ProducesResponseTypeMetadata(StatusCodes.Status202Accepted, typeof(TValue), new[] { "application/json" }));
+        builder.Metadata.Add(ProducesResponseTypeMetadata.CreateUnvalidated(typeof(TValue), StatusCodes.Status202Accepted, HttpResultsHelper.ApplicationJsonContentTypes));
     }
 }

--- a/src/Http/Http.Results/src/AcceptedOfT.cs
+++ b/src/Http/Http.Results/src/AcceptedOfT.cs
@@ -100,6 +100,6 @@ public sealed class Accepted<TValue> : IResult, IEndpointMetadataProvider, IStat
         ArgumentNullException.ThrowIfNull(method);
         ArgumentNullException.ThrowIfNull(builder);
 
-        builder.Metadata.Add(new ProducesResponseTypeMetadata(StatusCodes.Status202Accepted, typeof(TValue), new[] { "application/json" }));
+        builder.Metadata.Add(ProducesResponseTypeMetadata.CreateUnvalidated(typeof(TValue), StatusCodes.Status202Accepted, HttpResultsHelper.ApplicationJsonContentTypes));
     }
 }

--- a/src/Http/Http.Results/src/BadRequestOfT.cs
+++ b/src/Http/Http.Results/src/BadRequestOfT.cs
@@ -65,6 +65,6 @@ public sealed class BadRequest<TValue> : IResult, IEndpointMetadataProvider, ISt
         ArgumentNullException.ThrowIfNull(method);
         ArgumentNullException.ThrowIfNull(builder);
 
-        builder.Metadata.Add(new ProducesResponseTypeMetadata(StatusCodes.Status400BadRequest, typeof(TValue), new[] { "application/json" }));
+        builder.Metadata.Add(ProducesResponseTypeMetadata.CreateUnvalidated(typeof(TValue), StatusCodes.Status400BadRequest, HttpResultsHelper.ApplicationJsonContentTypes));
     }
 }

--- a/src/Http/Http.Results/src/ConflictOfT.cs
+++ b/src/Http/Http.Results/src/ConflictOfT.cs
@@ -65,6 +65,6 @@ public sealed class Conflict<TValue> : IResult, IEndpointMetadataProvider, IStat
         ArgumentNullException.ThrowIfNull(method);
         ArgumentNullException.ThrowIfNull(builder);
 
-        builder.Metadata.Add(new ProducesResponseTypeMetadata(StatusCodes.Status409Conflict, typeof(TValue), new[] { "application/json" }));
+        builder.Metadata.Add(ProducesResponseTypeMetadata.CreateUnvalidated(typeof(TValue), StatusCodes.Status409Conflict, HttpResultsHelper.ApplicationJsonContentTypes));
     }
 }

--- a/src/Http/Http.Results/src/CreatedAtRouteOfT.cs
+++ b/src/Http/Http.Results/src/CreatedAtRouteOfT.cs
@@ -125,6 +125,6 @@ public sealed class CreatedAtRoute<TValue> : IResult, IEndpointMetadataProvider,
         ArgumentNullException.ThrowIfNull(method);
         ArgumentNullException.ThrowIfNull(builder);
 
-        builder.Metadata.Add(new ProducesResponseTypeMetadata(StatusCodes.Status201Created, typeof(TValue), new[] { "application/json" }));
+        builder.Metadata.Add(ProducesResponseTypeMetadata.CreateUnvalidated(typeof(TValue), StatusCodes.Status201Created, HttpResultsHelper.ApplicationJsonContentTypes));
     }
 }

--- a/src/Http/Http.Results/src/CreatedOfT.cs
+++ b/src/Http/Http.Results/src/CreatedOfT.cs
@@ -99,6 +99,6 @@ public sealed class Created<TValue> : IResult, IEndpointMetadataProvider, IStatu
         ArgumentNullException.ThrowIfNull(method);
         ArgumentNullException.ThrowIfNull(builder);
 
-        builder.Metadata.Add(new ProducesResponseTypeMetadata(StatusCodes.Status201Created, typeof(TValue), new[] { "application/json" }));
+        builder.Metadata.Add(ProducesResponseTypeMetadata.CreateUnvalidated(typeof(TValue), StatusCodes.Status201Created, HttpResultsHelper.ApplicationJsonContentTypes));
     }
 }

--- a/src/Http/Http.Results/src/FileContentHttpResult.cs
+++ b/src/Http/Http.Results/src/FileContentHttpResult.cs
@@ -61,7 +61,7 @@ public sealed partial class FileContentHttpResult : IResult, IFileHttpResult, IC
     {
         FileContents = fileContents;
         FileLength = fileContents.Length;
-        ContentType = contentType ?? "application/octet-stream";
+        ContentType = contentType ?? HttpResultsHelper.BinaryContentType;
         FileDownloadName = fileDownloadName;
         EnableRangeProcessing = enableRangeProcessing;
         LastModified = lastModified;

--- a/src/Http/Http.Results/src/FileStreamHttpResult.cs
+++ b/src/Http/Http.Results/src/FileStreamHttpResult.cs
@@ -67,7 +67,7 @@ public sealed class FileStreamHttpResult : IResult, IFileHttpResult, IContentTyp
             FileLength = fileStream.Length;
         }
 
-        ContentType = contentType ?? "application/octet-stream";
+        ContentType = contentType ?? HttpResultsHelper.BinaryContentType;
         FileDownloadName = fileDownloadName;
         EnableRangeProcessing = enableRangeProcessing;
         LastModified = lastModified;

--- a/src/Http/Http.Results/src/HttpResultsHelper.cs
+++ b/src/Http/Http.Results/src/HttpResultsHelper.cs
@@ -17,7 +17,13 @@ namespace Microsoft.AspNetCore.Http;
 
 internal static partial class HttpResultsHelper
 {
+    internal const string BinaryContentType = "application/octet-stream";
     internal const string DefaultContentType = "text/plain; charset=utf-8";
+    internal const string ProblemDetailsContentType = "application/problem+json";
+
+    internal static IEnumerable<string> ApplicationJsonContentTypes { get; } = ["application/json"];
+    internal static IEnumerable<string> ProblemDetailsContentTypes { get; } = [ProblemDetailsContentType];
+
     private static readonly Encoding DefaultEncoding = Encoding.UTF8;
 
     [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",

--- a/src/Http/Http.Results/src/InternalServerErrorOfT.cs
+++ b/src/Http/Http.Results/src/InternalServerErrorOfT.cs
@@ -65,6 +65,6 @@ public sealed class InternalServerError<TValue> : IResult, IEndpointMetadataProv
         ArgumentNullException.ThrowIfNull(method);
         ArgumentNullException.ThrowIfNull(builder);
 
-        builder.Metadata.Add(new ProducesResponseTypeMetadata(StatusCodes.Status500InternalServerError, typeof(TValue), new[] { "application/json" }));
+        builder.Metadata.Add(ProducesResponseTypeMetadata.CreateUnvalidated(typeof(TValue), StatusCodes.Status500InternalServerError, HttpResultsHelper.ApplicationJsonContentTypes));
     }
 }

--- a/src/Http/Http.Results/src/NotFoundOfT.cs
+++ b/src/Http/Http.Results/src/NotFoundOfT.cs
@@ -64,6 +64,6 @@ public sealed class NotFound<TValue> : IResult, IEndpointMetadataProvider, IStat
         ArgumentNullException.ThrowIfNull(method);
         ArgumentNullException.ThrowIfNull(builder);
 
-        builder.Metadata.Add(new ProducesResponseTypeMetadata(StatusCodes.Status404NotFound, typeof(TValue), new[] { "application/json" }));
+        builder.Metadata.Add(ProducesResponseTypeMetadata.CreateUnvalidated(typeof(TValue), StatusCodes.Status404NotFound, HttpResultsHelper.ApplicationJsonContentTypes));
     }
 }

--- a/src/Http/Http.Results/src/OkOfT.cs
+++ b/src/Http/Http.Results/src/OkOfT.cs
@@ -64,6 +64,6 @@ public sealed class Ok<TValue> : IResult, IEndpointMetadataProvider, IStatusCode
         ArgumentNullException.ThrowIfNull(method);
         ArgumentNullException.ThrowIfNull(builder);
 
-        builder.Metadata.Add(new ProducesResponseTypeMetadata(StatusCodes.Status200OK, typeof(TValue), new[] { "application/json" }));
+        builder.Metadata.Add(ProducesResponseTypeMetadata.CreateUnvalidated(typeof(TValue), StatusCodes.Status200OK, HttpResultsHelper.ApplicationJsonContentTypes));
     }
 }

--- a/src/Http/Http.Results/src/PhysicalFileHttpResult.cs
+++ b/src/Http/Http.Results/src/PhysicalFileHttpResult.cs
@@ -58,7 +58,7 @@ public sealed partial class PhysicalFileHttpResult : IResult, IFileHttpResult, I
         EntityTagHeaderValue? entityTag = null)
     {
         FileName = fileName;
-        ContentType = contentType ?? "application/octet-stream";
+        ContentType = contentType ?? HttpResultsHelper.BinaryContentType;
         FileDownloadName = fileDownloadName;
         EnableRangeProcessing = enableRangeProcessing;
         LastModified = lastModified;

--- a/src/Http/Http.Results/src/ProblemHttpResult.cs
+++ b/src/Http/Http.Results/src/ProblemHttpResult.cs
@@ -36,7 +36,7 @@ public sealed class ProblemHttpResult : IResult, IStatusCodeHttpResult, IContent
     /// <summary>
     /// Gets the value for the <c>Content-Type</c> header: <c>application/problem+json</c>
     /// </summary>
-    public string ContentType => "application/problem+json";
+    public string ContentType => HttpResultsHelper.ProblemDetailsContentType;
 
     /// <summary>
     /// Gets the HTTP status code.

--- a/src/Http/Http.Results/src/UnprocessableEntityOfT.cs
+++ b/src/Http/Http.Results/src/UnprocessableEntityOfT.cs
@@ -65,6 +65,6 @@ public sealed class UnprocessableEntity<TValue> : IResult, IEndpointMetadataProv
         ArgumentNullException.ThrowIfNull(method);
         ArgumentNullException.ThrowIfNull(builder);
 
-        builder.Metadata.Add(new ProducesResponseTypeMetadata(StatusCodes.Status422UnprocessableEntity, typeof(TValue), new[] { "application/json" }));
+        builder.Metadata.Add(ProducesResponseTypeMetadata.CreateUnvalidated(typeof(TValue), StatusCodes.Status422UnprocessableEntity, HttpResultsHelper.ApplicationJsonContentTypes));
     }
 }

--- a/src/Http/Http.Results/src/ValidationProblem.cs
+++ b/src/Http/Http.Results/src/ValidationProblem.cs
@@ -39,7 +39,7 @@ public sealed class ValidationProblem : IResult, IEndpointMetadataProvider, ISta
     /// <summary>
     /// Gets the value for the <c>Content-Type</c> header: <c>application/problem+json</c>.
     /// </summary>
-    public string ContentType => "application/problem+json";
+    public string ContentType => HttpResultsHelper.ProblemDetailsContentType;
 
     /// <summary>
     /// Gets the HTTP status code: <see cref="StatusCodes.Status400BadRequest"/>
@@ -76,6 +76,6 @@ public sealed class ValidationProblem : IResult, IEndpointMetadataProvider, ISta
         ArgumentNullException.ThrowIfNull(method);
         ArgumentNullException.ThrowIfNull(builder);
 
-        builder.Metadata.Add(new ProducesResponseTypeMetadata(StatusCodes.Status400BadRequest, typeof(HttpValidationProblemDetails), new[] { "application/problem+json" }));
+        builder.Metadata.Add(ProducesResponseTypeMetadata.CreateUnvalidated(typeof(HttpValidationProblemDetails), StatusCodes.Status400BadRequest, HttpResultsHelper.ProblemDetailsContentTypes));
     }
 }

--- a/src/Http/Http.Results/src/VirtualFileHttpResult.cs
+++ b/src/Http/Http.Results/src/VirtualFileHttpResult.cs
@@ -63,7 +63,7 @@ public sealed class VirtualFileHttpResult : IResult, IFileHttpResult, IContentTy
         EntityTagHeaderValue? entityTag = null)
     {
         FileName = fileName;
-        ContentType = contentType ?? "application/octet-stream";
+        ContentType = contentType ?? HttpResultsHelper.BinaryContentType;
         FileDownloadName = fileDownloadName;
         EnableRangeProcessing = enableRangeProcessing;
         LastModified = lastModified;


### PR DESCRIPTION
# Amortise Content-Type arrays

Amortise the `Content-Type` arrays used for HTTP result endpoint metadata.

## Description

- Amortise arrays used for `TypedResults`' metadata.
- Use `ProducesResponseTypeMetadata.CreateUnvalidated()` to bypass `Content-Type` validation for these static values. If the `InternalsVisibleTo` is undesirable, this could be reverted but this would need the re-used content-types to a `string[]`, which then means they could _in theory_ be edited at runtime via a cast as the compiler generated ```<>z__ReadOnlyArray`1``` type would no longer be used for the collection expression.
- Add and use constant for `application/octet-stream`.

The changes resolve a number of `CA1861`, `IDE0028` and `IDE0300` analyser suggestions.

The theory is that the re-use of the arrays and ability to bypass the `Content-Type` validation will reduce the an application's memory usage and speed up the population of endpoint metadata.
