### PR TITLE
Simplify SignalR Client IAsyncEnumerable usage

### DIFF
--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -899,9 +899,7 @@ public partial class HubConnection : IAsyncDisposable
     {
         async Task ReadAsyncEnumerableStream()
         {
-            var streamValues = AsyncEnumerableAdapters.MakeCancelableTypedAsyncEnumerable(stream, tokenSource);
-
-            await foreach (var streamValue in streamValues.ConfigureAwait(false))
+            await foreach (var streamValue in stream.WithCancellation(tokenSource.Token).ConfigureAwait(false))
             {
                 await SendWithLock(connectionState, new StreamItemMessage(streamId, streamValue), tokenSource.Token).ConfigureAwait(false);
                 Log.SendingStreamItem(_logger, streamId);


### PR DESCRIPTION
Today we create a separate "cancelable" async enumerable so we can "link" the passed in CancellationTokenSource with the CancellationToken passed into GetAsyncEnumerator. We don't need to do this in this scenario because we are the ones enumerating over the object, and we aren't passing in a CancellationToken during the enumeration.

Instead, we can simply enumerate over the supplied IAsyncEnumerable and call WithCancellation, passing in the supplied CancellationTokenSource.