### PR TITLE
Removing unsafe code in BufferExtensions

### DIFF
--- a/src/Servers/Kestrel/Core/test/PipelineExtensionTests.cs
+++ b/src/Servers/Kestrel/Core/test/PipelineExtensionTests.cs
@@ -1,14 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Buffers;
 using System.Globalization;
 using System.IO.Pipelines;
 using System.Text;
-using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
-using Xunit;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests;
 

--- a/src/Servers/Kestrel/Core/test/PipelineExtensionTests.cs
+++ b/src/Servers/Kestrel/Core/test/PipelineExtensionTests.cs
@@ -35,6 +35,9 @@ public class PipelineExtensionTests : IDisposable
     [InlineData(ulong.MinValue)]
     [InlineData(ulong.MaxValue)]
     [InlineData(4_8_15_16_23_42)]
+    [InlineData(9)]
+    [InlineData(71)]
+    [InlineData(123)]
     public void WritesNumericToAscii(ulong number)
     {
         var writerBuffer = _pipe.Writer;

--- a/src/Shared/ServerInfrastructure/BufferExtensions.cs
+++ b/src/Shared/ServerInfrastructure/BufferExtensions.cs
@@ -133,14 +133,14 @@ internal static class BufferExtensions
     {
         const byte AsciiDigitStart = (byte)'0';
 
-        ref byte start = ref MemoryMarshal.GetReference(buffer.Span);
-        var bytesLeftInBlock = buffer.Span.Length;
+        var start = buffer.Span;
+        var bytesLeftInBlock = start.Length;
 
         // Fast path, try copying to the available memory directly
         var simpleWrite = true;
         if (number < 10 && bytesLeftInBlock >= 1)
         {
-            start = (byte)(((uint)number) + AsciiDigitStart);
+            start[0] = (byte)(((uint)number) + AsciiDigitStart);
             buffer.Advance(1);
         }
         else if (number < 100 && bytesLeftInBlock >= 2)
@@ -148,8 +148,8 @@ internal static class BufferExtensions
             var val = (uint)number;
             var tens = (byte)((val * 205u) >> 11); // div10, valid to 1028
 
-            start = (byte)(tens + AsciiDigitStart);
-            Unsafe.AddByteOffset(ref start, 1) = (byte)(val - (tens * 10) + AsciiDigitStart);
+            start[0] = (byte)(tens + AsciiDigitStart);
+            start[1] = (byte)(val - (tens * 10) + AsciiDigitStart);
             buffer.Advance(2);
         }
         else if (number < 1000 && bytesLeftInBlock >= 3)
@@ -158,9 +158,9 @@ internal static class BufferExtensions
             var digit0 = (byte)((val * 41u) >> 12); // div100, valid to 1098
             var digits01 = (byte)((val * 205u) >> 11); // div10, valid to 1028
 
-            start = (byte)(digit0 + AsciiDigitStart);
-            Unsafe.AddByteOffset(ref start, 1) = (byte)(digits01 - (digit0 * 10) + AsciiDigitStart);
-            Unsafe.AddByteOffset(ref start, 2) = (byte)(val - (digits01 * 10) + AsciiDigitStart);
+            start[0] = (byte)(digit0 + AsciiDigitStart);
+            start[1] = (byte)(digits01 - (digit0 * 10) + AsciiDigitStart);
+            start[2] = (byte)(val - (digits01 * 10) + AsciiDigitStart);
             buffer.Advance(3);
         }
         else

--- a/src/Shared/ServerInfrastructure/BufferExtensions.cs
+++ b/src/Shared/ServerInfrastructure/BufferExtensions.cs
@@ -134,29 +134,28 @@ internal static class BufferExtensions
         const byte AsciiDigitStart = (byte)'0';
 
         var start = buffer.Span;
-        var bytesLeftInBlock = start.Length;
 
         // Fast path, try copying to the available memory directly
         var simpleWrite = true;
