### PR TITLE
Add hpack decoding test

### DIFF
--- a/src/Shared/test/Shared.Tests/runtime/Http2/HPackDecoderTest.cs
+++ b/src/Shared/test/Shared.Tests/runtime/Http2/HPackDecoderTest.cs
@@ -159,17 +159,15 @@ namespace System.Net.Http.Unit.Tests.HPack
             _dynamicTable.Insert(_headerNameBytes, _headerValueBytes);
             Assert.Equal(1, _dynamicTable.Count);
 
-            Assert.InRange(_dynamicTable.MaxSize, 1, 4096); // Assert that our string will be too big
+            Assert.InRange(_dynamicTable.MaxSize, 1, _literalHeaderNameBytes.Length); // Assert that our string will be too big
 
-            var newHeaderValue = new string('a', 4096);
             byte[] encoded = (new byte[] { 0x40 | 0x3E }) // Indexing enabled (0x40) | dynamic table (62 = 0x3E) as a 6-integer, 
-                .Concat(new byte[] { 0x7F, 0x81, 0x1F }) // 0 Huffman bit | header value length (4096) as a 7-integer
-                .Concat(Encoding.ASCII.GetBytes(newHeaderValue)) // Non-Huffman encoded literal header value
+                .Concat(_literalHeaderName) // A header value that's too large to fit in the dynamic table
                 .ToArray();
 
             _decoder.Decode(encoded, endHeaders: true, handler: _handler);
             Assert.Equal(0, _dynamicTable.Count); // The large entry caused the table to be wiped
-            Assert.Equal(newHeaderValue, _handler.DecodedHeaders[_headerNameString]); // but we got the header anyway
+            Assert.Equal(_literalHeaderNameString, _handler.DecodedHeaders[_headerNameString]); // but we got the header anyway
         }
 
         [Fact]


### PR DESCRIPTION
There's a note in section 4.4 of the spec that an incoming header field can reference a dynamic table entry (i.e. for its name) that will be evicted as the incoming header field is inserted into the dynamic table.  Add a test validating that we do something sensible in this case.