### PR TITLE
FixHelixTestSubmission

### DIFF
--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -165,8 +165,12 @@
 
   <!-- In inner (per-queue) builds, Publish the test projects and create work items. -->
   <Target Name="Gather" BeforeTargets="BeforeTest" Condition=" '$(HelixTargetQueue)' != '' ">
-    <MSBuild Projects="@(ProjectToBuild)"
-        BuildInParallel="%(ProjectToBuild.BuildInParallel)"
+    <ItemGroup>
+      <ProjectToBuildDistinct Include="@(ProjectToBuild->Distinct())" />
+    </ItemGroup>
+
+    <MSBuild Projects="@(ProjectToBuildDistinct)"
+        BuildInParallel="%(ProjectToBuildDistinct.BuildInParallel)"
         Targets="CreateHelixPayload"
         SkipNonexistentTargets="true">
       <Output TaskParameter="TargetOutputs" ItemName="HelixWorkItem" />


### PR DESCRIPTION
I noticed that tests in at least the local dev workflow leg run twice since https://github.com/dotnet/aspnetcore/commit/e778af94c3cf701954f599177a9492263963c087

A new metadata got added to the ProjectToBuild items. Ignore that by using the Distinct msbuild item function to avoid submitting duplicate tests.



# {PR title}

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

{Detail}

Fixes #{bug number} (in this specific format)
