### PR TITLE
Add examples to AddOpenApi extension method/overloads

### DIFF
--- a/src/OpenApi/src/Extensions/OpenApiServiceCollectionExtensions.cs
+++ b/src/OpenApi/src/Extensions/OpenApiServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Http.Json;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.Extensions.ApiDescriptions;
@@ -20,8 +21,8 @@ public static class OpenApiServiceCollectionExtensions
     /// <param name="services">The <see cref="IServiceCollection"/> to register services onto.</param>
     /// <param name="documentName">The name of the OpenAPI document associated with registered services.</param>
     /// <example>
-    /// This method is commonly used to add OpenAPI services to the service collection of a
-    /// <see cref="WebApplicationBuilder"/>, as shown in the following example:
+    /// This method is commonly used to add OpenAPI services to the <see cref="WebApplicationBuilder.Services"/>
+    /// of a <see cref="WebApplicationBuilder"/>, as shown in the following example:
     /// <code>
     /// var builder = WebApplication.CreateBuilder(args);
     /// builder.Services.AddOpenApi("MyWebApi");
@@ -41,8 +42,8 @@ public static class OpenApiServiceCollectionExtensions
     /// <param name="documentName">The name of the OpenAPI document associated with registered services.</param>
     /// <param name="configureOptions">A delegate used to configure the target <see cref="OpenApiOptions"/>.</param>
     /// <example>
-    /// This method is commonly used to add OpenAPI services to the service collection of a
-    /// <see cref="WebApplicationBuilder"/>, as shown in the following example:
+    /// This method is commonly used to add OpenAPI services to the <see cref="WebApplicationBuilder.Services"/>
+    /// of a <see cref="WebApplicationBuilder"/>, as shown in the following example:
     /// <code>
     /// var builder = WebApplication.CreateBuilder(args);
     /// builder.Services.AddOpenApi("MyWebApi", options => {
@@ -71,8 +72,8 @@ public static class OpenApiServiceCollectionExtensions
     /// <param name="services">The <see cref="IServiceCollection"/> to register services onto.</param>
     /// <param name="configureOptions">A delegate used to configure the target <see cref="OpenApiOptions"/>.</param>
     /// <example>
-    /// This method is commonly used to add OpenAPI services to the service collection of a
-    /// <see cref="WebApplicationBuilder"/>, as shown in the following example:
+    /// This method is commonly used to add OpenAPI services to the <see cref="WebApplicationBuilder.Services"/>
+    /// of a <see cref="WebApplicationBuilder"/>, as shown in the following example:
     /// <code>
     /// var builder = WebApplication.CreateBuilder(args);
     /// builder.Services.AddOpenApi(options => {
@@ -89,8 +90,8 @@ public static class OpenApiServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> to register services onto.</param>
     /// <example>
-    /// This method is commonly used to add OpenAPI services to the service collection of a
-    /// <see cref="WebApplicationBuilder"/>, as shown in the following example:
+    /// This method is commonly used to add OpenAPI services to the <see cref="WebApplicationBuilder.Services"/>
+    /// of a <see cref="WebApplicationBuilder"/>, as shown in the following example:
     /// <code>
     /// var builder = WebApplication.CreateBuilder(args);
     /// builder.Services.AddOpenApi();

--- a/src/OpenApi/src/Extensions/OpenApiServiceCollectionExtensions.cs
+++ b/src/OpenApi/src/Extensions/OpenApiServiceCollectionExtensions.cs
@@ -21,7 +21,7 @@ public static class OpenApiServiceCollectionExtensions
     /// <param name="services">The <see cref="IServiceCollection"/> to register services onto.</param>
     /// <param name="documentName">The name of the OpenAPI document associated with registered services.</param>
     /// <example>
-    /// This method is commonly used to add OpenAPI services to the <see cref="WebApplicationBuilder.Services"/>
+    /// This method is commonly used to add OpenAPI services to the Services
     /// of a <see cref="WebApplicationBuilder"/>, as shown in the following example:
     /// <code>
     /// var builder = WebApplication.CreateBuilder(args);
@@ -42,7 +42,7 @@ public static class OpenApiServiceCollectionExtensions
     /// <param name="documentName">The name of the OpenAPI document associated with registered services.</param>
     /// <param name="configureOptions">A delegate used to configure the target <see cref="OpenApiOptions"/>.</param>
     /// <example>
-    /// This method is commonly used to add OpenAPI services to the <see cref="WebApplicationBuilder.Services"/>
+    /// This method is commonly used to add OpenAPI services to the Services
     /// of a <see cref="WebApplicationBuilder"/>, as shown in the following example:
     /// <code>
     /// var builder = WebApplication.CreateBuilder(args);
