### PR TITLE
Make serviceProviderIsService optional in constructor of EndpointMetadataApiDescriptionProvider

### DIFF
--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -33,7 +33,7 @@ internal sealed class EndpointMetadataApiDescriptionProvider : IApiDescriptionPr
         EndpointDataSource endpointDataSource,
         IHostEnvironment environment,
         ParameterPolicyFactory parameterPolicyFactory,
-        IServiceProviderIsService? serviceProviderIsService)
+        IServiceProviderIsService? serviceProviderIsService = null)
     {
         _endpointDataSource = endpointDataSource;
         _environment = environment;


### PR DESCRIPTION
# Make `serviceProviderIsService` optional in constructor of EndpointMetadataApiDescriptionProvider class

The constructor of the `EndpointMetadataApiDescriptionProvider` class has been modified to provide a default value of `null` for the `serviceProviderIsService` parameter. This change makes the `serviceProviderIsService` parameter optional when creating an instance of the class (even in Dependency Injection).

Fixes #57694
