### PR TITLE
Enable NuGet Audit

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -21,4 +21,8 @@
   <disabledPackageSources>
     <clear />
   </disabledPackageSources>
+  <auditSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </auditSources>
 </configuration>


### PR DESCRIPTION
Working on #57560 lead me to https://github.com/NuGet/docs.microsoft.com-nuget/pull/3336 which in turn pointed me to https://learn.microsoft.com/en-us/nuget/concepts/auditing-packages#audit-sources which talks about NuGet `<auditSources>`. This seems like it might be a better alternative to manually calling `dotnet list package --vulnerable --include-transitive --source https://api.nuget.org/v3/index.json` in projects created by our templates in an XUnit test like I'm doing in #57560.

@ViktorHofer I see that this is currently on your plate as part of https://github.com/dotnet/arcade/issues/15019. Feel free to take this over if you want. I plan to add something like `<WarningsNotAsErrors Condition="'$(OfficialBuildId)' != ''">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>` to the `Directory.Build.props` before undrafting this, but first I want to see what fails in the normal PR builds.