### PR TITLE
Unquarantine Http1Connection_RequestEndsWithIncompleteReadAsync

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/KestrelMetricsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/KestrelMetricsTests.cs
@@ -159,7 +159,6 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/57944")]
     public async Task Http1Connection_RequestEndsWithIncompleteReadAsync()
     {
         var testMeterFactory = new TestMeterFactory();


### PR DESCRIPTION
Fixes #57944

Test fixed and passing for 30 days
