### PR TITLE
Restrict permissions to the dev cert directory

### DIFF
--- a/src/ProjectTemplates/Shared/DevelopmentCertificate.cs
+++ b/src/ProjectTemplates/Shared/DevelopmentCertificate.cs
@@ -35,7 +35,7 @@ public readonly struct DevelopmentCertificate
         var manager = CertificateManager.Instance;
         var certificate = manager.CreateAspNetCoreHttpsDevelopmentCertificate(now, now.AddYears(1));
         var certificateThumbprint = certificate.Thumbprint;
-        CertificateManager.ExportCertificate(certificate, path: certificatePath, includePrivateKey: true, certificatePassword, CertificateKeyExportFormat.Pfx);
+        manager.ExportCertificate(certificate, path: certificatePath, includePrivateKey: true, certificatePassword, CertificateKeyExportFormat.Pfx);
 
         return certificateThumbprint;
     }

--- a/src/Shared/CertificateGeneration/CertificateManager.cs
+++ b/src/Shared/CertificateGeneration/CertificateManager.cs
@@ -328,7 +328,7 @@ internal abstract class CertificateManager
                 var exportDir = Path.GetDirectoryName(path);
                 if (!string.IsNullOrEmpty(exportDir) && !Directory.Exists(exportDir))
                 {
-                    throw new InvalidOperationException($"The directory '{exportDir}' does not exist.");
+                    throw new InvalidOperationException($"The directory '{exportDir}' does not exist.  Choose permissions carefully when creating it.");
                 }
 
                 ExportCertificate(certificate, path, includePrivateKey, password, keyExportFormat);

