### PR TITLE
Fix missing bullet list items in InputDate documentation

### DIFF
--- a/src/Components/Web/src/Forms/InputDate.cs
+++ b/src/Components/Web/src/Forms/InputDate.cs
@@ -12,10 +12,10 @@ namespace Microsoft.AspNetCore.Components.Forms;
 /// An input component for editing date values.
 /// The supported types for the date value are:
 /// <list type="bullet">
-/// <item><see cref="DateTime"/></item>
-/// <item><see cref="DateTimeOffset"/></item>
-/// <item><see cref="DateOnly"/></item>
-/// <item><see cref="TimeOnly"/></item>
+/// <item><description><see cref="DateTime"/></description></item>
+/// <item><description><see cref="DateTimeOffset"/></description></item>
+/// <item><description><see cref="DateOnly"/></description></item>
+/// <item><description><see cref="TimeOnly"/></description></item>
 /// </list>
 /// </summary>
 public class InputDate<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TValue> : InputBase<TValue>


### PR DESCRIPTION
# Fix missing bullet list items in InputDate documentation

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Add `<description>` element to the bullet list.

## Description

The documentation for `InputDate` has a bullet list with missing items as seem in the following page link:
https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.components.forms.inputdate-1?view=aspnetcore-8.0

As per the `<list>` XML documentation comments guideline, we need to supply a `<description>` entry within this list element's items. Link: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/recommended-tags#list

A working example can be seen [here](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.antiforgery.antiforgeryoptions.cookie?view=aspnetcore-8.0#remarks) and its corresponding [code](https://github.com/dotnet/aspnetcore/blob/3f1acb59718cadf111a0a796681e3d3509bb3381/src/Antiforgery/src/AntiforgeryOptions.cs#L47C1-L54C16).

Fixes #57357 
