### PR TITLE
ContinueOnError in windows local development job

### DIFF
--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -666,6 +666,8 @@ stages:
                   -NoBuildDeps
                   -configuration Release
           displayName: Run project template tests
+          # Continue on error until https://github.com/dotnet/aspnetcore/issues/58957 is resolved
+          continueOnError: true
 
         artifacts:
         - name: Local_Windows_x64_Logs_Attempt_$(System.JobAttempt)


### PR DESCRIPTION
The windows local development job is extremely flaky right now due to https://github.com/dotnet/aspnetcore/issues/58957. Continue the job on error until that issue is resolved