### PR TITLE
Remove LINQ usage for IEnumerable comparisons

### DIFF
--- a/src/OpenApi/src/Comparers/ComparerHelpers.cs
+++ b/src/OpenApi/src/Comparers/ComparerHelpers.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.OpenApi;
+
+internal static class ComparerHelpers
+{
+    internal static bool DictionaryEquals<TKey, TValue>(Dictionary<TKey, TValue> x, Dictionary<TKey, TValue> y, IEqualityComparer<TValue> comparer)
+        where TKey : notnull
+        where TValue : notnull
+    {
+        if (x.Keys.Count != y.Keys.Count)
+        {
+            return false;
+        }
+
+        foreach (var key in x.Keys)
+        {
+            if (!y.TryGetValue(key, out var value) || !comparer.Equals(x[key], value))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    internal static bool ListEquals<T>(List<T> x, IList<T> y, IEqualityComparer<T> comparer)
+    {
+        if (x.Count != y.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < x.Count; i++)
+        {
+            if (!comparer.Equals(x[i], y[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/OpenApi/src/Comparers/ComparerHelpers.cs
+++ b/src/OpenApi/src/Comparers/ComparerHelpers.cs
@@ -5,7 +5,33 @@ namespace Microsoft.AspNetCore.OpenApi;
 
 internal static class ComparerHelpers
 {
-    internal static bool DictionaryEquals<TKey, TValue>(Dictionary<TKey, TValue> x, Dictionary<TKey, TValue> y, IEqualityComparer<TValue> comparer)
+    internal static bool DictionaryEquals<TKey, TValue>(IDictionary<TKey, TValue> x, IDictionary<TKey, TValue> y, IEqualityComparer<TValue> comparer)
+        where TKey : notnull
+        where TValue : notnull
+    {
+        if (x is Dictionary<TKey, TValue> xDictionary && y is Dictionary<TKey, TValue> yDictionary)
+        {
+            return DictionaryEquals(xDictionary, yDictionary, comparer);
+        }
+
+        if (x.Keys.Count != y.Keys.Count)
+        {
+            return false;
+        }
+
+        foreach (var key in x.Keys)
+        {
+            if (!y.TryGetValue(key, out var value) || !comparer.Equals(x[key], value))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    // Private method to avoid interface dispatch.
+    private static bool DictionaryEquals<TKey, TValue>(Dictionary<TKey, TValue> x, Dictionary<TKey, TValue> y, IEqualityComparer<TValue> comparer)
         where TKey : notnull
         where TValue : notnull
     {
@@ -25,7 +51,31 @@ internal static class ComparerHelpers
         return true;
     }
 
-    internal static bool ListEquals<T>(List<T> x, IList<T> y, IEqualityComparer<T> comparer)
+    internal static bool ListEquals<T>(IList<T> x, IList<T> y, IEqualityComparer<T> comparer)
+    {
+        if (x is List<T> xList && y is List<T> yList)
+        {
+            return ListEquals(xList, yList, comparer);
+        }
+
+        if (x.Count != y.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < x.Count; i++)
+        {
+            if (!comparer.Equals(x[i], y[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    // Private method to avoid interface dispatch.
+    private static bool ListEquals<T>(List<T> x, List<T> y, IEqualityComparer<T> comparer)
     {
         if (x.Count != y.Count)
         {

--- a/src/OpenApi/src/Comparers/OpenApiAnyComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiAnyComparer.cs
@@ -3,10 +3,11 @@
 
 using System.Linq;
 using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Interfaces;
 
 namespace Microsoft.AspNetCore.OpenApi;
 
-internal sealed class OpenApiAnyComparer : IEqualityComparer<IOpenApiAny>
+internal sealed class OpenApiAnyComparer : IEqualityComparer<IOpenApiAny>, IEqualityComparer<IOpenApiExtension>
 {
     public static OpenApiAnyComparer Instance { get; } = new OpenApiAnyComparer();
 
@@ -29,8 +30,8 @@ internal sealed class OpenApiAnyComparer : IEqualityComparer<IOpenApiAny>
             (x switch
             {
                 OpenApiNull _ => y is OpenApiNull,
-                OpenApiArray arrayX => y is OpenApiArray arrayY && arrayX.SequenceEqual(arrayY, Instance),
-                OpenApiObject objectX => y is OpenApiObject objectY && objectX.Keys.Count == objectY.Keys.Count && objectX.Keys.All(key => objectY.TryGetValue(key, out var yValue) && Equals(objectX[key], yValue)),
+                OpenApiArray arrayX => y is OpenApiArray arrayY && ComparerHelpers.ListEquals(arrayX, arrayY, Instance),
+                OpenApiObject objectX => y is OpenApiObject objectY && ComparerHelpers.DictionaryEquals(objectX, objectY, Instance),
                 OpenApiBinary binaryX => y is OpenApiBinary binaryY && binaryX.Value.SequenceEqual(binaryY.Value),
                 OpenApiInteger integerX => y is OpenApiInteger integerY && integerX.Value == integerY.Value,
                 OpenApiLong longX => y is OpenApiLong longY && longX.Value == longY.Value,
@@ -77,5 +78,40 @@ internal sealed class OpenApiAnyComparer : IEqualityComparer<IOpenApiAny>
         });
 
         return hashCode.ToHashCode();
+    }
+
+    public bool Equals(IOpenApiExtension? x, IOpenApiExtension? y)
+    {
+        if (x is null && y is null)
+        {
+            return true;
+        }
+
+        if (x is null || y is null)
+        {
+            return false;
+        }
+
+        if (object.ReferenceEquals(x, y))
+        {
+            return true;
+        }
+
+        if (x is IOpenApiAny openApiAnyX && y is IOpenApiAny openApiAnyY)
+        {
+            return Equals(openApiAnyX, openApiAnyY);
+        }
+
+        return x.Equals(y);
+    }
+
+    public int GetHashCode(IOpenApiExtension obj)
+    {
+        if (obj is IOpenApiAny any)
+        {
+            return GetHashCode(any);
+        }
+
+        return obj.GetHashCode();
     }
 }

--- a/src/OpenApi/src/Comparers/OpenApiDiscriminatorComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiDiscriminatorComparer.cs
@@ -26,7 +26,7 @@ internal sealed class OpenApiDiscriminatorComparer : IEqualityComparer<OpenApiDi
 
         return x.PropertyName == y.PropertyName &&
             x.Mapping.Count == y.Mapping.Count &&
-            ComparerHelpers.DictionaryEquals((Dictionary<string, string>)x.Mapping, (Dictionary<string, string>)y.Mapping, StringComparer.Ordinal);
+            ComparerHelpers.DictionaryEquals(x.Mapping, y.Mapping, StringComparer.Ordinal);
     }
 
     public int GetHashCode(OpenApiDiscriminator obj)

--- a/src/OpenApi/src/Comparers/OpenApiDiscriminatorComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiDiscriminatorComparer.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Linq;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.AspNetCore.OpenApi;
@@ -27,7 +26,7 @@ internal sealed class OpenApiDiscriminatorComparer : IEqualityComparer<OpenApiDi
 
         return x.PropertyName == y.PropertyName &&
             x.Mapping.Count == y.Mapping.Count &&
-            x.Mapping.Keys.All(key => y.Mapping.TryGetValue(key, out var yValue) && x.Mapping[key] == yValue);
+            ComparerHelpers.DictionaryEquals((Dictionary<string, string>)x.Mapping, (Dictionary<string, string>)y.Mapping, StringComparer.Ordinal);
     }
 
     public int GetHashCode(OpenApiDiscriminator obj)

--- a/src/OpenApi/src/Comparers/OpenApiExternalDocsComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiExternalDocsComparer.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.AspNetCore.OpenApi;
@@ -27,7 +26,7 @@ internal sealed class OpenApiExternalDocsComparer : IEqualityComparer<OpenApiExt
 
         return x.Description == y.Description &&
             x.Url == y.Url &&
-            ComparerHelpers.DictionaryEquals((Dictionary<string, IOpenApiExtension>)x.Extensions, (Dictionary<string, IOpenApiExtension>)y.Extensions, OpenApiAnyComparer.Instance);
+            ComparerHelpers.DictionaryEquals(x.Extensions, y.Extensions, OpenApiAnyComparer.Instance);
     }
 
     public int GetHashCode(OpenApiExternalDocs obj)

--- a/src/OpenApi/src/Comparers/OpenApiExternalDocsComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiExternalDocsComparer.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Linq;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.AspNetCore.OpenApi;
@@ -27,8 +27,7 @@ internal sealed class OpenApiExternalDocsComparer : IEqualityComparer<OpenApiExt
 
         return x.Description == y.Description &&
             x.Url == y.Url &&
-            x.Extensions.Count == y.Extensions.Count
-            && x.Extensions.Keys.All(k => y.Extensions.TryGetValue(k, out var yValue) && yValue == x.Extensions[k]);
+            ComparerHelpers.DictionaryEquals((Dictionary<string, IOpenApiExtension>)x.Extensions, (Dictionary<string, IOpenApiExtension>)y.Extensions, OpenApiAnyComparer.Instance);
     }
 
     public int GetHashCode(OpenApiExternalDocs obj)

--- a/src/OpenApi/src/Comparers/OpenApiSchemaComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiSchemaComparer.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.AspNetCore.OpenApi;
@@ -31,12 +29,12 @@ internal sealed class OpenApiSchemaComparer : IEqualityComparer<OpenApiSchema>
             x.Type == y.Type &&
             x.Format == y.Format &&
             SchemaIdEquals(x, y) &&
-            ComparerHelpers.DictionaryEquals((Dictionary<string, OpenApiSchema>)x.Properties, (Dictionary<string, OpenApiSchema>)y.Properties, Instance) &&
+            ComparerHelpers.DictionaryEquals(x.Properties, y.Properties, Instance) &&
             OpenApiDiscriminatorComparer.Instance.Equals(x.Discriminator, y.Discriminator) &&
             Instance.Equals(x.AdditionalProperties, y.AdditionalProperties) &&
             x.AdditionalPropertiesAllowed == y.AdditionalPropertiesAllowed &&
-            ComparerHelpers.ListEquals((List<OpenApiSchema>)x.AllOf, (List<OpenApiSchema>)y.AllOf, Instance) &&
-            ComparerHelpers.ListEquals((List<OpenApiSchema>)x.AnyOf, (List<OpenApiSchema>)y.AnyOf, Instance) &&
+            ComparerHelpers.ListEquals(x.AllOf, y.AllOf, Instance) &&
+            ComparerHelpers.ListEquals(x.AnyOf, y.AnyOf, Instance) &&
             x.Deprecated == y.Deprecated &&
             OpenApiAnyComparer.Instance.Equals(x.Default, y.Default) &&
             x.Description == y.Description &&
@@ -44,9 +42,9 @@ internal sealed class OpenApiSchemaComparer : IEqualityComparer<OpenApiSchema>
             x.ExclusiveMaximum == y.ExclusiveMaximum &&
             x.ExclusiveMinimum == y.ExclusiveMinimum &&
             x.Extensions.Count == y.Extensions.Count &&
-            ComparerHelpers.DictionaryEquals((Dictionary<string, IOpenApiExtension>)x.Extensions, (Dictionary<string, IOpenApiExtension>)y.Extensions, OpenApiAnyComparer.Instance) &&
+            ComparerHelpers.DictionaryEquals(x.Extensions, y.Extensions, OpenApiAnyComparer.Instance) &&
             OpenApiExternalDocsComparer.Instance.Equals(x.ExternalDocs, y.ExternalDocs) &&
-            ComparerHelpers.ListEquals((List<IOpenApiAny>)x.Enum, (List<IOpenApiAny>)y.Enum, OpenApiAnyComparer.Instance) &&
+            ComparerHelpers.ListEquals(x.Enum, y.Enum, OpenApiAnyComparer.Instance) &&
             Instance.Equals(x.Items, y.Items) &&
             x.Title == y.Title &&
             x.Maximum == y.Maximum &&
@@ -58,7 +56,7 @@ internal sealed class OpenApiSchemaComparer : IEqualityComparer<OpenApiSchema>
             x.MinLength == y.MinLength &&
             x.MinProperties == y.MinProperties &&
             x.MultipleOf == y.MultipleOf &&
-            ComparerHelpers.ListEquals((List<OpenApiSchema>)x.OneOf, (List<OpenApiSchema>)y.OneOf, Instance) &&
+            ComparerHelpers.ListEquals(x.OneOf, y.OneOf, Instance) &&
             Instance.Equals(x.Not, y.Not) &&
             x.Nullable == y.Nullable &&
             x.Pattern == y.Pattern &&

--- a/src/OpenApi/src/Comparers/OpenApiSchemaComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiSchemaComparer.cs
@@ -1,8 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Linq;
 using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.AspNetCore.OpenApi;
@@ -31,12 +31,12 @@ internal sealed class OpenApiSchemaComparer : IEqualityComparer<OpenApiSchema>
             x.Type == y.Type &&
             x.Format == y.Format &&
             SchemaIdEquals(x, y) &&
-            x.Properties.Keys.All(k => y.Properties.TryGetValue(k, out var yValue) && Instance.Equals(x.Properties[k], yValue)) &&
+            ComparerHelpers.DictionaryEquals((Dictionary<string, OpenApiSchema>)x.Properties, (Dictionary<string, OpenApiSchema>)y.Properties, Instance) &&
             OpenApiDiscriminatorComparer.Instance.Equals(x.Discriminator, y.Discriminator) &&
             Instance.Equals(x.AdditionalProperties, y.AdditionalProperties) &&
             x.AdditionalPropertiesAllowed == y.AdditionalPropertiesAllowed &&
-            x.AllOf.SequenceEqual(y.AllOf, Instance) &&
-            x.AnyOf.SequenceEqual(y.AnyOf, Instance) &&
+            ComparerHelpers.ListEquals((List<OpenApiSchema>)x.AllOf, (List<OpenApiSchema>)y.AllOf, Instance) &&
+            ComparerHelpers.ListEquals((List<OpenApiSchema>)x.AnyOf, (List<OpenApiSchema>)y.AnyOf, Instance) &&
             x.Deprecated == y.Deprecated &&
             OpenApiAnyComparer.Instance.Equals(x.Default, y.Default) &&
             x.Description == y.Description &&
@@ -44,9 +44,9 @@ internal sealed class OpenApiSchemaComparer : IEqualityComparer<OpenApiSchema>
             x.ExclusiveMaximum == y.ExclusiveMaximum &&
             x.ExclusiveMinimum == y.ExclusiveMinimum &&
             x.Extensions.Count == y.Extensions.Count &&
-            x.Extensions.Keys.All(k => y.Extensions.TryGetValue(k, out var yValue) && x.Extensions[k] is IOpenApiAny anyX && yValue is IOpenApiAny anyY && OpenApiAnyComparer.Instance.Equals(anyX, anyY)) &&
+            ComparerHelpers.DictionaryEquals((Dictionary<string, IOpenApiExtension>)x.Extensions, (Dictionary<string, IOpenApiExtension>)y.Extensions, OpenApiAnyComparer.Instance) &&
             OpenApiExternalDocsComparer.Instance.Equals(x.ExternalDocs, y.ExternalDocs) &&
-            x.Enum.SequenceEqual(y.Enum, OpenApiAnyComparer.Instance) &&
+            ComparerHelpers.ListEquals((List<IOpenApiAny>)x.Enum, (List<IOpenApiAny>)y.Enum, OpenApiAnyComparer.Instance) &&
             Instance.Equals(x.Items, y.Items) &&
             x.Title == y.Title &&
             x.Maximum == y.Maximum &&
@@ -58,7 +58,7 @@ internal sealed class OpenApiSchemaComparer : IEqualityComparer<OpenApiSchema>
             x.MinLength == y.MinLength &&
             x.MinProperties == y.MinProperties &&
             x.MultipleOf == y.MultipleOf &&
-            x.OneOf.SequenceEqual(y.OneOf, Instance) &&
+            ComparerHelpers.ListEquals((List<OpenApiSchema>)x.OneOf, (List<OpenApiSchema>)y.OneOf, Instance) &&
             Instance.Equals(x.Not, y.Not) &&
             x.Nullable == y.Nullable &&
             x.Pattern == y.Pattern &&

--- a/src/OpenApi/src/Comparers/OpenApiXmlComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiXmlComparer.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.AspNetCore.OpenApi;
@@ -30,7 +29,7 @@ internal sealed class OpenApiXmlComparer : IEqualityComparer<OpenApiXml>
             x.Prefix == y.Prefix &&
             x.Attribute == y.Attribute &&
             x.Wrapped == y.Wrapped &&
-            ComparerHelpers.DictionaryEquals((Dictionary<string, IOpenApiExtension>)x.Extensions, (Dictionary<string, IOpenApiExtension>)y.Extensions, OpenApiAnyComparer.Instance);
+            ComparerHelpers.DictionaryEquals(x.Extensions, y.Extensions, OpenApiAnyComparer.Instance);
     }
 
     public int GetHashCode(OpenApiXml obj)

--- a/src/OpenApi/src/Comparers/OpenApiXmlComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiXmlComparer.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Linq;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.AspNetCore.OpenApi;
@@ -30,8 +30,7 @@ internal sealed class OpenApiXmlComparer : IEqualityComparer<OpenApiXml>
             x.Prefix == y.Prefix &&
             x.Attribute == y.Attribute &&
             x.Wrapped == y.Wrapped &&
-            x.Extensions.Count == y.Extensions.Count
-            && x.Extensions.Keys.All(k => y.Extensions.TryGetValue(k, out var yValue) && yValue == x.Extensions[k]);
+            ComparerHelpers.DictionaryEquals((Dictionary<string, IOpenApiExtension>)x.Extensions, (Dictionary<string, IOpenApiExtension>)y.Extensions, OpenApiAnyComparer.Instance);
     }
 
     public int GetHashCode(OpenApiXml obj)


### PR DESCRIPTION
Contributes towards https://github.com/dotnet/aspnetcore/issues/56829. Refresh of https://github.com/dotnet/aspnetcore/pull/56599.

- Replace use of `Enumerable.All` with a custom implementation of `DictionaryEquals` and `ListEquals` to avoid overhead due to lambda capture in existing comparers.
- Cast to concrete collection types in `DictionaryEquals` and `ListEquals` to avoid interface dispatch overhead. See https://github.com/dotnet/aspnetcore/pull/56599#discussion_r1671411261 fore more info.

Resulting benchmarks from this change are as follows:

**Before**

| Method           | EndpointCount | Mean        | Error     | StdDev    | Op/s     | Gen0     | Gen1     | Allocated  |
|----------------- |-------------- |------------:|----------:|----------:|---------:|---------:|---------:|-----------:|
| GenerateDocument | 10            |    303.7 μs |   2.43 μs |   2.27 μs | 3,292.87 |   3.9063 |        - |  538.06 KB |
| GenerateDocument | 100           |  2,843.4 μs |  35.50 μs |  29.65 μs |   351.69 |  31.2500 |  15.6250 |    4891 KB |
| GenerateDocument | 1000          | 31,125.8 μs | 492.27 μs | 460.47 μs |    32.13 | 333.3333 | 166.6667 | 48417.5 KB |

**After**

| Method           | EndpointCount | Mean        | Error     | StdDev    | Op/s     | Gen0     | Allocated   |
|----------------- |-------------- |------------:|----------:|----------:|---------:|---------:|------------:|
| GenerateDocument | 10            |    270.5 us |   1.39 us |   1.30 us | 3,697.22 |   2.9297 |    434.9 KB |
| GenerateDocument | 100           |  2,484.8 us |  25.84 us |  24.17 us |   402.45 |  31.2500 |  3944.06 KB |
| GenerateDocument | 1000          | 27,413.2 us | 219.91 us | 194.95 us |    36.48 | 166.6667 | 39030.74 KB |