### PR TITLE
Use [DebuggerDisableUserUnhandledExceptions]

### DIFF
--- a/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
+++ b/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Antiforgery;
@@ -33,6 +34,9 @@ internal partial class RazorComponentEndpointInvoker : IRazorComponentEndpointIn
         return _renderer.Dispatcher.InvokeAsync(() => RenderComponentCore(context));
     }
 
+    // We do not want the debugger to consider NavigationExceptions caught by this method as user unhandled.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    [DebuggerDisableUserUnhandledExceptions]
     private async Task RenderComponentCore(HttpContext context)
     {
         context.Response.ContentType = RazorComponentResultExecutor.DefaultContentType;

--- a/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
+++ b/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
@@ -3,7 +3,6 @@
 
 using System.Buffers;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Antiforgery;
@@ -34,8 +33,7 @@ internal partial class RazorComponentEndpointInvoker : IRazorComponentEndpointIn
         return _renderer.Dispatcher.InvokeAsync(() => RenderComponentCore(context));
     }
 
-    // We do not want the debugger to consider NavigationExceptions caught by this method as user unhandled.
-    [MethodImpl(MethodImplOptions.NoInlining)]
+    // We do not want the debugger to consider NavigationExceptions caught by this method as user-unhandled.
     [DebuggerDisableUserUnhandledExceptions]
     private async Task RenderComponentCore(HttpContext context)
     {

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Prerendering.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Prerendering.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.Web.HtmlRendering;
@@ -90,8 +89,7 @@ internal partial class EndpointHtmlRenderer
         ParameterView parameters)
         => PrerenderComponentAsync(httpContext, componentType, prerenderMode, parameters, waitForQuiescence: true);
 
-    // We do not want the debugger to consider NavigationExceptions caught by this method as user unhandled.
-    [MethodImpl(MethodImplOptions.NoInlining)]
+    // We do not want the debugger to consider NavigationExceptions caught by this method as user-unhandled.
     [DebuggerDisableUserUnhandledExceptions]
     public async ValueTask<IHtmlAsyncContent> PrerenderComponentAsync(
         HttpContext httpContext,
@@ -134,8 +132,7 @@ internal partial class EndpointHtmlRenderer
         }
     }
 
-    // We do not want the debugger to consider NavigationExceptions caught by this method as user unhandled.
-    [MethodImpl(MethodImplOptions.NoInlining)]
+    // We do not want the debugger to consider NavigationExceptions caught by this method as user-unhandled.
     [DebuggerDisableUserUnhandledExceptions]
     internal async ValueTask<PrerenderedComponentHtmlContent> RenderEndpointComponent(
         HttpContext httpContext,
@@ -206,7 +203,8 @@ internal partial class EndpointHtmlRenderer
             throw new InvalidOperationException(
                 "A navigation command was attempted during prerendering after the server already started sending the response. " +
                 "Navigation commands can not be issued during server-side prerendering after the response from the server has started. Applications must buffer the" +
-                "response and avoid using features like FlushAsync() before all components on the page have been rendered to prevent failed navigation commands.");
+                "response and avoid using features like FlushAsync() before all components on the page have been rendered to prevent failed navigation commands.",
+                navigationException);
         }
         else if (IsPossibleExternalDestination(httpContext.Request, navigationException.Location)
             && IsProgressivelyEnhancedNavigation(httpContext.Request))

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Prerendering.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Prerendering.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.Web.HtmlRendering;
@@ -88,6 +90,9 @@ internal partial class EndpointHtmlRenderer
         ParameterView parameters)
         => PrerenderComponentAsync(httpContext, componentType, prerenderMode, parameters, waitForQuiescence: true);
 
+    // We do not want the debugger to consider NavigationExceptions caught by this method as user unhandled.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    [DebuggerDisableUserUnhandledExceptions]
     public async ValueTask<IHtmlAsyncContent> PrerenderComponentAsync(
         HttpContext httpContext,
         [DynamicallyAccessedMembers(Component)] Type componentType,
@@ -129,6 +134,9 @@ internal partial class EndpointHtmlRenderer
         }
     }
 
