### PR TITLE
Http.Sys: Clean up Request parsing errors

### DIFF
--- a/src/Servers/HttpSys/src/LoggerEventIds.cs
+++ b/src/Servers/HttpSys/src/LoggerEventIds.cs
@@ -58,4 +58,5 @@ internal static class LoggerEventIds
     public const int AcceptSetExpectationMismatch = 51;
     public const int AcceptCancelExpectationMismatch = 52;
     public const int AcceptObserveExpectationMismatch = 53;
+    public const int RequestParsingError = 54;
 }

--- a/src/Servers/HttpSys/src/RequestProcessing/Request.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Request.cs
@@ -38,145 +38,152 @@ internal sealed partial class Request
     {
         // TODO: Verbose log
         RequestContext = requestContext;
-        _contentBoundaryType = BoundaryType.None;
 
-        RequestId = requestContext.RequestId;
-        // For HTTP/2 Http.Sys assigns each request a unique connection id for use with API calls, but the RawConnectionId represents the real connection.
-        UConnectionId = requestContext.ConnectionId;
-        RawConnectionId = requestContext.RawConnectionId;
-        SslStatus = requestContext.SslStatus;
-
-        KnownMethod = requestContext.VerbId;
-        Method = requestContext.GetVerb()!;
-
-        RawUrl = requestContext.GetRawUrl()!;
-
-        var cookedUrl = requestContext.GetCookedUrl();
-        QueryString = cookedUrl.GetQueryString() ?? string.Empty;
-
-        var rawUrlInBytes = requestContext.GetRawUrlInBytes();
-        var originalPath = RequestUriBuilder.DecodeAndUnescapePath(rawUrlInBytes);
-
-        PathBase = string.Empty;
-        Path = originalPath;
-        var prefix = requestContext.Server.Options.UrlPrefixes.GetPrefix((int)requestContext.UrlContext);
-
-        // 'OPTIONS * HTTP/1.1'
-        if (KnownMethod == HTTP_VERB.HttpVerbOPTIONS && string.Equals(RawUrl, "*", StringComparison.Ordinal))
+        try
         {
+            _contentBoundaryType = BoundaryType.None;
+
+            RequestId = requestContext.RequestId;
+            // For HTTP/2 Http.Sys assigns each request a unique connection id for use with API calls, but the RawConnectionId represents the real connection.
+            UConnectionId = requestContext.ConnectionId;
+            RawConnectionId = requestContext.RawConnectionId;
+            SslStatus = requestContext.SslStatus;
+
+            KnownMethod = requestContext.VerbId;
+            Method = requestContext.GetVerb()!;
+
+            RawUrl = requestContext.GetRawUrl()!;
+
+            var cookedUrl = requestContext.GetCookedUrl();
+            QueryString = cookedUrl.GetQueryString() ?? string.Empty;
+
+            var rawUrlInBytes = requestContext.GetRawUrlInBytes();
+            var originalPath = RequestUriBuilder.DecodeAndUnescapePath(rawUrlInBytes);
+
             PathBase = string.Empty;
-            Path = string.Empty;
-        }
-        // Prefix may be null if the requested has been transferred to our queue
-        else if (prefix is not null)
-        {
-            var pathBase = prefix.PathWithoutTrailingSlash;
+            Path = originalPath;
+            var prefix = requestContext.Server.Options.UrlPrefixes.GetPrefix((int)requestContext.UrlContext);
 
-            // url: /base/path, prefix: /base/, base: /base, path: /path
-            // url: /, prefix: /, base: , path: /
-            if (originalPath.Equals(pathBase, StringComparison.Ordinal))
+            // 'OPTIONS * HTTP/1.1'
+            if (KnownMethod == HTTP_VERB.HttpVerbOPTIONS && string.Equals(RawUrl, "*", StringComparison.Ordinal))
             {
-                // Exact match, no need to preserve the casing
-                PathBase = pathBase;
+                PathBase = string.Empty;
                 Path = string.Empty;
             }
-            else if (originalPath.Equals(pathBase, StringComparison.OrdinalIgnoreCase))
+            // Prefix may be null if the requested has been transferred to our queue
+            else if (prefix is not null)
             {
-                // Preserve the user input casing
-                PathBase = originalPath;
-                Path = string.Empty;
-            }
-            else if (originalPath.StartsWith(prefix.Path, StringComparison.Ordinal))
-            {
-                // Exact match, no need to preserve the casing
-                PathBase = pathBase;
-                Path = originalPath[pathBase.Length..];
-            }
-            else if (originalPath.StartsWith(prefix.Path, StringComparison.OrdinalIgnoreCase))
-            {
-                // Preserve the user input casing
-                PathBase = originalPath[..pathBase.Length];
-                Path = originalPath[pathBase.Length..];
-            }
-            else
-            {
-                // Http.Sys path base matching is based on the cooked url which applies some non-standard normalizations that we don't use
-                // like collapsing duplicate slashes "//", converting '\' to '/', and un-escaping "%2F" to '/'. Find the right split and
-                // ignore the normalizations.
-                var originalOffset = 0;
-                var baseOffset = 0;
-                while (originalOffset < originalPath.Length && baseOffset < pathBase.Length)
+                var pathBase = prefix.PathWithoutTrailingSlash;
+
+                // url: /base/path, prefix: /base/, base: /base, path: /path
+                // url: /, prefix: /, base: , path: /
+                if (originalPath.Equals(pathBase, StringComparison.Ordinal))
                 {
-                    var baseValue = pathBase[baseOffset];
-                    var offsetValue = originalPath[originalOffset];
-                    if (baseValue == offsetValue
-                        || char.ToUpperInvariant(baseValue) == char.ToUpperInvariant(offsetValue))
-                    {
-                        // case-insensitive match, continue
-                        originalOffset++;
-                        baseOffset++;
-                    }
-                    else if (baseValue == '/' && offsetValue == '\\')
-                    {
-                        // Http.Sys considers these equivalent
-                        originalOffset++;
-                        baseOffset++;
-                    }
-                    else if (baseValue == '/' && originalPath.AsSpan(originalOffset).StartsWith("%2F", StringComparison.OrdinalIgnoreCase))
-                    {
-                        // Http.Sys un-escapes this
-                        originalOffset += 3;
-                        baseOffset++;
-                    }
-                    else if (baseOffset > 0 && pathBase[baseOffset - 1] == '/'
-                        && (offsetValue == '/' || offsetValue == '\\'))
-                    {
-                        // Duplicate slash, skip
-                        originalOffset++;
-                    }
-                    else if (baseOffset > 0 && pathBase[baseOffset - 1] == '/'
-                        && originalPath.AsSpan(originalOffset).StartsWith("%2F", StringComparison.OrdinalIgnoreCase))
-                    {
-                        // Duplicate slash equivalent, skip
-                        originalOffset += 3;
-                    }
-                    else
-                    {
-                        // Mismatch, fall back
-                        // The failing test case here is "/base/call//../bat//path1//path2", reduced to "/base/call/bat//path1//path2",
-                        // where http.sys collapses "//" before "../", but we do "../" first. We've lost the context that there were dot segments,
-                        // or duplicate slashes, how do we figure out that "call/" can be eliminated?
-                        originalOffset = 0;
-                        break;
-                    }
+                    // Exact match, no need to preserve the casing
+                    PathBase = pathBase;
+                    Path = string.Empty;
                 }
-                PathBase = originalPath[..originalOffset];
-                Path = originalPath[originalOffset..];
+                else if (originalPath.Equals(pathBase, StringComparison.OrdinalIgnoreCase))
+                {
+                    // Preserve the user input casing
+                    PathBase = originalPath;
+                    Path = string.Empty;
+                }
+                else if (originalPath.StartsWith(prefix.Path, StringComparison.Ordinal))
+                {
+                    // Exact match, no need to preserve the casing
+                    PathBase = pathBase;
+                    Path = originalPath[pathBase.Length..];
+                }
+                else if (originalPath.StartsWith(prefix.Path, StringComparison.OrdinalIgnoreCase))
+                {
+                    // Preserve the user input casing
+                    PathBase = originalPath[..pathBase.Length];
+                    Path = originalPath[pathBase.Length..];
+                }
+                else
+                {
+                    // Http.Sys path base matching is based on the cooked url which applies some non-standard normalizations that we don't use
+                    // like collapsing duplicate slashes "//", converting '\' to '/', and un-escaping "%2F" to '/'. Find the right split and
+                    // ignore the normalizations.
+                    var originalOffset = 0;
+                    var baseOffset = 0;
+                    while (originalOffset < originalPath.Length && baseOffset < pathBase.Length)
+                    {
+                        var baseValue = pathBase[baseOffset];
+                        var offsetValue = originalPath[originalOffset];
+                        if (baseValue == offsetValue
+                            || char.ToUpperInvariant(baseValue) == char.ToUpperInvariant(offsetValue))
+                        {
+                            // case-insensitive match, continue
+                            originalOffset++;
+                            baseOffset++;
+                        }
+                        else if (baseValue == '/' && offsetValue == '\\')
+                        {
+                            // Http.Sys considers these equivalent
+                            originalOffset++;
+                            baseOffset++;
+                        }
+                        else if (baseValue == '/' && originalPath.AsSpan(originalOffset).StartsWith("%2F", StringComparison.OrdinalIgnoreCase))
+                        {
+                            // Http.Sys un-escapes this
+                            originalOffset += 3;
+                            baseOffset++;
+                        }
+                        else if (baseOffset > 0 && pathBase[baseOffset - 1] == '/'
+                            && (offsetValue == '/' || offsetValue == '\\'))
+                        {
+                            // Duplicate slash, skip
+                            originalOffset++;
+                        }
+                        else if (baseOffset > 0 && pathBase[baseOffset - 1] == '/'
+                            && originalPath.AsSpan(originalOffset).StartsWith("%2F", StringComparison.OrdinalIgnoreCase))
+                        {
+                            // Duplicate slash equivalent, skip
+                            originalOffset += 3;
+                        }
+                        else
+                        {
+                            // Mismatch, fall back
+                            // The failing test case here is "/base/call//../bat//path1//path2", reduced to "/base/call/bat//path1//path2",
+                            // where http.sys collapses "//" before "../", but we do "../" first. We've lost the context that there were dot segments,
+                            // or duplicate slashes, how do we figure out that "call/" can be eliminated?
+                            originalOffset = 0;
+                            break;
+                        }
+                    }
+                    PathBase = originalPath[..originalOffset];
+                    Path = originalPath[originalOffset..];
+                }
             }
+            else if (requestContext.Server.Options.UrlPrefixes.TryMatchLongestPrefix(IsHttps, cookedUrl.GetHost()!, originalPath, out var pathBase, out var path))
+            {
+                PathBase = pathBase;
+                Path = path;
+            }
+
+            ProtocolVersion = RequestContext.GetVersion();
+
+            Headers = new RequestHeaders(RequestContext);
+
+            User = RequestContext.GetUser();
+
+            SniHostName = string.Empty;
+            if (IsHttps)
+            {
+                GetTlsHandshakeResults();
+            }
+
+            // GetTlsTokenBindingInfo(); TODO: https://github.com/aspnet/HttpSysServer/issues/231
+
         }
-        else if (requestContext.Server.Options.UrlPrefixes.TryMatchLongestPrefix(IsHttps, cookedUrl.GetHost()!, originalPath, out var pathBase, out var path))
+        finally
         {
-            PathBase = pathBase;
-            Path = path;
+            // Finished directly accessing the HTTP_REQUEST structure.
+            RequestContext.ReleasePins();
+            // TODO: Verbose log parameters
         }
-
-        ProtocolVersion = RequestContext.GetVersion();
-
-        Headers = new RequestHeaders(RequestContext);
-
-        User = RequestContext.GetUser();
-
-        SniHostName = string.Empty;
-        if (IsHttps)
-        {
-            GetTlsHandshakeResults();
-        }
-
-        // GetTlsTokenBindingInfo(); TODO: https://github.com/aspnet/HttpSysServer/issues/231
-
-        // Finished directly accessing the HTTP_REQUEST structure.
-        RequestContext.ReleasePins();
-        // TODO: Verbose log parameters
 
         RemoveContentLengthIfTransferEncodingContainsChunked();
     }

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestContext.FeatureCollection.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestContext.FeatureCollection.cs
@@ -103,7 +103,7 @@ internal partial class RequestContext :
     {
         _initialized = true;
 
-        // Get the ID before creating the Request object as it releases the native memory
+        // Get the ID before creating the Request object as the Request ctor releases the native memory
         // We want the ID in case request processing fails and we need the ID to cancel the native request
         _requestId = RequestId;
         try

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestContext.FeatureCollection.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestContext.FeatureCollection.cs
@@ -113,6 +113,8 @@ internal partial class RequestContext :
         catch (Exception ex)
         {
             Log.RequestParsingError(Logger, ex);
+            // Synchronously calls Http.Sys and tells it to send an http response
+            // No one has written to the response yet (haven't even created the response object below)
             Server.SendError(_requestId.Value, StatusCodes.Status400BadRequest, authChallenges: null);
             return false;
         }

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestContext.FeatureCollection.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestContext.FeatureCollection.cs
@@ -64,6 +64,7 @@ internal partial class RequestContext :
     private bool _bodyCompleted;
     private IHeaderDictionary _responseHeaders = default!;
     private IHeaderDictionary? _responseTrailers;
+    private ulong? _requestId;
 
     private Fields _initializedFields;
 
@@ -98,11 +99,24 @@ internal partial class RequestContext :
         TraceIdentifier = 0x200,
     }
 
