### PR TITLE
Address flaky hosting event counters tests

### DIFF
--- a/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
@@ -67,18 +67,18 @@ public class HostingApplicationDiagnosticsTests : LoggedTest
         var context1 = hostingApplication1.CreateContext(features1);
         var context2 = hostingApplication2.CreateContext(features2);
 
-        await totalRequestValues.WaitForSumAsync(2);
-        await rpsValues.WaitForSumAsync(2);
-        await currentRequestValues.WaitForSumAsync(2);
-        await failedRequestValues.WaitForSumAsync(0);
+        await totalRequestValues.WaitForSumValueAsync(2);
+        await rpsValues.WaitForValueAsync(2);
+        await currentRequestValues.WaitForValueAsync(2);
+        await failedRequestValues.WaitForValueAsync(0);
 
         hostingApplication1.DisposeContext(context1, null);
         hostingApplication2.DisposeContext(context2, null);
 
-        await totalRequestValues.WaitForSumAsync(2);
-        await rpsValues.WaitForSumAsync(0);
-        await currentRequestValues.WaitForSumAsync(0);
-        await failedRequestValues.WaitForSumAsync(0);
+        await totalRequestValues.WaitForSumValueAsync(2);
+        await rpsValues.WaitForValueAsync(0);
+        await currentRequestValues.WaitForValueAsync(0);
+        await failedRequestValues.WaitForValueAsync(0);
 
         Assert.Collection(activeRequestsCollector1.GetMeasurementSnapshot(),
             m => Assert.Equal(1, m.Value),
@@ -95,10 +95,10 @@ public class HostingApplicationDiagnosticsTests : LoggedTest
         context1 = hostingApplication1.CreateContext(features1);
         context2 = hostingApplication2.CreateContext(features2);
 
-        await totalRequestValues.WaitForSumAsync(4);
-        await rpsValues.WaitForSumAsync(2);
-        await currentRequestValues.WaitForSumAsync(2);
-        await failedRequestValues.WaitForSumAsync(0);
+        await totalRequestValues.WaitForSumValueAsync(4);
+        await rpsValues.WaitForValueAsync(2);
+        await currentRequestValues.WaitForValueAsync(2);
+        await failedRequestValues.WaitForValueAsync(0);
 
         context1.HttpContext.Response.StatusCode = StatusCodes.Status500InternalServerError;
         context2.HttpContext.Response.StatusCode = StatusCodes.Status500InternalServerError;
@@ -106,10 +106,10 @@ public class HostingApplicationDiagnosticsTests : LoggedTest
         hostingApplication1.DisposeContext(context1, null);
         hostingApplication2.DisposeContext(context2, null);
 
-        await totalRequestValues.WaitForSumAsync(4);
-        await rpsValues.WaitForSumAsync(0);
-        await currentRequestValues.WaitForSumAsync(0);
-        await failedRequestValues.WaitForSumAsync(2);
+        await totalRequestValues.WaitForSumValueAsync(4);
+        await rpsValues.WaitForValueAsync(0);
+        await currentRequestValues.WaitForValueAsync(0);
+        await failedRequestValues.WaitForValueAsync(2);
 
         Assert.Collection(activeRequestsCollector1.GetMeasurementSnapshot(),
             m => Assert.Equal(1, m.Value),

--- a/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
@@ -1081,7 +1081,7 @@ public class HostingApplicationDiagnosticsTests : LoggedTest
         Assert.IsAssignableFrom<T>(value);
     }
 
-    private HostingApplication CreateApplication(out FeatureCollection features,
+    private static HostingApplication CreateApplication(out FeatureCollection features,
         DiagnosticListener diagnosticListener = null, ActivitySource activitySource = null, ILogger logger = null,
         Action<DefaultHttpContext> configure = null, HostingEventSource eventSource = null, IMeterFactory meterFactory = null)
     {

--- a/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
@@ -19,7 +19,7 @@ using Moq;
 
 namespace Microsoft.AspNetCore.Hosting.Tests;
 
-public class HostingApplicationDiagnosticsTests
+public class HostingApplicationDiagnosticsTests : LoggedTest
 {
     [Fact]
     [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/57259")]
@@ -28,16 +28,17 @@ public class HostingApplicationDiagnosticsTests
         // Arrange
         var hostingEventSource = new HostingEventSource(Guid.NewGuid().ToString());
 
-        var eventListener = new TestCounterListener(new[]
-        {
+        using var eventListener = new TestCounterListener(LoggerFactory, hostingEventSource.Name,
+        [
             "requests-per-second",
             "total-requests",
             "current-requests",
             "failed-requests"
-        });
+        ]);
 
         var timeout = !Debugger.IsAttached ? TimeSpan.FromSeconds(30) : Timeout.InfiniteTimeSpan;
         using CancellationTokenSource timeoutTokenSource = new CancellationTokenSource(timeout);
+        timeoutTokenSource.Token.Register(() => Logger.LogError("Timeout while waiting for counter value."));
 
         var rpsValues = eventListener.GetCounterValues("requests-per-second", timeoutTokenSource.Token).GetAsyncEnumerator();
         var totalRequestValues = eventListener.GetCounterValues("total-requests", timeoutTokenSource.Token).GetAsyncEnumerator();
@@ -53,8 +54,9 @@ public class HostingApplicationDiagnosticsTests
         var testMeterFactory1 = new TestMeterFactory();
         var testMeterFactory2 = new TestMeterFactory();
 
-        var hostingApplication1 = CreateApplication(out var features1, eventSource: hostingEventSource, meterFactory: testMeterFactory1);
-        var hostingApplication2 = CreateApplication(out var features2, eventSource: hostingEventSource, meterFactory: testMeterFactory2);
+        var logger = LoggerFactory.CreateLogger<HostingApplication>();
+        var hostingApplication1 = CreateApplication(out var features1, eventSource: hostingEventSource, meterFactory: testMeterFactory1, logger: logger);
+        var hostingApplication2 = CreateApplication(out var features2, eventSource: hostingEventSource, meterFactory: testMeterFactory2, logger: logger);
 
         using var activeRequestsCollector1 = new MetricCollector<long>(testMeterFactory1, HostingMetrics.MeterName, "http.server.active_requests");
         using var activeRequestsCollector2 = new MetricCollector<long>(testMeterFactory2, HostingMetrics.MeterName, "http.server.active_requests");
@@ -65,18 +67,18 @@ public class HostingApplicationDiagnosticsTests
         var context1 = hostingApplication1.CreateContext(features1);
         var context2 = hostingApplication2.CreateContext(features2);
 
-        Assert.Equal(2, await totalRequestValues.FirstOrDefault(v => v == 2));
-        Assert.Equal(2, await rpsValues.FirstOrDefault(v => v == 2));
-        Assert.Equal(2, await currentRequestValues.FirstOrDefault(v => v == 2));
-        Assert.Equal(0, await failedRequestValues.FirstOrDefault(v => v == 0));
+        await totalRequestValues.WaitForSumAsync(2);
+        await rpsValues.WaitForSumAsync(2);
+        await currentRequestValues.WaitForSumAsync(2);
+        await failedRequestValues.WaitForSumAsync(0);
 
         hostingApplication1.DisposeContext(context1, null);
         hostingApplication2.DisposeContext(context2, null);
 
-        Assert.Equal(2, await totalRequestValues.FirstOrDefault(v => v == 2));
-        Assert.Equal(0, await rpsValues.FirstOrDefault(v => v == 0));
-        Assert.Equal(0, await currentRequestValues.FirstOrDefault(v => v == 0));
-        Assert.Equal(0, await failedRequestValues.FirstOrDefault(v => v == 0));
+        await totalRequestValues.WaitForSumAsync(2);
+        await rpsValues.WaitForSumAsync(0);
+        await currentRequestValues.WaitForSumAsync(0);
+        await failedRequestValues.WaitForSumAsync(0);
 
         Assert.Collection(activeRequestsCollector1.GetMeasurementSnapshot(),
             m => Assert.Equal(1, m.Value),
@@ -93,10 +95,10 @@ public class HostingApplicationDiagnosticsTests
         context1 = hostingApplication1.CreateContext(features1);
         context2 = hostingApplication2.CreateContext(features2);
 
-        Assert.Equal(4, await totalRequestValues.FirstOrDefault(v => v == 4));
-        Assert.Equal(2, await rpsValues.FirstOrDefault(v => v == 2));
-        Assert.Equal(2, await currentRequestValues.FirstOrDefault(v => v == 2));
-        Assert.Equal(0, await failedRequestValues.FirstOrDefault(v => v == 0));
+        await totalRequestValues.WaitForSumAsync(4);
+        await rpsValues.WaitForSumAsync(2);
+        await currentRequestValues.WaitForSumAsync(2);
+        await failedRequestValues.WaitForSumAsync(0);
 
         context1.HttpContext.Response.StatusCode = StatusCodes.Status500InternalServerError;
         context2.HttpContext.Response.StatusCode = StatusCodes.Status500InternalServerError;
@@ -104,10 +106,10 @@ public class HostingApplicationDiagnosticsTests
         hostingApplication1.DisposeContext(context1, null);
         hostingApplication2.DisposeContext(context2, null);
 
-        Assert.Equal(4, await totalRequestValues.FirstOrDefault(v => v == 4));
-        Assert.Equal(0, await rpsValues.FirstOrDefault(v => v == 0));
-        Assert.Equal(0, await currentRequestValues.FirstOrDefault(v => v == 0));
-        Assert.Equal(2, await failedRequestValues.FirstOrDefault(v => v == 2));
+        await totalRequestValues.WaitForSumAsync(4);
+        await rpsValues.WaitForSumAsync(0);
+        await currentRequestValues.WaitForSumAsync(0);
+        await failedRequestValues.WaitForSumAsync(2);
 
         Assert.Collection(activeRequestsCollector1.GetMeasurementSnapshot(),
             m => Assert.Equal(1, m.Value),
@@ -133,13 +135,13 @@ public class HostingApplicationDiagnosticsTests
         // Arrange
         var hostingEventSource = new HostingEventSource(Guid.NewGuid().ToString());
 
-        var eventListener = new TestCounterListener(new[]
-        {
+        using var eventListener = new TestCounterListener(LoggerFactory, hostingEventSource.Name,
+        [
             "requests-per-second",
             "total-requests",
             "current-requests",
             "failed-requests"
-        });
+        ]);
 
         eventListener.EnableEvents(hostingEventSource, EventLevel.Informational, EventKeywords.None,
             new Dictionary<string, string>
@@ -1079,7 +1081,7 @@ public class HostingApplicationDiagnosticsTests
         Assert.IsAssignableFrom<T>(value);
     }
 
-    private static HostingApplication CreateApplication(out FeatureCollection features,
+    private HostingApplication CreateApplication(out FeatureCollection features,
         DiagnosticListener diagnosticListener = null, ActivitySource activitySource = null, ILogger logger = null,
         Action<DefaultHttpContext> configure = null, HostingEventSource eventSource = null, IMeterFactory meterFactory = null)
     {

--- a/src/Hosting/Hosting/test/Internal/AsyncEnumerableExtensions.cs
+++ b/src/Hosting/Hosting/test/Internal/AsyncEnumerableExtensions.cs
@@ -47,7 +47,7 @@ internal static class AsyncEnumerableExtensions
         }
         catch (Exception ex)
         {
-            throw new InvalidOperationException($"Results ended with final value of {value}. Expected sum value of {expectedValue}.", ex);
+            throw new InvalidOperationException($"Results ended with final sum value of {value}. Expected sum value of {expectedValue}.", ex);
         }
     }
 }

--- a/src/Hosting/Hosting/test/Internal/AsyncEnumerableExtensions.cs
+++ b/src/Hosting/Hosting/test/Internal/AsyncEnumerableExtensions.cs
@@ -1,20 +1,24 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Numerics;
+
 namespace System.Collections.Generic;
 
 internal static class AsyncEnumerableExtensions
 {
-    public static async Task<T> FirstOrDefault<T>(this IAsyncEnumerator<T> values, Func<T, bool> filter)
+    public static async Task WaitForSumAsync<T>(this IAsyncEnumerator<T> values, T expectedValue) where T: INumber<T>
     {
+        T value = T.Zero;
         while (await values.MoveNextAsync())
         {
-            if (filter(values.Current))
+            value += values.Current;
+            if (value == expectedValue)
             {
-                return values.Current;
+                return;
             }
         }
 
-        return default;
+        throw new InvalidOperationException($"Results ended with final value of {value}. Expected sum value of {expectedValue}.");
     }
 }

--- a/src/Hosting/Hosting/test/Internal/AsyncEnumerableExtensions.cs
+++ b/src/Hosting/Hosting/test/Internal/AsyncEnumerableExtensions.cs
@@ -2,23 +2,53 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Numerics;
+using Newtonsoft.Json.Linq;
 
 namespace System.Collections.Generic;
 
 internal static class AsyncEnumerableExtensions
 {
-    public static async Task WaitForSumAsync<T>(this IAsyncEnumerator<T> values, T expectedValue) where T: INumber<T>
+    public static async Task WaitForValueAsync<T>(this IAsyncEnumerator<T> values, T expectedValue) where T : INumber<T>
     {
         T value = T.Zero;
-        while (await values.MoveNextAsync())
+        try
         {
-            value += values.Current;
-            if (value == expectedValue)
+            while (await values.MoveNextAsync())
             {
-                return;
+                value = values.Current;
+                if (value == expectedValue)
+                {
+                    return;
+                }
             }
-        }
 
-        throw new InvalidOperationException($"Results ended with final value of {value}. Expected sum value of {expectedValue}.");
+            throw new InvalidOperationException("Data ended without match.");
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Results ended with final value of {value}. Expected value of {expectedValue}.", ex);
+        }
+    }
+
+    public static async Task WaitForSumValueAsync<T>(this IAsyncEnumerator<T> values, T expectedValue) where T: INumber<T>
+    {
+        T value = T.Zero;
+        try
+        {
+            while (await values.MoveNextAsync())
+            {
+                value += values.Current;
+                if (value == expectedValue)
+                {
+                    return;
+                }
+            }
+
+            throw new InvalidOperationException("Data ended without match.");
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Results ended with final value of {value}. Expected sum value of {expectedValue}.", ex);
+        }
     }
 }

--- a/src/Hosting/Hosting/test/Internal/AsyncEnumerableExtensions.cs
+++ b/src/Hosting/Hosting/test/Internal/AsyncEnumerableExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Numerics;
-using Newtonsoft.Json.Linq;
 
 namespace System.Collections.Generic;
 

--- a/src/Hosting/Hosting/test/Internal/HostingEventSourceTests.cs
+++ b/src/Hosting/Hosting/test/Internal/HostingEventSourceTests.cs
@@ -6,10 +6,11 @@ using System.Globalization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Internal;
 using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Hosting;
 
-public class HostingEventSourceTests
+public class HostingEventSourceTests : LoggedTest
 {
     [Fact]
     public void MatchesNameAndGuid()
@@ -179,15 +180,15 @@ public class HostingEventSourceTests
     public async Task VerifyCountersFireWithCorrectValues()
     {
         // Arrange
-        var eventListener = new TestCounterListener(new[]
-        {
+        var hostingEventSource = GetHostingEventSource();
+
+        using var eventListener = new TestCounterListener(LoggerFactory, hostingEventSource.Name,
+        [
             "requests-per-second",
             "total-requests",
             "current-requests",
             "failed-requests"
-        });
-
-        var hostingEventSource = GetHostingEventSource();
+        ]);
 
         using var timeoutTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
@@ -199,38 +200,43 @@ public class HostingEventSourceTests
         eventListener.EnableEvents(hostingEventSource, EventLevel.Informational, EventKeywords.None,
             new Dictionary<string, string>
             {
-                    { "EventCounterIntervalSec", "1" }
+                { "EventCounterIntervalSec", "1" }
             });
 
         // Act & Assert
+        Logger.LogInformation(nameof(HostingEventSource.RequestStart));
         hostingEventSource.RequestStart("GET", "/");
 
-        Assert.Equal(1, await totalRequestValues.FirstOrDefault(v => v == 1));
-        Assert.Equal(1, await rpsValues.FirstOrDefault(v => v == 1));
-        Assert.Equal(1, await currentRequestValues.FirstOrDefault(v => v == 1));
-        Assert.Equal(0, await failedRequestValues.FirstOrDefault(v => v == 0));
+        await totalRequestValues.WaitForSumAsync(1);
+        await rpsValues.WaitForSumAsync(1);
+        await currentRequestValues.WaitForSumAsync(1);
+        await failedRequestValues.WaitForSumAsync(0);
 
+        Logger.LogInformation(nameof(HostingEventSource.RequestStop));
         hostingEventSource.RequestStop();
 
-        Assert.Equal(1, await totalRequestValues.FirstOrDefault(v => v == 1));
-        Assert.Equal(0, await rpsValues.FirstOrDefault(v => v == 0));
-        Assert.Equal(0, await currentRequestValues.FirstOrDefault(v => v == 0));
-        Assert.Equal(0, await failedRequestValues.FirstOrDefault(v => v == 0));
+        await totalRequestValues.WaitForSumAsync(1);
+        await rpsValues.WaitForSumAsync(0);
+        await currentRequestValues.WaitForSumAsync(0);
+        await failedRequestValues.WaitForSumAsync(0);
 
+        Logger.LogInformation(nameof(HostingEventSource.RequestStart));
         hostingEventSource.RequestStart("POST", "/");
 
-        Assert.Equal(2, await totalRequestValues.FirstOrDefault(v => v == 2));
-        Assert.Equal(1, await rpsValues.FirstOrDefault(v => v == 1));
-        Assert.Equal(1, await currentRequestValues.FirstOrDefault(v => v == 1));
-        Assert.Equal(0, await failedRequestValues.FirstOrDefault(v => v == 0));
+        await totalRequestValues.WaitForSumAsync(2);
+        await rpsValues.WaitForSumAsync(1);
+        await currentRequestValues.WaitForSumAsync(1);
+        await failedRequestValues.WaitForSumAsync(0);
 
+        Logger.LogInformation(nameof(HostingEventSource.RequestFailed));
         hostingEventSource.RequestFailed();
+        Logger.LogInformation(nameof(HostingEventSource.RequestStop));
         hostingEventSource.RequestStop();
 
-        Assert.Equal(2, await totalRequestValues.FirstOrDefault(v => v == 2));
-        Assert.Equal(0, await rpsValues.FirstOrDefault(v => v == 0));
-        Assert.Equal(0, await currentRequestValues.FirstOrDefault(v => v == 0));
-        Assert.Equal(1, await failedRequestValues.FirstOrDefault(v => v == 1));
+        await totalRequestValues.WaitForSumAsync(2);
+        await rpsValues.WaitForSumAsync(0);
+        await currentRequestValues.WaitForSumAsync(0);
+        await failedRequestValues.WaitForSumAsync(1);
     }
 
     private static HostingEventSource GetHostingEventSource()

--- a/src/Hosting/Hosting/test/Internal/HostingEventSourceTests.cs
+++ b/src/Hosting/Hosting/test/Internal/HostingEventSourceTests.cs
@@ -191,6 +191,7 @@ public class HostingEventSourceTests : LoggedTest
         ]);
 
         using var timeoutTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        timeoutTokenSource.Token.Register(() => Logger.LogError("Timeout while waiting for counter value."));
 
         var rpsValues = eventListener.GetCounterValues("requests-per-second", timeoutTokenSource.Token).GetAsyncEnumerator();
         var totalRequestValues = eventListener.GetCounterValues("total-requests", timeoutTokenSource.Token).GetAsyncEnumerator();
@@ -207,36 +208,36 @@ public class HostingEventSourceTests : LoggedTest
         Logger.LogInformation(nameof(HostingEventSource.RequestStart));
         hostingEventSource.RequestStart("GET", "/");
 
-        await totalRequestValues.WaitForSumAsync(1);
-        await rpsValues.WaitForSumAsync(1);
-        await currentRequestValues.WaitForSumAsync(1);
-        await failedRequestValues.WaitForSumAsync(0);
+        await totalRequestValues.WaitForSumValueAsync(1);
+        await rpsValues.WaitForValueAsync(1);
+        await currentRequestValues.WaitForValueAsync(1);
+        await failedRequestValues.WaitForValueAsync(0);
 
         Logger.LogInformation(nameof(HostingEventSource.RequestStop));
         hostingEventSource.RequestStop();
 
-        await totalRequestValues.WaitForSumAsync(1);
-        await rpsValues.WaitForSumAsync(0);
-        await currentRequestValues.WaitForSumAsync(0);
-        await failedRequestValues.WaitForSumAsync(0);
+        await totalRequestValues.WaitForSumValueAsync(1);
+        await rpsValues.WaitForValueAsync(0);
+        await currentRequestValues.WaitForValueAsync(0);
+        await failedRequestValues.WaitForValueAsync(0);
 
         Logger.LogInformation(nameof(HostingEventSource.RequestStart));
         hostingEventSource.RequestStart("POST", "/");
 
-        await totalRequestValues.WaitForSumAsync(2);
-        await rpsValues.WaitForSumAsync(1);
-        await currentRequestValues.WaitForSumAsync(1);
-        await failedRequestValues.WaitForSumAsync(0);
+        await totalRequestValues.WaitForSumValueAsync(2);
+        await rpsValues.WaitForValueAsync(1);
+        await currentRequestValues.WaitForValueAsync(1);
+        await failedRequestValues.WaitForValueAsync(0);
 
         Logger.LogInformation(nameof(HostingEventSource.RequestFailed));
         hostingEventSource.RequestFailed();
         Logger.LogInformation(nameof(HostingEventSource.RequestStop));
         hostingEventSource.RequestStop();
 
-        await totalRequestValues.WaitForSumAsync(2);
-        await rpsValues.WaitForSumAsync(0);
-        await currentRequestValues.WaitForSumAsync(0);
-        await failedRequestValues.WaitForSumAsync(1);
+        await totalRequestValues.WaitForSumValueAsync(2);
+        await rpsValues.WaitForValueAsync(0);
+        await currentRequestValues.WaitForValueAsync(0);
+        await failedRequestValues.WaitForValueAsync(1);
     }
 
     private static HostingEventSource GetHostingEventSource()

--- a/src/Middleware/ConcurrencyLimiter/test/ConcurrencyLimiterEventSourceTests.cs
+++ b/src/Middleware/ConcurrencyLimiter/test/ConcurrencyLimiterEventSourceTests.cs
@@ -4,10 +4,11 @@
 using System.Globalization;
 using System.Diagnostics.Tracing;
 using Microsoft.AspNetCore.Internal;
+using Microsoft.AspNetCore.InternalTesting;
 
 namespace Microsoft.AspNetCore.ConcurrencyLimiter.Tests;
 
-public class ConcurrencyLimiterEventSourceTests
+public class ConcurrencyLimiterEventSourceTests : LoggedTest
 {
     [Fact]
     public void MatchesNameAndGuid()
@@ -44,7 +45,7 @@ public class ConcurrencyLimiterEventSourceTests
     public async Task TracksQueueLength()
     {
         // Arrange
-        using var eventListener = new TestCounterListener(new[] {
+        using var eventListener = new TestCounterListener(LoggerFactory, new[] {
                 "queue-length",
                 "queue-duration",
                 "requests-rejected",
@@ -85,7 +86,7 @@ public class ConcurrencyLimiterEventSourceTests
     public async Task TracksDurationSpentInQueue()
     {
         // Arrange
-        using var eventListener = new TestCounterListener(new[] {
+        using var eventListener = new TestCounterListener(LoggerFactory, new[] {
                 "queue-length",
                 "queue-duration",
                 "requests-rejected",

--- a/src/Middleware/ConcurrencyLimiter/test/ConcurrencyLimiterEventSourceTests.cs
+++ b/src/Middleware/ConcurrencyLimiter/test/ConcurrencyLimiterEventSourceTests.cs
@@ -45,13 +45,13 @@ public class ConcurrencyLimiterEventSourceTests : LoggedTest
     public async Task TracksQueueLength()
     {
         // Arrange
-        using var eventListener = new TestCounterListener(LoggerFactory, new[] {
-                "queue-length",
-                "queue-duration",
-                "requests-rejected",
-            });
-
         using var eventSource = GetConcurrencyLimiterEventSource();
+
+        using var eventListener = new TestCounterListener(LoggerFactory, eventSource.Name, [
+            "queue-length",
+            "queue-duration",
+            "requests-rejected",
+        ]);
 
         using var timeoutTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
@@ -60,7 +60,7 @@ public class ConcurrencyLimiterEventSourceTests : LoggedTest
         eventListener.EnableEvents(eventSource, EventLevel.Informational, EventKeywords.None,
             new Dictionary<string, string>
             {
-                    {"EventCounterIntervalSec", ".1" }
+                {"EventCounterIntervalSec", ".1" }
             });
 
         // Act
@@ -86,13 +86,13 @@ public class ConcurrencyLimiterEventSourceTests : LoggedTest
     public async Task TracksDurationSpentInQueue()
     {
         // Arrange
-        using var eventListener = new TestCounterListener(LoggerFactory, new[] {
-                "queue-length",
-                "queue-duration",
-                "requests-rejected",
-            });
-
         using var eventSource = GetConcurrencyLimiterEventSource();
+
+        using var eventListener = new TestCounterListener(LoggerFactory, eventSource.Name, [
+            "queue-length",
+            "queue-duration",
+            "requests-rejected",
+        ]);
 
         using var timeoutTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
@@ -101,7 +101,7 @@ public class ConcurrencyLimiterEventSourceTests : LoggedTest
         eventListener.EnableEvents(eventSource, EventLevel.Informational, EventKeywords.None,
             new Dictionary<string, string>
             {
-                    {"EventCounterIntervalSec", ".1" }
+                {"EventCounterIntervalSec", ".1" }
             });
 
         // Act

--- a/src/Shared/EventSource.Testing/TestCounterListener.cs
+++ b/src/Shared/EventSource.Testing/TestCounterListener.cs
@@ -5,23 +5,29 @@ using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.Threading;
 using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Internal;
 
 internal sealed class TestCounterListener : EventListener
 {
     private readonly Dictionary<string, Channel<double>> _counters = new Dictionary<string, Channel<double>>();
+    private readonly ILogger _logger;
+    private readonly string _eventSourceName;
 
     /// <summary>
     /// Creates a new TestCounterListener.
     /// </summary>
     /// <param name="counterNames">The names of ALL counters for the event source. You must name each counter, even if you do not intend to use it.</param>
-    public TestCounterListener(string[] counterNames)
+    public TestCounterListener(ILoggerFactory loggerFactory, string eventSourceName, string[] counterNames)
     {
+        _logger = loggerFactory.CreateLogger<TestCounterListener>();
         foreach (var item in counterNames)
         {
             _counters[item] = Channel.CreateUnbounded<double>();
         }
+
+        _eventSourceName = eventSourceName;
     }
 
     public IAsyncEnumerable<double> GetCounterValues(string counterName, CancellationToken cancellationToken = default)
@@ -31,14 +37,26 @@ internal sealed class TestCounterListener : EventListener
 
     protected override void OnEventWritten(EventWrittenEventArgs eventData)
     {
-        if (eventData.EventName == "EventCounters")
+        if (eventData.EventSource.Name == _eventSourceName && eventData.EventName == "EventCounters")
         {
             var payload = (IDictionary<string, object>)eventData.Payload[0];
             var counter = (string)payload["Name"];
             payload.TryGetValue("Increment", out var increment);
             payload.TryGetValue("Mean", out var mean);
+            var value = (double)(increment ?? mean);
+            
+            _logger.LogDebug("Counter {CounterName} on event source {EventSourceName} has value {Value}.", counter, eventData.EventSource.Name, value);
             var writer = _counters[counter].Writer;
-            writer.TryWrite((double)(increment ?? mean));
+            writer.TryWrite(value);
+        }
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        foreach (var item in _counters)
+        {
+            item.Value.Writer.TryComplete();
         }
     }
 }

--- a/src/Shared/EventSource.Testing/TestCounterListener.cs
+++ b/src/Shared/EventSource.Testing/TestCounterListener.cs
@@ -37,6 +37,7 @@ internal sealed class TestCounterListener : EventListener
 
     protected override void OnEventWritten(EventWrittenEventArgs eventData)
     {
+        // Work around https://github.com/dotnet/runtime/issues/31927
         if (eventData.EventSource.Name == _eventSourceName && eventData.EventName == "EventCounters")
         {
             var payload = (IDictionary<string, object>)eventData.Payload[0];

--- a/src/Shared/EventSource.Testing/TestCounterListener.cs
+++ b/src/Shared/EventSource.Testing/TestCounterListener.cs
@@ -41,11 +41,16 @@ internal sealed class TestCounterListener : EventListener
         {
             var payload = (IDictionary<string, object>)eventData.Payload[0];
             var counter = (string)payload["Name"];
-            payload.TryGetValue("Increment", out var increment);
-            payload.TryGetValue("Mean", out var mean);
+            if (payload.TryGetValue("Increment", out var increment))
+            {
+                _logger.LogDebug("Counter {CounterName} on event source {EventSourceName} has increment value {Value}.", counter, eventData.EventSource.Name, increment);
+            }
+            if (payload.TryGetValue("Mean", out var mean))
+            {
+                _logger.LogDebug("Counter {CounterName} on event source {EventSourceName} has mean value {Value}.", counter, eventData.EventSource.Name, mean);
+            }
+
             var value = (double)(increment ?? mean);
-            
-            _logger.LogDebug("Counter {CounterName} on event source {EventSourceName} has value {Value}.", counter, eventData.EventSource.Name, value);
             var writer = _counters[counter].Writer;
             writer.TryWrite(value);
         }


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/57259

Counter tests are flaky. Possible cause is a timing change for reporting counter values in dotnet/runtime.

PR changes:
* Adds logging to help find out what is going on.
* Sums changes from event counter events. Makes tests more resilient to counter events spread across intervals.
* Ensures test event listener is only listening to values from the current test.