### PR TITLE
[release/6.0] Bundle runtime .MSI's instead of .exe's

### DIFF
--- a/src/Installers/Windows/WindowsHostingBundle/DotNetCore.wxs
+++ b/src/Installers/Windows/WindowsHostingBundle/DotNetCore.wxs
@@ -1,44 +1,56 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
     <Fragment>
-        <util:ProductSearch Id="DotNetRedistLtsProductSearch_x86"
-                            Condition="NOT VersionNT64"
-                            ProductCode="$(var.DotNetRedistLtsInstallerProductCodex86)"
-                            Result="version"
-                            Variable="DotNetRedistLtsProductVersion_x86" />
-
-        <util:ProductSearch Id="DotNetRedistLtsProductSearch_x64"
-                            Condition="VersionNT64"
-                            ProductCode="$(var.DotNetRedistLtsInstallerProductCodex64)"
-                            Result="version"
-                            Variable="DotNetRedistLtsProductVersion_x64" />
-
         <PackageGroup Id="PG_DOTNET_REDIST_LTS_BUNDLE">
-            <RollbackBoundary Id="RB_DOTNET_REDIST_LTS_BUNDLE" />
-
+            <RollbackBoundary Id="RB_DOTNET_REDIST_LTS_BUNDLE" />         
+            
             <!-- OPT_NO_RUNTIME could be unset at this point, which we explicitly treat as 'false' -->
-            <ExePackage Id="DotNetRedistLts_x64" SourceFile="$(var.DepsPath)\$(var.DotNetRedistLtsInstallerx64)"
+            <MsiPackage Id="DotNetRedistLts_x64" SourceFile="$(var.DepsPath)\$(var.DotNetRedistLtsInstallerx64)"
                         Name="$(var.DotNetRedistLtsInstallerx64)"
                         Compressed="yes"
                         Vital="yes"
-                        InstallCondition="VersionNT64 AND (NOT OPT_NO_RUNTIME OR OPT_NO_RUNTIME=&quot;0&quot;)"
-                        InstallCommand="/quiet /norestart"
-                        RepairCommand="/quiet /norestart /repair"
-                        UninstallCommand="/quiet /norestart /uninstall"
-                        DetectCondition="DotNetRedistLtsProductVersion_x64 = v$(var.DotNetRedistLtsInstallerProductVersionx64)">
-            </ExePackage>
+                        InstallCondition="VersionNT64 AND (NOT OPT_NO_RUNTIME OR OPT_NO_RUNTIME=&quot;0&quot;)">
+            </MsiPackage>
 
             <!-- OPT_NO_X86 could be unset at this point, which we explicitly treat as 'false' -->
-            <ExePackage Id="DotNetRedistLts_x86" SourceFile="$(var.DepsPath)\$(var.DotNetRedistLtsInstallerx86)"
+            <MsiPackage Id="DotNetRedistLts_x86" SourceFile="$(var.DepsPath)\$(var.DotNetRedistLtsInstallerx86)"
                         Name="$(var.DotNetRedistLtsInstallerx86)"
                         Compressed="yes"
                         Vital="yes"
-                        InstallCondition="(NOT OPT_NO_RUNTIME OR OPT_NO_RUNTIME=&quot;0&quot;) AND (NOT OPT_NO_X86 OR OPT_NO_X86=&quot;0&quot;)"
-                        InstallCommand="/quiet /norestart"
-                        RepairCommand="/quiet /norestart /repair"
-                        UninstallCommand="/quiet /norestart /uninstall"
-                        DetectCondition="DotNetRedistLtsProductVersion_x86 = v$(var.DotNetRedistLtsInstallerProductVersionx86)">
-            </ExePackage>
+                        InstallCondition="(NOT OPT_NO_RUNTIME OR OPT_NO_RUNTIME=&quot;0&quot;) AND (NOT OPT_NO_X86 OR OPT_NO_X86=&quot;0&quot;)">
+            </MsiPackage>         
+            
+            <!-- OPT_NO_RUNTIME could be unset at this point, which we explicitly treat as 'false' -->
+            <MsiPackage Id="DotNetRedistHost_x64" SourceFile="$(var.DepsPath)\$(var.DotNetRedistHostInstallerx64)"
+                        Name="$(var.DotNetRedistHostInstallerx64)"
+                        Compressed="yes"
+                        Vital="yes"
+                        InstallCondition="VersionNT64 AND (NOT OPT_NO_RUNTIME OR OPT_NO_RUNTIME=&quot;0&quot;)">
+            </MsiPackage>
+
+            <!-- OPT_NO_X86 could be unset at this point, which we explicitly treat as 'false' -->
+            <MsiPackage Id="DotNetRedistHost_x86" SourceFile="$(var.DepsPath)\$(var.DotNetRedistHostInstallerx86)"
+                        Name="$(var.DotNetRedistHostInstallerx86)"
+                        Compressed="yes"
+                        Vital="yes"
+                        InstallCondition="(NOT OPT_NO_RUNTIME OR OPT_NO_RUNTIME=&quot;0&quot;) AND (NOT OPT_NO_X86 OR OPT_NO_X86=&quot;0&quot;)">
+            </MsiPackage>         
+            
+            <!-- OPT_NO_RUNTIME could be unset at this point, which we explicitly treat as 'false' -->
+            <MsiPackage Id="DotNetRedistHostfxr_x64" SourceFile="$(var.DepsPath)\$(var.DotNetRedistHostfxrInstallerx64)"
+                        Name="$(var.DotNetRedistHostfxrInstallerx64)"
+                        Compressed="yes"
+                        Vital="yes"
+                        InstallCondition="VersionNT64 AND (NOT OPT_NO_RUNTIME OR OPT_NO_RUNTIME=&quot;0&quot;)">
+            </MsiPackage>
+
+            <!-- OPT_NO_X86 could be unset at this point, which we explicitly treat as 'false' -->
+            <MsiPackage Id="DotNetRedistHostfxr_x86" SourceFile="$(var.DepsPath)\$(var.DotNetRedistHostfxrInstallerx86)"
+                        Name="$(var.DotNetRedistHostfxrInstallerx86)"
+                        Compressed="yes"
+                        Vital="yes"
+                        InstallCondition="(NOT OPT_NO_RUNTIME OR OPT_NO_RUNTIME=&quot;0&quot;) AND (NOT OPT_NO_X86 OR OPT_NO_X86=&quot;0&quot;)">
+            </MsiPackage>
         </PackageGroup>
     </Fragment>
 </Wix>

