### PR TITLE
Add `-sign` to build.sh

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -20,6 +20,7 @@ run_build=true
 run_pack=false
 run_publish=false
 run_tests=false
+run_sign=false
 build_all=false
 build_deps=true
 only_build_repo_tasks=false
@@ -64,6 +65,7 @@ Options:
     --[no-]pack                       Produce packages.
     --[no-]test                       Run tests.
     --[no-]publish                    Run publish.
+    --[no-]sign                       Run code signing.
 
     --projects                        A list of projects to build. (Must be an absolute path.)
                                       Globbing patterns are supported, such as \"$(pwd)/**/*.csproj\".
@@ -165,6 +167,12 @@ while [[ $# -gt 0 ]]; do
             ;;
         -no-test|-notest)
             run_tests=false
+            ;;
+        -sign)
+            run_sign=true
+            ;;
+        -no-sign|-nosign)
+            run_sign=false
             ;;
         -projects)
             shift
@@ -297,6 +305,7 @@ fi
 msbuild_args[${#msbuild_args[*]}]="-p:Pack=$run_pack"
 msbuild_args[${#msbuild_args[*]}]="-p:Publish=$run_publish"
 msbuild_args[${#msbuild_args[*]}]="-p:Test=$run_tests"
+msbuild_args[${#msbuild_args[*]}]="-p:Sign=$run_sign"
 
 msbuild_args[${#msbuild_args[*]}]="-p:TargetArchitecture=$target_arch"
 msbuild_args[${#msbuild_args[*]}]="-p:TargetOsName=$target_os_name"


### PR DESCRIPTION
Needed for https://github.com/dotnet/aspnetcore/issues/58445

Allows `-sign` to be passed to build.sh.