### PR TITLE
[Templates] Fix template scripts, make them more flexible and robust

### DIFF
--- a/src/ProjectTemplates/scripts/Run-BlazorWasm-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-BlazorWasm-Locally.ps1
@@ -3,11 +3,78 @@
 
 # This script packages, installs and creates a template to help with rapid iteration in the templating area.
 [CmdletBinding(PositionalBinding = $false)]
-param()
+param(
+    [ValidateSet("net9.0", "net10.0")]
+    [string] $Framework = "net9.0",
+    [Parameter(Mandatory = $false)]
+    [switch] $NoRestore,
+    [Parameter(Mandatory = $false)]
+    [switch] $ExcludeLaunchSettings,
+    [Parameter(Mandatory = $false)]
+    [switch] $Empty,
+    [Parameter(Mandatory = $false)]
+    [ValidateSet("None", "Individual")]
+    [string] $Auth = "None",
+    [Parameter(Mandatory = $false)]
+    [switch] $NoHttps,
+    [Parameter(Mandatory = $false)]
+    [switch] $UseProgramMain,
+    [Parameter(Mandatory = $false)]
+    [string] $Authority,
+    [Parameter(Mandatory = $false)]
+    [string] $ClientId,
+    [switch] $Pwa,
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]] $Args
+)
 
 Set-StrictMode -Version 2
 $ErrorActionPreference = 'Stop'
 
-. $PSScriptRoot\Test-Template.ps1
+$templateArguments = @("blazorwasm");
 
-Test-Template "blazorwasm" "blazorwasm --hosted --auth Individual" "Microsoft.DotNet.Web.ProjectTemplates.9.0.9.0.0-dev.nupkg" $true
+if ($ExcludeLaunchSettings) {
+    $templateArguments += "--exclude-launch-settings"
+}
+
+if ($Empty) {
+    $templateArguments += "-e"
+}
+
+if ($Auth) {
+    $templateArguments += "--auth";
+    $templateArguments += $Auth;
+}
+
+$mainProjectRelativePath = $null;
+
+if ($NoHttps) {
+    $templateArguments += "--no-https"
+}
+
+if ($Authority) {
+    $templateArguments += "--authority"
+    $templateArguments += $Authority
+}
+
+if ($ClientId) {
+    $templateArguments += "--client-id"
+    $templateArguments += $ClientId
+}
+
+if ($Pwa) {
+    $templateArguments += "--pwa"
+}
+
+if ($UseProgramMain) {
+    $templateArguments += "--use-program-main"
+}
+
+Import-Module -Name .\Test-Template.psm1;
+
+Test-Template `
+    -TemplateName "MyBlazorWasmApp" `
+    -TemplateArguments $templateArguments `
+    -MainProjectRelativePath $mainProjectRelativePath `
+    -TargetFramework $Framework `
+    -Verbose:$VerbosePreference;

--- a/src/ProjectTemplates/scripts/Run-BlazorWeb-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-BlazorWeb-Locally.ps1
@@ -2,12 +2,84 @@
 #requires -version 4
 
 # This script packages, installs and creates a template to help with rapid iteration in the templating area.
-[CmdletBinding(PositionalBinding = $false)]
-param()
+    [CmdletBinding(PositionalBinding = $false)]
+    param(
+        [Parameter(Mandatory = $false, Position = 0)]
+        [ValidateSet("net9.0", "net10.0")]
+        [string] $Framework = "net9.0",
+        [Parameter(Mandatory = $false)]
+        [switch] $NoRestore,
+        [Parameter(Mandatory = $false)]
+        [switch] $ExcludeLaunchSettings,
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("None", "Server", "WebAssembly", "Auto")]
+        [string] $Interactivity = "Server",
+        [Parameter(Mandatory = $false)]
+        [switch] $Empty,
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("None", "Individual")]
+        [string] $Auth = "None",
+        [Parameter(Mandatory = $false)]
+        [switch] $UseLocalDb,
+        [Parameter(Mandatory = $false)]
+        [switch] $AllInteractive,
+        [Parameter(Mandatory = $false)]
+        [switch] $NoHttps,
+        [Parameter(Mandatory = $false)]
+        [switch] $UseProgramMain,
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [string[]] $Args
+    )
 
-Set-StrictMode -Version 2
-$ErrorActionPreference = 'Stop'
+    Set-StrictMode -Version 2
+    $ErrorActionPreference = 'Stop'
 
-. $PSScriptRoot\Test-Template.ps1
+    $templateArguments = @("blazor");
 
-Test-Template "MyBlazorApp" "blazor" "Microsoft.DotNet.Web.ProjectTemplates.9.0.9.0.0-dev.nupkg" $true
+    if ($ExcludeLaunchSettings) {
+        $templateArguments += "--exclude-launch-settings"
+    }
+
+    if ($Interactivity) {
+        $templateArguments += "--interactivity"
+        $templateArguments += $Interactivity;
+    }
+
+    if ($Empty) {
+        $templateArguments += "-e"
+    }
+
+    if ($Auth) {
+        $templateArguments += "--auth";
+        $templateArguments += $Auth;
+    }
+
+    $mainProjectRelativePath = $null;
+    if($Interactivity -in @("Auto", "WebAssembly")){
+        $mainProjectRelativePath = "MyBlazorApp";
+    }
+
+    if ($UseLocalDb) {
+        $templateArguments += "-uld"
+    }
+
+    if ($AllInteractive) {
+        $templateArguments += "-ai"
+    }
+
+    if ($NoHttps) {
+        $templateArguments += "--no-https"
+    }
+
+    if ($UseProgramMain) {
+        $templateArguments += "--use-program-main"
+    }
+
+    Import-Module -Name .\Test-Template.psm1;
+
+    Test-Template `
+        -TemplateName "MyBlazorApp" `
+        -TemplateArguments $templateArguments `
+        -MainProjectRelativePath $mainProjectRelativePath `
+        -TargetFramework $Framework `
+        -Verbose:$VerbosePreference;

