### PR TITLE
Replaced Deprecated str.substr with str.substring in All Relevant Files

### DIFF
--- a/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts
+++ b/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts
@@ -72,7 +72,7 @@ export module DotNet {
       // However since we're the one calling the import keyword, they would be resolved relative to
       // this framework bundle URL. Fix this by providing an absolute URL.
       if (typeof url === "string" && url.startsWith("./")) {
-          url = new URL(url.substr(2), document.baseURI).toString();
+          url = new URL(url.substring(2), document.baseURI).toString();
       }
 
       return import(/* webpackIgnore: true */ url);

--- a/src/SignalR/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
+++ b/src/SignalR/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
@@ -302,7 +302,7 @@ describe("hubConnection", () => {
                 // client side method names are case insensitive
                 let methodName = "message";
                 const idx = Math.floor(Math.random() * (methodName.length - 1));
-                methodName = methodName.substr(0, idx) + methodName[idx].toUpperCase() + methodName.substr(idx + 1);
+                methodName = methodName.substring(0, idx) + methodName[idx].toUpperCase() + methodName.substring(idx + 1);
 
                 const receivePromise = new PromiseSource<string>();
                 hubConnection.on(methodName, (msg) => {
@@ -328,7 +328,7 @@ describe("hubConnection", () => {
                 // client side method names are case insensitive
                 let methodName = "message";
                 const idx = Math.floor(Math.random() * (methodName.length - 1));
-                methodName = methodName.substr(0, idx) + methodName[idx].toUpperCase() + methodName.substr(idx + 1);
+                methodName = methodName.substring(0, idx) + methodName[idx].toUpperCase() + methodName.substring(idx + 1);
 
                 let closeCount = 0;
                 let invocationCount = 0;

--- a/src/SignalR/clients/ts/signalr/src/Utils.ts
+++ b/src/SignalR/clients/ts/signalr/src/Utils.ts
@@ -87,7 +87,7 @@ export function formatArrayBuffer(data: ArrayBuffer): string {
     });
 
     // Trim of trailing space.
-    return str.substr(0, str.length - 1);
+    return str.substring(0, str.length - 1);
 }
 
 // Also in signalr-protocol-msgpack/Utils.ts


### PR DESCRIPTION
## Replaced Deprecated `str.substr` with `str.substring` 

## Description
- Fixed deprecation warnings in Visual Studio by replacing `str.substr` with `str.substring`.
- Applied changes in all relevant TypeScript and JavaScript files to prevent future compatibility issues.
- Ensured compatibility and future-proofed the code against potential deprecation-related issues.

Fixes #58720 