### PR TITLE
Provide analyzer for removing unneeded public partial class Program

### DIFF
--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
@@ -231,5 +231,6 @@ internal static class DiagnosticDescriptors
         "Usage",
         DiagnosticSeverity.Info,
         isEnabledByDefault: true,
-        helpLinkUri: "https://aka.ms/aspnet/analyzers");
+        helpLinkUri: "https://aka.ms/aspnet/analyzers",
+        customTags: WellKnownDiagnosticTags.Unnecessary);
 }

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
@@ -223,4 +223,13 @@ internal static class DiagnosticDescriptors
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         helpLinkUri: "https://aka.ms/aspnet/analyzers");
+
+    internal static readonly DiagnosticDescriptor PublicPartialProgramClassNotRequired = new(
+        "ASP0027",
+        new LocalizableResourceString(nameof(Resources.Analyzer_PublicPartialProgramClass_Title), Resources.ResourceManager, typeof(Resources)),
+        new LocalizableResourceString(nameof(Resources.Analyzer_PublicPartialProgramClass_Message), Resources.ResourceManager, typeof(Resources)),
+        "Usage",
+        DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        helpLinkUri: "https://aka.ms/aspnet/analyzers");
 }

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Resources.resx
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Resources.resx
@@ -322,9 +322,9 @@
     <value>[Authorize] overridden by [AllowAnonymous] from farther away</value>
   </data>
   <data name="Analyzer_PublicPartialProgramClass_Message" xml:space="preserve">
-    <value>Using public partial class Program { } to make generated Program class public is no longer required. See https://aka.ms/aspnetcore-warnings/ASP0027 for more details.</value>
+    <value>Using public partial class Program { } to make the generated Program class public is no longer required in ASP.NET Core apps. See https://aka.ms/aspnetcore-warnings/ASP0027 for more details.</value>
   </data>
   <data name="Analyzer_PublicPartialProgramClass_Title" xml:space="preserve">
-    <value>Explicit class declaration not required</value>
+    <value>Unnecessary public Program class declaration</value>
   </data>
 </root>

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Resources.resx
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Resources.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -320,5 +320,11 @@
   </data>
   <data name="Analyzer_OverriddenAuthorizeAttribute_Title" xml:space="preserve">
     <value>[Authorize] overridden by [AllowAnonymous] from farther away</value>
