### PR TITLE
Support IAsyncEnumerable<T> and ChannelReader<T> with ValueTypes in SignalR native AOT

### DIFF
--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -857,26 +857,69 @@ public partial class HubConnection : IAsyncDisposable
     [UnconditionalSuppressMessage("Trimming", "IL2060:MakeGenericMethod",
         Justification = "The methods passed into here (SendStreamItems and SendIAsyncEnumerableStreamItems) don't have trimming annotations.")]
     [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
-        Justification = "There is a runtime check for ValueType streaming item type when PublishAot=true. Developers will get an exception in this situation before publishing.")]
+        Justification = "ValueTypes are handled without using MakeGenericMethod.")]
     private void InvokeStreamMethod(MethodInfo methodInfo, Type[] genericTypes, ConnectionState connectionState, string streamId, object reader, CancellationTokenSource tokenSource)
     {
-#if NET
         Debug.Assert(genericTypes.Length == 1);
-
+#if NET6_0_OR_GREATER
         if (!RuntimeFeature.IsDynamicCodeSupported && genericTypes[0].IsValueType)
         {
-            // NativeAOT apps are not able to stream IAsyncEnumerable and ChannelReader of ValueTypes
-            // since we cannot create SendStreamItems and SendIAsyncEnumerableStreamItems methods with a generic ValueType.
-            throw new InvalidOperationException($"Unable to stream an item with type '{genericTypes[0]}' because it is a ValueType. Native code to support streaming this ValueType will not be available with native AOT.");
+            _ = ReflectionSendStreamItems(methodInfo, connectionState, streamId, reader, tokenSource);
         }
+        else
 #endif
-
-        _ = methodInfo
-            .MakeGenericMethod(genericTypes)
-            .Invoke(this, [connectionState, streamId, reader, tokenSource]);
+        {
+            _ = methodInfo
+                .MakeGenericMethod(genericTypes)
+                .Invoke(this, [connectionState, streamId, reader, tokenSource]);
+        }
     }
 
