### PR TITLE
Revert "Prefer keys old enough to have propagated (#54309)"

### DIFF
--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/KeyManagement/DefaultKeyResolverTests.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/KeyManagement/DefaultKeyResolverTests.cs
@@ -239,60 +239,6 @@ public class DefaultKeyResolverTests
     }
 
     [Fact]
-    public void ResolveDefaultKeyPolicy_PropagatedKeyPreferred()
-    {
-        // Arrange
-        var resolver = CreateDefaultKeyResolver();
-
-        var now = ParseDateTimeOffset("2010-01-01 00:00:00Z");
-
-        var creation1 = now - KeyManagementOptions.KeyPropagationWindow;
-        var creation2 = now;
-        var activation1 = now + TimeSpan.FromMinutes(1);
-        var activation2 = activation1 + TimeSpan.FromMinutes(1); // More recently activated, but not propagated
-        var expiration1 = creation1 + TimeSpan.FromDays(90);
-        var expiration2 = creation2 + TimeSpan.FromDays(90);
-
-        // Both active (key 2 more recently), key 1 propagated, key 2 not
-        var key1 = CreateKey(activation1, expiration1, creationDate: creation1);
-        var key2 = CreateKey(activation2, expiration2, creationDate: creation2);
-
-        // Act
-        var resolution = resolver.ResolveDefaultKeyPolicy(now, [key1, key2]);
-
-        // Assert
-        Assert.Same(key1, resolution.DefaultKey);
-        Assert.False(resolution.ShouldGenerateNewKey);
-    }
-
-    [Fact]
-    public void ResolveDefaultKeyPolicy_OlderUnpropagatedKeyPreferred()
-    {
-        // Arrange
-        var resolver = CreateDefaultKeyResolver();
-
-        var now = ParseDateTimeOffset("2010-01-01 00:00:00Z");
-
-        var creation1 = now - TimeSpan.FromHours(1);
-        var creation2 = creation1 - TimeSpan.FromHours(1);
-        var activation1 = creation1;
-        var activation2 = creation2;
-        var expiration1 = creation1 + TimeSpan.FromDays(90);
-        var expiration2 = creation2 + TimeSpan.FromDays(90);
-
-        // Both active (key 1 more recently), neither propagated
-        var key1 = CreateKey(activation1, expiration1, creationDate: creation1);
-        var key2 = CreateKey(activation2, expiration2, creationDate: creation2);
-
-        // Act
-        var resolution = resolver.ResolveDefaultKeyPolicy(now, [key1, key2]);
-
-        // Assert
-        Assert.Same(key2, resolution.DefaultKey);
-        Assert.False(resolution.ShouldGenerateNewKey);
-    }
-
-    [Fact]
     public void CreateEncryptor_NoRetryOnNullReturn()
     {
         // Arrange

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/KeyManagement/DefaultKeyResolverTests.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/KeyManagement/DefaultKeyResolverTests.cs
@@ -239,6 +239,42 @@ public class DefaultKeyResolverTests
     }
 
     [Fact]
+    public void ResolveDefaultKeyPolicy_OlderBadKeyVersusNewerGoodKey()
+    {
+        // In https://github.com/dotnet/aspnetcore/issues/57137, we encountered an issue
+        // where we selected the oldest unpropagated key, even though it could not be decrypted.
+        // Choosing the oldest unpropagated key makes sense in principle, but we were late
+        // enough in the release cycle that it made more sense to revert to the older behavior
+        // (preferring the most recently activated key, regardless of propagation) than to
+        // attempt a forward fix (i.e. harden the fancier logic against decryption failures).
+        // This test is intended to ensure that the bad key is never chosen, regardless of
+        // how we order the activated keys in the future.
+
+        // Arrange
+        var resolver = CreateDefaultKeyResolver();
+
+        var now = ParseDateTimeOffset("2010-01-01 00:00:00Z");
+
+        var creation1 = now - TimeSpan.FromHours(1);
+        var creation2 = creation1 - TimeSpan.FromHours(1);
+        var activation1 = creation1;
+        var activation2 = creation2;
+        var expiration1 = creation1 + TimeSpan.FromDays(90);
+        var expiration2 = creation2 + TimeSpan.FromDays(90);
+
+        // Both active (key 1 more recently), neither propagated, key2 can't be decrypted
+        var key1 = CreateKey(activation1, expiration1, creationDate: creation1);
+        var key2 = CreateKey(activation2, expiration2, creationDate: creation2, createEncryptorThrows: true);
+
+        // Act
+        var resolution = resolver.ResolveDefaultKeyPolicy(now, [key1, key2]);
+
+        // Assert
+        Assert.Same(key1, resolution.DefaultKey);
+        Assert.False(resolution.ShouldGenerateNewKey);
+    }
+
+    [Fact]
     public void CreateEncryptor_NoRetryOnNullReturn()
     {
         // Arrange


### PR DESCRIPTION
This reverts commit e72eca7cfda111047223ea5e5171a724b6a4e544.

It was a speculative improvement and now we have concrete evidence of (minor) problems.

Fixes #57137