### PR TITLE
Unquarantine Http1Connection_ServerAbort_HasErrorType

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/KestrelMetricsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/KestrelMetricsTests.cs
@@ -391,7 +391,6 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/58086")]
     public async Task Http1Connection_ServerAbort_HasErrorType()
     {
         var testMeterFactory = new TestMeterFactory();


### PR DESCRIPTION
Fixes #58086
