### PR TITLE
[release/6.0] Update the Microsoft.Identity.Web versions used by project templates

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -238,9 +238,9 @@
     <DuendeIdentityServerStorageVersion>5.2.0</DuendeIdentityServerStorageVersion>
     <DuendeIdentityServerEntityFrameworkStorageVersion>5.2.0</DuendeIdentityServerEntityFrameworkStorageVersion>
     <MessagePackVersion>2.1.90</MessagePackVersion>
-    <MicrosoftIdentityWebVersion>1.16.0</MicrosoftIdentityWebVersion>
-    <MicrosoftIdentityWebMicrosoftGraphVersion>1.16.0</MicrosoftIdentityWebMicrosoftGraphVersion>
-    <MicrosoftIdentityWebUIVersion>1.16.0</MicrosoftIdentityWebUIVersion>
+    <MicrosoftIdentityWebVersion>3.2.0</MicrosoftIdentityWebVersion>
+    <MicrosoftIdentityWebMicrosoftGraphVersion>3.2.0</MicrosoftIdentityWebMicrosoftGraphVersion>
+    <MicrosoftIdentityWebUIVersion>3.2.0</MicrosoftIdentityWebUIVersion>
     <MessagePackAnalyzerVersion>$(MessagePackVersion)</MessagePackAnalyzerVersion>
     <MoqVersion>4.10.0</MoqVersion>
     <MonoCecilVersion>0.11.2</MonoCecilVersion>


### PR DESCRIPTION
### Description

Due to a recent change NuGet restore now shows CVE warnings for transitive packages. This PR updates the Microsoft.Identity.Web version referenced by the ASP.NET Core project templates dependencies to as of now get rid of these warnings.

### Customer impact

Fixes warnings on restore/build in ASP.NET Core project templates referencing Microsoft.Identity.Web.

### How found

Manual CTI Testing.

### Regression

No

### Testing

Tested manually.

### Risk

Low. These are template-only changes, so the developer can manually change the dependency version if this version breaks their scenario. Manual testing verified the mainline scenario works.