### PR TITLE
Use `NullLogger` instead of `NullLoggerFactory.CreateLogger`

### DIFF
--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
@@ -75,7 +75,7 @@ internal sealed partial class WebSocketsTransport : ITransport, IStatefulReconne
         bool useStatefulReconnect = false)
     {
         _useStatefulReconnect = useStatefulReconnect;
-        _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger(typeof(WebSocketsTransport));
+        _logger = loggerFactory?.CreateLogger(typeof(WebSocketsTransport)) ?? NullLogger.Instance;
         _httpConnectionOptions = httpConnectionOptions ?? new HttpConnectionOptions();
 
         _closeTimeout = _httpConnectionOptions.CloseTimeout;


### PR DESCRIPTION
Use `NullLogger` instead of `NullLoggerFactory.CreateLogger` to simplify the logger

