### PR TITLE
referencing System.Text.Json to avoid deprecated nuget in wasm projects

### DIFF
--- a/src/Components/WebAssembly/WebAssembly/src/Microsoft.AspNetCore.Components.WebAssembly.csproj
+++ b/src/Components/WebAssembly/WebAssembly/src/Microsoft.AspNetCore.Components.WebAssembly.csproj
@@ -20,7 +20,8 @@
     <Reference Include="Microsoft.Extensions.Configuration.Json" />
     <Reference Include="Microsoft.Extensions.Configuration.Binder" />
     <Reference Include="Microsoft.Extensions.Logging" />
-    <Reference Include="Microsoft.JSInterop.WebAssembly" />
+    <Reference Include="Microsoft.JSInterop.WebAssembly" /> 
+    <Reference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
…BlazorWasm

Currently, by default Microsoft.AspNetCore.Components.WebAssembly gets included in a BlazorWasm project. This in-turn adds Microsoft.Extensions.Configuration.Json 8.0.0 which in-turn adds System.Text.Json (>= 8.0.0).

As a result, creating a new BlazorWasm project results in adding   System.Text.Json 8.0.0 by default. However, this version of System.Text.Json is know to have "at least one vulnerability with high severity". Adding a reference to System.Text.Json to Microsoft.AspNetCore.Components.WebAssembly should enxure the latest version of System.Text.Json is being used out of the box for a BlazorWasm app
