### PR TITLE
Remove unsafe from PathNormalizer

### DIFF
--- a/src/Servers/HttpSys/test/FunctionalTests/ResponseCachingTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/ResponseCachingTests.cs
@@ -383,6 +383,7 @@ public class ResponseCachingTests : LoggedTest
         }
     }
 
+    [QuarantinedTest("new issue")]
     [ConditionalFact]
     public async Task Caching_SendFileWithFullContentLength_Cached()
     {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/PathNormalizer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/PathNormalizer.cs
@@ -71,7 +71,7 @@ internal static class PathNormalizer
             }
             else if (nextDotSegmentIndex > 0)
             {
-                // Copy until the next segment excluding the trailer. Move the read pointer
+                // Copy until the next segment excluding the trailer.
                 // beyond the initial /. section, because FirstIndexOfDotSegment return the
                 // index of a complete dot segment.
                 src.Slice(0, nextDotSegmentIndex).CopyTo(dst[writtenLength..]);
@@ -150,45 +150,38 @@ internal static class PathNormalizer
 
     public static bool ContainsDotSegments(Span<byte> src)
     {
-        return FirstIndexOfDotSegment(src) > -1;
-    }
-
-    private static int FirstIndexOfDotSegment(Span<byte> src)
-    {
         Debug.Assert(src[0] == '/', "Path segment must always start with a '/'");
         ReadOnlySpan<byte> slashDot = "/."u8;
         ReadOnlySpan<byte> dotSlash = "./"u8;
-        int totalLength = 0;
         while (src.Length > 0)
         {
             var nextSlashDotIndex = src.IndexOf(slashDot);
             if (nextSlashDotIndex < 0)
             {
-                return -1;
+                return false;
             }
             else
             {
                 src = src[(nextSlashDotIndex + 2)..];
-                totalLength += nextSlashDotIndex + 2;
             }
             switch (src.Length)
             {
                 case 0: // Case of /.
-                    return totalLength - 2;
+                    return true;
                 case 1: // Case of /.. or /./
                     if (src[0] == ByteDot || src[0] == ByteSlash)
                     {
-                        return totalLength - 2;
+                        return true;
                     }
                     break;
                 default: // Case of /../ or /./ 
                     if (dotSlash.SequenceEqual(src.Slice(0, 2)) || src[0] == ByteSlash)
                     {
-                        return totalLength - 2;
+                        return true;
                     }
                     break;
             }
         }
-        return -1;
+        return false;
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/PathNormalizer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/PathNormalizer.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.AspNetCore.Internal;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/PathNormalizer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/PathNormalizer.cs
@@ -109,10 +109,10 @@ internal static class PathNormalizer
                 }
                 else
                 {
-                    // Not a dot segment e.g. /.a, copy the matched /. and bump the read pointer
-                    slashDot.CopyTo(src[writtenLength..]);
-                    writtenLength += 2;
-                    readPointer = nextIndex;
+                    // Not a dot segment e.g. /.a, copy the matched /. and the next character then bump the read pointer
+                    src.Slice(readPointer, 3).CopyTo(src[writtenLength..]);
+                    writtenLength += 3;
+                    readPointer = nextIndex + 1;
                 }
             }
 
@@ -145,10 +145,9 @@ internal static class PathNormalizer
                 }
                 else
                 {
-                    // Not a dot segment e.g. /.a, copy the /. and bump the read pointer.
-                    slashDot.CopyTo(src[writtenLength..]);
-                    writtenLength += 2;
-                    readPointer = nextIndex;
+                    // Not a dot segment e.g. /.a, copy the remaining part.
+                    src[readPointer..].CopyTo(src[writtenLength..]);
+                    return writtenLength + 3;
                 }
             }
             // Ending with /.

--- a/src/Servers/Kestrel/Core/test/PathNormalizerTests.cs
+++ b/src/Servers/Kestrel/Core/test/PathNormalizerTests.cs
@@ -66,12 +66,22 @@ public class PathNormalizerTests
     [InlineData("/.", "/")]
     [InlineData("/a/abc/../abc/../b", "/a/b")]
     [InlineData("/a/abc/.a", "/a/abc/.a")]
