### PR TITLE
Build installers at the end of the repo build and allow building with desktop msbuild

### DIFF
--- a/eng/AfterSolutionBuild.targets
+++ b/eng/AfterSolutionBuild.targets
@@ -1,12 +1,12 @@
 <Project>
 
+  <Import Project="Common.props" />
   <Import Project="tools\RepoTasks\RepoTasks.tasks" />
   <Import Project="SharedFramework.External.props" />
   <Import Project="SharedFramework.Local.props" />
 
   <!-- This is temporary until we can use FrameworkReference to build our own packages. -->
-  <Target Name="RemoveSharedFrameworkOnlyRefsFromNuspec" AfterTargets="Pack"
-      Condition=" '$(MSBuildRuntimeType)' == 'core' ">
+  <Target Name="RemoveSharedFrameworkOnlyRefsFromNuspec" AfterTargets="Pack" Condition="'$(BuildManaged)' == 'true'">
     <ItemGroup>
       <_BuildOutput Include="$(ArtifactsShippingPackagesDir)*.nupkg"
                     Exclude="$(ArtifactsShippingPackagesDir)*.symbols.nupkg" />

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -274,7 +274,7 @@
         <InstallerProject Include="$(RepoRoot)src\Installers\Windows\SharedFrameworkLib\SharedFrameworkLib.wixproj" AdditionalProperties="Platform=$(_WixTargetPlatform)" />
       </ItemGroup>
 
-      <ItemGroup Condition="'$(DotNetBuild)' == 'true' and ('$(DotNetBuildPass)' == '2') and and '$(TargetOsName)' == 'win' and '$(TargetArchitecture)' == 'x64'">
+      <ItemGroup Condition="'$(DotNetBuild)' == 'true' and ('$(DotNetBuildPass)' == '2') and '$(TargetOsName)' == 'win' and '$(TargetArchitecture)' == 'x64'">
         <InstallerProject Include="$(RepoRoot)src\Installers\Windows\WindowsHostingBundle\WindowsHostingBundle.wixproj" AdditionalProperties="Platform=x86" />
       </ItemGroup>
 

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -222,6 +222,7 @@
         <_WixTargetPlatform Condition="'$(TargetArchitecture)' == 'x64' ">x64</_WixTargetPlatform>
         <_WixTargetPlatform Condition="'$(TargetArchitecture)' == 'arm64' ">ARM64</_WixTargetPlatform>
       </PropertyGroup>
+
       <ItemGroup Condition="'$(DotNetBuild)' != 'true' and '$(_BuildWindowsInstallers)' == 'true' ">
         <!-- Build the ANCM custom action -->
         <InstallerProject Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\CustomAction\aspnetcoreCA.vcxproj" AdditionalProperties="Platform=x64" />
@@ -286,7 +287,6 @@
 
       <ItemGroup>
         <ProjectToBuild Condition=" '$(BuildInstallers)' == 'true'" Include="@(InstallerProject)" Exclude="@(ProjectToExclude)" BuildStep="4" />
-        <ProjectToExclude Condition=" '$(BuildInstallers)' != 'true'" Include="@(InstallerProject)" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -79,7 +79,7 @@
       </ItemGroup>
 
       <ItemGroup>
-        <ProjectToBuild Condition=" $(BuildNative) " Include="@(NativeProjects)" Exclude="@(ProjectToExclude)" BuildStep="1" />
+        <ProjectToBuild Condition=" $(BuildNative) " Include="@(NativeProjects)" Exclude="@(ProjectToExclude)" BuildStep="native" />
         <ProjectToExclude Condition=" !$(BuildNative) " Include="@(NativeProjects)" />
       </ItemGroup>
 
@@ -95,7 +95,7 @@
 
         <ExplicitRequiresDelay Include="$(RepoRoot)eng\Npm.Workspace.FunctionalTests.nodeproj" />
 
-        <ProjectToBuild Condition=" '$(BuildNodeJS)' == 'true'" Include="@(NodeJsProjects)" Exclude="@(ProjectToExclude)" BuildStep="2" />
+        <ProjectToBuild Condition=" '$(BuildNodeJS)' == 'true'" Include="@(NodeJsProjects)" Exclude="@(ProjectToExclude)" BuildStep="node" />
         <ProjectToExclude Condition=" '$(BuildNodeJS)' != 'true'" Include="@(NodeJsProjects)" />
       </ItemGroup>
 
