### PR TITLE
[8.0] Add support for trusting dev certs on linux

### DIFF
--- a/src/ProjectTemplates/Shared/DevelopmentCertificate.cs
+++ b/src/ProjectTemplates/Shared/DevelopmentCertificate.cs
@@ -35,7 +35,7 @@ public readonly struct DevelopmentCertificate
         var manager = CertificateManager.Instance;
         var certificate = manager.CreateAspNetCoreHttpsDevelopmentCertificate(now, now.AddYears(1));
         var certificateThumbprint = certificate.Thumbprint;
-        CertificateManager.ExportCertificate(certificate, path: certificatePath, includePrivateKey: true, certificatePassword, CertificateKeyExportFormat.Pfx);
+        manager.ExportCertificate(certificate, path: certificatePath, includePrivateKey: true, certificatePassword, CertificateKeyExportFormat.Pfx);
 
         return certificateThumbprint;
     }

--- a/src/Servers/Kestrel/Core/src/Internal/LoggerExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/LoggerExtensions.cs
@@ -40,4 +40,7 @@ internal static partial class LoggerExtensions
 
     [LoggerMessage(8, LogLevel.Warning, "The ASP.NET Core developer certificate is not trusted. For information about trusting the ASP.NET Core developer certificate, see https://aka.ms/aspnet/https-trust-dev-cert.", EventName = "DeveloperCertificateNotTrusted")]
     public static partial void DeveloperCertificateNotTrusted(this ILogger<KestrelServer> logger);
+
+    [LoggerMessage(9, LogLevel.Warning, "The ASP.NET Core developer certificate is only trusted by some clients. For information about trusting the ASP.NET Core developer certificate, see https://aka.ms/aspnet/https-trust-dev-cert", EventName = "DeveloperCertificatePartiallyTrusted")]
+    public static partial void DeveloperCertificatePartiallyTrusted(this ILogger<KestrelServer> logger);
 }

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -385,13 +385,16 @@ public class KestrelServerOptions
                 return null;
             }
 
-            var status = CertificateManager.Instance.CheckCertificateState(cert, interactive: false);
+            var status = CertificateManager.Instance.CheckCertificateState(cert);
             if (!status.Success)
             {
-                // Display a warning indicating to the user that a prompt might appear and provide instructions on what to do in that
-                // case. The underlying implementation of this check is specific to Mac OS and is handled within CheckCertificateState.
-                // Kestrel must NEVER cause a UI prompt on a production system. We only attempt this here because Mac OS is not supported
-                // in production.
+                // Failure is only possible on MacOS and indicates that, if there is a dev cert, it must be from
+                // a dotnet version prior to 7.0 - newer versions store it in such a way that this check succeeds.
+                // (Success does not mean that the dev cert has been trusted).
+                // In practice, success.FailureMessage will always be MacOSCertificateManager.InvalidCertificateState.
+                // Basically, we're just going to encourage the user to generate and trust the dev cert.  We support
+                // these older certificates not by accepting them as-is, but by modernizing them when dev-certs is run.
+                // If we detect an issue here, we can avoid a UI prompt below.
                 Debug.Assert(status.FailureMessage != null, "Status with a failure result must have a message.");
                 logger.DeveloperCertificateFirstRun(status.FailureMessage);
 
@@ -399,9 +402,17 @@ public class KestrelServerOptions
                 return null;
             }
 
-            if (!CertificateManager.Instance.IsTrusted(cert))
+            // On MacOS, this may cause a UI prompt, since it requires accessing the keychain.  Kestrel must NEVER
+            // cause a UI prompt on a production system. We only attempt this here because MacOS is not supported
+            // in production.
+            switch (CertificateManager.Instance.GetTrustLevel(cert))
             {
-                logger.DeveloperCertificateNotTrusted();
+                case CertificateManager.TrustLevel.Partial:
+                    logger.DeveloperCertificatePartiallyTrusted();
+                    break;
+                case CertificateManager.TrustLevel.None:
+                    logger.DeveloperCertificateNotTrusted();
+                    break;
             }
 
             return cert;

--- a/src/Servers/Kestrel/Core/src/TlsConfigurationLoader.cs
+++ b/src/Servers/Kestrel/Core/src/TlsConfigurationLoader.cs
@@ -176,20 +176,8 @@ internal sealed class TlsConfigurationLoader
 
     private static bool IsDevelopmentCertificate(X509Certificate2 certificate)
     {
-        if (!string.Equals(certificate.Subject, "CN=localhost", StringComparison.Ordinal))
-        {
-            return false;
-        }
-
-        foreach (var ext in certificate.Extensions)
-        {
-            if (string.Equals(ext.Oid?.Value, CertificateManager.AspNetHttpsOid, StringComparison.Ordinal))
-            {
-                return true;
-            }
-        }
-
-        return false;
+        return string.Equals(certificate.Subject, CertificateManager.LocalhostHttpsDistinguishedName, StringComparison.Ordinal) &&
+            CertificateManager.IsHttpsDevelopmentCertificate(certificate);
     }
 
     private static bool TryGetCertificatePath(string applicationName, [NotNullWhen(true)] out string? path)

--- a/src/Shared/CertificateGeneration/CertificateManager.cs
+++ b/src/Shared/CertificateGeneration/CertificateManager.cs
@@ -26,7 +26,7 @@ internal abstract class CertificateManager
     private const string ServerAuthenticationEnhancedKeyUsageOidFriendlyName = "Server Authentication";
 
     private const string LocalhostHttpsDnsName = "localhost";
-    private const string LocalhostHttpsDistinguishedName = "CN=" + LocalhostHttpsDnsName;
+    internal const string LocalhostHttpsDistinguishedName = "CN=" + LocalhostHttpsDnsName;
 
     public const int RSAMinimumKeySizeInBits = 2048;
 
@@ -62,9 +62,21 @@ internal abstract class CertificateManager
         AspNetHttpsCertificateVersion = version;
     }
 
