### PR TITLE
[release/8.0] Add explicit conversion for value-type returning handlers with filters

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -533,6 +533,11 @@ public static partial class RequestDelegateFactory
         }
         else
         {
+            if (returnType.IsValueType)
+            {
+                return Expression.Call(WrapObjectAsValueTaskMethod, Expression.Convert(methodCall, typeof(object)));
+            }
+
             return Expression.Call(WrapObjectAsValueTaskMethod, methodCall);
         }
     }

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.EndpointFilters.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.EndpointFilters.cs
@@ -1,0 +1,98 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.InternalTesting;
+
+namespace Microsoft.AspNetCore.Routing.Internal;
+
+public partial class RequestDelegateFactoryTests : LoggedTest
+{
+    public static object[][] ValueTypeReturningDelegates =>
+    [
+        [(Func<HttpContext, int>)((HttpContext httpContext) => 42)],
+        [(Func<HttpContext, char>)((HttpContext httpContext) => 'b')],
+        [(Func<HttpContext, bool>)((HttpContext httpContext) => true)],
+        [(Func<HttpContext, float>)((HttpContext httpContext) => 4.2f)],
+        [(Func<HttpContext, double>)((HttpContext httpContext) => 4.2)],
+        [(Func<HttpContext, decimal>)((HttpContext httpContext) => 4.2m)],
+        [(Func<HttpContext, long>)((HttpContext httpContext) => 42)],
+        [(Func<HttpContext, short>)((HttpContext httpContext) => 42)],
+        [(Func<HttpContext, byte>)((HttpContext httpContext) => 42)],
+        [(Func<HttpContext, uint>)((HttpContext httpContext) => 42)],
+        [(Func<HttpContext, ulong>)((HttpContext httpContext) => 42)],
+        [(Func<HttpContext, ushort>)((HttpContext httpContext) => 42)],
+        [(Func<HttpContext, sbyte>)((HttpContext httpContext) => 42)]
+    ];
+
+    [Theory]
+    [MemberData(nameof(ValueTypeReturningDelegates))]
+    public void Create_WithEndpointFilterOnBuiltInValueTypeReturningDelegate_Works(Delegate @delegate)
+    {
+        var invokeCount = 0;
+
+        RequestDelegateFactoryOptions options = new()
+        {
+            EndpointBuilder = CreateEndpointBuilderFromFilterFactories(
+            [
+                (routeHandlerContext, next) =>
+                {
+                    invokeCount++;
+                    return next;
+                },
+                (routeHandlerContext, next) =>
+                {
+                    invokeCount++;
+                    return next;
+                },
+            ]),
+        };
+
+        var result = RequestDelegateFactory.Create(@delegate, options);
+        Assert.Equal(2, invokeCount);
+    }
+
+    public static object[][] NullableValueTypeReturningDelegates =>
+    [
+        [(Func<HttpContext, int?>)((HttpContext httpContext) => 42)],
+        [(Func<HttpContext, char?>)((HttpContext httpContext) => 'b')],
+        [(Func<HttpContext, bool?>)((HttpContext httpContext) => true)],
+        [(Func<HttpContext, float?>)((HttpContext httpContext) => 4.2f)],
+        [(Func<HttpContext, double?>)((HttpContext httpContext) => 4.2)],
+        [(Func<HttpContext, decimal?>)((HttpContext httpContext) => 4.2m)],
+        [(Func<HttpContext, long?>)((HttpContext httpContext) => 42)],
+        [(Func<HttpContext, short?>)((HttpContext httpContext) => 42)],
+        [(Func<HttpContext, byte?>)((HttpContext httpContext) => 42)],
+        [(Func<HttpContext, uint?>)((HttpContext httpContext) => 42)],
+        [(Func<HttpContext, ulong?>)((HttpContext httpContext) => 42)],
+        [(Func<HttpContext, ushort?>)((HttpContext httpContext) => 42)],
+        [(Func<HttpContext, sbyte?>)((HttpContext httpContext) => 42)]
+    ];
+
+    [Theory]
+    [MemberData(nameof(NullableValueTypeReturningDelegates))]
+    public void Create_WithEndpointFilterOnNullableBuiltInValueTypeReturningDelegate_Works(Delegate @delegate)
+    {
+        var invokeCount = 0;
+
+        RequestDelegateFactoryOptions options = new()
+        {
+            EndpointBuilder = CreateEndpointBuilderFromFilterFactories(
+            [
+                (routeHandlerContext, next) =>
+                {
+                    invokeCount++;
+                    return next;
+                },
+                (routeHandlerContext, next) =>
+                {
+                    invokeCount++;
+                    return next;
+                },
+            ]),
+        };
+
+        var result = RequestDelegateFactory.Create(@delegate, options);
+        Assert.Equal(2, invokeCount);
+    }
+}

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.EndpointFilters.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.EndpointFilters.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.AspNetCore.Testing;
 
 namespace Microsoft.AspNetCore.Routing.Internal;
 


### PR DESCRIPTION
## Description

Merged in 10.0: https://github.com/dotnet/aspnetcore/pull/57428
Addresses https://github.com/dotnet/aspnetcore/issues/52128.

This PR fixes a bug with the handling of value type-returning handlers that are used in conjunction with endpoint filters. Such as:

```csharp
var app = WebApplication.Create();

app
	.MapGet("/", () => { return 1; })
	.AddEndpointFilter(async (context, next) => await next(context));

app.Run();
```

This currently throws:

> ArgumentException: Expression of type 'System.Int32' cannot be used for parameter of type 'System.Object' of method 'System.Threading.Tasks.ValueTask`1[System.Object] WrapObjectAsValueTask(System.Object)' (Parameter 'arg0')

Because the return type requires an explicit conversion before being wrapped as a `ValueTask<object>` to confirm with the [EndpointFilterDelegate's signature](https://source.dot.net/#Microsoft.AspNetCore.Http.Abstractions/EndpointFilterDelegate.cs,13).

## Customer Impact

Without this bug fix, user applications that contain minimal API endpoints that return value types and use endpoint filters will fail to launch. Viable workarounds exist (for example, wrapping the value return in a `Results.Ok`), but they are difficult for the typical user to discover.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

Scope of impact is limited to minimal APIs + endpoint filters + compile-time code generation.

## Verification

- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A