### PR TITLE
Pass -sign and -publish switch to dotnet build only

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -266,8 +266,6 @@ $MSBuildArguments += "/p:Build=$RunBuild"
 if (-not $RunBuild) { $MSBuildArguments += "/p:NoBuild=true" }
 $MSBuildArguments += "/p:Pack=$Pack"
 $MSBuildArguments += "/p:Test=$Test"
-$MSBuildArguments += "/p:Sign=$Sign"
-$MSBuildArguments += "/p:Publish=$Publish"
 
 $MSBuildArguments += "/p:TargetArchitecture=$Architecture"
 $MSBuildArguments += "/p:TargetOsName=win"
@@ -289,6 +287,11 @@ if ($RuntimeSourceFeed -or $RuntimeSourceFeedKey) {
 
 # Split build categories between dotnet msbuild and desktop msbuild. Use desktop msbuild as little as possible.
 [string[]]$dotnetBuildArguments = $MSBuildArguments
+
+# Don't pass Sign and Publish to desktop msbuild as that would result in double signing and publishing
+$dotnetBuildArguments += "/p:Sign=$Sign"
+$dotnetBuildArguments += "/p:Publish=$Publish"
+
 if ($All) { $dotnetBuildArguments += '/p:BuildAllProjects=true' }
 if ($Projects) {
     if ($BuildNative) {


### PR DESCRIPTION
Contributes to https://github.com/dotnet/sdk/pull/44855

As discussed offline with @wtgodbe, we need to be able to build the entire repository with a single invocation of eng/build.cmd. The problem is that with aspnetcore invoking the build twice in eng/build.ps1 the `-sign` and `-publish` flags get passed into both invocations and Arcade then fails to sign and publish the artifacts from the native build step.

Instead only ever pass those flags to the dotnet build.