### PR TITLE
Make Stream.Flush no-op on read-only streams

### DIFF
--- a/src/Components/Server/src/Circuits/RemoteJSDataStream.cs
+++ b/src/Components/Server/src/Circuits/RemoteJSDataStream.cs
@@ -161,7 +161,9 @@ internal sealed class RemoteJSDataStream : Stream
     }
 
     public override void Flush()
-        => throw new NotSupportedException();
+    {
+        // No-op
+    }
 
     public override int Read(byte[] buffer, int offset, int count)
         => throw new NotSupportedException("Synchronous reads are not supported.");

--- a/src/Components/Server/src/Circuits/RemoteJSDataStream.cs
+++ b/src/Components/Server/src/Circuits/RemoteJSDataStream.cs
@@ -165,6 +165,8 @@ internal sealed class RemoteJSDataStream : Stream
         // No-op
     }
 
+    public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
     public override int Read(byte[] buffer, int offset, int count)
         => throw new NotSupportedException("Synchronous reads are not supported.");
 

--- a/src/Components/Shared/src/PullFromJSDataStream.cs
+++ b/src/Components/Shared/src/PullFromJSDataStream.cs
@@ -55,7 +55,9 @@ internal sealed class PullFromJSDataStream : Stream
     }
 
     public override void Flush()
-        => throw new NotSupportedException();
+    {
+        // No-op
+    }
 
     public override int Read(byte[] buffer, int offset, int count)
         => throw new NotSupportedException("Synchronous reads are not supported.");

--- a/src/Components/Shared/src/PullFromJSDataStream.cs
+++ b/src/Components/Shared/src/PullFromJSDataStream.cs
@@ -59,6 +59,8 @@ internal sealed class PullFromJSDataStream : Stream
         // No-op
     }
 
+    public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
     public override int Read(byte[] buffer, int offset, int count)
         => throw new NotSupportedException("Synchronous reads are not supported.");
 

--- a/src/Hosting/TestHost/src/ResponseBodyReaderStream.cs
+++ b/src/Hosting/TestHost/src/ResponseBodyReaderStream.cs
@@ -53,7 +53,7 @@ internal sealed class ResponseBodyReaderStream : Stream
         // No-op
     }
 
-    public override Task FlushAsync(CancellationToken cancellationToken) => throw new NotSupportedException();
+    public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
     // Write with count 0 will still trigger OnFirstWrite
     public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();

--- a/src/Hosting/TestHost/src/ResponseBodyReaderStream.cs
+++ b/src/Hosting/TestHost/src/ResponseBodyReaderStream.cs
@@ -48,7 +48,10 @@ internal sealed class ResponseBodyReaderStream : Stream
 
     public override void SetLength(long value) => throw new NotSupportedException();
 
-    public override void Flush() => throw new NotSupportedException();
+    public override void Flush()
+    {
+        // No-op
+    }
 
     public override Task FlushAsync(CancellationToken cancellationToken) => throw new NotSupportedException();
 

--- a/src/Mvc/shared/Mvc.Core.TestCommon/NonSeekableReadableStream.cs
+++ b/src/Mvc/shared/Mvc.Core.TestCommon/NonSeekableReadableStream.cs
@@ -41,6 +41,8 @@ public class NonSeekableReadStream : Stream
         // No-op
     }
 
+    public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
     public override long Seek(long offset, SeekOrigin origin)
     {
         throw new NotSupportedException();

--- a/src/Mvc/shared/Mvc.Core.TestCommon/NonSeekableReadableStream.cs
+++ b/src/Mvc/shared/Mvc.Core.TestCommon/NonSeekableReadableStream.cs
@@ -38,7 +38,7 @@ public class NonSeekableReadStream : Stream
 
     public override void Flush()
     {
-        throw new NotImplementedException();
+        // No-op
     }
 
     public override long Seek(long offset, SeekOrigin origin)

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestStream.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestStream.cs
@@ -82,8 +82,7 @@ internal sealed partial class RequestStream : Stream
         // No-op
     }
 
-    public override Task FlushAsync(CancellationToken cancellationToken)
-        => throw new InvalidOperationException(Resources.Exception_ReadOnlyStream);
+    public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
     internal void SwitchToOpaqueMode()
     {

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestStream.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestStream.cs
@@ -77,7 +77,10 @@ internal sealed partial class RequestStream : Stream
 
     public override void SetLength(long value) => throw new NotSupportedException(Resources.Exception_NoSeek);
 
-    public override void Flush() => throw new InvalidOperationException(Resources.Exception_ReadOnlyStream);
+    public override void Flush()
+    {
+        // No-op
+    }
 
     public override Task FlushAsync(CancellationToken cancellationToken)
         => throw new InvalidOperationException(Resources.Exception_ReadOnlyStream);

--- a/src/Shared/SegmentWriteStream.cs
+++ b/src/Shared/SegmentWriteStream.cs
@@ -99,10 +99,7 @@ internal sealed class SegmentWriteStream : Stream
 
     public override void Flush()
     {
-        if (!CanWrite)
-        {
-            throw new ObjectDisposedException(nameof(SegmentWriteStream), "The stream has been closed for writing.");
-        }
+        // No-op
     }
 
     public override int Read(byte[] buffer, int offset, int count)

--- a/src/Shared/SegmentWriteStream.cs
+++ b/src/Shared/SegmentWriteStream.cs
@@ -102,6 +102,8 @@ internal sealed class SegmentWriteStream : Stream
         // No-op
     }
 
+    public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
     public override int Read(byte[] buffer, int offset, int count)
     {
         throw new NotSupportedException("The stream does not support reading.");


### PR DESCRIPTION
# Make Stream.Flush no-op

Make `Stream.Flush{Async}()` implementations a no-op.

## Description

Make implementations of `Stream.Flush{Async}()` a no-op instead of throw an exception.

Resolves #57064.