-    // this is called via reflection using the `_sendStreamItems` field
+#if NET6_0_OR_GREATER
+
+    /// <summary>
+    /// Uses reflection to read items from an IAsyncEnumerable{T} or ChannelReader{T} and send them to the server.
+    ///
+    /// Used when the runtime does not support dynamic code generation (ex. native AOT) and the generic type is a value type. In this scenario,
+    /// we cannot use MakeGenericMethod to call the appropriate SendStreamItems method because the generic type is a value type.
+    /// </summary>
+    private Task ReflectionSendStreamItems(MethodInfo methodInfo, ConnectionState connectionState, string streamId, object reader, CancellationTokenSource tokenSource)
+    {
+        async Task ReadAsyncEnumeratorStream(IAsyncEnumerator<object?> enumerator)
+        {
+            try
+            {
+                while (await enumerator.MoveNextAsync().ConfigureAwait(false))
+                {
+                    await SendWithLock(connectionState, new StreamItemMessage(streamId, enumerator.Current), tokenSource.Token).ConfigureAwait(false);
+                    Log.SendingStreamItem(_logger, streamId);
+                }
+            }
+            finally
+            {
+                await enumerator.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+        Func<Task> createAndConsumeStream;
+        if (methodInfo == _sendStreamItemsMethod)
+        {
+            // reader is a ChannelReader<T>
+            createAndConsumeStream = () => ReadAsyncEnumeratorStream(AsyncEnumerableAdapters.MakeReflectionAsyncEnumeratorFromChannel(reader, tokenSource.Token));
+        }
+        else
+        {
+            // reader is an IAsyncEnumerable<T>
+            Debug.Assert(methodInfo == _sendIAsyncStreamItemsMethod);
+
+            createAndConsumeStream = () => ReadAsyncEnumeratorStream(AsyncEnumerableAdapters.MakeReflectionAsyncEnumerator(reader, tokenSource.Token));
+        }
+
+        return CommonStreaming(connectionState, streamId, createAndConsumeStream, tokenSource);
+    }
+#endif
+
+    // this is called via reflection using the `_sendStreamItemsMethod` field
     private Task SendStreamItems<T>(ConnectionState connectionState, string streamId, ChannelReader<T> reader, CancellationTokenSource tokenSource)
     {
         async Task ReadChannelStream()

--- a/src/SignalR/common/Shared/AsyncEnumerableAdapters.cs
+++ b/src/SignalR/common/Shared/AsyncEnumerableAdapters.cs
@@ -49,10 +49,10 @@ internal static class AsyncEnumerableAdapters
                 return new ValueTask<bool>(true);
             }
 
-            return new ValueTask<bool>(MoveNextAsyncAwaited());
+            return MoveNextAsyncAwaited();
         }
 
-        private async Task<bool> MoveNextAsyncAwaited()
+        private async ValueTask<bool> MoveNextAsyncAwaited()
         {
             while (await _channel.WaitToReadAsync(_cancellationToken).ConfigureAwait(false))
             {
@@ -184,7 +184,7 @@ internal static class AsyncEnumerableAdapters
         {
             _enumerator = enumerator;
 
-            var type = ReflectionHelper.GetIAsyncEnumeratorInterface(enumerator.GetType())!;
+            var type = ReflectionHelper.GetIAsyncEnumeratorInterface(enumerator.GetType());
             _moveNextAsyncMethodInfo = (MethodInfo)type.GetMemberWithSameMetadataDefinitionAs(_asyncEnumeratorMoveNextAsyncMethodInfo)!;
             _getCurrentMethodInfo = (MethodInfo)type.GetMemberWithSameMetadataDefinitionAs(_asyncEnumeratorGetCurrentMethodInfo)!;
         }
@@ -227,10 +227,10 @@ internal static class AsyncEnumerableAdapters
                 return new ValueTask<bool>(true);
             }
 
-            return new ValueTask<bool>(MoveNextAsyncAwaited());
+            return MoveNextAsyncAwaited();
         }
 
-        private async Task<bool> MoveNextAsyncAwaited()
+        private async ValueTask<bool> MoveNextAsyncAwaited()
         {
             while (await ((ValueTask<bool>)_waitToReadAsyncMethodInfo.Invoke(_channelReader, _waitToReadArgs)!).ConfigureAwait(false))
             {

--- a/src/SignalR/common/Shared/AsyncEnumerableAdapters.cs
+++ b/src/SignalR/common/Shared/AsyncEnumerableAdapters.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -11,7 +13,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal;
 // True-internal because this is a weird and tricky class to use :)
 internal static class AsyncEnumerableAdapters
 {
-    public static IAsyncEnumerator<object?> MakeCancelableAsyncEnumerator<T>(IAsyncEnumerable<T> asyncEnumerable, CancellationToken cancellationToken = default)
+    public static IAsyncEnumerator<object?> MakeAsyncEnumerator<T>(IAsyncEnumerable<T> asyncEnumerable, CancellationToken cancellationToken = default)
     {
         var enumerator = asyncEnumerable.GetAsyncEnumerator(cancellationToken);
         return enumerator as IAsyncEnumerator<object?> ?? new BoxedAsyncEnumerator<T>(enumerator);
@@ -52,10 +54,13 @@ internal static class AsyncEnumerableAdapters
 
         private async Task<bool> MoveNextAsyncAwaited()
         {
-            if (await _channel.WaitToReadAsync(_cancellationToken).ConfigureAwait(false) && _channel.TryRead(out var item))
+            while (await _channel.WaitToReadAsync(_cancellationToken).ConfigureAwait(false))
             {
-                Current = item;
-                return true;
+                if (_channel.TryRead(out var item))
+                {
+                    Current = item;
+                    return true;
+                }
             }
             return false;
         }
@@ -137,4 +142,109 @@ internal static class AsyncEnumerableAdapters
             return _asyncEnumerator.DisposeAsync();
         }
     }
+
+#if NET6_0_OR_GREATER
+
+    private static readonly MethodInfo _asyncEnumerableGetAsyncEnumeratorMethodInfo = typeof(IAsyncEnumerable<>).GetMethod("GetAsyncEnumerator")!;
+
+    /// <summary>
+    /// Creates an IAsyncEnumerator{object} from an IAsyncEnumerable{T} using reflection.
+    ///
+    /// Used when the runtime does not support dynamic code generation (ex. native AOT) and the generic type is a value type. In this scenario,
+    /// we cannot use MakeGenericMethod to call a generic method because the generic type is a value type.
+    /// </summary>
+    public static IAsyncEnumerator<object?> MakeReflectionAsyncEnumerator(object asyncEnumerable, CancellationToken cancellationToken)
+    {
+        var constructedIAsyncEnumerableInterface = ReflectionHelper.GetIAsyncEnumerableInterface(asyncEnumerable.GetType())!;
+        var enumerator = ((MethodInfo)constructedIAsyncEnumerableInterface.GetMemberWithSameMetadataDefinitionAs(_asyncEnumerableGetAsyncEnumeratorMethodInfo)).Invoke(asyncEnumerable, [cancellationToken])!;
+        return new ReflectionAsyncEnumerator(enumerator);
+    }
+
+    /// <summary>
+    /// Creates an IAsyncEnumerator{object} from a ChannelReader{T} using reflection.
+    ///
+    /// Used when the runtime does not support dynamic code generation (ex. native AOT) and the generic type is a value type. In this scenario,
+    /// we cannot use MakeGenericMethod to call a generic method because the generic type is a value type.
+    /// </summary>
+    public static IAsyncEnumerator<object?> MakeReflectionAsyncEnumeratorFromChannel(object channelReader, CancellationToken cancellationToken)
+    {
+        return new ReflectionChannelAsyncEnumerator(channelReader, cancellationToken);
+    }
+
+    private sealed class ReflectionAsyncEnumerator : IAsyncEnumerator<object?>
+    {
+        private static readonly MethodInfo _asyncEnumeratorMoveNextAsyncMethodInfo = typeof(IAsyncEnumerator<>).GetMethod("MoveNextAsync")!;
+        private static readonly MethodInfo _asyncEnumeratorGetCurrentMethodInfo = typeof(IAsyncEnumerator<>).GetMethod("get_Current")!;
+
+        private readonly object _enumerator;
+        private readonly MethodInfo _moveNextAsyncMethodInfo;
+        private readonly MethodInfo _getCurrentMethodInfo;
+
+        public ReflectionAsyncEnumerator(object enumerator)
+        {
+            _enumerator = enumerator;
+
+            var type = ReflectionHelper.GetIAsyncEnumeratorInterface(enumerator.GetType())!;
+            _moveNextAsyncMethodInfo = (MethodInfo)type.GetMemberWithSameMetadataDefinitionAs(_asyncEnumeratorMoveNextAsyncMethodInfo)!;
+            _getCurrentMethodInfo = (MethodInfo)type.GetMemberWithSameMetadataDefinitionAs(_asyncEnumeratorGetCurrentMethodInfo)!;
+        }
+
+        public object? Current => _getCurrentMethodInfo.Invoke(_enumerator, []);
+
+        public ValueTask<bool> MoveNextAsync() => (ValueTask<bool>)_moveNextAsyncMethodInfo.Invoke(_enumerator, [])!;
+
+        public ValueTask DisposeAsync() => ((IAsyncDisposable)_enumerator).DisposeAsync();
+    }
+
+    private sealed class ReflectionChannelAsyncEnumerator : IAsyncEnumerator<object?>
+    {
+        private static readonly MethodInfo _channelReaderTryReadMethodInfo = typeof(ChannelReader<>).GetMethod("TryRead")!;
+        private static readonly MethodInfo _channelReaderWaitToReadAsyncMethodInfo = typeof(ChannelReader<>).GetMethod("WaitToReadAsync")!;
+
+        private readonly object _channelReader;
+        private readonly object?[] _tryReadResult = [null];
+        private readonly object[] _waitToReadArgs;
+        private readonly MethodInfo _tryReadMethodInfo;
+        private readonly MethodInfo _waitToReadAsyncMethodInfo;
+
+        public ReflectionChannelAsyncEnumerator(object channelReader, CancellationToken cancellationToken)
+        {
+            _channelReader = channelReader;
+            _waitToReadArgs = [cancellationToken];
+
+            var type = channelReader.GetType();
+            _tryReadMethodInfo = (MethodInfo)type.GetMemberWithSameMetadataDefinitionAs(_channelReaderTryReadMethodInfo)!;
+            _waitToReadAsyncMethodInfo = (MethodInfo)type.GetMemberWithSameMetadataDefinitionAs(_channelReaderWaitToReadAsyncMethodInfo)!;
+        }
+
+        public object? Current { get; private set; }
+
+        public ValueTask<bool> MoveNextAsync()
+        {
+            if ((bool)_tryReadMethodInfo.Invoke(_channelReader, _tryReadResult)!)
+            {
+                Current = _tryReadResult[0];
+                return new ValueTask<bool>(true);
+            }
+
+            return new ValueTask<bool>(MoveNextAsyncAwaited());
+        }
+
+        private async Task<bool> MoveNextAsyncAwaited()
+        {
+            while (await ((ValueTask<bool>)_waitToReadAsyncMethodInfo.Invoke(_channelReader, _waitToReadArgs)!).ConfigureAwait(false))
+            {
+                if ((bool)_tryReadMethodInfo.Invoke(_channelReader, _tryReadResult)!)
+                {
+                    Current = _tryReadResult[0];
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public ValueTask DisposeAsync() => default;
+    }
+
+#endif
 }

--- a/src/SignalR/common/Shared/ReflectionHelper.cs
+++ b/src/SignalR/common/Shared/ReflectionHelper.cs
@@ -69,4 +69,27 @@ internal static class ReflectionHelper
 
         return null;
     }
+
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
+        Justification = "The 'IAsyncEnumerator<>' Type must exist and so trimmer kept it. In which case " +
+            "It also kept it on any type which implements it. The below call to GetInterfaces " +
+            "may return fewer results when trimmed but it will return 'IAsyncEnumerator<>' " +
+            "if the type implemented it, even after trimming.")]
+    public static Type? GetIAsyncEnumeratorInterface(Type type)
+    {
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IAsyncEnumerator<>))
+        {
+            return type;
+        }
+
+        foreach (Type typeToCheck in type.GetInterfaces())
+        {
+            if (typeToCheck.IsGenericType && typeToCheck.GetGenericTypeDefinition() == typeof(IAsyncEnumerator<>))
+            {
+                return typeToCheck;
+            }
+        }
+
+        return null;
+    }
 }

