### PR TITLE
Handling CultureInfo.InvariantCulture in RequestLocalizationMiddleware

### DIFF
--- a/src/Middleware/Localization/src/RequestLocalizationMiddleware.cs
+++ b/src/Middleware/Localization/src/RequestLocalizationMiddleware.cs
@@ -154,16 +154,9 @@ public class RequestLocalizationMiddleware
         bool fallbackToParentCultures,
         int currentDepth)
     {
-        // If the cultureName is an empty string there
-        // is no chance we can resolve the culture info.
-        if (cultureName.Equals(string.Empty))
-        {
-            return null;
-        }
-
         var culture = GetCultureInfo(cultureName, supportedCultures);
 
-        if (culture == null && fallbackToParentCultures && currentDepth < MaxCultureFallbackDepth)
+        if (culture == null && fallbackToParentCultures && currentDepth < MaxCultureFallbackDepth && cultureName != CultureInfo.InvariantCulture.Name)
         {
             try
             {

--- a/src/Middleware/Localization/test/UnitTests/RequestLocalizationMiddlewareTest.cs
+++ b/src/Middleware/Localization/test/UnitTests/RequestLocalizationMiddlewareTest.cs
@@ -25,6 +25,7 @@ public class RequestLocalizationMiddlewareTest
     [InlineData("zh-Hans-CN", "zh-Hans")]
     [InlineData("zh-Hant-TW", "zh-Hant")]
     [InlineData("zh-TW", "zh-Hant")]
+    [InlineData("zh-Hans-CN", "")]
     public async Task RequestLocalizationMiddleware_ShouldFallBackToParentCultures_RegradlessOfHyphenSeparatorCheck(string requestedCulture, string parentCulture)
     {
         using var host = new HostBuilder()


### PR DESCRIPTION
# Handling CultureInfo.InvariantCulture in RequestLocalizationMiddleware

Handle CultureInfo.InvariantCulture if it's supported by the option

## Description

If we add CultureInfo.InvariantCulture as a supported culture the code rejecting it and defaulted to the default configured culture.
It's happening since version 8.

Fixes #58843

Test project: https://github.com/cloudlucky/RequestLocalizationMiddlewareCultureInvariant
