### PR TITLE
[release/9.0] Prevent unnecessary debugger stops for user-unhandled exceptions in Blazor apps with Just My Code enabled

### DIFF
--- a/src/Components/Components/src/RenderTree/Renderer.cs
+++ b/src/Components/Components/src/RenderTree/Renderer.cs
@@ -1039,6 +1039,8 @@ public abstract partial class Renderer : IDisposable, IAsyncDisposable
         }
     }
 
+    // We do not want the debugger to stop more than once per user-unhandled exception.
+    [DebuggerDisableUserUnhandledExceptions]
     private async Task GetErrorHandledTask(Task taskToHandle, ComponentState? owningComponentState)
     {
         try

--- a/src/Components/Components/src/Rendering/ComponentState.cs
+++ b/src/Components/Components/src/Rendering/ComponentState.cs
@@ -87,6 +87,8 @@ public class ComponentState : IAsyncDisposable
 
     internal Renderer Renderer => _renderer;
 
+    // We do not want the debugger to consider NavigationExceptions caught by this method as user-unhandled.
+    [DebuggerDisableUserUnhandledExceptions]
     internal void RenderIntoBatch(RenderBatchBuilder batchBuilder, RenderFragment renderFragment, out Exception? renderFragmentException)
     {
         renderFragmentException = null;
@@ -106,6 +108,11 @@ public class ComponentState : IAsyncDisposable
         }
         catch (Exception ex)
         {
+            if (ex is not NavigationException)
+            {
+                Debugger.BreakForUserUnhandledException(ex);
+            }
+
             // If an exception occurs in the render fragment delegate, we won't process the diff in any way, so child components,
             // event handlers, etc., will all be left untouched as if this component didn't re-render at all. The Renderer will
             // then forcibly clear the descendant subtree by rendering an empty fragment for this component.

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Streaming.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Streaming.cs
@@ -77,10 +77,6 @@ internal partial class EndpointHtmlRenderer
         }
         catch (Exception ex)
         {
-            // Rethrowing also informs the debugger that this exception should be considered user-unhandled unlike NavigationExceptions,
-            // but calling BreakForUserUnhandledException here allows the debugger to break before we modify the HttpContext.
-            Debugger.BreakForUserUnhandledException(ex);
-
             // Theoretically it might be possible to let the error middleware run, capture the output,
             // then emit it in a special format so the JS code can display the error page. However
             // for now we're not going to support that and will simply emit a message.


### PR DESCRIPTION
# Prevent unnecessary debugger stops for user-unhandled exceptions in Blazor apps with Just My Code enabled 

Improve usage of the new `[DebuggerDisableUserUnhandledExceptions]` and `Debugger.BreakForUserUnhandledException(ex)` APIs to prevent unnecessarily repeated debugger stops for the same user-unhandled exceptions in Blazor apps with Just My Code enabled.

## Description


This is a follow up to https://github.com/dotnet/aspnetcore/pull/57148 which I've made after testing Visual Studio's treatment of `NavigationExceptions` when debugging with `just my code` enabled. The intent was to ensure that `NavigationExceptions` that get handled properly by Blazor do not get treated as user-unhandled exceptions. Unfortunately, this didn't fully work because the debugger does not follow exceptions through multiple try-catch blocks. For example:

<details><summary>Sample code demonstrating what the debugger does and does not stop for</summary>

```csharp
// ExternalAssembly.dll
public class Class1
{
    // This attribute works, but only for Funcs that return faulted Tasks.
    [DebuggerDisableUserUnhandledExceptions]
    public static async Task RunNestedAsync(Func<Task> callback)
    {
        try
        {
            await Nested(callback);
        }
        catch
        {
        }
    }

    private static async Task Nested(Func<Task> callback)
    {
        await callback();
    }


    // This attribute works for Funcs that return faulted Tasks or throw directly.
    [DebuggerDisableUserUnhandledExceptions]
    public static async Task RunNestedPassThroughAsync(Func<Task> callback)
    {
        try
        {
            await NestedPassThrough(callback);
        }
        catch
        {
        }
    }

    private static Task NestedPassThrough(Func<Task> callback) => callback();

    // This attribute does nothing due to the try/catch block in NestedTryCatch.
    [DebuggerDisableUserUnhandledExceptions]
    public static async Task RunNestedTryCatchAsync(Func<Task> callback)
    {
        try
        {
            await NestedTryCatch(callback);
        }
        catch
        {
        }
    }

    private static async Task NestedTryCatch(Func<Task> callback)
    {
        try
        {
            await callback();
        }
        catch
        {
            throw;
        }
    }
}

// Program.cs in another assembly
app.MapGet("/nested", async () =>
{
    await Class1.RunNestedAsync(async () =>
    {
        // This is successfully ignored as a user-unhandled exception despite async nested method.
        throw new Exception();
    });
});

app.MapGet("/nested-non-async", async () =>
{
    await Class1.RunNestedAsync(() =>
    {
        // However, throwing from a non-"async" callback makes the debugger treat it as user-unhandled again.
        throw new Exception();
    });
});

app.MapGet("/nested-pass-through-non-async", async () =>
{
    await Class1.RunNestedPassThroughAsync(() =>
    {
        // This is successfully ignored as a user-unhandled exception again despite the non-async callback
        // now that the nested method is non-async.
        throw new Exception();
    });
});

app.MapGet("/nested-try-catch", async () =>
{
    await Class1.RunNestedTryCatchAsync(async () =>
    {
        // A nested method with a try/catch block makes the debugger treat all thrown exceptions 
        // as user-unhandled again regardless of the asyncness of the callback.
        throw new Exception();
    });
});
```

</details>

This caused the debugger to treat most `NavigationException`'s as user-unhandled exceptions, because the method with `[DebuggerDisableUserUnhandledExceptions]` was too far down the stack with multiple try/catch blocks in between. And in some cases, the debugger would stop for exceptions at a try/catch boundary and then extraneously stop again for the same exception because of calls `Debugger.BreakForUserUnhandledException(ex)`.

I used the `Redirect*.razor` pages in https://github.com/halter73/DebuggerDisableUserUnhandledExceptions/tree/nav/BlazorApp1/Components/Pages and https://github.com/halter73/DebuggerDisableUserUnhandledExceptions/tree/throw/BlazorApp1/Components/Pages to test these changes.

@gregg-miskelly

## Customer Impact

Without this change, Blazor developers with Just My Code enabled will sometimes see the debugger stop repeatedly for the same user-unhandled exception. They might also see the debugger stop for some `NavigationExceptions` which are a normal part of Blazor's operation when the `NavigationManager` is used during prerendering.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Previously, the debugger would not stop at all for these user-unhandled exceptions. [Breaking for Async User-Unhandled exceptions in the Visual Studio Debugger in async code](https://devblogs.microsoft.com/visualstudio/break-for-async-user-unhandled-exceptions-in-the-visual-studio-debugger/) is new in .NET 9.

If exceptions happen to be common in a given developer's workflow, they can easily disable breaking for user-unhandled exceptions either in general or on a per exception type basis to get the old behavior of never stopping for user-unhandled exceptions.

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