--- a/src/SignalR/common/Shared/ReflectionHelper.cs
+++ b/src/SignalR/common/Shared/ReflectionHelper.cs
@@ -75,7 +75,7 @@ internal static class ReflectionHelper
             "It also kept it on any type which implements it. The below call to GetInterfaces " +
             "may return fewer results when trimmed but it will return 'IAsyncEnumerator<>' " +
             "if the type implemented it, even after trimming.")]
-    public static Type? GetIAsyncEnumeratorInterface(Type type)
+    public static Type GetIAsyncEnumeratorInterface(Type type)
     {
         if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IAsyncEnumerator<>))
         {
@@ -90,6 +90,6 @@ internal static class ReflectionHelper
             }
         }
 
-        return null;
+        throw new InvalidOperationException($"Type '{type}' does not implement IAsyncEnumerator<>");
     }
 }

--- a/src/SignalR/server/Core/src/Internal/HubMethodDescriptor.cs
+++ b/src/SignalR/server/Core/src/Internal/HubMethodDescriptor.cs
@@ -299,7 +299,7 @@ internal sealed class HubMethodDescriptor
             // NativeAOT apps are not able to stream IAsyncEnumerable and ChannelReader of ValueTypes as parameters
             // since we cannot create a concrete IAsyncEnumerable and ChannelReader of ValueType to pass into the Hub method.
             var methodInfo = MethodExecutor.MethodInfo;
