### PR TITLE
Try to reduce IIS test event log flakiness

### DIFF
--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/LoggingTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/LoggingTests.cs
@@ -100,7 +100,7 @@ public class LoggingTests : IISFunctionalTestBase
         if (variant.HostingModel == HostingModel.InProcess)
         {
             // Error is getting logged twice, from shim and handler
-            EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.CouldNotStartStdoutFileRedirection("Q:\\std", deploymentResult), Logger, allowMultiple: true);
+            await EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.CouldNotStartStdoutFileRedirection("Q:\\std", deploymentResult), Logger, allowMultiple: true);
         }
     }
 
@@ -190,7 +190,7 @@ public class LoggingTests : IISFunctionalTestBase
         deploymentParameters.HandlerSettings["debugLevel"] = "file,eventlog";
         var deploymentResult = await StartAsync(deploymentParameters);
         StopServer();
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult, @"\[aspnetcorev2.dll\] Initializing logs for .*?Description: IIS ASP.NET Core Module V2", Logger);
+        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, @"\[aspnetcorev2.dll\] Initializing logs for .*?Description: IIS ASP.NET Core Module V2", Logger);
     }
 
     [ConditionalTheory]
@@ -216,7 +216,7 @@ public class LoggingTests : IISFunctionalTestBase
 
         var contents = Helpers.ReadAllTextFromFile(Helpers.GetExpectedLogName(deploymentResult, logFolderPath), Logger);
         Assert.Contains("彡⾔", contents);
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessThreadExitStdOut(deploymentResult, "12", "(.*)彡⾔(.*)"), Logger);
+        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessThreadExitStdOut(deploymentResult, "12", "(.*)彡⾔(.*)"), Logger);
     }
 
     [ConditionalTheory]
@@ -246,7 +246,7 @@ public class LoggingTests : IISFunctionalTestBase
 
         StopServer();
 
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.OutOfProcessFailedToStart(deploymentResult, "Wow!"), Logger);
+        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.OutOfProcessFailedToStart(deploymentResult, "Wow!"), Logger);
     }
 
     [ConditionalFact]
@@ -262,7 +262,7 @@ public class LoggingTests : IISFunctionalTestBase
 
         StopServer();
 
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.OutOfProcessFailedToStart(deploymentResult, ""), Logger);
+        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.OutOfProcessFailedToStart(deploymentResult, ""), Logger);
     }
 
     [ConditionalFact]
@@ -276,7 +276,7 @@ public class LoggingTests : IISFunctionalTestBase
 
         StopServer();
 
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.OutOfProcessFailedToStart(deploymentResult, new string('a', 30000)), Logger);
+        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.OutOfProcessFailedToStart(deploymentResult, new string('a', 30000)), Logger);
     }
 
     [ConditionalTheory]

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/LoggingTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/LoggingTests.cs
@@ -100,7 +100,7 @@ public class LoggingTests : IISFunctionalTestBase
         if (variant.HostingModel == HostingModel.InProcess)
         {
             // Error is getting logged twice, from shim and handler
-            await EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.CouldNotStartStdoutFileRedirection("Q:\\std", deploymentResult), Logger, allowMultiple: true);
+            await EventLogHelpers.VerifyEventLogEventAsync(deploymentResult, EventLogHelpers.CouldNotStartStdoutFileRedirection("Q:\\std", deploymentResult), Logger, allowMultiple: true);
         }
     }
 
@@ -190,7 +190,7 @@ public class LoggingTests : IISFunctionalTestBase
         deploymentParameters.HandlerSettings["debugLevel"] = "file,eventlog";
         var deploymentResult = await StartAsync(deploymentParameters);
         StopServer();
-        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, @"\[aspnetcorev2.dll\] Initializing logs for .*?Description: IIS ASP.NET Core Module V2", Logger);
+        await EventLogHelpers.VerifyEventLogEventAsync(deploymentResult, @"\[aspnetcorev2.dll\] Initializing logs for .*?Description: IIS ASP.NET Core Module V2", Logger);
     }
 
     [ConditionalTheory]
