### PR TITLE
Adds the ability to specify an appsettings file for user-jwts

### DIFF
--- a/src/Tools/dotnet-user-jwts/src/Commands/ClearCommand.cs
+++ b/src/Tools/dotnet-user-jwts/src/Commands/ClearCommand.cs
@@ -19,21 +19,43 @@ internal sealed class ClearCommand
                 Resources.ClearCommand_ForceOption_Description,
                 CommandOptionType.NoValue);
 
+            var appsettingsFileOption = cmd.Option(
+                "--appsettings-file",
+                Resources.CreateCommand_appsettingsFileOption_Description,
+                CommandOptionType.SingleValue);
+
             cmd.HelpOption("-h|--help");
 
             cmd.OnExecute(() =>
             {
-                return Execute(cmd.Reporter, cmd.ProjectOption.Value(), forceOption.HasValue());
+                if (!DevJwtCliHelpers.GetProjectAndSecretsId(cmd.ProjectOption.Value(), cmd.Reporter, out var project, out var userSecretsId))
+                {
+                    return 1;
+                }
+
+                var appsettingsFile = "appsettings.Development.json";
+                if (appsettingsFileOption.HasValue())
+                {
+                    appsettingsFile = appsettingsFileOption.Value();
+                    if (!appsettingsFile.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+                    {
+                        cmd.Reporter.Error(Resources.RemoveCommand_InvalidAppsettingsFile_Error);
+                        return 1;
+                    }
+                    else if (!File.Exists(Path.Combine(Path.GetDirectoryName(project), appsettingsFile)))
+                    {
+                        cmd.Reporter.Error(Resources.FormatRemoveCommand_AppsettingsFileNotFound_Error(Path.GetDirectoryName(project)));
+                        return 1;
+                    }
+                }
+
+                return Execute(cmd.Reporter, project, userSecretsId, forceOption.HasValue(), appsettingsFile);
             });
         });
     }
 
-    private static int Execute(IReporter reporter, string projectPath, bool force)
+    private static int Execute(IReporter reporter, string project, string userSecretsId, bool force, string appsettingsFile)
     {
-        if (!DevJwtCliHelpers.GetProjectAndSecretsId(projectPath, reporter, out var project, out var userSecretsId))
-        {
-            return 1;
-        }
         var jwtStore = new JwtStore(userSecretsId);
         var count = jwtStore.Jwts.Count;
 
@@ -54,7 +76,7 @@ internal sealed class ClearCommand
             }
         }
 
-        var appsettingsFilePath = Path.Combine(Path.GetDirectoryName(project), "appsettings.Development.json");
+        var appsettingsFilePath = Path.Combine(Path.GetDirectoryName(project), appsettingsFile);
         foreach (var jwt in jwtStore.Jwts)
         {
             JwtAuthenticationSchemeSettings.RemoveScheme(appsettingsFilePath, jwt.Value.Scheme);

--- a/src/Tools/dotnet-user-jwts/src/Commands/ClearCommand.cs
+++ b/src/Tools/dotnet-user-jwts/src/Commands/ClearCommand.cs
@@ -33,20 +33,9 @@ internal sealed class ClearCommand
                     return 1;
                 }
 
-                var appsettingsFile = "appsettings.Development.json";
-                if (appsettingsFileOption.HasValue())
+                if (!DevJwtCliHelpers.GetAppSettingsFile(project, appsettingsFileOption.Value(), cmd.Reporter, out var appsettingsFile))
                 {
-                    appsettingsFile = appsettingsFileOption.Value();
-                    if (!appsettingsFile.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
-                    {
-                        cmd.Reporter.Error(Resources.RemoveCommand_InvalidAppsettingsFile_Error);
-                        return 1;
-                    }
-                    else if (!File.Exists(Path.Combine(Path.GetDirectoryName(project), appsettingsFile)))
-                    {
-                        cmd.Reporter.Error(Resources.FormatRemoveCommand_AppsettingsFileNotFound_Error(Path.GetDirectoryName(project)));
-                        return 1;
-                    }
+                    return 1;
                 }
 
                 return Execute(cmd.Reporter, project, userSecretsId, forceOption.HasValue(), appsettingsFile);

--- a/src/Tools/dotnet-user-jwts/src/Commands/CreateCommand.cs
+++ b/src/Tools/dotnet-user-jwts/src/Commands/CreateCommand.cs
@@ -216,24 +216,12 @@ internal sealed class CreateCommand
             optionsString += $"{Resources.JwtPrint_CustomClaims}: [{string.Join(", ", claims.Select(kvp => $"{kvp.Key}={kvp.Value}"))}]{Environment.NewLine}";
         }
 
