### PR TITLE
Inline array and dictionary schemas in OpenAPI documents

### DIFF
--- a/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
@@ -67,7 +67,7 @@ internal static class JsonTypeInfoExtensions
         }
 
         // Although arrays are enumerable types they are not encoded correctly
-        // with JsonTypeInfoKind.Enumerable so we handle that the Enumerble type
+        // with JsonTypeInfoKind.Enumerable so we handle the Enumerble type
         // case here.
         if (jsonTypeInfo is JsonTypeInfo { Kind: JsonTypeInfoKind.Enumerable } || type.IsArray)
         {

--- a/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
@@ -66,17 +66,17 @@ internal static class JsonTypeInfoExtensions
             return simpleName;
         }
 
-        if (jsonTypeInfo is JsonTypeInfo { Kind: JsonTypeInfoKind.Enumerable, ElementType: { } elementType })
+        // Although arrays are enumerable types they are not encoded correctly
+        // with JsonTypeInfoKind.Enumerable so we handle that the Enumerble type
+        // case here.
+        if (jsonTypeInfo is JsonTypeInfo { Kind: JsonTypeInfoKind.Enumerable } || type.IsArray)
         {
-            var elementTypeInfo = jsonTypeInfo.Options.GetTypeInfo(elementType);
-            return $"ArrayOf{elementTypeInfo.GetSchemaReferenceId(isTopLevel: false)}";
+            return null;
         }
 
-        if (jsonTypeInfo is JsonTypeInfo { Kind: JsonTypeInfoKind.Dictionary, KeyType: { } keyType, ElementType: { } valueType })
+        if (jsonTypeInfo is JsonTypeInfo { Kind: JsonTypeInfoKind.Dictionary })
         {
-            var keyTypeInfo = jsonTypeInfo.Options.GetTypeInfo(keyType);
-            var valueTypeInfo = jsonTypeInfo.Options.GetTypeInfo(valueType);
-            return $"DictionaryOf{keyTypeInfo.GetSchemaReferenceId(isTopLevel: false)}And{valueTypeInfo.GetSchemaReferenceId(isTopLevel: false)}";
+            return null;
         }
 
         return type.GetSchemaReferenceId(jsonTypeInfo.Options);
@@ -89,14 +89,6 @@ internal static class JsonTypeInfoExtensions
         if (_simpleTypeToName.TryGetValue(type, out var simpleName))
         {
             return simpleName;
-        }
-
-        // Although arrays are enumerable types they are not encoded correctly
-        // with JsonTypeInfoKind.Enumerable so we handle that here
-        if (type.IsArray && type.GetElementType() is { } elementType)
-        {
-            var elementTypeInfo = options.GetTypeInfo(elementType);
-            return $"ArrayOf{elementTypeInfo.GetSchemaReferenceId(isTopLevel: false)}";
         }
 
         // Special handling for anonymous types

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Extensions/JsonTypeInfoExtensionsTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Extensions/JsonTypeInfoExtensionsTests.cs
@@ -35,10 +35,10 @@ public class JsonTypeInfoExtensionsTests
     public static IEnumerable<object[]> GetSchemaReferenceId_Data =>
     [
         [typeof(Todo), "Todo"],
-        [typeof(IEnumerable<Todo>), "ArrayOfTodo"],
-        [typeof(List<Todo>), "ArrayOfTodo"],
+        [typeof(IEnumerable<Todo>), null],
+        [typeof(List<Todo>), null],
         [typeof(TodoWithDueDate), "TodoWithDueDate"],
-        [typeof(IEnumerable<TodoWithDueDate>), "ArrayOfTodoWithDueDate"],
+        [typeof(IEnumerable<TodoWithDueDate>), null],
         [(new { Id = 1 }).GetType(), "AnonymousTypeOfint"],
         [(new { Id = 1, Name = "Todo" }).GetType(), "AnonymousTypeOfintAndstring"],
         [typeof(IFormFile), "IFormFile"],
@@ -50,14 +50,14 @@ public class JsonTypeInfoExtensionsTests
         [typeof(NotFound<TodoWithDueDate>), "NotFoundOfTodoWithDueDate"],
         [typeof(TestDelegate), "TestDelegate"],
         [typeof(Container.ContainedTestDelegate), "ContainedTestDelegate"],
-        [typeof(List<int>), "ArrayOfint"],
-        [typeof(List<List<int>>), "ArrayOfArrayOfint"],
-        [typeof(int[]), "ArrayOfint"],
+        [typeof(List<int>), null],
+        [typeof(List<List<int>>), null],
+        [typeof(int[]), null],
         [typeof(ValidationProblemDetails), "ValidationProblemDetails"],
         [typeof(ProblemDetails), "ProblemDetails"],
-        [typeof(Dictionary<string, string[]>), "DictionaryOfstringAndArrayOfstring"],
-        [typeof(Dictionary<string, List<string[]>>), "DictionaryOfstringAndArrayOfArrayOfstring"],
-        [typeof(Dictionary<string, IEnumerable<string[]>>), "DictionaryOfstringAndArrayOfArrayOfstring"],
+        [typeof(Dictionary<string, string[]>), null],
+        [typeof(Dictionary<string, List<string[]>>), null],
+        [typeof(Dictionary<string, IEnumerable<string[]>>), null],
     ];
 
     [Theory]

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
@@ -185,7 +185,11 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ArrayOfint"
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "int32"
+                }
               }
             }
           },
