### PR TITLE
Unquarantine ServerReset_BeforeRequestBody_ClientBodyThrows

### DIFF
--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpClientHttp2InteropTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpClientHttp2InteropTests.cs
@@ -689,7 +689,6 @@ public class HttpClientHttp2InteropTests : LoggedTest
         await host.StopAsync().DefaultTimeout();
     }
 
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/46717")]
     [Theory]
     [MemberData(nameof(SupportedSchemes))]
     public async Task ServerReset_BeforeRequestBody_ClientBodyThrows(string scheme)


### PR DESCRIPTION
Fixes #46717

There isn't an obvious race in the test and the component that timed out appears to be from runtime (`HttpClient` and/or `HttpContent`).  Since the test hasn't failed in 30 days and runtime has likely changed in the 18 months since the issue was filed, I think we should unquarantine the test.