### PR TITLE
Fix value type serialization issue

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -533,6 +533,10 @@ public static partial class RequestDelegateFactory
         }
         else
         {
+            if (returnType.IsValueType)
+            {
+                return Expression.Call(WrapObjectAsValueTaskMethod, Expression.Convert(methodCall, typeof(object)));
+            }
             return Expression.Call(WrapObjectAsValueTaskMethod, methodCall);
         }
     }


### PR DESCRIPTION
Some Copilot generated summaries of this pull request:

This pull request introduces modifications to handle value type return values in the `RequestDelegateFactory` and adds corresponding unit tests to ensure the new functionality works as expected.

### Enhancements to `RequestDelegateFactory`:

* [`src/Http/Http.Extensions/src/RequestDelegateFactory.cs`](diffhunk://#diff-f38f5cec66cf8010067587a59799e7aeb620388d108d0c58e63aa23849eb6eebR536-R539): Added a conditional check to handle value type return values by explicitly converting them to `object`.

### Unit Tests:

* `src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs`: Introduced new test cases to verify that delegates with value type return values are correctly processed by `RequestDelegateFactory`.