### PR TITLE
Add examples for attributes

### DIFF
--- a/src/Mvc/Mvc.Core/src/FromBodyAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/FromBodyAttribute.cs
@@ -10,9 +10,21 @@ namespace Microsoft.AspNetCore.Mvc;
 /// Specifies that a parameter or property should be bound using the request body.
 /// </summary>
 /// <remarks>
+/// Binds a parameter or property to the request body.
+///
 /// By default, ASP.NET Core MVC delegates the responsibility of reading the body to an input formatter.<br/>
 /// In the case of ASP.NET Core Minimal APIs, the body is deserialized by <see cref="System.Text.Json.JsonSerializer"/>.
+///
+/// For more information about parameter binding see
+/// <see href="https://learn.microsoft.com/aspnet/core/fundamentals/minimal-apis/parameter-binding?">Parameter binding</see>.
 /// </remarks>
+/// <example>
+/// In this example, the value of the 'name' field in the form-data request body is bound to the name parameter,
+/// and the value of the 'age' field is bound to the age parameter.
+/// <code>
+/// app.MapPost("/from-body", ([FromBody] Person person) => person);
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
 public class FromBodyAttribute : Attribute, IBindingSourceMetadata, IConfigureEmptyBodyBehavior, IFromBodyMetadata
 {

--- a/src/Mvc/Mvc.Core/src/FromBodyAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/FromBodyAttribute.cs
@@ -16,13 +16,25 @@ namespace Microsoft.AspNetCore.Mvc;
 /// In the case of ASP.NET Core Minimal APIs, the body is deserialized by <see cref="System.Text.Json.JsonSerializer"/>.
 ///
 /// For more information about parameter binding see
-/// <see href="https://learn.microsoft.com/aspnet/core/fundamentals/minimal-apis/parameter-binding?">Parameter binding</see>.
+/// <see href="https://learn.microsoft.com/aspnet/core/fundamentals/minimal-apis/parameter-binding">Parameter binding</see>.
 /// </remarks>
 /// <example>
 /// In this example, the value of the 'name' field in the form-data request body is bound to the name parameter,
 /// and the value of the 'age' field is bound to the age parameter.
 /// <code>
 /// app.MapPost("/from-body", ([FromBody] Person person) => person);
+///
+/// public record Person(string Name, int Age);
+/// </code>
+///
+/// If the EmptyBodyBehavior is set to EmptyBodyBehavior.Allow in the FromBody attribute,
+/// requests without a request body are allowed.
+/// <code>
+/// app.MapPost("/allow-empty-body",
+/// (
+///     [Description("An optional request body")]
+///     [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Allow)] Body body
+/// ) =>
 /// </code>
 /// </example>
 [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]

--- a/src/Mvc/Mvc.Core/src/FromFormAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/FromFormAttribute.cs
@@ -9,6 +9,22 @@ namespace Microsoft.AspNetCore.Mvc;
 /// <summary>
 /// Specifies that a parameter or property should be bound using form-data in the request body.
 /// </summary>
+/// <remarks>
+/// Binds a parameter or property to a field in a form-data request body with the same name,
+/// or the name specified in the <see cref="Name"/> property.
+/// Form parameter names are matched case-insensitively.
+///
+/// For more information about parameter binding see
+/// <see href="https://learn.microsoft.com/aspnet/core/fundamentals/minimal-apis/parameter-binding?">Parameter binding</see>.
+/// </remarks>
+/// <example>
+/// In this example, the value of the 'name' field in the form-data request body is bound to the name parameter,
+/// and the value of the 'age' field is bound to the age parameter.
+/// <code>
+/// app.MapPost("/from-form", ([FromForm] string name, [FromForm] int age)
+///     => new { Name = name, Age = age });
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
 public class FromFormAttribute : Attribute, IBindingSourceMetadata, IModelNameProvider, IFromFormMetadata
 {

--- a/src/Mvc/Mvc.Core/src/FromFormAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/FromFormAttribute.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Mvc;
 /// Form parameter names are matched case-insensitively.
 ///
 /// For more information about parameter binding see
-/// <see href="https://learn.microsoft.com/aspnet/core/fundamentals/minimal-apis/parameter-binding?">Parameter binding</see>.
+/// <see href="https://learn.microsoft.com/aspnet/core/fundamentals/minimal-apis/parameter-binding">Parameter binding</see>.
 /// </remarks>
 /// <example>
 /// In this example, the value of the 'name' field in the form-data request body is bound to the name parameter,

--- a/src/Mvc/Mvc.Core/src/FromHeaderAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/FromHeaderAttribute.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Mvc;
 /// Note that HTTP header names are case-insensitive, so the header name is matched without regard to case.
 ///
 /// For more information about parameter binding see
-/// <see href="https://learn.microsoft.com/aspnet/core/fundamentals/minimal-apis/parameter-binding?">Parameter binding</see>.
+/// <see href="https://learn.microsoft.com/aspnet/core/fundamentals/minimal-apis/parameter-binding">Parameter binding</see>.
 /// </remarks>
 /// <example>
 /// In this example, the value of the 'User-Agent' header is bound to the parameter.

--- a/src/Mvc/Mvc.Core/src/FromHeaderAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/FromHeaderAttribute.cs
@@ -10,16 +10,19 @@ namespace Microsoft.AspNetCore.Mvc;
 /// Specifies that a parameter or property should be bound using the request headers.
 /// </summary>
 /// <remarks>
-/// When placed on a parameter, the parameter will be bound to the value of the request header with the same name.
-/// Use the <see cref="Name"/> property to specify a different header name.
+/// Binds a parameter or property to the value of the request header with the same name,
+/// or the name specified in the <see cref="Name"/> property.
+/// Note that HTTP header names are case-insensitive, so the header name is matched without regard to case.
+///
+/// For more information about parameter binding see
+/// <see href="https://learn.microsoft.com/aspnet/core/fundamentals/minimal-apis/parameter-binding?">Parameter binding</see>.
 /// </remarks>
 /// <example>
 /// In this example, the value of the 'User-Agent' header is bound to the parameter.
 /// <code>
-/// [HttpGet]
-/// public string GetUserAgent([FromHeader("User-Agent")] string userAgent)
+/// app.MapGet("/user-agent", ([FromHeader(Name = "User-Agent")] string userAgent)
+///     => userAgent);
 /// </code>
-/// Note that HTTP header names are case-insensitive, so the header name is matched without regard to case.
 /// </example>
 [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
 public class FromHeaderAttribute : Attribute, IBindingSourceMetadata, IModelNameProvider, IFromHeaderMetadata

--- a/src/Mvc/Mvc.Core/src/FromHeaderAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/FromHeaderAttribute.cs
@@ -9,6 +9,18 @@ namespace Microsoft.AspNetCore.Mvc;
 /// <summary>
 /// Specifies that a parameter or property should be bound using the request headers.
 /// </summary>
+/// <remarks>
+/// When placed on a parameter, the parameter will be bound to the value of the request header with the same name.
+/// Use the <see cref="Name"/> property to specify a different header name.
+/// </remarks>
+/// <example>
+/// In this example, the value of the 'User-Agent' header is bound to the parameter.
+/// <code>
+/// [HttpGet]
+/// public string GetUserAgent([FromHeader("User-Agent")] string userAgent)
+/// </code>
+/// Note that HTTP header names are case-insensitive, so the header name is matched without regard to case.
+/// </example>
 [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
 public class FromHeaderAttribute : Attribute, IBindingSourceMetadata, IModelNameProvider, IFromHeaderMetadata
 {

--- a/src/Mvc/Mvc.Core/src/FromQueryAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/FromQueryAttribute.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Mvc;
 /// The query parameter name is matched case-insensitively.
 ///
 /// For more information about parameter binding see
-/// <see href="https://learn.microsoft.com/aspnet/core/fundamentals/minimal-apis/parameter-binding?">Parameter binding</see>.
+/// <see href="https://learn.microsoft.com/aspnet/core/fundamentals/minimal-apis/parameter-binding">Parameter binding</see>.
 /// </remarks>
 /// <example>
 /// In this example, the value of the 'User-Agent' header is bound to the parameter.

--- a/src/Mvc/Mvc.Core/src/FromQueryAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/FromQueryAttribute.cs
@@ -9,6 +9,21 @@ namespace Microsoft.AspNetCore.Mvc;
 /// <summary>
 /// Specifies that a parameter or property should be bound using the request query string.
 /// </summary>
+/// <remarks>
+/// Binds a parameter or property to the value of query string parameter with the same name,
+/// or the name specified in the <see cref="Name"/> property.
+/// The query parameter name is matched case-insensitively.
+///
+/// For more information about parameter binding see
+/// <see href="https://learn.microsoft.com/aspnet/core/fundamentals/minimal-apis/parameter-binding?">Parameter binding</see>.
+/// </remarks>
+/// <example>
+/// In this example, the value of the 'User-Agent' header is bound to the parameter.
+/// <code>
+/// app.MapGet("/version", ([FromQuery(Name = "api-version")] string apiVersion)
+///     => apiVersion);
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
 public class FromQueryAttribute : Attribute, IBindingSourceMetadata, IModelNameProvider, IFromQueryMetadata
 {

--- a/src/Mvc/Mvc.Core/src/FromRouteAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/FromRouteAttribute.cs
@@ -10,6 +10,20 @@ namespace Microsoft.AspNetCore.Mvc;
 /// <summary>
 /// Specifies that a parameter or property should be bound using route-data from the current request.
 /// </summary>
+/// <remarks>
+/// Binds a parameter or property to the value of a route parameter with the same name,
+/// or the name specified in the <see cref="Name"/> property.
+/// The route parameter name is matched against parameter segments of the route pattern case-insensitively.
+///
+/// For more information about parameter binding see
+/// <see href="https://learn.microsoft.com/aspnet/core/fundamentals/minimal-apis/parameter-binding?">Parameter binding</see>.
+/// </remarks>
+/// <example>
+/// In this example, the value of the 'id' route parameter is bound to the parameter.
+/// <code>
+/// app.MapGet("/from-route/{id}", ([FromRoute] string id) => id);
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
 public class FromRouteAttribute : Attribute, IBindingSourceMetadata, IModelNameProvider, IFromRouteMetadata
 {

--- a/src/Mvc/Mvc.Core/src/FromRouteAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/FromRouteAttribute.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Mvc;
 /// The route parameter name is matched against parameter segments of the route pattern case-insensitively.
 ///
 /// For more information about parameter binding see
-/// <see href="https://learn.microsoft.com/aspnet/core/fundamentals/minimal-apis/parameter-binding?">Parameter binding</see>.
+/// <see href="https://learn.microsoft.com/aspnet/core/fundamentals/minimal-apis/parameter-binding">Parameter binding</see>.
 /// </remarks>
 /// <example>
 /// In this example, the value of the 'id' route parameter is bound to the parameter.

--- a/src/Mvc/Mvc.Core/src/ProducesResponseTypeAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/ProducesResponseTypeAttribute.cs
@@ -11,6 +11,31 @@ namespace Microsoft.AspNetCore.Mvc;
 /// <summary>
 /// A filter that specifies the type of the value and status code returned by the action.
 /// </summary>
+/// <remarks>
+/// This attribute can be used to specify the type of the response body, the status code,
+/// and content-type(s) of the response.
+///
+/// In an MVC application, this attribute can be applied to an action method or controller class.
+/// In a Minimal API application, this attribute should be applied to the delegate method.
+///
+/// More than one instance of ProducesResponseTypeAttribute with different status codes may
+/// be used to specify multiple possible responses from an endpoint.
+/// </remarks>
+/// <example>
+/// In the following example, the ProducesResponseTypeAttribute is used to specify the type of the
+/// response body and the status code for the successful response and the status code, type, and content
+/// type for the error response.
+/// <code>
+/// app.MapGet("/todos/{id}",
+///     [ProducesResponseType(typeof(Todo), StatusCodes.Status200OK)]
+///     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound, "application/problem+json")]
+///     async (TodoDb db, string id) =>
+///         await db.Todos.FindAsync(id)
+///         is Todo todo
+///         ? Results.Ok(todo)
+///         : Results.NotFound());
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
 public class ProducesResponseTypeAttribute : Attribute, IApiResponseMetadataProvider
 {

--- a/src/Mvc/Mvc.Core/src/ProducesResponseTypeAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/ProducesResponseTypeAttribute.cs
@@ -11,31 +11,6 @@ namespace Microsoft.AspNetCore.Mvc;
 /// <summary>
 /// A filter that specifies the type of the value and status code returned by the action.
 /// </summary>
-/// <remarks>
-/// This attribute can be used to specify the type of the response body, the status code,
-/// and content-type(s) of the response.
-///
-/// In an MVC application, this attribute can be applied to an action method or controller class.
-/// In a Minimal API application, this attribute should be applied to the delegate method.
-///
-/// More than one instance of ProducesResponseTypeAttribute with different status codes may
-/// be used to specify multiple possible responses from an endpoint.
-/// </remarks>
-/// <example>
-/// In the following example, the ProducesResponseTypeAttribute is used to specify the type of the
-/// response body and the status code for the successful response and the status code, type, and content
-/// type for the error response.
-/// <code>
-/// app.MapGet("/todos/{id}",
-///     [ProducesResponseType(typeof(Todo), StatusCodes.Status200OK)]
-///     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound, "application/problem+json")]
-///     async (TodoDb db, string id) =>
-///         await db.Todos.FindAsync(id)
-///         is Todo todo
-///         ? Results.Ok(todo)
-///         : Results.NotFound());
-/// </code>
-/// </example>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
 public class ProducesResponseTypeAttribute : Attribute, IApiResponseMetadataProvider
 {


### PR DESCRIPTION
# Add examples for attributes

This PR just adds remarks and examples to the XML doc for some commonly used attributes.

## Description

Add remarks and examples to the XML doc for some commonly used attributes in Web apps to improve the documentation that appears on Learn and in VS / VSCode.

The intent is to add doc for:
- [x] FromBody
- [x] FromForm
- [x] FromHeader
- [x] FromQuery
- [x] FromRoute
- [ ] ~Produces~
- [ ] ~Produces\<T>~
- [ ] ~ProducesResponseType~
- [ ] ~ProducesResponseType\<T>~

and maybe a few more.

This will help developers understand some quirks about the way attributes can be used, such as using named parameters to set properties of the attribute even when these are not present in any constructor.

Update: Scoped this PR to just the attributes for parameter binding.