### PR TITLE
Use ImpersonationToken for IIS Windows Auth

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/managedexports.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/managedexports.cpp
@@ -516,7 +516,7 @@ http_get_authentication_information(
 )
 {
     *pstrAuthType = SysAllocString(pInProcessHandler->QueryHttpContext()->GetUser()->GetAuthenticationType());
-    *pvToken = pInProcessHandler->QueryHttpContext()->GetUser()->GetPrimaryToken();
+    *pvToken = pInProcessHandler->QueryHttpContext()->GetUser()->GetImpersonationToken();
 
     return S_OK;
 }

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/managedexports.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/managedexports.cpp
@@ -516,7 +516,13 @@ http_get_authentication_information(
 )
 {
     *pstrAuthType = SysAllocString(pInProcessHandler->QueryHttpContext()->GetUser()->GetAuthenticationType());
-    *pvToken = pInProcessHandler->QueryHttpContext()->GetUser()->GetImpersonationToken();
+    // prefer GetPrimaryToken over GetImpersonationToken as that's what we've been using since before .NET 10
+    // we'll fallback to GetImpersonationToken if GetPrimaryToken is not available
+    *pvToken = pInProcessHandler->QueryHttpContext()->GetUser()->GetPrimaryToken();
+    if (*pvToken == nullptr)
+    {
+        *pvToken = pInProcessHandler->QueryHttpContext()->GetUser()->GetImpersonationToken();
+    }
 
     return S_OK;
 }

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/forwardinghandler.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/forwardinghandler.cpp
@@ -819,12 +819,20 @@ FORWARDING_HANDLER::GetHeaders(
         (_wcsicmp(m_pW3Context->GetUser()->GetAuthenticationType(), L"negotiate") == 0 ||
             _wcsicmp(m_pW3Context->GetUser()->GetAuthenticationType(), L"ntlm") == 0))
     {
-        HANDLE impersonationToken = m_pW3Context->GetUser()->GetImpersonationToken();
-        if (impersonationToken != nullptr &&
-            impersonationToken != INVALID_HANDLE_VALUE)
+        // prefer GetPrimaryToken over GetImpersonationToken as that's what we've been using since before .NET 10
+        // we'll fallback to GetImpersonationToken if GetPrimaryToken is not available
+        HANDLE authToken = m_pW3Context->GetUser()->GetPrimaryToken();
+        if (authToken == nullptr ||
+            authToken == INVALID_HANDLE_VALUE)
+        {
+            authToken = m_pW3Context->GetUser()->GetImpersonationToken();
+        }
+
+        if (authToken != nullptr &&
+            authToken != INVALID_HANDLE_VALUE)
         {
             HANDLE hTargetTokenHandle = nullptr;
-            RETURN_IF_FAILED(pServerProcess->SetWindowsAuthToken(impersonationToken,
+            RETURN_IF_FAILED(pServerProcess->SetWindowsAuthToken(authToken,
                 &hTargetTokenHandle));
 
             //

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/forwardinghandler.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/forwardinghandler.cpp
@@ -819,11 +819,12 @@ FORWARDING_HANDLER::GetHeaders(
         (_wcsicmp(m_pW3Context->GetUser()->GetAuthenticationType(), L"negotiate") == 0 ||
             _wcsicmp(m_pW3Context->GetUser()->GetAuthenticationType(), L"ntlm") == 0))
     {
-        if (m_pW3Context->GetUser()->GetPrimaryToken() != nullptr &&
-            m_pW3Context->GetUser()->GetPrimaryToken() != INVALID_HANDLE_VALUE)
+        HANDLE impersonationToken = m_pW3Context->GetUser()->GetImpersonationToken();
+        if (impersonationToken != nullptr &&
+            impersonationToken != INVALID_HANDLE_VALUE)
         {
             HANDLE hTargetTokenHandle = nullptr;
-            RETURN_IF_FAILED(pServerProcess->SetWindowsAuthToken(m_pW3Context->GetUser()->GetPrimaryToken(),
+            RETURN_IF_FAILED(pServerProcess->SetWindowsAuthToken(impersonationToken,
                 &hTargetTokenHandle));
 
             //

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Infrastructure/RequiresIISAttribute.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Infrastructure/RequiresIISAttribute.cs
@@ -136,7 +136,7 @@ public sealed class RequiresIISAttribute : Attribute, ITestCondition
                 IsMet &= available;
                 if (!available)
                 {
-                    SkipReason += $"The machine does have {module.Capability} available.";
+                    SkipReason += $"The machine does not have {module.Capability} available.";
                 }
             }
         }


### PR DESCRIPTION
Closes https://github.com/dotnet/aspnetcore/issues/54175

The doc comments on [`GetPrimaryToken`](https://learn.microsoft.com/iis/web-development-reference/native-code-api-reference/ihttptokenentry-getprimarytoken-method) and [`GetImpersonationToken`](https://learn.microsoft.com/iis/web-development-reference/native-code-api-reference/ihttpuser-getimpersonationtoken-method) are next to useless so can't really comment on the difference between them. However, did look at the old .NET FX IIS code and it was using `GetImpersonationToken` so I feel a bit better about this change.

Looks like the same sort of issue is filed on corewcf as well https://github.com/CoreWCF/CoreWCF/issues/757
cc @mconnew 