### PR TITLE
IBrowserFile FormDataConverter Mismatch between Name and FileName

### DIFF
--- a/src/Components/Endpoints/src/FormMapping/BrowserFileFromFormFile.cs
+++ b/src/Components/Endpoints/src/FormMapping/BrowserFileFromFormFile.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Components.Endpoints.FormMapping;
 
 internal sealed class BrowserFileFromFormFile(IFormFile formFile) : IBrowserFile
 {
-    public string Name => formFile.Name;
+    public string Name => formFile.FileName;
 
     public DateTimeOffset LastModified => DateTimeOffset.Parse(formFile.Headers.LastModified.ToString(), CultureInfo.InvariantCulture);
 


### PR DESCRIPTION
The conversion in BrowserFileFromFormFile maps from IFormFile the Name property as if it was the FileName, so instead of [File.ext] the Name will have [Input.File].

This change will fix this conversion error so that the filename is correct.

# IBrowserFile FormDataConverter Mismatch between Name and FileName

Fixes BrowserFileFromFormFile to get the correct Name for the uploaded file

## Description

BrowserFileFromFormFile retrieves from IFileInput the property from Name and not from FileName, so just a minimal fix.

Fixes #56832
