### PR TITLE
Add client span to SignalR .NET client

### DIFF
--- a/src/SignalR/clients/csharp/Client.Core/src/Internal/SignalRClientActivitySource.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/Internal/SignalRClientActivitySource.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Microsoft.AspNetCore.SignalR.Client.Internal;
+
+// Internal for now so we don't need API review.
+// Just a wrapper for the ActivitySource. Don't want to put ActivitySource directly in DI as
+// it is a public type and could conflict with activity source from another library.
+internal sealed class SignalRClientActivitySource
+{
+    public static readonly SignalRClientActivitySource Instance = new();
+
+    public ActivitySource ActivitySource { get; } = new ActivitySource("Microsoft.AspNetCore.SignalR.Client");
+}

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.Tracing.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.Tracing.cs
@@ -1,0 +1,745 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using System.Net.WebSockets;
+using System.Text.Json;
+using System.Threading.Channels;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http.Connections;
+using Microsoft.AspNetCore.Http.Connections.Client;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.AspNetCore.SignalR.Client.Internal;
+using Microsoft.AspNetCore.SignalR.Internal;
+using Microsoft.AspNetCore.SignalR.Protocol;
+using Microsoft.AspNetCore.SignalR.Test.Internal;
+using Microsoft.AspNetCore.SignalR.Tests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
+
+namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests;
+
+partial class HubConnectionTests : FunctionalTestBase
+{
+    [Theory]
+    [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
+    public async Task InvokeAsync_SendTraceHeader(string protocolName, HttpTransportType transportType, string path)
+    {
+        var protocol = HubProtocols[protocolName];
+        await using (var server = await StartServer<Startup>())
+        {
+            var serverChannel = Channel.CreateUnbounded<Activity>();
+            var clientChannel = Channel.CreateUnbounded<Activity>();
+            var serverSource = server.Services.GetRequiredService<SignalRActivitySource>().ActivitySource;
+            var clientSourceContainer = new SignalRClientActivitySource();
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = activitySource => ReferenceEquals(activitySource, serverSource) || ReferenceEquals(activitySource, clientSourceContainer.ActivitySource),
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+                ActivityStarted = activity =>
+                {
+                    if (activity.Source == clientSourceContainer.ActivitySource)
+                    {
+                        clientChannel.Writer.TryWrite(activity);
+                    }
+                    else
+                    {
+                        serverChannel.Writer.TryWrite(activity);
+                    }
+                }
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var connectionBuilder = new HubConnectionBuilder()
+                .WithLoggerFactory(LoggerFactory)
+                .WithUrl(server.Url + path, transportType);
+            connectionBuilder.Services.AddSingleton(protocol);
+            connectionBuilder.Services.AddSingleton(clientSourceContainer);
+
+            var connection = connectionBuilder.Build();
+
+            Activity clientParentActivity1 = null;
+            Activity clientActivity1 = null;
+            Activity clientParentActivity2 = null;
+            Activity clientActivity2 = null;
+            try
+            {
+                await connection.StartAsync().DefaultTimeout();
+
+                // Invocation 1
+                try
+                {
+                    clientParentActivity1 = new Activity("ClientActivity1");
+                    clientParentActivity1.AddBaggage("baggage-1", "value-1");
+                    clientParentActivity1.Start();
+
+                    var resultTask = connection.InvokeAsync<string>(nameof(TestHub.HelloWorld)).DefaultTimeout();
+
+                    clientActivity1 = await clientChannel.Reader.ReadAsync().DefaultTimeout();
+
+                    // The SignalR client activity shouldn't escape into user code.
+                    Assert.Equal(clientParentActivity1, Activity.Current);
+
+                    var result = await resultTask.ConfigureAwait(false);
+                    Assert.Equal("Hello World!", result);
+                }
+                finally
+                {
+                    clientParentActivity1?.Stop();
+                }
+
+                // Invocation 2
+                try
+                {
+                    clientParentActivity2 = new Activity("ClientActivity2");
+                    clientParentActivity2.AddBaggage("baggage-2", "value-2");
+                    clientParentActivity2.Start();
+
+                    var resultTask = connection.InvokeAsync<string>(nameof(TestHub.HelloWorld));
+
+                    clientActivity2 = await clientChannel.Reader.ReadAsync().DefaultTimeout();
+
+                    // The SignalR client activity shouldn't escape into user code.
+                    Assert.Equal(clientParentActivity2, Activity.Current);
+
+                    var result = await resultTask.DefaultTimeout();
+                    Assert.Equal("Hello World!", result);
+                }
+                finally
+                {
+                    clientParentActivity2?.Stop();
+                }
+            }
+            catch (Exception ex)
+            {
+                LoggerFactory.CreateLogger<HubConnectionTests>().LogError(ex, "{ExceptionType} from test", ex.GetType().FullName);
+                throw;
+            }
+            finally
+            {
+                await connection.DisposeAsync().DefaultTimeout();
+            }
+
+            var port = new Uri(server.Url).Port;
+            var serverHubName = path switch
+            {
+                "/default" => typeof(TestHub).FullName,
+                "/hubT" => typeof(TestHubT).FullName,
+                "/dynamic" => typeof(DynamicTestHub).FullName,
+                _ => throw new InvalidOperationException("Unexpected path: " + path)
+            };
+            var clientHubName = path.TrimStart('/');
+
+            var serverActivities = await serverChannel.Reader.ReadAtLeastAsync(minimumCount: 4).DefaultTimeout();
+
+            Assert.Collection(serverActivities,
+                a =>
+                {
+                    Assert.Equal($"{serverHubName}/OnConnectedAsync", a.OperationName);
+                    Assert.Equal("Microsoft.AspNetCore.Hosting.HttpRequestIn", a.Parent.OperationName);
+                    Assert.Equal(ActivityKind.Server, a.Kind);
+                    Assert.False(a.HasRemoteParent);
+                    Assert.Equal(ActivityStatusCode.Unset, a.Status);
+                    Assert.Empty(a.Baggage);
+                },
+                a =>
+                {
+                    Assert.Equal($"{serverHubName}/HelloWorld", a.OperationName);
+                    Assert.Equal(clientActivity1.Id, a.ParentId);
+                    Assert.Equal(ActivityKind.Server, a.Kind);
+                    Assert.True(a.HasRemoteParent);
+                    Assert.Equal(ActivityStatusCode.Unset, a.Status);
+
+                    var baggage = a.Baggage.ToDictionary();
+                    Assert.Equal("value-1", baggage["baggage-1"]);
+                },
+                a =>
+                {
+                    Assert.Equal($"{serverHubName}/HelloWorld", a.OperationName);
+                    Assert.Equal(clientActivity2.Id, a.ParentId);
+                    Assert.Equal(ActivityKind.Server, a.Kind);
+                    Assert.True(a.HasRemoteParent);
+                    Assert.Equal(ActivityStatusCode.Unset, a.Status);
+
+                    var baggage = a.Baggage.ToDictionary();
+                    Assert.Equal("value-2", baggage["baggage-2"]);
+                },
+                a =>
+                {
+                    Assert.Equal($"{serverHubName}/OnDisconnectedAsync", a.OperationName);
+                    Assert.Equal("Microsoft.AspNetCore.Hosting.HttpRequestIn", a.Parent.OperationName);
+                    Assert.Equal(ActivityKind.Server, a.Kind);
+                    Assert.False(a.HasRemoteParent);
+                    Assert.Empty(a.Baggage);
+                    Assert.Equal(ActivityStatusCode.Unset, a.Status);
+                });
+
+            // Client activity 1
+            Assert.Equal(HubConnection.ActivityName, clientActivity1.OperationName);
+            Assert.Equal($"{clientHubName}/HelloWorld", clientActivity1.DisplayName);
+            Assert.Equal(ActivityKind.Client, clientActivity1.Kind);
+            Assert.Equal(clientParentActivity1, clientActivity1.Parent);
+            Assert.Equal(ActivityStatusCode.Unset, clientActivity1.Status);
+
+            var baggage = clientActivity1.Baggage.ToDictionary();
+            Assert.Equal("value-1", baggage["baggage-1"]);
+
+            var tags = clientActivity1.TagObjects.ToDictionary();
+            Assert.Equal("signalr", tags["rpc.system"]);
+            Assert.Equal("HelloWorld", tags["rpc.method"]);
+            Assert.Equal(clientHubName, tags["rpc.service"]);
+            Assert.Equal("127.0.0.1", tags["server.address"]);
+            Assert.Equal(port, (int)tags["server.port"]);
+
+            // Client activity 2
+            Assert.Equal(HubConnection.ActivityName, clientActivity2.OperationName);
+            Assert.Equal($"{clientHubName}/HelloWorld", clientActivity2.DisplayName);
+            Assert.Equal(ActivityKind.Client, clientActivity2.Kind);
+            Assert.Equal(clientParentActivity2, clientActivity2.Parent);
+            Assert.Equal(ActivityStatusCode.Unset, clientActivity2.Status);
+
+            baggage = clientActivity2.Baggage.ToDictionary();
+            Assert.Equal("value-2", baggage["baggage-2"]);
+
+            tags = clientActivity2.TagObjects.ToDictionary();
+            Assert.Equal("signalr", tags["rpc.system"]);
+            Assert.Equal("HelloWorld", tags["rpc.method"]);
+            Assert.Equal(clientHubName, tags["rpc.service"]);
+            Assert.Equal("127.0.0.1", tags["server.address"]);
+            Assert.Equal(port, (int)tags["server.port"]);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
+    public async Task StreamAsyncCore_SendTraceHeader(string protocolName, HttpTransportType transportType, string path)
+    {
+        var protocol = HubProtocols[protocolName];
+        await using (var server = await StartServer<Startup>())
+        {
+            var serverChannel = Channel.CreateUnbounded<Activity>();
+            var clientActivityTcs = new TaskCompletionSource<Activity>();
+            Activity clientActivity = null;
+            var serverSource = server.Services.GetRequiredService<SignalRActivitySource>().ActivitySource;
+            var clientSourceContainer = new SignalRClientActivitySource();
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = activitySource => ReferenceEquals(activitySource, serverSource) || ReferenceEquals(activitySource, clientSourceContainer.ActivitySource),
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+                ActivityStarted = activity =>
+                {
+                    if (activity.Source == clientSourceContainer.ActivitySource)
+                    {
+                        clientActivityTcs.SetResult(activity);
+                    }
+                    else
+                    {
+                        serverChannel.Writer.TryWrite(activity);
+                    }
+                }
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var connection = CreateHubConnection(server.Url, path, transportType, protocol, LoggerFactory, activitySourceContainer: clientSourceContainer);
+
+            Activity clientParentActivity = null;
+            try
+            {
+                await connection.StartAsync().DefaultTimeout();
+
+                clientParentActivity = new Activity("ClientActivity");
+                clientParentActivity.AddBaggage("baggage-1", "value-1");
+                clientParentActivity.Start();
+
+                var expectedValue = 0;
+                var streamTo = 5;
+                var asyncEnumerable = connection.StreamAsyncCore<int>("Stream", new object[] { streamTo });
+
+                await foreach (var streamValue in asyncEnumerable)
+                {
+                    // Call starts after user reads from the enumerable.
+                    if (streamValue == 0)
+                    {
+                        // The SignalR client activity should be:
+                        // - Started
+                        // - Still running
+                        // - Not escaped into user code
+                        clientActivity = await clientActivityTcs.Task.DefaultTimeout();
+                        Assert.NotNull(clientActivity);
+                        Assert.False(clientActivity.IsStopped);
+                        Assert.Equal(clientParentActivity, Activity.Current);
+                    }
+
+                    Assert.Equal(expectedValue, streamValue);
+                    expectedValue++;
+                }
+
+                Assert.Equal(streamTo, expectedValue);
+            }
+            catch (Exception ex)
+            {
+                LoggerFactory.CreateLogger<HubConnectionTests>().LogError(ex, "{ExceptionType} from test", ex.GetType().FullName);
+                throw;
+            }
+            finally
+            {
+                clientParentActivity?.Stop();
+                await connection.DisposeAsync().DefaultTimeout();
+            }
+
+            var port = new Uri(server.Url).Port;
+            var hubName = path switch
+            {
+                "/default" => typeof(TestHub).FullName,
+                "/hubT" => typeof(TestHubT).FullName,
+                "/dynamic" => typeof(DynamicTestHub).FullName,
+                _ => throw new InvalidOperationException("Unexpected path: " + path)
+            };
+            var clientHubName = path.TrimStart('/');
+
+            var serverActivities = await serverChannel.Reader.ReadAtLeastAsync(minimumCount: 3).DefaultTimeout();
+
+            Assert.Collection(serverActivities,
+                a =>
+                {
+                    Assert.Equal($"{hubName}/OnConnectedAsync", a.OperationName);
+                    Assert.Equal($"{hubName}/OnConnectedAsync", a.DisplayName);
+                    Assert.Equal(ActivityKind.Server, a.Kind);
+                    Assert.Equal("Microsoft.AspNetCore.Hosting.HttpRequestIn", a.Parent.OperationName);
+                    Assert.Equal(ActivityStatusCode.Unset, a.Status);
+                    Assert.False(a.HasRemoteParent);
+                    Assert.True(a.IsStopped);
+                    Assert.Empty(a.Baggage);
+                },
+                a =>
+                {
+                    Assert.Equal($"{hubName}/Stream", a.OperationName);
+                    Assert.Equal($"{hubName}/Stream", a.DisplayName);
+                    Assert.Equal(ActivityKind.Server, a.Kind);
+                    Assert.Equal(clientActivity.Id, a.ParentId);
+                    Assert.Equal(ActivityStatusCode.Unset, a.Status);
+                    Assert.True(a.HasRemoteParent);
+                    Assert.True(a.IsStopped);
+
+                    var baggage = a.Baggage.ToDictionary();
+                    Assert.Equal("value-1", baggage["baggage-1"]);
+                },
+                a =>
+                {
+                    Assert.Equal($"{hubName}/OnDisconnectedAsync", a.OperationName);
+                    Assert.Equal($"{hubName}/OnDisconnectedAsync", a.DisplayName);
+                    Assert.Equal(ActivityKind.Server, a.Kind);
+                    Assert.Equal("Microsoft.AspNetCore.Hosting.HttpRequestIn", a.Parent.OperationName);
+                    Assert.Equal(ActivityStatusCode.Unset, a.Status);
+                    Assert.False(a.HasRemoteParent);
+                    Assert.True(a.IsStopped);
+                    Assert.Empty(a.Baggage);
+                });
+
+            Assert.Equal(HubConnection.ActivityName, clientActivity.OperationName);
+            Assert.Equal($"{clientHubName}/Stream", clientActivity.DisplayName);
+            Assert.Equal(ActivityKind.Client, clientActivity.Kind);
+            Assert.Equal(clientParentActivity, clientActivity.Parent);
+            Assert.Equal(ActivityStatusCode.Unset, clientActivity.Status);
+            Assert.True(clientActivity.IsStopped);
+
+            var baggage = clientActivity.Baggage.ToDictionary();
+            Assert.Equal("value-1", baggage["baggage-1"]);
+
+            var tags = clientActivity.TagObjects.ToDictionary();
+            Assert.Equal("signalr", tags["rpc.system"]);
+            Assert.Equal("Stream", tags["rpc.method"]);
+            Assert.Equal(clientHubName, tags["rpc.service"]);
+            Assert.Equal("127.0.0.1", tags["server.address"]);
+            Assert.Equal(port, (int)tags["server.port"]);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
+    [LogLevel(LogLevel.Trace)]
+    public async Task StreamAsyncCanBeCanceled_Tracing(string protocolName, HttpTransportType transportType, string path)
+    {
+        var protocol = HubProtocols[protocolName];
+        await using (var server = await StartServer<Startup>())
+        {
+            var serverChannel = Channel.CreateUnbounded<Activity>();
+            var clientActivityTcs = new TaskCompletionSource<Activity>();
+            var serverSource = server.Services.GetRequiredService<SignalRActivitySource>().ActivitySource;
+            var clientSourceContainer = new SignalRClientActivitySource();
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = activitySource => ReferenceEquals(activitySource, serverSource) || ReferenceEquals(activitySource, clientSourceContainer.ActivitySource),
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+                ActivityStarted = activity =>
+                {
+                    if (activity.Source == clientSourceContainer.ActivitySource)
+                    {
+                        clientActivityTcs.SetResult(activity);
+                    }
+                    else
+                    {
+                        serverChannel.Writer.TryWrite(activity);
+                    }
+                }
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var connection = CreateHubConnection(server.Url, path, transportType, protocol, LoggerFactory, activitySourceContainer: clientSourceContainer);
+            try
+            {
+                await connection.StartAsync().DefaultTimeout();
+
+                var cts = new CancellationTokenSource();
+
+                var stream = connection.StreamAsync<int>("Stream", 1000, cts.Token);
+                var results = new List<int>();
+
+                var enumerator = stream.GetAsyncEnumerator();
+                await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+                {
+                    while (await enumerator.MoveNextAsync())
+                    {
+                        results.Add(enumerator.Current);
+                        cts.Cancel();
+                    }
+                });
+
+                Assert.True(results.Count > 0 && results.Count < 1000);
+            }
+            catch (Exception ex)
+            {
+                LoggerFactory.CreateLogger<HubConnectionTests>().LogError(ex, "{ExceptionType} from test", ex.GetType().FullName);
+                throw;
+            }
+            finally
+            {
+                await connection.DisposeAsync().DefaultTimeout();
+            }
+
+            var port = new Uri(server.Url).Port;
+            var hubName = path switch
+            {
+                "/default" => typeof(TestHub).FullName,
+                "/hubT" => typeof(TestHubT).FullName,
+                "/dynamic" => typeof(DynamicTestHub).FullName,
+                _ => throw new InvalidOperationException("Unexpected path: " + path)
+            };
+            var clientHubName = path.TrimStart('/');
+
+            var serverActivities = await serverChannel.Reader.ReadAtLeastAsync(minimumCount: 3).DefaultTimeout();
+            var clientActivity = await clientActivityTcs.Task.DefaultTimeout();
+
+            Assert.Collection(serverActivities,
+                a => Assert.Equal($"{hubName}/OnConnectedAsync", a.DisplayName),
+                a =>
+                {
+                    Assert.Equal($"{hubName}/Stream", a.DisplayName);
+                    Assert.Equal(ActivityStatusCode.Error, clientActivity.Status);
+
+                    var tags = clientActivity.TagObjects.ToDictionary();
+                    Assert.Equal(typeof(OperationCanceledException).FullName, tags["error.type"]);
+                },
+                a => Assert.Equal($"{hubName}/OnDisconnectedAsync", a.OperationName));
+
+            Assert.Equal($"{clientHubName}/Stream", clientActivity.DisplayName);
+            Assert.Equal(ActivityKind.Client, clientActivity.Kind);
+            Assert.Equal(ActivityStatusCode.Error, clientActivity.Status);
+
+            var tags = clientActivity.TagObjects.ToDictionary();
+            Assert.Equal(typeof(OperationCanceledException).FullName, tags["error.type"]);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
+    [LogLevel(LogLevel.Trace)]
+    public async Task StreamAsyncWithException_Tracing(string protocolName, HttpTransportType transportType, string path)
+    {
+        bool ExpectedErrors(WriteContext writeContext)
+        {
+            return writeContext.LoggerName == DefaultHubDispatcherLoggerName &&
+                   writeContext.EventId.Name == "FailedInvokingHubMethod";
+        }
+
+        var protocol = HubProtocols[protocolName];
+        await using (var server = await StartServer<Startup>(ExpectedErrors))
+        {
+            var serverChannel = Channel.CreateUnbounded<Activity>();
+            var clientActivityTcs = new TaskCompletionSource<Activity>();
+            var serverSource = server.Services.GetRequiredService<SignalRActivitySource>().ActivitySource;
+            var clientSourceContainer = new SignalRClientActivitySource();
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = activitySource => ReferenceEquals(activitySource, serverSource) || ReferenceEquals(activitySource, clientSourceContainer.ActivitySource),
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+                ActivityStarted = activity =>
+                {
+                    if (activity.Source == clientSourceContainer.ActivitySource)
+                    {
+                        clientActivityTcs.SetResult(activity);
+                    }
+                    else
+                    {
+                        serverChannel.Writer.TryWrite(activity);
+                    }
+                }
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var connection = CreateHubConnection(server.Url, path, transportType, protocol, LoggerFactory, activitySourceContainer: clientSourceContainer);
+            try
+            {
+                await connection.StartAsync().DefaultTimeout();
+                var asyncEnumerable = connection.StreamAsync<int>("StreamException");
+                var ex = await Assert.ThrowsAsync<HubException>(async () =>
+                {
+                    await foreach (var streamValue in asyncEnumerable)
+                    {
+                        Assert.True(false, "Expected an exception from the streaming invocation.");
+                    }
+                });
+
+                Assert.Equal("An unexpected error occurred invoking 'StreamException' on the server. InvalidOperationException: Error occurred while streaming.", ex.Message);
+
+            }
+            catch (Exception ex)
+            {
+                LoggerFactory.CreateLogger<HubConnectionTests>().LogError(ex, "{ExceptionType} from test", ex.GetType().FullName);
+                throw;
+            }
+            finally
+            {
+                await connection.DisposeAsync().DefaultTimeout();
+            }
+
+            var port = new Uri(server.Url).Port;
+            var serverHubName = path switch
+            {
+                "/default" => typeof(TestHub).FullName,
+                "/hubT" => typeof(TestHubT).FullName,
+                "/dynamic" => typeof(DynamicTestHub).FullName,
+                _ => throw new InvalidOperationException("Unexpected path: " + path)
+            };
+            var clientHubName = path.TrimStart('/');
+
+            var serverActivities = await serverChannel.Reader.ReadAtLeastAsync(minimumCount: 3).DefaultTimeout();
+            var clientActivity = await clientActivityTcs.Task.DefaultTimeout();
+
+            Assert.Collection(serverActivities,
+                a => Assert.Equal($"{serverHubName}/OnConnectedAsync", a.DisplayName),
+                a =>
+                {
+                    Assert.Equal($"{serverHubName}/StreamException", a.DisplayName);
+                    Assert.Equal(ActivityStatusCode.Error, clientActivity.Status);
+
+                    var tags = clientActivity.TagObjects.ToDictionary();
+                    Assert.Equal(typeof(HubException).FullName, tags["error.type"]);
+                },
+                a => Assert.Equal($"{serverHubName}/OnDisconnectedAsync", a.DisplayName));
+
+            Assert.Equal($"{clientHubName}/StreamException", clientActivity.DisplayName);
+            Assert.Equal(ActivityKind.Client, clientActivity.Kind);
+            Assert.Equal(ActivityStatusCode.Error, clientActivity.Status);
+
+            var tags = clientActivity.TagObjects.ToDictionary();
+            Assert.Equal(typeof(HubException).FullName, tags["error.type"]);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
+    public async Task InvokeAsyncWithException_Tracing(string protocolName, HttpTransportType transportType, string path)
+    {
+        bool ExpectedErrors(WriteContext writeContext)
+        {
+            return writeContext.LoggerName == DefaultHubDispatcherLoggerName &&
+                   writeContext.EventId.Name == "FailedInvokingHubMethod";
+        }
+
+        var protocol = HubProtocols[protocolName];
+        await using (var server = await StartServer<Startup>(ExpectedErrors))
+        {
+            var serverChannel = Channel.CreateUnbounded<Activity>();
+            var clientActivityTcs = new TaskCompletionSource<Activity>();
+            var serverSource = server.Services.GetRequiredService<SignalRActivitySource>().ActivitySource;
+            var clientSourceContainer = new SignalRClientActivitySource();
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = activitySource => ReferenceEquals(activitySource, serverSource) || ReferenceEquals(activitySource, clientSourceContainer.ActivitySource),
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+                ActivityStarted = activity =>
+                {
+                    if (activity.Source == clientSourceContainer.ActivitySource)
+                    {
+                        clientActivityTcs.SetResult(activity);
+                    }
+                    else
+                    {
+                        serverChannel.Writer.TryWrite(activity);
+                    }
+                }
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var connectionBuilder = new HubConnectionBuilder()
+                .WithLoggerFactory(LoggerFactory)
+                .WithUrl(server.Url + path, transportType);
+            connectionBuilder.Services.AddSingleton(protocol);
+            connectionBuilder.Services.AddSingleton(clientSourceContainer);
+
+            var connection = connectionBuilder.Build();
+
+            try
+            {
+                await connection.StartAsync().DefaultTimeout();
+
+                await Assert.ThrowsAnyAsync<Exception>(
+                    async () => await connection.InvokeAsync<string>(nameof(TestHub.InvokeException))).DefaultTimeout();
+            }
+            catch (Exception ex)
+            {
+                LoggerFactory.CreateLogger<HubConnectionTests>().LogError(ex, "{ExceptionType} from test", ex.GetType().FullName);
+                throw;
+            }
+            finally
+            {
+                await connection.DisposeAsync().DefaultTimeout();
+            }
+
+            var port = new Uri(server.Url).Port;
+            var serverHubName = path switch
+            {
+                "/default" => typeof(TestHub).FullName,
+                "/hubT" => typeof(TestHubT).FullName,
+                "/dynamic" => typeof(DynamicTestHub).FullName,
+                _ => throw new InvalidOperationException("Unexpected path: " + path)
+            };
+            var clientHubName = path.TrimStart('/');
+
+            var serverActivities = await serverChannel.Reader.ReadAtLeastAsync(minimumCount: 3).DefaultTimeout();
+            var clientActivity = await clientActivityTcs.Task.DefaultTimeout();
+
+            Assert.Collection(serverActivities,
+                a => Assert.Equal($"{serverHubName}/OnConnectedAsync", a.DisplayName),
+                a =>
+                {
+                    Assert.Equal($"{serverHubName}/InvokeException", a.DisplayName);
+                    Assert.Equal(ActivityStatusCode.Error, clientActivity.Status);
+
+                    var tags = clientActivity.TagObjects.ToDictionary();
+                    Assert.Equal(typeof(HubException).FullName, tags["error.type"]);
+                },
+                a => Assert.Equal($"{serverHubName}/OnDisconnectedAsync", a.DisplayName));
+
+            Assert.Equal(HubConnection.ActivityName, clientActivity.OperationName);
+            Assert.Equal($"{clientHubName}/InvokeException", clientActivity.DisplayName);
+            Assert.Equal(ActivityKind.Client, clientActivity.Kind);
+            Assert.Equal(ActivityStatusCode.Error, clientActivity.Status);
+
+            var tags = clientActivity.TagObjects.ToDictionary();
+            Assert.Equal(typeof(HubException).FullName, tags["error.type"]);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
+    public async Task SendAsync_Tracing(string protocolName, HttpTransportType transportType, string path)
+    {
+        var protocol = HubProtocols[protocolName];
+        await using (var server = await StartServer<Startup>())
+        {
+            var serverChannel = Channel.CreateUnbounded<Activity>();
+            var clientActivityTcs = new TaskCompletionSource<Activity>();
+            var serverSource = server.Services.GetRequiredService<SignalRActivitySource>().ActivitySource;
+            var clientSourceContainer = new SignalRClientActivitySource();
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = activitySource => ReferenceEquals(activitySource, serverSource) || ReferenceEquals(activitySource, clientSourceContainer.ActivitySource),
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+                ActivityStarted = activity =>
+                {
+                    if (activity.Source == clientSourceContainer.ActivitySource)
+                    {
+                        clientActivityTcs.SetResult(activity);
+                    }
+                    else
+                    {
+                        serverChannel.Writer.TryWrite(activity);
+                    }
+                }
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var connectionBuilder = new HubConnectionBuilder()
+                .WithLoggerFactory(LoggerFactory)
+                .WithUrl(server.Url + path, transportType);
+            connectionBuilder.Services.AddSingleton(protocol);
+            connectionBuilder.Services.AddSingleton(clientSourceContainer);
+
+            var connection = connectionBuilder.Build();
+
+            try
+            {
+                await connection.StartAsync().DefaultTimeout();
+
+                var echoTcs = new TaskCompletionSource<string>();
+                connection.On<string>("Echo", echoTcs.SetResult);
+
+                await connection.SendAsync(nameof(TestHub.CallEcho), "Hi");
+
+                // The SignalR client activity shouldn't escape into user code.
+                Assert.Null(Activity.Current);
+
+                // Wait until message is echoed back from the server.
+                // Needed so the client doesn't stop the connection before the server gets the invocation.
+                await echoTcs.Task.DefaultTimeout();
+            }
+            catch (Exception ex)
+            {
+                LoggerFactory.CreateLogger<HubConnectionTests>().LogError(ex, "{ExceptionType} from test", ex.GetType().FullName);
+                throw;
+            }
+            finally
+            {
+                await connection.DisposeAsync().DefaultTimeout();
+            }
+
+            var port = new Uri(server.Url).Port;
+            var serverHubName = path switch
+            {
+                "/default" => typeof(TestHub).FullName,
+                "/hubT" => typeof(TestHubT).FullName,
+                "/dynamic" => typeof(DynamicTestHub).FullName,
+                _ => throw new InvalidOperationException("Unexpected path: " + path)
+            };
+            var clientHubName = path.TrimStart('/');
+
+            var serverActivities = await serverChannel.Reader.ReadAtLeastAsync(minimumCount: 3).DefaultTimeout();
+            var clientActivity = await clientActivityTcs.Task.DefaultTimeout();
+
+            Assert.Collection(serverActivities,
+                a => Assert.Equal($"{serverHubName}/OnConnectedAsync", a.DisplayName),
+                a =>
+                {
+                    Assert.Equal($"{serverHubName}/CallEcho", a.DisplayName);
+                    Assert.Equal(clientActivity.Id, a.ParentId);
+                },
+                a => Assert.Equal($"{serverHubName}/OnDisconnectedAsync", a.DisplayName));
+
+            Assert.Equal(HubConnection.ActivityName, clientActivity.OperationName);
+            Assert.Equal($"{clientHubName}/CallEcho", clientActivity.DisplayName);
+            Assert.Equal(ActivityKind.Client, clientActivity.Kind);
+        }
+    }
+}

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.Tracing.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.Tracing.cs
@@ -318,7 +318,6 @@ partial class HubConnectionTests : FunctionalTestBase
                     Assert.Equal("Microsoft.AspNetCore.Hosting.HttpRequestIn", a.Parent.OperationName);
                     Assert.Equal(ActivityStatusCode.Unset, a.Status);
                     Assert.False(a.HasRemoteParent);
-                    Assert.True(a.IsStopped);
                     Assert.Empty(a.Baggage);
                 },
                 a =>
@@ -342,7 +341,6 @@ partial class HubConnectionTests : FunctionalTestBase
                     Assert.Equal("Microsoft.AspNetCore.Hosting.HttpRequestIn", a.Parent.OperationName);
                     Assert.Equal(ActivityStatusCode.Unset, a.Status);
                     Assert.False(a.HasRemoteParent);
-                    Assert.True(a.IsStopped);
                     Assert.Empty(a.Baggage);
                 });
 

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -116,11 +116,6 @@ public partial class HubConnectionTests : FunctionalTestBase
             {
                 await connection.DisposeAsync().DefaultTimeout();
             }
-            var serverSource = server.Services.GetRequiredService<SignalRActivitySource>().ActivitySource;
-                    Assert.Equal($"{hubName}/OnConnectedAsync", a.OperationName);
-                    Assert.Equal($"{hubName}/HelloWorld", a.OperationName);
-                    Assert.Equal($"{hubName}/HelloWorld", a.OperationName);
-                    Assert.Equal($"{hubName}/OnDisconnectedAsync", a.OperationName);
         }
     }
 
@@ -481,10 +476,6 @@ public partial class HubConnectionTests : FunctionalTestBase
     }
 
     [Theory]
-            var serverSource = server.Services.GetRequiredService<SignalRActivitySource>().ActivitySource;
-                    Assert.Equal($"{hubName}/OnConnectedAsync", a.OperationName);
-                    Assert.Equal($"{hubName}/Stream", a.OperationName);
-                    Assert.Equal($"{hubName}/OnDisconnectedAsync", a.OperationName);
     [InlineData("json")]
     [InlineData("messagepack")]
     public async Task CanStreamToHubWithIAsyncEnumerableMethodArg(string protocolName)

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/Hubs.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/Hubs.cs
@@ -20,6 +20,8 @@ public class TestHub : Hub
 
     public string Echo(string message) => TestHubMethodsImpl.Echo(message);
 
+    public string InvokeException() => TestHubMethodsImpl.InvokeException();
+
     public ChannelReader<int> Stream(int count) => TestHubMethodsImpl.Stream(count);
 
     public ChannelReader<int> StreamException() => TestHubMethodsImpl.StreamException();
@@ -140,6 +142,8 @@ public class DynamicTestHub : DynamicHub
 
     public string Echo(string message) => TestHubMethodsImpl.Echo(message);
 
+    public string InvokeException() => TestHubMethodsImpl.InvokeException();
+
     public ChannelReader<int> Stream(int count) => TestHubMethodsImpl.Stream(count);
 
     public ChannelReader<int> StreamException() => TestHubMethodsImpl.StreamException();
@@ -173,6 +177,8 @@ public class TestHubT : Hub<ITestHub>
     public string HelloWorld() => TestHubMethodsImpl.HelloWorld();
 
     public string Echo(string message) => TestHubMethodsImpl.Echo(message);
+
+    public string InvokeException() => TestHubMethodsImpl.InvokeException();
 
     public ChannelReader<int> Stream(int count) => TestHubMethodsImpl.Stream(count);
 
@@ -213,6 +219,8 @@ internal static class TestHubMethodsImpl
     {
         return message;
     }
+
+    public static string InvokeException() => throw new InvalidOperationException();
 
     public static ChannelReader<int> Stream(int count)
     {

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionTests.Negotiate.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionTests.Negotiate.cs
@@ -456,6 +456,7 @@ public partial class HttpConnectionTests
 
             testHttpHandler.OnLongPollDelete((token) => ResponseUtils.CreateResponse(HttpStatusCode.Accepted));
 
+            EndPoint connectedEndpoint = null;
             using (var noErrorScope = new VerifyNoErrorsScope())
             {
                 await WithConnectionAsync(
@@ -463,6 +464,7 @@ public partial class HttpConnectionTests
                     async (connection) =>
                     {
                         await connection.StartAsync().DefaultTimeout();
+                        connectedEndpoint = connection.RemoteEndPoint;
                     });
             }
 
@@ -471,6 +473,7 @@ public partial class HttpConnectionTests
             Assert.Equal("https://another.domain.url/chat?negotiateVersion=1&id=0rge0d00-0040-0030-0r00-000q00r00e00", testHttpHandler.ReceivedRequests[2].RequestUri.ToString());
             Assert.Equal("https://another.domain.url/chat?negotiateVersion=1&id=0rge0d00-0040-0030-0r00-000q00r00e00", testHttpHandler.ReceivedRequests[3].RequestUri.ToString());
             Assert.Equal(5, testHttpHandler.ReceivedRequests.Count);
+            Assert.Equal("https://another.domain.url/chat", connectedEndpoint.ToString());
         }
 
         [Fact]

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.Helpers.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.Helpers.cs
@@ -21,7 +21,11 @@ public partial class HubConnectionTests
         var builder = new HubConnectionBuilder().WithUrl("http://example.com");
 
         var delegateConnectionFactory = new DelegateConnectionFactory(
-            endPoint => connection.StartAsync());
+            async endPoint =>
+            {
+                connection.RemoteEndPoint = endPoint;
+                return await connection.StartAsync();
+            });
 
         builder.Services.AddSingleton<IConnectionFactory>(delegateConnectionFactory);
 

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.Helpers.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.Helpers.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.SignalR.Client.Internal;
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.AspNetCore.SignalR.Tests;
 using Microsoft.Extensions.DependencyInjection;
@@ -11,7 +12,11 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests;
 
 public partial class HubConnectionTests
 {
-    private static HubConnection CreateHubConnection(TestConnection connection, IHubProtocol protocol = null, ILoggerFactory loggerFactory = null)
+    private static HubConnection CreateHubConnection(
+        TestConnection connection,
+        IHubProtocol protocol = null,
+        ILoggerFactory loggerFactory = null,
+        SignalRClientActivitySource clientActivitySource = null)
     {
         var builder = new HubConnectionBuilder().WithUrl("http://example.com");
 
@@ -28,6 +33,11 @@ public partial class HubConnectionTests
         if (protocol != null)
         {
             builder.Services.AddSingleton(protocol);
+        }
+
+        if (clientActivitySource != null)
+        {
+            builder.Services.AddSingleton(clientActivitySource);
         }
 
         return builder.Build();

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.Protocol.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.Protocol.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.Threading.Channels;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.SignalR.Tests;
@@ -141,34 +140,6 @@ public partial class HubConnectionTests
         }
 
         [Fact]
-        public async Task InvokeSendsAnInvocationMessage_SendTraceHeaders()
-        {
-            var connection = new TestConnection();
-            var hubConnection = CreateHubConnection(connection);
-            try
-            {
-                await hubConnection.StartAsync().DefaultTimeout();
-
-                using var clientActivity = new Activity("ClientActivity");
-                clientActivity.Start();
-
-                var invokeTask = hubConnection.InvokeAsync("Foo");
-
-                var invokeMessage = await connection.ReadSentJsonAsync().DefaultTimeout();
-                var traceParent = (string)invokeMessage["headers"]["traceparent"];
-
-                Assert.Equal(clientActivity.Id, traceParent);
-
-                Assert.Equal(TaskStatus.WaitingForActivation, invokeTask.Status);
-            }
-            finally
-            {
-                await hubConnection.DisposeAsync().DefaultTimeout();
-                await connection.DisposeAsync().DefaultTimeout();
-            }
-        }
-
-        [Fact]
         public async Task ReceiveCloseMessageWithoutErrorWillCloseHubConnection()
         {
             var closedTcs = new TaskCompletionSource<Exception>();
@@ -241,36 +212,6 @@ public partial class HubConnectionTests
 
                 // ReadSentTextMessageAsync strips off the record separator (because it has use it as a separator now that we use Pipelines)
                 Assert.Equal("{\"type\":4,\"invocationId\":\"1\",\"target\":\"Foo\",\"arguments\":[]}", invokeMessage);
-
-                // Complete the channel
-                await connection.ReceiveJsonMessage(new { invocationId = "1", type = 3 }).DefaultTimeout();
-                await channel.Completion.DefaultTimeout();
-            }
-            finally
-            {
-                await hubConnection.DisposeAsync().DefaultTimeout();
-                await connection.DisposeAsync().DefaultTimeout();
-            }
-        }
-
-        [Fact]
-        public async Task StreamSendsAnInvocationMessage_SendTraceHeaders()
-        {
-            var connection = new TestConnection();
-            var hubConnection = CreateHubConnection(connection);
-            try
-            {
-                await hubConnection.StartAsync().DefaultTimeout();
-
-                using var clientActivity = new Activity("ClientActivity");
-                clientActivity.Start();
-
-                var channel = await hubConnection.StreamAsChannelAsync<object>("Foo").DefaultTimeout();
-
-                var invokeMessage = await connection.ReadSentJsonAsync().DefaultTimeout();
-                var traceParent = (string)invokeMessage["headers"]["traceparent"];
-
-                Assert.Equal(clientActivity.Id, traceParent);
 
                 // Complete the channel
                 await connection.ReceiveJsonMessage(new { invocationId = "1", type = 3 }).DefaultTimeout();

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.Tracing.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.Tracing.cs
@@ -1,0 +1,128 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.AspNetCore.SignalR.Client.Internal;
+using Microsoft.AspNetCore.SignalR.Tests;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.SignalR.Client.Tests;
+
+public partial class HubConnectionTests
+{
+    public class Tracing : VerifiableLoggedTest
+    {
+        [Fact]
+        public async Task InvokeSendsAnInvocationMessage_SendTraceHeaders()
+        {
+            var clientSourceContainer = new SignalRClientActivitySource();
+            Activity clientActivity = null;
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = activitySource => ReferenceEquals(activitySource, clientSourceContainer.ActivitySource),
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+                ActivityStarted = activity => clientActivity = activity
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var connection = new TestConnection();
+            var hubConnection = CreateHubConnection(connection, clientActivitySource: clientSourceContainer);
+            try
+            {
+                await hubConnection.StartAsync().DefaultTimeout();
+
+                var invokeTask = hubConnection.InvokeAsync("Foo");
+
+                var invokeMessage = await connection.ReadSentJsonAsync().DefaultTimeout();
+                var traceParent = (string)invokeMessage["headers"]["traceparent"];
+
+                Assert.Equal(clientActivity.Id, traceParent);
+
+                Assert.Equal(TaskStatus.WaitingForActivation, invokeTask.Status);
+            }
+            finally
+            {
+                await hubConnection.DisposeAsync().DefaultTimeout();
+                await connection.DisposeAsync().DefaultTimeout();
+            }
+        }
+
+        [Fact]
+        public async Task StreamSendsAnInvocationMessage_SendTraceHeaders()
+        {
+            var clientSourceContainer = new SignalRClientActivitySource();
+            Activity clientActivity = null;
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = activitySource => ReferenceEquals(activitySource, clientSourceContainer.ActivitySource),
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+                ActivityStarted = activity => clientActivity = activity
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var connection = new TestConnection();
+            var hubConnection = CreateHubConnection(connection, clientActivitySource: clientSourceContainer);
+            try
+            {
+                await hubConnection.StartAsync().DefaultTimeout();
+
+                var channel = await hubConnection.StreamAsChannelAsync<object>("Foo").DefaultTimeout();
+
+                var invokeMessage = await connection.ReadSentJsonAsync().DefaultTimeout();
+                var traceParent = (string)invokeMessage["headers"]["traceparent"];
+
+                Assert.Equal(clientActivity.Id, traceParent);
+
+                // Complete the channel
+                await connection.ReceiveJsonMessage(new { invocationId = "1", type = 3 }).DefaultTimeout();
+                await channel.Completion.DefaultTimeout();
+            }
+            finally
+            {
+                await hubConnection.DisposeAsync().DefaultTimeout();
+                await connection.DisposeAsync().DefaultTimeout();
+            }
+        }
+
+        [Fact]
+        public async Task SendAnInvocationMessage_SendTraceHeaders()
+        {
+            var clientSourceContainer = new SignalRClientActivitySource();
+            Activity clientActivity = null;
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = activitySource => ReferenceEquals(activitySource, clientSourceContainer.ActivitySource),
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+                ActivityStarted = activity => clientActivity = activity
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var connection = new TestConnection();
+            var hubConnection = CreateHubConnection(connection, clientActivitySource: clientSourceContainer);
+            try
+            {
+                await hubConnection.StartAsync().DefaultTimeout();
+
+                await hubConnection.SendAsync("Foo");
+
+                var invokeMessage = await connection.ReadSentJsonAsync().DefaultTimeout();
+                var traceParent = (string)invokeMessage["headers"]["traceparent"];
+
+                Assert.Equal(clientActivity.Id, traceParent);
+            }
+            finally
+            {
+                await hubConnection.DisposeAsync().DefaultTimeout();
+                await connection.DisposeAsync().DefaultTimeout();
+            }
+        }
+
+    }
+}

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.Tracing.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.Tracing.cs
@@ -184,7 +184,7 @@ public partial class HubConnectionTests
             connection = new TestConnection(onStart: async () =>
             {
                 await syncPoint.WaitToContinue();
-                connection.RemoteEndPoint = new UriEndPoint(new Uri("http://example.net"));
+                connection.RemoteEndPoint = new UriEndPoint(new Uri("http://example.net:5050"));
             });
             var hubConnection = CreateHubConnection(connection, clientActivitySource: clientSourceContainer);
             try
@@ -197,6 +197,7 @@ public partial class HubConnectionTests
 
                 // Initial server.address uses configured HubConnection URL.
                 Assert.Equal("example.com", clientActivity.TagObjects.Single(t => t.Key == "server.address").Value);
+                Assert.Equal(80, (int)clientActivity.TagObjects.Single(t => t.Key == "server.port").Value);
 
                 syncPoint.Continue();
 
@@ -206,6 +207,7 @@ public partial class HubConnectionTests
 
                 // After connection is started, server.address is updated to the connection's remote endpoint.
                 Assert.Equal("example.net", clientActivity.TagObjects.Single(t => t.Key == "server.address").Value);
+                Assert.Equal(5050, (int)clientActivity.TagObjects.Single(t => t.Key == "server.port").Value);
             }
             finally
             {

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
@@ -148,8 +148,6 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
 
         _url = _httpConnectionOptions.Url;
 
-        RemoteEndPoint = new UriEndPoint(_url);
-
         if (!httpConnectionOptions.SkipNegotiation || httpConnectionOptions.Transports != HttpTransportType.WebSockets)
         {
             _httpClient = CreateHttpClient();
@@ -353,6 +351,9 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
                 throw new InvalidOperationException("Negotiate redirection limit exceeded.");
             }
 
+            // Set the final negotiated URI as the endpoint.
+            RemoteEndPoint = new UriEndPoint(Utils.CreateEndPointUri(uri));
+
             // This should only need to happen once
             var connectUrl = CreateConnectUrl(uri, negotiationResponse.ConnectionToken);
 
@@ -405,6 +406,9 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
                             _httpConnectionOptions.UseStatefulReconnect = transportType == HttpTransportType.WebSockets ? _httpConnectionOptions.UseStatefulReconnect : false;
                             negotiationResponse = await GetNegotiationResponseAsync(uri, cancellationToken).ConfigureAwait(false);
                             connectUrl = CreateConnectUrl(uri, negotiationResponse.ConnectionToken);
+
+                            // Set the final negotiated URI as the endpoint.
+                            RemoteEndPoint = new UriEndPoint(Utils.CreateEndPointUri(uri));
                         }
 
                         Log.StartingTransport(_logger, transportType, uri);

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
@@ -148,6 +148,8 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
 
         _url = _httpConnectionOptions.Url;
 
+        RemoteEndPoint = new UriEndPoint(_url);
+
         if (!httpConnectionOptions.SkipNegotiation || httpConnectionOptions.Transports != HttpTransportType.WebSockets)
         {
             _httpClient = CreateHttpClient();

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/Utils.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/Utils.cs
@@ -7,6 +7,19 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal;
 
 internal static class Utils
 {
+    public static Uri CreateEndPointUri(Uri url)
+    {
+        // The EndPoint URI shouldn't have querystring or target.
+        var uriBuilder = new UriBuilder
+        {
+            Scheme = url.Scheme,
+            Host = url.Host,
+            Port = url.Port,
+            Path = url.AbsolutePath
+        };
+        return uriBuilder.Uri;
+    }
+
     public static Uri AppendPath(Uri url, string path)
     {
         var builder = new UriBuilder(url);


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/51557. Specifically, the client activity source item.

Follow up to https://github.com/dotnet/aspnetcore/pull/55439 and builds on top of https://github.com/dotnet/aspnetcore/pull/57049.

Changes:

* Invocations by the SignalR client now start a local activity.
* Activities are started for regular invocations and streaming methods.
* Activity starts with the invocation and ends when the client receives a completion message.

Not planned in this PR:

* Tracing in other clients.

Nothing is blocking additional work in the future in the future.