### PR TITLE
Fix unmatched paren in comment

### DIFF
--- a/src/Components/WebAssembly/Server/src/ComponentsWebAssemblyApplicationBuilderExtensions.cs
+++ b/src/Components/WebAssembly/Server/src/ComponentsWebAssemblyApplicationBuilderExtensions.cs
@@ -110,7 +110,7 @@ public static class ComponentsWebAssemblyApplicationBuilderExtensions
             var fileExtension = Path.GetExtension(requestPath.Value);
             if (string.Equals(fileExtension, ".gz") || string.Equals(fileExtension, ".br"))
             {
-                // When we are serving framework files (under _framework/ we perform content negotiation
+                // When we are serving framework files (under _framework/) we perform content negotiation
                 // on the accept encoding and replace the path with <<original>>.gz|br if we can serve gzip or brotli content
                 // respectively.
                 // Here we simply calculate the original content type by removing the extension and apply it


### PR DESCRIPTION
# Fix unmatched paren in comment

Fixes a missing paren in a comment in Blazor CreateStaticFilesOptions

## Description

Fixes a missing paren in a comment in Blazor CreateStaticFilesOptions

I can create an issue for this if required, it just seemed like a very small change to do so.
