### PR TITLE
Move Windows.Amd64.VS2022.Pre.Open to Helix-Matrix

### DIFF
--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -31,7 +31,6 @@
         <HelixAvailableTargetQueue Include="Ubuntu.2004.Amd64.Open" Platform="Linux" />
         <HelixAvailableTargetQueue Include="OSX.13.Amd64.Open" Platform="OSX" />
         <HelixAvailableTargetQueue Include="Windows.11.Amd64.Client.Open" Platform="Windows" />
-        <HelixAvailableTargetQueue Include="Windows.Amd64.VS2022.Pre.Open" Platform="Windows" />
       </ItemGroup>
     </When>
     <Otherwise>
@@ -53,6 +52,7 @@
 
         <!-- Windows -->
         <HelixAvailableTargetQueue Include="Windows.Amd64.Server2022.Open" Platform="Windows" />
+        <HelixAvailableTargetQueue Include="Windows.Amd64.VS2022.Pre.Open" Platform="Windows" />
 
         <!-- IIS Express isn't supported on arm64 and most of the IsWindowsOnlyTests depend on its setup scripts. -->
         <HelixAvailableTargetQueue Include="windows.11.arm64.open" Platform="Windows"


### PR DESCRIPTION
This will allow us to avoid hitting https://github.com/dotnet/dnceng/issues/3844 in PR CI, while still getting coverage for the Native AOT tests in Helix Matrix.