### PR TITLE
HybridCache - fix RemoveKeyAsync incorrectly calling RemoveByTagAsync

### DIFF
--- a/src/Caching/Hybrid/src/Runtime/HybridCache.cs
+++ b/src/Caching/Hybrid/src/Runtime/HybridCache.cs
@@ -81,7 +81,7 @@ public abstract class HybridCache
         {
             // for consistency with GetOrCreate/Set: interpret null as "none"
             null or ICollection<string> { Count: 0 } => default,
-            ICollection<string> { Count: 1 } => RemoveByTagAsync(keys.Single(), token),
+            ICollection<string> { Count: 1 } => RemoveAsync(keys.Single(), token),
             _ => ForEachAsync(this, keys, token),
         };
 

--- a/src/Caching/Hybrid/test/FunctionalTests.cs
+++ b/src/Caching/Hybrid/test/FunctionalTests.cs
@@ -1,0 +1,82 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Caching.Hybrid.Internal;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Extensions.Caching.Hybrid.Tests;
+public class FunctionalTests
+{
+    static ServiceProvider GetDefaultCache(out DefaultHybridCache cache, Action<ServiceCollection>? config = null)
+    {
+        var services = new ServiceCollection();
+        config?.Invoke(services);
+        services.AddHybridCache();
+        var provider = services.BuildServiceProvider();
+        cache = Assert.IsType<DefaultHybridCache>(provider.GetRequiredService<HybridCache>());
+        return provider;
+    }
+
+    [Fact]
+    public async Task RemoveSingleKey()
+    {
+        using var provider = GetDefaultCache(out var cache);
+        var key = Me();
+        Assert.Equal(42, await cache.GetOrCreateAsync(key, _ => new ValueTask<int>(42)));
+
+        // now slightly different func to show delta; should use cached value initially
+        await cache.RemoveAsync("unrelated");
+        Assert.Equal(42, await cache.GetOrCreateAsync(key, _ => new ValueTask<int>(96)));
+
+        // now remove and repeat - should get updated value
+        await cache.RemoveAsync(key);
+        Assert.Equal(96, await cache.GetOrCreateAsync(key, _ => new ValueTask<int>(96)));
+    }
+
+    [Fact]
+    public async Task RemoveNoKeyViaArray()
+    {
+        using var provider = GetDefaultCache(out var cache);
+        var key = Me();
+        Assert.Equal(42, await cache.GetOrCreateAsync(key, _ => new ValueTask<int>(42)));
+
+        // now slightly different func to show delta; should use same cached value
+        await cache.RemoveAsync([]);
+        Assert.Equal(42, await cache.GetOrCreateAsync(key, _ => new ValueTask<int>(96)));
+    }
+
+    [Fact]
+    public async Task RemoveSingleKeyViaArray()
+    {
+        using var provider = GetDefaultCache(out var cache);
+        var key = Me();
+        Assert.Equal(42, await cache.GetOrCreateAsync(key, _ => new ValueTask<int>(42)));
+
+        // now slightly different func to show delta; should use cached value initially
+        await cache.RemoveAsync(["unrelated"]);
+        Assert.Equal(42, await cache.GetOrCreateAsync(key, _ => new ValueTask<int>(96)));
+
+        // now remove and repeat - should get updated value
+        await cache.RemoveAsync([key]);
+        Assert.Equal(96, await cache.GetOrCreateAsync(key, _ => new ValueTask<int>(96)));
+    }
+
+    [Fact]
+    public async Task RemoveMultipleKeysViaArray()
+    {
+        using var provider = GetDefaultCache(out var cache);
+        var key = Me();
+        Assert.Equal(42, await cache.GetOrCreateAsync(key, _ => new ValueTask<int>(42)));
+
+        // now slightly different func to show delta; should use cached value initially
+        Assert.Equal(42, await cache.GetOrCreateAsync(key, _ => new ValueTask<int>(96)));
+
+        // now remove and repeat - should get updated value
+        await cache.RemoveAsync([key, "unrelated"]);
+        Assert.Equal(96, await cache.GetOrCreateAsync(key, _ => new ValueTask<int>(96)));
+    }
+
+    private static string Me([CallerMemberName] string caller = "") => caller;
+
+}

--- a/src/Caching/Hybrid/test/SampleUsage.cs
+++ b/src/Caching/Hybrid/test/SampleUsage.cs
@@ -1,13 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
 using System.Text.Json;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -16,7 +11,7 @@ namespace Microsoft.Extensions.Caching.Hybrid.Tests;
 public class SampleUsage
 {
     [Fact]
-    public async void DistributedCacheWorks()
+    public async Task DistributedCacheWorks()
     {
         var services = new ServiceCollection();
         services.AddDistributedMemoryCache();
@@ -36,7 +31,7 @@ public class SampleUsage
     }
 
     [Fact]
-    public async void HybridCacheWorks()
+    public async Task HybridCacheWorks()
     {
         var services = new ServiceCollection();
         services.AddHybridCache();
@@ -56,7 +51,7 @@ public class SampleUsage
     }
 
     [Fact]
-    public async void HybridCacheNoCaptureWorks()
+    public async Task HybridCacheNoCaptureWorks()
     {
         var services = new ServiceCollection();
         services.AddHybridCache();
@@ -76,7 +71,7 @@ public class SampleUsage
     }
 
     [Fact]
-    public async void HybridCacheNoCaptureObjReuseWorks()
+    public async Task HybridCacheNoCaptureObjReuseWorks()
     {
         var services = new ServiceCollection();
         services.AddHybridCache();


### PR DESCRIPTION
- fix RemoveKeyAsync incorrectly calling RemoveByTagAsync
- add Remove tests
- drive-by fix `async void` tests (probably auto-IDE)

Fixes #56581

