### PR TITLE
Prevent ArgumentOutOfRangeException when handling nested generic types

### DIFF
--- a/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
@@ -104,9 +104,13 @@ internal static class JsonTypeInfoExtensions
         // Generic types become a concatenation of the generic type name and the type arguments
         if (type.IsGenericType)
         {
-            // We need to handle the case where the generic type is a nested type, so we check if the name contains a backtick already.
-            // Example: https://github.com/dotnet/aspnetcore/issues/59092
-            var genericTypeName = type.Name.Contains('`') ? type.Name[..type.Name.LastIndexOf('`')] : type.Name;
+            // We need to handle the case where the generic type is a nested type,
+            // so we check if the name contains a backtick already.
+            // For more information: https://github.com/dotnet/aspnetcore/issues/59092
+            var backtickIndex = type.Name.LastIndexOf('`');
+            var isNestedGenericType = backtickIndex == -1;
+
+            var genericTypeName = isNestedGenericType ? type.Name : type.Name[..backtickIndex];
             var genericArguments = type.GetGenericArguments();
             var argumentNames = string.Join("And", genericArguments.Select(arg => arg.GetSchemaReferenceId(options)));
             return $"{genericTypeName}Of{argumentNames}";

--- a/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
@@ -67,7 +67,7 @@ internal static class JsonTypeInfoExtensions
         }
 
         // Although arrays are enumerable types they are not encoded correctly
-        // with JsonTypeInfoKind.Enumerable so we handle the Enumerble type
+        // with JsonTypeInfoKind.Enumerable so we handle the Enumerable type
         // case here.
         if (jsonTypeInfo is JsonTypeInfo { Kind: JsonTypeInfoKind.Enumerable } || type.IsArray)
         {

--- a/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
@@ -104,7 +104,9 @@ internal static class JsonTypeInfoExtensions
         // Generic types become a concatenation of the generic type name and the type arguments
         if (type.IsGenericType)
         {
-            var genericTypeName = type.Name[..type.Name.LastIndexOf('`')];
+            // We need to handle the case where the generic type is a nested type, so we check if the name contains a backtick already.
+            // Example: https://github.com/dotnet/aspnetcore/issues/59092
+            var genericTypeName = type.Name.Contains('`') ? type.Name[..type.Name.LastIndexOf('`')] : type.Name;
             var genericArguments = type.GetGenericArguments();
             var argumentNames = string.Join("And", genericArguments.Select(arg => arg.GetSchemaReferenceId(options)));
             return $"{genericTypeName}Of{argumentNames}";

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Extensions/JsonTypeInfoExtensionsTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Extensions/JsonTypeInfoExtensionsTests.cs
@@ -17,6 +17,21 @@ public class JsonTypeInfoExtensionsTests
         internal delegate void ContainedTestDelegate(int x, int y);
     }
 
+    /// <remarks>
+    /// https://github.com/dotnet/aspnetcore/issues/59092
+    /// </remarks>
+    public static class Foo<T>
+    {
+        public static class Bar<TT>
+        {
+            public class Baz
+            {
+                public required T One { get; set; }
+                public required TT Two { get; set; }
+            }
+        }
+    }
+
     /// <summary>
     /// This data is used to test the <see cref="TypeExtensions.GetSchemaReferenceId"/> method
     /// which is used to generate reference IDs for OpenAPI schemas in the OpenAPI document.
@@ -58,6 +73,7 @@ public class JsonTypeInfoExtensionsTests
         [typeof(Dictionary<string, string[]>), null],
         [typeof(Dictionary<string, List<string[]>>), null],
         [typeof(Dictionary<string, IEnumerable<string[]>>), null],
+        [typeof(Foo<int>.Bar<string>.Baz), "BazOfintAndstring"],
     ];
 
     [Theory]


### PR DESCRIPTION
# Prevent ArgumentOutOfRangeException when handling nested generic types

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->
Prevent `ArgumentOutOfRangeException`s when dealing with nested generic types

## Description
Take a look at the following type definition:

```csharp
public static class Foo<T>
{
    public static class Bar<TT>
    {
        public class Baz
        {
            public required T One { get; set; }
            public required TT Two { get; set; }
        }
    }
}
```

Based on the existing test cases in `JsonTypeInfoExtensionsTests.cs`, you'd expect this to be given `BazOfintAndstring` as the schema reference ID when passing in an `int` for `Foo` and `string` for `Bar`. 

However, it will throw an `ArgumentOutOfRangeException` because of the following code:

https://github.com/dotnet/aspnetcore/blob/cacdb971a55098c93b9a1807407e9b090edcfce4/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs#L103-L111

While it is a generic type because it's nested, it's not actually generic like the code expects. The code currently expects there to be `<TSomeType>`  (which is serialized as `` ` `` in a type), but that's not the case here, which results in an `ArgumentOutOfRangeException`.

I fixed this by checking if the type is actually generic ( by looking for `` ` `` in the type name). If there isn't a `` ` ``, it will grab the Type name (`Baz` in this case) and use that instead to build up the underlying types.

This results in `BazOfintAndstring`. 

Fixes #59092