--- a/src/ProjectTemplates/scripts/Run-Razor-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-Razor-Locally.ps1
@@ -1,9 +1,57 @@
-#!/usr/bin/env powershell
+#!/usr/bin/env pwsh
 #requires -version 4
 
+# This script packages, installs and creates a template to help with rapid iteration in the templating area.
 [CmdletBinding(PositionalBinding = $false)]
-param()
+param(
+    [Parameter(Mandatory = $false, Position = 0)]
+    [ValidateSet("net9.0", "net10.0")]
+    [string] $Framework = "net9.0",
+    [Parameter(Mandatory = $false)]
+    [switch] $ExcludeLaunchSettings,
+    [Parameter(Mandatory = $false)]
+    [ValidateSet("None", "Individual")]
+    [string] $Auth = "None",
+    [Parameter(Mandatory = $false)]
+    [switch] $UseLocalDb,
+    [Parameter(Mandatory = $false)]
+    [switch] $NoHttps,
+    [Parameter(Mandatory = $false)]
+    [switch] $UseProgramMain,
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]] $Args
+)
 
-. $PSScriptRoot\Test-Template.ps1
+Set-StrictMode -Version 2
+$ErrorActionPreference = 'Stop'
 
-Test-Template "webapp" "webapp -au Individual" "Microsoft.DotNet.Web.ProjectTemplates.9.0.9.0.0-dev.nupkg" $false
+$templateArguments = @("webapp");
+
+if ($ExcludeLaunchSettings) {
+    $templateArguments += "--exclude-launch-settings"
+}
+
+if ($Auth) {
+    $templateArguments += "--auth";
+    $templateArguments += $Auth;
+}
+
+if ($UseLocalDb) {
+    $templateArguments += "-uld"
+}
+
+if ($NoHttps) {
+    $templateArguments += "--no-https"
+}
+
+if ($UseProgramMain) {
+    $templateArguments += "--use-program-main"
+}
+
+Import-Module -Name .\Test-Template.psm1;
+
+Test-Template `
+    -TemplateName "MyWebApp" `
+    -TemplateArguments $templateArguments `
+    -TargetFramework $Framework `
+    -Verbose:$VerbosePreference;

--- a/src/ProjectTemplates/scripts/Run-Starterweb-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-Starterweb-Locally.ps1
@@ -1,12 +1,57 @@
 #!/usr/bin/env pwsh
 #requires -version 4
 
+# This script packages, installs and creates a template to help with rapid iteration in the templating area.
 [CmdletBinding(PositionalBinding = $false)]
