### PR TITLE
Renable GracefulTurnsAbortiveIfRequestsDoNotFinish

### DIFF
--- a/src/Servers/Kestrel/test/FunctionalTests/Http2/ShutdownTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/Http2/ShutdownTests.cs
@@ -161,7 +161,6 @@ public class ShutdownTests : TestApplicationErrorLoggerLoggedTest
     }
 
     [ConditionalFact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/39986")]
     public async Task GracefulTurnsAbortiveIfRequestsDoNotFinish()
     {
         var requestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);


### PR DESCRIPTION
Closes: #39986

Looks like it's now passing after @JamesNK's fix.