### PR TITLE
Avoid flakiness in template tests around URL validity checking

### DIFF
--- a/src/ProjectTemplates/Shared/AspNetProcess.cs
+++ b/src/ProjectTemplates/Shared/AspNetProcess.cs
@@ -172,11 +172,11 @@ public class AspNetProcess : IDisposable
             {
                 Assert.True(string.Equals(anchor.Href, expectedLink), $"Expected next link to be {expectedLink} but it was {anchor.Href}.");
 
-                if (!string.Equals(anchor.Protocol, "https:"))
+                if (!string.Equals(anchor.Protocol, "https:") || string.Equals(anchor.HostName, "localhost", StringComparison.OrdinalIgnoreCase))
                 {
-                    // This is a relative URI, so verify it goes to a real destination within the app.
-                    // We don't do this for external (absolute) URIs as it would introduce flakiness,
-                    // and the code above already checks that the URI is what we expect.
+                    // This is a relative or same-site URI, so verify it goes to a real destination within the app.
+                    // We don't do this for external (absolute) URIs as it would introduce flakiness, and the code
+                    // above already checks that the URI is what we expect.
                     var result = await RetryHelper.RetryRequest(async () =>
                     {
                         return await _httpClient.GetAsync(anchor.Href);

--- a/src/ProjectTemplates/Shared/AspNetProcess.cs
+++ b/src/ProjectTemplates/Shared/AspNetProcess.cs
@@ -171,6 +171,12 @@ public class AspNetProcess : IDisposable
             else
             {
                 Assert.True(string.Equals(anchor.Href, expectedLink), $"Expected next link to be {expectedLink} but it was {anchor.Href}.");
+
+                if (string.Equals(anchor.Protocol, "https:"))
+                {
+                    Assert.Fail("Found an absolute URL in the page. TODO: accept these and skip over the HttpClient call.");
+                }
+
                 var result = await RetryHelper.RetryRequest(async () =>
                 {
                     return await _httpClient.GetAsync(anchor.Href);

--- a/src/ProjectTemplates/Shared/AspNetProcess.cs
+++ b/src/ProjectTemplates/Shared/AspNetProcess.cs
@@ -174,7 +174,7 @@ public class AspNetProcess : IDisposable
 
                 if (string.Equals(anchor.Protocol, "https:"))
                 {
-                    Assert.Fail("Found an absolute URL in the page. TODO: accept these and skip over the HttpClient call.");
+                    Assert.Fail($"Found an absolute URL in the page: (actual:{anchor.Href}; expected:{expectedLink}). TODO: accept these and skip over the HttpClient call.");
                 }
 
                 var result = await RetryHelper.RetryRequest(async () =>


### PR DESCRIPTION
We've had several failures in `Templates.Mvc.Test.MvcTemplateTest.MvcTemplate_IndividualAuth` recently with the error:

```
https://learn.microsoft.com/aspnet/core is a broken link!
```

Example build: https://dev.azure.com/dnceng-public/public/_build/results?buildId=880536

This is purely a flaky test issue and not a product bug. That link is actually valid. We just have some issue validating that when running in CI sometimes. I propose to fix this by changing the test logic not to make a real HTTP request to check the link is valid if it's an external (absolute) link.

There's no reason for us to be checking that external links are valid in CI. We just need to check that the template produces the links we expect (which it already does anyway). Any reliance on making requests to external sites during CI are possible sources of flakiness.