### PR TITLE
Set additionalProperties when [JsonExtensionData] is present

### DIFF
--- a/src/OpenApi/sample/Program.cs
+++ b/src/OpenApi/sample/Program.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Frozen;
 using System.Collections.Immutable;
 using System.ComponentModel;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -111,6 +110,7 @@ schemas.MapGet("/frozen-dictionary-of-ints", () => ImmutableDictionary.CreateRan
 schemas.MapPost("/shape", (Shape shape) => { });
 schemas.MapPost("/weatherforecastbase", (WeatherForecastBase forecast) => { });
 schemas.MapPost("/person", (Person person) => { });
+schemas.MapPost("/problem-details", () => { }).ProducesProblem(statusCode: 500);
 
 app.MapControllers();
 

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -88,6 +88,17 @@ internal sealed class OpenApiSchemaService(
             {
                 schema = new JsonObject();
             }
+            // STJ operates under the assumption that JSON Schema makes around `additionalProperties` being
+            // true by default for all schemas. OpenAPI v3 takes a different interpretation and assumes that
+            // `additionalProperties` is false by default. We override the default behavior assumed by STJ to
+            // match the OpenAPI v3 interpretation here by checking to see if any properties on a type map to
+            // extension data and explicitly setting the `additionalProperties` keyword to an empty object.
+            // Since `[ExtensionData]` can only be applied on dictionaries with `object` or `JsonElement` values
+            // there is no need to encode a concrete schema for thm and the catch-all empty schema is sufficient.
+            if (context.TypeInfo.Properties.Any(jsonPropertyInfo => jsonPropertyInfo.IsExtensionData))
+            {
+                schema[OpenApiSchemaKeywords.AdditionalPropertiesKeyword] = new JsonObject();
+            }
             var createSchemaReferenceId = optionsMonitor.Get(documentName).CreateSchemaReferenceId;
             schema.ApplyPrimitiveTypesAndFormats(context, createSchemaReferenceId);
             schema.ApplySchemaReferenceId(context, createSchemaReferenceId);

--- a/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
+++ b/src/OpenApi/test/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
@@ -359,6 +359,25 @@
           }
         }
       }
+    },
+    "/schemas-by-ref/problem-details": {
+      "post": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -439,6 +458,33 @@
             "type": "string"
           }
         }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "detail": {
+            "type": "string",
+            "nullable": true
+          },
+          "instance": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": { }
       },
       "Product": {
         "type": "object",

--- a/src/OpenApi/test/Services/OpenApiSchemaService/OpenApiSchemaService.AdditionalProperties.cs
+++ b/src/OpenApi/test/Services/OpenApiSchemaService/OpenApiSchemaService.AdditionalProperties.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.OpenApi.Models;
+
+public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
+{
+    [Fact]
+    public async Task SetsAdditionalPropertiesOnBuiltInTypeWithExtensionData()
+    {
+        var builder = CreateBuilder();
+
+        builder.MapPost("/", () => new ProblemDetails());
+
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var schema = document.Components.Schemas["ProblemDetails"];
+            Assert.NotNull(schema.AdditionalProperties);
+            Assert.Null(schema.AdditionalProperties.Type);
+        });
+    }
+
+    [Fact]
+    public async Task SetAdditionalPropertiesOnDefinedTypeWithExtensionData()
+    {
+        var builder = CreateBuilder();
+
+        builder.MapPost("/", () => new MyExtensionDataType("test"));
+
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var schema = document.Components.Schemas["MyExtensionDataType"];
+            Assert.NotNull(schema.AdditionalProperties);
+            Assert.Null(schema.AdditionalProperties.Type);
+        });
+    }
+
+    [Fact]
+    public async Task SetsAdditionalPropertiesOnDictionaryTypesWithSchema()
+    {
+        var builder = CreateBuilder();
+
+        builder.MapPost("/", (Dictionary<string, Guid> data) => { });
+
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths["/"].Operations[OperationType.Post];
+            var schema = operation.RequestBody.Content["application/json"].Schema.GetEffective(document);
+            Assert.NotNull(schema.AdditionalProperties);
+            Assert.Equal("string", schema.AdditionalProperties.Type);
+            Assert.Equal("uuid", schema.AdditionalProperties.Format);
+        });
+    }
+
+    private class MyExtensionDataType(string name)
+    {
+        public string Name => name;
+
+        [JsonExtensionData]
+        public IDictionary<string, object> ExtensionData { get; set; }
+    }
+}


### PR DESCRIPTION
Reacting to feedback in https://github.com/dotnet/aspnetcore/issues/56318#issuecomment-2219378099 and discussion in https://github.com/dotnet/aspnetcore/issues/56707.

The `additionalProperties` keyword in a schema is used to indicate that a schema can match against properties explicitly defined in the `schema.properties` list _and_ additional unspecified properties.

The JSON Schema specification that STJ's JsonSchemaExporter targets assumes that `additionalProperties` is `true` by default for all schemas, meaning that a schema for a type will always be able to capture properties that are not explicitly defined in the properties list (see [here](https://json-schema.org/understanding-json-schema/reference/object#additionalproperties)).

The OpenAPI specification (as of v3 that we target) assumes the opposite. `additionalProperties` is assumed false and must be explicitly enabled in order to indicate that a schema can capture properties not explicitly defined. Furthermore, OpenAPI doesn't support a value `true` for the schema to support catch-alls. It requires that you implement an empty object to indicate that additional property values can match any type.

These two problems come together like Voltron in our handling of `[JsonExtensionData]` attributes on property. `JsonSchemaExporter` assumes that additionalProperties is implicitly true and doesn't set it when it generates a schema. We have to patch this mismatch in our `TransformSchemaNode` implementation to comply with what OpenAPI expects.

Since `[JsonExtensionData]` can only ever be applied on `Dictionary<string, object>` and `Dictionary<string, JsonElement>`, we don't have to worry about specifying concrete schemas for the values of additional properties. The empty object will do.