### PR TITLE
Revert "Quarantine flaky MVC functional tests (#55935)"

### DIFF
--- a/src/Mvc/test/Mvc.FunctionalTests/ClientValidationOptionsTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/ClientValidationOptionsTests.cs
@@ -1,8 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Reflection;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.InternalTesting;
 using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests;

--- a/src/Mvc/test/Mvc.FunctionalTests/ClientValidationOptionsTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/ClientValidationOptionsTests.cs
@@ -1,9 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Reflection;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.InternalTesting;
 using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests;
@@ -24,7 +23,6 @@ public class ClientValidationOptionsTests : LoggedTest
 
     public MvcTestFixture<RazorPagesWebSite.Startup> Factory { get; private set; }
 
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/55926")]
     [Fact]
     public async Task DisablingClientValidation_DisablesItForPagesAndViews()
     {

--- a/src/Mvc/test/Mvc.FunctionalTests/ComponentRenderingFunctionalTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/ComponentRenderingFunctionalTests.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using AngleSharp.Parser.Html;
 using BasicWebSite;
 using BasicWebSite.Services;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit.Abstractions;

--- a/src/Mvc/test/Mvc.FunctionalTests/ComponentRenderingFunctionalTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/ComponentRenderingFunctionalTests.cs
@@ -7,7 +7,6 @@ using System.Reflection;
 using AngleSharp.Parser.Html;
 using BasicWebSite;
 using BasicWebSite.Services;
-using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit.Abstractions;
@@ -45,7 +44,6 @@ public class ComponentRenderingFunctionalTests : LoggedTest
         AssertComponent("<p>Hello world!</p>", "Greetings", content);
     }
 
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/55928")]
     [Fact]
     public async Task Renders_RoutingComponent()
     {

--- a/src/Mvc/test/Mvc.FunctionalTests/ControllerEndpointFiltersTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/ControllerEndpointFiltersTest.cs
@@ -8,7 +8,6 @@ using System.Reflection;
 using System.Text.Json;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using RoutingWebSite;
 using Xunit.Abstractions;
@@ -33,7 +32,6 @@ public class ControllerEndpointFiltersTest : LoggedTest
 
     public WebApplicationFactory<StartupForEndpointFilters> Factory { get; private set; }
 
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/55929")]
     [Fact]
     public async Task CanApplyEndpointFilterToController()
     {

--- a/src/Mvc/test/Mvc.FunctionalTests/ControllerEndpointFiltersTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/ControllerEndpointFiltersTest.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Text.Json;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using RoutingWebSite;
 using Xunit.Abstractions;

--- a/src/Mvc/test/Mvc.FunctionalTests/HtmlGenerationWithCultureTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/HtmlGenerationWithCultureTest.cs
@@ -38,7 +38,6 @@ public class HtmlGenerationWithCultureTest : LoggedTest
     public WebApplicationFactory<StartupWithCultureReplace> Factory { get; private set; }
     public HttpClient Client { get; private set; }
 
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/4907")]
     [Fact]
     public async Task CacheTagHelper_AllowsVaryingByCulture()
     {
@@ -83,7 +82,6 @@ public class HtmlGenerationWithCultureTest : LoggedTest
         }
     }
 
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/4907")]
     [Fact]
     public async Task CacheTagHelper_AllowsVaryingByUICulture()
     {

--- a/src/Mvc/test/Mvc.FunctionalTests/RoutingAcrossPipelineBranchesTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RoutingAcrossPipelineBranchesTest.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Net.Http.Json;
 using System.Reflection;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using RoutingWebSite;
 using Xunit.Abstractions;

--- a/src/Mvc/test/Mvc.FunctionalTests/RoutingAcrossPipelineBranchesTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RoutingAcrossPipelineBranchesTest.cs
@@ -6,7 +6,6 @@ using System.Net.Http;
 using System.Net.Http.Json;
 using System.Reflection;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using RoutingWebSite;
 using Xunit.Abstractions;
@@ -33,7 +32,6 @@ public class RoutingAcrossPipelineBranchesTests : LoggedTest
     public WebApplicationFactory<RoutingWebSite.StartupRoutingDifferentBranches> Factory { get; private set; }
     public HttpClient Client { get; private set; }
 
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/55933")]
     [Fact]
     public async Task MatchesConventionalRoutesInTheirBranches()
     {

--- a/src/Mvc/test/Mvc.FunctionalTests/RoutingDynamicOrderTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RoutingDynamicOrderTest.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Net.Http.Json;
 using System.Reflection;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using RoutingWebSite;
 using Xunit.Abstractions;

--- a/src/Mvc/test/Mvc.FunctionalTests/RoutingDynamicOrderTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RoutingDynamicOrderTest.cs
@@ -6,7 +6,6 @@ using System.Net.Http;
 using System.Net.Http.Json;
 using System.Reflection;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using RoutingWebSite;
 using Xunit.Abstractions;
@@ -52,7 +51,6 @@ public class RoutingDynamicOrderTest : LoggedTest
         Assert.Equal("AttributeRouteSlug", content.RouteName);
     }
 
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/55934")]
     [Fact]
     public async Task DynamicRoutesAreMatchedInDefinitionOrderOverPrecedence()
     {

--- a/src/Mvc/test/Mvc.FunctionalTests/RoutingGroupsTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RoutingGroupsTest.cs
@@ -34,7 +34,6 @@ public class RoutingGroupsTests : LoggedTest
     public WebApplicationFactory<StartupForGroups> Factory { get; private set; }
     public HttpClient Client { get; private set; }
 
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/55931")]
     [Fact]
     public async Task MatchesControllerGroup()
     {

--- a/src/Mvc/test/Mvc.FunctionalTests/RoutingGroupsWithMetadataTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RoutingGroupsWithMetadataTest.cs
@@ -6,6 +6,7 @@ using System.Net.Http.Json;
 using System.Reflection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using RoutingWebSite;
 using Xunit.Abstractions;

--- a/src/Mvc/test/Mvc.FunctionalTests/RoutingGroupsWithMetadataTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RoutingGroupsWithMetadataTest.cs
@@ -6,7 +6,6 @@ using System.Net.Http.Json;
 using System.Reflection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using RoutingWebSite;
 using Xunit.Abstractions;
@@ -31,7 +30,6 @@ public class RoutingGroupsWithMetadataTests : LoggedTest
 
     public WebApplicationFactory<StartupForRouteGroupsWithMetadata> Factory { get; private set; }
 
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/55927")]
     [Fact]
     public async Task OrderedGroupMetadataForControllers()
     {

--- a/src/Mvc/test/Mvc.FunctionalTests/TestingInfrastructureTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/TestingInfrastructureTests.cs
@@ -7,7 +7,6 @@ using System.Net.Http.Formatting;
 using BasicWebSite;
 using BasicWebSite.Controllers;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.Mvc.Testing.Handlers;
 using Microsoft.AspNetCore.TestHost;
@@ -137,7 +136,6 @@ public class TestingInfrastructureTests : IClassFixture<WebApplicationFactory<Ba
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/55932")]
     [Fact]
     public async Task TestingInfrastructure_RedirectHandlerFollowsStatusCode303()
     {


### PR DESCRIPTION
This reverts commit 06c24665d4289373150e45a229138401494b05f1.

Tests have been passing for a month in quarantine. Normally that doesn't mean they should be removed, but we've added logging to Mvc.FunctionalTests since then and would like to make the failures (if any) more likely by adding them back to the main runs.