### PR TITLE
Add an option on the `ExceptionHandlerOptions` to select status codes based on exceptions

### DIFF
--- a/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerMiddlewareImpl.cs
+++ b/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerMiddlewareImpl.cs
@@ -165,7 +165,7 @@ internal sealed class ExceptionHandlerMiddlewareImpl
 
             context.Features.Set<IExceptionHandlerFeature>(exceptionHandlerFeature);
             context.Features.Set<IExceptionHandlerPathFeature>(exceptionHandlerFeature);
-            context.Response.StatusCode = DefaultStatusCode;
+            context.Response.StatusCode = _options.StatusCodeSelector?.Invoke(edi.SourceException) ?? DefaultStatusCode;
             context.Response.OnStarting(_clearCacheHeadersDelegate, context.Response);
 
             string? handler = null;
@@ -192,7 +192,7 @@ internal sealed class ExceptionHandlerMiddlewareImpl
                     {
                         HttpContext = context,
                         AdditionalMetadata = exceptionHandlerFeature.Endpoint?.Metadata,
-                        ProblemDetails = { Status = DefaultStatusCode },
+                        ProblemDetails = { Status = context.Response.StatusCode },
                         Exception = edi.SourceException,
                     });
                     if (handled)
@@ -202,7 +202,7 @@ internal sealed class ExceptionHandlerMiddlewareImpl
                 }
             }
             // If the response has already started, assume exception handler was successful.
-            if (context.Response.HasStarted || handled || context.Response.StatusCode != StatusCodes.Status404NotFound || _options.AllowStatusCode404Response)
+            if (context.Response.HasStarted || handled || _options.StatusCodeSelector != null || context.Response.StatusCode != StatusCodes.Status404NotFound || _options.AllowStatusCode404Response)
             {
                 const string eventName = "Microsoft.AspNetCore.Diagnostics.HandledException";
                 if (_diagnosticListener.IsEnabled() && _diagnosticListener.IsEnabled(eventName))

--- a/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerOptions.cs
+++ b/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerOptions.cs
@@ -38,4 +38,12 @@ public class ExceptionHandlerOptions
     /// the original exception.
     /// </summary>
     public bool AllowStatusCode404Response { get; set; }
+
+    /// <summary>
+    /// Gets or sets a delegate used to map an exception to a http status code.
+    /// </summary>
+    /// <remarks>
+    /// If <see cref="StatusCodeSelector"/> is <c>null</c>, the default exception status code 500 is used.
+    /// </remarks>
+    public Func<Exception, int>? StatusCodeSelector { get; set; }
 }

--- a/src/Middleware/Diagnostics/src/PublicAPI.Unshipped.txt
+++ b/src/Middleware/Diagnostics/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.AspNetCore.Builder.ExceptionHandlerOptions.StatusCodeSelector.get -> System.Func<System.Exception!, int>?
+Microsoft.AspNetCore.Builder.ExceptionHandlerOptions.StatusCodeSelector.set -> void

--- a/src/Middleware/Diagnostics/test/FunctionalTests/ProblemDetailsExceptionHandlerSampleTest.cs
+++ b/src/Middleware/Diagnostics/test/FunctionalTests/ProblemDetailsExceptionHandlerSampleTest.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using Microsoft.AspNetCore.Mvc;
 using System.Net.Http.Json;
 using System.Net.Http.Headers;
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Diagnostics.FunctionalTests;
 
@@ -33,5 +34,22 @@ public class ProblemDetailsExceptionHandlerSampleTest : IClassFixture<TestFixtur
         Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
         Assert.NotNull(body);
         Assert.Equal(500, body.Status);
+    }
+
+    [Fact]
+    public async Task StatusCodeSelector_ProducesProblemDetailsWith403()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost/throw/conflict");
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        var body = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+        Assert.NotNull(body);
+        Assert.Equal(StatusCodes.Status409Conflict, body.Status);
     }
 }

--- a/src/Middleware/Diagnostics/test/FunctionalTests/ProblemDetailsExceptionHandlerSampleTest.cs
+++ b/src/Middleware/Diagnostics/test/FunctionalTests/ProblemDetailsExceptionHandlerSampleTest.cs
@@ -37,10 +37,10 @@ public class ProblemDetailsExceptionHandlerSampleTest : IClassFixture<TestFixtur
     }
 
     [Fact]
-    public async Task StatusCodeSelector_ProducesProblemDetailsWith403()
+    public async Task StatusCodeSelector_ProducesProblemDetailsWithCustomStatusCode()
     {
         // Arrange
-        var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost/throw/conflict");
+        var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost/throw2/conflict");
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
         // Act

--- a/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerTest.cs
@@ -692,7 +692,7 @@ public class ExceptionHandlerTest
     }
 
     [Fact]
