### PR TITLE
[Static Assets] Improve development experience

### DIFF
--- a/src/StaticAssets/src/BuildAssetMetadata.cs
+++ b/src/StaticAssets/src/BuildAssetMetadata.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.StaticAssets;
+
+internal sealed class BuildAssetMetadata { }

--- a/src/StaticAssets/src/Development/StaticAssetDevelopmentRuntimeHandler.cs
+++ b/src/StaticAssets/src/Development/StaticAssetDevelopmentRuntimeHandler.cs
@@ -15,7 +15,6 @@ using Microsoft.AspNetCore.StaticAssets;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
@@ -156,11 +155,11 @@ internal sealed partial class StaticAssetDevelopmentRuntimeHandler(List<StaticAs
         throw new InvalidOperationException("The original asset was not found.");
     }
 
-    internal static bool IsEnabled(IServiceProvider serviceProvider, IWebHostEnvironment environment)
+    internal static bool IsEnabled(bool isBuildManifest, IServiceProvider serviceProvider)
     {
         var config = serviceProvider.GetRequiredService<IConfiguration>();
         var explicitlyConfigured = bool.TryParse(config[ReloadStaticAssetsAtRuntimeKey], out var hotReload);
-        return (!explicitlyConfigured && environment.IsDevelopment()) || (explicitlyConfigured && hotReload);
+        return (!explicitlyConfigured && isBuildManifest) || (explicitlyConfigured && hotReload);
     }
 
     internal static void EnableSupport(

--- a/src/StaticAssets/src/LoggerExtensions.cs
+++ b/src/StaticAssets/src/LoggerExtensions.cs
@@ -59,5 +59,10 @@ internal static partial class LoggerExtensions
     [LoggerMessage(16, LogLevel.Warning,
         "The WebRootPath was not found: {WebRootPath}. Static files may be unavailable.", EventName = "WebRootPathNotFound")]
     public static partial void WebRootPathNotFound(this ILogger logger, string webRootPath);
+
+    [LoggerMessage(17, LogLevel.Warning,
+        "The application is not running against the published output and Static Web Assets are not enabled." +
+        " To configure static web assets in other environments, call 'StaticWebAssetsLoader.UseStaticWebAssets(IWebHostEnvironment, IConfiguration)' to enable them.", EventName = "StaticWebAssetsNotEnabled")]
+    public static partial void EnsureStaticWebAssetsEnabled(this ILogger logger);
 }
 

--- a/src/StaticAssets/src/StaticAssetEndpointDataSource.cs
+++ b/src/StaticAssets/src/StaticAssetEndpointDataSource.cs
@@ -28,6 +28,7 @@ internal class StaticAssetsEndpointDataSource : EndpointDataSource
         IServiceProvider serviceProvider,
         StaticAssetEndpointFactory endpointFactory,
         string manifestName,
