### PR TITLE
Update `HtmlAttributePropertyHelper` to correctly follow the `MetadataUpdateHandlerAttribute` contract

### DIFF
--- a/src/Mvc/Mvc.ViewFeatures/src/HtmlAttributePropertyHelper.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/HtmlAttributePropertyHelper.cs
@@ -25,8 +25,7 @@ internal sealed class HtmlAttributePropertyHelper
     /// <summary>
     /// Part of <see cref="MetadataUpdateHandlerAttribute"/> contract.
     /// </summary>
-    /// <param name="_"></param>
-    public static void UpdateCache(Type _)
+    public static void ClearCache(Type[] _)
     {
         ReflectionCache.Clear();
     }


### PR DESCRIPTION
Fixes an issue where `HtmlAttributePropertyHelper` did not correctly follow the `MetadataUpdateHandlerAttribute` contract, causing hot reload to fail.

Fixes https://github.com/dotnet/AspNetCore-ManualTests/issues/3202