+    [InlineData("/a/abc/..a", "/a/abc/..a")]
+    [InlineData("/a/.b/c", "/a/.b/c")]
+    [InlineData("/a/.b/../c", "/a/c")]
+    [InlineData("/a/../.b/./c", "/.b/c")]
+    [InlineData("/a/.b/./c", "/a/.b/c")]
+    [InlineData("/a/./.b/./c", "/a/.b/c")]
+    [InlineData("/a/..b/c", "/a/..b/c")]
+    [InlineData("/a/..b/../c", "/a/c")]
+    [InlineData("/a/../..b/./c", "/..b/c")]
+    [InlineData("/a/..b/./c", "/a/..b/c")]
+    [InlineData("/a/./..b/./c", "/a/..b/c")]
     public void RemovesDotSegments(string input, string expected)
     {
         var data = Encoding.ASCII.GetBytes(input);
         var length = PathNormalizer.RemoveDotSegments(new Span<byte>(data));
         Assert.True(length >= 1);
         Assert.Equal(expected, Encoding.ASCII.GetString(data, 0, length));
-        Assert.Equal(input != expected, PathNormalizer.ContainsDotSegments(Encoding.ASCII.GetBytes(input)));
     }
 }

--- a/src/Servers/Kestrel/Core/test/PathNormalizerTests.cs
+++ b/src/Servers/Kestrel/Core/test/PathNormalizerTests.cs
@@ -64,6 +64,8 @@ public class PathNormalizerTests
     [InlineData("/./../", "/")]
     [InlineData("/..", "/")]
     [InlineData("/.", "/")]
+    [InlineData("/a/abc/../abc/../b", "/a/b")]
+    [InlineData("/a/abc/.a", "/a/abc/.a")]
     public void RemovesDotSegments(string input, string expected)
     {
         var data = Encoding.ASCII.GetBytes(input);

--- a/src/Servers/Kestrel/Core/test/PathNormalizerTests.cs
+++ b/src/Servers/Kestrel/Core/test/PathNormalizerTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -54,6 +54,16 @@ public class PathNormalizerTests
     [InlineData("/", "/")]
     [InlineData("/no/segments", "/no/segments")]
     [InlineData("/no/segments/", "/no/segments/")]
+    [InlineData("/././", "/")]
+    [InlineData("/./.", "/")]
+    [InlineData("/../..", "/")]
+    [InlineData("/../../", "/")]
+    [InlineData("/../.", "/")]
+    [InlineData("/./..", "/")]
+    [InlineData("/.././", "/")]
+    [InlineData("/./../", "/")]
+    [InlineData("/..", "/")]
+    [InlineData("/.", "/")]
     public void RemovesDotSegments(string input, string expected)
     {
         var data = Encoding.ASCII.GetBytes(input);

--- a/src/Servers/Kestrel/Core/test/PathNormalizerTests.cs
+++ b/src/Servers/Kestrel/Core/test/PathNormalizerTests.cs
@@ -70,5 +70,6 @@ public class PathNormalizerTests
         var length = PathNormalizer.RemoveDotSegments(new Span<byte>(data));
         Assert.True(length >= 1);
         Assert.Equal(expected, Encoding.ASCII.GetString(data, 0, length));
+        Assert.Equal(input != expected, PathNormalizer.ContainsDotSegments(Encoding.ASCII.GetBytes(input)));
     }
 }

--- a/src/Servers/Kestrel/perf/Microbenchmarks/DotSegmentRemovalBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/DotSegmentRemovalBenchmark.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text;
@@ -13,45 +13,53 @@ public class DotSegmentRemovalBenchmark
     private const string _noDotSegments = "/long/request/target/for/benchmarking/what/else/can/we/put/here";
     private const string _singleDotSegments = "/long/./request/./target/./for/./benchmarking/./what/./else/./can/./we/./put/./here";
     private const string _doubleDotSegments = "/long/../request/../target/../for/../benchmarking/../what/../else/../can/../we/../put/../here";
