### PR TITLE
using one style approach for all 3 configs WebAssembly, Web and Server

### DIFF
--- a/src/Components/Web.JS/src/Boot.Server.ts
+++ b/src/Components/Web.JS/src/Boot.Server.ts
@@ -18,7 +18,8 @@ function boot(userOptions?: Partial<CircuitStartOptions>): Promise<void> {
   }
   started = true;
 
-  const configuredOptions = resolveOptions(userOptions);
+  const circuitOptions = userOptions?.circuit ?? userOptions ?? {};
+  const configuredOptions = resolveOptions(circuitOptions);
   setCircuitOptions(Promise.resolve(configuredOptions || {}));
 
   JSEventRegistry.create(Blazor);

--- a/src/Components/Web.JS/src/Boot.WebAssembly.ts
+++ b/src/Components/Web.JS/src/Boot.WebAssembly.ts
@@ -20,7 +20,8 @@ async function boot(options?: Partial<WebAssemblyStartOptions>): Promise<void> {
   }
   started = true;
 
-  setWebAssemblyOptions(Promise.resolve(options || {}));
+  const webAssemblyOptions = options?.webAssembly ?? options ?? {};
+  setWebAssemblyOptions(Promise.resolve(webAssemblyOptions || {}));
 
   JSEventRegistry.create(Blazor);
   const webAssemblyComponents = discoverComponents(document, 'webassembly') as WebAssemblyComponentDescriptor[];

--- a/src/Components/Web.JS/src/Platform/Circuits/CircuitStartOptions.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/CircuitStartOptions.ts
@@ -20,6 +20,7 @@ export interface CircuitStartOptions {
   reconnectionHandler?: ReconnectionHandler;
   initializers : ServerInitializers;
   circuitHandlers: CircuitHandler[];
+  circuit?: CircuitStartOptions;
 }
 
 export function resolveOptions(userOptions?: Partial<CircuitStartOptions>): CircuitStartOptions {

--- a/src/Components/Web.JS/src/Platform/WebAssemblyStartOptions.ts
+++ b/src/Components/Web.JS/src/Platform/WebAssemblyStartOptions.ts
@@ -34,6 +34,11 @@ export interface WebAssemblyStartOptions {
    * Allows to override .NET runtime configuration.
    */
   configureRuntime(builder: DotnetHostBuilder): void;
+
+  /**
+   * Allows to use the same structure as WebStartOptions
+   */
+  webAssembly?: WebAssemblyStartOptions
 }
 
 // This type doesn't have to align with anything in BootConfig.


### PR DESCRIPTION
# [Blazor] Accept the blazor.web.js startup options format in blazor.{server|webassembly}.js


## Description

Added config properties to blazor.{server|webassembly}.js to follow the same structure as blazor.web.js

Fixes #51611
