### PR TITLE
Propagate PropertyInfo for AsParameters parameters

### DIFF
--- a/src/Mvc/Mvc.Abstractions/src/ModelBinding/Metadata/ModelMetadataIdentity.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ModelBinding/Metadata/ModelMetadataIdentity.cs
@@ -95,9 +95,7 @@ public readonly struct ModelMetadataIdentity : IEquatable<ModelMetadataIdentity>
         ArgumentNullException.ThrowIfNull(parameter);
         ArgumentNullException.ThrowIfNull(modelType);
 
-        var containerType = parameter.Member is PropertyInfo propertyInfo ? propertyInfo.DeclaringType : null;
-
-        return new ModelMetadataIdentity(modelType, parameter.Name, containerType, fieldInfo: parameter);
+        return new ModelMetadataIdentity(modelType, parameter.Name, fieldInfo: parameter);
     }
 
     /// <summary>

--- a/src/Mvc/Mvc.Abstractions/src/ModelBinding/Metadata/ModelMetadataIdentity.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ModelBinding/Metadata/ModelMetadataIdentity.cs
@@ -95,7 +95,9 @@ public readonly struct ModelMetadataIdentity : IEquatable<ModelMetadataIdentity>
         ArgumentNullException.ThrowIfNull(parameter);
         ArgumentNullException.ThrowIfNull(modelType);
 
-        return new ModelMetadataIdentity(modelType, parameter.Name, fieldInfo: parameter);
+        var containerType = parameter.Member is PropertyInfo propertyInfo ? propertyInfo.DeclaringType : null;
+
+        return new ModelMetadataIdentity(modelType, parameter.Name, containerType, fieldInfo: parameter);
     }
 
     /// <summary>