--- a/src/Installers/Windows/WindowsHostingBundle/Product.targets
+++ b/src/Installers/Windows/WindowsHostingBundle/Product.targets
@@ -37,22 +37,22 @@
 
     <!-- Use the BrowserDebugHost as a sentinel for the nonshipping version for NETCoreApp. -->
     <ItemGroup>
-      <RemoteAsset Include="$(MicrosoftNETCoreBrowserDebugHostTransportVersion)/dotnet-runtime-$(MicrosoftNETCoreAppRuntimeVersion)-win-x64.msi">
+      <RemoteAsset Include="Runtime/$(MicrosoftNETCoreBrowserDebugHostTransportVersion)/dotnet-runtime-$(MicrosoftNETCoreAppRuntimeVersion)-win-x64.msi">
         <TargetFileName>dotnet-runtime-$(MicrosoftNETCoreAppRuntimeVersion)-win-x64.msi</TargetFileName>
       </RemoteAsset>
-      <RemoteAsset Include="$(MicrosoftNETCoreBrowserDebugHostTransportVersion)/dotnet-runtime-$(MicrosoftNETCoreAppRuntimeVersion)-win-x86.msi">
+      <RemoteAsset Include="Runtime/$(MicrosoftNETCoreBrowserDebugHostTransportVersion)/dotnet-runtime-$(MicrosoftNETCoreAppRuntimeVersion)-win-x86.msi">
         <TargetFileName>dotnet-runtime-$(MicrosoftNETCoreAppRuntimeVersion)-win-x86.msi</TargetFileName>
       </RemoteAsset>
-      <RemoteAsset Include="$(MicrosoftNETCoreBrowserDebugHostTransportVersion)/dotnet-host-$(MicrosoftNETCoreAppRuntimeVersion)-win-x64.msi">
+      <RemoteAsset Include="Runtime/$(MicrosoftNETCoreBrowserDebugHostTransportVersion)/dotnet-host-$(MicrosoftNETCoreAppRuntimeVersion)-win-x64.msi">
         <TargetFileName>dotnet-host-$(MicrosoftNETCoreAppRuntimeVersion)-win-x64.msi</TargetFileName>
       </RemoteAsset>
-      <RemoteAsset Include="$(MicrosoftNETCoreBrowserDebugHostTransportVersion)/dotnet-host-$(MicrosoftNETCoreAppRuntimeVersion)-win-x86.msi">
+      <RemoteAsset Include="Runtime/$(MicrosoftNETCoreBrowserDebugHostTransportVersion)/dotnet-host-$(MicrosoftNETCoreAppRuntimeVersion)-win-x86.msi">
         <TargetFileName>dotnet-host-$(MicrosoftNETCoreAppRuntimeVersion)-win-x86.msi</TargetFileName>
       </RemoteAsset>
-      <RemoteAsset Include="$(MicrosoftNETCoreBrowserDebugHostTransportVersion)/dotnet-hostfxr-$(MicrosoftNETCoreAppRuntimeVersion)-win-x64.msi">
+      <RemoteAsset Include="Runtime/$(MicrosoftNETCoreBrowserDebugHostTransportVersion)/dotnet-hostfxr-$(MicrosoftNETCoreAppRuntimeVersion)-win-x64.msi">
         <TargetFileName>dotnet-hostfxr-$(MicrosoftNETCoreAppRuntimeVersion)-win-x64.msi</TargetFileName>
       </RemoteAsset>
