### PR TITLE
Don't require AttributeProvider for JsonPropertyInfo-based modifications

### DIFF
--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -91,7 +91,7 @@ internal sealed class OpenApiSchemaService(
             schema.ApplyPrimitiveTypesAndFormats(context);
             schema.ApplySchemaReferenceId(context);
             schema.ApplyPolymorphismOptions(context);
-            if (context.PropertyInfo is { AttributeProvider: { } attributeProvider } jsonPropertyInfo)
+            if (context.PropertyInfo is { } jsonPropertyInfo)
             {
                 // Short-circuit STJ's handling of nested properties, which uses a reference to the
                 // properties type schema with a schema that uses a document level reference.
@@ -102,6 +102,9 @@ internal sealed class OpenApiSchemaService(
                     return new JsonObject { [OpenApiSchemaKeywords.RefKeyword] = context.TypeInfo.GetSchemaReferenceId() };
                 }
                 schema.ApplyNullabilityContextInfo(jsonPropertyInfo);
+            }
+            if (context.PropertyInfo is { AttributeProvider: { } attributeProvider })
+            {
                 if (attributeProvider.GetCustomAttributes(inherit: false).OfType<ValidationAttribute>() is { } validationAttributes)
                 {
                     schema.ApplyValidationAttributes(validationAttributes);

--- a/src/OpenApi/test/Services/OpenApiDocumentServiceTestsBase.cs
+++ b/src/OpenApi/test/Services/OpenApiDocumentServiceTestsBase.cs
@@ -98,8 +98,9 @@ public abstract class OpenApiDocumentServiceTestBase
         provider.OnProvidersExecuted(context);
 
         var apiDescriptionGroupCollectionProvider = CreateApiDescriptionGroupCollectionProvider(context.Results);
+        var jsonOptions = builder.ServiceProvider.GetService<IOptions<Microsoft.AspNetCore.Http.Json.JsonOptions>>() ?? Options.Create(new Microsoft.AspNetCore.Http.Json.JsonOptions());
 
-        var schemaService = new OpenApiSchemaService("Test", Options.Create(new Microsoft.AspNetCore.Http.Json.JsonOptions()), builder.ServiceProvider, options.Object);
+        var schemaService = new OpenApiSchemaService("Test", jsonOptions, builder.ServiceProvider, options.Object);
         ((TestServiceProvider)builder.ServiceProvider).TestSchemaService = schemaService;
         var documentService = new OpenApiDocumentService("Test", apiDescriptionGroupCollectionProvider, hostEnvironment, options.Object, builder.ServiceProvider);
         ((TestServiceProvider)builder.ServiceProvider).TestDocumentService = documentService;


### PR DESCRIPTION
This PR fixes a bug reported by @JamesNK  in https://github.com/dotnet/aspnetcore/pull/56067.

Our OpenAPI implementation currently applies some transformations to the JSON schema produced by System.Text.Json in order to correctly produce `$ref`s for nested types. The application of this fix was guarded behind a check that validated if the `JsonPropertyInfo` associated with the given schema had an `AttributeProvider` that we could query, although the `AttributeProvider` was not strictly needed for this check.

It turns out that for the case of types generated from protobuf-definitions, there's no implementation of `IAtributeProvider` resolved by System.Text.Json, so the fix was never applied for types used in a gRPC context.

To resolve this issue, we split up the check in `TransformSchemaNode` to only check for `AttributeProvider` when we strictly need it.

Below are the before/after for OpenAPI documents generated from the gRPC JsonTranscoding Sandbox app. Note the `HelloReply` schema.

<details>

<summary>Before</summary>

```
// 20240709182825
// https://localhost:5001/openapi/v1.json

{
  "openapi": "3.0.1",
  "info": {
    "title": "Sandbox | v1",
    "version": "1.0.0"
  },
  "paths": {
    "/v1/greeter/{name}": {
      "get": {
        "tags": [
          "Greeter"
        ],
        "parameters": [
          {
            "name": "name",
            "in": "path",
            "required": true,
            "schema": {
              "type": "string"
            }
          }
        ],
        "responses": {
          "200": {
            "description": "OK",
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/HelloReply"
                }
              }
            }
          },
          "default": {
            "description": "",
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/Status"
                }
              }
            }
          }
        }
      }
    },
    "/v1/greeter": {
      "post": {
        "tags": [
          "Greeter"
        ],
        "requestBody": {
          "content": {
            "application/json": {
              "schema": {
                "$ref": "#/components/schemas/HelloRequestFrom"
              }
            }
          }
        },
        "responses": {
          "200": {
            "description": "OK",
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/HelloReply"
                }
              }
            }
          },
          "default": {
            "description": "",
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/Status"
                }
              }
            }
          }
        }
      }
    }
  },
  "components": {
    "schemas": {
      "ArrayOfAny": {
        "type": "array",
        "nullable": true
      },
      "HelloReply": {
        "type": "object",
        "properties": {
          "message": {
            "type": "string"
          },
          "nested": {
            "$ref": "#/components/schemas/HelloReply2"
          }
        }
      },
      "HelloReply2": {
        "type": "object",
        "properties": {
          "message": {
            "type": "string"
          },
          "nested": {
            "$ref": "#/components/schemas/#/properties/nested"
          }
        },
        "nullable": true
      },
      "HelloRequestFrom": {
        "type": "object",
        "properties": {
          "name": {
            "type": "string"
          },
          "from": {
            "type": "string"
          }
        }
      },
      "Status": {
        "type": "object",
        "properties": {
          "code": {
            "type": "integer",
            "format": "int32",
            "nullable": true
          },
          "message": {
            "type": "string"
          },
          "details": {
            "$ref": "#/components/schemas/ArrayOfAny"
          }
        }
      }
    }
  },
  "tags": [
    {
      "name": "Greeter"
    }
  ]
}
```

</details>

<details>
<summary>After</summary>

```
// 20240709183500
// https://localhost:5001/openapi/v1.json

{
  "openapi": "3.0.1",
  "info": {
    "title": "Sandbox | v1",
    "version": "1.0.0"
  },
  "paths": {
    "/v1/greeter/{name}": {
      "get": {
        "tags": [
          "Greeter"
        ],
        "parameters": [
          {
            "name": "name",
            "in": "path",
            "required": true,
            "schema": {
              "type": "string"
            }
          }
        ],
        "responses": {
          "200": {
            "description": "OK",
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/HelloReply"
                }
              }
            }
          },
          "default": {
            "description": "",
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/Status"
                }
              }
            }
          }
        }
      }
    },
    "/v1/greeter": {
      "post": {
        "tags": [
          "Greeter"
        ],
        "requestBody": {
          "content": {
            "application/json": {
              "schema": {
                "$ref": "#/components/schemas/HelloRequestFrom"
              }
            }
          }
        },
        "responses": {
          "200": {
            "description": "OK",
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/HelloReply"
                }
              }
            }
          },
          "default": {
            "description": "",
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/Status"
                }
              }
            }
          }
        }
      }
    }
  },
  "components": {
    "schemas": {
      "ArrayOfAny": {
        "type": "array",
        "nullable": true
      },
      "HelloReply": {
        "type": "object",
        "properties": {
          "message": {
            "type": "string",
            "nullable": true
          },
          "nested": {
            "$ref": "#/components/schemas/HelloReply"
          }
        }
      },
      "HelloRequestFrom": {
        "type": "object",
        "properties": {
          "name": {
            "type": "string",
            "nullable": true
          },
          "from": {
            "type": "string",
            "nullable": true
          }
        }
      },
      "Status": {
        "type": "object",
        "properties": {
          "code": {
            "type": "integer",
            "format": "int32",
            "nullable": true
          },
          "message": {
            "type": "string",
            "nullable": true
          },
          "details": {
            "$ref": "#/components/schemas/ArrayOfAny"
          }
        }
      }
    }
  },
  "tags": [
    {
      "name": "Greeter"
    }
  ]
}
```

</details>