### PR TITLE
Middleware/Rewrite: Update  XML comments for "AddRedirect" to indicate status code.

### DIFF
--- a/src/Middleware/Rewrite/src/RewriteOptionsExtensions.cs
+++ b/src/Middleware/Rewrite/src/RewriteOptionsExtensions.cs
@@ -50,7 +50,8 @@ public static class RewriteOptionsExtensions
     }
 
     /// <summary>
-    /// Redirect the request if the regex matches the HttpContext's PathString, with returning a 302 - Found status code.
+    /// Redirect the request if the regex matches the HttpContext's PathString, with returning a 302
+    /// status code for found.
     /// </summary>
     /// <param name="options">The <see cref="RewriteOptions"/>.</param>
     /// <param name="regex">The regex string to compare with.</param>
@@ -76,7 +77,7 @@ public static class RewriteOptionsExtensions
     }
 
     /// <summary>
-    /// Redirect a request to https if the incoming request is http, with returning a 301 - Moved Permanently status code.
+    /// Redirect a request to https if the incoming request is http, with returning a 301
     /// status code for permanently redirected.
     /// </summary>
     /// <param name="options">The <see cref="RewriteOptions"/>.</param>

--- a/src/Middleware/Rewrite/src/RewriteOptionsExtensions.cs
+++ b/src/Middleware/Rewrite/src/RewriteOptionsExtensions.cs
@@ -50,7 +50,7 @@ public static class RewriteOptionsExtensions
     }
 
     /// <summary>
-    /// Redirect the request if the regex matches the HttpContext's PathString
+    /// Redirect the request if the regex matches the HttpContext's PathString, with returning a 302 - Found status code.
     /// </summary>
     /// <param name="options">The <see cref="RewriteOptions"/>.</param>
     /// <param name="regex">The regex string to compare with.</param>
@@ -76,7 +76,7 @@ public static class RewriteOptionsExtensions
     }
 
     /// <summary>
-    /// Redirect a request to https if the incoming request is http, with returning a 301
+    /// Redirect a request to https if the incoming request is http, with returning a 301 - Moved Permanently status code.
     /// status code for permanently redirected.
     /// </summary>
     /// <param name="options">The <see cref="RewriteOptions"/>.</param>


### PR DESCRIPTION
# Tweak XML comments for AddRedirect extension methods

Update XML comments to indicate the status code that is returned with this overload.

## Description

Rationale here is I have just been burnt from thinking our site had permanent redirects in place, when they were actually temporary. There is no visibility into what status code is being used with this overload, unless you find it in the [documentation](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/url-rewriting?view=aspnetcore-8.0#url-redirect). This just exposes the status code in the code comments.

~~Also then tweaked the comment for the `AddRedirectToHttpsPermanent` method to make it consistent.~~

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

(Did not create a ticket first for this, as it didn't seem to fit the format of bug/feature)
