### PR TITLE
Fix OpenAPI transformer lifetimes and disposal

### DIFF
--- a/src/OpenApi/OpenApi.generated.sln
+++ b/src/OpenApi/OpenApi.generated.sln
@@ -1,0 +1,51 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample", "sample\Sample.csproj", "{27EF80D8-4A11-44F1-BDBB-8C0F6E7085F4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.OpenApi", "src\Microsoft.AspNetCore.OpenApi.csproj", "{E2CD734D-7E40-4E0C-9662-1D5B5B331146}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{87EC42C6-E18C-4DD2-9AD2-416195A50848}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.OpenApi.Tests", "test\Microsoft.AspNetCore.OpenApi.Tests\Microsoft.AspNetCore.OpenApi.Tests.csproj", "{8441A115-BF5D-47C9-BE1E-2BFF27BA24F2}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "perf", "perf", "{1C3FBADB-D913-467C-8E1E-7E87F342C5EC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.OpenApi.Microbenchmarks", "perf\Microbenchmarks\Microsoft.AspNetCore.OpenApi.Microbenchmarks.csproj", "{47BA0F58-A9BE-42D8-9B2E-EA2D4F1F72D7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{27EF80D8-4A11-44F1-BDBB-8C0F6E7085F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{27EF80D8-4A11-44F1-BDBB-8C0F6E7085F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{27EF80D8-4A11-44F1-BDBB-8C0F6E7085F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{27EF80D8-4A11-44F1-BDBB-8C0F6E7085F4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E2CD734D-7E40-4E0C-9662-1D5B5B331146}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E2CD734D-7E40-4E0C-9662-1D5B5B331146}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E2CD734D-7E40-4E0C-9662-1D5B5B331146}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E2CD734D-7E40-4E0C-9662-1D5B5B331146}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8441A115-BF5D-47C9-BE1E-2BFF27BA24F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8441A115-BF5D-47C9-BE1E-2BFF27BA24F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8441A115-BF5D-47C9-BE1E-2BFF27BA24F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8441A115-BF5D-47C9-BE1E-2BFF27BA24F2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{47BA0F58-A9BE-42D8-9B2E-EA2D4F1F72D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{47BA0F58-A9BE-42D8-9B2E-EA2D4F1F72D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{47BA0F58-A9BE-42D8-9B2E-EA2D4F1F72D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{47BA0F58-A9BE-42D8-9B2E-EA2D4F1F72D7}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{8441A115-BF5D-47C9-BE1E-2BFF27BA24F2} = {87EC42C6-E18C-4DD2-9AD2-416195A50848}
+		{47BA0F58-A9BE-42D8-9B2E-EA2D4F1F72D7} = {1C3FBADB-D913-467C-8E1E-7E87F342C5EC}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {DA0E25AF-669B-4D4B-9FCF-D0E56478E8F9}
+	EndGlobalSection
+EndGlobal

--- a/src/OpenApi/perf/Microbenchmarks/GenerationBenchmarks.cs
+++ b/src/OpenApi/perf/Microbenchmarks/GenerationBenchmarks.cs
@@ -5,6 +5,7 @@ using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.OpenApi.Microbenchmarks;
 
@@ -22,6 +23,7 @@ public class GenerationBenchmarks : OpenApiDocumentServiceTestBase
     private readonly IEndpointRouteBuilder _builder = CreateBuilder();
     private readonly OpenApiOptions _options = new OpenApiOptions();
     private OpenApiDocumentService _documentService;
+    private IServiceProvider _serviceProvider;
 
     [GlobalSetup(Target = nameof(GenerateDocument))]
     public void OperationTransformerAsDelegate_Setup()
@@ -34,11 +36,12 @@ public class GenerationBenchmarks : OpenApiDocumentServiceTestBase
             _builder.MapDelete($"/{i}", (string id) => Results.NoContent());
         }
         _documentService = CreateDocumentService(_builder, _options);
+        _serviceProvider = _builder.ServiceProvider.CreateScope().ServiceProvider;
     }
 
     [Benchmark]
     public async Task GenerateDocument()
     {
-        await _documentService.GetOpenApiDocumentAsync();
+        await _documentService.GetOpenApiDocumentAsync(_serviceProvider);
     }
 }

--- a/src/OpenApi/perf/Microbenchmarks/TransformersBenchmark.cs
+++ b/src/OpenApi/perf/Microbenchmarks/TransformersBenchmark.cs
@@ -4,6 +4,7 @@
 using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 
@@ -23,6 +24,7 @@ public class TransformersBenchmark : OpenApiDocumentServiceTestBase
     private readonly IEndpointRouteBuilder _builder = CreateBuilder();
     private readonly OpenApiOptions _options = new();
     private OpenApiDocumentService _documentService;
+    private IServiceProvider _serviceProvider;
 
     [GlobalSetup(Target = nameof(ActivatedOperationTransformer))]
     public void ActivatedOperationTransformer_Setup()
@@ -33,6 +35,7 @@ public class TransformersBenchmark : OpenApiDocumentServiceTestBase
             _options.AddOperationTransformer<OperationTransformer>();
         }
         _documentService = CreateDocumentService(_builder, _options);
+        _serviceProvider = _builder.ServiceProvider.CreateScope().ServiceProvider;
     }
 
     [GlobalSetup(Target = nameof(OperationTransformerAsDelegate))]
@@ -48,6 +51,7 @@ public class TransformersBenchmark : OpenApiDocumentServiceTestBase
             });
         }
         _documentService = CreateDocumentService(_builder, _options);
+        _serviceProvider = _builder.ServiceProvider.CreateScope().ServiceProvider;
     }
 
     [GlobalSetup(Target = nameof(ActivatedDocumentTransformer))]
@@ -59,6 +63,7 @@ public class TransformersBenchmark : OpenApiDocumentServiceTestBase
             _options.AddDocumentTransformer<DocumentTransformer>();
         }
         _documentService = CreateDocumentService(_builder, _options);
+        _serviceProvider = _builder.ServiceProvider.CreateScope().ServiceProvider;
     }
 
     [GlobalSetup(Target = nameof(DocumentTransformerAsDelegate))]
@@ -74,6 +79,7 @@ public class TransformersBenchmark : OpenApiDocumentServiceTestBase
             });
         }
         _documentService = CreateDocumentService(_builder, _options);
+        _serviceProvider = _builder.ServiceProvider.CreateScope().ServiceProvider;
     }
 
     [GlobalSetup(Target = nameof(ActivatedSchemaTransformer))]
@@ -85,6 +91,7 @@ public class TransformersBenchmark : OpenApiDocumentServiceTestBase
             _options.AddSchemaTransformer<SchemaTransformer>();
         }
         _documentService = CreateDocumentService(_builder, _options);
+        _serviceProvider = _builder.ServiceProvider.CreateScope().ServiceProvider;
     }
 
     [GlobalSetup(Target = nameof(SchemaTransformerAsDelegate))]
@@ -107,42 +114,43 @@ public class TransformersBenchmark : OpenApiDocumentServiceTestBase
             });
         }
         _documentService = CreateDocumentService(_builder, _options);
+        _serviceProvider = _builder.ServiceProvider.CreateScope().ServiceProvider;
     }
 
     [Benchmark]
     public async Task ActivatedOperationTransformer()
     {
-        await _documentService.GetOpenApiDocumentAsync();
+        await _documentService.GetOpenApiDocumentAsync(_serviceProvider);
     }
 
     [Benchmark]
     public async Task OperationTransformerAsDelegate()
     {
-        await _documentService.GetOpenApiDocumentAsync();
+        await _documentService.GetOpenApiDocumentAsync(_serviceProvider);
     }
 
     [Benchmark]
     public async Task ActivatedDocumentTransformer()
     {
-        await _documentService.GetOpenApiDocumentAsync();
+        await _documentService.GetOpenApiDocumentAsync(_serviceProvider);
     }
 
     [Benchmark]
     public async Task DocumentTransformerAsDelegate()
     {
-        await _documentService.GetOpenApiDocumentAsync();
+        await _documentService.GetOpenApiDocumentAsync(_serviceProvider);
     }
 
     [Benchmark]
     public async Task ActivatedSchemaTransformer()
     {
-        await _documentService.GetOpenApiDocumentAsync();
+        await _documentService.GetOpenApiDocumentAsync(_serviceProvider);
     }
 
     [Benchmark]
     public async Task SchemaTransformerAsDelegate()
     {
-        await _documentService.GetOpenApiDocumentAsync();
+        await _documentService.GetOpenApiDocumentAsync(_serviceProvider);
     }
 
     private class DocumentTransformer : IOpenApiDocumentTransformer

--- a/src/OpenApi/src/Extensions/OpenApiEndpointRouteBuilderExtensions.cs
+++ b/src/OpenApi/src/Extensions/OpenApiEndpointRouteBuilderExtensions.cs
@@ -43,7 +43,7 @@ public static class OpenApiEndpointRouteBuilderExtensions
                 }
                 else
                 {
-                    var document = await documentService.GetOpenApiDocumentAsync(context.RequestAborted);
+                    var document = await documentService.GetOpenApiDocumentAsync(context.RequestServices, context.RequestAborted);
                     var documentOptions = options.Get(documentName);
                     using var output = MemoryBufferWriter.Get();
                     using var writer = Utf8BufferTextWriter.Get(output);

--- a/src/OpenApi/src/Services/OpenApiDocumentProvider.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentProvider.cs
@@ -44,7 +44,8 @@ internal sealed class OpenApiDocumentProvider(IServiceProvider serviceProvider) 
         // document to a file. See https://github.com/microsoft/OpenAPI.NET/issues/421 for
         // more info.
         var targetDocumentService = serviceProvider.GetRequiredKeyedService<OpenApiDocumentService>(documentName);
-        var document = await targetDocumentService.GetOpenApiDocumentAsync();
+        var scopedService = serviceProvider.CreateScope();
+        var document = await targetDocumentService.GetOpenApiDocumentAsync(scopedService.ServiceProvider);
         var jsonWriter = new OpenApiJsonWriter(writer);
         document.Serialize(jsonWriter, openApiSpecVersion);
     }