-    protected internal void InitializeFeatures()
+    protected internal bool InitializeFeatures()
     {
         _initialized = true;
 
-        Request = new Request(this);
+        // Get the ID before creating the Request object as it releases the native memory
+        // We want the ID in case request processing fails and we need the ID to cancel the native request
+        _requestId = RequestId;
+        try
+        {
+            Request = new Request(this);
+        }
+        catch (Exception ex)
+        {
+            Log.RequestParsingError(Logger, ex);
+            Server.SendError(_requestId.Value, StatusCodes.Status400BadRequest, authChallenges: null);
+            return false;
+        }
+
         Response = new Response(this);
 
         _features = new FeatureCollection(new StandardFeatureCollection(this));
@@ -124,6 +138,7 @@ internal partial class RequestContext :
 
         _responseStream = new ResponseStream(Response.Body, OnResponseStart);
         _responseHeaders = Response.Headers;
+        return true;
     }
 
     private bool IsNotInitialized(Fields field)

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestContext.Log.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestContext.Log.cs
@@ -17,5 +17,8 @@ internal partial class RequestContext
 
         [LoggerMessage(LoggerEventIds.ChannelBindingRetrieved, LogLevel.Debug, "Channel binding retrieved.", EventName = "ChannelBindingRetrieved")]
         public static partial void ChannelBindingRetrieved(ILogger logger);