+        bool isBuildManifest,
         List<StaticAssetDescriptor> descriptors)
     {
         ServiceProvider = serviceProvider;
@@ -37,8 +38,14 @@ internal class StaticAssetsEndpointDataSource : EndpointDataSource
         _cancellationTokenSource = new CancellationTokenSource();
         _changeToken = new CancellationChangeToken(_cancellationTokenSource.Token);
 
+        if (isBuildManifest)
+        {
+            _conventions.Add(c => c.Metadata.Add(new BuildAssetMetadata()));
+        }
+
         DefaultBuilder = new StaticAssetsEndpointConventionBuilder(
             _lock,
+            isBuildManifest,
             descriptors,
             _conventions,
             _finallyConventions);

--- a/src/StaticAssets/src/StaticAssetsEndpointConventionBuilder.cs
+++ b/src/StaticAssets/src/StaticAssetsEndpointConventionBuilder.cs
@@ -11,19 +11,23 @@ namespace Microsoft.AspNetCore.StaticAssets;
 public sealed class StaticAssetsEndpointConventionBuilder : IEndpointConventionBuilder
 {
     private readonly object _lck;
+    private readonly bool _isBuildManifest;
     private readonly List<StaticAssetDescriptor> _descriptors;
     private readonly List<Action<EndpointBuilder>> _conventions;
     private readonly List<Action<EndpointBuilder>> _finallyConventions;
 
-    internal StaticAssetsEndpointConventionBuilder(object lck, List<StaticAssetDescriptor> descriptors, List<Action<EndpointBuilder>> conventions, List<Action<EndpointBuilder>> finallyConventions)
+    internal StaticAssetsEndpointConventionBuilder(object lck, bool isBuildManifest, List<StaticAssetDescriptor> descriptors, List<Action<EndpointBuilder>> conventions, List<Action<EndpointBuilder>> finallyConventions)
     {
         _lck = lck;
+        _isBuildManifest = isBuildManifest;
         _descriptors = descriptors;
         _conventions = conventions;
         _finallyConventions = finallyConventions;
     }
 
     internal List<StaticAssetDescriptor> Descriptors => _descriptors;
+
+    internal bool IsBuildManifest => _isBuildManifest;
 
     /// <inheritdoc/>
     public void Add(Action<EndpointBuilder> convention)

--- a/src/StaticAssets/src/StaticAssetsEndpointRouteBuilderExtensions.cs
+++ b/src/StaticAssets/src/StaticAssetsEndpointRouteBuilderExtensions.cs
@@ -36,7 +36,7 @@ public static class StaticAssetsEndpointRouteBuilderExtensions
 
         var result = MapStaticAssetsCore(endpoints, staticAssetsManifestPath);
 
-        if (StaticAssetDevelopmentRuntimeHandler.IsEnabled(endpoints.ServiceProvider, environment))
+        if (StaticAssetDevelopmentRuntimeHandler.IsEnabled(result.IsBuildManifest, endpoints.ServiceProvider))
         {
             StaticAssetDevelopmentRuntimeHandler.EnableSupport(endpoints, result, environment, result.Descriptors);
         }
@@ -56,7 +56,7 @@ public static class StaticAssetsEndpointRouteBuilderExtensions
 
         var manifest = ResolveManifest(manifestPath);
 
-        var dataSource = StaticAssetsManifest.CreateDataSource(endpoints, manifestPath, manifest.Endpoints);
+        var dataSource = StaticAssetsManifest.CreateDataSource(endpoints, manifestPath, manifest.Endpoints, manifest.IsBuildManifest());
         return dataSource.DefaultBuilder;
     }
 
@@ -89,9 +89,9 @@ public static class StaticAssetsEndpointRouteBuilderExtensions
         ArgumentNullException.ThrowIfNull(endpoints);
 
         var environment = endpoints.ServiceProvider.GetRequiredService<IWebHostEnvironment>();
-        var result = StaticAssetsManifest.CreateDataSource(endpoints, "", manifest.Endpoints).DefaultBuilder;
+        var result = StaticAssetsManifest.CreateDataSource(endpoints, "", manifest.Endpoints, manifest.IsBuildManifest()).DefaultBuilder;
 
-        if (StaticAssetDevelopmentRuntimeHandler.IsEnabled(endpoints.ServiceProvider, environment))
+        if (StaticAssetDevelopmentRuntimeHandler.IsEnabled(result.IsBuildManifest, endpoints.ServiceProvider))
         {
             StaticAssetDevelopmentRuntimeHandler.EnableSupport(endpoints, result, environment, result.Descriptors);
         }

--- a/src/StaticAssets/src/StaticAssetsManifest.cs
+++ b/src/StaticAssets/src/StaticAssetsManifest.cs
@@ -35,14 +35,23 @@ internal class StaticAssetsManifest
         return result;
     }
 
-    internal static StaticAssetsEndpointDataSource CreateDataSource(IEndpointRouteBuilder endpoints, string manifestName, List<StaticAssetDescriptor> descriptors)
+    internal static StaticAssetsEndpointDataSource CreateDataSource(IEndpointRouteBuilder endpoints, string manifestName, List<StaticAssetDescriptor> descriptors, bool isBuildManifest)
     {
-        var dataSource = new StaticAssetsEndpointDataSource(endpoints.ServiceProvider, new StaticAssetEndpointFactory(endpoints.ServiceProvider), manifestName, descriptors);
+        var dataSource = new StaticAssetsEndpointDataSource(
+            endpoints.ServiceProvider,
+            new StaticAssetEndpointFactory(endpoints.ServiceProvider),
+            manifestName,
+            isBuildManifest,
+            descriptors);
         endpoints.DataSources.Add(dataSource);
         return dataSource;
     }
 
     public int Version { get; set; }
 
+    public string ManifestType { get; set; } = "";
+
     public List<StaticAssetDescriptor> Endpoints { get; set; } = [];
+
+    public bool IsBuildManifest() => string.Equals(ManifestType, "Build", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/StaticAssets/test/StaticAssetsIntegrationTests.cs
+++ b/src/StaticAssets/test/StaticAssetsIntegrationTests.cs
@@ -492,6 +492,7 @@ public class StaticAssetsIntegrationTests
             var lastModified = DateTimeOffset.UtcNow;
             File.WriteAllText(filePath, resource.Content);
             var hash = GetEtag(resource.Content);
+            manifest.ManifestType = "Build";
             manifest.Endpoints.Add(new StaticAssetDescriptor
             {
                 Route = resource.Path,


### PR DESCRIPTION
* Logs a warning when a file is not found during development and static web assets don't appear enabled.
* Avoids wiring up any development functionality against the published output, even if the environment is set to Development.

Fixes https://github.com/dotnet/AspNetCore-ManualTests/issues/3007, #57449

The endpoint manifest exposes the manifest type (Build | Publish) https://github.com/dotnet/sdk/pull/43167 and we read it here to key off certain things:
* Turning on Development features only when running against build output.
* Improving the error message when we detect that static web assets weren't enabled if running against the build output.