@@ -216,7 +216,7 @@ public class LoggingTests : IISFunctionalTestBase
 
         var contents = Helpers.ReadAllTextFromFile(Helpers.GetExpectedLogName(deploymentResult, logFolderPath), Logger);
         Assert.Contains("彡⾔", contents);
-        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessThreadExitStdOut(deploymentResult, "12", "(.*)彡⾔(.*)"), Logger);
+        await EventLogHelpers.VerifyEventLogEventAsync(deploymentResult, EventLogHelpers.InProcessThreadExitStdOut(deploymentResult, "12", "(.*)彡⾔(.*)"), Logger);
     }
 
     [ConditionalTheory]
@@ -246,7 +246,7 @@ public class LoggingTests : IISFunctionalTestBase
 
         StopServer();
 
-        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.OutOfProcessFailedToStart(deploymentResult, "Wow!"), Logger);
+        await EventLogHelpers.VerifyEventLogEventAsync(deploymentResult, EventLogHelpers.OutOfProcessFailedToStart(deploymentResult, "Wow!"), Logger);
     }
 
     [ConditionalFact]
@@ -262,7 +262,7 @@ public class LoggingTests : IISFunctionalTestBase
 
         StopServer();
 
-        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.OutOfProcessFailedToStart(deploymentResult, ""), Logger);
+        await EventLogHelpers.VerifyEventLogEventAsync(deploymentResult, EventLogHelpers.OutOfProcessFailedToStart(deploymentResult, ""), Logger);
     }
 
     [ConditionalFact]
@@ -276,7 +276,7 @@ public class LoggingTests : IISFunctionalTestBase
 
         StopServer();
 
-        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.OutOfProcessFailedToStart(deploymentResult, new string('a', 30000)), Logger);
+        await EventLogHelpers.VerifyEventLogEventAsync(deploymentResult, EventLogHelpers.OutOfProcessFailedToStart(deploymentResult, new string('a', 30000)), Logger);
     }
 
     [ConditionalTheory]

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/MultiApplicationTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/MultiApplicationTests.cs
@@ -67,7 +67,7 @@ public class MultiApplicationTests : IISFunctionalTestBase
             Assert.Contains("500.35", await result2.Content.ReadAsStringAsync());
         }
 
-        await EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.OnlyOneAppPerAppPool(), Logger);
+        await EventLogHelpers.VerifyEventLogEventAsync(result, EventLogHelpers.OnlyOneAppPerAppPool(), Logger);
     }
 
     [ConditionalTheory]
@@ -94,7 +94,7 @@ public class MultiApplicationTests : IISFunctionalTestBase
             Assert.Contains("500.34", await result2.Content.ReadAsStringAsync());
         }
 
-        await EventLogHelpers.VerifyEventLogEvent(result, "Mixed hosting model is not supported.", Logger);
+        await EventLogHelpers.VerifyEventLogEventAsync(result, "Mixed hosting model is not supported.", Logger);
     }
 
     private void SetHostingModel(string directory, HostingModel model)

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/MultiApplicationTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/MultiApplicationTests.cs
@@ -67,7 +67,7 @@ public class MultiApplicationTests : IISFunctionalTestBase
             Assert.Contains("500.35", await result2.Content.ReadAsStringAsync());
         }
 
-        EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.OnlyOneAppPerAppPool(), Logger);
+        await EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.OnlyOneAppPerAppPool(), Logger);
     }
 
     [ConditionalTheory]
@@ -94,7 +94,7 @@ public class MultiApplicationTests : IISFunctionalTestBase
             Assert.Contains("500.34", await result2.Content.ReadAsStringAsync());
         }
 
-        EventLogHelpers.VerifyEventLogEvent(result, "Mixed hosting model is not supported.", Logger);
+        await EventLogHelpers.VerifyEventLogEvent(result, "Mixed hosting model is not supported.", Logger);
     }
 
     private void SetHostingModel(string directory, HostingModel model)