-        var appsettingsFile = "appsettings.Development.json";
+        var appsettingsFile = DevJwtCliHelpers.DefaultAppSettingsFile;
         if (appsettingsFileOption.HasValue())
         {
-            appsettingsFile = appsettingsFileOption.Value();
-            if (!appsettingsFile.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
-            {
-                reporter.Error(Resources.CreateCommand_InvalidAppsettingsFile_Error);
-                isValid = false;
-            }
-            else if (!File.Exists(Path.Combine(Path.GetDirectoryName(project), appsettingsFile)))
-            {
-                reporter.Error(Resources.FormatCreateCommand_AppsettingsFileNotFound_Error(Path.GetDirectoryName(project)));
-                isValid = false;
-            }
-            else
-            {
-                optionsString += appsettingsFileOption.HasValue() ? $"{Resources.JwtPrint_appsettingsFile}: {appsettingsFile}{Environment.NewLine}" : string.Empty;
-            }
+            isValid = DevJwtCliHelpers.GetAppSettingsFile(project, appsettingsFileOption.Value(), reporter, out appsettingsFile);
+
+            optionsString += appsettingsFileOption.HasValue() ? $"{Resources.JwtPrint_appsettingsFile}: {appsettingsFile}{Environment.NewLine}" : string.Empty;
         }
 
         return (

--- a/src/Tools/dotnet-user-jwts/src/Commands/CreateCommand.cs
+++ b/src/Tools/dotnet-user-jwts/src/Commands/CreateCommand.cs
@@ -77,24 +77,29 @@ internal sealed class CreateCommand
                 Resources.CreateCommand_ValidForOption_Description,
                 CommandOptionType.SingleValue);
 
+            var appsettingsFileOption = cmd.Option(
+                "--appsettings-file",
+                Resources.CreateCommand_appsettingsFileOption_Description,
+                CommandOptionType.SingleValue);
+
             cmd.HelpOption("-h|--help");
 
             cmd.OnExecute(() =>
             {
-                var (options, isValid, optionsString) = ValidateArguments(
-                    cmd.Reporter, cmd.ProjectOption, schemeNameOption, nameOption, audienceOption, issuerOption, notBeforeOption, expiresOnOption, validForOption, rolesOption, scopesOption, claimsOption);
+                var (options, isValid, optionsString, appsettingsFile) = ValidateArguments(
+                    cmd.Reporter, cmd.ProjectOption, schemeNameOption, nameOption, audienceOption, issuerOption, notBeforeOption, expiresOnOption, validForOption, rolesOption, scopesOption, claimsOption, appsettingsFileOption);
 
                 if (!isValid)
                 {
                     return 1;
                 }
 
-                return Execute(cmd.Reporter, cmd.ProjectOption.Value(), options, optionsString, cmd.OutputOption.Value(), program);
+                return Execute(cmd.Reporter, cmd.ProjectOption.Value(), options, optionsString, cmd.OutputOption.Value(), appsettingsFile, program);
             });
         });
     }
 
