### PR TITLE
don't throw a misleading exception upon a BadHttpRequestException

### DIFF
--- a/src/Antiforgery/src/Internal/DefaultAntiforgeryTokenStore.cs
+++ b/src/Antiforgery/src/Internal/DefaultAntiforgeryTokenStore.cs
@@ -57,6 +57,9 @@ internal sealed class DefaultAntiforgeryTokenStore : IAntiforgeryTokenStore
             {
                 form = await httpContext.Request.ReadFormAsync();
             }
+            catch (BadHttpRequestException) {
+                throw;
+            }
             catch (InvalidDataException ex)
             {
                 // ReadFormAsync can throw InvalidDataException if the form content is malformed.

--- a/src/Mvc/Mvc.Core/src/ModelBinding/FormValueProviderFactory.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/FormValueProviderFactory.cs
@@ -38,6 +38,9 @@ public class FormValueProviderFactory : IValueProviderFactory
         {
             form = await request.ReadFormAsync();
         }
+        catch (BadHttpRequestException) {
+            throw;
+        }
         catch (InvalidDataException ex)
         {
             // ReadFormAsync can throw InvalidDataException if the form content is malformed.


### PR DESCRIPTION
# don't throw a misleading exception upon a BadHttpRequestException

## Description

If a request is too large, you get a screen telling you, "A valid antiforgery token was not provided with the request. Add an antiforgery token, or disable antiforgery validation for this endpoint." This leads a developer to try and debug why the anti forgery token isn't working rather than telling them the issue is that the request is too large when there's nothing wrong with the anti forgery token. The issue is that the request body is too large.

Current behavior:

![image](https://github.com/user-attachments/assets/13be6a31-9bb0-4779-a7b6-5d657724b8a2)

Desired behavior:

![image](https://github.com/user-attachments/assets/e2905eb5-b4e5-47e6-ad4b-d9af34ef679f)

Fixes #40810
