### PR TITLE
Add `StringSyntax` to the `RouteAttribute`

### DIFF
--- a/src/Components/Components/src/RouteAttribute.cs
+++ b/src/Components/Components/src/RouteAttribute.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.AspNetCore.Components;
 
 /// <summary>
@@ -13,7 +15,7 @@ public sealed class RouteAttribute : Attribute
     /// Constructs an instance of <see cref="RouteAttribute"/>.
     /// </summary>
     /// <param name="template">The route template.</param>
-    public RouteAttribute(string template)
+    public RouteAttribute([StringSyntax("Route")] string template)
     {
         ArgumentNullException.ThrowIfNull(template);
 


### PR DESCRIPTION
# Add `StringSyntax` to the `RouteAttribute`

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] ~You've included unit or integration tests for your change, where applicable.~
- [ ] ~You've included inline docs for your change, where applicable.~
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Consistent syntax highlighting of template/patterns for routes.

## Description

I noticed when using the `[Route("/orders/{orderId:int}")]` attribute, as an example, doesn't display the same as when using the `EndpointRouteBuilderExtensions` APIs for `Map*` that accept a template/pattern.

**Example `MapGet` — includes string syntax**:

![image](https://github.com/user-attachments/assets/9c1225ac-f42b-4183-be0a-02774ef77f70)

**Example `Route` — doesn't include string syntax**:

![image](https://github.com/user-attachments/assets/4fba993e-f51a-4eb2-9044-9401b606c52f)


I think it would be great if we could also highlight routes when using the attribute. This PR adds the `StringSyntax` to decorate the `template` parameter to be highlighted like the method APIs.

Contributes to #44535