-      <RemoteAsset Include="$(MicrosoftNETCoreBrowserDebugHostTransportVersion)/dotnet-hostfxr-$(MicrosoftNETCoreAppRuntimeVersion)-win-x86.msi">
+      <RemoteAsset Include="Runtime/$(MicrosoftNETCoreBrowserDebugHostTransportVersion)/dotnet-hostfxr-$(MicrosoftNETCoreAppRuntimeVersion)-win-x86.msi">
         <TargetFileName>dotnet-hostfxr-$(MicrosoftNETCoreAppRuntimeVersion)-win-x86.msi</TargetFileName>
       </RemoteAsset>
     </ItemGroup>

--- a/src/Installers/Windows/WindowsHostingBundle/Product.targets
+++ b/src/Installers/Windows/WindowsHostingBundle/Product.targets
@@ -27,11 +27,14 @@
     </RuntimeInstallers>
   </ItemGroup>
 
-  <!--
-    Runs before FetchDependencies but can't be depended up because this sets up the item group that target
-    uses for batching.
-  -->
-  <Target Name="CollectDependencies" BeforeTargets="Restore;CollectPackageReferences">
+  <Target Name="FetchDependencies" BeforeTargets="Restore;CollectPackageReferences">
+    <PropertyGroup>
+      <DotNetAssetRootUrl Condition=" '$(DotNetAssetRootUrl)' == '' ">https://dotnetcli.azureedge.net/dotnet/</DotNetAssetRootUrl>
+      <DotNetAssetRootUrl Condition=" ! $(DotNetAssetRootUrl.EndsWith('/'))">$(DotNetAssetRootUrl)/</DotNetAssetRootUrl>
+      <DotNetPrivateAssetRootUrl Condition=" '$(DotNetPrivateAssetRootUrl)' == '' ">https://dotnetclimsrc.azureedge.net/dotnet/</DotNetPrivateAssetRootUrl>
+      <DotNetPrivateAssetRootUrl Condition=" ! $(DotNetPrivateAssetRootUrl.EndsWith('/'))">$(DotNetPrivateAssetRootUrl)/</DotNetPrivateAssetRootUrl>
+    </PropertyGroup>
+
     <!-- Use the BrowserDebugHost as a sentinel for the nonshipping version for NETCoreApp. -->
     <ItemGroup>
       <RemoteAsset Include="$(MicrosoftNETCoreBrowserDebugHostTransportVersion)/dotnet-runtime-$(MicrosoftNETCoreAppRuntimeVersion)-win-x64.msi">
@@ -55,27 +58,12 @@
     </ItemGroup>
 
     <MakeDir Directories="$(DepsPath)" />
-  </Target>
 
-  <Target Name="FetchDependencies" BeforeTargets="Restore;CollectPackageReferences"
-      Outputs="$(DepsPath)%(RemoteAsset.TargetFilename)">
-    <!--
-      Try various places to find the runtime. It's either released (use official version), public but
-      unreleased (use dotnetbuilds/public), or internal and unreleased (use dotnetbuilds/internal).
-    -->
-    <ItemGroup>
-      <UrisToDownload Remove="@(UrisToDownload)" />
-      <UrisToDownload Include="https://dotnetcli.azureedge.net/dotnet/Runtime/%(RemoteAsset.Identity)" />
-      <UrisToDownload Include="https://dotnetbuilds.azureedge.net/public/Runtime/%(RemoteAsset.Identity)" />
-      <UrisToDownload Include="https://dotnetbuilds.azureedge.net/internal/Runtime/%(RemoteAsset.Identity)"
-          Condition=" '$(DotnetRuntimeSourceFeedKey)' != '' ">
-        <token>$(DotnetRuntimeSourceFeedKey)</token>
-      </UrisToDownload>
-    </ItemGroup>
-
-    <DownloadFile Condition=" ! Exists('$(DepsPath)%(RemoteAsset.TargetFilename)') "
-                  Uris="@(UrisToDownload)"
-                  DestinationPath="$(DepsPath)%(RemoteAsset.TargetFilename)" />
+    <DownloadFile Condition=" ! Exists('$(DepsPath)%(RemoteAsset.TargetFileName)') "
+                  Uri="$(DotNetAssetRootUrl)%(RemoteAsset.Identity)"
+                  PrivateUri="$(DotNetPrivateAssetRootUrl)%(RemoteAsset.Identity)"
+                  PrivateUriSuffix="$(DotNetAssetRootAccessTokenSuffix)"
+                  DestinationPath="$(DepsPath)%(RemoteAsset.TargetFileName)" />
   </Target>
 
   <Target Name="ExtractPropertiesFromDotNetMsi" DependsOnTargets="CollectDependencies;FetchDependencies" BeforeTargets="BeforeBuild">

--- a/src/Installers/Windows/WindowsHostingBundle/Product.targets
+++ b/src/Installers/Windows/WindowsHostingBundle/Product.targets
@@ -66,7 +66,7 @@
                   DestinationPath="$(DepsPath)%(RemoteAsset.TargetFileName)" />
   </Target>
 
