### PR TITLE
Avoid OrderedIterator when comparing OpenApiSchema.Required equality

### DIFF
--- a/src/OpenApi/src/Comparers/OpenApiSchemaComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiSchemaComparer.cs
@@ -63,7 +63,7 @@ internal sealed class OpenApiSchemaComparer : IEqualityComparer<OpenApiSchema>
             x.Nullable == y.Nullable &&
             x.Pattern == y.Pattern &&
             x.ReadOnly == y.ReadOnly &&
-            x.Required.Order().SequenceEqual(y.Required.Order()) &&
+            x.Count == y.Count && x.Required.SetEquals(y.Required) &&
             OpenApiReferenceComparer.Instance.Equals(x.Reference, y.Reference) &&
             x.UniqueItems == y.UniqueItems &&
             x.UnresolvedReference == y.UnresolvedReference &&

--- a/src/OpenApi/src/Comparers/OpenApiSchemaComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiSchemaComparer.cs
@@ -63,7 +63,7 @@ internal sealed class OpenApiSchemaComparer : IEqualityComparer<OpenApiSchema>
             x.Nullable == y.Nullable &&
             x.Pattern == y.Pattern &&
             x.ReadOnly == y.ReadOnly &&
-            x.Count == y.Count && x.Required.SetEquals(y.Required) &&
+            x.Required.Count == y.Required.Count && x.Required.SetEquals(y.Required) &&
             OpenApiReferenceComparer.Instance.Equals(x.Reference, y.Reference) &&
             x.UniqueItems == y.UniqueItems &&
             x.UnresolvedReference == y.UnresolvedReference &&


### PR DESCRIPTION
Contributes towards https://github.com/dotnet/aspnetcore/issues/56829.

Required properties in an OpenAPI schema represented in an ISet. Previously, to support order-invariant comparisons we were using `.Order()` and `.SequenceEquals()`.

It turns out `.SetEquals()` exists and is order invariant so we can use that directly instead of constructing an `OrderedIterator` via the `Order` call.

> The [SetEquals](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.hashset-1.setequals?view=net-8.0) method ignores duplicate entries and the order of elements in the other parameter.
> -- [SetEquals API Remarks](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.hashset-1.setequals?view=net-8.0#remarks)

Results from a local benchmark run are below:

BenchmarkDotNet v0.13.12, macOS Sonoma 14.6.1 (23G93) [Darwin 23.6.0]
Apple M2 Max, 1 CPU, 12 logical and 12 physical cores
.NET SDK 9.0.100-preview.7.24371.4
  [Host]     : .NET 9.0.0 (9.0.24.41005), Arm64 RyuJIT AdvSIMD
  Job-JUVRYQ : .NET 9.0.0 (9.0.24.36618), Arm64 RyuJIT AdvSIMD

Server=True  Toolchain=.NET Core 9.0  RunStrategy=Throughput  

**Before**

| Method           | EndpointCount | Mean        | Error     | StdDev    | Op/s     | Gen0     | Gen1     | Allocated   |
|----------------- |-------------- |------------:|----------:|----------:|---------:|---------:|---------:|------------:|
| GenerateDocument | 10            |    316.7 μs |   6.20 μs |   6.09 μs | 3,157.61 |   3.9063 |        - |   586.53 KB |
| GenerateDocument | 100           |  3,066.2 μs |  58.45 μs |  51.82 μs |   326.14 |  31.2500 |        - |  5336.09 KB |
| GenerateDocument | 1000          | 32,198.7 μs | 387.17 μs | 343.22 μs |    31.06 | 333.3333 | 166.6667 | 52828.55 KB |

**After**

Server=True  Toolchain=.NET Core 9.0  RunStrategy=Throughput  

| Method           | EndpointCount | Mean        | Error     | StdDev    | Op/s     | Gen0     | Gen1    | Allocated   |
|----------------- |-------------- |------------:|----------:|----------:|---------:|---------:|--------:|------------:|
| GenerateDocument | 10            |    300.1 μs |   0.73 μs |   0.65 μs | 3,331.88 |   3.9063 |       - |   538.06 KB |
| GenerateDocument | 100           |  2,776.9 μs |  22.87 μs |  21.39 μs |   360.11 |  31.2500 | 15.6250 |     4891 KB |
| GenerateDocument | 1000          | 30,593.4 μs | 595.03 μs | 636.68 μs |    32.69 | 166.6667 |       - | 48415.86 KB |