### PR TITLE
Fix up handling for awaitable IResults in ApiExplorer

### DIFF
--- a/src/Mvc/Mvc.ApiExplorer/src/ApiResponseTypeProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/ApiResponseTypeProvider.cs
@@ -228,6 +228,13 @@ internal sealed class ApiResponseTypeProvider
 
         foreach (var metadata in responseMetadata)
         {
+            // `IResult` metadata inserted for awaitable types should
+            // not be considered for response metadata.
+            if (typeof(IResult).IsAssignableFrom(metadata.Type))
+            {
+                continue;
+            }
+
             var statusCode = metadata.StatusCode;
 
             var apiResponseType = new ApiResponseType


### PR DESCRIPTION
Closes https://github.com/dotnet/aspnetcore/issues/56975.

I introduced in a regression in https://github.com/dotnet/aspnetcore/commit/8da6daa1cd377f58b332d8402484e1e727e7d9cc that meant that `IResult` types (which don't expose any metadata) were erroneously inserted into `ApiResponseTypes`. This regression wasn't caught because the test cases that existed optimized for void-returning awaitables and didn't factor in result types that implemented `IEndpointMetadataProvider`.

To resolve this issue, I've made some changes to treat `IResult`-types directly in the response and those included in metadata as void responses that should not map to `ApiResponseType`s. I also included additional tests for handling of typed results in ApiExplorer. 