### PR TITLE
Add registry search for upgrade policy keys

### DIFF
--- a/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
+++ b/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:dep="http://schemas.microsoft.com/wix/DependencyExtension" xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension"
+     xmlns:dep="http://schemas.microsoft.com/wix/DependencyExtension" xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
     <Bundle Name="$(var.BundleName)" Version="$(var.BundleVersion)" Manufacturer="Microsoft Corporation" UpgradeCode="$(var.BundleUpgradeCode)">
         <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.HyperlinkLicense">
             <bal:WixStandardBootstrapperApplication LicenseUrl="https://go.microsoft.com/fwlink/?LinkId=329770"

--- a/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
+++ b/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
@@ -11,6 +11,10 @@
             <PayloadGroupRef Id="PG_Resources"/>
         </BootstrapperApplicationRef>
 
+        <util:RegistrySearchRef Id="RemovePreviousVersionRegistryKeySearch"/>
+        <util:RegistrySearchRef Id="RemoveSpecificPreviousVersionRegistryKeyExistsSearch"/>
+        <util:RegistrySearchRef Id="RemoveSpecificPreviousVersionRegistryKeySearch"/>
+
         <!-- Ensure upgrades from 3.0.0 preview 1, 2, and 3. Conditioned for the 3.0.0 family. -->
         <?if $(var.Version)=3.0.0.0?>
         <?if $(var.Platform)=x86?>

--- a/src/Installers/Windows/SharedFrameworkBundle/SharedFrameworkBundle.wixproj
+++ b/src/Installers/Windows/SharedFrameworkBundle/SharedFrameworkBundle.wixproj
@@ -13,6 +13,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <WixExtension Include="WixUtilExtension">
+      <HintPath>$(WixExtDir)\WixUtilExtension.dll</HintPath>
+      <Name>WixUtilExtension</Name>
+    </WixExtension>
     <WixExtension Include="WixDependencyExtension">
       <HintPath>$(WixExtDir)\WixDependencyExtension.dll</HintPath>
       <Name>WixDependencyExtension</Name>

--- a/src/Installers/Windows/SharedFrameworkBundle/SharedFrameworkBundle.wixproj
+++ b/src/Installers/Windows/SharedFrameworkBundle/SharedFrameworkBundle.wixproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <Compile Include="Bundle.wxs" />
+    <Compile Include="$(PkgMicrosoft_DotNet_Build_Tasks_Installers)\build\wix\bundle\upgradePolicies.wxs" />
     <Content Include="thm.xml" />
   </ItemGroup>
 

--- a/src/Installers/Windows/WindowsHostingBundle/Bundle.wxs
+++ b/src/Installers/Windows/WindowsHostingBundle/Bundle.wxs
@@ -13,6 +13,11 @@
             <PayloadGroupRef Id="PG_Resources"/>
         </BootstrapperApplicationRef>
 
+        <!-- Search references for upgrade policy keys -->
+        <util:RegistrySearchRef Id="RemovePreviousVersionRegistryKeySearch"/>
+        <util:RegistrySearchRef Id="RemoveSpecificPreviousVersionRegistryKeyExistsSearch"/>
+        <util:RegistrySearchRef Id="RemoveSpecificPreviousVersionRegistryKeySearch"/>
+
         <!-- Ensure upgrades from 3.0.0 preview 1 and 2 (Preview 3 was not shipped). Conditioned for the 3.0.0 family. Hosting bundle simships x86/x64 so there's
              a single set of upgrade codes. -->
         <?if $(var.Version)=3.0.0.0?>

--- a/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
+++ b/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
@@ -36,6 +36,7 @@
     <Compile Include="Bundle.wxs" />
     <Compile Include="DotNetCore.wxs" />
     <Compile Include="SharedFramework.wxs" />
+    <Compile Include="$(PkgMicrosoft_DotNet_Build_Tasks_Installers)\build\wix\bundle\upgradePolicies.wxs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Installers/Windows/Wix.targets
+++ b/src/Installers/Windows/Wix.targets
@@ -110,7 +110,7 @@
       NoLogo="true"
       Cultures="en-us"
       InstallerFile="%(WixInstallerFilesToProcess.Identity)"
-      AdditionalBasePaths="$(MSBuildProjectDirectory)"
+      AdditionalBasePaths="$(MSBuildProjectDirectory);$(PkgMicrosoft_DotNet_Build_Tasks_Installers)\build\wix\bundle"
       WixExtensions="@(WixExtension)"
       Loc="@(EmbeddedResource)"
       Sice="$(SuppressIces)"


### PR DESCRIPTION
Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2541983&view=results

Aspnetcore version of https://github.com/dotnet/arcade/pull/15048

# Description
Add registry search operations to Aspnetcore installer bundles. The search operation will check for a global and version specific registry key. The version specific key takes precedence when present.

This is related to a customer request and part of a larger change. 

Unlike the runtime and desktop runtime, Aspnetcore needs to explicitly pull in the additional source file.

# Risk
Medium/Low - this change modifies how bundles behave when upgrading. It is based off a modified copy of wixstdba (bootstrapper and UI layer) with changes to Burn (setup engine) and a copy of WiX v3 built from source.

# Testing
We've been testing the change for a while now. Verified against a private build of Aspnetcore. After installing preview7, followed by a new RC2 build, both runtimes remain present, and the RunOnce key for the removal is present for preview7.