-            throw new InvalidOperationException($"Method '{methodInfo.DeclaringType}.{methodInfo.Name}' is not supported with native AOT because it has a parameter of type '{parameterType}'. Streaming parameters of ValueTypes is not supported because the native code to support the ValueType will not be available with native AOT.");
+            throw new InvalidOperationException($"Method '{methodInfo.DeclaringType}.{methodInfo.Name}' is not supported with native AOT because it has a parameter of type '{parameterType}'. A ValueType streaming parameter is not supported because the native code to support the ValueType will not be available with native AOT.");
         }
 
         return streamType;

--- a/src/SignalR/server/Core/src/Internal/HubMethodDescriptor.cs
+++ b/src/SignalR/server/Core/src/Internal/HubMethodDescriptor.cs
@@ -17,16 +17,16 @@ namespace Microsoft.AspNetCore.SignalR.Internal;
 
 internal sealed class HubMethodDescriptor
 {
-    private static readonly MethodInfo MakeCancelableAsyncEnumeratorMethod = typeof(AsyncEnumerableAdapters)
+    private static readonly MethodInfo MakeAsyncEnumeratorMethod = typeof(AsyncEnumerableAdapters)
         .GetRuntimeMethods()
-        .Single(m => m.Name.Equals(nameof(AsyncEnumerableAdapters.MakeCancelableAsyncEnumerator)) && m.IsGenericMethod);
+        .Single(m => m.Name.Equals(nameof(AsyncEnumerableAdapters.MakeAsyncEnumerator)) && m.IsGenericMethod);
 
     private static readonly MethodInfo MakeAsyncEnumeratorFromChannelMethod = typeof(AsyncEnumerableAdapters)
         .GetRuntimeMethods()
         .Single(m => m.Name.Equals(nameof(AsyncEnumerableAdapters.MakeAsyncEnumeratorFromChannel)) && m.IsGenericMethod);
 
     private readonly MethodInfo? _makeCancelableEnumeratorMethodInfo;
-    private Func<object, CancellationToken, IAsyncEnumerator<object>>? _makeCancelableEnumerator;
+    private Func<object, CancellationToken, IAsyncEnumerator<object?>>? _makeCancelableEnumerator;
     // bitset to store which parameters come from DI up to 64 arguments
     private ulong _isServiceArgument;
 
@@ -41,8 +41,8 @@ internal sealed class HubMethodDescriptor
         var asyncEnumerableType = ReflectionHelper.GetIAsyncEnumerableInterface(NonAsyncReturnType);
         if (asyncEnumerableType is not null)
         {
-            StreamReturnType = ValidateStreamType(asyncEnumerableType.GetGenericArguments()[0]);
-            _makeCancelableEnumeratorMethodInfo = MakeCancelableAsyncEnumeratorMethod;
+            StreamReturnType = asyncEnumerableType.GetGenericArguments()[0];
+            _makeCancelableEnumeratorMethodInfo = MakeAsyncEnumeratorMethod;
         }
         else
         {
@@ -50,7 +50,7 @@ internal sealed class HubMethodDescriptor
             {
                 if (returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(ChannelReader<>))
                 {
-                    StreamReturnType = ValidateStreamType(returnType.GetGenericArguments()[0]);
+                    StreamReturnType = returnType.GetGenericArguments()[0];
                     _makeCancelableEnumeratorMethodInfo = MakeAsyncEnumeratorFromChannelMethod;
                     break;
                 }
@@ -73,7 +73,7 @@ internal sealed class HubMethodDescriptor
                     StreamingParameters = new List<Type>();
                 }
 
-                StreamingParameters.Add(ValidateStreamType(p.ParameterType.GetGenericArguments()[0]));
+                StreamingParameters.Add(ValidateParameterStreamType(p.ParameterType.GetGenericArguments()[0], p.ParameterType));
                 HasSyntheticArguments = true;
                 return false;
             }
@@ -201,7 +201,7 @@ internal sealed class HubMethodDescriptor
         return serviceProvider.GetRequiredService(parameterType);
     }
 
