### PR TITLE
Exclude some headers from OpenAPI parameters

### DIFF
--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Parameters.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Parameters.cs
@@ -164,4 +164,30 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
             Assert.Null(todosOperation.Parameters);
         });
     }
+
+    [Fact]
+    public async Task GetOpenApiParameters_SkipsDisallowedHeaders()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapGet("/api/accept", ([FromHeader(Name = "Accept")] string value) => { });
+        builder.MapGet("/api/accept-lower", ([FromHeader(Name = "accept")] string value) => { });
+        builder.MapGet("/api/authorization", ([FromHeader(Name = "Authorization")] string value) => { });
+        builder.MapGet("/api/authorization-lower", ([FromHeader(Name = "authorization")] string value) => { });
+        builder.MapGet("/api/content-type", ([FromHeader(Name = "Content-Type")] string value) => { });
+        builder.MapGet("/api/content-type-lower", ([FromHeader(Name = "content-type")] string value) => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            Assert.Null(document.Paths["/api/accept"].Operations[OperationType.Get].Parameters);
+            Assert.Null(document.Paths["/api/accept-lower"].Operations[OperationType.Get].Parameters);
+            Assert.Null(document.Paths["/api/authorization"].Operations[OperationType.Get].Parameters);
+            Assert.Null(document.Paths["/api/authorization-lower"].Operations[OperationType.Get].Parameters);
+            Assert.Null(document.Paths["/api/content-type"].Operations[OperationType.Get].Parameters);
+            Assert.Null(document.Paths["/api/content-type-lower"].Operations[OperationType.Get].Parameters);
+        });
+    }
 }


### PR DESCRIPTION
# Exclude some headers from OpenAPI parameters

Do not include disallowed headers in OpenAPI operation parameters.

## Description

Do not include the `Accept`, `Authorization` and `Content-Type` headers in OpenAPI operation parameters as suggested in the [OpenAPI 3.0 specification](https://swagger.io/docs/specification/describing-parameters/).

Fixes #57305.