-    private static (JwtCreatorOptions, bool, string) ValidateArguments(
+    private static (JwtCreatorOptions, bool, string, string) ValidateArguments(
         IReporter reporter,
         CommandOption projectOption,
         CommandOption schemeNameOption,
@@ -106,7 +111,8 @@ internal sealed class CreateCommand
         CommandOption validForOption,
         CommandOption rolesOption,
         CommandOption scopesOption,
-        CommandOption claimsOption)
+        CommandOption claimsOption,
+        CommandOption appsettingsFileOption)
     {
         var isValid = true;
         var finder = new MsBuildProjectFinder(Directory.GetCurrentDirectory());
@@ -121,6 +127,7 @@ internal sealed class CreateCommand
             return (
                 null,
                 isValid,
+                string.Empty,
                 string.Empty
             );
         }
@@ -209,10 +216,31 @@ internal sealed class CreateCommand
             optionsString += $"{Resources.JwtPrint_CustomClaims}: [{string.Join(", ", claims.Select(kvp => $"{kvp.Key}={kvp.Value}"))}]{Environment.NewLine}";
         }
 
+        var appsettingsFile = "appsettings.Development.json";
+        if (appsettingsFileOption.HasValue())
+        {
+            appsettingsFile = appsettingsFileOption.Value();
+            if (!appsettingsFile.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+            {
+                reporter.Error(Resources.CreateCommand_InvalidAppsettingsFile_Error);
+                isValid = false;
+            }
+            else if (!File.Exists(Path.Combine(Path.GetDirectoryName(project), appsettingsFile)))
+            {
+                reporter.Error(Resources.FormatCreateCommand_AppsettingsFileNotFound_Error(Path.GetDirectoryName(project)));
+                isValid = false;
+            }
+            else
+            {
+                optionsString += appsettingsFileOption.HasValue() ? $"{Resources.JwtPrint_appsettingsFile}: {appsettingsFile}{Environment.NewLine}" : string.Empty;
+            }
+        }
+
         return (
             new JwtCreatorOptions(scheme, name, audience, issuer, notBefore, expiresOn, roles, scopes, claims),
             isValid,
-            optionsString);
+            optionsString,
+            appsettingsFile);
 
         static bool ParseDate(string datetime, out DateTime parsedDateTime) =>
             DateTime.TryParseExact(datetime, _dateTimeFormats, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out parsedDateTime);
@@ -224,6 +252,7 @@ internal sealed class CreateCommand
         JwtCreatorOptions options,
         string optionsString,
         string outputFormat,
+        string appsettingsFile,
         Program program)
     {
         if (!DevJwtCliHelpers.GetProjectAndSecretsId(projectPath, reporter, out var project, out var userSecretsId))
@@ -244,7 +273,7 @@ internal sealed class CreateCommand
         jwtStore.Jwts.Add(jwtToken.Id, jwt);
         jwtStore.Save();
 
-        var appsettingsFilePath = Path.Combine(Path.GetDirectoryName(project), "appsettings.Development.json");
+        var appsettingsFilePath = Path.Combine(Path.GetDirectoryName(project), appsettingsFile);
         var settingsToWrite = new JwtAuthenticationSchemeSettings(options.Scheme, options.Audiences, options.Issuer);
         settingsToWrite.Save(appsettingsFilePath);
 

--- a/src/Tools/dotnet-user-jwts/src/Commands/RemoveCommand.cs
+++ b/src/Tools/dotnet-user-jwts/src/Commands/RemoveCommand.cs
@@ -36,20 +36,9 @@ internal sealed class RemoveCommand
                     return 1;
                 }
 