--- a/src/Servers/IIS/IIS/test/Common.LongTests/ShutdownTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.LongTests/ShutdownTests.cs
@@ -49,7 +49,7 @@ public class ShutdownTests : IISFunctionalTestBase
 
         StopServer();
 
-        EventLogHelpers.VerifyEventLogEvents(deploymentResult,
+        await EventLogHelpers.VerifyEventLogEvents(deploymentResult,
             EventLogHelpers.InProcessStarted(deploymentResult),
             EventLogHelpers.InProcessFailedToStop(deploymentResult, ""));
     }
@@ -256,7 +256,7 @@ public class ShutdownTests : IISFunctionalTestBase
         deploymentResult.AssertWorkerProcessStop();
 
         // Shutdown should be graceful here!
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult,
+        await EventLogHelpers.VerifyEventLogEvent(deploymentResult,
             EventLogHelpers.ShutdownMessage(deploymentResult), Logger);
     }
 
@@ -293,7 +293,7 @@ public class ShutdownTests : IISFunctionalTestBase
         await deploymentResult.AssertRecycledAsync();
 
         // Shutdown should be graceful here!
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult,
+        await EventLogHelpers.VerifyEventLogEvent(deploymentResult,
             EventLogHelpers.ShutdownMessage(deploymentResult), Logger);
     }
 
@@ -330,7 +330,7 @@ public class ShutdownTests : IISFunctionalTestBase
         await deploymentResult.AssertRecycledAsync();
 
         // Shutdown should be graceful here!
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult,
+        await EventLogHelpers.VerifyEventLogEvent(deploymentResult,
             EventLogHelpers.ShutdownMessage(deploymentResult), Logger);
     }
 

--- a/src/Servers/IIS/IIS/test/Common.LongTests/ShutdownTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.LongTests/ShutdownTests.cs
@@ -256,7 +256,7 @@ public class ShutdownTests : IISFunctionalTestBase
         deploymentResult.AssertWorkerProcessStop();
 
         // Shutdown should be graceful here!
-        await EventLogHelpers.VerifyEventLogEvent(deploymentResult,
+        await EventLogHelpers.VerifyEventLogEventAsync(deploymentResult,
             EventLogHelpers.ShutdownMessage(deploymentResult), Logger);
     }
 
@@ -293,7 +293,7 @@ public class ShutdownTests : IISFunctionalTestBase
         await deploymentResult.AssertRecycledAsync();
 
         // Shutdown should be graceful here!
-        await EventLogHelpers.VerifyEventLogEvent(deploymentResult,
+        await EventLogHelpers.VerifyEventLogEventAsync(deploymentResult,
             EventLogHelpers.ShutdownMessage(deploymentResult), Logger);
     }
 
@@ -330,7 +330,7 @@ public class ShutdownTests : IISFunctionalTestBase
         await deploymentResult.AssertRecycledAsync();
 
         // Shutdown should be graceful here!
-        await EventLogHelpers.VerifyEventLogEvent(deploymentResult,
+        await EventLogHelpers.VerifyEventLogEventAsync(deploymentResult,
             EventLogHelpers.ShutdownMessage(deploymentResult), Logger);
     }
 

--- a/src/Servers/IIS/IIS/test/Common.LongTests/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.LongTests/StartupTests.cs
@@ -71,7 +71,7 @@ public class StartupTests : IISFunctionalTestBase
 
         StopServer();
 
-        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.UnableToStart(deploymentResult, subError), Logger);
+        await EventLogHelpers.VerifyEventLogEventAsync(deploymentResult, EventLogHelpers.UnableToStart(deploymentResult, subError), Logger);
         if (DeployerSelector.HasNewShim)
         {
             Assert.Contains("500.0", await response.Content.ReadAsStringAsync());
@@ -180,7 +180,7 @@ public class StartupTests : IISFunctionalTestBase
 
             StopServer();
 
-            await EventLogHelpers.VerifyEventLogEvent(deploymentResult, "AspNetCore Module is disabled", Logger);
+            await EventLogHelpers.VerifyEventLogEventAsync(deploymentResult, "AspNetCore Module is disabled", Logger);
         }
     }
 
