### PR TITLE
[release/8.0] Skip MVC template tests on HelixQueueArmDebian12

### DIFF
--- a/src/ProjectTemplates/test/Templates.Mvc.Tests/Templates.Mvc.Tests.csproj
+++ b/src/ProjectTemplates/test/Templates.Mvc.Tests/Templates.Mvc.Tests.csproj
@@ -24,6 +24,7 @@
     <!-- These tests fail in Helix in Debian and Mariner due to error -901 -->
     <!-- Disabling on those OSes until a better fix can be identified -->
     <SkipHelixQueues>
+      $(HelixQueueArmDebian12);
       $(HelixQueueDebian11);
       $(HelixQueueMariner);
       $(SkipHelixQueues)


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/aspnetcore/pull/56978. We already skip this queue in main.