### PR TITLE
Use new Dictionary AlternateLookup to avoid allocation in DictionaryJumpTable

### DIFF
--- a/src/Http/Routing/perf/Microbenchmarks/Matching/JumpTableMultipleEntryBenchmark.cs
+++ b/src/Http/Routing/perf/Microbenchmarks/Matching/JumpTableMultipleEntryBenchmark.cs
@@ -27,7 +27,7 @@ public class JumpTableMultipleEntryBenchmark
 
         for (var i = 0; i < _strings.Length; i++)
         {
-            _segments[i] = new PathSegment(0, _strings[i].Length);
+            _segments[i] = new PathSegment(1, _strings[i].Length - 2);
         }
 
         var samples = new int[Count];
@@ -39,7 +39,9 @@ public class JumpTableMultipleEntryBenchmark
         var entries = new List<(string text, int _)>();
         for (var i = 0; i < samples.Length; i++)
         {
-            entries.Add((_strings[samples[i]], i));
+            var sampleIndex = samples[i];
+            var segment = _segments[sampleIndex];
+            entries.Add((_strings[sampleIndex].Substring(segment.Start, segment.Length), i));
         }
 
         _linearSearch = new LinearSearchJumpTable(0, -1, entries.ToArray());

--- a/src/Http/Routing/src/Matching/DictionaryJumpTable.cs
+++ b/src/Http/Routing/src/Matching/DictionaryJumpTable.cs
@@ -12,6 +12,7 @@ internal sealed class DictionaryJumpTable : JumpTable
     private readonly int _defaultDestination;
     private readonly int _exitDestination;
     private readonly FrozenDictionary<string, int> _dictionary;
+    private readonly FrozenDictionary<string, int>.AlternateLookup<ReadOnlySpan<char>> _lookup;
 
     public DictionaryJumpTable(
         int defaultDestination,
@@ -22,6 +23,7 @@ internal sealed class DictionaryJumpTable : JumpTable
         _exitDestination = exitDestination;
 
         _dictionary = entries.ToFrozenDictionary(e => e.text, e => e.destination, StringComparer.OrdinalIgnoreCase);
+        _lookup = _dictionary.GetAlternateLookup<ReadOnlySpan<char>>();
     }
 
     public override int GetDestination(string path, PathSegment segment)
@@ -31,8 +33,8 @@ internal sealed class DictionaryJumpTable : JumpTable
             return _exitDestination;
         }
 
-        var text = path.Substring(segment.Start, segment.Length);
-        if (_dictionary.TryGetValue(text, out var destination))
+        var text = path.AsSpan(segment.Start, segment.Length);
+        if (_lookup.TryGetValue(text, out var destination))
         {
             return destination;
         }


### PR DESCRIPTION
Use new Dictionary AlternateLookup to avoid allocation in DictionaryJumpTable

## Description

Simple change which removes the `substring` allocation in DictionaryJumpTable using the `GetAlternateLookup<ReadOnlySpan<char>>` feature of .NET 9.

With this change all JumpTable implementations can accept `ReadOnlySpan<char>` as a parameter instead of `string, PathSegment`. I'd be happy to include that change if it's wanted.