--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -188,7 +188,7 @@ internal sealed class EndpointMetadataApiDescriptionProvider : IApiDescriptionPr
         return new ApiParameterDescription
         {
             Name = name,
-            ModelMetadata = CreateModelMetadata(parameter, paramType),
+            ModelMetadata = new EndpointModelMetadata(ModelMetadataIdentity.ForParameter(parameter.ParameterInfo, paramType)),
             Source = source,
             DefaultValue = parameter.ParameterInfo.DefaultValue,
             Type = parameter.ParameterInfo.ParameterType,
@@ -435,15 +435,6 @@ internal sealed class EndpointMetadataApiDescriptionProvider : IApiDescriptionPr
 
     private static EndpointModelMetadata CreateModelMetadata(Type type) =>
         new(ModelMetadataIdentity.ForType(type));
-
-    private static EndpointModelMetadata CreateModelMetadata(IParameterBindingMetadata parameter, Type type)
-    {
-        if (parameter.ParameterInfo?.Member is PropertyInfo propertyInfo && propertyInfo.DeclaringType is not null)
-        {
-            return new(ModelMetadataIdentity.ForProperty(propertyInfo, type, propertyInfo.DeclaringType));
-        }
-        return CreateModelMetadata(type);
-    }
 
     private static void AddResponseContentTypes(IList<ApiResponseFormat> apiResponseFormats, IReadOnlyList<string> contentTypes)
     {

--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -188,7 +188,7 @@ internal sealed class EndpointMetadataApiDescriptionProvider : IApiDescriptionPr
         return new ApiParameterDescription
         {
             Name = name,
-            ModelMetadata = new EndpointModelMetadata(ModelMetadataIdentity.ForParameter(parameter.ParameterInfo, paramType)),
+            ModelMetadata = CreateModelMetadata(parameter, paramType),
             Source = source,
             DefaultValue = parameter.ParameterInfo.DefaultValue,
             Type = parameter.ParameterInfo.ParameterType,
@@ -435,6 +435,19 @@ internal sealed class EndpointMetadataApiDescriptionProvider : IApiDescriptionPr
 
     private static EndpointModelMetadata CreateModelMetadata(Type type) =>
         new(ModelMetadataIdentity.ForType(type));
+
+    private static EndpointModelMetadata CreateModelMetadata(IParameterBindingMetadata parameter, Type type)
+    {
+        if (parameter.ParameterInfo is { } parameterInfo)
+        {
+            if (parameterInfo.Member is PropertyInfo propertyInfo && propertyInfo.DeclaringType is not null)
+            {
+                return new(ModelMetadataIdentity.ForProperty(propertyInfo, type, propertyInfo.DeclaringType));
+            }
+            return new(ModelMetadataIdentity.ForParameter(parameterInfo, type));
+        }
+        return CreateModelMetadata(type);
+    }
 
     private static void AddResponseContentTypes(IList<ApiResponseFormat> apiResponseFormats, IReadOnlyList<string> contentTypes)
     {

--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -188,7 +188,7 @@ internal sealed class EndpointMetadataApiDescriptionProvider : IApiDescriptionPr
         return new ApiParameterDescription
         {
             Name = name,
-            ModelMetadata = CreateModelMetadata(paramType),
+            ModelMetadata = CreateModelMetadata(parameter, paramType),
             Source = source,
             DefaultValue = parameter.ParameterInfo.DefaultValue,
             Type = parameter.ParameterInfo.ParameterType,
@@ -435,6 +435,15 @@ internal sealed class EndpointMetadataApiDescriptionProvider : IApiDescriptionPr
 
     private static EndpointModelMetadata CreateModelMetadata(Type type) =>
         new(ModelMetadataIdentity.ForType(type));
+
+    private static EndpointModelMetadata CreateModelMetadata(IParameterBindingMetadata parameter, Type type)
+    {
+        if (parameter.ParameterInfo?.Member is PropertyInfo propertyInfo && propertyInfo.DeclaringType is not null)
+        {
+            return new(ModelMetadataIdentity.ForProperty(propertyInfo, type, propertyInfo.DeclaringType));
+        }
+        return CreateModelMetadata(type);
+    }
 
     private static void AddResponseContentTypes(IList<ApiResponseFormat> apiResponseFormats, IReadOnlyList<string> contentTypes)
     {

--- a/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
@@ -385,12 +385,13 @@ public class EndpointMetadataApiDescriptionProviderTest
         var apiDescription = GetApiDescription(
             [ProducesResponseType(typeof(InferredJsonClass), StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        async Task<Results<Created<InferredJsonClass>, ProblemHttpResult>> () => {
-            await Task.CompletedTask;
-            return Random.Shared.Next() % 2 == 0
-                ? TypedResults.Created<InferredJsonClass>("/", new InferredJsonClass())
-                : TypedResults.Problem();
-        });
+        async Task<Results<Created<InferredJsonClass>, ProblemHttpResult>> () =>
+            {
+                await Task.CompletedTask;
+                return Random.Shared.Next() % 2 == 0
+                    ? TypedResults.Created<InferredJsonClass>("/", new InferredJsonClass())
+                    : TypedResults.Problem();
+            });
 
         Assert.Equal(2, apiDescription.SupportedResponseTypes.Count);
 
@@ -704,6 +705,16 @@ public class EndpointMetadataApiDescriptionProviderTest
             param => Assert.False(param.IsRequired),
             param => Assert.True(param.IsRequired),
             param => Assert.False(param.IsRequired));
+    }
+
+    [Fact]
+    public void SupportsContainerTypeInAsParametersAttribute()
+    {
+        var apiDescription = GetApiDescription(([AsParameters] AsParametersWithRequiredMembers foo) => { });
+        Assert.Equal(4, apiDescription.ParameterDescriptions.Count);
+
+        Assert.NotNull(apiDescription.ParameterDescriptions[0].ModelMetadata.ContainerType);
+        Assert.Equal(typeof(AsParametersWithRequiredMembers), apiDescription.ParameterDescriptions[0].ModelMetadata.ContainerType);
     }
 
 #nullable disable


### PR DESCRIPTION
# Propagate PropertyInfo for AsParameters parameters

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Fixes the issue #56764 

It adds the ContainerType for AsParameters parameters to be able to solve the issue in SwashBuckle OpenApi documentation with XML comments