@@ -291,7 +291,7 @@ public class StartupTests : IISFunctionalTestBase
             await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult);
         }
 
-        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessHostfxrInvalid(deploymentResult), Logger);
+        await EventLogHelpers.VerifyEventLogEventAsync(deploymentResult, EventLogHelpers.InProcessHostfxrInvalid(deploymentResult), Logger);
     }
 
     [ConditionalFact]
@@ -354,7 +354,7 @@ public class StartupTests : IISFunctionalTestBase
             await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult);
         }
 
-        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessHostfxrUnableToLoad(deploymentResult), Logger);
+        await EventLogHelpers.VerifyEventLogEventAsync(deploymentResult, EventLogHelpers.InProcessHostfxrUnableToLoad(deploymentResult), Logger);
     }
 
     [ConditionalFact]
@@ -373,7 +373,7 @@ public class StartupTests : IISFunctionalTestBase
             await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult);
         }
 
-        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessFailedToFindNativeDependencies(deploymentResult), Logger);
+        await EventLogHelpers.VerifyEventLogEventAsync(deploymentResult, EventLogHelpers.InProcessFailedToFindNativeDependencies(deploymentResult), Logger);
     }
 
     [ConditionalFact]
@@ -393,7 +393,7 @@ public class StartupTests : IISFunctionalTestBase
 
         await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.31", "Provided application path does not exist, or isn't a .dll or .exe.");
 
-        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessFailedToFindApplication(), Logger);
+        await EventLogHelpers.VerifyEventLogEventAsync(deploymentResult, EventLogHelpers.InProcessFailedToFindApplication(), Logger);
     }
 
     [ConditionalFact]
@@ -450,13 +450,13 @@ public class StartupTests : IISFunctionalTestBase
         {
             await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.33");
 
-            await EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessFailedToFindRequestHandler(deploymentResult), Logger);
+            await EventLogHelpers.VerifyEventLogEventAsync(deploymentResult, EventLogHelpers.InProcessFailedToFindRequestHandler(deploymentResult), Logger);
         }
         else
         {
             await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult);
 
-            await EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessFailedToFindRequestHandler(deploymentResult), Logger);
+            await EventLogHelpers.VerifyEventLogEventAsync(deploymentResult, EventLogHelpers.InProcessFailedToFindRequestHandler(deploymentResult), Logger);
         }
     }
 
@@ -482,7 +482,7 @@ public class StartupTests : IISFunctionalTestBase
             // Startup timeout now recycles process.
             deploymentResult.AssertWorkerProcessStop();
 
-            await EventLogHelpers.VerifyEventLogEvent(deploymentResult,
+            await EventLogHelpers.VerifyEventLogEventAsync(deploymentResult,
                 EventLogHelpers.InProcessFailedToStart(deploymentResult, "Managed server didn't initialize after 1000 ms."),
                 Logger);
 
@@ -514,7 +514,7 @@ public class StartupTests : IISFunctionalTestBase
 
             StopServer(gracefulShutdown: false);
 
-            await EventLogHelpers.VerifyEventLogEvent(deploymentResult,
+            await EventLogHelpers.VerifyEventLogEventAsync(deploymentResult,
                 EventLogHelpers.InProcessFailedToStart(deploymentResult, "Managed server didn't initialize after 1000 ms."),
                 Logger);
 
@@ -1006,7 +1006,7 @@ public class StartupTests : IISFunctionalTestBase
         Assert.Contains(TestSink.Writes, context => context.Message.Contains(expectedLogString));
         var expectedEventLogString = new string('a', 30000);
 
-        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessThreadExitStdOut(deploymentResult, "12", expectedEventLogString), Logger);
+        await EventLogHelpers.VerifyEventLogEventAsync(deploymentResult, EventLogHelpers.InProcessThreadExitStdOut(deploymentResult, "12", expectedEventLogString), Logger);
     }
 
     [ConditionalTheory]