+
+        [LoggerMessage(LoggerEventIds.RequestParsingError, LogLevel.Debug, "Failed to parse request.", EventName = "RequestParsingError")]
+        public static partial void RequestParsingError(ILogger logger, Exception exception);
     }
 }

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestContextOfT.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestContextOfT.cs
@@ -27,7 +27,11 @@ internal sealed partial class RequestContext<TContext> : RequestContext where TC
 
         try
         {
-            InitializeFeatures();
+            if (!InitializeFeatures())
+            {
+                Abort();
+                return;
+            }
 
             if (messagePump.Stopping)
             {

--- a/src/Servers/HttpSys/test/FunctionalTests/Listener/RequestTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Listener/RequestTests.cs
@@ -1,15 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.IO;
-using System.Net.Http;
 using System.Net.Sockets;
 using System.Text;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.InternalTesting;
-using Microsoft.Extensions.Logging;
-using Xunit;
 
 namespace Microsoft.AspNetCore.Server.HttpSys.Listener;
 
@@ -142,6 +136,7 @@ public class RequestTests
     [InlineData("/", "/", "", "/")]
     [InlineData("/base", "/base", "/base", "")]
     [InlineData("/base", "/baSe", "/baSe", "")]
+    [InlineData("/base", "/baSe/", "/baSe", "/")]
     [InlineData("/base", "/base/path", "/base", "/path")]
     [InlineData("/base", "///base/path1/path2", "///base", "/path1/path2")]
     [InlineData("/base/ball", @"/baSe\ball//path1//path2", @"/baSe\ball", "//path1//path2")]

--- a/src/Servers/HttpSys/test/FunctionalTests/RequestTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/RequestTests.cs
@@ -1,25 +1,17 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Globalization;
-using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.HttpSys.Internal;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using Microsoft.Win32;
-using Xunit;
 
 namespace Microsoft.AspNetCore.Server.HttpSys;
 

--- a/src/Servers/HttpSys/test/FunctionalTests/RequestTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/RequestTests.cs
@@ -18,6 +18,7 @@ using Microsoft.AspNetCore.HttpSys.Internal;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Win32;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.HttpSys;
@@ -366,6 +367,43 @@ public class RequestTests : LoggedTest
             var responseStatusCode = response.Substring(9); // Skip "HTTP/1.1 "
             Assert.Equal("200", responseStatusCode);
         }
+    }
+
+    [Fact]
+    public async Task Latin1UrlIsRejected()
+    {
+        string root;
+        using (var server = Utilities.CreateHttpServerReturnRoot("/", out root, httpContext =>
+        {
+            Assert.Fail("Request should not reach here");
+            return Task.FromResult(0);
+        }, LoggerFactory))
+        {
+            var uri = new Uri(root);
+            StringBuilder builder = new StringBuilder();
+            builder.AppendLine(FormattableString.Invariant($"GET /a HTTP/1.1"));
+            builder.AppendLine("Connection: close");
+            builder.Append("HOST: ");
+            builder.AppendLine(uri.Authority);
+            builder.AppendLine();
+            byte[] request = Encoding.ASCII.GetBytes(builder.ToString());
+            // Replace the 'a' in the path with a Latin1 value
+            request[5] = 0xe1;
+
+            using (var socket = new Socket(SocketType.Stream, ProtocolType.Tcp))
+            {
+                socket.Connect(uri.Host, uri.Port);
+                socket.Send(request);
+                var response = new byte[12];
+                await Task.Run(() => socket.Receive(response));
+
+                var statusCode = Encoding.UTF8.GetString(response).Substring(9);
+                Assert.Equal("400", statusCode);
+            }
+        }
+
+        var errorLogs = TestSink.Writes.Where(w => w.LogLevel >= LogLevel.Error).Select(w => w.Exception);
+        Assert.False(errorLogs.Any(), string.Join(" ", errorLogs));
     }
 
     [ConditionalFact]

