### PR TITLE
fix: Microsoft.AspNetCore.Mvc.Testing RedirectHandler HasBody doesn't work with PATCH

### DIFF
--- a/src/Mvc/Mvc.Testing/src/Handlers/RedirectHandler.cs
+++ b/src/Mvc/Mvc.Testing/src/Handlers/RedirectHandler.cs
@@ -61,7 +61,7 @@ public class RedirectHandler : DelegatingHandler
     }
 
     private static bool HasBody(HttpRequestMessage request) =>
-        request.Method == HttpMethod.Post || request.Method == HttpMethod.Put;
+        request.Method == HttpMethod.Post || request.Method == HttpMethod.Put || request.Method == HttpMethod.Patch;
 
     private static async Task<HttpContent?> DuplicateRequestContent(HttpRequestMessage request)
     {


### PR DESCRIPTION
# fix: Microsoft.AspNetCore.Mvc.Testing RedirectHandler HasBody doesn't work with PATCH

<!-- Thank you for submitting a pull request to our repo. -->


- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Related #58270 

## Description

`RedirectHandler` doesn't work with Patch requests has it doesn't copy their body.

Fixes #{bug number} (in this specific format)
