### PR TITLE
[Blazor WebAssembly standalone] Don't cache `index.html` during development

### DIFF
--- a/src/Assets/build/Microsoft.AspNetCore.App.Internal.Assets.targets
+++ b/src/Assets/build/Microsoft.AspNetCore.App.Internal.Assets.targets
@@ -40,7 +40,10 @@
       <_FrameworkStaticWebAssetCandidate Remove="@(_MissingFrameworkStaticWebAssetCandidate)" />
     </ItemGroup>
 
-    <Message Importance="High" Text="Framework asset '%(_MissingFrameworkStaticWebAssetCandidate.Identity)' could not be found and won't be included in the project." />
+    <Message
+      Importance="High"
+      Condition="'@(_MissingFrameworkStaticWebAssetCandidate->Count())' != '0'"
+      Text="Framework asset '%(_MissingFrameworkStaticWebAssetCandidate.Identity)' could not be found and won't be included in the project." />
 
     <PropertyGroup>
       <_FrameworkAssetsPath>$(IntermediateOutputPath)frameworkassets</_FrameworkAssetsPath>

--- a/src/Components/WebAssembly/DevServer/src/Server/Startup.cs
+++ b/src/Components/WebAssembly/DevServer/src/Server/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Components.WebAssembly.DevServer.Server;
 
@@ -69,6 +70,14 @@ internal sealed class Startup
             {
                 OnPrepareResponse = fileContext =>
                 {
+                    // Avoid caching index.html during development.
+                    // When hot reload is enabled, a middleware injects a hot reload script into the response HTML.
+                    // We don't want the browser to bypass this injection by using a cached response that doesn't
+                    // contain the injected script. In the future, if script injection is removed in favor of a
+                    // different mechanism, we can delete this comment and the line below it.
+                    // See also: https://github.com/dotnet/aspnetcore/issues/45213
+                    fileContext.Context.Response.Headers[HeaderNames.CacheControl] = "no-store";
+
                     if (applyCopHeaders)
                     {
                         // Browser multi-threaded runtime requires cross-origin policy headers to enable SharedArrayBuffer.

--- a/src/Components/WebView/WebView/src/build/Microsoft.AspNetCore.Components.WebView.props
+++ b/src/Components/WebView/WebView/src/build/Microsoft.AspNetCore.Components.WebView.props
@@ -29,7 +29,10 @@
       <_WebViewAssetCandidates Remove="@(_MissingWebViewAssetCandidates)" />
     </ItemGroup>
 
-    <Message Importance="High" Text="WebView asset '%(_MissingWebViewAssetCandidates.Identity)' could not be found and won't be included in the project." />
+    <Message
+      Importance="High"
+      Condition="'@(_MissingWebViewAssetCandidates->Count())' != '0'"
+      Text="WebView asset '%(_MissingWebViewAssetCandidates.Identity)' could not be found and won't be included in the project." />
 
     <DefineStaticWebAssets
       CandidateAssets="@(_WebViewAssetCandidates)"


### PR DESCRIPTION
# [Blazor WebAssembly standalone] Don't cache `index.html` during development

Fixes an issue where the WebAssembly dev server (used during Blazor WebAssembly standalone development) returned `index.html` with incorrect caching headers, resulting in hot reload script injection sometimes being bypassed.

## Description

The fix is to add the `Cache-Control: no-store` header to the response for `index.html` when running the app via the WebAssembly dev server. This prevents the browser from using a cached response, which bypasses the script injection middleware.

Fixes #59276