@@ -72,7 +72,7 @@ public static class OpenApiServiceCollectionExtensions
     /// <param name="services">The <see cref="IServiceCollection"/> to register services onto.</param>
     /// <param name="configureOptions">A delegate used to configure the target <see cref="OpenApiOptions"/>.</param>
     /// <example>
-    /// This method is commonly used to add OpenAPI services to the <see cref="WebApplicationBuilder.Services"/>
+    /// This method is commonly used to add OpenAPI services to the Services
     /// of a <see cref="WebApplicationBuilder"/>, as shown in the following example:
     /// <code>
     /// var builder = WebApplication.CreateBuilder(args);
@@ -90,7 +90,7 @@ public static class OpenApiServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> to register services onto.</param>
     /// <example>
-    /// This method is commonly used to add OpenAPI services to the <see cref="WebApplicationBuilder.Services"/>
+    /// This method is commonly used to add OpenAPI services to the Services
     /// of a <see cref="WebApplicationBuilder"/>, as shown in the following example:
     /// <code>
     /// var builder = WebApplication.CreateBuilder(args);

--- a/src/OpenApi/src/Extensions/OpenApiServiceCollectionExtensions.cs
+++ b/src/OpenApi/src/Extensions/OpenApiServiceCollectionExtensions.cs
@@ -19,6 +19,14 @@ public static class OpenApiServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> to register services onto.</param>
     /// <param name="documentName">The name of the OpenAPI document associated with registered services.</param>
