### PR TITLE
Remove trailing trivia from IHeaderDictionary in "Use indexer" code fix

### DIFF
--- a/src/Framework/AspNetCoreAnalyzers/src/CodeFixes/Http/HeaderDictionaryAddFixer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/CodeFixes/Http/HeaderDictionaryAddFixer.cs
@@ -124,7 +124,7 @@ public sealed class HeaderDictionaryAddFixer : CodeFixProvider
                 SyntaxFactory.AssignmentExpression(
                     SyntaxKind.SimpleAssignmentExpression,
                     SyntaxFactory.ElementAccessExpression(
-                        memberAccessExpression.Expression,
+                        memberAccessExpression.Expression.WithoutTrailingTrivia(),
                         SyntaxFactory.BracketedArgumentList(
                             SyntaxFactory.SeparatedList(new[] { arguments[0] }))),
                     arguments[1].Expression);

--- a/src/Framework/AspNetCoreAnalyzers/test/Http/HeaderDictionaryAddTest.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/Http/HeaderDictionaryAddTest.cs
@@ -236,7 +236,7 @@ var context = new DefaultHttpContext();
 context.Request.Headers[""Accept""] = ""text/html""{|CS1002:|}"
         },
 
-        // With new line
+        // With trailing trivia
         {
             @"
 using Microsoft.AspNetCore.Http;

--- a/src/Framework/AspNetCoreAnalyzers/test/Http/HeaderDictionaryAddTest.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/Http/HeaderDictionaryAddTest.cs
@@ -234,6 +234,27 @@ using Microsoft.AspNetCore.Http;
 
 var context = new DefaultHttpContext();
 context.Request.Headers[""Accept""] = ""text/html""{|CS1002:|}"
+        },
+
+        // With new line
+        {
+            @"
+using Microsoft.AspNetCore.Http;
+
+var context = new DefaultHttpContext();
+{|#0:context.Request.Headers
+    .Add(""Accept"", ""text/html"")|}{|CS1002:|}",
+            new[]
+            {
+                new DiagnosticResult(DiagnosticDescriptors.DoNotUseIHeaderDictionaryAdd)
+                    .WithLocation(0)
+                    .WithMessage(Resources.Analyzer_HeaderDictionaryAdd_Message)
+            },
+            @"
+using Microsoft.AspNetCore.Http;
+
+var context = new DefaultHttpContext();
+context.Request.Headers[""Accept""] = ""text/html""{|CS1002:|}"
         }
     };
 


### PR DESCRIPTION
# Remove trailing trivia from IHeaderDictionary in "Use indexer" code fix

## Description

Updates the "Use indexer" code fix for ASP0019 to remove trailing trivia from `IHeaderDictionary` to prevent formatting issues.

Fixes #57648
