### PR TITLE
Verify project template dependencies

### DIFF
--- a/eng/Npm.Workspace.nodeproj
+++ b/eng/Npm.Workspace.nodeproj
@@ -36,7 +36,7 @@
 
     <Message Text="Building NPM packages..." Importance="high" />
 
-    <Exec Condition="'$(ContinuousIntegrationBuild)' == 'true'"
+    <Exec
       Command="node $(MSBuildThisFileDirectory)scripts/npm/pack-workspace.mjs --update-versions $(RepoRoot)package.json $(PackageVersion) $(PackageOutputPath) $(IntermediateOutputPath)"
       EnvironmentVariables="$(_NpmAdditionalEnvironmentVariables)" />
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -282,7 +282,6 @@
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension80x64Version>$(MicrosoftAspNetCoreAzureAppServicesSiteExtension80Version)</MicrosoftAspNetCoreAzureAppServicesSiteExtension80x64Version>
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension80x86Version>$(MicrosoftAspNetCoreAzureAppServicesSiteExtension80Version)</MicrosoftAspNetCoreAzureAppServicesSiteExtension80x86Version>
     <!-- 3rd party dependencies -->
-    <AzureIdentityVersion>1.11.3</AzureIdentityVersion>
     <AngleSharpVersion>0.9.9</AngleSharpVersion>
     <BenchmarkDotNetVersion>0.13.0</BenchmarkDotNetVersion>
     <CastleCoreVersion>4.2.1</CastleCoreVersion>
@@ -328,7 +327,7 @@
     <XunitExtensibilityCoreVersion>$(XunitVersion)</XunitExtensibilityCoreVersion>
     <XunitExtensibilityExecutionVersion>$(XunitVersion)</XunitExtensibilityExecutionVersion>
     <XUnitRunnerVisualStudioVersion>2.4.3</XUnitRunnerVisualStudioVersion>
-    <MicrosoftDataSqlClientVersion>4.0.5</MicrosoftDataSqlClientVersion>
+    <MicrosoftDataSqlClientVersion>5.2.2</MicrosoftDataSqlClientVersion>
     <MicrosoftOpenApiVersion>1.6.17</MicrosoftOpenApiVersion>
     <MicrosoftOpenApiReadersVersion>1.6.17</MicrosoftOpenApiReadersVersion>
     <!-- dotnet tool versions (see also auto-updated DotnetEfVersion property). -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -282,6 +282,7 @@
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension80x64Version>$(MicrosoftAspNetCoreAzureAppServicesSiteExtension80Version)</MicrosoftAspNetCoreAzureAppServicesSiteExtension80x64Version>
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension80x86Version>$(MicrosoftAspNetCoreAzureAppServicesSiteExtension80Version)</MicrosoftAspNetCoreAzureAppServicesSiteExtension80x86Version>
     <!-- 3rd party dependencies -->
+    <AzureIdentityVersion>1.11.4</AzureIdentityVersion>
     <AngleSharpVersion>0.9.9</AngleSharpVersion>
     <BenchmarkDotNetVersion>0.13.0</BenchmarkDotNetVersion>
     <CastleCoreVersion>4.2.1</CastleCoreVersion>

--- a/src/ProjectTemplates/TestInfrastructure/PrepareForTest.targets
+++ b/src/ProjectTemplates/TestInfrastructure/PrepareForTest.targets
@@ -88,7 +88,10 @@
       <_FilesToCopy Include="$(LocalDotNetRoot)sdk\**\*" DestinationRelativeFolder="sdk\" />
       <_FilesToCopy Include="$(SharedFrameworkLayoutRoot)\**\*" />
 
-      <_DestinationFiles Include="@(_FilesToCopy->'$(TemplateTestDotNetRoot)%(DestinationRelativeFolder)%(RecursiveDir)%(Filename)%(Extension)')" />
+      <_PrelimDestinationFiles Include="@(_FilesToCopy->'$(TemplateTestDotNetRoot)%(DestinationRelativeFolder)%(RecursiveDir)%(Filename)%(Extension)')" />
+      <_DestinationFiles Include="@(_PrelimDestinationFiles)" Condition="!$([MSBuild]::IsOSPlatform(`Windows`))" />
+      <!-- Prefix absolute destination paths with "\\?\" on Windows to avoid MSBuild MAX_PATH issues in VS. https://github.com/dotnet/msbuild/issues/53 -->
+      <_DestinationFiles Include="@(_PrelimDestinationFiles->'\\?\%(Identity)')" Condition="$([MSBuild]::IsOSPlatform(`Windows`))" />
     </ItemGroup>
 
     <Copy SourceFiles="@(_FilesToCopy)"
