### PR TITLE
[Blazor] Allow streams to get disposed while being transmitted to the browser

### DIFF
--- a/src/Components/Server/src/Circuits/CircuitClientProxy.cs
+++ b/src/Components/Server/src/Circuits/CircuitClientProxy.cs
@@ -5,14 +5,14 @@ using Microsoft.AspNetCore.SignalR;
 
 namespace Microsoft.AspNetCore.Components.Server.Circuits;
 
-internal sealed class CircuitClientProxy : IClientProxy
+internal sealed class CircuitClientProxy : ISingleClientProxy
 {
     public CircuitClientProxy()
     {
         Connected = false;
     }
 
-    public CircuitClientProxy(IClientProxy clientProxy, string connectionId)
+    public CircuitClientProxy(ISingleClientProxy clientProxy, string connectionId)
     {
         Transfer(clientProxy, connectionId);
     }
@@ -21,9 +21,9 @@ internal sealed class CircuitClientProxy : IClientProxy
 
     public string ConnectionId { get; private set; }
 
-    public IClientProxy Client { get; private set; }
+    public ISingleClientProxy Client { get; private set; }
 
-    public void Transfer(IClientProxy clientProxy, string connectionId)
+    public void Transfer(ISingleClientProxy clientProxy, string connectionId)
     {
         Client = clientProxy ?? throw new ArgumentNullException(nameof(clientProxy));
         ConnectionId = connectionId ?? throw new ArgumentNullException(nameof(connectionId));
@@ -43,5 +43,15 @@ internal sealed class CircuitClientProxy : IClientProxy
         }
 
         return Client.SendCoreAsync(method, args, cancellationToken);
+    }
+
+    public Task<T> InvokeCoreAsync<T>(string method, object?[] args, CancellationToken cancellationToken)
+    {
+        if (Client == null)
+        {
+            throw new InvalidOperationException($"{nameof(InvokeCoreAsync)} cannot be invoked with an offline client.");
+        }
+
+        return Client.InvokeCoreAsync<T>(method, args, cancellationToken);
     }
 }

--- a/src/Components/Server/src/Circuits/CircuitFactory.cs
+++ b/src/Components/Server/src/Circuits/CircuitFactory.cs
@@ -101,6 +101,7 @@ internal sealed partial class CircuitFactory : ICircuitFactory
             components,
             jsRuntime,
             navigationManager,
+            TimeProvider.System,
             circuitHandlers,
             _loggerFactory.CreateLogger<CircuitHost>());
         Log.CreatedCircuit(_logger, circuitHost);

--- a/src/Components/Server/src/Circuits/CircuitRegistry.cs
+++ b/src/Components/Server/src/Circuits/CircuitRegistry.cs
@@ -166,7 +166,7 @@ internal partial class CircuitRegistry
     // 1. If the circuit is not found return null
     // 2. If the circuit is found, but fails to connect, we need to dispose it here and return null
     // 3. If everything goes well, return the circuit.
-    public virtual async Task<CircuitHost> ConnectAsync(CircuitId circuitId, IClientProxy clientProxy, string connectionId, CancellationToken cancellationToken)
+    public virtual async Task<CircuitHost> ConnectAsync(CircuitId circuitId, ISingleClientProxy clientProxy, string connectionId, CancellationToken cancellationToken)
     {
         Log.CircuitConnectStarted(_logger, circuitId);
 
@@ -225,7 +225,7 @@ internal partial class CircuitRegistry
         }
     }
 
