### PR TITLE
Fix SignalR server activity name

### DIFF
--- a/src/SignalR/server/Core/src/Internal/SignalRServerActivitySource.cs
+++ b/src/SignalR/server/Core/src/Internal/SignalRServerActivitySource.cs
@@ -8,7 +8,10 @@ namespace Microsoft.AspNetCore.SignalR.Internal;
 // Internal for now so we don't need API review.
 // Just a wrapper for the ActivitySource
 // don't want to put ActivitySource directly in DI as hosting already does that and it could get overwritten.
-internal sealed class SignalRActivitySource
+internal sealed class SignalRServerActivitySource
 {
-    public ActivitySource ActivitySource { get; } = new ActivitySource("Microsoft.AspNetCore.SignalR.Server");
+    internal const string Name = "Microsoft.AspNetCore.SignalR.Server";
+    internal const string InvocationIn = $"{Name}.InvocationIn";
+
+    public ActivitySource ActivitySource { get; } = new ActivitySource(Name);
 }

--- a/src/SignalR/server/Core/src/SignalRDependencyInjectionExtensions.cs
+++ b/src/SignalR/server/Core/src/SignalRDependencyInjectionExtensions.cs
@@ -32,7 +32,7 @@ public static class SignalRDependencyInjectionExtensions
         services.TryAddScoped(typeof(IHubActivator<>), typeof(DefaultHubActivator<>));
         services.AddAuthorization();
 
-        services.TryAddSingleton(new SignalRActivitySource());
+        services.TryAddSingleton(new SignalRServerActivitySource());
 
         var builder = new SignalRServerBuilder(services);
         builder.AddJsonProtocol();

--- a/src/SignalR/server/SignalR/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.Activity.cs
+++ b/src/SignalR/server/SignalR/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.Activity.cs
@@ -29,7 +29,7 @@ public partial class HubConnectionHandlerTests
                 // Provided by hosting layer normally
                 builder.AddSingleton(testSource);
             }, LoggerFactory);
-            var signalrSource = serviceProvider.GetRequiredService<SignalRActivitySource>().ActivitySource;
+            var signalrSource = serviceProvider.GetRequiredService<SignalRServerActivitySource>().ActivitySource;
 
             using var listener = new ActivityListener
             {
@@ -100,7 +100,7 @@ public partial class HubConnectionHandlerTests
                 // Provided by hosting layer normally
                 builder.AddSingleton(testSource);
             }, LoggerFactory);
-            var signalrSource = serviceProvider.GetRequiredService<SignalRActivitySource>().ActivitySource;
+            var signalrSource = serviceProvider.GetRequiredService<SignalRServerActivitySource>().ActivitySource;
 
             using var listener = new ActivityListener
             {
@@ -165,7 +165,7 @@ public partial class HubConnectionHandlerTests
                 // Provided by hosting layer normally
                 builder.AddSingleton(testSource);
             }, LoggerFactory);
-            var signalrSource = serviceProvider.GetRequiredService<SignalRActivitySource>().ActivitySource;
+            var signalrSource = serviceProvider.GetRequiredService<SignalRServerActivitySource>().ActivitySource;
 
             using var listener = new ActivityListener
             {
@@ -212,7 +212,7 @@ public partial class HubConnectionHandlerTests
                 // Provided by hosting layer normally
                 builder.AddSingleton(testSource);
             }, LoggerFactory);
-            var signalrSource = serviceProvider.GetRequiredService<SignalRActivitySource>().ActivitySource;
+            var signalrSource = serviceProvider.GetRequiredService<SignalRServerActivitySource>().ActivitySource;
 
             using var listener = new ActivityListener
             {
@@ -263,7 +263,7 @@ public partial class HubConnectionHandlerTests
                 // Provided by hosting layer normally
                 builder.AddSingleton(testSource);
             }, LoggerFactory);
-            var signalrSource = serviceProvider.GetRequiredService<SignalRActivitySource>().ActivitySource;
+            var signalrSource = serviceProvider.GetRequiredService<SignalRServerActivitySource>().ActivitySource;
 
             using var listener = new ActivityListener
             {
@@ -313,7 +313,7 @@ public partial class HubConnectionHandlerTests
                 // Provided by hosting layer normally
                 builder.AddSingleton(testSource);
             }, LoggerFactory);
-            var signalrSource = serviceProvider.GetRequiredService<SignalRActivitySource>().ActivitySource;
+            var signalrSource = serviceProvider.GetRequiredService<SignalRServerActivitySource>().ActivitySource;
 
             using var listener = new ActivityListener
             {
@@ -348,7 +348,9 @@ public partial class HubConnectionHandlerTests
     {
         Assert.Null(activity.Parent);
         Assert.True(activity.IsStopped);
-        Assert.Equal($"{typeof(THub).FullName}/{methodName}", activity.OperationName);
+        Assert.Equal(SignalRServerActivitySource.Name, activity.Source.Name);
+        Assert.Equal(SignalRServerActivitySource.InvocationIn, activity.OperationName);
+        Assert.Equal($"{typeof(THub).FullName}/{methodName}", activity.DisplayName);
 
         var tags = activity.Tags.ToArray();
         if (exceptionType is not null)


### PR DESCRIPTION
Changes:

* `Activity.OperationName` should be a constant.
* `Activity.DisplayName` is what OpenTelemetry uses for the span name. Dynamic value moved there.
* Minor clean up and test improvements