### PR TITLE
ArcadeBuildFromSource -> DotNetBuildSourceOnly

### DIFF
--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -103,7 +103,7 @@
 
     <PropertyGroup>
       <!-- Disable installing puppeteer browsers when running in source build -->
-      <_AdditionalEnvironmentVariable Condition="$(ArcadeBuildFromSource) == 'true'">PUPPETEER_SKIP_DOWNLOAD=1</_AdditionalEnvironmentVariable>
+      <_AdditionalEnvironmentVariable Condition="$(DotNetBuildSourceOnly) == 'true'">PUPPETEER_SKIP_DOWNLOAD=1</_AdditionalEnvironmentVariable>
     </PropertyGroup>
 
     <Exec


### PR DESCRIPTION
Change from old control to new control. I think the intention here was that we should never install puppeteer in outer or inner source-only scenarios.