### PR TITLE
Fix CanBindToFormWithFiles

### DIFF
--- a/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
@@ -1596,7 +1596,7 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
             if (!dispatch.FormIsEnhanced)
             {
                 // Verify the same form element is *not* still in the page
-                Assert.Throws<StaleElementReferenceException>(() => form.GetAttribute("method"));
+                Browser.True(() => IsElementStale(form));
             }
             else if (!dispatch.SuppressEnhancedNavigation)
             {
@@ -1646,6 +1646,19 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
     private void GoTo(string relativePath)
     {
         Navigate($"{ServerPathBase}/{relativePath}");
+    }
+
+    private static bool IsElementStale(IWebElement element)
+    {
+        try
+        {
+            _ = element.Enabled;
+            return false;
+        }
+        catch (StaleElementReferenceException)
+        {
+            return true;
+        }
     }
 
     private struct TempFile


### PR DESCRIPTION
# Fix CanBindToFormWithFiles

Fixes `FormWithParentBindingContextTest.CanBindToFormWithFiles` by allowing the stale element check to retry.

Marks #54447 as `test-fixed`.