### PR TITLE
[Blazor] Add Blazor Web Endpoints to the endpoint data source

### DIFF
--- a/src/Components/Endpoints/src/Builder/OpaqueRedirection.cs
+++ b/src/Components/Endpoints/src/Builder/OpaqueRedirection.cs
@@ -53,7 +53,10 @@ internal partial class OpaqueRedirection
         var routeEndpointBuidler = new RouteEndpointBuilder(
             OpaqueRedirect,
             RoutePatternFactory.Parse($"/{RedirectionEndpointBaseRelativeUrl}"),
-            0);
+            0)
+        {
+            DisplayName = "Blazor Opaque Redirection",
+        };
 
         routeEndpointBuidler.Metadata.Add(new HttpMethodMetadata([HttpMethods.Get]));
 

--- a/src/Components/Endpoints/src/Builder/OpaqueRedirection.cs
+++ b/src/Components/Endpoints/src/Builder/OpaqueRedirection.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -47,37 +48,46 @@ internal partial class OpaqueRedirection
         return $"{RedirectionEndpointBaseRelativeUrl}?url={UrlEncoder.Default.Encode(protectedUrl)}";
     }
 
-    public static void AddBlazorOpaqueRedirectionEndpoint(IEndpointRouteBuilder endpoints)
+    public static EndpointBuilder GetBlazorOpaqueRedirectionEndpoint()
     {
-        endpoints.MapGet($"/{RedirectionEndpointBaseRelativeUrl}", httpContext =>
+        var routeEndpointBuidler = new RouteEndpointBuilder(
+            OpaqueRedirect,
+            RoutePatternFactory.Parse($"/{RedirectionEndpointBaseRelativeUrl}"),
+            0);
+
+        routeEndpointBuidler.Metadata.Add(new HttpMethodMetadata([HttpMethods.Get]));
+
+        return routeEndpointBuidler;
+    }
+
+    private static Task OpaqueRedirect(HttpContext httpContext)
+    {
+        if (!httpContext.Request.Query.TryGetValue("url", out var protectedUrl))
         {
-            if (!httpContext.Request.Query.TryGetValue("url", out var protectedUrl))
-            {
-                httpContext.Response.StatusCode = 400;
-                return Task.CompletedTask;
-            }
-
-            var protector = CreateProtector(httpContext);
-            string url;
-
-            try
-            {
-                url = protector.Unprotect(protectedUrl[0]!);
-            }
-            catch (CryptographicException ex)
-            {
-                if (httpContext.RequestServices.GetService<ILogger<OpaqueRedirection>>() is { } logger)
-                {
-                    Log.OpaqueUrlUnprotectionFailed(logger, ex);
-                }
-
-                httpContext.Response.StatusCode = 400;
-                return Task.CompletedTask;
-            }
-
-            httpContext.Response.Redirect(url);
+            httpContext.Response.StatusCode = 400;
             return Task.CompletedTask;
-        });
+        }
+
+        var protector = CreateProtector(httpContext);
+        string url;
+
+        try
+        {
+            url = protector.Unprotect(protectedUrl[0]!);
+        }
+        catch (CryptographicException ex)
+        {
+            if (httpContext.RequestServices.GetService<ILogger<OpaqueRedirection>>() is { } logger)
+            {
+                Log.OpaqueUrlUnprotectionFailed(logger, ex);
+            }
+
+            httpContext.Response.StatusCode = 400;
+            return Task.CompletedTask;
+        }
+
+        httpContext.Response.Redirect(url);
+        return Task.CompletedTask;
     }
 
     private static ITimeLimitedDataProtector CreateProtector(HttpContext httpContext)

--- a/src/Components/Endpoints/src/Builder/RazorComponentEndpointDataSource.cs
+++ b/src/Components/Endpoints/src/Builder/RazorComponentEndpointDataSource.cs
@@ -10,6 +10,9 @@ using Microsoft.AspNetCore.Components.Discovery;
 using Microsoft.AspNetCore.Components.Endpoints.Infrastructure;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
 using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
