### PR TITLE
Avoid StringSegment conversions

### DIFF
--- a/src/Http/Headers/src/StringWithQualityHeaderValueComparer.cs
+++ b/src/Http/Headers/src/StringWithQualityHeaderValueComparer.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Net.Http.Headers;
 /// </summary>
 public class StringWithQualityHeaderValueComparer : IComparer<StringWithQualityHeaderValue>
 {
+    private static readonly StringSegment Any = new("*");
+
     private StringWithQualityHeaderValueComparer()
     {
     }
@@ -55,11 +57,11 @@ public class StringWithQualityHeaderValueComparer : IComparer<StringWithQualityH
 
         if (!StringSegment.Equals(stringWithQuality1.Value, stringWithQuality2.Value, StringComparison.OrdinalIgnoreCase))
         {
-            if (StringSegment.Equals(stringWithQuality1.Value, "*", StringComparison.Ordinal))
+            if (StringSegment.Equals(stringWithQuality1.Value, Any, StringComparison.Ordinal))
             {
                 return -1;
             }
-            else if (StringSegment.Equals(stringWithQuality2.Value, "*", StringComparison.Ordinal))
+            else if (StringSegment.Equals(stringWithQuality2.Value, Any, StringComparison.Ordinal))
             {
                 return 1;
             }


### PR DESCRIPTION
# Avoid StringSegment conversions

Avoid implicit conversions from `string` to `StringSegment`.

## Description

Avoid 1 or 2 implicit conversions to `StringSegment` from `string` per invocation of `StringWithQualityHeaderValueComparer.Compare()` by re-using a static field.
