### PR TITLE
Fix XmlDocs for StaticAssetsEndpointRouteBuilderExtensions MapStaticAssets

### DIFF
--- a/src/StaticAssets/src/StaticAssetsEndpointRouteBuilderExtensions.cs
+++ b/src/StaticAssets/src/StaticAssetsEndpointRouteBuilderExtensions.cs
@@ -20,7 +20,7 @@ public static class StaticAssetsEndpointRouteBuilderExtensions
     /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/>.</param>
     /// <param name="staticAssetsManifestPath">The path to the static assets manifest file.</param>
     /// <remarks>
-    /// The <paramref name="staticAssetsManifestPath"/> can be null to use the <see cref="IHostEnvironment.ApplicationName"/> to locate the manifest.
+    /// The <paramref name="staticAssetsManifestPath"/> can be <see langword="null"/> to use the <see cref="IHostEnvironment.ApplicationName"/> to locate the manifest.
     /// As an alternative, a full path can be specified to the manifest file. If a relative path is used, we'll search for the file in the <see cref="AppContext.BaseDirectory"/>.
     /// </remarks>
     public static StaticAssetsEndpointConventionBuilder MapStaticAssets(this IEndpointRouteBuilder endpoints, string? staticAssetsManifestPath = null)

--- a/src/StaticAssets/src/StaticAssetsEndpointRouteBuilderExtensions.cs
+++ b/src/StaticAssets/src/StaticAssetsEndpointRouteBuilderExtensions.cs
@@ -20,8 +20,8 @@ public static class StaticAssetsEndpointRouteBuilderExtensions
     /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/>.</param>
     /// <param name="staticAssetsManifestPath">The path to the static assets manifest file.</param>
     /// <remarks>
-    /// The <paramref name="staticAssetsManifestPath"/> can be null to use the <see cref="IHostEnvironment.ApplicationName"/> to locate the manifes.
-    /// As an alternative, a full path can be specified to the manifest file. If a relative path is used, we'll search for the file in the <see cref="AppContext.BaseDirectory"/>." />
+    /// The <paramref name="staticAssetsManifestPath"/> can be null to use the <see cref="IHostEnvironment.ApplicationName"/> to locate the manifest.
+    /// As an alternative, a full path can be specified to the manifest file. If a relative path is used, we'll search for the file in the <see cref="AppContext.BaseDirectory"/>.
     /// </remarks>
     public static StaticAssetsEndpointConventionBuilder MapStaticAssets(this IEndpointRouteBuilder endpoints, string? staticAssetsManifestPath = null)
     {


### PR DESCRIPTION
# Fix XmlDocs for StaticAssetsEndpointRouteBuilderExtensions MapStaticAssets


- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

- Fix `manifes` typo
- Remove extraneous trailing characters `" />`
- Change `null` to `<see langword="null"/>`
