### PR TITLE
[MVC] Preserve type attribute when defined in Script tag helper

### DIFF
--- a/src/Mvc/Mvc.TagHelpers/src/ScriptTagHelper.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/ScriptTagHelper.cs
@@ -265,6 +265,11 @@ public class ScriptTagHelper : UrlResolutionTagHelper
             output.CopyHtmlAttribute(SrcAttributeName, context);
         }
 
+        if (Type != null)
+        {
+            output.CopyHtmlAttribute(TypeAttributeName, context);
+        }
+
         // If there's no "src" attribute in output.Attributes this will noop.
         ProcessUrlAttribute(SrcAttributeName, output);
 

--- a/src/Mvc/Mvc.TagHelpers/test/ScriptTagHelperTest.cs
+++ b/src/Mvc/Mvc.TagHelpers/test/ScriptTagHelperTest.cs
@@ -1025,6 +1025,44 @@ public class ScriptTagHelperTest
         Assert.Equal(expectedContent, content);
     }
 
+    [Theory]
+    [InlineData("~/js/site.js")]
+    [InlineData("/approot/js/site.js")]
+    public void RenderScriptTags_PathBase_WithFileVersion_UsingResourceCollection_PreservesModule(string path)
+    {
+        // Arrange
+        var context = MakeTagHelperContext(
+            attributes: new TagHelperAttributeList
+            {
+                    new TagHelperAttribute("src", path),
+                    new TagHelperAttribute("type", "module"),
+                    new TagHelperAttribute("asp-append-version", "true")
+            });
+        var output = MakeTagHelperOutput("script", attributes: new TagHelperAttributeList());
+
+        var urlHelperFactory = MakeUrlHelperFactory(value =>
+        {
+            return value.StartsWith("~/", StringComparison.Ordinal) ?
+                value.Replace("~/", "/approot/") :
+                value;
+        });
+
+        var helper = GetHelper(urlHelperFactory: urlHelperFactory);
+        helper.ViewContext.HttpContext.SetEndpoint(CreateEndpoint());
+        helper.ViewContext.HttpContext.Request.PathBase = "/approot";
+        helper.Src = path;
+        helper.Type = "module";
+        helper.AppendVersion = true;
+
+        // Act
+        helper.Process(context, output);
+
+        // Assert
+        Assert.Equal("script", output.TagName);
+        Assert.Equal("module", output.Attributes["type"].Value);
+        Assert.Equal("/approot/js/site.fingerprint.js", output.Attributes["src"].Value);
+    }
+
     private static ScriptTagHelper GetHelper(
         IWebHostEnvironment hostingEnvironment = null,
         IUrlHelperFactory urlHelperFactory = null,


### PR DESCRIPTION
Since we now handle the `type` attribute for `importmap`, we also need to make sure that it gets copied to the output in other scenarios if defined.

This only matters when type is required, (like for modules) as otherwise, default scripts just work.

Fixes https://github.com/dotnet/aspnetcore/issues/57138