### PR TITLE
Remove bulk disables of CA warnings

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/EventTracing.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/EventTracing.h
@@ -4,13 +4,7 @@
 #pragma once
 
 #include <httptrace.h>
-
-#pragma warning( push )
-#pragma warning ( disable : ALL_CODE_ANALYSIS_WARNINGS )
-
 #include "aspnetcore_event.h"
-
-#pragma warning( pop )
 
 template< class EVENT, typename ...Params >
 void RaiseEvent(IHttpTraceContext * pTraceContext,Params&&... params)

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/aspnetcore_event.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/aspnetcore_event.h
@@ -49,7 +49,7 @@ public:
         {
         case 0x10000: return L"ANCM";
         }
-        return NULL;
+        return nullptr;
     };
 
     static
@@ -127,8 +127,8 @@ public:
             Event.dwEventVersion = 1;
             Event.dwVerbosity = 4;
             Event.cEventItems = 2;
-            Event.pActivityGuid = NULL;
-            Event.pRelatedActivityGuid = NULL;
+            Event.pActivityGuid = nullptr;
+            Event.pRelatedActivityGuid = nullptr;
             Event.dwTimeStamp = 0;
             Event.dwFlags = HTTP_TRACE_EVENT_FLAG_STATIC_DESCRIPTIVE_FIELDS;
     
@@ -139,13 +139,13 @@ public:
             Items[ 0 ].dwDataType = HTTP_TRACE_TYPE_LPCGUID; // mof type (object)
             Items[ 0 ].pbData = (PBYTE) pContextId;
             Items[ 0 ].cbData = 16;
-            Items[ 0 ].pszDataDescription = NULL;
+            Items[ 0 ].pszDataDescription = nullptr;
             Items[ 1 ].pszName = L"AppDescription";
             Items[ 1 ].dwDataType = HTTP_TRACE_TYPE_LPCWSTR; // mof type (string)
             Items[ 1 ].pbData = (PBYTE) pAppDescription;
             Items[ 1 ].cbData  = 
-                 ( Items[ 1 ].pbData == NULL )? 0 : ( sizeof(WCHAR) * (1 + (DWORD) wcslen( (PWSTR) Items[ 1 ].pbData  ) ) );
-            Items[ 1 ].pszDataDescription = NULL;
+                 ( Items[ 1 ].pbData == nullptr )? 0 : ( sizeof(WCHAR) * (1 + (DWORD) wcslen( (PWSTR) Items[ 1 ].pbData  ) ) );
+            Items[ 1 ].pszDataDescription = nullptr;
             Event.pEventItems = Items;
             pHttpTraceContext->RaiseTraceEvent( &Event );
             return S_OK;
@@ -194,8 +194,8 @@ public:
             Event.dwEventVersion = 1;
             Event.dwVerbosity = 2;
             Event.cEventItems = 2;
-            Event.pActivityGuid = NULL;
-            Event.pRelatedActivityGuid = NULL;
+            Event.pActivityGuid = nullptr;
+            Event.pRelatedActivityGuid = nullptr;
             Event.dwTimeStamp = 0;
             Event.dwFlags = HTTP_TRACE_EVENT_FLAG_STATIC_DESCRIPTIVE_FIELDS;
     
@@ -206,13 +206,13 @@ public:
             Items[ 0 ].dwDataType = HTTP_TRACE_TYPE_LPCGUID; // mof type (object)
             Items[ 0 ].pbData = (PBYTE) pContextId;
             Items[ 0 ].cbData = 16;
-            Items[ 0 ].pszDataDescription = NULL;
+            Items[ 0 ].pszDataDescription = nullptr;
             Items[ 1 ].pszName = L"FailureDescription";
             Items[ 1 ].dwDataType = HTTP_TRACE_TYPE_LPCWSTR; // mof type (string)
             Items[ 1 ].pbData = (PBYTE) pFailureDescription;
             Items[ 1 ].cbData  = 
-                 ( Items[ 1 ].pbData == NULL )? 0 : ( sizeof(WCHAR) * (1 + (DWORD) wcslen( (PWSTR) Items[ 1 ].pbData  ) ) );
-            Items[ 1 ].pszDataDescription = NULL;
+                 ( Items[ 1 ].pbData == nullptr)? 0 : ( sizeof(WCHAR) * (1 + (DWORD) wcslen( (PWSTR) Items[ 1 ].pbData  ) ) );
+            Items[ 1 ].pszDataDescription = nullptr;
             Event.pEventItems = Items;
             pHttpTraceContext->RaiseTraceEvent( &Event );
             return S_OK;
@@ -260,8 +260,8 @@ public:
             Event.dwEventVersion = 1;
             Event.dwVerbosity = 4;
             Event.cEventItems = 1;
