### PR TITLE
Fix parameter description in GetAuthenticatorKeyAsync

### DIFF
--- a/src/Identity/Extensions.Core/src/IUserAuthenticatorKeyStore.cs
+++ b/src/Identity/Extensions.Core/src/IUserAuthenticatorKeyStore.cs
@@ -24,7 +24,7 @@ public interface IUserAuthenticatorKeyStore<TUser> : IUserStore<TUser> where TUs
     /// <summary>
     /// Get the authenticator key for the specified <paramref name="user" />.
     /// </summary>
-    /// <param name="user">The user whose authenticator key must be get.</param>
+    /// <param name="user">The user whose authenticator key should be retrieved.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
     /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing the security stamp for the specified <paramref name="user"/>.</returns>
     Task<string?> GetAuthenticatorKeyAsync(TUser user, CancellationToken cancellationToken);

--- a/src/Identity/Extensions.Core/src/IUserAuthenticatorKeyStore.cs
+++ b/src/Identity/Extensions.Core/src/IUserAuthenticatorKeyStore.cs
@@ -24,7 +24,7 @@ public interface IUserAuthenticatorKeyStore<TUser> : IUserStore<TUser> where TUs
     /// <summary>
     /// Get the authenticator key for the specified <paramref name="user" />.
     /// </summary>
-    /// <param name="user">The user whose security stamp should be set.</param>
+    /// <param name="user">The user whose authenticator key must be get.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
     /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing the security stamp for the specified <paramref name="user"/>.</returns>
     Task<string?> GetAuthenticatorKeyAsync(TUser user, CancellationToken cancellationToken);


### PR DESCRIPTION
# Fix `user` parameter description for IUserAuthenticatorKeyStore.GetAuthenticatorKeyAsync method

Corrected the parameter description for the `user` parameter in the `GetAuthenticatorKeyAsync` method of the `IUserAuthenticatorKeyStore<TUser>` interface. The previous description incorrectly referred to the security stamp, while the new description accurately refers to the authenticator key.

Fixes #57832