@@ -1032,7 +1032,7 @@ public class StartupTests : IISFunctionalTestBase
 
         var expectedEventLogString = new string('a', 30000);
 
-        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessThreadExitStdOut(deploymentResult, "12", expectedEventLogString), Logger);
+        await EventLogHelpers.VerifyEventLogEventAsync(deploymentResult, EventLogHelpers.InProcessThreadExitStdOut(deploymentResult, "12", expectedEventLogString), Logger);
     }
 
     [ConditionalFact]

--- a/src/Servers/IIS/IIS/test/Common.LongTests/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.LongTests/StartupTests.cs
@@ -71,7 +71,7 @@ public class StartupTests : IISFunctionalTestBase
 
         StopServer();
 
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.UnableToStart(deploymentResult, subError), Logger);
+        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.UnableToStart(deploymentResult, subError), Logger);
         if (DeployerSelector.HasNewShim)
         {
             Assert.Contains("500.0", await response.Content.ReadAsStringAsync());
@@ -180,7 +180,7 @@ public class StartupTests : IISFunctionalTestBase
 
             StopServer();
 
-            EventLogHelpers.VerifyEventLogEvent(deploymentResult, "AspNetCore Module is disabled", Logger);
+            await EventLogHelpers.VerifyEventLogEvent(deploymentResult, "AspNetCore Module is disabled", Logger);
         }
     }
 
@@ -230,7 +230,7 @@ public class StartupTests : IISFunctionalTestBase
 
         StopServer();
 
-        EventLogHelpers.VerifyEventLogEvents(deploymentResult,
+        await EventLogHelpers.VerifyEventLogEvents(deploymentResult,
             EventLogHelpers.InProcessFailedToStart(deploymentResult, "CLR worker thread exited prematurely"),
             EventLogHelpers.InProcessThreadException(deploymentResult, ".*?Application is running inside IIS process but is not configured to use IIS server"));
     }
@@ -248,7 +248,7 @@ public class StartupTests : IISFunctionalTestBase
 
         StopServer();
 
-        EventLogHelpers.VerifyEventLogEvents(deploymentResult,
+        await EventLogHelpers.VerifyEventLogEvents(deploymentResult,
             EventLogHelpers.InProcessFailedToStart(deploymentResult, "CLR worker thread exited prematurely"),
             EventLogHelpers.InProcessThreadException(deploymentResult, ", exception code = '0xe0434352'"));
     }
@@ -265,7 +265,7 @@ public class StartupTests : IISFunctionalTestBase
 
         StopServer();
 
-        EventLogHelpers.VerifyEventLogEvents(deploymentResult,
+        await EventLogHelpers.VerifyEventLogEvents(deploymentResult,
             EventLogHelpers.InProcessFailedToStart(deploymentResult, "CLR worker thread exited prematurely"),
             EventLogHelpers.InProcessThreadExit(deploymentResult, "12"));
     }
@@ -291,7 +291,7 @@ public class StartupTests : IISFunctionalTestBase
             await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult);
         }
 
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessHostfxrInvalid(deploymentResult), Logger);
+        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessHostfxrInvalid(deploymentResult), Logger);
     }
 
     [ConditionalFact]
@@ -354,7 +354,7 @@ public class StartupTests : IISFunctionalTestBase
             await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult);
         }
 
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessHostfxrUnableToLoad(deploymentResult), Logger);
+        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessHostfxrUnableToLoad(deploymentResult), Logger);
     }
 
     [ConditionalFact]
@@ -373,7 +373,7 @@ public class StartupTests : IISFunctionalTestBase
             await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult);
         }
 
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessFailedToFindNativeDependencies(deploymentResult), Logger);
+        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessFailedToFindNativeDependencies(deploymentResult), Logger);
     }
 
     [ConditionalFact]
