### PR TITLE
Set up Windows installer build for the VMR

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -243,6 +243,33 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <OfficialBaseURL>https://dotnetcli.azureedge.net/dotnet/</OfficialBaseURL>
+    <!-- Allow overriding the public base URL for Unified Build scenarios to pull assets from a local build. -->
+    <PublicBaseURL Condition="'$(PublicBaseURL)' == ''">https://dotnetbuilds.azureedge.net/public/</PublicBaseURL>
+    <InternalBaseURL>https://dotnetbuilds.azureedge.net/internal/</InternalBaseURL>
+  </PropertyGroup>
+
+  <!-- Try various places to find the runtime. It's either released (use official version),
+        public but un-released (use dotnetbuilds/public), or internal and unreleased (use dotnetbuilds/internal) -->
+  <ItemGroup Condition="'$(DotNetBuild) ' != 'true'">
+    <RemoteAssetBaseURL Include="$(OfficialBaseURL)" />
+    <RemoteAssetBaseURL Include="$(PublicBaseURL)" />
+    <!-- Include the token here as we'll generate the URLs to download based on this item group. -->
+    <RemoteAssetBaseURL Include="$(InternalBaseURL)"
+                        Condition=" '$(DotnetRuntimeSourceFeedKey)' != '' ">
+      <token>$(DotnetRuntimeSourceFeedKey)</token>
+    </RemoteAssetBaseURL>
+  </ItemGroup>
+
+  <!--
+    Only try downloading from the "public" base URL when doing a vertical build.
+    In a vertical build, the public URL will be overwritten to point to local build artifacts.
+  -->
+  <ItemGroup Condition="'$(DotNetBuild)' == 'true'">
+    <RemoteAssetBaseURL Include="$(PublicBaseURL)" />
+  </ItemGroup>
+
+  <PropertyGroup>
     <!-- PackageReadmeFile specifies the package readme file name in the package. PackageReadmeFilePath points to the package readme file on disk. -->
     <EnableDefaultPackageReadmeFile Condition="'$(EnableDefaultPackageReadmeFile)' == '' and '$(IsShipping)' != 'false'">true</EnableDefaultPackageReadmeFile>
     <PackageReadmeFilePath Condition="'$(PackageReadmeFilePath)' == '' and '$(EnableDefaultPackageReadmeFile)' == 'true'">PACKAGE.md</PackageReadmeFilePath>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -247,6 +247,8 @@
     <!-- Allow overriding the public base URL for Unified Build scenarios to pull assets from a local build. -->
     <PublicBaseURL Condition="'$(PublicBaseURL)' == ''">https://dotnetbuilds.azureedge.net/public/</PublicBaseURL>
     <InternalBaseURL>https://dotnetbuilds.azureedge.net/internal/</InternalBaseURL>
+    <!-- Allow overriding where installers are pulled in from previously completed jobs in Unified Build scenarios. -->
+    <CrossArchitectureInstallerBasePath Condition="'$(CrossArchitectureInstallerBasePath)' == ''">$(InstallersOutputPath)</CrossArchitectureInstallerBasePath>
   </PropertyGroup>
 
   <!-- Try various places to find the runtime. It's either released (use official version),

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -246,8 +246,6 @@
     <OfficialBaseURL>https://dotnetcli.azureedge.net/dotnet/</OfficialBaseURL>
     <!-- Allow overriding the public base URL for Unified Build scenarios to pull assets from a local build. -->
     <PublicBaseURL Condition="'$(PublicBaseURL)' == ''">https://dotnetbuilds.azureedge.net/public/</PublicBaseURL>
-    <!-- MSBuild removes the '//' slashes when passing PublicBaseURL from the outer to the inner build. -->
-    <PublicBaseURL Condition="$(PublicBaseURL.StartsWith('file:')) and '$(OS)' != 'Windows_NT'">$([System.Text.RegularExpressions.Regex]::Replace('$(PublicBaseURL)', '%28file:\/{1,}%29%28.+%29', 'file:///%242'))</PublicBaseURL>
     <InternalBaseURL>https://dotnetbuilds.azureedge.net/internal/</InternalBaseURL>
     <!-- Allow overriding where installers are pulled in from previously completed jobs in Unified Build scenarios. -->
     <CrossArchitectureInstallerBasePath Condition="'$(CrossArchitectureInstallerBasePath)' == ''">$(InstallersOutputPath)</CrossArchitectureInstallerBasePath>
@@ -270,7 +268,9 @@
     In a vertical build, the public URL will be overwritten to point to local build artifacts.
   -->
   <ItemGroup Condition="'$(DotNetBuild)' == 'true'">
