### PR TITLE
Use char overloads to Join/Index strings

### DIFF
--- a/src/Hosting/TestHost/src/ClientHandler.cs
+++ b/src/Hosting/TestHost/src/ClientHandler.cs
@@ -159,7 +159,7 @@ public class ClientHandler : HttpMessageHandler
                 // User-Agent is a space delineated single line header but HttpRequestHeaders parses it as multiple elements.
                 if (string.Equals(header.Key, HeaderNames.UserAgent, StringComparison.OrdinalIgnoreCase))
                 {
-                    req.Headers.Append(header.Key, string.Join(" ", header.Value));
+                    req.Headers.Append(header.Key, string.Join(' ', header.Value));
                 }
                 else
                 {

--- a/src/Http/Authentication.Abstractions/src/TokenExtensions.cs
+++ b/src/Http/Authentication.Abstractions/src/TokenExtensions.cs
@@ -46,7 +46,7 @@ public static class AuthenticationTokenExtensions
 
         if (tokenNames.Count > 0)
         {
-            properties.Items[TokenNamesKey] = string.Join(";", tokenNames);
+            properties.Items[TokenNamesKey] = string.Join(';', tokenNames);
         }
     }
 

--- a/src/Http/Http.Abstractions/src/Internal/ParsingHelpers.cs
+++ b/src/Http/Http.Abstractions/src/Internal/ParsingHelpers.cs
@@ -57,7 +57,7 @@ internal static class ParsingHelpers
         }
         else
         {
-            headers[key] = string.Join(",", value.Select(QuoteIfNeeded));
+            headers[key] = string.Join(',', value.Select(QuoteIfNeeded));
         }
     }
 
@@ -116,7 +116,7 @@ internal static class ParsingHelpers
         }
         else
         {
-            headers[key] = existing + "," + string.Join(",", values.Select(QuoteIfNeeded));
+            headers[key] = existing + "," + string.Join(',', values.Select(QuoteIfNeeded));
         }
     }
 

--- a/src/Http/Http.Abstractions/src/WebSocketManager.cs
+++ b/src/Http/Http.Abstractions/src/WebSocketManager.cs
@@ -51,7 +51,7 @@ public abstract class WebSocketManager
         return IsWebSocketRequest switch
         {
             false => "IsWebSocketRequest = false",
-            true => $"IsWebSocketRequest = true, RequestedProtocols = {string.Join(",", WebSocketRequestedProtocols)}",
+            true => $"IsWebSocketRequest = true, RequestedProtocols = {string.Join(',', WebSocketRequestedProtocols)}",
         };
     }
 

--- a/src/Http/Http/src/BindingAddress.cs
+++ b/src/Http/Http/src/BindingAddress.cs
@@ -179,17 +179,17 @@ public class BindingAddress
                 }
             }
 
-            pathDelimiterStart = address.IndexOf(":", schemeDelimiterEnd + unixPipeHostPrefixLength, StringComparison.Ordinal);
+            pathDelimiterStart = address.IndexOf(':', schemeDelimiterEnd + unixPipeHostPrefixLength);
             pathDelimiterEnd = pathDelimiterStart + ":".Length;
         }
         else if (isNamedPipe)
         {
-            pathDelimiterStart = address.IndexOf(":", schemeDelimiterEnd + NamedPipeHostPrefix.Length, StringComparison.Ordinal);
+            pathDelimiterStart = address.IndexOf(':', schemeDelimiterEnd + NamedPipeHostPrefix.Length);
             pathDelimiterEnd = pathDelimiterStart + ":".Length;
         }
         else
         {
-            pathDelimiterStart = address.IndexOf("/", schemeDelimiterEnd, StringComparison.Ordinal);
+            pathDelimiterStart = address.IndexOf('/', schemeDelimiterEnd);
             pathDelimiterEnd = pathDelimiterStart;
         }
 
