### PR TITLE
Add remarks to FromBodyAttrbiute

### DIFF
--- a/src/Mvc/Mvc.Core/src/FromBodyAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/FromBodyAttribute.cs
@@ -9,6 +9,10 @@ namespace Microsoft.AspNetCore.Mvc;
 /// <summary>
 /// Specifies that a parameter or property should be bound using the request body.
 /// </summary>
+/// <remarks>
+/// Be default for MVC ASP.NET Core runtime delegates the responsibility of reading the body to an input formatter.<br/>
+/// In the case of Minimal API, the body is deserialized by <see cref="System.Text.Json.JsonSerializer">JsonSerializer</see>.
+/// </remarks>
 [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
 public class FromBodyAttribute : Attribute, IBindingSourceMetadata, IConfigureEmptyBodyBehavior, IFromBodyMetadata
 {

--- a/src/Mvc/Mvc.Core/src/FromBodyAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/FromBodyAttribute.cs
@@ -10,8 +10,8 @@ namespace Microsoft.AspNetCore.Mvc;
 /// Specifies that a parameter or property should be bound using the request body.
 /// </summary>
 /// <remarks>
-/// Be default for MVC ASP.NET Core runtime delegates the responsibility of reading the body to an input formatter.<br/>
-/// In the case of Minimal API, the body is deserialized by <see cref="System.Text.Json.JsonSerializer">JsonSerializer</see>.
+/// By default, ASP.NET Core MVC delegates the responsibility of reading the body to an input formatter.<br/>
+/// In the case of ASP.NET Core Minimal APIs, the body is deserialized by <see cref="System.Text.Json.JsonSerializer"/>.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
 public class FromBodyAttribute : Attribute, IBindingSourceMetadata, IConfigureEmptyBodyBehavior, IFromBodyMetadata


### PR DESCRIPTION
# Add remarks to FromBodyAttrbiute

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

Summary of the changes (Less than 80 chars)

## Description

[[FromBody] attrbiute](https://learn.microsoft.com/en-us/aspnet/core/mvc/models/model-binding?view=aspnetcore-8.0#frombody-attribute) section of the docs dedicated to Model Binding contains a very important statement:
> The ASP.NET Core runtime delegates the responsibility of reading the body to an input formatter.

This is quite an important detail (gotcha, actually) to capture it in the xmldoc of the attribute, so it's imediately visible in IDE.