-    <RemoteAssetBaseURL Include="$(PublicBaseURL)" />
+    <!-- MSBuild removes the '//' slashes when passing PublicBaseURL from the outer to the inner build. -->
+    <RemoteAssetBaseURL Condition="$(PublicBaseURL.StartsWith('file:')) and '$(OS)' != 'Windows_NT'" Include="$([System.Text.RegularExpressions.Regex]::Replace('$(PublicBaseURL)', '%28file:\/{1,}%29%28.+%29', 'file:///%242'))" />
+    <RemoteAssetBaseURL Condition="!$(PublicBaseURL.StartsWith('file:')) or '$(OS)' == 'Windows_NT'" Include="$(PublicBaseURL)" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -246,6 +246,8 @@
     <OfficialBaseURL>https://dotnetcli.azureedge.net/dotnet/</OfficialBaseURL>
     <!-- Allow overriding the public base URL for Unified Build scenarios to pull assets from a local build. -->
     <PublicBaseURL Condition="'$(PublicBaseURL)' == ''">https://dotnetbuilds.azureedge.net/public/</PublicBaseURL>
+    <!-- MSBuild removes the '//' slashes when passing PublicBaseURL from the outer to the inner build. -->
+    <PublicBaseURL Condition="$(PublicBaseURL.StartsWith('file:')) and '$(OS)' != 'Windows_NT'">$([System.Text.RegularExpressions.Regex]::Replace('$(PublicBaseURL)', '%28file:\/{1,}%29%28.+%29', 'file:///%242'))</PublicBaseURL>
     <InternalBaseURL>https://dotnetbuilds.azureedge.net/internal/</InternalBaseURL>
     <!-- Allow overriding where installers are pulled in from previously completed jobs in Unified Build scenarios. -->
     <CrossArchitectureInstallerBasePath Condition="'$(CrossArchitectureInstallerBasePath)' == ''">$(InstallersOutputPath)</CrossArchitectureInstallerBasePath>

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -71,7 +71,13 @@
       </ItemGroup>
     </When>
     <Otherwise>
-      <ItemGroup Condition=" '$(BuildInstallers)' == 'true' AND '$(TargetOsName)' == 'win' AND ('$(TargetArchitecture)' == 'x86' OR '$(TargetArchitecture)' == 'x64' OR '$(TargetArchitecture)' == 'arm64') ">
+      <PropertyGroup>
+        <_BuildWindowsInstallers Condition="'$(BuildInstallers)' == 'true' AND '$(TargetOsName)' == 'win' AND ('$(TargetArchitecture)' == 'x86' OR '$(TargetArchitecture)' == 'x64' OR '$(TargetArchitecture)' == 'arm64') ">true</_BuildWindowsInstallers>
+        <_WixTargetPlatform Condition="'$(TargetArchitecture)' == 'x86' ">Win32</_WixTargetPlatform>
+        <_WixTargetPlatform Condition="'$(TargetArchitecture)' == 'x64' ">x64</_WixTargetPlatform>
+        <_WixTargetPlatform Condition="'$(TargetArchitecture)' == 'arm64' ">ARM64</_WixTargetPlatform>
+      </PropertyGroup>
+      <ItemGroup Condition="'$(DotNetBuild)' != 'true' and '$(_BuildWindowsInstallers)' == 'true' ">
         <!-- Build the ANCM custom action -->
         <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\CustomAction\aspnetcoreCA.vcxproj" AdditionalProperties="Platform=x64" />
         <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\CustomAction\aspnetcoreCA.vcxproj" AdditionalProperties="Platform=Win32" />
@@ -103,7 +109,26 @@
         <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\SharedFrameworkLib\SharedFrameworkLib.wixproj" AdditionalProperties="Platform=x86" />
         <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\SharedFrameworkLib\SharedFrameworkLib.wixproj" AdditionalProperties="Platform=arm64" />
 
