### PR TITLE
Provide `Microsoft.AspNetCore.Components.WebAssembly.Authentication` package README

### DIFF
--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/PACKAGE.md
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/PACKAGE.md
@@ -1,0 +1,21 @@
+## About
+
+`Microsoft.AspNetCore.Components.WebAssembly.Authentication` provides client-side authentication for Blazor apps running under WebAssembly.
+
+## How to Use
+
+To use `Microsoft.AspNetCore.Components.WebAssembly.Authentication`, follow these steps:
+
+### Installation
+
+```shell
+dotnet add package Microsoft.AspNetCore.Components.WebAssembly.Authentication
+```
+
+### Usage
+
+For usage examples and documentation, refer to the [offical documentation](https://learn.microsoft.com/aspnet/core/blazor/security/webassembly) on Blazor WebAssembly security and identity.
+
+## Feedback &amp; Contributing
+
+`Microsoft.AspNetCore.Components.WebAssembly.Authentication` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/dotnet/aspnetcore).


### PR DESCRIPTION
Contributes to #48392

Like #57773, this one is a bit short because it's usually included automatically when you create a project from a Blazor project template.