### PR TITLE
Allow Response Caching for Authorized Endpoints

### DIFF
--- a/src/Middleware/ResponseCaching/src/Interfaces/IResponseCachingPolicyProvider.cs
+++ b/src/Middleware/ResponseCaching/src/Interfaces/IResponseCachingPolicyProvider.cs
@@ -10,7 +10,7 @@ internal interface IResponseCachingPolicyProvider
     /// </summary>
     /// <param name="context">The <see cref="ResponseCachingContext"/>.</param>
     /// <returns><c>true</c> if response caching logic should be attempted; otherwise <c>false</c>.</returns>
-    bool AttemptResponseCaching(ResponseCachingContext context);
+    bool AttemptResponseCaching(ResponseCachingContext context, ResponseCachingOptions _options);
 
     /// <summary>
     /// Determine whether a cache lookup is allowed for the incoming HTTP request.

--- a/src/Middleware/ResponseCaching/src/ResponseCachingMiddleware.cs
+++ b/src/Middleware/ResponseCaching/src/ResponseCachingMiddleware.cs
@@ -87,7 +87,7 @@ public class ResponseCachingMiddleware
         var context = new ResponseCachingContext(httpContext, _logger);
 
         // Should we attempt any caching logic?
-        if (_policyProvider.AttemptResponseCaching(context))
+        if (_policyProvider.AttemptResponseCaching(context, _options))
         {
             // Can this request be served from cache?
             if (_policyProvider.AllowCacheLookup(context) && await TryServeFromCacheAsync(context))

--- a/src/Middleware/ResponseCaching/src/ResponseCachingOptions.cs
+++ b/src/Middleware/ResponseCaching/src/ResponseCachingOptions.cs
@@ -30,4 +30,9 @@ public class ResponseCachingOptions
     /// For testing purposes only.
     /// </summary>
     internal TimeProvider TimeProvider { get; set; } = TimeProvider.System;
+
+    /// <summary>
+    /// <c>true</c> if caching is allowed for authorised endpoints
+    /// </summary>
+    public bool AllowAuthorizedEndpoint { get; set; } = false;
 }

--- a/src/Middleware/ResponseCaching/src/ResponseCachingPolicyProvider.cs
+++ b/src/Middleware/ResponseCaching/src/ResponseCachingPolicyProvider.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.ResponseCaching;
 
 internal sealed class ResponseCachingPolicyProvider : IResponseCachingPolicyProvider
 {
-    public bool AttemptResponseCaching(ResponseCachingContext context)
+  public bool AttemptResponseCaching(ResponseCachingContext context, ResponseCachingOptions _options)
     {
         var request = context.HttpContext.Request;
 
@@ -21,7 +21,7 @@ internal sealed class ResponseCachingPolicyProvider : IResponseCachingPolicyProv
         }
 
         // Verify existence of authorization headers
-        if (!StringValues.IsNullOrEmpty(request.Headers.Authorization))
+    if (!_options.AllowAuthorizedEndpoint && !StringValues.IsNullOrEmpty(request.Headers.Authorization))
         {
             context.Logger.RequestWithAuthorizationNotCacheable();
             return false;


### PR DESCRIPTION
# Allow Response Caching for Authorized Endpoints

## Description

These changes are very simple. 

- add a bool ```AllowAuthorizedEndpoint``` option to ResponseCachingOptions. The default value is ```false``` to retain backwards compatibility (ie. non breaking change)
-  modify ResponseCachingKeyProvider.AttemptResponseCaching behaviour to allow caching for endpoints having a ```request.Headers.Authorization``` value if the option is ```true```
-  modify ```IResponseCachingKeyProvider``` to support new options

Unit testing for this would be complex since it involves checking for cached files on a client (eg. browser), or using Postman to examine the response. I am hoping the change is so simple that this will not be required.

Fixes #6836
