### PR TITLE
Unquarantine `Microsoft.AspNetCore.Components.E2ETest.Tests.EventTest.Cancel_CanTrigger`

### DIFF
--- a/src/Components/test/E2ETest/Tests/EventTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventTest.cs
@@ -199,7 +199,6 @@ public class EventTest : ServerTestBase<ToggleExecutionModeServerFixture<Program
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/52783")]
     public void Cancel_CanTrigger()
     {
         Browser.MountTestComponent<DialogEventsComponent>();


### PR DESCRIPTION
This test has been passing for the past 30 days.

Fixes #52783