### PR TITLE
Map all true schemas to empty object schemas in OpenAPI

### DIFF
--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -82,9 +82,9 @@ internal sealed class OpenApiSchemaService(
                 };
             }
             // STJ uses `true` in place of an empty object to represent a schema that matches
-            // anything. We override this default behavior here to match the style traditionally
-            // expected in OpenAPI documents.
-            if (type == typeof(object))
+            // anything (like the `object` type) or types with user-defined converters. We override
+            // this default behavior here to match the style traditionally expected in OpenAPI documents.
+            if (schema.GetValueKind() == JsonValueKind.True)
             {
                 schema = new JsonObject();
             }

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -83,7 +83,7 @@ internal sealed class OpenApiSchemaService(
             }
             // STJ uses `true` in place of an empty object to represent a schema that matches
             // anything (like the `object` type) or types with user-defined converters. We override
-            // this default behavior here to match the style traditionally expected in OpenAPI documents.
+            // this default behavior here to match the format expected in OpenAPI v3.
             if (schema.GetValueKind() == JsonValueKind.True)
             {
                 schema = new JsonObject();

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.ParameterSchemas.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.ParameterSchemas.cs
@@ -509,4 +509,27 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             throw new NotImplementedException();
         }
     }
+
+    [Fact]
+    public async Task SupportsParameterWithDynamicType()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPost("/api", (dynamic id) => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths["/api"].Operations[OperationType.Post];
+            Assert.NotNull(operation.RequestBody);
+            Assert.NotNull(operation.RequestBody.Content);
+            Assert.NotNull(operation.RequestBody.Content["application/json"]);
+            Assert.NotNull(operation.RequestBody.Content["application/json"].Schema);
+            // Type is null, it's up to the user to configure this via a custom schema
+            // transformer for types with a converter.
+            Assert.Null(operation.RequestBody.Content["application/json"].Schema.Type);
+        });
+    }
 }


### PR DESCRIPTION
Closes #57041.

This PR is an extension of the changes that was introduced in https://github.com/dotnet/aspnetcore/commit/4c8b5fefd708130453d4ac029dc78e87d6fb63b7 to replace the use of `true` schemas with empty object schemas in the OpenAPI implementation.

`JsonSchemaExporter` uses the `true` schemas as catch-all schema for types. OpenAPI schema diverges from JSON schema and expects that empty schemas `{ }` be used to represent catch-all values. The previous logic special cased fixing up these mappings for `object` types. This PR updates the implementation to do the mapping if the underlying schema is a `true` schema, regardless of the type. This makes the implementation resilient to other cases where a `true` schema is returned by STJ, like [when a user defined converter is associated with a type](https://github.com/dotnet/runtime/blob/3471de7ffda7105f395a25a57094097a7cc0dc88/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchemaExporter.cs#L345-L347).

With these changes, we'd expect the following diff in the generated schema.

```csharp
public class ContainerType
{
	public string Name { get; }
	public TypeWithUserDefinedConverter ChildType { get; }
}
```

```diff
{
	"type": "object",
	"properties": {
		"name": {
			"type": "string"
		},
-		"childType": true,
+		"childType": { },
	}
}
```



