### PR TITLE
Fixed the hot-keys for Blazor WebApp template options

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/.template.config/template.json
@@ -344,7 +344,7 @@
       "type": "parameter",
       "datatype": "choice",
       "defaultValue": "InteractivePerPage",
-      "displayName": "_Interactivity location",
+      "displayName": "Interactivity _location",
       "description": "Chooses which components will have interactive rendering enabled",
       "isEnabled": "(InteractivityPlatform != \"None\")",
       "choices": [
@@ -372,7 +372,7 @@
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "true",
-      "displayName": "_Include sample pages",
+      "displayName": "Include _sample pages",
       "description": "Configures whether to add sample pages and styling to demonstrate basic usage patterns."
     },
     "Empty": {


### PR DESCRIPTION
# Fixes the repeating hot-keys used for different template options

## Description

Currently the following three template options use the same hot-keys:
- Interactive render mode
- Interactivity location
- Include sample pages

The change addresses this problem by using different hotkeys for the last two options.

Fixes #58750
