### PR TITLE
feat: extending `ApiBehaviorOptions` with skip `SkipStatusCodePages`

### DIFF
--- a/src/Mvc/Mvc.Core/src/ApiBehaviorOptions.cs
+++ b/src/Mvc/Mvc.Core/src/ApiBehaviorOptions.cs
@@ -61,6 +61,13 @@ public class ApiBehaviorOptions : IEnumerable<ICompatibilitySwitch>
     public bool SuppressConsumesConstraintForFormFileParameters { get; set; }
 
     /// <summary>
+    /// Gets or sets a value that determines whether the is suppressed for
+    /// API controllers. This feature prevents MVC's status code pages from overriding raw API responses with
+    /// HTML-based status code pages when mixing MVC Controllers with API Controllers in the same application.
+    /// </summary>
+    public bool SkipStatusCodePages { get; set; }
+
+    /// <summary>
     /// Gets or sets a value that determines if controllers with <see cref="ApiControllerAttribute"/>
     /// transform certain client errors.
     /// <para>

--- a/src/Mvc/Mvc.Core/src/ApplicationModels/ApiBehaviorApplicationModelProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ApplicationModels/ApiBehaviorApplicationModelProvider.cs
@@ -40,6 +40,11 @@ internal sealed class ApiBehaviorApplicationModelProvider : IApplicationModelPro
             ActionModelConventions.Add(new ConsumesConstraintForFormFileParameterConvention());
         }
 
+        if (options.SkipStatusCodePages)
+        {
+            ActionModelConventions.Add(new SkipStatusCodePagesConvention());
+        }
+
         var defaultErrorType = options.SuppressMapClientErrors ? typeof(void) : typeof(ProblemDetails);
         var defaultErrorTypeAttribute = new ProducesErrorResponseTypeAttribute(defaultErrorType);
         ActionModelConventions.Add(new ApiConventionApplicationModelConvention(defaultErrorTypeAttribute));

--- a/src/Mvc/Mvc.Core/src/ApplicationModels/SkipStatusCodePagesConvention.cs
+++ b/src/Mvc/Mvc.Core/src/ApplicationModels/SkipStatusCodePagesConvention.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Mvc.ApplicationModels;
+
+/// <summary>
+/// An <see cref="IActionModelConvention"/> that adds a <see cref="SkipStatusCodePagesAttribute"/>
+/// to controllers
+/// </summary>
+public class SkipStatusCodePagesConvention : IActionModelConvention
+{
+    /// <inheritdoc />
+    public void Apply(ActionModel action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        if (!ShouldApply(action))
+        {
+            return;
+        }
+
+        AddSkipStatusCodePagesAttribute(action);
+    }
+
+    /// <summary>
+    /// Determines if this instance of <see cref="IActionModelConvention"/> applies to a specified <paramref name="action"/>.
+    /// </summary>
+    /// <param name="action">The <see cref="ActionModel"/>.</param>
+    /// <returns>
+    /// <see langword="true"/> if the convention applies, otherwise <see langword="false"/>.
+    /// Derived types may override this method to selectively apply this convention.
+    /// </returns>
+    protected virtual bool ShouldApply(ActionModel action) => true;
+
+    // Internal for unit testing
+    internal static void AddSkipStatusCodePagesAttribute(ActionModel action)
+    {
+        action.Filters.Add(new SkipStatusCodePagesAttribute());
+        return;
+    }
+}

--- a/src/Mvc/Mvc.Core/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.Core/src/PublicAPI.Unshipped.txt
@@ -1,6 +1,12 @@
 #nullable enable
 *REMOVED*virtual Microsoft.AspNetCore.Mvc.ControllerBase.Problem(string? detail = null, string? instance = null, int? statusCode = null, string? title = null, string? type = null) -> Microsoft.AspNetCore.Mvc.ObjectResult!
 *REMOVED*virtual Microsoft.AspNetCore.Mvc.ControllerBase.ValidationProblem(string? detail = null, string? instance = null, int? statusCode = null, string? title = null, string? type = null, Microsoft.AspNetCore.Mvc.ModelBinding.ModelStateDictionary? modelStateDictionary = null) -> Microsoft.AspNetCore.Mvc.ActionResult!
+Microsoft.AspNetCore.Mvc.ApiBehaviorOptions.SkipStatusCodePages.get -> bool
+Microsoft.AspNetCore.Mvc.ApiBehaviorOptions.SkipStatusCodePages.set -> void
+Microsoft.AspNetCore.Mvc.ApplicationModels.SkipStatusCodePagesConvention
+Microsoft.AspNetCore.Mvc.ApplicationModels.SkipStatusCodePagesConvention.Apply(Microsoft.AspNetCore.Mvc.ApplicationModels.ActionModel! action) -> void
+Microsoft.AspNetCore.Mvc.ApplicationModels.SkipStatusCodePagesConvention.SkipStatusCodePagesConvention() -> void
+virtual Microsoft.AspNetCore.Mvc.ApplicationModels.SkipStatusCodePagesConvention.ShouldApply(Microsoft.AspNetCore.Mvc.ApplicationModels.ActionModel! action) -> bool
 virtual Microsoft.AspNetCore.Mvc.ControllerBase.Problem(string? detail, string? instance, int? statusCode, string? title, string? type) -> Microsoft.AspNetCore.Mvc.ObjectResult!
 virtual Microsoft.AspNetCore.Mvc.ControllerBase.Problem(string? detail = null, string? instance = null, int? statusCode = null, string? title = null, string? type = null, System.Collections.Generic.IDictionary<string!, object?>? extensions = null) -> Microsoft.AspNetCore.Mvc.ObjectResult!
 virtual Microsoft.AspNetCore.Mvc.ControllerBase.ValidationProblem(string? detail, string? instance, int? statusCode, string? title, string? type, Microsoft.AspNetCore.Mvc.ModelBinding.ModelStateDictionary? modelStateDictionary) -> Microsoft.AspNetCore.Mvc.ActionResult!


### PR DESCRIPTION
# Extending `ApiBehaviorOptions` with skip `SkipStatusCodePages`

I added a `SkipStatusCodePages` property to the `ApiBehaviorOptions` class to extend its functionality. I then referenced the new `SkipStatusCodePagesConvention` from the `ApiBehaviorApplicationModelProvider` class. The `SkipStatusCodePagesConvention` class adds a `SkipStatusCodePagesAttribute` to the API controller to disable the skip status code pages feature.

However, I am encountering the following reference error:

> error CS0246: The type or namespace name ‘SkipStatusCodePagesAttribute’ could not be found (are you missing a using directive or an assembly reference?)

What could be causing this problem, and how can I resolve it? What might I be missing?

Fixes #45369 , #45260 