-            Event.pActivityGuid = NULL;
-            Event.pRelatedActivityGuid = NULL;
+            Event.pActivityGuid = nullptr;
+            Event.pRelatedActivityGuid = nullptr;
             Event.dwTimeStamp = 0;
             Event.dwFlags = HTTP_TRACE_EVENT_FLAG_STATIC_DESCRIPTIVE_FIELDS;
     
@@ -272,7 +272,7 @@ public:
             Items[ 0 ].dwDataType = HTTP_TRACE_TYPE_LPCGUID; // mof type (object)
             Items[ 0 ].pbData = (PBYTE) pContextId;
             Items[ 0 ].cbData = 16;
-            Items[ 0 ].pszDataDescription = NULL;
+            Items[ 0 ].pszDataDescription = nullptr;
             Event.pEventItems = Items;
             pHttpTraceContext->RaiseTraceEvent( &Event );
             return S_OK;
@@ -320,8 +320,8 @@ public:
             Event.dwEventVersion = 1;
             Event.dwVerbosity = 4;
             Event.cEventItems = 1;
-            Event.pActivityGuid = NULL;
-            Event.pRelatedActivityGuid = NULL;
+            Event.pActivityGuid = nullptr;
+            Event.pRelatedActivityGuid = nullptr;
             Event.dwTimeStamp = 0;
             Event.dwFlags = HTTP_TRACE_EVENT_FLAG_STATIC_DESCRIPTIVE_FIELDS;
     
@@ -332,7 +332,7 @@ public:
             Items[ 0 ].dwDataType = HTTP_TRACE_TYPE_LPCGUID; // mof type (object)
             Items[ 0 ].pbData = (PBYTE) pContextId;
             Items[ 0 ].cbData = 16;
-            Items[ 0 ].pszDataDescription = NULL;
+            Items[ 0 ].pszDataDescription = nullptr;
             Event.pEventItems = Items;
             pHttpTraceContext->RaiseTraceEvent( &Event );
             return S_OK;
@@ -381,8 +381,8 @@ public:
             Event.dwEventVersion = 1;
             Event.dwVerbosity = 2;
             Event.cEventItems = 2;
-            Event.pActivityGuid = NULL;
-            Event.pRelatedActivityGuid = NULL;
+            Event.pActivityGuid = nullptr;
+            Event.pRelatedActivityGuid = nullptr;
             Event.dwTimeStamp = 0;
             Event.dwFlags = HTTP_TRACE_EVENT_FLAG_STATIC_DESCRIPTIVE_FIELDS;
     
@@ -393,12 +393,12 @@ public:
             Items[ 0 ].dwDataType = HTTP_TRACE_TYPE_LPCGUID; // mof type (object)
             Items[ 0 ].pbData = (PBYTE) pContextId;
             Items[ 0 ].cbData = 16;
-            Items[ 0 ].pszDataDescription = NULL;
+            Items[ 0 ].pszDataDescription = nullptr;
             Items[ 1 ].pszName = L"ErrorCode";
             Items[ 1 ].dwDataType = HTTP_TRACE_TYPE_ULONG; // mof type (uint32)
             Items[ 1 ].pbData = (PBYTE) &ErrorCode;
             Items[ 1 ].cbData = 4;
-            Items[ 1 ].pszDataDescription = NULL;
+            Items[ 1 ].pszDataDescription = nullptr;
             Event.pEventItems = Items;
             pHttpTraceContext->RaiseTraceEvent( &Event );
             return S_OK;
@@ -447,8 +447,8 @@ public:
             Event.dwEventVersion = 1;
             Event.dwVerbosity = 4;
             Event.cEventItems = 2;
-            Event.pActivityGuid = NULL;
-            Event.pRelatedActivityGuid = NULL;
+            Event.pActivityGuid = nullptr;
+            Event.pRelatedActivityGuid = nullptr;
             Event.dwTimeStamp = 0;
             Event.dwFlags = HTTP_TRACE_EVENT_FLAG_STATIC_DESCRIPTIVE_FIELDS;
     
@@ -459,12 +459,12 @@ public:
             Items[ 0 ].dwDataType = HTTP_TRACE_TYPE_LPCGUID; // mof type (object)
             Items[ 0 ].pbData = (PBYTE) pContextId;
             Items[ 0 ].cbData = 16;
-            Items[ 0 ].pszDataDescription = NULL;
+            Items[ 0 ].pszDataDescription = nullptr;
             Items[ 1 ].pszName = L"InternetStatus";
             Items[ 1 ].dwDataType = HTTP_TRACE_TYPE_ULONG; // mof type (uint32)
             Items[ 1 ].pbData = (PBYTE) &InternetStatus;
             Items[ 1 ].cbData = 4;