@@ -96,8 +99,6 @@
           SkipUnchangedFiles="true" />
 
     <Message Importance="high" Text="Removed directory %(_CleanedUpDirectories.Identity)" />
-
-    <Message Importance="high" Text="Created directory %(_CreatedDirectories.Identity)" />
 
     <GenerateFileFromTemplate
       TemplateFile="$(MSBuildThisFileDirectory)..\TestInfrastructure\Directory.Build.targets.in"

--- a/src/ProjectTemplates/Web.ProjectTemplates/BlazorWeb-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/BlazorWeb-CSharp.csproj.in
@@ -22,9 +22,12 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="${MicrosoftAspNetCoreComponentsWebAssemblyServerVersion}" Condition="'$(UseWebAssembly)' == 'True'" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="${MicrosoftAspNetCoreDiagnosticsEntityFrameworkCoreVersion}" Condition="'$(IndividualLocalAuth)' == 'True'" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="${MicrosoftAspNetCoreIdentityEntityFrameworkCoreVersion}" Condition="'$(IndividualLocalAuth)' == 'True'" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="${MicrosoftDataSqlClientVersion}" Condition="'$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' == 'True'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="${MicrosoftEntityFrameworkCoreSqliteVersion}" Condition="'$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' != 'True'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="${MicrosoftEntityFrameworkCoreSqlServerVersion}" Condition="'$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' == 'True'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="${MicrosoftEntityFrameworkCoreToolsVersion}" Condition="'$(IndividualLocalAuth)' == 'True'" />
+    <PackageReference Include="System.Drawing.Common" Version="${SystemDrawingCommonVersion}" Condition="'$(IndividualLocalAuth)' == 'True'" />
+    <PackageReference Include="System.Text.Json" Version="${SystemTextJsonVersion}" Condition="'$(IndividualLocalAuth)' == 'True'" />
   </ItemGroup>
 
   <!--#endif -->

--- a/src/ProjectTemplates/Web.ProjectTemplates/Microsoft.DotNet.Web.ProjectTemplates.csproj
+++ b/src/ProjectTemplates/Web.ProjectTemplates/Microsoft.DotNet.Web.ProjectTemplates.csproj
@@ -64,6 +64,8 @@
     <GeneratedContent Include="BlazorWeb-CSharp.csproj.in" OutputPath="content/BlazorWeb-CSharp/BlazorWeb-CSharp/BlazorWeb-CSharp.csproj" />
     <GeneratedContent Include="BlazorWeb-CSharp.Client.csproj.in" OutputPath="content/BlazorWeb-CSharp/BlazorWeb-CSharp.Client/BlazorWeb-CSharp.Client.csproj" />
     <GeneratedContent Include="ComponentsWebAssembly-CSharp.csproj.in" OutputPath="content/ComponentsWebAssembly-CSharp/ComponentsWebAssembly-CSharp.csproj" />
+    <!-- Use None Include to make csproj.in files visible in VS Solution Explorer. -->
+    <None Include="*.csproj.in" />
   </ItemGroup>
 
 </Project>

--- a/src/ProjectTemplates/Web.ProjectTemplates/Microsoft.DotNet.Web.ProjectTemplates.csproj
+++ b/src/ProjectTemplates/Web.ProjectTemplates/Microsoft.DotNet.Web.ProjectTemplates.csproj
@@ -6,6 +6,9 @@
     <Description>ASP.NET Core Web Template Pack for Microsoft Template Engine</Description>
     <ComponentsWebAssemblyProjectsRoot>$(RepoRoot)src\Components\WebAssembly\</ComponentsWebAssemblyProjectsRoot>
     <UsingToolTemplateLocalizer>true</UsingToolTemplateLocalizer>
+    <!-- Unfortunately, UpToDateCheckInput and UpToDateCheckBuilt don't seem to have any effect on VS builds of this project. -->
+    <!-- https://github.com/dotnet/project-system/blob/d0a44e00b723283d8520cfbe3b6d7876bd7e128c/docs/up-to-date-check.md -->
+    <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -14,6 +17,7 @@
       DefaultNetCoreTargetFramework=$(DefaultNetCoreTargetFramework);
       GrpcAspNetCoreVersion=$(GrpcAspNetCoreVersion);
       MicrosoftAspNetCoreMvcRazorRuntimeCompilationVersion=$(MicrosoftAspNetCoreMvcRazorRuntimeCompilationVersion);
