### PR TITLE
Explain msquic limitations in Http3SampleApp

### DIFF
--- a/src/Servers/Kestrel/samples/Http3SampleApp/Program.cs
+++ b/src/Servers/Kestrel/samples/Http3SampleApp/Program.cs
@@ -35,6 +35,13 @@ public class Program
                         listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
                     });
 
+                    // On a machine that supports IPv6, msquic will resolve `localhost` to `::1`, which `IPAddress.Any` will not accept.
+                    // (To make it work, you'd need to use `IPv6Any`, as `ListenAnyIP` does.)  As a result, a client built on msquic, 
+                    // e.g. `HttpClient` on Windows, will not be able to make HTTP/3.0 requests to `localhost:5001`.  HTTP/1.x and 
+                    // HTTP/2.0 will still work.
+                    // Example: https://github.com/dotnet/runtime/issues/108259
+                    // msquic: https://github.com/microsoft/msquic/issues/1181 (resolve both)
+                    // System.Net.Quic: https://github.com/dotnet/runtime/issues/82404 (improve consistency with sockets)
                     options.Listen(IPAddress.Any, 5001, listenOptions =>
                     {
                         listenOptions.UseHttps();


### PR DESCRIPTION
`HttpClient` HTTP/3.0 requests to https://localhost:5001 won't work.  Explaining why not seems more valuable that working around it, especially since the workaround is demonstrated elsewhere in the sample.