-            Items[ 1 ].pszDataDescription = NULL;
+            Items[ 1 ].pszDataDescription = nullptr;
             Event.pEventItems = Items;
             pHttpTraceContext->RaiseTraceEvent( &Event );
             return S_OK;
@@ -512,8 +512,8 @@ public:
             Event.dwEventVersion = 1;
             Event.dwVerbosity = 4;
             Event.cEventItems = 1;
-            Event.pActivityGuid = NULL;
-            Event.pRelatedActivityGuid = NULL;
+            Event.pActivityGuid = nullptr;
+            Event.pRelatedActivityGuid = nullptr;
             Event.dwTimeStamp = 0;
             Event.dwFlags = HTTP_TRACE_EVENT_FLAG_STATIC_DESCRIPTIVE_FIELDS;
     
@@ -524,7 +524,7 @@ public:
             Items[ 0 ].dwDataType = HTTP_TRACE_TYPE_LPCGUID; // mof type (object)
             Items[ 0 ].pbData = (PBYTE) pContextId;
             Items[ 0 ].cbData = 16;
-            Items[ 0 ].pszDataDescription = NULL;
+            Items[ 0 ].pszDataDescription = nullptr;
             Event.pEventItems = Items;
             pHttpTraceContext->RaiseTraceEvent( &Event );
             return S_OK;
@@ -573,8 +573,8 @@ public:
             Event.dwEventVersion = 1;
             Event.dwVerbosity = 5;
             Event.cEventItems = 2;
-            Event.pActivityGuid = NULL;
-            Event.pRelatedActivityGuid = NULL;
+            Event.pActivityGuid = nullptr;
+            Event.pRelatedActivityGuid = nullptr;
             Event.dwTimeStamp = 0;
             Event.dwFlags = HTTP_TRACE_EVENT_FLAG_STATIC_DESCRIPTIVE_FIELDS;
     
@@ -585,12 +585,12 @@ public:
             Items[ 0 ].dwDataType = HTTP_TRACE_TYPE_LPCGUID; // mof type (object)
             Items[ 0 ].pbData = (PBYTE) pContextId;
             Items[ 0 ].cbData = 16;
-            Items[ 0 ].pszDataDescription = NULL;
+            Items[ 0 ].pszDataDescription = nullptr;
             Items[ 1 ].pszName = L"requestStatus";
             Items[ 1 ].dwDataType = HTTP_TRACE_TYPE_ULONG; // mof type (uint32)
             Items[ 1 ].pbData = (PBYTE) &requestStatus;
             Items[ 1 ].cbData = 4;
-            Items[ 1 ].pszDataDescription = NULL;
+            Items[ 1 ].pszDataDescription = nullptr;
             Event.pEventItems = Items;
             pHttpTraceContext->RaiseTraceEvent( &Event );
             return S_OK;
@@ -638,8 +638,8 @@ public:
             Event.dwEventVersion = 1;
             Event.dwVerbosity = 5;
             Event.cEventItems = 1;
-            Event.pActivityGuid = NULL;
-            Event.pRelatedActivityGuid = NULL;
+            Event.pActivityGuid = nullptr;
+            Event.pRelatedActivityGuid = nullptr;
             Event.dwTimeStamp = 0;
             Event.dwFlags = HTTP_TRACE_EVENT_FLAG_STATIC_DESCRIPTIVE_FIELDS;
     
@@ -650,7 +650,7 @@ public:
             Items[ 0 ].dwDataType = HTTP_TRACE_TYPE_LPCGUID; // mof type (object)
             Items[ 0 ].pbData = (PBYTE) pContextId;
             Items[ 0 ].cbData = 16;
-            Items[ 0 ].pszDataDescription = NULL;
+            Items[ 0 ].pszDataDescription = nullptr;
             Event.pEventItems = Items;
             pHttpTraceContext->RaiseTraceEvent( &Event );
             return S_OK;
@@ -699,8 +699,8 @@ public:
             Event.dwEventVersion = 1;
             Event.dwVerbosity = 5;
             Event.cEventItems = 2;
-            Event.pActivityGuid = NULL;
-            Event.pRelatedActivityGuid = NULL;
+            Event.pActivityGuid = nullptr;
+            Event.pRelatedActivityGuid = nullptr;
             Event.dwTimeStamp = 0;
             Event.dwFlags = HTTP_TRACE_EVENT_FLAG_STATIC_DESCRIPTIVE_FIELDS;
     
@@ -711,12 +711,12 @@ public:
             Items[ 0 ].dwDataType = HTTP_TRACE_TYPE_LPCGUID; // mof type (object)
             Items[ 0 ].pbData = (PBYTE) pContextId;
             Items[ 0 ].cbData = 16;
