### PR TITLE
Don't throw exception for parameters with custom binding source

### DIFF
--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -410,7 +410,7 @@ internal sealed class OpenApiDocumentService(
                     "Query" => ParameterLocation.Query,
                     "Header" => ParameterLocation.Header,
                     "Path" => ParameterLocation.Path,
-                    _ => throw new InvalidOperationException($"Unsupported parameter source: {parameter.Source.Id}")
+                    _ => null
                 },
                 Required = IsRequired(parameter),
                 Schema = await _componentService.GetOrCreateSchemaAsync(GetTargetType(description, parameter), scopedServiceProvider, schemaTransformers, parameter, cancellationToken: cancellationToken),

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -410,7 +410,7 @@ internal sealed class OpenApiDocumentService(
                     "Query" => ParameterLocation.Query,
                     "Header" => ParameterLocation.Header,
                     "Path" => ParameterLocation.Path,
-                    _ => null
+                    _ => ParameterLocation.Query
                 },
                 Required = IsRequired(parameter),
                 Schema = await _componentService.GetOrCreateSchemaAsync(GetTargetType(description, parameter), scopedServiceProvider, schemaTransformers, parameter, cancellationToken: cancellationToken),

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Parameters.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Parameters.cs
@@ -202,7 +202,7 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
             var operation = document.Paths["/custom-binding"].Operations[OperationType.Get];
             var parameter = Assert.Single(operation.Parameters);
             Assert.Equal("model", parameter.Name);
-            Assert.Null(parameter.In);
+            Assert.Equal(ParameterLocation.Query, parameter.In);
         });
     }
 

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Parameters.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Parameters.cs
@@ -4,6 +4,7 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.OpenApi.Models;
 
 public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBase
@@ -189,5 +190,30 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
             Assert.Null(document.Paths["/api/content-type"].Operations[OperationType.Get].Parameters);
             Assert.Null(document.Paths["/api/content-type-lower"].Operations[OperationType.Get].Parameters);
         });
+    }
+
+    [Fact]
+    public async Task GetOpenApiParameters_ToleratesCustomBindingSource()
+    {
+        var action = CreateActionDescriptor(nameof(ActionWithCustomBinder));
+
+        await VerifyOpenApiDocument(action, document =>
+        {
+            var operation = document.Paths["/custom-binding"].Operations[OperationType.Get];
+            var parameter = Assert.Single(operation.Parameters);
+            Assert.Equal("model", parameter.Name);
+            Assert.Null(parameter.In);
+        });
+    }
+
+    [Route("/custom-binding")]
+    private void ActionWithCustomBinder([ModelBinder(BinderType = typeof(CustomBinder))] Todo model) { }
+
+    public class CustomBinder : IModelBinder
+    {
+        public Task BindModelAsync(ModelBindingContext bindingContext)
+        {
+            return Task.CompletedTask;
+        }
     }
 }


### PR DESCRIPTION
Closes https://github.com/dotnet/aspnetcore/issues/59013.

We can probably afford to be more lax here. One thing to note is that this means that users will have to do the due diligence to set the parameter location themselves via transformers since we can't figure out this information implicitly.

Also, if users want to specify custom binder for a parameter that is actually from the body, they will need to define the binding source correctly on the model binder so that the argument appears under the `requestBody` field of the operation instead of the `parameters` field.