### PR TITLE
[Blazor] Apply CORS also to .mjs files

### DIFF
--- a/src/Components/WebAssembly/DevServer/src/Server/Startup.cs
+++ b/src/Components/WebAssembly/DevServer/src/Server/Startup.cs
@@ -42,7 +42,7 @@ internal sealed class Startup
             else if (applyCopHeaders && ctx.Request.Path.StartsWithSegments("/_framework") && !ctx.Request.Path.StartsWithSegments("/_framework/blazor.server.js") && !ctx.Request.Path.StartsWithSegments("/_framework/blazor.web.js"))
             {
                 var fileExtension = Path.GetExtension(ctx.Request.Path);
-                if (string.Equals(fileExtension, ".js", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(fileExtension, ".js", StringComparison.OrdinalIgnoreCase) || string.Equals(fileExtension, ".mjs", StringComparison.OrdinalIgnoreCase))
                 {
                     // Browser multi-threaded runtime requires cross-origin policy headers to enable SharedArrayBuffer.
                     ApplyCrossOriginPolicyHeaders(ctx);


### PR DESCRIPTION
Emscripten as use produces worker script as `dotnet.runtime.worker.mjs`. 
We need to serve CORS headers for it as well.