### PR TITLE
Add support for trusting dev certs on linux

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/LoggerExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/LoggerExtensions.cs
@@ -40,4 +40,7 @@ internal static partial class LoggerExtensions
 
     [LoggerMessage(8, LogLevel.Warning, "The ASP.NET Core developer certificate is not trusted. For information about trusting the ASP.NET Core developer certificate, see https://aka.ms/aspnet/https-trust-dev-cert", EventName = "DeveloperCertificateNotTrusted")]
     public static partial void DeveloperCertificateNotTrusted(this ILogger<KestrelServer> logger);
+
+    [LoggerMessage(9, LogLevel.Warning, "The ASP.NET Core developer certificate is only trusted by some clients. For information about trusting the ASP.NET Core developer certificate, see https://aka.ms/aspnet/https-trust-dev-cert", EventName = "DeveloperCertificatePartiallyTrusted")]
+    public static partial void DeveloperCertificatePartiallyTrusted(this ILogger<KestrelServer> logger);
 }

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -398,9 +398,14 @@ public class KestrelServerOptions
                 return null;
             }
 
-            if (!CertificateManager.Instance.IsTrusted(cert))
+            switch (CertificateManager.Instance.GetTrustLevel(cert))
             {
-                logger.DeveloperCertificateNotTrusted();
+                case CertificateManager.TrustLevel.Partial:
+                    logger.DeveloperCertificatePartiallyTrusted();
+                    break;
+                case CertificateManager.TrustLevel.None:
+                    logger.DeveloperCertificateNotTrusted();
+                    break;
             }
 
             return cert;

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -384,7 +384,7 @@ public class KestrelServerOptions
                 return null;
             }
 
