### PR TITLE
[s390x] Fix Extensions.ApiDescription.Client tests on s390x 

### DIFF
--- a/src/Tools/Extensions.ApiDescription.Client/test/GetOpenApiReferenceMetadataTest.cs
+++ b/src/Tools/Extensions.ApiDescription.Client/test/GetOpenApiReferenceMetadataTest.cs
@@ -60,7 +60,9 @@ public class GetOpenApiReferenceMetadataTest
             orderedMetadata.Add(key, metadata[key]);
         }
 
-        Assert.Equal(expectedMetadata, orderedMetadata);
+       expectedMetadata["SerializedMetadata"] = string.Join("|", expectedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
+       orderedMetadata["SerializedMetadata"] = string.Join("|", orderedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
+       Assert.Equal(expectedMetadata, orderedMetadata);
     }
 
     [Fact]
@@ -118,7 +120,9 @@ public class GetOpenApiReferenceMetadataTest
             orderedMetadata.Add(key, metadata[key]);
         }
 
-        Assert.Equal(expectedMetadata, orderedMetadata);
+       expectedMetadata["SerializedMetadata"] = string.Join("|", expectedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
+       orderedMetadata["SerializedMetadata"] = string.Join("|", orderedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
+       Assert.Equal(expectedMetadata, orderedMetadata);
     }
 
     [Fact]
@@ -176,7 +180,9 @@ public class GetOpenApiReferenceMetadataTest
             orderedMetadata.Add(key, metadata[key]);
         }
 
-        Assert.Equal(expectedMetadata, orderedMetadata);
+       expectedMetadata["SerializedMetadata"] = string.Join("|", expectedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
+       orderedMetadata["SerializedMetadata"] = string.Join("|", orderedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
+       Assert.Equal(expectedMetadata, orderedMetadata);
     }
 
     [Fact]
@@ -233,8 +239,11 @@ public class GetOpenApiReferenceMetadataTest
         {
             orderedMetadata.Add(key, metadata[key]);
         }
+       // sort the values, since order is undefined for Dictionary
+       expectedMetadata["SerializedMetadata"] = string.Join("|", expectedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
+       orderedMetadata["SerializedMetadata"] = string.Join("|", orderedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
 
-        Assert.Equal(expectedMetadata, orderedMetadata);
+        Assert.Equal<SortedDictionary<string, string>>(expectedMetadata, orderedMetadata);
     }
 
     [Fact]
@@ -384,7 +393,9 @@ public class GetOpenApiReferenceMetadataTest
             orderedMetadata.Add(key, metadata[key]);
         }
 
-        Assert.Equal(expectedMetadata, orderedMetadata);
+       expectedMetadata["SerializedMetadata"] = string.Join("|", expectedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
+       orderedMetadata["SerializedMetadata"] = string.Join("|", orderedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
+       Assert.Equal(expectedMetadata, orderedMetadata);
     }
 
     [Theory]
@@ -446,8 +457,9 @@ public class GetOpenApiReferenceMetadataTest
         {
             orderedMetadata.Add(key, metadata[key]);
         }
-
-        Assert.Equal(expectedMetadata, orderedMetadata);
+       expectedMetadata["SerializedMetadata"] = string.Join("|", expectedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
+       orderedMetadata["SerializedMetadata"] = string.Join("|", orderedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
+       Assert.Equal(expectedMetadata, orderedMetadata);
     }
 
     [Fact]
@@ -545,7 +557,9 @@ public class GetOpenApiReferenceMetadataTest
                     orderedMetadata.Add(key, metadata[key]);
                 }
 
-                Assert.Equal(expectedMetadata1, orderedMetadata);
+               expectedMetadata1["SerializedMetadata"] = string.Join("|", expectedMetadata1["SerializedMetadata"].Split('|').OrderBy(s => s));
+               orderedMetadata["SerializedMetadata"] = string.Join("|", orderedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
+               Assert.Equal(expectedMetadata1, orderedMetadata);
             },
             output =>
             {
@@ -557,7 +571,9 @@ public class GetOpenApiReferenceMetadataTest
                     orderedMetadata.Add(key, metadata[key]);
                 }
 
-                Assert.Equal(expectedMetadata2, orderedMetadata);
+               expectedMetadata2["SerializedMetadata"] = string.Join("|", expectedMetadata2["SerializedMetadata"].Split('|').OrderBy(s => s));
+               orderedMetadata["SerializedMetadata"] = string.Join("|", orderedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
+               Assert.Equal(expectedMetadata2, orderedMetadata);
             },
             output =>
             {
@@ -569,7 +585,9 @@ public class GetOpenApiReferenceMetadataTest
                     orderedMetadata.Add(key, metadata[key]);
                 }
 
-                Assert.Equal(expectedMetadata3, orderedMetadata);
+               expectedMetadata3["SerializedMetadata"] = string.Join("|", expectedMetadata3["SerializedMetadata"].Split('|').OrderBy(s => s));
+               orderedMetadata["SerializedMetadata"] = string.Join("|", orderedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
+               Assert.Equal(expectedMetadata3, orderedMetadata);
             });
     }
 }

