### PR TITLE
Add empty Pack target to .wixproj

### DIFF
--- a/src/Installers/Windows/Wix.targets
+++ b/src/Installers/Windows/Wix.targets
@@ -121,4 +121,7 @@
     </CreateLightCommandPackageDrop>
   </Target>
 
+  <!-- wixprojs don't do any packaging but the target is called from Arcade's Build.proj. -->
+  <Target Name="Pack" />
+
 </Project>


### PR DESCRIPTION
Fixes issues in https://github.com/dotnet/sdk/pull/45109:

> D:\a\_work\1\vmr\src\aspnetcore\src\Installers\Windows\AspNetCoreModule-Setup\ANCMIISExpressV2\AncmIISExpressV2.wixproj : error MSB4057: The target "Pack" does not exist in the project.