### PR TITLE
Allow same version when updating versions in node packages

### DIFF
--- a/eng/scripts/npm/update-dependency-versions.mjs
+++ b/eng/scripts/npm/update-dependency-versions.mjs
@@ -52,7 +52,7 @@ function applyPackageVersion(packagesToPack, defaultPackageVersion) {
     renames.push([`${packagePath}.bak`, packagePath]);
 
     process.chdir(packageDir);
-    execSync(`npm version ${packageVersion} --no-git-tag-version`, { stdio: 'inherit' });
+    execSync(`npm version ${packageVersion} --no-git-tag-version --allow-same-version`, { stdio: 'inherit' });
     process.chdir(currentDir);
     console.log(`Applied version ${packageVersion} to ${packageName} in ${packageDir}...`);
   }


### PR DESCRIPTION
It's possible to end up with the package.json files for the node packages having the same version as the target version, typically if you cancel the build at just the right time and the package.json files end up edited. I think this can also happen if one of the node commands fails and leaves the backup files