-            var status = CertificateManager.Instance.CheckCertificateState(cert, interactive: false);
+            var status = CertificateManager.Instance.CheckCertificateState(cert);
             if (!status.Success)
             {
                 // Display a warning indicating to the user that a prompt might appear and provide instructions on what to do in that

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -387,10 +387,13 @@ public class KestrelServerOptions
             var status = CertificateManager.Instance.CheckCertificateState(cert);
             if (!status.Success)
             {
-                // Display a warning indicating to the user that a prompt might appear and provide instructions on what to do in that
-                // case. The underlying implementation of this check is specific to Mac OS and is handled within CheckCertificateState.
-                // Kestrel must NEVER cause a UI prompt on a production system. We only attempt this here because Mac OS is not supported
-                // in production.
+                // Failure is only possible on MacOS and indicates that, if there is a dev cert, it must be from
+                // a dotnet version prior to 7.0 - newer versions store it in such a way that this check succeeds.
+                // (Success does not mean that the dev cert has been trusted).
+                // In practice, success.FailureMessage will always be MacOSCertificateManager.InvalidCertificateState.
+                // Basically, we're just going to encourage the user to generate and trust the dev cert.  We support
+                // these older certificates not by accepting them as-is, but by modernizing them when dev-certs is run.
+                // If we detect an issue here, we can avoid a UI prompt below.
                 Debug.Assert(status.FailureMessage != null, "Status with a failure result must have a message.");
                 logger.DeveloperCertificateFirstRun(status.FailureMessage);
 
@@ -398,6 +401,9 @@ public class KestrelServerOptions
                 return null;
             }
 
+            // On MacOS, this may cause a UI prompt, since it requires accessing the keychain.  Kestrel must NEVER
+            // cause a UI prompt on a production system. We only attempt this here because MacOS is not supported
+            // in production.
             switch (CertificateManager.Instance.GetTrustLevel(cert))
             {
                 case CertificateManager.TrustLevel.Partial:

--- a/src/Shared/CertificateGeneration/CertificateManager.cs
+++ b/src/Shared/CertificateGeneration/CertificateManager.cs
@@ -208,7 +208,7 @@ internal abstract class CertificateManager
                 // as we don't want to prompt on first run experience.
                 foreach (var candidate in currentUserCertificates)
                 {
-                    var status = CheckCertificateState(candidate, true);
+                    var status = CheckCertificateState(candidate);
                     if (!status.Success)
                     {
                         try
@@ -735,7 +735,7 @@ internal abstract class CertificateManager
         }
     }
 
-    internal abstract CheckCertificateStateResult CheckCertificateState(X509Certificate2 candidate, bool interactive);
+    internal abstract CheckCertificateStateResult CheckCertificateState(X509Certificate2 candidate);
 
     internal abstract void CorrectCertificateState(X509Certificate2 candidate);
 

--- a/src/Shared/CertificateGeneration/CertificateManager.cs
+++ b/src/Shared/CertificateGeneration/CertificateManager.cs
@@ -1135,83 +1135,86 @@ internal abstract class CertificateManager
         [Event(86, Level = EventLevel.Warning, Message = "Failed to trust the certificate in .NET: {0}.")]
         internal void UnixDotnetTrustException(string exceptionMessage) => WriteEvent(86, exceptionMessage);
 
-        [Event(87, Level = EventLevel.Warning, Message = "Clients that validate certificate trust using OpenSSL will not trust the certificate.")]
-        internal void UnixOpenSslTrustFailed() => WriteEvent(87);
+        [Event(87, Level = EventLevel.Verbose, Message = "Trusted the certificate in .NET.")]
+        internal void UnixDotnetTrustSucceeded() => WriteEvent(87);
 
-        [Event(88, Level = EventLevel.Verbose, Message = "Trusted the certificate in OpenSSL.")]
-        internal void UnixOpenSslTrustSucceeded() => WriteEvent(88);
+        [Event(88, Level = EventLevel.Warning, Message = "Clients that validate certificate trust using OpenSSL will not trust the certificate.")]
+        internal void UnixOpenSslTrustFailed() => WriteEvent(88);
 
-        [Event(89, Level = EventLevel.Warning, Message = "Failed to trust the certificate in the NSS database in '{0}'. This will likely affect the {1} family of browsers.")]
-        internal void UnixNssDbTrustFailed(string path, string browser) => WriteEvent(89, path, browser);
+        [Event(89, Level = EventLevel.Verbose, Message = "Trusted the certificate in OpenSSL.")]
+        internal void UnixOpenSslTrustSucceeded() => WriteEvent(89);
 
-        [Event(90, Level = EventLevel.Verbose, Message = "Trusted the certificate in the NSS database in '{0}'.")]
-        internal void UnixNssDbTrustSucceeded(string path) => WriteEvent(90, path);
+        [Event(90, Level = EventLevel.Warning, Message = "Failed to trust the certificate in the NSS database in '{0}'. This will likely affect the {1} family of browsers.")]
+        internal void UnixNssDbTrustFailed(string path, string browser) => WriteEvent(90, path, browser);
 
-        [Event(91, Level = EventLevel.Warning, Message = "Failed to untrust the certificate in .NET: {0}.")]
-        internal void UnixDotnetUntrustException(string exceptionMessage) => WriteEvent(91, exceptionMessage);
+        [Event(91, Level = EventLevel.Verbose, Message = "Trusted the certificate in the NSS database in '{0}'.")]
+        internal void UnixNssDbTrustSucceeded(string path) => WriteEvent(91, path);
 
-        [Event(92, Level = EventLevel.Warning, Message = "Failed to untrust the certificate in OpenSSL.")]
-        internal void UnixOpenSslUntrustFailed() => WriteEvent(92);
+        [Event(92, Level = EventLevel.Warning, Message = "Failed to untrust the certificate in .NET: {0}.")]
+        internal void UnixDotnetUntrustException(string exceptionMessage) => WriteEvent(92, exceptionMessage);
 
-        [Event(93, Level = EventLevel.Verbose, Message = "Untrusted the certificate in OpenSSL.")]
-        internal void UnixOpenSslUntrustSucceeded() => WriteEvent(93);
+        [Event(93, Level = EventLevel.Warning, Message = "Failed to untrust the certificate in OpenSSL.")]
+        internal void UnixOpenSslUntrustFailed() => WriteEvent(93);
 
-        [Event(94, Level = EventLevel.Warning, Message = "Failed to remove the certificate from the NSS database in '{0}'.")]
-        internal void UnixNssDbUntrustFailed(string path) => WriteEvent(94, path);
+        [Event(94, Level = EventLevel.Verbose, Message = "Untrusted the certificate in OpenSSL.")]
+        internal void UnixOpenSslUntrustSucceeded() => WriteEvent(94);
 
-        [Event(95, Level = EventLevel.Verbose, Message = "Removed the certificate from the NSS database in '{0}'.")]
-        internal void UnixNssDbUntrustSucceeded(string path) => WriteEvent(95, path);
+        [Event(95, Level = EventLevel.Warning, Message = "Failed to remove the certificate from the NSS database in '{0}'.")]
+        internal void UnixNssDbUntrustFailed(string path) => WriteEvent(95, path);
 
-        [Event(96, Level = EventLevel.Warning, Message = "The certificate is only partially trusted - some clients will not accept it.")]
-        internal void UnixTrustPartiallySucceeded() => WriteEvent(96);
+        [Event(96, Level = EventLevel.Verbose, Message = "Removed the certificate from the NSS database in '{0}'.")]
+        internal void UnixNssDbUntrustSucceeded(string path) => WriteEvent(96, path);
 
-        [Event(97, Level = EventLevel.Warning, Message = "Failed to look up the certificate in the NSS database in '{0}': {1}.")]
-        internal void UnixNssDbCheckException(string path, string exceptionMessage) => WriteEvent(97, path, exceptionMessage);
+        [Event(97, Level = EventLevel.Warning, Message = "The certificate is only partially trusted - some clients will not accept it.")]
+        internal void UnixTrustPartiallySucceeded() => WriteEvent(97);
 
-        [Event(98, Level = EventLevel.Warning, Message = "Failed to add the certificate to the NSS database in '{0}': {1}.")]
-        internal void UnixNssDbAdditionException(string path, string exceptionMessage) => WriteEvent(98, path, exceptionMessage);
+        [Event(98, Level = EventLevel.Warning, Message = "Failed to look up the certificate in the NSS database in '{0}': {1}.")]
+        internal void UnixNssDbCheckException(string path, string exceptionMessage) => WriteEvent(98, path, exceptionMessage);
 
-        [Event(99, Level = EventLevel.Warning, Message = "Failed to remove the certificate from the NSS database in '{0}': {1}.")]
-        internal void UnixNssDbRemovalException(string path, string exceptionMessage) => WriteEvent(99, path, exceptionMessage);
+        [Event(99, Level = EventLevel.Warning, Message = "Failed to add the certificate to the NSS database in '{0}': {1}.")]
+        internal void UnixNssDbAdditionException(string path, string exceptionMessage) => WriteEvent(99, path, exceptionMessage);
 
-        [Event(100, Level = EventLevel.Warning, Message = "Failed to find the Firefox profiles in directory '{0}': {1}.")]
-        internal void UnixFirefoxProfileEnumerationException(string firefoxDirectory, string message) => WriteEvent(100, firefoxDirectory, message);
+        [Event(100, Level = EventLevel.Warning, Message = "Failed to remove the certificate from the NSS database in '{0}': {1}.")]
+        internal void UnixNssDbRemovalException(string path, string exceptionMessage) => WriteEvent(100, path, exceptionMessage);
 
-        [Event(101, Level = EventLevel.Verbose, Message = "No Firefox profiles found in directory '{0}'.")]
-        internal void UnixNoFirefoxProfilesFound(string firefoxDirectory) => WriteEvent(101, firefoxDirectory);
+        [Event(101, Level = EventLevel.Warning, Message = "Failed to find the Firefox profiles in directory '{0}': {1}.")]
+        internal void UnixFirefoxProfileEnumerationException(string firefoxDirectory, string message) => WriteEvent(101, firefoxDirectory, message);
 
-        [Event(102, Level = EventLevel.Warning, Message = "Failed to trust the certificate in the NSS database in '{0}'. This will likely affect the {1} family of browsers. " +
+        [Event(102, Level = EventLevel.Verbose, Message = "No Firefox profiles found in directory '{0}'.")]
+        internal void UnixNoFirefoxProfilesFound(string firefoxDirectory) => WriteEvent(102, firefoxDirectory);
+
+        [Event(103, Level = EventLevel.Warning, Message = "Failed to trust the certificate in the NSS database in '{0}'. This will likely affect the {1} family of browsers. " +
             "This likely indicates that the database already contains an entry for the certificate under a different name. Please remove it and try again.")]
-        internal void UnixNssDbTrustFailedWithProbableConflict(string path, string browser) => WriteEvent(102, path, browser);
+        internal void UnixNssDbTrustFailedWithProbableConflict(string path, string browser) => WriteEvent(103, path, browser);
 
         // This may be annoying, since anyone setting the variable for un/trust will likely leave it set for --check.
         // However, it seems important to warn users who set it specifically for --check.
-        [Event(103, Level = EventLevel.Warning, Message = "The {0} environment variable is set but will not be consumed while checking trust.")]
-        internal void UnixOpenSslCertificateDirectoryOverrideIgnored(string openSslCertDirectoryOverrideVariableName) => WriteEvent(103, openSslCertDirectoryOverrideVariableName);
+        [Event(104, Level = EventLevel.Warning, Message = "The {0} environment variable is set but will not be consumed while checking trust.")]
+        internal void UnixOpenSslCertificateDirectoryOverrideIgnored(string openSslCertDirectoryOverrideVariableName) => WriteEvent(104, openSslCertDirectoryOverrideVariableName);
 
-        [Event(104, Level = EventLevel.Warning, Message = "The {0} command is unavailable.  It is required for updating certificate trust in OpenSSL.")]
-        internal void UnixMissingOpenSslCommand(string openSslCommand) => WriteEvent(104, openSslCommand);
+        [Event(105, Level = EventLevel.Warning, Message = "The {0} command is unavailable.  It is required for updating certificate trust in OpenSSL.")]
+        internal void UnixMissingOpenSslCommand(string openSslCommand) => WriteEvent(105, openSslCommand);
 
-        [Event(105, Level = EventLevel.Warning, Message = "The {0} command is unavailable.  It is required for querying and updating NSS databases, which are chiefly used to trust certificates in browsers.")]
-        internal void UnixMissingCertUtilCommand(string certUtilCommand) => WriteEvent(105, certUtilCommand);
+        [Event(106, Level = EventLevel.Warning, Message = "The {0} command is unavailable.  It is required for querying and updating NSS databases, which are chiefly used to trust certificates in browsers.")]
+        internal void UnixMissingCertUtilCommand(string certUtilCommand) => WriteEvent(106, certUtilCommand);
 
-        [Event(106, Level = EventLevel.Verbose, Message = "Untrusting the certificate in OpenSSL was skipped since '{0}' does not exist.")]
-        internal void UnixOpenSslUntrustSkipped(string certPath) => WriteEvent(106, certPath);
+        [Event(107, Level = EventLevel.Verbose, Message = "Untrusting the certificate in OpenSSL was skipped since '{0}' does not exist.")]
+        internal void UnixOpenSslUntrustSkipped(string certPath) => WriteEvent(107, certPath);
 
-        [Event(107, Level = EventLevel.Warning, Message = "Failed to delete certificate file '{0}': {1}.")]
-        internal void UnixCertificateFileDeletionException(string certPath, string exceptionMessage) => WriteEvent(107, certPath, exceptionMessage);
+        [Event(108, Level = EventLevel.Warning, Message = "Failed to delete certificate file '{0}': {1}.")]
+        internal void UnixCertificateFileDeletionException(string certPath, string exceptionMessage) => WriteEvent(108, certPath, exceptionMessage);
 
-        [Event(108, Level = EventLevel.Error, Message = "Unable to export the certificate since '{0}' already exists. Please remove it.")]
-        internal void UnixNotOverwritingCertificate(string certPath) => WriteEvent(108, certPath);
-
-        [Event(109, Level = EventLevel.LogAlways, Message = "For OpenSSL trust to take effect, '{0}' must be listed in the {2} environment variable. " +
-            "For example, `export SSL_CERT_DIR={0}:{1}`. " +
-            "See https://aka.ms/dev-certs-trust for more information.")]
-        internal void UnixSuggestSettingEnvironmentVariable(string certDir, string openSslDir, string envVarName) => WriteEvent(109, certDir, openSslDir, envVarName);
+        [Event(109, Level = EventLevel.Error, Message = "Unable to export the certificate since '{0}' already exists. Please remove it.")]
+        internal void UnixNotOverwritingCertificate(string certPath) => WriteEvent(109, certPath);
 
         [Event(110, Level = EventLevel.LogAlways, Message = "For OpenSSL trust to take effect, '{0}' must be listed in the {2} environment variable. " +
+            "For example, `export SSL_CERT_DIR={0}:{1}`. " +
             "See https://aka.ms/dev-certs-trust for more information.")]
-        internal void UnixSuggestSettingEnvironmentVariableWithoutExample(string certDir, string envVarName) => WriteEvent(110, certDir, envVarName);
+        internal void UnixSuggestSettingEnvironmentVariable(string certDir, string openSslDir, string envVarName) => WriteEvent(110, certDir, openSslDir, envVarName);
+
+        [Event(111, Level = EventLevel.LogAlways, Message = "For OpenSSL trust to take effect, '{0}' must be listed in the {2} environment variable. " +
+            "See https://aka.ms/dev-certs-trust for more information.")]
+        internal void UnixSuggestSettingEnvironmentVariableWithoutExample(string certDir, string envVarName) => WriteEvent(111, certDir, envVarName);
     }
 
     internal sealed class UserCancelledTrustException : Exception

--- a/src/Shared/CertificateGeneration/CertificateManager.cs
+++ b/src/Shared/CertificateGeneration/CertificateManager.cs
@@ -182,8 +182,8 @@ internal abstract class CertificateManager
         var result = EnsureCertificateResult.Succeeded;
 
         var currentUserCertificates = ListCertificates(StoreName.My, StoreLocation.CurrentUser, isValid: true, requireExportable: true);
-        var trustedCertificates = ListCertificates(StoreName.My, StoreLocation.LocalMachine, isValid: true, requireExportable: true);
-        var certificates = currentUserCertificates.Concat(trustedCertificates);
+        var localMachineCertificates = ListCertificates(StoreName.My, StoreLocation.LocalMachine, isValid: true, requireExportable: true);
+        var certificates = currentUserCertificates.Concat(localMachineCertificates);
 
         var filteredCertificates = certificates.Where(c => c.Subject == Subject);
 

--- a/src/Shared/CertificateGeneration/CertificateManager.cs
+++ b/src/Shared/CertificateGeneration/CertificateManager.cs
@@ -1090,11 +1090,11 @@ internal abstract class CertificateManager
         [Event(74, Level = EventLevel.Warning, Message = "The NSS database '{0}' provided via {1} does not exist.")]
         internal void UnixNssDbDoesNotExist(string nssDb, string environmentVariable) => WriteEvent(74, nssDb, environmentVariable);
 
-        [Event(75, Level = EventLevel.Warning, Message = "The certificate is not trusted by OpenSSL. This will likely affect System.Net.Http.HttpClient.")]
-        internal void UnixNotTrustedByOpenSsl() => WriteEvent(75);
+        [Event(75, Level = EventLevel.Warning, Message = "The certificate is not trusted by .NET. This will likely affect System.Net.Http.HttpClient.")]
+        internal void UnixNotTrustedByDotnet() => WriteEvent(75);
 
-        [Event(76, Level = EventLevel.Warning, Message = "The certificate is not trusted by OpenSSL.  Ensure that the {0} environment variable is set correctly. This will likely affect System.Net.Http.HttpClient.")]
-        internal void UnixNotTrustedByOpenSslVariableUnset(string envVarName) => WriteEvent(76, envVarName);
+        [Event(76, Level = EventLevel.Warning, Message = "The certificate is not trusted by OpenSSL.  Ensure that the {0} environment variable is set correctly.")]
+        internal void UnixNotTrustedByOpenSsl(string envVarName) => WriteEvent(76, envVarName);
 
         [Event(77, Level = EventLevel.Warning, Message = "The certificate is not trusted in the NSS database in '{0}'. This will likely affect the {1} family of browsers.")]
         internal void UnixNotTrustedByNss(string path, string browser) => WriteEvent(77, path, browser);
@@ -1132,80 +1132,86 @@ internal abstract class CertificateManager
             "Manually rehashing may help. See https://aka.ms/dev-certs-trust for more information.")] // This should recommend manually running c_rehash.
         internal void UnixOpenSslRehashException(string exceptionMessage) => WriteEvent(85, exceptionMessage);
 
-        [Event(86, Level = EventLevel.Warning, Message = "Clients that validate certificate trust using OpenSSL, including System.Net.Http.HttpClient, will not trust the certificate.")]
-        internal void UnixOpenSslTrustFailed() => WriteEvent(86);
+        [Event(86, Level = EventLevel.Warning, Message = "Failed to trust the certificate in .NET: {0}.")]
+        internal void UnixDotnetTrustException(string exceptionMessage) => WriteEvent(86, exceptionMessage);
 
-        [Event(87, Level = EventLevel.Verbose, Message = "Trusted the certificate in OpenSSL.")]
-        internal void UnixOpenSslTrustSucceeded() => WriteEvent(87);
+        [Event(87, Level = EventLevel.Warning, Message = "Clients that validate certificate trust using OpenSSL will not trust the certificate.")]
+        internal void UnixOpenSslTrustFailed() => WriteEvent(87);
 
-        [Event(88, Level = EventLevel.Warning, Message = "Failed to trust the certificate in the NSS database in '{0}'. This will likely affect the {1} family of browsers.")]
-        internal void UnixNssDbTrustFailed(string path, string browser) => WriteEvent(88, path, browser);
+        [Event(88, Level = EventLevel.Verbose, Message = "Trusted the certificate in OpenSSL.")]
+        internal void UnixOpenSslTrustSucceeded() => WriteEvent(88);
 
-        [Event(89, Level = EventLevel.Verbose, Message = "Trusted the certificate in the NSS database in '{0}'.")]
-        internal void UnixNssDbTrustSucceeded(string path) => WriteEvent(89, path);
+        [Event(89, Level = EventLevel.Warning, Message = "Failed to trust the certificate in the NSS database in '{0}'. This will likely affect the {1} family of browsers.")]
+        internal void UnixNssDbTrustFailed(string path, string browser) => WriteEvent(89, path, browser);
 
-        [Event(90, Level = EventLevel.Warning, Message = "Failed to untrust the certificate in OpenSSL.")]
-        internal void UnixOpenSslUntrustFailed() => WriteEvent(90);
+        [Event(90, Level = EventLevel.Verbose, Message = "Trusted the certificate in the NSS database in '{0}'.")]
+        internal void UnixNssDbTrustSucceeded(string path) => WriteEvent(90, path);
 
-        [Event(91, Level = EventLevel.Verbose, Message = "Untrusted the certificate in OpenSSL.")]
-        internal void UnixOpenSslUntrustSucceeded() => WriteEvent(91);
+        [Event(91, Level = EventLevel.Warning, Message = "Failed to untrust the certificate in .NET: {0}.")]
+        internal void UnixDotnetUntrustException(string exceptionMessage) => WriteEvent(91, exceptionMessage);
 
-        [Event(92, Level = EventLevel.Warning, Message = "Failed to remove the certificate from the NSS database in '{0}'.")]
-        internal void UnixNssDbUntrustFailed(string path) => WriteEvent(92, path);
+        [Event(92, Level = EventLevel.Warning, Message = "Failed to untrust the certificate in OpenSSL.")]
+        internal void UnixOpenSslUntrustFailed() => WriteEvent(92);
 
-        [Event(93, Level = EventLevel.Verbose, Message = "Removed the certificate from the NSS database in '{0}'.")]
-        internal void UnixNssDbUntrustSucceeded(string path) => WriteEvent(93, path);
+        [Event(93, Level = EventLevel.Verbose, Message = "Untrusted the certificate in OpenSSL.")]
+        internal void UnixOpenSslUntrustSucceeded() => WriteEvent(93);
 
-        [Event(94, Level = EventLevel.Warning, Message = "The certificate is only partially trusted - some clients will not accept it.")]
-        internal void UnixTrustPartiallySucceeded() => WriteEvent(94);
+        [Event(94, Level = EventLevel.Warning, Message = "Failed to remove the certificate from the NSS database in '{0}'.")]
+        internal void UnixNssDbUntrustFailed(string path) => WriteEvent(94, path);
 
-        [Event(95, Level = EventLevel.Warning, Message = "Failed to look up the certificate in the NSS database in '{0}': {1}.")]
-        internal void UnixNssDbCheckException(string path, string exceptionMessage) => WriteEvent(95, path, exceptionMessage);
+        [Event(95, Level = EventLevel.Verbose, Message = "Removed the certificate from the NSS database in '{0}'.")]
+        internal void UnixNssDbUntrustSucceeded(string path) => WriteEvent(95, path);
 
-        [Event(96, Level = EventLevel.Warning, Message = "Failed to add the certificate to the NSS database in '{0}': {1}.")]
-        internal void UnixNssDbAdditionException(string path, string exceptionMessage) => WriteEvent(96, path, exceptionMessage);
+        [Event(96, Level = EventLevel.Warning, Message = "The certificate is only partially trusted - some clients will not accept it.")]
+        internal void UnixTrustPartiallySucceeded() => WriteEvent(96);
 
-        [Event(97, Level = EventLevel.Warning, Message = "Failed to remove the certificate from the NSS database in '{0}': {1}.")]
-        internal void UnixNssDbRemovalException(string path, string exceptionMessage) => WriteEvent(97, path, exceptionMessage);
+        [Event(97, Level = EventLevel.Warning, Message = "Failed to look up the certificate in the NSS database in '{0}': {1}.")]
+        internal void UnixNssDbCheckException(string path, string exceptionMessage) => WriteEvent(97, path, exceptionMessage);
 
-        [Event(98, Level = EventLevel.Warning, Message = "Failed to find the Firefox profiles in directory '{0}': {1}.")]
-        internal void UnixFirefoxProfileEnumerationException(string firefoxDirectory, string message) => WriteEvent(98, firefoxDirectory, message);
+        [Event(98, Level = EventLevel.Warning, Message = "Failed to add the certificate to the NSS database in '{0}': {1}.")]
+        internal void UnixNssDbAdditionException(string path, string exceptionMessage) => WriteEvent(98, path, exceptionMessage);
 
-        [Event(99, Level = EventLevel.Verbose, Message = "No Firefox profiles found in directory '{0}'.")]
-        internal void UnixNoFirefoxProfilesFound(string firefoxDirectory) => WriteEvent(99, firefoxDirectory);
+        [Event(99, Level = EventLevel.Warning, Message = "Failed to remove the certificate from the NSS database in '{0}': {1}.")]
+        internal void UnixNssDbRemovalException(string path, string exceptionMessage) => WriteEvent(99, path, exceptionMessage);
 
-        [Event(100, Level = EventLevel.Warning, Message = "Failed to trust the certificate in the NSS database in '{0}'. This will likely affect the {1} family of browsers. " +
+        [Event(100, Level = EventLevel.Warning, Message = "Failed to find the Firefox profiles in directory '{0}': {1}.")]
+        internal void UnixFirefoxProfileEnumerationException(string firefoxDirectory, string message) => WriteEvent(100, firefoxDirectory, message);
+
+        [Event(101, Level = EventLevel.Verbose, Message = "No Firefox profiles found in directory '{0}'.")]
+        internal void UnixNoFirefoxProfilesFound(string firefoxDirectory) => WriteEvent(101, firefoxDirectory);
+
+        [Event(102, Level = EventLevel.Warning, Message = "Failed to trust the certificate in the NSS database in '{0}'. This will likely affect the {1} family of browsers. " +
             "This likely indicates that the database already contains an entry for the certificate under a different name. Please remove it and try again.")]
-        internal void UnixNssDbTrustFailedWithProbableConflict(string path, string browser) => WriteEvent(100, path, browser);
+        internal void UnixNssDbTrustFailedWithProbableConflict(string path, string browser) => WriteEvent(102, path, browser);
 
         // This may be annoying, since anyone setting the variable for un/trust will likely leave it set for --check.
         // However, it seems important to warn users who set it specifically for --check.
-        [Event(101, Level = EventLevel.Warning, Message = "The {0} environment variable is set but will not be consumed while checking trust.")]
-        internal void UnixOpenSslCertificateDirectoryOverrideIgnored(string openSslCertDirectoryOverrideVariableName) => WriteEvent(101, openSslCertDirectoryOverrideVariableName);
+        [Event(103, Level = EventLevel.Warning, Message = "The {0} environment variable is set but will not be consumed while checking trust.")]
+        internal void UnixOpenSslCertificateDirectoryOverrideIgnored(string openSslCertDirectoryOverrideVariableName) => WriteEvent(103, openSslCertDirectoryOverrideVariableName);
 
-        [Event(102, Level = EventLevel.Warning, Message = "The {0} command is unavailable.  It is required for updating certificate trust in OpenSSL, which is used by System.Net.Http.HttpClient.")]
-        internal void UnixMissingOpenSslCommand(string openSslCommand) => WriteEvent(102, openSslCommand);
+        [Event(104, Level = EventLevel.Warning, Message = "The {0} command is unavailable.  It is required for updating certificate trust in OpenSSL.")]
+        internal void UnixMissingOpenSslCommand(string openSslCommand) => WriteEvent(104, openSslCommand);
 
-        [Event(103, Level = EventLevel.Warning, Message = "The {0} command is unavailable.  It is required for querying and updating NSS databases, which are chiefly used to trust certificates in browsers.")]
-        internal void UnixMissingCertUtilCommand(string certUtilCommand) => WriteEvent(103, certUtilCommand);
+        [Event(105, Level = EventLevel.Warning, Message = "The {0} command is unavailable.  It is required for querying and updating NSS databases, which are chiefly used to trust certificates in browsers.")]
+        internal void UnixMissingCertUtilCommand(string certUtilCommand) => WriteEvent(105, certUtilCommand);
 
-        [Event(104, Level = EventLevel.Verbose, Message = "Untrusting the certificate in OpenSSL was skipped since '{0}' does not exist.")]
-        internal void UnixOpenSslUntrustSkipped(string certPath) => WriteEvent(104, certPath);
+        [Event(106, Level = EventLevel.Verbose, Message = "Untrusting the certificate in OpenSSL was skipped since '{0}' does not exist.")]
+        internal void UnixOpenSslUntrustSkipped(string certPath) => WriteEvent(106, certPath);
 
-        [Event(105, Level = EventLevel.Warning, Message = "Failed to delete certificate file '{0}': {1}.")]
-        internal void UnixCertificateFileDeletionException(string certPath, string exceptionMessage) => WriteEvent(105, certPath, exceptionMessage);
+        [Event(107, Level = EventLevel.Warning, Message = "Failed to delete certificate file '{0}': {1}.")]
+        internal void UnixCertificateFileDeletionException(string certPath, string exceptionMessage) => WriteEvent(107, certPath, exceptionMessage);
 
-        [Event(106, Level = EventLevel.Error, Message = "Unable to export the certificate since '{0}' already exists. Please remove it.")]
-        internal void UnixCertificateAlreadyExists(string certPath) => WriteEvent(106, certPath);
+        [Event(108, Level = EventLevel.Error, Message = "Unable to export the certificate since '{0}' already exists. Please remove it.")]
+        internal void UnixNotOverwritingCertificate(string certPath) => WriteEvent(108, certPath);
 
-        [Event(107, Level = EventLevel.LogAlways, Message = "For OpenSSL trust to take effect, '{0}' must be listed in the {2} environment variable. " +
+        [Event(109, Level = EventLevel.LogAlways, Message = "For OpenSSL trust to take effect, '{0}' must be listed in the {2} environment variable. " +
             "For example, `export SSL_CERT_DIR={0}:{1}`. " +
             "See https://aka.ms/dev-certs-trust for more information.")]
-        internal void UnixSuggestSettingEnvironmentVariable(string certDir, string openSslDir, string envVarName) => WriteEvent(107, certDir, openSslDir, envVarName);
+        internal void UnixSuggestSettingEnvironmentVariable(string certDir, string openSslDir, string envVarName) => WriteEvent(109, certDir, openSslDir, envVarName);
 
-        [Event(108, Level = EventLevel.LogAlways, Message = "For OpenSSL trust to take effect, '{0}' must be listed in the {2} environment variable. " +
+        [Event(110, Level = EventLevel.LogAlways, Message = "For OpenSSL trust to take effect, '{0}' must be listed in the {2} environment variable. " +
             "See https://aka.ms/dev-certs-trust for more information.")]
-        internal void UnixSuggestSettingEnvironmentVariableWithoutExample(string certDir, string envVarName) => WriteEvent(108, certDir, envVarName);
+        internal void UnixSuggestSettingEnvironmentVariableWithoutExample(string certDir, string envVarName) => WriteEvent(110, certDir, envVarName);
     }
 
     internal sealed class UserCancelledTrustException : Exception

--- a/src/Shared/CertificateGeneration/CertificateManager.cs
+++ b/src/Shared/CertificateGeneration/CertificateManager.cs
@@ -782,7 +782,7 @@ internal abstract class CertificateManager
         }
     }
 
-    protected virtual void RemoveCertificateFromUserStore(X509Certificate2 certificate)
+    protected void RemoveCertificateFromUserStore(X509Certificate2 certificate)
     {
         try
         {

--- a/src/Shared/CertificateGeneration/CertificateManager.cs
+++ b/src/Shared/CertificateGeneration/CertificateManager.cs
@@ -1195,14 +1195,17 @@ internal abstract class CertificateManager
         [Event(105, Level = EventLevel.Warning, Message = "Failed to delete certificate file '{0}': {1}.")]
         internal void UnixCertificateFileDeletionException(string certPath, string exceptionMessage) => WriteEvent(105, certPath, exceptionMessage);
 
-        [Event(106, Level = EventLevel.LogAlways, Message = "For OpenSSL trust to take effect, '{0}' must be listed in the {2} environment variable. " +
-            "For example, `export SSL_CERT_DIR={0}:{1}`. " +
-            "See https://aka.ms/dev-certs-trust for more information.")]
-        internal void UnixSuggestSettingEnvironmentVariable(string certDir, string openSslDir, string envVarName) => WriteEvent(106, certDir, openSslDir, envVarName);
+        [Event(106, Level = EventLevel.Error, Message = "Unable to export the certificate since '{0}' already exists. Please remove it.")]
+        internal void UnixCertificateAlreadyExists(string certPath) => WriteEvent(106, certPath);
 
         [Event(107, Level = EventLevel.LogAlways, Message = "For OpenSSL trust to take effect, '{0}' must be listed in the {2} environment variable. " +
+            "For example, `export SSL_CERT_DIR={0}:{1}`. " +
             "See https://aka.ms/dev-certs-trust for more information.")]
-        internal void UnixSuggestSettingEnvironmentVariableWithoutExample(string certDir, string envVarName) => WriteEvent(107, certDir, envVarName);
+        internal void UnixSuggestSettingEnvironmentVariable(string certDir, string openSslDir, string envVarName) => WriteEvent(107, certDir, openSslDir, envVarName);
+
+        [Event(108, Level = EventLevel.LogAlways, Message = "For OpenSSL trust to take effect, '{0}' must be listed in the {2} environment variable. " +
+            "See https://aka.ms/dev-certs-trust for more information.")]
+        internal void UnixSuggestSettingEnvironmentVariableWithoutExample(string certDir, string envVarName) => WriteEvent(108, certDir, envVarName);
     }
 
     internal sealed class UserCancelledTrustException : Exception

--- a/src/Shared/CertificateGeneration/EnsureCertificateResult.cs
+++ b/src/Shared/CertificateGeneration/EnsureCertificateResult.cs
@@ -11,6 +11,7 @@ internal enum EnsureCertificateResult
     ErrorSavingTheCertificateIntoTheCurrentUserPersonalStore,
     ErrorExportingTheCertificate,
     FailedToTrustTheCertificate,
+    PartiallyFailedToTrustTheCertificate,
     UserCancelledTrustStep,
     FailedToMakeKeyAccessible,
     ExistingHttpsCertificateTrusted,

--- a/src/Shared/CertificateGeneration/MacOSCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/MacOSCertificateManager.cs
@@ -71,11 +71,6 @@ internal sealed class MacOSCertificateManager : CertificateManager
         "and create a new untrusted developer certificate. " +
         "Use 'dotnet dev-certs https --trust' to trust the new certificate.";
 
-    public const string KeyNotAccessibleWithoutUserInteraction =
-        "The application is trying to access the ASP.NET Core developer certificate key. " +
-        "A prompt might appear to ask for permission to access the key. " +
-        "When that happens, select 'Always Allow' to grant 'dotnet' access to the certificate key in the future.";
-
     public MacOSCertificateManager()
     {
     }
@@ -128,7 +123,7 @@ internal sealed class MacOSCertificateManager : CertificateManager
         }
     }
 
-    internal override CheckCertificateStateResult CheckCertificateState(X509Certificate2 candidate, bool interactive)
+    internal override CheckCertificateStateResult CheckCertificateState(X509Certificate2 candidate)
     {
         return File.Exists(GetCertificateFilePath(candidate)) ?
             new CheckCertificateStateResult(true, null) :

--- a/src/Shared/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/UnixCertificateManager.cs
@@ -196,6 +196,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
                 using var publicCertificate = X509CertificateLoader.LoadCertificate(certificate.Export(X509ContentType.Cert));
                 // FriendlyName is Windows-only, so we don't set it here.
                 store.Add(publicCertificate);
+                Log.UnixDotnetTrustSucceeded();
                 sawTrustSuccess = true;
             }
             catch (Exception ex)

--- a/src/Shared/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/UnixCertificateManager.cs
@@ -445,7 +445,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
 
     private static string GetCertificateNickname(X509Certificate2 certificate)
     {
-        return $"aspnetcore-localhost-{certificate.Thumbprint[0..6]}";
+        return $"aspnetcore-localhost-{certificate.Thumbprint}";
     }
 
     /// <remarks>

--- a/src/Shared/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/UnixCertificateManager.cs
@@ -565,7 +565,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
             return @override;
         }
 
-        return Path.Combine(homeDirectory, ".dotnet", "corefx", "cryptography", "trusted");
+        return Path.Combine(homeDirectory, ".aspnet", "dev-certs", "trust");
     }
 
     private static bool TryDeleteCertificateFile(string certPath)

--- a/src/Shared/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/UnixCertificateManager.cs
@@ -127,7 +127,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
         return certificate;
     }
 
