### PR TITLE
Fix setting BuildNodeJs

### DIFF
--- a/eng/Common.props
+++ b/eng/Common.props
@@ -8,6 +8,10 @@
     <TargetRuntimeIdentifier Condition="'$(TargetRuntimeIdentifier)' == ''">$(TargetOsName)-$(TargetArchitecture)</TargetRuntimeIdentifier>
     <PortableBuild Condition="'$(PortableBuild)' == ''">true</PortableBuild>
     <DefaultAppHostRuntimeIdentifier Condition=" '$(DotNetBuildSourceOnly)' == 'true' ">$(TargetRuntimeIdentifier)</DefaultAppHostRuntimeIdentifier>
+
+    <BuildNodeJS>$(BuildNodeJSUnlessSourcebuild)</BuildNodeJS>
+    <BuildNodeJS Condition="'$(DotNetBuildSourceOnly)' == 'true'">false</BuildNodeJS>
+    <BuildNodeJS Condition="'$(BuildNodeJS)' == ''">true</BuildNodeJS>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(BuildAllProjects)' == 'true' ">
@@ -18,9 +22,6 @@
     <BuildNative Condition=" '$(BuildNative)' == '' ">true</BuildNative>
 
     <BuildManaged Condition="'$(BuildManaged)' == ''">true</BuildManaged>
-    <BuildNodeJS>$(BuildNodeJSUnlessSourcebuild)</BuildNodeJS>
-    <BuildNodeJS Condition="'$(DotNetBuildSourceOnly)' == 'true'">false</BuildNodeJS>
-    <BuildNodeJS Condition="'$(BuildNodeJS)' == ''">true</BuildNodeJS>
     <BuildJava Condition="'$(BuildJava)' == ''">true</BuildJava>
   </PropertyGroup>
 

--- a/eng/Common.props
+++ b/eng/Common.props
@@ -11,7 +11,6 @@
 
     <BuildNodeJS>$(BuildNodeJSUnlessSourcebuild)</BuildNodeJS>
     <BuildNodeJS Condition="'$(DotNetBuildSourceOnly)' == 'true'">false</BuildNodeJS>
-    <BuildNodeJS Condition="'$(BuildNodeJS)' == ''">true</BuildNodeJS>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(BuildAllProjects)' == 'true' ">
@@ -20,7 +19,7 @@
     <BuildNative Condition=" '$(TargetOsName)' != 'win' ">false</BuildNative>
     <BuildNative Condition=" '$(VCTargetsPath)' == '' ">false</BuildNative>
     <BuildNative Condition=" '$(BuildNative)' == '' ">true</BuildNative>
-
+    <BuildNodeJS Condition="'$(BuildNodeJS)' == ''">true</BuildNodeJS>
     <BuildManaged Condition="'$(BuildManaged)' == ''">true</BuildManaged>
     <BuildJava Condition="'$(BuildJava)' == ''">true</BuildJava>
   </PropertyGroup>


### PR DESCRIPTION
Should fix build errors in SourceIndex - previously we were only defaulting `BuildNodeJs` when building all projects, leading subset builds to fail when we _should_ be building NodeJS. Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2501099&view=results