-    public async Task ExceptionHandler_SelectsStatusCode404_When404ThrowedAndNotNotAllowed()
+    public async Task StatusCodeSelector_CanSelect404()
     {
         using var host = new HostBuilder()
             .ConfigureWebHost(webHostBuilder =>

--- a/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerTest.cs
@@ -657,6 +657,80 @@ public class ExceptionHandlerTest
     }
 
     [Fact]
+    public async Task ExceptionHandler_SelectsStatusCode()
+    {
+        using var host = new HostBuilder()
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder
+                    .UseTestServer()
+                    .ConfigureServices(services => services.AddProblemDetails())
+                    .Configure(app =>
+                    {
+                        app.UseExceptionHandler(new ExceptionHandlerOptions
+                        {
+                            StatusCodeSelector = ex => ex is ApplicationException
+                                ? StatusCodes.Status409Conflict
+                                : StatusCodes.Status500InternalServerError,
+                        });
+
+                        app.Map("/throw", innerAppBuilder =>
+                        {
+                            innerAppBuilder.Run(_ => throw new ApplicationException("Something bad happened."));
+                        });
+                    });
+            }).Build();
+
+        await host.StartAsync();
+
+        using (var server = host.GetTestServer())
+        {
+            var client = server.CreateClient();
+            var response = await client.GetAsync("throw");
+            Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+        }
+    }
+
+    [Fact]
+    public async Task ExceptionHandler_SelectsStatusCode404_When404ThrowedAndNotNotAllowed()
+    {
+        using var host = new HostBuilder()
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder
+                    .UseTestServer()
+                    .ConfigureServices(services => services.AddProblemDetails())
+                    .Configure(app =>
+                    {
+                        app.UseExceptionHandler(new ExceptionHandlerOptions
+                        {
+                            // 404 is not allowed,
+                            // but as the exception is explicitly mapped to 404 by the StatusCodeSelector,
+                            // it should be set anyway.
+                            AllowStatusCode404Response = false,
+                            StatusCodeSelector = ex => ex is ApplicationException
+                                ? StatusCodes.Status404NotFound
+                                : StatusCodes.Status500InternalServerError,
+                        });
+
+                        app.Map("/throw", innerAppBuilder =>
+                        {
+                            innerAppBuilder.Run(_ => throw new ApplicationException("Something bad happened."));
+                        });
+                    });
+            }).Build();
+
+        await host.StartAsync();
+
+        using (var server = host.GetTestServer())
+        {
+            var client = server.CreateClient();
+            var response = await client.GetAsync("throw");
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+    }
+
+    [Fact]
     public async Task ExceptionHandlerWithOwnBuilder()
     {
         var sink = new TestSink(TestSink.EnableWithTypeName<ExceptionHandlerMiddleware>);

--- a/src/Middleware/Diagnostics/test/testassets/ExceptionHandlerSample/ConflictException.cs
+++ b/src/Middleware/Diagnostics/test/testassets/ExceptionHandlerSample/ConflictException.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace ExceptionHandlerSample;
+
+public class ConflictException(string message) : Exception(message);

--- a/src/Middleware/Diagnostics/test/testassets/ExceptionHandlerSample/StartupWithProblemDetails.cs
+++ b/src/Middleware/Diagnostics/test/testassets/ExceptionHandlerSample/StartupWithProblemDetails.cs
@@ -17,12 +17,22 @@ public class StartupWithProblemDetails
     public void Configure(IApplicationBuilder app)
     {
         // Configure the error handler to produces a ProblemDetails.
-        app.UseExceptionHandler();
+        app.UseExceptionHandler(new ExceptionHandlerOptions
+        {
+            StatusCodeSelector = ex => ex is ConflictException
+                ? StatusCodes.Status409Conflict
+                : StatusCodes.Status500InternalServerError,
+        });
 
         // The broken section of our application.
         app.Map("/throw", throwApp =>
         {
-            throwApp.Run(context => { throw new Exception("Application Exception"); });
+            throwApp.Map("/conflict", throwConflictApp =>
+            {
+                throwConflictApp.Run(_ => throw new ConflictException("Conflict Exception"));
+            });
+
+            throwApp.Run(_ => throw new Exception("Application Exception"));
         });
 
         app.UseStaticFiles();
@@ -32,7 +42,8 @@ public class StartupWithProblemDetails
         {
             context.Response.ContentType = "text/html";
             await context.Response.WriteAsync("<html><body>Welcome to the sample<br><br>\r\n");
-            await context.Response.WriteAsync("Click here to throw an exception: <a href=\"/throw\">throw</a>\r\n");
+            await context.Response.WriteAsync("Click here to throw an exception: <a href=\"/throw\">throw</a><br>\r\n");
+            await context.Response.WriteAsync("Click here to throw a conflict exception: <a href=\"/throw/conflict\">throw conflict</a>\r\n");
             await context.Response.WriteAsync("</body></html>\r\n");
         });
     }


### PR DESCRIPTION
# Add an option on the `ExceptionHandlerOptions` to select status codes based on exceptions

Adds `Func<Exception, int>? StatusCodeSelector` to the `ExceptionHandlerOptions` which allows users to easily map an exception to a status code. The `ExceptionHandlerMiddlewareImpl` uses that new status code selector whenever the default status code of 500 was used and only falls back to 500 if no status code selector is set on the options.
If a status code selector is set, 404 status codes are allowed (`AllowStatusCode404Response` is ignored).

Fixes #44156
