### PR TITLE
Use Ascii.ToUtf16 in StringUtilities

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -290,6 +290,7 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
 
     public void OnStartLine(HttpVersionAndMethod versionAndMethod, TargetOffsetPathLength targetPath, Span<byte> startLine)
     {
+        // Null characters are not allowed and should have been checked by HttpParser before calling this method
         Debug.Assert(startLine.IndexOf((byte)0) == -1);
 
         var targetStart = targetPath.Offset;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -290,6 +290,8 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
 
     public void OnStartLine(HttpVersionAndMethod versionAndMethod, TargetOffsetPathLength targetPath, Span<byte> startLine)
     {
+        Debug.Assert(startLine.IndexOf((byte)0) == -1);
+
         var targetStart = targetPath.Offset;
         // Slice out target
         var target = startLine[targetStart..];
@@ -322,7 +324,7 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
         Method = method;
         if (method == HttpMethod.Custom)
         {
-            _methodText = startLine[..versionAndMethod.MethodEnd].GetAsciiStringNonNullCharacters();
+            _methodText = startLine[..versionAndMethod.MethodEnd].GetAsciiString();
         }
 
         _httpVersion = versionAndMethod.Version;
@@ -386,7 +388,7 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
         {
             // The previous string does not match what the bytes would convert to,
             // so we will need to generate a new string.
-            RawTarget = _parsedRawTarget = target.GetAsciiStringNonNullCharacters();
+            RawTarget = _parsedRawTarget = target.GetAsciiString();
 
             var queryLength = 0;
             if (target.Length == targetPath.Length)
@@ -436,7 +438,7 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
         {
             // The previous string does not match what the bytes would convert to,
             // so we will need to generate a new string.
-            QueryString = _parsedQueryString = query.GetAsciiStringNonNullCharacters();
+            QueryString = _parsedQueryString = query.GetAsciiString();
         }
         else
         {
@@ -482,7 +484,7 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
         {
             // The previous string does not match what the bytes would convert to,
             // so we will need to generate a new string.
-            RawTarget = _parsedRawTarget = target.GetAsciiStringNonNullCharacters();
+            RawTarget = _parsedRawTarget = target.GetAsciiString();
         }
         else
         {
@@ -542,7 +544,7 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
             {
                 // The previous string does not match what the bytes would convert to,
                 // so we will need to generate a new string.
-                RawTarget = _parsedRawTarget = target.GetAsciiStringNonNullCharacters();
+                RawTarget = _parsedRawTarget = target.GetAsciiString();
             }
             catch (InvalidOperationException)
             {
@@ -572,7 +574,7 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
             {
                 // The previous string does not match what the bytes would convert to,
                 // so we will need to generate a new string.
-                QueryString = _parsedQueryString = query.GetAsciiStringNonNullCharacters();
+                QueryString = _parsedQueryString = query.GetAsciiString();
             }
             else
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
@@ -7481,7 +7481,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static unsafe ushort ReadUnalignedLittleEndian_ushort(ref byte source)
+        internal static ushort ReadUnalignedLittleEndian_ushort(ref byte source)
         {
             ushort result = Unsafe.ReadUnaligned<ushort>(ref source);
             if (!BitConverter.IsLittleEndian)
@@ -7491,7 +7491,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return result;
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static unsafe uint ReadUnalignedLittleEndian_uint(ref byte source)
+        internal static uint ReadUnalignedLittleEndian_uint(ref byte source)
         {
             uint result = Unsafe.ReadUnaligned<uint>(ref source);
             if (!BitConverter.IsLittleEndian)
@@ -7501,7 +7501,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return result;
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static unsafe ulong ReadUnalignedLittleEndian_ulong(ref byte source)
+        internal static ulong ReadUnalignedLittleEndian_ulong(ref byte source)
         {
             ulong result = Unsafe.ReadUnaligned<ulong>(ref source);
             if (!BitConverter.IsLittleEndian)
@@ -7511,11 +7511,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return result;
         }
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        public unsafe void Append(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value, bool checkForNewlineChars)
+        public void Append(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value, bool checkForNewlineChars)
         {
             ref byte nameStart = ref MemoryMarshal.GetReference(name);
             var nameStr = string.Empty;
-            ref StringValues values = ref Unsafe.AsRef<StringValues>(null);
+            ref StringValues values = ref Unsafe.NullRef<StringValues>();
             var flag = 0L;
 
             // Does the name match any "known" headers
@@ -7924,9 +7924,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         }
 
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        public unsafe bool TryHPackAppend(int index, ReadOnlySpan<byte> value, bool checkForNewlineChars)
+        public bool TryHPackAppend(int index, ReadOnlySpan<byte> value, bool checkForNewlineChars)
         {
-            ref StringValues values = ref Unsafe.AsRef<StringValues>(null);
+            ref StringValues values = ref Unsafe.NullRef<StringValues>();
             var nameStr = string.Empty;
             var flag = 0L;
 
@@ -8136,9 +8136,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         }
 
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        public unsafe bool TryQPackAppend(int index, ReadOnlySpan<byte> value, bool checkForNewlineChars)
+        public bool TryQPackAppend(int index, ReadOnlySpan<byte> value, bool checkForNewlineChars)
         {
-            ref StringValues values = ref Unsafe.AsRef<StringValues>(null);
+            ref StringValues values = ref Unsafe.NullRef<StringValues>();
             var nameStr = string.Empty;
             var flag = 0L;
 
@@ -14806,7 +14806,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             _bits &= ~13161725953;
         }
-        internal unsafe void CopyToFast(ref BufferWriter<PipeWriter> output)
+        internal void CopyToFast(ref BufferWriter<PipeWriter> output)
         {
             var tempBits = (ulong)_bits;
             // Set exact next
@@ -14823,7 +14823,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 return;
             }
 
-            ref readonly StringValues values = ref Unsafe.AsRef<StringValues>(null);
+            ref readonly StringValues values = ref Unsafe.NullRef<StringValues>();
             do
             {
                 int keyStart;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
@@ -69,10 +69,14 @@ public class HttpParser<TRequestHandler> : IHttpParser<TRequestHandler> where TR
         }
 
         // Consume the delimiter.
-        bool foundDelimiter = reader.TryRead(out var next);
+        var foundDelimiter = reader.TryRead(out var next);
         Debug.Assert(foundDelimiter);
         if (next == 0 || requestLine.Length == 0)
         {
+            reader.Rewind(requestLine.Length + 1);
+            var readResult = reader.TryReadExact(requestLine.Length + 1, out var requestLineSequence);
+            Debug.Assert(readResult);
+            requestLine = requestLineSequence.IsSingleSegment ? requestLineSequence.FirstSpan : requestLineSequence.ToArray();
             RejectRequestLine(requestLine);
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
@@ -54,7 +54,7 @@ public class HttpParser<TRequestHandler> : IHttpParser<TRequestHandler> where TR
     private const byte ByteQuestionMark = (byte)'?';
     private const byte BytePercentage = (byte)'%';
     private const int MinTlsRequestSize = 1; // We need at least 1 byte to check for a proper TLS request line
-    private static ReadOnlySpan<byte> RequestLineDelimeters => new byte[] { ByteLF, 0 };
+    private static ReadOnlySpan<byte> RequestLineDelimiters => new byte[] { ByteLF, 0 };
 
     /// <summary>
     /// This API supports framework infrastructure and is not intended to be used
@@ -62,8 +62,8 @@ public class HttpParser<TRequestHandler> : IHttpParser<TRequestHandler> where TR
     /// </summary>
     public bool ParseRequestLine(TRequestHandler handler, ref SequenceReader<byte> reader)
     {
-        // Find the next delimeter.
-        if (!reader.TryReadToAny(out ReadOnlySpan<byte> requestLine, RequestLineDelimeters, advancePastDelimiter: false))
+        // Find the next delimiter.
+        if (!reader.TryReadToAny(out ReadOnlySpan<byte> requestLine, RequestLineDelimiters, advancePastDelimiter: false))
         {
             return false;
         }
@@ -71,8 +71,10 @@ public class HttpParser<TRequestHandler> : IHttpParser<TRequestHandler> where TR
         // Consume the delimiter.
         var foundDelimiter = reader.TryRead(out var next);
         Debug.Assert(foundDelimiter);
+        // If null character found, or request line is empty
         if (next == 0 || requestLine.Length == 0)
         {
+            // Rewind and re-read to format error message correctly
             reader.Rewind(requestLine.Length + 1);
             var readResult = reader.TryReadExact(requestLine.Length + 1, out var requestLineSequence);
             Debug.Assert(readResult);

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
@@ -54,7 +54,7 @@ public class HttpParser<TRequestHandler> : IHttpParser<TRequestHandler> where TR
     private const byte ByteQuestionMark = (byte)'?';
     private const byte BytePercentage = (byte)'%';
     private const int MinTlsRequestSize = 1; // We need at least 1 byte to check for a proper TLS request line
-    private static ReadOnlySpan<byte> RequestLineDelimiters => new byte[] { ByteLF, 0 };
+    private static ReadOnlySpan<byte> RequestLineDelimiters => [ByteLF, 0];
 
     /// <summary>
     /// This API supports framework infrastructure and is not intended to be used

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
@@ -147,7 +147,7 @@ internal sealed partial class HttpRequestHeaders : HttpHeaders
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private unsafe void AppendUnknownHeaders(string name, string valueString)
+    private void AppendUnknownHeaders(string name, string valueString)
     {
         name = GetInternedHeaderName(name);
         Unknown.TryGetValue(name, out var existing);

--- a/src/Servers/Kestrel/Core/src/Internal/Http/PathDecoder.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/PathDecoder.cs
@@ -42,6 +42,6 @@ internal static class PathDecoder
             return rawTarget;
         }
 
-        return path.Slice(0, pathLength).GetAsciiStringNonNullCharacters();
+        return path.Slice(0, pathLength).GetAsciiString();
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpUtilities.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpUtilities.cs
@@ -29,8 +29,6 @@ internal static partial class HttpUtilities
 
     private static readonly UTF8Encoding DefaultRequestHeaderEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 
-    private static readonly SearchValues<char> _nullAndNewLineSearchValues = SearchValues.Create(['\r', '\n', '\0']);
-
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void SetKnownMethod(ulong mask, ulong knownMethodUlong, HttpMethod knownMethod, int length)
     {
@@ -127,7 +125,7 @@ internal static partial class HttpUtilities
         // New Line characters (CR, LF) are considered invalid at this point.
         // Null characters are also not allowed.
         var invalidCharIndex = checkForNewlineChars ?
-            ((ReadOnlySpan<char>)result).IndexOfAny(_nullAndNewLineSearchValues)
+            ((ReadOnlySpan<char>)result).IndexOfAny('\r', '\n', '\0')
             : ((ReadOnlySpan<char>)result).IndexOf('\0');
 
         if (invalidCharIndex >= 0)

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpUtilities.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpUtilities.cs
@@ -80,7 +80,7 @@ internal static partial class HttpUtilities
         return BinaryPrimitives.ReadUInt64LittleEndian(bytes);
     }
 
-    // The same as GetAsciiStringNonNullCharacters but throws BadRequest
+    // The same as GetAsciiString but throws BadRequest for null character
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static string GetHeaderName(this ReadOnlySpan<byte> span)
     {
@@ -107,6 +107,7 @@ internal static partial class HttpUtilities
     public static string GetAsciiString(this Span<byte> span)
         => StringUtilities.GetAsciiString(span);
 
+    // Null checks must be done independently of this method (if required)
     public static string GetAsciiOrUTF8String(this ReadOnlySpan<byte> span)
         => StringUtilities.GetAsciiOrUTF8String(span, DefaultRequestHeaderEncoding);
 

--- a/src/Servers/Kestrel/Core/test/AsciiDecoding.cs
+++ b/src/Servers/Kestrel/Core/test/AsciiDecoding.cs
@@ -35,7 +35,7 @@ public class AsciiDecodingTests
 
         static void Test(Span<byte> asciiBytes)
         {
-            var s = asciiBytes.GetAsciiStringNonNullCharacters();
+            var s = asciiBytes.GetAsciiString();
 
             Assert.True(StringUtilities.BytesOrdinalEqualsStringAndAscii(s, asciiBytes));
             Assert.Equal(s.Length, asciiBytes.Length);
@@ -50,11 +50,10 @@ public class AsciiDecodingTests
         }
     }
 
-    [Theory]
-    [InlineData(0x00)]
-    [InlineData(0x80)]
-    private void ExceptionThrownForZeroOrNonAscii(byte b)
+    [Fact]
+    private void ExceptionThrownForNonAscii()
     {
+        byte b = 0x80;
         for (var length = 1; length < Vector<sbyte>.Count * 4; length++)
         {
             for (var position = 0; position < length; position++)
@@ -62,7 +61,7 @@ public class AsciiDecodingTests
                 var byteRange = Enumerable.Range(1, length).Select(x => (byte)x).ToArray();
                 byteRange[position] = b;
 
-                Assert.Throws<InvalidOperationException>(() => new Span<byte>(byteRange).GetAsciiStringNonNullCharacters());
+                Assert.Throws<InvalidOperationException>(() => new Span<byte>(byteRange).GetAsciiString());
             }
         }
     }
@@ -74,7 +73,7 @@ public class AsciiDecodingTests
         var expectedByteRange = byteRange.Concat(byteRange).ToArray();
 
         var span = new Span<byte>(expectedByteRange);
-        var s = span.GetAsciiStringNonNullCharacters();
+        var s = span.GetAsciiString();
 
         Assert.Equal(expectedByteRange.Length, s.Length);
 
@@ -96,7 +95,7 @@ public class AsciiDecodingTests
         for (var i = 1; i < byteRange.Length; i++)
         {
             var span = new Span<byte>(expectedByteRange);
-            var s = span.GetAsciiStringNonNullCharacters();
+            var s = span.GetAsciiString();
 
             Assert.True(StringUtilities.BytesOrdinalEqualsStringAndAscii(s, span));
 
@@ -133,7 +132,7 @@ public class AsciiDecodingTests
 
         static void Test(Span<byte> asciiBytes)
         {
-            var s = asciiBytes.GetAsciiStringNonNullCharacters();
+            var s = asciiBytes.GetAsciiString();
 
             // Should start as equal
             Assert.True(StringUtilities.BytesOrdinalEqualsStringAndAscii(s, asciiBytes));

--- a/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTests.cs
@@ -494,7 +494,8 @@ public class Http1ConnectionTests : Http1ConnectionTestsBase
         TakeStartLine(readableBuffer, out _consumed, out _examined));
         _transport.Input.AdvanceTo(_consumed, _examined);
 
-        Assert.Equal(CoreStrings.FormatBadRequest_InvalidRequestTarget_Detail(target.EscapeNonPrintable()), exception.Message);
+        var partialTarget = target.AsSpan(0, target.IndexOf('\0') + 1).ToString();
+        Assert.Equal(CoreStrings.FormatBadRequest_InvalidRequestLine_Detail($"GET {partialTarget.EscapeNonPrintable()}"), exception.Message);
     }
 
     [Theory]
@@ -510,7 +511,8 @@ public class Http1ConnectionTests : Http1ConnectionTestsBase
         TakeStartLine(readableBuffer, out _consumed, out _examined));
         _transport.Input.AdvanceTo(_consumed, _examined);
 
-        Assert.Equal(CoreStrings.FormatBadRequest_InvalidRequestLine_Detail(requestLine[..^1].EscapeNonPrintable()), exception.Message);
+        var partialRequestLine = requestLine.AsSpan(0, requestLine.IndexOf('\0') + 1).ToString();
+        Assert.Equal(CoreStrings.FormatBadRequest_InvalidRequestLine_Detail(partialRequestLine.EscapeNonPrintable()), exception.Message);
     }
 
     [Theory]
@@ -526,7 +528,8 @@ public class Http1ConnectionTests : Http1ConnectionTestsBase
          TakeStartLine(readableBuffer, out _consumed, out _examined));
         _transport.Input.AdvanceTo(_consumed, _examined);
 
-        Assert.Equal(CoreStrings.FormatBadRequest_InvalidRequestTarget_Detail(target.EscapeNonPrintable()), exception.Message);
+        var partialTarget = target.AsSpan(0, target.IndexOf('\0') + 1).ToString();
+        Assert.Equal(CoreStrings.FormatBadRequest_InvalidRequestLine_Detail($"GET {partialTarget.EscapeNonPrintable()}"), exception.Message);
     }
 
     [Theory]

--- a/src/Servers/Kestrel/Core/test/HttpParserTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpParserTests.cs
@@ -87,7 +87,13 @@ public class HttpParserTests : LoggedTest
 #pragma warning restore CS0618 // Type or member is obsolete
         ParseRequestLine(parser, requestHandler, buffer, out var consumed, out var examined));
 
-        Assert.Equal(CoreStrings.FormatBadRequest_InvalidRequestLine_Detail(requestLine[..^1].EscapeNonPrintable()), exception.Message);
+        var line = requestLine;
+        var nullIndex = line.IndexOf('\0');
+        if (nullIndex >= 0)
+        {
+            line = line.AsSpan().Slice(0, nullIndex + 2).ToString();
+        }
+        Assert.Equal(CoreStrings.FormatBadRequest_InvalidRequestLine_Detail(line[..^1].EscapeNonPrintable()), exception.Message);
         Assert.Equal(StatusCodes.Status400BadRequest, exception.StatusCode);
     }
 
@@ -134,7 +140,16 @@ public class HttpParserTests : LoggedTest
 #pragma warning restore CS0618 // Type or member is obsolete
             ParseRequestLine(parser, requestHandler, buffer, out var consumed, out var examined));
 
-        Assert.Equal(CoreStrings.FormatBadRequest_InvalidRequestLine_Detail(method.EscapeNonPrintable() + @" / HTTP/1.1\x0D"), exception.Message);
+        var nullIndex = method.IndexOf('\0');
+        if (nullIndex >= 0)
+        {
+            var line = method.AsSpan().Slice(0, nullIndex + 1).ToString();
+            Assert.Equal(CoreStrings.FormatBadRequest_InvalidRequestLine_Detail(line.EscapeNonPrintable()), exception.Message);
+        }
+        else
+        {
+            Assert.Equal(CoreStrings.FormatBadRequest_InvalidRequestLine_Detail(method.EscapeNonPrintable() + @" / HTTP/1.1\x0D"), exception.Message);
+        }
         Assert.Equal(StatusCodes.Status400BadRequest, exception.StatusCode);
     }
 
@@ -871,18 +886,18 @@ public class HttpParserTests : LoggedTest
 
         public void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
         {
-            Headers[name.GetAsciiStringNonNullCharacters()] = value.GetAsciiStringNonNullCharacters();
+            Headers[name.GetAsciiString()] = value.GetAsciiString();
         }
 
         void IHttpHeadersHandler.OnHeadersComplete(bool endStream) { }
 
         public void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded)
         {
-            Method = method != HttpMethod.Custom ? HttpUtilities.MethodToString(method) : customMethod.GetAsciiStringNonNullCharacters();
+            Method = method != HttpMethod.Custom ? HttpUtilities.MethodToString(method) : customMethod.GetAsciiString();
             Version = HttpUtilities.VersionToString(version);
-            RawTarget = target.GetAsciiStringNonNullCharacters();
-            RawPath = path.GetAsciiStringNonNullCharacters();
-            Query = query.GetAsciiStringNonNullCharacters();
+            RawTarget = target.GetAsciiString();
+            RawPath = path.GetAsciiString();
+            Query = query.GetAsciiString();
             PathEncoded = pathEncoded;
         }
 
@@ -896,11 +911,11 @@ public class HttpParserTests : LoggedTest
             var path = target[..targetPath.Length];
             var query = target[targetPath.Length..];
 
-            Method = method != HttpMethod.Custom ? HttpUtilities.MethodToString(method) : customMethod.GetAsciiStringNonNullCharacters();
+            Method = method != HttpMethod.Custom ? HttpUtilities.MethodToString(method) : customMethod.GetAsciiString();
             Version = HttpUtilities.VersionToString(version);
-            RawTarget = target.GetAsciiStringNonNullCharacters();
-            RawPath = path.GetAsciiStringNonNullCharacters();
-            Query = query.GetAsciiStringNonNullCharacters();
+            RawTarget = target.GetAsciiString();
+            RawPath = path.GetAsciiString();
+            Query = query.GetAsciiString();
             PathEncoded = targetPath.IsEncoded;
         }
 

