### PR TITLE
Fix up nullability and form schema handling in OpenAPI

### DIFF
--- a/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
@@ -12,6 +12,7 @@ using System.Text.Json.Schema;
 using System.Text.Json.Serialization.Metadata;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Constraints;
 using Microsoft.OpenApi.Models;
@@ -316,6 +317,12 @@ internal static class JsonNodeSchemaExtensions
         if (parameterDescription.RouteInfo?.Constraints is { } constraints)
         {
             schema.ApplyRouteConstraints(constraints);
+        }
+        // Parameters sourced from the header, query, and route parameter cannot be nullable.
+        if (parameterDescription.Source is { } bindingSource &&
+            (bindingSource == BindingSource.Header || bindingSource == BindingSource.Query || bindingSource == BindingSource.Path))
+        {
+            schema[OpenApiSchemaKeywords.NullableKeyword] = false;
         }
     }
 

--- a/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
@@ -318,12 +318,19 @@ internal static class JsonNodeSchemaExtensions
         {
             schema.ApplyRouteConstraints(constraints);
         }
-        // Parameters sourced from the header, query, and route parameter cannot be nullable.
-        if (parameterDescription.Source is { } bindingSource &&
-            (bindingSource == BindingSource.Header || bindingSource == BindingSource.Query || bindingSource == BindingSource.Path))
+
+        if (parameterDescription.Source is { } bindingSource && SupportsNullableProperty(bindingSource))
         {
             schema[OpenApiSchemaKeywords.NullableKeyword] = false;
         }
+
+        // Parameters sourced from the header, query, route, and/or form cannot be nullable based on our binding
+        // rules but can be optional.
+        static bool SupportsNullableProperty(BindingSource bindingSource) =>bindingSource == BindingSource.Header
+            || bindingSource == BindingSource.Query
+            || bindingSource == BindingSource.Path
+            || bindingSource == BindingSource.Form
+            || bindingSource == BindingSource.FormFile;
     }
 
     /// <summary>

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -38,8 +38,6 @@ internal sealed class OpenApiDocumentService(
     private readonly OpenApiSchemaService _componentService = serviceProvider.GetRequiredKeyedService<OpenApiSchemaService>(documentName);
     private readonly OpenApiSchemaReferenceTransformer _schemaReferenceTransformer = new();
 
-    private static readonly OpenApiEncoding _defaultFormEncoding = new() { Style = ParameterStyle.Form, Explode = true };
-
     /// <summary>
     /// Cache of <see cref="OpenApiOperationTransformerContext"/> instances keyed by the
     /// `ApiDescription.ActionDescriptor.Id` of the associated operation. ActionDescriptor IDs
@@ -495,8 +493,7 @@ internal sealed class OpenApiDocumentService(
             var contentType = requestFormat.MediaType;
             requestBody.Content[contentType] = new OpenApiMediaType
             {
-                Schema = schema,
-                Encoding = new Dictionary<string, OpenApiEncoding>() { [contentType] = _defaultFormEncoding }
+                Schema = schema
             };
         }
 

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -407,7 +407,7 @@ internal sealed class OpenApiDocumentService(
             if (parameter.All(parameter => parameter.ModelMetadata.ContainerType is null))
             {
                 var description = parameter.Single();
-                var parameterSchema = await _componentService.GetOrCreateSchemaAsync(description.Type, null, cancellationToken: cancellationToken);
+                var parameterSchema = await _componentService.GetOrCreateSchemaAsync(description.Type, description, cancellationToken: cancellationToken);
                 // Form files are keyed by their parameter name so we must capture the parameter name
                 // as a property in the schema.
                 if (description.Type == typeof(IFormFile) || description.Type == typeof(IFormFileCollection))
@@ -476,7 +476,7 @@ internal sealed class OpenApiDocumentService(
                     var propertySchema = new OpenApiSchema { Type = "object", Properties = new Dictionary<string, OpenApiSchema>() };
                     foreach (var description in parameter)
                     {
-                        propertySchema.Properties[description.Name] = await _componentService.GetOrCreateSchemaAsync(description.Type, null, cancellationToken: cancellationToken);
+                        propertySchema.Properties[description.Name] = await _componentService.GetOrCreateSchemaAsync(description.Type, description, cancellationToken: cancellationToken);
                     }
                     schema.AllOf.Add(propertySchema);
                 }
@@ -484,7 +484,7 @@ internal sealed class OpenApiDocumentService(
                 {
                     foreach (var description in parameter)
                     {
-                        schema.Properties[description.Name] = await _componentService.GetOrCreateSchemaAsync(description.Type, null, cancellationToken: cancellationToken);
+                        schema.Properties[description.Name] = await _componentService.GetOrCreateSchemaAsync(description.Type, description, cancellationToken: cancellationToken);
                     }
                 }
             }

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -66,7 +66,8 @@ internal sealed class OpenApiSchemaService(
                 schema = new JsonObject
                 {
                     [OpenApiSchemaKeywords.TypeKeyword] = "string",
-                    [OpenApiSchemaKeywords.FormatKeyword] = "binary"
+                    [OpenApiSchemaKeywords.FormatKeyword] = "binary",
+                    [OpenApiConstants.SchemaId] = "IFormFile"
                 };
             }
             else if (type == typeof(IFormFileCollection))
@@ -77,7 +78,8 @@ internal sealed class OpenApiSchemaService(
                     [OpenApiSchemaKeywords.ItemsKeyword] = new JsonObject
                     {
                         [OpenApiSchemaKeywords.TypeKeyword] = "string",
-                        [OpenApiSchemaKeywords.FormatKeyword] = "binary"
+                        [OpenApiSchemaKeywords.FormatKeyword] = "binary",
+                        [OpenApiConstants.SchemaId] = "IFormFile"
                     }
                 };
             }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=controllers.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=controllers.verified.txt
@@ -77,12 +77,6 @@
                     "type": "boolean"
                   }
                 }
