### PR TITLE
[release/9.0] Stabilize branding

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -122,7 +122,7 @@
     <NoWarn>$(NoWarn.Replace('1591', ''))</NoWarn>
     <NoWarn Condition=" '$(BuildingInsideVisualStudio)' == 'true' ">$(NoWarn);0105</NoWarn>
     <!-- Allow prerelease dependencies in stable packages when we're running the IdentityModel nightly tests -->
-    <NoWarn Condition=" '$(IsIdentityModelTestJob)' == 'true' ">$(NoWarn);NU5104</NoWarn>
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
 
     <!-- For local builds, don't make missing XML docs a fatal build error, but still surface so we have visibility into undocumented APIs. -->
     <WarningsNotAsErrors Condition=" '$(ContinuousIntegrationBuild)' != 'true' ">$(WarningsNotAsErrors);CS1591</WarningsNotAsErrors>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,7 +17,7 @@
     <!--
         When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages
     -->
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
     <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
     <PreReleaseBrandingLabel>RTM</PreReleaseBrandingLabel>

--- a/src/Grpc/JsonTranscoding/perf/Microsoft.AspNetCore.Grpc.Microbenchmarks/Microsoft.AspNetCore.Grpc.Microbenchmarks.csproj
+++ b/src/Grpc/JsonTranscoding/perf/Microsoft.AspNetCore.Grpc.Microbenchmarks/Microsoft.AspNetCore.Grpc.Microbenchmarks.csproj
@@ -6,6 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TieredCompilation>false</TieredCompilation>
     <DefineConstants>$(DefineConstants);IS_BENCHMARKS</DefineConstants>
+    <SkipMicrobenchmarksValidation>true</SkipMicrobenchmarksValidation>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
CI will fail until we ingest a stable runtime/efcore