### PR TITLE
Update xcopy-msbuild to minimum available version

### DIFF
--- a/global.json
+++ b/global.json
@@ -21,7 +21,7 @@
         "Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
       ]
     },
-    "xcopy-msbuild": "17.1.0"
+    "xcopy-msbuild": "17.8.5"
   },
   "native-tools": {
     "jdk": "11"


### PR DESCRIPTION
I fail to build aspnetcore inside the VMR because this version can't be found. The latest available version on dotnet-eng is 17.8.5. Update to that.

It's possible that this only happens inside the VMR because of package source mapping enabled there.