+  </data>
+  <data name="Analyzer_PublicPartialProgramClass_Message" xml:space="preserve">
+    <value>Using public partial class Program { } to make generated Program class public is no longer required. See https://aka.ms/aspnetcore-warnings/ASP0027 for more details.</value>
+  </data>
+  <data name="Analyzer_PublicPartialProgramClass_Title" xml:space="preserve">
+    <value>Explicit class declaration not required</value>
   </data>
 </root>

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/WebApplicationBuilder/PublicPartialProgramClassAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/WebApplicationBuilder/PublicPartialProgramClassAnalyzer.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.AspNetCore.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class PublicPartialProgramClassAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DiagnosticDescriptors.PublicPartialProgramClassNotRequired);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(context =>
+        {
+            var syntaxNode = context.Node;
+            if (IsPublicPartialClassProgram(syntaxNode))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.PublicPartialProgramClassNotRequired, syntaxNode.GetLocation()));
+            }
+        }, SyntaxKind.ClassDeclaration);
+    }
+
+    private static bool IsPublicPartialClassProgram(SyntaxNode syntaxNode)
+    {
+        return syntaxNode is ClassDeclarationSyntax { Modifiers: { } modifiers } classDeclaration
+            && modifiers is { Count: > 1 }
+            && modifiers.Any(SyntaxKind.PublicKeyword)
+            && modifiers.Any(SyntaxKind.PartialKeyword)
+            && classDeclaration is { Identifier.ValueText: "Program" };
+    }
+}

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/WebApplicationBuilder/PublicPartialProgramClassAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/WebApplicationBuilder/PublicPartialProgramClassAnalyzer.cs
@@ -34,12 +34,12 @@ public sealed class PublicPartialProgramClassAnalyzer : DiagnosticAnalyzer
     private static bool IsPublicPartialClassProgram(SyntaxNode syntaxNode)
     {
         return syntaxNode is ClassDeclarationSyntax { Modifiers: { } modifiers } classDeclaration
+            && classDeclaration.Parent is CompilationUnitSyntax parentNode
+            && classDeclaration is { Identifier.ValueText: "Program" }
             && (classDeclaration.Members == null || classDeclaration.Members.Count == 0) // Skip non-empty declarations
             && modifiers is { Count: > 1 }
             && modifiers.Any(SyntaxKind.PublicKeyword)
             && modifiers.Any(SyntaxKind.PartialKeyword)
-            && classDeclaration is { Identifier.ValueText: "Program" }
-            && classDeclaration.Parent is CompilationUnitSyntax parentNode
             && parentNode.DescendantNodes().Count() > 1;
     }
 }

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/WebApplicationBuilder/PublicPartialProgramClassAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/WebApplicationBuilder/PublicPartialProgramClassAnalyzer.cs
@@ -34,6 +34,7 @@ public sealed class PublicPartialProgramClassAnalyzer : DiagnosticAnalyzer
     private static bool IsPublicPartialClassProgram(SyntaxNode syntaxNode)
     {
         return syntaxNode is ClassDeclarationSyntax { Modifiers: { } modifiers } classDeclaration
+            && (classDeclaration.Members == null || classDeclaration.Members.Count == 0) // Skip non-empty declarations
             && modifiers is { Count: > 1 }
             && modifiers.Any(SyntaxKind.PublicKeyword)
             && modifiers.Any(SyntaxKind.PartialKeyword)

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/WebApplicationBuilder/PublicPartialProgramClassAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/WebApplicationBuilder/PublicPartialProgramClassAnalyzer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -23,7 +24,9 @@ public sealed class PublicPartialProgramClassAnalyzer : DiagnosticAnalyzer
             var syntaxNode = context.Node;
             if (IsPublicPartialClassProgram(syntaxNode))
             {
-                context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.PublicPartialProgramClassNotRequired, syntaxNode.GetLocation()));
+                context.ReportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.PublicPartialProgramClassNotRequired,
+                    syntaxNode.GetLocation()));
             }
         }, SyntaxKind.ClassDeclaration);
     }
@@ -34,6 +37,8 @@ public sealed class PublicPartialProgramClassAnalyzer : DiagnosticAnalyzer
             && modifiers is { Count: > 1 }
             && modifiers.Any(SyntaxKind.PublicKeyword)
             && modifiers.Any(SyntaxKind.PartialKeyword)
-            && classDeclaration is { Identifier.ValueText: "Program" };
+            && classDeclaration is { Identifier.ValueText: "Program" }
+            && classDeclaration.Parent is CompilationUnitSyntax parentNode
+            && parentNode.DescendantNodes().Count() > 1;
     }
 }