@@ -205,7 +205,7 @@ public class BindingAddress
         var hasSpecifiedPort = false;
         if (!isUnixPipe)
         {
-            var portDelimiterStart = address.LastIndexOf(":", pathDelimiterStart - 1, pathDelimiterStart - schemeDelimiterEnd, StringComparison.Ordinal);
+            var portDelimiterStart = address.LastIndexOf(':', pathDelimiterStart - 1, pathDelimiterStart - schemeDelimiterEnd);
             if (portDelimiterStart >= 0)
             {
                 var portDelimiterEnd = portDelimiterStart + ":".Length;

--- a/src/Http/Http/src/Features/FormFeature.cs
+++ b/src/Http/Http/src/Features/FormFeature.cs
@@ -72,19 +72,19 @@ public class FormFeature : IFormFeature
     {
         get
         {
-			MediaTypeHeaderValue? mt = null;
+            MediaTypeHeaderValue? mt = null;
 
-			if (_request is not null)
-			{
-				_ = MediaTypeHeaderValue.TryParse(_request.ContentType, out mt);
-			}
+            if (_request is not null)
+            {
+                _ = MediaTypeHeaderValue.TryParse(_request.ContentType, out mt);
+            }
 
-			if (_form is not null && mt is null)
-			{
-				mt = _formContentType;
-			}
+            if (_form is not null && mt is null)
+            {
+                mt = _formContentType;
+            }
 
-			return mt;
+            return mt;
         }
     }
 
@@ -127,9 +127,9 @@ public class FormFeature : IFormFeature
             {
                 _formContentType = null;
             }
-			else
+            else
             {
-				_formContentType ??= new MediaTypeHeaderValue("application/x-www-form-urlencoded");
+                _formContentType ??= new MediaTypeHeaderValue("application/x-www-form-urlencoded");
             }
         }
     }

--- a/src/Http/Routing/src/HostAttribute.cs
+++ b/src/Http/Routing/src/HostAttribute.cs
@@ -53,7 +53,7 @@ public sealed class HostAttribute : Attribute, IHostMetadata
     {
         var hostsDisplay = (Hosts.Count == 0)
             ? "*:*"
-            : string.Join(",", Hosts.Select(h => h.Contains(':') ? h : h + ":*"));
+            : string.Join(',', Hosts.Select(h => h.Contains(':') ? h : h + ":*"));
 
         return DebuggerHelpers.GetDebugText(nameof(Hosts), hostsDisplay);
     }

--- a/src/Mvc/Mvc.Abstractions/src/ModelBinding/CompositeBindingSource.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ModelBinding/CompositeBindingSource.cs
@@ -53,7 +53,7 @@ public class CompositeBindingSource : BindingSource
             }
         }
 
-        var id = string.Join("&", bindingSources.Select(s => s.Id).OrderBy(s => s, StringComparer.Ordinal));
+        var id = string.Join('&', bindingSources.Select(s => s.Id).OrderBy(s => s, StringComparer.Ordinal));
         return new CompositeBindingSource(id, displayName, bindingSources);
     }
 

--- a/src/Security/Authorization/Policy/src/PolicyEvaluator.cs
+++ b/src/Security/Authorization/Policy/src/PolicyEvaluator.cs
@@ -54,7 +54,7 @@ public class PolicyEvaluator : IPolicyEvaluator
             if (newPrincipal != null)
             {
                 context.User = newPrincipal;
-                var ticket = new AuthenticationTicket(newPrincipal, string.Join(";", policy.AuthenticationSchemes));
+                var ticket = new AuthenticationTicket(newPrincipal, string.Join(';', policy.AuthenticationSchemes));
                 // ExpiresUtc is the easiest property to reason about when dealing with multiple schemes
                 // SignalR will use this property to evaluate auth expiration for long running connections
                 ticket.Properties.ExpiresUtc = minExpiresUtc;

--- a/src/Shared/Diagnostics/BaseView.cs
+++ b/src/Shared/Diagnostics/BaseView.cs
@@ -118,7 +118,7 @@ internal abstract class BaseView
         Debug.Assert(AttributeValues != null);
         Debug.Assert(!string.IsNullOrEmpty(AttributeEnding));
 
-        var attributes = string.Join(" ", AttributeValues);
+        var attributes = string.Join(' ', AttributeValues);
         Output.Write(attributes);
         AttributeValues = null;
 

--- a/src/Shared/RazorViews/BaseView.cs
+++ b/src/Shared/RazorViews/BaseView.cs
@@ -158,7 +158,7 @@ internal abstract class BaseView
         Debug.Assert(AttributeValues != null);
         Debug.Assert(!string.IsNullOrEmpty(AttributeEnding));
 
-        var attributes = string.Join(" ", AttributeValues);
+        var attributes = string.Join(' ', AttributeValues);
         Output.Write(attributes);
         AttributeValues = null;
 


### PR DESCRIPTION
# Use char overloads to Join/Index strings

Use overloads that take a `char` for single-character strings.

## Description

Use overloads that take a `char` for single-character strings where relevant with `string.Join()` or `{Last}IndexOf()` to resolve a number of analyser suggestions.

Also fixes a few IDE0055 diagnostics.
