### PR TITLE
Fully qualify type names for services when resolving in RequestDelegateGenerator

### DIFF
--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointParameterEmitter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointParameterEmitter.cs
@@ -389,8 +389,8 @@ internal static class EndpointParameterEmitter
         // Unlike other scenarios, this will result in an exception being thrown
         // at runtime.
         var assigningCode = endpointParameter.IsOptional ?
-            $"httpContext.RequestServices.GetService<{endpointParameter.Type}>();" :
-            $"httpContext.RequestServices.GetRequiredService<{endpointParameter.Type}>()";
+            $"httpContext.RequestServices.GetService<{endpointParameter.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}>();" :
+            $"httpContext.RequestServices.GetRequiredService<{endpointParameter.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}>()";
         codeWriter.WriteLine($"var {endpointParameter.EmitHandlerArgument()} = {assigningCode};");
     }
 
@@ -404,8 +404,8 @@ internal static class EndpointParameterEmitter
         codeWriter.EndBlock();
 
         var assigningCode = endpointParameter.IsOptional ?
-            $"httpContext.RequestServices.GetKeyedService<{endpointParameter.Type}>({endpointParameter.KeyedServiceKey});" :
-            $"httpContext.RequestServices.GetRequiredKeyedService<{endpointParameter.Type}>({endpointParameter.KeyedServiceKey})";
+            $"httpContext.RequestServices.GetKeyedService<{endpointParameter.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}>({endpointParameter.KeyedServiceKey});" :
+            $"httpContext.RequestServices.GetRequiredKeyedService<{endpointParameter.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}>({endpointParameter.KeyedServiceKey})";
         codeWriter.WriteLine($"var {endpointParameter.EmitHandlerArgument()} = {assigningCode};");
     }
 

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointParameterEmitter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointParameterEmitter.cs
@@ -389,8 +389,8 @@ internal static class EndpointParameterEmitter
         // Unlike other scenarios, this will result in an exception being thrown
         // at runtime.
         var assigningCode = endpointParameter.IsOptional ?
-            $"httpContext.RequestServices.GetService<{endpointParameter.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}>();" :
-            $"httpContext.RequestServices.GetRequiredService<{endpointParameter.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}>()";
+            $"httpContext.RequestServices.GetService<{endpointParameter.Type.ToDisplayString(EmitterConstants.DisplayFormat)}>();" :
+            $"httpContext.RequestServices.GetRequiredService<{endpointParameter.Type.ToDisplayString(EmitterConstants.DisplayFormat)}>()";
         codeWriter.WriteLine($"var {endpointParameter.EmitHandlerArgument()} = {assigningCode};");
     }
 
@@ -404,8 +404,8 @@ internal static class EndpointParameterEmitter
         codeWriter.EndBlock();
 
         var assigningCode = endpointParameter.IsOptional ?