-              },
-              "encoding": {
-                "application/x-www-form-urlencoded": {
-                  "style": "form",
-                  "explode": true
-                }
               }
             }
           }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=forms.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=forms.verified.txt
@@ -20,12 +20,6 @@
                     "$ref": "#/components/schemas/IFormFile"
                   }
                 }
-              },
-              "encoding": {
-                "multipart/form-data": {
-                  "style": "form",
-                  "explode": true
-                }
               }
             }
           },
@@ -52,12 +46,6 @@
                   "files": {
                     "$ref": "#/components/schemas/IFormFileCollection"
                   }
-                }
-              },
-              "encoding": {
-                "multipart/form-data": {
-                  "style": "form",
-                  "explode": true
                 }
               }
             }
@@ -99,12 +87,6 @@
                     }
                   }
                 ]
-              },
-              "encoding": {
-                "multipart/form-data": {
-                  "style": "form",
-                  "explode": true
-                }
               }
             }
           },
@@ -127,23 +109,11 @@
             "multipart/form-data": {
               "schema": {
                 "$ref": "#/components/schemas/Todo"
-              },
-              "encoding": {
-                "multipart/form-data": {
-                  "style": "form",
-                  "explode": true
-                }
               }
             },
             "application/x-www-form-urlencoded": {
               "schema": {
                 "$ref": "#/components/schemas/Todo"
-              },
-              "encoding": {
-                "application/x-www-form-urlencoded": {
-                  "style": "form",
-                  "explode": true
-                }
               }
             }
           },
@@ -179,12 +149,6 @@
                     }
                   }
                 ]
-              },
-              "encoding": {
-                "multipart/form-data": {
-                  "style": "form",
-                  "explode": true
-                }
               }
             }
           },

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.RequestBody.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.RequestBody.cs
@@ -681,6 +681,16 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
         public string Name { get; set; }
     }
 
