### PR TITLE
Add requirements comment to update-npm-dependencies

### DIFF
--- a/eng/scripts/update-npm-dependencies.ps1
+++ b/eng/scripts/update-npm-dependencies.ps1
@@ -1,4 +1,5 @@
 # This script needs to be run on PowerShell 7+ (for ConvertFrom-Json) on Windows (for vsts-npm-auth).
+# The GitHub CLI (gh) is required unless `-SkipPullRequestCreation` is passed.
 
 param (
     [switch]$WhatIf,

--- a/eng/scripts/update-npm-dependencies.ps1
+++ b/eng/scripts/update-npm-dependencies.ps1
@@ -1,3 +1,5 @@
+# This script needs to be run on PowerShell 7+ (for ConvertFrom-Json) on Windows (for vsts-npm-auth).
+
 param (
     [switch]$WhatIf,
     [switch]$SkipPullRequestCreation


### PR DESCRIPTION
Unfortunately, it can't be run in a CodeSpace since `vsts-npm-auth` only works on Windows.