+      MicrosoftDataSqlClientVersion=$(MicrosoftDataSqlClientVersion);
       MicrosoftEntityFrameworkCoreSqliteVersion=$(MicrosoftEntityFrameworkCoreSqliteVersion);
       MicrosoftEntityFrameworkCoreSqlServerVersion=$(MicrosoftEntityFrameworkCoreSqlServerVersion);
       MicrosoftEntityFrameworkCoreToolsVersion=$(MicrosoftEntityFrameworkCoreToolsVersion);
@@ -24,8 +28,9 @@
       MicrosoftIdentityWebUIVersion=$(MicrosoftIdentityWebUIVersion);
       MicrosoftIdentityWebDownstreamApiVersion=$(MicrosoftIdentityWebDownstreamApiVersion);
       MicrosoftNETCoreAppRuntimeVersion=$(MicrosoftNETCoreAppRuntimeVersion);
-      SystemNetHttpJsonVersion=$(SystemNetHttpJsonVersion);
       MicrosoftGraphVersion=$(MicrosoftGraphVersion);
+      SystemDrawingCommonVersion=$(SystemDrawingCommonVersion);
+      SystemTextJsonVersion=$(SystemTextJsonVersion);
     </GeneratedContentProperties>
   </PropertyGroup>
 
@@ -64,8 +69,11 @@
     <GeneratedContent Include="BlazorWeb-CSharp.csproj.in" OutputPath="content/BlazorWeb-CSharp/BlazorWeb-CSharp/BlazorWeb-CSharp.csproj" />
     <GeneratedContent Include="BlazorWeb-CSharp.Client.csproj.in" OutputPath="content/BlazorWeb-CSharp/BlazorWeb-CSharp.Client/BlazorWeb-CSharp.Client.csproj" />
     <GeneratedContent Include="ComponentsWebAssembly-CSharp.csproj.in" OutputPath="content/ComponentsWebAssembly-CSharp/ComponentsWebAssembly-CSharp.csproj" />
-    <!-- Use None Include to make csproj.in files visible in VS Solution Explorer. -->
-    <None Include="*.csproj.in" />
+    <!-- This appears to use the right UpToDateCheckBuilt parameters, but DisableFastUpToDateCheck is still necessary for VS to pick up incremental updates. -->
+    <!-- Maybe this is related to the OutputPath being inside of the projects content directory rather than bin or obj. -->
+    <!--<UpToDateCheckBuilt Include="@(GeneratedContent->'%(OutputPath)')" Original="@(GeneratedContent)" />-->
+    <!-- Use "None Include" to make csproj.in files visible in VS Solution Explorer. -->
+    <None Include="@(GeneratedContent)" />
   </ItemGroup>
 
 </Project>