@@ -115,6 +118,8 @@ internal class RazorComponentEndpointDataSource<[DynamicallyAccessedMembers(Comp
 
             DefaultBuilder.OnBeforeCreateEndpoints(endpointContext);
 
+            AddBlazorWebEndpoints(endpoints);
+
             foreach (var definition in context.Pages)
             {
                 _factory.AddEndpoints(
@@ -170,6 +175,78 @@ internal class RazorComponentEndpointDataSource<[DynamicallyAccessedMembers(Comp
                 _disposableChangeToken = SetDisposableChangeTokenAction(ChangeToken.OnChange(_hotReloadService.GetChangeToken, UpdateEndpoints));
             }
         }
+    }
+
+    private void AddBlazorWebEndpoints(List<Endpoint> endpoints)
+    {
+        List<EndpointBuilder> blazorWebEndpoints = [
+            ..GetBlazorWebJsEndpoint(_endpointRouteBuilder),
+            OpaqueRedirection.GetBlazorOpaqueRedirectionEndpoint()];
+
+        foreach (var endpoint in blazorWebEndpoints)
+        {
+            foreach (var convention in _conventions)
+            {
+                convention(endpoint);
+            }
+
+            foreach (var convention in _finallyConventions)
+            {
+                convention(endpoint);
+            }
+
+            endpoints.Add(endpoint.Build());
+        }
+    }
+
+    private static IEnumerable<EndpointBuilder> GetBlazorWebJsEndpoint(IEndpointRouteBuilder endpoints)
+    {
+        var app = endpoints.CreateApplicationBuilder();
+
+        var options = new StaticFileOptions
+        {
+            FileProvider = new ManifestEmbeddedFileProvider(typeof(RazorComponentsEndpointRouteBuilderExtensions).Assembly),
+            OnPrepareResponse = CacheHeaderSettings.SetCacheHeaders
+        };
+
+        app.Use(next => context =>
+        {
+            // Set endpoint to null so the static files middleware will handle the request.
+            context.SetEndpoint(null);
+
+            return next(context);
+        });
+
+        app.UseStaticFiles(options);
+
+        var requestDelegate = app.Build();
+
+        var blazorWebJsBuilder = new RouteEndpointBuilder(
+            requestDelegate,
+            RoutePatternFactory.Parse("/_framework/blazor.web.js"),
+            int.MinValue)
+        {
+            DisplayName = "Blazor web static files"
+        };
+
+        var allowedHttpMethods = new HttpMethodMetadata([HttpMethods.Get, HttpMethods.Head]);
+        blazorWebJsBuilder.Metadata.Add(allowedHttpMethods);
+
+#if !DEBUG
+        return [blazorWebJsBuilder];
+#else
+        // We only need to serve the sourcemap when working on the framework, not in the distributed packages
+        var blazorWebJsDebugBuilder = new RouteEndpointBuilder(
+            requestDelegate,
+            RoutePatternFactory.Parse("/_framework/blazor.web.js.map"),
+            int.MinValue)
+        {
+            DisplayName = "Blazor web static files sourcemap"
+        };
+        blazorWebJsDebugBuilder.Metadata.Add(allowedHttpMethods);
+
+        return [blazorWebJsBuilder, blazorWebJsDebugBuilder];
+#endif
     }
 
     public void OnHotReloadClearCache(Type[]? types)

--- a/src/Components/Endpoints/src/Builder/RazorComponentsEndpointRouteBuilderExtensions.cs
+++ b/src/Components/Endpoints/src/Builder/RazorComponentsEndpointRouteBuilderExtensions.cs
@@ -5,11 +5,8 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.AspNetCore.Components.Endpoints;
 using Microsoft.AspNetCore.Components.Infrastructure;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.FileProviders;
 using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
 namespace Microsoft.AspNetCore.Builder;
@@ -30,8 +27,6 @@ public static class RazorComponentsEndpointRouteBuilderExtensions
         ArgumentNullException.ThrowIfNull(endpoints);
 
         EnsureRazorComponentServices(endpoints);
-        AddBlazorWebJsEndpoint(endpoints);
-        OpaqueRedirection.AddBlazorOpaqueRedirectionEndpoint(endpoints);
 
         var result = GetOrCreateDataSource<TRootComponent>(endpoints).DefaultBuilder;
 
@@ -44,46 +39,12 @@ public static class RazorComponentsEndpointRouteBuilderExtensions
         return result;
     }
 
-    private static void AddBlazorWebJsEndpoint(IEndpointRouteBuilder endpoints)
-    {
-        var options = new StaticFileOptions
-        {
-            FileProvider = new ManifestEmbeddedFileProvider(typeof(RazorComponentsEndpointRouteBuilderExtensions).Assembly),
-            OnPrepareResponse = CacheHeaderSettings.SetCacheHeaders
-        };
-
-        var app = endpoints.CreateApplicationBuilder();
-        app.Use(next => context =>
-        {
-            // Set endpoint to null so the static files middleware will handle the request.
-            context.SetEndpoint(null);
-
-            return next(context);
-        });
-        app.UseStaticFiles(options);
-
-        var blazorEndpoint = endpoints.Map("/_framework/blazor.web.js", app.Build())
-            .WithDisplayName("Blazor web static files");
-
-        blazorEndpoint.Add((builder) => ((RouteEndpointBuilder)builder).Order = int.MinValue);
-
-#if DEBUG
-        // We only need to serve the sourcemap when working on the framework, not in the distributed packages
-        endpoints.Map("/_framework/blazor.web.js.map", app.Build())
-            .WithDisplayName("Blazor web static files sourcemap")
-            .Add((builder) => ((RouteEndpointBuilder)builder).Order = int.MinValue);
-#endif
-    }
-
     private static RazorComponentEndpointDataSource<TRootComponent> GetOrCreateDataSource<[DynamicallyAccessedMembers(Component)] TRootComponent>(
         IEndpointRouteBuilder endpoints)
     {
         var dataSource = endpoints.DataSources.OfType<RazorComponentEndpointDataSource<TRootComponent>>().FirstOrDefault();
         if (dataSource == null)
         {
-            // Very likely this needs to become a factory and we might need to have multiple endpoint data
-            // sources, once we figure out the exact scenarios for
-            // https://github.com/dotnet/aspnetcore/issues/46992
             var factory = endpoints.ServiceProvider.GetRequiredService<RazorComponentEndpointDataSourceFactory>();
             dataSource = factory.CreateDataSource<TRootComponent>(endpoints);
             endpoints.DataSources.Add(dataSource);

--- a/src/Components/Endpoints/test/Builder/RazorComponentsEndpointConventionBuilderExtensionsTest.cs
+++ b/src/Components/Endpoints/test/Builder/RazorComponentsEndpointConventionBuilderExtensionsTest.cs
@@ -216,6 +216,31 @@ public class RazorComponentsEndpointConventionBuilderExtensionsTest
         });
     }
 
+    [Fact]
+    public void MapRazorComponents_CanAddConventions_ToBlazorWebEndpoints()
+    {
+        // Arrange
+        var endpointBuilder = new TestEndpointRouteBuilder();
+        // Act
+        var builder = CreateRazorComponentsAppBuilder(endpointBuilder);
+        var obj = new object();
+        builder.Add(e =>
+        {
+            if (e is RouteEndpointBuilder rb)
+            {
+                if (rb.RoutePattern.RawText == "/_framework/blazor.web.js")
+                {
+                    rb.Metadata.Add(obj);
+                }
+            }
+        });
+
+        // Assert
+        var endpoints = endpointBuilder.DataSources.Single().Endpoints;
+        var webJSEndpoint = Assert.Single(endpoints, e => e.Metadata.Contains(obj));
+        Assert.Equal("/_framework/blazor.web.js", ((RouteEndpoint)webJSEndpoint).RoutePattern.RawText);
+    }
+
     private RazorComponentsEndpointConventionBuilder CreateRazorComponentsAppBuilder(IEndpointRouteBuilder endpointBuilder)
     {
         var builder = endpointBuilder.MapRazorComponents<App>();

--- a/src/Components/Endpoints/test/Builder/RazorComponentsEndpointConventionBuilderExtensionsTest.cs
+++ b/src/Components/Endpoints/test/Builder/RazorComponentsEndpointConventionBuilderExtensionsTest.cs
@@ -26,7 +26,7 @@ public class RazorComponentsEndpointConventionBuilderExtensionsTest
         builder.WithStaticAssets();
 
         // Assert
-        Assert.All(endpointBuilder.DataSources.Skip(1).First().Endpoints, e =>
+        Assert.All(endpointBuilder.DataSources.First().Endpoints, e =>
         {
             if (e.Metadata.GetMetadata<ComponentTypeMetadata>() == null)
             {
@@ -50,7 +50,7 @@ public class RazorComponentsEndpointConventionBuilderExtensionsTest
         builder.WithStaticAssets();
 
         // Assert
-        Assert.All(endpointBuilder.DataSources.Skip(2).First().Endpoints, e =>
+        Assert.All(endpointBuilder.DataSources.Skip(1).First().Endpoints, e =>
         {
             var metadata = e.Metadata.GetMetadata<ResourceAssetCollection>();
             Assert.Null(metadata);
@@ -69,7 +69,7 @@ public class RazorComponentsEndpointConventionBuilderExtensionsTest
         builder.WithStaticAssets("TestManifests/Test.staticwebassets.endpoints.json");
 
         // Assert
-        Assert.All(endpointBuilder.DataSources.Skip(2).First().Endpoints, e =>
+        Assert.All(endpointBuilder.DataSources.Skip(1).First().Endpoints, e =>
         {
             var metadata = e.Metadata.GetMetadata<ResourceAssetCollection>();
             Assert.NotNull(metadata);
@@ -90,7 +90,7 @@ public class RazorComponentsEndpointConventionBuilderExtensionsTest
         var builder = CreateRazorComponentsAppBuilder(endpointBuilder);
 
         // Assert
-        Assert.All(endpointBuilder.DataSources.Skip(2).First().Endpoints, e =>
+        Assert.All(endpointBuilder.DataSources.Skip(1).First().Endpoints, e =>
         {
             var metadata = e.Metadata.GetMetadata<ResourceAssetCollection>();
             Assert.NotNull(metadata);
@@ -112,7 +112,7 @@ public class RazorComponentsEndpointConventionBuilderExtensionsTest
         builder.WithStaticAssets();
 
         // Assert
-        Assert.All(endpointBuilder.DataSources.Skip(2).First().Endpoints, e =>
+        Assert.All(endpointBuilder.DataSources.Skip(1).First().Endpoints, e =>
         {
             var metadata = e.Metadata.GetMetadata<ResourceAssetCollection>();
             Assert.NotNull(metadata);
@@ -134,7 +134,7 @@ public class RazorComponentsEndpointConventionBuilderExtensionsTest
         var builder = CreateRazorComponentsAppBuilder(endpointBuilder);
 
         // Assert
-        Assert.All(endpointBuilder.DataSources.Skip(3).First().Endpoints, e =>
+        Assert.All(endpointBuilder.DataSources.Skip(2).First().Endpoints, e =>
         {
             var metadata = e.Metadata.GetMetadata<ResourceAssetCollection>();
             Assert.NotNull(metadata);
@@ -157,7 +157,7 @@ public class RazorComponentsEndpointConventionBuilderExtensionsTest
         builder.WithStaticAssets("TestManifests/Test.staticwebassets.endpoints.json");
 
         // Assert
-        Assert.All(endpointBuilder.DataSources.Skip(3).First().Endpoints, e =>
+        Assert.All(endpointBuilder.DataSources.Skip(2).First().Endpoints, e =>
         {
             var metadata = e.Metadata.GetMetadata<ResourceAssetCollection>();
             Assert.NotNull(metadata);
@@ -183,7 +183,7 @@ public class RazorComponentsEndpointConventionBuilderExtensionsTest
 
         // Assert
         var groupEndpoints = Assert.IsAssignableFrom<IEndpointRouteBuilder>(group).DataSources;
-        Assert.All(groupEndpoints.Skip(2).First().Endpoints, e =>
+        Assert.All(groupEndpoints.Skip(1).First().Endpoints, e =>
         {
             var metadata = e.Metadata.GetMetadata<ResourceAssetCollection>();
             Assert.NotNull(metadata);
@@ -209,7 +209,7 @@ public class RazorComponentsEndpointConventionBuilderExtensionsTest
 
         // Assert
         var groupEndpoints = Assert.IsAssignableFrom<IEndpointRouteBuilder>(group).DataSources;
-        Assert.All(groupEndpoints.Skip(2).First().Endpoints, e =>
+        Assert.All(groupEndpoints.Skip(1).First().Endpoints, e =>
         {
             var metadata = e.Metadata.GetMetadata<ResourceAssetCollection>();
             Assert.Null(metadata);

--- a/src/Components/Endpoints/test/Builder/RazorComponentsEndpointConventionBuilderExtensionsTest.cs
+++ b/src/Components/Endpoints/test/Builder/RazorComponentsEndpointConventionBuilderExtensionsTest.cs
@@ -216,8 +216,10 @@ public class RazorComponentsEndpointConventionBuilderExtensionsTest
         });
     }
 
-    [Fact]
-    public void MapRazorComponents_CanAddConventions_ToBlazorWebEndpoints()
+    [Theory]
+    [InlineData("/_framework/blazor.web.js")]
+    [InlineData("/_framework/opaque-redirect")]
+    public void MapRazorComponents_CanAddConventions_ToBlazorWebEndpoints(string frameworkEndpoint)
     {
         // Arrange
         var endpointBuilder = new TestEndpointRouteBuilder();
@@ -228,7 +230,7 @@ public class RazorComponentsEndpointConventionBuilderExtensionsTest
         {
             if (e is RouteEndpointBuilder rb)
             {
-                if (rb.RoutePattern.RawText == "/_framework/blazor.web.js")
+                if (rb.RoutePattern.RawText == frameworkEndpoint)
                 {
                     rb.Metadata.Add(obj);
                 }
@@ -238,7 +240,7 @@ public class RazorComponentsEndpointConventionBuilderExtensionsTest
         // Assert
         var endpoints = endpointBuilder.DataSources.Single().Endpoints;
         var webJSEndpoint = Assert.Single(endpoints, e => e.Metadata.Contains(obj));
-        Assert.Equal("/_framework/blazor.web.js", ((RouteEndpoint)webJSEndpoint).RoutePattern.RawText);
+        Assert.Equal(frameworkEndpoint, ((RouteEndpoint)webJSEndpoint).RoutePattern.RawText);
     }
 
     private RazorComponentsEndpointConventionBuilder CreateRazorComponentsAppBuilder(IEndpointRouteBuilder endpointBuilder)

--- a/src/Components/Endpoints/test/HotReloadServiceTests.cs
+++ b/src/Components/Endpoints/test/HotReloadServiceTests.cs
@@ -12,6 +12,8 @@ using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.AspNetCore.Components.Endpoints.Infrastructure;
 using Microsoft.AspNetCore.Components.Infrastructure;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.FileProviders;
 
 namespace Microsoft.AspNetCore.Components.Endpoints.Tests;
 
@@ -44,7 +46,9 @@ public class HotReloadServiceTests
         var endpointDataSource = CreateDataSource<App>(builder, services);
 
         // Assert - 1
-        var endpoint = Assert.IsType<RouteEndpoint>(Assert.Single(endpointDataSource.Endpoints));
+        var endpoint = Assert.IsType<RouteEndpoint>(
+            Assert.Single(endpointDataSource.Endpoints, e => e.Metadata.GetMetadata<RootComponentMetadata>() != null));
+
         Assert.Equal("/server", endpoint.RoutePattern.RawText);
 
         // Act - 2
@@ -60,9 +64,10 @@ public class HotReloadServiceTests
         HotReloadService.UpdateApplication(null);
 
         // Assert - 2
-        Assert.Equal(2, endpointDataSource.Endpoints.Count);
+        var pageEndpoints = endpointDataSource.Endpoints.Where(e => e.Metadata.GetMetadata<RootComponentMetadata>() != null).ToList();
+        Assert.Equal(2, pageEndpoints.Count);
         Assert.Collection(
-            endpointDataSource.Endpoints,
+            pageEndpoints,
             (ep) => Assert.Equal("/app/test", ((RouteEndpoint)ep).RoutePattern.RawText),
             (ep) => Assert.Equal("/server", ((RouteEndpoint)ep).RoutePattern.RawText));
     }
@@ -76,7 +81,9 @@ public class HotReloadServiceTests
         var endpointDataSource = CreateDataSource<App>(builder, services);
 
         // Assert - 1
-        var endpoint = Assert.IsType<RouteEndpoint>(Assert.Single(endpointDataSource.Endpoints));
+        var endpoint = Assert.IsType<RouteEndpoint>(Assert.Single(endpointDataSource.Endpoints,
+            e => e.Metadata.GetMetadata<RootComponentMetadata>() != null));
+
         Assert.Equal("/server", endpoint.RoutePattern.RawText);
 
         // Act - 2
@@ -85,7 +92,8 @@ public class HotReloadServiceTests
         HotReloadService.UpdateApplication(null);
 
         // Assert - 2
-        Assert.Empty(endpointDataSource.Endpoints);
+        var pageEndpoints = endpointDataSource.Endpoints.Where(e => e.Metadata.GetMetadata<RootComponentMetadata>() != null).ToList();
+        Assert.Empty(pageEndpoints);
     }
 
     [Fact]
@@ -97,7 +105,7 @@ public class HotReloadServiceTests
         var endpointDataSource = CreateDataSource<App>(builder, services);
 
         // Assert - 1
-        var endpoint = Assert.IsType<RouteEndpoint>(Assert.Single(endpointDataSource.Endpoints));
+        var endpoint = Assert.IsType<RouteEndpoint>(Assert.Single(endpointDataSource.Endpoints, e => e.Metadata.GetMetadata<RootComponentMetadata>() != null));
         Assert.Equal("/server", endpoint.RoutePattern.RawText);
         Assert.DoesNotContain(endpoint.Metadata, (element) => element is TestMetadata);
 
@@ -107,7 +115,7 @@ public class HotReloadServiceTests
         HotReloadService.UpdateApplication(null);
 
         // Assert - 2
-        var updatedEndpoint = Assert.IsType<RouteEndpoint>(Assert.Single(endpointDataSource.Endpoints));
+        var updatedEndpoint = Assert.IsType<RouteEndpoint>(Assert.Single(endpointDataSource.Endpoints, e => e.Metadata.GetMetadata<RootComponentMetadata>() != null));
         Assert.Equal("/server", updatedEndpoint.RoutePattern.RawText);
         Assert.Contains(updatedEndpoint.Metadata, (element) => element is TestMetadata);
     }
@@ -123,9 +131,9 @@ public class HotReloadServiceTests
             new[] { endpointDataSource });
 
         // Assert - 1
-        var endpoint = Assert.IsType<RouteEndpoint>(Assert.Single(endpointDataSource.Endpoints));
+        var endpoint = Assert.IsType<RouteEndpoint>(Assert.Single(endpointDataSource.Endpoints, e => e.Metadata.GetMetadata<RootComponentMetadata>() != null));
         Assert.Equal("/server", endpoint.RoutePattern.RawText);
-        var compositeEndpoint = Assert.IsType<RouteEndpoint>(Assert.Single(compositeEndpointDataSource.Endpoints));
+        var compositeEndpoint = Assert.IsType<RouteEndpoint>(Assert.Single(compositeEndpointDataSource.Endpoints, e => e.Metadata.GetMetadata<RootComponentMetadata>() != null));
         Assert.Equal("/server", compositeEndpoint.RoutePattern.RawText);
 
         // Act - 2
@@ -134,8 +142,10 @@ public class HotReloadServiceTests
         HotReloadService.UpdateApplication(null);
 
         // Assert - 2
-        Assert.Empty(endpointDataSource.Endpoints);
-        Assert.Empty(compositeEndpointDataSource.Endpoints);
+        var pageEndpoints = endpointDataSource.Endpoints.Where(e => e.Metadata.GetMetadata<RootComponentMetadata>() != null).ToList();
+        var compositePageEndpoints = compositeEndpointDataSource.Endpoints.Where(e => e.Metadata.GetMetadata<RootComponentMetadata>() != null).ToList();
+        Assert.Empty(pageEndpoints);
+        Assert.Empty(compositePageEndpoints);
     }
 
     private sealed class WrappedChangeTokenDisposable : IDisposable
@@ -170,7 +180,7 @@ public class HotReloadServiceTests
             return wrappedChangeTokenDisposable;
         };
 
-        var endpoint = Assert.IsType<RouteEndpoint>(Assert.Single(endpointDataSource.Endpoints));
+        var endpoint = Assert.IsType<RouteEndpoint>(Assert.Single(endpointDataSource.Endpoints, e => e.Metadata.GetMetadata<RootComponentMetadata>() != null));
         Assert.Equal("/server", endpoint.RoutePattern.RawText);
         Assert.DoesNotContain(endpoint.Metadata, (element) => element is TestMetadata);
 
@@ -209,6 +219,9 @@ public class HotReloadServiceTests
         {
             services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(RenderModeEndpointProvider), type));
         }
+
+        services.AddSingleton<IWebHostEnvironment, TestWebHostEnvironment>();
+        services.AddLogging();
 
         return services.BuildServiceProvider();
     }
@@ -256,6 +269,23 @@ public class HotReloadServiceTests
         }
 
         public override bool Supports(IComponentRenderMode renderMode) => true;
+    }
+
+    private class TestWebHostEnvironment : IWebHostEnvironment
+    {
+        public string ApplicationName { get; set; } = "TestApplication";
+        public string EnvironmentName { get; set; } = "TestEnvironment";
+        public string WebRootPath { get; set; } = "";
+        public IFileProvider WebRootFileProvider { get => ContentRootFileProvider; set { } }
+        public string ContentRootPath { get; set; } = Directory.GetCurrentDirectory();
+        public IFileProvider ContentRootFileProvider { get; set; } = CreateTestFileProvider();
+
+        private static TestFileProvider CreateTestFileProvider()
+        {
+            var provider = new TestFileProvider();
+            provider.AddFile("site.css", "body { color: red; }");
+            return provider;
+        }
     }
 
     private class TestEndpointRouteBuilder : IEndpointRouteBuilder

--- a/src/Components/Endpoints/test/RazorComponentEndpointDataSourceTest.cs
+++ b/src/Components/Endpoints/test/RazorComponentEndpointDataSourceTest.cs
@@ -7,10 +7,14 @@ using Microsoft.AspNetCore.Components.Discovery;
 using Microsoft.AspNetCore.Components.Endpoints.Infrastructure;
 using Microsoft.AspNetCore.Components.Endpoints.Tests;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
 
 namespace Microsoft.AspNetCore.Components.Endpoints;
 
@@ -22,7 +26,12 @@ public class RazorComponentEndpointDataSourceTest
         var endpointDataSource = CreateDataSource<App>();
 
         var endpoints = endpointDataSource.Endpoints;
-        Assert.Equal(2, endpoints.Count);
+
+#if DEBUG
+        Assert.Equal(5, endpoints.Count);
+#else
+        Assert.Equal(4, endpoints.Count);
+#endif
     }
 
     [Fact]
@@ -34,7 +43,12 @@ public class RazorComponentEndpointDataSourceTest
         var endpointDataSource = CreateDataSource<App>(builder, services);
 
         var endpoints = endpointDataSource.Endpoints;
-        Assert.Empty(endpoints);
+
+#if DEBUG
+        Assert.Equal(3, endpoints.Count);
+#else
+        Assert.Equal(2, endpoints.Count);
+#endif
     }
 
     // renderModes, providers, components, expectedEndpoints
@@ -217,6 +231,9 @@ public class RazorComponentEndpointDataSourceTest
             services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(RenderModeEndpointProvider), type));
         }
 
+        services.AddSingleton<IWebHostEnvironment, TestWebHostEnvironment>();
+        services.AddLogging();
+
         return services.BuildServiceProvider();
     }
 
@@ -228,7 +245,7 @@ public class RazorComponentEndpointDataSourceTest
         var result = new RazorComponentEndpointDataSource<TComponent>(
             builder ?? DefaultRazorComponentApplication<TComponent>.Instance.GetBuilder(),
             services?.GetService<IEnumerable<RenderModeEndpointProvider>>() ?? Enumerable.Empty<RenderModeEndpointProvider>(),
-            new TestEndpointRouteBuilder(services ?? new ServiceCollection().BuildServiceProvider()),
+            new TestEndpointRouteBuilder(services ?? CreateServices()),
             new RazorComponentEndpointFactory(),
             new HotReloadService() { MetadataUpdateSupported = true });
 
@@ -276,6 +293,23 @@ public class RazorComponentEndpointDataSourceTest
         }
 
         public override bool Supports(IComponentRenderMode renderMode) => renderMode is InteractiveWebAssemblyRenderMode or InteractiveAutoRenderMode;
+    }
+
+    private class TestWebHostEnvironment : IWebHostEnvironment
+    {
+        public string ApplicationName { get; set; } = "TestApplication";
+        public string EnvironmentName { get; set; } = "TestEnvironment";
+        public string WebRootPath { get; set; } = "";
+        public IFileProvider WebRootFileProvider { get => ContentRootFileProvider; set { } }
+        public string ContentRootPath { get; set; } = Directory.GetCurrentDirectory();
+        public IFileProvider ContentRootFileProvider { get; set; } = CreateTestFileProvider();
+
+        private static TestFileProvider CreateTestFileProvider()
+        {
+            var provider = new TestFileProvider();
+            provider.AddFile("site.css", "body { color: red; }");
+            return provider;
+        }
     }
 
     private class TestEndpointRouteBuilder : IEndpointRouteBuilder

--- a/src/Components/Server/src/DependencyInjection/ServerRazorComponentsBuilderExtensions.cs
+++ b/src/Components/Server/src/DependencyInjection/ServerRazorComponentsBuilderExtensions.cs
@@ -156,7 +156,6 @@ public static class ServerRazorComponentsBuilderExtensions
                     }
                 }
             }
-
         }
 
         private sealed class ServerComponentsSocketFeature(


### PR DESCRIPTION
Register the `blazor.web.js` file and the `opaque-redirect` endpoints into the endpoint data source.

Fixes #57081