### PR TITLE
Add Job Attempt Number to Artifact Names for Logs and Test Results

### DIFF
--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -101,7 +101,7 @@ stages:
       - powershell: ./eng/scripts/CodeCheck.ps1 -ci $(_InternalRuntimeDownloadArgs)
         displayName: Run eng/scripts/CodeCheck.ps1
       artifacts:
-      - name: Code_Check_Logs
+      - name: Code_Check_Logs_Attempt_$(System.JobAttempt)
         path: artifacts/log/
         publishOnError: true
         includeForks: true
@@ -227,7 +227,7 @@ stages:
         displayName: Build ARM64 Installers
 
       artifacts:
-      - name: Windows_Logs
+      - name: Windows_Logs_Attempt_$(System.JobAttempt)
         path: artifacts/log/
         publishOnError: true
         includeForks: true
@@ -259,7 +259,7 @@ stages:
         $(_PublishArgs)
         $(_InternalRuntimeDownloadArgs)
       artifacts:
-      - name: MacOS_arm64_Logs
+      - name: MacOS_arm64_Logs_Attempt_$(System.JobAttempt)
         path: artifacts/log/
         publishOnError: true
         includeForks: true
@@ -289,7 +289,7 @@ stages:
         $(_PublishArgs)
         $(_InternalRuntimeDownloadArgs)
       artifacts:
-      - name: MacOS_x64_Logs
+      - name: MacOS_x64_Logs_Attempt_$(System.JobAttempt)
         path: artifacts/log/
         publishOnError: true
         includeForks: true
@@ -351,7 +351,7 @@ stages:
         displayName: Build RPM installers
         target: rpmpkg
       artifacts:
-      - name: Linux_x64_Logs
+      - name: Linux_x64_Logs_Attempt_$(System.JobAttempt)
         path: artifacts/log/
         publishOnError: true
         includeForks: true
@@ -381,7 +381,7 @@ stages:
         $(_PublishArgs)
         $(_InternalRuntimeDownloadArgs)
       artifacts:
-      - name: Linux_arm_Logs
+      - name: Linux_arm_Logs_Attempt_$(System.JobAttempt)
         path: artifacts/log/
         publishOnError: true
         includeForks: true
@@ -428,7 +428,7 @@ stages:
         displayName: Build RPM installers
         target: rpmpkg
       artifacts:
-      - name: Linux_arm64_Logs
+      - name: Linux_arm64_Logs_Attempt_$(System.JobAttempt)
         path: artifacts/log/
         publishOnError: true
         includeForks: true
@@ -462,7 +462,7 @@ stages:
       installNodeJs: false
       disableComponentGovernance: true
       artifacts:
-      - name: Linux_musl_x64_Logs
+      - name: Linux_musl_x64_Logs_Attempt_$(System.JobAttempt)
         path: artifacts/log/
         publishOnError: true
         includeForks: true
@@ -495,7 +495,7 @@ stages:
         $(_PublishArgs)
         $(_InternalRuntimeDownloadArgs)
       artifacts:
-      - name: Linux_musl_arm_Logs
+      - name: Linux_musl_arm_Logs_Attempt_$(System.JobAttempt)
         path: artifacts/log/
         publishOnError: true
         includeForks: true
@@ -528,7 +528,7 @@ stages:
         $(_PublishArgs)
         $(_InternalRuntimeDownloadArgs)
       artifacts:
-      - name: Linux_musl_arm64_Logs
+      - name: Linux_musl_arm64_Logs_Attempt_$(System.JobAttempt)
         path: artifacts/log/
         publishOnError: true
         includeForks: true
@@ -557,11 +557,11 @@ stages:
         - powershell: "& ./src/Servers/IIS/tools/UpdateIISExpressCertificate.ps1; & ./src/Servers/IIS/tools/update_schema.ps1"
           displayName: Setup IISExpress test certificates and schema
         artifacts:
-        - name: Windows_Test_Logs
+        - name: Windows_Test_Logs_Attempt_$(System.JobAttempt)
           path: artifacts/log/
           publishOnError: true
           includeForks: true