@@ -104,7 +104,7 @@
         <JavaProjects Include="$(RepoRoot)src\SignalR\**\*.javaproj"
                       Exclude="@(ProjectToExclude)" />
 
-        <ProjectToBuild Condition=" '$(BuildJava)' == 'true'" Include="@(JavaProjects)" Exclude="@(ProjectToExclude)" BuildStep="3" />
+        <ProjectToBuild Condition=" '$(BuildJava)' == 'true'" Include="@(JavaProjects)" Exclude="@(ProjectToExclude)" BuildStep="managed" />
         <ProjectToExclude Condition=" '$(BuildJava)' != 'true'" Include="@(JavaProjects)" />
       </ItemGroup>
 
@@ -211,7 +211,7 @@
                           $(RepoRoot)**\obj\**\*;"
                         Condition=" '$(BuildMainlyReferenceProviders)' == 'true' " />
 
-        <ProjectToBuild Condition=" '$(BuildManaged)' == 'true'" Include="@(DotNetProjects)" Exclude="@(ProjectToExclude)" BuildStep="3" />
+        <ProjectToBuild Condition=" '$(BuildManaged)' == 'true'" Include="@(DotNetProjects)" Exclude="@(ProjectToExclude)" BuildStep="managed" />
         <ProjectToExclude Condition=" '$(BuildManaged)' != 'true'" Include="@(DotNetProjects)" />
       </ItemGroup>
 
@@ -286,7 +286,7 @@
       </ItemGroup>
 
       <ItemGroup>
-        <ProjectToBuild Condition=" '$(BuildInstallers)' == 'true'" Include="@(InstallerProject)" Exclude="@(ProjectToExclude)" BuildStep="4" />
+        <ProjectToBuild Condition=" '$(BuildInstallers)' == 'true'" Include="@(InstallerProject)" Exclude="@(ProjectToExclude)" BuildStep="installer" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -71,74 +71,7 @@
       </ItemGroup>
     </When>
     <Otherwise>
