### PR TITLE
Update ANCM file monitoring to hopefully avoid unneeded shutdowns

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/AppOfflineTrackingApplication.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/AppOfflineTrackingApplication.h
@@ -16,7 +16,8 @@ public:
         m_applicationPath(application.GetApplicationPhysicalPath()),
         m_fileWatcher(nullptr),
         m_fAppOfflineProcessed(false),
-        m_shutdownTimeout(120000) // default to 2 minutes
+        m_shutdownTimeout(120000), // default to 2 minutes
+        m_detectedAppOffline(false)
     {
     }
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/filewatcher.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/filewatcher.cpp
@@ -172,19 +172,21 @@ Win32 error
     while (true)
     {
 
-        DWORD       cbCompletion = 0;
+        DWORD       bytesTransferred = 0;
         OVERLAPPED* pOverlapped = nullptr;
         ULONG_PTR   completionKey;
 
         BOOL success = GetQueuedCompletionStatus(
             pFileMonitor->m_hCompletionPort,
-            &cbCompletion,
+            &bytesTransferred,
             &completionKey,
             &pOverlapped,
             INFINITE);
 
-        DBG_ASSERT(success);
-        (void)success;
+        if (!success)
+        {
+            LOG_INFOF(L"Failure when watching app directory. HR: 0x%x", HRESULT_FROM_WIN32(GetLastError()));
+        }
 
         if (completionKey == FILE_WATCHER_SHUTDOWN_KEY)
         {
@@ -194,7 +196,7 @@ Win32 error
         DBG_ASSERT(pOverlapped != nullptr);
         if (pOverlapped != nullptr)
         {
-            pFileMonitor->HandleChangeCompletion(cbCompletion);
+            pFileMonitor->HandleChangeCompletion(bytesTransferred);
 
             if (!pFileMonitor->_lStopMonitorCalled)
             {
@@ -222,7 +224,7 @@ Win32 error
 
 HRESULT
 FILE_WATCHER::HandleChangeCompletion(
-    _In_ DWORD          cbCompletion
+    _In_ DWORD          bytesTransferred
 )
 /*++
 
@@ -234,7 +236,7 @@ need to be flushed)
 Arguments:
 
 dwCompletionStatus - Completion status
-cbCompletion - Bytes of completion
+bytesTransferred - Bytes of completion
 
 Return Value:
 
@@ -259,13 +261,28 @@ HRESULT
     }
 
     //
-    // There could be a FCN overflow
-    // Let assume the file got changed instead of checking files
-    // Otherwise we have to cache the file info
+    // There could be a FCN overflow, see https://learn.microsoft.com/windows/win32/api/winbase/nf-winbase-readdirectorychangesw#remarks
+    // specifically about lpBytesReturned being zero on a successful call
     //
-    if (cbCompletion == 0)
+    // We'll do a manual check for the existence of app_offline.htm since it's possible the file was added
+    // When ShadowCopy is enabled we also look for .dll changes, in order to detect a dll change in this edge case we'd need to cache all dll information
+    // and manually iterate over the directory and compare the file attributes. For now we'll assume that if dlls are changing we'll get another
+    // file change notification in that case
+    //
+    if (bytesTransferred == 0)
     {
-        fAppOfflineChanged = TRUE;
+        LOG_INFO(L"0 bytes transferred for file notifications. Falling back to manually looking for app_offline.");
+        DWORD fileAttr = GetFileAttributesW(_strFullName.QueryStr());
+        if (fileAttr != INVALID_FILE_ATTRIBUTES && !(fileAttr & FILE_ATTRIBUTE_DIRECTORY))
+        {
+            fAppOfflineChanged = TRUE;
+            auto app = _pApplication.get();
+            app->m_detectedAppOffline = true;
+        }
+        else
+        {
+            return S_OK;
+        }
     }
     else
     {
@@ -427,7 +444,7 @@ FILE_WATCHER::Monitor(VOID)
         _buffDirectoryChanges.QueryPtr(),
         _buffDirectoryChanges.QuerySize(),
         FALSE,        // Watching sub dirs. Set to False now as only monitoring app_offline
-        FILE_NOTIFY_VALID_MASK & ~FILE_NOTIFY_CHANGE_LAST_ACCESS,
+        FILE_NOTIFY_VALID_MASK & ~FILE_NOTIFY_CHANGE_LAST_ACCESS & ~FILE_NOTIFY_CHANGE_SECURITY & ~FILE_NOTIFY_CHANGE_ATTRIBUTES,
         &cbRead,
         &_overlapped,
         nullptr));

--- a/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/filewatcher.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/filewatcher.cpp
@@ -294,7 +294,8 @@ HRESULT
             //
             // check whether the monitored file got changed
             //
-            if (_wcsnicmp(pNotificationInfo->FileName,
+            if (_strFileName.QuerySizeCCH() == (pNotificationInfo->FileNameLength / sizeof(WCHAR))
+                && _wcsnicmp(pNotificationInfo->FileName,
                 _strFileName.QueryStr(),
                 pNotificationInfo->FileNameLength / sizeof(WCHAR)) == 0)
             {


### PR DESCRIPTION
Hoping it fixes issues like https://github.com/dotnet/aspnetcore/issues/55939 where it looks like a phantom `app_offline.htm` file is seen by ANCM which causes the app to shutdown.

There were three specific issues found in the code:
1. `m_detectedAppOffline` wasn't initialized, so it could have any value, if it was `true` and there was a file notification then we'd trigger an app shutdown due to "detecting" app_offline
2. We just assumed if `cbCompletion` (now `bytesTransferred`) was 0 that app_offline was added to the directory. That's not really a good assumption, so changed it to manually check for app_offline
3. Any file or directory name that is a subset of `app_offline.htm` (e.g. `app_o`) would be detected as `app_offline.htm`

Also updated what file changes we look for to not include `FILE_NOTIFY_CHANGE_SECURITY` and `FILE_NOTIFY_CHANGE_ATTRIBUTES` ([ref](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-readdirectorychangesw#parameters)) to hopefully minimize the likelihood of getting `bytesTransferred == 0` and it just seems like extra work when we aren't interested in those events.