-        <!-- Windows hosting bundled -->
+        <!-- Windows hosting bundle -->
+        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\WindowsHostingBundle\WindowsHostingBundle.wixproj" AdditionalProperties="Platform=x86" />
+      </ItemGroup>
+
+      <!-- In a vertical build, only build the MSIs for the current vertical in the first pass and build the hosting bundle in the second pass -->
+      <ItemGroup Condition="'$(DotNetBuild)' == 'true' and ('$(DotNetBuildPass)' == '' or '$(DotNetBuildPass)' == '1') and '$(_BuildWindowsInstallers)' == 'true'">
+        <!-- Build the ANCM custom action -->
+        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\CustomAction\aspnetcoreCA.vcxproj" AdditionalProperties="Platform=$(_WixTargetPlatform)" />
+        <!-- Build the ANCM msis -->
+        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\ANCMIISExpressV2\AncmIISExpressV2.wixproj" AdditionalProperties="Platform=$(_WixTargetPlatform)" />
+        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\ANCMV2\ANCMV2.wixproj" AdditionalProperties="Platform=$(_WixTargetPlatform)" />
+        <!-- Build the targeting pack installers -->
+        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\TargetingPack\TargetingPack.wixproj" AdditionalProperties="Platform=$(_WixTargetPlatform)" />
+        <!-- Build the SharedFramework installers -->
+        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\SharedFrameworkBundle\SharedFrameworkBundle.wixproj" AdditionalProperties="Platform=$(_WixTargetPlatform)" />
+        <!-- Build the SharedFramework wixlib -->
+        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\SharedFrameworkLib\SharedFrameworkLib.wixproj" AdditionalProperties="Platform=$(_WixTargetPlatform)" />
+      </ItemGroup>
+
+      <ItemGroup Condition="'$(DotNetBuild)' == 'true' and ('$(DotNetBuildPass)' == '2') and '$(BuildInstallers)' == 'true' AND '$(TargetOsName)' == 'win' and '$(TargetArchitecture)' == 'x64'">
         <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\WindowsHostingBundle\WindowsHostingBundle.wixproj" AdditionalProperties="Platform=x86" />
       </ItemGroup>
 

--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -558,7 +558,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   -->
   <Target Name="_DownloadAndExtractDotNetRuntime">
     <ItemGroup>
-      <UrisToDownload Include="@(RemoteAssetBaseURL->'%(Identity)/$(DotNetRuntimeDownloadPath)')" />
+      <UrisToDownload Include="@(RemoteAssetBaseURL->'%(Identity)$(DotNetRuntimeDownloadPath)')" />
     </ItemGroup>
 
     <DownloadFile Condition=" !Exists('$(DotNetRuntimeArchive)') "

--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -556,16 +556,9 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   Targets related to creating .zip/.tar.gz
   #########################################
   -->
-  <Target Name="_DownloadAndExtractDotNetRuntime" Condition="'$(DotNetBuild)' != 'true'">
-    <!-- Try various places to find the runtime. It's either released (use official version),
-         public but un-released (use dotnetbuilds/public), or internal and unreleased (use dotnetbuilds/internal) -->
+  <Target Name="_DownloadAndExtractDotNetRuntime">
     <ItemGroup>
-      <UrisToDownload Include="https://dotnetcli.azureedge.net/dotnet/$(DotNetRuntimeDownloadPath)" />
-      <UrisToDownload Include="https://dotnetbuilds.azureedge.net/public/$(DotNetRuntimeDownloadPath)" />
-      <UrisToDownload Include="https://dotnetbuilds.azureedge.net/internal/$(DotNetRuntimeDownloadPath)"
-          Condition=" '$(DotnetRuntimeSourceFeedKey)' != '' ">
-        <token>$(DotnetRuntimeSourceFeedKey)</token>
-      </UrisToDownload>
+      <UrisToDownload Include="@(RemoteAssetBaseURL->'%(Identity)/$(DotNetRuntimeDownloadPath)')" />
     </ItemGroup>
 
     <DownloadFile Condition=" !Exists('$(DotNetRuntimeArchive)') "

--- a/src/Installers/Windows/WindowsHostingBundle/Product.targets
+++ b/src/Installers/Windows/WindowsHostingBundle/Product.targets
@@ -77,13 +77,12 @@
 
   <Target Name="FetchDependencies" BeforeTargets="Restore;CollectPackageReferences"
       Outputs="$(DepsPath)%(RemoteAsset.TargetFilename)">
-    <!--
-      Try various places to find the runtime. It's either released (use official version), public but
-      unreleased (use dotnetbuilds/public), or internal and unreleased (use dotnetbuilds/internal).
-    -->
+    <PropertyGroup>
+      <_CurrentRemoteAsset>%(RemoteAsset.Identity)</_CurrentRemoteAsset>
+    </PropertyGroup>
     <ItemGroup>
       <UrisToDownload Remove="@(UrisToDownload)" />
-      <UrisToDownload Include="@(RemoteAssetBaseURL->'%(Identity)Runtime/%(RemoteAsset.Identity)')" />
+      <UrisToDownload Include="@(RemoteAssetBaseURL->'%(Identity)Runtime/$(_CurrentRemoteAsset)')" />
     </ItemGroup>
 
     <DownloadFile Condition=" ! Exists('$(DepsPath)%(RemoteAsset.TargetFilename)') "