-        if (number < 10 && bytesLeftInBlock >= 1)
+        if (number < 10 && start.Length >= 1)
         {
             start[0] = (byte)(((uint)number) + AsciiDigitStart);
             buffer.Advance(1);
         }
-        else if (number < 100 && bytesLeftInBlock >= 2)
+        else if (number < 100 && start.Length >= 2)
         {
             var val = (uint)number;
-            var tens = (byte)((val * 205u) >> 11); // div10, valid to 1028
+            uint tens = (byte)((val * 205u) >> 11); // div10, valid to 1028
 
             start[0] = (byte)(tens + AsciiDigitStart);
             start[1] = (byte)(val - (tens * 10) + AsciiDigitStart);
             buffer.Advance(2);
         }
-        else if (number < 1000 && bytesLeftInBlock >= 3)
+        else if (number < 1000 && start.Length >= 3)
         {
             var val = (uint)number;
-            var digit0 = (byte)((val * 41u) >> 12); // div100, valid to 1098
-            var digits01 = (byte)((val * 205u) >> 11); // div10, valid to 1028
+            uint digit0 = (byte)((val * 41u) >> 12); // div100, valid to 1098
+            uint digits01 = (byte)((val * 205u) >> 11); // div10, valid to 1028
 
             start[0] = (byte)(digit0 + AsciiDigitStart);
             start[1] = (byte)(digits01 - (digit0 * 10) + AsciiDigitStart);

--- a/src/Shared/ServerInfrastructure/BufferExtensions.cs
+++ b/src/Shared/ServerInfrastructure/BufferExtensions.cs
@@ -129,47 +129,41 @@ internal static class BufferExtensions
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void WriteNumeric(ref this BufferWriter<PipeWriter> buffer, ulong number)
+    internal static void WriteNumeric(ref this BufferWriter<PipeWriter> bufferWriter, ulong number)
     {
         const byte AsciiDigitStart = (byte)'0';
 
-        var start = buffer.Span;
+        var buffer = bufferWriter.Span;
 
         // Fast path, try copying to the available memory directly
-        var simpleWrite = true;
-        if (number < 10 && start.Length >= 1)
+        if (number < 10 && buffer.Length >= 1)
         {
-            start[0] = (byte)(((uint)number) + AsciiDigitStart);
-            buffer.Advance(1);
+            buffer[0] = (byte)(((uint)number) + AsciiDigitStart);
+            bufferWriter.Advance(1);
         }
-        else if (number < 100 && start.Length >= 2)
+        else if (number < 100 && buffer.Length >= 2)
         {
             var val = (uint)number;
             var tens = (uint)(byte)((val * 205u) >> 11); // div10, valid to 1028
 
-            start[0] = (byte)(tens + AsciiDigitStart);
-            start[1] = (byte)(val - (tens * 10) + AsciiDigitStart);
-            buffer.Advance(2);
+            buffer[0] = (byte)(tens + AsciiDigitStart);
+            buffer[1] = (byte)(val - (tens * 10) + AsciiDigitStart);
+            bufferWriter.Advance(2);
         }
-        else if (number < 1000 && start.Length >= 3)
+        else if (number < 1000 && buffer.Length >= 3)
         {
             var val = (uint)number;
             var digit0 = (uint)(byte)((val * 41u) >> 12); // div100, valid to 1098
             var digits01 = (uint)(byte)((val * 205u) >> 11); // div10, valid to 1028
 
-            start[0] = (byte)(digit0 + AsciiDigitStart);
-            start[1] = (byte)(digits01 - (digit0 * 10) + AsciiDigitStart);
-            start[2] = (byte)(val - (digits01 * 10) + AsciiDigitStart);
-            buffer.Advance(3);
+            buffer[0] = (byte)(digit0 + AsciiDigitStart);
+            buffer[1] = (byte)(digits01 - (digit0 * 10) + AsciiDigitStart);
+            buffer[2] = (byte)(val - (digits01 * 10) + AsciiDigitStart);
+            bufferWriter.Advance(3);
         }
         else
         {
-            simpleWrite = false;
-        }
-
-        if (!simpleWrite)
-        {
-            WriteNumericMultiWrite(ref buffer, number);
+            WriteNumericMultiWrite(ref bufferWriter, number);
         }
     }
 

--- a/src/Shared/ServerInfrastructure/BufferExtensions.cs
+++ b/src/Shared/ServerInfrastructure/BufferExtensions.cs
@@ -145,7 +145,7 @@ internal static class BufferExtensions
         else if (number < 100 && start.Length >= 2)
         {
             var val = (uint)number;
-            uint tens = (byte)((val * 205u) >> 11); // div10, valid to 1028
+            var tens = (uint)(byte)((val * 205u) >> 11); // div10, valid to 1028
 
             start[0] = (byte)(tens + AsciiDigitStart);
             start[1] = (byte)(val - (tens * 10) + AsciiDigitStart);
@@ -154,8 +154,8 @@ internal static class BufferExtensions
         else if (number < 1000 && start.Length >= 3)
         {
             var val = (uint)number;
-            uint digit0 = (byte)((val * 41u) >> 12); // div100, valid to 1098
-            uint digits01 = (byte)((val * 205u) >> 11); // div10, valid to 1028
+            var digit0 = (uint)(byte)((val * 41u) >> 12); // div100, valid to 1098
+            var digits01 = (uint)(byte)((val * 205u) >> 11); // div10, valid to 1028
 
             start[0] = (byte)(digit0 + AsciiDigitStart);
             start[1] = (byte)(digits01 - (digit0 * 10) + AsciiDigitStart);

--- a/src/Shared/ServerInfrastructure/BufferExtensions.cs
+++ b/src/Shared/ServerInfrastructure/BufferExtensions.cs
@@ -133,14 +133,14 @@ internal static class BufferExtensions
     {
         const byte AsciiDigitStart = (byte)'0';
 
-        var start = buffer.Span;
-        var bytesLeftInBlock = start.Length;
+        ref byte start = ref MemoryMarshal.GetReference(buffer.Span);
+        var bytesLeftInBlock = buffer.Span.Length;
 
         // Fast path, try copying to the available memory directly
         var simpleWrite = true;
         if (number < 10 && bytesLeftInBlock >= 1)
         {
-            start[0] = (byte)(((uint)number) + AsciiDigitStart);
+            start = (byte)(((uint)number) + AsciiDigitStart);
             buffer.Advance(1);
         }
         else if (number < 100 && bytesLeftInBlock >= 2)
@@ -148,8 +148,8 @@ internal static class BufferExtensions
             var val = (uint)number;
             var tens = (byte)((val * 205u) >> 11); // div10, valid to 1028
 
-            start[0] = (byte)(tens + AsciiDigitStart);
-            start[1] = (byte)(val - (tens * 10) + AsciiDigitStart);
+            start = (byte)(tens + AsciiDigitStart);
+            Unsafe.AddByteOffset(ref start, 1) = (byte)(val - (tens * 10) + AsciiDigitStart);
             buffer.Advance(2);
         }
         else if (number < 1000 && bytesLeftInBlock >= 3)
@@ -158,9 +158,9 @@ internal static class BufferExtensions
             var digit0 = (byte)((val * 41u) >> 12); // div100, valid to 1098
             var digits01 = (byte)((val * 205u) >> 11); // div10, valid to 1028
 
-            start[0] = (byte)(digit0 + AsciiDigitStart);
-            start[1] = (byte)(digits01 - (digit0 * 10) + AsciiDigitStart);
-            start[2] = (byte)(val - (digits01 * 10) + AsciiDigitStart);
+            start = (byte)(digit0 + AsciiDigitStart);
+            Unsafe.AddByteOffset(ref start, 1) = (byte)(digits01 - (digit0 * 10) + AsciiDigitStart);
+            Unsafe.AddByteOffset(ref start, 2) = (byte)(val - (digits01 * 10) + AsciiDigitStart);
             buffer.Advance(3);
         }
         else

--- a/src/Shared/ServerInfrastructure/BufferExtensions.cs
+++ b/src/Shared/ServerInfrastructure/BufferExtensions.cs
@@ -129,47 +129,43 @@ internal static class BufferExtensions
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static unsafe void WriteNumeric(ref this BufferWriter<PipeWriter> buffer, ulong number)
+    internal static void WriteNumeric(ref this BufferWriter<PipeWriter> buffer, ulong number)
     {
         const byte AsciiDigitStart = (byte)'0';
 
-        var span = buffer.Span;
-        var bytesLeftInBlock = span.Length;
+        var start = buffer.Span;
+        var bytesLeftInBlock = start.Length;
 
         // Fast path, try copying to the available memory directly
         var simpleWrite = true;
-        fixed (byte* output = span)
+        if (number < 10 && bytesLeftInBlock >= 1)
         {
-            var start = output;
-            if (number < 10 && bytesLeftInBlock >= 1)
-            {
-                *(start) = (byte)(((uint)number) + AsciiDigitStart);
-                buffer.Advance(1);
-            }
-            else if (number < 100 && bytesLeftInBlock >= 2)
-            {
-                var val = (uint)number;
-                var tens = (byte)((val * 205u) >> 11); // div10, valid to 1028
+            start[0] = (byte)(((uint)number) + AsciiDigitStart);
+            buffer.Advance(1);
+        }
+        else if (number < 100 && bytesLeftInBlock >= 2)
+        {
+            var val = (uint)number;
+            var tens = (byte)((val * 205u) >> 11); // div10, valid to 1028
 
-                *(start) = (byte)(tens + AsciiDigitStart);
-                *(start + 1) = (byte)(val - (tens * 10) + AsciiDigitStart);
-                buffer.Advance(2);
-            }
-            else if (number < 1000 && bytesLeftInBlock >= 3)
-            {
-                var val = (uint)number;
-                var digit0 = (byte)((val * 41u) >> 12); // div100, valid to 1098
-                var digits01 = (byte)((val * 205u) >> 11); // div10, valid to 1028
+            start[0] = (byte)(tens + AsciiDigitStart);
+            start[1] = (byte)(val - (tens * 10) + AsciiDigitStart);
+            buffer.Advance(2);
+        }
+        else if (number < 1000 && bytesLeftInBlock >= 3)
+        {
+            var val = (uint)number;
+            var digit0 = (byte)((val * 41u) >> 12); // div100, valid to 1098
+            var digits01 = (byte)((val * 205u) >> 11); // div10, valid to 1028
 
-                *(start) = (byte)(digit0 + AsciiDigitStart);
-                *(start + 1) = (byte)(digits01 - (digit0 * 10) + AsciiDigitStart);
-                *(start + 2) = (byte)(val - (digits01 * 10) + AsciiDigitStart);
-                buffer.Advance(3);
-            }
-            else
-            {
-                simpleWrite = false;
-            }
+            start[0] = (byte)(digit0 + AsciiDigitStart);
+            start[1] = (byte)(digits01 - (digit0 * 10) + AsciiDigitStart);
+            start[2] = (byte)(val - (digits01 * 10) + AsciiDigitStart);
+            buffer.Advance(3);
+        }
+        else
+        {
+            simpleWrite = false;
         }
 
         if (!simpleWrite)


### PR DESCRIPTION
# Removing unsafe code in BufferExtensions

Removing unsafe code, using Span to write numbers directly to the buffer

## Description

- Removing the `unsafe` keyword required for pinning
- Removing the `fixed` keyword doing the pinning
- Using `Span<T>` to write directly to the buffer
- Adding a testcase for values smaller to 1000, 100 and 10.
- As a result for values <1000, the JIT generates smaller code
- I only seem to find usage of this in KnowHeaders's generated code

Fixes #56534