-    public IAsyncEnumerator<object> FromReturnedStream(object stream, CancellationToken cancellationToken)
+    public IAsyncEnumerator<object?> FromReturnedStream(object stream, CancellationToken cancellationToken)
     {
         // there is the potential for _makeCancelableEnumerator to be set multiple times but this has no harmful effect other than startup perf
         if (_makeCancelableEnumerator == null)
@@ -220,12 +220,12 @@ internal sealed class HubMethodDescriptor
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2060:MakeGenericMethod",
-        Justification = "The adapter methods passed into here (MakeCancelableAsyncEnumerator and MakeAsyncEnumeratorFromChannel) don't have trimming annotations.")]
+        Justification = "The adapter methods passed into here (MakeAsyncEnumerator and MakeAsyncEnumeratorFromChannel) don't have trimming annotations.")]
     [RequiresDynamicCode("Calls MakeGenericMethod with types that may be ValueTypes")]
-    private static Func<object, CancellationToken, IAsyncEnumerator<object>> CompileConvertToEnumerator(MethodInfo adapterMethodInfo, Type streamReturnType)
+    private static Func<object, CancellationToken, IAsyncEnumerator<object?>> CompileConvertToEnumerator(MethodInfo adapterMethodInfo, Type streamReturnType)
     {
         // This will call one of two adapter methods to wrap the passed in streamable value into an IAsyncEnumerable<object>:
-        // - AsyncEnumerableAdapters.MakeCancelableAsyncEnumerator<T>(asyncEnumerable, cancellationToken);
+        // - AsyncEnumerableAdapters.MakeAsyncEnumerator<T>(asyncEnumerable, cancellationToken);
         // - AsyncEnumerableAdapters.MakeCancelableAsyncEnumeratorFromChannel<T>(channelReader, cancellationToken);
 
         var parameters = new[]
@@ -243,23 +243,39 @@ internal sealed class HubMethodDescriptor
         };
 
         var methodCall = Expression.Call(null, genericMethodInfo, methodArguments);
