### PR TITLE
[Blazor] Invoke inbound activity handlers on circuit initialization

### DIFF
--- a/src/Components/Server/src/Circuits/CircuitHost.cs
+++ b/src/Components/Server/src/Circuits/CircuitHost.cs
@@ -104,7 +104,7 @@ internal partial class CircuitHost : IAsyncDisposable
     {
         Log.InitializationStarted(_logger);
 
-        return Renderer.Dispatcher.InvokeAsync(async () =>
+        return HandleInboundActivityAsync(() => Renderer.Dispatcher.InvokeAsync(async () =>
         {
             if (_initialized)
             {
@@ -165,7 +165,7 @@ internal partial class CircuitHost : IAsyncDisposable
                 UnhandledException?.Invoke(this, new UnhandledExceptionEventArgs(ex, isTerminating: false));
                 await TryNotifyClientErrorAsync(Client, GetClientErrorMessage(ex), ex);
             }
-        });
+        }));
     }
 
     // We handle errors in DisposeAsync because there's no real value in letting it propagate.

--- a/src/Components/test/E2ETest/ServerExecutionTests/CircuitContextTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/CircuitContextTest.cs
@@ -22,28 +22,39 @@ public class CircuitContextTest : ServerTestBase<BasicTestAppServerSiteFixture<S
     {
     }
 
-    protected override void InitializeAsyncCore()
-    {
-        Navigate(ServerPathBase);
-        Browser.MountTestComponent<CircuitContextComponent>();
-        Browser.Equal("Circuit Context", () => Browser.Exists(By.TagName("h1")).Text);
-    }
-
     [Fact]
     public void ComponentMethods_HaveCircuitContext()
     {
-        Browser.Click(By.Id("trigger-click-event-button"));
+        Navigate(ServerPathBase);
+        Browser.MountTestComponent<CircuitContextComponent>();
+        TestCircuitContextCore(Browser);
+    }
 
