### PR TITLE
Always use --apply-cop-headers in ThreadingAppTest

### DIFF
--- a/src/Components/test/E2ETest/Infrastructure/ServerFixtures/BlazorWasmTestAppFixture.cs
+++ b/src/Components/test/E2ETest/Infrastructure/ServerFixtures/BlazorWasmTestAppFixture.cs
@@ -25,6 +25,8 @@ public class BlazorWasmTestAppFixture<TProgram> : WebHostServerFixture
     public string PathBase { get; set; }
     public string ContentRoot { get; private set; }
 
+    public bool RequiresMultithreadingHeaders { get; set; }
+
     protected override IHost CreateWebHost()
     {
         if (TestTrimmedOrMultithreadingApps)
@@ -61,7 +63,7 @@ public class BlazorWasmTestAppFixture<TProgram> : WebHostServerFixture
             args.Add(Environment);
         }
 
-        if (WebAssemblyTestHelper.MultithreadingIsEnabled())
+        if (RequiresMultithreadingHeaders || WebAssemblyTestHelper.MultithreadingIsEnabled())
         {
             args.Add("--apply-cop-headers");
         }

--- a/src/Components/test/E2ETest/Tests/ThreadingAppTest.cs
+++ b/src/Components/test/E2ETest/Tests/ThreadingAppTest.cs
@@ -29,12 +29,14 @@ public class ThreadingAppTest
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/54761")]
     public void HasTitle()
     {
         Assert.Equal("Blazor standalone", Browser.Title);
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/54761")]
     public void HasHeading()
     {
         Assert.Equal("Hello, world!", Browser.Exists(By.TagName("h1")).Text);
@@ -86,6 +88,7 @@ public class ThreadingAppTest
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/54761")]
     public void HasFetchDataPage()
     {
         // Navigate to "Fetch data"
@@ -107,6 +110,7 @@ public class ThreadingAppTest
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/54761")]
     public void IsStarted()
     {
         // Read from property

--- a/src/Components/test/E2ETest/Tests/ThreadingAppTest.cs
+++ b/src/Components/test/E2ETest/Tests/ThreadingAppTest.cs
@@ -19,6 +19,7 @@ public class ThreadingAppTest
         ITestOutputHelper output)
         : base(browserFixture, serverFixture, output)
     {
+        serverFixture.RequiresMultithreadingHeaders = true;
     }
 
     protected override void InitializeAsyncCore()


### PR DESCRIPTION
I'm not sure why this wasn't necessary before, but recently a bunch of builds are failing due to timeouts in `ThreadingAppTest`. When running the tests locally in `main`, I see the following errors in the browser developer console:

```
logging.ts:49  MONO_WASM: Assert failed: SharedArrayBuffer is not enabled on this page. Please use a modern browser and set Cross-Origin-Opener-Policy and Cross-Origin-Embedder-Policy http headers. See also https://aka.ms/dotnet-wasm-features Error: Assert failed: SharedArrayBuffer is not enabled on this page. Please use a modern browser and set Cross-Origin-Opener-Policy and Cross-Origin-Embedder-Policy http headers. See also https://aka.ms/dotnet-wasm-features
y @ logging.ts:49
Boot.WebAssembly.Common.ts:183  Uncaught (in promise) Error: Failed to start platform. Reason: Error: Assert failed: SharedArrayBuffer is not enabled on this page. Please use a modern browser and set Cross-Origin-Opener-Policy and Cross-Origin-Embedder-Policy http headers. See also https://aka.ms/dotnet-wasm-features
    at qt (Boot.WebAssembly.Common.ts:183:11)
```

Given the name of `ThreadingAppTest`, I assume the Cross-Origin-Opener-Policy and Cross-Origin-Embedder-Policy headers are indeed required, but they weren't being sent previously. I saw https://github.com/dotnet/aspnetcore/pull/54351 which added the ability to run all E2E tests on a multithreaded runtime, but I assume that we don't want to touch assembly metadata for this because most `Components.TestServer`-based tests (which is what `WebAssemblyTestHelper` reads the metadata from) don't need it.

I first noticed this in a [runtime dependency update](https://github.com/dotnet/aspnetcore/pull/58606), but I also saw this locally on main and other unrelated PRs, so I decided to open a new PR for this.

The error appears to surface as a timeout establishing an HTTP connection on the CI, but locally, I get a timeout waiting for the app to transition out of the "Loading..." state. There are some other differences like the local errors I see being consistent while the CI errors are hard to predict. Maybe this is explained by the CI runs occurring on different machines though. So, it's possible this won't fix the CI error, but it still seems worth it to fix the error for local dev.

<details><summary>Local Error:</summary>

```
[xUnit.net 00:01:03.10]     Microsoft.AspNetCore.Components.E2ETest.Tests.ThreadingAppTest.CounterPageCanUseThreads [FAIL]
[xUnit.net 00:01:03.10]       OpenQA.Selenium.BrowserAssertFailedException : Xunit.Sdk.NotEqualException: Assert.NotEqual() Failure: Strings are equal
[xUnit.net 00:01:03.10]       Expected: Not "Loading..."
[xUnit.net 00:01:03.10]       Actual:       "Loading..."
[xUnit.net 00:01:03.10]          at Xunit.Assert.NotEqual[T](T expected, T actual, IEqualityComparer`1 comparer) in /_/src/xunit.assert/Asserts/EqualityAsserts.cs:line 630
[xUnit.net 00:01:03.10]          at Microsoft.AspNetCore.E2ETesting.WaitAssert.<>c__DisplayClass4_0`1.<NotEqual>b__0() in C:\dev\dotnet\aspnetcore\src\Shared\E2ETesting\WaitAssert.cs:line 30
[xUnit.net 00:01:03.10]          at Microsoft.AspNetCore.E2ETesting.WaitAssert.<>c__DisplayClass17_0.<WaitAssertCore>b__0() in C:\dev\dotnet\aspnetcore\src\Shared\E2ETesting\WaitAssert.cs:line 83
[xUnit.net 00:01:03.10]          at Microsoft.AspNetCore.E2ETesting.WaitAssert.<>c__DisplayClass18_0`1.<WaitAssertCore>b__0(IWebDriver _) in C:\dev\dotnet\aspnetcore\src\Shared\E2ETesting\WaitAssert.cs:line 101
[xUnit.net 00:01:03.10]       Screen shot captured at 'C:\dev\dotnet\aspnetcore\src\Components\test\E2ETest\bin\screenshots\24a57a500a4f4b229f610c7a86da5c36.png'
[xUnit.net 00:01:03.10]       Encountered browser errors
[xUnit.net 00:01:03.10]       [2024-10-25T22:32:51Z] [Severe] http://127.0.0.1:58823/_framework/dotnet.js 2:1138 "MONO_WASM: Assert failed: SharedArrayBuffer is not enabled on this page. Please use a modern browser and set Cross-Origin-Opener-Policy and Cross-Origin-Embedder-Policy http headers. See also https://aka.ms/dotnet-wasm-features" "Error: Assert failed: SharedArrayBuffer is not enabled on this page. Please use a modern browser and set Cross-Origin-Opener-Policy and Cross-Origin-Embedder-Policy http headers. See also https://aka.ms/dotnet-wasm-features"
[xUnit.net 00:01:03.10]       [2024-10-25T22:32:51Z] [Severe] http://127.0.0.1:58823/_framework/blazor.webassembly.js 0:55615 Uncaught Error: Failed to start platform. Reason: Error: Assert fa…ers. See also https://aka.ms/dotnet-wasm-featuresPage content:
[xUnit.net 00:01:03.10]       <head>
[xUnit.net 00:01:03.10]           <meta charset="utf-8">
[xUnit.net 00:01:03.10]           <!-- Forcing the device width here so that our automated tests work consistently on mobile browsers. -->
[xUnit.net 00:01:03.10]           <meta name="viewport" content="width=1024">
[xUnit.net 00:01:03.10]           <title>Blazor standalone</title>
[xUnit.net 00:01:03.10]           <base href="/">
[xUnit.net 00:01:03.10]           <link href="bootstrap.min.css" rel="stylesheet">
[xUnit.net 00:01:03.10]           <link href="app.css" rel="stylesheet">
[xUnit.net 00:01:03.10]       </head>
[xUnit.net 00:01:03.10]       <body>
[xUnit.net 00:01:03.10]           <app>Loading...</app>
[xUnit.net 00:01:03.10]
[xUnit.net 00:01:03.10]           <div id="blazor-error-ui">
[xUnit.net 00:01:03.10]               An unhandled exception has occurred. See browser dev tools for details.
[xUnit.net 00:01:03.10]               <a href="" class="reload">Reload</a>
[xUnit.net 00:01:03.10]               <a class="dismiss">🗙</a>
[xUnit.net 00:01:03.10]           </div>
[xUnit.net 00:01:03.10]
[xUnit.net 00:01:03.10]           <script src="_framework/blazor.webassembly.js" autostart="false"></script>
[xUnit.net 00:01:03.10]           <script>
[xUnit.net 00:01:03.10]               (function(){
[xUnit.net 00:01:03.10]                   Blazor.start().then(function () {
[xUnit.net 00:01:03.10]                       window['__aspnetcore__testing__blazor_wasm__started__'] = true;
[xUnit.net 00:01:03.10]                   });
[xUnit.net 00:01:03.10]               })();
[xUnit.net 00:01:03.10]           </script>
[xUnit.net 00:01:03.10]
[xUnit.net 00:01:03.10]
[xUnit.net 00:01:03.10]       </body>
[xUnit.net 00:01:03.10]
[xUnit.net 00:01:03.10]       ---- Assert.NotEqual() Failure: Strings are equal
[xUnit.net 00:01:03.11]       Expected: Not "Loading..."
[xUnit.net 00:01:03.11]       Actual:       "Loading..."
[xUnit.net 00:01:03.11]       Stack Trace:
[xUnit.net 00:01:03.11]         C:\dev\dotnet\aspnetcore\src\Shared\E2ETesting\WaitAssert.cs(129,0): at Microsoft.AspNetCore.E2ETesting.WaitAssert.WaitAssertCore[TResult](IWebDriver driver, Func`1 assertion, TimeSpan timeout)
[xUnit.net 00:01:03.11]         C:\dev\dotnet\aspnetcore\src\Shared\E2ETesting\WaitAssert.cs(83,0): at Microsoft.AspNetCore.E2ETesting.WaitAssert.WaitAssertCore(IWebDriver driver, Action assertion, TimeSpan timeout)
[xUnit.net 00:01:03.11]         C:\dev\dotnet\aspnetcore\src\Shared\E2ETesting\WaitAssert.cs(30,0): at Microsoft.AspNetCore.E2ETesting.WaitAssert.NotEqual[T](IWebDriver driver, T expected, Func`1 actual)
[xUnit.net 00:01:03.11]         C:\dev\dotnet\aspnetcore\src\Components\test\E2ETest\Tests\ThreadingAppTest.cs(128,0): at Microsoft.AspNetCore.Components.E2ETest.Tests.ThreadingAppTest.WaitUntilLoaded()
[xUnit.net 00:01:03.11]         C:\dev\dotnet\aspnetcore\src\Components\test\E2ETest\Tests\ThreadingAppTest.cs(28,0): at Microsoft.AspNetCore.Components.E2ETest.Tests.ThreadingAppTest.InitializeAsyncCore()
[xUnit.net 00:01:03.11]         C:\dev\dotnet\aspnetcore\src\Shared\E2ETesting\BrowserTestBase.cs(65,0): at Microsoft.AspNetCore.E2ETesting.BrowserTestBase.InitializeAsync(String isolationContext)
[xUnit.net 00:01:03.11]         C:\dev\dotnet\aspnetcore\src\Shared\E2ETesting\BrowserTestBase.cs(59,0): at Microsoft.AspNetCore.E2ETesting.BrowserTestBase.InitializeAsync()
[xUnit.net 00:01:03.11]         ----- Inner Stack Trace -----
[xUnit.net 00:01:03.11]         C:\dev\dotnet\aspnetcore\src\Shared\E2ETesting\WaitAssert.cs(30,0): at Microsoft.AspNetCore.E2ETesting.WaitAssert.<>c__DisplayClass4_0`1.<NotEqual>b__0()
[xUnit.net 00:01:03.11]         C:\dev\dotnet\aspnetcore\src\Shared\E2ETesting\WaitAssert.cs(83,0): at Microsoft.AspNetCore.E2ETesting.WaitAssert.<>c__DisplayClass17_0.<WaitAssertCore>b__0()
[xUnit.net 00:01:03.11]         C:\dev\dotnet\aspnetcore\src\Shared\E2ETesting\WaitAssert.cs(101,0): at Microsoft.AspNetCore.E2ETesting.WaitAssert.<>c__DisplayClass18_0`1.<WaitAssertCore>b__0(IWebDriver _)
```
</details>

<details><summary>CI Error:</summary>

```
Error message
OpenQA.Selenium.WebDriverException : The HTTP request to the remote WebDriver server for URL http://localhost:41877/session/f57f2ada63777517619fc3a32d752b48/url timed out after 60 seconds.
---- System.Threading.Tasks.TaskCanceledException : The request was canceled due to the configured HttpClient.Timeout of 60 seconds elapsing.
-------- System.TimeoutException : The operation was canceled.
------------ System.Threading.Tasks.TaskCanceledException : The operation was canceled.
---------------- System.IO.IOException : Unable to read data from the transport connection: Operation canceled.
-------------------- System.Net.Sockets.SocketException : Operation canceled

Stack trace
   at OpenQA.Selenium.Remote.HttpCommandExecutor.ExecuteAsync(Command commandToExecute)
   at OpenQA.Selenium.Remote.DriverServiceCommandExecutor.ExecuteAsync(Command commandToExecute)
   at OpenQA.Selenium.WebDriver.ExecuteAsync(String driverCommandToExecute, Dictionary`2 parameters)
   at OpenQA.Selenium.Navigator.GoToUrlAsync(String url)
   at OpenQA.Selenium.Navigator.<>c__DisplayClass6_0.<<GoToUrl>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at OpenQA.Selenium.Navigator.GoToUrl(String url)
   at Microsoft.AspNetCore.Components.E2ETest.WebDriverExtensions.Navigate(IWebDriver browser, Uri baseUri, String relativeUrl) in /home/vsts/work/1/s/src/Components/test/E2ETest/Infrastructure/WebDriverExtensions/WebDriverExtensions.cs:line 14
   at Microsoft.AspNetCore.Components.E2ETest.Tests.ThreadingAppTest.InitializeAsyncCore() in /home/vsts/work/1/s/src/Components/test/E2ETest/Tests/ThreadingAppTest.cs:line 26
   at Microsoft.AspNetCore.E2ETesting.BrowserTestBase.InitializeAsync(String isolationContext) in /home/vsts/work/1/s/src/Shared/E2ETesting/BrowserTestBase.cs:line 65
----- Inner Stack Trace -----
   at System.Net.Http.HttpClient.HandleFailure(Exception e, Boolean telemetryStarted, HttpResponseMessage response, CancellationTokenSource cts, CancellationToken cancellationToken, CancellationTokenSource pendingRequestsCts)
   at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
   at OpenQA.Selenium.Remote.HttpCommandExecutor.MakeHttpRequest(HttpRequestInfo requestInfo)
   at OpenQA.Selenium.Remote.HttpCommandExecutor.ExecuteAsync(Command commandToExecute)
----- Inner Stack Trace -----

----- Inner Stack Trace -----
   at System.Net.Http.HttpConnection.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.SendWithVersionDetectionAndRetryAsync(HttpRequestMessage request, Boolean async, Boolean doRequestAuth, CancellationToken cancellationToken)
   at System.Net.Http.RedirectHandler.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
----- Inner Stack Trace -----
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Net.Http.HttpConnection.InitialFillAsync(Boolean async)
   at System.Net.Http.HttpConnection.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
----- Inner Stack Trace -----
```
</details>

Ex:

https://dev.azure.com/dnceng-public/public/_build/results?buildId=853162&view=ms.vss-test-web.build-test-results-tab
https://dev.azure.com/dnceng-public/public/_build/results?buildId=852847&view=logs&j=fe94c0c9-bb8c-5d6f-3b51-887173cc2f5c&t=b4bd3469-f776-5941-b623-568498d38bde&s=96ac2280-8cb4-5df5-99de-dd2da759617d

You might have to look at previous builds if they've be rerun.

I plan on labeling #54497 and #58242 as `test-fixed` since these tests both failed for me locally before but now pass. However, the error I'm seeing is more similar to #54497 than #58242. @MackinnonBuck let me know if I should leave the latter open.
