### PR TITLE
[Blazor] Update `WebAssembly.DevServer` to serve the `Blazor-Environment` header

### DIFF
--- a/src/Components/WebAssembly/DevServer/src/Server/Startup.cs
+++ b/src/Components/WebAssembly/DevServer/src/Server/Startup.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -29,27 +30,29 @@ internal sealed class Startup
 
         app.UseWebAssemblyDebugging();
 
-        bool applyCopHeaders = configuration.GetValue<bool>("ApplyCopHeaders");
+        var webHostEnvironment = app.ApplicationServices.GetRequiredService<IWebHostEnvironment>();
+        var applyCopHeaders = configuration.GetValue<bool>("ApplyCopHeaders");
 
-        if (applyCopHeaders)
+        app.Use(async (ctx, next) =>
         {
-            app.Use(async (ctx, next) =>
+            if (ctx.Request.Path.StartsWithSegments("/_framework") && !ctx.Request.Path.StartsWithSegments("/_framework/blazor.server.js") && !ctx.Request.Path.StartsWithSegments("/_framework/blazor.web.js"))
             {
-                if (ctx.Request.Path.StartsWithSegments("/_framework") && !ctx.Request.Path.StartsWithSegments("/_framework/blazor.server.js") && !ctx.Request.Path.StartsWithSegments("/_framework/blazor.web.js"))
+                ctx.Response.Headers.Append("Blazor-Environment", webHostEnvironment.EnvironmentName);
+
+                if (applyCopHeaders)
                 {
-                    string fileExtension = Path.GetExtension(ctx.Request.Path);
-                    if (string.Equals(fileExtension, ".js"))
+                    var fileExtension = Path.GetExtension(ctx.Request.Path);
+                    if (string.Equals(fileExtension, ".js", StringComparison.Ordinal))
                     {
                         // Browser multi-threaded runtime requires cross-origin policy headers to enable SharedArrayBuffer.
                         ApplyCrossOriginPolicyHeaders(ctx);
                     }
                 }
+            }
 
-                await next(ctx);
-            });
-        }
+            await next(ctx);
+        });
 
-        //app.UseBlazorFrameworkFiles();
         app.UseRouting();
 
         app.UseStaticFiles(new StaticFileOptions

--- a/src/Components/WebAssembly/DevServer/src/Server/Startup.cs
+++ b/src/Components/WebAssembly/DevServer/src/Server/Startup.cs
@@ -35,18 +35,17 @@ internal sealed class Startup
 
         app.Use(async (ctx, next) =>
         {
-            if (ctx.Request.Path.StartsWithSegments("/_framework") && !ctx.Request.Path.StartsWithSegments("/_framework/blazor.server.js") && !ctx.Request.Path.StartsWithSegments("/_framework/blazor.web.js"))
+            if (ctx.Request.Path.StartsWithSegments("/_framework/blazor.boot.json"))
             {
                 ctx.Response.Headers.Append("Blazor-Environment", webHostEnvironment.EnvironmentName);
-
-                if (applyCopHeaders)
+            }
+            else if (applyCopHeaders && ctx.Request.Path.StartsWithSegments("/_framework") && !ctx.Request.Path.StartsWithSegments("/_framework/blazor.server.js") && !ctx.Request.Path.StartsWithSegments("/_framework/blazor.web.js"))
+            {
+                var fileExtension = Path.GetExtension(ctx.Request.Path);
+                if (string.Equals(fileExtension, ".js", StringComparison.Ordinal))
                 {
-                    var fileExtension = Path.GetExtension(ctx.Request.Path);
-                    if (string.Equals(fileExtension, ".js", StringComparison.Ordinal))
-                    {
-                        // Browser multi-threaded runtime requires cross-origin policy headers to enable SharedArrayBuffer.
-                        ApplyCrossOriginPolicyHeaders(ctx);
-                    }
+                    // Browser multi-threaded runtime requires cross-origin policy headers to enable SharedArrayBuffer.
+                    ApplyCrossOriginPolicyHeaders(ctx);
                 }
             }
 

--- a/src/Components/WebAssembly/DevServer/src/Server/Startup.cs
+++ b/src/Components/WebAssembly/DevServer/src/Server/Startup.cs
@@ -42,7 +42,7 @@ internal sealed class Startup
             else if (applyCopHeaders && ctx.Request.Path.StartsWithSegments("/_framework") && !ctx.Request.Path.StartsWithSegments("/_framework/blazor.server.js") && !ctx.Request.Path.StartsWithSegments("/_framework/blazor.web.js"))
             {
                 var fileExtension = Path.GetExtension(ctx.Request.Path);
-                if (string.Equals(fileExtension, ".js", StringComparison.Ordinal))
+                if (string.Equals(fileExtension, ".js", StringComparison.OrdinalIgnoreCase))
                 {
                     // Browser multi-threaded runtime requires cross-origin policy headers to enable SharedArrayBuffer.
                     ApplyCrossOriginPolicyHeaders(ctx);

--- a/src/Components/test/E2ETest/Tests/WebAssemblyConfigurationTest.cs
+++ b/src/Components/test/E2ETest/Tests/WebAssemblyConfigurationTest.cs
@@ -37,6 +37,9 @@ public class WebAssemblyConfigurationTest : ServerTestBase<BlazorWasmTestAppFixt
         // Verify values from the default 'appsettings.json' are read.
         Browser.Equal("Default key1-value", () => _appElement.FindElement(By.Id("key1")).Text);
 
+        // Verify that the dev server always correctly serves the 'Blazor-Environment: Development' header.
+        Browser.Equal("Development", () => _appElement.FindElement(By.Id("environment")).Text);
+
         if (_serverFixture.TestTrimmedOrMultithreadingApps)
         {
             // Verify values overriden by an environment specific 'appsettings.$(Environment).json are read

--- a/src/Components/test/E2ETest/Tests/WebAssemblyConfigurationTest.cs
+++ b/src/Components/test/E2ETest/Tests/WebAssemblyConfigurationTest.cs
@@ -37,11 +37,11 @@ public class WebAssemblyConfigurationTest : ServerTestBase<BlazorWasmTestAppFixt
         // Verify values from the default 'appsettings.json' are read.
         Browser.Equal("Default key1-value", () => _appElement.FindElement(By.Id("key1")).Text);
 
-        // Verify that the dev server always correctly serves the 'Blazor-Environment: Development' header.
-        Browser.Equal("Development", () => _appElement.FindElement(By.Id("environment")).Text);
-
         if (_serverFixture.TestTrimmedOrMultithreadingApps)
         {
+            // Verify that the environment gets detected as 'Production'.
+            Browser.Equal("Production", () => _appElement.FindElement(By.Id("environment")).Text);
+
             // Verify values overriden by an environment specific 'appsettings.$(Environment).json are read
             Assert.Equal("Prod key2-value", _appElement.FindElement(By.Id("key2")).Text);
 
@@ -50,6 +50,9 @@ public class WebAssemblyConfigurationTest : ServerTestBase<BlazorWasmTestAppFixt
         }
         else
         {
+            // Verify that the dev server always correctly serves the 'Blazor-Environment: Development' header.
+            Browser.Equal("Development", () => _appElement.FindElement(By.Id("environment")).Text);
+
             // Verify values overriden by an environment specific 'appsettings.$(Environment).json are read
             Assert.Equal("Development key2-value", _appElement.FindElement(By.Id("key2")).Text);
 


### PR DESCRIPTION
Since the dev server no longer calls `UseBlazorFrameworkFiles()`, we need to manually add the `Blazor-Environment` header when applicable.

Fixes #57941