-            Items[ 0 ].pszDataDescription = NULL;
+            Items[ 0 ].pszDataDescription = nullptr;
             Items[ 1 ].pszName = L"requestStatus";
             Items[ 1 ].dwDataType = HTTP_TRACE_TYPE_ULONG; // mof type (uint32)
             Items[ 1 ].pbData = (PBYTE) &requestStatus;
             Items[ 1 ].cbData = 4;
-            Items[ 1 ].pszDataDescription = NULL;
+            Items[ 1 ].pszDataDescription = nullptr;
             Event.pEventItems = Items;
             pHttpTraceContext->RaiseTraceEvent( &Event );
             return S_OK;
@@ -764,8 +764,8 @@ public:
             Event.dwEventVersion = 1;
             Event.dwVerbosity = 4;
             Event.cEventItems = 1;
-            Event.pActivityGuid = NULL;
-            Event.pRelatedActivityGuid = NULL;
+            Event.pActivityGuid = nullptr;
+            Event.pRelatedActivityGuid = nullptr;
             Event.dwTimeStamp = 0;
             Event.dwFlags = HTTP_TRACE_EVENT_FLAG_STATIC_DESCRIPTIVE_FIELDS;
     
@@ -776,7 +776,7 @@ public:
             Items[ 0 ].dwDataType = HTTP_TRACE_TYPE_LPCGUID; // mof type (object)
             Items[ 0 ].pbData = (PBYTE) pContextId;
             Items[ 0 ].cbData = 16;
-            Items[ 0 ].pszDataDescription = NULL;
+            Items[ 0 ].pszDataDescription = nullptr;
             Event.pEventItems = Items;
             pHttpTraceContext->RaiseTraceEvent( &Event );
             return S_OK;
@@ -824,8 +824,8 @@ public:
             Event.dwEventVersion = 1;
             Event.dwVerbosity = 4;
             Event.cEventItems = 1;
-            Event.pActivityGuid = NULL;
-            Event.pRelatedActivityGuid = NULL;
+            Event.pActivityGuid = nullptr;
+            Event.pRelatedActivityGuid = nullptr;
             Event.dwTimeStamp = 0;
             Event.dwFlags = HTTP_TRACE_EVENT_FLAG_STATIC_DESCRIPTIVE_FIELDS;
     
@@ -836,7 +836,7 @@ public:
             Items[ 0 ].dwDataType = HTTP_TRACE_TYPE_LPCGUID; // mof type (object)
             Items[ 0 ].pbData = (PBYTE) pContextId;
             Items[ 0 ].cbData = 16;
-            Items[ 0 ].pszDataDescription = NULL;
+            Items[ 0 ].pszDataDescription = nullptr;
             Event.pEventItems = Items;
             pHttpTraceContext->RaiseTraceEvent( &Event );
             return S_OK;
@@ -884,8 +884,8 @@ public:
             Event.dwEventVersion = 1;
             Event.dwVerbosity = 4;
             Event.cEventItems = 1;
-            Event.pActivityGuid = NULL;
-            Event.pRelatedActivityGuid = NULL;
+            Event.pActivityGuid = nullptr;
+            Event.pRelatedActivityGuid = nullptr;
             Event.dwTimeStamp = 0;
             Event.dwFlags = HTTP_TRACE_EVENT_FLAG_STATIC_DESCRIPTIVE_FIELDS;
     
@@ -896,7 +896,7 @@ public:
             Items[ 0 ].dwDataType = HTTP_TRACE_TYPE_LPCGUID; // mof type (object)
             Items[ 0 ].pbData = (PBYTE) pContextId;
             Items[ 0 ].cbData = 16;
-            Items[ 0 ].pszDataDescription = NULL;
+            Items[ 0 ].pszDataDescription = nullptr;
             Event.pEventItems = Items;
             pHttpTraceContext->RaiseTraceEvent( &Event );
             return S_OK;
@@ -947,8 +947,8 @@ public:
             Event.dwEventVersion = 1;
             Event.dwVerbosity = 3;
             Event.cEventItems = 4;
-            Event.pActivityGuid = NULL;
-            Event.pRelatedActivityGuid = NULL;
+            Event.pActivityGuid = nullptr;
+            Event.pRelatedActivityGuid = nullptr;
             Event.dwTimeStamp = 0;
             Event.dwFlags = HTTP_TRACE_EVENT_FLAG_STATIC_DESCRIPTIVE_FIELDS;
     
@@ -959,23 +959,23 @@ public:
             Items[ 0 ].dwDataType = HTTP_TRACE_TYPE_LPCGUID; // mof type (object)
             Items[ 0 ].pbData = (PBYTE) pContextId;
             Items[ 0 ].cbData = 16;
