### PR TITLE
Update ServiceFilterAttribute.cs

### DIFF
--- a/src/Mvc/Mvc.Core/src/ServiceFilterAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/ServiceFilterAttribute.cs
@@ -20,7 +20,8 @@ namespace Microsoft.AspNetCore.Mvc;
 /// </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
-[DebuggerDisplay("Type = {ServiceType}, Order = {Order}")]
+[DebuggerDisplay("Type = {ServiceType}/{Key}, Order = {Order}")]
+
 public class ServiceFilterAttribute : Attribute, IFilterFactory, IOrderedFilter
 {
     /// <summary>
@@ -40,6 +41,12 @@ public class ServiceFilterAttribute : Attribute, IFilterFactory, IOrderedFilter
     /// </summary>
     public Type ServiceType { get; }
 
+    /// <summary>
+    /// optional key for the registration
+    /// </summary>
+    public object? Key { get; set; }
+
+
     /// <inheritdoc />
     public bool IsReusable { get; set; }
 
@@ -48,7 +55,16 @@ public class ServiceFilterAttribute : Attribute, IFilterFactory, IOrderedFilter
     {
         ArgumentNullException.ThrowIfNull(serviceProvider);
 
-        var filter = (IFilterMetadata)serviceProvider.GetRequiredService(ServiceType);
+        IFilterMetadata filter;
+        if (string.IsNullOrWhiteSpace(Key as string))
+        {
+            filter = (IFilterMetadata)serviceProvider.GetRequiredService(ServiceType);
+        }
+        else
+        {
+            filter = (IFilterMetadata)serviceProvider.GetRequiredKeyedService(ServiceType, Key);
+
+        }
         if (filter is IFilterFactory filterFactory)
         {
             // Unwrap filter factories


### PR DESCRIPTION
Add Key Property to ServiceFilterAttribute  #58017


<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

 Added an optional Key property.
and also handled null scenerio if key is null then call GetRequiredService method else call GetRequiredKeyedService method

## Description

Since .NET 8, the service provider supports keyed service registrations. However, the ServiceFilterAttribute, which uses dependency injection from a type, does not allow specifying an optional key for the registration. Added an optional Key property.

Fixes #{ #58017} was a suggestion
