### PR TITLE
Set requiredness for primitive and files in forms

### DIFF
--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -381,7 +381,10 @@ internal sealed class OpenApiDocumentService(
 
         var requestBody = new OpenApiRequestBody
         {
-            Required = formParameters.Any(IsRequired),
+            // Form bodies are always required because the framework doesn't support
+            // serializing a form collection from an empty body. Instead, requiredness
+            // must be set on a per-parameter basis. See below.
+            Required = true,
             Content = new Dictionary<string, OpenApiMediaType>()
         };
 
@@ -410,6 +413,10 @@ internal sealed class OpenApiDocumentService(
                 // as a property in the schema.
                 if (description.Type == typeof(IFormFile) || description.Type == typeof(IFormFileCollection))
                 {
+                    if (IsRequired(description))
+                    {
+                        schema.Required.Add(description.Name);
+                    }
                     if (hasMultipleFormParameters)
                     {
                         schema.AllOf.Add(new OpenApiSchema
@@ -444,6 +451,10 @@ internal sealed class OpenApiDocumentService(
                         }
                         else
                         {
+                            if (IsRequired(description))
+                            {
+                                schema.Required.Add(description.Name);
+                            }
                             schema.AllOf.Add(new OpenApiSchema
                             {
                                 Type = "object",
@@ -462,6 +473,10 @@ internal sealed class OpenApiDocumentService(
                         }
                         else
                         {
+                            if (IsRequired(description))
+                            {
+                                schema.Required.Add(description.Name);
+                            }
                             schema.Properties[description.Name] = parameterSchema;
                         }
                     }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=controllers.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=controllers.verified.txt
@@ -79,7 +79,8 @@
                 }
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=forms.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=forms.verified.txt
@@ -14,6 +14,9 @@
           "content": {
             "multipart/form-data": {
               "schema": {
+                "required": [
+                  "resume"
+                ],
                 "type": "object",
                 "properties": {
                   "resume": {
@@ -41,6 +44,9 @@
           "content": {
             "multipart/form-data": {
               "schema": {
+                "required": [
+                  "files"
+                ],
                 "type": "object",
                 "properties": {
                   "files": {
@@ -68,6 +74,10 @@
           "content": {
             "multipart/form-data": {
               "schema": {
+                "required": [
+                  "resume",
+                  "files"
+                ],
                 "type": "object",
                 "allOf": [
                   {
@@ -135,6 +145,9 @@
           "content": {
             "multipart/form-data": {
               "schema": {
+                "required": [
+                  "file"
+                ],
                 "type": "object",
                 "allOf": [
                   {

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.RequestBodySchemas.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.RequestBodySchemas.cs
@@ -135,8 +135,10 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
         {
             Assert.True(GetRequestBodyForPath(document, "/required-poco").Required);
             Assert.False(GetRequestBodyForPath(document, "/non-required-poco").Required);
+            // Form bodies are always required for form-based requests Individual elements
+            // within the form can be optional.
             Assert.True(GetRequestBodyForPath(document, "/required-form").Required);
-            Assert.False(GetRequestBodyForPath(document, "/non-required-form").Required);
+            Assert.True(GetRequestBodyForPath(document, "/non-required-form").Required);
         });
 
         static OpenApiRequestBody GetRequestBodyForPath(OpenApiDocument document, string path)


### PR DESCRIPTION
Closes https://github.com/dotnet/aspnetcore/issues/57112.

This PR updates the handling of required parameters within the form body to match the framework implementation.

- The top-level `OpenApiRequestBody.Required` property is always set to true for forms. The framework does not support empty bodies for form-based requests in the same way that it does for JSON-based requests.
- The `OpenApiRequestBody.Content.Required` property is updated to include required parameters of a primitive type in the list if they are required.
- While testing this I discovered https://github.com/dotnet/aspnetcore/issues/57195, which makes it difficult to verify the optional of FormFile/FormFileCollection. Requiredness is still configured for these parameter types but we'll need to fix the underlying bug and test the end-to-end.
- Requiredness for complex types (like `[FromForm] Todo todo`) is not affected by this change since the JsonSchemaExporter will set requiredness correctly for complex types.