-            Items[ 0 ].pszDataDescription = NULL;
+            Items[ 0 ].pszDataDescription = nullptr;
             Items[ 1 ].pszName = L"File";
             Items[ 1 ].dwDataType = HTTP_TRACE_TYPE_LPCSTR; // mof type (string)
             Items[ 1 ].pbData = (PBYTE) pFile;
             Items[ 1 ].cbData  = 
-                 ( Items[ 1 ].pbData == NULL )? 0 : (1 + (DWORD) strlen( (PSTR) Items[ 1 ].pbData ) );
-            Items[ 1 ].pszDataDescription = NULL;
+                 ( Items[ 1 ].pbData == nullptr )? 0 : (1 + (DWORD) strlen( (PSTR) Items[ 1 ].pbData ) );
+            Items[ 1 ].pszDataDescription = nullptr;
             Items[ 2 ].pszName = L"Line";
             Items[ 2 ].dwDataType = HTTP_TRACE_TYPE_ULONG; // mof type (uint32)
             Items[ 2 ].pbData = (PBYTE) &Line;
             Items[ 2 ].cbData = 4;
-            Items[ 2 ].pszDataDescription = NULL;
+            Items[ 2 ].pszDataDescription = nullptr;
             Items[ 3 ].pszName = L"HResult";
             Items[ 3 ].dwDataType = HTTP_TRACE_TYPE_ULONG; // mof type (uint32)
             Items[ 3 ].pbData = (PBYTE) &HResult;
             Items[ 3 ].cbData = 4;
-            Items[ 3 ].pszDataDescription = NULL;
+            Items[ 3 ].pszDataDescription = nullptr;
             Event.pEventItems = Items;
             pHttpTraceContext->RaiseTraceEvent( &Event );
             return S_OK;
@@ -1026,8 +1026,8 @@ public:
             Event.dwEventVersion = 1;
             Event.dwVerbosity = 3;
             Event.cEventItems = 4;
-            Event.pActivityGuid = NULL;
-            Event.pRelatedActivityGuid = NULL;
+            Event.pActivityGuid = nullptr;
+            Event.pRelatedActivityGuid = nullptr;
             Event.dwTimeStamp = 0;
             Event.dwFlags = HTTP_TRACE_EVENT_FLAG_STATIC_DESCRIPTIVE_FIELDS;
     
@@ -1038,24 +1038,24 @@ public:
             Items[ 0 ].dwDataType = HTTP_TRACE_TYPE_LPCGUID; // mof type (object)
             Items[ 0 ].pbData = (PBYTE) pContextId;
             Items[ 0 ].cbData = 16;
-            Items[ 0 ].pszDataDescription = NULL;
+            Items[ 0 ].pszDataDescription = nullptr;
             Items[ 1 ].pszName = L"File";
             Items[ 1 ].dwDataType = HTTP_TRACE_TYPE_LPCSTR; // mof type (string)
             Items[ 1 ].pbData = (PBYTE) pFile;
             Items[ 1 ].cbData  = 
-                 ( Items[ 1 ].pbData == NULL )? 0 : (1 + (DWORD) strlen( (PSTR) Items[ 1 ].pbData ) );
-            Items[ 1 ].pszDataDescription = NULL;
+                 ( Items[ 1 ].pbData == nullptr )? 0 : (1 + (DWORD) strlen( (PSTR) Items[ 1 ].pbData ) );
+            Items[ 1 ].pszDataDescription = nullptr;
             Items[ 2 ].pszName = L"Line";
             Items[ 2 ].dwDataType = HTTP_TRACE_TYPE_ULONG; // mof type (uint32)
             Items[ 2 ].pbData = (PBYTE) &Line;
             Items[ 2 ].cbData = 4;
-            Items[ 2 ].pszDataDescription = NULL;
+            Items[ 2 ].pszDataDescription = nullptr;
             Items[ 3 ].pszName = L"Description";
             Items[ 3 ].dwDataType = HTTP_TRACE_TYPE_LPCSTR; // mof type (string)
             Items[ 3 ].pbData = (PBYTE) pDescription;
             Items[ 3 ].cbData  = 
-                 ( Items[ 3 ].pbData == NULL )? 0 : (1 + (DWORD) strlen( (PSTR) Items[ 3 ].pbData ) );
-            Items[ 3 ].pszDataDescription = NULL;
+                 ( Items[ 3 ].pbData == nullptr )? 0 : (1 + (DWORD) strlen( (PSTR) Items[ 3 ].pbData ) );
+            Items[ 3 ].pszDataDescription = nullptr;
             Event.pEventItems = Items;
             pHttpTraceContext->RaiseTraceEvent( &Event );
             return S_OK;

--- a/src/Servers/IIS/AspNetCoreModuleV2/IISLib/acache.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/IISLib/acache.cpp
@@ -3,11 +3,14 @@
 
 #include "precomp.h"
 
