### PR TITLE
Add some comments to various internal HTTP/2 types

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -26,7 +26,7 @@ using BadHttpRequestException = Microsoft.AspNetCore.Http.BadHttpRequestExceptio
 /// <remarks>
 /// Request processing code (especially <see cref="ProcessRequestsAsync"/>) shared across HTTP protocols
 /// via inheritance.
-/// <para>
+/// <para/>
 /// HTTP/1.1 uses it at the connection level and resets it between requests.
 /// HTTP/2 and HTTP/3 use it at the stream level.
 /// </remarks>

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -23,6 +23,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 
 using BadHttpRequestException = Microsoft.AspNetCore.Http.BadHttpRequestException;
 
+/// <remarks>
+/// Request processing code (especially <see cref="ProcessRequestsAsync"/>) shared across HTTP protocols
+/// via inheritance.
+///
+/// HTTP/1.1 uses it at the connection level and resets it between requests.
+/// HTTP/2 and HTTP/3 use it at the stream level.
+/// </remarks>
 internal abstract partial class HttpProtocol : IHttpResponseControl
 {
     private static readonly byte[] _bytesConnectionClose = Encoding.ASCII.GetBytes("\r\nConnection: close");

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -26,7 +26,7 @@ using BadHttpRequestException = Microsoft.AspNetCore.Http.BadHttpRequestExceptio
 /// <remarks>
 /// Request processing code (especially <see cref="ProcessRequestsAsync"/>) shared across HTTP protocols
 /// via inheritance.
-///
+/// <para>
 /// HTTP/1.1 uses it at the connection level and resets it between requests.
 /// HTTP/2 and HTTP/3 use it at the stream level.
 /// </remarks>

--- a/src/Servers/Kestrel/Core/src/Internal/Http/IHttpOutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/IHttpOutputProducer.cs
@@ -5,6 +5,9 @@ using System.IO.Pipelines;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 
+/// <remarks>
+/// Used to plug HTTP version-specific functionality into <see cref="HttpProtocol"/>.
+/// </remarks>
 internal interface IHttpOutputProducer
 {
     ValueTask<FlushResult> WriteChunkAsync(ReadOnlySpan<byte> data, CancellationToken cancellationToken);
@@ -13,6 +16,7 @@ internal interface IHttpOutputProducer
     void WriteResponseHeaders(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, bool appCompleted);
     // This takes ReadOnlySpan instead of ReadOnlyMemory because it always synchronously copies data before flushing.
     ValueTask<FlushResult> WriteDataToPipeAsync(ReadOnlySpan<byte> data, CancellationToken cancellationToken);
+    // Test hook
     Task WriteDataAsync(ReadOnlySpan<byte> data, CancellationToken cancellationToken);
     ValueTask<FlushResult> WriteStreamSuffixAsync();
     void Advance(int bytes);

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/FlowControl/FlowControl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/FlowControl/FlowControl.cs
@@ -5,6 +5,13 @@ using System.Diagnostics;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.FlowControl;
 
+/// <summary>
+/// Represents the flow control window for an <see cref="InputFlowControl"/>.
+/// Mutated as the available quota changes.
+/// </summary>
+/// <remarks>
+/// "FlowControlWindow" would probably be a clearer name.
+/// </remarks>
 internal struct FlowControl
 {
     public FlowControl(uint initialWindowSize)

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/FlowControl/InputFlowControl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/FlowControl/InputFlowControl.cs
@@ -5,6 +5,18 @@ using System.Diagnostics;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.FlowControl;
 
+/// <summary>
+/// Represents the in-bound flow control state of a stream or connection.
+/// </summary>
+/// <remarks>
+/// Owns a <see cref="FlowControl"/> that it uses to track the present window size.
+/// 
+/// <see cref="Http2Connection"/> owns an instance for the connection-level flow control.
+/// <see cref="StreamInputFlowControl"/> owns an instance for the stream-level flow control.
+/// 
+/// Reusable after calling <see cref="Reset"/>.
+/// </remarks>
+/// <seealso href="https://datatracker.ietf.org/doc/html/rfc9113#name-flow-control"/>
 internal sealed class InputFlowControl
 {
     private readonly int _initialWindowSize;

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/FlowControl/InputFlowControl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/FlowControl/InputFlowControl.cs
@@ -10,10 +10,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.FlowControl;
 /// </summary>
 /// <remarks>
 /// Owns a <see cref="FlowControl"/> that it uses to track the present window size.
-/// <para>
+/// <para/>
 /// <see cref="Http2Connection"/> owns an instance for the connection-level flow control.
 /// <see cref="StreamInputFlowControl"/> owns an instance for the stream-level flow control.
-/// <para>
+/// <para/>
 /// Reusable after calling <see cref="Reset"/>.
 /// </remarks>
 /// <seealso href="https://datatracker.ietf.org/doc/html/rfc9113#name-flow-control"/>

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/FlowControl/InputFlowControl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/FlowControl/InputFlowControl.cs
@@ -10,10 +10,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.FlowControl;
 /// </summary>
 /// <remarks>
 /// Owns a <see cref="FlowControl"/> that it uses to track the present window size.
-/// 
+/// <para>
 /// <see cref="Http2Connection"/> owns an instance for the connection-level flow control.
 /// <see cref="StreamInputFlowControl"/> owns an instance for the stream-level flow control.
-/// 
+/// <para>
 /// Reusable after calling <see cref="Reset"/>.
 /// </remarks>
 /// <seealso href="https://datatracker.ietf.org/doc/html/rfc9113#name-flow-control"/>

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/FlowControl/StreamInputFlowControl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/FlowControl/StreamInputFlowControl.cs
@@ -12,9 +12,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.FlowControl;
 /// Owns an <see cref="InputFlowControl"/> for the stream-level flow control and
 /// references another (owned by a <see cref="Http2Connection"/>) for the
 /// connection-level flow control.
-/// <para>
+/// <para/>
 /// <see cref="Http2Stream"/> owns an instance for the stream-level flow control.
-/// <para>
+/// <para/>
 /// Reusable after calling <see cref="Reset"/>.
 /// </remarks>
 /// <seealso href="https://datatracker.ietf.org/doc/html/rfc9113#name-flow-control"/>

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/FlowControl/StreamInputFlowControl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/FlowControl/StreamInputFlowControl.cs
@@ -12,9 +12,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.FlowControl;
 /// Owns an <see cref="InputFlowControl"/> for the stream-level flow control and
 /// references another (owned by a <see cref="Http2Connection"/>) for the
 /// connection-level flow control.
-///
+/// <para>
 /// <see cref="Http2Stream"/> owns an instance for the stream-level flow control.
-///
+/// <para>
 /// Reusable after calling <see cref="Reset"/>.
 /// </remarks>
 /// <seealso href="https://datatracker.ietf.org/doc/html/rfc9113#name-flow-control"/>

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/FlowControl/StreamInputFlowControl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/FlowControl/StreamInputFlowControl.cs
@@ -5,6 +5,19 @@ using System.Diagnostics;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.FlowControl;
 
+/// <summary>
+/// Represents the in-bound flow control state of a stream.
+/// </summary>
+/// <remarks>
+/// Owns an <see cref="InputFlowControl"/> for the stream-level flow control and
+/// references another (owned by a <see cref="Http2Connection"/>) for the
+/// connection-level flow control.
+///
+/// <see cref="Http2Stream"/> owns an instance for the stream-level flow control.
+///
+/// Reusable after calling <see cref="Reset"/>.
+/// </remarks>
+/// <seealso href="https://datatracker.ietf.org/doc/html/rfc9113#name-flow-control"/>
 internal sealed class StreamInputFlowControl
 {
     private readonly InputFlowControl _connectionLevelFlowControl;

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 /// </summary>
 /// <remarks>
 /// Owned by <see cref="HttpConnection"/>.
-///
+/// <para>
 /// Not reusable.
 /// </remarks>
 internal sealed partial class Http2Connection : IHttp2StreamLifetimeHandler, IHttpStreamHeadersHandler, IRequestProcessor

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -21,6 +21,14 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 
+/// <summary>
+/// An HTTP/2 connection - owns the request processing and lifetime.
+/// </summary>
+/// <remarks>
+/// Owned by <see cref="HttpConnection"/>.
+///
+/// Not reusable.
+/// </remarks>
 internal sealed partial class Http2Connection : IHttp2StreamLifetimeHandler, IHttpStreamHeadersHandler, IRequestProcessor
 {
     // This uses C# compiler's ability to refer to static data directly. For more information see https://vcsjones.dev/2019/02/01/csharp-readonly-span-bytes-static

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -23,11 +23,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 
 /// <summary>
 /// An HTTP/2 connection - owns the request processing and lifetime.
+/// <para>
+/// Responsible for reading incoming HTTP/2 frames. New requests create streams and execution
+/// for the request is dispatched to the thread pool.
+/// <para>
 /// </summary>
 /// <remarks>
 /// Owned by <see cref="HttpConnection"/>.
 /// <para>
-/// Not reusable.
+/// For performance, streams are pooled when an HTTP/2 request completes gracefully. Future requests
+/// reuse a pooled stream if available. There are limits on the number of pooled streams, and unused
+/// streams are automatically removed from the pool after a timeout.
+/// <para>
+/// The connection itself is not reusable.
 /// </remarks>
 internal sealed partial class Http2Connection : IHttp2StreamLifetimeHandler, IHttpStreamHeadersHandler, IRequestProcessor
 {

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -23,18 +23,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 
 /// <summary>
 /// An HTTP/2 connection - owns the request processing and lifetime.
-/// <para>
+/// <para/>
 /// Responsible for reading incoming HTTP/2 frames. New requests create streams and execution
 /// for the request is dispatched to the thread pool.
-/// <para>
+/// <para/>
 /// </summary>
 /// <remarks>
 /// Owned by <see cref="HttpConnection"/>.
-/// <para>
+/// <para/>
 /// For performance, streams are pooled when an HTTP/2 request completes gracefully. Future requests
 /// reuse a pooled stream if available. There are limits on the number of pooled streams, and unused
 /// streams are automatically removed from the pool after a timeout.
-/// <para>
+/// <para/>
 /// The connection itself is not reusable.
 /// </remarks>
 internal sealed partial class Http2Connection : IHttp2StreamLifetimeHandler, IHttpStreamHeadersHandler, IRequestProcessor

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
@@ -19,14 +19,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 /// </summary>
 /// <remarks>
 /// Owned by <see cref="Http2Connection"/>.
-///
+/// <para>
 /// Since a connection has multiple streams, this class maintains a <see cref="Channel{T}"/> (i.e. bounded queue)
 /// of <see cref="Http2OutputProducer"/> instances (each of which is owned by a stream) that want to write frames.
-///
+/// <para>
 /// Reuses a single <see cref="Http2Frame"/>, which it populates based on the next <see cref="Http2OutputProducer"/>
 /// (and corresponding <see cref="Http2Stream{TContext}"/>) and then serializes to binary in
 /// <see cref="WriteToOutputPipe"/>.
-///
+/// <para>
 /// Tracks the outgoing connection window size while <see cref="Http2OutputProducer"/> tracks the stream window size.
 /// </remarks>
 internal sealed class Http2FrameWriter

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
@@ -14,6 +14,21 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.PipeWrite
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 
+/// <summary>
+/// Encodes HTTP/2 stream responses as frames and sends them over the wire.
+/// </summary>
+/// <remarks>
+/// Owned by <see cref="Http2Connection"/>.
+///
+/// Since a connection has multiple streams, this class maintains a <see cref="Channel{T}"/> (i.e. bounded queue)
+/// of <see cref="Http2OutputProducer"/> instances (each of which is owned by a stream) that want to write frames.
+///
+/// Reuses a single <see cref="Http2Frame"/>, which it populates based on the next <see cref="Http2OutputProducer"/>
+/// (and corresponding <see cref="Http2Stream{TContext}"/>) and then serializes to binary in
+/// <see cref="WriteToOutputPipe"/>.
+///
+/// Tracks the outgoing connection window size while <see cref="Http2OutputProducer"/> tracks the stream window size.
+/// </remarks>
 internal sealed class Http2FrameWriter
 {
     // Literal Header Field without Indexing - Indexed Name (Index 8 - :status)

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
@@ -19,14 +19,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 /// </summary>
 /// <remarks>
 /// Owned by <see cref="Http2Connection"/>.
-/// <para>
+/// <para/>
 /// Since a connection has multiple streams, this class maintains a <see cref="Channel{T}"/> (i.e. bounded queue)
 /// of <see cref="Http2OutputProducer"/> instances (each of which is owned by a stream) that want to write frames.
-/// <para>
+/// <para/>
 /// Reuses a single <see cref="Http2Frame"/>, which it populates based on the next <see cref="Http2OutputProducer"/>
 /// (and corresponding <see cref="Http2Stream{TContext}"/>) and then serializes to binary in
 /// <see cref="WriteToOutputPipe"/>.
-/// <para>
+/// <para/>
 /// Tracks the outgoing connection window size while <see cref="Http2OutputProducer"/> tracks the stream window size.
 /// </remarks>
 internal sealed class Http2FrameWriter

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2KeepAlive.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2KeepAlive.cs
@@ -16,7 +16,7 @@ internal enum KeepAliveState
 /// <summary>
 /// Used by a <see cref="Http2Connection"/> to determine whether the connection is still alive.
 /// If no frames have been received within a given period of time, triggers a ping that should
-/// draw a response.  After a further timeout, signals that the connection should be dropped.
+/// draw a response. After a further timeout, signals that the connection should be dropped.
 /// </summary>
 internal sealed class Http2KeepAlive
 {

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2KeepAlive.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2KeepAlive.cs
@@ -13,6 +13,11 @@ internal enum KeepAliveState
     Timeout
 }
 
+/// <summary>
+/// Used by a <see cref="Http2Connection"/> to determine whether the connection is still alive.
+/// If no frames have been received within a given period of time, triggers a ping that should
+/// draw a response.  After a further timeout, signals that the connection should be dropped.
+/// </summary>
 internal sealed class Http2KeepAlive
 {
     // An empty ping payload

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2MessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2MessageBody.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 /// </summary>
 /// <remarks>
 /// Owned by an <see cref="Http2Stream"/>.
-///
+/// <para>
 /// Reusable after calling <see cref="Reset"/>.
 /// </remarks>
 internal sealed class Http2MessageBody : MessageBody

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2MessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2MessageBody.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 /// </summary>
 /// <remarks>
 /// Owned by an <see cref="Http2Stream"/>.
-/// <para>
+/// <para/>
 /// Reusable after calling <see cref="Reset"/>.
 /// </remarks>
 internal sealed class Http2MessageBody : MessageBody

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2MessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2MessageBody.cs
@@ -10,6 +10,14 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 
+/// <summary>
+/// Exposes the bytes of an incoming request.
+/// </summary>
+/// <remarks>
+/// Owned by an <see cref="Http2Stream"/>.
+///
+/// Reusable after calling <see cref="Reset"/>.
+/// </remarks>
 internal sealed class Http2MessageBody : MessageBody
 {
     private readonly Http2Stream _context;

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
@@ -12,6 +12,13 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.PipeWrite
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 
+/// <remarks>
+/// Owned by <see cref="Http2Stream"/>.
+///
+/// Tracks the outgoing stream flow control window.
+///
+/// Reusable after calling <see cref="StreamReset"/> (<see cref="Reset"/> is unrelated and does nothing).
+/// </remarks>
 internal sealed class Http2OutputProducer : IHttpOutputProducer, IHttpOutputAborter, IDisposable
 {
     private int StreamId => _stream.StreamId;

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
@@ -14,9 +14,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 
 /// <remarks>
 /// Owned by <see cref="Http2Stream"/>.
-/// <para>
+/// <para/>
 /// Tracks the outgoing stream flow control window.
-/// <para>
+/// <para/>
 /// Reusable after calling <see cref="StreamReset"/> (<see cref="Reset"/> is unrelated and does nothing).
 /// </remarks>
 internal sealed class Http2OutputProducer : IHttpOutputProducer, IHttpOutputAborter, IDisposable

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
@@ -14,9 +14,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 
 /// <remarks>
 /// Owned by <see cref="Http2Stream"/>.
-///
+/// <para>
 /// Tracks the outgoing stream flow control window.
-///
+/// <para>
 /// Reusable after calling <see cref="StreamReset"/> (<see cref="Reset"/> is unrelated and does nothing).
 /// </remarks>
 internal sealed class Http2OutputProducer : IHttpOutputProducer, IHttpOutputAborter, IDisposable

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 /// A poolable HTTP/2 stream.
 /// </summary>
 /// <remarks>
-/// In practice, the product code uses <see cref="Http2Stream{TContext}"/>.  This appears to be
+/// In practice, the product code uses <see cref="Http2Stream{TContext}"/>. This appears to be
 /// a simplified version omitting <see cref="Hosting.Server.IHttpApplication{TContext}"/> that
 /// the tests can subtype for mocking.
 /// <para>

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -16,6 +16,18 @@ using HttpMethods = Microsoft.AspNetCore.Http.HttpMethods;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 
+/// <summary>
+/// A poolable HTTP/2 stream.
+/// </summary>
+/// <remarks>
+/// In practice, the product code uses <see cref="Http2Stream{TContext}"/>.  This appears to be
+/// a simplified version omitting <see cref="Hosting.Server.IHttpApplication{TContext}"/> that
+/// the tests can subtype for mocking.
+///
+/// Reusable after calling <see cref="Initialize"/> or <see cref="InitializeWithExistingContext"/>.
+///
+/// Indirectly owned, via <see cref="PooledStreamStack{TValue}"/>, by an <see cref="Http2Connection"/>.
+/// </remarks>
 internal abstract partial class Http2Stream : HttpProtocol, IThreadPoolWorkItem, IDisposable, IPooledStream
 {
     private Http2StreamContext _context = default!;

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -23,9 +23,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 /// In practice, the product code uses <see cref="Http2Stream{TContext}"/>.  This appears to be
 /// a simplified version omitting <see cref="Hosting.Server.IHttpApplication{TContext}"/> that
 /// the tests can subtype for mocking.
-///
+/// <para>
 /// Reusable after calling <see cref="Initialize"/> or <see cref="InitializeWithExistingContext"/>.
-///
+/// <para>
 /// Indirectly owned, via <see cref="PooledStreamStack{TValue}"/>, by an <see cref="Http2Connection"/>.
 /// </remarks>
 internal abstract partial class Http2Stream : HttpProtocol, IThreadPoolWorkItem, IDisposable, IPooledStream

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -23,9 +23,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 /// In practice, the product code uses <see cref="Http2Stream{TContext}"/>. This appears to be
 /// a simplified version omitting <see cref="Hosting.Server.IHttpApplication{TContext}"/> that
 /// the tests can subtype for mocking.
-/// <para>
+/// <para/>
 /// Reusable after calling <see cref="Initialize"/> or <see cref="InitializeWithExistingContext"/>.
-/// <para>
+/// <para/>
 /// Indirectly owned, via <see cref="PooledStreamStack{TValue}"/>, by an <see cref="Http2Connection"/>.
 /// </remarks>
 internal abstract partial class Http2Stream : HttpProtocol, IThreadPoolWorkItem, IDisposable, IPooledStream

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamOfT.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamOfT.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 
+/// <inheritdoc />
 internal sealed class Http2Stream<TContext> : Http2Stream, IHostContextContainer<TContext> where TContext : notnull
 {
     private readonly IHttpApplication<TContext> _application;

--- a/src/Servers/Kestrel/Core/src/Internal/HttpConnection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/HttpConnection.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 
 /// <remarks>
 /// Instantiated by <see cref="HttpConnectionMiddleware{TContext}"/> when a connection is received.
-/// <para>
+/// <para/>
 /// Not related, type-wise, to <see cref="Http1Connection{TContext}"/>, <see cref="Http2Connection"/>,
 /// or <see cref="Http3Connection"/>. It does, however, instantiate one of those types as its
 /// <see cref="_requestProcessor"/> based on the protocol.

--- a/src/Servers/Kestrel/Core/src/Internal/HttpConnection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/HttpConnection.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 
 /// <remarks>
 /// Instantiated by <see cref="HttpConnectionMiddleware{TContext}"/> when a connection is received.
-///
+/// <para>
 /// Not related, type-wise, to <see cref="Http1Connection{TContext}"/>, <see cref="Http2Connection"/>,
 /// or <see cref="Http3Connection"/>.  It does, however, instantiate one of those types as its
 /// <see cref="_requestProcessor"/> based on the protocol.

--- a/src/Servers/Kestrel/Core/src/Internal/HttpConnection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/HttpConnection.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 /// Instantiated by <see cref="HttpConnectionMiddleware{TContext}"/> when a connection is received.
 /// <para>
 /// Not related, type-wise, to <see cref="Http1Connection{TContext}"/>, <see cref="Http2Connection"/>,
-/// or <see cref="Http3Connection"/>.  It does, however, instantiate one of those types as its
+/// or <see cref="Http3Connection"/>. It does, however, instantiate one of those types as its
 /// <see cref="_requestProcessor"/> based on the protocol.
 /// </remarks>
 internal sealed class HttpConnection : ITimeoutHandler

--- a/src/Servers/Kestrel/Core/src/Internal/HttpConnection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/HttpConnection.cs
@@ -15,6 +15,13 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 
+/// <remarks>
+/// Instantiated by <see cref="HttpConnectionMiddleware{TContext}"/> when a connection is received.
+///
+/// Not related, type-wise, to <see cref="Http1Connection{TContext}"/>, <see cref="Http2Connection"/>,
+/// or <see cref="Http3Connection"/>.  It does, however, instantiate one of those types as its
+/// <see cref="_requestProcessor"/> based on the protocol.
+/// </remarks>
 internal sealed class HttpConnection : ITimeoutHandler
 {
     private static ReadOnlySpan<byte> Http2Id => "h2"u8;

--- a/src/Servers/Kestrel/shared/PooledStreamStack.cs
+++ b/src/Servers/Kestrel/shared/PooledStreamStack.cs
@@ -8,13 +8,26 @@ using System.Runtime.CompilerServices;
 
 namespace Microsoft.AspNetCore.Server.Kestrel;
 
+/// <summary>
+/// A pooled HTTP/2 or HTTP/3 stream.
+/// </summary>
 internal interface IPooledStream
 {
     long PoolExpirationTimestamp { get; }
     void DisposeCore();
 }
 
-// See https://github.com/dotnet/runtime/blob/da9b16f2804e87c9c1ca9dcd9036e7b53e724f5d/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegmentStack.cs
+/// <summary>
+/// A pool of <see cref="IPooledStream"/> instances.
+/// </summary>
+/// <typeparam name="TValue">The type of stream.</typeparam>
+/// <remarks>
+/// Inspired by https://github.com/dotnet/runtime/blob/da9b16f2804e87c9c1ca9dcd9036e7b53e724f5d/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegmentStack.cs
+///
+/// We seem to have chosen a stack for its quick insertion and removal, rather than for LIFO semantics.
+///
+/// Owned by an Http2Connection or QuicConnectionContext.
+/// </remarks>
 internal struct PooledStreamStack<TValue> where TValue : class, IPooledStream
 {
     // Internal for testing

--- a/src/Servers/Kestrel/shared/PooledStreamStack.cs
+++ b/src/Servers/Kestrel/shared/PooledStreamStack.cs
@@ -23,9 +23,9 @@ internal interface IPooledStream
 /// <typeparam name="TValue">The type of stream.</typeparam>
 /// <remarks>
 /// Inspired by https://github.com/dotnet/runtime/blob/da9b16f2804e87c9c1ca9dcd9036e7b53e724f5d/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegmentStack.cs
-///
+/// <para>
 /// We seem to have chosen a stack for its quick insertion and removal, rather than for LIFO semantics.
-///
+/// <para>
 /// Owned by an Http2Connection or QuicConnectionContext.
 /// </remarks>
 internal struct PooledStreamStack<TValue> where TValue : class, IPooledStream

--- a/src/Servers/Kestrel/shared/PooledStreamStack.cs
+++ b/src/Servers/Kestrel/shared/PooledStreamStack.cs
@@ -23,9 +23,9 @@ internal interface IPooledStream
 /// <typeparam name="TValue">The type of stream.</typeparam>
 /// <remarks>
 /// Inspired by https://github.com/dotnet/runtime/blob/da9b16f2804e87c9c1ca9dcd9036e7b53e724f5d/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegmentStack.cs
-/// <para>
+/// <para/>
 /// We seem to have chosen a stack for its quick insertion and removal, rather than for LIFO semantics.
-/// <para>
+/// <para/>
 /// Owned by an Http2Connection or QuicConnectionContext.
 /// </remarks>
 internal struct PooledStreamStack<TValue> where TValue : class, IPooledStream

--- a/src/Shared/ServerInfrastructure/Http2/Http2Frame.cs
+++ b/src/Shared/ServerInfrastructure/Http2/Http2Frame.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 
 /// <summary>
-/// Represents an HTTP/2 frame.  The expected use pattern is that it will be instantiated once
+/// Represents an HTTP/2 frame. The expected use pattern is that it will be instantiated once
 /// and then, each time a frame is received or sent, it is reset with a PrepareX method.
 /// This type is not responsible for binary serialization or deserialization.
 /// </summary>

--- a/src/Shared/ServerInfrastructure/Http2/Http2Frame.cs
+++ b/src/Shared/ServerInfrastructure/Http2/Http2Frame.cs
@@ -3,17 +3,23 @@
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 
-/* https://tools.ietf.org/html/rfc7540#section-4.1
-    +-----------------------------------------------+
-    |                 Length (24)                   |
-    +---------------+---------------+---------------+
-    |   Type (8)    |   Flags (8)   |
-    +-+-------------+---------------+-------------------------------+
-    |R|                 Stream Identifier (31)                      |
-    +=+=============================================================+
-    |                   Frame Payload (0...)                      ...
-    +---------------------------------------------------------------+
-*/
+/// <summary>
+/// Represents an HTTP/2 frame.  The expected use pattern is that it will be instantiated once
+/// and then, each time a frame is received or sent, it is reset with a PrepareX method.
+/// This type is not responsible for binary serialization or deserialization.
+/// </summary>
+/// <remarks>
+/// From https://tools.ietf.org/html/rfc7540#section-4.1:
+///    +-----------------------------------------------+
+///    |                 Length (24)                   |
+///    +---------------+---------------+---------------+
+///    |   Type (8)    |   Flags (8)   |
+///    +-+-------------+---------------+-------------------------------+
+///    |R|                 Stream Identifier (31)                      |
+///    +=+=============================================================+
+///    |                   Frame Payload (0...)                      ...
+///    +---------------------------------------------------------------+
+/// </remarks>
 internal partial class Http2Frame
 {
     public int PayloadLength { get; set; }

--- a/src/Shared/ServerInfrastructure/Http2/Http2FrameReader.cs
+++ b/src/Shared/ServerInfrastructure/Http2/Http2FrameReader.cs
@@ -9,6 +9,12 @@ using System.Diagnostics;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 
+/// <summary>
+/// Deserializes a binary buffer into an <see cref="Http2Frame"/>.
+/// </summary>
+/// <remarks>
+/// Populates an existing <see cref="Http2Frame"/> instance, rather than creating a new one.
+/// </remarks>
 internal static class Http2FrameReader
 {
     /* https://tools.ietf.org/html/rfc7540#section-4.1

--- a/src/Shared/ServerInfrastructure/Http2/Http2PeerSettings.cs
+++ b/src/Shared/ServerInfrastructure/Http2/Http2PeerSettings.cs
@@ -5,6 +5,14 @@ using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 
+/// <summary>
+/// Tracks HTTP/2 settings for a peer (client or server).
+/// </summary>
+/// <remarks>
+/// There are expected to be exactly two instances, one for the client and one for the server.
+/// Both are owned by the <see cref="Http2Connection"/>.
+/// </remarks>
+/// <seealso href="https://datatracker.ietf.org/doc/html/rfc9113#name-defined-settings"/>
 internal sealed class Http2PeerSettings
 {
     // Note these are protocol defaults, not Kestrel defaults.


### PR DESCRIPTION
We have at least cursory comments on our public types, but not on our internal types.  Add some comments that explain the relationships among them.

Note that these are based on code inspection and not historical or empirical knowledge.