@@ -215,7 +219,11 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ArrayOfint"
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "int32"
+                }
               }
             }
           },
@@ -267,7 +275,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DictionaryOfstringAndint"
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "integer",
+                    "format": "int32"
+                  }
                 }
               }
             }
@@ -286,7 +298,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DictionaryOfstringAndint"
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "integer",
+                    "format": "int32"
+                  }
                 }
               }
             }
@@ -373,20 +389,6 @@
           "name": {
             "type": "string"
           }
-        }
-      },
-      "ArrayOfint": {
-        "type": "array",
-        "items": {
-          "type": "integer",
-          "format": "int32"
-        }
-      },
-      "DictionaryOfstringAndint": {
-        "type": "object",
-        "additionalProperties": {
-          "type": "integer",
-          "format": "int32"
         }
       },
       "Person": {

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v1.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v1.verified.txt
@@ -16,7 +16,11 @@
             "in": "query",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/ArrayOfGuid"
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "uuid"
+              }
             }
           },
           {
@@ -34,7 +38,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ArrayOfGuid"
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
                 }
               }
             }
@@ -117,13 +125,6 @@
   },
   "components": {
     "schemas": {
-      "ArrayOfGuid": {
-        "type": "array",
-        "items": {
-          "type": "string",
-          "format": "uuid"
-        }
-      },
       "Todo": {
         "required": [
           "id",

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v2.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v2.verified.txt
@@ -23,7 +23,18 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ArrayOfstring"
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "externalDocs": {
+                      "description": "Documentation for this OpenAPI schema",
+                      "url": "https://example.com/api/docs/schemas/string"
+                    }
+                  },
+                  "externalDocs": {
+                    "description": "Documentation for this OpenAPI schema",
+                    "url": "https://example.com/api/docs/schemas/array"
+                  }
                 }
               }
             }
@@ -47,24 +58,7 @@
       }
     }
   },
-  "components": {
-    "schemas": {
-      "ArrayOfstring": {
-        "type": "array",
-        "items": {
-          "type": "string",
-          "externalDocs": {
-            "description": "Documentation for this OpenAPI schema",
-            "url": "https://example.com/api/docs/schemas/string"
-          }
-        },
-        "externalDocs": {
-          "description": "Documentation for this OpenAPI schema",
-          "url": "https://example.com/api/docs/schemas/array"
-        }
-      }
-    }
-  },
+  "components": { },
   "tags": [
     {
       "name": "users"

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.RequestBodySchemas.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.RequestBodySchemas.cs
@@ -242,11 +242,11 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
 
             var enumerableTodoSchema = enumerableTodo.RequestBody.Content["application/json"].Schema;
             var arrayTodoSchema = arrayTodo.RequestBody.Content["application/json"].Schema;
-            // Assert that both IEnumerable<Todo> and Todo[] map to the same schemas
-            Assert.Equal(enumerableTodoSchema.Reference.Id, arrayTodoSchema.Reference.Id);
+            // Assert that both IEnumerable<Todo> and Todo[] have items that map to the same schema
+            Assert.Equal(enumerableTodoSchema.Items.Reference.Id, arrayTodoSchema.Items.Reference.Id);
             // Assert all types materialize as arrays
-            Assert.Equal("array", enumerableTodoSchema.GetEffective(document).Type);
-            Assert.Equal("array", arrayTodoSchema.GetEffective(document).Type);
+            Assert.Equal("array", enumerableTodoSchema.Type);
+            Assert.Equal("array", arrayTodoSchema.Type);
 
             Assert.Equal("array", parameter.Schema.Type);
             Assert.Equal("string", parameter.Schema.Items.Type);
@@ -255,7 +255,7 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             // Assert the array items are the same as the Todo schema
             foreach (var element in new[] { enumerableTodoSchema, arrayTodoSchema })
             {
-                Assert.Collection(element.GetEffective(document).Items.GetEffective(document).Properties,
+                Assert.Collection(element.Items.GetEffective(document).Properties,
                     property =>
                     {
                         Assert.Equal("id", property.Key);


### PR DESCRIPTION
This PR updates our reference ID implementation to avoid generating schemas for arrays/dictionaries by ref. In those scenarios, we can assume that client and code generators will be able to generate type names based on the target langauge they are emitting code for.