-  <Target Name="ExtractPropertiesFromDotNetMsi" DependsOnTargets="CollectDependencies;FetchDependencies" BeforeTargets="BeforeBuild">
+  <Target Name="ExtractPropertiesFromDotNetMsi" DependsOnTargets="FetchDependencies" BeforeTargets="BeforeBuild">
     <!-- Create properties that holds the executable name. These are passed to the bundles so we can reference them as variables
              from inside the ExePackage authoring. -->
     <CreateProperty Value="%(RuntimeInstallers.Filename)%(Extension)">

--- a/src/Installers/Windows/WindowsHostingBundle/Product.targets
+++ b/src/Installers/Windows/WindowsHostingBundle/Product.targets
@@ -7,85 +7,91 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Platforms Include="x64;x86" />
-    <RuntimeInstallers Include="$(DepsPath)dotnet-runtime-$(MicrosoftNETCoreAppRuntimeVersion)-win-x64.exe">
-      <TargetPlatform>x64</TargetPlatform>
+    <RuntimeInstallers Include="$(DepsPath)dotnet-runtime-$(MicrosoftNETCoreAppRuntimeVersion)-win-x64.msi">
       <BundleNameProperty>DotNetRedistLtsInstallerx64</BundleNameProperty>
-      <Version>$(MicrosoftNETCoreAppRuntimeVersion)</Version>
     </RuntimeInstallers>
-    <RuntimeInstallers Include="$(DepsPath)dotnet-runtime-$(MicrosoftNETCoreAppRuntimeVersion)-win-x86.exe">
-      <TargetPlatform>x86</TargetPlatform>
+    <RuntimeInstallers Include="$(DepsPath)dotnet-runtime-$(MicrosoftNETCoreAppRuntimeVersion)-win-x86.msi">
       <BundleNameProperty>DotNetRedistLtsInstallerx86</BundleNameProperty>
-      <Version>$(MicrosoftNETCoreAppRuntimeVersion)</Version>
+    </RuntimeInstallers>
+    <RuntimeInstallers Include="$(DepsPath)dotnet-host-$(MicrosoftNETCoreAppRuntimeVersion)-win-x64.msi">
+      <BundleNameProperty>DotNetRedistHostInstallerx64</BundleNameProperty>
+    </RuntimeInstallers>
+    <RuntimeInstallers Include="$(DepsPath)dotnet-host-$(MicrosoftNETCoreAppRuntimeVersion)-win-x86.msi">
+      <BundleNameProperty>DotNetRedistHostInstallerx86</BundleNameProperty>
+    </RuntimeInstallers>
+    <RuntimeInstallers Include="$(DepsPath)dotnet-hostfxr-$(MicrosoftNETCoreAppRuntimeVersion)-win-x64.msi">
+      <BundleNameProperty>DotNetRedistHostfxrInstallerx64</BundleNameProperty>
+    </RuntimeInstallers>
+    <RuntimeInstallers Include="$(DepsPath)dotnet-hostfxr-$(MicrosoftNETCoreAppRuntimeVersion)-win-x86.msi">
+      <BundleNameProperty>DotNetRedistHostfxrInstallerx86</BundleNameProperty>
     </RuntimeInstallers>
   </ItemGroup>
 
-  <Target Name="FetchDependencies" BeforeTargets="Restore;CollectPackageReferences">
-    <PropertyGroup>
-      <DotNetAssetRootUrl Condition=" '$(DotNetAssetRootUrl)' == '' ">https://dotnetcli.azureedge.net/dotnet/</DotNetAssetRootUrl>
-      <DotNetAssetRootUrl Condition=" ! $(DotNetAssetRootUrl.EndsWith('/'))">$(DotNetAssetRootUrl)/</DotNetAssetRootUrl>
-      <DotNetPrivateAssetRootUrl Condition=" '$(DotNetPrivateAssetRootUrl)' == '' ">https://dotnetclimsrc.azureedge.net/dotnet/</DotNetPrivateAssetRootUrl>
-      <DotNetPrivateAssetRootUrl Condition=" ! $(DotNetPrivateAssetRootUrl.EndsWith('/'))">$(DotNetPrivateAssetRootUrl)/</DotNetPrivateAssetRootUrl>
-    </PropertyGroup>
-
+  <!--
+    Runs before FetchDependencies but can't be depended up because this sets up the item group that target
+    uses for batching.
+  -->
+  <Target Name="CollectDependencies" BeforeTargets="Restore;CollectPackageReferences">
     <!-- Use the BrowserDebugHost as a sentinel for the nonshipping version for NETCoreApp. -->
     <ItemGroup>
