### PR TITLE
Fix typo in HubConnectionExtensions xml docs

### DIFF
--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnectionExtensions.InvokeAsync.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnectionExtensions.InvokeAsync.cs
@@ -10,7 +10,7 @@ using Microsoft.AspNetCore.Shared;
 namespace Microsoft.AspNetCore.SignalR.Client;
 
 /// <summary>
-/// Extension methods for <see cref="HubConnectionExtensions"/>.
+/// Extension methods for <see cref="HubConnection"/>.
 /// </summary>
 public partial class HubConnectionExtensions
 {

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnectionExtensions.InvokeAsyncGeneric.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnectionExtensions.InvokeAsyncGeneric.cs
@@ -10,7 +10,7 @@ using Microsoft.AspNetCore.Shared;
 namespace Microsoft.AspNetCore.SignalR.Client;
 
 /// <summary>
-/// Extension methods for <see cref="HubConnectionExtensions"/>.
+/// Extension methods for <see cref="HubConnection"/>.
 /// </summary>
 public static partial class HubConnectionExtensions
 {

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnectionExtensions.OnResult.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnectionExtensions.OnResult.cs
@@ -9,6 +9,10 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Shared;
 
 namespace Microsoft.AspNetCore.SignalR.Client;
+
+/// <summary>
+/// Extension methods for <see cref="HubConnection"/>.
+/// </summary>
 public static partial class HubConnectionExtensions
 {
     private static IDisposable On<TResult>(this HubConnection hubConnection, string methodName, Type[] parameterTypes, Func<object?[], TResult> handler)

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnectionExtensions.SendAsync.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnectionExtensions.SendAsync.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 namespace Microsoft.AspNetCore.SignalR.Client;
 
 /// <summary>
-/// Extension methods for <see cref="HubConnectionExtensions"/>.
+/// Extension methods for <see cref="HubConnection"/>.
 /// </summary>
 public static partial class HubConnectionExtensions
 {

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnectionExtensions.StreamAsChannelAsync.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnectionExtensions.StreamAsChannelAsync.cs
@@ -11,7 +11,7 @@ using Microsoft.AspNetCore.Shared;
 namespace Microsoft.AspNetCore.SignalR.Client;
 
 /// <summary>
-/// Extension methods for <see cref="HubConnectionExtensions"/>.
+/// Extension methods for <see cref="HubConnection"/>.
 /// </summary>
 public static partial class HubConnectionExtensions
 {

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnectionExtensions.StreamAsync.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnectionExtensions.StreamAsync.cs
@@ -9,7 +9,7 @@ using System.Threading;
 namespace Microsoft.AspNetCore.SignalR.Client;
 
 /// <summary>
-/// Extension methods for <see cref="HubConnectionExtensions"/>.
+/// Extension methods for <see cref="HubConnection"/>.
 /// </summary>
 public static partial class HubConnectionExtensions
 {

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnectionExtensions.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnectionExtensions.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Shared;
 namespace Microsoft.AspNetCore.SignalR.Client;
 
 /// <summary>
-/// Extension methods for <see cref="HubConnectionExtensions"/>.
+/// Extension methods for <see cref="HubConnection"/>.
 /// </summary>
 public static partial class HubConnectionExtensions
 {


### PR DESCRIPTION
# Fix typo in HubConnectionExtensions xml docs

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Fixed a typo in the SignalR HubConnectionExtensions partial classes (class reference was incorrect)

Fixes #57959
