### PR TITLE
[release/8.0] Upgrade `serialize-javascript` transient dependency

### DIFF
--- a/src/Components/CustomElements/src/js/yarn.lock
+++ b/src/Components/CustomElements/src/js/yarn.lock
@@ -2463,9 +2463,9 @@ semver@^7.3.4, semver@^7.3.7:
     lru-cache "^6.0.0"
 
 serialize-javascript@^6.0.0:
-  version "6.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/serialize-javascript/-/serialize-javascript-6.0.1.tgz#b206efb27c3da0b0ab6b52f48d170b7996458e5c"
-  integrity sha1-sgbvsnw9oLCra1L0jRcLeZZFjlw=
+  version "6.0.2"
+  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
+  integrity sha1-3voeBVyDv21Z6oBdjahiJU62psI=
   dependencies:
     randombytes "^2.1.0"
 

--- a/src/Components/Web.JS/yarn.lock
+++ b/src/Components/Web.JS/yarn.lock
@@ -4028,9 +4028,9 @@ semver@^7.3.4, semver@^7.3.5, semver@^7.3.7:
     lru-cache "^6.0.0"
 
 serialize-javascript@^6.0.1:
-  version "6.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/serialize-javascript/-/serialize-javascript-6.0.1.tgz#b206efb27c3da0b0ab6b52f48d170b7996458e5c"
-  integrity "sha1-sgbvsnw9oLCra1L0jRcLeZZFjlw= sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w=="
+  version "6.0.2"
+  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
+  integrity sha1-3voeBVyDv21Z6oBdjahiJU62psI=
   dependencies:
     randombytes "^2.1.0"
 

--- a/src/Components/WebAssembly/Authentication.Msal/src/Interop/yarn.lock
+++ b/src/Components/WebAssembly/Authentication.Msal/src/Interop/yarn.lock
@@ -2475,9 +2475,9 @@ semver@^7.3.4, semver@^7.3.7:
     lru-cache "^6.0.0"
 
 serialize-javascript@^6.0.0:
-  version "6.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/serialize-javascript/-/serialize-javascript-6.0.1.tgz#b206efb27c3da0b0ab6b52f48d170b7996458e5c"
-  integrity sha1-sgbvsnw9oLCra1L0jRcLeZZFjlw=
+  version "6.0.2"
+  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
+  integrity sha1-3voeBVyDv21Z6oBdjahiJU62psI=
   dependencies:
     randombytes "^2.1.0"
 

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Interop/yarn.lock
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Interop/yarn.lock
@@ -2537,9 +2537,9 @@ serialize-javascript@^4.0.0:
     randombytes "^2.1.0"
 
 serialize-javascript@^6.0.1:
-  version "6.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/serialize-javascript/-/serialize-javascript-6.0.1.tgz#b206efb27c3da0b0ab6b52f48d170b7996458e5c"
-  integrity sha1-sgbvsnw9oLCra1L0jRcLeZZFjlw=
+  version "6.0.2"
+  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
+  integrity sha1-3voeBVyDv21Z6oBdjahiJU62psI=
   dependencies:
     randombytes "^2.1.0"
 

--- a/src/SignalR/clients/ts/FunctionalTests/yarn.lock
+++ b/src/SignalR/clients/ts/FunctionalTests/yarn.lock
@@ -3205,9 +3205,9 @@ serialize-error@^8.0.0:
     type-fest "^0.20.2"
 
 serialize-javascript@^6.0.0:
-  version "6.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/serialize-javascript/-/serialize-javascript-6.0.1.tgz#b206efb27c3da0b0ab6b52f48d170b7996458e5c"
-  integrity sha1-sgbvsnw9oLCra1L0jRcLeZZFjlw=
+  version "6.0.2"
+  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
+  integrity sha1-3voeBVyDv21Z6oBdjahiJU62psI=
   dependencies:
     randombytes "^2.1.0"
 
@@ -3833,7 +3833,7 @@ wrappy@1:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@8.11.0, ws@>=7.4.6, ws@^7.2.3, ws@^7.4.5, ws@~8.11.0:
+ws@8.11.0, ws@>=7.4.6, ws@^7.2.3, ws@^7.5.10, ws@~8.11.0:
   version "8.12.1"
   resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ws/-/ws-8.12.1.tgz#c51e583d79140b5e42e39be48c934131942d4a8f"
   integrity sha1-xR5YPXkUC15C45vkjJNBMZQtSo8=

--- a/src/SignalR/clients/ts/common/yarn.lock
+++ b/src/SignalR/clients/ts/common/yarn.lock
@@ -3198,9 +3198,9 @@ semver@^6.0.0, semver@^6.3.0:
   integrity sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=
 
 serialize-javascript@^6.0.0:
-  version "6.0.1"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/serialize-javascript/-/serialize-javascript-6.0.1.tgz#b206efb27c3da0b0ab6b52f48d170b7996458e5c"
-  integrity sha1-sgbvsnw9oLCra1L0jRcLeZZFjlw=
+  version "6.0.2"
+  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
+  integrity sha1-3voeBVyDv21Z6oBdjahiJU62psI=
   dependencies:
     randombytes "^2.1.0"
 


### PR DESCRIPTION
This PR updates each `yarn.lock` file referencing `serialize-javascript` version 6.0.1 to instead reference version 6.0.2.