### PR TITLE
feat: analyzer and codeFix for kestrel setup `ListenOptions.Listen(IPAddress.Any)` usage

### DIFF
--- a/docs/list-of-diagnostics.md
+++ b/docs/list-of-diagnostics.md
@@ -30,6 +30,10 @@
 |  __`ASP0022`__ | Route conflict detected between route handlers |
 |  __`ASP0023`__ | Route conflict detected between controller actions |
 |  __`ASP0024`__ | Route handler has multiple parameters with the [FromBody] attribute |
+|  __`ASP0025`__ | Use AddAuthorizationBuilder |
+|  __`ASP0026`__ | [Authorize] overridden by [AllowAnonymous] from farther away |
+|  __`ASP0027`__ | Unnecessary public Program class declaration |
+|  __`ASP0028`__ | Consider using IPAddress.IPv6Any instead of IPAddress.Any |
 
 ### API (`API1000-API1003`)
 

--- a/docs/list-of-diagnostics.md
+++ b/docs/list-of-diagnostics.md
@@ -33,7 +33,7 @@
 |  __`ASP0025`__ | Use AddAuthorizationBuilder |
 |  __`ASP0026`__ | [Authorize] overridden by [AllowAnonymous] from farther away |
 |  __`ASP0027`__ | Unnecessary public Program class declaration |
-|  __`ASP0028`__ | Consider using IPAddress.IPv6Any instead of IPAddress.Any |
+|  __`ASP0028`__ | Consider using ListenAnyIP() instead of Listen(IPAddress.Any) |
 
 ### API (`API1000-API1003`)
 

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
@@ -237,7 +237,7 @@ internal static class DiagnosticDescriptors
     internal static readonly DiagnosticDescriptor KestrelShouldListenOnIPv6AnyInsteadOfIpAny = new(
         "ASP0028",
         new LocalizableResourceString(nameof(Resources.Analyzer_KestrelShouldListenOnIPv6AnyInsteadOfIpAny_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.Analyzer_KestrelShouldListenOnIPv6AnyInsteadOfIpAny_Message), Resources.ResourceManager, typeof(Resources)), // make a doc? https://aka.ms/aspnetcore-warnings/ASP0027
+        new LocalizableResourceString(nameof(Resources.Analyzer_KestrelShouldListenOnIPv6AnyInsteadOfIpAny_Message), Resources.ResourceManager, typeof(Resources)),
         "Usage",
         DiagnosticSeverity.Info,
         isEnabledByDefault: true,

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
@@ -241,6 +241,5 @@ internal static class DiagnosticDescriptors
         "Usage",
         DiagnosticSeverity.Info,
         isEnabledByDefault: true,
-        helpLinkUri: "https://aka.ms/aspnet/analyzers",
-        customTags: WellKnownDiagnosticTags.Unnecessary);
+        helpLinkUri: "https://aka.ms/aspnet/analyzers");
 }

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
@@ -233,4 +233,14 @@ internal static class DiagnosticDescriptors
         isEnabledByDefault: true,
         helpLinkUri: "https://aka.ms/aspnet/analyzers",
         customTags: WellKnownDiagnosticTags.Unnecessary);
