### PR TITLE
Use TryGetValue for dictionary lookups in OpenAPI comparers

### DIFF
--- a/src/OpenApi/src/Comparers/OpenApiAnyComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiAnyComparer.cs
@@ -30,7 +30,7 @@ internal sealed class OpenApiAnyComparer : IEqualityComparer<IOpenApiAny>
             {
                 OpenApiNull _ => y is OpenApiNull,
                 OpenApiArray arrayX => y is OpenApiArray arrayY && arrayX.SequenceEqual(arrayY, Instance),
-                OpenApiObject objectX => y is OpenApiObject objectY && objectX.Keys.Count == objectY.Keys.Count && objectX.Keys.All(key => objectY.ContainsKey(key) && Equals(objectX[key], objectY[key])),
+                OpenApiObject objectX => y is OpenApiObject objectY && objectX.Keys.Count == objectY.Keys.Count && objectX.Keys.All(key => objectY.TryGetValue(key, out var yValue) && Equals(objectX[key], yValue)),
                 OpenApiBinary binaryX => y is OpenApiBinary binaryY && binaryX.Value.SequenceEqual(binaryY.Value),
                 OpenApiInteger integerX => y is OpenApiInteger integerY && integerX.Value == integerY.Value,
                 OpenApiLong longX => y is OpenApiLong longY && longX.Value == longY.Value,

--- a/src/OpenApi/src/Comparers/OpenApiDiscriminatorComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiDiscriminatorComparer.cs
@@ -27,7 +27,7 @@ internal sealed class OpenApiDiscriminatorComparer : IEqualityComparer<OpenApiDi
 
         return x.PropertyName == y.PropertyName &&
             x.Mapping.Count == y.Mapping.Count &&
-            x.Mapping.Keys.All(key => y.Mapping.ContainsKey(key) && x.Mapping[key] == y.Mapping[key]);
+            x.Mapping.Keys.All(key => y.Mapping.TryGetValue(key, out var yValue) && x.Mapping[key] == yValue);
     }
 
     public int GetHashCode(OpenApiDiscriminator obj)

--- a/src/OpenApi/src/Comparers/OpenApiExternalDocsComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiExternalDocsComparer.cs
@@ -28,7 +28,7 @@ internal sealed class OpenApiExternalDocsComparer : IEqualityComparer<OpenApiExt
         return x.Description == y.Description &&
             x.Url == y.Url &&
             x.Extensions.Count == y.Extensions.Count
-            && x.Extensions.Keys.All(k => y.Extensions.ContainsKey(k) && y.Extensions[k] == x.Extensions[k]);
+            && x.Extensions.Keys.All(k => y.Extensions.TryGetValue(k, out var yValue) && yValue == x.Extensions[k]);
     }
 
     public int GetHashCode(OpenApiExternalDocs obj)

--- a/src/OpenApi/src/Comparers/OpenApiSchemaComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiSchemaComparer.cs
@@ -37,8 +37,8 @@ internal sealed class OpenApiSchemaComparer : IEqualityComparer<OpenApiSchema>
             OpenApiAnyComparer.Instance.Equals(x.Example, y.Example) &&
             x.ExclusiveMaximum == y.ExclusiveMaximum &&
             x.ExclusiveMinimum == y.ExclusiveMinimum &&
-            x.Extensions.Count == y.Extensions.Count
-            && x.Extensions.Keys.All(k => y.Extensions.ContainsKey(k) && x.Extensions[k] is IOpenApiAny anyX && y.Extensions[k] is IOpenApiAny anyY && OpenApiAnyComparer.Instance.Equals(anyX, anyY)) &&
+            x.Extensions.Count == y.Extensions.Count &&
+            x.Extensions.Keys.All(k => y.Extensions.TryGetValue(k, out var yValue) && x.Extensions[k] is IOpenApiAny anyX && yValue is IOpenApiAny anyY && OpenApiAnyComparer.Instance.Equals(anyX, anyY)) &&
             OpenApiExternalDocsComparer.Instance.Equals(x.ExternalDocs, y.ExternalDocs) &&
             x.Enum.SequenceEqual(y.Enum, OpenApiAnyComparer.Instance) &&
             x.Format == y.Format &&
@@ -58,7 +58,7 @@ internal sealed class OpenApiSchemaComparer : IEqualityComparer<OpenApiSchema>
             Instance.Equals(x.Not, y.Not) &&
             x.Nullable == y.Nullable &&
             x.Pattern == y.Pattern &&
-            x.Properties.Keys.All(k => y.Properties.ContainsKey(k) && Instance.Equals(x.Properties[k], y.Properties[k])) &&
+            x.Properties.Keys.All(k => y.Properties.TryGetValue(k, out var yValue) && Instance.Equals(x.Properties[k], yValue)) &&
             x.ReadOnly == y.ReadOnly &&
             x.Required.Order().SequenceEqual(y.Required.Order()) &&
             OpenApiReferenceComparer.Instance.Equals(x.Reference, y.Reference) &&

--- a/src/OpenApi/src/Comparers/OpenApiSchemaComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiSchemaComparer.cs
@@ -26,7 +26,13 @@ internal sealed class OpenApiSchemaComparer : IEqualityComparer<OpenApiSchema>
             return true;
         }
 
