### PR TITLE
Update gRPC, Protobuf package versions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -329,7 +329,7 @@
     <SerilogSinksFileVersion>4.0.0</SerilogSinksFileVersion>
     <StackExchangeRedisVersion>2.7.27</StackExchangeRedisVersion>
     <SystemReactiveLinqVersion>5.0.0</SystemReactiveLinqVersion>
-    <SwashbuckleAspNetCoreVersion>6.4.0</SwashbuckleAspNetCoreVersion>
+    <SwashbuckleAspNetCoreVersion>6.6.2</SwashbuckleAspNetCoreVersion>
     <VerifyXunitVersion>19.14.0</VerifyXunitVersion>
     <XunitAbstractionsVersion>2.0.3</XunitAbstractionsVersion>
     <XunitAnalyzersVersion>1.0.0</XunitAnalyzersVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -299,7 +299,7 @@
     <CastleCoreVersion>4.2.1</CastleCoreVersion>
     <CommandLineParserVersion>2.3.0</CommandLineParserVersion>
     <FSharpCoreVersion>6.0.0</FSharpCoreVersion>
-    <GoogleApiCommonProtosVersion>2.5.0</GoogleApiCommonProtosVersion>
+    <GoogleApiCommonProtosVersion>2.15.0</GoogleApiCommonProtosVersion>
     <GoogleProtobufVersion>3.27.0</GoogleProtobufVersion>
     <GrpcAspNetCoreVersion>2.64.0</GrpcAspNetCoreVersion>
     <GrpcAspNetCoreServerVersion>2.64.0</GrpcAspNetCoreServerVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -299,7 +299,7 @@
     <CastleCoreVersion>4.2.1</CastleCoreVersion>
     <CommandLineParserVersion>2.3.0</CommandLineParserVersion>
     <FSharpCoreVersion>6.0.0</FSharpCoreVersion>
-    <GoogleApiCommonProtosVersion>2.15.0</GoogleApiCommonProtosVersion>
+    <GoogleApiCommonProtosVersion>2.5.0</GoogleApiCommonProtosVersion>
     <GoogleProtobufVersion>3.27.0</GoogleProtobufVersion>
     <GrpcAspNetCoreVersion>2.64.0</GrpcAspNetCoreVersion>
     <GrpcAspNetCoreServerVersion>2.64.0</GrpcAspNetCoreServerVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -299,13 +299,13 @@
     <CastleCoreVersion>4.2.1</CastleCoreVersion>
     <CommandLineParserVersion>2.3.0</CommandLineParserVersion>
     <FSharpCoreVersion>6.0.0</FSharpCoreVersion>
-    <GoogleApiCommonProtosVersion>2.5.0</GoogleApiCommonProtosVersion>
-    <GoogleProtobufVersion>3.23.1</GoogleProtobufVersion>
-    <GrpcAspNetCoreVersion>2.57.0</GrpcAspNetCoreVersion>
-    <GrpcAspNetCoreServerVersion>2.57.0</GrpcAspNetCoreServerVersion>
-    <GrpcAuthVersion>2.57.0</GrpcAuthVersion>
-    <GrpcNetClientVersion>2.57.0</GrpcNetClientVersion>
-    <GrpcToolsVersion>2.57.0</GrpcToolsVersion>
+    <GoogleApiCommonProtosVersion>2.15.0</GoogleApiCommonProtosVersion>
+    <GoogleProtobufVersion>3.27.0</GoogleProtobufVersion>
+    <GrpcAspNetCoreVersion>2.64.0</GrpcAspNetCoreVersion>
+    <GrpcAspNetCoreServerVersion>2.64.0</GrpcAspNetCoreServerVersion>
+    <GrpcAuthVersion>2.64.0</GrpcAuthVersion>
+    <GrpcNetClientVersion>2.64.0</GrpcNetClientVersion>
+    <GrpcToolsVersion>2.64.0</GrpcToolsVersion>
     <MessagePackVersion>2.5.108</MessagePackVersion>
     <MicrosoftIdentityWebVersion>3.0.0-preview3</MicrosoftIdentityWebVersion>
     <MicrosoftIdentityWebGraphServiceClientVersion>3.0.0-preview3</MicrosoftIdentityWebGraphServiceClientVersion>

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Binding/JsonTranscodingProviderServiceBinder.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Binding/JsonTranscodingProviderServiceBinder.cs
@@ -58,7 +58,7 @@ internal sealed partial class JsonTranscodingProviderServiceBinder<TService> : S
         _logger = loggerFactory.CreateLogger<JsonTranscodingProviderServiceBinder<TService>>();
     }
 
