### PR TITLE
Add IsEmptyOrAtEnd method to StringSegment

### DIFF
--- a/src/Http/Headers/src/BaseHeaderParser.cs
+++ b/src/Http/Headers/src/BaseHeaderParser.cs
@@ -23,7 +23,7 @@ internal abstract class BaseHeaderParser<T> : HttpHeaderParser<T>
         //  Accept: text/xml; q=1
         //  Accept:
         //  Accept: text/plain; q=0.2
-        if (HeaderUtilities.IsEmptyOrAtEnd(value, index, SupportsMultipleValues))
+        if (HeaderUtilities.IsEmptyOrAtEnd(value, index))
         {
             return SupportsMultipleValues;
         }

--- a/src/Http/Headers/src/BaseHeaderParser.cs
+++ b/src/Http/Headers/src/BaseHeaderParser.cs
@@ -23,7 +23,7 @@ internal abstract class BaseHeaderParser<T> : HttpHeaderParser<T>
         //  Accept: text/xml; q=1
         //  Accept:
         //  Accept: text/plain; q=0.2
-        if (HeaderParserUtils.IsEmptyOrAtEnd(value, index, SupportsMultipleValues))
+        if (HeaderUtilities.IsEmptyOrAtEnd(value, index, SupportsMultipleValues))
         {
             return SupportsMultipleValues;
         }

--- a/src/Http/Headers/src/BaseHeaderParser.cs
+++ b/src/Http/Headers/src/BaseHeaderParser.cs
@@ -23,7 +23,7 @@ internal abstract class BaseHeaderParser<T> : HttpHeaderParser<T>
         //  Accept: text/xml; q=1
         //  Accept:
         //  Accept: text/plain; q=0.2
-        if (StringSegment.IsNullOrEmpty(value) || (index == value.Length))
+        if (HeaderParserUtils.IsEmptyOrAtEnd(value, index, SupportsMultipleValues))
         {
             return SupportsMultipleValues;
         }

--- a/src/Http/Headers/src/HeaderUtilities.cs
+++ b/src/Http/Headers/src/HeaderUtilities.cs
@@ -737,7 +737,7 @@ public static class HeaderUtilities
         }
     }
 
-    internal static bool IsEmptyOrAtEnd(StringSegment value, int index, bool supportsMultipleValues)
+    internal static bool IsEmptyOrAtEnd(StringSegment value, int index)
     {
         return StringSegment.IsNullOrEmpty(value) || index == value.Length;
     }

--- a/src/Http/Headers/src/HeaderUtilities.cs
+++ b/src/Http/Headers/src/HeaderUtilities.cs
@@ -737,7 +737,7 @@ public static class HeaderUtilities
         }
     }
 
-    private static bool IsEmptyOrAtEnd(StringSegment value, int index, bool supportsMultipleValues)
+    internal static bool IsEmptyOrAtEnd(StringSegment value, int index, bool supportsMultipleValues)
     {
         return StringSegment.IsNullOrEmpty(value) || index == value.Length;
     }

--- a/src/Http/Headers/src/HeaderUtilities.cs
+++ b/src/Http/Headers/src/HeaderUtilities.cs
@@ -736,4 +736,9 @@ public static class HeaderUtilities
             throw new InvalidOperationException("The object cannot be modified because it is read-only.");
         }
     }
+
+    public static bool IsEmptyOrAtEnd(StringSegment value, int index, bool supportsMultipleValues)
+    {
+        return StringSegment.IsNullOrEmpty(value) || index == value.Length;
+    }
 }

--- a/src/Http/Headers/src/HeaderUtilities.cs
+++ b/src/Http/Headers/src/HeaderUtilities.cs
@@ -737,7 +737,7 @@ public static class HeaderUtilities
         }
     }
 
-    public static bool IsEmptyOrAtEnd(StringSegment value, int index, bool supportsMultipleValues)
+    private static bool IsEmptyOrAtEnd(StringSegment value, int index, bool supportsMultipleValues)
     {
         return StringSegment.IsNullOrEmpty(value) || index == value.Length;
     }

--- a/src/Http/Shared/CookieHeaderParserShared.cs
+++ b/src/Http/Shared/CookieHeaderParserShared.cs
@@ -66,12 +66,10 @@ internal static class CookieHeaderParserShared
         //  Accept: text/xml; q=1
         //  Accept:
         //  Accept: text/plain; q=0.2
-
-        if (HeaderUtilities.IsEmptyOrAtEnd(value, index, supportsMultipleValues))
+        if (HeaderUtilities.IsEmptyOrAtEnd(value, index))
         {
             return supportsMultipleValues;
         }
-
         var current = GetNextNonEmptyOrWhitespaceIndex(value, index, supportsMultipleValues, out var separatorFound);
 
         if (separatorFound && !supportsMultipleValues)

--- a/src/Http/Shared/CookieHeaderParserShared.cs
+++ b/src/Http/Shared/CookieHeaderParserShared.cs
@@ -66,9 +66,9 @@ internal static class CookieHeaderParserShared
         //  Accept: text/xml; q=1
         //  Accept:
         //  Accept: text/plain; q=0.2
-        if (StringSegment.IsNullOrEmpty(value) || (index == value.Length))
+        if (HeaderParserUtils.IsEmptyOrAtEnd(value, index, SupportsMultipleValues))
         {
-            return supportsMultipleValues;
+            return SupportsMultipleValues;
         }
 
         var current = GetNextNonEmptyOrWhitespaceIndex(value, index, supportsMultipleValues, out var separatorFound);

--- a/src/Http/Shared/CookieHeaderParserShared.cs
+++ b/src/Http/Shared/CookieHeaderParserShared.cs
@@ -66,7 +66,7 @@ internal static class CookieHeaderParserShared
         //  Accept: text/xml; q=1
         //  Accept:
         //  Accept: text/plain; q=0.2
-        if (HeaderParserUtils.IsEmptyOrAtEnd(value, index, SupportsMultipleValues))
+        if (HeaderUtilities.IsEmptyOrAtEnd(value, index, SupportsMultipleValues))
         {
             return SupportsMultipleValues;
         }

--- a/src/Http/Shared/CookieHeaderParserShared.cs
+++ b/src/Http/Shared/CookieHeaderParserShared.cs
@@ -66,9 +66,10 @@ internal static class CookieHeaderParserShared
         //  Accept: text/xml; q=1
         //  Accept:
         //  Accept: text/plain; q=0.2
-        if (HeaderUtilities.IsEmptyOrAtEnd(value, index, SupportsMultipleValues))
+
+        if (HeaderUtilities.IsEmptyOrAtEnd(value, index, supportsMultipleValues))
         {
-            return SupportsMultipleValues;
+            return supportsMultipleValues;
         }
 
         var current = GetNextNonEmptyOrWhitespaceIndex(value, index, supportsMultipleValues, out var separatorFound);


### PR DESCRIPTION
This commit adds the IsEmptyOrAtEnd method to the StringSegment class. The method checks if the StringSegment is null or empty, or if the provided index is at the end of the segment. This enhances the validation capabilities of StringSegment.

# Add IsEmptyOrAtEnd method to StringSegment

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

adds the IsEmptyOrAtEnd method to the StringSegment class

Fixes #59242