-      <RemoteAsset Include="Runtime/$(MicrosoftNETCoreBrowserDebugHostTransportVersion)/dotnet-runtime-$(MicrosoftNETCoreAppRuntimeVersion)-win-x64.exe">
-        <TargetFileName>dotnet-runtime-$(MicrosoftNETCoreAppRuntimeVersion)-win-x64.exe</TargetFileName>
+      <RemoteAsset Include="$(MicrosoftNETCoreBrowserDebugHostTransportVersion)/dotnet-runtime-$(MicrosoftNETCoreAppRuntimeVersion)-win-x64.msi">
+        <TargetFileName>dotnet-runtime-$(MicrosoftNETCoreAppRuntimeVersion)-win-x64.msi</TargetFileName>
       </RemoteAsset>
-      <RemoteAsset Include="Runtime/$(MicrosoftNETCoreBrowserDebugHostTransportVersion)/dotnet-runtime-$(MicrosoftNETCoreAppRuntimeVersion)-win-x86.exe">
-        <TargetFileName>dotnet-runtime-$(MicrosoftNETCoreAppRuntimeVersion)-win-x86.exe</TargetFileName>
+      <RemoteAsset Include="$(MicrosoftNETCoreBrowserDebugHostTransportVersion)/dotnet-runtime-$(MicrosoftNETCoreAppRuntimeVersion)-win-x86.msi">
+        <TargetFileName>dotnet-runtime-$(MicrosoftNETCoreAppRuntimeVersion)-win-x86.msi</TargetFileName>
+      </RemoteAsset>
+      <RemoteAsset Include="$(MicrosoftNETCoreBrowserDebugHostTransportVersion)/dotnet-host-$(MicrosoftNETCoreAppRuntimeVersion)-win-x64.msi">
+        <TargetFileName>dotnet-host-$(MicrosoftNETCoreAppRuntimeVersion)-win-x64.msi</TargetFileName>
+      </RemoteAsset>
+      <RemoteAsset Include="$(MicrosoftNETCoreBrowserDebugHostTransportVersion)/dotnet-host-$(MicrosoftNETCoreAppRuntimeVersion)-win-x86.msi">
+        <TargetFileName>dotnet-host-$(MicrosoftNETCoreAppRuntimeVersion)-win-x86.msi</TargetFileName>
+      </RemoteAsset>
+      <RemoteAsset Include="$(MicrosoftNETCoreBrowserDebugHostTransportVersion)/dotnet-hostfxr-$(MicrosoftNETCoreAppRuntimeVersion)-win-x64.msi">
+        <TargetFileName>dotnet-hostfxr-$(MicrosoftNETCoreAppRuntimeVersion)-win-x64.msi</TargetFileName>
+      </RemoteAsset>
+      <RemoteAsset Include="$(MicrosoftNETCoreBrowserDebugHostTransportVersion)/dotnet-hostfxr-$(MicrosoftNETCoreAppRuntimeVersion)-win-x86.msi">
+        <TargetFileName>dotnet-hostfxr-$(MicrosoftNETCoreAppRuntimeVersion)-win-x86.msi</TargetFileName>
       </RemoteAsset>
     </ItemGroup>
 
     <MakeDir Directories="$(DepsPath)" />
-
-    <DownloadFile Condition=" ! Exists('$(DepsPath)%(RemoteAsset.TargetFileName)') "
-                  Uri="$(DotNetAssetRootUrl)%(RemoteAsset.Identity)"
-                  PrivateUri="$(DotNetPrivateAssetRootUrl)%(RemoteAsset.Identity)"
-                  PrivateUriSuffix="$(DotNetAssetRootAccessTokenSuffix)"
-                  DestinationPath="$(DepsPath)%(RemoteAsset.TargetFileName)" />
   </Target>
 
-  <Target Name="ExtractPropertiesFromDotNetMsi" DependsOnTargets="FetchDependencies" BeforeTargets="BeforeBuild">
+  <Target Name="FetchDependencies" BeforeTargets="Restore;CollectPackageReferences"
+      Outputs="$(DepsPath)%(RemoteAsset.TargetFilename)">
+    <!--
+      Try various places to find the runtime. It's either released (use official version), public but
+      unreleased (use dotnetbuilds/public), or internal and unreleased (use dotnetbuilds/internal).
+    -->
+    <ItemGroup>
+      <UrisToDownload Remove="@(UrisToDownload)" />
+      <UrisToDownload Include="https://dotnetcli.azureedge.net/dotnet/Runtime/%(RemoteAsset.Identity)" />
+      <UrisToDownload Include="https://dotnetbuilds.azureedge.net/public/Runtime/%(RemoteAsset.Identity)" />
+      <UrisToDownload Include="https://dotnetbuilds.azureedge.net/internal/Runtime/%(RemoteAsset.Identity)"
+          Condition=" '$(DotnetRuntimeSourceFeedKey)' != '' ">
+        <token>$(DotnetRuntimeSourceFeedKey)</token>
+      </UrisToDownload>
+    </ItemGroup>
+
+    <DownloadFile Condition=" ! Exists('$(DepsPath)%(RemoteAsset.TargetFilename)') "
+                  Uris="@(UrisToDownload)"
+                  DestinationPath="$(DepsPath)%(RemoteAsset.TargetFilename)" />
+  </Target>
+
+  <Target Name="ExtractPropertiesFromDotNetMsi" DependsOnTargets="CollectDependencies;FetchDependencies" BeforeTargets="BeforeBuild">
     <!-- Create properties that holds the executable name. These are passed to the bundles so we can reference them as variables
              from inside the ExePackage authoring. -->
     <CreateProperty Value="%(RuntimeInstallers.Filename)%(Extension)">
       <Output TaskParameter="Value" PropertyName="%(RuntimeInstallers.BundleNameProperty)"/>
     </CreateProperty>
 