--- a/src/Installers/Windows/WindowsHostingBundle/Product.targets
+++ b/src/Installers/Windows/WindowsHostingBundle/Product.targets
@@ -83,7 +83,7 @@
     -->
     <ItemGroup>
       <UrisToDownload Remove="@(UrisToDownload)" />
-      <UrisToDownload Include="@(RemoteAssetBaseURL->'%(Identity)/Runtime/%(RemoteAsset.Identity)')" />
+      <UrisToDownload Include="@(RemoteAssetBaseURL->'%(Identity)Runtime/%(RemoteAsset.Identity)')" />
     </ItemGroup>
 
     <DownloadFile Condition=" ! Exists('$(DepsPath)%(RemoteAsset.TargetFilename)') "

--- a/src/Installers/Windows/WindowsHostingBundle/Product.targets
+++ b/src/Installers/Windows/WindowsHostingBundle/Product.targets
@@ -83,12 +83,7 @@
     -->
     <ItemGroup>
       <UrisToDownload Remove="@(UrisToDownload)" />
-      <UrisToDownload Include="https://dotnetcli.azureedge.net/dotnet/Runtime/%(RemoteAsset.Identity)" />
-      <UrisToDownload Include="https://dotnetbuilds.azureedge.net/public/Runtime/%(RemoteAsset.Identity)" />
-      <UrisToDownload Include="https://dotnetbuilds.azureedge.net/internal/Runtime/%(RemoteAsset.Identity)"
-          Condition=" '$(DotnetRuntimeSourceFeedKey)' != '' ">
-        <token>$(DotnetRuntimeSourceFeedKey)</token>
-      </UrisToDownload>
+      <UrisToDownload Include="@(RemoteAssetBaseURL->'%(Identity)/Runtime/%(RemoteAsset.Identity)')" />
     </ItemGroup>
 
     <DownloadFile Condition=" ! Exists('$(DepsPath)%(RemoteAsset.TargetFilename)') "

--- a/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
+++ b/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
@@ -104,17 +104,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <SharedFxInstallers Include="$(InstallersOutputPath)$(RuntimeInstallerBaseName)-$(SharedFxMsiVersion)-win-x64.msi">
+    <SharedFxInstallers Include="$(CrossArchitectureInstallerBasePath)$(RuntimeInstallerBaseName)-$(SharedFxMsiVersion)-win-x64.msi">
       <TargetPlatform>x64</TargetPlatform>
       <BundleNameProperty>SharedFxRedistInstallerx64</BundleNameProperty>
       <Version>$(SharedFxPackageVersion)</Version>
     </SharedFxInstallers>
-    <SharedFxInstallers Include="$(InstallersOutputPath)$(RuntimeInstallerBaseName)-$(SharedFxMsiVersion)-win-x86.msi">
+    <SharedFxInstallers Include="$(CrossArchitectureInstallerBasePath)$(RuntimeInstallerBaseName)-$(SharedFxMsiVersion)-win-x86.msi">
       <TargetPlatform>x86</TargetPlatform>
       <BundleNameProperty>SharedFxRedistInstallerx86</BundleNameProperty>
       <Version>$(SharedFxPackageVersion)</Version>
     </SharedFxInstallers>
-    <SharedFxInstallers Include="$(InstallersOutputPath)$(RuntimeInstallerBaseName)-$(SharedFxMsiVersion)-win-arm64.msi">
+    <SharedFxInstallers Include="$(CrossArchitectureInstallerBasePath)$(RuntimeInstallerBaseName)-$(SharedFxMsiVersion)-win-arm64.msi">
       <TargetPlatform>arm64</TargetPlatform>
       <BundleNameProperty>SharedFxRedistInstallerarm64</BundleNameProperty>
       <Version>$(SharedFxPackageVersion)</Version>


### PR DESCRIPTION
Add support for only building the current vertical's installers in pass 1 (and building the hosting bundle in pass 2) when building aspnetcore in the VMR.

Also, change how we download "known" assets to use the same mechanism as dotnet/sdk so the VMR can point to local artifacts.

This PR will require a reactive change in the VMR that adds https://github.com/dotnet/sdk/blob/b5a9089d86579d5a0f600478634db4ac1044cc75/src/SourceBuild/content/repo-projects/sdk.proj#L37 to the `aspnetcore.proj` project (which I'll prep now).

This should set up enough infra that we can turn on building installers on Windows for aspnetcore in the VMR and that (I hope) most if not all changes required for the hosting bundle can be done within the VMR.

Contributes to https://github.com/dotnet/source-build/issues/4692 (Windows)