### PR TITLE
chore: fixed missed conditional theory for testing named pipe

### DIFF
--- a/src/Servers/Kestrel/Transport.NamedPipes/test/NamedPipeConnectionListenerTests.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/test/NamedPipeConnectionListenerTests.cs
@@ -136,7 +136,7 @@ public class NamedPipeConnectionListenerTests : TestApplicationErrorLoggerLogged
         Assert.DoesNotContain(LogMessages, m => m.LogLevel >= LogLevel.Error);
     }
 
-    [Theory]
+    [ConditionalTheory]
     [InlineData(1)]
     [InlineData(4)]
     [InlineData(16)]


### PR DESCRIPTION
# Fixed missed conditional theory for testing named pipe

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

This PR aims to replace the `[Theory]` attribute with `[ConditionalTheory]` in `NamedPipeConnectionListenerTests`, as these tests are Windows-specific and were causing errors on macOS.