+
+    internal static readonly DiagnosticDescriptor KestrelShouldListenOnIPv6AnyInsteadOfIpAny = new(
+        "ASP0028",
+        new LocalizableResourceString(nameof(Resources.Analyzer_KestrelShouldListenOnIPv6AnyInsteadOfIpAny_Title), Resources.ResourceManager, typeof(Resources)),
+        new LocalizableResourceString(nameof(Resources.Analyzer_KestrelShouldListenOnIPv6AnyInsteadOfIpAny_Message), Resources.ResourceManager, typeof(Resources)), // make a doc? https://aka.ms/aspnetcore-warnings/ASP0027
+        "Usage",
+        DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        helpLinkUri: "https://aka.ms/aspnet/analyzers",
+        customTags: WellKnownDiagnosticTags.Unnecessary);
 }

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Kestrel/ListenOnIPv6AnyAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Kestrel/ListenOnIPv6AnyAnalyzer.cs
@@ -1,0 +1,115 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Linq;
+
+namespace Microsoft.AspNetCore.Analyzers.Kestrel;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class ListenOnIPv6AnyAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [ DiagnosticDescriptors.KestrelShouldListenOnIPv6AnyInsteadOfIpAny ];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterSyntaxNodeAction(KestrelServerOptionsListenInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private void KestrelServerOptionsListenInvocation(SyntaxNodeAnalysisContext context)
+    {
+        // fail fast before accessing SemanticModel
+        if (context.Node is not InvocationExpressionSyntax
+            {
+                Expression: MemberAccessExpressionSyntax
+                {
+                    Name: IdentifierNameSyntax { Identifier.ValueText: "Listen" }
+                }
+            } kestrelOptionsListenExpressionSyntax)
+        {
+            return;
+        }
+
+        var nodeOperation = context.SemanticModel.GetOperation(context.Node, context.CancellationToken);
+        if (!IsKestrelServerOptionsType(nodeOperation, out var kestrelOptionsListenInvocation))
+        {
+            return;
+        }
+
+        var addressArgument = kestrelOptionsListenInvocation?.Arguments.FirstOrDefault();
+        if (!IsIPAddressType(addressArgument?.Parameter))
+        {
+            return;
+        }
+
+        var args = kestrelOptionsListenExpressionSyntax.ArgumentList;
+        var ipAddressArgumentSyntax = args.Arguments.FirstOrDefault();
+
+        // explicit usage like `options.Listen(IPAddress.Any, ...)`
+        if (ipAddressArgumentSyntax is ArgumentSyntax
+        {
+            Expression: MemberAccessExpressionSyntax
+            {
+                Name: IdentifierNameSyntax { Identifier.ValueText: "Any" }
+            }
+        })
+        {
+            context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.KestrelShouldListenOnIPv6AnyInsteadOfIpAny, ipAddressArgumentSyntax.GetLocation()));
+        }
+
+        
+    }
+
+    private static bool IsIPAddressType(IParameterSymbol? parameter) => parameter is 
+    {
+        Type: // searching type `System.Net.IPAddress`
+        {
+            Name: "IPAddress",
+            ContainingNamespace: { Name: "Net", ContainingNamespace: { Name: "System", ContainingNamespace.IsGlobalNamespace: true } }
+        }
+    };
+
+    private static bool IsKestrelServerOptionsType(IOperation? operation, out IInvocationOperation? kestrelOptionsListenInvocation)
+    {
+        var result = operation is IInvocationOperation // searching type `Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions`
+        {
+            TargetMethod: { Name: "Listen" },
+            Instance.Type:
+            {
+                Name: "KestrelServerOptions",
+                ContainingNamespace:
+                {
+                    Name: "Core",
+                    ContainingNamespace:
+                    {
+                        Name: "Kestrel",
+                        ContainingNamespace:
+                        {
+                            Name: "Server",
+                            ContainingNamespace:
+                            {
+                                Name: "AspNetCore",
+                                ContainingNamespace:
+                                {
+                                    Name: "Microsoft",
+                                    ContainingNamespace.IsGlobalNamespace: true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        kestrelOptionsListenInvocation = result ? (IInvocationOperation)operation! : null;
+        return result;
+    }
+}

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Kestrel/ListenOnIPv6AnyAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Kestrel/ListenOnIPv6AnyAnalyzer.cs
@@ -64,8 +64,6 @@ public class ListenOnIPv6AnyAnalyzer : DiagnosticAnalyzer
         {
             context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.KestrelShouldListenOnIPv6AnyInsteadOfIpAny, ipAddressArgumentSyntax.GetLocation()));
         }
-
-        
     }
 
     private static bool IsIPAddressType(IParameterSymbol? parameter) => parameter is 

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Resources.resx
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Resources.resx
@@ -331,6 +331,6 @@
     <value>Consider using IPAddress.IPv6Any instead of IPAddress.Any</value>
   </data>
   <data name="Analyzer_KestrelShouldListenOnIPv6AnyInsteadOfIpAny_Message" xml:space="preserve">
-    <value>If server does not specifically reject IPv6, IPAddress.IPv6Any is preferred over IPAddress.Any usage due to safety and performance reasons. See https://aka.ms/aspnetcore-warnings/ASP0028 for more details.</value>
+    <value>If the server does not specifically reject IPv6, IPAddress.IPv6Any is preferred over IPAddress.Any usage for safety and performance reasons. See https://aka.ms/aspnetcore-warnings/ASP0028 for more details.</value>
   </data>
 </root>

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Resources.resx
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Resources.resx
@@ -328,7 +328,7 @@
     <value>Unnecessary public Program class declaration</value>
   </data>
   <data name="Analyzer_KestrelShouldListenOnIPv6AnyInsteadOfIpAny_Title" xml:space="preserve">
-    <value>Consider using IPAddress.IPv6Any instead of IPAddress.Any</value>
+    <value>Consider using ListenAnyIP() instead of Listen(IPAddress.Any)</value>
   </data>
   <data name="Analyzer_KestrelShouldListenOnIPv6AnyInsteadOfIpAny_Message" xml:space="preserve">
     <value>If the server does not specifically reject IPv6, IPAddress.IPv6Any is preferred over IPAddress.Any usage for safety and performance reasons. See https://aka.ms/aspnetcore-warnings/ASP0028 for more details.</value>

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Resources.resx
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Resources.resx
@@ -327,4 +327,10 @@
   <data name="Analyzer_PublicPartialProgramClass_Title" xml:space="preserve">
     <value>Unnecessary public Program class declaration</value>
   </data>
+  <data name="Analyzer_KestrelShouldListenOnIPv6AnyInsteadOfIpAny_Title" xml:space="preserve">
+    <value>Consider using IPAddress.IPv6Any instead of IPAddress.Any</value>
+  </data>
+  <data name="Analyzer_KestrelShouldListenOnIPv6AnyInsteadOfIpAny_Message" xml:space="preserve">
+    <value>If server does not specifically reject IPv6, IPAddress.IPv6Any is preferred over IPAddress.Any usage due to safety and performance reasons. See https://aka.ms/aspnetcore-warnings/ASP0028 for more details.</value>
+  </data>
 </root>

--- a/src/Framework/AspNetCoreAnalyzers/src/CodeFixes/Kestrel/ListenOnIPv6AnyFixer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/CodeFixes/Kestrel/ListenOnIPv6AnyFixer.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Composition;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Analyzers;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.AspNetCore.Fixers.Kestrel;
+
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public class ListenOnIPv6AnyFixer : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds => [ DiagnosticDescriptors.KestrelShouldListenOnIPv6AnyInsteadOfIpAny.Id ];
+
+    public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    "Consider using IPAddress.IPv6Any instead of IPAddress.Any",
+                    async cancellationToken =>
+                    {
+                        throw new System.NotImplementedException();
+
+                        //var editor = await DocumentEditor.CreateAsync(context.Document, cancellationToken).ConfigureAwait(false);
+                        //var root = await context.Document.GetSyntaxRootAsync(cancellationToken);
+                        //if (root is null)
+                        //{
+                        //    return context.Document;
+                        //}
+
+                        //var classDeclaration = root.FindNode(diagnostic.Location.SourceSpan)
+                        //    .FirstAncestorOrSelf<ClassDeclarationSyntax>();
+                        //if (classDeclaration is null)
+                        //{
+                        //    return context.Document;
+                        //}
+                        //editor.RemoveNode(classDeclaration, SyntaxRemoveOptions.KeepExteriorTrivia);
+                        //return editor.GetChangedDocument();
+
+                    },
+                    equivalenceKey: DiagnosticDescriptors.KestrelShouldListenOnIPv6AnyInsteadOfIpAny.Id),
+                diagnostic);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Framework/AspNetCoreAnalyzers/test/Kestrel/ListenOnIPv6AnyAnalyzerAndFixerTests.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/Kestrel/ListenOnIPv6AnyAnalyzerAndFixerTests.cs
@@ -11,27 +11,32 @@ using VerifyCS = Microsoft.AspNetCore.Analyzers.Verifiers.CSharpCodeFixVerifier<
 
 namespace Microsoft.AspNetCore.Analyzers.Kestrel;
 
-public class ListenOnIPv6AnyAnalyzerTests
+public class ListenOnIPv6AnyAnalyzerAndFixerTests
 {
     [Fact] // do we need any other scenarios except the direct usage one?
     public async Task ReportsDiagnostic_IPAddressAsLocalVariable()
     {
         var source = GetKestrelSetupSource("myIp", "var myIp = IPAddress.Any;");
-
-        await VerifyCS.VerifyAnalyzerAsync(source, [
-            new DiagnosticResult(DiagnosticDescriptors.KestrelShouldListenOnIPv6AnyInsteadOfIpAny).WithLocation(0)
-        ]);
+        await VerifyCS.VerifyAnalyzerAsync(source, codeSampleDiagnosticResult);
     }
 
     [Fact]
     public async Task ReportsDiagnostic_ExplicitUsage()
     {
         var source = GetKestrelSetupSource("IPAddress.Any");
-
-        await VerifyCS.VerifyAnalyzerAsync(source, [
-            new DiagnosticResult(DiagnosticDescriptors.KestrelShouldListenOnIPv6AnyInsteadOfIpAny).WithLocation(0)
-        ]);
+        await VerifyCS.VerifyAnalyzerAsync(source, codeSampleDiagnosticResult);
     }
+
+    [Fact]
+    public async Task CodeFix_ExplicitUsage()
+    {
+        var source = GetKestrelSetupSource("IPAddress.Any");
+        var fixedSource = GetKestrelSetupSource("IPAddress.IPv6Any");
+        await VerifyCS.VerifyCodeFixAsync(source, codeSampleDiagnosticResult, fixedSource);
+    }
+
+    private static DiagnosticResult codeSampleDiagnosticResult
+        = new DiagnosticResult(DiagnosticDescriptors.KestrelShouldListenOnIPv6AnyInsteadOfIpAny).WithLocation(0);
 
     static string GetKestrelSetupSource(string ipAddressArgument, string extraInlineCode = null) => $$"""
         using Microsoft.Extensions.Hosting;

--- a/src/Framework/AspNetCoreAnalyzers/test/Kestrel/ListenOnIPv6AnyAnalyzerTests.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/Kestrel/ListenOnIPv6AnyAnalyzerTests.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.CodeAnalysis.Testing;
+using VerifyCS = Microsoft.AspNetCore.Analyzers.Verifiers.CSharpCodeFixVerifier<
+    Microsoft.AspNetCore.Analyzers.Kestrel.ListenOnIPv6AnyAnalyzer,
+    Microsoft.AspNetCore.Fixers.Kestrel.ListenOnIPv6AnyFixer>;
+
+namespace Microsoft.AspNetCore.Analyzers.Kestrel;
+
+public class ListenOnIPv6AnyAnalyzerTests
+{
+    [Fact] // do we need any other scenarios except the direct usage one?
+    public async Task ReportsDiagnostic_IPAddressAsLocalVariable()
+    {
+        var source = GetKestrelSetupSource("myIp", "var myIp = IPAddress.Any;");
+
+        await VerifyCS.VerifyAnalyzerAsync(source, [
+            new DiagnosticResult(DiagnosticDescriptors.KestrelShouldListenOnIPv6AnyInsteadOfIpAny).WithLocation(0)
+        ]);
+    }
+
+    [Fact]
+    public async Task ReportsDiagnostic_ExplicitUsage()
+    {
+        var source = GetKestrelSetupSource("IPAddress.Any");
+
+        await VerifyCS.VerifyAnalyzerAsync(source, [
+            new DiagnosticResult(DiagnosticDescriptors.KestrelShouldListenOnIPv6AnyInsteadOfIpAny).WithLocation(0)
+        ]);
+    }
+
+    static string GetKestrelSetupSource(string ipAddressArgument, string extraInlineCode = null) => $$"""
+        using Microsoft.Extensions.Hosting;
+        using Microsoft.AspNetCore.Hosting;
+        using Microsoft.AspNetCore.Server.Kestrel.Core;
+        using System.Net;
+    
+        var hostBuilder = new HostBuilder()
+            .ConfigureWebHost(webHost =>
+            {
+                webHost.UseKestrel().ConfigureKestrel(options =>
+                {
+                    {{extraInlineCode}}
+                    
+                    options.ListenLocalhost(5000);
+                    options.ListenAnyIP(5000);
+                    options.Listen({|#0:{{ipAddressArgument}}|}, 5000, listenOptions =>
+                    {
+                        listenOptions.UseHttps();
+                        listenOptions.Protocols = HttpProtocols.Http1AndHttp2AndHttp3;
+                    });
+                });
+            });
+    
+        var host = hostBuilder.Build();
+        host.Run();
+    """;
+}

--- a/src/Framework/AspNetCoreAnalyzers/test/Verifiers/CSharpAnalyzerVerifier.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/Verifiers/CSharpAnalyzerVerifier.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Hosting;
 
 namespace Microsoft.AspNetCore.Analyzers.Verifiers;
 
@@ -63,10 +64,12 @@ public static partial class CSharpAnalyzerVerifier<TAnalyzer>
 
         return net10Ref.AddAssemblies(ImmutableArray.Create(
             TrimAssemblyExtension(typeof(System.IO.Pipelines.PipeReader).Assembly.Location),
+            TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServer).Assembly.Location),
             TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Authorization.IAuthorizeData).Assembly.Location),
             TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Mvc.ModelBinding.IBinderTypeProviderMetadata).Assembly.Location),
             TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Mvc.BindAttribute).Assembly.Location),
             TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions).Assembly.Location),
+            TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Hosting.WebHostBuilderKestrelExtensions).Assembly.Location),
             TrimAssemblyExtension(typeof(Microsoft.Extensions.Hosting.IHostBuilder).Assembly.Location),
             TrimAssemblyExtension(typeof(Microsoft.Extensions.Hosting.HostingHostBuilderExtensions).Assembly.Location),
             TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Builder.ConfigureHostBuilder).Assembly.Location),


### PR DESCRIPTION
On a machine that supports IPv6, listening to `Any`, rather than `IPv6Any` will either not work or be slower than necessary.  For HTTP/1.x and 2/0, a name like `localhost` will resolve to `[::1]`, which won't be accepted by the server, forcing a retry with `127.0.0.1` (i.e. failed attempt before each connection).

Implemented in a way, [as specified](https://github.com/dotnet/aspnetcore/issues/58172#issuecomment-2420742931) by @amcasey:
> Probably best to just always report the diagnostic and let users disable it if they know it doesn't apply

PR adds the analyzer, which catches `options.Listen(IPAddress.Any, ...)` usage, and a code fix, which explicitly changes the argument to `IPAddress.IPv6Any`.

[Docs PR](https://github.com/dotnet/AspNetCore.Docs/pull/34084)

Fixes #58172
