### PR TITLE
Harden parsing of [Range] attribute values

### DIFF
--- a/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
@@ -91,8 +91,23 @@ internal static class JsonNodeSchemaExtensions
             }
             else if (attribute is RangeAttribute rangeAttribute)
             {
-                schema[OpenApiSchemaKeywords.MinimumKeyword] = decimal.Parse(rangeAttribute.Minimum.ToString()!, CultureInfo.InvariantCulture);
-                schema[OpenApiSchemaKeywords.MaximumKeyword] = decimal.Parse(rangeAttribute.Maximum.ToString()!, CultureInfo.InvariantCulture);
+                // Use InvariantCulture if explicitly requested or if the range has been set via the
+                // RangeAttribute(double, double) or RangeAttribute(int, int) constructors.
+                var targetCulture = rangeAttribute.ParseLimitsInInvariantCulture || rangeAttribute.Minimum is double || rangeAttribute.Maximum is int
+                    ? CultureInfo.InvariantCulture
+                    : CultureInfo.CurrentCulture;
+
+                var minString = rangeAttribute.Minimum.ToString();
+                var maxString = rangeAttribute.Maximum.ToString();
+
+                if (decimal.TryParse(minString, NumberStyles.Any, targetCulture, out var minDecimal))
+                {
+                    schema[OpenApiSchemaKeywords.MinimumKeyword] = minDecimal;
+                }
+                if (decimal.TryParse(maxString, NumberStyles.Any, targetCulture, out var maxDecimal))
+                {
+                    schema[OpenApiSchemaKeywords.MaximumKeyword] = maxDecimal;
+                }
             }
             else if (attribute is RegularExpressionAttribute regularExpressionAttribute)
             {


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/57390.

This change hardens the parsing logic for `[Range]` attributes to handle:

- Values that cannot be mapped to a decimal as is required by the `minimum` and `maximum` keywords in the OpenAPI schema, like `DateTime`.
- Handling for InvariantCulture as is set in `RangeAttribute.ParseLimitsInInvariantCulture`.

For scenarios where the range value is too large to be represented as a decimal, this implementation will no-op and not set the corresponding minimum or maximum in the OpenAPI document.