### PR TITLE
Add test for the order of activity and metrics with HTTP requests

### DIFF
--- a/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
@@ -208,7 +208,10 @@ internal sealed class HostingApplicationDiagnostics
         }
 
         var activity = context.Activity;
-        // Always stop activity if it was started
+        // Always stop activity if it was started.
+        // The HTTP activity must be stopped after the HTTP request duration metric is recorded.
+        // This order means the activity is ongoing while the metric is recorded and libraries like OTEL
+        // can capture the activity as a metric exemplar.
         if (activity is not null)
         {
             StopActivity(httpContext, activity, context.HasDiagnosticListener);

--- a/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
@@ -156,17 +156,61 @@ public class HostingApplicationDiagnosticsTests
     }
 
     [Fact]
+    public void Metrics_RequestDuration_RecordedWithHttpActivity()
+    {
+        // Arrange
+        using var activityListener = new ActivityListener
+        {
+            ShouldListenTo = activitySource => activitySource.Name == "Microsoft.AspNetCore",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+        };
+        ActivitySource.AddActivityListener(activityListener);
+
+        var testMeterFactory = new TestMeterFactory();
+
+        var meterListener = new MeterListener();
+        meterListener.InstrumentPublished = (i, l) =>
+        {
+            if (i.Meter.Scope == testMeterFactory && i.Meter.Name == HostingMetrics.MeterName && i.Name == "http.server.request.duration")
+            {
+                l.EnableMeasurementEvents(i);
+            }
+        };
+
+        Activity measurementActivity = null;
+        var measureCount = 0;
+        meterListener.SetMeasurementEventCallback<double>((i, m, t, s) =>
+        {
+            if (Interlocked.Increment(ref measureCount) > 1)
+            {
+                throw new Exception("Unexpected measurement count.");
+            }
+
+            measurementActivity = Activity.Current;
+        });
+        meterListener.Start();
+
+        // Act
+        var hostingApplication = CreateApplication(out var features, meterFactory: testMeterFactory);
+        var context = hostingApplication.CreateContext(features);
+        hostingApplication.DisposeContext(context, null);
+
+        // Assert
+        Assert.Equal(1, measureCount);
+        Assert.NotNull(measurementActivity);
+        Assert.Equal(HostingApplicationDiagnostics.ActivityName, measurementActivity.OperationName);
+    }
+
+    [Fact]
     public void MetricsEnabled()
     {
         // Arrange
-        var hostingEventSource = new HostingEventSource(Guid.NewGuid().ToString());
-
         var testMeterFactory = new TestMeterFactory();
         using var activeRequestsCollector = new MetricCollector<long>(testMeterFactory, HostingMetrics.MeterName, "http.server.active_requests");
         using var requestDurationCollector = new MetricCollector<double>(testMeterFactory, HostingMetrics.MeterName, "http.server.request.duration");
 
         // Act
-        var hostingApplication = CreateApplication(out var features, eventSource: hostingEventSource, meterFactory: testMeterFactory);
+        var hostingApplication = CreateApplication(out var features, meterFactory: testMeterFactory);
         var context = hostingApplication.CreateContext(features);
 
         // Assert


### PR DESCRIPTION
[Exemplars](https://github.com/open-telemetry/opentelemetry-dotnet/blob/d8ce51b1b482e7432da0e7498fdc1052eb2ca807/docs/metrics/exemplars/README.md) require metrics and activities are completed in the correct order. ASP.NET Core fortunately already does the right thing.

Add comments and a unit test to assert the correct behavior.