### PR TITLE
Fix compilation with latest roslyn

### DIFF
--- a/src/Components/Server/test/Circuits/ServerComponentDeserializerTest.cs
+++ b/src/Components/Server/test/Circuits/ServerComponentDeserializerTest.cs
@@ -156,7 +156,7 @@ public class ServerComponentDeserializerTest
     public void DoesNotParseOutOfOrderMarkers()
     {
         // Arrange
-        var markers = SerializeMarkers(CreateMarkers(typeof(TestComponent), typeof(TestComponent)).Reverse().ToArray());
+        var markers = SerializeMarkers(Enumerable.Reverse(CreateMarkers(typeof(TestComponent), typeof(TestComponent))).ToArray());
         var serverComponentDeserializer = CreateServerComponentDeserializer();
 
         // Act & assert

--- a/src/Components/test/testassets/BasicTestApp/EventDuringBatchRendering.razor
+++ b/src/Components/test/testassets/BasicTestApp/EventDuringBatchRendering.razor
@@ -45,7 +45,7 @@
     @foreach (var item in itemsList)
     {
         <div @key="item">
-            <input @oninput="@(() => itemsList.Reverse())"
+            <input @oninput="@(() => Enumerable.Reverse(itemsList))"
                    @onchange="@(evt => eventLog += $"Change event on item {item.Name} with value {evt.Value}\n")" />
         </div>
     }

--- a/src/Components/test/testassets/BasicTestApp/EventDuringBatchRendering.razor
+++ b/src/Components/test/testassets/BasicTestApp/EventDuringBatchRendering.razor
@@ -45,7 +45,7 @@
     @foreach (var item in itemsList)
     {
         <div @key="item">
-            <input @oninput="@(() => Enumerable.Reverse(itemsList))"
+            <input @oninput="@(() => itemsList.Reverse())"
                    @onchange="@(evt => eventLog += $"Change event on item {item.Name} with value {evt.Value}\n")" />
         </div>
     }

--- a/src/DataProtection/DataProtection/src/Internal/ContainerUtils.cs
+++ b/src/DataProtection/DataProtection/src/Internal/ContainerUtils.cs
@@ -103,7 +103,7 @@ internal static class ContainerUtils
 
         var lines = File.ReadAllLines(procFile);
         // typically the last line in the file is "1:name=openrc:/docker"
-        return lines.Reverse().Any(l => l.EndsWith("name=openrc:/docker", StringComparison.Ordinal));
+        return Enumerable.Reverse(lines).Any(l => l.EndsWith("name=openrc:/docker", StringComparison.Ordinal));
     }
 
     private static bool GetBooleanEnvVar(string envVarName)

