### PR TITLE
Disable automated inter-branch merges

### DIFF
--- a/github-merge-flow.jsonc
+++ b/github-merge-flow.jsonc
@@ -1,20 +1,5 @@
 // IMPORTANT: This file is read by the merge flow from main branch only. 
 {
     "merge-flow-configurations": {
-        // Automate opening PRs to merge release/9.0 to main
-        "release/9.0":{
-            "MergeToBranch": "main",
-            "ExtraSwitches": "-QuietComments"
-        },
-        // Automate opening PRs to merge release/9.0-rc1 to release/9.0
-        "release/9.0-rc1":{
-            "MergeToBranch": "release/9.0",
-            "ExtraSwitches": "-QuietComments"
-        },
-        // Automate opening PRs to merge release/9.0-rc2 to release/9.0
-        "release/9.0-rc2":{
-            "MergeToBranch": "release/9.0",
-            "ExtraSwitches": "-QuietComments"
-        }
     }
 }


### PR DESCRIPTION
Now that RC2 has locked down, we can start treating `release/9.0` as a regular servicing branch, which means no more automated inter-branch merges up to `main`.

@mmitche do I need to backport this config change to `release/9.0`?