### PR TITLE
Remove Winforms reference

### DIFF
--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -80,7 +80,6 @@ and are generated based on the last package release.
     <LatestPackageReference Include="System.Diagnostics.DiagnosticSource" />
     <LatestPackageReference Include="System.Diagnostics.EventLog" />
     <LatestPackageReference Include="System.DirectoryServices.Protocols" />
-    <LatestPackageReference Include="System.Drawing.Common" />
     <LatestPackageReference Include="System.IdentityModel.Tokens.Jwt" />
     <LatestPackageReference Include="System.IO.Pipelines" />
     <LatestPackageReference Include="System.Net.Http" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -384,10 +384,6 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>a038f65e16afd2592c313bd2ee7dbcf4a00ae17b</Sha>
     </Dependency>
-    <Dependency Name="System.Drawing.Common" Version="10.0.0-alpha.1.24504.3">
-      <Uri>https://github.com/dotnet/winforms</Uri>
-      <Sha>efe6e112d821ad55a060f5c7e244c85a2478e9c3</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.24510.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>380002a14775d7f68f098c7e6b7d1c3638bd4c5d</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -175,8 +175,6 @@
     <MicrosoftSourceBuildIntermediatesourcebuildreferencepackagesVersion>10.0.0-alpha.1.24507.1</MicrosoftSourceBuildIntermediatesourcebuildreferencepackagesVersion>
     <!-- Packages from dotnet/symreader -->
     <MicrosoftSourceBuildIntermediatesymreaderVersion>2.2.0-beta.24327.2</MicrosoftSourceBuildIntermediatesymreaderVersion>
-    <!-- Packages from dotnet/winforms -->
-    <SystemDrawingCommonVersion>10.0.0-alpha.1.24504.3</SystemDrawingCommonVersion>
     <!-- Packages from dotnet/xdt -->
     <MicrosoftWebXdtVersion>9.0.0-preview.24510.1</MicrosoftWebXdtVersion>
     <MicrosoftSourceBuildIntermediatexdtVersion>9.0.0-preview.24510.1</MicrosoftSourceBuildIntermediatexdtVersion>

--- a/src/Tools/LinkabilityChecker/LinkabilityChecker.csproj
+++ b/src/Tools/LinkabilityChecker/LinkabilityChecker.csproj
@@ -15,7 +15,6 @@
   <ItemGroup>
     <!-- Packages required to produce a complete dependency graph for the trimmer -->
     <Reference Include="System.Configuration.ConfigurationManager" />
-    <Reference Include="System.Drawing.Common" />
     <Reference Include="System.Security.Permissions" />
     <Reference Include="System.Threading.AccessControl" />
   </ItemGroup>


### PR DESCRIPTION
We just randomly added the reference to winforms in https://github.com/dotnet/aspnetcore/pull/49243

There shouldn't need to be any references to winforms in this repo.