-    <!-- Decompile the bundles so that we can extract the MSI and read their version information. We need this to author ExePackage@DetectCondition
-          in the bundles that chain the runtime bundles -->
-    <Exec Command="$(DarkToolPath) -x $(DotNetDarkOutputPath)\%(RuntimeInstallers.Version)\%(TargetPlatform) %(Identity)" />
-
-    <ItemGroup>
-      <DotNetPayload Include="$(DotNetDarkOutputPath)\$(MicrosoftNETCoreAppRuntimeVersion)\%(Platforms.Identity)\AttachedContainer\**\dotnet-host-*win-*.msi">
-        <ProductVersionProperty>DotNetRedistLtsInstallerProductVersion%(Platforms.Identity)</ProductVersionProperty>
-        <ProductCodeProperty>DotNetRedistLtsInstallerProductCode%(Platforms.Identity)</ProductCodeProperty>
-        <UpgradeCodeProperty>DotNetRedistLtsInstallerUpgradeCode%(Platforms.Identity)</UpgradeCodeProperty>
-      </DotNetPayload>
-    </ItemGroup>
-
-    <!-- Read MSI properties -->
-    <GetMsiProperty InstallPackage="%(DotNetPayload.Identity)" Property="ProductVersion">
-      <Output TaskParameter="Value" PropertyName="%(ProductVersionProperty)" />
-    </GetMsiProperty>
-    <GetMsiProperty InstallPackage="%(DotNetPayload.Identity)" Property="ProductCode">
-      <Output TaskParameter="Value" PropertyName="%(ProductCodeProperty)" />
-    </GetMsiProperty>
-    <GetMsiProperty InstallPackage="%(DotNetPayload.Identity)" Property="UpgradeCode">
-      <Output TaskParameter="Value" PropertyName="%(UpgradeCodeProperty)" />
-    </GetMsiProperty>
-
     <PropertyGroup>
       <DefineConstants>$(DefineConstants);DotNetRedistLtsInstallerx64=$(DotNetRedistLtsInstallerx64)</DefineConstants>
-      <DefineConstants>$(DefineConstants);DotNetRedistLtsInstallerProductVersionx64=$(DotNetRedistLtsInstallerProductVersionx64)</DefineConstants>
-      <DefineConstants>$(DefineConstants);DotNetRedistLtsInstallerProductCodex64=$(DotNetRedistLtsInstallerProductCodex64)</DefineConstants>
-      <DefineConstants>$(DefineConstants);DotNetRedistLtsInstallerUpgradeCodex64=$(DotNetRedistLtsInstallerUpgradeCodex64)</DefineConstants>
       <DefineConstants>$(DefineConstants);DotNetRedistLtsInstallerx86=$(DotNetRedistLtsInstallerx86)</DefineConstants>
-      <DefineConstants>$(DefineConstants);DotNetRedistLtsInstallerProductVersionx86=$(DotNetRedistLtsInstallerProductVersionx86)</DefineConstants>
-      <DefineConstants>$(DefineConstants);DotNetRedistLtsInstallerProductCodex86=$(DotNetRedistLtsInstallerProductCodex86)</DefineConstants>
-      <DefineConstants>$(DefineConstants);DotNetRedistLtsInstallerUpgradeCodex86=$(DotNetRedistLtsInstallerUpgradeCodex86)</DefineConstants>
+      <DefineConstants>$(DefineConstants);DotNetRedistHostInstallerx64=$(DotNetRedistHostInstallerx64)</DefineConstants>
+      <DefineConstants>$(DefineConstants);DotNetRedistHostInstallerx86=$(DotNetRedistHostInstallerx86)</DefineConstants>
+      <DefineConstants>$(DefineConstants);DotNetRedistHostfxrInstallerx64=$(DotNetRedistHostfxrInstallerx64)</DefineConstants>
+      <DefineConstants>$(DefineConstants);DotNetRedistHostfxrInstallerx86=$(DotNetRedistHostfxrInstallerx86)</DefineConstants>
     </PropertyGroup>
   </Target>
 </Project>