-      <PropertyGroup>
-        <_BuildWindowsInstallers Condition="'$(BuildInstallers)' == 'true' AND '$(TargetOsName)' == 'win' AND ('$(TargetArchitecture)' == 'x86' OR '$(TargetArchitecture)' == 'x64' OR '$(TargetArchitecture)' == 'arm64') ">true</_BuildWindowsInstallers>
-        <_WixTargetPlatform Condition="'$(TargetArchitecture)' == 'x86' ">Win32</_WixTargetPlatform>
-        <_WixTargetPlatform Condition="'$(TargetArchitecture)' == 'x64' ">x64</_WixTargetPlatform>
-        <_WixTargetPlatform Condition="'$(TargetArchitecture)' == 'arm64' ">ARM64</_WixTargetPlatform>
-      </PropertyGroup>
-      <ItemGroup Condition="'$(DotNetBuild)' != 'true' and '$(_BuildWindowsInstallers)' == 'true' ">
-        <!-- Build the ANCM custom action -->
-        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\CustomAction\aspnetcoreCA.vcxproj" AdditionalProperties="Platform=x64" />
-        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\CustomAction\aspnetcoreCA.vcxproj" AdditionalProperties="Platform=Win32" />
-        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\CustomAction\aspnetcoreCA.vcxproj" AdditionalProperties="Platform=ARM64" />
-
-        <!-- Build the ANCM msis -->
-        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\ANCMIISExpressV2\AncmIISExpressV2.wixproj" AdditionalProperties="Platform=x64" />
-        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\ANCMIISExpressV2\AncmIISExpressV2.wixproj" AdditionalProperties="Platform=x86" />
-        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\ANCMIISExpressV2\AncmIISExpressV2.wixproj" AdditionalProperties="Platform=arm64" />
-        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\ANCMV2\ANCMV2.wixproj" AdditionalProperties="Platform=x64" />
-        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\ANCMV2\ANCMV2.wixproj" AdditionalProperties="Platform=x86" />
-        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\ANCMV2\ANCMV2.wixproj" AdditionalProperties="Platform=arm64" />
-
-        <!-- Build the targeting pack installers -->
-        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\TargetingPack\TargetingPack.wixproj" AdditionalProperties="Platform=x64" />
-        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\TargetingPack\TargetingPack.wixproj" AdditionalProperties="Platform=x86" />
-        <!-- This really shouldn't be here, but instead of harvesting from the intermediate/output directories, the targeting pack installer logic
-        harvests from a zip of the reference assemblies. Producing it in each leg ends up with multiple targeting packs
-        getting produced and the BAR will reject the build. Centralize building the targeting pack in the x86/x64 leg. -->
-        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\TargetingPack\TargetingPack.wixproj" AdditionalProperties="Platform=arm64" />
-
-        <!-- Build the SharedFramework installers -->
-        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\SharedFrameworkBundle\SharedFrameworkBundle.wixproj" AdditionalProperties="Platform=x64" />
-        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\SharedFrameworkBundle\SharedFrameworkBundle.wixproj" AdditionalProperties="Platform=x86" />
-        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\SharedFrameworkBundle\SharedFrameworkBundle.wixproj" AdditionalProperties="Platform=arm64" />
-
-        <!-- Build the SharedFramework wixlib -->
-        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\SharedFrameworkLib\SharedFrameworkLib.wixproj" AdditionalProperties="Platform=x64" />
-        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\SharedFrameworkLib\SharedFrameworkLib.wixproj" AdditionalProperties="Platform=x86" />
-        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\SharedFrameworkLib\SharedFrameworkLib.wixproj" AdditionalProperties="Platform=arm64" />
-
-        <!-- Windows hosting bundle -->
-        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\WindowsHostingBundle\WindowsHostingBundle.wixproj" AdditionalProperties="Platform=x86" />
-      </ItemGroup>
-
-      <!-- In a vertical build, only build the MSIs for the current vertical in the first pass and build the hosting bundle in the second pass -->
-      <ItemGroup Condition="'$(DotNetBuild)' == 'true' and ('$(DotNetBuildPass)' == '' or '$(DotNetBuildPass)' == '1') and '$(_BuildWindowsInstallers)' == 'true'">
-        <!-- Build the ANCM custom action -->
-        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\CustomAction\aspnetcoreCA.vcxproj" AdditionalProperties="Platform=$(_WixTargetPlatform)" />
-        <!-- Build the ANCM msis -->
-        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\ANCMIISExpressV2\AncmIISExpressV2.wixproj" AdditionalProperties="Platform=$(_WixTargetPlatform)" />
-        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\ANCMV2\ANCMV2.wixproj" AdditionalProperties="Platform=$(_WixTargetPlatform)" />
-        <!-- Build the targeting pack installers -->
-        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\TargetingPack\TargetingPack.wixproj" AdditionalProperties="Platform=$(_WixTargetPlatform)" />
-        <!-- Build the SharedFramework installers -->
-        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\SharedFrameworkBundle\SharedFrameworkBundle.wixproj" AdditionalProperties="Platform=$(_WixTargetPlatform)" />
-        <!-- Build the SharedFramework wixlib -->
-        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\SharedFrameworkLib\SharedFrameworkLib.wixproj" AdditionalProperties="Platform=$(_WixTargetPlatform)" />
-      </ItemGroup>
-
-      <ItemGroup Condition="'$(DotNetBuild)' == 'true' and ('$(DotNetBuildPass)' == '2') and '$(BuildInstallers)' == 'true' AND '$(TargetOsName)' == 'win' and '$(TargetArchitecture)' == 'x64'">
-        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\WindowsHostingBundle\WindowsHostingBundle.wixproj" AdditionalProperties="Platform=x86" />
-      </ItemGroup>
-
-      <ItemGroup Condition="'$(BuildInstallers)' == 'true' AND ('$(TargetRuntimeIdentifier)' == 'linux-x64' OR '$(TargetRuntimeIdentifier)' == 'linux-arm64')">
-        <ProjectToBuild Condition=" '$(LinuxInstallerType)' == 'deb' "
-                        Include="$(RepoRoot)src\Installers\Debian\**\*.*proj" />
-        <ProjectToBuild Condition=" '$(LinuxInstallerType)' == 'rpm' "
-                        Include="$(RepoRoot)src\Installers\Rpm\**\*.*proj" />
-      </ItemGroup>
-
+      <!-- BuildNative -->
       <ItemGroup Condition=" '$(TargetOsName)' == 'win' AND ('$(TargetArchitecture)' == 'x86' OR '$(TargetArchitecture)' == 'x64' OR '$(TargetArchitecture)' == 'arm64') ">
         <NativeProjects Include="$(RepoRoot)src\**\*.vcxproj" Exclude="@(ProjectToExclude)" AdditionalProperties="Platform=x64" />
         <NativeProjects Include="$(RepoRoot)src\**\*.vcxproj" Exclude="@(ProjectToExclude)" AdditionalProperties="Platform=Win32" />