-param()
+param(
+    [Parameter(Mandatory = $false, Position = 0)]
+    [ValidateSet("net9.0", "net10.0")]
+    [string] $Framework = "net9.0",
+    [Parameter(Mandatory = $false)]
+    [switch] $ExcludeLaunchSettings,
+    [Parameter(Mandatory = $false)]
+    [ValidateSet("None", "Individual")]
+    [string] $Auth = "None",
+    [Parameter(Mandatory = $false)]
+    [switch] $UseLocalDb,
+    [Parameter(Mandatory = $false)]
+    [switch] $NoHttps,
+    [Parameter(Mandatory = $false)]
+    [switch] $UseProgramMain,
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]] $Args
+)
 
 Set-StrictMode -Version 2
 $ErrorActionPreference = 'Stop'
 
-. $PSScriptRoot\Test-Template.ps1
+$templateArguments = @("mvc");
 
-Test-Template "mvc" "mvc -au Individual" "Microsoft.DotNet.Web.ProjectTemplates.9.0.9.0.0-dev.nupkg" $false
+if ($ExcludeLaunchSettings) {
+    $templateArguments += "--exclude-launch-settings"
+}
+
+if ($Auth) {
+    $templateArguments += "--auth";
+    $templateArguments += $Auth;
+}
+
+if ($UseLocalDb) {
+    $templateArguments += "-uld"
+}
+
+if ($NoHttps) {
+    $templateArguments += "--no-https"
+}
+
+if ($UseProgramMain) {
+    $templateArguments += "--use-program-main"
+}
+
+Import-Module -Name .\Test-Template.psm1;
+
+Test-Template `
+    -TemplateName "MyMvcApp" `
+    -TemplateArguments $templateArguments `
+    -TargetFramework $Framework `
+    -Verbose:$VerbosePreference;