-    internal override CheckCertificateStateResult CheckCertificateState(X509Certificate2 candidate, bool interactive)
+    internal override CheckCertificateStateResult CheckCertificateState(X509Certificate2 candidate)
     {
         // Return true as we don't perform any check.
         // This is about checking storage, not trust.

--- a/src/Shared/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/UnixCertificateManager.cs
@@ -1,14 +1,35 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
+#nullable enable
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Security.Cryptography.X509Certificates;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.AspNetCore.Certificates.Generation;
 
-internal sealed class UnixCertificateManager : CertificateManager
+internal sealed partial class UnixCertificateManager : CertificateManager
 {
+    /// <summary>The name of an environment variable consumed by OpenSSL to locate certificates.</summary>
+    private const string OpenSslCertificateDirectoryVariableName = "SSL_CERT_DIR";
+
+    private const string OpenSslCertDirectoryOverrideVariableName = "DOTNET_DEV_CERTS_OPENSSL_CERTIFICATE_DIRECTORY";
+    private const string NssDbOverrideVariableName = "DOTNET_DEV_CERTS_NSSDB_PATHS";
+    // CONSIDER: we could have a distinct variable for Mozilla NSS DBs, but detecting them from the path seems sufficient for now.
+
+    private const string BrowserFamilyChromium = "Chromium";
+    private const string BrowserFamilyFirefox = "Firefox";
+
+    private const string OpenSslCommand = "openssl";
+    private const string CertUtilCommand = "certutil";
+
+    private const int MaxHashCollisions = 10; // Something is going badly wrong if we have this many dev certs with the same hash
+
+    private HashSet<string>? _availableCommands;
+
     public UnixCertificateManager()
     {
     }
@@ -18,13 +39,75 @@ internal sealed class UnixCertificateManager : CertificateManager
     {
     }
 
-    public override bool IsTrusted(X509Certificate2 certificate)
+    public override TrustLevel GetTrustLevel(X509Certificate2 certificate)
     {
-        using X509Chain chain = new X509Chain();
+        var sawTrustSuccess = false;
+        var sawTrustFailure = false;
+
+        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(OpenSslCertDirectoryOverrideVariableName)))
+        {
+            // Warn but don't bail.
+            Log.UnixOpenSslCertificateDirectoryOverrideIgnored(OpenSslCertDirectoryOverrideVariableName);
+        }
+
+        // Building the chain will check whether openssl (which covers HttpClient) trusts the cert.
+        // An alternative approach would be to look for the file and link in the trust folder, but
+        // this tests the real-world behavior.
+        using var chain = new X509Chain();
         // This is just a heuristic for whether or not we should prompt the user to re-run with `--trust`
         // so we don't need to check revocation (which doesn't really make sense for dev certs anyway)
         chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-        return chain.Build(certificate);
+        if (chain.Build(certificate))
+        {
+            sawTrustSuccess = true;
+        }
+        else
+        {
+            sawTrustFailure = true;
+
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(OpenSslCertificateDirectoryVariableName)))
+            {
+                Log.UnixNotTrustedByOpenSslVariableUnset(OpenSslCertificateDirectoryVariableName);
+            }
+            else
+            {
+                Log.UnixNotTrustedByOpenSsl();
+            }
+        }
+
+        var nssDbs = GetNssDbs(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
+        if (nssDbs.Count > 0)
+        {
+            if (!IsCommandAvailable(CertUtilCommand))
+            {
+                // If there are browsers but we don't have certutil, we can't check trust and,
+                // in all probability, we can't have previously established it.
+                Log.UnixMissingCertUtilCommand(CertUtilCommand);
+                sawTrustFailure = true;
+            }
+            else
+            {
+                var nickname = GetCertificateNickname(certificate);
+                foreach (var nssDb in nssDbs)
+                {
+                    if (IsCertificateInNssDb(nickname, nssDb))
+                    {
+                        sawTrustSuccess = true;
+                    }
+                    else
+                    {
+                        sawTrustFailure = true;
+                        Log.UnixNotTrustedByNss(nssDb.Path, nssDb.IsFirefox ? BrowserFamilyFirefox : BrowserFamilyChromium);
+                    }
+                }
+            }
+        }
+
+        return sawTrustSuccess
+            ? sawTrustFailure
+                ? TrustLevel.Partial
+                : TrustLevel.Full
+            : TrustLevel.None;
     }
 
     protected override X509Certificate2 SaveCertificateCore(X509Certificate2 certificate, StoreName storeName, StoreLocation storeLocation)
