### PR TITLE
Add ClaimData for AuthenticationStateData and fix overtrimming

### DIFF
--- a/src/Components/Authorization/src/AuthenticationStateData.cs
+++ b/src/Components/Authorization/src/AuthenticationStateData.cs
@@ -13,7 +13,7 @@ public class AuthenticationStateData
     /// <summary>
     /// The client-readable claims that describe the <see cref="AuthenticationState.User"/>.
     /// </summary>
-    public IList<KeyValuePair<string, string>> Claims { get; set; } = [];
+    public IList<ClaimData> Claims { get; set; } = [];
 
     /// <summary>
     /// Gets the value that identifies 'Name' claims. This is used when returning the property <see cref="ClaimsIdentity.Name"/>.

--- a/src/Components/Authorization/src/ClaimData.cs
+++ b/src/Components/Authorization/src/ClaimData.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Security.Claims;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.AspNetCore.Components.Authorization;
+
+/// <summary>
+/// This is a serializable representation of a <see cref="Claim"/> object that only consists of the type and value.
+/// </summary>
+public readonly struct ClaimData
+{
+    /// <summary>
+    /// Constructs a new instance of <see cref="ClaimData"/> from a type and value.
+    /// </summary>
+    /// <param name="type">The claim type.</param>
+    /// <param name="value">The claim value</param>
+    [JsonConstructor]
+    public ClaimData(string type, string value)
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Constructs a new instance of <see cref="ClaimData"/> from a <see cref="Claim"/> copying only the
+    /// <see cref="Claim.Type"/> and <see cref="Claim.Value"/> into their corresponding properties.
+    /// </summary>
+    /// <param name="claim">The <see cref="Claim"/> to copy from.</param>
+    public ClaimData(Claim claim)
+        : this(claim.Type, claim.Value)
+    {
+    }
+
+    /// <summary>
+    /// Gets the claim type of the claim. <seealso cref="ClaimTypes"/>.
+    /// </summary>
+    public string Type { get; }
+
+    /// <summary>
+    /// Gets the value of the claim.
+    /// </summary>
+    public string Value { get; }
+}

--- a/src/Components/Authorization/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Authorization/src/PublicAPI.Unshipped.txt
@@ -1,9 +1,15 @@
 #nullable enable
 Microsoft.AspNetCore.Components.Authorization.AuthenticationStateData
 Microsoft.AspNetCore.Components.Authorization.AuthenticationStateData.AuthenticationStateData() -> void
-Microsoft.AspNetCore.Components.Authorization.AuthenticationStateData.Claims.get -> System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string!, string!>>!
+Microsoft.AspNetCore.Components.Authorization.AuthenticationStateData.Claims.get -> System.Collections.Generic.IList<Microsoft.AspNetCore.Components.Authorization.ClaimData>!
 Microsoft.AspNetCore.Components.Authorization.AuthenticationStateData.Claims.set -> void
 Microsoft.AspNetCore.Components.Authorization.AuthenticationStateData.NameClaimType.get -> string!
 Microsoft.AspNetCore.Components.Authorization.AuthenticationStateData.NameClaimType.set -> void
 Microsoft.AspNetCore.Components.Authorization.AuthenticationStateData.RoleClaimType.get -> string!
 Microsoft.AspNetCore.Components.Authorization.AuthenticationStateData.RoleClaimType.set -> void
+Microsoft.AspNetCore.Components.Authorization.ClaimData
+Microsoft.AspNetCore.Components.Authorization.ClaimData.ClaimData() -> void
+Microsoft.AspNetCore.Components.Authorization.ClaimData.ClaimData(string! type, string! value) -> void
+Microsoft.AspNetCore.Components.Authorization.ClaimData.ClaimData(System.Security.Claims.Claim! claim) -> void
+Microsoft.AspNetCore.Components.Authorization.ClaimData.Type.get -> string!
+Microsoft.AspNetCore.Components.Authorization.ClaimData.Value.get -> string!

