### PR TITLE
Propagate trace parent to SignalR hub invocations

### DIFF
--- a/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Shared;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Hosting;
@@ -389,80 +390,23 @@ internal sealed class HostingApplicationDiagnostics
         hasDiagnosticListener = false;
 
         var headers = httpContext.Request.Headers;
-        _propagator.ExtractTraceIdAndState(headers,
+        var activity = ActivityCreator.CreateFromRemote(
+            _activitySource,
+            _propagator,
+            headers,
             static (object? carrier, string fieldName, out string? fieldValue, out IEnumerable<string>? fieldValues) =>
             {
                 fieldValues = default;
                 var headers = (IHeaderDictionary)carrier!;
                 fieldValue = headers[fieldName];
             },
-            out var requestId,
-            out var traceState);
-
-        Activity? activity = null;
-        if (_activitySource.HasListeners())
-        {
-            if (ActivityContext.TryParse(requestId, traceState, isRemote: true, out ActivityContext context))
-            {
-                // The requestId used the W3C ID format. Unfortunately, the ActivitySource.CreateActivity overload that
-                // takes a string parentId never sets HasRemoteParent to true. We work around that by calling the
-                // ActivityContext overload instead which sets HasRemoteParent to parentContext.IsRemote.
-                // https://github.com/dotnet/aspnetcore/pull/41568#discussion_r868733305
-                activity = _activitySource.CreateActivity(ActivityName, ActivityKind.Server, context);
-            }
-            else
-            {
-                // Pass in the ID we got from the headers if there was one.
-                activity = _activitySource.CreateActivity(ActivityName, ActivityKind.Server, string.IsNullOrEmpty(requestId) ? null! : requestId);
-            }
-        }
-
+            ActivityName,
+            tags: null,
+            links: null,
+            loggingEnabled || diagnosticListenerActivityCreationEnabled);
         if (activity is null)
         {
-            // CreateActivity didn't create an Activity (this is an optimization for the
-            // case when there are no listeners). Let's create it here if needed.
-            if (loggingEnabled || diagnosticListenerActivityCreationEnabled)
-            {
-                activity = new Activity(ActivityName);
-                if (!string.IsNullOrEmpty(requestId))
-                {
-                    activity.SetParentId(requestId);
-                }
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        // The trace id was successfully extracted, so we can set the trace state
-        // https://www.w3.org/TR/trace-context/#tracestate-header
-        if (!string.IsNullOrEmpty(requestId))
-        {
-            if (!string.IsNullOrEmpty(traceState))
-            {
-                activity.TraceStateString = traceState;
-            }
-        }
-
-        // Baggage can be used regardless of whether a distributed trace id was present on the inbound request.
-        // https://www.w3.org/TR/baggage/#abstract
-        var baggage = _propagator.ExtractBaggage(headers, static (object? carrier, string fieldName, out string? fieldValue, out IEnumerable<string>? fieldValues) =>
-        {
-            fieldValues = default;
-            var headers = (IHeaderDictionary)carrier!;
-            fieldValue = headers[fieldName];
-        });
-
-        // AddBaggage adds items at the beginning  of the list, so we need to add them in reverse to keep the same order as the client
-        // By contract, the propagator has already reversed the order of items so we need not reverse it again
-        // Order could be important if baggage has two items with the same key (that is allowed by the contract)
-        if (baggage is not null)
-        {
-            foreach (var baggageItem in baggage)
-            {
-                activity.AddBaggage(baggageItem.Key, baggageItem.Value);
-            }
+            return null;
         }
 
         _diagnosticListener.OnActivityImport(activity, httpContext);

--- a/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
@@ -401,6 +401,7 @@ internal sealed class HostingApplicationDiagnostics
                 fieldValue = headers[fieldName];
             },
             ActivityName,
+            ActivityKind.Server,
             tags: null,
             links: null,
             loggingEnabled || diagnosticListenerActivityCreationEnabled);

--- a/src/Hosting/Hosting/src/Microsoft.AspNetCore.Hosting.csproj
+++ b/src/Hosting/Hosting/src/Microsoft.AspNetCore.Hosting.csproj
@@ -18,6 +18,7 @@
     <Compile Include="$(SharedSourceRoot)StaticWebAssets\**\*.cs" LinkBase="StaticWebAssets" />
     <Compile Include="$(SharedSourceRoot)Metrics\MetricsExtensions.cs" />
     <Compile Include="$(SharedSourceRoot)Metrics\MetricsConstants.cs" />
