### PR TITLE
Fix mapping for nested schemas and [Produces] attributes in OpenAPI implementation

### DIFF
--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -382,7 +382,7 @@ internal sealed class OpenApiDocumentService(
             .SelectMany(attr => attr.ContentTypes);
         foreach (var contentType in explicitContentTypes)
         {
-            response.Content[contentType] = new OpenApiMediaType();
+            response.Content.TryAdd(contentType, new OpenApiMediaType());
         }
 
         return response;

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/CreateSchemaReferenceIdTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/CreateSchemaReferenceIdTests.cs
@@ -65,7 +65,7 @@ public class CreateSchemaReferenceIdTests : OpenApiDocumentServiceTestBase
 
         // Act
         builder.MapPost("/", (Todo todo) => { });
-        var options = new OpenApiOptions { CreateSchemaReferenceId = (type) => $"{type.Type.Name}Schema" };
+        var options = new OpenApiOptions { CreateSchemaReferenceId = (type) => type.Type.Name == "Todo" ? $"{type.Type.Name}Schema" : OpenApiOptions.CreateDefaultSchemaReferenceId(type) };
 
         // Assert
         await VerifyOpenApiDocument(builder, options, document =>
@@ -114,7 +114,7 @@ public class CreateSchemaReferenceIdTests : OpenApiDocumentServiceTestBase
 
         // Act
         builder.MapPost("/", (Todo todo) => { });
-        var options = new OpenApiOptions { CreateSchemaReferenceId = (type) => type.Type.Name == "Todo" ? null : $"{type.Type.Name}Schema" };
+        var options = new OpenApiOptions { CreateSchemaReferenceId = (type) => type.Type.Name == "Todo" ? null : OpenApiOptions.CreateDefaultSchemaReferenceId(type) };
 
         // Assert
         await VerifyOpenApiDocument(builder, options, document =>

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.ResponseSchemas.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.ResponseSchemas.cs
@@ -293,8 +293,9 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
                 property =>
                 {
                     Assert.Equal("value", property.Key);
-                    Assert.Equal("object", property.Value.Type);
-                    Assert.Collection(property.Value.Properties,
+                    var propertyValue = property.Value.GetEffective(document);
+                    Assert.Equal("object", propertyValue.Type);
+                    Assert.Collection(propertyValue.Properties,
                     property =>
                     {
                         Assert.Equal("id", property.Key);
@@ -318,8 +319,9 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
                 property =>
                 {
                     Assert.Equal("error", property.Key);
-                    Assert.Equal("object", property.Value.Type);
-                    Assert.Collection(property.Value.Properties, property =>
+                    var propertyValue = property.Value.GetEffective(document);
+                    Assert.Equal("object", propertyValue.Type);
+                    Assert.Collection(propertyValue.Properties, property =>
                     {
                         Assert.Equal("code", property.Key);
                         Assert.Equal("integer", property.Value.Type);
@@ -405,8 +407,10 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
                 property =>
                 {
                     Assert.Equal("todo", property.Key);
-                    Assert.Equal("object", property.Value.Type);
-                    Assert.Collection(property.Value.Properties,
+                    Assert.NotNull(property.Value.Reference);
+                    var propertyValue = property.Value.GetEffective(document);
+                    Assert.Equal("object", propertyValue.Type);
+                    Assert.Collection(propertyValue.Properties,
                         property =>
                         {
                             Assert.Equal("id", property.Key);
@@ -530,8 +534,10 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
                     Assert.Equal("items", property.Key);
                     Assert.Equal("array", property.Value.Type);
                     Assert.NotNull(property.Value.Items);
-                    Assert.Equal("object", property.Value.Items.Type);
-                    Assert.Collection(property.Value.Items.Properties,
+                    Assert.NotNull(property.Value.Items.Reference);
+                    Assert.Equal("object", property.Value.Items.GetEffective(document).Type);
+                    var itemsValue = property.Value.Items.GetEffective(document);
+                    Assert.Collection(itemsValue.Properties,
                         property =>
                         {
                             Assert.Equal("id", property.Key);

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Shared/SharedTypes.DeeplyNestedType.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Shared/SharedTypes.DeeplyNestedType.cs
@@ -1,0 +1,181 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+internal class DeeplyNestedLevel1
+{
+    public DeeplyNestedLevel2 Item2 { get; set; }
+}
+
+internal class DeeplyNestedLevel2
+{
+    public DeeplyNestedLevel3 Item3 { get; set; }
+}
+
+internal class DeeplyNestedLevel3
+{
+    public DeeplyNestedLevel4 Item4 { get; set; }
+}
+
+internal class DeeplyNestedLevel4
+{
+    public DeeplyNestedLevel5 Item5 { get; set; }
+}
+
+internal class DeeplyNestedLevel5
+{
+    public DeeplyNestedLevel6 Item6 { get; set; }
+}
+
+internal class DeeplyNestedLevel6
+{
+    public DeeplyNestedLevel7 Item7 { get; set; }
+}
+
+internal class DeeplyNestedLevel7
+{
+    public DeeplyNestedLevel8 Item8 { get; set; }
+}
+
+internal class DeeplyNestedLevel8
+{
+    public DeeplyNestedLevel9 Item9 { get; set; }
+}
+
+internal class DeeplyNestedLevel9
+{
+    public DeeplyNestedLevel10 Item10 { get; set; }
+}
+
+internal class DeeplyNestedLevel10
+{
+    public DeeplyNestedLevel11 Item11 { get; set; }
+}
+
+internal class DeeplyNestedLevel11
+{
+    public DeeplyNestedLevel12 Item12 { get; set; }
+}
+
+internal class DeeplyNestedLevel12
+{
+    public DeeplyNestedLevel13 Item13 { get; set; }
+}
+
+internal class DeeplyNestedLevel13
+{
+    public DeeplyNestedLevel14 Item14 { get; set; }
+}
+
+internal class DeeplyNestedLevel14
+{
+    public DeeplyNestedLevel15 Item15 { get; set; }
+}
+
+internal class DeeplyNestedLevel15
+{
+    public DeeplyNestedLevel16 Item16 { get; set; }
+}
+
+internal class DeeplyNestedLevel16
+{
+    public DeeplyNestedLevel17 Item17 { get; set; }
+}
+
+internal class DeeplyNestedLevel17
+{
+    public DeeplyNestedLevel18 Item18 { get; set; }
+}
+
+internal class DeeplyNestedLevel18
+{
+    public DeeplyNestedLevel19 Item19 { get; set; }
+}
+
+internal class DeeplyNestedLevel19
+{
+    public DeeplyNestedLevel20 Item20 { get; set; }
+}
+
+internal class DeeplyNestedLevel20
+{
+    public DeeplyNestedLevel21 Item21 { get; set; }
+}
+
+internal class DeeplyNestedLevel21
+{
+    public DeeplyNestedLevel22 Item22 { get; set; }
+}
+
+internal class DeeplyNestedLevel22
+{
+    public DeeplyNestedLevel23 Item23 { get; set; }
+}
+
+internal class DeeplyNestedLevel23
+{
+    public DeeplyNestedLevel24 Item24 { get; set; }
+}
+
+internal class DeeplyNestedLevel24
+{
+    public DeeplyNestedLevel25 Item25 { get; set; }
+}
+
+internal class DeeplyNestedLevel25
+{
+    public DeeplyNestedLevel26 Item26 { get; set; }
+}
+
+internal class DeeplyNestedLevel26
+{
+    public DeeplyNestedLevel27 Item27 { get; set; }
+}
+
+internal class DeeplyNestedLevel27
+{
+    public DeeplyNestedLevel28 Item28 { get; set; }
+}
+
+internal class DeeplyNestedLevel28
+{
+    public DeeplyNestedLevel29 Item29 { get; set; }
+}
+
+internal class DeeplyNestedLevel29
+{
+    public DeeplyNestedLevel30 Item30 { get; set; }
+}
+
+internal class DeeplyNestedLevel30
+{
+    public DeeplyNestedLevel31 Item31 { get; set; }
+}
+
+internal class DeeplyNestedLevel31
+{
+    public DeeplyNestedLevel32 Item32 { get; set; }
+}
+
+internal class DeeplyNestedLevel32
+{
+    public DeeplyNestedLevel33 Item33 { get; set; }
+}
+
+internal class DeeplyNestedLevel33
+{
+    public DeeplyNestedLevel34 Item34 { get; set; }
+}
+
+internal class DeeplyNestedLevel34
+{
+    public DeeplyNestedLevel35 Item35 { get; set; }
+}
+
+internal class DeeplyNestedLevel35
+{
+    public DeeplyNestedLevel36 Item36 { get; set; }
+}
+
+internal class DeeplyNestedLevel36
+{
+}

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/Implementations/OpenApiSchemaReferenceTransformerTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/Implementations/OpenApiSchemaReferenceTransformerTests.cs
@@ -441,17 +441,13 @@ public class OpenApiSchemaReferenceTransformerTests : OpenApiDocumentServiceTest
             // Assert $ref used for top-level
             Assert.Equal("DeeplyNestedLevel1", requestSchema.Reference.Id);
 
-            // Assert that $ref is used for DeeplyNestedLevel1.Item2
-            var level1Schema = requestSchema.GetEffective(document);
-            Assert.Equal("DeeplyNestedLevel2", level1Schema.Properties["item2"].Reference.Id);
-
-            // Assert that $ref is used for DeeplyNestedLevel2.Item3
-            var level2Schema = level1Schema.Properties["item2"].GetEffective(document);
-            Assert.Equal("DeeplyNestedLevel3", level2Schema.Properties["item3"].Reference.Id);
-
-            // Assert that $ref is used for DeeplyNestedLevel3.Item4
-            var level3Schema = level2Schema.Properties["item3"].GetEffective(document);
-            Assert.Equal("DeeplyNestedLevel4", level3Schema.Properties["item4"].Reference.Id);
+            // Assert that $ref is used for all nested levels
+            var levelSchema = requestSchema.GetEffective(document);
+            for (var level = 2; level < 36; level++)
+            {
+                Assert.Equal($"DeeplyNestedLevel{level}", levelSchema.Properties[$"item{level}"].Reference.Id);
+                levelSchema = levelSchema.Properties[$"item{level}"].GetEffective(document);
+            }
         });
     }
 }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/SchemaTransformerTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/SchemaTransformerTests.cs
@@ -531,14 +531,14 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
             var path = document.Paths["/list-of-todo"];
             var getOperation = path.Operations[OperationType.Get];
             var responseSchema = getOperation.Responses["200"].Content["application/json"].Schema;
-            var itemSchema = responseSchema.GetEffective(document).Items;
+            var itemSchema = responseSchema.GetEffective(document).Items.GetEffective(document);
             Assert.Equal("modified-number-format", itemSchema.Properties["id"].Format);
 
             // Assert that the integer type within the list has been updated
             var otherPath = document.Paths["/list-of-int"];
             var otherGetOperation = otherPath.Operations[OperationType.Get];
             var otherResponseSchema = otherGetOperation.Responses["200"].Content["application/json"].Schema;
-            var otherItemSchema = otherResponseSchema.GetEffective(document).Items;
+            var otherItemSchema = otherResponseSchema.GetEffective(document).Items.GetEffective(document);
             Assert.Equal("modified-number-format", otherItemSchema.Format);
         });
     }
@@ -611,7 +611,7 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
             var path = document.Paths["/list"];
             var getOperation = path.Operations[OperationType.Get];
             var responseSchema = getOperation.Responses["200"].Content["application/json"].Schema;
-            var someShapeSchema = responseSchema.GetEffective(document).Properties["someShape"];
+            var someShapeSchema = responseSchema.GetEffective(document).Properties["someShape"].GetEffective(document);
             var triangleSubschema = Assert.Single(someShapeSchema.AnyOf.Where(s => s.Reference.Id == "ShapeTriangle"));
             // Assert that the x-my-extension type is set to this-is-a-triangle
             Assert.True(triangleSubschema.GetEffective(document).Extensions.TryGetValue("x-my-extension", out var triangleExtension));
@@ -652,7 +652,7 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
             var path = document.Paths["/list"];
             var getOperation = path.Operations[OperationType.Get];
             var responseSchema = getOperation.Responses["200"].Content["application/json"].Schema;
-            var someShapeSchema = responseSchema.GetEffective(document).Items.GetEffective(document).Properties["someShape"];
+            var someShapeSchema = responseSchema.GetEffective(document).Items.GetEffective(document).Properties["someShape"].GetEffective(document);
             var triangleSubschema = Assert.Single(someShapeSchema.AnyOf.Where(s => s.Reference.Id == "ShapeTriangle"));
             // Assert that the x-my-extension type is set to this-is-a-triangle
             Assert.True(triangleSubschema.GetEffective(document).Extensions.TryGetValue("x-my-extension", out var triangleExtension));


### PR DESCRIPTION
## Description

This PR consists of two changes to address feedback received after .NET 9 RC 1 for the new APIs in the Microsoft.AspNetCore.OpenApi package.

- Resolves a bug where a `[Produces]` attribute with no-type would override the schema for a pre-existing schema by replacing direct assignment for content types with `TryAdd` in `OpenApiDocumentService.GetResponseAsync`.
- Adds sub-schemas recursively into the schema-by-reference cache by updating `OpenApiSchemaStore.PopulateSchemaIntoReferenceCache`.

Fixes https://github.com/dotnet/aspnetcore/issues/57799

## Customer Impact

This PR resolves issues reported in the OpenAPI implementation that don't currently have any viable workarounds for users. Without these changes, documents generated by this implementation may unintentionally drop schemas for responses generated controller actions with certain attributes. This change also stabilizes the generations of schema names for deeply nested type hierarchies in the OpenAPI document.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

Changes in this PR only impact the `Microsoft.AspNetCore.OpenApi` and don't affect any APIs in the shared framework. Changes are in new code paths that were introduced in .NET 9 so there is no risk of version-to-version regression.

## Verification

- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A