-        - name: Windows_Test_Results
+        - name: Windows_Test_Results_Attempt_$(System.JobAttempt)
           path: artifacts/TestResults/
           publishOnError: true
           includeForks: true
@@ -578,11 +578,11 @@ stages:
         - bash: "./eng/scripts/install-nginx-mac.sh"
           displayName: Installing Nginx
         artifacts:
-        - name: MacOS_Test_Logs
+        - name: MacOS_Test_Logs_Attempt_$(System.JobAttempt)
           path: artifacts/log/
           publishOnError: true
           includeForks: true
-        - name: MacOS_Test_Results
+        - name: MacOS_Test_Results_Attempt_$(System.JobAttempt)
           path: artifacts/TestResults/
           publishOnError: true
           includeForks: true
@@ -601,11 +601,11 @@ stages:
         - bash: "echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p"
           displayName: Increase inotify limit
         artifacts:
-        - name: Linux_Test_Logs
+        - name: Linux_Test_Logs_Attempt_$(System.JobAttempt)
           path: artifacts/log/
           publishOnError: true
           includeForks: true
-        - name: Linux_Test_Results
+        - name: Linux_Test_Results_Attempt_$(System.JobAttempt)
           path: artifacts/TestResults/
           publishOnError: true
           includeForks: true
@@ -632,7 +632,7 @@ stages:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
 
         artifacts:
-        - name: Helix_logs
+        - name: Helix_Logs_Attempt_$(System.JobAttempt)
           path: artifacts/log/
           publishOnError: true
           includeForks: true

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -166,7 +166,7 @@ extends:
             - powershell: ./eng/scripts/CodeCheck.ps1 -ci $(_InternalRuntimeDownloadArgs)
               displayName: Run eng/scripts/CodeCheck.ps1
             artifacts:
-            - name: Code_Check_Logs
+            - name: Code_Check_Logs_Attempt_$(System.JobAttempt)
               path: artifacts/log/
               publishOnError: true
               includeForks: true
@@ -292,7 +292,7 @@ extends:
             displayName: Build ARM64 Installers
 
           artifacts:
-          - name: Windows_Logs
+          - name: Windows_Logs_Attempt_$(System.JobAttempt)
             path: artifacts/log/
             publishOnError: true
             includeForks: true
@@ -324,7 +324,7 @@ extends:
             $(_PublishArgs)
             $(_InternalRuntimeDownloadArgs)
           artifacts:
-          - name: MacOS_arm64_Logs
+          - name: MacOS_arm64_Logs_Attempt_$(System.JobAttempt)
             path: artifacts/log/
             publishOnError: true
             includeForks: true
@@ -354,7 +354,7 @@ extends:
             $(_PublishArgs)
             $(_InternalRuntimeDownloadArgs)
           artifacts:
-          - name: MacOS_x64_Logs
+          - name: MacOS_x64_Logs_Attempt_$(System.JobAttempt)
             path: artifacts/log/
             publishOnError: true
             includeForks: true
@@ -416,7 +416,7 @@ extends:
             displayName: Build RPM installers
             target: rpmpkg
           artifacts:
-          - name: Linux_x64_Logs
+          - name: Linux_x64_Logs_Attempt_$(System.JobAttempt)
             path: artifacts/log/
             publishOnError: true
             includeForks: true
@@ -446,7 +446,7 @@ extends:
             $(_PublishArgs)
             $(_InternalRuntimeDownloadArgs)
           artifacts:
-          - name: Linux_arm_Logs
+          - name: Linux_arm_Logs_Attempt_$(System.JobAttempt)
             path: artifacts/log/
             publishOnError: true
             includeForks: true
@@ -493,7 +493,7 @@ extends:
             displayName: Build RPM installers
             target: rpmpkg
           artifacts:
-          - name: Linux_arm64_Logs
+          - name: Linux_arm64_Logs_Attempt_$(System.JobAttempt)
             path: artifacts/log/
             publishOnError: true
             includeForks: true