--- a/src/Components/WebAssembly/Server/src/AuthenticationStateSerializationOptions.cs
+++ b/src/Components/WebAssembly/Server/src/AuthenticationStateSerializationOptions.cs
@@ -51,19 +51,19 @@ public class AuthenticationStateSerializationOptions
             {
                 foreach (var claim in authenticationState.User.Claims)
                 {
-                    data.Claims.Add(new(claim.Type, claim.Value));
+                    data.Claims.Add(new(claim));
                 }
             }
             else
             {
                 if (authenticationState.User.FindFirst(data.NameClaimType) is { } nameClaim)
                 {
-                    data.Claims.Add(new(nameClaim.Type, nameClaim.Value));
+                    data.Claims.Add(new(nameClaim));
                 }
 
                 foreach (var roleClaim in authenticationState.User.FindAll(data.RoleClaimType))
                 {
-                    data.Claims.Add(new(roleClaim.Type, roleClaim.Value));
+                    data.Claims.Add(new(roleClaim));
                 }
             }
         }

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Options/AuthenticationStateDeserializationOptions.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Options/AuthenticationStateDeserializationOptions.cs
@@ -31,7 +31,7 @@ public sealed class AuthenticationStateDeserializationOptions
 
         return Task.FromResult(
             new AuthenticationState(new ClaimsPrincipal(
-                new ClaimsIdentity(authenticationStateData.Claims.Select(c => new Claim(c.Key, c.Value)),
+                new ClaimsIdentity(authenticationStateData.Claims.Select(c => new Claim(c.Type, c.Value)),
                     authenticationType: nameof(DeserializedAuthenticationStateProvider),
                     nameType: authenticationStateData.NameClaimType,
                     roleType: authenticationStateData.RoleClaimType))));

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Services/DeserializedAuthenticationStateProvider.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Services/DeserializedAuthenticationStateProvider.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.Extensions.Options;
+using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
 namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 
@@ -21,7 +22,10 @@ internal sealed class DeserializedAuthenticationStateProvider : AuthenticationSt
     [UnconditionalSuppressMessage(
         "Trimming",
         "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code",
-        Justification = $"{nameof(DeserializedAuthenticationStateProvider)} uses the {nameof(PersistentComponentState)} APIs to deserialize the token, which are already annotated.")]
+        Justification = $"{nameof(DeserializedAuthenticationStateProvider)} uses the {nameof(DynamicDependencyAttribute)} to preserve the necessary members.")]
+    [DynamicDependency(JsonSerialized, typeof(AuthenticationStateData))]
+    [DynamicDependency(JsonSerialized, typeof(IList<ClaimData>))]
+    [DynamicDependency(JsonSerialized, typeof(ClaimData))]
     public DeserializedAuthenticationStateProvider(PersistentComponentState state, IOptions<AuthenticationStateDeserializationOptions> options)
     {
         if (!state.TryTakeFromJson<AuthenticationStateData?>(PersistenceKey, out var authenticationStateData) || authenticationStateData is null)

--- a/src/Components/test/E2ETest/Infrastructure/ServerFixtures/BasicTestAppServerSiteFixture.cs
+++ b/src/Components/test/E2ETest/Infrastructure/ServerFixtures/BasicTestAppServerSiteFixture.cs
@@ -7,6 +7,7 @@ public class BasicTestAppServerSiteFixture<TStartup> : AspNetSiteServerFixture w
 {
     public BasicTestAppServerSiteFixture()
     {
+        ApplicationAssembly = typeof(TStartup).Assembly;
         BuildWebHostMethod = TestServer.Program.BuildWebHost<TStartup>;
     }
 }

--- a/src/Components/test/E2ETest/Infrastructure/ServerFixtures/TrimmingServerFixture.cs
+++ b/src/Components/test/E2ETest/Infrastructure/ServerFixtures/TrimmingServerFixture.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
+
+namespace Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
+
+// REVIEW: Should this be merged into BasicTestAppServerSiteFixture? Is there any case where we wouldn't
+// want to trim BasicTestAppServerSiteFixture tests when TestTrimmedOrMultithreadingApps is true?
+public class TrimmingServerFixture<TStartup> : BasicTestAppServerSiteFixture<TStartup> where TStartup : class
+{
+    public readonly bool TestTrimmedApps = typeof(ToggleExecutionModeServerFixture<>).Assembly
+        .GetCustomAttributes<AssemblyMetadataAttribute>()
+        .First(m => m.Key == "Microsoft.AspNetCore.E2ETesting.TestTrimmedOrMultithreadingApps")
+        .Value == "true";
+
+    public TrimmingServerFixture()
+    {
+        if (TestTrimmedApps)
+        {
+            BuildWebHostMethod = BuildPublishedWebHost;
+            GetContentRootMethod = GetPublishedContentRoot;
+        }
+    }
+
+    private static IHost BuildPublishedWebHost(string[] args) =>
+        Extensions.Hosting.Host.CreateDefaultBuilder(args)
+            .ConfigureLogging((ctx, lb) =>
+            {
+                var sink = new TestSink();
+                lb.AddProvider(new TestLoggerProvider(sink));
+                lb.Services.AddSingleton(sink);
+            })
+            .ConfigureWebHostDefaults(webHostBuilder =>
+            {
+                webHostBuilder.UseStartup<TStartup>();
+                // Avoid UseStaticAssets or we won't use the trimmed published output.
+            })
+            .Build();
+
+    private static string GetPublishedContentRoot(Assembly assembly)
+    {
+        var contentRoot = Path.Combine(AppContext.BaseDirectory, "trimmed-or-threading", assembly.GetName().Name);
+
+        if (!Directory.Exists(contentRoot))
+        {
+            throw new DirectoryNotFoundException($"Test is configured to use trimmed outputs, but trimmed outputs were not found in {contentRoot}.");
+        }
+
+        return contentRoot;
+    }
+}

--- a/src/Components/test/E2ETest/Infrastructure/ServerFixtures/TrimmingServerFixture.cs
+++ b/src/Components/test/E2ETest/Infrastructure/ServerFixtures/TrimmingServerFixture.cs
@@ -10,8 +10,6 @@ using Microsoft.Extensions.Logging.Testing;
 
 namespace Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 
-// REVIEW: Should this be merged into BasicTestAppServerSiteFixture? Is there any case where we wouldn't
-// want to trim BasicTestAppServerSiteFixture tests when TestTrimmedOrMultithreadingApps is true?
 public class TrimmingServerFixture<TStartup> : BasicTestAppServerSiteFixture<TStartup> where TStartup : class
 {
     public readonly bool TestTrimmedApps = typeof(ToggleExecutionModeServerFixture<>).Assembly

--- a/src/Components/test/E2ETest/ServerRenderingTests/AuthTests/DefaultAuthenticationStateSerializationOptionsTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/AuthTests/DefaultAuthenticationStateSerializationOptionsTest.cs
@@ -12,11 +12,11 @@ using Xunit.Abstractions;
 namespace Microsoft.AspNetCore.Components.E2ETests.ServerRenderingTests.AuthTests;
 
 public class DefaultAuthenticationStateSerializationOptionsTest
-     : ServerTestBase<BasicTestAppServerSiteFixture<RazorComponentEndpointsStartup<App>>>
+     : ServerTestBase<TrimmingServerFixture<RazorComponentEndpointsStartup<App>>>
 {
     public DefaultAuthenticationStateSerializationOptionsTest(
         BrowserFixture browserFixture,
-        BasicTestAppServerSiteFixture<RazorComponentEndpointsStartup<App>> serverFixture,
+        TrimmingServerFixture<RazorComponentEndpointsStartup<App>> serverFixture,
         ITestOutputHelper output)
         : base(browserFixture, serverFixture, output)
     {

--- a/src/Components/test/E2ETest/ServerRenderingTests/AuthTests/ServerRenderedAuthenticationStateTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/AuthTests/ServerRenderedAuthenticationStateTest.cs
@@ -12,11 +12,11 @@ using Xunit.Abstractions;
 namespace Microsoft.AspNetCore.Components.E2ETests.ServerRenderingTests.AuthTests;
 
 public class ServerRenderedAuthenticationStateTest
-     : ServerTestBase<BasicTestAppServerSiteFixture<RazorComponentEndpointsStartup<App>>>
+     : ServerTestBase<TrimmingServerFixture<RazorComponentEndpointsStartup<App>>>
 {
     public ServerRenderedAuthenticationStateTest(
         BrowserFixture browserFixture,
-        BasicTestAppServerSiteFixture<RazorComponentEndpointsStartup<App>> serverFixture,
+        TrimmingServerFixture<RazorComponentEndpointsStartup<App>> serverFixture,
         ITestOutputHelper output)
         : base(browserFixture, serverFixture, output)
     {

--- a/src/Components/test/E2ETest/Tests/RemoteAuthenticationTest.cs
+++ b/src/Components/test/E2ETest/Tests/RemoteAuthenticationTest.cs
@@ -1,15 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Reflection;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.E2ETesting;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Testing;
 using OpenQA.Selenium;
 using TestServer;
 using Xunit.Abstractions;
@@ -17,26 +11,14 @@ using Xunit.Abstractions;
 namespace Microsoft.AspNetCore.Components.E2ETest.Tests;
 
 public class RemoteAuthenticationTest :
-    ServerTestBase<BasicTestAppServerSiteFixture<RemoteAuthenticationStartup>>
+    ServerTestBase<TrimmingServerFixture<RemoteAuthenticationStartup>>
 {
-    public readonly bool TestTrimmedApps = typeof(ToggleExecutionModeServerFixture<>).Assembly
-        .GetCustomAttributes<AssemblyMetadataAttribute>()
-        .First(m => m.Key == "Microsoft.AspNetCore.E2ETesting.TestTrimmedOrMultithreadingApps")
-        .Value == "true";
-
     public RemoteAuthenticationTest(
         BrowserFixture browserFixture,
-        BasicTestAppServerSiteFixture<RemoteAuthenticationStartup> serverFixture,
+        TrimmingServerFixture<RemoteAuthenticationStartup> serverFixture,
         ITestOutputHelper output)
         : base(browserFixture, serverFixture, output)
     {
-        serverFixture.ApplicationAssembly = typeof(RemoteAuthenticationStartup).Assembly;
-
-        if (TestTrimmedApps)
-        {
-            serverFixture.BuildWebHostMethod = BuildPublishedWebHost;
-            serverFixture.GetContentRootMethod = GetPublishedContentRoot;
-        }
     }
 
     [Fact]
@@ -48,32 +30,5 @@ public class RemoteAuthenticationTest :
 
         var heading = Browser.Exists(By.TagName("h1"));
         Browser.Equal("Hello, Jane Doe!", () => heading.Text);
-    }
-
-    private static IHost BuildPublishedWebHost(string[] args) =>
-        Host.CreateDefaultBuilder(args)
-            .ConfigureLogging((ctx, lb) =>
-            {
-                var sink = new TestSink();
-                lb.AddProvider(new TestLoggerProvider(sink));
-                lb.Services.AddSingleton(sink);
-            })
-            .ConfigureWebHostDefaults(webHostBuilder =>
-            {
-                webHostBuilder.UseStartup<RemoteAuthenticationStartup>();
-                // Avoid UseStaticAssets or we won't use the trimmed published output.
-            })
-            .Build();
-
-    private static string GetPublishedContentRoot(Assembly assembly)
-    {
-        var contentRoot = Path.Combine(AppContext.BaseDirectory, "trimmed-or-threading", assembly.GetName().Name);
-
-        if (!Directory.Exists(contentRoot))
-        {
-            throw new DirectoryNotFoundException($"Test is configured to use trimmed outputs, but trimmed outputs were not found in {contentRoot}.");
-        }
-
-        return contentRoot;
     }
 }

--- a/src/Components/test/E2ETest/Tests/WebAssemblyPrerenderedTest.cs
+++ b/src/Components/test/E2ETest/Tests/WebAssemblyPrerenderedTest.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Reflection;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.E2ETesting;
@@ -10,26 +9,15 @@ using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Components.E2ETest.Tests;
 
-public class WebAssemblyPrerenderedTest : ServerTestBase<AspNetSiteServerFixture>
+public class WebAssemblyPrerenderedTest : ServerTestBase<TrimmingServerFixture<Wasm.Prerendered.Server.Startup>>
 {
     public WebAssemblyPrerenderedTest(
         BrowserFixture browserFixture,
-        AspNetSiteServerFixture serverFixture,
+        TrimmingServerFixture<Wasm.Prerendered.Server.Startup> serverFixture,
         ITestOutputHelper output)
         : base(browserFixture, serverFixture, output)
     {
-        serverFixture.BuildWebHostMethod = Wasm.Prerendered.Server.Program.BuildWebHost;
         serverFixture.Environment = AspNetEnvironment.Development;
-
-        var testTrimmedApps = typeof(ToggleExecutionModeServerFixture<>).Assembly
-            .GetCustomAttributes<AssemblyMetadataAttribute>()
-            .First(m => m.Key == "Microsoft.AspNetCore.E2ETesting.TestTrimmedOrMultithreadingApps")
-            .Value == "true";
-
-        if (testTrimmedApps)
-        {
-            serverFixture.GetContentRootMethod = GetPublishedContentRoot;
-        }
     }
 
     [Fact]
@@ -52,17 +40,5 @@ public class WebAssemblyPrerenderedTest : ServerTestBase<AspNetSiteServerFixture
     {
         var jsExecutor = (IJavaScriptExecutor)Browser;
         Browser.True(() => jsExecutor.ExecuteScript("return window['__aspnetcore__testing__blazor_wasm__started__'];") is not null);
-    }
-
-    private static string GetPublishedContentRoot(Assembly assembly)
-    {
-        var contentRoot = Path.Combine(AppContext.BaseDirectory, "trimmed-or-threading", assembly.GetName().Name);
-
-        if (!Directory.Exists(contentRoot))
-        {
-            throw new DirectoryNotFoundException($"Test is configured to use trimmed outputs, but trimmed outputs were not found in {contentRoot}.");
-        }
-
-        return contentRoot;
     }
 }

--- a/src/Components/test/testassets/Components.TestServer/RazorComponentEndpointsStartup.cs
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponentEndpointsStartup.cs
@@ -86,7 +86,6 @@ public class RazorComponentEndpointsStartup<TRootComponent>
 
             _ = app.UseEndpoints(endpoints =>
             {
-                // REVIEW: Why doesn't MapStaticAssets search env.ContentRootPath before AppContext.BaseDirectory first to begin with?
                 var contentRootStaticAssetsPath = Path.Combine(env.ContentRootPath, "Components.TestServer.staticwebassets.endpoints.json");
                 if (File.Exists(contentRootStaticAssetsPath))
                 {

--- a/src/Components/test/testassets/Components.TestServer/RazorComponentEndpointsStartup.cs
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponentEndpointsStartup.cs
@@ -86,7 +86,17 @@ public class RazorComponentEndpointsStartup<TRootComponent>
 
             _ = app.UseEndpoints(endpoints =>
             {
-                endpoints.MapStaticAssets();
+                // REVIEW: Why doesn't MapStaticAssets search env.ContentRootPath before AppContext.BaseDirectory first to begin with?
+                var contentRootStaticAssetsPath = Path.Combine(env.ContentRootPath, "Components.TestServer.staticwebassets.endpoints.json");
+                if (File.Exists(contentRootStaticAssetsPath))
+                {
+                    endpoints.MapStaticAssets(contentRootStaticAssetsPath);
+                }
+                else
+                {
+                    endpoints.MapStaticAssets();
+                }
+
                 _ = endpoints.MapRazorComponents<TRootComponent>()
                     .AddAdditionalAssemblies(Assembly.Load("Components.WasmMinimal"))
                     .AddInteractiveServerRenderMode(options =>

--- a/src/Components/test/testassets/Components.TestServer/RemoteAuthenticationStartup.cs
+++ b/src/Components/test/testassets/Components.TestServer/RemoteAuthenticationStartup.cs
@@ -28,11 +28,16 @@ public class RemoteAuthenticationStartup
             app.UseAntiforgery();
             app.UseEndpoints(endpoints =>
             {
-#if !DEBUG
-                endpoints.MapStaticAssets(Path.Combine("trimmed-or-threading", "Components.TestServer", "Components.TestServer.staticwebassets.endpoints.json"));
-#else
-                endpoints.MapStaticAssets("Components.TestServer.staticwebassets.endpoints.json");
-#endif
+                var contentRootStaticAssetsPath = Path.Combine(env.ContentRootPath, "Components.TestServer.staticwebassets.endpoints.json");
+                if (File.Exists(contentRootStaticAssetsPath))
+                {
+                    endpoints.MapStaticAssets(contentRootStaticAssetsPath);
+                }
+                else
+                {
+                    endpoints.MapStaticAssets();
+                }
+
                 endpoints.MapRazorComponents<RemoteAuthenticationApp>()
                     .AddAdditionalAssemblies(Assembly.Load("Components.WasmRemoteAuthentication"))
                     .AddInteractiveWebAssemblyRenderMode(options => options.PathPrefix = "/WasmRemoteAuthentication");


### PR DESCRIPTION
This PR is a follow up to #55821 which added the `AuthenticationStateProvider` implementations from the .NET 8 Blazor web project templates to the runtime. You can opt into using these by adding the new services as follows.

```csharp
// Server Program.cs
builder.Services.AddRazorComponents()
    .AddInteractiveWebAssemblyComponents()
    .AddAuthenticationStateSerialization();
```

```csharp
// Client Program.cs
builder.Services.AddAuthenticationStateDeserialization();
```

These services rely on JSON serializing and deserializing the newly added `AuthenticationStateData` type which previously contained a `Claims` property of type `IList<KeyValuePair<string, string>>`. After API review feedback in #52769, we've decided to update `AuthenticationStateData.Claims` to be an `IList<ClaimData>`.

This PR also fixes #56207 which was caused by the overtrimming `AuthenticationStateData.Claims` and updates the `ServerRenderedAuthenticationStateTest` and  `DefaultAuthenticationStateSerializationOptionsTest` to test published trimmed WebAssembly static assets.

As part of this, I refactored the common logic of most tests that currently use static assets published to the "trimmed-or-threading" to use the new `TrimmingServerFixture`. However, I wonder if we should go further and make `BasicTestAppServerSiteFixture` use trimmed static assets by default when `TestTrimmedOrMultithreadingApps` is configured.

Fixes #52769
Fixes #56207