### PR TITLE
Adjust PGO data path

### DIFF
--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -429,7 +429,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <PropertyGroup>
       <CrossgenToolPath>$([System.IO.Path]::Combine('$(Crossgen2PackageRoot)', 'tools', '$(Crossgen2ToolFileName)'))</CrossgenToolPath>
       <CrossgenSymbolsTargetDir>$(TargetDir)</CrossgenSymbolsTargetDir>
-      <CrossgenOptimizationData Condition="'$(RuntimePackageRoot)' != ''">$(RuntimePackageRoot)tools\StandardOptimizationData.mibc</CrossgenOptimizationData>
+      <CrossgenOptimizationData Condition="'$(RuntimePackageRoot)' != ''">$(RuntimePackageRoot)PgoData\StandardOptimizationData.mibc</CrossgenOptimizationData>
       <CrossgenOptimizationData Condition="!Exists('$(CrossgenOptimizationData)')"></CrossgenOptimizationData>
 
       <!-- Escaping (double backslash at end) required due to the way batch processes backslashes. -->


### PR DESCRIPTION
# Adjust PGO path in the Microsoft.NETCore.App runtime package to account for https://github.com/dotnet/runtime/pull/109169

## Description

The managed PGO data in the runtime pack is moving to the initially-intended standard location (the current one is a workaround that was never undone). Adjust the path here to ensure that aspnetcore consumes the optimization data for the R2R commands.

Blocked on https://github.com/dotnet/runtime/pull/109169