### PR TITLE
[Blazor] Allow cascading value subscribers to get added and removed during change notification

### DIFF
--- a/src/Components/Components/src/CascadingValueSource.cs
+++ b/src/Components/Components/src/CascadingValueSource.cs
@@ -96,8 +96,9 @@ public class CascadingValueSource<TValue> : ICascadingValueSupplier
             {
                 tasks.Add(dispatcher.InvokeAsync(() =>
                 {
-                    Span<ComponentState> subscribersCopy = [.. subscribers];
-                    foreach (var subscriber in subscribersCopy)
+                    // We iterate over a copy of the list because new subscribers might get
+                    // added or removed during change notification
+                    foreach (var subscriber in subscribers.ToArray())
                     {
                         subscriber.NotifyCascadingValueChanged(ParameterViewLifetime.Unbound);
                     }

--- a/src/Components/Components/src/CascadingValueSource.cs
+++ b/src/Components/Components/src/CascadingValueSource.cs
@@ -186,11 +186,13 @@ public class CascadingValueSource<TValue> : ICascadingValueSupplier
     }
 
     [InlineArray(Capacity)]
-    private struct ComponentStateBuffer
+    internal struct ComponentStateBuffer
     {
         public const int Capacity = 64;
 #pragma warning disable IDE0051 // Remove unused private members
+#pragma warning disable IDE0044 // Add readonly modifier
         private ComponentState _values;
+#pragma warning restore IDE0044 // Add readonly modifier
 #pragma warning restore IDE0051 // Remove unused private members
     }
 }

--- a/src/Components/Components/src/CascadingValueSource.cs
+++ b/src/Components/Components/src/CascadingValueSource.cs
@@ -96,7 +96,8 @@ public class CascadingValueSource<TValue> : ICascadingValueSupplier
             {
                 tasks.Add(dispatcher.InvokeAsync(() =>
                 {
-                    foreach (var subscriber in subscribers)
+                    Span<ComponentState> subscribersCopy = [.. subscribers];
+                    foreach (var subscriber in subscribersCopy)
                     {
                         subscriber.NotifyCascadingValueChanged(ParameterViewLifetime.Unbound);
                     }

--- a/src/Components/Components/test/CascadingParameterTest.cs
+++ b/src/Components/Components/test/CascadingParameterTest.cs
@@ -648,7 +648,7 @@ public class CascadingParameterTest
             RenderWhenEqualTo = "Final value",
         };
 
-        // Act/Assert 1: Initial render
+        // Act/Assert: Initial render
         var componentId = await renderer.Dispatcher.InvokeAsync(() => renderer.AssignRootComponentId(component));
         renderer.RenderRootComponent(componentId);
         var firstBatch = renderer.Batches.Single();

--- a/src/Components/Components/test/CascadingParameterTest.cs
+++ b/src/Components/Components/test/CascadingParameterTest.cs
@@ -635,6 +635,61 @@ public class CascadingParameterTest
     }
 
     [Fact]
+    public async Task CanAddSubscriberDuringChangeNotification()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var paramValue = new MyParamType("Initial value");
+        var cascadingValueSource = new CascadingValueSource<MyParamType>(paramValue, isFixed: false);
+        services.AddCascadingValue(_ => cascadingValueSource);
+        var renderer = new TestRenderer(services.BuildServiceProvider());
+        var component = new ConditionallyRenderSubscriberComponent()
+        {
+            RenderWhenEqualTo = "Final value",
+        };
+
+        // Act/Assert 1: Initial render
+        var componentId = await renderer.Dispatcher.InvokeAsync(() => renderer.AssignRootComponentId(component));
+        renderer.RenderRootComponent(componentId);
+        var firstBatch = renderer.Batches.Single();
+        var diff = firstBatch.DiffsByComponentId[componentId].Single();
+        Assert.Collection(diff.Edits,
+            edit =>
+            {
+                Assert.Equal(RenderTreeEditType.PrependFrame, edit.Type);
+                AssertFrame.Text(
+                    firstBatch.ReferenceFrames[edit.ReferenceFrameIndex],
+                    "CascadingParameter=Initial value");
+            });
+        Assert.Equal(1, component.NumRenders);
+
+        // Act: Second render
+        paramValue.ChangeValue("Final value");
+        await cascadingValueSource.NotifyChangedAsync();
+        var secondBatch = renderer.Batches[1];
+        var diff2 = secondBatch.DiffsByComponentId[componentId].Single();
+
+        // Assert: Subscriber can get added during change notification and receive the cascading value
+        AssertFrame.Text(
+            secondBatch.ReferenceFrames[diff2.Edits[0].ReferenceFrameIndex],
+            "CascadingParameter=Final value");
+        Assert.Equal(2, component.NumRenders);
+
+        // Assert: Subscriber can get added during change notification and receive the cascading value
+        var nestedComponent = FindComponent<SimpleSubscriberComponent>(secondBatch, out var nestedComponentId);
+        var nestedComponentDiff = secondBatch.DiffsByComponentId[nestedComponentId].Single();
+        Assert.Collection(nestedComponentDiff.Edits,
+            edit =>
+            {
+                Assert.Equal(RenderTreeEditType.PrependFrame, edit.Type);
+                AssertFrame.Text(
+                    secondBatch.ReferenceFrames[edit.ReferenceFrameIndex],
+                    "CascadingParameter=Final value");
+            });
+        Assert.Equal(1, nestedComponent.NumRenders);
+    }
+
+    [Fact]
     public async Task AfterSupplyingValueThroughNotifyChanged_InitialValueFactoryIsNotUsed()
     {
         // Arrange
@@ -858,6 +913,43 @@ public class CascadingParameterTest
             // You're not allowed to hold onto a ParameterView and access it later,
             // so this should throw
             lastParameterView.TryGetValue<object>("anything", out _);
+        }
+    }
+
+    class ConditionallyRenderSubscriberComponent : AutoRenderComponent
+    {
+        public int NumRenders { get; private set; }
+
+        public SimpleSubscriberComponent NestedSubscriber { get; private set; }
+
+        [Parameter] public string RenderWhenEqualTo { get; set; }
+
+        [CascadingParameter] MyParamType CascadingParameter { get; set; }
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            NumRenders++;
+            builder.AddContent(0, $"CascadingParameter={CascadingParameter}");
+
+            if (string.Equals(RenderWhenEqualTo, CascadingParameter.ToString(), StringComparison.OrdinalIgnoreCase))
+            {
+                builder.OpenComponent<SimpleSubscriberComponent>(1);
+                builder.AddComponentReferenceCapture(2, component => NestedSubscriber = component as SimpleSubscriberComponent);
+                builder.CloseComponent();
+            }
+        }
+    }
+
+    class SimpleSubscriberComponent : AutoRenderComponent
+    {
+        public int NumRenders { get; private set; }
+
+        [CascadingParameter] MyParamType CascadingParameter { get; set; }
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            NumRenders++;
+            builder.AddContent(0, $"CascadingParameter={CascadingParameter}");
         }
     }
 


### PR DESCRIPTION
# [Blazor] Allow cascading value subscribers to get added and removed during change notification

Updates cascading value change notification logic to operate on a copy of the subscriber list to avoid cases where the list could get mutated during enumeration.

Fixes #56741
Fixes #53075