### PR TITLE
Do not close connection for http1.0 when client request connection keep-alive

### DIFF
--- a/src/Servers/HttpSys/src/RequestProcessing/Response.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Response.cs
@@ -409,7 +409,8 @@ internal sealed class Response
         // HTTP/1.0 clients upon receipt of a Keep-Alive connection token.
         // However, a persistent connection with an HTTP/1.0 client cannot make
         // use of the chunked transfer-coding. From: https://www.rfc-editor.org/rfc/rfc2068#section-19.7.1
-        if ((requestVersion <= Constants.V1_0 && (!requestConnectionKeepAliveSet || responseChunkedSet))
+        if (requestVersion < Constants.V1_0
+            || (requestVersion == Constants.V1_0 && (!requestConnectionKeepAliveSet || responseChunkedSet))
             || (requestVersion == Constants.V1_1 && requestCloseSet)
             || responseCloseSet)
         {

--- a/src/Servers/HttpSys/src/RequestProcessing/Response.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Response.cs
@@ -406,7 +406,7 @@ internal sealed class Response
         var keepConnectionAlive = true;
 
         // An HTTP/1.1 server may also establish persistent connections with
-        // HTTP / 1.0 clients upon receipt of a Keep-Alive connection token.
+        // HTTP/1.0 clients upon receipt of a Keep-Alive connection token.
         // However, a persistent connection with an HTTP/1.0 client cannot make
         // use of the chunked transfer-coding. From: https://www.rfc-editor.org/rfc/rfc2068#section-19.7.1
         if ((requestVersion <= Constants.V1_0 && (!requestConnectionKeepAliveSet || responseChunkedSet))

--- a/src/Servers/HttpSys/src/RequestProcessing/Response.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Response.cs
@@ -389,8 +389,11 @@ internal sealed class Response
         // Gather everything from the request that affects the response:
         var requestVersion = Request.ProtocolVersion;
         var requestConnectionString = Request.Headers[HeaderNames.Connection];
+        var requestKeepAliveString = Request.Headers[HeaderNames.KeepAlive];
         var isHeadRequest = Request.IsHeadMethod;
         var requestCloseSet = Matches(Constants.Close, requestConnectionString);
+        var requestConnectionKeepAliveSet = Matches(Constants.KeepAlive, requestConnectionString);
+        var requestKeepAliveSet = Matches(bool.TrueString, requestKeepAliveString);
 
         // Gather everything the app may have set on the response:
         // Http.Sys does not allow us to specify the response protocol version, assume this is a HTTP/1.1 response when making decisions.
@@ -403,7 +406,7 @@ internal sealed class Response
 
         // Determine if the connection will be kept alive or closed.
         var keepConnectionAlive = true;
-        if (requestVersion <= Constants.V1_0 // Http.Sys does not support "Keep-Alive: true" or "Connection: Keep-Alive"
+        if ((requestVersion <= Constants.V1_0 && !(requestConnectionKeepAliveSet || requestKeepAliveSet))
             || (requestVersion == Constants.V1_1 && requestCloseSet)
             || responseCloseSet)
         {

--- a/src/Servers/HttpSys/test/FunctionalTests/Listener/ResponseHeaderTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Listener/ResponseHeaderTests.cs
@@ -207,12 +207,11 @@ public class ResponseHeaderTests : IDisposable
     }
 
     [ConditionalFact]
-    public async Task ResponseHeaders_HTTP10KeepAliveRequest_Gets11Close()
+    public async Task ResponseHeaders_HTTP10KeepAliveRequest_Gets11NoClose()
     {
         string address;
         using (var server = Utilities.CreateHttpServer(out address))
         {
-            // Http.Sys does not support 1.0 keep-alives.
             Task<HttpResponseMessage> responseTask = SendRequestAsync(address, usehttp11: false, sendKeepAlive: true);
 
             var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
@@ -221,7 +220,7 @@ public class ResponseHeaderTests : IDisposable
             HttpResponseMessage response = await responseTask;
             response.EnsureSuccessStatusCode();
             Assert.Equal(new Version(1, 1), response.Version);
-            Assert.True(response.Headers.ConnectionClose.Value);
+            Assert.Null(response.Headers.ConnectionClose);
         }
     }
 

--- a/src/Servers/HttpSys/test/FunctionalTests/Listener/ResponseHeaderTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Listener/ResponseHeaderTests.cs
@@ -242,6 +242,7 @@ public class ResponseHeaderTests : IDisposable
             response.EnsureSuccessStatusCode();
             Assert.Equal(new Version(1, 1), response.Version);
             Assert.True(response.Headers.TransferEncodingChunked.HasValue, "Chunked");
+            Assert.True(response.Headers.ConnectionClose.Value);
         }
     }
 

--- a/src/Shared/HttpSys/Constants.cs
+++ b/src/Shared/HttpSys/Constants.cs
@@ -9,6 +9,7 @@ internal static class Constants
     internal const string HttpsScheme = "https";
     internal const string Chunked = "chunked";
     internal const string Close = "close";
+    internal const string KeepAlive = "keep-alive";
     internal const string Zero = "0";
     internal const string SchemeDelimiter = "://";
     internal const string DefaultServerAddress = "http://localhost:5000";


### PR DESCRIPTION
# Do not close connection for http1.0 when client request connection keep-alive

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

The comment in the code indicates http.sys does not support "Connection: Keep-Alive". However, we certainly see that header got to work in IIS, so the comment might be wrong. Thus, we want to change the behavior so that it aligns with IIS.

The reason we want to change this behavior on the server-side is that we don't want to keep closing connections on every request for http1.0, that will increase TLS costs on our end for subsequent re-connects. Given http1.0 traffic is not trivial amount.

The expected behavior would be - If the request is http1.0 AND the request contains "Connection: keep-alive", we also send the "Connection: keep-alive" header in the response.

Fixes #56223 (in this specific format)
