### PR TITLE
Resolve potential XSS concerns from scanners in SignalR

### DIFF
--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
@@ -344,7 +344,7 @@ internal sealed partial class HttpConnectionDispatcher
             var queryStringVersionValue = queryStringVersion.ToString();
             if (!int.TryParse(queryStringVersionValue, out clientProtocolVersion))
             {
-                error = $"The client requested an invalid protocol version '{queryStringVersionValue}'";
+                error = $"The client requested a non-integer protocol version.";
                 Log.InvalidNegotiateProtocolVersion(_logger, queryStringVersionValue);
             }
             else if (clientProtocolVersion < options.MinimumProtocolVersion)

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -159,7 +159,7 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
             var negotiateResponse = JsonConvert.DeserializeObject<JObject>(Encoding.UTF8.GetString(ms.ToArray()));
 
             var error = negotiateResponse.Value<string>("error");
-            Assert.Equal("The client requested an invalid protocol version 'Invalid'", error);
+            Assert.Equal("The client requested a non-integer protocol version.", error);
 
             var connectionId = negotiateResponse.Value<string>("connectionId");
             Assert.Null(connectionId);


### PR DESCRIPTION
Closes https://github.com/dotnet/aspnetcore/issues/57091

As Barry explained in https://github.com/dotnet/aspnetcore/issues/57091#issuecomment-2262843395, the client already has to be [owned](https://en.wikipedia.org/wiki/Owned_(slang)) in order for an XSS attack to be effective, which means they don't need to do an XSS to attack the client at that point.

But since we've now had a couple people file issues based on security scanners, it's easier to just not reflect the query string so we can avoid this being flagged again in the future.