### PR TITLE
[release/2.3] Fix Mvc.FunctionalTests referencing RazorPagesClassLibrary

### DIFF
--- a/src/Mvc/test/WebSites/RazorPagesClassLibrary/RazorPagesClassLibrary.csproj
+++ b/src/Mvc/test/WebSites/RazorPagesClassLibrary/RazorPagesClassLibrary.csproj
@@ -7,6 +7,22 @@
     <IsTestAssetProject>true</IsTestAssetProject>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <_RazorMSBuildRoot>$(RepositoryRoot)src\Razor\Razor.Design\src\bin\$(Configuration)\netstandard2.0\</_RazorMSBuildRoot>
+    <_RazorTaskFolder Condition=" '$(MSBuildRuntimeType)' == 'Core' ">netstandard2.0</_RazorTaskFolder>
+    <_RazorTaskFolder Condition=" '$(MSBuildRuntimeType)' != 'Core' ">net46</_RazorTaskFolder>
+    <_RazorTaskAssembly>$(RepositoryRoot)src\Razor\Razor.Tasks\src\bin\$(Configuration)\$(_RazorTaskFolder)\Microsoft.AspNetCore.Razor.Tasks.dll</_RazorTaskAssembly>
+  </PropertyGroup>
+
+  <Import Project="$(RepositoryRoot)src\Razor\Razor.Design\src\build\netstandard2.0\Microsoft.AspNetCore.Razor.Design.props" />
+
+  <PropertyGroup>
+    <!-- Override for the MVC extension -->
+    <_MvcExtensionAssemblyPath>$(RepositoryRoot)src\Razor\Mvc.Razor.Extensions\src\bin\$(Configuration)\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.dll</_MvcExtensionAssemblyPath>
+  </PropertyGroup>
+  <Import Project="$(RepositoryRoot)src\Razor\Mvc.Razor.Extensions\src\build\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.props" />
+  <Import Project="$(RepositoryRoot)src\Razor\Mvc.Razor.Extensions\src\build\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.targets" />
+
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Mvc" />
     <Reference Include="System.Threading.Tasks.Extensions" />


### PR DESCRIPTION
This fixes the [Mvc.FunctionalTests test failures involving RazorPagesClassLibrary](https://dev.azure.com/dnceng-public/public/_build/results?buildId=880408&view=ms.vss-test-web.build-test-results-tab&runId=22998322&resultId=108237&paneView=debug) on my local machine. It appears that while testing in the release/2.3 aspnetcore repo, Microsoft.NET.Sdk.Razor SDK does not bring in all the properties and targets from Microsoft.AspNetCore.Razor.Design and Microsoft.AspNetCore.Mvc.Razor.Extensions, so this PR manually imports them into the RazorPagesClassLibrary test project.

I got inspiration from [ClassLibrary test project](https://github.com/dotnet/aspnetcore/blob/376a3f573907ed71077e2cc28f6f045d7941772d/src/Razor/Razor.Design/test/testassets/ClassLibrary/ClassLibrary.csproj) in the Razor.Design testassets. The main difference is that I manually set the `_RazorTaskAssembly` property to point inside the bin folder instead of letting it be derived solely from the `_RazorMSBuildRoot` like the `_RazorToolAssembly`.

I'm not sure why this difference is necessary, or why these changes are only needed now. That's why I'm opening this PR up as a draft so someone like @javiercn can determine if this makes sense, or if the test failures might be indicative of some build-time regression.
