### PR TITLE
Remove Inputs&Outputs from GenerateDirectoryBuildFiles

### DIFF
--- a/eng/tools/GenerateFiles/GenerateFiles.csproj
+++ b/eng/tools/GenerateFiles/GenerateFiles.csproj
@@ -12,12 +12,7 @@
   </ItemGroup>
 
   <!-- Update artifacts/bin/GenerateFiles/Directory.Build.* files. -->
-  <Target Name="GenerateDirectoryBuildFiles"
-          Inputs="$(MSBuildThisFileDirectory)Directory.Build.props.in;
-                  $(MSBuildThisFileDirectory)Directory.Build.targets.in"
-          Outputs="$(BaseOutputPath)Directory.Build.props;
-                   $(BaseOutputPath)Directory.Build.targets;
-                   $(ConfigDirectory)dotnet-tools.json">
+  <Target Name="GenerateDirectoryBuildFiles">
     <PropertyGroup>
       <_TemplateProperties>
         AspNetCorePatchVersion=$(AspNetCorePatchVersion);


### PR DESCRIPTION
Fixes the broken official builds. Regressed with https://github.com/dotnet/aspnetcore/pull/58987

My assumption is that the targets is invoked again in a later stage and the inputs & outputs hinder it from re-generating the file.

# {PR title}

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

{Detail}

Fixes #{bug number} (in this specific format)
