### PR TITLE
Perf improvement: Fix Cumulative Layout Shift issue in blank Blazor templates

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/wwwroot/css/app.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/wwwroot/css/app.css
@@ -70,11 +70,12 @@ a, .btn-link {
     }
 
 .loading-progress {
-    position: relative;
+    position: absolute;
     display: block;
     width: 8rem;
     height: 8rem;
-    margin: 20vh auto 1rem auto;
+    inset: 20vh 0 auto 0;
+    margin: 0 auto 0 auto;
 }
 
     .loading-progress circle {


### PR DESCRIPTION
Fix loading progress svg CSS positioning. This updated CSS style stops a Cumulative Layout Shift from happening during the render of the default Blazor templates.

# Fix Cumulative Layout Shift issue in blank Blazor templates

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars):
Change the css of the loading circle to use absolute positioning to prevent CLS

## Description
The default  `loading-progress` svg has a short height and positioned part way through the page. This is the initial `<body>` for the page. When the main app loads, the `<body>` needs repositioned to 0,0 and becomes the full length of the webpage.

The change I've made makes the `loading-progress` svg positioned absolutely. This means the body tag's location will be 0,0 by default and not impacted by the default `loading-progress` svg's position. When the app loads this means no cumulative layout shift happens.

| Performance tab before | Performance tab after|
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/fcf37a3e-d2fb-47ee-b13b-b2de074c5b81) | ![image](https://github.com/user-attachments/assets/cc52c38d-3bc1-4cd5-8ae9-d3ee353860ce) |

| Lighthouse tab desktop before | Lighthouse tab desktop after|
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/2db9f5f8-0fa8-4522-8a77-659505daae12) | ![image](https://github.com/user-attachments/assets/c43567f1-cf78-409a-b5a9-6f59678679fd) |

Cumulative Layout Shift is reduced to **0** for both mobile and desktop. Overall performance score rises to 69 (from 61).

On a live WASM website where I applied this change, the overall performance score rose from 31 to 40 on mobile and 60 to 68 on desktop.

Fixes #57212
