### PR TITLE
Add WebAssemblyHotReloadCapabilities msbuild property

### DIFF
--- a/src/Components/WebAssembly/WebAssembly/src/targets/Microsoft.AspNetCore.Components.WebAssembly.props
+++ b/src/Components/WebAssembly/WebAssembly/src/targets/Microsoft.AspNetCore.Components.WebAssembly.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <BlazorWebAssemblyJSPath>$(MSBuildThisFileDirectory)blazor.webassembly.js</BlazorWebAssemblyJSPath>
     <BlazorRoutingEnableRegexConstraint Condition="'$(BlazorRoutingEnableRegexConstraint)' == ''">false</BlazorRoutingEnableRegexConstraint>
+    <WebAssemblyHotReloadCapabilities>Baseline;AddMethodToExistingType;AddStaticFieldToExistingType;NewTypeDefinition;ChangeCustomAttributes;AddInstanceFieldToExistingType;GenericAddMethodToExistingType;GenericUpdateMethod;UpdateParameters;GenericAddFieldToExistingType</WebAssemblyHotReloadCapabilities>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Enables Hot Reload to detect capabilities before WASM runtime is loaded into the browser.

Contributes to a fix of https://github.com/dotnet/aspnetcore/issues/59027