+    [Route("/form-model-nullable")]
+    private void ActionWithFormModelNullableProps([FromForm] ModelWithNullableProperties model) { }
+
+#nullable enable
+    private class ModelWithNullableProperties
+    {
+        public string? Name { get; set; }
+    }
+#nullable restore
+
     [Fact]
     public async Task GetOpenApiRequestBody_HandlesFormModelWithFile_MvcAction()
     {

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.ParameterSchemas.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.ParameterSchemas.cs
@@ -14,46 +14,46 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
 #nullable enable
     public static object?[][] RouteParametersWithPrimitiveTypes =>
     [
-        [(int id) => {}, "integer", "int32", false],
-        [(long id) => {}, "integer", "int64", false],
-        [(float id) => {}, "number", "float", false],
-        [(double id) => {}, "number", "double", false],
-        [(decimal id) => {}, "number", "double", false],
-        [(bool id) => {}, "boolean", null, false],
-        [(string id) => {}, "string", null, false],
-        [(char id) => {}, "string", "char", false],
-        [(byte id) => {}, "integer", "uint8", false],
-        [(byte[] id) => {}, "string", "byte", false],
-        [(short id) => {}, "integer", "int16", false],
-        [(ushort id) => {}, "integer", "uint16", false],
-        [(uint id) => {}, "integer", "uint32", false],
-        [(ulong id) => {}, "integer", "uint64", false],
-        [(Uri id) => {}, "string", "uri", false],
-        [(TimeOnly id) => {}, "string", "time", false],
-        [(DateOnly id) => {}, "string", "date", false],
-        [(int? id) => {}, "integer", "int32", true],
-        [(long? id) => {}, "integer", "int64", true],
-        [(float? id) => {}, "number", "float", true],
-        [(double? id) => {}, "number", "double", true],
-        [(decimal? id) => {}, "number", "double", true],
-        [(bool? id) => {}, "boolean", null, true],
-        [(string? id) => {}, "string", null, true],
-        [(char? id) => {}, "string", "char", true],
-        [(byte? id) => {}, "integer", "uint8", true],
-        [(byte[]? id) => {}, "string", "byte", true],
-        [(short? id) => {}, "integer", "int16", true],
-        [(ushort? id) => {}, "integer", "uint16", true],
-        [(uint? id) => {}, "integer", "uint32", true],
-        [(ulong? id) => {}, "integer", "uint64", true],
-        [(Uri? id) => {}, "string", "uri", true],
-        [(TimeOnly? id) => {}, "string", "time", true],
-        [(DateOnly? id) => {}, "string", "date", true]
+        [(int id) => {}, "integer", "int32"],
+        [(long id) => {}, "integer", "int64"],
+        [(float id) => {}, "number", "float"],
+        [(double id) => {}, "number", "double"],
+        [(decimal id) => {}, "number", "double"],
+        [(bool id) => {}, "boolean", null],
+        [(string id) => {}, "string", null],
+        [(char id) => {}, "string", "char"],
+        [(byte id) => {}, "integer", "uint8"],
+        [(byte[] id) => {}, "string", "byte"],
+        [(short id) => {}, "integer", "int16"],
+        [(ushort id) => {}, "integer", "uint16"],
+        [(uint id) => {}, "integer", "uint32"],
+        [(ulong id) => {}, "integer", "uint64"],
+        [(Uri id) => {}, "string", "uri"],
+        [(TimeOnly id) => {}, "string", "time"],
+        [(DateOnly id) => {}, "string", "date"],
+        [(int? id) => {}, "integer", "int32"],
+        [(long? id) => {}, "integer", "int64"],
+        [(float? id) => {}, "number", "float"],
+        [(double? id) => {}, "number", "double"],
+        [(decimal? id) => {}, "number", "double"],
+        [(bool? id) => {}, "boolean", null],
+        [(string? id) => {}, "string", null],
+        [(char? id) => {}, "string", "char"],
+        [(byte? id) => {}, "integer", "uint8"],
+        [(byte[]? id) => {}, "string", "byte"],
+        [(short? id) => {}, "integer", "int16"],
+        [(ushort? id) => {}, "integer", "uint16"],
+        [(uint? id) => {}, "integer", "uint32"],
+        [(ulong? id) => {}, "integer", "uint64"],
+        [(Uri? id) => {}, "string", "uri"],
+        [(TimeOnly? id) => {}, "string", "time"],
+        [(DateOnly? id) => {}, "string", "date"]
     ];
 #nullable restore
 
     [Theory]
     [MemberData(nameof(RouteParametersWithPrimitiveTypes))]
-    public async Task GetOpenApiParameters_HandlesRouteParameterWithPrimitiveType(Delegate requestHandler, string schemaType, string schemaFormat, bool isNullable)
+    public async Task GetOpenApiParameters_HandlesRouteParameterWithPrimitiveType(Delegate requestHandler, string schemaType, string schemaFormat)
     {
         // Arrange
         var builder = CreateBuilder();
@@ -68,7 +68,7 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             var parameter = Assert.Single(operation.Parameters);
             Assert.Equal(schemaType, parameter.Schema.Type);
             Assert.Equal(schemaFormat, parameter.Schema.Format);
-            Assert.Equal(isNullable, parameter.Schema.Nullable);
+            Assert.False(parameter.Schema.Nullable);
         });
     }
 
@@ -416,6 +416,11 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             var parameter = Assert.Single(operation.Parameters);
             Assert.Equal("array", parameter.Schema.Type);
             Assert.Equal(innerSchemaType, parameter.Schema.Items.Type);
+            // Array items can be serialized to nullable values when the element
+            // type is nullable. For example, array-of-ints?ints=1&ints=2&ints=&ints=4
+            // will produce [1, 2, null, 4] when the parameter is int?[] ints.
+            // When the element type is not nullable (int[] ints), the binding
+            // will produce [1, 2, 0, 4]
             Assert.Equal(isNullable, parameter.Schema.Items.Nullable);
         });
     }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.RequestBodySchemas.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.RequestBodySchemas.cs
@@ -63,6 +63,7 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
     [Theory]
     [InlineData(false, "application/json")]
     [InlineData(true, "application/x-www-form-urlencoded")]
+    [InlineData(true, "multipart/form-data")]
     public async Task GetOpenApiRequestBody_GeneratesSchemaForPoco_WithValidationAttributes(bool isFromForm, string targetContentType)
     {
         // Arrange
@@ -563,7 +564,7 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
 
         // Act
 #nullable enable
-        builder.MapPost("/api", ([FromForm] string? name, [FromForm] int? number) => { });
+        builder.MapPost("/api", ([FromForm] string? name, [FromForm] int? number, [FromForm] int[]? ids) => { });
 #nullable restore
 
         // Assert
@@ -581,6 +582,12 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
                 {
                     var property = schema.Properties["number"];
                     Assert.Equal("integer", property.Type);
+                    Assert.False(property.Nullable);
+                },
+                schema =>
+                {
+                    var property = schema.Properties["ids"];
+                    Assert.Equal("array", property.Type);
                     Assert.False(property.Nullable);
                 });
         });


### PR DESCRIPTION
Closes #56903.

Mark all parameters sourced from the query, header, route, and form from being marked as nullable.

Cloes https://github.com/dotnet/aspnetcore/issues/57082.

Attributes on the parameter associated with a `[FromForm]` attribute now get applied correctly because we pass in `ApiParameterDescription` when we generate the schema.

Addresses https://github.com/dotnet/aspnetcore/issues/57083.

Remove the `encoding` field on form parameters until we figure out the correct values to set.