--- a/src/Shared/CertificateGeneration/CertificateManager.cs
+++ b/src/Shared/CertificateGeneration/CertificateManager.cs
@@ -323,6 +323,14 @@ internal abstract class CertificateManager
         {
             try
             {
+                // If the user specified a non-existent directory, we don't want to be responsible
+                // for setting the permissions appropriately, so we'll bail.
+                var exportDir = Path.GetDirectoryName(path);
+                if (!string.IsNullOrEmpty(exportDir) && !Directory.Exists(exportDir))
+                {
+                    throw new InvalidOperationException($"The directory '{exportDir}' does not exist.");
+                }
+
                 ExportCertificate(certificate, path, includePrivateKey, password, keyExportFormat);
             }
             catch (Exception e)
@@ -486,6 +494,10 @@ internal abstract class CertificateManager
 
     protected abstract void CreateDirectoryWithPermissions(string directoryPath);
 
+    /// <remarks>
+    /// Will create directories to make it possible to write to <paramref name="path"/>.
+    /// If you don't want that, check for existence before calling this method.
+    /// </remarks>
     internal void ExportCertificate(X509Certificate2 certificate, string path, bool includePrivateKey, string? password, CertificateKeyExportFormat format)
     {
         if (Log.IsEnabled())
@@ -1232,6 +1244,9 @@ internal abstract class CertificateManager
         [Event(111, Level = EventLevel.LogAlways, Message = "For OpenSSL trust to take effect, '{0}' must be listed in the {2} environment variable. " +
             "See https://aka.ms/dev-certs-trust for more information.")]
         internal void UnixSuggestSettingEnvironmentVariableWithoutExample(string certDir, string envVarName) => WriteEvent(111, certDir, envVarName);
+
+        [Event(112, Level = EventLevel.Warning, Message = "Directory '{0}' may be readable by other users.")]
+        internal void DirectoryPermissionsNotSecure(string directoryPath) => WriteEvent(112, directoryPath);
     }
 
     internal sealed class UserCancelledTrustException : Exception

--- a/src/Shared/CertificateGeneration/CertificateManager.cs
+++ b/src/Shared/CertificateGeneration/CertificateManager.cs
@@ -484,7 +484,9 @@ internal abstract class CertificateManager
 
     protected abstract IList<X509Certificate2> GetCertificatesToRemove(StoreName storeName, StoreLocation storeLocation);
 
-    internal static void ExportCertificate(X509Certificate2 certificate, string path, bool includePrivateKey, string? password, CertificateKeyExportFormat format)
+    protected abstract void CreateDirectoryWithPermissions(string directoryPath);
+
+    internal void ExportCertificate(X509Certificate2 certificate, string path, bool includePrivateKey, string? password, CertificateKeyExportFormat format)
     {
         if (Log.IsEnabled())
         {
@@ -500,7 +502,7 @@ internal abstract class CertificateManager
         if (!string.IsNullOrEmpty(targetDirectoryPath))
         {
             Log.CreateExportCertificateDirectory(targetDirectoryPath);
-            Directory.CreateDirectory(targetDirectoryPath);
+            CreateDirectoryWithPermissions(targetDirectoryPath);
         }
 
         byte[] bytes;

--- a/src/Shared/CertificateGeneration/MacOSCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/MacOSCertificateManager.cs
@@ -485,7 +485,7 @@ internal sealed class MacOSCertificateManager : CertificateManager
         {
             if ((dirInfo.UnixFileMode & ~DirectoryPermissions) != 0)
             {
-                // TODO (acasey): Log.DirectoryPermissionsNotSecure(dirInfo.FullName);
+                Log.DirectoryPermissionsNotSecure(dirInfo.FullName);
             }
         }
         else

--- a/src/Shared/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/UnixCertificateManager.cs
@@ -459,7 +459,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
         {
             if ((dirInfo.UnixFileMode & ~DirectoryPermissions) != 0)
             {
-                // TODO (acasey): Log.DirectoryPermissionsNotSecure(dirInfo.FullName);
+                Log.DirectoryPermissionsNotSecure(dirInfo.FullName);
             }
         }
         else

--- a/src/Shared/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/UnixCertificateManager.cs
@@ -248,7 +248,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
         if (needToExport)
         {
             // Security: we don't need the private key for trust, so we don't export it.
-            // Note that this will create directories as needed.
+            // Note that this will create directories as needed.  We control `certPath`, so the permissions should be fine.
             ExportCertificate(certificate, certPath, includePrivateKey: false, password: null, CertificateKeyExportFormat.Pem);
         }
 

--- a/src/Shared/CertificateGeneration/WindowsCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/WindowsCertificateManager.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Runtime.Versioning;
 using System.Security.AccessControl;
@@ -162,7 +160,7 @@ internal sealed class WindowsCertificateManager : CertificateManager
                 // is to allow access to anyone other than the current user, system, or administrators
                 // is very complicated.  We're not going to do anything but log, so an approximation
                 // is fine.
-                // TODO (acasey): Log.DirectoryPermissionsNotSecure(dirInfo.FullName);
+                Log.DirectoryPermissionsNotSecure(dirInfo.FullName);
                 break;
             }
         }

--- a/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
+++ b/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
@@ -357,7 +357,7 @@ public class CertificateManagerTests : IClassFixture<CertFixture>
     public void EnsureCreateHttpsCertificate_CannotExportToNonExistentDirectory()
     {
         // Arrange
-        const string CertificateName = nameof(EnsureCreateHttpsCertificate_DoesNotCreateACertificate_WhenThereIsAnExistingHttpsCertificates) + ".pem";
+        const string CertificateName = nameof(EnsureCreateHttpsCertificate_CannotExportToNonExistentDirectory) + ".pem";
 
         _fixture.CleanupCertificates();
 

--- a/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
+++ b/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
@@ -368,6 +368,7 @@ public class CertificateManagerTests : IClassFixture<CertFixture>
         ListCertificates();
 
         // Act
+        // Export the certificate (same method, but this time with an output path)
         var result = _manager
             .EnsureAspNetCoreHttpsDevelopmentCertificate(now, now.AddYears(1), Path.Combine("NoSuchDirectory", CertificateName));
 


### PR DESCRIPTION
1. If we choose the path, make sure it's not world-readable.
2. If the user chooses the path (e.g. on export), require that they create it so they also choose the permissions.

Note: we already have some [code](https://github.com/dotnet/aspnetcore/blob/23170777b056e4c894d506d1dc1c3c3f1d9a83df/src/Shared/CertificateGeneration/CertificateManager.cs#L553) that attempts to manage the permissions of the exported file itself.