+    // We do not want the debugger to consider NavigationExceptions caught by this method as user unhandled.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    [DebuggerDisableUserUnhandledExceptions]
     internal async ValueTask<PrerenderedComponentHtmlContent> RenderEndpointComponent(
         HttpContext httpContext,
         [DynamicallyAccessedMembers(Component)] Type rootComponentType,

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Streaming.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Streaming.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Encodings.Web;
@@ -39,8 +38,7 @@ internal partial class EndpointHtmlRenderer
         }
     }
 
-    // We do not want the debugger to consider NavigationExceptions caught by this method as user unhandled.
-    [MethodImpl(MethodImplOptions.NoInlining)]
+    // We do not want the debugger to consider NavigationExceptions caught by this method as user-unhandled.
     [DebuggerDisableUserUnhandledExceptions]
     public async Task SendStreamingUpdatesAsync(HttpContext httpContext, Task untilTaskCompleted, TextWriter writer)
     {
@@ -70,7 +68,7 @@ internal partial class EndpointHtmlRenderer
             EmitInitializersIfNecessary(httpContext, writer);
 
             // At this point we yield the sync context. SSR batches may then be emitted at any time.
-            await writer.FlushAsync(); 
+            await writer.FlushAsync();
             await untilTaskCompleted;
         }
         catch (NavigationException navigationException)
@@ -79,16 +77,16 @@ internal partial class EndpointHtmlRenderer
         }
         catch (Exception ex)
         {
+            // Rethrowing also informs the debugger that this exception should be considered user-unhandled unlike NavigationExceptions,
+            // but calling BreakForUserUnhandledException here allows the debugger to break before we modify the HttpContext.
+            Debugger.BreakForUserUnhandledException(ex);
+
             // Theoretically it might be possible to let the error middleware run, capture the output,
             // then emit it in a special format so the JS code can display the error page. However
             // for now we're not going to support that and will simply emit a message.
             HandleExceptionAfterResponseStarted(_httpContext, writer, ex);
             await writer.FlushAsync(); // Important otherwise the client won't receive the error message, as we're about to fail the pipeline
             await _httpContext.Response.CompleteAsync();
-
-            // We need to inform the debugger that this exception should be considered user unhandled unlike the NavigationException.
-            // Review: Is this necessary if the method attributed with [DebuggerDisableUserUnhandledExceptions] rethrows like this does?
-            Debugger.BreakForUserUnhandledException(ex);
             throw;
         }
     }

--- a/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddlewareImpl.cs
+++ b/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddlewareImpl.cs
@@ -181,7 +181,8 @@ internal class DeveloperExceptionPageMiddlewareImpl
             }
 
             _metrics.RequestException(exceptionName, ExceptionResult.Unhandled, handler: null);
-            Debugger.BreakForUserUnhandledException(ex);
+
+            // Rethrowing informs the debugger that this exception should be considered user-unhandled.
             throw;
         }
 


### PR DESCRIPTION
This PR takes advantage of `[DebuggerDisableUserUnhandledExceptions]` which was recently added to the runtime. https://github.com/dotnet/runtime/issues/103105

> In .NET 9, Visual Studio is adding support for catching *async* user-unhandled exceptions which will be enabled by default. This feature has existed for a long time for synchronous methods, but not for async methods. There are several exceptions in ASP.NET Core that propagate through user code but are expected to be handled by framework code. One example is the `NavigationException` used to force redirects when calling `NavigationManager.NavigateTo()` during static Blazor rendering.
>
> ![Async user unhandled exception](https://github.com/dotnet/AspNetCore-ManualTests/assets/70516076/a638d4dc-3014-407d-b65b-34844a43a610)

This covers two cases:

- NavigationExceptions that are properly handled by Blazor and turned into a redirect.
- Exceptions handled by a custom filter in `DeveloperExceptionPageMiddleware` like `DatabaseDeveloperPageExceptionFilter`. I think this one is a little more questionable because there could be a custom filter registered that "handles" exceptions that still should be considered unhandled, but I think it's okay to slightly over suppress to begin with considering that the debugger would never break user-unhandled exceptions before .NET 9.

Fixes #57085

@martincostello FYI