--- a/src/Installers/Windows/WindowsHostingBundle/SharedFramework.wxs
+++ b/src/Installers/Windows/WindowsHostingBundle/SharedFramework.wxs
@@ -1,44 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
-    <Fragment>
-        <util:ProductSearch Id="SharedFxRedistProductSearch_x86"
-                            Condition="NOT VersionNT64"
-                            ProductCode="$(var.SharedFxInstallerProductCodex86)"
-                            Result="version"
-                            Variable="SharedFxRedistProductVersion_x86" />
-
-        <util:ProductSearch Id="SharedFxRedistProductSearch_x64"
-                            Condition="VersionNT64"
-                            ProductCode="$(var.SharedFxInstallerProductCodex64)"
-                            Result="version"
-                            Variable="SharedFxRedistProductVersion_x64" />
-
+    <Fragment>                           
         <PackageGroup Id="PG_SHAREDFX_REDIST_BUNDLE">
             <RollbackBoundary Id="RB_SHAREDFX_REDIST_BUNDLE" />
-
+            
             <!-- OPT_NO_SHAREDFX could be unset at this point, which we explicitly treat as 'false' -->
-            <ExePackage Id="SharedFxRedist_x64" SourceFile="$(var.InstallersOutputPath)\$(var.SharedFxRedistInstallerx64)"
+            <MsiPackage Id="SharedFxRedist_x64" SourceFile="$(var.InstallersOutputPath)\$(var.SharedFxRedistInstallerx64)"
                         Name="$(var.SharedFxRedistInstallerx64)"
                         Compressed="yes"
                         Vital="yes"
-                        InstallCondition="VersionNT64 AND (NOT OPT_NO_SHAREDFX OR OPT_NO_SHAREDFX=&quot;0&quot;)"
-                        InstallCommand="/quiet /norestart"
-                        RepairCommand="/quiet /norestart /repair"
-                        UninstallCommand="/quiet /norestart /uninstall"
-                        DetectCondition="SharedFxRedistProductVersion_x64 = v$(var.SharedFxInstallerProductVersionx64)">
-            </ExePackage>
+                        InstallCondition="VersionNT64 AND (NOT OPT_NO_SHAREDFX OR OPT_NO_SHAREDFX=&quot;0&quot;)">
+            </MsiPackage>
 
             <!-- OPT_NO_X86 could be unset at this point, which we explicitly treat as 'false' -->
-            <ExePackage Id="SharedFxRedist_x86" SourceFile="$(var.InstallersOutputPath)\$(var.SharedFxRedistInstallerx86)"
+            <MsiPackage Id="SharedFxRedist_x86" SourceFile="$(var.InstallersOutputPath)\$(var.SharedFxRedistInstallerx86)"
                         Name="$(var.SharedFxRedistInstallerx86)"
                         Compressed="yes"
                         Vital="yes"
-                        InstallCondition="(NOT OPT_NO_SHAREDFX OR OPT_NO_SHAREDFX=&quot;0&quot;) AND (NOT OPT_NO_X86 OR OPT_NO_X86=&quot;0&quot;)"
-                        InstallCommand="/quiet /norestart"
-                        RepairCommand="/quiet /norestart /repair"
-                        UninstallCommand="/quiet /norestart /uninstall"
-                        DetectCondition="SharedFxRedistProductVersion_x86 = v$(var.SharedFxInstallerProductVersionx86)">
-            </ExePackage>
+                        InstallCondition="(NOT OPT_NO_SHAREDFX OR OPT_NO_SHAREDFX=&quot;0&quot;) AND (NOT OPT_NO_X86 OR OPT_NO_X86=&quot;0&quot;)">
+            </MsiPackage>
+            
         </PackageGroup>
     </Fragment>
 </Wix>

--- a/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
+++ b/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
@@ -36,7 +36,6 @@
     <Compile Include="Bundle.wxs" />
     <Compile Include="DotNetCore.wxs" />
     <Compile Include="SharedFramework.wxs" />
-    <EmbeddedResource Include="thm.wxl" />
   </ItemGroup>
 
   <ItemGroup>
@@ -54,10 +53,10 @@
       <Private>True</Private>
       <DoNotHarvest>true</DoNotHarvest>
     </ProjectReference>
-    <ProjectReference Include="..\SharedFrameworkBundle\SharedFrameworkBundle.wixproj">
-      <Private>True</Private>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-    </ProjectReference>
+    <ProjectReference Include="..\SharedFrameworkLib\SharedFrameworkLib.wixproj"
+      Private="false"
+      ReferenceOutputAssembly="false"
+      SkipGetTargetFrameworkProperties="true" />
     <ProjectReference Include="..\HostOptions\HostOptions.wixproj">
       <Name>HostOptions</Name>
       <Project>20248cd1-c5aa-4f42-ad88-bc260d64deea</Project>
@@ -97,12 +96,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <SharedFxInstallers Include="$(InstallersOutputPath)$(RuntimeInstallerBaseName)-$(SharedFxPackageVersion)-win-x64.exe">
+    <SharedFxInstallers Include="$(InstallersOutputPath)$(RuntimeInstallerBaseName)-$(SharedFxMsiVersion)-win-x64.msi">
       <TargetPlatform>x64</TargetPlatform>
       <BundleNameProperty>SharedFxRedistInstallerx64</BundleNameProperty>
       <Version>$(SharedFxPackageVersion)</Version>
     </SharedFxInstallers>
