### PR TITLE
Skip H2Spec 6.9.2/2

### DIFF
--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/H2SpecTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/H2SpecTests.cs
@@ -61,7 +61,11 @@ public class H2SpecTests : LoggedTest
         get
         {
             var dataset = new TheoryData<H2SpecTestCase>();
-            var toSkip = new string[] { "http2/6.9.2/2" };
+            // { Test name, Skip Reason }
+            var toSkip = new Dictionary<string, string>
+            {
+                { "http2/6.9.2/2", "https://github.com/dotnet/aspnetcore/issues/47452" }
+            };
 
             var testCases = H2SpecCommands.EnumerateTestCases();
 
@@ -79,9 +83,9 @@ public class H2SpecTests : LoggedTest
             foreach (var testcase in testCases)
             {
                 string skip = null;
-                if (toSkip.Contains(testcase.Item1))
+                if (toSkip.TryGetValue(testcase.Item1, out var skipReason))
                 {
-                    skip = "https://github.com/dotnet/aspnetcore/issues/47452";
+                    skip = skipReason;
                 }
 
                 dataset.Add(new H2SpecTestCase

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/H2SpecTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/H2SpecTests.cs
@@ -61,6 +61,7 @@ public class H2SpecTests : LoggedTest
         get
         {
             var dataset = new TheoryData<H2SpecTestCase>();
+            var toSkip = new string[] { "http2/6.9.2/2" };
 
             var testCases = H2SpecCommands.EnumerateTestCases();
 
@@ -77,11 +78,18 @@ public class H2SpecTests : LoggedTest
 
             foreach (var testcase in testCases)
             {
+                string skip = null;
+                if (toSkip.Contains(testcase.Item1))
+                {
+                    skip = "https://github.com/dotnet/aspnetcore/issues/47452";
+                }
+
                 dataset.Add(new H2SpecTestCase
                 {
                     Id = testcase.Item1,
                     Description = testcase.Item2,
                     Https = false,
+                    Skip = skip,
                 });
 
                 // https://github.com/dotnet/aspnetcore/issues/11301 We should use Skip but it's broken at the moment.
@@ -92,6 +100,7 @@ public class H2SpecTests : LoggedTest
                         Id = testcase.Item1,
                         Description = testcase.Item2,
                         Https = true,
+                        Skip = skip,
                     });
                 }
             }


### PR DESCRIPTION
Test occasionally fails on CI. We don't have the ability to quarantine individual H2Spec tests currently so we'll skip it.

Pretty sure this failure is covered by issue https://github.com/dotnet/aspnetcore/issues/47452