### PR TITLE
Apply schema transformers on properties and other subschemas

### DIFF
--- a/src/OpenApi/perf/Microbenchmarks/TransformersBenchmark.cs
+++ b/src/OpenApi/perf/Microbenchmarks/TransformersBenchmark.cs
@@ -95,7 +95,7 @@ public class TransformersBenchmark : OpenApiDocumentServiceTestBase
         {
             _options.AddSchemaTransformer((schema, context, token) =>
             {
-                if (context.Type == typeof(Todo) && context.ParameterDescription != null)
+                if (context.JsonTypeInfo.Type == typeof(Todo) && context.ParameterDescription != null)
                 {
                     schema.Extensions["x-my-extension"] = new OpenApiString(context.ParameterDescription.Name);
                 }
@@ -167,7 +167,7 @@ public class TransformersBenchmark : OpenApiDocumentServiceTestBase
     {
         public Task TransformAsync(OpenApiSchema schema, OpenApiSchemaTransformerContext context, CancellationToken cancellationToken)
         {
-            if (context.Type == typeof(Todo) && context.ParameterDescription != null)
+            if (context.JsonTypeInfo.Type == typeof(Todo) && context.ParameterDescription != null)
             {
                 schema.Extensions["x-my-extension"] = new OpenApiString(context.ParameterDescription.Name);
             }

--- a/src/OpenApi/src/PublicAPI.Unshipped.txt
+++ b/src/OpenApi/src/PublicAPI.Unshipped.txt
@@ -30,11 +30,13 @@ Microsoft.AspNetCore.OpenApi.OpenApiSchemaTransformerContext.ApplicationServices
 Microsoft.AspNetCore.OpenApi.OpenApiSchemaTransformerContext.ApplicationServices.init -> void
 Microsoft.AspNetCore.OpenApi.OpenApiSchemaTransformerContext.DocumentName.get -> string!
 Microsoft.AspNetCore.OpenApi.OpenApiSchemaTransformerContext.DocumentName.init -> void
+Microsoft.AspNetCore.OpenApi.OpenApiSchemaTransformerContext.JsonPropertyInfo.get -> System.Text.Json.Serialization.Metadata.JsonPropertyInfo?
+Microsoft.AspNetCore.OpenApi.OpenApiSchemaTransformerContext.JsonPropertyInfo.init -> void
+Microsoft.AspNetCore.OpenApi.OpenApiSchemaTransformerContext.JsonTypeInfo.get -> System.Text.Json.Serialization.Metadata.JsonTypeInfo!
+Microsoft.AspNetCore.OpenApi.OpenApiSchemaTransformerContext.JsonTypeInfo.init -> void
 Microsoft.AspNetCore.OpenApi.OpenApiSchemaTransformerContext.OpenApiSchemaTransformerContext() -> void
 Microsoft.AspNetCore.OpenApi.OpenApiSchemaTransformerContext.ParameterDescription.get -> Microsoft.AspNetCore.Mvc.ApiExplorer.ApiParameterDescription?
 Microsoft.AspNetCore.OpenApi.OpenApiSchemaTransformerContext.ParameterDescription.init -> void
-Microsoft.AspNetCore.OpenApi.OpenApiSchemaTransformerContext.Type.get -> System.Type!
-Microsoft.AspNetCore.OpenApi.OpenApiSchemaTransformerContext.Type.init -> void
 Microsoft.Extensions.DependencyInjection.OpenApiServiceCollectionExtensions
 static Microsoft.AspNetCore.Builder.OpenApiEndpointRouteBuilderExtensions.MapOpenApi(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints, string! pattern = "/openapi/{documentName}.json") -> Microsoft.AspNetCore.Builder.IEndpointConventionBuilder!
 static Microsoft.AspNetCore.OpenApi.OpenApiOptions.CreateDefaultSchemaReferenceId(System.Text.Json.Serialization.Metadata.JsonTypeInfo! jsonTypeInfo) -> string?

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -195,6 +195,10 @@ internal sealed class OpenApiSchemaService(
             {
                 var derivedJsonTypeInfo = _jsonSerializerOptions.GetTypeInfo(derivedType.DerivedType);
                 context.UpdateJsonTypeInfo(derivedJsonTypeInfo, null);
+                if (schema.AnyOf.Count <= anyOfIndex)
+                {
+                    break;
+                }
                 await InnerApplySchemaTransformersAsync(schema.AnyOf[anyOfIndex], derivedJsonTypeInfo, context, transformer, cancellationToken);
                 anyOfIndex++;
             }
@@ -212,7 +216,10 @@ internal sealed class OpenApiSchemaService(
             foreach (var propertyInfo in jsonTypeInfo.Properties)
             {
                 context.UpdateJsonTypeInfo(_jsonSerializerOptions.GetTypeInfo(propertyInfo.PropertyType), propertyInfo);
-                await InnerApplySchemaTransformersAsync(schema.Properties[propertyInfo.Name], jsonTypeInfo, context, transformer, cancellationToken);
+                if (schema.Properties.TryGetValue(propertyInfo.Name, out var propertySchema))
+                {
+                    await InnerApplySchemaTransformersAsync(propertySchema, _jsonSerializerOptions.GetTypeInfo(propertyInfo.PropertyType), context, transformer, cancellationToken);
+                }
             }
         }
     }

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -161,14 +161,14 @@ internal sealed class OpenApiSchemaService(
             // it on.
             if (transformer is TypeBasedOpenApiSchemaTransformer typeBasedTransformer)
             {
-                typeBasedTransformer.InitializeTransformer(serviceProvider);
+                var initializedTransformer = typeBasedTransformer.InitializeTransformer(serviceProvider);
                 try
                 {
-                    await InnerApplySchemaTransformersAsync(schema, jsonTypeInfo, context, typeBasedTransformer, cancellationToken);
+                    await InnerApplySchemaTransformersAsync(schema, jsonTypeInfo, context, initializedTransformer, cancellationToken);
                 }
                 finally
                 {
-                    await typeBasedTransformer.FinalizeTransformer();
+                    await TypeBasedOpenApiSchemaTransformer.FinalizeTransformer(initializedTransformer);
                 }
             }
             else

--- a/src/OpenApi/src/Transformers/OpenApiSchemaTransformerContext.cs
+++ b/src/OpenApi/src/Transformers/OpenApiSchemaTransformerContext.cs
@@ -1,8 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization.Metadata;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
-using Microsoft.OpenApi.Models;
 
 namespace Microsoft.AspNetCore.OpenApi;
 
@@ -11,15 +11,13 @@ namespace Microsoft.AspNetCore.OpenApi;
 /// </summary>
 public sealed class OpenApiSchemaTransformerContext
 {
+    private JsonTypeInfo? _jsonTypeInfo;
+    private JsonPropertyInfo? _jsonPropertyInfo;
+
     /// <summary>
     /// Gets the name of the associated OpenAPI document.
     /// </summary>
     public required string DocumentName { get; init; }
-
-    /// <summary>
-    /// Gets the <see cref="Type" /> associated with the current <see cref="OpenApiSchema"/>.
-    /// </summary>
-    public required Type Type { get; init; }
 
     /// <summary>
     /// Gets the <see cref="ApiParameterDescription"/> associated with the target schema.
@@ -28,7 +26,26 @@ public sealed class OpenApiSchemaTransformerContext
     public required ApiParameterDescription? ParameterDescription { get; init; }
 
     /// <summary>
+    /// Gets the <see cref="JsonTypeInfo"/> associated with the target schema.
+    /// </summary>
+    public required JsonTypeInfo JsonTypeInfo { get => _jsonTypeInfo!; init => _jsonTypeInfo = value; }
+
+    /// <summary>
+    /// Gets the <see cref="JsonPropertyInfo"/> associated with the target schema if the
+    /// target schema is a property of a parent schema.
+    /// </summary>
+    public required JsonPropertyInfo? JsonPropertyInfo { get => _jsonPropertyInfo; init => _jsonPropertyInfo = value; }
+
+    /// <summary>
     /// Gets the application services associated with the current document the target schema is in.
     /// </summary>
     public required IServiceProvider ApplicationServices { get; init; }
+
+    // Expose internal setters for the properties that only allow initializations to avoid allocating
+    // new instances of the context for each sub-schema transformation.
+    internal void UpdateJsonTypeInfo(JsonTypeInfo jsonTypeInfo, JsonPropertyInfo? jsonPropertyInfo)
+    {
+        _jsonTypeInfo = jsonTypeInfo;
+        _jsonPropertyInfo = jsonPropertyInfo;
+    }
 }

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v2.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v2.verified.txt
@@ -52,7 +52,11 @@
       "ArrayOfstring": {
         "type": "array",
         "items": {
-          "type": "string"
+          "type": "string",
+          "externalDocs": {
+            "description": "Documentation for this OpenAPI schema",
+            "url": "https://example.com/api/docs/schemas/string"
+          }
         },
         "externalDocs": {
           "description": "Documentation for this OpenAPI schema",

--- a/src/OpenApi/test/Transformers/Implementations/OpenApiSchemaReferenceTransformerTests.cs
+++ b/src/OpenApi/test/Transformers/Implementations/OpenApiSchemaReferenceTransformerTests.cs
@@ -269,7 +269,7 @@ public class OpenApiSchemaReferenceTransformerTests : OpenApiDocumentServiceTest
         var options = new OpenApiOptions();
         options.AddSchemaTransformer((schema, context, cancellationToken) =>
         {
-            if (context.Type == typeof(Todo) && context.ParameterDescription is not null)
+            if (context.JsonTypeInfo.Type == typeof(Todo) && context.ParameterDescription is not null)
             {
                 schema.Extensions["x-my-extension"] = new OpenApiString(context.ParameterDescription.Name);
             }

--- a/src/OpenApi/test/Transformers/SchemaTransformerTests.cs
+++ b/src/OpenApi/test/Transformers/SchemaTransformerTests.cs
@@ -334,7 +334,7 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
             Assert.True(responseSchema.Extensions.ContainsKey("x-my-extension"));
         });
         var countAfter = Dependency.InstantiationCount;
-        Assert.Equal(countBefore + 20, countAfter);
+        Assert.Equal(countBefore + 4, countAfter);
     }
 
     [Fact]
@@ -359,9 +359,8 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
             var responseSchema = getOperation.Responses["200"].Content["application/json"].Schema.GetEffective(document);
             Assert.Equal("Schema Description", responseSchema.Description);
         });
-        // Assert that the transformer is disposed for each top-level schema
-        // and the four properties within that schema.
-        Assert.Equal(10, DisposableTransformer.DisposeCount);
+        // Assert that the transformer is disposed twice for each top-level schema.
+        Assert.Equal(2, DisposableTransformer.DisposeCount);
     }
 
     [Fact]
@@ -386,9 +385,8 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
             var responseSchema = getOperation.Responses["200"].Content["application/json"].Schema.GetEffective(document);
             Assert.Equal("Schema Description", responseSchema.Description);
         });
-        // Assert that the transformer is disposed after the top-level
-        // schema and each sub-property within the schema.
-        Assert.Equal(10, AsyncDisposableTransformer.DisposeCount);
+        // Assert that the transformer is disposed twice for each top-level schema.
+        Assert.Equal(2, AsyncDisposableTransformer.DisposeCount);
     }
 
     [Fact]


### PR DESCRIPTION
Closes https://github.com/dotnet/aspnetcore/issues/56584.

Schema transformers are currently only called on schemas that are generated at the top-level for respones, parameters, and request bodies. This PR allows schema transformers to be applied recursively into sub-schemas that might appear in these arguments (for example, the schema for an `int` property that is part of a `Todo` type). We currently apply transformations to subschema types where we understand how to resolve `TypeInfo` for them:

- `schema.items`: for schemas that represent lists of elements
- `schema.anyOf`: for schemas that represent polymorphic schemas with subtypes
- `schema.properties`: for schemas associated with properties in a type

Changes in this PR include:

- Remove the `OpenApiSchemaTransformerContext.Type` property and adding `OpenApiSchemaTransformerContext.JsonTypeInfo` and `OpenApiSchemaTransformerContext.JsonPropertyInfo`
- Changes to `OpenApiSchemaService` to support applying schemas recursively into the subschemas mentioned above
- Additional tests in `SchemaTransformerTests` to cover relevant scenarios

Note: One of the new tests introduced here (`SchemaTransformer_CanModifyListOfPolymorphicTypes`) is currently skipped because of a bug I discovered in `ApplyPolymorphismOptions` where we don't handle things correctly if a polymorphic type is a child of another type (like `List<Shape>` or a type with a `Shape` property) because of the [context.Path.Length == 0 check](https://github.com/dotnet/aspnetcore/blob/c52c28458e86029555bf1a88e94b64e7f37ef6d3/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs#L329) we currently use to check for base types. This should be resolved once we have can consume https://github.com/dotnet/runtime/issues/104046 in an upcoming runtime update.

Another note: I'm hoping to bring these changes in to https://github.com/dotnet/aspnetcore/pull/56599 for more complete perf coverage for these transformer types.