-                var appsettingsFile = "appsettings.Development.json";
-                if (appsettingsFileOption.HasValue())
+                if (!DevJwtCliHelpers.GetAppSettingsFile(project, appsettingsFileOption.Value(), cmd.Reporter, out var appsettingsFile))
                 {
-                    appsettingsFile = appsettingsFileOption.Value();
-                    if (!appsettingsFile.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
-                    {
-                        cmd.Reporter.Error(Resources.RemoveCommand_InvalidAppsettingsFile_Error);
-                        return 1;
-                    }
-                    else if (!File.Exists(Path.Combine(Path.GetDirectoryName(project), appsettingsFile)))
-                    {
-                        cmd.Reporter.Error(Resources.FormatRemoveCommand_AppsettingsFileNotFound_Error(Path.GetDirectoryName(project)));
-                        return 1;
-                    }
+                    return 1;
                 }
 
                 return Execute(cmd.Reporter, project, userSecretsId, idArgument.Value, appsettingsFile);

--- a/src/Tools/dotnet-user-jwts/src/Helpers/DevJwtCliHelpers.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/DevJwtCliHelpers.cs
@@ -11,6 +11,8 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer.Tools;
 
 internal static class DevJwtCliHelpers
 {
+    public const string DefaultAppSettingsFile = "appsettings.Development.json";
+
     public static string GetOrSetUserSecretsId(string projectFilePath)
     {
         var resolver = new ProjectIdResolver(NullReporter.Singleton, projectFilePath);
@@ -39,6 +41,27 @@ internal static class DevJwtCliHelpers
             reporter.Error(Resources.ProjectOption_SercretIdNotFound);
             return false;
         }
+        return true;
+    }
+
+    public static bool GetAppSettingsFile(string projectPath, string appsettingsFileOption, IReporter reporter, out string appsettingsFile)
+    {
+        appsettingsFile = DevJwtCliHelpers.DefaultAppSettingsFile;
+        if (appsettingsFileOption is not null)
+        {
+            appsettingsFile = appsettingsFileOption;
+            if (!appsettingsFile.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+            {
+                reporter.Error(Resources.RemoveCommand_InvalidAppsettingsFile_Error);
+                return false;
+            }
+            else if (!File.Exists(Path.Combine(Path.GetDirectoryName(projectPath), appsettingsFile)))
+            {
+                reporter.Error(Resources.FormatRemoveCommand_AppsettingsFileNotFound_Error(Path.GetDirectoryName(projectPath)));
+                return false;
+            }
+        }
+
         return true;
     }
 
@@ -213,4 +236,5 @@ internal static class DevJwtCliHelpers
     {
         return enumerable == null || !enumerable.Any();
     }
+
 }

--- a/src/Tools/dotnet-user-jwts/src/Helpers/DevJwtCliHelpers.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/DevJwtCliHelpers.cs
@@ -57,7 +57,7 @@ internal static class DevJwtCliHelpers
             }
             else if (!File.Exists(Path.Combine(Path.GetDirectoryName(projectPath), appsettingsFile)))
             {
-                reporter.Error(Resources.FormatRemoveCommand_AppsettingsFileNotFound_Error(Path.GetDirectoryName(projectPath)));
+                reporter.Error(Resources.FormatRemoveCommand_AppsettingsFileNotFound_Error(Path.Combine(Path.GetDirectoryName(projectPath), appsettingsFile)));
                 return false;
             }
         }

--- a/src/Tools/dotnet-user-jwts/src/Resources.resx
+++ b/src/Tools/dotnet-user-jwts/src/Resources.resx
@@ -150,6 +150,12 @@
   <data name="CreateCommand_ExpiresOnOption_Description" xml:space="preserve">
     <value>The UTC date &amp; time the JWT should expire in the format 'yyyy-MM-dd [[[[HH:mm]]:ss]]'. Defaults to 3 months after the --not-before date. Do not use this option in conjunction with the --valid-for option.</value>
   </data>
+  <data name="CreateCommand_InvalidAppsettingsFile_Error" xml:space="preserve">
+    <value>Invalid Appsettings file extension. Ensure file extension is .json.</value>
+  </data>
+  <data name="CreateCommand_AppsettingsFileNotFound_Error" xml:space="preserve">
+    <value>Could not find Appsettings file in '{0}'. Check the filename and that the file exists.</value>
+  </data>
   <data name="CreateCommand_InvalidClaims_Error" xml:space="preserve">
     <value>Malformed claims supplied. Ensure each claim is in the format "name=value".</value>
   </data>