+    /// <example>
+    /// This method is commonly used to add OpenAPI services to the service collection of a
+    /// <see cref="WebApplicationBuilder"/>, as shown in the following example:
+    /// <code>
+    /// var builder = WebApplication.CreateBuilder(args);
+    /// builder.Services.AddOpenApi("MyWebApi");
+    /// </code>
+    /// </example>
     public static IServiceCollection AddOpenApi(this IServiceCollection services, string documentName)
     {
         ArgumentNullException.ThrowIfNull(services);
@@ -32,6 +40,17 @@ public static class OpenApiServiceCollectionExtensions
     /// <param name="services">The <see cref="IServiceCollection"/> to register services onto.</param>
     /// <param name="documentName">The name of the OpenAPI document associated with registered services.</param>
     /// <param name="configureOptions">A delegate used to configure the target <see cref="OpenApiOptions"/>.</param>
+    /// <example>
+    /// This method is commonly used to add OpenAPI services to the service collection of a
+    /// <see cref="WebApplicationBuilder"/>, as shown in the following example:
+    /// <code>
+    /// var builder = WebApplication.CreateBuilder(args);
+    /// builder.Services.AddOpenApi("MyWebApi", options => {
+    ///     // Add a custom schema transformer for decimal types
+    ///     options.AddSchemaTransformer(DecimalTransformer.TransformAsync);
+    /// });
+    /// </code>
+    /// </example>
     public static IServiceCollection AddOpenApi(this IServiceCollection services, string documentName, Action<OpenApiOptions> configureOptions)
     {
         ArgumentNullException.ThrowIfNull(services);
@@ -51,6 +70,17 @@ public static class OpenApiServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> to register services onto.</param>
     /// <param name="configureOptions">A delegate used to configure the target <see cref="OpenApiOptions"/>.</param>
+    /// <example>
+    /// This method is commonly used to add OpenAPI services to the service collection of a
+    /// <see cref="WebApplicationBuilder"/>, as shown in the following example:
+    /// <code>
+    /// var builder = WebApplication.CreateBuilder(args);
+    /// builder.Services.AddOpenApi(options => {
+    ///     // Add a custom schema transformer for decimal types
+    ///     options.AddSchemaTransformer(DecimalTransformer.TransformAsync);
+    /// });
+    /// </code>
+    /// </example>
     public static IServiceCollection AddOpenApi(this IServiceCollection services, Action<OpenApiOptions> configureOptions)
             => services.AddOpenApi(OpenApiConstants.DefaultDocumentName, configureOptions);
 
@@ -58,6 +88,14 @@ public static class OpenApiServiceCollectionExtensions
     /// Adds OpenAPI services related to the default document to the specified <see cref="IServiceCollection"/>.
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> to register services onto.</param>
+    /// <example>
+    /// This method is commonly used to add OpenAPI services to the service collection of a
+    /// <see cref="WebApplicationBuilder"/>, as shown in the following example:
+    /// <code>
+    /// var builder = WebApplication.CreateBuilder(args);
+    /// builder.Services.AddOpenApi();
+    /// </code>
+    /// </example>
     public static IServiceCollection AddOpenApi(this IServiceCollection services)
         => services.AddOpenApi(OpenApiConstants.DefaultDocumentName);
 

--- a/src/OpenApi/src/Extensions/OpenApiServiceCollectionExtensions.cs
+++ b/src/OpenApi/src/Extensions/OpenApiServiceCollectionExtensions.cs
@@ -21,7 +21,7 @@ public static class OpenApiServiceCollectionExtensions
     /// <param name="services">The <see cref="IServiceCollection"/> to register services onto.</param>
     /// <param name="documentName">The name of the OpenAPI document associated with registered services.</param>
     /// <example>
-    /// This method is commonly used to add OpenAPI services to the Services
+    /// This method is commonly used to add OpenAPI services to the <see cref="WebApplicationBuilder.Services"/>
     /// of a <see cref="WebApplicationBuilder"/>, as shown in the following example:
     /// <code>
     /// var builder = WebApplication.CreateBuilder(args);
@@ -42,7 +42,7 @@ public static class OpenApiServiceCollectionExtensions
     /// <param name="documentName">The name of the OpenAPI document associated with registered services.</param>
     /// <param name="configureOptions">A delegate used to configure the target <see cref="OpenApiOptions"/>.</param>
     /// <example>
-    /// This method is commonly used to add OpenAPI services to the Services
+    /// This method is commonly used to add OpenAPI services to the <see cref="WebApplicationBuilder.Services"/>
     /// of a <see cref="WebApplicationBuilder"/>, as shown in the following example:
     /// <code>
     /// var builder = WebApplication.CreateBuilder(args);
@@ -72,7 +72,7 @@ public static class OpenApiServiceCollectionExtensions
     /// <param name="services">The <see cref="IServiceCollection"/> to register services onto.</param>
     /// <param name="configureOptions">A delegate used to configure the target <see cref="OpenApiOptions"/>.</param>
     /// <example>
-    /// This method is commonly used to add OpenAPI services to the Services
+    /// This method is commonly used to add OpenAPI services to the <see cref="WebApplicationBuilder.Services"/>
     /// of a <see cref="WebApplicationBuilder"/>, as shown in the following example:
     /// <code>
     /// var builder = WebApplication.CreateBuilder(args);
@@ -90,7 +90,7 @@ public static class OpenApiServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> to register services onto.</param>
     /// <example>
-    /// This method is commonly used to add OpenAPI services to the Services
+    /// This method is commonly used to add OpenAPI services to the <see cref="WebApplicationBuilder.Services"/>
     /// of a <see cref="WebApplicationBuilder"/>, as shown in the following example:
     /// <code>
     /// var builder = WebApplication.CreateBuilder(args);

--- a/src/OpenApi/src/Extensions/OpenApiServiceCollectionExtensions.cs
+++ b/src/OpenApi/src/Extensions/OpenApiServiceCollectionExtensions.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Json;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.Extensions.ApiDescriptions;

--- a/src/OpenApi/src/Microsoft.AspNetCore.OpenApi.csproj
+++ b/src/OpenApi/src/Microsoft.AspNetCore.OpenApi.csproj
@@ -20,7 +20,7 @@
     <Reference Include="Microsoft.AspNetCore.Routing" />
     <Reference Include="Microsoft.AspNetCore.Mvc.Core" />
     <Reference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" />
-    <Reference Include="Microsoft.AspNetCore.DefaultBuilder" />
+    <Reference Include="Microsoft.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenApi/src/Microsoft.AspNetCore.OpenApi.csproj
+++ b/src/OpenApi/src/Microsoft.AspNetCore.OpenApi.csproj
@@ -20,7 +20,7 @@
     <Reference Include="Microsoft.AspNetCore.Routing" />
     <Reference Include="Microsoft.AspNetCore.Mvc.Core" />
     <Reference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" />
-    <Reference Include="Microsoft.AspNetCore" />
+    <Reference Include="Microsoft.AspNetCore.Builder" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenApi/src/Microsoft.AspNetCore.OpenApi.csproj
+++ b/src/OpenApi/src/Microsoft.AspNetCore.OpenApi.csproj
@@ -20,7 +20,7 @@
     <Reference Include="Microsoft.AspNetCore.Routing" />
     <Reference Include="Microsoft.AspNetCore.Mvc.Core" />
     <Reference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" />
-    <Reference Include="Microsoft.AspNetCore.Builder" />
+    <Reference Include="Microsoft.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenApi/src/Microsoft.AspNetCore.OpenApi.csproj
+++ b/src/OpenApi/src/Microsoft.AspNetCore.OpenApi.csproj
@@ -20,6 +20,7 @@
     <Reference Include="Microsoft.AspNetCore.Routing" />
     <Reference Include="Microsoft.AspNetCore.Mvc.Core" />
     <Reference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" />
+    <Reference Include="Microsoft.AspNetCore.DefaultBuilder" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Add examples to AddOpenApi extension method/overloads

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Adds examples to the xmldoc for the `AddOpenApi` extension methods/overloads.

## Description

Added an example to the xmldoc of each method showing the most common usage of this extension method -- to add OpenAPI services to the service collection of  WebApplicationBuilder.