### PR TITLE
Fix `InjectedStartup_DefaultApplicationNameIsEntryAssembly`

### DIFF
--- a/src/Hosting/test/FunctionalTests/WebHostBuilderTests.cs
+++ b/src/Hosting/test/FunctionalTests/WebHostBuilderTests.cs
@@ -44,11 +44,11 @@ public class WebHostBuilderTests : LoggedTest
                     if (!string.IsNullOrWhiteSpace(data))
                     {
                         output += data + '\n';
-                        tcs.TrySetResult();
                     }
                 };
 
-                await deployer.DeployAsync();
+                var deploymentResult = await deployer.DeployAsync();
+                deploymentResult.HostShutdownToken.Register(tcs.SetResult);
 
                 try
                 {

--- a/src/Hosting/test/testassets/IStartupInjectionAssemblyName/Program.cs
+++ b/src/Hosting/test/testassets/IStartupInjectionAssemblyName/Program.cs
@@ -14,7 +14,6 @@ public class Program
         var webHost = CreateWebHostBuilder(args).Build();
         var applicationName = webHost.Services.GetRequiredService<IHostEnvironment>().ApplicationName;
         Console.WriteLine(applicationName);
-        Console.ReadKey();
     }
 
     // Do not change the signature of this method. It's used for tests.


### PR DESCRIPTION
Attempts to fix #52429 by waiting for the test app process to exit gracefully.