@@ -47,26 +130,680 @@ internal sealed class UnixCertificateManager : CertificateManager
     internal override CheckCertificateStateResult CheckCertificateState(X509Certificate2 candidate, bool interactive)
     {
         // Return true as we don't perform any check.
+        // This is about checking storage, not trust.
         return new CheckCertificateStateResult(true, null);
     }
 
     internal override void CorrectCertificateState(X509Certificate2 candidate)
     {
         // Do nothing since we don't have anything to check here.
+        // This is about correcting storage, not trust.
     }
 
     protected override bool IsExportable(X509Certificate2 c) => true;
 
-    protected override void TrustCertificateCore(X509Certificate2 certificate) =>
-        throw new InvalidOperationException("Trusting the certificate is not supported on linux");
+    protected override TrustLevel TrustCertificateCore(X509Certificate2 certificate)
+    {
+        var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+        // Rather than create a temporary file we'll have to clean up, we prefer to export the dev cert
+        // to its final location in the OpenSSL directory.  As a result, any failure up until that point
+        // is fatal (i.e. we can't trust the cert in other locations).
+
+        var certDir = GetOpenSslCertificateDirectory(homeDirectory)!; // May not exist
+
+        var nickname = GetCertificateNickname(certificate);
+        var certPath = Path.Combine(certDir, nickname) + ".pem";
+
+        // Security: we don't need the private key for trust, so we don't export it.
+        // Note that this will create directories as needed.
+        ExportCertificate(certificate, certPath, includePrivateKey: false, password: null, CertificateKeyExportFormat.Pem);
+
+        // Once the certificate is on disk, we prefer not to throw - some subsequent trust step might succeed.
+
+        var sawTrustFailure = false;
+        var sawTrustSuccess = false;
+
+        var openSslTrustSucceeded = false;
+
+        var isOpenSslAvailable = IsCommandAvailable(OpenSslCommand);
+        if (isOpenSslAvailable)
+        {
+            if (TryRehashOpenSslCertificates(certDir))
+            {
+                openSslTrustSucceeded = true;
+            }
+        }
+        else
+        {
+            Log.UnixMissingOpenSslCommand(OpenSslCommand);
+        }
+
+        if (openSslTrustSucceeded)
+        {
+            Log.UnixOpenSslTrustSucceeded();
+            sawTrustSuccess = true;
+        }
+        else
+        {
+            // The helpers log their own failure reasons - we just describe the consequences
+            Log.UnixOpenSslTrustFailed();
+            sawTrustFailure = true;
+        }
+
+        var nssDbs = GetNssDbs(homeDirectory);
+        if (nssDbs.Count > 0)
+        {
+            var isCertUtilAvailable = IsCommandAvailable(CertUtilCommand);
+            if (!isCertUtilAvailable)
+            {
+                Log.UnixMissingCertUtilCommand(CertUtilCommand);
+                // We'll loop over the nssdbs anyway so they'll be listed
+            }
+
+            foreach (var nssDb in nssDbs)
+            {
+                if (isCertUtilAvailable && TryAddCertificateToNssDb(certPath, nickname, nssDb))
+                {
+                    if (IsCertificateInNssDb(nickname, nssDb))
+                    {
+                        Log.UnixNssDbTrustSucceeded(nssDb.Path);
+                        sawTrustSuccess = true;
+                    }
+                    else
+                    {
+                        // If the dev cert is in the db under a different nickname, adding it will succeed (and probably even cause it to be trusted)
+                        // but IsTrusted won't find it.  This is unlikely to happen in practice, so we warn here, rather than hardening IsTrusted.
+                        Log.UnixNssDbTrustFailedWithProbableConflict(nssDb.Path, nssDb.IsFirefox ? BrowserFamilyFirefox : BrowserFamilyChromium);
+                        sawTrustFailure = true;
+                    }
+                }
+                else
+                {
+                    Log.UnixNssDbTrustFailed(nssDb.Path, nssDb.IsFirefox ? BrowserFamilyFirefox : BrowserFamilyChromium);
+                    sawTrustFailure = true;
+                }
+            }
+        }
+
+        if (sawTrustFailure)
+        {
+            if (sawTrustSuccess)
+            {
+                // Untrust throws in this case, but we're more lenient since a partially trusted state may be useful in practice.
+                Log.UnixTrustPartiallySucceeded();
+            }
+            else
+            {
+                return TrustLevel.None;
+            }
+        }
+
+        if (openSslTrustSucceeded)
+        {
+            Debug.Assert(IsCommandAvailable(OpenSslCommand), "How did we trust without the openssl command?");
+
+            var homeDirectoryWithSlash = homeDirectory[^1] == Path.DirectorySeparatorChar
+                ? homeDirectory
+                : homeDirectory + Path.DirectorySeparatorChar;
+
+            var prettyCertDir = certDir.StartsWith(homeDirectoryWithSlash, StringComparison.Ordinal)
+                ? Path.Combine("$HOME", certDir[homeDirectoryWithSlash.Length..])
+                : certDir;
+
+            if (TryGetOpenSslDirectory(out var openSslDir))
+            {
+                Log.UnixSuggestSettingEnvironmentVariable(prettyCertDir, Path.Combine(openSslDir, "certs"), OpenSslCertificateDirectoryVariableName);
+            }
+            else
+            {
+                Log.UnixSuggestSettingEnvironmentVariableWithoutExample(prettyCertDir, OpenSslCertificateDirectoryVariableName);
+            }
+        }
+
+        return sawTrustFailure
+            ? TrustLevel.Partial
+            : TrustLevel.Full;
+    }
 
     protected override void RemoveCertificateFromTrustedRoots(X509Certificate2 certificate)
     {
-        // No-op here as is benign
+        var sawUntrustFailure = false;
+
+        var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)!;
+
+        // We don't attempt to clean this up when it's empty - it's a standard location
+        // and will almost certainly be used in the future.
+        var certDir = GetOpenSslCertificateDirectory(homeDirectory); // May not exist
+
+        var nickname = GetCertificateNickname(certificate);
+        var certPath = Path.Combine(certDir, nickname) + ".pem";
+
+        if (File.Exists(certPath))
+        {
+            var openSslUntrustSucceeded = false;
+
+            if (IsCommandAvailable(OpenSslCommand))
+            {
+                if (TryDeleteCertificateFile(certPath) && TryRehashOpenSslCertificates(certDir))
+                {
+                    openSslUntrustSucceeded = true;
+                }
+            }
+            else
+            {
+                Log.UnixMissingOpenSslCommand(OpenSslCommand);
+            }
+
+            if (openSslUntrustSucceeded)
+            {
+                Log.UnixOpenSslUntrustSucceeded();
+            }
+            else
+            {
+                // The helpers log their own failure reasons - we just describe the consequences
+                Log.UnixOpenSslUntrustFailed();
+                sawUntrustFailure = true;
+            }
+        }
+        else
+        {
+            Log.UnixOpenSslUntrustSkipped(certPath);
+        }
+
+        var nssDbs = GetNssDbs(homeDirectory);
+        if (nssDbs.Count > 0)
+        {
+            var isCertUtilAvailable = IsCommandAvailable(CertUtilCommand);
+            if (!isCertUtilAvailable)
+            {
+                Log.UnixMissingCertUtilCommand(CertUtilCommand);
+                // We'll loop over the nssdbs anyway so they'll be listed
+            }
+
+            foreach (var nssDb in nssDbs)
+            {
+                if (isCertUtilAvailable && TryRemoveCertificateFromNssDb(nickname, nssDb))
+                {
+                    Log.UnixNssDbUntrustSucceeded(nssDb.Path);
+                }
+                else
+                {
+                    Log.UnixNssDbUntrustFailed(nssDb.Path);
+                    sawUntrustFailure = true;
+                }
+            }
+        }
+
+        if (sawUntrustFailure)
+        {
+            // It might be nice to include more specific error information in the exception message, but we've logged it anyway.
+            throw new InvalidOperationException($@"There was an error removing the certificate with thumbprint '{certificate.Thumbprint}'.");
+        }
     }
 
     protected override IList<X509Certificate2> GetCertificatesToRemove(StoreName storeName, StoreLocation storeLocation)
     {
         return ListCertificates(StoreName.My, StoreLocation.CurrentUser, isValid: false, requireExportable: false);
+    }
+
+    private static string GetChromiumNssDb(string homeDirectory)
+    {
+        return Path.Combine(homeDirectory, ".pki", "nssdb");
+    }
+
+    private static string GetFirefoxDirectory(string homeDirectory)
+    {
+        return Path.Combine(homeDirectory, ".mozilla", "firefox");
+    }
+
+    private static string GetFirefoxSnapDirectory(string homeDirectory)
+    {
+        return Path.Combine(homeDirectory, "snap", "firefox", "common", ".mozilla", "firefox");
+    }
+
+    private bool IsCommandAvailable(string command)
+    {
+        _availableCommands ??= FindAvailableCommands();
+        return _availableCommands.Contains(command);
+    }
+
+    private static HashSet<string> FindAvailableCommands()
+    {
+        var availableCommands = new HashSet<string>();
+
+        // We need OpenSSL 1.1.1h or newer (to pick up https://github.com/openssl/openssl/pull/12357),
+        // but, given that all of v1 is EOL, it doesn't seem worthwhile to check the version.
+        var commands = new[] { OpenSslCommand, CertUtilCommand };
+
+        var searchPath = Environment.GetEnvironmentVariable("PATH");
+
+        if (searchPath is null)
+        {
+            return availableCommands;
+        }
+
+        var searchFolders = searchPath.Split(Path.PathSeparator);
+
+        foreach (var searchFolder in searchFolders)
+        {
+            foreach (var command in commands)
+            {
+                if (!availableCommands.Contains(command))
+                {
+                    try
+                    {
+                        if (File.Exists(Path.Combine(searchFolder, command)))
+                        {
+                            availableCommands.Add(command);
+                        }
+                    }
+                    catch
+                    {
+                        // It's not interesting to report (e.g.) permission errors here.
+                    }
+                }
+            }
+
+            // Stop early if we've found all the required commands.
+            // They're usually all in the same folder (/bin or /usr/bin).
+            if (availableCommands.Count == commands.Length)
+            {
+                break;
+            }
+        }
+
+        return availableCommands;
+    }
+
+    private static string GetCertificateNickname(X509Certificate2 certificate)
+    {
+        return $"aspnetcore-localhost-{certificate.Thumbprint[0..6]}";
+    }
+
+    /// <remarks>
+    /// It is the caller's responsibility to ensure that <see cref="CertUtilCommand"/> is available.
+    /// </remarks>
+    private static bool IsCertificateInNssDb(string nickname, NssDb nssDb)
+    {
+        // -V will validate that a cert can be used for a given purpose, in this case, server verification.
+        // There is no corresponding -V check for the "Trusted CA" status required by Firefox, so we just check for existence.
+        // (The docs suggest that "-V -u A" should do this, but it seems to accept all certs.)
+        var operation = nssDb.IsFirefox ? "-L" : "-V -u V";
+
+        var startInfo = new ProcessStartInfo(CertUtilCommand, $"-d sql:{nssDb.Path} -n {nickname} {operation}")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        try
+        {
+            using var process = Process.Start(startInfo)!;
+            process.WaitForExit();
+            return process.ExitCode == 0;
+        }
+        catch (Exception ex)
+        {
+            Log.UnixNssDbCheckException(nssDb.Path, ex.Message);
+            // This method is used to determine whether more trust is needed, so it's better to underestimate the amount of trust.
+            return false;
+        }
+    }
+
+    /// <remarks>
+    /// It is the caller's responsibility to ensure that <see cref="CertUtilCommand"/> is available.
+    /// </remarks>
+    private static bool TryAddCertificateToNssDb(string certificatePath, string nickname, NssDb nssDb)
+    {
+        // Firefox doesn't seem to respected the more correct "trusted peer" (P) usage, so we use "trusted CA" (C) instead.
+        var usage = nssDb.IsFirefox ? "C" : "P";
+
+        // This silently clobbers an existing entry, so there's no need to check for existence first.
+        var startInfo = new ProcessStartInfo(CertUtilCommand, $"-d sql:{nssDb.Path} -n {nickname} -A -i {certificatePath} -t \"{usage},,\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        try
+        {
+            using var process = Process.Start(startInfo)!;
+            process.WaitForExit();
+            return process.ExitCode == 0;
+        }
+        catch (Exception ex)
+        {
+            Log.UnixNssDbAdditionException(nssDb.Path, ex.Message);
+            return false;
+        }
+    }
+
+    /// <remarks>
+    /// It is the caller's responsibility to ensure that <see cref="CertUtilCommand"/> is available.
+    /// </remarks>
+    private static bool TryRemoveCertificateFromNssDb(string nickname, NssDb nssDb)
+    {
+        var startInfo = new ProcessStartInfo(CertUtilCommand, $"-d sql:{nssDb.Path} -D -n {nickname}")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        try
+        {
+            using var process = Process.Start(startInfo)!;
+            process.WaitForExit();
+            if (process.ExitCode == 0)
+            {
+                return true;
+            }
+
+            // Maybe it wasn't in there because the overrides have change or trust only partially succeeded.
+            return !IsCertificateInNssDb(nickname, nssDb);
+        }
+        catch (Exception ex)
+        {
+            Log.UnixNssDbRemovalException(nssDb.Path, ex.Message);
+            return false;
+        }
+    }
+
+    private static IEnumerable<string> GetFirefoxProfiles(string firefoxDirectory)
+    {
+        try
+        {
+            var profiles = Directory.GetDirectories(firefoxDirectory, "*.default", SearchOption.TopDirectoryOnly).Concat(
+                Directory.GetDirectories(firefoxDirectory, "*.default-*", SearchOption.TopDirectoryOnly)); // There can be one of these for each release channel
+            if (!profiles.Any())
+            {
+                // This is noteworthy, given that we're in a firefox directory.
+                Log.UnixNoFirefoxProfilesFound(firefoxDirectory);
+            }
+            return profiles;
+        }
+        catch (Exception ex)
+        {
+            Log.UnixFirefoxProfileEnumerationException(firefoxDirectory, ex.Message);
+            return [];
+        }
+    }
+
+    private static string GetOpenSslCertificateDirectory(string homeDirectory)
+    {
+        var @override = Environment.GetEnvironmentVariable(OpenSslCertDirectoryOverrideVariableName);
+        if (!string.IsNullOrEmpty(@override))
+        {
+            Log.UnixOpenSslCertificateDirectoryOverridePresent(OpenSslCertDirectoryOverrideVariableName);
+            return @override;
+        }
+
+        return Path.Combine(homeDirectory, ".dotnet", "corefx", "cryptography", "trusted");
+    }
+
+    private static bool TryDeleteCertificateFile(string certPath)
+    {
+        try
+        {
+            File.Delete(certPath);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.UnixCertificateFileDeletionException(certPath, ex.Message);
+            return false;
+        }
+    }
+
+    private static bool TryGetNssDbOverrides(out IReadOnlyList<string> overrides)
+    {
+        var nssDbOverride = Environment.GetEnvironmentVariable(NssDbOverrideVariableName);
+        if (string.IsNullOrEmpty(nssDbOverride))
+        {
+            overrides = [];
+            return false;
+        }
+
+        // Normally, we'd let the caller log this, since it's not really an exceptional condition,
+        // but it's not worth duplicating the code and the work.
+        Log.UnixNssDbOverridePresent(NssDbOverrideVariableName);
+
+        var nssDbs = new List<string>();
+
+        var paths = nssDbOverride.Split(Path.PathSeparator); // May be empty - the user may not want to add browser trust
+        foreach (var path in paths)
+        {
+            var nssDb = Path.GetFullPath(path);
+            if (!Directory.Exists(nssDb))
+            {
+                Log.UnixNssDbDoesNotExist(nssDb, NssDbOverrideVariableName);
+                continue;
+            }
+            nssDbs.Add(nssDb);
+        }
+
+        overrides = nssDbs;
+        return true;
+    }
+
+    private static List<NssDb> GetNssDbs(string homeDirectory)
+    {
+        var nssDbs = new List<NssDb>();
+
+        if (TryGetNssDbOverrides(out var nssDbOverrides))
+        {
+            foreach (var nssDb in nssDbOverrides)
+            {
+                // Our Firefox approach is a hack, so we'd rather under-recognize it than over-recognize it.
+                var isFirefox = nssDb.Contains("/.mozilla/firefox/", StringComparison.Ordinal);
+                nssDbs.Add(new NssDb(nssDb, isFirefox));
+            }
+
+            return nssDbs;
+        }
+
+        if (!Directory.Exists(homeDirectory))
+        {
+            Log.UnixHomeDirectoryDoesNotExist(homeDirectory, Environment.UserName);
+            return nssDbs;
+        }
+
+        // Chrome, Chromium, Edge, and their respective snaps all use this directory
+        var chromiumNssDb = GetChromiumNssDb(homeDirectory);
+        if (Directory.Exists(chromiumNssDb))
+        {
+            nssDbs.Add(new NssDb(chromiumNssDb, isFirefox: false));
+        }
+
+        var firefoxDir = GetFirefoxDirectory(homeDirectory);
+        if (Directory.Exists(firefoxDir))
+        {
+            var profileDirs = GetFirefoxProfiles(firefoxDir);
+            foreach (var profileDir in profileDirs)
+            {
+                nssDbs.Add(new NssDb(profileDir, isFirefox: true));
+            }
+        }
+
+        var firefoxSnapDir = GetFirefoxSnapDirectory(homeDirectory);
+        if (Directory.Exists(firefoxSnapDir))
+        {
+            var profileDirs = GetFirefoxProfiles(firefoxSnapDir);
+            foreach (var profileDir in profileDirs)
+            {
+                nssDbs.Add(new NssDb(profileDir, isFirefox: true));
+            }
+        }
+
+        return nssDbs;
+    }
+
+    [GeneratedRegex("OPENSSLDIR:\\s*\"([^\"]+)\"")]
+    private static partial Regex OpenSslVersionRegex();
+
+    /// <remarks>
+    /// It is the caller's responsibility to ensure that <see cref="OpenSslCommand"/> is available.
+    /// </remarks>
+    private static bool TryGetOpenSslDirectory([NotNullWhen(true)] out string? openSslDir)
+    {
+        openSslDir = null;
+
+        try
+        {
+            var processInfo = new ProcessStartInfo(OpenSslCommand, $"version -d")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+
+            using var process = Process.Start(processInfo);
+            var stdout = process!.StandardOutput.ReadToEnd();
+
+            process.WaitForExit();
+            if (process.ExitCode != 0)
+            {
+                Log.UnixOpenSslVersionFailed();
+                return false;
+            }
+
+            var match = OpenSslVersionRegex().Match(stdout);
+            if (!match.Success)
+            {
+                Log.UnixOpenSslVersionParsingFailed();
+                return false;
+            }
+
+            openSslDir = match.Groups[1].Value;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.UnixOpenSslVersionException(ex.Message);
+            return false;
+        }
+    }
+
+    /// <remarks>
+    /// It is the caller's responsibility to ensure that <see cref="OpenSslCommand"/> is available.
+    /// </remarks>
+    private static bool TryGetOpenSslHash(string certificatePath, [NotNullWhen(true)] out string? hash)
+    {
+        hash = null;
+
+        try
+        {
+            // c_rehash actually does this twice: once with -subject_hash (equivalent to -hash) and again
+            // with -subject_hash_old.  Old hashes are only  needed for pre-1.0.0, so we skip that.
+            var processInfo = new ProcessStartInfo(OpenSslCommand, $"x509 -hash -noout -in {certificatePath}")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+
+            using var process = Process.Start(processInfo);
+            var stdout = process!.StandardOutput.ReadToEnd();
+
+            process.WaitForExit();
+            if (process.ExitCode != 0)
+            {
+                Log.UnixOpenSslHashFailed(certificatePath);
+                return false;
+            }
+
+            hash = stdout.Trim();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.UnixOpenSslHashException(certificatePath, ex.Message);
+            return false;
+        }
+    }
+
+    [GeneratedRegex("^[0-9a-f]+\\.[0-9]+$")]
+    private static partial Regex OpenSslHashFilenameRegex();
+
+    /// <remarks>
+    /// We only ever use .pem, but someone will eventually put their own cert in this directory,
+    /// so we should handle the same extensions as c_rehash (other than .crl).
+    /// </remarks>
+    [GeneratedRegex("\\.(pem|crt|cer)$")]
+    private static partial Regex OpenSslCertificateExtensionRegex();
+
+    /// <remarks>
+    /// This is a simplified version of c_rehash from OpenSSL.  Using the real one would require
+    /// installing the OpenSSL perl tools and perl itself, which might be annoying in a container.
+    /// </remarks>
+    private static bool TryRehashOpenSslCertificates(string certificateDirectory)
+    {
+        try
+        {
+            // First, delete all the existing symlinks, so we don't have to worry about fragmentation or leaks.
+
+            var hashRegex = OpenSslHashFilenameRegex();
+            var extensionRegex = OpenSslCertificateExtensionRegex();
+
+            var certs = new List<FileInfo>();
+
+            var dirInfo = new DirectoryInfo(certificateDirectory);
+            foreach (var file in dirInfo.EnumerateFiles())
+            {
+                var isSymlink = (file.Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
+                if (isSymlink && hashRegex.IsMatch(file.Name))
+                {
+                    file.Delete();
+                }
+                else if (extensionRegex.IsMatch(file.Name))
+                {
+                    certs.Add(file);
+                }
+            }
+
+            // Then, enumerate all certificates - there will usually be zero or one.
+
+            // c_rehash doesn't create additional symlinks for certs with the same fingerprint,
+            // but we don't expect this to happen, so we favor slightly slower look-ups when it
+            // does, rather than slightly slower rehashing when it doesn't.
+
+            foreach (var cert in certs)
+            {
+                if (!TryGetOpenSslHash(cert.FullName, out var hash))
+                {
+                    return false;
+                }
+
+                var linkCreated = false;
+                for (var i = 0; i < MaxHashCollisions; i++)
+                {
+                    var linkPath = Path.Combine(certificateDirectory, $"{hash}.{i}");
+                    if (!File.Exists(linkPath))
+                    {
+                        // As in c_rehash, we link using a relative path.
+                        File.CreateSymbolicLink(linkPath, cert.Name);
+                        linkCreated = true;
+                        break;
+                    }
+                }
+
+                if (!linkCreated)
+                {
+                    Log.UnixOpenSslRehashTooManyHashes(cert.FullName, hash, MaxHashCollisions);
+                    return false;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.UnixOpenSslRehashException(ex.Message);
+            return false;
+        }
+
+        return true;
+    }
+
+    private sealed class NssDb(string path, bool isFirefox)
+    {
+        public string Path => path;
+        public bool IsFirefox => isFirefox;
     }
 }

--- a/src/Shared/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/UnixCertificateManager.cs
@@ -162,7 +162,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
         {
             try
             {
-                var existingCert = X509Certificate2.CreateFromPemFile(certPath);
+                var existingCert = new X509Certificate2(certPath);
                 if (!existingCert.RawDataMemory.Span.SequenceEqual(certificate.RawDataMemory.Span))
                 {
                     Log.UnixCertificateAlreadyExists(certPath);

--- a/src/Shared/CertificateGeneration/WindowsCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/WindowsCertificateManager.cs
@@ -69,7 +69,7 @@ internal sealed class WindowsCertificateManager : CertificateManager
         return certificate;
     }
 
-    protected override void TrustCertificateCore(X509Certificate2 certificate)
+    protected override TrustLevel TrustCertificateCore(X509Certificate2 certificate)
     {
         using var store = new X509Store(StoreName.Root, StoreLocation.CurrentUser);
         store.Open(OpenFlags.ReadWrite);
@@ -77,7 +77,7 @@ internal sealed class WindowsCertificateManager : CertificateManager
         if (TryFindCertificateInStore(store, certificate, out _))
         {
             Log.WindowsCertificateAlreadyTrusted();
-            return;
+            return TrustLevel.Full;
         }
 
         try
@@ -87,6 +87,7 @@ internal sealed class WindowsCertificateManager : CertificateManager
             using var publicCertificate = X509CertificateLoader.LoadCertificate(certificate.Export(X509ContentType.Cert));
             publicCertificate.FriendlyName = certificate.FriendlyName;
             store.Add(publicCertificate);
+            return TrustLevel.Full;
         }
         catch (CryptographicException exception) when (exception.HResult == UserCancelledErrorCode)
         {
@@ -114,10 +115,11 @@ internal sealed class WindowsCertificateManager : CertificateManager
         Log.WindowsRemoveCertificateFromRootStoreEnd();
     }
 
-    public override bool IsTrusted(X509Certificate2 certificate)
+    public override TrustLevel GetTrustLevel(X509Certificate2 certificate)
     {
-        return ListCertificates(StoreName.Root, StoreLocation.CurrentUser, isValid: true, requireExportable: false)
+        var isTrusted = ListCertificates(StoreName.Root, StoreLocation.CurrentUser, isValid: true, requireExportable: false)
             .Any(c => AreCertificatesEqual(c, certificate));
+        return isTrusted ? TrustLevel.Full : TrustLevel.None;
     }
 
     protected override IList<X509Certificate2> GetCertificatesToRemove(StoreName storeName, StoreLocation storeLocation)

--- a/src/Shared/CertificateGeneration/WindowsCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/WindowsCertificateManager.cs
@@ -39,7 +39,7 @@ internal sealed class WindowsCertificateManager : CertificateManager
 #endif
     }
 
-    internal override CheckCertificateStateResult CheckCertificateState(X509Certificate2 candidate, bool interactive)
+    internal override CheckCertificateStateResult CheckCertificateState(X509Certificate2 candidate)
     {
         return new CheckCertificateStateResult(true, null);
     }

--- a/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
+++ b/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
@@ -468,7 +468,7 @@ public class CertFixture : IDisposable
     internal void CleanupCertificates()
     {
         Manager.RemoveAllCertificates(StoreName.My, StoreLocation.CurrentUser);
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
             Manager.RemoveAllCertificates(StoreName.Root, StoreLocation.CurrentUser);
         }

--- a/src/Tools/dotnet-dev-certs/src/Program.cs
+++ b/src/Tools/dotnet-dev-certs/src/Program.cs
@@ -289,7 +289,7 @@ internal sealed class Program
                 // We never want check to require interaction.
                 // When IDEs run dotnet dev-certs https after calling --check, we will try to access the key and
                 // that will trigger a prompt if necessary.
-                var status = certificateManager.CheckCertificateState(certificate, interactive: false);
+                var status = certificateManager.CheckCertificateState(certificate);
                 if (!status.Success)
                 {
                     reporter.Warn(status.FailureMessage);
@@ -344,7 +344,7 @@ internal sealed class Program
             var certificates = manager.ListCertificates(StoreName.My, StoreLocation.CurrentUser, isValid: true, exportPath.HasValue());
             foreach (var certificate in certificates)
             {
-                var status = manager.CheckCertificateState(certificate, interactive: true);
+                var status = manager.CheckCertificateState(certificate);
                 if (!status.Success)
                 {
                     reporter.Warn("One or more certificates might be in an invalid state. We will try to access the certificate key " +

--- a/src/Tools/dotnet-dev-certs/src/Program.cs
+++ b/src/Tools/dotnet-dev-certs/src/Program.cs
@@ -164,7 +164,7 @@ internal sealed class Program
 
                     if (check.HasValue())
                     {
-                        return CheckHttpsCertificate(trust, reporter);
+                        return CheckHttpsCertificate(trust, verbose, reporter);
                     }
 
                     if (clean.HasValue())
@@ -252,6 +252,12 @@ internal sealed class Program
                 reporter.Output("Cleaning HTTPS development certificates from the machine. This operation might " +
                     "require elevated privileges. If that is the case, a prompt for credentials will be displayed.");
             }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                reporter.Output("Cleaning HTTPS development certificates from the machine. You may wish to update the " +
+                    "SSL_CERT_DIR environment variable. " +
+                    "See https://aka.ms/dev-certs-trust for more information.");
+            }
 
             manager.CleanupHttpsCertificates();
             reporter.Output("HTTPS development certificates successfully removed from the machine.");
@@ -266,7 +272,7 @@ internal sealed class Program
         }
     }
 
-    private static int CheckHttpsCertificate(CommandOption trust, IReporter reporter)
+    private static int CheckHttpsCertificate(CommandOption trust, CommandOption verbose, IReporter reporter)
     {
         var certificateManager = CertificateManager.Instance;
         var certificates = certificateManager.ListCertificates(StoreName.My, StoreLocation.CurrentUser, isValid: true);
@@ -295,32 +301,25 @@ internal sealed class Program
 
         if (trust != null && trust.HasValue())
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            var trustedCertificates = certificates.Where(cert => certificateManager.GetTrustLevel(cert) == CertificateManager.TrustLevel.Full).ToList();
+            if (trustedCertificates.Count == 0)
             {
-                var trustedCertificates = certificates.Where(certificateManager.IsTrusted).ToList();
-                if (!trustedCertificates.Any())
+                reporter.Output($@"The following certificates were found, but none of them is trusted: {CertificateManager.ToCertificateDescription(certificates)}");
+                if (verbose == null || !verbose.HasValue())
                 {
-                    reporter.Output($@"The following certificates were found, but none of them is trusted: {CertificateManager.ToCertificateDescription(certificates)}");
-                    return ErrorCertificateNotTrusted;
+                    reporter.Output($@"Run the command with --verbose for more details.");
                 }
-                else
-                {
-                    ReportCertificates(reporter, trustedCertificates, "trusted");
-                }
+                return ErrorCertificateNotTrusted;
             }
             else
             {
-                reporter.Warn("Checking the HTTPS development certificate trust status was requested. Checking whether the certificate is trusted or not is not supported on Linux distributions." +
-                    "For instructions on how to manually validate the certificate is trusted on your Linux distribution, go to https://aka.ms/dev-certs-trust");
+                ReportCertificates(reporter, trustedCertificates, "trusted");
             }
         }
         else
         {
             ReportCertificates(reporter, validCertificates, "valid");
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                reporter.Output("Run the command with both --check and --trust options to ensure that the certificate is not only valid but also trusted.");
-            }
+            reporter.Output("Run the command with both --check and --trust options to ensure that the certificate is not only valid but also trusted.");
         }
 
         return Success;
@@ -358,7 +357,9 @@ internal sealed class Program
             }
         }
 
-        if (trust?.HasValue() == true)
+        var isTrustOptionSet = trust?.HasValue() == true;
+
+        if (isTrustOptionSet)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
@@ -377,8 +378,9 @@ internal sealed class Program
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                reporter.Warn("Trusting the HTTPS development certificate was requested. Trusting the certificate on Linux distributions automatically is not supported. " +
-                    "For instructions on how to manually trust the certificate on your Linux distribution, go to https://aka.ms/dev-certs-trust");
+                reporter.Warn("Trusting the HTTPS development certificate was requested. " +
+                    "Trust is per-user and may require additional configuration. " +
+                    "See https://aka.ms/dev-certs-trust for more information.");
             }
         }
 