-            $"httpContext.RequestServices.GetKeyedService<{endpointParameter.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}>({endpointParameter.KeyedServiceKey});" :
-            $"httpContext.RequestServices.GetRequiredKeyedService<{endpointParameter.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}>({endpointParameter.KeyedServiceKey})";
+            $"httpContext.RequestServices.GetKeyedService<{endpointParameter.Type.ToDisplayString(EmitterConstants.DisplayFormat)}>({endpointParameter.KeyedServiceKey});" :
+            $"httpContext.RequestServices.GetRequiredKeyedService<{endpointParameter.Type.ToDisplayString(EmitterConstants.DisplayFormat)}>({endpointParameter.KeyedServiceKey})";
         codeWriter.WriteLine($"var {endpointParameter.EmitHandlerArgument()} = {assigningCode};");
     }
 

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitServiceParam_SimpleReturn_Snapshot.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitServiceParam_SimpleReturn_Snapshot.generated.txt
@@ -107,7 +107,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 {
                     var wasParamCheckFailure = false;
                     // Endpoint Parameter: svc (Type = Microsoft.AspNetCore.Http.Generators.Tests.TestService, IsOptional = False, IsParsable = False, IsArray = False, Source = Service)
-                    var svc_local = httpContext.RequestServices.GetRequiredService<Microsoft.AspNetCore.Http.Generators.Tests.TestService>();
+                    var svc_local = httpContext.RequestServices.GetRequiredService<global::Microsoft.AspNetCore.Http.Generators.Tests.TestService>();
 
                     if (wasParamCheckFailure)
                     {
@@ -130,7 +130,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 {
                     var wasParamCheckFailure = false;
                     // Endpoint Parameter: svc (Type = Microsoft.AspNetCore.Http.Generators.Tests.TestService, IsOptional = False, IsParsable = False, IsArray = False, Source = Service)
-                    var svc_local = httpContext.RequestServices.GetRequiredService<Microsoft.AspNetCore.Http.Generators.Tests.TestService>();
+                    var svc_local = httpContext.RequestServices.GetRequiredService<global::Microsoft.AspNetCore.Http.Generators.Tests.TestService>();
 
                     if (wasParamCheckFailure)
                     {
@@ -207,7 +207,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 {
                     var wasParamCheckFailure = false;
                     // Endpoint Parameter: svc (Type = System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Http.Generators.Tests.TestService>, IsOptional = False, IsParsable = False, IsArray = False, Source = Service)
-                    var svc_local = httpContext.RequestServices.GetRequiredService<System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Http.Generators.Tests.TestService>>();
+                    var svc_local = httpContext.RequestServices.GetRequiredService<global::System.Collections.Generic.IEnumerable<global::Microsoft.AspNetCore.Http.Generators.Tests.TestService>>();
 
                     if (wasParamCheckFailure)
                     {
@@ -230,7 +230,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 {
                     var wasParamCheckFailure = false;
                     // Endpoint Parameter: svc (Type = System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Http.Generators.Tests.TestService>, IsOptional = False, IsParsable = False, IsArray = False, Source = Service)
-                    var svc_local = httpContext.RequestServices.GetRequiredService<System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Http.Generators.Tests.TestService>>();
+                    var svc_local = httpContext.RequestServices.GetRequiredService<global::System.Collections.Generic.IEnumerable<global::Microsoft.AspNetCore.Http.Generators.Tests.TestService>>();
 
                     if (wasParamCheckFailure)
                     {
@@ -308,9 +308,9 @@ namespace Microsoft.AspNetCore.Http.Generated
                 {
                     var wasParamCheckFailure = false;
                     // Endpoint Parameter: svc (Type = Microsoft.AspNetCore.Http.Generators.Tests.TestService?, IsOptional = True, IsParsable = False, IsArray = False, Source = Service)
-                    var svc_local = httpContext.RequestServices.GetService<Microsoft.AspNetCore.Http.Generators.Tests.TestService?>();;
+                    var svc_local = httpContext.RequestServices.GetService<global::Microsoft.AspNetCore.Http.Generators.Tests.TestService?>();;
                     // Endpoint Parameter: svcs (Type = System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Http.Generators.Tests.TestService>, IsOptional = False, IsParsable = False, IsArray = False, Source = Service)
-                    var svcs_local = httpContext.RequestServices.GetRequiredService<System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Http.Generators.Tests.TestService>>();
+                    var svcs_local = httpContext.RequestServices.GetRequiredService<global::System.Collections.Generic.IEnumerable<global::Microsoft.AspNetCore.Http.Generators.Tests.TestService>>();
 
                     if (wasParamCheckFailure)
                     {
@@ -333,9 +333,9 @@ namespace Microsoft.AspNetCore.Http.Generated
                 {
                     var wasParamCheckFailure = false;
                     // Endpoint Parameter: svc (Type = Microsoft.AspNetCore.Http.Generators.Tests.TestService?, IsOptional = True, IsParsable = False, IsArray = False, Source = Service)
-                    var svc_local = httpContext.RequestServices.GetService<Microsoft.AspNetCore.Http.Generators.Tests.TestService?>();;
+                    var svc_local = httpContext.RequestServices.GetService<global::Microsoft.AspNetCore.Http.Generators.Tests.TestService?>();;
                     // Endpoint Parameter: svcs (Type = System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Http.Generators.Tests.TestService>, IsOptional = False, IsParsable = False, IsArray = False, Source = Service)
-                    var svcs_local = httpContext.RequestServices.GetRequiredService<System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Http.Generators.Tests.TestService>>();
+                    var svcs_local = httpContext.RequestServices.GetRequiredService<global::System.Collections.Generic.IEnumerable<global::Microsoft.AspNetCore.Http.Generators.Tests.TestService>>();
 
                     if (wasParamCheckFailure)
                     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTestBase.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTestBase.cs
@@ -287,6 +287,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Http.Generators.Tests;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Extensions.DependencyInjection;
+using Http;
 
 public static class {{className}}
 {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/SharedTypes.Http.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/SharedTypes.Http.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+
+namespace Http;
+
+#nullable  enable
+
+public sealed class ExampleService
+{
+    public string Act(string line) => line;
+}


### PR DESCRIPTION
# Fully Qualify Type Names When Resolving in RDG

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

These two places correspond to resolution of a service from DI when attributed with `FromServicesAttribute` or with
`FromKeyedServicesAttribute`. When the type name of the service is not fully qualified, the generator can generate code which fails to compile.

## Description

For example, given a service `ExampleService` in namespace `Http`, the generator can generate code to resolve an instance of such a service like this:

```c#
var e_local = httpContext.RequestServices.GetRequiredKeyedService<Http.ExampleService>("example");
```

…but `Microsoft.AspNetCore.Http` is a nearer match for the reference to "Http", so the compiler will look for a type
`Microsoft.AspNetCore.Http.ExampleService` (which doesn't exist – at least, not at time of writing), and compilation will fail.

Fixes #58633