--- a/src/Servers/Kestrel/perf/Microbenchmarks/BytesToStringBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/BytesToStringBenchmark.cs
@@ -65,7 +65,7 @@ public class BytesToStringBenchmark
     {
         for (uint i = 0; i < Iterations; i++)
         {
-            HttpUtilities.GetAsciiStringNonNullCharacters(_asciiBytes);
+            HttpUtilities.GetAsciiString(_asciiBytes);
         }
     }
 

--- a/src/Servers/Kestrel/shared/KnownHeaders.cs
+++ b/src/Servers/Kestrel/shared/KnownHeaders.cs
@@ -1213,7 +1213,7 @@ $@"        private void Clear(long bitsToClear)
         {{
             _bits &= ~{InvalidH2H3ResponseHeadersBits};
         }}
-        internal unsafe void CopyToFast(ref BufferWriter<PipeWriter> output)
+        internal void CopyToFast(ref BufferWriter<PipeWriter> output)
         {{
             var tempBits = (ulong)_bits;
             // Set exact next
@@ -1230,7 +1230,7 @@ $@"        private void Clear(long bitsToClear)
                 return;
             }}
 
-            ref readonly StringValues values = ref Unsafe.AsRef<StringValues>(null);
+            ref readonly StringValues values = ref Unsafe.NullRef<StringValues>();
             do
             {{
                 int keyStart;
@@ -1303,7 +1303,7 @@ $@"        private void Clear(long bitsToClear)
         }}
         {Each(new string[] { "ushort", "uint", "ulong" }, type => $@"
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static unsafe {type} ReadUnalignedLittleEndian_{type}(ref byte source)
+        internal static {type} ReadUnalignedLittleEndian_{type}(ref byte source)
         {{
             {type} result = Unsafe.ReadUnaligned<{type}>(ref source);
             if (!BitConverter.IsLittleEndian)
@@ -1313,11 +1313,11 @@ $@"        private void Clear(long bitsToClear)
             return result;
         }}")}
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        public unsafe void Append(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value, bool checkForNewlineChars)
+        public void Append(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value, bool checkForNewlineChars)
         {{
             ref byte nameStart = ref MemoryMarshal.GetReference(name);
             var nameStr = string.Empty;
-            ref StringValues values = ref Unsafe.AsRef<StringValues>(null);
+            ref StringValues values = ref Unsafe.NullRef<StringValues>();
             var flag = 0L;
 
             // Does the name match any ""known"" headers
@@ -1339,9 +1339,9 @@ $@"        private void Clear(long bitsToClear)
         }}
 
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        public unsafe bool TryHPackAppend(int index, ReadOnlySpan<byte> value, bool checkForNewlineChars)
+        public bool TryHPackAppend(int index, ReadOnlySpan<byte> value, bool checkForNewlineChars)
         {{
-            ref StringValues values = ref Unsafe.AsRef<StringValues>(null);
+            ref StringValues values = ref Unsafe.NullRef<StringValues>();
             var nameStr = string.Empty;
             var flag = 0L;
 
@@ -1360,9 +1360,9 @@ $@"        private void Clear(long bitsToClear)
         }}
 
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        public unsafe bool TryQPackAppend(int index, ReadOnlySpan<byte> value, bool checkForNewlineChars)
+        public bool TryQPackAppend(int index, ReadOnlySpan<byte> value, bool checkForNewlineChars)
         {{
-            ref StringValues values = ref Unsafe.AsRef<StringValues>(null);
+            ref StringValues values = ref Unsafe.NullRef<StringValues>();
             var nameStr = string.Empty;
             var flag = 0L;
 

--- a/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
+++ b/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
@@ -771,7 +771,7 @@ internal class Http3RequestStream : Http3StreamBase, IHttpStreamHeadersHandler
 
     public void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
     {
-        _headerHandler.DecodedHeaders[name.GetAsciiStringNonNullCharacters()] = value.GetAsciiOrUTF8StringNonNullCharacters();
+        _headerHandler.DecodedHeaders[name.GetAsciiString()] = value.GetAsciiOrUTF8String();
     }
 
     public void OnHeadersComplete(bool endHeaders)
@@ -781,12 +781,12 @@ internal class Http3RequestStream : Http3StreamBase, IHttpStreamHeadersHandler
     public void OnStaticIndexedHeader(int index)
     {
         var knownHeader = H3StaticTable.Get(index);
-        _headerHandler.DecodedHeaders[((Span<byte>)knownHeader.Name).GetAsciiStringNonNullCharacters()] = HttpUtilities.GetAsciiOrUTF8StringNonNullCharacters((ReadOnlySpan<byte>)knownHeader.Value);
+        _headerHandler.DecodedHeaders[((Span<byte>)knownHeader.Name).GetAsciiString()] = HttpUtilities.GetAsciiOrUTF8String((ReadOnlySpan<byte>)knownHeader.Value);
     }
 
     public void OnStaticIndexedHeader(int index, ReadOnlySpan<byte> value)
     {
-        _headerHandler.DecodedHeaders[((Span<byte>)H3StaticTable.Get(index).Name).GetAsciiStringNonNullCharacters()] = value.GetAsciiOrUTF8StringNonNullCharacters();
+        _headerHandler.DecodedHeaders[((Span<byte>)H3StaticTable.Get(index).Name).GetAsciiString()] = value.GetAsciiOrUTF8String();
     }
 
     public void Complete()
@@ -796,7 +796,7 @@ internal class Http3RequestStream : Http3StreamBase, IHttpStreamHeadersHandler
 
     public void OnDynamicIndexedHeader(int? index, ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
     {
-        _headerHandler.DecodedHeaders[name.GetAsciiStringNonNullCharacters()] = value.GetAsciiOrUTF8StringNonNullCharacters();
+        _headerHandler.DecodedHeaders[name.GetAsciiString()] = value.GetAsciiOrUTF8String();
     }
 }
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
@@ -584,7 +584,13 @@ public class BadHttpRequestTests : LoggedTest
 
             foreach (var requestLine in HttpParsingData.RequestLineInvalidData)
             {
-                data.Add(requestLine, CoreStrings.FormatBadRequest_InvalidRequestLine_Detail(requestLine[..^1].EscapeNonPrintable()));
+                var line = requestLine;
+                var nullIndex = line.IndexOf('\0');
+                if (nullIndex >= 0)
+                {
+                    line = line.AsSpan().Slice(0, nullIndex + 2).ToString();
+                }
+                data.Add(requestLine, CoreStrings.FormatBadRequest_InvalidRequestLine_Detail(line[..^1].EscapeNonPrintable()));
             }
 
             foreach (var target in HttpParsingData.TargetWithEncodedNullCharData)
@@ -594,7 +600,8 @@ public class BadHttpRequestTests : LoggedTest
 
             foreach (var target in HttpParsingData.TargetWithNullCharData)
             {
-                data.Add($"GET {target} HTTP/1.1\r\n", CoreStrings.FormatBadRequest_InvalidRequestTarget_Detail(target.EscapeNonPrintable()));
+                var printableTarget = target.AsSpan().Slice(0, target.IndexOf('\0') + 1).ToString();
+                data.Add($"GET {target} HTTP/1.1\r\n", CoreStrings.FormatBadRequest_InvalidRequestLine_Detail($"GET {printableTarget.EscapeNonPrintable()}"));
             }
 
             return data;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -2959,7 +2959,7 @@ public class Http2ConnectionTests : Http2TestBase
     }
 
     [Fact]
-    public Task HEADERS_Received_InvalidCharacters_ConnectionError()
+    public Task HEADERS_Received_InvalidCharactersInHeaderValue_ConnectionError()
     {
         var headers = new[]
         {
@@ -2973,6 +2973,20 @@ public class Http2ConnectionTests : Http2TestBase
             headers,
             CoreStrings.BadRequest_MalformedRequestInvalidHeaders,
             expectedEndReason: ConnectionEndReason.InvalidRequestHeaders);
+    }
+
+    [Fact]
+    public Task HEADERS_Received_InvalidCharactersInHeaderName_ConnectionError()
+    {
+        var headers = new[]
+        {
+            new KeyValuePair<string, string>(InternalHeaderNames.Method, "GET"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Path, "/"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Scheme, "http"),
+            new KeyValuePair<string, string>("Cus\0tom", "value"),
+        };
+
+        return HEADERS_Received_InvalidHeaderFields_ConnectionError(headers, CoreStrings.BadRequest_InvalidCharactersInHeaderName);
     }
 
     [Fact]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -2986,7 +2986,8 @@ public class Http2ConnectionTests : Http2TestBase
             new KeyValuePair<string, string>("Cus\0tom", "value"),
         };
 
-        return HEADERS_Received_InvalidHeaderFields_ConnectionError(headers, CoreStrings.BadRequest_InvalidCharactersInHeaderName);
+        return HEADERS_Received_InvalidHeaderFields_ConnectionError(headers, CoreStrings.BadRequest_InvalidCharactersInHeaderName,
+            expectedEndReason: ConnectionEndReason.InvalidRequestHeaders);
     }
 
     [Fact]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
@@ -2418,7 +2418,7 @@ public class Http3StreamTests : Http3TestBase
     }
 
     [Fact]