@@ -189,6 +195,9 @@
   <data name="CreateCommand_ValidForOption_Description" xml:space="preserve">
     <value>The period the JWT should expire after. Specify using a number followed by a duration type like 'd' for days, 'h' for hours, 'm' for minutes, and 's' for seconds, e.g. '365d'. Do not use this option in conjunction with the --expires-on option.</value>
   </data>
+  <data name="CreateCommand_appsettingsFileOption_Description" xml:space="preserve">
+    <value>The appSettings configuration file to add the test scheme to.</value>
+  </data>
   <data name="JwtPrint_Audiences" xml:space="preserve">
     <value>Audience(s)</value>
   </data>
@@ -224,6 +233,9 @@
   </data>
   <data name="JwtPrint_Scopes" xml:space="preserve">
     <value>Scopes</value>
+  </data>
+  <data name="JwtPrint_appsettingsFile" xml:space="preserve">
+    <value>Appsettings File</value>
   </data>
   <data name="JwtPrint_Token" xml:space="preserve">
     <value>Token</value>
@@ -311,6 +323,12 @@
   </data>
   <data name="RemoveCommand_NoJwtFound" xml:space="preserve">
     <value>No JWT with ID '{0}' found.</value>
+  </data>
+  <data name="RemoveCommand_InvalidAppsettingsFile_Error" xml:space="preserve">
+    <value>Invalid Appsettings file extension. Ensure file extension is .json.</value>
+  </data>
+  <data name="RemoveCommand_AppsettingsFileNotFound_Error" xml:space="preserve">
+    <value>Could not find Appsettings file in '{0}'. Check the filename and that the file exists.</value>
   </data>
   <data name="KeyCommand_IssuerOption_Description" xml:space="preserve">
     <value>The issuer associated with the signing key to be reset or displayed. Defaults to 'dotnet-user-jwts'.</value>

--- a/src/Tools/dotnet-user-jwts/src/Resources.resx
+++ b/src/Tools/dotnet-user-jwts/src/Resources.resx
@@ -325,10 +325,10 @@
     <value>No JWT with ID '{0}' found.</value>
   </data>
   <data name="RemoveCommand_InvalidAppsettingsFile_Error" xml:space="preserve">
-    <value>Invalid Appsettings file extension. Ensure file extension is .json.</value>
+    <value>The specified appsettings file is invalid. Please provide a valid JSON file.</value>
   </data>
   <data name="RemoveCommand_AppsettingsFileNotFound_Error" xml:space="preserve">
-    <value>Could not find Appsettings file in '{0}'. Check the filename and that the file exists.</value>
+    <value>Could not find Appsettings file '{0}'. Check the filename and that the file exists.</value>
   </data>
   <data name="KeyCommand_IssuerOption_Description" xml:space="preserve">
     <value>The issuer associated with the signing key to be reset or displayed. Defaults to 'dotnet-user-jwts'.</value>

--- a/src/Tools/dotnet-user-jwts/test/UserJwtsTestFixture.cs
+++ b/src/Tools/dotnet-user-jwts/test/UserJwtsTestFixture.cs
@@ -81,6 +81,10 @@ public sealed class UserJwtsTestFixture : IDisposable
             Path.Combine(projectPath.FullName, "appsettings.Development.json"),
             "{}");
 
