### PR TITLE
Add comment to OpenApiDocumentProvider

### DIFF
--- a/src/OpenApi/src/Services/OpenApiDocumentProvider.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentProvider.cs
@@ -10,6 +10,10 @@ using System.Linq;
 
 namespace Microsoft.Extensions.ApiDescriptions;
 
+/// <summary>
+/// Provides an implementation of <see cref="IDocumentProvider"/> to use for build-time generation of OpenAPI documents.
+/// </summary>
+/// <param name="serviceProvider">The <see cref="IServiceProvider"/> to use.</param>
 internal sealed class OpenApiDocumentProvider(IServiceProvider serviceProvider) : IDocumentProvider
 {
     /// <summary>


### PR DESCRIPTION
# Add comment to OpenApiDocumentProvider

Add a comment explaining what the `OpenApiDocumentProvider` class is for.

## Description

I was looking through the code to see if it was possible for the new OpenAPI library to output YAML instead of JSON yet (context: https://github.com/dotnet/aspnetcore/issues/54598#issuecomment-2004775500), and at first I thought `OpenApiDocumentProvider` was only used by tests, so it seemed redundant.

Then I found this comment:

https://github.com/dotnet/aspnetcore/blob/06155c05af89c957de20d2c53cee0e37171b9a09/src/OpenApi/src/Extensions/OpenApiServiceCollectionExtensions.cs#L70-L71

This PR adds a class-level summary explaining what the purpose of the internal class is, as otherwise it seems unused (it's accessed through reflection here):

https://github.com/dotnet/aspnetcore/blob/06155c05af89c957de20d2c53cee0e37171b9a09/src/Tools/GetDocumentInsider/src/Commands/GetDocumentCommandWorker.cs#L27

https://github.com/dotnet/aspnetcore/blob/06155c05af89c957de20d2c53cee0e37171b9a09/src/Tools/GetDocumentInsider/src/Commands/GetDocumentCommandWorker.cs#L193-L207
