### PR TITLE
Quarantine `ThreadingAppTest.CounterPageCanUseThreads`

### DIFF
--- a/src/Components/test/E2ETest/Tests/ThreadingAppTest.cs
+++ b/src/Components/test/E2ETest/Tests/ThreadingAppTest.cs
@@ -67,6 +67,7 @@ public class ThreadingAppTest
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/58242")]
     public void CounterPageCanUseThreads()
     {
         // Navigate to "Counter"


### PR DESCRIPTION
This test has been failing consistently for several days.

See: https://github.com/dotnet/aspnetcore/issues/58242