--- a/src/ProjectTemplates/Web.ProjectTemplates/RazorPagesWeb-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/RazorPagesWeb-CSharp.csproj.in
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="${MicrosoftAspNetCoreDiagnosticsEntityFrameworkCoreVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' " />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="${MicrosoftAspNetCoreIdentityEntityFrameworkCoreVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' " />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="${MicrosoftAspNetCoreIdentityUIVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' " />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="${MicrosoftDataSqlClientVersion}" Condition="'$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' == 'True'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="${MicrosoftEntityFrameworkCoreSqliteVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' != 'True'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="${MicrosoftEntityFrameworkCoreSqlServerVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' == 'True'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="${MicrosoftEntityFrameworkCoreToolsVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' " />
@@ -30,6 +31,8 @@
     <PackageReference Include="Microsoft.Identity.Web.GraphServiceClient" Version="${MicrosoftIdentityWebGraphServiceClientVersion}" Condition=" '$(GenerateGraph)' == 'True' " />
     <PackageReference Include="Microsoft.Identity.Web.UI" Version="${MicrosoftIdentityWebUIVersion}" Condition=" '$(IndividualB2CAuth)' == 'True' OR '$(OrganizationalAuth)' == 'True'" />
     <PackageReference Include="Microsoft.Identity.Web.DownstreamApi" Version="${MicrosoftIdentityWebDownstreamApiVersion}" Condition=" '$(IndividualB2CAuth)' == 'True' OR '$(OrganizationalAuth)' == 'True'" />
+    <PackageReference Include="System.Drawing.Common" Version="${SystemDrawingCommonVersion}" Condition="'$(IndividualLocalAuth)' == 'True'" />
+    <PackageReference Include="System.Text.Json" Version="${SystemTextJsonVersion}" Condition="'$(IndividualLocalAuth)' == 'True'" />
   </ItemGroup>
 
   <!--#endif -->

--- a/src/ProjectTemplates/Web.ProjectTemplates/StarterWeb-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/StarterWeb-CSharp.csproj.in
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="${MicrosoftAspNetCoreDiagnosticsEntityFrameworkCoreVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' " />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="${MicrosoftAspNetCoreIdentityEntityFrameworkCoreVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' " />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="${MicrosoftAspNetCoreIdentityUIVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' " />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="${MicrosoftDataSqlClientVersion}" Condition="'$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' == 'True'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="${MicrosoftEntityFrameworkCoreSqlServerVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' == 'True'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="${MicrosoftEntityFrameworkCoreSqliteVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' != 'True'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="${MicrosoftEntityFrameworkCoreToolsVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' " />
@@ -30,6 +31,8 @@
     <PackageReference Include="Microsoft.Identity.Web.GraphServiceClient" Version="${MicrosoftIdentityWebGraphServiceClientVersion}" Condition=" '$(GenerateGraph)' == 'True' " />
     <PackageReference Include="Microsoft.Identity.Web.UI" Version="${MicrosoftIdentityWebUIVersion}" Condition=" '$(IndividualB2CAuth)' == 'True' OR '$(OrganizationalAuth)' == 'True'" />
     <PackageReference Include="Microsoft.Identity.Web.DownstreamApi" Version="${MicrosoftIdentityWebDownstreamApiVersion}" Condition=" '$(IndividualB2CAuth)' == 'True' OR '$(OrganizationalAuth)' == 'True'" />
+    <PackageReference Include="System.Drawing.Common" Version="${SystemDrawingCommonVersion}" Condition="'$(IndividualLocalAuth)' == 'True'" />
+    <PackageReference Include="System.Text.Json" Version="${SystemTextJsonVersion}" Condition="'$(IndividualLocalAuth)' == 'True'" />
   </ItemGroup>
 
   <!--#endif -->


### PR DESCRIPTION
Some of our project templates transitively reference vulnerable NuGet packages. This PR adds automated testing to verify restoring NuGet packages for our project templates does not produce any vulnerability warnings.

This is complicated by the fact that we do not restore packages from nuget.org to avoid supply chain attacks, but the vulnerability warnings only appear if you use nuget.org as a package source. To work around this, I updated the `RunDotNetNewAsync` method used by most of our project template tests to call `dotnet list package --vulnerable --include-transitive --source https://api.nuget.org/v3/index.json`

I updated the templates that I already know produce vulnerability warnings to directly reference the vulnerable packages and require up-to-date versions of them. I also made some updates to make it easier to run our template tests locally.

I'm leaving this as a draft for now since I want to confirm that it will be necessary to directly reference these packages. Some of these references, like the System.Text.Json ones, shouldn't be necessary because the version should already be hoisted to 9.* by the net9.0 shared runtime, but `dotnet restore`, `dotnet nuget why` and `dotnet list package --vulnerable --include-transitive` don't appear to realize this. However, this wasn't a problem until recently because Microsoft.Extensions.DependencyModel took a new enough NuGet dependency until https://github.com/dotnet/runtime/pull/106172 changed that for the net9.0 target. I plan to follow up with the SDK team about this.

I'm also looking into whether Microsoft.EntityFrameworkCore.SqlServer can update its Microsoft.Data.SqlClient dependency to 5.2.2 (which was just released a few hours ago) before .NET 9 ships. @dotnet/efteam Do you know if this is something you're already planning?

I tried to encourage efcore to update its Microsoft.CodeAnalysis dependency and thereby its System.Drawing.Common dependency by opening https://github.com/dotnet/efcore/pull/34116, but this caused some test failures, and there doesn't appear to be interest in updating this dependency for .NET 9. I think this means we'll be forced to at least add a direct System.Drawing.Common dependency to some of our templates.
