### PR TITLE
Import Common.props after the Arcade.SDK in props file

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,4 @@
 <Project>
-  <Import Project="eng\Common.props" />
 
   <PropertyGroup>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
@@ -98,6 +97,7 @@
   <Import Project="eng\QuarantinedTests.BeforeArcade.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
   <Import Project="eng\QuarantinedTests.AfterArcade.props" />
+  <Import Project="eng\Common.props" />
 
   <PropertyGroup>
     <Product>Microsoft ASP.NET Core</Product>


### PR DESCRIPTION
The Common.props file now depends on the `DotNetBuild` property which isn't available before the Arcade SDK is imported. Therefore move the import down after the Arcade SDK is imported. I verified (for every single property defined in Common.props) that it isn't used anywhere in the Arcade.SDK or in aspnetcore before where it's now imported.

It felt more correct to move this down than to change the condition in Common.props from `DotNetBuild` to `DotNetBuildRepo`. I don't see any reason why to restrict that file from using Arcade SDK properties. The general recommendation from the Arcade team is to import the Arcade SDK as early as possbile in the Directory.Build.* files.