@@ -527,7 +527,7 @@ extends:
           installNodeJs: false
           disableComponentGovernance: true
           artifacts:
-          - name: Linux_musl_x64_Logs
+          - name: Linux_musl_x64_Logs_Attempt_$(System.JobAttempt)
             path: artifacts/log/
             publishOnError: true
             includeForks: true
@@ -560,7 +560,7 @@ extends:
             $(_PublishArgs)
             $(_InternalRuntimeDownloadArgs)
           artifacts:
-          - name: Linux_musl_arm_Logs
+          - name: Linux_musl_arm_Logs_Attempt_$(System.JobAttempt)
             path: artifacts/log/
             publishOnError: true
             includeForks: true
@@ -593,7 +593,7 @@ extends:
             $(_PublishArgs)
             $(_InternalRuntimeDownloadArgs)
           artifacts:
-          - name: Linux_musl_arm64_Logs
+          - name: Linux_musl_arm64_Logs_Attempt_$(System.JobAttempt)
             path: artifacts/log/
             publishOnError: true
             includeForks: true
@@ -622,11 +622,11 @@ extends:
             - powershell: "& ./src/Servers/IIS/tools/UpdateIISExpressCertificate.ps1; & ./src/Servers/IIS/tools/update_schema.ps1"
               displayName: Setup IISExpress test certificates and schema
             artifacts:
-            - name: Windows_Test_Logs
+            - name: Windows_Test_Logs_Attempt_$(System.JobAttempt)
               path: artifacts/log/
               publishOnError: true
               includeForks: true
-            - name: Windows_Test_Results
+            - name: Windows_Test_Results_Attempt_$(System.JobAttempt)
               path: artifacts/TestResults/
               publishOnError: true
               includeForks: true
@@ -643,11 +643,11 @@ extends:
             - bash: "./eng/scripts/install-nginx-mac.sh"
               displayName: Installing Nginx
             artifacts:
-            - name: MacOS_Test_Logs
+            - name: MacOS_Test_Logs_Attempt_$(System.JobAttempt)
               path: artifacts/log/
               publishOnError: true
               includeForks: true
-            - name: MacOS_Test_Results
+            - name: MacOS_Test_Results_Attempt_$(System.JobAttempt)
               path: artifacts/TestResults/
               publishOnError: true
               includeForks: true
@@ -666,11 +666,11 @@ extends:
             - bash: "echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p"
               displayName: Increase inotify limit
             artifacts:
-            - name: Linux_Test_Logs
+            - name: Linux_Test_Logs_Attempt_$(System.JobAttempt)
               path: artifacts/log/
               publishOnError: true
               includeForks: true
-            - name: Linux_Test_Results
+            - name: Linux_Test_Results_Attempt_$(System.JobAttempt)
               path: artifacts/TestResults/
               publishOnError: true
               includeForks: true
@@ -697,7 +697,7 @@ extends:
                 SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
 
             artifacts:
-            - name: Helix_logs
+            - name: Helix_Logs_Attempt_$(System.JobAttempt)
               path: artifacts/log/
               publishOnError: true
               includeForks: true

--- a/.azure/pipelines/jobs/codesign-xplat.yml
+++ b/.azure/pipelines/jobs/codesign-xplat.yml
@@ -45,7 +45,7 @@ jobs:
         $(_InternalRuntimeDownloadCodeSignArgs)
       displayName: Sign and publish packages
     artifacts:
-    - name: CodeSign_Xplat_${{ parameters.inputName }}_Logs
+    - name: CodeSign_Xplat_${{ parameters.inputName }}_Logs_Attempt_$(System.JobAttempt)
       path: artifacts/log/
       publishOnError: true
       includeForks: true


### PR DESCRIPTION
# Add Job Attempt Number to Artifact Names for Logs and Test Results
Make the log artifact names unique between retries of a failed job. 

## Description

Adds Job Attempt # to the name of logs and test results produced by the ci and public-ci pipelines. 

Without this, failed jobs cannot be retried without a new run of the pipeline. 
