### PR TITLE
Don't run IIS websocket tests on unsupported queue

### DIFF
--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Infrastructure/IISTestSiteFixture.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Infrastructure/IISTestSiteFixture.cs
@@ -51,7 +51,7 @@ public class IISTestSiteFixture : IDisposable
         //DeploymentParameters.EnvironmentVariables.Add("ASPNETCORE_MODULE_DEBUG", "console");
 
         // This queue does not have websockets enabled currently, adding the module will break all tests using this fixture.
-        if (HelixHelper.GetTargetHelixQueue().ToLowerInvariant().Contains("windows.amd64.server2022"))
+        if (!HelixHelper.GetTargetHelixQueue().ToLowerInvariant().Contains("windows.amd64.server2022"))
         {
             DeploymentParameters.EnableModule("WebSocketModule", "%IIS_BIN%/iiswsock.dll");
         }

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Infrastructure/IISTestSiteFixture.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Infrastructure/IISTestSiteFixture.cs
@@ -50,7 +50,11 @@ public class IISTestSiteFixture : IDisposable
         // Uncomment to add IIS debug logs to test output.
         //DeploymentParameters.EnvironmentVariables.Add("ASPNETCORE_MODULE_DEBUG", "console");
 
-        DeploymentParameters.EnableModule("WebSocketModule", "%IIS_BIN%/iiswsock.dll");
+        // This queue does not have websockets enabled currently, adding the module will break all tests using this fixture.
+        if (HelixHelper.GetTargetHelixQueue().ToLowerInvariant().Contains("windows.amd64.server2022"))
+        {
+            DeploymentParameters.EnableModule("WebSocketModule", "%IIS_BIN%/iiswsock.dll");
+        }
     }
 
     public HttpClient Client => DeploymentResult.HttpClient;

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/WebSocketTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/WebSocketTests.cs
@@ -32,6 +32,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 #if IISEXPRESS_FUNCTIONALS
 [SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open")]
 #else
+// These queues do not have websockets enabled currently for full IIS
 [SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;Windows.Amd64.Server2022.Open")]
 #endif
 public abstract class WebSocketsTests : FunctionalTestsBase

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/WebSocketTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/WebSocketTests.cs
@@ -29,7 +29,11 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 #endif
 
 [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win8, SkipReason = "No WebSocket supported on Win7")]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
+#if IISEXPRESS_FUNCTIONALS
+[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open")]
+#else
+[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;Windows.Amd64.Server2022.Open")]
+#endif
 public abstract class WebSocketsTests : FunctionalTestsBase
 {
     public IISTestSiteFixture Fixture { get; }
@@ -37,7 +41,6 @@ public abstract class WebSocketsTests : FunctionalTestsBase
     public WebSocketsTests(IISTestSiteFixture fixture, ITestOutputHelper testOutput) : base(testOutput)
     {
         Fixture = fixture;
-        Fixture.DeploymentParameters.EnableLogging("C:/github/aspnetcore/artifacts/log");
     }
 
     [ConditionalFact]


### PR DESCRIPTION
Shortly after pushing https://github.com/dotnet/aspnetcore/pull/58846 the daily Helix runs started consistently failing on IIS.FunctionalTests. It looks like it fails the tests that are using IISTestSiteFixture, and the only modification to that file was adding the websocket module. Looking at the failing helix queue, IIS websockets doesn't look like it's enabled so it's probably failing to start the server application due to use arbitrarily adding the module.

I've asked if we can enable websockets on the helix queue, but in the meantime we can try avoiding this problem when running on that queue.