+    <Compile Include="$(SharedSourceRoot)Diagnostics\ActivityCreator.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Shared/Diagnostics/ActivityCreator.cs
+++ b/src/Shared/Diagnostics/ActivityCreator.cs
@@ -1,0 +1,122 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Microsoft.AspNetCore.Shared;
+
+internal static class ActivityCreator
+{
+    /// <summary>
+    /// Create an activity with details received from a remote source.
+    /// </summary>
+    public static Activity? CreateFromRemote(
+        ActivitySource activitySource,
+        DistributedContextPropagator propagator,
+        object distributedContextCarrier,
+        DistributedContextPropagator.PropagatorGetterCallback propagatorGetter,
+        string activityName,
+        IEnumerable<KeyValuePair<string, object?>>? tags,
+        IEnumerable<ActivityLink>? links,
+        bool diagnosticsOrLoggingEnabled)
+    {
+        Activity? activity = null;
+        string? requestId = null;
+        string? traceState = null;
+
+        if (activitySource.HasListeners())
+        {
+            propagator.ExtractTraceIdAndState(
+                distributedContextCarrier,
+                propagatorGetter,
+                out requestId,
+                out traceState);
+
+            if (ActivityContext.TryParse(requestId, traceState, isRemote: true, out ActivityContext context))
+            {
+                // The requestId used the W3C ID format. Unfortunately, the ActivitySource.CreateActivity overload that
+                // takes a string parentId never sets HasRemoteParent to true. We work around that by calling the
+                // ActivityContext overload instead which sets HasRemoteParent to parentContext.IsRemote.
+                // https://github.com/dotnet/aspnetcore/pull/41568#discussion_r868733305
+                activity = activitySource.CreateActivity(activityName, ActivityKind.Server, context, tags: tags, links: links);
+            }
+            else
+            {
+                // Pass in the ID we got from the headers if there was one.
+                activity = activitySource.CreateActivity(activityName, ActivityKind.Server, string.IsNullOrEmpty(requestId) ? null : requestId, tags: tags, links: links);
+            }
+        }
+
+        if (activity is null)
+        {
+            // CreateActivity didn't create an Activity (this is an optimization for the
+            // case when there are no listeners). Let's create it here if needed.
+            if (diagnosticsOrLoggingEnabled)
+            {
+                // Note that there is a very small chance that propagator has already been called.
+                // Requires that the activity source had listened, but it didn't create an activity.
+                // Can only happen if there is a race between HasListeners and CreateActivity calls,
+                // and someone removing the listener.
+                //
+                // The only negative of calling the propagator twice is a small performance hit.
+                // It's small and unlikely so it's not worth trying to optimize.
+                propagator.ExtractTraceIdAndState(
+                    distributedContextCarrier,
+                    propagatorGetter,
+                    out requestId,
+                    out traceState);
+
+                activity = new Activity(activityName);
+                if (!string.IsNullOrEmpty(requestId))
+                {
+                    activity.SetParentId(requestId);
+                }
+                if (tags != null)
+                {
+                    foreach (var tag in tags)
+                    {
+                        activity.AddTag(tag.Key, tag.Value);
+                    }
+                }
+                if (links != null)
+                {
+                    foreach (var link in links)
+                    {
+                        activity.AddLink(link);
+                    }
+                }
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        // The trace id was successfully extracted, so we can set the trace state
+        // https://www.w3.org/TR/trace-context/#tracestate-header
+        if (!string.IsNullOrEmpty(requestId))
+        {
+            if (!string.IsNullOrEmpty(traceState))
+            {
+                activity.TraceStateString = traceState;
+            }
+        }
+
+        // Baggage can be used regardless of whether a distributed trace id was present on the inbound request.
+        // https://www.w3.org/TR/baggage/#abstract
+        var baggage = propagator.ExtractBaggage(distributedContextCarrier, propagatorGetter);
+
+        // AddBaggage adds items at the beginning  of the list, so we need to add them in reverse to keep the same order as the client
+        // By contract, the propagator has already reversed the order of items so we need not reverse it again
+        // Order could be important if baggage has two items with the same key (that is allowed by the contract)
+        if (baggage is not null)
+        {
+            foreach (var baggageItem in baggage)
+            {
+                activity.AddBaggage(baggageItem.Key, baggageItem.Value);
+            }
+        }
+
+        return activity;
+    }
+}

--- a/src/Shared/Diagnostics/ActivityCreator.cs
+++ b/src/Shared/Diagnostics/ActivityCreator.cs
@@ -16,6 +16,7 @@ internal static class ActivityCreator
         object distributedContextCarrier,
         DistributedContextPropagator.PropagatorGetterCallback propagatorGetter,
         string activityName,
+        ActivityKind kind,
         IEnumerable<KeyValuePair<string, object?>>? tags,
         IEnumerable<ActivityLink>? links,
         bool diagnosticsOrLoggingEnabled)
@@ -38,12 +39,12 @@ internal static class ActivityCreator
                 // takes a string parentId never sets HasRemoteParent to true. We work around that by calling the
                 // ActivityContext overload instead which sets HasRemoteParent to parentContext.IsRemote.
                 // https://github.com/dotnet/aspnetcore/pull/41568#discussion_r868733305
-                activity = activitySource.CreateActivity(activityName, ActivityKind.Server, context, tags: tags, links: links);
+                activity = activitySource.CreateActivity(activityName, kind, context, tags: tags, links: links);
             }
             else
             {
                 // Pass in the ID we got from the headers if there was one.
-                activity = activitySource.CreateActivity(activityName, ActivityKind.Server, string.IsNullOrEmpty(requestId) ? null : requestId, tags: tags, links: links);
+                activity = activitySource.CreateActivity(activityName, kind, string.IsNullOrEmpty(requestId) ? null : requestId, tags: tags, links: links);
             }
         }
 

