### PR TITLE
Address variable initialization warnings in ANCM (C26494)

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxrResolver.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxrResolver.cpp
@@ -402,21 +402,21 @@ HostFxrResolver::InvokeWhereToFindDotnet()
     // Arguments to call where.exe
     STARTUPINFOW        startupInfo{};
     PROCESS_INFORMATION processInformation{};
-    SECURITY_ATTRIBUTES securityAttributes;
+    SECURITY_ATTRIBUTES securityAttributes{};
 
-    CHAR                pzFileContents[READ_BUFFER_SIZE];
+    CHAR                pzFileContents[READ_BUFFER_SIZE]{0};
     HandleWrapper<InvalidHandleTraits>     hStdOutReadPipe;
     HandleWrapper<InvalidHandleTraits>     hStdOutWritePipe;
     HandleWrapper<InvalidHandleTraits>     hProcess;
     HandleWrapper<InvalidHandleTraits>     hThread;
     CComBSTR            pwzDotnetName = nullptr;
-    DWORD               dwFilePointer;
-    BOOL                fIsCurrentProcess64Bit;
-    DWORD               dwExitCode;
+    DWORD               dwFilePointer = 0;
+    BOOL                fIsCurrentProcess64Bit = FALSE;
+    DWORD               dwExitCode = 0;
     STRU                struDotnetSubstring;
     STRU                struDotnetLocationsString;
