### PR TITLE
Enable CA1861 and IDE0300 warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -410,6 +410,8 @@ dotnet_diagnostic.CA1856.severity = suggestion
 dotnet_diagnostic.CA1857.severity = suggestion
 # CA1858: Use 'StartsWith' instead of 'IndexOf'
 dotnet_diagnostic.CA1858.severity = suggestion
+# CA1861: Avoid constant arrays as arguments
+dotnet_diagnostic.CA1861.severity = suggestion
 # CA2007: Consider calling ConfigureAwait on the awaited task
 dotnet_diagnostic.CA2007.severity = suggestion
 # CA2008: Do not create tasks without passing a TaskScheduler
@@ -446,6 +448,8 @@ dotnet_diagnostic.IDE0060.severity = suggestion
 dotnet_diagnostic.IDE0062.severity = suggestion
 # IDE0200: Lambda expression can be removed
 dotnet_diagnostic.IDE0200.severity = suggestion
+# IDE0300: Use collection expression for array
+dotnet_diagnostic.IDE0300.severity = suggestion
 
 # CA2016: Forward the 'CancellationToken' parameter to methods that take one
 dotnet_diagnostic.CA2016.severity = suggestion

--- a/.editorconfig
+++ b/.editorconfig
@@ -473,3 +473,5 @@ dotnet_diagnostic.IDE0161.severity = silent
 [{**/Shared/**.cs,**/microsoft.extensions.hostfactoryresolver.sources/**.{cs,vb}}]
 # IDE0005: Remove unused usings. Ignore for shared src files since imports for those depend on the projects in which they are included.
 dotnet_diagnostic.IDE0005.severity = silent
+# IDE0300: Use collection expression for array
+dotnet_diagnostic.IDE0300.severity = silent

--- a/.editorconfig
+++ b/.editorconfig
@@ -230,6 +230,9 @@ dotnet_diagnostic.CA1857.severity = warning
 # CA1858: Use 'StartsWith' instead of 'IndexOf'
 dotnet_diagnostic.CA1858.severity = warning
 
+# CA1861: Avoid constant arrays as arguments
+dotnet_diagnostic.CA1861.severity = warning
+
 # CA2007: Consider calling ConfigureAwait on the awaited task
 dotnet_diagnostic.CA2007.severity = warning
 
@@ -334,6 +337,9 @@ dotnet_diagnostic.IDE0161.severity = warning
 
 # IDE0200: Lambda expression can be removed
 dotnet_diagnostic.IDE0200.severity = warning
+
+# IDE0300: Use collection expression for array
+dotnet_diagnostic.IDE0300.severity = warning
 
 # IDE2000: Disallow multiple blank lines
 dotnet_style_allow_multiple_blank_lines_experimental = false


### PR DESCRIPTION
# Enable CA1861 and IDE0300 warnings

Enable warnings for CA1861 and IDE0300 in EditorConfig.

## Description

Enable warnings for CA1861 and IDE0300 in EditorConfig, see https://github.com/dotnet/aspnetcore/pull/56525#issuecomment-2229516540.

I didn't enable IDE0028 due to https://github.com/dotnet/aspnetcore/pull/56395#discussion_r1678254722.

Draft for now to see what fails and whether fixes for what does fail are net positive.

/cc @BrennanConroy