+    private const string _oneSingleDotSegments = "/long/request/target/for/./benchmarking/what/else/can/we/put/here";
+    private const string _oneDoubleDotSegments = "/long/request/target/for/../benchmarking/what/else/can/we/put/here";
 
     private readonly byte[] _noDotSegmentsAscii = Encoding.ASCII.GetBytes(_noDotSegments);
     private readonly byte[] _singleDotSegmentsAscii = Encoding.ASCII.GetBytes(_singleDotSegments);
     private readonly byte[] _doubleDotSegmentsAscii = Encoding.ASCII.GetBytes(_doubleDotSegments);
+    private readonly byte[] _oneDingleDotSegmentsAscii = Encoding.ASCII.GetBytes(_oneSingleDotSegments);
+    private readonly byte[] _oneDoubleDotSegmentsAscii = Encoding.ASCII.GetBytes(_oneDoubleDotSegments);
 
     private readonly byte[] _noDotSegmentsBytes = new byte[_noDotSegments.Length];
     private readonly byte[] _singleDotSegmentsBytes = new byte[_singleDotSegments.Length];
     private readonly byte[] _doubleDotSegmentsBytes = new byte[_doubleDotSegments.Length];
+    private readonly byte[] _oneSingleDotSegmentsBytes = new byte[_singleDotSegments.Length];
+    private readonly byte[] _oneDoubleDotSegmentsBytes = new byte[_doubleDotSegments.Length];
 
     [Benchmark(Baseline = true)]
-    public unsafe int NoDotSegments()
+    public int NoDotSegments()
     {
         _noDotSegmentsAscii.CopyTo(_noDotSegmentsBytes, 0);
-
-        fixed (byte* start = _noDotSegmentsBytes)
-        {
-            return PathNormalizer.RemoveDotSegments(start, start + _noDotSegments.Length);
-        }
+        return PathNormalizer.RemoveDotSegments(_noDotSegmentsBytes);
     }
 
     [Benchmark]
-    public unsafe int SingleDotSegments()
+    public int SingleDotSegments()
     {
         _singleDotSegmentsAscii.CopyTo(_singleDotSegmentsBytes, 0);
-
-        fixed (byte* start = _singleDotSegmentsBytes)
-        {
-            return PathNormalizer.RemoveDotSegments(start, start + _singleDotSegments.Length);
-        }
+        return PathNormalizer.RemoveDotSegments(_singleDotSegmentsBytes);
     }
 
     [Benchmark]
-    public unsafe int DoubleDotSegments()
+    public int DoubleDotSegments()
     {
         _doubleDotSegmentsAscii.CopyTo(_doubleDotSegmentsBytes, 0);
+        return PathNormalizer.RemoveDotSegments(_doubleDotSegmentsBytes);
+    }
 
-        fixed (byte* start = _doubleDotSegmentsBytes)
-        {
-            return PathNormalizer.RemoveDotSegments(start, start + _doubleDotSegments.Length);
-        }
+    [Benchmark]
+    public int OneSingleDotSegments()
+    {
+        _oneDingleDotSegmentsAscii.CopyTo(_oneSingleDotSegmentsBytes, 0);
+        return PathNormalizer.RemoveDotSegments(_oneSingleDotSegmentsBytes);
+    }
+
+    [Benchmark]
+    public int OneDoubleDotSegments()
+    {
+        _oneDoubleDotSegmentsAscii.CopyTo(_oneDoubleDotSegmentsBytes, 0);
+        return PathNormalizer.RemoveDotSegments(_oneDoubleDotSegmentsBytes);
     }
 }

--- a/src/Shared/HttpSys/RequestProcessing/PathNormalizer.cs
+++ b/src/Shared/HttpSys/RequestProcessing/PathNormalizer.cs
@@ -121,41 +121,4 @@ internal static class PathNormalizer
         }
         return writtenLength;
     }
-
-    public static bool ContainsDotSegments(Span<byte> src)
-    {
-        Debug.Assert(src[0] == '/', "Path segment must always start with a '/'");
-        ReadOnlySpan<byte> slashDot = "/."u8;
-        ReadOnlySpan<byte> dotSlash = "./"u8;
-        while (src.Length > 0)
-        {
-            var nextSlashDotIndex = src.IndexOf(slashDot);
-            if (nextSlashDotIndex < 0)
-            {
-                return false;
-            }
-            else
-            {
-                src = src[(nextSlashDotIndex + 2)..];
-            }
-            switch (src.Length)
-            {
-                case 0: // Case of /.
-                    return true;
-                case 1: // Case of /.. or /./
-                    if (src[0] == ByteDot || src[0] == ByteSlash)
-                    {
-                        return true;
-                    }
-                    break;
-                default: // Case of /../ or /./ 
-                    if (dotSlash.SequenceEqual(src[..2]) || src[0] == ByteSlash)
-                    {
-                        return true;
-                    }
-                    break;
-            }
-        }
-        return false;
-    }
 }

