### PR TITLE
Add CreateNamedPipeServerStream to named pipes options

### DIFF
--- a/src/Servers/Kestrel/Transport.NamedPipes/src/CreateNamedPipeServerStreamContext.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/CreateNamedPipeServerStreamContext.cs
@@ -18,7 +18,7 @@ public sealed class CreateNamedPipeServerStreamContext
     /// <summary>
     /// Gets the pipe options.
     /// </summary>
-    public PipeOptions PipeOptions { get; init; }
+    public required PipeOptions PipeOptions { get; init; }
     /// <summary>
     /// Gets the default access control and audit security.
     /// </summary>

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/CreateNamedPipeServerStreamContext.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/CreateNamedPipeServerStreamContext.cs
@@ -1,9 +1,8 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO.Pipes;
 using Microsoft.AspNetCore.Connections;
-using PipeOptions = System.IO.Pipes.PipeOptions;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes;
 

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/CreateNamedPipeServerStreamContext.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/CreateNamedPipeServerStreamContext.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO.Pipes;
+using Microsoft.AspNetCore.Connections;
+using PipeOptions = System.IO.Pipes.PipeOptions;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes;
+
+/// <summary>
+/// Provides information about an endpoint when creating a <see cref="NamedPipeServerStream"/>.
+/// </summary>
+public sealed class CreateNamedPipeServerStreamContext
+{
+    /// <summary>
+    /// Gets the endpoint.
+    /// </summary>
+    public required NamedPipeEndPoint NamedPipeEndPoint { get; init; }
+    /// <summary>
+    /// Gets the pipe options.
+    /// </summary>
+    public PipeOptions PipeOptions { get; init; }
+    /// <summary>
+    /// Gets the default access control and audit security.
+    /// </summary>
+    public PipeSecurity? PipeSecurity { get; init; }
+}

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnectionListener.cs
@@ -194,7 +194,6 @@ internal sealed class NamedPipeConnectionListener : IConnectionListener
 
         public NamedPipeServerStream Create()
         {
-            NamedPipeServerStream stream;
             var pipeOptions = NamedPipeOptions.Asynchronous | NamedPipeOptions.WriteThrough;
             if (!_hasFirstPipeStarted)
             {
@@ -209,30 +208,13 @@ internal sealed class NamedPipeConnectionListener : IConnectionListener
                 pipeOptions |= NamedPipeOptions.CurrentUserOnly;
             }
 
-            if (_options.PipeSecurity != null)
+            var context = new CreateNamedPipeServerStreamContext
             {
-                stream = NamedPipeServerStreamAcl.Create(
-                    _endpoint.PipeName,
-                    PipeDirection.InOut,
-                    NamedPipeServerStream.MaxAllowedServerInstances,
-                    PipeTransmissionMode.Byte,
-                    pipeOptions,
-                    inBufferSize: 0, // Buffer in System.IO.Pipelines
-                    outBufferSize: 0, // Buffer in System.IO.Pipelines
-                    _options.PipeSecurity);
-            }
-            else
-            {
-                stream = new NamedPipeServerStream(
-                    _endpoint.PipeName,
-                    PipeDirection.InOut,
-                    NamedPipeServerStream.MaxAllowedServerInstances,
-                    PipeTransmissionMode.Byte,
-                    pipeOptions,
-                    inBufferSize: 0,
-                    outBufferSize: 0);
-            }
-            return stream;
+                NamedPipeEndPoint = _endpoint,
+                PipeOptions = pipeOptions,
+                PipeSecurity = _options.PipeSecurity
+            };
+            return _options.CreateNamedPipeServerStream(context);
         }
 
         public bool Return(NamedPipeServerStream obj) => !obj.IsConnected;

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
@@ -89,6 +89,8 @@ public sealed class NamedPipeTransportOptions
     /// </returns>
     public static NamedPipeServerStream CreateDefaultNamedPipeServerStream(CreateNamedPipeServerStreamContext context)
     {
+        ArgumentNullException.ThrowIfNull(context);
+
         if (context.PipeSecurity != null)
         {
             return NamedPipeServerStreamAcl.Create(

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
@@ -83,7 +83,7 @@ public sealed class NamedPipeTransportOptions
     /// <see cref="CreateNamedPipeServerStreamContext"/> that can be used by a connection listener
     /// to listen for inbound requests.
     /// </summary>
-    /// <param name="context">An <see cref="CreateNamedPipeServerStreamContext"/>.</param>
+    /// <param name="context">A <see cref="CreateNamedPipeServerStreamContext"/>.</param>
     /// <returns>
     /// A <see cref="NamedPipeServerStream"/> instance.
     /// </returns>

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
@@ -56,9 +56,63 @@ public sealed class NamedPipeTransportOptions
     public bool CurrentUserOnly { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets the security information that determines the access control and audit security for pipes.
+    /// Gets or sets the security information that determines the default access control and audit security for pipes.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Defaults to <c>null</c>, which is no pipe security.
+    /// </para>
+    /// <para>
+    /// Configuring <see cref="PipeSecurity"/> sets the default access control and audit security for pipes.
+    /// If per-endpoint security is needed then <see cref="CreateNamedPipeServerStream"/> can be configured
+    /// to create streams with different security settings.</para>
+    /// </remarks>
     public PipeSecurity? PipeSecurity { get; set; }
+
+    /// <summary>
+    /// A function used to create a new <see cref="NamedPipeServerStream"/> to listen with. If
+    /// not set, <see cref="CreateDefaultNamedPipeServerStream" /> is used.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="CreateDefaultNamedPipeServerStream"/>.
+    /// </remarks>
+    public Func<CreateNamedPipeServerStreamContext, NamedPipeServerStream> CreateNamedPipeServerStream { get; set; } = CreateDefaultNamedPipeServerStream;
+
+    /// <summary>
+    /// Creates a default instance of <see cref="NamedPipeServerStream"/> for the given
+    /// <see cref="CreateNamedPipeServerStreamContext"/> that can be used by a connection listener
+    /// to listen for inbound requests.
+    /// </summary>
+    /// <param name="context">An <see cref="CreateNamedPipeServerStreamContext"/>.</param>
+    /// <returns>
+    /// A <see cref="NamedPipeServerStream"/> instance.
+    /// </returns>
+    public static NamedPipeServerStream CreateDefaultNamedPipeServerStream(CreateNamedPipeServerStreamContext context)
+    {
+        if (context.PipeSecurity != null)
+        {
+            return NamedPipeServerStreamAcl.Create(
+                context.NamedPipeEndPoint.PipeName,
+                PipeDirection.InOut,
+                NamedPipeServerStream.MaxAllowedServerInstances,
+                PipeTransmissionMode.Byte,
+                context.PipeOptions,
+                inBufferSize: 0, // Buffer in System.IO.Pipelines
+                outBufferSize: 0, // Buffer in System.IO.Pipelines
+                context.PipeSecurity);
+        }
+        else
+        {
+            return new NamedPipeServerStream(
+                context.NamedPipeEndPoint.PipeName,
+                PipeDirection.InOut,
+                NamedPipeServerStream.MaxAllowedServerInstances,
+                PipeTransmissionMode.Byte,
+                context.PipeOptions,
+                inBufferSize: 0,
+                outBufferSize: 0);
+        }
+    }
 
     internal Func<MemoryPool<byte>> MemoryPoolFactory { get; set; } = PinnedBlockMemoryPoolFactory.Create;
 }

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,12 @@
 #nullable enable
+Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.CreateNamedPipeServerStreamContext
+Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.CreateNamedPipeServerStreamContext.CreateNamedPipeServerStreamContext() -> void
+Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.CreateNamedPipeServerStreamContext.NamedPipeEndPoint.get -> Microsoft.AspNetCore.Connections.NamedPipeEndPoint!
+Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.CreateNamedPipeServerStreamContext.NamedPipeEndPoint.init -> void
+Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.CreateNamedPipeServerStreamContext.PipeOptions.get -> System.IO.Pipes.PipeOptions
+Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.CreateNamedPipeServerStreamContext.PipeOptions.init -> void
+Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.CreateNamedPipeServerStreamContext.PipeSecurity.get -> System.IO.Pipes.PipeSecurity?
+Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.CreateNamedPipeServerStreamContext.PipeSecurity.init -> void
+Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.NamedPipeTransportOptions.CreateNamedPipeServerStream.get -> System.Func<Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.CreateNamedPipeServerStreamContext!, System.IO.Pipes.NamedPipeServerStream!>!
+Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.NamedPipeTransportOptions.CreateNamedPipeServerStream.set -> void
+static Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.NamedPipeTransportOptions.CreateDefaultNamedPipeServerStream(Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.CreateNamedPipeServerStreamContext! context) -> System.IO.Pipes.NamedPipeServerStream!

--- a/src/Servers/Kestrel/Transport.NamedPipes/test/WebHostTests.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/test/WebHostTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using System.IO.Pipes;
 using System.Net;
 using System.Net.Http;
@@ -14,13 +15,11 @@ using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Internal;
-using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using System.Reflection.Metadata;
-using System.Globalization;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.Tests;
 

--- a/src/Servers/Kestrel/Transport.NamedPipes/test/WebHostTests.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/test/WebHostTests.cs
@@ -19,6 +19,8 @@ using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using System.Reflection.Metadata;
+using System.Globalization;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.Tests;
 
@@ -263,6 +265,132 @@ public class WebHostTests : LoggedTest
             var impersonatedIdentity = string.Join(",", response.Headers.GetValues("X-Impersonated-Identity"));
 
             Assert.Equal(serverIdentity.Split('\\')[1], impersonatedIdentity);
+
+            await host.StopAsync().DefaultTimeout();
+        }
+    }
+
+    [ConditionalFact]
+    [NamedPipesSupported]
+    public async Task ListenNamedPipeEndpoint_Security_PerEndpointSecuritySettings()
+    {
+        AppDomain.CurrentDomain.SetPrincipalPolicy(PrincipalPolicy.WindowsPrincipal);
+
+        // Arrange
+        using var httpEventSource = new HttpEventSourceListener(LoggerFactory);
+        var defaultSecurityPipeName = NamedPipeTestHelpers.GetUniquePipeName();
+        var customSecurityPipeName = NamedPipeTestHelpers.GetUniquePipeName();
+
+        var builder = new HostBuilder()
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder
+                    .UseKestrel(o =>
+                    {
+                        o.ListenNamedPipe(defaultSecurityPipeName, listenOptions =>
+                        {
+                            listenOptions.Protocols = HttpProtocols.Http1;
+                        });
+                        o.ListenNamedPipe(customSecurityPipeName, listenOptions =>
+                        {
+                            listenOptions.Protocols = HttpProtocols.Http1;
+                        });
+                    })
+                    .UseNamedPipes(options =>
+                    {
+                        var defaultSecurity = new PipeSecurity();
+                        defaultSecurity.AddAccessRule(new PipeAccessRule("Users", PipeAccessRights.ReadWrite | PipeAccessRights.CreateNewInstance, AccessControlType.Allow));
+
+                        options.PipeSecurity = defaultSecurity;
+                        options.CurrentUserOnly = false;
+                        options.CreateNamedPipeServerStream = (context) =>
+                        {
+                            if (context.NamedPipeEndPoint.PipeName == defaultSecurityPipeName)
+                            {
+                                return NamedPipeTransportOptions.CreateDefaultNamedPipeServerStream(context);
+                            }
+
+                            var allowSecurity = new PipeSecurity();
+                            allowSecurity.AddAccessRule(new PipeAccessRule("Users", PipeAccessRights.FullControl, AccessControlType.Allow));
+
+                            return NamedPipeServerStreamAcl.Create(
+                                context.NamedPipeEndPoint.PipeName,
+                                PipeDirection.InOut,
+                                NamedPipeServerStream.MaxAllowedServerInstances,
+                                PipeTransmissionMode.Byte,
+                                context.PipeOptions,
+                                inBufferSize: 0, // Buffer in System.IO.Pipelines
+                                outBufferSize: 0, // Buffer in System.IO.Pipelines
+                                allowSecurity);
+                        };
+                    })
+                    .Configure(app =>
+                    {
+                        app.Run(async context =>
+                        {
+                            var serverName = Thread.CurrentPrincipal.Identity.Name;
+
+                            var namedPipeStream = context.Features.Get<IConnectionNamedPipeFeature>().NamedPipe;
+
+                            var security = namedPipeStream.GetAccessControl();
+                            var rules = security.GetAccessRules(includeExplicit: true, includeInherited: false, typeof(SecurityIdentifier));
+
+                            context.Response.Headers.Add("X-PipeAccessRights", ((int)rules.OfType<PipeAccessRule>().Single().PipeAccessRights).ToString(CultureInfo.InvariantCulture));
+
+                            await context.Response.WriteAsync("hello, world");
+                        });
+                    });
+            })
+            .ConfigureServices(AddTestLogging);
+
+        using (var host = builder.Build())
+        {
+            await host.StartAsync().DefaultTimeout();
+
+            using (var client = CreateClient(defaultSecurityPipeName))
+            {
+                var request = new HttpRequestMessage(HttpMethod.Get, $"http://127.0.0.1/")
+                {
+                    Version = HttpVersion.Version11,
+                    VersionPolicy = HttpVersionPolicy.RequestVersionExact
+                };
+
+                // Act
+                var response = await client.SendAsync(request).DefaultTimeout();
+
+                // Assert
+                response.EnsureSuccessStatusCode();
+                Assert.Equal(HttpVersion.Version11, response.Version);
+                var responseText = await response.Content.ReadAsStringAsync().DefaultTimeout();
+                Assert.Equal("hello, world", responseText);
+
+                var pipeAccessRights = (PipeAccessRights)Convert.ToInt32(string.Join(",", response.Headers.GetValues("X-PipeAccessRights")), CultureInfo.InvariantCulture); 
+
+                Assert.Equal(PipeAccessRights.ReadWrite, pipeAccessRights & PipeAccessRights.ReadWrite);
+                Assert.Equal(PipeAccessRights.CreateNewInstance, pipeAccessRights & PipeAccessRights.CreateNewInstance);
+            }
+
+            using (var client = CreateClient(customSecurityPipeName))
+            {
+                var request = new HttpRequestMessage(HttpMethod.Get, $"http://127.0.0.1/")
+                {
+                    Version = HttpVersion.Version11,
+                    VersionPolicy = HttpVersionPolicy.RequestVersionExact
+                };
+
+                // Act
+                var response = await client.SendAsync(request).DefaultTimeout();
+
+                // Assert
+                response.EnsureSuccessStatusCode();
+                Assert.Equal(HttpVersion.Version11, response.Version);
+                var responseText = await response.Content.ReadAsStringAsync().DefaultTimeout();
+                Assert.Equal("hello, world", responseText);
+
+                var pipeAccessRights = (PipeAccessRights)Convert.ToInt32(string.Join(",", response.Headers.GetValues("X-PipeAccessRights")), CultureInfo.InvariantCulture);
+
+                Assert.Equal(PipeAccessRights.FullControl, pipeAccessRights & PipeAccessRights.FullControl);
+            }
 
             await host.StopAsync().DefaultTimeout();
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/53306
Fixes https://github.com/dotnet/aspnetcore/issues/56568

Named pipes transport allows pipe security to be configured, but it's applied to all of server's named pipe endpoints.

This PR adds `CreateNamedPipeServerStream` func to options, allowing advanced users to customize creating endpoints. They can choose to specify different `PipeSecurity` options on a per-endpoint basis.

This feature is modeled after `SocketTransportOptions.CreateBoundListenSocket`.