### PR TITLE
Add pre-commit hook with code formatting

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,24 @@
+#!/bin/sh
+LC_ALL=C
+
+# Get the list of staged files
+staged_files=$(git diff --cached --name-only --diff-filter=ACM | grep '\.cs$')
+
+# Exit if no staged C# files
+[ -z "$staged_files" ] && exit 0
+
+# Stash unstaged changes
+stash_message="pre-commit-$(date +%s)"
+git stash push -k -u -m "$stash_message"
+
+# Run dotnet format on the staged files
+dotnet format --include $(echo "$staged_files" | xargs)
+
+# Add the formatted files back to staging
+git add $staged_files
+
+# Restore unstaged changes
+git stash pop -q $(git stash list | grep "$stash_message" | head -n 1 | awk -F: '{print $1}')
+
+# Exit with success
+exit 0

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -322,6 +322,10 @@ $performDotnetBuild = $BuildJava -or $BuildManaged -or $BuildNodeJS -or `
     ($All -and -not ($NoBuildJava -and $NoBuildManaged -and $NoBuildNodeJS)) -or `
     ($Projects -and -not ($BuildInstallers -or $specifiedBuildNative))
 
+# We need to change default git hooks directory as .git folder is not tracked. And by default hooks are stored in .git/hooks folder.
+# So we are setting git hooks default directory to .githooks, so that we can track and version the git hooks.
+& git config core.hooksPath .githooks
+
 # Initialize global variables need to be set before the import of Arcade is imported
 $restore = $RunRestore
 

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -321,6 +321,10 @@ if [ ! -z "$runtime_source_feed$runtime_source_feed_key" ]; then
     toolset_build_args[${#toolset_build_args[*]}]=$runtimeFeedKeyArg
 fi
 
+# We need to change default git hooks directory as .git folder is not tracked. And by default hooks are stored in .git/hooks folder.
+# So we are setting git hooks default directory to .githooks, so that we can track and version the git hooks.
+git config core.hooksPath .githooks
+
 # Initialize global variables need to be set before the import of Arcade is imported
 restore=$run_restore
 


### PR DESCRIPTION
# Add pre-commit hook with code formatter under the hood

In the context of PR, trying to solve an issue related to file formatting during pre-commit hook.

## Description
The issue #30145 outlines the backward of the previous approach and why it was reverted. Based on that, wanna suggest some improvements:

1. Working with the files only in staged/unstaged areas.
2. Resolving the issue with partially committed files.
3. Setting up the hook inside both build.ps1 and build.sh - Might need help with setting the hook up correctly

Fixes #27632 