-    public Task HEADERS_Received_InvalidCharacters_ConnectionError()
+    public Task HEADERS_Received_InvalidCharactersInHeaderValue_ConnectionError()
     {
         var headers = new[]
         {
@@ -2429,6 +2429,20 @@ public class Http3StreamTests : Http3TestBase
         };
 
         return HEADERS_Received_InvalidHeaderFields_StreamError(headers, CoreStrings.BadRequest_MalformedRequestInvalidHeaders);
+    }
+
+    [Fact]
+    public Task HEADERS_Received_InvalidCharactersInHeaderName_ConnectionError()
+    {
+        var headers = new[]
+        {
+            new KeyValuePair<string, string>(InternalHeaderNames.Method, "GET"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Path, "/"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Scheme, "http"),
+            new KeyValuePair<string, string>("Cus\0tom", "value"),
+        };
+
+        return HEADERS_Received_InvalidHeaderFields_StreamError(headers, CoreStrings.BadRequest_InvalidCharactersInHeaderName);
     }
 
     [Fact]

--- a/src/Shared/Http2cat/Http2Utilities.cs
+++ b/src/Shared/Http2cat/Http2Utilities.cs
@@ -145,7 +145,14 @@ internal sealed class Http2Utilities : IHttpStreamHeadersHandler
 
     void IHttpStreamHeadersHandler.OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
     {
-        _decodedHeaders[name.GetAsciiStringNonNullCharacters()] = value.GetAsciiOrUTF8StringNonNullCharacters(HeaderValueEncoding);
+        var headerName = name.GetAsciiString();
+        var headerValue = value.GetAsciiOrUTF8String(HeaderValueEncoding);
+        if (headerName.Contains('\0') || headerValue.Contains('\0'))
+        {
+            throw new InvalidOperationException();
+        }
+
+        _decodedHeaders[headerName] = headerValue;
     }
 
     void IHttpStreamHeadersHandler.OnHeadersComplete(bool endStream) { }