--- a/src/Framework/App.Runtime/src/CompatibilitySuppressions.xml
+++ b/src/Framework/App.Runtime/src/CompatibilitySuppressions.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>PKV0001</DiagnosticId>

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/SyntaxNodeExtensions.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/SyntaxNodeExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Linq;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -126,7 +127,7 @@ internal static class SyntaxNodeExtensions
     /// </summary>
     private static SyntaxToken FindSkippedTokenBackward(SyntaxTriviaList triviaList, int position)
     {
-        foreach (var trivia in triviaList.Reverse())
+        foreach (var trivia in Enumerable.Reverse(triviaList))
         {
             if (trivia.HasStructure)
             {

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DetectMisplacedLambdaAttribute.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DetectMisplacedLambdaAttribute.cs
@@ -70,7 +70,7 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
 
         static IMethodSymbol? GetReturnedInvocation(IBlockOperation blockOperation)
         {
-            foreach (var op in blockOperation.ChildOperations.Reverse())
+            foreach (var op in Enumerable.Reverse(blockOperation.ChildOperations))
             {
                 if (op is IReturnOperation returnStatement)
                 {

--- a/src/Grpc/JsonTranscoding/src/Shared/Server/MethodOptions.cs
+++ b/src/Grpc/JsonTranscoding/src/Shared/Server/MethodOptions.cs
@@ -116,7 +116,7 @@ internal sealed class MethodOptions
         string? responseCompressionAlgorithm = null;
         CompressionLevel? responseCompressionLevel = null;
 
-        foreach (var options in serviceOptions.Reverse())
+        foreach (var options in Enumerable.Reverse(serviceOptions))
         {
             AddCompressionProviders(resolvedCompressionProviders, options.CompressionProviders);
             tempInterceptors.InsertRange(0, options.Interceptors);

--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostService.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostService.cs
@@ -132,7 +132,7 @@ internal sealed partial class GenericWebHostService : IHostedService
 
             var builder = ApplicationBuilderFactory.CreateBuilder(Server.Features);
 
-            foreach (var filter in StartupFilters.Reverse())
+            foreach (var filter in Enumerable.Reverse(StartupFilters))
             {
                 configure = filter.Configure(configure);
             }

--- a/src/Hosting/Hosting/src/Internal/StartupLoader.cs
+++ b/src/Hosting/Hosting/src/Internal/StartupLoader.cs
@@ -222,7 +222,7 @@ internal sealed class StartupLoader
 #pragma warning restore CS0612 // Type or member is obsolete
 
                 Action<TContainerBuilder> pipeline = InvokeConfigureContainer;
-                foreach (var filter in filters.Reverse())
+                foreach (var filter in Enumerable.Reverse(filters))
                 {
                     pipeline = filter.ConfigureContainer(pipeline);
                 }

--- a/src/Hosting/Hosting/src/Internal/WebHost.cs
+++ b/src/Hosting/Hosting/src/Internal/WebHost.cs
@@ -214,7 +214,7 @@ internal sealed partial class WebHost : IWebHost, IAsyncDisposable
             Action<IApplicationBuilder> configure = _startup!.Configure;
             if (startupFilters != null)
             {
-                foreach (var filter in startupFilters.Reverse())
+                foreach (var filter in Enumerable.Reverse(startupFilters))
                 {
                     configure = filter.Configure(configure);
                 }

--- a/src/Http/Routing/test/UnitTests/Tree/TreeRouterTest.cs
+++ b/src/Http/Routing/test/UnitTests/Tree/TreeRouterTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing.Constraints;
 using Microsoft.AspNetCore.Routing.Template;
@@ -100,7 +101,7 @@ public class TreeRouterTest
 
         // We setup the route entries in reverse order of precedence to ensure that when we
         // try to route the request, the route with a higher precedence gets tried first.
-        foreach (var template in routes.Reverse())
+        foreach (var template in Enumerable.Reverse(routes))
         {
             MapInboundEntry(builder, template);
         }
@@ -147,7 +148,7 @@ public class TreeRouterTest
 
         // We setup the route entries in reverse order of precedence to ensure that when we
         // try to route the request, the route with a higher precedence gets tried first.
-        foreach (var template in routes.Reverse())
+        foreach (var template in Enumerable.Reverse(routes))
         {
             MapInboundEntry(builder, template);
         }
@@ -199,7 +200,7 @@ public class TreeRouterTest
 
         // We setup the route entries in reverse order of precedence to ensure that when we
         // try to route the request, the route with a higher precedence gets tried first.
-        foreach (var template in routes.Reverse())
+        foreach (var template in Enumerable.Reverse(routes))
         {
             MapInboundEntry(builder, template);
         }
@@ -242,7 +243,7 @@ public class TreeRouterTest
 
         // We setup the route entries in reverse order of precedence to ensure that when we
         // try to route the request, the route with a higher precedence gets tried first.
-        foreach (var template in routes.Reverse())
+        foreach (var template in Enumerable.Reverse(routes))
         {
             MapInboundEntry(builder, template);
         }
@@ -340,7 +341,7 @@ public class TreeRouterTest
 
         // We setup the route entries in reverse order of precedence to ensure that when we
         // try to route the request, the route with a higher precedence gets tried first.
-        foreach (var template in routes.Reverse())
+        foreach (var template in Enumerable.Reverse(routes))
         {
             MapInboundEntry(builder, template);
         }

--- a/src/Http/WebUtilities/test/FileBufferingReadStreamTests.cs
+++ b/src/Http/WebUtilities/test/FileBufferingReadStreamTests.cs
@@ -488,7 +488,7 @@ public class FileBufferingReadStreamTests
         // 4K is the lower bound on buffer sizes
         var bufferSize = 4096;
         var mostExpectedWrites = 8;
-        var data = Enumerable.Range(0, bufferSize * mostExpectedWrites).Select(b => (byte)b).Reverse().ToArray();
+        var data = Enumerable.Reverse(Enumerable.Range(0, bufferSize * mostExpectedWrites).Select(b => (byte)b)).ToArray();
         var inner = new MemoryStream(data);
 
         using var stream = new FileBufferingReadStream(inner, 100, bufferLimit: null, GetCurrentDirectory());

--- a/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddlewareImpl.cs
+++ b/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddlewareImpl.cs
@@ -67,7 +67,7 @@ internal class DeveloperExceptionPageMiddlewareImpl
         _exceptionHandler = DisplayException;
         _serializationContext = CreateSerializationContext(jsonOptions?.Value);
         _problemDetailsService = problemDetailsService;
-        foreach (var filter in filters.Reverse())
+        foreach (var filter in Enumerable.Reverse(filters))
         {
             var nextFilter = _exceptionHandler;
             _exceptionHandler = errorContext => filter.HandleExceptionAsync(errorContext, nextFilter);
@@ -228,8 +228,8 @@ internal class DeveloperExceptionPageMiddlewareImpl
         if (_problemDetailsService == null || !await _problemDetailsService.TryWriteAsync(new()
             {
                 HttpContext = httpContext,
-                ProblemDetails = CreateProblemDetails(errorContext, httpContext), 
-                Exception = errorContext.Exception 
+                ProblemDetails = CreateProblemDetails(errorContext, httpContext),
+                Exception = errorContext.Exception
             }))
         {
             httpContext.Response.ContentType = "text/plain; charset=utf-8";

--- a/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
@@ -196,7 +196,7 @@ internal static class JsonNodeSchemaExtensions
     {
         // Apply constraints in reverse order because when it comes to the routing
         // layer the first constraint that is violated causes routing to short circuit.
-        foreach (var constraint in constraints.Reverse())
+        foreach (var constraint in Enumerable.Reverse(constraints))
         {
             if (constraint is MinRouteConstraint minRouteConstraint)
             {

--- a/src/Servers/Connections.Abstractions/src/ConnectionBuilder.cs
+++ b/src/Servers/Connections.Abstractions/src/ConnectionBuilder.cs
@@ -42,7 +42,7 @@ public class ConnectionBuilder : IConnectionBuilder
             return Task.CompletedTask;
         };
 
-        foreach (var component in _components.Reverse())
+        foreach (var component in Enumerable.Reverse(_components))
         {
             app = component(app);
         }

--- a/src/Servers/Connections.Abstractions/src/MultiplexedConnectionBuilder.cs
+++ b/src/Servers/Connections.Abstractions/src/MultiplexedConnectionBuilder.cs
@@ -42,7 +42,7 @@ public class MultiplexedConnectionBuilder : IMultiplexedConnectionBuilder
             return Task.CompletedTask;
         };
 
-        foreach (var component in _components.Reverse())
+        foreach (var component in Enumerable.Reverse(_components))
         {
             app = component(app);
         }

--- a/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
@@ -54,8 +54,8 @@ internal sealed class KestrelServerImpl : IServer
     {
         ArgumentNullException.ThrowIfNull(transportFactories);
 
-        _transportFactories = transportFactories.Reverse().ToList();
-        _multiplexedTransportFactories = multiplexedFactories.Reverse().ToList();
+        _transportFactories = Enumerable.Reverse(transportFactories).ToList();
+        _multiplexedTransportFactories = Enumerable.Reverse(multiplexedFactories).ToList();
         _httpsConfigurationService = httpsConfigurationService;
 
         if (_transportFactories.Count == 0 && _multiplexedTransportFactories.Count == 0)

--- a/src/Testing/src/xunit/DockerOnlyAttribute.cs
+++ b/src/Testing/src/xunit/DockerOnlyAttribute.cs
@@ -31,7 +31,7 @@ public sealed class DockerOnlyAttribute : Attribute, ITestCondition
 
             var lines = File.ReadAllLines(procFile);
             // typically the last line in the file is "1:name=openrc:/docker"
-            return lines.Reverse().Any(l => l.EndsWith("name=openrc:/docker", StringComparison.Ordinal));
+            return Enumerable.Reverse(lines).Any(l => l.EndsWith("name=openrc:/docker", StringComparison.Ordinal));
         }
     }
 }


### PR DESCRIPTION
Related PR in runtime: https://github.com/dotnet/runtime/pull/109467

To unblock https://github.com/dotnet/sdk/pull/43015, errors like these:
> /vmr/src/aspnetcore/src/DataProtection/DataProtection/src/Internal/ContainerUtils.cs(106,31): error CS0023: Operator '.' cannot be applied to operand of type 'void' [/vmr/src/aspnetcore/src/DataProtection/DataProtection/src/Microsoft.AspNetCore.DataProtection.csproj::TargetFramework=netstandard2.0]