-    protected virtual (CircuitHost circuitHost, bool previouslyConnected) ConnectCore(CircuitId circuitId, IClientProxy clientProxy, string connectionId)
+    protected virtual (CircuitHost circuitHost, bool previouslyConnected) ConnectCore(CircuitId circuitId, ISingleClientProxy clientProxy, string connectionId)
     {
         if (ConnectedCircuits.TryGetValue(circuitId, out var connectedCircuitHost))
         {

--- a/src/Components/Server/test/Circuits/CircuitClientProxyTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitClientProxyTest.cs
@@ -13,7 +13,7 @@ public class CircuitClientProxyTest
     {
         // Arrange
         bool? isCancelled = null;
-        var clientProxy = new Mock<IClientProxy>();
+        var clientProxy = new Mock<ISingleClientProxy>();
         clientProxy.Setup(c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
             .Callback((string _, object[] __, CancellationToken token) =>
             {
@@ -34,13 +34,13 @@ public class CircuitClientProxyTest
     public void Transfer_SetsConnected()
     {
         // Arrange
-        var clientProxy = Mock.Of<IClientProxy>(
+        var clientProxy = Mock.Of<ISingleClientProxy>(
             c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()) == Task.CompletedTask);
         var circuitClient = new CircuitClientProxy(clientProxy, "connection0");
         circuitClient.SetDisconnected();
 
         // Act
-        circuitClient.Transfer(Mock.Of<IClientProxy>(), "connection1");
+        circuitClient.Transfer(Mock.Of<ISingleClientProxy>(), "connection1");
 
         // Assert
         Assert.True(circuitClient.Connected);

--- a/src/Components/Server/test/Circuits/CircuitRegistryTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitRegistryTest.cs
@@ -37,7 +37,7 @@ public class CircuitRegistryTest
         var circuitHost = TestCircuitHost.Create(circuitIdFactory.CreateCircuitId());
         registry.Register(circuitHost);
 
-        var newClient = Mock.Of<IClientProxy>();
+        var newClient = Mock.Of<ISingleClientProxy>();
         var newConnectionId = "new-id";
 
         // Act
@@ -62,7 +62,7 @@ public class CircuitRegistryTest
         var circuitHost = TestCircuitHost.Create(circuitIdFactory.CreateCircuitId());
         registry.RegisterDisconnectedCircuit(circuitHost);
 
-        var newClient = Mock.Of<IClientProxy>();
+        var newClient = Mock.Of<ISingleClientProxy>();
         var newConnectionId = "new-id";
 
         // Act
@@ -88,7 +88,7 @@ public class CircuitRegistryTest
         var circuitHost = TestCircuitHost.Create(circuitIdFactory.CreateCircuitId(), handlers: new[] { handler.Object });
         registry.RegisterDisconnectedCircuit(circuitHost);
 
-        var newClient = Mock.Of<IClientProxy>();
+        var newClient = Mock.Of<ISingleClientProxy>();
         var newConnectionId = "new-id";
 
         // Act
@@ -112,7 +112,7 @@ public class CircuitRegistryTest
         var circuitHost = TestCircuitHost.Create(circuitIdFactory.CreateCircuitId(), handlers: new[] { handler.Object });
         registry.Register(circuitHost);
 
-        var newClient = Mock.Of<IClientProxy>();
+        var newClient = Mock.Of<ISingleClientProxy>();
         var newConnectionId = "new-id";
 
         // Act
@@ -137,7 +137,7 @@ public class CircuitRegistryTest
         var circuitHost = TestCircuitHost.Create(circuitIdFactory.CreateCircuitId(), handlers: new[] { handler.Object });
         registry.Register(circuitHost);
 
-        var newClient = Mock.Of<IClientProxy>();
+        var newClient = Mock.Of<ISingleClientProxy>();
         var newConnectionId = "new-id";
 
         // Act
@@ -234,7 +234,7 @@ public class CircuitRegistryTest
 
         var circuitHost = TestCircuitHost.Create(circuitIdFactory.CreateCircuitId());
         registry.Register(circuitHost);
-        var client = Mock.Of<IClientProxy>();
+        var client = Mock.Of<ISingleClientProxy>();
         var newId = "new-connection";
 
         // Act
@@ -273,7 +273,7 @@ public class CircuitRegistryTest
         registry.BeforeConnect = new ManualResetEventSlim();
         var circuitHost = TestCircuitHost.Create(circuitIdFactory.CreateCircuitId());
         registry.Register(circuitHost);
-        var client = Mock.Of<IClientProxy>();
+        var client = Mock.Of<ISingleClientProxy>();
         var oldId = circuitHost.Client.ConnectionId;
         var newId = "new-connection";
 
@@ -339,7 +339,7 @@ public class CircuitRegistryTest
         var circuitHost = TestCircuitHost.Create(circuitIdFactory.CreateCircuitId());
 
         registry.RegisterDisconnectedCircuit(circuitHost);
-        await registry.ConnectAsync(circuitHost.CircuitId, Mock.Of<IClientProxy>(), "new-connection", default);
+        await registry.ConnectAsync(circuitHost.CircuitId, Mock.Of<ISingleClientProxy>(), "new-connection", default);
 
         // Act
         await Task.Run(() => tcs.Task.TimeoutAfter(TimeSpan.FromSeconds(10)));
@@ -363,7 +363,7 @@ public class CircuitRegistryTest
 
         public Action OnAfterEntryEvicted { get; set; }
 
-        protected override (CircuitHost, bool) ConnectCore(CircuitId circuitId, IClientProxy clientProxy, string connectionId)
+        protected override (CircuitHost, bool) ConnectCore(CircuitId circuitId, ISingleClientProxy clientProxy, string connectionId)
         {
             if (BeforeConnect != null)
             {

--- a/src/Components/Server/test/Circuits/RemoteRendererTest.cs
+++ b/src/Components/Server/test/Circuits/RemoteRendererTest.cs
@@ -137,7 +137,7 @@ public class RemoteRendererTest
         var secondBatchTCS = new TaskCompletionSource();
         var thirdBatchTCS = new TaskCompletionSource();
 
-        var initialClient = new Mock<IClientProxy>();
+        var initialClient = new Mock<ISingleClientProxy>();
         initialClient.Setup(c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
             .Callback((string name, object[] value, CancellationToken token) => renderIds.Add((long)value[0]))
             .Returns(firstBatchTCS.Task);
@@ -150,7 +150,7 @@ public class RemoteRendererTest
             builder.CloseElement();
         });
 
-        var client = new Mock<IClientProxy>();
+        var client = new Mock<ISingleClientProxy>();
         client.Setup(c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
             .Callback((string name, object[] value, CancellationToken token) => renderIds.Add((long)value[0]))
             .Returns<string, object[], CancellationToken>((n, v, t) => (long)v[0] == 3 ? secondBatchTCS.Task : thirdBatchTCS.Task);
@@ -195,7 +195,7 @@ public class RemoteRendererTest
         var serviceProvider = CreateServiceProvider();
         var firstBatchTCS = new TaskCompletionSource();
         var secondBatchTCS = new TaskCompletionSource();
-        var offlineClient = new CircuitClientProxy(new Mock<IClientProxy>(MockBehavior.Strict).Object, "offline-client");
+        var offlineClient = new CircuitClientProxy(new Mock<ISingleClientProxy>(MockBehavior.Strict).Object, "offline-client");
         offlineClient.SetDisconnected();
         var renderer = GetRemoteRenderer(serviceProvider, offlineClient);
         RenderFragment initialContent = (builder) =>
@@ -206,7 +206,7 @@ public class RemoteRendererTest
         };
         var trigger = new Trigger();
         var renderIds = new List<long>();
-        var onlineClient = new Mock<IClientProxy>();
+        var onlineClient = new Mock<ISingleClientProxy>();
         onlineClient.Setup(c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
             .Callback((string name, object[] value, CancellationToken token) => renderIds.Add((long)value[1]))
             .Returns<string, object[], CancellationToken>((n, v, t) => (long)v[1] == 2 ? firstBatchTCS.Task : secondBatchTCS.Task);
@@ -258,7 +258,7 @@ public class RemoteRendererTest
         var serviceProvider = CreateServiceProvider();
         var firstBatchTCS = new TaskCompletionSource();
         var secondBatchTCS = new TaskCompletionSource();
-        var offlineClient = new CircuitClientProxy(new Mock<IClientProxy>(MockBehavior.Strict).Object, "offline-client");
+        var offlineClient = new CircuitClientProxy(new Mock<ISingleClientProxy>(MockBehavior.Strict).Object, "offline-client");
         offlineClient.SetDisconnected();
         var renderer = GetRemoteRenderer(serviceProvider, offlineClient);
         RenderFragment initialContent = (builder) =>
@@ -269,7 +269,7 @@ public class RemoteRendererTest
         };
         var trigger = new Trigger();
         var renderIds = new List<long>();
-        var onlineClient = new Mock<IClientProxy>();
+        var onlineClient = new Mock<ISingleClientProxy>();
         onlineClient.Setup(c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
             .Callback((string name, object[] value, CancellationToken token) => renderIds.Add((long)value[1]))
             .Returns<string, object[], CancellationToken>((n, v, t) => (long)v[1] == 2 ? firstBatchTCS.Task : secondBatchTCS.Task);
@@ -323,7 +323,7 @@ public class RemoteRendererTest
         var secondBatchTCS = new TaskCompletionSource();
         var renderIds = new List<long>();
 
-        var onlineClient = new Mock<IClientProxy>();
+        var onlineClient = new Mock<ISingleClientProxy>();
         onlineClient.Setup(c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
             .Callback((string name, object[] value, CancellationToken token) => renderIds.Add((long)value[1]))
             .Returns<string, object[], CancellationToken>((n, v, t) => (long)v[1] == 2 ? firstBatchTCS.Task : secondBatchTCS.Task);
@@ -380,7 +380,7 @@ public class RemoteRendererTest
         var secondBatchTCS = new TaskCompletionSource();
         var renderIds = new List<long>();
 
-        var onlineClient = new Mock<IClientProxy>();
+        var onlineClient = new Mock<ISingleClientProxy>();
         onlineClient.Setup(c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
             .Callback((string name, object[] value, CancellationToken token) => renderIds.Add((long)value[1]))
             .Returns<string, object[], CancellationToken>((n, v, t) => (long)v[1] == 2 ? firstBatchTCS.Task : secondBatchTCS.Task);

--- a/src/Components/Server/test/Microsoft.AspNetCore.Components.Server.Tests.csproj
+++ b/src/Components/Server/test/Microsoft.AspNetCore.Components.Server.Tests.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Components.Server" />
     <Reference Include="Microsoft.AspNetCore.Html.Abstractions" />
+    <Reference Include="Microsoft.Extensions.TimeProvider.Testing" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Components/test/E2ETest/Tests/InteropTest.cs
+++ b/src/Components/test/E2ETest/Tests/InteropTest.cs
@@ -92,6 +92,8 @@ public class InteropTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
             ["invokeAsyncThrowsUndefinedJSObjectReference"] = "Success",
             ["invokeAsyncThrowsNullJSObjectReference"] = "Success",
             ["disposeJSObjectReferenceAsync"] = "Success",
+            ["dotNetToJSReceiveDisposedDotNetStreamReferenceAsync"] = "Success",
+            ["dotNetToJSReadDisposedDotNetStreamReferenceExceptionAsync"] = "Error reading stream",
         };
 
         var expectedSyncValues = new Dictionary<string, string>

--- a/src/Components/test/testassets/BasicTestApp/InteropComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/InteropComponent.razor
@@ -280,6 +280,9 @@
         var dotNetStreamReferenceWrapper = DotNetStreamReferenceInterop.GetDotNetStreamWrapperReference();
         ReturnValues["dotNetToJSReceiveDotNetStreamWrapperReferenceAsync"] = await JSRuntime.InvokeAsync<string>("jsInteropTests.receiveDotNetStreamWrapperReference", dotNetStreamReferenceWrapper);
 
+        ReturnValues["dotNetToJSReceiveDisposedDotNetStreamReferenceAsync"] = await SendDisposedStreamToJSAsync(shouldRead: false);
+        ReturnValues["dotNetToJSReadDisposedDotNetStreamReferenceExceptionAsync"] = await SendDisposedStreamToJSAsync(shouldRead: true);
+
         Invocations = invocations;
         DoneWithInterop = true;
     }
@@ -307,6 +310,15 @@
 
         // Mark the test as successful if we haven't already set a failure above
         ReturnValues.TryAdd(testName, "Success");
+    }
+
+    private async Task<string> SendDisposedStreamToJSAsync(bool shouldRead)
+    {
+        var stream = DotNetStreamReferenceInterop.GetDotNetStreamReference();
+        var task = JSRuntime.InvokeAsync<string>("jsInteropTests.receiveDisposedDotNetStreamReference", stream, shouldRead);
+        stream.Dispose();
+
+        return await task;
     }
 
     public void InvokeInProcessInterop()

--- a/src/Components/test/testassets/BasicTestApp/wwwroot/js/jsinteroptests.js
+++ b/src/Components/test/testassets/BasicTestApp/wwwroot/js/jsinteroptests.js
@@ -233,6 +233,7 @@ window.jsInteropTests = {
   receiveDotNetObjectByRefAsync: receiveDotNetObjectByRefAsync,
   receiveDotNetStreamReference: receiveDotNetStreamReference,
   receiveDotNetStreamWrapperReference: receiveDotNetStreamWrapperReference,
+  receiveDisposedDotNetStreamReference: receiveDisposedDotNetStreamReference,
 };
 
 function returnUndefined() {
@@ -437,4 +438,19 @@ async function receiveDotNetStreamReference(streamRef) {
 
 async function receiveDotNetStreamWrapperReference(wrapper) {
   return await validateDotNetStreamWrapperReference(wrapper);
+}
+
+async function receiveDisposedDotNetStreamReference(streamRef, shouldRead) {
+  try {
+    const stream = await streamRef.stream();
+    const reader = stream.getReader();
+    if (shouldRead) {
+      while (!(await reader.read()).done) {
+        // Don't need to do anything with the data.
+      }
+    }
+    return "Success";
+  } catch (error) {
+    return `Error reading stream: ${error}`;
+  }
 }


### PR DESCRIPTION
## Allow streams to get disposed while being transmitted to the browser

Fixes an issue where if a stream backing a `DotNetStreamReference` was disposed during transmission to the browser, an exception would get thrown that terminates the circuit. This PR makes the following improvements:
* Enables streams to be disposed mid-transmission without throwing an exception on the server
* Dispatches the error from JS, allowing it to be handled by application code
* Prevents the error from being thrown when it doesn't need to be (e.g., the stream gets disposed mid-transmission, but is never read by JS logic anyway)

Fixes #53376

### Description

This PR implements the following changes to .NET->JS stream transmission:
1. The server checks if the stream can be read before reading the next chunk
2. If the stream cannot be read, a SignalR method on the client gets invoked to indicate so
3. The server waits for the client to acknowledge the message (with a timeout of 10 seconds)
4. The server completes the client-initiated stream hub invocation
5. The client dispatches the error _only if the stream gets read from JS_
    * i.e., if the stream does not get read by the app's JS logic, the error never surfaces

**Alternatives considered:**
* Throw an exception in the stream hub invocation on the server to communicate the error message to the client
  * This logs an error on the server, and the error received by the client is generated by SignalR and contains the string "An error occurred on the server...". The goal of this PR is for this scenario to not be considered an error on the server, so these behaviors don't align well with that.
* Treat this error the same way that we would treat the stream being read to completion; the client does not get notified of an error
  * This means the client has no way to determine whether the stream has been correctly read to completion.
* Don't allow disposing the stream while it's being transmitted to JS and continue to treat it as a fatal error. Also consider updating the `DotNetStreamReference.Dispose()` method to detect this case and throw an exception that can be caught in application code rather than disposing the underlying stream.
  * While this improves the error experience slightly, it wouldn't make it easier to cancel the transmission of a stream to JS.