### PR TITLE
Add named pipes methods to Kestrel configuration loader

### DIFF
--- a/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
-using System.Reflection.Metadata;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;

--- a/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
+using System.Reflection.Metadata;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
@@ -186,6 +187,27 @@ public class KestrelConfigurationLoader
         EndpointsToAdd.Add(() =>
         {
             Options.ListenUnixSocket(socketPath, configure);
+        });
+
+        return this;
+    }
+
+    /// <summary>
+    /// Bind to given named pipe.
+    /// </summary>
+    public KestrelConfigurationLoader NamedPipeEndpoint(string socketPath) => NamedPipeEndpoint(socketPath, _ => { });
+
+    /// <summary>
+    /// Bind to given named pipe.
+    /// </summary>
+    public KestrelConfigurationLoader NamedPipeEndpoint(string pipeName, Action<ListenOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(pipeName);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        EndpointsToAdd.Add(() =>
+        {
+            Options.ListenNamedPipe(pipeName, configure);
         });
 
         return this;

--- a/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
@@ -194,7 +194,7 @@ public class KestrelConfigurationLoader
     /// <summary>
     /// Bind to given named pipe.
     /// </summary>
-    public KestrelConfigurationLoader NamedPipeEndpoint(string socketPath) => NamedPipeEndpoint(socketPath, _ => { });
+    public KestrelConfigurationLoader NamedPipeEndpoint(string pipeName) => NamedPipeEndpoint(pipeName, _ => { });
 
     /// <summary>
     /// Bind to given named pipe.

--- a/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,3 @@
 #nullable enable
+Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader.NamedPipeEndpoint(string! pipeName) -> Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader!
 Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader.NamedPipeEndpoint(string! pipeName, System.Action<Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions!>! configure) -> Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader!
-Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader.NamedPipeEndpoint(string! socketPath) -> Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader!

--- a/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader.NamedPipeEndpoint(string! pipeName, System.Action<Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions!>! configure) -> Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader!
+Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader.NamedPipeEndpoint(string! socketPath) -> Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader!

--- a/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
+++ b/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
@@ -1844,6 +1844,23 @@ public class KestrelConfigurationLoaderTests
         _ = serverOptions.ConfigurationLoader.Reload();
     }
 
+    [Fact]
+    public void AddNamedPipeEndpoint()
+    {
+        var serverOptions = CreateServerOptions();
+        var builder = serverOptions.Configure()
+            .NamedPipeEndpoint("abc");
+
+        Assert.Empty(serverOptions.GetListenOptions());
+        Assert.Equal(builder, serverOptions.ConfigurationLoader);
+
+        builder.Load();
+
+        Assert.Single(serverOptions.GetListenOptions());
+        Assert.Equal("abc", serverOptions.CodeBackedListenOptions[0].PipeName);
+        Assert.NotNull(serverOptions.ConfigurationLoader);
+    }
+
     private static string GetCertificatePath()
     {
         var appData = Environment.GetEnvironmentVariable("APPDATA");


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/54314
Fixes https://github.com/dotnet/aspnetcore/issues/56565

Named pipes were added in .NET 8. APIs weren't added to `KestrelConfigurationLoader`.