@@ -393,7 +395,7 @@ internal sealed class Program
             now,
             now.Add(HttpsCertificateValidity),
             exportPath.Value(),
-            trust == null ? false : trust.HasValue() && !RuntimeInformation.IsOSPlatform(OSPlatform.Linux),
+            isTrustOptionSet,
             password.HasValue() || (noPassword.HasValue() && format == CertificateKeyExportFormat.Pem),
             password.Value(),
             exportFormat.HasValue() ? format : CertificateKeyExportFormat.Pfx);
@@ -421,10 +423,14 @@ internal sealed class Program
                 reporter.Error("There was an error saving the HTTPS developer certificate to the current user personal certificate store.");
                 return ErrorSavingTheCertificate;
             case EnsureCertificateResult.ErrorExportingTheCertificate:
-                reporter.Warn("There was an error exporting HTTPS developer certificate to a file.");
+                reporter.Warn("There was an error exporting the HTTPS developer certificate to a file.");
                 return ErrorExportingTheCertificate;
+            case EnsureCertificateResult.PartiallyFailedToTrustTheCertificate:
+                // A distinct warning is useful, but a distinct error code is probably not.
+                reporter.Warn("There was an error trusting the HTTPS developer certificate. It will be trusted by some clients but not by others.");
+                return ErrorTrustingTheCertificate;
             case EnsureCertificateResult.FailedToTrustTheCertificate:
