### PR TITLE
fix: target current LTS framework for `Microsoft.AspNetCore.Connections.Abstractions`

### DIFF
--- a/src/Servers/Connections.Abstractions/src/Microsoft.AspNetCore.Connections.Abstractions.csproj
+++ b/src/Servers/Connections.Abstractions/src/Microsoft.AspNetCore.Connections.Abstractions.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Core components of ASP.NET Core networking protocol stack.</Description>
-    <TargetFrameworks>$(DefaultNetFxTargetFramework);netstandard2.0;netstandard2.1;$(DefaultNetCoreTargetFramework)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetFxTargetFramework);netstandard2.0;netstandard2.1;$(DefaultNetCoreTargetFramework);$(CurrentLtsTargetFramework)</TargetFrameworks>
     <TargetFrameworks Condition="'$(DotNetBuildSourceOnly)' == 'true'">$(DefaultNetCoreTargetFramework)</TargetFrameworks>
     <IsAspNetCoreApp>true</IsAspNetCoreApp>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Orleans users filed [issue](https://github.com/dotnet/orleans/issues/9238), where `Microsoft.AspNetCore.Connections.Abstractions` was used as a `netstandard2.1` NuGet, because of missing .net8 (current LTS) framework target.

This resulted in missing specific properties on interfaces (see [ITlsHandshakeFeature.NegotiatedCipherSuite](https://github.com/dotnet/aspnetcore/blob/81a2bab8704d87d324039b42eb1bab0d977f25b8/src/Servers/Connections.Abstractions/src/Features/ITlsHandshakeFeature.cs#L22-L26)), which are not included with `netstandard` package because of preprocessor directives.

@ReubenBond has already changed the references for Orleans; now it is targeting .net8, so the issue is resolved: 
https://github.com/dotnet/orleans/issues/9238#issuecomment-2495550597

However, I think including LTS as a target framework for `Microsoft.AspNetCore.Connections.Abstractions` library would still be safe and useful from the aspnetcore side.

Fixes #59095
