### PR TITLE
Fix Kestrel host header mismatch handling when port in Url

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -3,7 +3,6 @@
 
 using System.Buffers;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO.Pipelines;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
@@ -649,11 +648,16 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
             if (hostText != _absoluteRequestTarget!.Authority)
             {
                 if (!_absoluteRequestTarget.IsDefaultPort
-                    || hostText != _absoluteRequestTarget.Authority + ":" + _absoluteRequestTarget.Port.ToString(CultureInfo.InvariantCulture))
+                    || hostText != $"{_absoluteRequestTarget.Authority}:{_absoluteRequestTarget.Port}")
                 {
                     if (_context.ServiceContext.ServerOptions.AllowHostHeaderOverride)
                     {
-                        hostText = _absoluteRequestTarget.Authority + ":" + _absoluteRequestTarget.Port.ToString(CultureInfo.InvariantCulture);
+                        // No need to include the port here, it's either already in the Authority
+                        // or it's the default port
+                        // see: https://datatracker.ietf.org/doc/html/rfc2616/#section-14.23
+                        // A "host" without any trailing port information implies the default
+                        // port for the service requested (e.g., "80" for an HTTP URL).
+                        hostText = _absoluteRequestTarget.Authority;
                         HttpRequestHeaders.HeaderHost = hostText;
                     }
                     else

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -643,12 +643,15 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
             // authority component, excluding any userinfo subcomponent and its "@"
             // delimiter.
 
+            // Accessing authority always allocates, store it in a local to only allocate once
+            var authority = _absoluteRequestTarget!.Authority;
+
             // System.Uri doesn't not tell us if the port was in the original string or not.
             // When IsDefaultPort = true, we will allow Host: with or without the default port
-            if (hostText != _absoluteRequestTarget!.Authority)
+            if (hostText != authority)
             {
                 if (!_absoluteRequestTarget.IsDefaultPort
-                    || hostText != $"{_absoluteRequestTarget.Authority}:{_absoluteRequestTarget.Port}")
+                    || hostText != $"{authority}:{_absoluteRequestTarget.Port}")
                 {
                     if (_context.ServiceContext.ServerOptions.AllowHostHeaderOverride)
                     {
@@ -657,7 +660,7 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
                         // see: https://datatracker.ietf.org/doc/html/rfc2616/#section-14.23
                         // A "host" without any trailing port information implies the default
                         // port for the service requested (e.g., "80" for an HTTP URL).
-                        hostText = _absoluteRequestTarget.Authority;
+                        hostText = authority;
                         HttpRequestHeaders.HeaderHost = hostText;
                     }
                     else

--- a/src/Servers/Kestrel/shared/test/HttpParsingData.cs
+++ b/src/Servers/Kestrel/shared/test/HttpParsingData.cs
@@ -497,8 +497,10 @@ public class HttpParsingData
                     { "GET /pub/WWW/", "www.example.org" },
                     { "GET http://localhost/", "localhost" },
                     { "GET http://localhost:80/", "localhost:80" },
+                    { "GET http://localhost:80/", "localhost" },
                     { "GET https://localhost/", "localhost" },
                     { "GET https://localhost:443/", "localhost:443" },
+                    { "GET https://localhost:443/", "localhost" },
                     { "CONNECT asp.net:80", "asp.net:80" },
                     { "CONNECT asp.net:443", "asp.net:443" },
                     { "CONNECT user-images.githubusercontent.com:443", "user-images.githubusercontent.com:443" },
@@ -534,9 +536,12 @@ public class HttpParsingData
                 data.Add("CONNECT contoso.com", host);
             }
 
-            // port mismatch when target contains port
+            // port mismatch when target contains default https port
             data.Add("GET https://contoso.com:443/", "contoso.com:5000");
             data.Add("CONNECT contoso.com:443", "contoso.com:5000");
+
+            // port mismatch when target contains default http port
+            data.Add("GET http://contoso.com:80/", "contoso.com:5000");
 
             return data;
         }


### PR DESCRIPTION
When using the `KestrelServerOptions.AllowHostHeaderOverride` option, if a port was included in the request URL and the Host header didn't match, the request would still fail with a 400 Bad Request due to us double including the port in the computed Host string.

Fails with `Invalid Host header: 'www.foo.com:1234:1234'`
```
GET https://localhost:1234 HTTP/1.1
Host: localhost
```

Worked
```
GET https://localhost HTTP/1.1
Host: localhost:1234
```

Since `Uri.Authority` doesn't include the default port (80 for http, 443 for https), we should only append the port in the computed host header if it's not the default port for the scheme.