### PR TITLE
Breaking change fix for IdentityRole.ConcurrencyStamp to initialize with new Guid.

### DIFF
--- a/src/Identity/Extensions.Stores/src/IdentityRole.cs
+++ b/src/Identity/Extensions.Stores/src/IdentityRole.cs
@@ -72,7 +72,7 @@ public class IdentityRole<TKey> where TKey : IEquatable<TKey>
     /// <summary>
     /// A random value that should change whenever a role is persisted to the store
     /// </summary>
-    public virtual string? ConcurrencyStamp { get; set; }
+    public virtual string? ConcurrencyStamp { get; set; } = Guid.NewGuid().ToString();
 
     /// <summary>
     /// Returns the name of the role.


### PR DESCRIPTION
# Breaking change fix for IdentityRole.ConcurrencyStamp to initialize with new Guid.

Summary of the changes (Less than 80 chars)

## Description
As mentioned in below bug, there was a breaking regression happened from `6.0.33` version to `7.0.0`. This PR fixes it.
[https://github.com/dotnet/aspnetcore/issues/57427](https://github.com/dotnet/aspnetcore/issues/57427)

Fixes #57427 