--- a/src/Tools/Extensions.ApiDescription.Client/test/GetOpenApiReferenceMetadataTest.cs
+++ b/src/Tools/Extensions.ApiDescription.Client/test/GetOpenApiReferenceMetadataTest.cs
@@ -11,6 +11,10 @@ namespace Microsoft.Extensions.ApiDescription.Client;
 
 public class GetOpenApiReferenceMetadataTest
 {
+    public string SortMetadata(string Metadata)
+    {
+        return string.Join("|", Metadata.Split('|').OrderBy(s => s));
+    }
     [Fact]
     public void Execute_AddsExpectedMetadata()
     {
@@ -60,9 +64,9 @@ public class GetOpenApiReferenceMetadataTest
             orderedMetadata.Add(key, metadata[key]);
         }
 
-       expectedMetadata["SerializedMetadata"] = string.Join("|", expectedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
-       orderedMetadata["SerializedMetadata"] = string.Join("|", orderedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
-       Assert.Equal(expectedMetadata, orderedMetadata);
+        expectedMetadata["SerializedMetadata"] = SortMetadata(expectedMetadata["SerializedMetadata"]); 
+        orderedMetadata["SerializedMetadata"] = SortMetadata(orderedMetadata["SerializedMetadata"]);
+        Assert.Equal(expectedMetadata, orderedMetadata);
     }
 
     [Fact]
@@ -120,9 +124,9 @@ public class GetOpenApiReferenceMetadataTest
             orderedMetadata.Add(key, metadata[key]);
         }
 
-       expectedMetadata["SerializedMetadata"] = string.Join("|", expectedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
-       orderedMetadata["SerializedMetadata"] = string.Join("|", orderedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
-       Assert.Equal(expectedMetadata, orderedMetadata);
+        expectedMetadata["SerializedMetadata"] = SortMetadata(expectedMetadata["SerializedMetadata"]);
+        orderedMetadata["SerializedMetadata"] = SortMetadata(orderedMetadata["SerializedMetadata"]);
+        Assert.Equal(expectedMetadata, orderedMetadata);
     }
 
     [Fact]
@@ -180,9 +184,9 @@ public class GetOpenApiReferenceMetadataTest
             orderedMetadata.Add(key, metadata[key]);
         }
 
-       expectedMetadata["SerializedMetadata"] = string.Join("|", expectedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
-       orderedMetadata["SerializedMetadata"] = string.Join("|", orderedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
-       Assert.Equal(expectedMetadata, orderedMetadata);
+        expectedMetadata["SerializedMetadata"] = SortMetadata(expectedMetadata["SerializedMetadata"]);
+        orderedMetadata["SerializedMetadata"] = SortMetadata(orderedMetadata["SerializedMetadata"]);
+        Assert.Equal(expectedMetadata, orderedMetadata);
     }
 
     [Fact]
@@ -240,9 +244,8 @@ public class GetOpenApiReferenceMetadataTest
             orderedMetadata.Add(key, metadata[key]);
         }
        // sort the values, since order is undefined for Dictionary
-       expectedMetadata["SerializedMetadata"] = string.Join("|", expectedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
-       orderedMetadata["SerializedMetadata"] = string.Join("|", orderedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
-
+        expectedMetadata["SerializedMetadata"] = SortMetadata(expectedMetadata["SerializedMetadata"]);
+        orderedMetadata["SerializedMetadata"] = SortMetadata(orderedMetadata["SerializedMetadata"]);
         Assert.Equal<SortedDictionary<string, string>>(expectedMetadata, orderedMetadata);
     }
 
@@ -392,10 +395,9 @@ public class GetOpenApiReferenceMetadataTest
         {
             orderedMetadata.Add(key, metadata[key]);
         }
-
-       expectedMetadata["SerializedMetadata"] = string.Join("|", expectedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
-       orderedMetadata["SerializedMetadata"] = string.Join("|", orderedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
-       Assert.Equal(expectedMetadata, orderedMetadata);
+        expectedMetadata["SerializedMetadata"] = SortMetadata(expectedMetadata["SerializedMetadata"]);
+        orderedMetadata["SerializedMetadata"] = SortMetadata(orderedMetadata["SerializedMetadata"]);
+        Assert.Equal(expectedMetadata, orderedMetadata);
     }
 
     [Theory]
@@ -457,9 +459,9 @@ public class GetOpenApiReferenceMetadataTest
         {
             orderedMetadata.Add(key, metadata[key]);
         }
-       expectedMetadata["SerializedMetadata"] = string.Join("|", expectedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
-       orderedMetadata["SerializedMetadata"] = string.Join("|", orderedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
-       Assert.Equal(expectedMetadata, orderedMetadata);
+        expectedMetadata["SerializedMetadata"] = SortMetadata(expectedMetadata["SerializedMetadata"]);
+        orderedMetadata["SerializedMetadata"] = SortMetadata(orderedMetadata["SerializedMetadata"]);
+        Assert.Equal(expectedMetadata, orderedMetadata);
     }
 
     [Fact]
@@ -557,9 +559,9 @@ public class GetOpenApiReferenceMetadataTest
                     orderedMetadata.Add(key, metadata[key]);
                 }
 
-               expectedMetadata1["SerializedMetadata"] = string.Join("|", expectedMetadata1["SerializedMetadata"].Split('|').OrderBy(s => s));
-               orderedMetadata["SerializedMetadata"] = string.Join("|", orderedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
-               Assert.Equal(expectedMetadata1, orderedMetadata);
+                expectedMetadata1["SerializedMetadata"] = SortMetadata(expectedMetadata1["SerializedMetadata"]);
+                orderedMetadata["SerializedMetadata"] = SortMetadata(orderedMetadata["SerializedMetadata"]);
+                Assert.Equal(expectedMetadata1, orderedMetadata);
             },
             output =>
             {
@@ -570,10 +572,9 @@ public class GetOpenApiReferenceMetadataTest
                 {
                     orderedMetadata.Add(key, metadata[key]);
                 }
-
-               expectedMetadata2["SerializedMetadata"] = string.Join("|", expectedMetadata2["SerializedMetadata"].Split('|').OrderBy(s => s));
-               orderedMetadata["SerializedMetadata"] = string.Join("|", orderedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
-               Assert.Equal(expectedMetadata2, orderedMetadata);
+                expectedMetadata2["SerializedMetadata"] = SortMetadata(expectedMetadata2["SerializedMetadata"]);
+                orderedMetadata["SerializedMetadata"] = SortMetadata(orderedMetadata["SerializedMetadata"]);
+                Assert.Equal(expectedMetadata2, orderedMetadata);
             },
             output =>
             {
@@ -585,9 +586,9 @@ public class GetOpenApiReferenceMetadataTest
                     orderedMetadata.Add(key, metadata[key]);
                 }
 
-               expectedMetadata3["SerializedMetadata"] = string.Join("|", expectedMetadata3["SerializedMetadata"].Split('|').OrderBy(s => s));
-               orderedMetadata["SerializedMetadata"] = string.Join("|", orderedMetadata["SerializedMetadata"].Split('|').OrderBy(s => s));
-               Assert.Equal(expectedMetadata3, orderedMetadata);
+                expectedMetadata3["SerializedMetadata"] = SortMetadata(expectedMetadata3["SerializedMetadata"]);
+                orderedMetadata["SerializedMetadata"] = SortMetadata(orderedMetadata["SerializedMetadata"]);
+                Assert.Equal(expectedMetadata3, orderedMetadata);
             });
     }
 }

