### PR TITLE
Use FullName in InstallJdk script

### DIFF
--- a/eng/scripts/InstallJdk.ps1
+++ b/eng/scripts/InstallJdk.ps1
@@ -46,7 +46,7 @@ Expand-Archive "$tempDir/jdk.zip" -d "$tempDir/jdk/"
 Write-Host "Expanded JDK to $tempDir"
 Write-Host "Installing JDK to $installDir"
 # The name of the file directory within the zip is based on the version, but may contain a +N for build number.
-Move-Item "$tempDir/jdk/$(Get-ChildItem -Path "$tempDir/jdk" | Select-Object -First 1)/*" $installDir
+Move-Item "$(Get-ChildItem -Path "$tempDir/jdk" | Select-Object -First 1 -ExpandProperty FullName)/*" $installDir
 Write-Host "Done installing JDK to $installDir"
 
 if ($env:TF_BUILD) {


### PR DESCRIPTION
#58557 broke InstallJdk.ps1 on my machine, so I'm updating the fix to explicitly use the `FullName` property from `Get-ChildItem`.

Error for reference:

```
(aspnetcore) PS C:\dev\dotnet\aspnetcore> .\eng\scripts\InstallJdk.ps2
Starting download of JDK 11.0.24
GET https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/java/microsoft-jdk-11.0.24-windows-x64.zip
Download of 'https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/java/microsoft-jdk-11.0.24-windows-x64.zip' complete, saved to C:\dev\dotnet\aspnetcore\obj/jdk.zip...
Done downloading JDK 11.0.24
Expanded JDK to C:\dev\dotnet\aspnetcore\obj
Installing JDK to C:\dev\dotnet\aspnetcore\.tools\jdk\win-x64\
Move-Item: C:\dev\dotnet\aspnetcore\eng\scripts\InstallJdk.ps1:49
Line |
  49 |  Move-Item "$tempDir/jdk/$(Get-ChildItem -Path "$tempDir/jdk" | Select …
     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Cannot find path 'C:\dev\dotnet\aspnetcore\obj\jdk\C:\dev\dotnet\aspnetcore\obj\jdk\jdk-11.0.24+8' because it does not exist.
```
