### PR TITLE
Log registered IApiDescriptionProvider implementations on load

### DIFF
--- a/src/Mvc/Mvc.ApiExplorer/src/ApiDescriptionGroupCollectionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/ApiDescriptionGroupCollectionProvider.cs
@@ -33,23 +33,11 @@ public partial class ApiDescriptionGroupCollectionProvider : IApiDescriptionGrou
         _apiDescriptionProviders = [.. apiDescriptionProviders.OrderBy(item => item.Order)];
     }
 
-    /// <summary>
-    /// Creates a new instance of <see cref="ApiDescriptionGroupCollectionProvider"/>.
-    /// </summary>
-    /// <param name="actionDescriptorCollectionProvider">
-    /// The <see cref="IActionDescriptorCollectionProvider"/>.
-    /// </param>
-    /// <param name="apiDescriptionProviders">
-    /// The <see cref="IEnumerable{IApiDescriptionProvider}"/>.
-    /// </param>
-    /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to construct a logger.</param>
-    public ApiDescriptionGroupCollectionProvider(
+    internal ApiDescriptionGroupCollectionProvider(
         IActionDescriptorCollectionProvider actionDescriptorCollectionProvider,
         IEnumerable<IApiDescriptionProvider> apiDescriptionProviders,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory) : this(actionDescriptorCollectionProvider, apiDescriptionProviders)
     {
-        _actionDescriptorCollectionProvider = actionDescriptorCollectionProvider;
-        _apiDescriptionProviders = [.. apiDescriptionProviders.OrderBy(item => item.Order)];
         _logger = loggerFactory.CreateLogger<ApiDescriptionGroupCollectionProvider>();
     }
 
@@ -76,7 +64,7 @@ public partial class ApiDescriptionGroupCollectionProvider : IApiDescriptionGrou
         {
             if (_logger is not null)
             {
-                Log.ApiDescriptionProviderExecuting(_logger, provider.GetType().Name, provider.GetType().Assembly.GetName().Name);
+                Log.ApiDescriptionProviderExecuting(_logger, provider.GetType().Name, provider.GetType().Assembly.GetName().Name, provider.GetType().Assembly.GetName().Version?.ToString());
             }
             provider.OnProvidersExecuting(context);
         }
@@ -96,7 +84,7 @@ public partial class ApiDescriptionGroupCollectionProvider : IApiDescriptionGrou
 
     private static partial class Log
     {
-        [LoggerMessage(2, LogLevel.Debug, "Executing API description provider '{ProviderName}' from assembly {ProviderAssembly}.", EventName = "ApiDescriptionProviderExecuting")]
-        public static partial void ApiDescriptionProviderExecuting(ILogger logger, string providerName, string? providerAssembly);
+        [LoggerMessage(2, LogLevel.Debug, "Executing API description provider '{ProviderName}' from assembly {ProviderAssembly} v{AssemblyVersion}.", EventName = "ApiDescriptionProviderExecuting")]
+        public static partial void ApiDescriptionProviderExecuting(ILogger logger, string providerName, string? providerAssembly, string? assemblyVersion);
     }
 }

--- a/src/Mvc/Mvc.ApiExplorer/src/DependencyInjection/EndpointMethodInfoApiExplorerServiceCollectionExtensions.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/DependencyInjection/EndpointMethodInfoApiExplorerServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -21,7 +22,10 @@ public static class EndpointMetadataApiExplorerServiceCollectionExtensions
     {
         // Try to add default services in case MVC services aren't added.
         services.TryAddSingleton<IActionDescriptorCollectionProvider, DefaultActionDescriptorCollectionProvider>();
-        services.TryAddSingleton<IApiDescriptionGroupCollectionProvider, ApiDescriptionGroupCollectionProvider>();
+        services.TryAddSingleton<IApiDescriptionGroupCollectionProvider>(sp => new ApiDescriptionGroupCollectionProvider(
+            sp.GetRequiredService<IActionDescriptorCollectionProvider>(),
+            sp.GetServices<IApiDescriptionProvider>(),
+            sp.GetRequiredService<ILoggerFactory>()));
 
         services.TryAddEnumerable(
             ServiceDescriptor.Transient<IApiDescriptionProvider, EndpointMetadataApiDescriptionProvider>());

--- a/src/Mvc/Mvc.ApiExplorer/src/DependencyInjection/MvcApiExplorerMvcCoreBuilderExtensions.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/DependencyInjection/MvcApiExplorerMvcCoreBuilderExtensions.cs
@@ -3,7 +3,9 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -30,7 +32,10 @@ public static class MvcApiExplorerMvcCoreBuilderExtensions
     [RequiresUnreferencedCode("MVC does not currently support trimming or native AOT.", Url = "https://aka.ms/aspnet/trimming")]
     internal static void AddApiExplorerServices(IServiceCollection services)
     {
-        services.TryAddSingleton<IApiDescriptionGroupCollectionProvider, ApiDescriptionGroupCollectionProvider>();
+        services.TryAddSingleton<IApiDescriptionGroupCollectionProvider>(sp => new ApiDescriptionGroupCollectionProvider(
+            sp.GetRequiredService<IActionDescriptorCollectionProvider>(),
+            sp.GetServices<IApiDescriptionProvider>(),
+            sp.GetRequiredService<ILoggerFactory>()));
         services.TryAddEnumerable(
             ServiceDescriptor.Transient<IApiDescriptionProvider, DefaultApiDescriptionProvider>());
     }

--- a/src/Mvc/Mvc.ApiExplorer/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.ApiExplorer/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Microsoft.AspNetCore.Mvc.ApiExplorer.ApiDescriptionGroupCollectionProvider.ApiDescriptionGroupCollectionProvider(Microsoft.AspNetCore.Mvc.Infrastructure.IActionDescriptorCollectionProvider! actionDescriptorCollectionProvider, System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Mvc.ApiExplorer.IApiDescriptionProvider!>! apiDescriptionProviders, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void

--- a/src/Mvc/Mvc.ApiExplorer/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.ApiExplorer/src/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
 #nullable enable
-Microsoft.AspNetCore.Mvc.ApiExplorer.ApiDescriptionGroupCollectionProvider.ApiDescriptionGroupCollectionProvider(Microsoft.AspNetCore.Mvc.Infrastructure.IActionDescriptorCollectionProvider! actionDescriptorCollectionProvider, System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Mvc.ApiExplorer.IApiDescriptionProvider!>! apiDescriptionProviders, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void

--- a/src/Mvc/test/Mvc.FunctionalTests/ApiExplorerTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/ApiExplorerTest.cs
@@ -1552,6 +1552,19 @@ public class ApiExplorerTest : LoggedTest
             });
     }
 
