### PR TITLE
Set target platform for wixproj and vcxproj correctly

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -218,9 +218,10 @@
       <!-- BuildInstallers -->
       <PropertyGroup>
         <_BuildWindowsInstallers Condition="'$(TargetOsName)' == 'win' AND ('$(TargetArchitecture)' == 'x86' OR '$(TargetArchitecture)' == 'x64' OR '$(TargetArchitecture)' == 'arm64') ">true</_BuildWindowsInstallers>
-        <_WixTargetPlatform Condition="'$(TargetArchitecture)' == 'x86' ">Win32</_WixTargetPlatform>
-        <_WixTargetPlatform Condition="'$(TargetArchitecture)' == 'x64' ">x64</_WixTargetPlatform>
-        <_WixTargetPlatform Condition="'$(TargetArchitecture)' == 'arm64' ">ARM64</_WixTargetPlatform>
+
+        <_VcxTargetPlatform Condition="'$(TargetArchitecture)' == 'x86'">Win32</_VcxTargetPlatform>
+        <_VcxTargetPlatform Condition="'$(TargetArchitecture)' == 'x64'">x64</_VcxTargetPlatform>
+        <_VcxTargetPlatform Condition="'$(TargetArchitecture)' == 'arm64'">ARM64</_VcxTargetPlatform>
       </PropertyGroup>
 
       <ItemGroup Condition="'$(DotNetBuild)' != 'true' and '$(_BuildWindowsInstallers)' == 'true' ">
@@ -262,16 +263,16 @@
       <!-- In a vertical build, only build the MSIs for the current vertical in the first pass and build the hosting bundle in the second pass -->
       <ItemGroup Condition="'$(DotNetBuild)' == 'true' and ('$(DotNetBuildPass)' == '' or '$(DotNetBuildPass)' == '1') and '$(_BuildWindowsInstallers)' == 'true'">
         <!-- Build the ANCM custom action -->
-        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\CustomAction\aspnetcoreCA.vcxproj" AdditionalProperties="Platform=$(_WixTargetPlatform)" />
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\CustomAction\aspnetcoreCA.vcxproj" AdditionalProperties="Platform=$(_VcxTargetPlatform)" />
         <!-- Build the ANCM msis -->
-        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\ANCMIISExpressV2\AncmIISExpressV2.wixproj" AdditionalProperties="Platform=$(_WixTargetPlatform)" />
-        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\ANCMV2\ANCMV2.wixproj" AdditionalProperties="Platform=$(_WixTargetPlatform)" />
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\ANCMIISExpressV2\AncmIISExpressV2.wixproj" AdditionalProperties="Platform=$(TargetArchitecture)" />
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\ANCMV2\ANCMV2.wixproj" AdditionalProperties="Platform=$(TargetArchitecture)" />
         <!-- Build the targeting pack installers -->
-        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\TargetingPack\TargetingPack.wixproj" AdditionalProperties="Platform=$(_WixTargetPlatform)" />
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\TargetingPack\TargetingPack.wixproj" AdditionalProperties="Platform=$(TargetArchitecture)" />
         <!-- Build the SharedFramework installers -->
-        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\SharedFrameworkBundle\SharedFrameworkBundle.wixproj" AdditionalProperties="Platform=$(_WixTargetPlatform)" />
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\SharedFrameworkBundle\SharedFrameworkBundle.wixproj" AdditionalProperties="Platform=$(TargetArchitecture)" />
         <!-- Build the SharedFramework wixlib -->
-        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\SharedFrameworkLib\SharedFrameworkLib.wixproj" AdditionalProperties="Platform=$(_WixTargetPlatform)" />
+        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\SharedFrameworkLib\SharedFrameworkLib.wixproj" AdditionalProperties="Platform=$(TargetArchitecture)" />
       </ItemGroup>
 
       <ItemGroup Condition="'$(DotNetBuild)' == 'true' and ('$(DotNetBuildPass)' == '2') and '$(TargetOsName)' == 'win' and '$(TargetArchitecture)' == 'x64'">

--- a/src/Installers/Windows/SharedFrameworkBundle/SharedFrameworkBundle.wixproj
+++ b/src/Installers/Windows/SharedFrameworkBundle/SharedFrameworkBundle.wixproj
@@ -48,7 +48,7 @@
       <ItemGroup>
         <ProjectReference Include="..\SharedFrameworkLib\SharedFrameworkLib.wixproj"
                           SetPlatform="Platform=x86"
-                          Condition="'$(DotNetBuild)' != 'true' or '$(Platform)' == 'Win32'">
+                          Condition="'$(DotNetBuild)' != 'true' or '$(Platform)' == 'x86'">
           <Name>SharedFrameworkLib</Name>
           <Project>{5244BC49-2568-4701-80A6-EAB8950AB5FA}</Project>
           <Private>True</Private>


### PR DESCRIPTION
wixprojs allow x86, x64 and arm64 (idetical to the TargetArchitecture platform) vcxprojs allow Win32, x64 and ARM64

Identified in https://github.com/dotnet/sdk/pull/45162
Fixes https://github.com/dotnet/source-build/issues/4767