@@ -393,7 +393,7 @@ public class StartupTests : IISFunctionalTestBase
 
         await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.31", "Provided application path does not exist, or isn't a .dll or .exe.");
 
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessFailedToFindApplication(), Logger);
+        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessFailedToFindApplication(), Logger);
     }
 
     [ConditionalFact]
@@ -450,13 +450,13 @@ public class StartupTests : IISFunctionalTestBase
         {
             await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.33");
 
-            EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessFailedToFindRequestHandler(deploymentResult), Logger);
+            await EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessFailedToFindRequestHandler(deploymentResult), Logger);
         }
         else
         {
             await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult);
 
-            EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessFailedToFindRequestHandler(deploymentResult), Logger);
+            await EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessFailedToFindRequestHandler(deploymentResult), Logger);
         }
     }
 
@@ -482,7 +482,7 @@ public class StartupTests : IISFunctionalTestBase
             // Startup timeout now recycles process.
             deploymentResult.AssertWorkerProcessStop();
 
-            EventLogHelpers.VerifyEventLogEvent(deploymentResult,
+            await EventLogHelpers.VerifyEventLogEvent(deploymentResult,
                 EventLogHelpers.InProcessFailedToStart(deploymentResult, "Managed server didn't initialize after 1000 ms."),
                 Logger);
 
@@ -514,7 +514,7 @@ public class StartupTests : IISFunctionalTestBase
 
             StopServer(gracefulShutdown: false);
 
-            EventLogHelpers.VerifyEventLogEvent(deploymentResult,
+            await EventLogHelpers.VerifyEventLogEvent(deploymentResult,
                 EventLogHelpers.InProcessFailedToStart(deploymentResult, "Managed server didn't initialize after 1000 ms."),
                 Logger);
 
@@ -540,7 +540,7 @@ public class StartupTests : IISFunctionalTestBase
 
         StopServer();
 
-        EventLogHelpers.VerifyEventLogEvents(deploymentResult,
+        await EventLogHelpers.VerifyEventLogEvents(deploymentResult,
             EventLogHelpers.ConfigurationLoadError(deploymentResult, "Unknown hosting model 'bogus'. Please specify either hostingModel=\"inprocess\" or hostingModel=\"outofprocess\" in the web.config file.")
             );
     }
@@ -564,7 +564,7 @@ public class StartupTests : IISFunctionalTestBase
 
         StopServer();
 
-        EventLogHelpers.VerifyEventLogEvents(deploymentResult,
+        await EventLogHelpers.VerifyEventLogEvents(deploymentResult,
             EventLogHelpers.ConfigurationLoadError(deploymentResult, expectedError)
         );
     }
@@ -1006,7 +1006,7 @@ public class StartupTests : IISFunctionalTestBase
         Assert.Contains(TestSink.Writes, context => context.Message.Contains(expectedLogString));
         var expectedEventLogString = new string('a', 30000);
 
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessThreadExitStdOut(deploymentResult, "12", expectedEventLogString), Logger);
+        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessThreadExitStdOut(deploymentResult, "12", expectedEventLogString), Logger);
     }
 
     [ConditionalTheory]
@@ -1032,7 +1032,7 @@ public class StartupTests : IISFunctionalTestBase
 
         var expectedEventLogString = new string('a', 30000);
 
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessThreadExitStdOut(deploymentResult, "12", expectedEventLogString), Logger);
+        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessThreadExitStdOut(deploymentResult, "12", expectedEventLogString), Logger);
     }
 
     [ConditionalFact]

--- a/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/ApplicationInitializationTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/ApplicationInitializationTests.cs
@@ -57,11 +57,11 @@ public class ApplicationInitializationTests : IISFunctionalTestBase
 
             await Helpers.Retry(async () => await File.ReadAllTextAsync(Path.Combine(result.ContentRoot, "Started.txt")), TimeoutExtensions.DefaultTimeoutValue);
             StopServer();