-        var lambda = Expression.Lambda<Func<object, CancellationToken, IAsyncEnumerator<object>>>(methodCall, parameters);
+        var lambda = Expression.Lambda<Func<object, CancellationToken, IAsyncEnumerator<object?>>>(methodCall, parameters);
         return lambda.Compile();
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2060:MakeGenericMethod",
-        Justification = "The adapter methods passed into here (MakeCancelableAsyncEnumerator and MakeAsyncEnumeratorFromChannel) don't have trimming annotations.")]
+        Justification = "The adapter methods passed into here (MakeAsyncEnumerator and MakeAsyncEnumeratorFromChannel) don't have trimming annotations.")]
     [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
-        Justification = "There is a runtime check for ValueType streaming item type when PublishAot=true. Developers will get an exception in this situation before publishing.")]
-    private static Func<object, CancellationToken, IAsyncEnumerator<object>> ConvertToEnumeratorWithReflection(MethodInfo adapterMethodInfo, Type streamReturnType)
+        Justification = "ValueTypes are handled without using MakeGenericMethod.")]
+    private static Func<object, CancellationToken, IAsyncEnumerator<object?>> ConvertToEnumeratorWithReflection(MethodInfo adapterMethodInfo, Type streamReturnType)
     {
-        Debug.Assert(!streamReturnType.IsValueType, "ValidateStreamType will throw during the ctor if the streamReturnType is a ValueType when PublishAot=true.");
-
-        var genericAdapterMethodInfo = adapterMethodInfo.MakeGenericMethod(streamReturnType);
-        return (stream, cancellationToken) =>
+        if (streamReturnType.IsValueType)
         {
-            return (IAsyncEnumerator<object>)genericAdapterMethodInfo.Invoke(null, [stream, cancellationToken])!;
-        };
+            if (adapterMethodInfo == MakeAsyncEnumeratorMethod)
+            {
+                // return type is an IAsyncEnumerable<T>
+                return AsyncEnumerableAdapters.MakeReflectionAsyncEnumerator;
+            }
+            else
+            {
+                // must be a ChannelReader<T>
+                Debug.Assert(adapterMethodInfo == MakeAsyncEnumeratorFromChannelMethod);
+
+                return AsyncEnumerableAdapters.MakeReflectionAsyncEnumeratorFromChannel;
+            }
+        }
+        else
+        {
+            var genericAdapterMethodInfo = adapterMethodInfo.MakeGenericMethod(streamReturnType);
+            return (stream, cancellationToken) =>
+            {
+                return (IAsyncEnumerator<object?>)genericAdapterMethodInfo.Invoke(null, [stream, cancellationToken])!;
+            };
+        }
     }
 
     private static Type GetServiceType(Type type)
