### PR TITLE
Increase quarantine pr timeout

### DIFF
--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -50,7 +50,7 @@ jobs:
     jobDisplayName: 'Tests: Helix'
     agentOs: Windows
     installJdk: false
-    timeoutInMinutes: 120
+    timeoutInMinutes: 150
     steps:
     # Build the shared framework
     - script: ./eng/build.cmd -ci -prepareMachine -nobl -all -noBuildJava -pack -arch x64
@@ -110,7 +110,7 @@ jobs:
     jobName: MacOS_Quarantined_Test
     jobDisplayName: "Tests: macOS"
     agentOs: macOS
-    timeoutInMinutes: 120
+    timeoutInMinutes: 150
     isAzDOTestingJob: true
     enablePublishTestResults: false
     steps:


### PR DESCRIPTION
Builds have been failing on timeouts since CodeQL was added on July 1st.