--- a/src/Shared/HttpSys/RequestProcessing/PathNormalizer.cs
+++ b/src/Shared/HttpSys/RequestProcessing/PathNormalizer.cs
@@ -70,10 +70,10 @@ internal static class PathNormalizer
                 }
                 else
                 {
-                    // Not a dot segment e.g. /.a, copy the matched /. and bump the read pointer
-                    slashDot.CopyTo(src[writtenLength..]);
-                    writtenLength += 2;
-                    readPointer = nextIndex;
+                    // Not a dot segment e.g. /.a, copy the matched /. and the next character then bump the read pointer
+                    src.Slice(readPointer, 3).CopyTo(src[writtenLength..]);
+                    writtenLength += 3;
+                    readPointer = nextIndex + 1;
                 }
             }
 
@@ -106,10 +106,9 @@ internal static class PathNormalizer
                 }
                 else
                 {
-                    // Not a dot segment e.g. /.a, copy the /. and bump the read pointer.
-                    slashDot.CopyTo(src[writtenLength..]);
-                    writtenLength += 2;
-                    readPointer = nextIndex;
+                    // Not a dot segment e.g. /.a, copy the remaining part.
+                    src[readPointer..].CopyTo(src[writtenLength..]);
+                    return writtenLength + 3;
                 }
             }
             // Ending with /.


### PR DESCRIPTION
# Remove unsafe from PathNormalizer

Updated `ContainsDotSegments` and `RemoveDotSegments` to be safe in Kestrel's PathNormalizer.

## Description

Using `Span<T>` where possible to remove pointer arithmetic and unsafe code. Added some new unit test cases and extended performance comparison from `DotSegmentRemovalBenchmark`.

While some cases got faster, some got slower. Looking at the performance results, I think the cases that got faster are probably the more life-like scenarios, while the results that are slower may be the less likely to occur. I leave it up to the maintainers to decide which cases should be in focus when it comes to performance.

