### PR TITLE
AddConnections: AddRouting -> AddRoutingCore

### DIFF
--- a/src/SignalR/common/Http.Connections/src/ConnectionsDependencyInjectionExtensions.cs
+++ b/src/SignalR/common/Http.Connections/src/ConnectionsDependencyInjectionExtensions.cs
@@ -20,7 +20,7 @@ public static class ConnectionsDependencyInjectionExtensions
     /// <returns>The same instance of the <see cref="IServiceCollection"/> for chaining.</returns>
     public static IServiceCollection AddConnections(this IServiceCollection services)
     {
-        services.AddRouting();
+        services.AddRoutingCore();
         services.AddAuthorization();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<ConnectionOptions>, ConnectionOptionsSetup>());
         services.TryAddSingleton<HttpConnectionDispatcher>();


### PR DESCRIPTION
Closes https://github.com/dotnet/aspnetcore/issues/56559

SignalR doesn't require regex constraints so doesn't need the additional config from `AddRouting`. Someone can add it back by calling `AddRouting` manually.