-                reporter.Warn("There was an error trusting HTTPS developer certificate.");
+                reporter.Warn("There was an error trusting the HTTPS developer certificate.");
                 return ErrorTrustingTheCertificate;
             case EnsureCertificateResult.UserCancelledTrustStep:
                 reporter.Warn("The user cancelled the trust step.");


### PR DESCRIPTION
# Overview

There's no consistent way to do this that works for all clients on all Linux distros, but this approach gives us pretty good coverage.  In particular, we aim to support .NET (esp HttpClient), Chromium, and Firefox on Ubuntu- and Fedora-based distros.

Certificate trust is applied per-user, which is simpler and preferable for security reasons, but comes with the notable downside that the process can't be completed within the tool - the user has to update an environment variable, probably in their user profile.  In particular, OpenSSL consumes the `SSL_CERT_DIR` environment variable to determine where it should look for trusted certificates.

We break establishing trust into two categories: OpenSSL, which backs .NET, and NSS databases (henceforth, nssdb), which backs browsers.

To establish trust in OpenSSL, we put the certificate in `~/.dotnet/corefx/cryptography/trusted`, run a simplified version of OpenSSL's `c_rehash` tool on the directory, and ask the user to update `SSL_CERT_DIR`.

To establish trust in nssdb, we search the home directory for Firefox profiles and `~/.pki/nssdb`.  For each one found, we add an entry to the nssdb therein.