--- a/src/OpenApi/src/Services/OpenApiDocumentProvider.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentProvider.cs
@@ -44,7 +44,7 @@ internal sealed class OpenApiDocumentProvider(IServiceProvider serviceProvider) 
         // document to a file. See https://github.com/microsoft/OpenAPI.NET/issues/421 for
         // more info.
         var targetDocumentService = serviceProvider.GetRequiredKeyedService<OpenApiDocumentService>(documentName);
-        var scopedService = serviceProvider.CreateScope();
+        using var scopedService = serviceProvider.CreateScope();
         var document = await targetDocumentService.GetOpenApiDocumentAsync(scopedService.ServiceProvider);
         var jsonWriter = new OpenApiJsonWriter(writer);
         document.Serialize(jsonWriter, openApiSpecVersion);

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -38,8 +38,8 @@ internal sealed class OpenApiDocumentService(
     private readonly OpenApiSchemaService _componentService = serviceProvider.GetRequiredKeyedService<OpenApiSchemaService>(documentName);
     private readonly OpenApiSchemaReferenceTransformer _schemaReferenceTransformer = new();
 
-    private List<IOpenApiSchemaTransformer>? _schemaTransformers;
-    private List<IOpenApiOperationTransformer>? _operationTransformers;
+    private List<IOpenApiSchemaTransformer> _schemaTransformers = [];
+    private List<IOpenApiOperationTransformer> _operationTransformers = [];
 
     /// <summary>
     /// Cache of <see cref="OpenApiOperationTransformerContext"/> instances keyed by the
@@ -99,7 +99,6 @@ internal sealed class OpenApiDocumentService(
     {
         for (var i = 0; i < _options.SchemaTransformers.Count; i++)
         {
-            _schemaTransformers ??= [];
             var schemaTransformer = _options.SchemaTransformers[i];
             if (schemaTransformer is TypeBasedOpenApiSchemaTransformer typeBasedTransformer)
             {
@@ -113,7 +112,6 @@ internal sealed class OpenApiDocumentService(
 
         for (var i = 0; i < _options.OperationTransformers.Count; i++)
         {
-            _operationTransformers ??= [];
             var operationTransformer = _options.OperationTransformers[i];
             if (operationTransformer is TypeBasedOpenApiOperationTransformer typeBasedTransformer)
             {
@@ -128,22 +126,16 @@ internal sealed class OpenApiDocumentService(
 
     internal async Task FinalizeTransformers()
     {
-        if (_schemaTransformers is not null)
+        for (var i = 0; i < _schemaTransformers.Count; i++)
         {
-            for (var i = 0; i < _schemaTransformers.Count; i++)
-            {
-                await _schemaTransformers[i].FinalizeTransformer();
-            }
+            await _schemaTransformers[i].FinalizeTransformer();
         }
-        if (_operationTransformers is not null)
+        for (var i = 0; i < _operationTransformers.Count; i++)
         {
-            for (var i = 0; i < _operationTransformers.Count; i++)
-            {
-                await _operationTransformers[i].FinalizeTransformer();
-            }
+            await _operationTransformers[i].FinalizeTransformer();
         }
-        _schemaTransformers = null;
-        _operationTransformers = null;
+        _schemaTransformers = [];
+        _operationTransformers = [];
     }
 
     internal async Task ForEachOperationAsync(

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -245,7 +245,7 @@ internal sealed class OpenApiDocumentService(
             operations[description.GetOperationType()] = operation;
 
             // Use index-based for loop to avoid allocating an enumerator with a foreach.
-            if (_operationTransformers is not null)
+            if (_operationTransformers is not null && _operationTransformers.Count > 0)
             {
                 for (var i = 0; i < _operationTransformers.Count; i++)
                 {

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -38,6 +38,9 @@ internal sealed class OpenApiDocumentService(
     private readonly OpenApiSchemaService _componentService = serviceProvider.GetRequiredKeyedService<OpenApiSchemaService>(documentName);
     private readonly OpenApiSchemaReferenceTransformer _schemaReferenceTransformer = new();
 
+    private List<IOpenApiSchemaTransformer>? _schemaTransformers;
+    private List<IOpenApiOperationTransformer>? _operationTransformers;
+
     /// <summary>
     /// Cache of <see cref="OpenApiOperationTransformerContext"/> instances keyed by the
     /// `ApiDescription.ActionDescriptor.Id` of the associated operation. ActionDescriptor IDs
@@ -50,28 +53,36 @@ internal sealed class OpenApiDocumentService(
     internal bool TryGetCachedOperationTransformerContext(string descriptionId, [NotNullWhen(true)] out OpenApiOperationTransformerContext? context)
         => _operationTransformerContextCache.TryGetValue(descriptionId, out context);
 
-    public async Task<OpenApiDocument> GetOpenApiDocumentAsync(CancellationToken cancellationToken = default)
+    public async Task<OpenApiDocument> GetOpenApiDocumentAsync(IServiceProvider scopedServiceProvider, CancellationToken cancellationToken = default)
     {
         // For good hygiene, operation-level tags must also appear in the document-level
         // tags collection. This set captures all tags that have been seen so far.
         HashSet<OpenApiTag> capturedTags = new(OpenApiTagComparer.Instance);
+        InitializeTransformers(scopedServiceProvider);
         var document = new OpenApiDocument
         {
             Info = GetOpenApiInfo(),
-            Paths = await GetOpenApiPathsAsync(capturedTags, cancellationToken),
+            Paths = await GetOpenApiPathsAsync(capturedTags, scopedServiceProvider, cancellationToken),
             Servers = GetOpenApiServers(),
             Tags = [.. capturedTags]
         };
-        await ApplyTransformersAsync(document, cancellationToken);
+        try
+        {
+            await ApplyTransformersAsync(document, scopedServiceProvider, cancellationToken);
+        }
+        finally
+        {
+            await FinalizeTransformers();
+        }
         return document;
     }
 
-    private async Task ApplyTransformersAsync(OpenApiDocument document, CancellationToken cancellationToken)
+    private async Task ApplyTransformersAsync(OpenApiDocument document, IServiceProvider scopedServiceProvider, CancellationToken cancellationToken)
     {
         var documentTransformerContext = new OpenApiDocumentTransformerContext
         {
             DocumentName = documentName,
-            ApplicationServices = serviceProvider,
+            ApplicationServices = scopedServiceProvider,
             DescriptionGroups = apiDescriptionGroupCollectionProvider.ApiDescriptionGroups.Items,
         };
         // Use index-based for loop to avoid allocating an enumerator with a foreach.
@@ -82,6 +93,57 @@ internal sealed class OpenApiDocumentService(
         }
         // Move duplicated JSON schemas to the global components.schemas object and map references after all transformers have run.
         await _schemaReferenceTransformer.TransformAsync(document, documentTransformerContext, cancellationToken);
+    }
+
+    internal void InitializeTransformers(IServiceProvider scopedServiceProvider)
+    {
+        for (var i = 0; i < _options.SchemaTransformers.Count; i++)
+        {
+            _schemaTransformers ??= [];
+            var schemaTransformer = _options.SchemaTransformers[i];
+            if (schemaTransformer is TypeBasedOpenApiSchemaTransformer typeBasedTransformer)
+            {
+                _schemaTransformers.Add(typeBasedTransformer.InitializeTransformer(scopedServiceProvider));
+            }
+            else
+            {
+                _schemaTransformers.Add(schemaTransformer);
+            }
+        }
+
+        for (var i = 0; i < _options.OperationTransformers.Count; i++)
+        {
+            _operationTransformers ??= [];
+            var operationTransformer = _options.OperationTransformers[i];
+            if (operationTransformer is TypeBasedOpenApiOperationTransformer typeBasedTransformer)
+            {
+                _operationTransformers.Add(typeBasedTransformer.InitializeTransformer(scopedServiceProvider));
+            }
+            else
+            {
+                _operationTransformers.Add(operationTransformer);
+            }
+        }
+    }
+
+    internal async Task FinalizeTransformers()
+    {
+        if (_schemaTransformers is not null)
+        {
+            for (var i = 0; i < _schemaTransformers.Count; i++)
+            {
+                await _schemaTransformers[i].FinalizeTransformer();
+            }
+        }
+        if (_operationTransformers is not null)
+        {
+            for (var i = 0; i < _operationTransformers.Count; i++)
+            {
+                await _operationTransformers[i].FinalizeTransformer();
+            }
+        }
+        _schemaTransformers = null;
+        _operationTransformers = null;
     }
 
     internal async Task ForEachOperationAsync(
@@ -148,7 +210,7 @@ internal sealed class OpenApiDocumentService(
     /// the object to support filtering each
     /// description instance into its appropriate document.
     /// </remarks>
-    private async Task<OpenApiPaths> GetOpenApiPathsAsync(HashSet<OpenApiTag> capturedTags, CancellationToken cancellationToken)
+    private async Task<OpenApiPaths> GetOpenApiPathsAsync(HashSet<OpenApiTag> capturedTags, IServiceProvider scopedServiceProvider, CancellationToken cancellationToken)
     {
         var descriptionsByPath = apiDescriptionGroupCollectionProvider.ApiDescriptionGroups.Items
             .SelectMany(group => group.Items)
@@ -158,17 +220,17 @@ internal sealed class OpenApiDocumentService(
         foreach (var descriptions in descriptionsByPath)
         {
             Debug.Assert(descriptions.Key != null, "Relative path mapped to OpenApiPath key cannot be null.");
-            paths.Add(descriptions.Key, new OpenApiPathItem { Operations = await GetOperationsAsync(descriptions, capturedTags, cancellationToken) });
+            paths.Add(descriptions.Key, new OpenApiPathItem { Operations = await GetOperationsAsync(descriptions, capturedTags, scopedServiceProvider, cancellationToken) });
         }
         return paths;
     }
 
-    private async Task<Dictionary<OperationType, OpenApiOperation>> GetOperationsAsync(IGrouping<string?, ApiDescription> descriptions, HashSet<OpenApiTag> capturedTags, CancellationToken cancellationToken)
+    private async Task<Dictionary<OperationType, OpenApiOperation>> GetOperationsAsync(IGrouping<string?, ApiDescription> descriptions, HashSet<OpenApiTag> capturedTags, IServiceProvider scopedServiceProvider, CancellationToken cancellationToken)
     {
         var operations = new Dictionary<OperationType, OpenApiOperation>();
         foreach (var description in descriptions)
         {
-            var operation = await GetOperationAsync(description, capturedTags, cancellationToken);
+            var operation = await GetOperationAsync(description, capturedTags, scopedServiceProvider, cancellationToken);
             operation.Annotations ??= new Dictionary<string, object>();
             operation.Annotations.Add(OpenApiConstants.DescriptionId, description.ActionDescriptor.Id);
 
@@ -176,23 +238,26 @@ internal sealed class OpenApiDocumentService(
             {
                 DocumentName = documentName,
                 Description = description,
-                ApplicationServices = serviceProvider,
+                ApplicationServices = scopedServiceProvider,
             };
 
             _operationTransformerContextCache.TryAdd(description.ActionDescriptor.Id, operationContext);
             operations[description.GetOperationType()] = operation;
 
             // Use index-based for loop to avoid allocating an enumerator with a foreach.
-            for (var i = 0; i < _options.OperationTransformers.Count; i++)
+            if (_operationTransformers is not null)
             {
-                var transformer = _options.OperationTransformers[i];
-                await transformer.TransformAsync(operation, operationContext, cancellationToken);
+                for (var i = 0; i < _operationTransformers.Count; i++)
+                {
+                    var transformer = _operationTransformers[i];
+                    await transformer.TransformAsync(operation, operationContext, cancellationToken);
+                }
             }
         }
         return operations;
     }
 
-    private async Task<OpenApiOperation> GetOperationAsync(ApiDescription description, HashSet<OpenApiTag> capturedTags, CancellationToken cancellationToken)
+    private async Task<OpenApiOperation> GetOperationAsync(ApiDescription description, HashSet<OpenApiTag> capturedTags, IServiceProvider scopedServiceProvider, CancellationToken cancellationToken)
     {
         var tags = GetTags(description);
         if (tags != null)
@@ -207,9 +272,9 @@ internal sealed class OpenApiDocumentService(
             OperationId = GetOperationId(description),
             Summary = GetSummary(description),
             Description = GetDescription(description),
-            Responses = await GetResponsesAsync(description, cancellationToken),
-            Parameters = await GetParametersAsync(description, cancellationToken),
-            RequestBody = await GetRequestBodyAsync(description, cancellationToken),
+            Responses = await GetResponsesAsync(description, scopedServiceProvider, cancellationToken),
+            Parameters = await GetParametersAsync(description, scopedServiceProvider, cancellationToken),
+            RequestBody = await GetRequestBodyAsync(description, scopedServiceProvider, cancellationToken),
             Tags = tags,
         };
         return operation;
@@ -237,7 +302,7 @@ internal sealed class OpenApiDocumentService(
         return [new OpenApiTag { Name = description.ActionDescriptor.RouteValues["controller"] }];
     }
 
-    private async Task<OpenApiResponses> GetResponsesAsync(ApiDescription description, CancellationToken cancellationToken)
+    private async Task<OpenApiResponses> GetResponsesAsync(ApiDescription description, IServiceProvider scopedServiceProvider, CancellationToken cancellationToken)
     {
         // OpenAPI requires that each operation have a response, usually a successful one.
         // if there are no response types defined, we assume a successful 200 OK response
@@ -246,7 +311,7 @@ internal sealed class OpenApiDocumentService(
         {
             return new OpenApiResponses
             {
-                ["200"] = await GetResponseAsync(description, StatusCodes.Status200OK, _defaultApiResponseType, cancellationToken)
+                ["200"] = await GetResponseAsync(description, StatusCodes.Status200OK, _defaultApiResponseType, scopedServiceProvider, cancellationToken)
             };
         }
 
@@ -260,12 +325,12 @@ internal sealed class OpenApiDocumentService(
             var responseKey = responseType.IsDefaultResponse
                 ? OpenApiConstants.DefaultOpenApiResponseKey
                 : responseType.StatusCode.ToString(CultureInfo.InvariantCulture);
-            responses.Add(responseKey, await GetResponseAsync(description, responseType.StatusCode, responseType, cancellationToken));
+            responses.Add(responseKey, await GetResponseAsync(description, responseType.StatusCode, responseType, scopedServiceProvider, cancellationToken));
         }
         return responses;
     }
 
-    private async Task<OpenApiResponse> GetResponseAsync(ApiDescription apiDescription, int statusCode, ApiResponseType apiResponseType, CancellationToken cancellationToken)
+    private async Task<OpenApiResponse> GetResponseAsync(ApiDescription apiDescription, int statusCode, ApiResponseType apiResponseType, IServiceProvider scopedServiceProvider, CancellationToken cancellationToken)
     {
         var description = ReasonPhrases.GetReasonPhrase(statusCode);
         var response = new OpenApiResponse
@@ -282,7 +347,7 @@ internal sealed class OpenApiDocumentService(
             .Select(responseFormat => responseFormat.MediaType);
         foreach (var contentType in apiResponseFormatContentTypes)
         {
-            var schema = apiResponseType.Type is { } type ? await _componentService.GetOrCreateSchemaAsync(type, null, captureSchemaByRef: true, cancellationToken) : new OpenApiSchema();
+            var schema = apiResponseType.Type is { } type ? await _componentService.GetOrCreateSchemaAsync(type, scopedServiceProvider, _schemaTransformers, null, captureSchemaByRef: true, cancellationToken) : new OpenApiSchema();
             response.Content[contentType] = new OpenApiMediaType { Schema = schema };
         }
 
@@ -300,7 +365,7 @@ internal sealed class OpenApiDocumentService(
         return response;
     }
 
-    private async Task<List<OpenApiParameter>?> GetParametersAsync(ApiDescription description, CancellationToken cancellationToken)
+    private async Task<List<OpenApiParameter>?> GetParametersAsync(ApiDescription description, IServiceProvider scopedServiceProvider, CancellationToken cancellationToken)
     {
         List<OpenApiParameter>? parameters = null;
         foreach (var parameter in description.ParameterDescriptions)
@@ -323,7 +388,7 @@ internal sealed class OpenApiDocumentService(
                     _ => throw new InvalidOperationException($"Unsupported parameter source: {parameter.Source.Id}")
                 },
                 Required = IsRequired(parameter),
-                Schema = await _componentService.GetOrCreateSchemaAsync(parameter.Type, parameter, cancellationToken: cancellationToken),
+                Schema = await _componentService.GetOrCreateSchemaAsync(parameter.Type, scopedServiceProvider, _schemaTransformers, parameter, cancellationToken: cancellationToken),
                 Description = GetParameterDescriptionFromAttribute(parameter)
             };
 
@@ -349,12 +414,12 @@ internal sealed class OpenApiDocumentService(
             descriptionAttribute.Description :
             null;
 
-    private async Task<OpenApiRequestBody?> GetRequestBodyAsync(ApiDescription description, CancellationToken cancellationToken)
+    private async Task<OpenApiRequestBody?> GetRequestBodyAsync(ApiDescription description, IServiceProvider scopedServiceProvider, CancellationToken cancellationToken)
     {
         // Only one parameter can be bound from the body in each request.
         if (description.TryGetBodyParameter(out var bodyParameter))
         {
-            return await GetJsonRequestBody(description.SupportedRequestFormats, bodyParameter, cancellationToken);
+            return await GetJsonRequestBody(description.SupportedRequestFormats, bodyParameter, scopedServiceProvider, cancellationToken);
         }
         // If there are no body parameters, check for form parameters.
         // Note: Form parameters and body parameters cannot exist simultaneously
@@ -362,7 +427,7 @@ internal sealed class OpenApiDocumentService(
         if (description.TryGetFormParameters(out var formParameters))
         {
             var endpointMetadata = description.ActionDescriptor.EndpointMetadata;
-            return await GetFormRequestBody(description.SupportedRequestFormats, formParameters, endpointMetadata, cancellationToken);
+            return await GetFormRequestBody(description.SupportedRequestFormats, formParameters, endpointMetadata, scopedServiceProvider, cancellationToken);
         }
         return null;
     }
@@ -371,6 +436,7 @@ internal sealed class OpenApiDocumentService(
         IList<ApiRequestFormat> supportedRequestFormats,
         IEnumerable<ApiParameterDescription> formParameters,
         IList<object> endpointMetadata,
+        IServiceProvider scopedServiceProvider,
         CancellationToken cancellationToken)
     {
         if (supportedRequestFormats.Count == 0)
@@ -409,7 +475,7 @@ internal sealed class OpenApiDocumentService(
             if (parameter.All(parameter => parameter.ModelMetadata.ContainerType is null))
             {
                 var description = parameter.Single();
-                var parameterSchema = await _componentService.GetOrCreateSchemaAsync(description.Type, description, cancellationToken: cancellationToken);
+                var parameterSchema = await _componentService.GetOrCreateSchemaAsync(description.Type, scopedServiceProvider, _schemaTransformers, description, cancellationToken: cancellationToken);
                 // Form files are keyed by their parameter name so we must capture the parameter name
                 // as a property in the schema.
                 if (description.Type == typeof(IFormFile) || description.Type == typeof(IFormFileCollection))
@@ -490,7 +556,7 @@ internal sealed class OpenApiDocumentService(
                     var propertySchema = new OpenApiSchema { Type = "object", Properties = new Dictionary<string, OpenApiSchema>() };
                     foreach (var description in parameter)
                     {
-                        propertySchema.Properties[description.Name] = await _componentService.GetOrCreateSchemaAsync(description.Type, description, cancellationToken: cancellationToken);
+                        propertySchema.Properties[description.Name] = await _componentService.GetOrCreateSchemaAsync(description.Type, scopedServiceProvider, _schemaTransformers, description, cancellationToken: cancellationToken);
                     }
                     schema.AllOf.Add(propertySchema);
                 }
@@ -498,7 +564,7 @@ internal sealed class OpenApiDocumentService(
                 {
                     foreach (var description in parameter)
                     {
-                        schema.Properties[description.Name] = await _componentService.GetOrCreateSchemaAsync(description.Type, description, cancellationToken: cancellationToken);
+                        schema.Properties[description.Name] = await _componentService.GetOrCreateSchemaAsync(description.Type, scopedServiceProvider, _schemaTransformers, description, cancellationToken: cancellationToken);
                     }
                 }
             }
@@ -516,7 +582,7 @@ internal sealed class OpenApiDocumentService(
         return requestBody;
     }
 
-    private async Task<OpenApiRequestBody> GetJsonRequestBody(IList<ApiRequestFormat> supportedRequestFormats, ApiParameterDescription bodyParameter, CancellationToken cancellationToken)
+    private async Task<OpenApiRequestBody> GetJsonRequestBody(IList<ApiRequestFormat> supportedRequestFormats, ApiParameterDescription bodyParameter, IServiceProvider scopedServiceProvider, CancellationToken cancellationToken)
     {
         if (supportedRequestFormats.Count == 0)
         {
@@ -544,7 +610,7 @@ internal sealed class OpenApiDocumentService(
         foreach (var requestForm in supportedRequestFormats)
         {
             var contentType = requestForm.MediaType;
-            requestBody.Content[contentType] = new OpenApiMediaType { Schema = await _componentService.GetOrCreateSchemaAsync(bodyParameter.Type, bodyParameter, captureSchemaByRef: true, cancellationToken: cancellationToken) };
+            requestBody.Content[contentType] = new OpenApiMediaType { Schema = await _componentService.GetOrCreateSchemaAsync(bodyParameter.Type, scopedServiceProvider, _schemaTransformers, bodyParameter, captureSchemaByRef: true, cancellationToken: cancellationToken) };
         }
 
         return requestBody;

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -125,7 +125,7 @@ internal sealed class OpenApiSchemaService(
         }
     };
 
-    internal async Task<OpenApiSchema> GetOrCreateSchemaAsync(Type type, IServiceProvider scopedServiceProvider, List<IOpenApiSchemaTransformer>? schemaTransformers, ApiParameterDescription? parameterDescription = null, bool captureSchemaByRef = false, CancellationToken cancellationToken = default)
+    internal async Task<OpenApiSchema> GetOrCreateSchemaAsync(Type type, IServiceProvider scopedServiceProvider, List<IOpenApiSchemaTransformer> schemaTransformers, ApiParameterDescription? parameterDescription = null, bool captureSchemaByRef = false, CancellationToken cancellationToken = default)
     {
         var key = parameterDescription?.ParameterDescriptor is IParameterInfoParameterDescriptor parameterInfoDescription
             && parameterDescription.ModelMetadata.PropertyName is null
@@ -143,9 +143,9 @@ internal sealed class OpenApiSchemaService(
         return schema;
     }
 
-    internal async Task ApplySchemaTransformersAsync(OpenApiSchema schema, Type type, IServiceProvider scopedServiceProvider, List<IOpenApiSchemaTransformer>? schemaTransformers, ApiParameterDescription? parameterDescription = null, CancellationToken cancellationToken = default)
+    internal async Task ApplySchemaTransformersAsync(OpenApiSchema schema, Type type, IServiceProvider scopedServiceProvider, List<IOpenApiSchemaTransformer> schemaTransformers, ApiParameterDescription? parameterDescription = null, CancellationToken cancellationToken = default)
     {
-        if (schemaTransformers is null || schemaTransformers.Count == 0)
+        if (schemaTransformers.Count == 0)
         {
             return;
         }

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -145,7 +145,7 @@ internal sealed class OpenApiSchemaService(
 
     internal async Task ApplySchemaTransformersAsync(OpenApiSchema schema, Type type, IServiceProvider scopedServiceProvider, List<IOpenApiSchemaTransformer>? schemaTransformers, ApiParameterDescription? parameterDescription = null, CancellationToken cancellationToken = default)
     {
-        if (schemaTransformers is null)
+        if (schemaTransformers is null || schemaTransformers.Count == 0)
         {
             return;
         }

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -32,7 +32,6 @@ internal sealed class OpenApiSchemaService(
     IOptionsMonitor<OpenApiOptions> optionsMonitor)
 {
     private readonly OpenApiSchemaStore _schemaStore = serviceProvider.GetRequiredKeyedService<OpenApiSchemaStore>(documentName);
-    private readonly OpenApiOptions _openApiOptions = optionsMonitor.Get(documentName);
     private readonly JsonSerializerOptions _jsonSerializerOptions = new(jsonOptions.Value.SerializerOptions)
     {
         // In order to properly handle the `RequiredAttribute` on type properties, add a modifier to support
@@ -126,7 +125,7 @@ internal sealed class OpenApiSchemaService(
         }
     };
 
-    internal async Task<OpenApiSchema> GetOrCreateSchemaAsync(Type type, ApiParameterDescription? parameterDescription = null, bool captureSchemaByRef = false, CancellationToken cancellationToken = default)
+    internal async Task<OpenApiSchema> GetOrCreateSchemaAsync(Type type, IServiceProvider scopedServiceProvider, List<IOpenApiSchemaTransformer>? schemaTransformers, ApiParameterDescription? parameterDescription = null, bool captureSchemaByRef = false, CancellationToken cancellationToken = default)
     {
         var key = parameterDescription?.ParameterDescriptor is IParameterInfoParameterDescriptor parameterInfoDescription
             && parameterDescription.ModelMetadata.PropertyName is null
@@ -139,13 +138,17 @@ internal sealed class OpenApiSchemaService(
         var deserializedSchema = JsonSerializer.Deserialize(schemaAsJsonObject, OpenApiJsonSchemaContext.Default.OpenApiJsonSchema);
         Debug.Assert(deserializedSchema != null, "The schema should have been deserialized successfully and materialize a non-null value.");
         var schema = deserializedSchema.Schema;
-        await ApplySchemaTransformersAsync(schema, type, parameterDescription, cancellationToken);
+        await ApplySchemaTransformersAsync(schema, type, scopedServiceProvider, schemaTransformers, parameterDescription, cancellationToken);
         _schemaStore.PopulateSchemaIntoReferenceCache(schema, captureSchemaByRef);
         return schema;
     }
 
-    internal async Task ApplySchemaTransformersAsync(OpenApiSchema schema, Type type, ApiParameterDescription? parameterDescription = null, CancellationToken cancellationToken = default)
+    internal async Task ApplySchemaTransformersAsync(OpenApiSchema schema, Type type, IServiceProvider scopedServiceProvider, List<IOpenApiSchemaTransformer>? schemaTransformers, ApiParameterDescription? parameterDescription = null, CancellationToken cancellationToken = default)
     {
+        if (schemaTransformers is null)
+        {
+            return;
+        }
         var jsonTypeInfo = _jsonSerializerOptions.GetTypeInfo(type);
         var context = new OpenApiSchemaTransformerContext
         {
@@ -153,31 +156,13 @@ internal sealed class OpenApiSchemaService(
             JsonTypeInfo = jsonTypeInfo,
             JsonPropertyInfo = null,
             ParameterDescription = parameterDescription,
-            ApplicationServices = serviceProvider
+            ApplicationServices = scopedServiceProvider
         };
-        for (var i = 0; i < _openApiOptions.SchemaTransformers.Count; i++)
+        for (var i = 0; i < schemaTransformers.Count; i++)
         {
             // Reset context object to base state before running each transformer.
-            var transformer = _openApiOptions.SchemaTransformers[i];
-            // If the transformer is a type-based transformer, we need to initialize and finalize it
-            // once in the context of the top-level assembly and not the child properties we are invoking
-            // it on.
-            if (transformer is TypeBasedOpenApiSchemaTransformer typeBasedTransformer)
-            {
-                var initializedTransformer = typeBasedTransformer.InitializeTransformer(serviceProvider);
-                try
-                {
-                    await InnerApplySchemaTransformersAsync(schema, jsonTypeInfo, null, context, initializedTransformer, cancellationToken);
-                }
-                finally
-                {
-                    await TypeBasedOpenApiSchemaTransformer.FinalizeTransformer(initializedTransformer);
-                }
-            }
-            else
-            {
-                await InnerApplySchemaTransformersAsync(schema, jsonTypeInfo, null, context, transformer, cancellationToken);
-            }
+            var transformer = schemaTransformers[i];
+            await InnerApplySchemaTransformersAsync(schema, jsonTypeInfo, null, context, transformer, cancellationToken);
         }
     }
 

--- a/src/OpenApi/src/Transformers/TypeBasedOpenApiOperationTransformer.cs
+++ b/src/OpenApi/src/Transformers/TypeBasedOpenApiOperationTransformer.cs
@@ -20,25 +20,13 @@ internal sealed class TypeBasedOpenApiOperationTransformer : IOpenApiOperationTr
         _transformerFactory = ActivatorUtilities.CreateFactory(_transformerType, []);
     }
 
-    public async Task TransformAsync(OpenApiOperation operation, OpenApiOperationTransformerContext context, CancellationToken cancellationToken)
+    internal IOpenApiOperationTransformer InitializeTransformer(IServiceProvider serviceProvider)
     {
-        var transformer = _transformerFactory.Invoke(context.ApplicationServices, []) as IOpenApiOperationTransformer;
-        Debug.Assert(transformer is not null, $"The type {_transformerType} does not implement {nameof(IOpenApiOperationTransformer)}.");
-
-        try
-        {
-            await transformer.TransformAsync(operation, context, cancellationToken);
-        }
-        finally
-        {
-            if (transformer is IAsyncDisposable asyncDisposable)
-            {
-                await asyncDisposable.DisposeAsync();
-            }
-            else if (transformer is IDisposable disposable)
-            {
-                disposable.Dispose();
-            }
-        }
+        var transformer = _transformerFactory.Invoke(serviceProvider, []) as IOpenApiOperationTransformer;
+        Debug.Assert(transformer != null, $"The type {_transformerType} does not implement {nameof(IOpenApiOperationTransformer)}.");
+        return transformer;
     }
+
+    public Task TransformAsync(OpenApiOperation operation, OpenApiOperationTransformerContext context, CancellationToken cancellationToken)
+        => Task.CompletedTask;
 }

--- a/src/OpenApi/src/Transformers/TypeBasedOpenApiSchemaTransformer.cs
+++ b/src/OpenApi/src/Transformers/TypeBasedOpenApiSchemaTransformer.cs
@@ -27,18 +27,6 @@ internal sealed class TypeBasedOpenApiSchemaTransformer : IOpenApiSchemaTransfor
         return transformer;
     }
 
-    internal static async Task FinalizeTransformer(IOpenApiSchemaTransformer transformer)
-    {
-        if (transformer is IAsyncDisposable asyncDisposable)
-        {
-            await asyncDisposable.DisposeAsync();
-        }
-        else if (transformer is IDisposable disposable)
-        {
-            disposable.Dispose();
-        }
-    }
-
     // No-op because the activate instance is invoked by the OpenApiSchema service.
     public Task TransformAsync(OpenApiSchema schema, OpenApiSchemaTransformerContext context, CancellationToken cancellationToken)
         => Task.CompletedTask;

--- a/src/OpenApi/src/Transformers/TypeBasedTransforrmerExtensions.cs
+++ b/src/OpenApi/src/Transformers/TypeBasedTransforrmerExtensions.cs
@@ -10,7 +10,7 @@ internal static class TypeBasedTransformerExtensions
     /// after a given OpenAPI document generation request has been completed.
     /// </summary>
     /// <remarks>
-    /// This method is intended to be invoked on <see cref="TypeBasedOpenApiOperationTransformer" /> and <see cref="TypeBasedOpenApiSchemaTransformer" /> instances.
+    /// This method is intended to be invoked on <see cref="TypeBasedOpenApiOperationTransformer" /> and <see cref="TypeBasedOpenApiSchemaTransformer" />.
     /// instances which can be invoked multiple times within the same document generation request.
     /// </remarks>
     public static async Task FinalizeTransformer<ITransformer>(this ITransformer transformer)

--- a/src/OpenApi/src/Transformers/TypeBasedTransforrmerExtensions.cs
+++ b/src/OpenApi/src/Transformers/TypeBasedTransforrmerExtensions.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.OpenApi;
+
+internal static class TypeBasedTransformerExtensions
+{
+    /// <summary>
+    /// Supports disposing of factory-based transformers that implement <see cref="IDisposable"/> or <see cref="IAsyncDisposable"/>
+    /// after a given OpenAPI document generation request has been completed.
+    /// </summary>
+    /// <remarks>
+    /// This method is intended to be invoked on <see cref="TypeBasedOpenApiOperationTransformer" /> and <see cref="TypeBasedOpenApiSchemaTransformer" /> instances.
+    /// instances which can be invoked multiple times within the same document generation request.
+    /// </remarks>
+    public static async Task FinalizeTransformer<ITransformer>(this ITransformer transformer)
+    {
+        if (transformer is IAsyncDisposable asyncDisposable)
+        {
+            await asyncDisposable.DisposeAsync();
+        }
+        else if (transformer is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+    }
+}

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/OpenApiDocumentIntegrationTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/OpenApiDocumentIntegrationTests.cs
@@ -21,7 +21,8 @@ public sealed class OpenApiDocumentIntegrationTests(SampleAppFixture fixture) : 
     public async Task VerifyOpenApiDocument(string documentName)
     {
         var documentService = fixture.Services.GetRequiredKeyedService<OpenApiDocumentService>(documentName);
-        var document = await documentService.GetOpenApiDocumentAsync();
+        var scopedServiceProvider = fixture.Services.CreateScope();
+        var document = await documentService.GetOpenApiDocumentAsync(scopedServiceProvider.ServiceProvider);
         await Verifier.Verify(GetOpenApiJson(document))
             .UseDirectory(SkipOnHelixAttribute.OnHelix()
                 ? Path.Combine(Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT"), "Integration", "snapshots")

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Info.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Info.cs
@@ -22,7 +22,7 @@ public partial class OpenApiDocumentServiceTests
             "v1",
             new Mock<IApiDescriptionGroupCollectionProvider>().Object,
             hostEnvironment,
-            new Mock<IOptionsMonitor<OpenApiOptions>>().Object,
+            GetMockOptionsMonitor(),
             new Mock<IKeyedServiceProvider>().Object,
             new OpenApiTestServer());
 
@@ -45,7 +45,7 @@ public partial class OpenApiDocumentServiceTests
             "v2",
             new Mock<IApiDescriptionGroupCollectionProvider>().Object,
             hostEnvironment,
-            new Mock<IOptionsMonitor<OpenApiOptions>>().Object,
+            GetMockOptionsMonitor(),
             new Mock<IKeyedServiceProvider>().Object,
             new OpenApiTestServer());
 
@@ -54,5 +54,12 @@ public partial class OpenApiDocumentServiceTests
 
         // Assert
         Assert.Equal("TestApplication | v2", info.Title);
+    }
+
+    internal IOptionsMonitor<OpenApiOptions> GetMockOptionsMonitor()
+    {
+        var openApiOptions = new Mock<IOptionsMonitor<OpenApiOptions>>();
+        openApiOptions.Setup(o => o.Get(It.IsAny<string>())).Returns(new OpenApiOptions());
+        return openApiOptions.Object;
     }
 }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Servers.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Servers.cs
@@ -23,7 +23,7 @@ public partial class OpenApiDocumentServiceTests
             "v1",
             new Mock<IApiDescriptionGroupCollectionProvider>().Object,
             hostEnvironment,
-            new Mock<IOptionsMonitor<OpenApiOptions>>().Object,
+            GetMockOptionsMonitor(),
             new Mock<IKeyedServiceProvider>().Object,
             new OpenApiTestServer(["http://localhost:5000"]));
 
@@ -47,7 +47,7 @@ public partial class OpenApiDocumentServiceTests
             "v1",
             new Mock<IApiDescriptionGroupCollectionProvider>().Object,
             hostEnvironment,
-            new Mock<IOptionsMonitor<OpenApiOptions>>().Object,
+            GetMockOptionsMonitor(),
             new Mock<IKeyedServiceProvider>().Object,
             new OpenApiTestServer(["http://localhost:5000", "http://localhost:5002"]));
 
@@ -72,7 +72,7 @@ public partial class OpenApiDocumentServiceTests
             "v1",
             new Mock<IApiDescriptionGroupCollectionProvider>().Object,
             hostEnvironment,
-            new Mock<IOptionsMonitor<OpenApiOptions>>().Object,
+            GetMockOptionsMonitor(),
             new Mock<IKeyedServiceProvider>().Object,
             new OpenApiTestServer(["http://localhost:5000"]));
 
@@ -96,7 +96,7 @@ public partial class OpenApiDocumentServiceTests
             "v2",
             new Mock<IApiDescriptionGroupCollectionProvider>().Object,
             hostEnvironment,
-            new Mock<IOptionsMonitor<OpenApiOptions>>().Object,
+            GetMockOptionsMonitor(),
             new Mock<IKeyedServiceProvider>().Object,
             new OpenApiTestServer());
 

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/SchemaTransformerTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/SchemaTransformerTests.cs
@@ -326,11 +326,7 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
         var options = new OpenApiOptions();
         options.AddSchemaTransformer<ActivatedTransformerWithDependency>();
 
-        // Assert that transient dependency is instantiated once for each
-        // request to the OpenAPI document for each created schema and its
-        // sub-schemas. In this case, it's instantiated 4 times for each top-level
-        // schema, 16 times for each property within each schema.
-        var countBefore = Dependency.InstantiationCount;
+        Dependency.InstantiationCount = 0;
         await VerifyOpenApiDocument(builder, options, document =>
         {
             var path = Assert.Single(document.Paths.Values);
@@ -351,8 +347,9 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
             var responseSchema = getOperation.Responses["200"].Content["application/json"].Schema.GetEffective(document);
             Assert.True(responseSchema.Extensions.ContainsKey("x-my-extension"));
         });
-        var countAfter = Dependency.InstantiationCount;
-        Assert.Equal(countBefore + 4, countAfter);
+        // Assert that the transient dependency has a "scoped" lifetime within
+        // the context of the transformer and is called twice, once for each request.
+        Assert.Equal(2, Dependency.InstantiationCount);
     }
 
     [Fact]
@@ -377,8 +374,8 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
             var responseSchema = getOperation.Responses["200"].Content["application/json"].Schema.GetEffective(document);
             Assert.Equal("Schema Description", responseSchema.Description);
         });
-        // Assert that the transformer is disposed twice for each top-level schema.
-        Assert.Equal(2, DisposableTransformer.DisposeCount);
+        // Assert that the transformer is disposed once for the entire document.
+        Assert.Equal(1, DisposableTransformer.DisposeCount);
     }
 
     [Fact]
@@ -403,8 +400,8 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
             var responseSchema = getOperation.Responses["200"].Content["application/json"].Schema.GetEffective(document);
             Assert.Equal("Schema Description", responseSchema.Description);
         });
-        // Assert that the transformer is disposed twice for each top-level schema.
-        Assert.Equal(2, AsyncDisposableTransformer.DisposeCount);
+        // Assert that the transformer is disposed once for the entire document.
+        Assert.Equal(1, AsyncDisposableTransformer.DisposeCount);
     }
 
     [Fact]
@@ -756,6 +753,88 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
                 return;
             });
         }
+    }
+
+    [Fact]
+    public async Task SchemaTransformer_CanAccessSingletonServiceFromContextApplicationServices()
+    {
+        var serviceCollection = new ServiceCollection().AddSingleton<Dependency>();
+        var builder = CreateBuilder(serviceCollection);
+
+        builder.MapGet("/todo", () => new Todo(1, "Item1", false, DateTime.Now));
+
+        var options = new OpenApiOptions();
+        Dependency.InstantiationCount = 0;
+        options.AddSchemaTransformer((schema, context, cancellationToken) =>
+        {
+            var service = context.ApplicationServices.GetRequiredService<Dependency>();
+            var sameServiceAgain = context.ApplicationServices.GetRequiredService<Dependency>();
+            service.TestMethod();
+            sameServiceAgain.TestMethod();
+            return Task.CompletedTask;
+        });
+
+        await VerifyOpenApiDocument(builder, options, document => { });
+        await VerifyOpenApiDocument(builder, options, document => { });
+
+        // Assert that the singleton dependency is instantiated only once
+        // for the entire lifetime of the application.
+        Assert.Equal(1, Dependency.InstantiationCount);
+    }
+
+    [Fact]
+    public async Task SchemaTransformer_CanAccessScopedServiceFromContextApplicationServices()
+    {
+        var serviceCollection = new ServiceCollection().AddScoped<Dependency>();
+        var builder = CreateBuilder(serviceCollection);
+
+        builder.MapGet("/todo", () => new Todo(1, "Item1", false, DateTime.Now));
+
+        var options = new OpenApiOptions();
+        Dependency.InstantiationCount = 0;
+        options.AddSchemaTransformer((schema, context, cancellationToken) =>
+        {
+            var service = context.ApplicationServices.GetRequiredService<Dependency>();
+            var sameServiceAgain = context.ApplicationServices.GetRequiredService<Dependency>();
+            service.TestMethod();
+            sameServiceAgain.TestMethod();
+            return Task.CompletedTask;
+        });
+
+        await VerifyOpenApiDocument(builder, options, document => { });
+        await VerifyOpenApiDocument(builder, options, document => { });
+
+        // Assert that the scoped dependency is instantiated twice. Once for
+        // each request to the document.
+        Assert.Equal(2, Dependency.InstantiationCount);
+    }
+
+    [Fact]
+    public async Task SchemaTransformer_CanAccessTransientServiceFromContextApplicationServices()
+    {
+        var serviceCollection = new ServiceCollection().AddTransient<Dependency>();
+        var builder = CreateBuilder(serviceCollection);
+
+        builder.MapGet("/todo", () => new Todo(1, "Item1", false, DateTime.Now));
+
+        var options = new OpenApiOptions();
+        Dependency.InstantiationCount = 0;
+        options.AddSchemaTransformer((schema, context, cancellationToken) =>
+        {
+            var service = context.ApplicationServices.GetRequiredService<Dependency>();
+            var sameServiceAgain = context.ApplicationServices.GetRequiredService<Dependency>();
+            service.TestMethod();
+            sameServiceAgain.TestMethod();
+            return Task.CompletedTask;
+        });
+
+        await VerifyOpenApiDocument(builder, options, document => { });
+        // Assert that the transient dependency is invoked for each schema
+        // in the document. In this case, we have five total schemas in the document.
+        // One for the top-level `Todo` type and four for the properties of the `Todo` type.
+        // Since we call GetRequiredService twice in the transformer, the total number of
+        // instantiations should be 10.
+        Assert.Equal(10, Dependency.InstantiationCount);
     }
 
     private class PolymorphicContainer

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/TypeBasedTransformerLifetimeTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/TypeBasedTransformerLifetimeTests.cs
@@ -1,0 +1,428 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+
+public class TypeBasedTransformerLifetimeTests : OpenApiDocumentServiceTestBase
+{
+    [Fact]
+    public async Task ActivatedSchemaTransformerIsInitializedOncePerDocument()
+    {
+        var builder = CreateBuilder();
+        var options = new OpenApiOptions();
+
+        builder.MapGet("/todo", () => new Todo(1, "Item1", false, DateTime.Now));
+        builder.MapPost("/shape", (Shape shape) => { });
+        builder.MapPost("/triangle", (Triangle triangle) => { });
+
+        options.AddSchemaTransformer<ActivatedSchemaTransformer>();
+
+        ActivatedSchemaTransformer.InstantiationCount = 0;
+
+        await VerifyOpenApiDocument(builder, options, document => { });
+
+        // Assert that the transformer is only instantiated once per document
+        // even though there are multiple schemas in the document.
+        Assert.Equal(1, ActivatedSchemaTransformer.InstantiationCount);
+    }
+
+    [Fact]
+    public async Task ActivatedSchemaTransformerWithSingletonDependencyIsInitializedForLifetime()
+    {
+        var serviceCollection = new ServiceCollection().AddSingleton<Dependency>();
+        var builder = CreateBuilder(serviceCollection);
+        var options = new OpenApiOptions();
+
+        builder.MapGet("/todo", () => new Todo(1, "Item1", false, DateTime.Now));
+        builder.MapPost("/shape", (Shape shape) => { });
+        builder.MapPost("/triangle", (Triangle triangle) => { });
+
+        options.AddSchemaTransformer<ActivatedSchemaTransformerWithDependency>();
+
+        ActivatedSchemaTransformerWithDependency.InstantiationCount = 0;
+        Dependency.InstantiationCount = 0;
+
+        await VerifyOpenApiDocument(builder, options, document => { });
+        await VerifyOpenApiDocument(builder, options, document => { });
+        await VerifyOpenApiDocument(builder, options, document => { });
+
+        // Assert that the transformer is instantiated three times, once for each request to the document.
+        Assert.Equal(3, ActivatedSchemaTransformerWithDependency.InstantiationCount);
+        // Assert that the singleton dependency utilized initialized by the transformer is instantiated once.
+        Assert.Equal(1, Dependency.InstantiationCount);
+    }
+
+    [Fact]
+    public async Task ActivatedSchemaTransformerWithScopedDependencyIsInitializedPerScope()
+    {
+        var serviceCollection = new ServiceCollection().AddScoped<Dependency>();
+        var builder = CreateBuilder(serviceCollection);
+        var options = new OpenApiOptions();
+
+        builder.MapGet("/todo", () => new Todo(1, "Item1", false, DateTime.Now));
+        builder.MapPost("/shape", (Shape shape) => { });
+        builder.MapPost("/triangle", (Triangle triangle) => { });
+
+        options.AddSchemaTransformer<ActivatedSchemaTransformerWithDependency>();
+
+        ActivatedSchemaTransformerWithDependency.InstantiationCount = 0;
+        Dependency.InstantiationCount = 0;
+
+        await VerifyOpenApiDocument(builder, options, document => { });
+        await VerifyOpenApiDocument(builder, options, document => { });
+        await VerifyOpenApiDocument(builder, options, document => { });
+
+        // Assert that the transformer is instantiated three times, once for each request to the document.
+        Assert.Equal(3, ActivatedSchemaTransformerWithDependency.InstantiationCount);
+        // Assert that the scoped dependency is instantiated once per request.
+        Assert.Equal(3, Dependency.InstantiationCount);
+    }
+
+    [Fact]
+    public async Task ActivatedSchemaTransformerWithTransientDependencyIsInitializedPerRequest()
+    {
+        var serviceCollection = new ServiceCollection().AddTransient<Dependency>();
+        var builder = CreateBuilder(serviceCollection);
+        var options = new OpenApiOptions();
+
+        builder.MapGet("/todo", () => new Todo(1, "Item1", false, DateTime.Now));
+        builder.MapPost("/shape", (Shape shape) => { });
+        builder.MapPost("/triangle", (Triangle triangle) => { });
+
+        options.AddSchemaTransformer<ActivatedSchemaTransformerWithDependency>();
+
+        ActivatedSchemaTransformerWithDependency.InstantiationCount = 0;
+        Dependency.InstantiationCount = 0;
+
+        await VerifyOpenApiDocument(builder, options, document => { });
+        await VerifyOpenApiDocument(builder, options, document => { });
+        await VerifyOpenApiDocument(builder, options, document => { });
+
+        // Assert that the transformer is instantiated three times, once for each request to the document.
+        Assert.Equal(3, ActivatedSchemaTransformerWithDependency.InstantiationCount);
+        // Assert that the transient dependency is instantiated once per request.
+        Assert.Equal(3, Dependency.InstantiationCount);
+    }
+
+    [Fact]
+    public async Task ActivatedOperationTransformerIsInitializedOncePerDocument()
+    {
+        var builder = CreateBuilder();
+        var options = new OpenApiOptions();
+
+        builder.MapGet("/todo", () => new Todo(1, "Item1", false, DateTime.Now));
+        builder.MapPost("/shape", (Shape shape) => { });
+        builder.MapPost("/triangle", (Triangle triangle) => { });
+
+        options.AddOperationTransformer<ActivatedOperationTransformer>();
+
+        ActivatedOperationTransformer.InstantiationCount = 0;
+
+        await VerifyOpenApiDocument(builder, options, document => { });
+
+        // Assert that the transformer is only instantiated once per document
+        // even though there are 3 operations in the document.
+        Assert.Equal(1, ActivatedOperationTransformer.InstantiationCount);
+    }
+
+    [Fact]
+    public async Task ActivatedOperationTransformerWithSingletonDependencyIsInitializedForLifetime()
+    {
+        var serviceCollection = new ServiceCollection().AddSingleton<Dependency>();
+        var builder = CreateBuilder(serviceCollection);
+        var options = new OpenApiOptions();
+
+        builder.MapGet("/todo", () => new Todo(1, "Item1", false, DateTime.Now));
+        builder.MapPost("/shape", (Shape shape) => { });
+
+        options.AddOperationTransformer<ActivatedOperationTransformerWithDependency>();
+
+        ActivatedOperationTransformerWithDependency.InstantiationCount = 0;
+        Dependency.InstantiationCount = 0;
+
+        await VerifyOpenApiDocument(builder, options, document => { });
+        await VerifyOpenApiDocument(builder, options, document => { });
+        await VerifyOpenApiDocument(builder, options, document => { });
+
+        // Assert that the transformer is instantiated three times, once for each request to the document.
+        Assert.Equal(3, ActivatedOperationTransformerWithDependency.InstantiationCount);
+        // Assert that the singleton dependency utilized initialized by the transformer is instantiated once.
+        Assert.Equal(1, Dependency.InstantiationCount);
+    }
+
+    [Fact]
+    public async Task ActivatedOperationTransformerWithScopedDependencyIsInitializedPerScope()
+    {
+        var serviceCollection = new ServiceCollection().AddScoped<Dependency>();
+        var builder = CreateBuilder(serviceCollection);
+        var options = new OpenApiOptions();
+
+        builder.MapGet("/todo", () => new Todo(1, "Item1", false, DateTime.Now));
+        builder.MapPost("/shape", (Shape shape) => { });
+        builder.MapPost("/triangle", (Triangle triangle) => { });
+
+        options.AddOperationTransformer<ActivatedOperationTransformerWithDependency>();
+
+        ActivatedOperationTransformerWithDependency.InstantiationCount = 0;
+        Dependency.InstantiationCount = 0;
+
+        await VerifyOpenApiDocument(builder, options, document => { });
+        await VerifyOpenApiDocument(builder, options, document => { });
+        await VerifyOpenApiDocument(builder, options, document => { });
+
+        // Assert that the transformer is instantiated three times, once for each request to the document.
+        Assert.Equal(3, ActivatedOperationTransformerWithDependency.InstantiationCount);
+        // Assert that the singleton dependency utilized initialized by the transformer is instantiated once.
+        Assert.Equal(3, Dependency.InstantiationCount);
+    }
+
+        [Fact]
+    public async Task ActivatedOperationTransformerWithTransientDependencyIsInitializedPerRequest()
+    {
+        var serviceCollection = new ServiceCollection().AddTransient<Dependency>();
+        var builder = CreateBuilder(serviceCollection);
+        var options = new OpenApiOptions();
+
+        builder.MapGet("/todo", () => new Todo(1, "Item1", false, DateTime.Now));
+        builder.MapPost("/shape", (Shape shape) => { });
+        builder.MapPost("/triangle", (Triangle triangle) => { });
+
+        options.AddOperationTransformer<ActivatedOperationTransformerWithDependency>();
+
+        ActivatedOperationTransformerWithDependency.InstantiationCount = 0;
+        Dependency.InstantiationCount = 0;
+
+        await VerifyOpenApiDocument(builder, options, document => { });
+        await VerifyOpenApiDocument(builder, options, document => { });
+        await VerifyOpenApiDocument(builder, options, document => { });
+
+        // Assert that the transformer is instantiated three times, once for each request to the document.
+        Assert.Equal(3, ActivatedOperationTransformerWithDependency.InstantiationCount);
+        // Assert that the transient dependency is instantiated once per request.
+        Assert.Equal(3, Dependency.InstantiationCount);
+    }
+
+    [Fact]
+    public async Task ActivatedDocumentTransformerIsInitializedOncePerDocument()
+    {
+        var builder = CreateBuilder();
+        var options = new OpenApiOptions();
+
+        builder.MapGet("/todo", () => new Todo(1, "Item1", false, DateTime.Now));
+        builder.MapPost("/shape", (Shape shape) => { });
+        builder.MapPost("/triangle", (Triangle triangle) => { });
+
+        options.AddDocumentTransformer<ActivatedDocumentTransformer>();
+
+        ActivatedDocumentTransformer.InstantiationCount = 0;
+
+        await VerifyOpenApiDocument(builder, options, document => { });
+
+        // Assert that the transformer is only instantiated once per call
+        // to generate the document.
+        Assert.Equal(1, ActivatedDocumentTransformer.InstantiationCount);
+    }
+
+    [Fact]
+    public async Task ActivatedDocumentTransformerIsInitializedPerDocumentRequest()
+    {
+        var builder = CreateBuilder();
+        var options = new OpenApiOptions();
+
+        builder.MapGet("/todo", () => new Todo(1, "Item1", false, DateTime.Now));
+        builder.MapPost("/shape", (Shape shape) => { });
+        builder.MapPost("/triangle", (Triangle triangle) => { });
+
+        options.AddDocumentTransformer<ActivatedDocumentTransformer>();
+
+        ActivatedDocumentTransformer.InstantiationCount = 0;
+
+        await VerifyOpenApiDocument(builder, options, document => { });
+        await VerifyOpenApiDocument(builder, options, document => { });
+
+        // Assert that the transformer is only instantiated twice, once per call
+        // to generate the document.
+        Assert.Equal(2, ActivatedDocumentTransformer.InstantiationCount);
+    }
+
+    [Fact]
+    public async Task ActivatedDocumentTransformerWithSingletonDependencyIsInitializedForLifetime()
+    {
+        var serviceCollection = new ServiceCollection().AddSingleton<Dependency>();
+        var builder = CreateBuilder(serviceCollection);
+        var options = new OpenApiOptions();
+
+        builder.MapGet("/todo", () => new Todo(1, "Item1", false, DateTime.Now));
+        builder.MapPost("/shape", (Shape shape) => { });
+        builder.MapPost("/triangle", (Triangle triangle) => { });
+
+        options.AddDocumentTransformer<ActivatedDocumentTransformerWithDependency>();
+
+        ActivatedDocumentTransformerWithDependency.InstantiationCount = 0;
+        Dependency.InstantiationCount = 0;
+
+        await VerifyOpenApiDocument(builder, options, document => { });
+        await VerifyOpenApiDocument(builder, options, document => { });
+        await VerifyOpenApiDocument(builder, options, document => { });
+
+        // Assert that the transformer is instantiated three times, once for each request to the document.
+        Assert.Equal(3, ActivatedDocumentTransformerWithDependency.InstantiationCount);
+        // Assert that the singleton dependency utilized initialized by the transformer is instantiated once.
+        Assert.Equal(1, Dependency.InstantiationCount);
+    }
+
+    [Fact]
+    public async Task ActivatedDocumentTransformerWithScopedDependencyIsInitializedPerScope()
+    {
+        var serviceCollection = new ServiceCollection().AddScoped<Dependency>();
+        var builder = CreateBuilder(serviceCollection);
+        var options = new OpenApiOptions();
+
+        builder.MapGet("/todo", () => new Todo(1, "Item1", false, DateTime.Now));
+        builder.MapPost("/shape", (Shape shape) => { });
+        builder.MapPost("/triangle", (Triangle triangle) => { });
+
+        options.AddDocumentTransformer<ActivatedDocumentTransformerWithDependency>();
+
+        ActivatedDocumentTransformerWithDependency.InstantiationCount = 0;
+        Dependency.InstantiationCount = 0;
+
+        await VerifyOpenApiDocument(builder, options, document => { });
+        await VerifyOpenApiDocument(builder, options, document => { });
+        await VerifyOpenApiDocument(builder, options, document => { });
+
+        // Assert that the transformer is instantiated three times, once for each request to the document.
+        Assert.Equal(3, ActivatedDocumentTransformerWithDependency.InstantiationCount);
+        // Assert that the singleton dependency utilized initialized by the transformer is instantiated once.
+        Assert.Equal(3, Dependency.InstantiationCount);
+    }
+
+    [Fact]
+    public async Task ActivatedDocumentTransformerWithTransientDependencyIsInitializedPerRequest()
+    {
+        var serviceCollection = new ServiceCollection().AddTransient<Dependency>();
+        var builder = CreateBuilder(serviceCollection);
+        var options = new OpenApiOptions();
+
+        builder.MapGet("/todo", () => new Todo(1, "Item1", false, DateTime.Now));
+        builder.MapPost("/shape", (Shape shape) => { });
+        builder.MapPost("/triangle", (Triangle triangle) => { });
+
+        options.AddDocumentTransformer<ActivatedDocumentTransformerWithDependency>();
+
+        ActivatedDocumentTransformerWithDependency.InstantiationCount = 0;
+        Dependency.InstantiationCount = 0;
+
+        await VerifyOpenApiDocument(builder, options, document => { });
+        await VerifyOpenApiDocument(builder, options, document => { });
+        await VerifyOpenApiDocument(builder, options, document => { });
+
+        // Assert that the transformer is instantiated three times, once for each request to the document.
+        Assert.Equal(3, ActivatedDocumentTransformerWithDependency.InstantiationCount);
+        // Assert that the transient dependency is instantiated once per request.
+        Assert.Equal(3, Dependency.InstantiationCount);
+    }
+
+    private class Dependency
+    {
+        public static int InstantiationCount = 0;
+        public Dependency()
+        {
+            InstantiationCount += 1;
+        }
+    }
+
+    private class ActivatedSchemaTransformer : IOpenApiSchemaTransformer
+    {
+        public static int InstantiationCount = 0;
+        public ActivatedSchemaTransformer()
+        {
+            InstantiationCount += 1;
+        }
+
+        public Task TransformAsync(OpenApiSchema schema, OpenApiSchemaTransformerContext context, CancellationToken cancellationToken)
+        {
+            if (context.JsonTypeInfo.Type == typeof(Todo))
+            {
+                schema.Extensions["x-my-extension"] = new OpenApiString("1");
+            }
+            return Task.CompletedTask;
+        }
+    }
+
+    private class ActivatedSchemaTransformerWithDependency: IOpenApiSchemaTransformer
+    {
+        public static int InstantiationCount = 0;
+        public ActivatedSchemaTransformerWithDependency(Dependency dependency)
+        {
+            InstantiationCount += 1;
+        }
+
+        public Task TransformAsync(OpenApiSchema schema, OpenApiSchemaTransformerContext context, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    private class ActivatedOperationTransformer : IOpenApiOperationTransformer
+    {
+        public static int InstantiationCount = 0;
+        public ActivatedOperationTransformer()
+        {
+            InstantiationCount += 1;
+        }
+
+        public Task TransformAsync(OpenApiOperation operation, OpenApiOperationTransformerContext context, CancellationToken cancellationToken)
+        {
+            operation.Description = "Operation Description";
+            return Task.CompletedTask;
+        }
+    }
+
+    private class ActivatedOperationTransformerWithDependency: IOpenApiOperationTransformer
+    {
+        public static int InstantiationCount = 0;
+        public ActivatedOperationTransformerWithDependency(Dependency dependency)
+        {
+            InstantiationCount += 1;
+        }
+
+        public Task TransformAsync(OpenApiOperation operation, OpenApiOperationTransformerContext context, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    private class ActivatedDocumentTransformer : IOpenApiDocumentTransformer
+    {
+        public static int InstantiationCount = 0;
+        public ActivatedDocumentTransformer()
+        {
+            InstantiationCount += 1;
+        }
+
+        public Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken)
+        {
+            document.Info.Description = "Info Description";
+            return Task.CompletedTask;
+        }
+    }
+
+    private class ActivatedDocumentTransformerWithDependency : IOpenApiDocumentTransformer
+    {
+        public static int InstantiationCount = 0;
+        public ActivatedDocumentTransformerWithDependency(Dependency dependency)
+        {
+            InstantiationCount += 1;
+        }
+
+        public Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
Closes #57211.

This PR fixes an underlying issue with factory-activated operation and schema transformers being initialized/disposed too frequently in the OpenAPI document generation pipeline.

Prior to this change, factory-activated schema transformers would be activated/disposed once for each schema within a document. Factory-activated operation transformers would be activated/disposed once for each endpoint within an application.

For an application like the following:

```csharp
var builder = WebApplication.CreateBuilder();

builder.Services.AddOpenApi(options =>
{
	options.AddOperationTransformer<ActivatedOperationTransformer>();
	options.AddSchemaTransformer<ActivatedSchemaTransformer>();
})

var app = builder.Build();

app.MapPost("/"project, (Todo todo) => new Project(todo));
app.MapPost("/project", (Project project) => project);
app.MapGet("/project", () => new Project());
```

The `ActivatedOperationTransformer` would be instantiated/disposed three times for each endpoint and the `AddSchemaTransformer` would be instantiated/disposed twice for each request to the document. After this change, both transformers are activated/disposed once.

This PR also updates the `OpenApiDocumentService` to consume the scoped IServiceProvider instance from `HttpContext.RequestServices` to all transformer contexts to support resolving scoped dependencies. Factory-activated transformers have the following behavior for constructor-injected dependencies:

- Transformers always have a scoped lifetime where the "unit-of-work" is a single request to generate the OpenAPI document.
- Factory-activated transformers respect the singleton lifetime of constructor-injected dependencies they take with that lifetime.
- Factory-activated transformers respect the scoped lifetime of constructor-dependencies they take with that lifetime.
- Factory-activated transformers do not respect the transient lifetime of dependencies they take on (those are always effectively scoped).
	- Transient scope is respected if transient services are resolved using `OpenApiXTransformerContext.ApplicationServices`. 

The transformer benchmarks are as follows after this change:


|                         Method | TransformerCount |       Mean |     Error |    StdDev |      Op/s |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------------------- |----------------- |-----------:|----------:|----------:|----------:|-------:|-------:|------:|----------:|
|  ActivatedOperationTransformer |               10 |   2.628 us | 0.0229 us | 0.0191 us | 380,574.6 | 0.0572 | 0.0153 |     - |      7 KB |
| OperationTransformerAsDelegate |               10 |   2.568 us | 0.0234 us | 0.0219 us | 389,388.6 | 0.0534 | 0.0114 |     - |      7 KB |
|   ActivatedDocumentTransformer |               10 |   2.487 us | 0.0312 us | 0.0261 us | 402,106.0 | 0.0534 | 0.0114 |     - |      7 KB |
|  DocumentTransformerAsDelegate |               10 |   2.433 us | 0.0466 us | 0.0436 us | 410,945.3 | 0.0534 | 0.0114 |     - |      6 KB |
|     ActivatedSchemaTransformer |               10 |  33.116 us | 0.5669 us | 0.5026 us |  30,197.3 | 0.2441 |      - |     - |     48 KB |
|    SchemaTransformerAsDelegate |               10 |  32.653 us | 0.5819 us | 0.7768 us |  30,625.3 | 0.2441 |      - |     - |     48 KB |
|  ActivatedOperationTransformer |              100 |   4.832 us | 0.0705 us | 0.0659 us | 206,961.1 | 0.0839 | 0.0153 |     - |     11 KB |
| OperationTransformerAsDelegate |              100 |   4.687 us | 0.0455 us | 0.0426 us | 213,375.7 | 0.0687 | 0.0153 |     - |      9 KB |
|   ActivatedDocumentTransformer |              100 |   3.991 us | 0.0705 us | 0.0625 us | 250,570.7 | 0.0687 | 0.0153 |     - |      9 KB |
|  DocumentTransformerAsDelegate |              100 |   3.238 us | 0.0531 us | 0.0496 us | 308,811.6 | 0.0534 | 0.0114 |     - |      6 KB |
|     ActivatedSchemaTransformer |              100 |  88.081 us | 0.3926 us | 0.3672 us |  11,353.2 | 0.4883 |      - |     - |     87 KB |
|    SchemaTransformerAsDelegate |              100 |  86.935 us | 0.2593 us | 0.2426 us |  11,502.8 | 0.4883 |      - |     - |     85 KB |
|  ActivatedOperationTransformer |             1000 |  38.982 us | 0.7751 us | 0.8926 us |  25,652.8 | 0.3662 | 0.0610 |     - |     46 KB |
| OperationTransformerAsDelegate |             1000 |  26.782 us | 0.5325 us | 0.6340 us |  37,338.1 | 0.1831 | 0.0305 |     - |     23 KB |
|   ActivatedDocumentTransformer |             1000 |  34.239 us | 0.5840 us | 0.5463 us |  29,206.1 | 0.2441 |      - |     - |     30 KB |
|  DocumentTransformerAsDelegate |             1000 |  12.339 us | 0.0918 us | 0.0858 us |  81,043.6 | 0.0458 | 0.0153 |     - |      6 KB |
|     ActivatedSchemaTransformer |             1000 | 600.651 us | 5.7270 us | 5.3570 us |   1,664.9 |      - |      - |     - |    474 KB |
|    SchemaTransformerAsDelegate |             1000 | 613.103 us | 2.8785 us | 2.5517 us |   1,631.0 | 1.9531 |      - |     - |    450 KB |