### PR TITLE
Provide `Microsoft.AspNetCore.Components.WebAssembly` package README

### DIFF
--- a/src/Components/WebAssembly/WebAssembly/src/PACKAGE.md
+++ b/src/Components/WebAssembly/WebAssembly/src/PACKAGE.md
@@ -1,0 +1,11 @@
+## About
+
+`Microsoft.AspNetCore.Components.WebAssembly` provides support for building client-side single-page applications (SPAs) with Blazor running under WebAssembly.
+
+## How to Use
+
+To get started with Blazor, see the [official documentation](https://learn.microsoft.com/aspnet/core/blazor).
+
+## Feedback &amp; Contributing
+
+`Microsoft.AspNetCore.Components.WebAssembly` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/dotnet/aspnetcore).


### PR DESCRIPTION
Contributes to https://github.com/dotnet/aspnetcore/issues/48392

This one is a little shorter because it's less common for developers to add this package reference manually. It's included automatically when you create a Blazor project via the built-in project templates.