### PR TITLE
Grammatical error in ChangeEventArgs.cs

### DIFF
--- a/src/Components/Components/src/ChangeEventArgs.cs
+++ b/src/Components/Components/src/ChangeEventArgs.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.AspNetCore.Components;
 
 /// <summary>
-/// Supplies information about an change event that is being raised.
+/// Supplies information about the change event that is being raised.
 /// </summary>
 public class ChangeEventArgs : EventArgs
 {


### PR DESCRIPTION
There is a grammatical error in the ChangeEventArgs class:  "Supplies information about an change event that is being raised." 

"an change event" is better to change to "a change event" or "the change event"

Besides, we should also change the ChangeEventArgs Class relates official document. 

https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.components.changeeventargs?view=aspnetcore-8.0


# {PR title}

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

{Detail}

Fixes #{bug number} (in this specific format)
