### PR TITLE
Unquarantine ShutdownTestWaitForShutdown

### DIFF
--- a/src/Hosting/test/FunctionalTests/ShutdownTests.cs
+++ b/src/Hosting/test/FunctionalTests/ShutdownTests.cs
@@ -27,7 +27,6 @@ public class ShutdownTests : LoggedTest
         await ExecuteShutdownTest(nameof(ShutdownTestRun), "Run");
     }
 
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/27371")]
     [ConditionalFact]
     [OSSkipCondition(OperatingSystems.Windows)]
     [OSSkipCondition(OperatingSystems.MacOSX)]


### PR DESCRIPTION
The only failure description in the issue is from 2020 and it hasn't failed in the last 30 days (also seemed to be true in Jan 2022).

Fixes #27371