-#pragma warning( push )
-#pragma warning ( disable : ALL_CODE_ANALYSIS_WARNINGS )
-
 LONG    ALLOC_CACHE_HANDLER::sm_nFillPattern = 0xACA50000;
 HANDLE  ALLOC_CACHE_HANDLER::sm_hHeap;
+
+#if defined(_MSC_VER)
+static_assert(_MSC_VER >= 1600, "This code requires MSVC 10 or later.");
+#else
+static_assert(false, "This code requires MSVC");
+#endif
 
 //
 // This class is used to implement the free list.  We cast the free'd
@@ -33,7 +36,7 @@ public:
 ALLOC_CACHE_HANDLER::ALLOC_CACHE_HANDLER(
 ) : m_nThreshold(0),
     m_cbSize(0),
-    m_pFreeLists(NULL),
+    m_pFreeLists(nullptr),
     m_nTotal(0)
 {
 }
@@ -41,11 +44,11 @@ ALLOC_CACHE_HANDLER::ALLOC_CACHE_HANDLER(
 ALLOC_CACHE_HANDLER::~ALLOC_CACHE_HANDLER(
 )
 {
-    if (m_pFreeLists != NULL)
+    if (m_pFreeLists != nullptr)
     {
         CleanupLookaside();
         m_pFreeLists->Dispose();
-        m_pFreeLists = NULL;
+        m_pFreeLists = nullptr;
     }
 }
 
@@ -140,7 +143,7 @@ VOID
 ALLOC_CACHE_HANDLER::StaticTerminate(
 )
 {
-    sm_hHeap = NULL;
+    sm_hHeap = nullptr;
 }
 
 VOID
@@ -163,13 +166,12 @@ ALLOC_CACHE_HANDLER::CleanupLookaside(
     // memory must be 16 bytes aligned and currently it is 64.
     //
 
-#if defined(_MSC_VER) && _MSC_VER >= 1600 // VC10
     auto Predicate = [=] (SLIST_HEADER * pListHeader)
     {
         LONG NodesToDelete = QueryDepthSList( pListHeader );
 
         PSLIST_ENTRY pl = InterlockedPopEntrySList(pListHeader);
-        while ( pl != NULL && --NodesToDelete >= 0 )
+        while ( pl != nullptr && --NodesToDelete >= 0 )
         {
             InterlockedDecrement( &m_nTotal);
 
@@ -178,48 +180,22 @@ ALLOC_CACHE_HANDLER::CleanupLookaside(
             pl = InterlockedPopEntrySList(pListHeader);
         }
     };
-#else
-    class Functor
-    {
-    public:
-        explicit Functor(ALLOC_CACHE_HANDLER * pThis) : _pThis(pThis)
-        {
-        }
-        void operator()(SLIST_HEADER * pListHeader)
-        {
-            PSLIST_ENTRY pl;
-            LONG NodesToDelete = QueryDepthSList( pListHeader );
-
-            pl = InterlockedPopEntrySList( pListHeader );
-            while ( pl != NULL && --NodesToDelete >= 0 )
-            {
-                InterlockedDecrement( &_pThis->m_nTotal);
-
-                ::HeapFree( sm_hHeap, 0, pl );
-
-                pl = InterlockedPopEntrySList(pListHeader);
-            }
-        }
-    private:
-        ALLOC_CACHE_HANDLER * _pThis;
-    } Predicate(this);
-#endif
 
     m_pFreeLists ->ForEach(Predicate);
 }
-
+
 LPVOID
 ALLOC_CACHE_HANDLER::Alloc(
 )
 {
-    LPVOID pMemory = NULL;
+    LPVOID pMemory = nullptr;
 
     if ( m_nThreshold > 0 )
     {
         SLIST_HEADER * pListHeader = m_pFreeLists ->GetLocal();
         pMemory = (LPVOID) InterlockedPopEntrySList(pListHeader);  // get the real object
 
-        if (pMemory != NULL)
+        if (pMemory != nullptr)
         {
             FREE_LIST_HEADER* pfl = static_cast<FREE_LIST_HEADER*>(pMemory);
             //
@@ -231,7 +207,7 @@ ALLOC_CACHE_HANDLER::Alloc(
         }
     }
 
-    if ( pMemory == NULL )
+    if ( pMemory == nullptr )
     {
         //
         // No free entry. Need to alloc a new object.
@@ -240,7 +216,7 @@ ALLOC_CACHE_HANDLER::Alloc(
                                         0,
                                         m_cbSize );
 
-        if ( pMemory != NULL )
+        if ( pMemory != nullptr )
         {
             //
             // Update counters.
@@ -249,7 +225,7 @@ ALLOC_CACHE_HANDLER::Alloc(
         }
     }
 
-    if ( pMemory == NULL )
+    if ( pMemory == nullptr )
     {
         SetLastError( ERROR_NOT_ENOUGH_MEMORY );
     }
@@ -261,7 +237,7 @@ ALLOC_CACHE_HANDLER::Alloc(
 
     return pMemory;
 }
-
+
 VOID
 ALLOC_CACHE_HANDLER::Free(
     __in LPVOID pMemory
@@ -270,7 +246,7 @@ ALLOC_CACHE_HANDLER::Free(
     //
     // Assume that this is allocated using the Alloc() function.
     //
-    DBG_ASSERT(NULL != pMemory);
+    DBG_ASSERT(nullptr != pMemory);
 
     //
     // Use a signature to check against double deletions.
@@ -339,7 +315,7 @@ Return Value:
 {
     DWORD Count = 0;
 
-    if (m_pFreeLists  != NULL)
+    if (m_pFreeLists  != nullptr)
     {
 #if defined(_MSC_VER) && _MSC_VER >= 1600 // VC10
         auto Predicate = [&Count] (SLIST_HEADER * pListHeader)
@@ -377,17 +353,17 @@ ALLOC_CACHE_HANDLER::IsPageheapEnabled(
 {
     BOOL        fRet = FALSE;
     BOOL        fLockedHeap = FALSE;
-    HMODULE     hModule = NULL;
-    HANDLE      hHeap = NULL;
-    PROCESS_HEAP_ENTRY heapEntry = {0};
+    HMODULE     hModule = nullptr;
+    HANDLE      hHeap = nullptr;
+    PROCESS_HEAP_ENTRY heapEntry = {};
 
     //
     // If verifier.dll is loaded - we are running under app verifier == pageheap is enabled
     //
     hModule = GetModuleHandle( L"verifier.dll" );
-    if ( hModule != NULL )
+    if ( hModule != nullptr)
     {
-        hModule = NULL;
+        hModule = nullptr;
         fRet = TRUE;
         goto Finished;
     }
@@ -397,7 +373,7 @@ ALLOC_CACHE_HANDLER::IsPageheapEnabled(
     // otherwise HeapWalk turns off lookasides for a useful heap
     //
     hHeap = ::HeapCreate( 0, 0, 0 );
-    if ( hHeap == NULL )
+    if ( hHeap == nullptr )
     {
         fRet = FALSE;
         goto Finished;
@@ -435,10 +411,8 @@ Finished:
     if ( hHeap )
     {
         DBG_REQUIRE( ::HeapDestroy( hHeap ) );
-        hHeap = NULL;
+        hHeap = nullptr;
     }
 
     return fRet;
 }
-
-#pragma warning( pop )

--- a/src/Servers/IIS/AspNetCoreModuleV2/IISLib/buffer.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/IISLib/buffer.h
@@ -6,9 +6,6 @@
 #include <crtdbg.h>
 #include <CodeAnalysis/Warnings.h>
 
-#pragma warning( push )
-#pragma warning ( disable : ALL_CODE_ANALYSIS_WARNINGS )
-
 //
 // BUFFER_T class shouldn't be used directly. Use BUFFER specialization class instead.
 // The only BUFFER_T partners are STRU and STRA classes.
@@ -69,7 +66,7 @@ public:
 
     --*/
     {
-        _ASSERTE( NULL != pbInit );
+        _ASSERTE(nullptr != pbInit );
         _ASSERTE( cbInit > 0 );
     }
 
@@ -77,9 +74,9 @@ public:
     {
         if( IsHeapAllocated() )
         {
-            _ASSERTE( NULL != m_pBuffer );
+            _ASSERTE( nullptr != m_pBuffer );
             HeapFree( GetProcessHeap(), 0, m_pBuffer );
-            m_pBuffer = NULL;
+            m_pBuffer = nullptr;
             m_cbBuffer = 0;
             m_fHeapAllocated = false;
         }
@@ -155,7 +152,7 @@ public:
             pNewMem = HeapAlloc( GetProcessHeap(), dwHeapAllocFlags, cbNewSize );
         }
 
-        if( pNewMem == NULL )
+        if( pNewMem == nullptr )
         {
             SetLastError( ERROR_NOT_ENOUGH_MEMORY );
             return false;
@@ -272,5 +269,3 @@ C_ASSERT( sizeof(VOID*) <= sizeof(ULONGLONG) );
 
 #define INLINE_BUFFER_INIT( _name )     \
     _name( (BYTE*)__aqw##_name, sizeof( __aqw##_name ) )
-
-#pragma warning( pop )

--- a/src/Servers/IIS/AspNetCoreModuleV2/IISLib/percpu.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/IISLib/percpu.h
@@ -94,7 +94,7 @@ PER_CPU<T>::Create(
     DWORD           CacheLineSize = 0;
     DWORD           ObjectCacheLineSize = 0;
     DWORD           NumberOfProcessors = 0;
-    PER_CPU<T> *    pInstance = NULL;
+    PER_CPU<T> *    pInstance = nullptr;
 
     hr = GetProcessorInformation(&CacheLineSize,
                                  &NumberOfProcessors);
@@ -124,7 +124,7 @@ PER_CPU<T>::Create(
         SIZE_T Size = CacheLineSize + NumberOfProcessors * ObjectCacheLineSize;
 
         pInstance = (PER_CPU<T>*) _aligned_malloc(Size, CacheLineSize);
-        if (pInstance == NULL)
+        if (pInstance == nullptr)
         {
             hr = E_OUTOFMEMORY;
             goto Finished;
@@ -150,17 +150,17 @@ PER_CPU<T>::Create(
     }
 
     *ppInstance = pInstance;
-    pInstance = NULL;
+    pInstance = nullptr;
 
 Finished:
 
-    if (pInstance != NULL)
+    if (pInstance != nullptr)
     {
         //
         // Free the instance without disposing it.
         //
         pInstance->Dispose();
-        pInstance = NULL;
+        pInstance = nullptr;
     }
 
     return hr;

--- a/src/Servers/IIS/AspNetCoreModuleV2/IISLib/reftrace.c
+++ b/src/Servers/IIS/AspNetCoreModuleV2/IISLib/reftrace.c
@@ -4,7 +4,6 @@
 #include <windows.h>
 #include "reftrace.h"
 
-
 PTRACE_LOG
 CreateRefTraceLog(
     IN LONG LogSize,
@@ -40,7 +39,6 @@ Return Value:
 
 }   // CreateRefTraceLog
 
-
 VOID
 DestroyRefTraceLog(
     IN PTRACE_LOG Log
@@ -66,7 +64,6 @@ Return Value:
 
 }   // DestroyRefTraceLog
 
-
 //
 // N.B. For RtlCaptureBacktrace() to work properly, the calling function
 // *must* be __cdecl, and must have a "normal" stack frame. So, we decorate
@@ -119,8 +116,6 @@ Return Value:
 }   // WriteRefTraceLog
 
 
-
-
 LONG
 __cdecl
 WriteRefTraceLogEx(

--- a/src/Servers/IIS/AspNetCoreModuleV2/IISLib/stringu.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/IISLib/stringu.h
@@ -7,9 +7,6 @@
 #include <CodeAnalysis/Warnings.h>
 #include <strsafe.h>
 
-#pragma warning( push )
-#pragma warning ( disable : ALL_CODE_ANALYSIS_WARNINGS )
-
 class STRU
 {
 
@@ -53,7 +50,7 @@ public:
     ) const
     {
         _ASSERTE( NULL != pszRhs );
-        if ( NULL == pszRhs )
+        if ( nullptr == pszRhs )
         {
             return FALSE;
         }
@@ -348,12 +345,7 @@ public:
         __in PCWSTR pwszFormatString,
         va_list     argsList
     );
-    
-    static
-    HRESULT  ExpandEnvironmentVariables(
-        __in PCWSTR                  pszString,
-        __out STRU *                 pstrExpandedString
-    );
+
 private:
 
     //
@@ -423,4 +415,3 @@ MakePathCanonicalizationProof(
     IN PCWSTR               pszName,
     OUT STRU *              pstrPath
 );
-#pragma warning( pop )

--- a/src/Servers/IIS/AspNetCoreModuleV2/IISLib/tracelog.c
+++ b/src/Servers/IIS/AspNetCoreModuleV2/IISLib/tracelog.c
@@ -10,7 +10,6 @@
 #define FREE_MEM(ptr) (VOID)LocalFree( (HLOCAL)(ptr) )
 
 
-
 PTRACE_LOG
 CreateTraceLog(
     IN LONG LogSize,
@@ -130,7 +129,6 @@ Return Value:
 
 }   // CreateTraceLog
 
-
 VOID
 DestroyTraceLog(
     IN PTRACE_LOG Log
@@ -160,7 +158,6 @@ Return Value:
 
 }   // DestroyTraceLog
 
-
 LONG
 WriteTraceLog(
     IN PTRACE_LOG Log,
@@ -213,7 +210,6 @@ Return Value:
     return index;
 }   // WriteTraceLog
 
-
 VOID
 ResetTraceLog(
     IN PTRACE_LOG Log
@@ -231,4 +227,3 @@ ResetTraceLog(
     Log->NextEntry = -1;
 
 }   // ResetTraceLog
-


### PR DESCRIPTION
Several files were pragma disabling `ALL_CODE_ANALYSIS_WARNINGS`. This removes all of those and fixes the resulting warnings.

Re the whitespace changes, I noticed some stray form feed characters in a few places (which are harmless) and decided to clean those up too.