### PR TITLE
[Identity] Fix Identity UI asset definitions

### DIFF
--- a/src/Identity/UI/src/Microsoft.AspNetCore.Identity.UI.csproj
+++ b/src/Identity/UI/src/Microsoft.AspNetCore.Identity.UI.csproj
@@ -90,11 +90,27 @@
         <RelativePath>%(RecursiveDir)%(FileName)%(Extension)</RelativePath>
       </V5AssetsCandidates>
     </ItemGroup>
-    
-    <DefineStaticWebAssets Condition="'@(V4AssetsCandidates->Count())' != '0'" CandidateAssets="@(V4AssetsCandidates)" SourceId="$(PackageId)" SourceType="Discovered" AssetKind="All" ContentRoot="assets/V4" BasePath="$(StaticWebAssetBasePath)">
+
+    <DefineStaticWebAssets
+      Condition="'@(V4AssetsCandidates->Count())' != '0'"
+      CandidateAssets="@(V4AssetsCandidates)" SourceId="$(PackageId)"
+      SourceType="Package"
+      AssetKind="All"
+      ContentRoot="assets/V4"
+      BasePath="$(StaticWebAssetBasePath)"
+    >
       <Output TaskParameter="Assets" ItemName="V4Assets" />
     </DefineStaticWebAssets>
-    <DefineStaticWebAssets Condition="'@(V5AssetsCandidates->Count())' != '0'" CandidateAssets="@(V5AssetsCandidates)" SourceId="$(PackageId)" SourceType="Discovered" AssetKind="All" ContentRoot="assets/V5" BasePath="$(StaticWebAssetBasePath)">
+
+    <DefineStaticWebAssets
+      Condition="'@(V5AssetsCandidates->Count())' != '0'"
+      CandidateAssets="@(V5AssetsCandidates)"
+      SourceId="$(PackageId)"
+      SourceType="Package"
+      AssetKind="All"
+      ContentRoot="assets/V5"
+      BasePath="$(StaticWebAssetBasePath)"
+    >
       <Output TaskParameter="Assets" ItemName="V5Assets" />
     </DefineStaticWebAssets>
 
@@ -106,7 +122,7 @@
     >
       <Output TaskParameter="Endpoints" ItemName="V4AssetEndpoints" />
     </DefineStaticWebAssetEndpoints>
-    
+
     <DefineStaticWebAssetEndpoints
       Condition="'@(V5Assets)' != ''"
       CandidateAssets="@(V5Assets)"
@@ -116,23 +132,34 @@
       <Output TaskParameter="Endpoints" ItemName="V5AssetEndpoints" />
     </DefineStaticWebAssetEndpoints>
 
-    <GenerateStaticWebAssetsPropsFile StaticWebAssets="@(V4Assets)" PackagePathPrefix="staticwebassets/V4" TargetPropsFilePath="$(IntermediateOutputPath)IdentityUI.V4.targets" />
-    <GenerateStaticWebAssetsPropsFile StaticWebAssets="@(V5Assets)" PackagePathPrefix="staticwebassets/V5" TargetPropsFilePath="$(IntermediateOutputPath)IdentityUI.V5.targets" />
+    <ItemGroup>
+      <FinalV4Assets Include="@(V4Assets)">
+        <SourceType>Discovered</SourceType>
+      </FinalV4Assets>
+      <FinalV5Assets Include="@(V5Assets)">
+        <SourceType>Discovered</SourceType>
+      </FinalV5Assets>
+    </ItemGroup>
+
+    <GenerateStaticWebAssetsPropsFile StaticWebAssets="@(FinalV4Assets)" PackagePathPrefix="staticwebassets/V4" TargetPropsFilePath="$(IntermediateOutputPath)IdentityUI.V4.targets" />
+    <GenerateStaticWebAssetsPropsFile StaticWebAssets="@(FinalV5Assets)" PackagePathPrefix="staticwebassets/V5" TargetPropsFilePath="$(IntermediateOutputPath)IdentityUI.V5.targets" />
 
     <GenerateStaticWebAssetEndpointsPropsFile
       StaticWebAssets="@(V4Assets)"
+      PackagePathPrefix="staticwebassets/V4"
       StaticWebAssetEndpoints="@(V4AssetEndpoints)"
       TargetPropsFilePath="$(IntermediateOutputPath)IdentityUI.V4.endpoints.targets" />
 
     <GenerateStaticWebAssetEndpointsPropsFile
       StaticWebAssets="@(V5Assets)"
+      PackagePathPrefix="staticwebassets/V5"
       StaticWebAssetEndpoints="@(V5AssetEndpoints)"
       TargetPropsFilePath="$(IntermediateOutputPath)IdentityUI.V5.endpoints.targets" />
 
-    <ComputeStaticWebAssetsTargetPaths Assets="@(V4Assets)" PathPrefix="staticwebassets/V4" AdjustPathsForPack="true">
+    <ComputeStaticWebAssetsTargetPaths Assets="@(FinalV4Assets)" PathPrefix="staticwebassets/V4" AdjustPathsForPack="true">
       <Output TaskParameter="AssetsWithTargetPath" ItemName="_PackStaticWebAssetWithTargetPath" />
     </ComputeStaticWebAssetsTargetPaths>
-    <ComputeStaticWebAssetsTargetPaths Assets="@(V5Assets)" PathPrefix="staticwebassets/V5" AdjustPathsForPack="true">
+    <ComputeStaticWebAssetsTargetPaths Assets="@(FinalV5Assets)" PathPrefix="staticwebassets/V5" AdjustPathsForPack="true">
       <Output TaskParameter="AssetsWithTargetPath" ItemName="_PackStaticWebAssetWithTargetPath" />
     </ComputeStaticWebAssetsTargetPaths>
 


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspnetcore/pull/55218

* Fix the package definitions for Identity UI as they were wrong and break when compiled against a newer (10.0) SDK.
* Previously, if we didn't find the endpoints for the assets, they would get re-generated on the fly.
* As part of optimizing our build performance we reduce the cases in which that happened.
* As a result, the identity UI endpoints (which were incorrectly defined) no longer are defined on the flight and break.
* This fix corrects the endpoints that are embedded into the package and avoids the need to re-generate them.