### PR TITLE
Fix handling for inert route parameters in MVC

### DIFF
--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -409,6 +409,10 @@ internal sealed class OpenApiDocumentService(
             var targetType = parameter.Type == typeof(string) && parameter.ModelMetadata.ModelType != parameter.Type
                 ? parameter.ModelMetadata.ModelType
                 : parameter.Type;
+            // If the type is null, then we're dealing with an inert
+            // route parameter that does not define a specific parameter type in the
+            // route handler or in the response. In this case, we default to a string schema.
+            targetType ??= typeof(string);
             var openApiParameter = new OpenApiParameter
             {
                 Name = parameter.Name,

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -126,8 +126,15 @@ internal sealed class OpenApiSchemaService(
         }
     };
 
-    internal async Task<OpenApiSchema> GetOrCreateSchemaAsync(Type type, IServiceProvider scopedServiceProvider, IOpenApiSchemaTransformer[] schemaTransformers, ApiParameterDescription? parameterDescription = null, bool captureSchemaByRef = false, CancellationToken cancellationToken = default)
+    internal async Task<OpenApiSchema> GetOrCreateSchemaAsync(Type? type, IServiceProvider scopedServiceProvider, IOpenApiSchemaTransformer[] schemaTransformers, ApiParameterDescription? parameterDescription = null, bool captureSchemaByRef = false, CancellationToken cancellationToken = default)
     {
+        // If the type is null, then we're dealing with an ambient
+        // route parameter that does not define a specific parameter type in the
+        // route handler or in the response. In this case, we default to a string schema.
+        if (type is null)
+        {
+            return new OpenApiSchema { Type = "string" };
+        }
         var key = parameterDescription?.ParameterDescriptor is IParameterInfoParameterDescriptor parameterInfoDescription
             && parameterDescription.ModelMetadata.PropertyName is null
             ? new OpenApiSchemaKey(type, parameterInfoDescription.ParameterInfo) : new OpenApiSchemaKey(type, null);

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -126,15 +126,8 @@ internal sealed class OpenApiSchemaService(
         }
     };
 
-    internal async Task<OpenApiSchema> GetOrCreateSchemaAsync(Type? type, IServiceProvider scopedServiceProvider, IOpenApiSchemaTransformer[] schemaTransformers, ApiParameterDescription? parameterDescription = null, bool captureSchemaByRef = false, CancellationToken cancellationToken = default)
+    internal async Task<OpenApiSchema> GetOrCreateSchemaAsync(Type type, IServiceProvider scopedServiceProvider, IOpenApiSchemaTransformer[] schemaTransformers, ApiParameterDescription? parameterDescription = null, bool captureSchemaByRef = false, CancellationToken cancellationToken = default)
     {
-        // If the type is null, then we're dealing with an ambient
-        // route parameter that does not define a specific parameter type in the
-        // route handler or in the response. In this case, we default to a string schema.
-        if (type is null)
-        {
-            return new OpenApiSchema { Type = "string" };
-        }
         var key = parameterDescription?.ParameterDescriptor is IParameterInfoParameterDescriptor parameterInfoDescription
             && parameterDescription.ModelMetadata.PropertyName is null
             ? new OpenApiSchemaKey(type, parameterInfoDescription.ParameterInfo) : new OpenApiSchemaKey(type, null);

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.ParameterSchemas.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.ParameterSchemas.cs
@@ -592,4 +592,22 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
         Approved = 1,
         Rejected = 2,
     }
+
+    [Fact]
+    public async Task SupportsMvcActionWithAmbientRouteParameter()
+    {
+        // Arrange
+        var action = CreateActionDescriptor(nameof(AmbientRouteParameter));
+
+        // Assert
+        await VerifyOpenApiDocument(action, document =>
+        {
+            var operation = document.Paths["/api/with-ambient-route-param/{versionId}"].Operations[OperationType.Get];
+            var parameter = Assert.Single(operation.Parameters);
+            Assert.Equal("string", parameter.Schema.Type);
+        });
+    }
+
+    [Route("/api/with-ambient-route-param/{versionId}")]
+    private void AmbientRouteParameter() { }
 }


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/58219.

[This comment](https://github.com/dotnet/aspnetcore/issues/58219#issuecomment-2394788741) provides some details about what's causing this issue when users use the Asp.Versioning library in conjunction with OpenAPI support.

We'll still need to investigate why the Asp.Versioning library isn't populating `ParameterType` correctly but this adds a guard in our code for these scenarios.

Note: I intended to backport this PR to .NET 9.