### PR TITLE
Fix concurrent request handling for OpenAPI documents

### DIFF
--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Collections.Frozen;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
@@ -46,7 +47,7 @@ internal sealed class OpenApiDocumentService(
     /// are unique within the lifetime of an application and serve as helpful associators between
     /// operations, API descriptions, and their respective transformer contexts.
     /// </summary>
-    private readonly Dictionary<string, OpenApiOperationTransformerContext> _operationTransformerContextCache = new();
+    private readonly ConcurrentDictionary<string, OpenApiOperationTransformerContext> _operationTransformerContextCache = new();
     private static readonly ApiResponseType _defaultApiResponseType = new() { StatusCode = StatusCodes.Status200OK };
 
     private static readonly FrozenSet<string> _disallowedHeaderParameters = new[] { HeaderNames.Accept, HeaderNames.Authorization, HeaderNames.ContentType }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaStore.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaStore.cs
@@ -60,7 +60,7 @@ internal sealed class OpenApiSchemaStore
     /// <returns>A <see cref="JsonObject" /> representing the JSON schema associated with the key.</returns>
     public JsonNode GetOrAdd(OpenApiSchemaKey key, Func<OpenApiSchemaKey, JsonNode> valueFactory)
     {
-        return _schemas.GetOrAdd(key, valueFactory(key));
+        return _schemas.GetOrAdd(key, _ => valueFactory(key));
     }
 
     /// <summary>

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaStore.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaStore.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.IO.Pipelines;
 using System.Text.Json.Nodes;
 using Microsoft.AspNetCore.Http;
@@ -14,7 +15,7 @@ namespace Microsoft.AspNetCore.OpenApi;
 /// </summary>
 internal sealed class OpenApiSchemaStore
 {
-    private readonly Dictionary<OpenApiSchemaKey, JsonNode> _schemas = new()
+    private readonly ConcurrentDictionary<OpenApiSchemaKey, JsonNode> _schemas = new()
     {
         // Pre-populate OpenAPI schemas for well-defined types in ASP.NET Core.
         [new OpenApiSchemaKey(typeof(IFormFile), null)] = new JsonObject
@@ -48,8 +49,8 @@ internal sealed class OpenApiSchemaStore
         },
     };
 
-    public readonly Dictionary<OpenApiSchema, string?> SchemasByReference = new(OpenApiSchemaComparer.Instance);
-    private readonly Dictionary<string, int> _referenceIdCounter = new();
+    public readonly ConcurrentDictionary<OpenApiSchema, string?> SchemasByReference = new(OpenApiSchemaComparer.Instance);
+    private readonly ConcurrentDictionary<string, int> _referenceIdCounter = new();
 
     /// <summary>
     /// Resolves the JSON schema for the given type and parameter description.
@@ -59,13 +60,7 @@ internal sealed class OpenApiSchemaStore
     /// <returns>A <see cref="JsonObject" /> representing the JSON schema associated with the key.</returns>
     public JsonNode GetOrAdd(OpenApiSchemaKey key, Func<OpenApiSchemaKey, JsonNode> valueFactory)
     {
-        if (_schemas.TryGetValue(key, out var schema))
-        {
-            return schema;
-        }
-        var targetSchema = valueFactory(key);
-        _schemas.Add(key, targetSchema);
-        return targetSchema;
+        return _schemas.GetOrAdd(key, valueFactory(key));
     }
 
     /// <summary>

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaStore.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaStore.cs
@@ -60,7 +60,7 @@ internal sealed class OpenApiSchemaStore
     /// <returns>A <see cref="JsonObject" /> representing the JSON schema associated with the key.</returns>
     public JsonNode GetOrAdd(OpenApiSchemaKey key, Func<OpenApiSchemaKey, JsonNode> valueFactory)
     {
-        return _schemas.GetOrAdd(key, _ => valueFactory(key));
+        return _schemas.GetOrAdd(key, valueFactory);
     }
 
     /// <summary>

--- a/src/OpenApi/src/Transformers/Implementations/OpenApiSchemaReferenceTransformer.cs
+++ b/src/OpenApi/src/Transformers/Implementations/OpenApiSchemaReferenceTransformer.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
@@ -85,7 +86,7 @@ internal sealed class OpenApiSchemaReferenceTransformer : IOpenApiDocumentTransf
     /// <param name="schema">The inline schema to replace with a reference.</param>
     /// <param name="schemasByReference">A cache of schemas and their associated reference IDs.</param>
     /// <param name="isTopLevel">When <see langword="true" />, will skip resolving references for the top-most schema provided.</param>
-    internal static OpenApiSchema? ResolveReferenceForSchema(OpenApiSchema? schema, Dictionary<OpenApiSchema, string?> schemasByReference, bool isTopLevel = false)
+    internal static OpenApiSchema? ResolveReferenceForSchema(OpenApiSchema? schema, ConcurrentDictionary<OpenApiSchema, string?> schemasByReference, bool isTopLevel = false)
     {
         if (schema is null)
         {

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/OpenApiDocumentConcurrentRequestTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/OpenApiDocumentConcurrentRequestTests.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using System.Net.Http;
+
+namespace Microsoft.AspNetCore.OpenApi.Tests.Integration;
+
+public class OpenApiDocumentConcurrentRequestTests(SampleAppFixture fixture) : IClassFixture<SampleAppFixture>
+{
+    [Fact]
+    public async Task MapOpenApi_HandlesConcurrentRequests()
+    {
+        var client = fixture.CreateClient();
+        Task<HttpResponseMessage>[] requests =
+        [
+            client.GetAsync("/openapi/v1.json"),
+            client.GetAsync("/openapi/v1.json"),
+            client.GetAsync("/openapi/v1.json")
+        ];
+
+        var results = await Task.WhenAll(requests);
+
+        foreach (var result in results)
+        {
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        }
+
+    }
+}

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/OpenApiDocumentConcurrentRequestTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/OpenApiDocumentConcurrentRequestTests.cs
@@ -11,20 +11,22 @@ public class OpenApiDocumentConcurrentRequestTests(SampleAppFixture fixture) : I
     [Fact]
     public async Task MapOpenApi_HandlesConcurrentRequests()
     {
+        // Arrange
         var client = fixture.CreateClient();
-        Task<HttpResponseMessage>[] requests =
-        [
+        var requests = new List<Task<HttpResponseMessage>>
+        {
             client.GetAsync("/openapi/v1.json"),
             client.GetAsync("/openapi/v1.json"),
             client.GetAsync("/openapi/v1.json")
-        ];
+        };
 
+        // Act
         var results = await Task.WhenAll(requests);
 
+        // Assert
         foreach (var result in results)
         {
             Assert.Equal(HttpStatusCode.OK, result.StatusCode);
         }
-
     }
 }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/OpenApiDocumentConcurrentRequestTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/OpenApiDocumentConcurrentRequestTests.cs
@@ -13,20 +13,14 @@ public class OpenApiDocumentConcurrentRequestTests(SampleAppFixture fixture) : I
     {
         // Arrange
         var client = fixture.CreateClient();
-        var requests = new List<Task<HttpResponseMessage>>
-        {
-            client.GetAsync("/openapi/v1.json"),
-            client.GetAsync("/openapi/v1.json"),
-            client.GetAsync("/openapi/v1.json")
-        };
 
         // Act
-        var results = await Task.WhenAll(requests);
-
-        // Assert
-        foreach (var result in results)
+        await Parallel.ForAsync(0, 150, async (_, ctx) =>
         {
-            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
-        }
+            var response = await client.GetAsync("/openapi/v1.json", ctx);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        });
     }
 }


### PR DESCRIPTION
# Fix: Concurrent request for OpenApi documents

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

This PR allows concurrent requests for OpenApi documents by switching from a `Dictionary` to a `ConcurrentDictionary`. The fields `_schemas`, `SchemasByReference` and `_operationTransformerContextCache` had to be changed to `ConcurrentDictionary` to pass the test. Additionally, I updated` _referenceIdCounter` for consistency.

Fixes #57876