--- a/src/Shared/HttpSys/RequestProcessing/HeaderEncoding.cs
+++ b/src/Shared/HttpSys/RequestProcessing/HeaderEncoding.cs
@@ -10,13 +10,20 @@ internal static class HeaderEncoding
 {
     internal static unsafe string GetString(byte* pBytes, int byteCount, bool useLatin1)
     {
+        string header;
         if (useLatin1)
         {
-            return new ReadOnlySpan<byte>(pBytes, byteCount).GetLatin1StringNonNullCharacters();
+            header = new ReadOnlySpan<byte>(pBytes, byteCount).GetLatin1String();
         }
         else
         {
-            return new ReadOnlySpan<byte>(pBytes, byteCount).GetAsciiOrUTF8StringNonNullCharacters(Encoding.UTF8);
+            header = new ReadOnlySpan<byte>(pBytes, byteCount).GetAsciiOrUTF8String(Encoding.UTF8);
         }
+
+        if (header.Contains('\0'))
+        {
+            throw new InvalidOperationException();
+        }
+        return header;
     }
 }

--- a/src/Shared/ServerInfrastructure/StringUtilities.cs
+++ b/src/Shared/ServerInfrastructure/StringUtilities.cs
@@ -23,13 +23,15 @@ internal static class StringUtilities
             return string.Empty;
         }
 
