### PR TITLE
Quarantine ResponseTests.ConnectionClosedWhenResponseDoesNotSatisfyMinimumDataRate

### DIFF
--- a/src/Servers/Kestrel/test/FunctionalTests/ResponseTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/ResponseTests.cs
@@ -466,6 +466,7 @@ public class ResponseTests : TestApplicationErrorLoggerLoggedTest
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/49974")]
     public async Task ConnectionClosedWhenResponseDoesNotSatisfyMinimumDataRate(bool fin)
     {
         var logger = LoggerFactory.CreateLogger($"{ typeof(ResponseTests).FullName}.{ nameof(ConnectionClosedWhenResponseDoesNotSatisfyMinimumDataRate)}");


### PR DESCRIPTION
Continuation of https://github.com/dotnet/aspnetcore/issues/49974