### PR TITLE
Fixes for OpenAPI document generation with M.E.ApiDescription.Server

### DIFF
--- a/src/Tools/Extensions.ApiDescription.Client/test/Microsoft.Extensions.ApiDescription.Client.Tests.csproj
+++ b/src/Tools/Extensions.ApiDescription.Client/test/Microsoft.Extensions.ApiDescription.Client.Tests.csproj
@@ -16,9 +16,9 @@
         Link="ProcessHelpers\DotNetMuxer.cs" />
     <Compile Include="$(ToolSharedSourceRoot)TestHelpers\Temporary*.cs" LinkBase="TestHelpers" />
 
-    <Content Include="..\src\build\**\*" LinkBase="build" />
-    <Content Include="..\src\buildMultiTargeting\**\*" LinkBase="buildMultiTargeting" />
-    <Content Include="TestProjects\**\*" />
+    <Content Include="..\src\build\**\*" LinkBase="build" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="..\src\buildMultiTargeting\**\*" LinkBase="buildMultiTargeting" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestProjects\**\*" CopyToOutputDirectory="PreserveNewest" />
 
     <Reference Include="Microsoft.Extensions.ApiDescription.Client" />
   </ItemGroup>

--- a/src/Tools/Extensions.ApiDescription.Client/test/TargetTest.cs
+++ b/src/Tools/Extensions.ApiDescription.Client/test/TargetTest.cs
@@ -77,7 +77,7 @@ public class TargetTest : IDisposable
 
         Assert.Equal(0, process.ExitCode);
         Assert.Empty(process.Error);
-        Assert.Contains($"Compile: {Path.Combine("obj", "azureMonitorClient.cs")}", process.Output);
+        Assert.Contains($"Compile: {Path.Combine(_temporaryDirectory.Root, "obj", "azureMonitorClient.cs")}", process.Output);
         Assert.Contains($"FileWrites: {Path.Combine("obj", "azureMonitorClient.cs")}", process.Output);
         Assert.DoesNotContain("TypeScriptCompile:", process.Output);
     }
@@ -120,9 +120,9 @@ public class TargetTest : IDisposable
 
         Assert.Equal(0, process.ExitCode);
         Assert.Empty(process.Error);
-        Assert.Contains($"Compile: {Path.Combine("obj", "azureMonitorClient.cs")}", process.Output);
-        Assert.Contains($"Compile: {Path.Combine("obj", "NSwagClient.cs")}", process.Output);
-        Assert.Contains($"Compile: {Path.Combine("obj", "swashbuckleClient.cs")}", process.Output);
+        Assert.Contains($"Compile: {Path.Combine(_temporaryDirectory.Root, "obj", "azureMonitorClient.cs")}", process.Output);
+        Assert.Contains($"Compile: {Path.Combine(_temporaryDirectory.Root, "obj", "NSwagClient.cs")}", process.Output);
+        Assert.Contains($"Compile: {Path.Combine(_temporaryDirectory.Root, "obj", "swashbuckleClient.cs")}", process.Output);
         Assert.Contains($"FileWrites: {Path.Combine("obj", "azureMonitorClient.cs")}", process.Output);
         Assert.Contains($"FileWrites: {Path.Combine("obj", "NSwagClient.cs")}", process.Output);
         Assert.Contains($"FileWrites: {Path.Combine("obj", "swashbuckleClient.cs")}", process.Output);

--- a/src/Tools/Extensions.ApiDescription.Server/src/build/Microsoft.Extensions.ApiDescription.Server.targets
+++ b/src/Tools/Extensions.ApiDescription.Server/src/build/Microsoft.Extensions.ApiDescription.Server.targets
@@ -51,9 +51,11 @@
         Text="OpenAPI document generation is not supported when targeting netcoreapp2.0 or earlier. Disable the feature or move to a later target framework." />
 
     <PropertyGroup>
+      <_DotNetGetDocumentOutputPath>$(OpenApiDocumentsDirectory.TrimEnd('\'))</_DotNetGetDocumentOutputPath>
+      <_DotNetGetDocumentOutputPath>$([System.IO.Path]::GetFullPath('$(_DotNetGetDocumentOutputPath)'))</_DotNetGetDocumentOutputPath>
       <_DotNetGetDocumentCommand>dotnet "$(MSBuildThisFileDirectory)../tools/dotnet-getdocument.dll" --assembly "$(TargetPath)"</_DotNetGetDocumentCommand>
       <_DotNetGetDocumentCommand>$(_DotNetGetDocumentCommand) --file-list "$(_OpenApiDocumentsCache)" --framework "$(TargetFrameworkMoniker)"</_DotNetGetDocumentCommand>
-      <_DotNetGetDocumentCommand>$(_DotNetGetDocumentCommand) --output "$(OpenApiDocumentsDirectory.TrimEnd('\'))" --project "$(MSBuildProjectName)"</_DotNetGetDocumentCommand>
+      <_DotNetGetDocumentCommand>$(_DotNetGetDocumentCommand) --output "$(_DotNetGetDocumentOutputPath)" --project "$(MSBuildProjectName)"</_DotNetGetDocumentCommand>
       <_DotNetGetDocumentCommand Condition=" '$(ProjectAssetsFile)' != '' ">$(_DotNetGetDocumentCommand) --assets-file "$(ProjectAssetsFile)"</_DotNetGetDocumentCommand>
       <_DotNetGetDocumentCommand Condition=" '$(PlatformTarget)' != '' ">$(_DotNetGetDocumentCommand) --platform "$(PlatformTarget)"</_DotNetGetDocumentCommand>
       <_DotNetGetDocumentCommand Condition=" '$(PlatformTarget)' == '' AND '$(Platform)' != '' ">$(_DotNetGetDocumentCommand) --platform "$(Platform)"</_DotNetGetDocumentCommand>

--- a/src/Tools/GetDocumentInsider/src/Commands/GetDocumentCommandWorker.cs
+++ b/src/Tools/GetDocumentInsider/src/Commands/GetDocumentCommandWorker.cs
@@ -326,7 +326,10 @@ internal sealed class GetDocumentCommandWorker
                 }
                 else
                 {
-                    _reporter.WriteWarning(Resources.FormatInvalidOpenApiVersion(_context.OpenApiVersion));
+                    if (!string.IsNullOrWhiteSpace(_context.OpenApiVersion))
+                    {
+                        _reporter.WriteWarning(Resources.FormatInvalidOpenApiVersion(_context.OpenApiVersion));
+                    }
                     arguments = [documentName, writer, OpenApiSpecVersion.OpenApi3_0];
                 }
             }


### PR DESCRIPTION
# Fixes for OpenAPI document generation tool

Fix two issues with the M.E.ApiDescription.Server package.

## Description

- Convert `$(OpenApiDocumentsDirectory)` to a full path before passing it to the `dotnet-getdocument` tool.
- Do not emit warning about an invalid OpenAPI version in the `dotnet-getdocument` tool if no explicit value was passed to the tool via the `--openapi-version` argument.
- Fix broken tests for the MSBuild targets.

Relates to #57044