+    [Fact]
+    public async Task ApiExplorer_LogsInvokedDescriptionProvidersOnStartup()
+    {
+        // Arrange & Act
+        var response = await Client.GetAsync("http://localhost/ApiExplorerHttpMethod/All");
+
+        // Assert
+        Assert.Contains(TestSink.Writes, w => w.EventId.Name?.Equals("ApiDescriptionProviderExecuting", StringComparison.Ordinal) == true);
+        Assert.Contains(TestSink.Writes, w => w.LoggerName.Equals("Microsoft.AspNetCore.Mvc.ApiExplorer.ApiDescriptionGroupCollectionProvider", StringComparison.Ordinal));
+        Assert.Contains(TestSink.Writes, w => w.Message.Equals("Executing API description provider 'DefaultApiDescriptionProvider' from assembly Microsoft.AspNetCore.Mvc.ApiExplorer.", StringComparison.Ordinal));
+        Assert.Contains(TestSink.Writes, w => w.Message.Equals("Executing API description provider 'JsonPatchOperationsArrayProvider' from assembly Microsoft.AspNetCore.Mvc.NewtonsoftJson.", StringComparison.Ordinal));
+    }
+
     private IEnumerable<string> GetSortedMediaTypes(ApiExplorerResponseType apiResponseType)
     {
         return apiResponseType.ResponseFormats

--- a/src/Mvc/test/Mvc.FunctionalTests/ApiExplorerTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/ApiExplorerTest.cs
@@ -1561,8 +1561,8 @@ public class ApiExplorerTest : LoggedTest
         // Assert
         Assert.Contains(TestSink.Writes, w => w.EventId.Name?.Equals("ApiDescriptionProviderExecuting", StringComparison.Ordinal) == true);
         Assert.Contains(TestSink.Writes, w => w.LoggerName.Equals("Microsoft.AspNetCore.Mvc.ApiExplorer.ApiDescriptionGroupCollectionProvider", StringComparison.Ordinal));
-        Assert.Contains(TestSink.Writes, w => w.Message.Equals("Executing API description provider 'DefaultApiDescriptionProvider' from assembly Microsoft.AspNetCore.Mvc.ApiExplorer.", StringComparison.Ordinal));
-        Assert.Contains(TestSink.Writes, w => w.Message.Equals("Executing API description provider 'JsonPatchOperationsArrayProvider' from assembly Microsoft.AspNetCore.Mvc.NewtonsoftJson.", StringComparison.Ordinal));
+        Assert.Contains(TestSink.Writes, w => w.Message.Equals("Executing API description provider 'DefaultApiDescriptionProvider' from assembly Microsoft.AspNetCore.Mvc.ApiExplorer v9.0.0.0.", StringComparison.Ordinal));
+        Assert.Contains(TestSink.Writes, w => w.Message.Equals("Executing API description provider 'JsonPatchOperationsArrayProvider' from assembly Microsoft.AspNetCore.Mvc.NewtonsoftJson v42.42.42.42.", StringComparison.Ordinal));
     }
 
     private IEnumerable<string> GetSortedMediaTypes(ApiExplorerResponseType apiResponseType)


### PR DESCRIPTION
This PR adds support for logging discovered `IApiDescriptionProvider` instances in the ApiExplorer codepath.

This PR is a precursor to https://github.com/dotnet/aspnetcore/issues/57295 which supports the same via new public API.

Note: because we are not introducing new public API here support for logging is not lit up in the gRPC implementation _unless_ `AddEndpointsApiExplorer` or `AddApiExplorer` have already been invoked in the application's setup.