### PR TITLE
no dispatchGlobalEventToAllElements when no renderer attached

### DIFF
--- a/src/Components/Web.JS/src/Rendering/Events/EventDelegator.ts
+++ b/src/Components/Web.JS/src/Rendering/Events/EventDelegator.ts
@@ -138,8 +138,6 @@ export class EventDelegator {
 
     if (!isRendererAttached(this.browserRendererId)) {
       // when connection closed, it will detachWebRendererInterop, so we need to check if the renderer is still attached
-      const targetElement = evt.target as Element;
-      console.warn(`${evt.type} on ${targetElement.localName}${targetElement.className ? ' with class ' + targetElement.className : ''} is not handled because the renderer is not attached`);
       return;
     }
 

--- a/src/Components/Web.JS/src/Rendering/Events/EventDelegator.ts
+++ b/src/Components/Web.JS/src/Rendering/Events/EventDelegator.ts
@@ -3,7 +3,7 @@
 
 import { EventFieldInfo } from './EventFieldInfo';
 import { eventNameAliasRegisteredCallbacks, getBrowserEventName, getEventNameAliases, getEventTypeOptions } from './EventTypes';
-import { dispatchEvent } from '../WebRendererInteropMethods';
+import { isRendererAttached, dispatchEvent } from '../WebRendererInteropMethods';
 
 const nonBubblingEvents = toLookup([
   'abort',
@@ -133,6 +133,13 @@ export class EventDelegator {
 
   private onGlobalEvent(evt: Event) {
     if (!(evt.target instanceof Element)) {
+      return;
+    }
+
+    if (!isRendererAttached(this.browserRendererId)) {
+      // when connection closed, it will detachWebRendererInterop, so we need to check if the renderer is still attached
+      const targetElement = evt.target as Element;
+      console.warn(`${evt.type} on ${targetElement.localName}${targetElement.className ? ' with class ' + targetElement.className : ''} is not handled because the renderer is not attached`);
       return;
     }
 


### PR DESCRIPTION
## ROOT CAUSE
when Blazor connection closed, the [detachWebRendererInterop](https://github.com/dotnet/aspnetcore/blob/7e21f2e65a5dfaed143015cfbcf0139ce3cce8da/src/Components/Web.JS/src/Platform/Circuits/CircuitManager.ts#L160C45-L160C69) in the callback of connection.onclose will be invoked. here, it will invoke [interopMethodsByRenderer.delete(rendererId);](https://github.com/dotnet/aspnetcore/blob/7e21f2e65a5dfaed143015cfbcf0139ce3cce8da/src/Components/Web.JS/src/Rendering/WebRendererInteropMethods.ts#L48C1-L49C1), all the interopMethodsByRenderer will be cleaned. also There are lots of global event listener in form.js like window.addEventListener('focus'), window.addEventListener('keydown'). if user still interact with our app like focus, click, the global event will be triggered, then invoked [EventDelegator.onGlobalEvent](https://github.com/dotnet/aspnetcore/blob/7e21f2e65a5dfaed143015cfbcf0139ce3cce8da/src/Components/Web.JS/src/Rendering/Events/EventDelegator.ts#L134), invoked [EventDelegator.dispatchGlobalEventToAllElements](https://github.com/dotnet/aspnetcore/blob/7e21f2e65a5dfaed143015cfbcf0139ce3cce8da/src/Components/Web.JS/src/Rendering/Events/EventDelegator.ts#L153) invoked [WebRendererInteropMethods.dispatchEvent](https://github.com/dotnet/aspnetcore/blob/7e21f2e65a5dfaed143015cfbcf0139ce3cce8da/src/Components/Web.JS/src/Rendering/WebRendererInteropMethods.ts#L66C17-L66C30) invoked [WebRendererInteropMethods.getInteropMethods](https://github.com/dotnet/aspnetcore/blob/7e21f2e65a5dfaed143015cfbcf0139ce3cce8da/src/Components/Web.JS/src/Rendering/WebRendererInteropMethods.ts#L78C10-L78C27), here since the interopMethodsByRenderer is empty, will throw this exception.

## SOLUTION:
check isRendererAttached before dispatchGlobalEventToAllElements in EventDelegator

Fixes #57828 

Before Fixes:
![no_interop_methods_for_render](https://github.com/user-attachments/assets/53144662-4e7a-4df5-b0a9-9886684da7b0)

After Fixes:
![no_interop_methods_for_render_solution](https://github.com/user-attachments/assets/24820de7-0850-437c-b816-8e4ddd02b0ae)
