### PR TITLE
Unquarantine ServerShutsDownGracefullyWhenMaxRequestBufferSizeExceeded

### DIFF
--- a/src/Servers/Kestrel/test/FunctionalTests/MaxRequestBufferSizeTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/MaxRequestBufferSizeTests.cs
@@ -211,7 +211,6 @@ public class MaxRequestBufferSizeTests : LoggedTest
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/24557")]
     public async Task ServerShutsDownGracefullyWhenMaxRequestBufferSizeExceeded()
     {
         // Parameters


### PR DESCRIPTION
Reenabling a quarantined test.

Closes #24557