@@ -146,9 +79,12 @@
       </ItemGroup>
 
       <ItemGroup>
-        <ProjectToBuild Condition=" $(BuildNative) " Include="@(NativeProjects)" Exclude="@(ProjectToExclude)" />
+        <ProjectToBuild Condition=" $(BuildNative) " Include="@(NativeProjects)" Exclude="@(ProjectToExclude)" BuildStep="1" />
         <ProjectToExclude Condition=" !$(BuildNative) " Include="@(NativeProjects)" />
+      </ItemGroup>
 
+      <!-- BuildNode -->
+      <ItemGroup>
         <NodeJsProjects
           Include="$(RepoRoot)eng\Npm.Workspace.nodeproj;
                    $(RepoRoot)eng\Npm.Workspace.FunctionalTests.nodeproj;"
@@ -159,15 +95,21 @@
 
         <ExplicitRequiresDelay Include="$(RepoRoot)eng\Npm.Workspace.FunctionalTests.nodeproj" />
 
-        <ProjectToBuild Condition=" '$(BuildNodeJS)' == 'true'" Include="@(NodeJsProjects)" Exclude="@(ProjectToExclude)" />
+        <ProjectToBuild Condition=" '$(BuildNodeJS)' == 'true'" Include="@(NodeJsProjects)" Exclude="@(ProjectToExclude)" BuildStep="2" />
         <ProjectToExclude Condition=" '$(BuildNodeJS)' != 'true'" Include="@(NodeJsProjects)" />
+      </ItemGroup>
 
+      <!-- BuildJava -->
+      <ItemGroup>
         <JavaProjects Include="$(RepoRoot)src\SignalR\**\*.javaproj"
                       Exclude="@(ProjectToExclude)" />
 
-        <ProjectToBuild Condition=" '$(BuildJava)' == 'true'" Include="@(JavaProjects)" Exclude="@(ProjectToExclude)" />
+        <ProjectToBuild Condition=" '$(BuildJava)' == 'true'" Include="@(JavaProjects)" Exclude="@(ProjectToExclude)" BuildStep="3" />
         <ProjectToExclude Condition=" '$(BuildJava)' != 'true'" Include="@(JavaProjects)" />
+      </ItemGroup>
 
+      <!-- BuildManaged (runs in parallel with BuildJava) -->
+      <ItemGroup>
         <!--
           Use caution to avoid deep recursion. If the globbing pattern picks up something which exceeds MAX_PATH,
           the entire pattern will silently fail to evaluate correctly.
@@ -269,8 +211,82 @@
                           $(RepoRoot)**\obj\**\*;"
                         Condition=" '$(BuildMainlyReferenceProviders)' == 'true' " />
 
-        <ProjectToBuild Condition=" '$(BuildManaged)' == 'true'" Include="@(DotNetProjects)" Exclude="@(ProjectToExclude)" />
+        <ProjectToBuild Condition=" '$(BuildManaged)' == 'true'" Include="@(DotNetProjects)" Exclude="@(ProjectToExclude)" BuildStep="3" />
         <ProjectToExclude Condition=" '$(BuildManaged)' != 'true'" Include="@(DotNetProjects)" />
