### PR TITLE
Removing unsafe parts of Decode method in QueryStringEnumerable

### DIFF
--- a/src/Http/Http/perf/Microbenchmarks/QueryCollectionBenchmarks.cs
+++ b/src/Http/Http/perf/Microbenchmarks/QueryCollectionBenchmarks.cs
@@ -18,7 +18,7 @@ public class QueryCollectionBenchmarks
     private string _singleValueWithPlus;
     private string _encoded;
 
-    [IterationSetup]
+    [GlobalSetup]
     public void Setup()
     {
         _queryString = "?key1=value1&key2=value2&key3=value3&key4=&key5=";

--- a/src/Http/Http/perf/Microbenchmarks/QueryCollectionBenchmarks.cs
+++ b/src/Http/Http/perf/Microbenchmarks/QueryCollectionBenchmarks.cs
@@ -13,19 +13,10 @@ namespace Microsoft.AspNetCore.Http;
 [CategoriesColumn]
 public class QueryCollectionBenchmarks
 {
-    private string _queryString;
-    private string _singleValue;
-    private string _singleValueWithPlus;
-    private string _encoded;
-
-    [GlobalSetup]
-    public void Setup()
-    {
-        _queryString = "?key1=value1&key2=value2&key3=value3&key4=&key5=";
-        _singleValue = "?key1=value1";
-        _singleValueWithPlus = "?key1=value1+value2+value3";
-        _encoded = "?key1=value%231";
-    }
+    private const string _queryString = "?key1=value1&key2=value2&key3=value3&key4=&key5=";
+    private const string _singleValue = "?key1=value1";
+    private const string _singleValueWithPlus = "?key1=value1+value2+value3";
+    private const string _encoded = "?key1=value%231";
 
     [Benchmark(Description = "ParseNew")]
     [BenchmarkCategory("QueryString")]

--- a/src/Shared/QueryStringEnumerable.cs
+++ b/src/Shared/QueryStringEnumerable.cs
@@ -91,10 +91,8 @@ internal
 
         private static ReadOnlyMemory<char> Decode(ReadOnlyMemory<char> chars)
         {
-            // If the value is short, it's cheap to check up front if it really needs decoding. If it doesn't,
-            // then we can save some allocations.
             ReadOnlySpan<char> source = chars.Span;
-            if (source.Length < 16 && source.IndexOfAny('%', '+') < 0)
+            if (!source.ContainsAny('%', '+'))
             {
                 return chars;
             }

--- a/src/Shared/QueryStringEnumerable.cs
+++ b/src/Shared/QueryStringEnumerable.cs
@@ -57,8 +57,6 @@ internal
     /// </summary>
     public readonly struct EncodedNameValuePair
     {
-        private static readonly SearchValues<char> DecodingChars = SearchValues.Create("%+");
-
         /// <summary>
         /// Gets the name from this name/value pair in its original encoded form.
         /// To get the decoded string, call <see cref="DecodeName"/>.
@@ -96,7 +94,7 @@ internal
             // If the value is short, it's cheap to check up front if it really needs decoding. If it doesn't,
             // then we can save some allocations.
             ReadOnlySpan<char> source = chars.Span;
-            if (source.Length < 16 && source.IndexOfAny(DecodingChars) < 0)
+            if (source.Length < 16 && source.IndexOfAny('%', '+') < 0)
             {
                 return chars;
             }

--- a/src/Shared/QueryStringEnumerable.cs
+++ b/src/Shared/QueryStringEnumerable.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Buffers;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
@@ -99,7 +100,11 @@ internal
             {
                 return chars;
             }
-            return Uri.UnescapeDataString(string.Create(source.Length, source, static (dest, source) => source.Replace(dest, '+', ' '))).AsMemory();
+            var buffer = new char[source.Length];
+            source.Replace(buffer, '+', ' ');
+            var success = Uri.TryUnescapeDataString(buffer, buffer, out var unescapedLength);
+            Debug.Assert(success);
+            return buffer.AsMemory(0, unescapedLength);
         }
     }
 


### PR DESCRIPTION
Removing unsafe parts of Decode method in QueryStringEnumerable

## Description

- Removing unsafe part and using string.Create passing in a ROS
- Fixing IterationCount related data consistency issues in QueryCollectionBenchmarks
- Executing QueryCollectionBenchmarks
- Experimented avoiding the `string.Create` by stack allocating a buffer when the input is smaller than 256 chars and using the ROS overload of `Uri.UnescapeDataString`. While this reduced some allocations overall, it cost a performance penalty (ie. the *Single* case below is executing in the ~74 ns range instead of ~67ns) on my machine.

## Performance

Just to confirm there is no perf degradation.

### BEFORE:

BenchmarkDotNet=v0.13.0, OS=Windows 10.0.22631
12th Gen Intel Core i7-1255U, 1 CPU, 12 logical and 10 physical cores
.NET SDK=9.0.100-preview.6.24316.4
  [Host]     : .NET 9.0.0 (9.0.24.32008), X64 RyuJIT
  Job-PTTTFA : .NET 9.0.0 (9.0.24.30702), X64 RyuJIT

Server=True  Toolchain=.NET Core 9.0  RunStrategy=Throughput

Measurement 1:

```
|   Method |     Categories |        Mean |     Error |    StdDev |                Op/s |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------- |--------------- |------------:|----------:|----------:|--------------------:|-------:|------:|------:|----------:|
| ParseNew |    QueryString | 267.7844 ns | 3.5603 ns | 3.3303 ns |         3,734,347.7 | 0.0052 |     - |     - |     512 B |
|          |                |             |           |           |                     |        |       |       |
| ParseNew |         Single |  65.8172 ns | 0.5523 ns | 0.4612 ns |        15,193,595.8 | 0.0032 |     - |     - |     304 B |
|          |                |             |           |           |                     |        |       |       |
| ParseNew | SingleWithPlus |  82.7875 ns | 0.4517 ns | 0.4004 ns |        12,079,119.8 | 0.0042 |     - |     - |     392 B |
|          |                |             |           |           |                     |        |       |       |
| ParseNew |        Encoded |  98.9658 ns | 0.3215 ns | 0.2850 ns |        10,104,503.6 | 0.0042 |     - |     - |     384 B |
```

Measurement 2:

```
|   Method |     Categories |        Mean |     Error |    StdDev |                Op/s |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------- |--------------- |------------:|----------:|----------:|--------------------:|-------:|------:|------:|----------:|
| ParseNew |    QueryString | 275.0711 ns | 3.5305 ns | 3.3025 ns |         3,635,423.8 | 0.0052 |     - |     - |     512 B |
|          |                |             |           |           |                     |        |       |       |           |
| ParseNew |         Single |  67.2911 ns | 0.6149 ns | 0.5752 ns |        14,860,804.6 | 0.0032 |     - |     - |     304 B |
|          |                |             |           |           |                     |        |       |       |           |
| ParseNew | SingleWithPlus |  83.6517 ns | 0.6121 ns | 0.5726 ns |        11,954,328.4 | 0.0042 |     - |     - |     392 B |
|          |                |             |           |           |                     |        |       |       |           |
| ParseNew |        Encoded |  99.3918 ns | 0.4289 ns | 0.3802 ns |        10,061,194.3 | 0.0042 |     - |     - |     384 B |
```

### AFTER:

Measurement 1:

```
|   Method |     Categories |      Mean |    Error |   StdDev |         Op/s |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------- |--------------- |----------:|---------:|---------:|-------------:|-------:|------:|------:|----------:|
| ParseNew |    QueryString | 274.17 ns | 4.893 ns | 4.577 ns |  3,647,342.1 | 0.0052 |     - |     - |     512 B |
|          |                |           |          |          |              |        |       |       |           |
| ParseNew |         Single |  68.62 ns | 0.595 ns | 0.527 ns | 14,571,966.8 | 0.0032 |     - |     - |     304 B |
|          |                |           |          |          |              |        |       |       |           |
| ParseNew | SingleWithPlus |  89.93 ns | 0.541 ns | 0.480 ns | 11,119,491.8 | 0.0042 |     - |     - |     392 B |
|          |                |           |          |          |              |        |       |       |           |
| ParseNew |        Encoded |  93.91 ns | 0.704 ns | 0.624 ns | 10,648,088.7 | 0.0038 |     - |     - |     352 B |
```

Measurement 2:

```
|   Method |     Categories |      Mean |    Error |   StdDev |         Op/s |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------- |--------------- |----------:|---------:|---------:|-------------:|-------:|------:|------:|----------:|
| ParseNew |    QueryString | 275.22 ns | 2.572 ns | 2.406 ns |  3,633,462.4 | 0.0052 |     - |     - |     512 B |
|          |                |           |          |          |              |        |       |       |           |
| ParseNew |         Single |  69.96 ns | 0.784 ns | 0.695 ns | 14,293,085.2 | 0.0032 |     - |     - |     304 B |
|          |                |           |          |          |              |        |       |       |           |
| ParseNew | SingleWithPlus |  92.03 ns | 0.841 ns | 0.787 ns | 10,865,661.8 | 0.0042 |     - |     - |     392 B |
|          |                |           |          |          |              |        |       |       |           |
| ParseNew |        Encoded |  93.94 ns | 0.716 ns | 0.670 ns | 10,645,632.4 | 0.0038 |     - |     - |     352 B |
```

Part of: https://github.com/dotnet/aspnetcore/issues/56534