Each of these locations (the trusted certificate folder and the list of nssdbs) can be overridden with an environment variable.

This large number of steps introduces a problem that doesn't exist on Windows or macOS - the dev cert can end up trusted by some clients but not by others.  This change introduces a `TrustLevel` concept so that we can produce clearer output when this happens.

The only non-bundled tools required to update certificate trust are `openssl` (the CLI) and `certutil`.  `sudo` is not required, since all changes are within the user's home directory.

# Comparison with community tools

There are some community projects that have added this functionality, but they differ from this implementation in some notable ways:

1. We're using the same certificate as on Windows and macOS - it's not a CA
2. We're only trusting the certificate for a single-user
3. We require the additional step of setting `SSL_CERT_DIR`
4. We require OpenSSL 1.1.1**h** or greater to handle the fact that our cert is not a CA

# Work outside this repo

1. We need to update the docs.  Presently, they say this is impossible.  Instead, they should explain limitations and provide troubleshooting steps
2. More docs: https://learn.microsoft.com/en-us/aspnet/core/security/enforcing-ssl?view=aspnetcore-8.0&tabs=visual-studio%2Clinux-ubuntu#ssl-linux
3. We need to update the docker tools docs (cc @richlander).
4. We need to write manual testing instructions for pre-release validation
5. ~We could consider pre-setting `SSL_CERT_DIR` in our official docker images~
6. ~We could consider setting `SSL_CERT_DIR` in install-dotnet.sh (assuming it's already setting things like `DOTNET_ROOT`)~