### PR TITLE
 Support returning OpenAPI document in YAML from MapOpenApi

### DIFF
--- a/src/OpenApi/sample/Program.cs
+++ b/src/OpenApi/sample/Program.cs
@@ -37,6 +37,7 @@ builder.Services.AddOpenApi("schemas-by-ref");
 var app = builder.Build();
 
 app.MapOpenApi();
+app.MapOpenApi("/openapi/{documentName}.yaml");
 if (app.Environment.IsDevelopment())
 {
     app.MapSwaggerUi();

--- a/src/OpenApi/src/Extensions/OpenApiEndpointRouteBuilderExtensions.cs
+++ b/src/OpenApi/src/Extensions/OpenApiEndpointRouteBuilderExtensions.cs
@@ -49,8 +49,16 @@ public static class OpenApiEndpointRouteBuilderExtensions
                     using var writer = Utf8BufferTextWriter.Get(output);
                     try
                     {
-                        document.Serialize(new OpenApiJsonWriter(writer), documentOptions.OpenApiVersion);
-                        context.Response.ContentType = "application/json;charset=utf-8";
+                        if (UseYaml(pattern))
+                        {
+                            document.Serialize(new OpenApiYamlWriter(writer), documentOptions.OpenApiVersion);
+                            context.Response.ContentType = "application/yaml;charset=utf-8";
+                        }
+                        else
+                        {
+                            document.Serialize(new OpenApiJsonWriter(writer), documentOptions.OpenApiVersion);
+                            context.Response.ContentType = "application/json;charset=utf-8";
+                        }
                         await context.Response.BodyWriter.WriteAsync(output.ToArray(), context.RequestAborted);
                         await context.Response.BodyWriter.FlushAsync(context.RequestAborted);
                     }
@@ -63,4 +71,8 @@ public static class OpenApiEndpointRouteBuilderExtensions
                 }
             }).ExcludeFromDescription();
     }
+
+    private static bool UseYaml(string pattern) =>
+        pattern.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase) ||
+        pattern.EndsWith(".yml", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/OpenApi/src/Extensions/OpenApiEndpointRouteBuilderExtensions.cs
+++ b/src/OpenApi/src/Extensions/OpenApiEndpointRouteBuilderExtensions.cs
@@ -52,7 +52,7 @@ public static class OpenApiEndpointRouteBuilderExtensions
                         if (UseYaml(pattern))
                         {
                             document.Serialize(new OpenApiYamlWriter(writer), documentOptions.OpenApiVersion);
-                            context.Response.ContentType = "application/yaml;charset=utf-8";
+                            context.Response.ContentType = "text/plain+yaml;charset=utf-8";
                         }
                         else
                         {

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Extensions/OpenApiEndpointRouteBuilderExtensionsTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Extensions/OpenApiEndpointRouteBuilderExtensionsTests.cs
@@ -75,10 +75,11 @@ public class OpenApiEndpointRouteBuilderExtensionsTests : OpenApiDocumentService
     }
 
     [Theory]
-    [InlineData("/openapi.json", "application/json;charset=utf-8")]
-    [InlineData("/openapi.yaml", "application/yaml;charset=utf-8")]
-    [InlineData("/openapi.yml", "application/yaml;charset=utf-8")]
-    public async Task MapOpenApi_ReturnsDefaultDocumentIfNoNameProvided(string expectedPath, string expectedContentType)
+    [InlineData("/openapi.json", "application/json;charset=utf-8", false)]
+    [InlineData("/openapi.toml", "application/json;charset=utf-8", false)]
+    [InlineData("/openapi.yaml", "text/plain+yaml;charset=utf-8", true)]
+    [InlineData("/openapi.yml", "text/plain+yaml;charset=utf-8", true)]
+    public async Task MapOpenApi_ReturnsDefaultDocumentIfNoNameProvided(string expectedPath, string expectedContentType, bool isYaml)
     {
         // Arrange
         var serviceProvider = CreateServiceProvider();
@@ -97,6 +98,10 @@ public class OpenApiEndpointRouteBuilderExtensionsTests : OpenApiDocumentService
         // Assert
         Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
         Assert.Equal(expectedContentType, context.Response.ContentType);
+        var responseString = Encoding.UTF8.GetString(responseBodyStream.ToArray());
+        // String check to validate that generated document starts with YAML syntax
+        Assert.Equal(isYaml, responseString.StartsWith("openapi: 3.0.1", StringComparison.OrdinalIgnoreCase));
+        responseBodyStream.Position = 0;
         ValidateOpenApiDocument(responseBodyStream, document =>
         {
             Assert.Equal("OpenApiEndpointRouteBuilderExtensionsTests | v1", document.Info.Title);
@@ -128,10 +133,10 @@ public class OpenApiEndpointRouteBuilderExtensionsTests : OpenApiDocumentService
     }
 
     [Theory]
-    [InlineData("/openapi.json", "application/json;charset=utf-8")]
-    [InlineData("/openapi.yaml", "application/yaml;charset=utf-8")]
-    [InlineData("/openapi.yml", "application/yaml;charset=utf-8")]
-    public async Task MapOpenApi_ReturnsDocumentIfNameProvidedInQuery(string expectedPath, string expectedContentType)
+    [InlineData("/openapi.json", "application/json;charset=utf-8", false)]
+    [InlineData("/openapi.yaml", "text/plain+yaml;charset=utf-8", true)]
+    [InlineData("/openapi.yml", "text/plain+yaml;charset=utf-8", true)]
+    public async Task MapOpenApi_ReturnsDocumentIfNameProvidedInQuery(string expectedPath, string expectedContentType, bool isYaml)
     {
         // Arrange
         var documentName = "v2";
@@ -154,6 +159,10 @@ public class OpenApiEndpointRouteBuilderExtensionsTests : OpenApiDocumentService
         // Assert
         Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
         Assert.Equal(expectedContentType, context.Response.ContentType);
+        var responseString = Encoding.UTF8.GetString(responseBodyStream.ToArray());
+        // String check to validate that generated document starts with YAML syntax
+        Assert.Equal(isYaml, responseString.StartsWith("openapi: 3.0.1", StringComparison.OrdinalIgnoreCase));
+        responseBodyStream.Position = 0;
         ValidateOpenApiDocument(responseBodyStream, document =>
         {
             Assert.Equal($"OpenApiEndpointRouteBuilderExtensionsTests | {documentName}", document.Info.Title);


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/58516.

This PR adds support for returning the OpenAPI document at runtime in the YAML format.  It does this by checking the extension on the route pattern that is provided for resolving the OpenAPI document. If a user calls:

```csharp
app.MapOpenApi("/openapi/{documentName}.yaml");
```

Then visiting the `/openapi/v1.yaml` route in their application will return the document in YAML format. The implementation treats routes ending in either `yaml` or `yml` as YAML-generating by default. All other routes will produce an OpenAPI document serialized to JSON.

As an alternative approach, we could follow the pattern proposed in [this issue](https://github.com/dotnet/aspnetcore/issues/58516#issue-2598863236) and introduce an additional `OpenApiFormat` argument to the `MapOpenApi` method. However, because the implementation assumes that the extension appears in the route pattern by default we run the risk of users inadvertently calling:

```csharp
app.MapOpenApi(format: OpenApiFormat.Yaml);
```

Which would use the default route pattern for the document that uses a JSON file extension with the incorrect file format. I figured it was more straightforward if we define the format based on the route pattern and avoid adding another option. There is a risk that more formats get added in the future and the complexity of our checks increases but that isn't a likely eventuality at the moment.