--- a/src/Shared/SignalR/InProcessTestServer.cs
+++ b/src/Shared/SignalR/InProcessTestServer.cs
@@ -27,6 +27,8 @@ public abstract class InProcessTestServer : IAsyncDisposable
 
     public abstract string Url { get; }
 
+    public abstract IServiceProvider Services { get; }
+
     public abstract ValueTask DisposeAsync();
 }
 
@@ -53,6 +55,8 @@ public class InProcessTestServer<TStartup> : InProcessTestServer
     public override string WebSocketsUrl => Url.Replace("http", "ws");
 
     public override string Url => _url;
+
+    public override IServiceProvider Services => _host.Services;
 
     public static async Task<InProcessTestServer<TStartup>> StartServer(ILoggerFactory loggerFactory, Action<KestrelServerOptions> configureKestrelServerOptions = null, IDisposable disposable = null)
     {

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
 using System.Net.WebSockets;
@@ -10,10 +11,11 @@ using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.Http.Connections.Client;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.AspNetCore.SignalR.Internal;
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.AspNetCore.SignalR.Test.Internal;
 using Microsoft.AspNetCore.SignalR.Tests;
-using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
@@ -110,6 +112,131 @@ public class HubConnectionTests : FunctionalTestBase
             {
                 await connection.DisposeAsync().DefaultTimeout();
             }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
+    public async Task InvokeAsync_SendTraceHeader(string protocolName, HttpTransportType transportType, string path)
+    {
+        var protocol = HubProtocols[protocolName];
+        await using (var server = await StartServer<Startup>())
+        {
+            var channel = Channel.CreateUnbounded<Activity>();
+            var serverSource = server.Services.GetRequiredService<SignalRActivitySource>().ActivitySource;
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = activitySource => ReferenceEquals(activitySource, serverSource),
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+                ActivityStarted = activity => channel.Writer.TryWrite(activity)
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var connectionBuilder = new HubConnectionBuilder()
+                .WithLoggerFactory(LoggerFactory)
+                .WithUrl(server.Url + path, transportType);
+            connectionBuilder.Services.AddSingleton(protocol);
+
+            var connection = connectionBuilder.Build();
+
+            Activity clientActivity1 = null;
+            Activity clientActivity2 = null;
+            try
+            {
+                await connection.StartAsync().DefaultTimeout();
+
+                // Invocation 1
+                try
+                {
+                    clientActivity1 = new Activity("ClientActivity1");
+                    clientActivity1.AddBaggage("baggage-1", "value-1");
+                    clientActivity1.Start();
+
+                    var result = await connection.InvokeAsync<string>(nameof(TestHub.HelloWorld)).DefaultTimeout();
+
+                    Assert.Equal("Hello World!", result);
+                }
+                finally
+                {
+                    clientActivity1?.Stop();
+                }
+
+                // Invocation 2
+                try
+                {
+                    clientActivity2 = new Activity("ClientActivity2");
+                    clientActivity2.AddBaggage("baggage-2", "value-2");
+                    clientActivity2.Start();
+
+                    var result = await connection.InvokeAsync<string>(nameof(TestHub.HelloWorld)).DefaultTimeout();
+
+                    Assert.Equal("Hello World!", result);
+                }
+                finally
+                {
+                    clientActivity2?.Stop();
+                }
+            }
+            catch (Exception ex)
+            {
+                LoggerFactory.CreateLogger<HubConnectionTests>().LogError(ex, "{ExceptionType} from test", ex.GetType().FullName);
+                throw;
+            }
+            finally
+            {
+                await connection.DisposeAsync().DefaultTimeout();
+            }
+
+            var activities = await channel.Reader.ReadAtLeastAsync(minimumCount: 4).DefaultTimeout();
+
+            var hubName = path switch
+            {
+                "/default" => typeof(TestHub).FullName,
+                "/hubT" => typeof(TestHubT).FullName,
+                "/dynamic" => typeof(DynamicTestHub).FullName,
+                _ => throw new InvalidOperationException("Unexpected path: " + path)
+            };
+
+            Assert.Collection(activities,
+                a =>
+                {
+                    Assert.Equal($"{hubName}/OnConnectedAsync", a.OperationName);
+                    Assert.Equal("Microsoft.AspNetCore.Hosting.HttpRequestIn", a.Parent.OperationName);
+                    Assert.False(a.HasRemoteParent);
+                    Assert.Empty(a.Baggage);
+                },
+                a =>
+                {
+                    Assert.Equal($"{hubName}/HelloWorld", a.OperationName);
+                    Assert.Equal(clientActivity1.Id, a.ParentId);
+                    Assert.True(a.HasRemoteParent);
+                    Assert.Collection(a.Baggage,
+                        b =>
+                        {
+                            Assert.Equal("baggage-1", b.Key);
+                            Assert.Equal("value-1", b.Value);
+                        });
+                },
+                a =>
+                {
+                    Assert.Equal($"{hubName}/HelloWorld", a.OperationName);
+                    Assert.Equal(clientActivity2.Id, a.ParentId);
+                    Assert.True(a.HasRemoteParent);
+                    Assert.Collection(a.Baggage,
+                        b =>
+                        {
+                            Assert.Equal("baggage-2", b.Key);
+                            Assert.Equal("value-2", b.Value);
+                        });
+                },
+                a =>
+                {
+                    Assert.Equal($"{hubName}/OnDisconnectedAsync", a.OperationName);
+                    Assert.Equal("Microsoft.AspNetCore.Hosting.HttpRequestIn", a.Parent.OperationName);
+                    Assert.False(a.HasRemoteParent);
+                    Assert.Empty(a.Baggage);
+                });
         }
     }
 
@@ -466,6 +593,97 @@ public class HubConnectionTests : FunctionalTestBase
             {
                 await connection.DisposeAsync().DefaultTimeout();
             }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
+    public async Task StreamAsyncCore_SendTraceHeader(string protocolName, HttpTransportType transportType, string path)
+    {
+        var protocol = HubProtocols[protocolName];
+        await using (var server = await StartServer<Startup>())
+        {
+            var channel = Channel.CreateUnbounded<Activity>();
+            var serverSource = server.Services.GetRequiredService<SignalRActivitySource>().ActivitySource;
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = activitySource => ReferenceEquals(activitySource, serverSource),
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+                ActivityStarted = activity => channel.Writer.TryWrite(activity)
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var connection = CreateHubConnection(server.Url, path, transportType, protocol, LoggerFactory);
+
+            Activity clientActivity = null;
+            try
+            {
+                await connection.StartAsync().DefaultTimeout();
+
+                clientActivity = new Activity("ClientActivity");
+                clientActivity.AddBaggage("baggage-1", "value-1");
+                clientActivity.Start();
+
+                var expectedValue = 0;
+                var streamTo = 5;
+                var asyncEnumerable = connection.StreamAsyncCore<int>("Stream", new object[] { streamTo });
+                await foreach (var streamValue in asyncEnumerable)
+                {
+                    Assert.Equal(expectedValue, streamValue);
+                    expectedValue++;
+                }
+
+                Assert.Equal(streamTo, expectedValue);
+            }
+            catch (Exception ex)
+            {
+                LoggerFactory.CreateLogger<HubConnectionTests>().LogError(ex, "{ExceptionType} from test", ex.GetType().FullName);
+                throw;
+            }
+            finally
+            {
+                clientActivity?.Stop();
+                await connection.DisposeAsync().DefaultTimeout();
+            }
+
+            var activities = await channel.Reader.ReadAtLeastAsync(minimumCount: 3).DefaultTimeout();
+
+            var hubName = path switch
+            {
+                "/default" => typeof(TestHub).FullName,
+                "/hubT" => typeof(TestHubT).FullName,
+                "/dynamic" => typeof(DynamicTestHub).FullName,
+                _ => throw new InvalidOperationException("Unexpected path: " + path)
+            };
+
+            Assert.Collection(activities,
+                a =>
+                {
+                    Assert.Equal($"{hubName}/OnConnectedAsync", a.OperationName);
+                    Assert.Equal("Microsoft.AspNetCore.Hosting.HttpRequestIn", a.Parent.OperationName);
+                    Assert.False(a.HasRemoteParent);
+                    Assert.Empty(a.Baggage);
+                },
+                a =>
+                {
+                    Assert.Equal($"{hubName}/Stream", a.OperationName);
+                    Assert.Equal(clientActivity.Id, a.ParentId);
+                    Assert.True(a.HasRemoteParent);
+                    Assert.Collection(a.Baggage,
+                        b =>
+                        {
+                            Assert.Equal("baggage-1", b.Key);
+                            Assert.Equal("value-1", b.Value);
+                        });
+                },
+                a =>
+                {
+                    Assert.Equal($"{hubName}/OnDisconnectedAsync", a.OperationName);
+                    Assert.Equal("Microsoft.AspNetCore.Hosting.HttpRequestIn", a.Parent.OperationName);
+                    Assert.False(a.HasRemoteParent);
+                    Assert.Empty(a.Baggage);
+                });
         }
     }
 

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -123,7 +123,7 @@ public class HubConnectionTests : FunctionalTestBase
         await using (var server = await StartServer<Startup>())
         {
             var channel = Channel.CreateUnbounded<Activity>();
-            var serverSource = server.Services.GetRequiredService<SignalRActivitySource>().ActivitySource;
+            var serverSource = server.Services.GetRequiredService<SignalRServerActivitySource>().ActivitySource;
 
             using var listener = new ActivityListener
             {
@@ -201,14 +201,14 @@ public class HubConnectionTests : FunctionalTestBase
             Assert.Collection(activities,
                 a =>
                 {
-                    Assert.Equal($"{hubName}/OnConnectedAsync", a.OperationName);
+                    Assert.Equal(SignalRServerActivitySource.OnConnected, a.OperationName);
                     Assert.Equal("Microsoft.AspNetCore.Hosting.HttpRequestIn", a.Parent.OperationName);
                     Assert.False(a.HasRemoteParent);
                     Assert.Empty(a.Baggage);
                 },
                 a =>
                 {
-                    Assert.Equal($"{hubName}/HelloWorld", a.OperationName);
+                    Assert.Equal(SignalRServerActivitySource.InvocationIn, a.OperationName);
                     Assert.Equal(clientActivity1.Id, a.ParentId);
                     Assert.True(a.HasRemoteParent);
                     Assert.Collection(a.Baggage,
@@ -220,7 +220,7 @@ public class HubConnectionTests : FunctionalTestBase
                 },
                 a =>
                 {
-                    Assert.Equal($"{hubName}/HelloWorld", a.OperationName);
+                    Assert.Equal(SignalRServerActivitySource.InvocationIn, a.OperationName);
                     Assert.Equal(clientActivity2.Id, a.ParentId);
                     Assert.True(a.HasRemoteParent);
                     Assert.Collection(a.Baggage,
@@ -232,7 +232,7 @@ public class HubConnectionTests : FunctionalTestBase
                 },
                 a =>
                 {
-                    Assert.Equal($"{hubName}/OnDisconnectedAsync", a.OperationName);
+                    Assert.Equal(SignalRServerActivitySource.OnDisconnected, a.OperationName);
                     Assert.Equal("Microsoft.AspNetCore.Hosting.HttpRequestIn", a.Parent.OperationName);
                     Assert.False(a.HasRemoteParent);
                     Assert.Empty(a.Baggage);
@@ -604,7 +604,7 @@ public class HubConnectionTests : FunctionalTestBase
         await using (var server = await StartServer<Startup>())
         {
             var channel = Channel.CreateUnbounded<Activity>();
-            var serverSource = server.Services.GetRequiredService<SignalRActivitySource>().ActivitySource;
+            var serverSource = server.Services.GetRequiredService<SignalRServerActivitySource>().ActivitySource;
 
             using var listener = new ActivityListener
             {
@@ -660,14 +660,14 @@ public class HubConnectionTests : FunctionalTestBase
             Assert.Collection(activities,
                 a =>
                 {
-                    Assert.Equal($"{hubName}/OnConnectedAsync", a.OperationName);
+                    Assert.Equal(SignalRServerActivitySource.OnConnected, a.OperationName);
                     Assert.Equal("Microsoft.AspNetCore.Hosting.HttpRequestIn", a.Parent.OperationName);
                     Assert.False(a.HasRemoteParent);
                     Assert.Empty(a.Baggage);
                 },
                 a =>
                 {
-                    Assert.Equal($"{hubName}/Stream", a.OperationName);
+                    Assert.Equal(SignalRServerActivitySource.InvocationIn, a.OperationName);
                     Assert.Equal(clientActivity.Id, a.ParentId);
                     Assert.True(a.HasRemoteParent);
                     Assert.Collection(a.Baggage,
@@ -679,7 +679,7 @@ public class HubConnectionTests : FunctionalTestBase
                 },
                 a =>
                 {
-                    Assert.Equal($"{hubName}/OnDisconnectedAsync", a.OperationName);
+                    Assert.Equal(SignalRServerActivitySource.OnDisconnected, a.OperationName);
                     Assert.Equal("Microsoft.AspNetCore.Hosting.HttpRequestIn", a.Parent.OperationName);
                     Assert.False(a.HasRemoteParent);
                     Assert.Empty(a.Baggage);

--- a/src/SignalR/common/testassets/Tests.Utils/ChannelExtensions.cs
+++ b/src/SignalR/common/testassets/Tests.Utils/ChannelExtensions.cs
@@ -31,4 +31,34 @@ public static class ChannelExtensions
 
         return list;
     }
+
+    public static async Task<List<T>> ReadAtLeastAsync<T>(this ChannelReader<T> reader, int minimumCount, CancellationToken cancellationToken = default)
+    {
+        if (minimumCount <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(minimumCount), "minimumCount must be greater than zero.");
+        }
+
+        var items = new List<T>();
+
+        while (items.Count < minimumCount && !cancellationToken.IsCancellationRequested)
+        {
+            while (reader.TryRead(out var item))
+            {
+                items.Add(item);
+                if (items.Count >= minimumCount)
+                {
+                    return items;
+                }
+            }
+
+            var readTask = reader.WaitToReadAsync(cancellationToken).AsTask();
+            if (!await readTask.ConfigureAwait(false))
+            {
+                throw new InvalidOperationException($"Channel ended after writing {items.Count} items.");
+            }
+        }
+
+        return items;
+    }
 }

--- a/src/SignalR/common/testassets/Tests.Utils/TestClient.cs
+++ b/src/SignalR/common/testassets/Tests.Utils/TestClient.cs
@@ -99,6 +99,12 @@ internal
         return await ListenAllAsync(invocationId);
     }
 
+    public async Task<IList<HubMessage>> StreamAsync(string methodName, string[] streamIds, IDictionary<string, string> headers, params object[] args)
+    {
+        var invocationId = await SendStreamInvocationAsync(methodName, streamIds, headers, args);
+        return await ListenAllAsync(invocationId);
+    }
+
     public async Task<IList<HubMessage>> ListenAllAsync(string invocationId)
     {
         var result = new List<HubMessage>();
@@ -185,10 +191,20 @@ internal
         return SendInvocationAsync(methodName, nonBlocking: false, args: args);
     }
 
+    public Task<string> SendInvocationAsync(string methodName, IDictionary<string, string> headers, params object[] args)
+    {
+        return SendInvocationAsync(methodName, nonBlocking: false, headers: headers, args: args);
+    }
+
     public Task<string> SendInvocationAsync(string methodName, bool nonBlocking, params object[] args)
     {
+        return SendInvocationAsync(methodName, nonBlocking: nonBlocking, headers: null, args: args);
+    }
+
+    public Task<string> SendInvocationAsync(string methodName, bool nonBlocking, IDictionary<string, string> headers, params object[] args)
+    {
         var invocationId = nonBlocking ? null : GetInvocationId();
-        return SendHubMessageAsync(new InvocationMessage(invocationId, methodName, args));
+        return SendHubMessageAsync(new InvocationMessage(invocationId, methodName, args) { Headers = headers });
     }
 
     public Task<string> SendStreamInvocationAsync(string methodName, params object[] args)
@@ -198,8 +214,13 @@ internal
 
     public Task<string> SendStreamInvocationAsync(string methodName, string[] streamIds, params object[] args)
     {
+        return SendStreamInvocationAsync(methodName, streamIds: streamIds, headers: null, args);
+    }
+
+    public Task<string> SendStreamInvocationAsync(string methodName, string[] streamIds, IDictionary<string, string> headers, params object[] args)
+    {
         var invocationId = GetInvocationId();
-        return SendHubMessageAsync(new StreamInvocationMessage(invocationId, methodName, args, streamIds));
+        return SendHubMessageAsync(new StreamInvocationMessage(invocationId, methodName, args, streamIds) { Headers = headers });
     }
 
     public Task<string> BeginUploadStreamAsync(string invocationId, string methodName, string[] streamIds, params object[] args)

--- a/src/SignalR/server/Core/src/HubConnectionHandler.cs
+++ b/src/SignalR/server/Core/src/HubConnectionHandler.cs
@@ -136,10 +136,6 @@ public class HubConnectionHandler<[DynamicallyAccessedMembers(Hub.DynamicallyAcc
             OriginalActivity = Activity.Current,
         };
 
-        // Get off the parent span.
-        // This is likely the Http Request span and we want Hub method invocations to not be collected under a long running span.
-        Activity.Current = null;
-
         var resolvedSupportedProtocols = (supportedProtocols as IReadOnlyList<string>) ?? supportedProtocols.ToList();
         if (!await connectionContext.HandshakeAsync(handshakeTimeout, resolvedSupportedProtocols, _protocolResolver, _userIdProvider, _enableDetailedErrors))
         {

--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -9,6 +9,7 @@ using System.Security.Claims;
 using System.Threading.Channels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Internal;
+using Microsoft.AspNetCore.Shared;
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Internal;
@@ -91,7 +92,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
             // OnConnectedAsync won't work with client results (ISingleClientProxy.InvokeAsync)
             InitializeHub(hub, connection, invokeAllowed: false);
 
-            activity = StartActivity(connection, scope.ServiceProvider, nameof(hub.OnConnectedAsync));
+            activity = StartActivity(connection.OriginalActivity, scope.ServiceProvider, nameof(hub.OnConnectedAsync), headers: null, _logger);
 
             if (_onConnectedMiddleware != null)
             {
@@ -126,7 +127,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
         {
             InitializeHub(hub, connection);
 
-            activity = StartActivity(connection, scope.ServiceProvider, nameof(hub.OnDisconnectedAsync));
+            activity = StartActivity(connection.OriginalActivity, scope.ServiceProvider, nameof(hub.OnDisconnectedAsync), headers: null, _logger);
 
             if (_onDisconnectedMiddleware != null)
             {
@@ -394,9 +395,16 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
                         var logger = dispatcher._logger;
                         var enableDetailedErrors = dispatcher._enableDetailedErrors;
 
+                        // Hub invocation gets its parent from a remote source. Clear any current activity and restore it later.
+                        var previousActivity = Activity.Current;
+                        if (previousActivity != null)
+                        {
+                            Activity.Current = null;
+                        }
+
                         // Use hubMethodInvocationMessage.Target instead of methodExecutor.MethodInfo.Name
                         // We want to take HubMethodNameAttribute into account which will be the same as what the invocation target is
-                        var activity = StartActivity(connection, scope.ServiceProvider, hubMethodInvocationMessage.Target);
+                        var activity = StartActivity(connection.OriginalActivity, scope.ServiceProvider, hubMethodInvocationMessage.Target, hubMethodInvocationMessage.Headers, logger);
 
                         object? result;
                         try
@@ -416,6 +424,11 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
                         finally
                         {
                             activity?.Stop();
+
+                            if (Activity.Current != previousActivity)
+                            {
+                                Activity.Current = previousActivity;
+                            }
 
                             // Stream response handles cleanup in StreamResultsAsync
                             // And normal invocations handle cleanup below in the finally
@@ -502,7 +515,14 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
 
         streamCts ??= CancellationTokenSource.CreateLinkedTokenSource(connection.ConnectionAborted);
 
-        var activity = StartActivity(connection, scope.ServiceProvider, hubMethodInvocationMessage.Target);
+        // Hub invocation gets its parent from a remote source. Clear any current activity and restore it later.
+        var previousActivity = Activity.Current;
+        if (previousActivity != null)
+        {
+            Activity.Current = null;
+        }
+
+        var activity = StartActivity(connection.OriginalActivity, scope.ServiceProvider, hubMethodInvocationMessage.Target, hubMethodInvocationMessage.Headers, _logger);
 
         try
         {
@@ -568,6 +588,11 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
         finally
         {
             activity?.Stop();
+
+            if (Activity.Current != previousActivity)
+            {
+                Activity.Current = previousActivity;
+            }
 
             await CleanupInvocation(connection, hubMethodInvocationMessage, hubActivator, hub, scope);
 
@@ -806,34 +831,63 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
 
     // Starts an Activity for a Hub method invocation and sets up all the tags and other state.
     // Make sure to call Activity.Stop() once the Hub method completes, and consider calling SetActivityError on exception.
-    private static Activity? StartActivity(HubConnectionContext connectionContext, IServiceProvider serviceProvider, string methodName)
+    private static Activity? StartActivity(Activity? linkedActivity, IServiceProvider serviceProvider, string methodName, IDictionary<string, string>? headers, ILogger logger)
     {
-        if (serviceProvider.GetService<SignalRServerActivitySource>() is SignalRServerActivitySource signalRActivitySource
-            && signalRActivitySource.ActivitySource.HasListeners())
+        var activitySource = serviceProvider.GetService<SignalRActivitySource>()?.ActivitySource;
+        if (activitySource is null)
         {
-            var requestContext = connectionContext.OriginalActivity?.Context;
-
-            var activity = signalRActivitySource.ActivitySource.CreateActivity(SignalRServerActivitySource.InvocationIn, ActivityKind.Server, parentId: null,
-                // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/rpc/rpc-spans.md#server-attributes
-                tags: [
-                    new("rpc.method", methodName),
-                    new("rpc.system", "signalr"),
-                    new("rpc.service", _fullHubName),
-                    // See https://github.com/dotnet/aspnetcore/blob/027c60168383421750f01e427e4f749d0684bc02/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelMetrics.cs#L308
-                    // And https://github.com/dotnet/aspnetcore/issues/43786
-                    //new("server.address", ...),
-                    ],
-                links: requestContext.HasValue ? [new ActivityLink(requestContext.Value)] : null);
-            if (activity != null)
-            {
-                activity.DisplayName = $"{_fullHubName}/{methodName}";
-                activity.Start();
-            }
-
-            return activity;
+            return null;
         }
 
-        return null;
+        var loggingEnabled = logger.IsEnabled(LogLevel.Critical);
+        if (!activitySource.HasListeners() && !loggingEnabled)
+        {
+            return null;
+        }
+
+        IEnumerable<KeyValuePair<string, object?>> tags =
+        [
+            new("rpc.method", methodName),
+            new("rpc.system", "signalr"),
+            new("rpc.service", _fullHubName),
+            // See https://github.com/dotnet/aspnetcore/blob/027c60168383421750f01e427e4f749d0684bc02/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelMetrics.cs#L308
+            // And https://github.com/dotnet/aspnetcore/issues/43786
+            //new("server.address", ...),
+        ];
+        IEnumerable<ActivityLink>? links = (linkedActivity is not null) ? [new ActivityLink(linkedActivity.Context)] : null;
+
+        Activity? activity;
+        if (headers != null)
+        {
+            var propagator = serviceProvider.GetService<DistributedContextPropagator>() ?? DistributedContextPropagator.Current;
+
+            activity = ActivityCreator.CreateFromRemote(
+                activitySource,
+                propagator,
+                headers,
+                static (object? carrier, string fieldName, out string? fieldValue, out IEnumerable<string>? fieldValues) =>
+                {
+                    fieldValues = default;
+                    var headers = (IDictionary<string, string>)carrier!;
+                    headers.TryGetValue(fieldName, out fieldValue);
+                },
+                SignalRServerActivitySource.InvocationIn,
+                tags,
+                links,
+                loggingEnabled);
+        }
+        else
+        {
+            activity = activitySource.CreateActivity(SignalRServerActivitySource.InvocationIn, ActivityKind.Server, parentId: null, tags: tags, links: links);
+        }
+
+        if (activity is not null)
+        {
+            activity.DisplayName = $"{_fullHubName}/{methodName}";
+            activity.Start();
+        }
+
+        return activity;
     }
 
     private static void SetActivityError(Activity? activity, Exception ex)

--- a/src/SignalR/server/Core/src/Internal/SignalRServerActivitySource.cs
+++ b/src/SignalR/server/Core/src/Internal/SignalRServerActivitySource.cs
@@ -12,6 +12,8 @@ internal sealed class SignalRServerActivitySource
 {
     internal const string Name = "Microsoft.AspNetCore.SignalR.Server";
     internal const string InvocationIn = $"{Name}.InvocationIn";
+    internal const string OnConnected = $"{Name}.OnConnected";
+    internal const string OnDisconnected = $"{Name}.OnDisconnected";
 
     public ActivitySource ActivitySource { get; } = new ActivitySource(Name);
 }

--- a/src/SignalR/server/Core/src/Microsoft.AspNetCore.SignalR.Core.csproj
+++ b/src/SignalR/server/Core/src/Microsoft.AspNetCore.SignalR.Core.csproj
@@ -21,6 +21,7 @@
     <Compile Include="$(SignalRSharedSourceRoot)MessageBuffer.cs" Link="MessageBuffer.cs" />
     <Compile Include="$(SharedSourceRoot)ThrowHelpers\ArgumentNullThrowHelper.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)CallerArgument\CallerArgumentExpressionAttribute.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Diagnostics\ActivityCreator.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -36,6 +37,7 @@
     <InternalsVisibleTo Include="Microsoft.AspNetCore.SignalR.Microbenchmarks" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.SignalR.Tests" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis.Tests" />
+    <InternalsVisibleTo Include="Microsoft.AspNetCore.SignalR.Client.FunctionalTests" />    
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/51557. Specifically, the [Distributed tracing (trace ids sent between client and server)](https://github.com/dotnet/aspnetcore/issues/51557#issuecomment-2136051137) item.

Follow up to https://github.com/dotnet/aspnetcore/pull/55439. The previous PR added activities for signalr server invocations. However, the server hub invocation activity never has a parent, so the activity always starts a new trace. This PR updates signalr to get trace information from the hub invocation message headers, which are set by the client, when it creates the activity.

The benefit of this change is you can now see the context of the hub invocation. For example, if web api sends a hub invocation to SignalR, the hub invocation span is nested beneath the web api span.

Changes:

* SignalR server changed to **not** clear the request activity when a connection starts. I believe this is an improvement because we want most telemetry on the connection (e.g. logging and OnConnected and OnDisconnected activities) to be correlated to the request activity.
* SignalR server changed to clear and restore the request activity when invocations are run. These are the pieces of telemetry we don't want to be a child of the request activity.
* .NET SignalR client sets tracing headers on hub invocation request if there is an activity. Headers are sent with the invocation to the server.
* SignalR server reads trace headers and creates an activity from the remote parent. Shares logic with ASP.NET Core for creating activity from remote.

Not planned in this PR:

* Creating an activity for sending the invocation in .NET client.
* Sending tracing headers from other clients.

Nothing is blocking these from being added in the future.

~TODO: Write tests for client. Write integration test for client to server.~