-    public static bool IsHttpsDevelopmentCertificate(X509Certificate2 certificate) =>
-        certificate.Extensions.OfType<X509Extension>()
-        .Any(e => string.Equals(AspNetHttpsOid, e.Oid?.Value, StringComparison.Ordinal));
+    /// <remarks>
+    /// This only checks if the certificate has the OID for ASP.NET Core HTTPS development certificates -
+    /// it doesn't check the subject, validity, key usages, etc.
+    /// </remarks>
+    public static bool IsHttpsDevelopmentCertificate(X509Certificate2 certificate)
+    {
+        foreach (var extension in certificate.Extensions.OfType<X509Extension>())
+        {
+            if (string.Equals(AspNetHttpsOid, extension.Oid?.Value, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
 
     public IList<X509Certificate2> ListCertificates(
         StoreName storeName,
@@ -398,7 +410,10 @@ internal abstract class CertificateManager
             return ImportCertificateResult.InvalidCertificate;
         }
 
-        if (!IsHttpsDevelopmentCertificate(certificate))
+        // Note that we're checking Subject, rather than LocalhostHttpsDistinguishedName,
+        // because the tests use a different subject.
+        if (!string.Equals(certificate.Subject, Subject, StringComparison.Ordinal) || // Kestrel requires this
+            !IsHttpsDevelopmentCertificate(certificate))
         {
             if (Log.IsEnabled())
             {

--- a/src/Shared/CertificateGeneration/EnsureCertificateResult.cs
+++ b/src/Shared/CertificateGeneration/EnsureCertificateResult.cs
@@ -11,6 +11,7 @@ internal enum EnsureCertificateResult
     ErrorSavingTheCertificateIntoTheCurrentUserPersonalStore,
     ErrorExportingTheCertificate,
     FailedToTrustTheCertificate,
+    PartiallyFailedToTrustTheCertificate,
     UserCancelledTrustStep,
     FailedToMakeKeyAccessible,
     ExistingHttpsCertificateTrusted,

--- a/src/Shared/CertificateGeneration/MacOSCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/MacOSCertificateManager.cs
@@ -18,6 +18,8 @@ namespace Microsoft.AspNetCore.Certificates.Generation;
 /// </remarks>
 internal sealed class MacOSCertificateManager : CertificateManager
 {
+    private const UnixFileMode DirectoryPermissions = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
+
     // User keychain. Guard with quotes when using in command lines since users may have set
     // their user profile (HOME) directory to a non-standard path that includes whitespace.
     private static readonly string MacOSUserKeychain = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) + "/Library/Keychains/login.keychain-db";
@@ -93,6 +95,7 @@ internal sealed class MacOSCertificateManager : CertificateManager
         var tmpFile = Path.GetTempFileName();
         try
         {
+            // We can't guarantee that the temp file is in a directory with sensible permissions, but we're not exporting the private key
             ExportCertificate(publicCertificate, tmpFile, includePrivateKey: false, password: null, CertificateKeyExportFormat.Pfx);
             if (Log.IsEnabled())
             {
@@ -134,9 +137,7 @@ internal sealed class MacOSCertificateManager : CertificateManager
     {
         try
         {
-            // Ensure that the directory exists before writing to the file.
-            Directory.CreateDirectory(MacOSUserHttpsCertificateLocation);
-
+            // This path is in a well-known folder, so we trust the permissions.
             var certificatePath = GetCertificateFilePath(candidate);
             ExportCertificate(candidate, certificatePath, includePrivateKey: true, null, CertificateKeyExportFormat.Pfx);
         }
@@ -152,6 +153,7 @@ internal sealed class MacOSCertificateManager : CertificateManager
         var tmpFile = Path.GetTempFileName();
         try
         {
+            // We can't guarantee that the temp file is in a directory with sensible permissions, but we're not exporting the private key
             ExportCertificate(certificate, tmpFile, includePrivateKey: false, password: null, CertificateKeyExportFormat.Pem);
 
             using var checkTrustProcess = Process.Start(new ProcessStartInfo(
@@ -316,7 +318,7 @@ internal sealed class MacOSCertificateManager : CertificateManager
             }
 
             // Ensure that the directory exists before writing to the file.
-            Directory.CreateDirectory(MacOSUserHttpsCertificateLocation);
+            CreateDirectoryWithPermissions(MacOSUserHttpsCertificateLocation);
 
             File.WriteAllBytes(GetCertificateFilePath(certificate), certBytes);
         }
@@ -473,5 +475,23 @@ internal sealed class MacOSCertificateManager : CertificateManager
         {
             RemoveCertificateFromKeychain(MacOSUserKeychain, certificate);
         }
+    }
+
+    protected override void CreateDirectoryWithPermissions(string directoryPath)
+    {
+#pragma warning disable CA1416 // Validate platform compatibility (not supported on Windows)
+        var dirInfo = new DirectoryInfo(directoryPath);
+        if (dirInfo.Exists)
+        {
+            if ((dirInfo.UnixFileMode & ~DirectoryPermissions) != 0)
+            {
+                Log.DirectoryPermissionsNotSecure(dirInfo.FullName);
+            }
+        }
+        else
+        {
+            Directory.CreateDirectory(directoryPath, DirectoryPermissions);
+        }
+#pragma warning restore CA1416 // Validate platform compatibility
     }
 }

--- a/src/Shared/CertificateGeneration/MacOSCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/MacOSCertificateManager.cs
@@ -11,6 +11,11 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.AspNetCore.Certificates.Generation;
 
+/// <remarks>
+/// Normally, we avoid the use of <see cref="X509Certificate2.Thumbprint"/> because it's a SHA-1 hash and, therefore,
+/// not adequate for security applications.  However, the MacOS security tool uses SHA-1 hashes for certificate
+/// identification, so we're stuck.
+/// </remarks>
 internal sealed class MacOSCertificateManager : CertificateManager
 {
     // User keychain. Guard with quotes when using in command lines since users may have set

--- a/src/Shared/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/UnixCertificateManager.cs
@@ -1,14 +1,42 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
+#nullable enable
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Security.Cryptography.X509Certificates;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.AspNetCore.Certificates.Generation;
 
-internal sealed class UnixCertificateManager : CertificateManager
+/// <remarks>
+/// On Unix, we trust the certificate in the following locations:
+///   1. dotnet (i.e. the CurrentUser/Root store)
+///   2. OpenSSL (i.e. adding it to a directory in $SSL_CERT_DIR)
+///   3. Firefox &amp; Chromium (i.e. adding it to an NSS DB for each browser)
+/// All of these locations are per-user.
+/// </remarks>
+internal sealed partial class UnixCertificateManager : CertificateManager
 {
+    /// <summary>The name of an environment variable consumed by OpenSSL to locate certificates.</summary>
+    private const string OpenSslCertificateDirectoryVariableName = "SSL_CERT_DIR";
+
+    private const string OpenSslCertDirectoryOverrideVariableName = "DOTNET_DEV_CERTS_OPENSSL_CERTIFICATE_DIRECTORY";
+    private const string NssDbOverrideVariableName = "DOTNET_DEV_CERTS_NSSDB_PATHS";
+    // CONSIDER: we could have a distinct variable for Mozilla NSS DBs, but detecting them from the path seems sufficient for now.
+
+    private const string BrowserFamilyChromium = "Chromium";
+    private const string BrowserFamilyFirefox = "Firefox";
+
+    private const string OpenSslCommand = "openssl";
+    private const string CertUtilCommand = "certutil";
+
+    private const int MaxHashCollisions = 10; // Something is going badly wrong if we have this many dev certs with the same hash
+
+    private HashSet<string>? _availableCommands;
+
     public UnixCertificateManager()
     {
     }
@@ -18,7 +46,104 @@ internal sealed class UnixCertificateManager : CertificateManager
     {
     }
 
-    public override bool IsTrusted(X509Certificate2 certificate) => false;
+    public override TrustLevel GetTrustLevel(X509Certificate2 certificate)
+    {
+        var sawTrustSuccess = false;
+        var sawTrustFailure = false;
+
+        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(OpenSslCertDirectoryOverrideVariableName)))
+        {
+            // Warn but don't bail.
+            Log.UnixOpenSslCertificateDirectoryOverrideIgnored(OpenSslCertDirectoryOverrideVariableName);
+        }
+
+        // Building the chain will check whether dotnet trusts the cert.  We could, instead,
+        // enumerate the Root store and/or look for the file in the OpenSSL directory, but
+        // this tests the real-world behavior.
+        using var chain = new X509Chain();
+        // This is just a heuristic for whether or not we should prompt the user to re-run with `--trust`
+        // so we don't need to check revocation (which doesn't really make sense for dev certs anyway)
+        chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+        if (chain.Build(certificate))
+        {
+            sawTrustSuccess = true;
+        }
+        else
+        {
+            sawTrustFailure = true;
+            Log.UnixNotTrustedByDotnet();
+        }
+
+        var nickname = GetCertificateNickname(certificate);
+
+        var sslCertDirString = Environment.GetEnvironmentVariable(OpenSslCertificateDirectoryVariableName);
+        if (string.IsNullOrEmpty(sslCertDirString))
+        {
+            sawTrustFailure = true;
+            Log.UnixNotTrustedByOpenSsl(OpenSslCertificateDirectoryVariableName);
+        }
+        else
+        {
+            var foundCert = false;
+            var sslCertDirs = sslCertDirString.Split(Path.PathSeparator);
+            foreach (var sslCertDir in sslCertDirs)
+            {
+                var certPath = Path.Combine(sslCertDir, nickname + ".pem");
+                if (File.Exists(certPath))
+                {
+                    var candidate = X509CertificateLoader.LoadCertificateFromFile(certPath);
+                    if (AreCertificatesEqual(certificate, candidate))
+                    {
+                        foundCert = true;
+                        break;
+                    }
+                }
+            }
+
+            if (foundCert)
+            {
+                sawTrustSuccess = true;
+            }
+            else
+            {
+                sawTrustFailure = true;
+                Log.UnixNotTrustedByOpenSsl(OpenSslCertificateDirectoryVariableName);
+            }
+        }
+
+        var nssDbs = GetNssDbs(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
+        if (nssDbs.Count > 0)
+        {
+            if (!IsCommandAvailable(CertUtilCommand))
+            {
+                // If there are browsers but we don't have certutil, we can't check trust and,
+                // in all probability, we can't have previously established it.
+                Log.UnixMissingCertUtilCommand(CertUtilCommand);
+                sawTrustFailure = true;
+            }
+            else
+            {
+                foreach (var nssDb in nssDbs)
+                {
+                    if (IsCertificateInNssDb(nickname, nssDb))
+                    {
+                        sawTrustSuccess = true;
+                    }
+                    else
+                    {
+                        sawTrustFailure = true;
+                        Log.UnixNotTrustedByNss(nssDb.Path, nssDb.IsFirefox ? BrowserFamilyFirefox : BrowserFamilyChromium);
+                    }
+                }
+            }
+        }
+
+        return sawTrustSuccess
+            ? sawTrustFailure
+                ? TrustLevel.Partial
+                : TrustLevel.Full
+            : TrustLevel.None;
+    }
 
     protected override X509Certificate2 SaveCertificateCore(X509Certificate2 certificate, StoreName storeName, StoreLocation storeLocation)
     {
@@ -37,29 +162,750 @@ internal sealed class UnixCertificateManager : CertificateManager
         return certificate;
     }
 
-    internal override CheckCertificateStateResult CheckCertificateState(X509Certificate2 candidate, bool interactive)
+    internal override CheckCertificateStateResult CheckCertificateState(X509Certificate2 candidate)
     {
         // Return true as we don't perform any check.
+        // This is about checking storage, not trust.
         return new CheckCertificateStateResult(true, null);
     }
 
     internal override void CorrectCertificateState(X509Certificate2 candidate)
     {
         // Do nothing since we don't have anything to check here.
+        // This is about correcting storage, not trust.
     }
 
     protected override bool IsExportable(X509Certificate2 c) => true;
 
-    protected override void TrustCertificateCore(X509Certificate2 certificate) =>
-        throw new InvalidOperationException("Trusting the certificate is not supported on linux");
+    protected override TrustLevel TrustCertificateCore(X509Certificate2 certificate)
+    {
+        var sawTrustFailure = false;
+        var sawTrustSuccess = false;
+
+        using var store = new X509Store(StoreName.Root, StoreLocation.CurrentUser);
+        store.Open(OpenFlags.ReadWrite);
+
+        if (TryFindCertificateInStore(store, certificate, out _))
+        {
+            sawTrustSuccess = true;
+        }
+        else
+        {
+            try
+            {
+                using var publicCertificate = X509CertificateLoader.LoadCertificate(certificate.Export(X509ContentType.Cert));
+                // FriendlyName is Windows-only, so we don't set it here.
+                store.Add(publicCertificate);
+                Log.UnixDotnetTrustSucceeded();
+                sawTrustSuccess = true;
+            }
+            catch (Exception ex)
+            {
+                sawTrustFailure = true;
+                Log.UnixDotnetTrustException(ex.Message);
+            }
+        }
+
+        var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+        // Rather than create a temporary file we'll have to clean up, we prefer to export the dev cert
+        // to its final location in the OpenSSL directory.  As a result, any failure up until that point
+        // is fatal (i.e. we can't trust the cert in other locations).
+
+        var certDir = GetOpenSslCertificateDirectory(homeDirectory)!; // May not exist
+
+        var nickname = GetCertificateNickname(certificate);
+        var certPath = Path.Combine(certDir, nickname) + ".pem";
+
+        var needToExport = true;
+
+        // We do our own check for file collisions since ExportCertificate silently overwrites.
+        if (File.Exists(certPath))
+        {
+            try
+            {
+                using var existingCert = X509CertificateLoader.LoadCertificateFromFile(certPath);
+                if (!AreCertificatesEqual(existingCert, certificate))
+                {
+                    Log.UnixNotOverwritingCertificate(certPath);
+                    return TrustLevel.None;
+                }
+
+                needToExport = false; // If the bits are on disk, we don't need to re-export
+            }
+            catch
+            {
+                // If we couldn't load the file, then we also can't safely overwite it.
+                Log.UnixNotOverwritingCertificate(certPath);
+                return TrustLevel.None;
+            }
+        }
+
+        if (needToExport)
+        {
+            // Security: we don't need the private key for trust, so we don't export it.
+            // Note that this will create directories as needed.
+            ExportCertificate(certificate, certPath, includePrivateKey: false, password: null, CertificateKeyExportFormat.Pem);
+        }
+
+        // Once the certificate is on disk, we prefer not to throw - some subsequent trust step might succeed.
+
+        var openSslTrustSucceeded = false;
+
+        var isOpenSslAvailable = IsCommandAvailable(OpenSslCommand);
+        if (isOpenSslAvailable)
+        {
+            if (TryRehashOpenSslCertificates(certDir))
+            {
+                openSslTrustSucceeded = true;
+            }
+        }
+        else
+        {
+            Log.UnixMissingOpenSslCommand(OpenSslCommand);
+        }
+
+        if (openSslTrustSucceeded)
+        {
+            Log.UnixOpenSslTrustSucceeded();
+            sawTrustSuccess = true;
+        }
+        else
+        {
+            // The helpers log their own failure reasons - we just describe the consequences
+            Log.UnixOpenSslTrustFailed();
+            sawTrustFailure = true;
+        }
+
+        var nssDbs = GetNssDbs(homeDirectory);
+        if (nssDbs.Count > 0)
+        {
+            var isCertUtilAvailable = IsCommandAvailable(CertUtilCommand);
+            if (!isCertUtilAvailable)
+            {
+                Log.UnixMissingCertUtilCommand(CertUtilCommand);
+                // We'll loop over the nssdbs anyway so they'll be listed
+            }
+
+            foreach (var nssDb in nssDbs)
+            {
+                if (isCertUtilAvailable && TryAddCertificateToNssDb(certPath, nickname, nssDb))
+                {
+                    if (IsCertificateInNssDb(nickname, nssDb))
+                    {
+                        Log.UnixNssDbTrustSucceeded(nssDb.Path);
+                        sawTrustSuccess = true;
+                    }
+                    else
+                    {
+                        // If the dev cert is in the db under a different nickname, adding it will succeed (and probably even cause it to be trusted)
+                        // but IsTrusted won't find it.  This is unlikely to happen in practice, so we warn here, rather than hardening IsTrusted.
+                        Log.UnixNssDbTrustFailedWithProbableConflict(nssDb.Path, nssDb.IsFirefox ? BrowserFamilyFirefox : BrowserFamilyChromium);
+                        sawTrustFailure = true;
+                    }
+                }
+                else
+                {
+                    Log.UnixNssDbTrustFailed(nssDb.Path, nssDb.IsFirefox ? BrowserFamilyFirefox : BrowserFamilyChromium);
+                    sawTrustFailure = true;
+                }
+            }
+        }
+
+        if (sawTrustFailure)
+        {
+            if (sawTrustSuccess)
+            {
+                // Untrust throws in this case, but we're more lenient since a partially trusted state may be useful in practice.
+                Log.UnixTrustPartiallySucceeded();
+            }
+            else
+            {
+                return TrustLevel.None;
+            }
+        }
+
+        if (openSslTrustSucceeded)
+        {
+            Debug.Assert(IsCommandAvailable(OpenSslCommand), "How did we trust without the openssl command?");
+
+            var homeDirectoryWithSlash = homeDirectory[^1] == Path.DirectorySeparatorChar
+                ? homeDirectory
+                : homeDirectory + Path.DirectorySeparatorChar;
+
+            var prettyCertDir = certDir.StartsWith(homeDirectoryWithSlash, StringComparison.Ordinal)
+                ? Path.Combine("$HOME", certDir[homeDirectoryWithSlash.Length..])
+                : certDir;
+
+            if (TryGetOpenSslDirectory(out var openSslDir))
+            {
+                Log.UnixSuggestSettingEnvironmentVariable(prettyCertDir, Path.Combine(openSslDir, "certs"), OpenSslCertificateDirectoryVariableName);
+            }
+            else
+            {
+                Log.UnixSuggestSettingEnvironmentVariableWithoutExample(prettyCertDir, OpenSslCertificateDirectoryVariableName);
+            }
+        }
+
+        return sawTrustFailure
+            ? TrustLevel.Partial
+            : TrustLevel.Full;
+    }
 
     protected override void RemoveCertificateFromTrustedRoots(X509Certificate2 certificate)
     {
-        // No-op here as is benign
+        var sawUntrustFailure = false;
+
+        using var store = new X509Store(StoreName.Root, StoreLocation.CurrentUser);
+        store.Open(OpenFlags.ReadWrite);
+
+        if (TryFindCertificateInStore(store, certificate, out var matching))
+        {
+            try
+            {
+                store.Remove(matching);
+            }
+            catch (Exception ex)
+            {
+                Log.UnixDotnetUntrustException(ex.Message);
+                sawUntrustFailure = true;
+            }
+        }
+
+        var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)!;
+
+        // We don't attempt to remove the directory when it's empty - it's a standard location
+        // and will almost certainly be used in the future.
+        var certDir = GetOpenSslCertificateDirectory(homeDirectory); // May not exist
+
+        var nickname = GetCertificateNickname(certificate);
+        var certPath = Path.Combine(certDir, nickname) + ".pem";
+
+        if (File.Exists(certPath))
+        {
+            var openSslUntrustSucceeded = false;
+
+            if (IsCommandAvailable(OpenSslCommand))
+            {
+                if (TryDeleteCertificateFile(certPath) && TryRehashOpenSslCertificates(certDir))
+                {
+                    openSslUntrustSucceeded = true;
+                }
+            }
+            else
+            {
+                Log.UnixMissingOpenSslCommand(OpenSslCommand);
+            }
+
+            if (openSslUntrustSucceeded)
+            {
+                Log.UnixOpenSslUntrustSucceeded();
+            }
+            else
+            {
+                // The helpers log their own failure reasons - we just describe the consequences
+                Log.UnixOpenSslUntrustFailed();
+                sawUntrustFailure = true;
+            }
+        }
+        else
+        {
+            Log.UnixOpenSslUntrustSkipped(certPath);
+        }
+
+        var nssDbs = GetNssDbs(homeDirectory);
+        if (nssDbs.Count > 0)
+        {
+            var isCertUtilAvailable = IsCommandAvailable(CertUtilCommand);
+            if (!isCertUtilAvailable)
+            {
+                Log.UnixMissingCertUtilCommand(CertUtilCommand);
+                // We'll loop over the nssdbs anyway so they'll be listed
+            }
+
+            foreach (var nssDb in nssDbs)
+            {
+                if (isCertUtilAvailable && TryRemoveCertificateFromNssDb(nickname, nssDb))
+                {
+                    Log.UnixNssDbUntrustSucceeded(nssDb.Path);
+                }
+                else
+                {
+                    Log.UnixNssDbUntrustFailed(nssDb.Path);
+                    sawUntrustFailure = true;
+                }
+            }
+        }
+
+        if (sawUntrustFailure)
+        {
+            // It might be nice to include more specific error information in the exception message, but we've logged it anyway.
+            throw new InvalidOperationException($@"There was an error removing the certificate with thumbprint '{certificate.Thumbprint}'.");
+        }
     }
 
     protected override IList<X509Certificate2> GetCertificatesToRemove(StoreName storeName, StoreLocation storeLocation)
     {
         return ListCertificates(StoreName.My, StoreLocation.CurrentUser, isValid: false, requireExportable: false);
+    }
+
+    private static string GetChromiumNssDb(string homeDirectory)
+    {
+        return Path.Combine(homeDirectory, ".pki", "nssdb");
+    }
+
+    private static string GetFirefoxDirectory(string homeDirectory)
+    {
+        return Path.Combine(homeDirectory, ".mozilla", "firefox");
+    }
+
+    private static string GetFirefoxSnapDirectory(string homeDirectory)
+    {
+        return Path.Combine(homeDirectory, "snap", "firefox", "common", ".mozilla", "firefox");
+    }
+
+    private bool IsCommandAvailable(string command)
+    {
+        _availableCommands ??= FindAvailableCommands();
+        return _availableCommands.Contains(command);
+    }
+
+    private static HashSet<string> FindAvailableCommands()
+    {
+        var availableCommands = new HashSet<string>();
+
+        // We need OpenSSL 1.1.1h or newer (to pick up https://github.com/openssl/openssl/pull/12357),
+        // but, given that all of v1 is EOL, it doesn't seem worthwhile to check the version.
+        var commands = new[] { OpenSslCommand, CertUtilCommand };
+
+        var searchPath = Environment.GetEnvironmentVariable("PATH");
+
+        if (searchPath is null)
+        {
+            return availableCommands;
+        }
+
+        var searchFolders = searchPath.Split(Path.PathSeparator);
+
+        foreach (var searchFolder in searchFolders)
+        {
+            foreach (var command in commands)
+            {
+                if (!availableCommands.Contains(command))
+                {
+                    try
+                    {
+                        if (File.Exists(Path.Combine(searchFolder, command)))
+                        {
+                            availableCommands.Add(command);
+                        }
+                    }
+                    catch
+                    {
+                        // It's not interesting to report (e.g.) permission errors here.
+                    }
+                }
+            }
+
+            // Stop early if we've found all the required commands.
+            // They're usually all in the same folder (/bin or /usr/bin).
+            if (availableCommands.Count == commands.Length)
+            {
+                break;
+            }
+        }
+
+        return availableCommands;
+    }
+
+    private static string GetCertificateNickname(X509Certificate2 certificate)
+    {
+        return $"aspnetcore-localhost-{certificate.Thumbprint}";
+    }
+
+    /// <remarks>
+    /// It is the caller's responsibility to ensure that <see cref="CertUtilCommand"/> is available.
+    /// </remarks>
+    private static bool IsCertificateInNssDb(string nickname, NssDb nssDb)
+    {
+        // -V will validate that a cert can be used for a given purpose, in this case, server verification.
+        // There is no corresponding -V check for the "Trusted CA" status required by Firefox, so we just check for existence.
+        // (The docs suggest that "-V -u A" should do this, but it seems to accept all certs.)
+        var operation = nssDb.IsFirefox ? "-L" : "-V -u V";
+
+        var startInfo = new ProcessStartInfo(CertUtilCommand, $"-d sql:{nssDb.Path} -n {nickname} {operation}")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        try
+        {
+            using var process = Process.Start(startInfo)!;
+            process.WaitForExit();
+            return process.ExitCode == 0;
+        }
+        catch (Exception ex)
+        {
+            Log.UnixNssDbCheckException(nssDb.Path, ex.Message);
+            // This method is used to determine whether more trust is needed, so it's better to underestimate the amount of trust.
+            return false;
+        }
+    }
+
+    /// <remarks>
+    /// It is the caller's responsibility to ensure that <see cref="CertUtilCommand"/> is available.
+    /// </remarks>
+    private static bool TryAddCertificateToNssDb(string certificatePath, string nickname, NssDb nssDb)
+    {
+        // Firefox doesn't seem to respected the more correct "trusted peer" (P) usage, so we use "trusted CA" (C) instead.
+        var usage = nssDb.IsFirefox ? "C" : "P";
+
+        // This silently clobbers an existing entry, so there's no need to check for existence first.
+        var startInfo = new ProcessStartInfo(CertUtilCommand, $"-d sql:{nssDb.Path} -n {nickname} -A -i {certificatePath} -t \"{usage},,\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        try
+        {
+            using var process = Process.Start(startInfo)!;
+            process.WaitForExit();
+            return process.ExitCode == 0;
+        }
+        catch (Exception ex)
+        {
+            Log.UnixNssDbAdditionException(nssDb.Path, ex.Message);
+            return false;
+        }
+    }
+
+    /// <remarks>
+    /// It is the caller's responsibility to ensure that <see cref="CertUtilCommand"/> is available.
+    /// </remarks>
+    private static bool TryRemoveCertificateFromNssDb(string nickname, NssDb nssDb)
+    {
+        var startInfo = new ProcessStartInfo(CertUtilCommand, $"-d sql:{nssDb.Path} -D -n {nickname}")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        try
+        {
+            using var process = Process.Start(startInfo)!;
+            process.WaitForExit();
+            if (process.ExitCode == 0)
+            {
+                return true;
+            }
+
+            // Maybe it wasn't in there because the overrides have change or trust only partially succeeded.
+            return !IsCertificateInNssDb(nickname, nssDb);
+        }
+        catch (Exception ex)
+        {
+            Log.UnixNssDbRemovalException(nssDb.Path, ex.Message);
+            return false;
+        }
+    }
+
+    private static IEnumerable<string> GetFirefoxProfiles(string firefoxDirectory)
+    {
+        try
+        {
+            var profiles = Directory.GetDirectories(firefoxDirectory, "*.default", SearchOption.TopDirectoryOnly).Concat(
+                Directory.GetDirectories(firefoxDirectory, "*.default-*", SearchOption.TopDirectoryOnly)); // There can be one of these for each release channel
+            if (!profiles.Any())
+            {
+                // This is noteworthy, given that we're in a firefox directory.
+                Log.UnixNoFirefoxProfilesFound(firefoxDirectory);
+            }
+            return profiles;
+        }
+        catch (Exception ex)
+        {
+            Log.UnixFirefoxProfileEnumerationException(firefoxDirectory, ex.Message);
+            return [];
+        }
+    }
+
+    private static string GetOpenSslCertificateDirectory(string homeDirectory)
+    {
+        var @override = Environment.GetEnvironmentVariable(OpenSslCertDirectoryOverrideVariableName);
+        if (!string.IsNullOrEmpty(@override))
+        {
+            Log.UnixOpenSslCertificateDirectoryOverridePresent(OpenSslCertDirectoryOverrideVariableName);
+            return @override;
+        }
+
+        return Path.Combine(homeDirectory, ".aspnet", "dev-certs", "trust");
+    }
+
+    private static bool TryDeleteCertificateFile(string certPath)
+    {
+        try
+        {
+            File.Delete(certPath);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.UnixCertificateFileDeletionException(certPath, ex.Message);
+            return false;
+        }
+    }
+
+    private static bool TryGetNssDbOverrides(out IReadOnlyList<string> overrides)
+    {
+        var nssDbOverride = Environment.GetEnvironmentVariable(NssDbOverrideVariableName);
+        if (string.IsNullOrEmpty(nssDbOverride))
+        {
+            overrides = [];
+            return false;
+        }
+
+        // Normally, we'd let the caller log this, since it's not really an exceptional condition,
+        // but it's not worth duplicating the code and the work.
+        Log.UnixNssDbOverridePresent(NssDbOverrideVariableName);
+
+        var nssDbs = new List<string>();
+
+        var paths = nssDbOverride.Split(Path.PathSeparator); // May be empty - the user may not want to add browser trust
+        foreach (var path in paths)
+        {
+            var nssDb = Path.GetFullPath(path);
+            if (!Directory.Exists(nssDb))
+            {
+                Log.UnixNssDbDoesNotExist(nssDb, NssDbOverrideVariableName);
+                continue;
+            }
+            nssDbs.Add(nssDb);
+        }
+
+        overrides = nssDbs;
+        return true;
+    }
+
+    private static List<NssDb> GetNssDbs(string homeDirectory)
+    {
+        var nssDbs = new List<NssDb>();
+
+        if (TryGetNssDbOverrides(out var nssDbOverrides))
+        {
+            foreach (var nssDb in nssDbOverrides)
+            {
+                // Our Firefox approach is a hack, so we'd rather under-recognize it than over-recognize it.
+                var isFirefox = nssDb.Contains("/.mozilla/firefox/", StringComparison.Ordinal);
+                nssDbs.Add(new NssDb(nssDb, isFirefox));
+            }
+
+            return nssDbs;
+        }
+
+        if (!Directory.Exists(homeDirectory))
+        {
+            Log.UnixHomeDirectoryDoesNotExist(homeDirectory, Environment.UserName);
+            return nssDbs;
+        }
+
+        // Chrome, Chromium, Edge, and their respective snaps all use this directory
+        var chromiumNssDb = GetChromiumNssDb(homeDirectory);
+        if (Directory.Exists(chromiumNssDb))
+        {
+            nssDbs.Add(new NssDb(chromiumNssDb, isFirefox: false));
+        }
+
+        var firefoxDir = GetFirefoxDirectory(homeDirectory);
+        if (Directory.Exists(firefoxDir))
+        {
+            var profileDirs = GetFirefoxProfiles(firefoxDir);
+            foreach (var profileDir in profileDirs)
+            {
+                nssDbs.Add(new NssDb(profileDir, isFirefox: true));
+            }
+        }
+
+        var firefoxSnapDir = GetFirefoxSnapDirectory(homeDirectory);
+        if (Directory.Exists(firefoxSnapDir))
+        {
+            var profileDirs = GetFirefoxProfiles(firefoxSnapDir);
+            foreach (var profileDir in profileDirs)
+            {
+                nssDbs.Add(new NssDb(profileDir, isFirefox: true));
+            }
+        }
+
+        return nssDbs;
+    }
+
+    [GeneratedRegex("OPENSSLDIR:\\s*\"([^\"]+)\"")]
+    private static partial Regex OpenSslVersionRegex();
+
+    /// <remarks>
+    /// It is the caller's responsibility to ensure that <see cref="OpenSslCommand"/> is available.
+    /// </remarks>
+    private static bool TryGetOpenSslDirectory([NotNullWhen(true)] out string? openSslDir)
+    {
+        openSslDir = null;
+
+        try
+        {
+            var processInfo = new ProcessStartInfo(OpenSslCommand, $"version -d")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+
+            using var process = Process.Start(processInfo);
+            var stdout = process!.StandardOutput.ReadToEnd();
+
+            process.WaitForExit();
+            if (process.ExitCode != 0)
+            {
+                Log.UnixOpenSslVersionFailed();
+                return false;
+            }
+
+            var match = OpenSslVersionRegex().Match(stdout);
+            if (!match.Success)
+            {
+                Log.UnixOpenSslVersionParsingFailed();
+                return false;
+            }
+
+            openSslDir = match.Groups[1].Value;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.UnixOpenSslVersionException(ex.Message);
+            return false;
+        }
+    }
+
+    /// <remarks>
+    /// It is the caller's responsibility to ensure that <see cref="OpenSslCommand"/> is available.
+    /// </remarks>
+    private static bool TryGetOpenSslHash(string certificatePath, [NotNullWhen(true)] out string? hash)
+    {
+        hash = null;
+
+        try
+        {
+            // c_rehash actually does this twice: once with -subject_hash (equivalent to -hash) and again
+            // with -subject_hash_old.  Old hashes are only  needed for pre-1.0.0, so we skip that.
+            var processInfo = new ProcessStartInfo(OpenSslCommand, $"x509 -hash -noout -in {certificatePath}")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+
+            using var process = Process.Start(processInfo);
+            var stdout = process!.StandardOutput.ReadToEnd();
+
+            process.WaitForExit();
+            if (process.ExitCode != 0)
+            {
+                Log.UnixOpenSslHashFailed(certificatePath);
+                return false;
+            }
+
+            hash = stdout.Trim();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.UnixOpenSslHashException(certificatePath, ex.Message);
+            return false;
+        }
+    }
+
+    [GeneratedRegex("^[0-9a-f]+\\.[0-9]+$")]
+    private static partial Regex OpenSslHashFilenameRegex();
+
+    /// <remarks>
+    /// We only ever use .pem, but someone will eventually put their own cert in this directory,
+    /// so we should handle the same extensions as c_rehash (other than .crl).
+    /// </remarks>
+    [GeneratedRegex("\\.(pem|crt|cer)$")]
+    private static partial Regex OpenSslCertificateExtensionRegex();
+
+    /// <remarks>
+    /// This is a simplified version of c_rehash from OpenSSL.  Using the real one would require
+    /// installing the OpenSSL perl tools and perl itself, which might be annoying in a container.
+    /// </remarks>
+    private static bool TryRehashOpenSslCertificates(string certificateDirectory)
+    {
+        try
+        {
+            // First, delete all the existing symlinks, so we don't have to worry about fragmentation or leaks.
+
+            var hashRegex = OpenSslHashFilenameRegex();
+            var extensionRegex = OpenSslCertificateExtensionRegex();
+
+            var certs = new List<FileInfo>();
+
+            var dirInfo = new DirectoryInfo(certificateDirectory);
+            foreach (var file in dirInfo.EnumerateFiles())
+            {
+                var isSymlink = (file.Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
+                if (isSymlink && hashRegex.IsMatch(file.Name))
+                {
+                    file.Delete();
+                }
+                else if (extensionRegex.IsMatch(file.Name))
+                {
+                    certs.Add(file);
+                }
+            }
+
+            // Then, enumerate all certificates - there will usually be zero or one.
+
+            // c_rehash doesn't create additional symlinks for certs with the same fingerprint,
+            // but we don't expect this to happen, so we favor slightly slower look-ups when it
+            // does, rather than slightly slower rehashing when it doesn't.
+
+            foreach (var cert in certs)
+            {
+                if (!TryGetOpenSslHash(cert.FullName, out var hash))
+                {
+                    return false;
+                }
+
+                var linkCreated = false;
+                for (var i = 0; i < MaxHashCollisions; i++)
+                {
+                    var linkPath = Path.Combine(certificateDirectory, $"{hash}.{i}");
+                    if (!File.Exists(linkPath))
+                    {
+                        // As in c_rehash, we link using a relative path.
+                        File.CreateSymbolicLink(linkPath, cert.Name);
+                        linkCreated = true;
+                        break;
+                    }
+                }
+
+                if (!linkCreated)
+                {
+                    Log.UnixOpenSslRehashTooManyHashes(cert.FullName, hash, MaxHashCollisions);
+                    return false;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.UnixOpenSslRehashException(ex.Message);
+            return false;
+        }
+
+        return true;
+    }
+
+    private sealed class NssDb(string path, bool isFirefox)
+    {
+        public string Path => path;
+        public bool IsFirefox => isFirefox;
     }
 }

--- a/src/Shared/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/UnixCertificateManager.cs
@@ -20,6 +20,8 @@ namespace Microsoft.AspNetCore.Certificates.Generation;
 /// </remarks>
 internal sealed partial class UnixCertificateManager : CertificateManager
 {
+	private const UnixFileMode DirectoryPermissions = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
+
     /// <summary>The name of an environment variable consumed by OpenSSL to locate certificates.</summary>
     private const string OpenSslCertificateDirectoryVariableName = "SSL_CERT_DIR";
 
@@ -74,7 +76,8 @@ internal sealed partial class UnixCertificateManager : CertificateManager
             Log.UnixNotTrustedByDotnet();
         }
 
-        var nickname = GetCertificateNickname(certificate);
+        // Will become the name of the file on disk and the nickname in the NSS DBs
+        var certificateNickname = GetCertificateNickname(certificate);
 
         var sslCertDirString = Environment.GetEnvironmentVariable(OpenSslCertificateDirectoryVariableName);
         if (string.IsNullOrEmpty(sslCertDirString))
@@ -88,7 +91,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
             var sslCertDirs = sslCertDirString.Split(Path.PathSeparator);
             foreach (var sslCertDir in sslCertDirs)
             {
-                var certPath = Path.Combine(sslCertDir, nickname + ".pem");
+                var certPath = Path.Combine(sslCertDir, certificateNickname + ".pem");
                 if (File.Exists(certPath))
                 {
                     var candidate = new X509Certificate2(certPath);
@@ -125,7 +128,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
             {
                 foreach (var nssDb in nssDbs)
                 {
-                    if (IsCertificateInNssDb(nickname, nssDb))
+                    if (IsCertificateInNssDb(certificateNickname, nssDb))
                     {
                         sawTrustSuccess = true;
                     }
@@ -138,6 +141,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
             }
         }
 
+        // Success & Failure => Partial; Success => Full; Failure => None
         return sawTrustSuccess
             ? sawTrustFailure
                 ? TrustLevel.Partial
@@ -244,7 +248,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
         if (needToExport)
         {
             // Security: we don't need the private key for trust, so we don't export it.
-            // Note that this will create directories as needed.
+            // Note that this will create directories as needed.  We control `certPath`, so the permissions should be fine.
             ExportCertificate(certificate, certPath, includePrivateKey: false, password: null, CertificateKeyExportFormat.Pem);
         }
 
@@ -447,6 +451,24 @@ internal sealed partial class UnixCertificateManager : CertificateManager
     protected override IList<X509Certificate2> GetCertificatesToRemove(StoreName storeName, StoreLocation storeLocation)
     {
         return ListCertificates(StoreName.My, StoreLocation.CurrentUser, isValid: false, requireExportable: false);
+    }
+
+    protected override void CreateDirectoryWithPermissions(string directoryPath)
+    {
+#pragma warning disable CA1416 // Validate platform compatibility (not supported on Windows)
+        var dirInfo = new DirectoryInfo(directoryPath);
+        if (dirInfo.Exists)
+        {
+            if ((dirInfo.UnixFileMode & ~DirectoryPermissions) != 0)
+            {
+                Log.DirectoryPermissionsNotSecure(dirInfo.FullName);
+            }
+        }
+        else
+        {
+            Directory.CreateDirectory(directoryPath, DirectoryPermissions);
+        }
+#pragma warning restore CA1416 // Validate platform compatibility
     }
 
     private static string GetChromiumNssDb(string homeDirectory)

--- a/src/Shared/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/UnixCertificateManager.cs
@@ -91,7 +91,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
                 var certPath = Path.Combine(sslCertDir, nickname + ".pem");
                 if (File.Exists(certPath))
                 {
-                    var candidate = X509CertificateLoader.LoadCertificateFromFile(certPath);
+                    var candidate = new X509Certificate2(certPath);
                     if (AreCertificatesEqual(certificate, candidate))
                     {
                         foundCert = true;
@@ -193,7 +193,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
         {
             try
             {
-                using var publicCertificate = X509CertificateLoader.LoadCertificate(certificate.Export(X509ContentType.Cert));
+                using var publicCertificate = new X509Certificate2(certificate.Export(X509ContentType.Cert));
                 // FriendlyName is Windows-only, so we don't set it here.
                 store.Add(publicCertificate);
                 Log.UnixDotnetTrustSucceeded();
@@ -224,7 +224,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
         {
             try
             {
-                using var existingCert = X509CertificateLoader.LoadCertificateFromFile(certPath);
+                using var existingCert = new X509Certificate2(certPath);
                 if (!AreCertificatesEqual(existingCert, certificate))
                 {
                     Log.UnixNotOverwritingCertificate(certPath);

--- a/src/Shared/CertificateGeneration/WindowsCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/WindowsCertificateManager.cs
@@ -84,7 +84,7 @@ internal sealed class WindowsCertificateManager : CertificateManager
         {
             Log.WindowsAddCertificateToRootStore();
 
-            using var publicCertificate = X509CertificateLoader.LoadCertificate(certificate.Export(X509ContentType.Cert));
+            using var publicCertificate = new X509Certificate2(certificate.Export(X509ContentType.Cert));
             publicCertificate.FriendlyName = certificate.FriendlyName;
             store.Add(publicCertificate);
             return TrustLevel.Full;

--- a/src/Shared/CertificateGeneration/WindowsCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/WindowsCertificateManager.cs
@@ -5,8 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Versioning;
+using System.Security.AccessControl;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Security.Principal;
 
 namespace Microsoft.AspNetCore.Certificates.Generation;
 
@@ -125,5 +127,42 @@ internal sealed class WindowsCertificateManager : CertificateManager
     protected override IList<X509Certificate2> GetCertificatesToRemove(StoreName storeName, StoreLocation storeLocation)
     {
         return ListCertificates(storeName, storeLocation, isValid: false);
+    }
+
+    protected override void CreateDirectoryWithPermissions(string directoryPath)
+    {
+        var dirInfo = new DirectoryInfo(directoryPath);
+
+        if (!dirInfo.Exists)
+        {
+            // We trust the default permissions on Windows enough not to apply custom ACLs.
+            // We'll warn below if things seem really off.
+            dirInfo.Create();
+        }
+
+        var currentUser = WindowsIdentity.GetCurrent();
+        var currentUserSid = currentUser.User;
+        var systemSid = new SecurityIdentifier(WellKnownSidType.LocalSystemSid, domainSid: null);
+        var adminGroupSid = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, domainSid: null);
+
+        var dirSecurity = dirInfo.GetAccessControl();
+        var accessRules = dirSecurity.GetAccessRules(true, true, typeof(SecurityIdentifier));
+
+        foreach (FileSystemAccessRule rule in accessRules)
+        {
+            var idRef = rule.IdentityReference;
+            if (rule.AccessControlType == AccessControlType.Allow &&
+                !idRef.Equals(currentUserSid) &&
+                !idRef.Equals(systemSid) &&
+                !idRef.Equals(adminGroupSid))
+            {
+                // This is just a heuristic - determining whether the cumulative effect of the rules
+                // is to allow access to anyone other than the current user, system, or administrators
+                // is very complicated.  We're not going to do anything but log, so an approximation
+                // is fine.
+                Log.DirectoryPermissionsNotSecure(dirInfo.FullName);
+                break;
+            }
+        }
     }
 }

--- a/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
+++ b/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
@@ -509,7 +509,7 @@ public class CertFixture : IDisposable
     internal void CleanupCertificates()
     {
         Manager.RemoveAllCertificates(StoreName.My, StoreLocation.CurrentUser);
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
             Manager.RemoveAllCertificates(StoreName.Root, StoreLocation.CurrentUser);
         }

--- a/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
+++ b/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
@@ -352,6 +352,30 @@ public class CertificateManagerTests : IClassFixture<CertFixture>
         Assert.Equal(httpsCertificate.GetCertHashString(), exportedCertificate.GetCertHashString());
     }
 
+    [ConditionalFact]
+    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/6720", Queues = "All.OSX")]
+    public void EnsureCreateHttpsCertificate_CannotExportToNonExistentDirectory()
+    {
+        // Arrange
+        const string CertificateName = nameof(EnsureCreateHttpsCertificate_CannotExportToNonExistentDirectory) + ".pem";
+
+        _fixture.CleanupCertificates();
+
+        var now = DateTimeOffset.UtcNow;
+        now = new DateTimeOffset(now.Year, now.Month, now.Day, now.Hour, now.Minute, now.Second, 0, now.Offset);
+        var creation = _manager.EnsureAspNetCoreHttpsDevelopmentCertificate(now, now.AddYears(1), path: null, trust: false, isInteractive: false);
+        Output.WriteLine(creation.ToString());
+        ListCertificates();
+
+        // Act
+        // Export the certificate (same method, but this time with an output path)
+        var result = _manager
+            .EnsureAspNetCoreHttpsDevelopmentCertificate(now, now.AddYears(1), Path.Combine("NoSuchDirectory", CertificateName));
+
+        // Assert
+        Assert.Equal(EnsureCertificateResult.ErrorExportingTheCertificate, result);
+    }
+
     [Fact]
     public void EnsureCreateHttpsCertificate_ReturnsExpiredCertificateIfVersionIsIncorrect()
     {

--- a/src/Tools/dotnet-dev-certs/src/Program.cs
+++ b/src/Tools/dotnet-dev-certs/src/Program.cs
@@ -164,7 +164,7 @@ internal sealed class Program
 
                     if (check.HasValue())
                     {
-                        return CheckHttpsCertificate(trust, reporter);
+                        return CheckHttpsCertificate(trust, verbose, reporter);
                     }
 
                     if (clean.HasValue())
@@ -252,6 +252,12 @@ internal sealed class Program
                 reporter.Output("Cleaning HTTPS development certificates from the machine. This operation might " +
                     "require elevated privileges. If that is the case, a prompt for credentials will be displayed.");
             }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                reporter.Output("Cleaning HTTPS development certificates from the machine. You may wish to update the " +
+                    "SSL_CERT_DIR environment variable. " +
+                    "See https://aka.ms/dev-certs-trust for more information.");
+            }
 
             manager.CleanupHttpsCertificates();
             reporter.Output("HTTPS development certificates successfully removed from the machine.");
@@ -266,7 +272,7 @@ internal sealed class Program
         }
     }
 
-    private static int CheckHttpsCertificate(CommandOption trust, IReporter reporter)
+    private static int CheckHttpsCertificate(CommandOption trust, CommandOption verbose, IReporter reporter)
     {
         var certificateManager = CertificateManager.Instance;
         var certificates = certificateManager.ListCertificates(StoreName.My, StoreLocation.CurrentUser, isValid: true);
@@ -283,7 +289,7 @@ internal sealed class Program
                 // We never want check to require interaction.
                 // When IDEs run dotnet dev-certs https after calling --check, we will try to access the key and
                 // that will trigger a prompt if necessary.
-                var status = certificateManager.CheckCertificateState(certificate, interactive: false);
+                var status = certificateManager.CheckCertificateState(certificate);
                 if (!status.Success)
                 {
                     reporter.Warn(status.FailureMessage);
@@ -295,32 +301,25 @@ internal sealed class Program
 
         if (trust != null && trust.HasValue())
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            var trustedCertificates = certificates.Where(cert => certificateManager.GetTrustLevel(cert) == CertificateManager.TrustLevel.Full).ToList();
+            if (trustedCertificates.Count == 0)
             {
-                var trustedCertificates = certificates.Where(certificateManager.IsTrusted).ToList();
-                if (!trustedCertificates.Any())
+                reporter.Output($@"The following certificates were found, but none of them is trusted: {CertificateManager.ToCertificateDescription(certificates)}");
+                if (verbose == null || !verbose.HasValue())
                 {
-                    reporter.Output($@"The following certificates were found, but none of them is trusted: {CertificateManager.ToCertificateDescription(certificates)}");
-                    return ErrorCertificateNotTrusted;
+                    reporter.Output($@"Run the command with --verbose for more details.");
                 }
-                else
-                {
-                    ReportCertificates(reporter, trustedCertificates, "trusted");
-                }
+                return ErrorCertificateNotTrusted;
             }
             else
             {
-                reporter.Warn("Checking the HTTPS development certificate trust status was requested. Checking whether the certificate is trusted or not is not supported on Linux distributions." +
-                    "For instructions on how to manually validate the certificate is trusted on your Linux distribution, go to https://aka.ms/dev-certs-trust");
+                ReportCertificates(reporter, trustedCertificates, "trusted");
             }
         }
         else
         {
             ReportCertificates(reporter, validCertificates, "valid");
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                reporter.Output("Run the command with both --check and --trust options to ensure that the certificate is not only valid but also trusted.");
-            }
+            reporter.Output("Run the command with both --check and --trust options to ensure that the certificate is not only valid but also trusted.");
         }
 
         return Success;
@@ -345,7 +344,7 @@ internal sealed class Program
             var certificates = manager.ListCertificates(StoreName.My, StoreLocation.CurrentUser, isValid: true, exportPath.HasValue());
             foreach (var certificate in certificates)
             {
-                var status = manager.CheckCertificateState(certificate, interactive: true);
+                var status = manager.CheckCertificateState(certificate);
                 if (!status.Success)
                 {
                     reporter.Warn("One or more certificates might be in an invalid state. We will try to access the certificate key " +
@@ -358,7 +357,9 @@ internal sealed class Program
             }
         }
 
-        if (trust?.HasValue() == true)
+        var isTrustOptionSet = trust?.HasValue() == true;
+
+        if (isTrustOptionSet)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
@@ -377,8 +378,9 @@ internal sealed class Program
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                reporter.Warn("Trusting the HTTPS development certificate was requested. Trusting the certificate on Linux distributions automatically is not supported. " +
-                    "For instructions on how to manually trust the certificate on your Linux distribution, go to https://aka.ms/dev-certs-trust");
+                reporter.Warn("Trusting the HTTPS development certificate was requested. " +
+                    "Trust is per-user and may require additional configuration. " +
+                    "See https://aka.ms/dev-certs-trust for more information.");
             }
         }
 
@@ -393,7 +395,7 @@ internal sealed class Program
             now,
             now.Add(HttpsCertificateValidity),
             exportPath.Value(),
-            trust == null ? false : trust.HasValue() && !RuntimeInformation.IsOSPlatform(OSPlatform.Linux),
+            isTrustOptionSet,
             password.HasValue() || (noPassword.HasValue() && format == CertificateKeyExportFormat.Pem),
             password.Value(),
             exportFormat.HasValue() ? format : CertificateKeyExportFormat.Pfx);
@@ -421,10 +423,14 @@ internal sealed class Program
                 reporter.Error("There was an error saving the HTTPS developer certificate to the current user personal certificate store.");
                 return ErrorSavingTheCertificate;
             case EnsureCertificateResult.ErrorExportingTheCertificate:
-                reporter.Warn("There was an error exporting HTTPS developer certificate to a file.");
+                reporter.Warn("There was an error exporting the HTTPS developer certificate to a file.");
                 return ErrorExportingTheCertificate;
+            case EnsureCertificateResult.PartiallyFailedToTrustTheCertificate:
+                // A distinct warning is useful, but a distinct error code is probably not.
+                reporter.Warn("There was an error trusting the HTTPS developer certificate. It will be trusted by some clients but not by others.");
+                return ErrorTrustingTheCertificate;
             case EnsureCertificateResult.FailedToTrustTheCertificate:
-                reporter.Warn("There was an error trusting HTTPS developer certificate.");
+                reporter.Warn("There was an error trusting the HTTPS developer certificate.");
                 return ErrorTrustingTheCertificate;
             case EnsureCertificateResult.UserCancelledTrustStep:
                 reporter.Warn("The user cancelled the trust step.");


### PR DESCRIPTION
# Add support for trusting dev certs on linux

Make `dotnet dev-certs https trust` work on (select distros of) Linux.

## Description

Backport of #56701, #57014, #56582, and #56985 to make the functionality available in Aspire, which targets 8.0.

There's no consistent way to do this that works for all clients on all Linux distros, but this approach gives us pretty good coverage.  In particular, we aim to support .NET (esp HttpClient), Chromium, and Firefox on Ubuntu- and Fedora-based distros.

Certificate trust is applied per-user, which is simpler and preferable for security reasons, but comes with the notable downside that the process can't be completed within the tool - the user has to update an environment variable, probably in their user profile.  In particular, OpenSSL consumes the `SSL_CERT_DIR` environment variable to determine where it should look for trusted certificates.

We break establishing trust into two categories: OpenSSL, which backs .NET, and NSS databases (henceforth, nssdb), which backs browsers.

To establish trust in OpenSSL, we put the certificate in `~/.dotnet/corefx/cryptography/trusted`, run a simplified version of OpenSSL's `c_rehash` tool on the directory, and ask the user to update `SSL_CERT_DIR`.

To establish trust in dotnet, we put the certificate in the `My/Root` certificate store.

To establish trust in nssdb, we search the home directory for Firefox profiles and `~/.pki/nssdb`.  For each one found, we add an entry to the nssdb therein.

Each of these locations (the trusted certificate folder and the list of nssdbs) can be overridden with an environment variable.

This large number of steps introduces a problem that doesn't exist on Windows or macOS - the dev cert can end up trusted by some clients but not by others.  This change introduces a `TrustLevel` concept so that we can produce clearer output when this happens.

The only non-bundled tools required to update certificate trust are `openssl` (the CLI) and `certutil`.  `sudo` is not required, since all changes are within the user's home directory.

## Customer Impact

Without a trusted dev cert, you can't use TLS in local development on Linux.  This has proven to be particularly noticeable when building Aspire apps.

Available workarounds include using a [community](https://github.com/tmds/linux-dev-certs) [tool](https://github.com/BorisWilhelms/create-dotnet-devcert) or installing aspnetcore 9.0 and using the tool from there.

## Regression?

- [ ] Yes
- [x] No

This is new functionality.

## Risk

- [ ] High
- [ ] Medium
- [x] Low

The scenario has never worked, so there's little room for regression.

## Verification

- [x] Manual (required)
- [ ] Automated

Tested HttpClient, curl, Chrome, and Firefox on Ubuntu 22.04.

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A