-    DWORD               dwNumBytesRead;
-    DWORD               dwBinaryType;
+    DWORD               dwNumBytesRead = 0;
+    DWORD               dwBinaryType = 0;
     INT                 index = 0;
     INT                 prevIndex = 0;
     std::optional<fs::path> result;

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/StandardStreamRedirection.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/StandardStreamRedirection.cpp
@@ -55,8 +55,8 @@ StandardStreamRedirection::~StandardStreamRedirection() noexcept(false)
 void StandardStreamRedirection::Start()
 {
     SECURITY_ATTRIBUTES     saAttr = { 0 };
-    HANDLE                  hStdErrReadPipe;
-    HANDLE                  hStdErrWritePipe;
+    HANDLE                  hStdErrReadPipe = nullptr;
+    HANDLE                  hStdErrWritePipe = nullptr;
 
     // To make Console.* functions work, allocate a console
     // in the current process.

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/StdWrapper.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/StdWrapper.cpp
@@ -32,7 +32,7 @@ StdWrapper::~StdWrapper() = default;
 HRESULT
 StdWrapper::StartRedirection()
 {
-    HANDLE stdHandle;
+    HANDLE stdHandle = nullptr;
 
     // In IIS, stdout and stderr are set to null as w3wp is created with DETACHED_PROCESS,
     // so fileno(m_stdStream) returns -2.

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/WebConfigConfigurationSection.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/WebConfigConfigurationSection.cpp
@@ -65,7 +65,7 @@ std::optional<std::shared_ptr<ConfigurationSection>> WebConfigConfigurationSecti
 std::vector<std::shared_ptr<ConfigurationSection>> WebConfigConfigurationSection::GetCollection() const
 {
     std::vector<std::shared_ptr<ConfigurationSection>> elements;
-    HRESULT findElementResult;
+    HRESULT findElementResult = S_OK;
     CComPtr<IAppHostElementCollection> elementCollection = nullptr;
     CComPtr<IAppHostElement>           collectionEntry = nullptr;
     ENUM_INDEX                         index{};

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/aspnetcore_event.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/aspnetcore_event.h
@@ -59,10 +59,9 @@ public:
         enumAreaFlags       AreaFlags,
         DWORD               dwVerbosity )
     {
-        HRESULT                  hr;
         HTTP_TRACE_CONFIGURATION TraceConfig;
         TraceConfig.pProviderGuid = GetProviderGuid();
-        hr = pHttpTraceContext->GetTraceConfiguration( &TraceConfig );
+        HRESULT hr = pHttpTraceContext->GetTraceConfiguration( &TraceConfig );
         if ( FAILED( hr )  || !TraceConfig.fProviderEnabled )
         {
             return FALSE;

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/config_utility.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/config_utility.h
@@ -61,7 +61,7 @@ private:
     HRESULT
     FindKeyValuePair(IAppHostElement* pElement, PCWSTR key, STRU& strHandlerVersionValue)
     {
-        HRESULT hr;
+        HRESULT hr = S_OK;
         CComPtr<IAppHostElement>           pHandlerSettings = nullptr;
         CComPtr<IAppHostElementCollection> pHandlerSettingsCollection = nullptr;
         CComPtr<IAppHostElement>           pHandlerVar = nullptr;

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/debugutil.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/debugutil.cpp
@@ -211,9 +211,9 @@ DebugInitialize(HMODULE hModule)
             KEY_READ,
             &hKey) == NO_ERROR)
     {
-        DWORD dwType;
-        DWORD dwData;
-        DWORD cbData;
+        DWORD dwType{0};
+        DWORD dwData{0};
+        DWORD cbData{0};
 
         cbData = sizeof(dwData);
         if ((RegQueryValueEx(hKey,
@@ -373,7 +373,7 @@ DebugPrintW(
 
         if (IsEnabled(ASPNETCORE_DEBUG_FLAG_EVENTLOG))
         {
-            WORD eventType;
+            WORD eventType = EVENTLOG_INFORMATION_TYPE;
             switch (dwFlag)
             {
                 case ASPNETCORE_DEBUG_FLAG_ERROR:

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/sttimer.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/sttimer.h
@@ -61,7 +61,7 @@ public:
         DWORD dwPeriod = 0
         )
     {
-        FILETIME ftInitialWait;
+        FILETIME ftInitialWait{};
 
         if ( dwInitialWait == 0 && dwPeriod == 0 )
         {
@@ -186,12 +186,10 @@ public:
           _dwPerfCountsPerMillisecond( 0 ),
           _fUsingHighResolution( FALSE )
     {
-        LARGE_INTEGER li;
-        BOOL          fResult;
-
+        LARGE_INTEGER li{};
         _dwInitTickCount = GetTickCount64();
 
-        fResult = QueryPerformanceFrequency( &li );
+        BOOL fResult = QueryPerformanceFrequency( &li );
 
         if ( !fResult )
         {
@@ -224,7 +222,7 @@ Finished:
     LONGLONG
     QueryElapsedTime()
     {
-        LARGE_INTEGER li;
+        LARGE_INTEGER li{};
 
         if ( _fUsingHighResolution && QueryPerformanceCounter( &li ) )
         {

--- a/src/Servers/IIS/AspNetCoreModuleV2/DefaultRules.ruleset
+++ b/src/Servers/IIS/AspNetCoreModuleV2/DefaultRules.ruleset
@@ -92,7 +92,7 @@
     <Rule Id="C26491" Action="Error" />
     <Rule Id="C26492" Action="None" /> <!-- Don't use const_cast to cast away const. -->
     <Rule Id="C26493" Action="None" /> <!-- Don't use C-style casts. -->
-    <Rule Id="C26494" Action="None" /> <!-- Variable 'variable' is uninitialized. Always initialize an object. -->
+    <Rule Id="C26494" Action="Error" /> <!-- Variable 'variable' is uninitialized. Always initialize an object. -->
     <Rule Id="C26495" Action="None" /> <!-- Variable 'variable' is uninitialized. Always initialize a member variable -->
     <Rule Id="C26496" Action="None" /> <!-- The variable 'variable' is assigned only once, mark it as const. -->
     <Rule Id="C26497" Action="Error" />

--- a/src/Servers/IIS/AspNetCoreModuleV2/IISLib/ahutil.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/IISLib/ahutil.cpp
@@ -489,7 +489,7 @@ DeleteElementFromCollection(
     )
 {
     HRESULT hr = NOERROR;
-    ULONG index;
+    ULONG index = 0;
 
     VARIANT varIndex;
     VariantInit( &varIndex );
@@ -627,15 +627,13 @@ FindElementInCollection(
     VARIANT varKeyValue;
     VariantInit( &varKeyValue );
 
-    DWORD   count;
-    DWORD   i;
+    DWORD   count = 0;
+    DWORD   i = 0;
 
     BSTR bstrKeyName = nullptr;
-    PFN_FIND_COMPARE_PROC compareProc;
-
-    compareProc = (BehaviorFlags & FIND_ELEMENT_CASE_INSENSITIVE)
-                      ? &FindCompareCaseInsensitive
-                      : &FindCompareCaseSensitive;
+    PFN_FIND_COMPARE_PROC compareProc = (BehaviorFlags & FIND_ELEMENT_CASE_INSENSITIVE)
+                                      ? &FindCompareCaseInsensitive
+                                      : &FindCompareCaseSensitive;
 
     bstrKeyName = SysAllocString( szKeyName );
     if( !bstrKeyName )
@@ -761,8 +759,6 @@ GetLocationFromFile(
     CComPtr<IAppHostConfigLocationCollection>   pLocationCollection;
     CComPtr<IAppHostConfigLocation>             pLocation;
 
-    BSTR bstrLocationPath = nullptr;
-
     *ppLocation = nullptr;
     *pFound = FALSE;
 
@@ -773,11 +769,11 @@ GetLocationFromFile(
     if( FAILED(hr) )
     {
         DBGERROR_HR(hr);
-        goto exit;
+        return hr;
     }
 
-    DWORD count;
-    DWORD i;
+    DWORD count = 0;
+    DWORD i = 0;
     VARIANT varIndex;
     VariantInit( &varIndex );
 
@@ -785,8 +781,10 @@ GetLocationFromFile(
     if( FAILED(hr) )
     {
         DBGERROR_HR(hr);
-        goto exit;
+        return hr;
     }
+
+    BSTR bstrLocationPath = nullptr;
 
     for( i = 0; i < count; i++ )
     {
@@ -841,8 +839,8 @@ GetSectionFromLocation(
 
     CComPtr<IAppHostElement>    pSectionElement;
 
-    DWORD count;
-    DWORD i;
+    DWORD count = 0;
+    DWORD i = 0;
 
     VARIANT varIndex;
     VariantInit( &varIndex );
@@ -1002,8 +1000,8 @@ ClearElementFromAllSites(
     CComPtr<IAppHostElementCollection> pSitesCollection;
     CComPtr<IAppHostElement> pSiteElement;
     CComPtr<IAppHostChildElementCollection> pChildCollection;
-    ENUM_INDEX index;
-    BOOL found;
+    ENUM_INDEX index{};
+    BOOL found = false;
 
     //
     // Enumerate the sites, remove the specified elements.
@@ -1074,7 +1072,7 @@ ClearElementFromAllLocations(
     CComPtr<IAppHostConfigLocationCollection> pLocationCollection;
     CComPtr<IAppHostConfigLocation> pLocation;
     CComPtr<IAppHostChildElementCollection> pChildCollection;
-    ENUM_INDEX index;
+    ENUM_INDEX index{};
 
     //
     // Enum the <location> tags, remove the specified elements.
@@ -1125,10 +1123,10 @@ ClearLocationElements(
     IN      CONST WCHAR *               szElementName
     )
 {
-    HRESULT hr;
+    HRESULT hr = S_OK;
     CComPtr<IAppHostElement> pElement;
-    ENUM_INDEX index;
-    BOOL matched;
+    ENUM_INDEX index{};
+    BOOL matched = false;
 
     for (hr = FindFirstLocationElement(pLocation, &index, &pElement) ;
          SUCCEEDED(hr) ;
@@ -1199,10 +1197,10 @@ ClearChildElementsByName(
     OUT     BOOL *                              pFound
     )
 {
-    HRESULT hr;
+    HRESULT hr = S_OK;
     CComPtr<IAppHostElement> pElement;
-    ENUM_INDEX index;
-    BOOL matched;
+    ENUM_INDEX index{};
+    BOOL matched = false;
 
     *pFound = FALSE;
 
@@ -1253,7 +1251,7 @@ GetSitesCollection(
     OUT     IAppHostElementCollection **        pSitesCollection
     )
 {
-    HRESULT hr;
+    HRESULT hr = S_OK;
     CComPtr<IAppHostElement> pSitesElement;
 
     BSTR bstrConfigPath = SysAllocString(szConfigPath);
@@ -1304,7 +1302,7 @@ GetLocationCollection(
     OUT     IAppHostConfigLocationCollection ** pLocationCollection
     )
 {
-    HRESULT hr;
+    HRESULT hr = S_OK;
     CComPtr<IAppHostConfigManager>      pConfigMgr;
     CComPtr<IAppHostConfigFile>         pConfigFile;
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/IISLib/base64.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/IISLib/base64.cpp
@@ -40,10 +40,10 @@ Return Values:
         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'
     };
 
-    DWORD   ib;
-    DWORD   ich;
-    DWORD   cchEncoded;
-    BYTE    b0, b1, b2;
+    DWORD   ib{0};
+    DWORD   ich{0};
+    DWORD   cchEncoded{0};
+    BYTE    b0{0}, b1{0}, b2{0};
     BYTE *  pbDecodedBuffer = static_cast<BYTE*>(pDecodedBuffer);
 
     // Calculate encoded string size.
@@ -177,10 +177,10 @@ Return Values:
         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'
     };
 
-    DWORD   ib;
-    DWORD   ich;
-    DWORD   cchEncoded;
-    BYTE    b0, b1, b2;
+    DWORD   ib{0};
+    DWORD   ich{0};
+    DWORD   cchEncoded{0};
+    BYTE    b0{0}, b1{0}, b2{0};
     BYTE *  pbDecodedBuffer = (BYTE *) pDecodedBuffer;
 
     // Calculate encoded string size.

--- a/src/Servers/IIS/AspNetCoreModuleV2/IISLib/buffer.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/IISLib/buffer.h
@@ -128,7 +128,7 @@ public:
 
     --*/
     {
-        PVOID pNewMem;
+        PVOID pNewMem = nullptr;
 
         if ( cbNewSize <= m_cbBuffer )
         {

--- a/src/Servers/IIS/AspNetCoreModuleV2/IISLib/hashtable.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/IISLib/hashtable.h
@@ -528,8 +528,8 @@ HASH_TABLE<_Record,_Key>::DeleteIf(
     PVOID                       pvContext
 )
 {
-    HASH_NODE<_Record> *pNode;
-    HASH_NODE<_Record> **ppPreviousNodeNextPointer;
+    HASH_NODE<_Record> *pNode = nullptr;
+    HASH_NODE<_Record> **ppPreviousNodeNextPointer = nullptr;
 
     _tableLock.ExclusiveAcquire();
 
@@ -568,7 +568,7 @@ HASH_TABLE<_Record,_Key>::Apply(
     PVOID                       pvContext
 )
 {
-    HASH_NODE<_Record> *pNode;
+    HASH_NODE<_Record> *pNode = nullptr;
 
     _tableLock.SharedAcquire();
 
@@ -595,13 +595,13 @@ HASH_TABLE<_Record,_Key>::RehashTableIfNeeded(
     VOID
 )
 {
-    HASH_NODE<_Record> **ppBuckets;
-    DWORD nBuckets;
-    HASH_NODE<_Record> *pNode;
-    HASH_NODE<_Record> *pNextNode;
-    HASH_NODE<_Record> **ppNextPointer;
-    HASH_NODE<_Record> *pNewNextNode;
-    DWORD               nNewBuckets;
+    HASH_NODE<_Record> **ppBuckets = nullptr;
+    DWORD nBuckets = 0;
+    HASH_NODE<_Record> *pNode = nullptr;
+    HASH_NODE<_Record> *pNextNode = nullptr;
+    HASH_NODE<_Record> **ppNextPointer = nullptr;
+    HASH_NODE<_Record> *pNewNextNode = nullptr;
+    DWORD               nNewBuckets = 0;
 
     //
     // If number of items has become too many, we will double the hash table

--- a/src/Servers/IIS/AspNetCoreModuleV2/IISLib/listentry.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/IISLib/listentry.h
@@ -39,8 +39,8 @@ RemoveEntryList(
     IN PLIST_ENTRY Entry
     )
 {
-    PLIST_ENTRY Blink;
-    PLIST_ENTRY Flink;
+    PLIST_ENTRY Blink = nullptr;
+    PLIST_ENTRY Flink = nullptr;
 
     Flink = Entry->Flink;
     Blink = Entry->Blink;
@@ -55,8 +55,8 @@ RemoveHeadList(
     IN PLIST_ENTRY ListHead
     )
 {
-    PLIST_ENTRY Flink;
-    PLIST_ENTRY Entry;
+    PLIST_ENTRY Flink = nullptr;
+    PLIST_ENTRY Entry = nullptr;
 
     Entry = ListHead->Flink;
     Flink = Entry->Flink;
@@ -73,8 +73,8 @@ RemoveTailList(
     IN PLIST_ENTRY ListHead
     )
 {
-    PLIST_ENTRY Blink;
-    PLIST_ENTRY Entry;
+    PLIST_ENTRY Blink = nullptr;
+    PLIST_ENTRY Entry = nullptr;
 
     Entry = ListHead->Blink;
     Blink = Entry->Blink;

--- a/src/Servers/IIS/AspNetCoreModuleV2/IISLib/reftrace.c
+++ b/src/Servers/IIS/AspNetCoreModuleV2/IISLib/reftrace.c
@@ -115,7 +115,6 @@ Return Value:
 
 }   // WriteRefTraceLog
 
-
 LONG
 __cdecl
 WriteRefTraceLogEx(
@@ -156,9 +155,9 @@ Return Value:
 --*/
 {
 
-    REF_TRACE_LOG_ENTRY entry;
-    ULONG hash;
-    DWORD cStackFramesSkipped;
+    REF_TRACE_LOG_ENTRY entry{};
+    ULONG hash = 0;
+    DWORD cStackFramesSkipped = 0;
 
     //
     // Initialize the entry.

--- a/src/Servers/IIS/AspNetCoreModuleV2/IISLib/stringa.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/IISLib/stringa.cpp
@@ -681,7 +681,7 @@ STRA::ConvertUnicodeToCodePage(
     _ASSERTE(nullptr != pszSrcUnicodeString);
     _ASSERTE(nullptr != pbufDstAnsiString);
 
-    DWORD dwFlags;
+    DWORD dwFlags{0};
 
     if (uCodePage == CP_ACP)
     {

--- a/src/Servers/IIS/AspNetCoreModuleV2/IISLib/tracelog.c
+++ b/src/Servers/IIS/AspNetCoreModuleV2/IISLib/tracelog.c
@@ -66,12 +66,12 @@ Return Value:
     ulExtraBytesInHeader = (ULONG) ExtraBytesInHeader;
 
     //
-    // Check if the multiplication operation will overflow a LONG 
+    // Check if the multiplication operation will overflow a LONG
     // ulTotalSize = LogSize * EntrySize;
     //
     hr = ULongMult( ulLogSize, ulEntrySize, &ulTotalSize );
     if ( FAILED(hr) )
-    { 
+    {
         SetLastError( ERROR_ARITHMETIC_OVERFLOW );
         return nullptr;
     }
@@ -82,24 +82,24 @@ Return Value:
     //
     hr = ULongAdd( (ULONG) sizeof(TRACE_LOG), ulExtraBytesInHeader, &ulTmpResult );
     if ( FAILED(hr) )
-    { 
+    {
         SetLastError( ERROR_ARITHMETIC_OVERFLOW );
         return nullptr;
     }
-  
+
     //
     // check for overflow in addition operation.
     // ulTotalSize = ulTotalSize + ulTmpResult;
     //
     hr = ULongAdd( ulTmpResult, ulTotalSize, &ulTotalSize );
     if ( FAILED(hr) )
-    { 
+    {
         SetLastError( ERROR_ARITHMETIC_OVERFLOW );
         return nullptr;
     }
 
     if ( ulTotalSize > (ULONG) 0x7FFFFFFF )
-    { 
+    {
         SetLastError( ERROR_ARITHMETIC_OVERFLOW );
         return nullptr;
     }
@@ -184,8 +184,8 @@ Return Value:
 --*/
 {
 
-    PUCHAR target;
-    ULONG index;
+    PUCHAR target = nullptr;
+    ULONG index = 0;
 
     //DBG_ASSERT( Log != NULL );
     //DBG_ASSERT( Log->Signature == TRACE_LOG_SIGNATURE );

--- a/src/Servers/IIS/AspNetCoreModuleV2/IISLib/util.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/IISLib/util.cpp
@@ -27,7 +27,7 @@ Return Values:
 
 --*/
 {
-    HRESULT hr;
+    HRESULT hr = S_OK;
 
     if (pszName[0] == L'\\' && pszName[1] == L'\\')
     {
@@ -74,7 +74,7 @@ Return Values:
     else
     {
         pstrPath->Reset();
-    }  
+    }
 
     return pstrPath->Append(pszName);
 }

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -351,7 +351,7 @@ IN_PROCESS_APPLICATION::ExecuteApplication()
             RETURN_IF_NOT_ZERO(context->m_hostFxr.SetRuntimePropertyValue(APP_CONTEXT_BASE_DIRECTORY, Environment::GetCurrentDirectoryValue().c_str()));
         }
 
-        bool clrThreadExited;
+        bool clrThreadExited = false;
         {
             //Start CLR thread
             m_clrThread = std::thread(ClrThreadEntryPoint, context);

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/managedexports.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/managedexports.cpp
@@ -114,8 +114,8 @@ http_get_server_variable(
     _Out_ BSTR* pwszReturn
 )
 {
-    PCWSTR pszVariableValue;
-    DWORD cbLength;
+    PCWSTR pszVariableValue = nullptr;
+    DWORD cbLength = 0;
 
     *pwszReturn = nullptr;
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/dllmain.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/dllmain.cpp
@@ -28,7 +28,7 @@ InitializeGlobalConfiguration(
     IHttpServer * pServer
 )
 {
-    HKEY hKey;
+    HKEY hKey{};
     BOOL fLocked = FALSE;
 
     if (!g_fGlobalInitialize)
@@ -58,9 +58,9 @@ InitializeGlobalConfiguration(
             KEY_READ,
             &hKey) == NO_ERROR)
         {
-            DWORD dwType;
-            DWORD dwData;
-            DWORD cbData;
+            DWORD dwType = 0;
+            DWORD dwData = 0;
+            DWORD cbData = 0;
 
             cbData = sizeof(dwData);
             if ((RegQueryValueEx(hKey,

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/forwardinghandler.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/forwardinghandler.cpp
@@ -744,17 +744,17 @@ FORWARDING_HANDLER::GetHeaders(
     _Inout_ DWORD *                 pcchHeaders
 )
 {
-    PCSTR pszCurrentHeader;
-    PCSTR ppHeadersToBeRemoved;
-    PCSTR pszFinalHeader;
-    USHORT cchCurrentHeader;
-    DWORD cchFinalHeader;
+    PCSTR pszCurrentHeader = nullptr;
+    PCSTR ppHeadersToBeRemoved = nullptr;
+    PCSTR pszFinalHeader = nullptr;
+    USHORT cchCurrentHeader = 0;
+    DWORD cchFinalHeader = 0;
     BOOL  fSecure = FALSE;  // dummy. Used in SplitUrl. Value will not be used
                             // as ANCM always use http protocol to communicate with backend
     STRU  struDestination;
     STRU  struUrl;
     STACK_STRA(strTemp, 64);
-    HTTP_REQUEST_HEADERS *pHeaders;
+    HTTP_REQUEST_HEADERS *pHeaders = nullptr;
     IHttpRequest *pRequest = m_pW3Context->GetRequest();
     MULTISZA mszMsAspNetCoreHeaders;
 
@@ -964,7 +964,7 @@ FORWARDING_HANDLER::CreateWinHttpRequest(
 {
     HRESULT         hr = S_OK;
     PCWSTR          pszVersion = nullptr;
-    PCSTR           pszVerb;
+    PCSTR           pszVerb = nullptr;
     DWORD           dwTimeout = INFINITE;
     STACK_STRU(strVerb, 32);
 
@@ -1861,7 +1861,7 @@ FORWARDING_HANDLER::OnSendingRequest(
     }
     else if (SUCCEEDED(hrCompletionStatus))
     {
-        DWORD cbOffset;
+        DWORD cbOffset = 0;
 
         if (m_BytesToReceive != INFINITE)
         {
@@ -2038,8 +2038,8 @@ FORWARDING_HANDLER::SetStatusAndHeaders(
     STACK_STRA(strHeaderName, 128);
     STACK_STRA(strHeaderValue, 2048);
     DWORD           index = 0;
-    PSTR            pchNewline;
-    PCSTR           pchEndofHeaderValue;
+    PSTR            pchNewline = nullptr;
+    PCSTR           pchEndofHeaderValue = nullptr;
     BOOL            fServerHeaderPresent = FALSE;
 
     _ASSERT(pszHeaders != nullptr);
@@ -2281,10 +2281,10 @@ FORWARDING_HANDLER::DoReverseRewrite(
     DBG_ASSERT(pResponse == m_pW3Context->GetResponse());
     BOOL fSecure = (m_pW3Context->GetRequest()->GetRawHttpRequest()->pSslInfo != nullptr);
     STRA strTemp;
-    PCSTR pszHeader;
-    PCSTR pszStartHost;
-    PCSTR pszEndHost;
-    HTTP_RESPONSE_HEADERS *pHeaders;
+    PCSTR pszHeader = nullptr;
+    PCSTR pszStartHost = nullptr;
+    PCSTR pszEndHost = nullptr;
+    HTTP_RESPONSE_HEADERS *pHeaders = nullptr;
 
     //
     // Content-Location and Location are easy, one known header in

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/processmanager.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/processmanager.cpp
@@ -13,8 +13,8 @@ PROCESS_MANAGER::Initialize(
     VOID
 )
 {
-    WSADATA                              wsaData;
-    int                                  result;
+    WSADATA                              wsaData{};
+    int                                  result = 0;
 
     if( !sm_fWSAStartupDone )
     {

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/serverprocess.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/serverprocess.cpp
@@ -102,8 +102,8 @@ SERVER_PROCESS::GetRandomPort
 
     std::uniform_int_distribution<> dist(MIN_PORT_RANDOM, MAX_PORT);
 
-    BOOL fPortInUse;
-    DWORD dwActualProcessId; // Ignored, but required for the function call.
+    BOOL fPortInUse = FALSE;
+    DWORD dwActualProcessId = 0; // Ignored, but required for the function call.
     constexpr int maxRetries = 10;
     for (int retry = 0; retry < maxRetries; ++retry)
     {
@@ -165,7 +165,7 @@ SERVER_PROCESS::SetupListenPort(
         }
     }
 
-    WCHAR buffer[15];
+    WCHAR buffer[15]{};
     if (FAILED_LOG(hr = GetRandomPort(&m_dwPort)))
     {
         goto Finished;
@@ -251,10 +251,10 @@ SERVER_PROCESS::SetupAppToken(
 )
 {
     HRESULT     hr = S_OK;
-    UUID        logUuid;
+    UUID        logUuid{};
     PSTR        pszLogUuid = nullptr;
     BOOL        fRpcStringAllocd = FALSE;
-    RPC_STATUS  rpcStatus;
+    RPC_STATUS  rpcStatus = 0;
     STRU        strAppToken;
     ENVIRONMENT_VAR_ENTRY*  pEntry = nullptr;
 
@@ -991,8 +991,8 @@ SERVER_PROCESS::SetupStdHandles(
 )
 {
     HRESULT                 hr = S_OK;
-    SYSTEMTIME              systemTime;
-    SECURITY_ATTRIBUTES     saAttr = { 0 };
+    SYSTEMTIME              systemTime{};
+    SECURITY_ATTRIBUTES     saAttr{};
 
     STRU                    struPath;
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/websockethandler.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/websockethandler.cpp
@@ -468,7 +468,7 @@ Routine Description:
         //
 
         DWORD dwError = NO_ERROR;
-        USHORT uStatus;
+        USHORT uStatus = 0;
         DWORD  dwReceived = 0;
         STACK_STRU(strCloseReason, 128);
 
@@ -991,7 +991,7 @@ Routine Description:
     HRESULT    hr = S_OK;
     BOOL       fLocked = FALSE;
     CleanupReason cleanupReason = CleanupReasonUnknown;
-    WINHTTP_WEB_SOCKET_BUFFER_TYPE  BufferType;
+    WINHTTP_WEB_SOCKET_BUFFER_TYPE  BufferType{};
 
     LOG_TRACE(L"WEBSOCKET_HANDLER::OnIisReceiveComplete");
 


### PR DESCRIPTION
Continuing the march of CA progress... this PR flips C26494 to be an error and addresses all the fallout from that.