-    <SharedFxInstallers Include="$(InstallersOutputPath)$(RuntimeInstallerBaseName)-$(SharedFxPackageVersion)-win-x86.exe">
+    <SharedFxInstallers Include="$(InstallersOutputPath)$(RuntimeInstallerBaseName)-$(SharedFxMsiVersion)-win-x86.msi">
       <TargetPlatform>x86</TargetPlatform>
       <BundleNameProperty>SharedFxRedistInstallerx86</BundleNameProperty>
       <Version>$(SharedFxPackageVersion)</Version>
@@ -128,32 +127,9 @@
       <Output TaskParameter="Value" PropertyName="%(SharedFxInstallers.BundleNameProperty)"/>
     </CreateProperty>
 
-    <ItemGroup>
-      <SharedFxPayload Include="$(InstallersOutputPath)$(RuntimeInstallerBaseName)-$(SharedFxMsiVersion)-win-x64.msi">
-        <ProductVersionProperty>SharedFxInstallerProductVersionx64</ProductVersionProperty>
-        <ProductCodeProperty>SharedFxInstallerProductCodex64</ProductCodeProperty>
-      </SharedFxPayload>
-      <SharedFxPayload Include="$(InstallersOutputPath)$(RuntimeInstallerBaseName)-$(SharedFxMsiVersion)-win-x86.msi">
-        <ProductVersionProperty>SharedFxInstallerProductVersionx86</ProductVersionProperty>
-        <ProductCodeProperty>SharedFxInstallerProductCodex86</ProductCodeProperty>
-      </SharedFxPayload>
-    </ItemGroup>
-
-    <!-- Read MSI properties -->
-    <GetMsiProperty InstallPackage="%(SharedFxPayload.Identity)" Property="ProductVersion">
-      <Output TaskParameter="Value" PropertyName="%(ProductVersionProperty)" />
-    </GetMsiProperty>
-    <GetMsiProperty InstallPackage="%(SharedFxPayload.Identity)" Property="ProductCode">
-      <Output TaskParameter="Value" PropertyName="%(ProductCodeProperty)" />
-    </GetMsiProperty>
-
     <PropertyGroup>
       <DefineConstants>$(DefineConstants);SharedFxRedistInstallerx64=$(SharedFxRedistInstallerx64)</DefineConstants>
-      <DefineConstants>$(DefineConstants);SharedFxInstallerProductVersionx64=$(SharedFxInstallerProductVersionx64)</DefineConstants>
-      <DefineConstants>$(DefineConstants);SharedFxInstallerProductCodex64=$(SharedFxInstallerProductCodex64)</DefineConstants>
       <DefineConstants>$(DefineConstants);SharedFxRedistInstallerx86=$(SharedFxRedistInstallerx86)</DefineConstants>
-      <DefineConstants>$(DefineConstants);SharedFxInstallerProductVersionx86=$(SharedFxInstallerProductVersionx86)</DefineConstants>
-      <DefineConstants>$(DefineConstants);SharedFxInstallerProductCodex86=$(SharedFxInstallerProductCodex86)</DefineConstants>
     </PropertyGroup>
   </Target>
 </Project>

--- a/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
+++ b/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
@@ -36,6 +36,7 @@
     <Compile Include="Bundle.wxs" />
     <Compile Include="DotNetCore.wxs" />
     <Compile Include="SharedFramework.wxs" />
+    <EmbeddedResource Include="thm.wxl" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Part of https://github.com/dotnet/aspnetcore/issues/55950

Port of https://github.com/dotnet/aspnetcore/pull/56459

Test build https://dev.azure.com/dnceng/internal/_build/results?buildId=2488913&view=results

# [release/6.0] Chain runtime .Msi's instead of .Exe's in hosting bundle

Chains the dotnet/runtime & dotnet/aspnetcore runtime .msi's in the Hosting Bundle, instead of the .exe's containing those .msi's

## Description

Installing a new Hosting Bundle currently leaves old runtimes around, because the detect condition for the previously installed runtimes isn't firing correctly. The logic is easier to author when you chain the .msi's directly in the Hosting Bundle, rather than chaining the .exe's containing those .msi's (which is what we do today).

Fixes https://github.com/dotnet/aspnetcore/issues/55950

## Customer Impact

Asked for by an S&P 500 customer

## Regression?

- [x] Yes
- [ ] No

The upgrade logic used to work correctly, but one of our other hosting bundle updates broke it. Using the .msi's instead of the .exe's makes the upgrade logic simpler and more future proof (plus it actually works today)

## Risk

- [ ] High
- [x] Medium
- [ ] Low

Upgrades from versions before this change to versions after this change will leave all runtimes behind (today we only leave behind 3 out of 4). Customers will have to pay a 1-time cost to manually remove those older runtimes (but that's better than manually removing 3 runtimes every month).

## Verification

- [x] Manual (required)
- [ ] Automated

Verified on clean Windows Sandbox

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A