### PR TITLE
Validate scopes in OpenApiDocumentProvider tests and fix scope

### DIFF
--- a/src/OpenApi/src/Services/OpenApiDocumentProvider.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentProvider.cs
@@ -25,7 +25,9 @@ internal sealed class OpenApiDocumentProvider(IServiceProvider serviceProvider) 
     /// <param name="writer">A text writer associated with the document to write to.</param>
     public async Task GenerateAsync(string documentName, TextWriter writer)
     {
-        var optionsSnapshot = serviceProvider.GetRequiredService<IOptionsSnapshot<OpenApiOptions>>();
+        // Resolving IOptionsSnapshot requires a scoped service provider.
+        using var scopedService = serviceProvider.CreateScope();
+        var optionsSnapshot = scopedService.ServiceProvider.GetRequiredService<IOptionsSnapshot<OpenApiOptions>>();
         var namedOption = optionsSnapshot.Get(documentName);
         var resolvedOpenApiVersion = namedOption.OpenApiVersion;
         await GenerateAsync(documentName, writer, resolvedOpenApiVersion);

--- a/src/OpenApi/src/Services/OpenApiDocumentProvider.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentProvider.cs
@@ -25,10 +25,8 @@ internal sealed class OpenApiDocumentProvider(IServiceProvider serviceProvider) 
     /// <param name="writer">A text writer associated with the document to write to.</param>
     public async Task GenerateAsync(string documentName, TextWriter writer)
     {
-        // Resolving IOptionsSnapshot requires a scoped service provider.
-        using var scopedService = serviceProvider.CreateScope();
-        var optionsSnapshot = scopedService.ServiceProvider.GetRequiredService<IOptionsSnapshot<OpenApiOptions>>();
-        var namedOption = optionsSnapshot.Get(documentName);
+        var options = serviceProvider.GetRequiredService<IOptionsMonitor<OpenApiOptions>>();
+        var namedOption = options.Get(documentName);
         var resolvedOpenApiVersion = namedOption.OpenApiVersion;
         await GenerateAsync(documentName, writer, resolvedOpenApiVersion);
     }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentProviderTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentProviderTests.cs
@@ -68,7 +68,7 @@ public class OpenApiDocumentProviderTests : OpenApiDocumentServiceTestBase
         {
             serviceCollection.AddOpenApi(documentName);
         }
-        var serviceProvider = serviceCollection.BuildServiceProvider();
+        var serviceProvider = serviceCollection.BuildServiceProvider(validateScopes: true);
         return serviceProvider;
     }
 }


### PR DESCRIPTION
This PR resolves an issue where an `IOptionsSnapshot<>` instance was incorrectly resolved from the root provider. It also updates the tests for `OpenApiDocumentProvider` to validate scopes so we can catch this issue in tests.