@@ -276,14 +292,14 @@ internal sealed class HubMethodDescriptor
         return type;
     }
 
-    private Type ValidateStreamType(Type streamType)
+    private Type ValidateParameterStreamType(Type streamType, Type parameterType)
     {
         if (!RuntimeFeature.IsDynamicCodeSupported && streamType.IsValueType)
         {
-            // NativeAOT apps are not able to stream IAsyncEnumerable and ChannelReader of ValueTypes
-            // since we cannot create AsyncEnumerableAdapters.MakeCancelableAsyncEnumerator and AsyncEnumerableAdapters.MakeAsyncEnumeratorFromChannel methods with a generic ValueType.
+            // NativeAOT apps are not able to stream IAsyncEnumerable and ChannelReader of ValueTypes as parameters
+            // since we cannot create a concrete IAsyncEnumerable and ChannelReader of ValueType to pass into the Hub method.
             var methodInfo = MethodExecutor.MethodInfo;
-            throw new InvalidOperationException($"Unable to stream an item with type '{streamType}' on method '{methodInfo.DeclaringType}.{methodInfo.Name}' because it is a ValueType. Native code to support streaming this ValueType will not be available with native AOT.");
+            throw new InvalidOperationException($"Method '{methodInfo.DeclaringType}.{methodInfo.Name}' is not supported with native AOT because it has a parameter of type '{parameterType}'. Streaming parameters of ValueTypes is not supported because the native code to support the ValueType will not be available with native AOT.");
         }
 
         return streamType;

--- a/src/SignalR/server/SignalR/test/Microsoft.AspNetCore.SignalR.Tests/NativeAotTests.cs
+++ b/src/SignalR/server/SignalR/test/Microsoft.AspNetCore.SignalR.Tests/NativeAotTests.cs
@@ -295,11 +295,12 @@ public partial class NativeAotTests : FunctionalTestBase
             return output.Reader;
         }
 
+        // using 'object' as the streaming parameter type because streaming ValueTypes is not supported on the server
         public async Task<string> EnumerableIntParameter(IAsyncEnumerable<object> source)
         {
             var result = new StringBuilder();
             var first = true;
-            // These get deserialized as JsonElement since the parameter is 'ChannelReader<object>'
+            // These get deserialized as JsonElement since the streaming parameter is 'object'
             await foreach (JsonElement item in source)
             {
                 if (first)
@@ -316,11 +317,12 @@ public partial class NativeAotTests : FunctionalTestBase
             return result.ToString();
         }
 
+        // using 'object' as the streaming parameter type because streaming ValueTypes is not supported on the server
         public async Task<string> ChannelShortParameter(ChannelReader<object> source)
         {
             var result = new StringBuilder();
             var first = true;
-            // These get deserialized as JsonElement since the parameter is 'ChannelReader<object>'
+            // These get deserialized as JsonElement since the streaming parameter is 'object'
             await foreach (JsonElement item in source.ReadAllAsync())
             {
                 if (first)


### PR DESCRIPTION
Support streaming ValueTypes from a SignalR Hub method in both the client and the server in native AOT. In order to make this work, we need to use pure reflection to read from the streaming object.

Support passing in an IAsyncEnumerable/ChannelReader of ValueType to a parameter in SignalR.Client. This works because the user code creates the concrete object, and the SignalR.Client library just needs to read from it using reflection.

The only scenario that can't be supported is on the SignalR server we can't support receiving an IAsyncEnumerable/ChannelReader of ValueType. This is because there is no way for the SignalR library code to construct a concrete instance to pass into the user-defined method on native AOT.

Fix #56179