--- a/src/Tools/Extensions.ApiDescription.Client/test/GetOpenApiReferenceMetadataTest.cs
+++ b/src/Tools/Extensions.ApiDescription.Client/test/GetOpenApiReferenceMetadataTest.cs
@@ -11,10 +11,11 @@ namespace Microsoft.Extensions.ApiDescription.Client;
 
 public class GetOpenApiReferenceMetadataTest
 {
-    public string SortMetadata(string Metadata)
+    string SortMetadata(string metadata)
     {
-        return string.Join("|", Metadata.Split('|').OrderBy(s => s));
+        return string.Join("|", metadata.Split('|').OrderBy(s => s));
     }
+
     [Fact]
     public void Execute_AddsExpectedMetadata()
     {
@@ -243,10 +244,11 @@ public class GetOpenApiReferenceMetadataTest
         {
             orderedMetadata.Add(key, metadata[key]);
         }
-       // sort the values, since order is undefined for Dictionary
+
+        // sort the values, since order is undefined for Dictionary
         expectedMetadata["SerializedMetadata"] = SortMetadata(expectedMetadata["SerializedMetadata"]);
         orderedMetadata["SerializedMetadata"] = SortMetadata(orderedMetadata["SerializedMetadata"]);
-        Assert.Equal<SortedDictionary<string, string>>(expectedMetadata, orderedMetadata);
+        Assert.Equal(expectedMetadata, orderedMetadata);
     }
 
     [Fact]

--- a/src/Tools/Extensions.ApiDescription.Client/test/MetadataSerializerTest.cs
+++ b/src/Tools/Extensions.ApiDescription.Client/test/MetadataSerializerTest.cs
@@ -193,7 +193,10 @@ public class MetadataSerializerTest
         // Act
         var result = MetadataSerializer.SerializeMetadata(input);
 
-        // Assert
+       // sort the values, since order is undefined for Dictionary
+       expectedResult = string.Join("|", expectedResult.Split('|').OrderBy(s => s));
+       result = string.Join("|", result.Split('|').OrderBy(s => s));
+       // Assert
         Assert.Equal(expectedResult, result);
     }
 