--- a/src/ProjectTemplates/scripts/Test-Template.psm1
+++ b/src/ProjectTemplates/scripts/Test-Template.psm1
@@ -1,0 +1,130 @@
+#!/usr/bin/env pwsh
+#requires -version 4
+
+Set-StrictMode -Version 2
+$ErrorActionPreference = 'Stop'
+
+function Test-Template {
+    [CmdletBinding()]
+    param (
+        [string] $TemplateName,
+        [string[]] $TemplateArguments,
+        [string] $TemplatePackagePath = "Microsoft.DotNet.Web.ProjectTemplates.*-dev.nupkg",
+        [string] $PackagePattern = "(?<PackageId>([A-Za-z]+(\.[A-Za-z]+)*))\.(?<Version>\d+\.\d)\.(?<Suffix>.*)",
+        [string] $MainProjectRelativePath = $null,
+        [ValidateSet("Debug", "Release")]
+        [string] $Configuration = "Release",
+        [ValidatePattern("net\d+\.\d+")]
+        [string] $TargetFramework = "net9.0"
+    )
+
+    if(-not (Test-Path "$PSScriptRoot/.dotnet")){
+        $dotnetFolder = Get-Command dotnet | Select-Object -ExpandProperty Source | Split-Path -Parent;
+        Write-Verbose "Copying dotnet folder from $dotnetFolder to $PSScriptRoot/.dotnet";
+        Copy-Item -Path $dotnetFolder -Destination "$PSScriptRoot/.dotnet" -Recurse;
+    }
+
+    Write-Verbose "Patching Microsoft.AspNetCore.App";
+    $builtRuntime = Resolve-Path "$PSScriptRoot/../../../artifacts/installers/$Configuration/aspnetcore-runtime-*-dev-win-x64.zip";
+    Write-Verbose "Patching Microsoft.AspNetCore.App from $builtRuntime";
+    Remove-Item "$PSScriptRoot/.runtime" -Recurse -ErrorAction Ignore;
+    Expand-Archive -Path $builtRuntime -DestinationPath "$PSScriptRoot/.runtime" -Force;
+    Remove-Item "$PSScriptRoot/.dotnet/shared/Microsoft.AspNetCore.App/*-dev" -Recurse -ErrorAction Ignore;
+    Write-Verbose "Copying $PSScriptRoot/.runtime/shared/Microsoft.AspNetCore.App to $PSScriptRoot/.dotnet/shared";
+    Copy-Item -Path "$PSScriptRoot/.runtime/shared/Microsoft.AspNetCore.App" -Destination "$PSScriptRoot/.dotnet/shared" -Recurse -Force;
+
+    $env:DOTNET_ROOT = "$PSScriptRoot/.dotnet";
+    $env:DOTNET_ROOT_X86 = "$PSScriptRoot/.dotnet";
+    $env:Path = "$PSScriptRoot/.dotnet;$env:Path";
+    $tmpDir = "$PSScriptRoot/$templateName";
+    Remove-Item -Path $tmpDir -Recurse -ErrorAction Ignore;
+    Push-Location ..;
+    try {
+        dotnet pack
+    }
+    finally {
+        Pop-Location;
+    }
+
+    $PackagePath = Resolve-Path "$PSScriptRoot/../../../artifacts/packages/$Configuration/Shipping/$TemplatePackagePath";
+
+    $PackageName = (Get-Item $PackagePath).Name;
+
+    if (-not (Test-Path "$($env:USERPROFILE)/.templateengine/packages/$PackageName")) {
+        Write-Verbose "Installing package from $PackagePath";
+        dotnet new install $PackagePath;
+    }
+    else {
+        Write-Verbose "Uninstalling package from $PackagePath";
+        if (-not ($PackageName -match $PackagePattern)) {
+            Write-Error "$PackageName did not match $PackagePattern";
+        }
+        $PackageId = $Matches["PackageId"];
+        $PackageVersion = $Matches["Version"];
+        Write-Verbose "Uninstalling existing package $PackageId.$PackageVersion";
+        dotnet new uninstall "$PackageId.$PackageVersion";
+
+        Write-Verbose "Installing package from $PackagePath";
+        dotnet new install $PackagePath;
+    }
+
+
+    Write-Verbose "Creating directory $tmpDir"
+    New-Item -ErrorAction Ignore -Path $tmpDir -ItemType Directory | Out-Null;
+    Push-Location $tmpDir -StackName TemplateFolder;
+    try {
+        $TemplateArguments = , "new" + $TemplateArguments + , "--no-restore";
+        Write-Verbose "Running dotnet command with arguments: $TemplateArguments";
+        dotnet @TemplateArguments;
+
+        $proj = Get-ChildItem $tmpDir -Recurse -File -Filter '*.csproj' -Depth 3;
+        if ($proj.Length -eq 0) {
+            $proj = Get-ChildItem $tmpDir -Recurse -File -Filter '*.fsproj' -Depth 3;
+        }
+
+        $importPath = "$PSScriptRoot/../test/Templates.Tests/bin/$Configuration/$TargetFramework/TestTemplates";
+        # Define the XML string literals
+        [xml]$importPropsXml = "<Import Project='$importPath/Directory.Build.props' />";
+        [xml]$importTargetsXml = "<Import Project='$importPath/Directory.Build.targets' />";
+        [xml]$propertyGroupXml = @"
+<PropertyGroup>
+    <DisablePackageReferenceRestrictions>true</DisablePackageReferenceRestrictions>
+    <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+</PropertyGroup>
+"@;
+
+        foreach ($projPath in $proj) {
+            Write-Verbose "Updating project file '$projPath'";
+            # Read the XML content from the file
+            [xml]$xmlContent = Get-Content -Path $projPath;
+
+            # Find the Project element and add the new elements
+            $projectElement = $xmlContent.Project;
+            $projectElement.PrependChild($xmlContent.ImportNode($propertyGroupXml.PropertyGroup, $true)) | Out-Null;
+            $projectElement.PrependChild($xmlContent.ImportNode($importTargetsXml.Import, $true)) | Out-Null;
+            $projectElement.PrependChild($xmlContent.ImportNode($importPropsXml.Import, $true)) | Out-Null;
+
+            # Save the modified XML content back to the file
+            $xmlContent.Save($projPath);
+        }
+
+        if ($null -ne $MainProjectRelativePath) {
+            Push-Location $MainProjectRelativePath;
+        }
+
+        if ('--auth' -in $TemplateArguments -and 'Individual' -in $TemplateArguments) {
+            Write-Verbose "Running dotnet ef migrations"
+            dotnet.exe ef migrations add Initial;
+        }
+
+        $publishOutputDir = "./.publish";
+        Write-Verbose "Running dotnet publish --configuration $Configuration --output $publishOutputDir";
+        dotnet.exe publish --configuration $Configuration --output $publishOutputDir;
+    }
+    finally {
+        Pop-Location -StackName TemplateFolder;
+    }
+}
+
+Export-ModuleMember Test-Template;


### PR DESCRIPTION
Provides an updated `Test-Templates` module with a new `Test-Template` function to create a given template and replaces the old `Test-Templates.ps1` script, which has been left there for `other` template scripts.

The new command allows passing parameters to the templates instead of hardcoding them into the wrapping scripts and the wrapping commands expose specific parameters for the templates they instantiate.

Other wrapping scripts have been left untouched.