--- a/src/Framework/AspNetCoreAnalyzers/src/CodeFixes/PublicPartialProgramClassFixer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/CodeFixes/PublicPartialProgramClassFixer.cs
@@ -29,7 +29,7 @@ public class PublicPartialProgramClassFixer : CodeFixProvider
                     async cancellationToken =>
                     {
                         var editor = await DocumentEditor.CreateAsync(context.Document, cancellationToken).ConfigureAwait(false);
-                        var root = context.Document.GetSyntaxRootAsync(cancellationToken).Result;
+                        var root = await context.Document.GetSyntaxRootAsync(cancellationToken);
                         if (root is null)
                         {
                             return context.Document;

--- a/src/Framework/AspNetCoreAnalyzers/src/CodeFixes/PublicPartialProgramClassFixer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/CodeFixes/PublicPartialProgramClassFixer.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Analyzers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+
+namespace Microsoft.AspNetCore.Fixers;
+
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public class PublicPartialProgramClassFixer : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds { get; } = [DiagnosticDescriptors.PublicPartialProgramClassNotRequired.Id];
+
+    public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            context.RegisterCodeFix(
+                CodeAction.Create("Fix unnecessary public partial class Program",
+                    async cancellationToken =>
+                    {
+                        var editor = await DocumentEditor.CreateAsync(context.Document, cancellationToken).ConfigureAwait(false);
+                        var root = context.Document.GetSyntaxRootAsync(cancellationToken).Result;
+                        if (root is null)
+                        {
+                            return context.Document;
+                        }
+
+                        var classDeclaration = root.FindNode(diagnostic.Location.SourceSpan)
+                            .FirstAncestorOrSelf<ClassDeclarationSyntax>();
+                        if (classDeclaration is null)
+                        {
+                            return context.Document;
+                        }
+                        editor.RemoveNode(classDeclaration, SyntaxRemoveOptions.KeepNoTrivia);
+                        return editor.GetChangedDocument();
+                    },
+                    equivalenceKey: DiagnosticDescriptors.PublicPartialProgramClassNotRequired.Id),
+                diagnostic);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Framework/AspNetCoreAnalyzers/src/CodeFixes/PublicPartialProgramClassFixer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/CodeFixes/PublicPartialProgramClassFixer.cs
@@ -25,7 +25,7 @@ public class PublicPartialProgramClassFixer : CodeFixProvider
         foreach (var diagnostic in context.Diagnostics)
         {
             context.RegisterCodeFix(
-                CodeAction.Create("Fix unnecessary public partial class Program",
+                CodeAction.Create("Remove unnecessary public partial class Program declaration",
                     async cancellationToken =>
                     {
                         var editor = await DocumentEditor.CreateAsync(context.Document, cancellationToken).ConfigureAwait(false);
@@ -41,7 +41,7 @@ public class PublicPartialProgramClassFixer : CodeFixProvider
                         {
                             return context.Document;
                         }
-                        editor.RemoveNode(classDeclaration, SyntaxRemoveOptions.KeepNoTrivia);
+                        editor.RemoveNode(classDeclaration, SyntaxRemoveOptions.KeepExteriorTrivia);
                         return editor.GetChangedDocument();
                     },
                     equivalenceKey: DiagnosticDescriptors.PublicPartialProgramClassNotRequired.Id),

--- a/src/Framework/AspNetCoreAnalyzers/test/WebApplicationBuilder/PublicPartialProgramClassTest.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/WebApplicationBuilder/PublicPartialProgramClassTest.cs
@@ -147,6 +147,28 @@ public class Program
     }
 
     [Fact]
+    public async Task DoesNotFix_ExplicitPublicPartialProgramClass()
+    {
+        var source = """
+using Microsoft.AspNetCore.Builder;
+
+public partial class Program
+{
+    public static void Main()
+    {
+        var app = WebApplication.Create();
+
+        app.MapGet("/", () => "Hello, World!");
+
+        app.Run();
+    }
+}
+""";
+
+        await VerifyCS.VerifyCodeFixAsync(source, source);
+    }
+
+    [Fact]
     public async Task DoesNotFix_ExplicitInternalProgramClass()
     {
         var source = """

--- a/src/Framework/AspNetCoreAnalyzers/test/WebApplicationBuilder/PublicPartialProgramClassTest.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/WebApplicationBuilder/PublicPartialProgramClassTest.cs
@@ -168,6 +168,52 @@ public partial class Program
         await VerifyCS.VerifyCodeFixAsync(source, source);
     }
 
+    [Theory]
+    [InlineData("public int Number { get; set; }")]
+    [InlineData("private int _foo = 2;")]
+    public async Task DoesNotFix_ExplicitPublicPartialProgramClass_WithProperty(string contents)
+    {
+        var source = $$"""
+using Microsoft.AspNetCore.Builder;
+
+var app = WebApplication.Create();
+
+app.MapGet("/", () => "Hello, World!");
+
+app.Run();
+
+public partial class Program
+{
+    {{contents}}
+}
+""";
+
+        await VerifyCS.VerifyCodeFixAsync(source, source);
+    }
+
+    [Theory]
+    [InlineData("namespace Foo")]
+    [InlineData("public class Foo")]
+    public async Task DoesNotFix_ExplicitPublicPartialProgramClassInNestedPattern(string parentDefinition)
+    {
+        var source = $$"""
+using Microsoft.AspNetCore.Builder;
+
+var app = WebApplication.Create();
+
+app.MapGet("/", () => "Hello, World!");
+
+app.Run();
+
+{{parentDefinition}}
+{
+    public partial class Program { }
+}
+""";
+
+        await VerifyCS.VerifyCodeFixAsync(source, source);
+    }
+
     [Fact]
     public async Task DoesNotFix_ExplicitInternalProgramClass()
     {

--- a/src/Framework/AspNetCoreAnalyzers/test/WebApplicationBuilder/PublicPartialProgramClassTest.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/WebApplicationBuilder/PublicPartialProgramClassTest.cs
@@ -60,6 +60,46 @@ app.MapGet("/", () => "Hello, World!");
 
 app.Run();
 
+
+""";
+
+        // Assert
+        await VerifyCS.VerifyCodeFixAsync(source, [diagnostic], fixedSource);
+    }
+
+    [Fact]
+    public async Task RemovesDeclarationIfItIsFound_WithLeadingTrivia()
+    {
+        // Arrange
+        var source = """
+using Microsoft.AspNetCore.Builder;
+
+var app = WebApplication.Create();
+
+app.MapGet("/", () => "Hello, World!");
+
+app.Run();
+
+// This is a test
+
+{|#0:public partial class Program;|}
+""";
+
+        var diagnostic = new DiagnosticResult(DiagnosticDescriptors.PublicPartialProgramClassNotRequired)
+                .WithLocation(0);
+
+        var fixedSource = """
+using Microsoft.AspNetCore.Builder;
+
+var app = WebApplication.Create();
+
+app.MapGet("/", () => "Hello, World!");
+
+app.Run();
+
+// This is a test
+
+
 """;
 
         // Assert

--- a/src/Framework/AspNetCoreAnalyzers/test/WebApplicationBuilder/PublicPartialProgramClassTest.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/WebApplicationBuilder/PublicPartialProgramClassTest.cs
@@ -1,0 +1,151 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis.Testing;
+using VerifyCS = Microsoft.AspNetCore.Analyzers.Verifiers.CSharpCodeFixVerifier<
+    Microsoft.AspNetCore.Analyzers.PublicPartialProgramClassAnalyzer,
+    Microsoft.AspNetCore.Fixers.PublicPartialProgramClassFixer>;
+
+namespace Microsoft.AspNetCore.Analyzers;
+
+public class PublicPartialProgramClassTest
+{
+    [Fact]
+    public async Task DoesNothingWhenNoDeclarationIsFound()
+    {
+        // Arrange
+        var source = """
+using Microsoft.AspNetCore.Builder;
+
+var app = WebApplication.Create();
+
+app.MapGet("/", () => "Hello, World!");
+
+app.Run();
+""";
+
+        // Assert
+        await VerifyCS.VerifyCodeFixAsync(source, source);
+    }
+
+    [Fact]
+    public async Task RemovesDeclarationIfItIsFound()
+    {
+        // Arrange
+        var source = """
+using Microsoft.AspNetCore.Builder;
+
+var app = WebApplication.Create();
+
+app.MapGet("/", () => "Hello, World!");
+
+app.Run();
+
+{|#0:public partial class Program { }|}
+""";
+
+        var diagnostic = new DiagnosticResult(DiagnosticDescriptors.PublicPartialProgramClassNotRequired)
+                .WithLocation(0);
+
+        var fixedSource = """
+using Microsoft.AspNetCore.Builder;
+
+var app = WebApplication.Create();
+
+app.MapGet("/", () => "Hello, World!");
+
+app.Run();
+
+""";
+
+        // Assert
+        await VerifyCS.VerifyCodeFixAsync(source, [diagnostic], fixedSource);
+    }
+
+    [Fact]
+    public async Task DoesNotGeneratesSource_IfProgramDeclaresExplicitInternalAccess()
+    {
+        var source = """
+using Microsoft.AspNetCore.Builder;
+
+var app = WebApplication.Create();
+
+app.MapGet("/", () => "Hello, World!");
+
+app.Run();
+
+internal partial class Program { }
+""";
+
+        await VerifyCS.VerifyCodeFixAsync(source, source);
+    }
+
+    [Fact]
+    public async Task DoesNotFix_ExplicitPublicProgramClass()
+    {
+        var source = """
+using Microsoft.AspNetCore.Builder;
+
+public class Program
+{
+    public static void Main()
+    {
+        var app = WebApplication.Create();
+
+        app.MapGet("/", () => "Hello, World!");
+
+        app.Run();
+    }
+}
+""";
+
+        await VerifyCS.VerifyCodeFixAsync(source, source);
+    }
+
+    [Fact]
+    public async Task DoesNotFix_ExplicitInternalProgramClass()
+    {
+        var source = """
+using Microsoft.AspNetCore.Builder;
+
+internal class Program
+{
+    public static void Main()
+    {
+        var app = WebApplication.Create();
+
+        app.MapGet("/", () => "Hello, World!");
+
+        app.Run();
+    }
+}
+""";
+
+        await VerifyCS.VerifyCodeFixAsync(source, source);
+    }
+
+    [Theory]
+    [InlineData("interface")]
+    [InlineData("struct")]
+    public async Task DoesNotFix_ExplicitInternalProgramType(string type)
+    {
+        var source = $$"""
+using Microsoft.AspNetCore.Builder;
+
+internal {{type}} Program
+{
+    public static void Main(string[] args)
+    {
+        var app = WebApplication.Create();
+
+        app.MapGet("/", () => "Hello, World!");
+
+        app.Run();
+    }
+}
+""";
+
+        await VerifyCS.VerifyCodeFixAsync(source, source);
+    }
+}
+

--- a/src/Framework/AspNetCoreAnalyzers/test/WebApplicationBuilder/PublicPartialProgramClassTest.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/WebApplicationBuilder/PublicPartialProgramClassTest.cs
@@ -28,11 +28,15 @@ app.Run();
         await VerifyCS.VerifyCodeFixAsync(source, source);
     }
 
-    [Fact]
-    public async Task RemovesDeclarationIfItIsFound()
+    [Theory]
+    [InlineData("public partial class Program { }")]
+    [InlineData("public partial class Program { /* This is just for tests */ }")]
+    [InlineData("public partial class Program { \n // This is just for tests \n }")]
+    [InlineData("public partial class Program;")]
+    public async Task RemovesDeclarationIfItIsFound(string declarationStyle)
     {
         // Arrange
-        var source = """
+        var source = $$"""
 using Microsoft.AspNetCore.Builder;
 
 var app = WebApplication.Create();
@@ -41,7 +45,7 @@ app.MapGet("/", () => "Hello, World!");
 
 app.Run();
 
-{|#0:public partial class Program { }|}
+{|#0:{{declarationStyle}}|}
 """;
 
         var diagnostic = new DiagnosticResult(DiagnosticDescriptors.PublicPartialProgramClassNotRequired)


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/aspnetcore/pull/58199.

Based on the code generation that we introduced earlier, users can get rid of the explicit `public partial class Program { }` declarations in their source code and rely on the new default behavior.

This PR introduces an analyzer to find these explicit declarations and a code fixer to remove them.

Implements https://github.com/dotnet/aspnetcore/issues/58488