### PR TITLE
Fix `E2ETest.ServerExecutionTests.CircuitTests.ComponentLifecycleMethodThrowsExceptionTerminatesTheCircuit`

### DIFF
--- a/src/Components/test/E2ETest/Tests/CircuitTests.cs
+++ b/src/Components/test/E2ETest/Tests/CircuitTests.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.E2ETesting;
 using Microsoft.AspNetCore.InternalTesting;
 using OpenQA.Selenium;
+using OpenQA.Selenium.Support.Extensions;
 using TestServer;
 using Xunit.Abstractions;
 
@@ -48,6 +49,7 @@ public class CircuitTests : ServerTestBase<BasicTestAppServerSiteFixture<ServerS
         Browser.Exists(By.CssSelector("#blazor-error-ui[style='display: block;']"));
 
         // Clicking the button again will trigger a server disconnect
+        Browser.ExecuteJavaScript("arguments[0].scrollIntoView();", targetButton);
         targetButton.Click();
 
         AssertLogContains("Connection disconnected.");
@@ -70,6 +72,7 @@ public class CircuitTests : ServerTestBase<BasicTestAppServerSiteFixture<ServerS
         Browser.Exists(By.CssSelector("#blazor-error-ui[style='display: block;']"));
 
         // Clicking it again causes the circuit to disconnect
+        Browser.ExecuteJavaScript("arguments[0].scrollIntoView();", targetButton);
         targetButton.Click();
         AssertLogContains("Connection disconnected.");
     }

--- a/src/Components/test/E2ETest/Tests/CircuitTests.cs
+++ b/src/Components/test/E2ETest/Tests/CircuitTests.cs
@@ -49,7 +49,7 @@ public class CircuitTests : ServerTestBase<BasicTestAppServerSiteFixture<ServerS
         Browser.Exists(By.CssSelector("#blazor-error-ui[style='display: block;']"));
 
         // Clicking the button again will trigger a server disconnect
-        Browser.ExecuteJavaScript("arguments[0].scrollIntoView();", targetButton);
+        Browser.ExecuteJavaScript("arguments[0].scrollIntoView(true);", targetButton);
         targetButton.Click();
 
         AssertLogContains("Connection disconnected.");
@@ -72,7 +72,7 @@ public class CircuitTests : ServerTestBase<BasicTestAppServerSiteFixture<ServerS
         Browser.Exists(By.CssSelector("#blazor-error-ui[style='display: block;']"));
 
         // Clicking it again causes the circuit to disconnect
-        Browser.ExecuteJavaScript("arguments[0].scrollIntoView();", targetButton);
+        Browser.ExecuteJavaScript("arguments[0].scrollIntoView(true);", targetButton);
         targetButton.Click();
         AssertLogContains("Connection disconnected.");
     }


### PR DESCRIPTION
Blazor's error UI was overlaying the button that the test was trying to click. This PR fixes the issue by scrolling the button into view before attempting to click it.

Marks https://github.com/dotnet/aspnetcore/issues/57551 as `test-fixed`.