### PR TITLE
Revert "Unquarantine ServerReset_BeforeRequestBody_ClientBodyThrows"

### DIFF
--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpClientHttp2InteropTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpClientHttp2InteropTests.cs
@@ -689,6 +689,7 @@ public class HttpClientHttp2InteropTests : LoggedTest
         await host.StopAsync().DefaultTimeout();
     }
 
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/46717")]
     [Theory]
     [MemberData(nameof(SupportedSchemes))]
     public async Task ServerReset_BeforeRequestBody_ClientBodyThrows(string scheme)


### PR DESCRIPTION
Reverts dotnet/aspnetcore#57470

The test [failed again](https://github.com/dotnet/aspnetcore/issues/46717#issuecomment-2369356852).