### PR TITLE
Unskip RunIndividualTestCase(http2_6.9.1_2)

### DIFF
--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/H2SpecTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/H2SpecTests.cs
@@ -61,7 +61,6 @@ public class H2SpecTests : LoggedTest
         get
         {
             var dataset = new TheoryData<H2SpecTestCase>();
-            var toSkip = new string[] { "http2/6.9.1/2" };
 
             var testCases = H2SpecCommands.EnumerateTestCases();
 
@@ -78,18 +77,11 @@ public class H2SpecTests : LoggedTest
 
             foreach (var testcase in testCases)
             {
-                string skip = null;
-                if (toSkip.Contains(testcase.Item1))
-                {
-                    skip = "https://github.com/dotnet/aspnetcore/issues/30373";
-                }
-
                 dataset.Add(new H2SpecTestCase
                 {
                     Id = testcase.Item1,
                     Description = testcase.Item2,
                     Https = false,
-                    Skip = skip,
                 });
 
                 // https://github.com/dotnet/aspnetcore/issues/11301 We should use Skip but it's broken at the moment.
@@ -100,7 +92,6 @@ public class H2SpecTests : LoggedTest
                         Id = testcase.Item1,
                         Description = testcase.Item2,
                         Https = true,
-                        Skip = skip,
                     });
                 }
             }


### PR DESCRIPTION
It's not quarantined, so there's no pass rate, but I can't get it to fail locally - even with a synthetic delay - and the code has been substantially rewritten since the bug was opened.

Fixes #30373