+      </ItemGroup>
+
+      <!-- BuildInstallers -->
+      <PropertyGroup>
+        <_BuildWindowsInstallers Condition="'$(TargetOsName)' == 'win' AND ('$(TargetArchitecture)' == 'x86' OR '$(TargetArchitecture)' == 'x64' OR '$(TargetArchitecture)' == 'arm64') ">true</_BuildWindowsInstallers>
+        <_WixTargetPlatform Condition="'$(TargetArchitecture)' == 'x86' ">Win32</_WixTargetPlatform>
+        <_WixTargetPlatform Condition="'$(TargetArchitecture)' == 'x64' ">x64</_WixTargetPlatform>
+        <_WixTargetPlatform Condition="'$(TargetArchitecture)' == 'arm64' ">ARM64</_WixTargetPlatform>
+      </PropertyGroup>
+      <ItemGroup Condition="'$(DotNetBuild)' != 'true' and '$(_BuildWindowsInstallers)' == 'true' ">
+        <!-- Build the ANCM custom action -->
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\CustomAction\aspnetcoreCA.vcxproj" AdditionalProperties="Platform=x64" />
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\CustomAction\aspnetcoreCA.vcxproj" AdditionalProperties="Platform=Win32" />
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\CustomAction\aspnetcoreCA.vcxproj" AdditionalProperties="Platform=ARM64" />
+
+        <!-- Build the ANCM msis -->
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\ANCMIISExpressV2\AncmIISExpressV2.wixproj" AdditionalProperties="Platform=x64" />
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\ANCMIISExpressV2\AncmIISExpressV2.wixproj" AdditionalProperties="Platform=x86" />
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\ANCMIISExpressV2\AncmIISExpressV2.wixproj" AdditionalProperties="Platform=arm64" />
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\ANCMV2\ANCMV2.wixproj" AdditionalProperties="Platform=x64" />
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\ANCMV2\ANCMV2.wixproj" AdditionalProperties="Platform=x86" />
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\ANCMV2\ANCMV2.wixproj" AdditionalProperties="Platform=arm64" />
+
+        <!-- Build the targeting pack installers -->
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\TargetingPack\TargetingPack.wixproj" AdditionalProperties="Platform=x64" />
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\TargetingPack\TargetingPack.wixproj" AdditionalProperties="Platform=x86" />
+        <!-- This really shouldn't be here, but instead of harvesting from the intermediate/output directories, the targeting pack installer logic
+        harvests from a zip of the reference assemblies. Producing it in each leg ends up with multiple targeting packs
+        getting produced and the BAR will reject the build. Centralize building the targeting pack in the x86/x64 leg. -->
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\TargetingPack\TargetingPack.wixproj" AdditionalProperties="Platform=arm64" />
+
+        <!-- Build the SharedFramework installers -->
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\SharedFrameworkBundle\SharedFrameworkBundle.wixproj" AdditionalProperties="Platform=x64" />
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\SharedFrameworkBundle\SharedFrameworkBundle.wixproj" AdditionalProperties="Platform=x86" />
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\SharedFrameworkBundle\SharedFrameworkBundle.wixproj" AdditionalProperties="Platform=arm64" />
+
+        <!-- Build the SharedFramework wixlib -->
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\SharedFrameworkLib\SharedFrameworkLib.wixproj" AdditionalProperties="Platform=x64" />
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\SharedFrameworkLib\SharedFrameworkLib.wixproj" AdditionalProperties="Platform=x86" />
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\SharedFrameworkLib\SharedFrameworkLib.wixproj" AdditionalProperties="Platform=arm64" />
+
+        <!-- Windows hosting bundle -->
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\WindowsHostingBundle\WindowsHostingBundle.wixproj" AdditionalProperties="Platform=x86" />
+      </ItemGroup>
+
+      <!-- In a vertical build, only build the MSIs for the current vertical in the first pass and build the hosting bundle in the second pass -->
+      <ItemGroup Condition="'$(DotNetBuild)' == 'true' and ('$(DotNetBuildPass)' == '' or '$(DotNetBuildPass)' == '1') and '$(_BuildWindowsInstallers)' == 'true'">
+        <!-- Build the ANCM custom action -->
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\CustomAction\aspnetcoreCA.vcxproj" AdditionalProperties="Platform=$(_WixTargetPlatform)" />
+        <!-- Build the ANCM msis -->
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\ANCMIISExpressV2\AncmIISExpressV2.wixproj" AdditionalProperties="Platform=$(_WixTargetPlatform)" />
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\ANCMV2\ANCMV2.wixproj" AdditionalProperties="Platform=$(_WixTargetPlatform)" />
+        <!-- Build the targeting pack installers -->
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\TargetingPack\TargetingPack.wixproj" AdditionalProperties="Platform=$(_WixTargetPlatform)" />
+        <!-- Build the SharedFramework installers -->
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\SharedFrameworkBundle\SharedFrameworkBundle.wixproj" AdditionalProperties="Platform=$(_WixTargetPlatform)" />
+        <!-- Build the SharedFramework wixlib -->
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\SharedFrameworkLib\SharedFrameworkLib.wixproj" AdditionalProperties="Platform=$(_WixTargetPlatform)" />
+      </ItemGroup>
+
+      <ItemGroup Condition="'$(DotNetBuild)' == 'true' and ('$(DotNetBuildPass)' == '2') and and '$(TargetOsName)' == 'win' and '$(TargetArchitecture)' == 'x64'">
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\WindowsHostingBundle\WindowsHostingBundle.wixproj" AdditionalProperties="Platform=x86" />
+      </ItemGroup>
+
+      <ItemGroup Condition="'$(TargetRuntimeIdentifier)' == 'linux-x64' OR '$(TargetRuntimeIdentifier)' == 'linux-arm64'">
+        <InstallerProject Condition=" '$(LinuxInstallerType)' == 'deb' "
+                        Include="$(RepoRoot)src\Installers\Debian\**\*.*proj" />
+        <InstallerProject Condition=" '$(LinuxInstallerType)' == 'rpm' "
+                        Include="$(RepoRoot)src\Installers\Rpm\**\*.*proj" />
+      </ItemGroup>
+
+      <ItemGroup>
+        <ProjectToBuild Condition=" '$(BuildInstallers)' == 'true'" Include="@(InstallerProject)" Exclude="@(ProjectToExclude)" BuildStep="4" />
+        <ProjectToExclude Condition=" '$(BuildInstallers)' != 'true'" Include="@(InstallerProject)" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -286,7 +286,7 @@
       </ItemGroup>
 
       <ItemGroup>
