### PR TITLE
Avoid unnecessary HealthStatus comparison

### DIFF
--- a/src/HealthChecks/Abstractions/src/HealthReport.cs
+++ b/src/HealthChecks/Abstractions/src/HealthReport.cs
@@ -66,13 +66,13 @@ public sealed class HealthReport
             if (currentValue > entry.Status)
             {
                 currentValue = entry.Status;
-            }
 
-            if (currentValue == HealthStatus.Unhealthy)
-            {
-                // Game over, man! Game over!
-                // (We hit the worst possible status, so there's no need to keep iterating)
-                return currentValue;
+                if (currentValue == HealthStatus.Unhealthy)
+                {
+                    // Game over, man! Game over!
+                    // (We hit the worst possible status, so there's no need to keep iterating)
+                    return currentValue;
+                }
             }
         }
 


### PR DESCRIPTION
# Avoid unnecessary HealthStatus comparison

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
   - There's no open issue for this. It's a drive-by micro-optimisation.


## Description

It's only necessary to check `currentValue == HealthStatus.Unhealthy` when `currentValue` changes. During the first iteration, it is known to be `Healthy`.
