### PR TITLE
Disable launching browser on Web API template

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Properties/launchSettings.json
@@ -5,8 +5,7 @@
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "launchUrl": "weatherforecast",
+      "launchBrowser": false,
       "applicationUrl": "http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -21,8 +20,7 @@
     "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "launchUrl": "weatherforecast",
+      "launchBrowser": false,
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"


### PR DESCRIPTION
## Description

Earlier in this release cycle, we removed the Swagger UI from the built-in templates and updated the launch URL on the Web API templates to point to the `/weatherforecast` endpoint.

Recently, we discovered that this default might be problematic for scenarios where the templates are instantiated with authentication configured. In this case, navigating to `/weatherforecast` on launch will result in 401 errors as the browser is unauthenticated.

This sparked conversation about whether it was meaningful to launch URL to this endpoint at all and we decided to remove it in favor of allowing editors/users to configure the launch behavior as desired by their launch configuration.

Resolve https://github.com/dotnet/AspNetCore-ManualTests/issues/3002.

## Customer Impact

Prior to this PR, customers that are creating new templates with authentication enabled might see confusing behavior when launching their applications without authentication configured correctly. 

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

This change only impacts the Web API templates in .NET 9 and beyond and doesn't affect the runtime behavior of the application.

## Verification

- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A