-            await EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.Started(result), Logger);
+            await EventLogHelpers.VerifyEventLogEventAsync(result, EventLogHelpers.Started(result), Logger);
 
             if (delayShutdown)
             {
-                await EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.ShutdownMessage(result), Logger);
+                await EventLogHelpers.VerifyEventLogEventAsync(result, EventLogHelpers.ShutdownMessage(result), Logger);
             }
             else
             {
@@ -101,8 +101,8 @@ public class ApplicationInitializationTests : IISFunctionalTestBase
 
             await Helpers.Retry(async () => await File.ReadAllTextAsync(Path.Combine(result.ContentRoot, "Started.txt")), TimeoutExtensions.DefaultTimeoutValue);
             StopServer();
-            await EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.Started(result), Logger);
-            await EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.ShutdownMessage(result), Logger);
+            await EventLogHelpers.VerifyEventLogEventAsync(result, EventLogHelpers.Started(result), Logger);
+            await EventLogHelpers.VerifyEventLogEventAsync(result, EventLogHelpers.ShutdownMessage(result), Logger);
         }
     }
 

--- a/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/ApplicationInitializationTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/ApplicationInitializationTests.cs
@@ -57,11 +57,11 @@ public class ApplicationInitializationTests : IISFunctionalTestBase
 
             await Helpers.Retry(async () => await File.ReadAllTextAsync(Path.Combine(result.ContentRoot, "Started.txt")), TimeoutExtensions.DefaultTimeoutValue);
             StopServer();
-            EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.Started(result), Logger);
+            await EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.Started(result), Logger);
 
             if (delayShutdown)
             {
-                EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.ShutdownMessage(result), Logger);
+                await EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.ShutdownMessage(result), Logger);
             }
             else
             {
@@ -101,8 +101,8 @@ public class ApplicationInitializationTests : IISFunctionalTestBase
 
             await Helpers.Retry(async () => await File.ReadAllTextAsync(Path.Combine(result.ContentRoot, "Started.txt")), TimeoutExtensions.DefaultTimeoutValue);
             StopServer();
-            EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.Started(result), Logger);
-            EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.ShutdownMessage(result), Logger);
+            await EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.Started(result), Logger);
+            await EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.ShutdownMessage(result), Logger);
         }
     }
 

--- a/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/StdOutRedirectionTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/StdOutRedirectionTests.cs
@@ -47,9 +47,9 @@ public class StdOutRedirectionTests : IISFunctionalTestBase
 
         StopServer();
 
-        await EventLogHelpers.VerifyEventLogEvent(deploymentResult,
+        await EventLogHelpers.VerifyEventLogEventAsync(deploymentResult,
             @"Framework: 'Microsoft.NETCore.App', version '2.9.9' \(x64\)", Logger);
-        await EventLogHelpers.VerifyEventLogEvent(deploymentResult,
+        await EventLogHelpers.VerifyEventLogEventAsync(deploymentResult,
             "To install missing framework, download:", Logger);
     }
 
@@ -73,9 +73,9 @@ public class StdOutRedirectionTests : IISFunctionalTestBase
 
         var contents = Helpers.ReadAllTextFromFile(Helpers.GetExpectedLogName(deploymentResult, LogFolderPath), Logger);
         var missingFrameworkString = "To install missing framework, download:";
-        await EventLogHelpers.VerifyEventLogEvent(deploymentResult,
+        await EventLogHelpers.VerifyEventLogEventAsync(deploymentResult,
             @"Framework: 'Microsoft.NETCore.App', version '2.9.9' \(x64\)", Logger);
-        await EventLogHelpers.VerifyEventLogEvent(deploymentResult,
+        await EventLogHelpers.VerifyEventLogEventAsync(deploymentResult,
             missingFrameworkString, Logger);
         Assert.Contains(@"Framework: 'Microsoft.NETCore.App', version '2.9.9' (x64)", contents);
         Assert.Contains(missingFrameworkString, contents);
@@ -103,7 +103,7 @@ public class StdOutRedirectionTests : IISFunctionalTestBase
 
         var fileInDirectory = Directory.GetFiles(LogFolderPath).Single();
         var contents = Helpers.ReadAllTextFromFile(fileInDirectory, Logger);
-        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, "Invoked hostfxr", Logger);
+        await EventLogHelpers.VerifyEventLogEventAsync(deploymentResult, "Invoked hostfxr", Logger);
         Assert.Contains("Invoked hostfxr", contents);
     }
 
@@ -128,7 +128,7 @@ public class StdOutRedirectionTests : IISFunctionalTestBase
 
         StopServer();
 
-        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, "Invoked hostfxr", Logger);
+        await EventLogHelpers.VerifyEventLogEventAsync(deploymentResult, "Invoked hostfxr", Logger);
     }
 
     [ConditionalTheory]
