### PR TITLE
Parse enum unions in config

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/ConfigurationReader.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/ConfigurationReader.cs
@@ -202,7 +202,7 @@ internal sealed class ConfigurationReader
 
         return null;
 
-        static bool TryParseProtocol(string protocol, [NotNullWhen(true)] out HttpProtocols result)
+        static bool TryParseProtocol(string protocol, out HttpProtocols result)
         {
             if (Enum.TryParse<HttpProtocols>(protocol, ignoreCase: true, out var parsed))
             {
@@ -250,7 +250,7 @@ internal sealed class ConfigurationReader
 
         return result;
 
-        static bool TryParseSslProtocol(string protocol, [NotNullWhen(true)] out SslProtocols result)
+        static bool TryParseSslProtocol(string protocol, out SslProtocols result)
         {
             if (Enum.TryParse<SslProtocols>(protocol, ignoreCase: true, out var parsed))
             {


### PR DESCRIPTION
In particular, `HttpProtocols` and `SslProtocols`.  This should be more forward compatible than adding an explicit enum member for each combination of values.

For #58088