### PR TITLE
Quarantine ConfigureEndpointDevelopmentCertificateGetsLoadedWhenPresent

### DIFF
--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -4,7 +4,6 @@
   "localRerunCount" : 3,
   "retryOnRules": [
     {"testName": {"contains": "FlakyTestToEnsureRetryWorks" }},
-    {"testName": {"contains": "ConfigureEndpointDevelopmentCertificateGetsLoadedWhenPresent" }}, // writes to a well-known path
     {"testName": {"contains": "MaxRequestBufferSizeTests.LargeUpload" }}, // tries to manipulate the state of the server's buffer
     {"testName": {"contains": "CertificateChangedOnDisk"}}, // depends on FS event timing
     {"testName": {"contains": "CertificateChangedOnDisk_Symlink"}}, // depends on FS event timing

--- a/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
+++ b/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
@@ -238,8 +238,9 @@ public class KestrelConfigurationLoaderTests
         Assert.True(serverOptions.CodeBackedListenOptions[0].IsTls);
     }
 
-    // On helix retry list - inherently flaky (writes to a well-known path)
     [Fact]
+    // inherently flaky (writes to a well-known path)
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/48736")]
     public void ConfigureEndpointDevelopmentCertificateGetsLoadedWhenPresent()
     {
         try


### PR DESCRIPTION
Test: `KestrelConfigurationLoaderTests.ConfigureEndpointDevelopmentCertificateGetsLoadedWhenPresent`
Issue: https://github.com/dotnet/aspnetcore/issues/48736

This was on the helix retry list, but still failed.
