### PR TITLE
bumping ws dependency to fix component vulnerability

### DIFF
--- a/src/SignalR/clients/ts/signalr/package.json
+++ b/src/SignalR/clients/ts/signalr/package.json
@@ -45,7 +45,7 @@
     "eventsource": "^2.0.2",
     "fetch-cookie": "^2.0.3",
     "node-fetch": "^2.6.7",
-    "ws": "^8.17.1"
+    "ws": "^7.5.10"
   },
   "overrides": {
     "ansi-regex": "5.0.1",

--- a/src/SignalR/clients/ts/signalr/package.json
+++ b/src/SignalR/clients/ts/signalr/package.json
@@ -45,7 +45,7 @@
     "eventsource": "^2.0.2",
     "fetch-cookie": "^2.0.3",
     "node-fetch": "^2.6.7",
-    "ws": "^7.4.5"
+    "ws": "^7.5.10"
   },
   "overrides": {
     "ansi-regex": "5.0.1",

--- a/src/SignalR/clients/ts/signalr/package.json
+++ b/src/SignalR/clients/ts/signalr/package.json
@@ -45,7 +45,7 @@
     "eventsource": "^2.0.2",
     "fetch-cookie": "^2.0.3",
     "node-fetch": "^2.6.7",
-    "ws": "^7.5.10"
+    "ws": "^8.17.1"
   },
   "overrides": {
     "ansi-regex": "5.0.1",


### PR DESCRIPTION
# Bumping `ws` dependency to fix `Component Vulnerability` issue

[ws](https://www.npmjs.com/package/ws) package has a DoS attach vulnerability between v7.0.0 and v7.5.10

Details can be found here; https://security.snyk.io/package/npm/ws

GitHub Code Scanning feature shows a `High Severity` alert

## Description

`ws` dependency in the [package.json](https://github.com/dotnet/aspnetcore/blob/main/src/SignalR/clients/ts/signalr/package.json#L48) is pinned to v7.4.5, and it needs to be updated to _at least_ v7.5.10

Fixes #56723 