@@ -157,7 +157,7 @@ public class StdOutRedirectionTests : IISFunctionalTestBase
         var fileInDirectory = Directory.GetFiles(LogFolderPath).First();
         var contents = Helpers.ReadAllTextFromFile(fileInDirectory, Logger);
 
-        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, "Invoked hostfxr", Logger);
+        await EventLogHelpers.VerifyEventLogEventAsync(deploymentResult, "Invoked hostfxr", Logger);
         Assert.Contains("Invoked hostfxr", contents);
     }
 }

--- a/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/StdOutRedirectionTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/StdOutRedirectionTests.cs
@@ -47,9 +47,9 @@ public class StdOutRedirectionTests : IISFunctionalTestBase
 
         StopServer();
 
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult,
+        await EventLogHelpers.VerifyEventLogEvent(deploymentResult,
             @"Framework: 'Microsoft.NETCore.App', version '2.9.9' \(x64\)", Logger);
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult,
+        await EventLogHelpers.VerifyEventLogEvent(deploymentResult,
             "To install missing framework, download:", Logger);
     }
 
@@ -73,9 +73,9 @@ public class StdOutRedirectionTests : IISFunctionalTestBase
 
         var contents = Helpers.ReadAllTextFromFile(Helpers.GetExpectedLogName(deploymentResult, LogFolderPath), Logger);
         var missingFrameworkString = "To install missing framework, download:";
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult,
+        await EventLogHelpers.VerifyEventLogEvent(deploymentResult,
             @"Framework: 'Microsoft.NETCore.App', version '2.9.9' \(x64\)", Logger);
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult,
+        await EventLogHelpers.VerifyEventLogEvent(deploymentResult,
             missingFrameworkString, Logger);
         Assert.Contains(@"Framework: 'Microsoft.NETCore.App', version '2.9.9' (x64)", contents);
         Assert.Contains(missingFrameworkString, contents);
@@ -103,7 +103,7 @@ public class StdOutRedirectionTests : IISFunctionalTestBase
 
         var fileInDirectory = Directory.GetFiles(LogFolderPath).Single();
         var contents = Helpers.ReadAllTextFromFile(fileInDirectory, Logger);
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult, "Invoked hostfxr", Logger);
+        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, "Invoked hostfxr", Logger);
         Assert.Contains("Invoked hostfxr", contents);
     }
 
@@ -128,7 +128,7 @@ public class StdOutRedirectionTests : IISFunctionalTestBase
 
         StopServer();
 
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult, "Invoked hostfxr", Logger);
+        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, "Invoked hostfxr", Logger);
     }
 
     [ConditionalTheory]
@@ -157,7 +157,7 @@ public class StdOutRedirectionTests : IISFunctionalTestBase
         var fileInDirectory = Directory.GetFiles(LogFolderPath).First();
         var contents = Helpers.ReadAllTextFromFile(fileInDirectory, Logger);
 
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult, "Invoked hostfxr", Logger);
+        await EventLogHelpers.VerifyEventLogEvent(deploymentResult, "Invoked hostfxr", Logger);
         Assert.Contains("Invoked hostfxr", contents);
     }
 }


### PR DESCRIPTION
Looking at some recent IIS test failures, they fail to find an event log, but when looking at the logs the event log **was** logged. Adding some retries to the event log checking in hopes of reducing flakiness. 