### PR TITLE
Add partitioned to cookie for SignalR browser testing

### DIFF
--- a/src/SignalR/clients/ts/FunctionalTests/Startup.cs
+++ b/src/SignalR/clients/ts/FunctionalTests/Startup.cs
@@ -184,9 +184,11 @@ public class Startup
                 {
                     cookieOptions.SameSite = Microsoft.AspNetCore.Http.SameSiteMode.None;
                     cookieOptions.Secure = true;
+                    cookieOptions.Extensions.Add("partitioned");
 
                     expiredCookieOptions.SameSite = Microsoft.AspNetCore.Http.SameSiteMode.None;
                     expiredCookieOptions.Secure = true;
+                    expiredCookieOptions.Extensions.Add("partitioned");
                 }
                 context.Response.Cookies.Append("testCookie", "testValue", cookieOptions);
                 context.Response.Cookies.Append("testCookie2", "testValue2", cookieOptions);

--- a/src/SignalR/clients/ts/FunctionalTests/Startup.cs
+++ b/src/SignalR/clients/ts/FunctionalTests/Startup.cs
@@ -184,11 +184,11 @@ public class Startup
                 {
                     cookieOptions.SameSite = Microsoft.AspNetCore.Http.SameSiteMode.None;
                     cookieOptions.Secure = true;
-                    cookieOptions.Extensions.Add("partitioned");
+                    cookieOptions.Extensions.Add("partitioned"); // Required by Chromium
 
                     expiredCookieOptions.SameSite = Microsoft.AspNetCore.Http.SameSiteMode.None;
                     expiredCookieOptions.Secure = true;
-                    expiredCookieOptions.Extensions.Add("partitioned");
+                    expiredCookieOptions.Extensions.Add("partitioned"); // Required by Chromium
                 }
                 context.Response.Cookies.Append("testCookie", "testValue", cookieOptions);
                 context.Response.Cookies.Append("testCookie2", "testValue2", cookieOptions);


### PR DESCRIPTION
Looks like Chromium (not chrome) headless now requires 'partitioned' on the cookie when using `Secure` and `Same-Site=None`