-        var resultString = string.Create(span.Length, span, (destination, spanPtr) =>
+        var resultString = string.Create(span.Length, span, static (destination, source) =>
         {
-            if (Ascii.ToUtf16(spanPtr, destination, out _) != OperationStatus.Done)
+            if (Ascii.ToUtf16(source, destination, out var written) != OperationStatus.Done)
             {
                 // Mark resultString for UTF-8 encoding
                 destination[0] = '\0';
             }
+
+            Debug.Assert(destination[0] == '\0' || written == destination.Length);
         });
 
         // If resultString is marked, perform UTF-8 encoding
@@ -51,12 +53,14 @@ internal static class StringUtilities
     // Null checks must be done independently of this method (if required)
     public static string GetAsciiString(this ReadOnlySpan<byte> span)
     {
-        return string.Create(span.Length, span, (destination, spanPtr) =>
+        return string.Create(span.Length, span, static (destination, source) =>
         {
-            if (Ascii.ToUtf16(spanPtr, destination, out _) != OperationStatus.Done)
+            if (Ascii.ToUtf16(source, destination, out var written) != OperationStatus.Done)
             {
                 throw new InvalidOperationException();
             }
+
+            Debug.Assert(written == destination.Length);
         });
     }
 

--- a/src/Shared/ServerInfrastructure/StringUtilities.cs
+++ b/src/Shared/ServerInfrastructure/StringUtilities.cs
@@ -17,11 +17,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 
 internal static class StringUtilities
 {
-    private static readonly SpanAction<char, IntPtr> s_getLatin1StringNonNullCharacters = GetLatin1StringNonNullCharacters;
     private static readonly SpanAction<char, (string? str, char separator, uint number)> s_populateSpanWithHexSuffix = PopulateSpanWithHexSuffix;
 
-    public static unsafe string GetAsciiOrUTF8StringNonNullCharacters(this ReadOnlySpan<byte> span, Encoding defaultEncoding)
+    // Null checks must be done independently of this method (if required)
+    public static unsafe string GetAsciiOrUTF8String(this ReadOnlySpan<byte> span, Encoding defaultEncoding)
     {
+        if (span.IsEmpty)
+        {
+            return string.Empty;
+        }
+
         var resultString = string.Create(span.Length, (IntPtr)(&span), (destination, spanPtr) =>
         {
             if (Ascii.ToUtf16(*(ReadOnlySpan<byte>*)spanPtr, destination, out _) != OperationStatus.Done)
@@ -47,7 +52,8 @@ internal static class StringUtilities
         return resultString;
     }
 
-    public static unsafe string GetAsciiStringNonNullCharacters(this ReadOnlySpan<byte> span)
+    // Null checks must be done independently of this method (if required)
+    public static unsafe string GetAsciiString(this ReadOnlySpan<byte> span)
     {
         return string.Create(span.Length, (IntPtr)(&span), (destination, spanPtr) =>
         {
@@ -58,162 +64,24 @@ internal static class StringUtilities
         });
     };
 
-    public static unsafe string GetLatin1StringNonNullCharacters(this ReadOnlySpan<byte> span)
+    // Null checks must be done independently of this method (if required)
+    public static unsafe string GetLatin1String(this ReadOnlySpan<byte> span)
     {
         if (span.IsEmpty)
         {
             return string.Empty;
         }
 
-        fixed (byte* source = &MemoryMarshal.GetReference(span))
-        {
-            return string.Create(span.Length, (IntPtr)source, s_getLatin1StringNonNullCharacters);
-        }
+        return Encoding.Latin1.GetString(span);
     }
-
-    private static readonly unsafe SpanAction<char, IntPtr> s_getLatin1StringNonNullCharacters = (Span<char> buffer, IntPtr state) =>
-    {
-        fixed (char* output = &MemoryMarshal.GetReference(buffer))
-        {
-            if (!TryGetLatin1String((byte*)state.ToPointer(), output, buffer.Length))
-            {
-                // null characters are considered invalid
-                throw new InvalidOperationException();
-            }
-        }
-    };
 
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-    public static unsafe bool TryGetLatin1String(byte* input, char* output, int count)
-    {
-        Debug.Assert(input != null);
-        Debug.Assert(output != null);
-
-        // Calculate end position
-        var end = input + count;
-        // Start as valid
-        var isValid = true;
-
-        do
-        {
-            // If Vector not-accelerated or remaining less than vector size
-            if (!Vector.IsHardwareAccelerated || input > end - Vector<sbyte>.Count)
-            {
-                if (Environment.Is64BitProcess) // Use Intrinsic switch for branch elimination
-                {
-                    // 64-bit: Loop longs by default
-                    while (input <= end - sizeof(long))
-                    {
-                        isValid &= CheckBytesNotNull(((long*)input)[0]);
-
-                        output[0] = (char)input[0];
-                        output[1] = (char)input[1];
-                        output[2] = (char)input[2];
-                        output[3] = (char)input[3];
-                        output[4] = (char)input[4];
-                        output[5] = (char)input[5];
-                        output[6] = (char)input[6];
-                        output[7] = (char)input[7];
-
-                        input += sizeof(long);
-                        output += sizeof(long);
-                    }
-                    if (input <= end - sizeof(int))
-                    {
-                        isValid &= CheckBytesNotNull(((int*)input)[0]);
-
-                        output[0] = (char)input[0];
-                        output[1] = (char)input[1];
-                        output[2] = (char)input[2];
-                        output[3] = (char)input[3];
-
-                        input += sizeof(int);
-                        output += sizeof(int);
-                    }
-                }
-                else
-                {
-                    // 32-bit: Loop ints by default
-                    while (input <= end - sizeof(int))
-                    {
-                        isValid &= CheckBytesNotNull(((int*)input)[0]);
-
-                        output[0] = (char)input[0];
-                        output[1] = (char)input[1];
-                        output[2] = (char)input[2];
-                        output[3] = (char)input[3];
-
-                        input += sizeof(int);
-                        output += sizeof(int);
-                    }
-                }
-                if (input <= end - sizeof(short))
-                {
-                    isValid &= CheckBytesNotNull(((short*)input)[0]);
-
-                    output[0] = (char)input[0];
-                    output[1] = (char)input[1];
-
-                    input += sizeof(short);
-                    output += sizeof(short);
-                }
-                if (input < end)
-                {
-                    isValid &= CheckBytesNotNull(((sbyte*)input)[0]);
-                    output[0] = (char)input[0];
-                }
-
-                return isValid;
-            }
-
-            // do/while as entry condition already checked
-            do
-            {
-                // Use byte/ushort instead of signed equivalents to ensure it doesn't fill based on the high bit.
-                var vector = Unsafe.AsRef<Vector<byte>>(input);
-                isValid &= CheckBytesNotNull(vector);
-                Vector.Widen(
-                    vector,
-                    out Unsafe.AsRef<Vector<ushort>>(output),
-                    out Unsafe.AsRef<Vector<ushort>>(output + Vector<ushort>.Count));
-
-                input += Vector<byte>.Count;
-                output += Vector<byte>.Count;
-            } while (input <= end - Vector<byte>.Count);
-
-            // Vector path done, loop back to do non-Vector
-            // If is a exact multiple of vector size, bail now
-        } while (input < end);
-
-        return isValid;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool BytesOrdinalEqualsStringAndAscii(string previousValue, ReadOnlySpan<byte> newValue)
     {
         // previousValue is a previously materialized string which *must* have already passed validation.
         Debug.Assert(IsValidHeaderString(previousValue));
 
         return Ascii.Equals(previousValue, newValue);
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static unsafe void WidenFourAsciiBytesToUtf16AndWriteToBuffer(char* output, byte* input, int value, Vector128<sbyte> zero)
-    {
-        // BMI2 could be used, but this variant is faster on both Intel and AMD.
-        if (Sse2.X64.IsSupported)
-        {
-            var vecNarrow = Sse2.ConvertScalarToVector128Int32(value).AsSByte();
-            var vecWide = Sse2.UnpackLow(vecNarrow, zero).AsUInt64();
-            Unsafe.WriteUnaligned(output, Sse2.X64.ConvertToUInt64(vecWide));
-        }
-        else
-        {
-            output[0] = (char)input[0];
-            output[1] = (char)input[1];
-            output[2] = (char)input[2];
-            output[3] = (char)input[3];
-        }
     }
 
     private static bool IsValidHeaderString(string value)
@@ -335,85 +203,4 @@ internal static class StringUtilities
         // Vectorized byte range check, signed byte > 0 for 1-127
         return Vector.GreaterThanAll(check, Vector<sbyte>.Zero);
     }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool CheckBytesInAsciiRange(Vector256<sbyte> check, Vector256<sbyte> zero)
-    {
-        Debug.Assert(Avx2.IsSupported);
-
-        var mask = Avx2.CompareGreaterThan(check, zero);
-        return (uint)Avx2.MoveMask(mask) == 0xFFFF_FFFF;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool CheckBytesInAsciiRange(Vector128<sbyte> check, Vector128<sbyte> zero)
-    {
-        Debug.Assert(Sse2.IsSupported);
-
-        var mask = Sse2.CompareGreaterThan(check, zero);
-        return Sse2.MoveMask(mask) == 0xFFFF;
-    }
-
-    // Validate: bytes != 0 && bytes <= 127
-    //  Subtract 1 from all bytes to move 0 to high bits
-    //  bitwise or with self to catch all > 127 bytes
-    //  mask off non high bits and check if 0
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)] // Needs a push
-    private static bool CheckBytesInAsciiRange(long check)
-    {
-        const long HighBits = unchecked((long)0x8080808080808080L);
-        return (((check - 0x0101010101010101L) | check) & HighBits) == 0;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool CheckBytesInAsciiRange(int check)
-    {
-        const int HighBits = unchecked((int)0x80808080);
-        return (((check - 0x01010101) | check) & HighBits) == 0;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool CheckBytesInAsciiRange(short check)
-    {
-        const short HighBits = unchecked((short)0x8080);
-        return (((short)(check - 0x0101) | check) & HighBits) == 0;
-    }
-
-    private static bool CheckBytesInAsciiRange(sbyte check)
-        => check > 0;
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)] // Needs a push
-    private static bool CheckBytesNotNull(Vector<byte> check)
-    {
-        // Vectorized byte range check, signed byte != null
-        return !Vector.EqualsAny(check, Vector<byte>.Zero);
-    }
-
-    // Validate: bytes != 0
-    //  Subtract 1 from all bytes to move 0 to high bits
-    //  bitwise and with ~check so high bits are only set for bytes that were originally 0
-    //  mask off non high bits and check if 0
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)] // Needs a push
-    private static bool CheckBytesNotNull(long check)
-    {
-        const long HighBits = unchecked((long)0x8080808080808080L);
-        return ((check - 0x0101010101010101L) & ~check & HighBits) == 0;
-    }
-
-    private static bool CheckBytesNotNull(int check)
-    {
-        const int HighBits = unchecked((int)0x80808080);
-        return ((check - 0x01010101) & ~check & HighBits) == 0;
-    }
-
-    private static bool CheckBytesNotNull(short check)
-    {
-        const short HighBits = unchecked((short)0x8080);
-        return ((check - 0x0101) & ~check & HighBits) == 0;
-    }
-
-    private static bool CheckBytesNotNull(sbyte check)
-        => check != 0;
 }


### PR DESCRIPTION
Switches to `Ascii.ToUtf16` over hand rolled vectorized code. This allows us to remove a nice chunk of unsafe+vectorized code in AspNetCore and take advantage of newer features like AVX512 without updating our code.

One issue is that our old code would not allow the null character (`\0`) but `Ascii.ToUtf16` does. To fix this I moved the main null check to when we first iterate over the request line so it should result in an almost free null check (since we're already searching through the whole request) and preserve behavior.

See https://github.com/dotnet/runtime/issues/80366 for some discussion on the null character as well as some perf discussion around `Ascii.ToUtf16` vs. our vectorized code. TBF I ran on hardware without AVX512 so I didn't get the benefits from that code path.