### PR TITLE
Provide `Microsoft.Authentication.WebAssembly.Msal` package README

### DIFF
--- a/src/Components/WebAssembly/Authentication.Msal/src/PACKAGE.md
+++ b/src/Components/WebAssembly/Authentication.Msal/src/PACKAGE.md
@@ -1,0 +1,21 @@
+## About
+
+`Microsoft.Authentication.WebAssembly.Msal` provides client-side authentication using Microsoft Authentication Library (MSAL) for Blazor apps running under WebAssembly.
+
+## How to Use
+
+To use `Microsoft.Authentication.WebAssembly.Msal`, follow these steps:
+
+### Installation
+
+```shell
+dotnet add package Microsoft.Authentication.WebAssembly.Msal
+```
+
+### Usage
+
+For usage examples and documentation, refer to the [offical documentation](https://learn.microsoft.com/aspnet/core/blazor/security/webassembly) on Blazor WebAssembly security and identity.
+
+## Feedback &amp; Contributing
+
+`Microsoft.Authentication.WebAssembly.Msal` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/dotnet/aspnetcore).


### PR DESCRIPTION
Contributes to #48392

Like #57791, this one is a bit short because it's usually included automatically when you create a project from a Blazor project template.