The idea proposed in the PR uses two integers to track the read and write positions. In my performance comparison this yielded the best (reasonable) performance.
A different [implementation](https://github.com/ladeak/aspnetcore/blob/ladeak-56534-2/src/Servers/Kestrel/Core/src/Internal/Http/PathNormalizer.cs) uses `Span<T>` to track the read position instead of the `int readPointer`. While to code may be simpler, it is also about 7-8ns slower in the `SingleDotSegments` and `DoubleDotSegments` benchmarks.

There is another [implementation](https://github.com/ladeak/aspnetcore/blob/ladeak-56534-vector/src/Servers/Kestrel/Core/src/Internal/Http/PathNormalizer.cs) which tries to unroll the `IndexOf` and copy into vectorized operations - it is not complete; I did not want to spend too much time on it before it is agreed. This second implementation yields `SingleDotSegments | 56.36 ns` results, while the rest of the measurements are on-par with the *AFTER cases shown below.

## Performance

Performance results for the current changes:

BEFORE:

```
BenchmarkDotNet=v0.13.0, OS=Windows 10.0.22631
12th Gen Intel Core i7-1255U, 1 CPU, 12 logical and 10 physical cores
.NET SDK=9.0.100-preview.6.24316.4
  [Host]     : .NET 9.0.0 (9.0.24.35501), X64 RyuJIT
  Job-SNLRNU : .NET 9.0.0 (9.0.24.30702), X64 RyuJIT

Server=True  Toolchain=.NET Core 9.0  RunStrategy=Throughput

|               Method |     Mean |    Error |   StdDev |         Op/s | Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------- |---------:|---------:|---------:|-------------:|------:|--------:|------:|------:|------:|----------:|
|        NoDotSegments | 27.53 ns | 0.154 ns | 0.128 ns | 36,323,959.6 |  1.00 |    0.00 |     - |     - |     - |         - |
|    SingleDotSegments | 72.42 ns | 1.331 ns | 1.245 ns | 13,808,221.4 |  2.63 |    0.04 |     - |     - |     - |         - |
|    DoubleDotSegments | 73.39 ns | 0.972 ns | 0.909 ns | 13,626,033.6 |  2.67 |    0.03 |     - |     - |     - |         - |
| OneSingleDotSegments | 71.97 ns | 1.331 ns | 1.245 ns | 13,894,999.6 |  2.62 |    0.05 |     - |     - |     - |         - |
| OneDoubleDotSegments | 53.33 ns | 0.451 ns | 0.376 ns | 18,749,760.5 |  1.94 |    0.01 |     - |     - |     - |         - |
```
```
|               Method |     Mean |    Error |   StdDev |         Op/s | Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------- |---------:|---------:|---------:|-------------:|------:|--------:|------:|------:|------:|----------:|
|        NoDotSegments | 27.87 ns | 0.250 ns | 0.234 ns | 35,874,484.8 |  1.00 |    0.00 |     - |     - |     - |         - |
|    SingleDotSegments | 72.49 ns | 0.561 ns | 0.497 ns | 13,794,394.2 |  2.60 |    0.03 |     - |     - |     - |         - |
|    DoubleDotSegments | 73.94 ns | 1.098 ns | 1.027 ns | 13,524,773.4 |  2.65 |    0.05 |     - |     - |     - |         - |
| OneSingleDotSegments | 63.54 ns | 0.882 ns | 0.825 ns | 15,738,183.1 |  2.28 |    0.03 |     - |     - |     - |         - |
| OneDoubleDotSegments | 61.15 ns | 0.934 ns | 0.874 ns | 16,352,111.0 |  2.19 |    0.04 |     - |     - |     - |         - |
```

AFTER (Commit: [Review feedback copy 3 chars when not matched a dot segment](https://github.com/dotnet/aspnetcore/pull/56805/commits/239f511218bdee6390b221e0079a1dffb72c5dc6))

```
|               Method |     Mean |    Error |   StdDev |         Op/s | Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------- |---------:|---------:|---------:|-------------:|------:|--------:|------:|------:|------:|----------:|
|        NoDotSegments | 11.55 ns | 0.119 ns | 0.100 ns | 86,603,144.6 |  1.00 |    0.00 |     - |     - |     - |         - |
|    SingleDotSegments | 86.58 ns | 0.714 ns | 0.668 ns | 11,549,398.0 |  7.51 |    0.09 |     - |     - |     - |         - |
|    DoubleDotSegments | 92.44 ns | 0.777 ns | 0.727 ns | 10,818,128.3 |  8.01 |    0.11 |     - |     - |     - |         - |
| OneSingleDotSegments | 21.93 ns | 0.184 ns | 0.172 ns | 45,608,856.4 |  1.90 |    0.03 |     - |     - |     - |         - |
| OneDoubleDotSegments | 24.50 ns | 0.312 ns | 0.277 ns | 40,815,649.1 |  2.12 |    0.03 |     - |     - |     - |         - |
```

```
|               Method |     Mean |    Error |   StdDev |         Op/s | Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------- |---------:|---------:|---------:|-------------:|------:|--------:|------:|------:|------:|----------:|
|        NoDotSegments | 11.65 ns | 0.112 ns | 0.105 ns | 85,866,950.4 |  1.00 |    0.00 |     - |     - |     - |         - |
|    SingleDotSegments | 87.05 ns | 0.908 ns | 0.805 ns | 11,488,305.3 |  7.47 |    0.08 |     - |     - |     - |         - |
|    DoubleDotSegments | 94.28 ns | 0.555 ns | 0.464 ns | 10,606,751.7 |  8.09 |    0.09 |     - |     - |     - |         - |
| OneSingleDotSegments | 22.25 ns | 0.202 ns | 0.189 ns | 44,935,385.0 |  1.91 |    0.02 |     - |     - |     - |         - |
| OneDoubleDotSegments | 24.71 ns | 0.281 ns | 0.262 ns | 40,476,357.9 |  2.12 |    0.03 |     - |     - |     - |         - |
```

Linked to #56534 