-    public override void AddMethod<TRequest, TResponse>(Method<TRequest, TResponse> method, ClientStreamingServerMethod<TRequest, TResponse> handler)
+    public override void AddMethod<TRequest, TResponse>(Method<TRequest, TResponse> method, ClientStreamingServerMethod<TRequest, TResponse>? handler)
     {
         if (TryGetMethodDescriptor(method.Name, out var methodDescriptor) &&
             ServiceDescriptorHelpers.TryGetHttpRule(methodDescriptor, out _))
@@ -67,7 +67,7 @@ internal sealed partial class JsonTranscodingProviderServiceBinder<TService> : S
         }
     }
 
-    public override void AddMethod<TRequest, TResponse>(Method<TRequest, TResponse> method, DuplexStreamingServerMethod<TRequest, TResponse> handler)
+    public override void AddMethod<TRequest, TResponse>(Method<TRequest, TResponse> method, DuplexStreamingServerMethod<TRequest, TResponse>? handler)
     {
         if (TryGetMethodDescriptor(method.Name, out var methodDescriptor) &&
             ServiceDescriptorHelpers.TryGetHttpRule(methodDescriptor, out _))
@@ -76,7 +76,7 @@ internal sealed partial class JsonTranscodingProviderServiceBinder<TService> : S
         }
     }
 
-    public override void AddMethod<TRequest, TResponse>(Method<TRequest, TResponse> method, ServerStreamingServerMethod<TRequest, TResponse> handler)
+    public override void AddMethod<TRequest, TResponse>(Method<TRequest, TResponse> method, ServerStreamingServerMethod<TRequest, TResponse>? handler)
     {
         if (TryGetMethodDescriptor(method.Name, out var methodDescriptor))
         {
@@ -97,7 +97,7 @@ internal sealed partial class JsonTranscodingProviderServiceBinder<TService> : S
         }
     }
 
-    public override void AddMethod<TRequest, TResponse>(Method<TRequest, TResponse> method, UnaryServerMethod<TRequest, TResponse> handler)
+    public override void AddMethod<TRequest, TResponse>(Method<TRequest, TResponse> method, UnaryServerMethod<TRequest, TResponse>? handler)
     {
         if (TryGetMethodDescriptor(method.Name, out var methodDescriptor))
         {

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/GrpcSwaggerServiceExtensionsTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/GrpcSwaggerServiceExtensionsTests.cs
@@ -46,7 +46,7 @@ public class GrpcSwaggerServiceExtensionsTests
 
         var path = swagger.Paths["/v1/greeter/{name}"];
         Assert.True(path.Operations.TryGetValue(OperationType.Get, out var operation));
-        Assert.Equal("Success", operation.Responses["200"].Description);
+        Assert.Equal("OK", operation.Responses["200"].Description);
         Assert.Equal("Error", operation.Responses["default"].Description);
     }
 


### PR DESCRIPTION
Update templates to a more modern version.

* Grpc.* (used by gRPC templates, gRPC JSON transcoding
* Google.Protobuf (keep in sync with the reference from Grpc.AspNetCore)
* Google.Api.Common.Protos (used by gRPC JSON transcoding)
* Swashbuckle.AspNetCore (used by gRPC JSON transcoding Swagger package)