-        Browser.True(() => HasCircuitContext("SetParametersAsync"));
-        Browser.True(() => HasCircuitContext("OnInitializedAsync"));
-        Browser.True(() => HasCircuitContext("OnParametersSetAsync"));
-        Browser.True(() => HasCircuitContext("OnAfterRenderAsync"));
-        Browser.True(() => HasCircuitContext("InvokeDotNet"));
-        Browser.True(() => HasCircuitContext("OnClickEvent"));
+    [Fact]
+    public void ComponentMethods_HaveCircuitContext_OnInitialPageLoad()
+    {
+        // https://github.com/dotnet/aspnetcore/issues/57481
+        Navigate($"{ServerPathBase}?initial-component-type={typeof(CircuitContextComponent).AssemblyQualifiedName}");
+        TestCircuitContextCore(Browser);
+    }
+
+    // Internal for reuse in Blazor Web tests
+    internal static void TestCircuitContextCore(IWebDriver browser)
+    {
+        browser.Equal("Circuit Context", () => browser.Exists(By.TagName("h1")).Text);
+
+        browser.Click(By.Id("trigger-click-event-button"));
+
+        browser.True(() => HasCircuitContext("SetParametersAsync"));
+        browser.True(() => HasCircuitContext("OnInitializedAsync"));
+        browser.True(() => HasCircuitContext("OnParametersSetAsync"));
+        browser.True(() => HasCircuitContext("OnAfterRenderAsync"));
+        browser.True(() => HasCircuitContext("InvokeDotNet"));
+        browser.True(() => HasCircuitContext("OnClickEvent"));
 
         bool HasCircuitContext(string eventName)
         {
-            var resultText = Browser.FindElement(By.Id($"circuit-context-result-{eventName}")).Text;
+            var resultText = browser.FindElement(By.Id($"circuit-context-result-{eventName}")).Text;
             var result = bool.Parse(resultText);
             return result;
         }

--- a/src/Components/test/E2ETest/ServerRenderingTests/InteractivityTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/InteractivityTest.cs
@@ -4,6 +4,7 @@
 using Components.TestServer.RazorComponents;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
+using Microsoft.AspNetCore.Components.E2ETests.ServerExecutionTests;
 using Microsoft.AspNetCore.E2ETesting;
 using OpenQA.Selenium;
 using TestServer;
@@ -1142,8 +1143,7 @@ public class InteractivityTest : ServerTestBase<BasicTestAppServerSiteFixture<Ra
     public void InteractiveServerRootComponent_CanAccessCircuitContext()
     {
         Navigate($"{ServerPathBase}/interactivity/circuit-context");
-
-        Browser.Equal("True", () => Browser.FindElement(By.Id("has-circuit-context")).Text);
+        CircuitContextTest.TestCircuitContextCore(Browser);
     }
 
     [Fact]

--- a/src/Components/test/testassets/BasicTestApp/Index.razor
+++ b/src/Components/test/testassets/BasicTestApp/Index.razor
@@ -137,6 +137,17 @@
     Type SelectedComponentType
         => SelectedComponentTypeName == "none" ? null : Type.GetType(SelectedComponentTypeName, throwOnError: true);
 
+    [SupplyParameterFromQuery(Name = "initial-component-type")]
+    private string InitialComponentTypeName { get; set; }
+
+    protected override void OnInitialized()
+    {
+        if (InitialComponentTypeName is { Length: > 0 } initialComponentTypeName)
+        {
+            SelectedComponentTypeName = initialComponentTypeName;
+        }
+    }
+
     void RenderSelectedComponent(RenderTreeBuilder builder)
     {
         if (SelectedComponentType != null)

--- a/src/Components/test/testassets/BasicTestApp/Index.razor
+++ b/src/Components/test/testassets/BasicTestApp/Index.razor
@@ -1,4 +1,6 @@
 ﻿@using Microsoft.AspNetCore.Components.Rendering
+@using System.Web
+@inject NavigationManager NavigationManager
 <div id="test-selector">
     Select test:
     <select id="test-selector-select" @bind=SelectedComponentTypeName>
@@ -137,12 +139,10 @@
     Type SelectedComponentType
         => SelectedComponentTypeName == "none" ? null : Type.GetType(SelectedComponentTypeName, throwOnError: true);
 
-    [SupplyParameterFromQuery(Name = "initial-component-type")]
-    private string InitialComponentTypeName { get; set; }
-
     protected override void OnInitialized()
     {
-        if (InitialComponentTypeName is { Length: > 0 } initialComponentTypeName)
+        var uri = new Uri(NavigationManager.Uri);
+        if (HttpUtility.ParseQueryString(uri.Query)["initial-component-type"] is { Length: > 0 } initialComponentTypeName)
         {
             SelectedComponentTypeName = initialComponentTypeName;
         }

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/App.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/App.razor
@@ -25,6 +25,7 @@
     </script>
     <script src="_framework/blazor.web.js" autostart="false" suppress-error="BL9992"></script>
     <script src="_content/TestContentPackage/counterInterop.js"></script>
+    <script src="js/circuitContextTest.js"></script>
     <script>
         // This is called by the Components.WasmMinimal project.
         function getQueryParam(key) {

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Interactivity/CircuitContextPage.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Interactivity/CircuitContextPage.razor
@@ -1,25 +1,3 @@
 ﻿@page "/interactivity/circuit-context"
-@rendermode RenderMode.InteractiveServer
-@inject TestCircuitContextAccessor CircuitContextAccessor
 
-<h1>Circuit context</h1>
-
-<p>
-    Has circuit context: <span id="has-circuit-context">@_hasCircuitContext</span>
-</p>
-
-@code {
-    private bool _hasCircuitContext;
-
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        if (firstRender)
-        {
-            await Task.Yield();
-
-            _hasCircuitContext = CircuitContextAccessor.HasCircuitContext;
-
-            StateHasChanged();
-        }
-    }
-}
+<CircuitContextComponent @rendermode="RenderMode.InteractiveServer" />


### PR DESCRIPTION
# [Blazor] Invoke inbound activity handlers on circuit initialization

Fixes an issue where inbound activity handlers don't get invoked on circuit initialization.

## Description

> [!NOTE]
> This bug only affects Blazor Server apps, _not_ Blazor Web apps utilizing server interactivity

**Changes:**
* Updated `CircuitHost` to invoke inbound activity handlers on circuit initialization
* Added an extra test to verify that inbound activity handlers work on the initial page load
* Updated existing Blazor Web tests to reuse test logic from the non-web tests
  * The previous web-specific tests were not as elaborate, so this helps to ensure that the feature works the same way on Blazor Server and Blazor Web

Fixes #57481

