### PR TITLE
[release/8.0] Update the Microsoft.Identity.Web versions used by project templates

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -300,10 +300,10 @@
     <GrpcNetClientVersion>2.57.0</GrpcNetClientVersion>
     <GrpcToolsVersion>2.57.0</GrpcToolsVersion>
     <MessagePackVersion>2.5.108</MessagePackVersion>
-    <MicrosoftIdentityWebVersion>2.15.2</MicrosoftIdentityWebVersion>
-    <MicrosoftIdentityWebGraphServiceClientVersion>2.15.2</MicrosoftIdentityWebGraphServiceClientVersion>
-    <MicrosoftIdentityWebUIVersion>2.15.2</MicrosoftIdentityWebUIVersion>
-    <MicrosoftIdentityWebDownstreamApiVersion>2.15.2</MicrosoftIdentityWebDownstreamApiVersion>
+    <MicrosoftIdentityWebVersion>3.2.0</MicrosoftIdentityWebVersion>
+    <MicrosoftIdentityWebGraphServiceClientVersion>3.2.0</MicrosoftIdentityWebGraphServiceClientVersion>
+    <MicrosoftIdentityWebUIVersion>3.2.0</MicrosoftIdentityWebUIVersion>
+    <MicrosoftIdentityWebDownstreamApiVersion>3.2.0</MicrosoftIdentityWebDownstreamApiVersion>
     <MicrosoftIoRedistVersion>6.0.1</MicrosoftIoRedistVersion>
     <MessagePackAnalyzerVersion>$(MessagePackVersion)</MessagePackAnalyzerVersion>
     <MoqVersion>4.10.0</MoqVersion>


### PR DESCRIPTION
### Description

Due to a recent change NuGet restore now shows CVE warnings for transitive packages. This PR updates the Microsoft.Identity.Web version referenced by the ASP.NET Core project templates dependencies to as of now get rid of these warnings.

### Customer impact

Fixes warnings on restore/build in ASP.NET Core project templates referencing Microsoft.Identity.Web.

### How found

Manual CTI Testing.

### Regression

No

### Testing

Tested manually.

### Risk

Low. These are template-only changes, so the developer can manually change the dependency version if this version breaks their scenario. Manual testing verified the mainline scenario works.