### PR TITLE
Upgrade Benchmark.DotNet dependency

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -284,7 +284,7 @@
     <!-- 3rd party dependencies -->
     <AzureIdentityVersion>1.11.3</AzureIdentityVersion>
     <AngleSharpVersion>0.9.9</AngleSharpVersion>
-    <BenchmarkDotNetVersion>0.13.0</BenchmarkDotNetVersion>
+    <BenchmarkDotNetVersion>0.13.12</BenchmarkDotNetVersion>
     <CastleCoreVersion>4.2.1</CastleCoreVersion>
     <CommandLineParserVersion>2.3.0</CommandLineParserVersion>
     <FSharpCoreVersion>6.0.0</FSharpCoreVersion>

--- a/src/Shared/BenchmarkRunner/DefaultCoreValidationConfig.cs
+++ b/src/Shared/BenchmarkRunner/DefaultCoreValidationConfig.cs
@@ -4,7 +4,7 @@
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
-using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
+using BenchmarkDotNet.Toolchains.InProcess.Emit;
 
 namespace BenchmarkDotNet.Attributes;
 
@@ -14,6 +14,6 @@ internal sealed class DefaultCoreValidationConfig : ManualConfig
     {
         AddLogger(ConsoleLogger.Default);
 
-        AddJob(Job.Dry.WithToolchain(InProcessNoEmitToolchain.Instance));
+        AddJob(Job.Dry.WithToolchain(InProcessEmitToolchain.Instance));
     }
 }


### PR DESCRIPTION
Updating to the latest patch version of 0.13.x.

This resolves some issues I was seeing locally getting the `EventPipeProfiler` to work on macOS.

I'd been upgrading the package locally but hadn't committed the changes up to main.
