### PR TITLE
[release/8.0] Skip timing out MVC template tests in 8.0

### DIFF
--- a/src/ProjectTemplates/test/Templates.Mvc.Tests/Templates.Mvc.Tests.csproj
+++ b/src/ProjectTemplates/test/Templates.Mvc.Tests/Templates.Mvc.Tests.csproj
@@ -20,6 +20,14 @@
     <RestoreFolderName>Mvc</RestoreFolderName>
     <TestDependsOnAspNetPackages>true</TestDependsOnAspNetPackages>
     <HelixTimeout>01:20:00</HelixTimeout>
+
+    <!-- These tests fail in Helix in Debian and Mariner due to error -901 -->
+    <!-- Disabling on those OSes until a better fix can be identified -->
+    <SkipHelixQueues>
+      $(HelixQueueDebian11);
+      $(HelixQueueMariner);
+      $(SkipHelixQueues)
+    </SkipHelixQueues>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspnetcore/pull/56291