-        return Instance.Equals(x.AdditionalProperties, y.AdditionalProperties) &&
+        // Compare property equality in an order that should help us find inequality faster
+        return
+            x.Type == y.Type &&
+            x.Format == y.Format &&
+            SchemaIdEquals(x, y) &&
+            x.Properties.Keys.All(k => y.Properties.TryGetValue(k, out var yValue) && Instance.Equals(x.Properties[k], yValue)) &&
+            Instance.Equals(x.AdditionalProperties, y.AdditionalProperties) &&
             x.AdditionalPropertiesAllowed == y.AdditionalPropertiesAllowed &&
             x.AllOf.SequenceEqual(y.AllOf, Instance) &&
             x.AnyOf.SequenceEqual(y.AnyOf, Instance) &&
@@ -41,10 +47,8 @@ internal sealed class OpenApiSchemaComparer : IEqualityComparer<OpenApiSchema>
             x.Extensions.Keys.All(k => y.Extensions.TryGetValue(k, out var yValue) && x.Extensions[k] is IOpenApiAny anyX && yValue is IOpenApiAny anyY && OpenApiAnyComparer.Instance.Equals(anyX, anyY)) &&
             OpenApiExternalDocsComparer.Instance.Equals(x.ExternalDocs, y.ExternalDocs) &&
             x.Enum.SequenceEqual(y.Enum, OpenApiAnyComparer.Instance) &&
-            x.Format == y.Format &&
             Instance.Equals(x.Items, y.Items) &&
             x.Title == y.Title &&
-            x.Type == y.Type &&
             x.Maximum == y.Maximum &&
             x.MaxItems == y.MaxItems &&
             x.MaxLength == y.MaxLength &&
@@ -58,15 +62,13 @@ internal sealed class OpenApiSchemaComparer : IEqualityComparer<OpenApiSchema>
             Instance.Equals(x.Not, y.Not) &&
             x.Nullable == y.Nullable &&
             x.Pattern == y.Pattern &&
-            x.Properties.Keys.All(k => y.Properties.TryGetValue(k, out var yValue) && Instance.Equals(x.Properties[k], yValue)) &&
             x.ReadOnly == y.ReadOnly &&
             x.Required.Order().SequenceEqual(y.Required.Order()) &&
             OpenApiReferenceComparer.Instance.Equals(x.Reference, y.Reference) &&
             x.UniqueItems == y.UniqueItems &&
             x.UnresolvedReference == y.UnresolvedReference &&
             x.WriteOnly == y.WriteOnly &&
-            OpenApiXmlComparer.Instance.Equals(x.Xml, y.Xml) &&
-            SchemaIdEquals(x, y);
+            OpenApiXmlComparer.Instance.Equals(x.Xml, y.Xml);
     }
 
     private static bool SchemaIdEquals(OpenApiSchema x, OpenApiSchema y)

--- a/src/OpenApi/src/Comparers/OpenApiSchemaComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiSchemaComparer.cs
@@ -32,6 +32,7 @@ internal sealed class OpenApiSchemaComparer : IEqualityComparer<OpenApiSchema>
             x.Format == y.Format &&
             SchemaIdEquals(x, y) &&
             x.Properties.Keys.All(k => y.Properties.TryGetValue(k, out var yValue) && Instance.Equals(x.Properties[k], yValue)) &&
+            OpenApiDiscriminatorComparer.Instance.Equals(x.Discriminator, y.Discriminator) &&
             Instance.Equals(x.AdditionalProperties, y.AdditionalProperties) &&
             x.AdditionalPropertiesAllowed == y.AdditionalPropertiesAllowed &&
             x.AllOf.SequenceEqual(y.AllOf, Instance) &&
@@ -39,7 +40,6 @@ internal sealed class OpenApiSchemaComparer : IEqualityComparer<OpenApiSchema>
             x.Deprecated == y.Deprecated &&
             OpenApiAnyComparer.Instance.Equals(x.Default, y.Default) &&
             x.Description == y.Description &&
-            OpenApiDiscriminatorComparer.Instance.Equals(x.Discriminator, y.Discriminator) &&
             OpenApiAnyComparer.Instance.Equals(x.Example, y.Example) &&
             x.ExclusiveMaximum == y.ExclusiveMaximum &&
             x.ExclusiveMinimum == y.ExclusiveMinimum &&

--- a/src/OpenApi/src/Comparers/OpenApiXmlComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiXmlComparer.cs
@@ -31,7 +31,7 @@ internal sealed class OpenApiXmlComparer : IEqualityComparer<OpenApiXml>
             x.Attribute == y.Attribute &&
             x.Wrapped == y.Wrapped &&
             x.Extensions.Count == y.Extensions.Count
-            && x.Extensions.Keys.All(k => y.Extensions.ContainsKey(k) && y.Extensions[k] == x.Extensions[k]);
+            && x.Extensions.Keys.All(k => y.Extensions.TryGetValue(k, out var yValue) && yValue == x.Extensions[k]);
     }
 
     public int GetHashCode(OpenApiXml obj)


### PR DESCRIPTION
# Use TryGetValue for dictionary lookups in OpenAPI comparers

Use `TryGetValue()` to avoid multiple dictionary lookups in OpenAPI schema comparers.

## Description

I was doing some benchmarking of M.A.OpenApi compared to NSwag and Swashbuckle and noticed in the speedscope samples that a lot of the relative time was being spent in `Enumerable.All()`.

This lead me to spot that the comparers were doing double dictionary lookups, which shows up due to various key lookups in dictionaries to find schemas:

![image](https://github.com/user-attachments/assets/e42d3599-9037-4617-ba24-6ec861d02fc2)

![image](https://github.com/user-attachments/assets/6141e635-7b0f-4e78-8122-0ffbba648f17)
