### PR TITLE
Remove setting IsStableBuild in Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -48,15 +48,6 @@
         '$(IsBenchmarkProject)' == 'true' OR
         '$(IsPublishedAppTestProject)' == 'true' OR
         $(IsUnitTestProject) ">false</IsShipping>
-
-    <!--
-      Following logic mimics core-setup approach as well as
-      https://github.com/dotnet/arcade/blob/694d59f090b743f894779d04a7ffe11cbaf352e7/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj#L30-L31
-      $(DotNetFinalVersionKind) is set globally when doing final aka stable builds. Arcade infrastructure should pick
-      up $(IsStableBuild) automatically; property is also used to control prerelease branding.
-    -->
-    <IsStableBuild>false</IsStableBuild>
-    <IsStableBuild Condition=" '$(DotNetFinalVersionKind)' == 'release' ">true</IsStableBuild>
   </PropertyGroup>
 
   <!-- Disable logging of some task parameters or metadata to reduce binlog size.


### PR DESCRIPTION
It is a no-op.

Arcade already sets this in https://github.com/dotnet/arcade/blob/7fff497cdf80039a4f2996699e5561e50812d948/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj#L55-L57 and as we discovered in https://github.com/dotnet/aspnetcore/pull/59309 the `DotNetFinalVersionKind` property isn't even set at that point.