--- a/src/Servers/HttpSys/test/FunctionalTests/ResponseCachingTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/ResponseCachingTests.cs
@@ -22,8 +22,23 @@ public class ResponseCachingTests : LoggedTest
 
     public ResponseCachingTests()
     {
-        _absoluteFilePath = Path.Combine(Directory.GetCurrentDirectory(), "Microsoft.AspNetCore.Server.HttpSys.dll");
-        _fileLength = new FileInfo(_absoluteFilePath).Length;
+        _absoluteFilePath = Path.Combine(Directory.GetCurrentDirectory(), Path.GetRandomFileName());
+        using var file = File.Create(_absoluteFilePath);
+        // HttpSys will cache responses up to ~260k, keep this value below that
+        // 30k is an arbitrary choice
+        file.Write(new byte[30000]);
+        _fileLength = 30000;
+    }
+
+    public override void Dispose()
+    {
+        try
+        {
+            File.Delete(_absoluteFilePath);
+        }
+        catch { }
+
+        base.Dispose();
     }
 
     [ConditionalFact]
@@ -383,7 +398,6 @@ public class ResponseCachingTests : LoggedTest
         }
     }
 
-    [QuarantinedTest("new issue")]
     [ConditionalFact]
     public async Task Caching_SendFileWithFullContentLength_Cached()
     {

--- a/src/Servers/HttpSys/test/FunctionalTests/ResponseSendFileTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/ResponseSendFileTests.cs
@@ -30,6 +30,7 @@ public class ResponseSendFileTests : LoggedTest
         AbsoluteFilePath = Directory.GetFiles(Directory.GetCurrentDirectory()).First();
         RelativeFilePath = Path.GetFileName(AbsoluteFilePath);
         FileLength = new FileInfo(AbsoluteFilePath).Length;
+        Assert.True(FileLength > 0, "FileLength is 0");
     }
 
     [ConditionalFact]


### PR DESCRIPTION
# Http.Sys: Clean up Request parsing errors

## Description

There are a few errors logged in the event that request processing fails. Additionally, there isn't a clean error on the client side when this occurs.

This change catches the errors earlier, logs a Debug level log, and sends an Http 400 response.

## Customer Impact

Better client-side error and removes potential Error level logs on the server.

## Regression?

- [x] Yes
- [ ] No

Regressed in 6.0

## Risk

- [ ] High
- [ ] Medium
- [x] Low

The change does not affect happy path scenarios and is limited to improved exception handling for non-happy path scenarios. Test added to verify new behavior. Lots of manual testing was done with individual parts of the change to make sure everything worked well.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A