### PR TITLE
Use pattern matching

### DIFF
--- a/src/Http/Http.Abstractions/src/FragmentString.cs
+++ b/src/Http/Http.Abstractions/src/FragmentString.cs
@@ -128,7 +128,7 @@ public readonly struct FragmentString : IEquatable<FragmentString>
         {
             return !HasValue;
         }
-        return obj is FragmentString && Equals((FragmentString)obj);
+        return obj is FragmentString value && Equals(value);
     }
 
     /// <summary>

--- a/src/Http/Http.Abstractions/src/HostString.cs
+++ b/src/Http/Http.Abstractions/src/HostString.cs
@@ -298,7 +298,7 @@ public readonly struct HostString : IEquatable<HostString>
         {
             return !HasValue;
         }
-        return obj is HostString && Equals((HostString)obj);
+        return obj is HostString value && Equals(value);
     }
 
     /// <summary>

--- a/src/Http/Http.Abstractions/src/Internal/HeaderSegment.cs
+++ b/src/Http/Http.Abstractions/src/Internal/HeaderSegment.cs
@@ -41,7 +41,7 @@ internal readonly struct HeaderSegment : IEquatable<HeaderSegment>
             return false;
         }
 
-        return obj is HeaderSegment && Equals((HeaderSegment)obj);
+        return obj is HeaderSegment value && Equals(value);
     }
 
     public override int GetHashCode()

--- a/src/Http/Http.Abstractions/src/Internal/HeaderSegmentCollection.cs
+++ b/src/Http/Http.Abstractions/src/Internal/HeaderSegmentCollection.cs
@@ -27,7 +27,7 @@ internal readonly struct HeaderSegmentCollection : IEnumerable<HeaderSegment>, I
             return false;
         }
 
-        return obj is HeaderSegmentCollection && Equals((HeaderSegmentCollection)obj);
+        return obj is HeaderSegmentCollection collection && Equals(collection);
     }
 
     public override int GetHashCode()

--- a/src/Http/Http.Abstractions/src/QueryString.cs
+++ b/src/Http/Http.Abstractions/src/QueryString.cs
@@ -231,7 +231,7 @@ public readonly struct QueryString : IEquatable<QueryString>
         {
             return !HasValue;
         }
-        return obj is QueryString && Equals((QueryString)obj);
+        return obj is QueryString query && Equals(query);
     }
 
     /// <summary>

--- a/src/Shared/RazorViews/BaseView.cs
+++ b/src/Shared/RazorViews/BaseView.cs
@@ -193,9 +193,9 @@ internal abstract class BaseView
             // instead of the string 'true'. If the value is the bool 'false' we don't want to write anything.
             // Otherwise the value is another object (perhaps an HtmlString) and we'll ask it to format itself.
             string? stringValue;
-            if (value.Value is bool)
+            if (value.Value is bool flag)
             {
-                if ((bool)value.Value)
+                if (flag)
                 {
                     stringValue = name;
                 }


### PR DESCRIPTION
# Use pattern matching

Use pattern matching to avoid casts.

## Description

Use pattern matching to avoid casts to resolve a number of analyser diagnostics.
