### PR TITLE
Make dev-certs import consistent with kestrel

### DIFF
--- a/src/Servers/Kestrel/Core/src/TlsConfigurationLoader.cs
+++ b/src/Servers/Kestrel/Core/src/TlsConfigurationLoader.cs
@@ -176,20 +176,8 @@ internal sealed class TlsConfigurationLoader
 
     private static bool IsDevelopmentCertificate(X509Certificate2 certificate)
     {
-        if (!string.Equals(certificate.Subject, "CN=localhost", StringComparison.Ordinal))
-        {
-            return false;
-        }
-
-        foreach (var ext in certificate.Extensions)
-        {
-            if (string.Equals(ext.Oid?.Value, CertificateManager.AspNetHttpsOid, StringComparison.Ordinal))
-            {
-                return true;
-            }
-        }
-
-        return false;
+        return string.Equals(certificate.Subject, CertificateManager.LocalhostHttpsDistinguishedName, StringComparison.Ordinal) &&
+            CertificateManager.IsHttpsDevelopmentCertificate(certificate);
     }
 
     private static bool TryGetCertificatePath(string applicationName, [NotNullWhen(true)] out string? path)

--- a/src/Shared/CertificateGeneration/CertificateManager.cs
+++ b/src/Shared/CertificateGeneration/CertificateManager.cs
@@ -66,9 +66,17 @@ internal abstract class CertificateManager
     /// This only checks if the certificate has the OID for ASP.NET Core HTTPS development certificates -
     /// it doesn't check the subject, validity, key usages, etc.
     /// </remarks>
-    public static bool IsHttpsDevelopmentCertificate(X509Certificate2 certificate) =>
-        certificate.Extensions.OfType<X509Extension>()
-        .Any(e => string.Equals(AspNetHttpsOid, e.Oid?.Value, StringComparison.Ordinal));
+    public static bool IsHttpsDevelopmentCertificate(X509Certificate2 certificate)
+    {
+        foreach (var extension in certificate.Extensions.OfType<X509Extension>())
+        {
+            if (string.Equals(AspNetHttpsOid, extension.Oid?.Value, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
 
     public IList<X509Certificate2> ListCertificates(
         StoreName storeName,


### PR DESCRIPTION
Kestrel checks the subject name and our magic extension - import was only checking the extension.  They can't easily share a method because import has a test hook.