-        <ProjectToBuild Condition=" '$(BuildInstallers)' == 'true'" Include="@(InstallerProject)" Exclude="@(ProjectToExclude)" BuildStep="installer" />
+        <ProjectToBuild Condition=" '$(BuildInstallers)' == 'true'" Include="@(InstallerProject)" BuildStep="installer" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/eng/Npm.Workspace.FunctionalTests.nodeproj
+++ b/eng/Npm.Workspace.FunctionalTests.nodeproj
@@ -1,4 +1,4 @@
-<Project>
+<Project DefaultTargets="Build">
 
   <!-- Import Directory.Build.Props -->
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props" />

--- a/eng/Npm.Workspace.nodeproj
+++ b/eng/Npm.Workspace.nodeproj
@@ -1,4 +1,4 @@
-<Project>
+<Project DefaultTargets="Build">
 
   <!-- Import Directory.Build.Props -->
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props" />

--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -1,8 +1,7 @@
 <Project>
-  <!-- Update the generated files when we restore projects. Skip in desktop msbuild due to VS 16.8 requirements. -->
+  <!-- Update the generated files when we restore projects. -->
   <Target Name="GenerateDirectoryBuildFiles"
-      AfterTargets="Restore"
-      Condition=" '$(MSBuildRuntimeType)' == 'core' ">
+      AfterTargets="Restore">
     <!-- Separate invocations and use different properties to ensure second can load the restored package info. -->
     <MSBuild Projects="$(RepoRoot)eng\tools\GenerateFiles\GenerateFiles.csproj"
         RemoveProperties="BaseIntermediateOutputPath"

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -184,6 +184,7 @@ param(
     [Alias('v')]
     [string]$Verbosity = 'minimal',
     [switch]$DumpProcesses, # Capture all running processes and dump them to a file.
+    [string]$msbuildEngine = 'dotnet',
 
     # Other lifecycle targets
     [switch]$Help, # Show help
@@ -288,24 +289,20 @@ if ($RuntimeSourceFeed -or $RuntimeSourceFeedKey) {
 }
 
 # Split build categories between dotnet msbuild and desktop msbuild. Use desktop msbuild as little as possible.
-[string[]]$dotnetBuildArguments = $MSBuildArguments
-if ($All) { $dotnetBuildArguments += '/p:BuildAllProjects=true' }
-if ($Projects) {
-    if ($BuildNative) {
-        $MSBuildArguments += "/p:ProjectToBuild=$Projects"
-    } else {
-        $dotnetBuildArguments += "/p:ProjectToBuild=$Projects"
-    }
-}
+[string[]]$dotnetBuildArguments = ''
+[string[]]$MSBuildOnlyArguments = ''
 
-if ($NoBuildInstallers) { $MSBuildArguments += "/p:BuildInstallers=false"; $BuildInstallers = $false }
-if ($BuildInstallers) { $MSBuildArguments += "/p:BuildInstallers=true" }
+if ($All) { $dotnetBuildArguments += '/p:BuildAllProjects=true' }
+if ($Projects) { $MSBuildArguments += "/p:ProjectToBuild=$Projects" }
+
+if ($NoBuildInstallers) { $MSBuildOnlyArguments += "/p:BuildInstallers=false"; $BuildInstallers = $false }
+if ($BuildInstallers) { $MSBuildOnlyArguments += "/p:BuildInstallers=true" }
 
 # Build native projects by default unless -NoBuildNative was specified.
 $specifiedBuildNative = $BuildNative
 $BuildNative = $true
-if ($NoBuildNative) { $MSBuildArguments += "/p:BuildNative=false"; $BuildNative = $false }
-if ($BuildNative) { $MSBuildArguments += "/p:BuildNative=true"}
+if ($NoBuildNative) { $MSBuildOnlyArguments += "/p:BuildNative=false"; $BuildNative = $false }
+if ($BuildNative) { $MSBuildOnlyArguments += "/p:BuildNative=true"}
 
 if ($NoBuildJava) { $dotnetBuildArguments += "/p:BuildJava=false"; $BuildJava = $false }
 if ($BuildJava) { $dotnetBuildArguments += "/p:BuildJava=true" }
@@ -317,22 +314,23 @@ if ($BuildNodeJS) { $dotnetBuildArguments += "/p:BuildNodeJSUnlessSourcebuild=tr
 # Don't bother with two builds if just one will build everything. Ignore super-weird cases like
 # "-Projects ... -NoBuildJava -NoBuildManaged -NoBuildNodeJS". An empty `./build.ps1` command will build both
 # managed and native projects.
-$performDesktopBuild = $BuildInstallers -or $BuildNative
-$performDotnetBuild = $BuildJava -or $BuildManaged -or $BuildNodeJS -or `
+
+# If -msbuildEngine vs is explicitly passed in, use desktop msbuild only.
+# This is necessary for one-shot builds like within the VMR.
+
+$performDesktopBuild = $BuildInstallers -or $BuildNative -or $msbuildEngine -eq 'vs'
+$performDotnetBuild = $msBuildEngine -ne 'vs' -and ($BuildJava -or $BuildManaged -or $BuildNodeJS -or `
     ($All -and -not ($NoBuildJava -and $NoBuildManaged -and $NoBuildNodeJS)) -or `
-    ($Projects -and -not ($BuildInstallers -or $specifiedBuildNative))
+    ($Projects -and -not ($BuildInstallers -or $specifiedBuildNative)))
 
 # Initialize global variables need to be set before the import of Arcade is imported
 $restore = $RunRestore
 
-# Though VS Code may indicate $nodeReuse and $msbuildEngine are unused, tools.ps1 uses them.
+# Though VS Code may indicate $nodeReuse is unused, tools.ps1 uses them.
 
 # Disable node reuse - Workaround perpetual issues in node reuse and custom task assemblies
 $nodeReuse = $false
 $env:MSBUILDDISABLENODEREUSE=1
-
-# Use `dotnet msbuild` by default
-$msbuildEngine = 'dotnet'
 
 # Ensure passing neither -bl nor -nobl on CI avoids errors in tools.ps1. This is needed because both parameters are
 # $false by default i.e. they always exist. (We currently avoid binary logs but that is made visible in the YAML.)
@@ -414,12 +412,17 @@ if ($BinaryLog) {
     $bl = GetMSBuildBinaryLogCommandLineArgument($MSBuildArguments)
     if (-not $bl) {
         $dotnetBuildArguments += "/bl:" + (Join-Path $LogDir "Build.binlog")
-        $MSBuildArguments += "/bl:" + (Join-Path $LogDir "Build.native.binlog")
+
+        # When running both builds, use a different binary log path for the desktop msbuild.
+        if ($performDesktopBuild -and $performDotnetBuild) {
+            $MSBuildOnlyArguments += "/bl:" + (Join-Path $LogDir "Build.native.binlog")
+        }
+
         $ToolsetBuildArguments += "/bl:" + (Join-Path $LogDir "Build.repotasks.binlog")
     } else {
         # Use a different binary log path when running desktop msbuild if doing both builds.
         if ($performDesktopBuild -and $performDotnetBuild) {
-            $MSBuildArguments += "/bl:" + [System.IO.Path]::ChangeExtension($bl, "native.binlog")
+            $MSBuildOnlyArguments += "/bl:" + [System.IO.Path]::ChangeExtension($bl, "native.binlog")
         }
 
         $ToolsetBuildArguments += "/bl:" + [System.IO.Path]::ChangeExtension($bl, "repotasks.binlog")
@@ -478,7 +481,12 @@ try {
             Remove-Item variable:global:_BuildTool -ErrorAction Ignore
             $msbuildEngine = 'vs'
 
-            MSBuild $toolsetBuildProj /p:RepoRoot=$RepoRoot @MSBuildArguments
+            # When running with desktop msbuild only, append the dotnet build specific arguments.
+            if (-not $performDotnetBuild) {
+                $MSBuildOnlyArguments += $dotnetBuildArguments
+            }
+
+            MSBuild $toolsetBuildProj /p:RepoRoot=$RepoRoot @MSBuildArguments @MSBuildOnlyArguments
         }
 
         if ($performDotnetBuild) {
@@ -486,7 +494,7 @@ try {
             Remove-Item variable:global:_BuildTool -ErrorAction Ignore
             $msbuildEngine = 'dotnet'
 
-            MSBuild $toolsetBuildProj /p:RepoRoot=$RepoRoot @dotnetBuildArguments
+            MSBuild $toolsetBuildProj /p:RepoRoot=$RepoRoot @MSBuildArguments @dotnetBuildArguments
         }
     }
 }

--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -228,10 +228,6 @@
       Code="BUILD004"
       Text="%25(Private) metadata should not be applied to the %(Identity) package reference. Did you mean %25(PrivateAssets)?" />
     <Warning
-      Condition=" '@(ProjectReference->HasMetadata('PrivateAssets')->Count())' != '0' "
-      Code="BUILD005"
-      Text="%25(PrivateAssets) metadata should not be applied to the %(Identity) project reference. Did you mean %25(Private)?" />
-    <Warning
       Condition=" '@(Reference->HasMetadata('PrivateAssets')->Count())' != '0' "
       Code="BUILD006"
       Text="%25(PrivateAssets) metadata should not be applied to the %(Identity) assembly reference. Did you mean %25(Private)?" />

--- a/eng/tools/GenerateFiles/GenerateFiles.csproj
+++ b/eng/tools/GenerateFiles/GenerateFiles.csproj
@@ -12,7 +12,12 @@
   </ItemGroup>
 
   <!-- Update artifacts/bin/GenerateFiles/Directory.Build.* files. -->
-  <Target Name="GenerateDirectoryBuildFiles">
+  <Target Name="GenerateDirectoryBuildFiles"
+          Inputs="$(MSBuildThisFileDirectory)Directory.Build.props.in;
+                  $(MSBuildThisFileDirectory)Directory.Build.targets.in"
+          Outputs="$(BaseOutputPath)Directory.Build.props;
+                   $(BaseOutputPath)Directory.Build.targets;
+                   $(ConfigDirectory)dotnet-tools.json">
     <PropertyGroup>
       <_TemplateProperties>
         AspNetCorePatchVersion=$(AspNetCorePatchVersion);

--- a/src/Installers/Windows/SharedFrameworkBundle/SharedFrameworkBundle.wixproj
+++ b/src/Installers/Windows/SharedFrameworkBundle/SharedFrameworkBundle.wixproj
@@ -46,13 +46,17 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <ProjectReference Include="..\SharedFrameworkLib\SharedFrameworkLib.wixproj" SetPlatform="Platform=x86">
+        <ProjectReference Include="..\SharedFrameworkLib\SharedFrameworkLib.wixproj"
+                          SetPlatform="Platform=x86"
+                          Condition="'$(DotNetBuild)' != 'true' or '$(Platform)' == 'Win32'">
           <Name>SharedFrameworkLib</Name>
           <Project>{5244BC49-2568-4701-80A6-EAB8950AB5FA}</Project>
           <Private>True</Private>
           <DoNotHarvest>True</DoNotHarvest>
         </ProjectReference>
-        <ProjectReference Include="..\SharedFrameworkLib\SharedFrameworkLib.wixproj" SetPlatform="Platform=x64">
+        <ProjectReference Include="..\SharedFrameworkLib\SharedFrameworkLib.wixproj"
+                          SetPlatform="Platform=x64"
+                          Condition="'$(DotNetBuild)' != 'true' or '$(Platform)' == 'x64'">
           <Name>SharedFrameworkLib</Name>
           <Project>{5244BC49-2568-4701-80A6-EAB8950AB5FA}</Project>
           <Private>True</Private>


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/58984
Unblocks https://github.com/dotnet/sdk/pull/44828 (removes the patch)
Depends on https://github.com/dotnet/aspnetcore/pull/59150

- Build the Installer projects after everything else got built by using Arcade's new `BuildStep` metadata.
- Allow building the entire repository from a single build invocation.
- When using desktop msbuild, build the entire repository from a single build invocation.
- Condition SharedFrameworkBundle.wixproj correctly when building inside the VMR.

# {PR title}

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

{Detail}

Fixes #{bug number} (in this specific format)