### PR DESCRIPTION
Extensions.ApiDescription client tests cases were failing on s390x

```
Microsoft.Extensions.ApiDescription.Client.GetOpenApiReferenceMetadataTest.Execute_SetsClassName_BasedOnSanitizedOutputPath(outputPath: "aabb.cs", className: "aa__bb") [FAIL]
[xUnit.net 00:00:00.54]       Assert.Equal() Failure: Collections differ
[xUnit.net 00:00:00.54]       Expected: [["ClassName"] = "aa__bb", ["CodeGenerator"] = "NSwagCSharp", ["FirstForGenerator"] = "true", ["Namespace"] = "Console.Client", ["OriginalItemSpec"] = "TestProjects/files/NSwag.json", ···]
[xUnit.net 00:00:00.54]       Actual:   [["ClassName"] = "aa__bb", ["CodeGenerator"] = "NSwagCSharp", ["FirstForGenerator"] = "true", ["Namespace"] = "Console.Client", ["OriginalItemSpec"] = "TestProjects/files/NSwag.json", ···]
[xUnit.net 00:00:00.54]       Stack Trace:
[xUnit.net 00:00:00.54]         /home/sanjam/aspnetcore/src/Tools/Extensions.ApiDescription.Client/test/GetOpenApiReferenceMetadataTest.cs(450,0): at Microsoft.Extensions.ApiDescription.Client.GetOpenApiReferenceMetadataTest.Execute_SetsClassName_BasedOnSanitizedOutputPath(String outputPath, String className)
[xUnit.net 00:00:00.54]            at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
[xUnit.net 00:00:00.54]            at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
[xUnit.net 00:00:00.54]    
```
according to the msdocs
```
For purposes of enumeration, each item in the dictionary is treated as a [KeyValuePair<TKey,TValue>](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.keyvaluepair-2?view=net-8.0) structure representing a value and its key. The order in which the items are returned is undefined.
```

This is just a snippet of a particular failure, I have attached the other failures as well
[Untitled.txt](https://github.com/user-attachments/files/17254191/Untitled.txt)
