### PR TITLE
Unquarantine StreamPool_MultipleStreamsConcurrent_StreamsReturnedToPool

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -434,7 +434,6 @@ public class Http2ConnectionTests : Http2TestBase
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/39477")]
     public async Task StreamPool_MultipleStreamsConcurrent_StreamsReturnedToPool()
     {
         await InitializeConnectionAsync(_echoApplication);


### PR DESCRIPTION
Part of build-ops cycle https://github.com/dotnet/aspnetcore-internal/issues/4635

This test has a 100% pass rate over the last 30 days, is marked `test-fixed`, and had a PR containing a proposed fix over 30 days ago. So I believe it qualifies for unquarantining.

@amcasey Can you confirm you're happy for this test to be unquarantined?