+        File.WriteAllText(
+            Path.Combine(projectPath.FullName, "appsettings.Local.json"),
+            "{}");
+
         if (hasSecret)
         {
             _disposables.Push(() =>

--- a/src/Tools/dotnet-user-jwts/test/UserJwtsTests.cs
+++ b/src/Tools/dotnet-user-jwts/test/UserJwtsTests.cs
@@ -683,11 +683,12 @@ public class UserJwtsTests(UserJwtsTestFixture fixture, ITestOutputHelper output
     {
         var projectPath = fixture.CreateProject();
         Directory.SetCurrentDirectory(projectPath);
+        var expectedAppsettingsPath = Path.Combine(Directory.GetCurrentDirectory(), "appsettings.DoesNotExist.json");
 
         var app = new Program(_console);
         app.Run(["create", "--appsettings-file", "appsettings.DoesNotExist.json"]);
 
-        Assert.Contains($"Could not find Appsettings file in '{Directory.GetCurrentDirectory()}'. Check the filename and that the file exists.", _console.GetOutput());
+        Assert.Contains($"Could not find Appsettings file '{expectedAppsettingsPath}'. Check the filename and that the file exists.", _console.GetOutput());
     }
 
     [Fact]
@@ -707,11 +708,12 @@ public class UserJwtsTests(UserJwtsTestFixture fixture, ITestOutputHelper output
     {
         var projectPath = fixture.CreateProject();
         Directory.SetCurrentDirectory(projectPath);
+        var expectedAppsettingsPath = Path.Combine(Directory.GetCurrentDirectory(), "appsettings.DoesNotExist.json");
 
         var app = new Program(_console);
         app.Run(["remove", "some-id", "--appsettings-file", "appsettings.DoesNotExist.json"]);
 
-        Assert.Contains($"Could not find Appsettings file in '{Directory.GetCurrentDirectory()}'. Check the filename and that the file exists.", _console.GetOutput());
+        Assert.Contains($"Could not find Appsettings file '{expectedAppsettingsPath}'. Check the filename and that the file exists.", _console.GetOutput());
     }
 
     [Fact]
@@ -731,11 +733,12 @@ public class UserJwtsTests(UserJwtsTestFixture fixture, ITestOutputHelper output
     {
         var projectPath = fixture.CreateProject();
         Directory.SetCurrentDirectory(projectPath);
+        var expectedAppsettingsPath = Path.Combine(Directory.GetCurrentDirectory(), "appsettings.DoesNotExist.json");
 
         var app = new Program(_console);
         app.Run(["clear", "--appsettings-file", "appsettings.DoesNotExist.json"]);
 
-        Assert.Contains($"Could not find Appsettings file in '{Directory.GetCurrentDirectory()}'. Check the filename and that the file exists.", _console.GetOutput());
+        Assert.Contains($"Could not find Appsettings file '{expectedAppsettingsPath}'. Check the filename and that the file exists.", _console.GetOutput());
     }
 
     [Fact]
@@ -804,7 +807,7 @@ public class UserJwtsTests(UserJwtsTestFixture fixture, ITestOutputHelper output
         var app = new Program(_console);
         app.Run(new[] { "create", "--project", targetPath, "--appsettings-file", "appsettings.Local.json" });
         
-        Assert.DoesNotContain($"Could not find Appsettings file in '{projectPath}'. Check the filename and that the file exists.", _console.GetOutput());
+        Assert.DoesNotContain($"Could not find Appsettings file '{projectPath}'. Check the filename and that the file exists.", _console.GetOutput());
         Assert.Contains("New JWT saved", _console.GetOutput());
     }
 


### PR DESCRIPTION
# Adds the ability to specify an appsettings file for user-jwts

Adds the ability to specify an appsettings file for user-jwts

## Description

Currently the `user-jwts` tool amends `appsettings.Development.json` when adding a mock JWT scheme for local testing. Many people use `appsettings.Development.json` for environments other than local development, i.e. a cloud Development environment, and so this amendment causes issues.  In my particular case, we have `appsettings.Local.json` instead and so the tool fails to execute because it cannot find `appsettings.Development.json`. 

As described in https://github.com/dotnet/aspnetcore/issues/56169 this affects multiple other teams too.  

This PR allows for an appsettings file to be specified which will be amended instead of the default `appsettings.Development.json`.  The tool still assumes the file lives next to the project, as it currently does, and checks that the file both exists and ends in `.json`.  Tests have been added to confirm the functionality.

Fixes #56169
