### PR TITLE
Upgrade Facebook Graph API version to v22.0

### DIFF
--- a/src/Security/Authentication/Facebook/src/FacebookDefaults.cs
+++ b/src/Security/Authentication/Facebook/src/FacebookDefaults.cs
@@ -24,15 +24,15 @@ public static class FacebookDefaults
     /// <remarks>
     /// For more details about this endpoint, see <see href="https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow#login"/>.
     /// </remarks>
-    public static readonly string AuthorizationEndpoint = "https://www.facebook.com/v14.0/dialog/oauth";
+    public static readonly string AuthorizationEndpoint = "https://www.facebook.com/v21.0/dialog/oauth";
 
     /// <summary>
     /// The OAuth endpoint used to retrieve access tokens.
     /// </summary>
-    public static readonly string TokenEndpoint = "https://graph.facebook.com/v14.0/oauth/access_token";
+    public static readonly string TokenEndpoint = "https://graph.facebook.com/v21.0/oauth/access_token";
 
     /// <summary>
     /// The Facebook Graph API endpoint that is used to gather additional user information.
     /// </summary>
-    public static readonly string UserInformationEndpoint = "https://graph.facebook.com/v14.0/me";
+    public static readonly string UserInformationEndpoint = "https://graph.facebook.com/v21.0/me";
 }

--- a/src/Security/Authentication/Facebook/src/FacebookDefaults.cs
+++ b/src/Security/Authentication/Facebook/src/FacebookDefaults.cs
@@ -24,15 +24,15 @@ public static class FacebookDefaults
     /// <remarks>
     /// For more details about this endpoint, see <see href="https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow#login"/>.
     /// </remarks>
-    public static readonly string AuthorizationEndpoint = "https://www.facebook.com/v21.0/dialog/oauth";
+    public static readonly string AuthorizationEndpoint = "https://www.facebook.com/v22.0/dialog/oauth";
 
     /// <summary>
     /// The OAuth endpoint used to retrieve access tokens.
     /// </summary>
-    public static readonly string TokenEndpoint = "https://graph.facebook.com/v21.0/oauth/access_token";
+    public static readonly string TokenEndpoint = "https://graph.facebook.com/v22.0/oauth/access_token";
 
     /// <summary>
     /// The Facebook Graph API endpoint that is used to gather additional user information.
     /// </summary>
-    public static readonly string UserInformationEndpoint = "https://graph.facebook.com/v21.0/me";
+    public static readonly string UserInformationEndpoint = "https://graph.facebook.com/v22.0/me";
 }

--- a/src/Security/Authentication/test/FacebookTests.cs
+++ b/src/Security/Authentication/test/FacebookTests.cs
@@ -230,7 +230,7 @@ public class FacebookTests : RemoteAuthenticationTests<FacebookOptions>
         var transaction = await server.SendAsync("http://example.com/base/login");
         Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
         var location = transaction.Response.Headers.Location.AbsoluteUri;
-        Assert.Contains("https://www.facebook.com/v14.0/dialog/oauth", location);
+        Assert.Contains("https://www.facebook.com/v21.0/dialog/oauth", location);
         Assert.Contains("response_type=code", location);
         Assert.Contains("client_id=", location);
         Assert.Contains("redirect_uri=" + UrlEncoder.Default.Encode("http://example.com/base/signin-facebook"), location);
@@ -263,7 +263,7 @@ public class FacebookTests : RemoteAuthenticationTests<FacebookOptions>
         var transaction = await server.SendAsync("http://example.com/login");
         Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
         var location = transaction.Response.Headers.Location.AbsoluteUri;
-        Assert.Contains("https://www.facebook.com/v14.0/dialog/oauth", location);
+        Assert.Contains("https://www.facebook.com/v21.0/dialog/oauth", location);
         Assert.Contains("response_type=code", location);
         Assert.Contains("client_id=", location);
         Assert.Contains("redirect_uri=" + UrlEncoder.Default.Encode("http://example.com/signin-facebook"), location);
@@ -298,7 +298,7 @@ public class FacebookTests : RemoteAuthenticationTests<FacebookOptions>
         var transaction = await server.SendAsync("http://example.com/challenge");
         Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
         var location = transaction.Response.Headers.Location.AbsoluteUri;
-        Assert.Contains("https://www.facebook.com/v14.0/dialog/oauth", location);
+        Assert.Contains("https://www.facebook.com/v21.0/dialog/oauth", location);
         Assert.Contains("response_type=code", location);
         Assert.Contains("client_id=", location);
         Assert.Contains("redirect_uri=", location);
@@ -388,7 +388,7 @@ public class FacebookTests : RemoteAuthenticationTests<FacebookOptions>
                         {
                             Sender = req =>
                             {
-                                if (req.RequestUri.AbsoluteUri == "https://graph.facebook.com/v14.0/oauth/access_token")
+                                if (req.RequestUri.AbsoluteUri == "https://graph.facebook.com/v21.0/oauth/access_token")
                                 {
                                     var body = req.Content.ReadAsStringAsync().Result;
                                     var form = new FormReader(body);
@@ -407,7 +407,7 @@ public class FacebookTests : RemoteAuthenticationTests<FacebookOptions>
                                         token_type = "Bearer",
                                     });
                                 }
-                                else if (req.RequestUri.GetComponents(UriComponents.SchemeAndServer | UriComponents.Path, UriFormat.UriEscaped) == "https://graph.facebook.com/v14.0/me")
+                                else if (req.RequestUri.GetComponents(UriComponents.SchemeAndServer | UriComponents.Path, UriFormat.UriEscaped) == "https://graph.facebook.com/v21.0/me")
                                 {
                                     return ReturnJsonResponse(new
                                     {
@@ -433,7 +433,7 @@ public class FacebookTests : RemoteAuthenticationTests<FacebookOptions>
         var transaction = await server.SendAsync("https://example.com/challenge");
         Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
         var locationUri = transaction.Response.Headers.Location;
-        Assert.StartsWith("https://www.facebook.com/v14.0/dialog/oauth", locationUri.AbsoluteUri);
+        Assert.StartsWith("https://www.facebook.com/v21.0/dialog/oauth", locationUri.AbsoluteUri);
 
         var queryParams = QueryHelpers.ParseQuery(locationUri.Query);
         Assert.False(string.IsNullOrEmpty(queryParams["code_challenge"]));

--- a/src/Security/Authentication/test/FacebookTests.cs
+++ b/src/Security/Authentication/test/FacebookTests.cs
@@ -230,7 +230,7 @@ public class FacebookTests : RemoteAuthenticationTests<FacebookOptions>
         var transaction = await server.SendAsync("http://example.com/base/login");
         Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
         var location = transaction.Response.Headers.Location.AbsoluteUri;
-        Assert.Contains("https://www.facebook.com/v21.0/dialog/oauth", location);
+        Assert.Contains("https://www.facebook.com/v22.0/dialog/oauth", location);
         Assert.Contains("response_type=code", location);
         Assert.Contains("client_id=", location);
         Assert.Contains("redirect_uri=" + UrlEncoder.Default.Encode("http://example.com/base/signin-facebook"), location);
@@ -263,7 +263,7 @@ public class FacebookTests : RemoteAuthenticationTests<FacebookOptions>
         var transaction = await server.SendAsync("http://example.com/login");
         Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
         var location = transaction.Response.Headers.Location.AbsoluteUri;
-        Assert.Contains("https://www.facebook.com/v21.0/dialog/oauth", location);
+        Assert.Contains("https://www.facebook.com/v22.0/dialog/oauth", location);
         Assert.Contains("response_type=code", location);
         Assert.Contains("client_id=", location);
         Assert.Contains("redirect_uri=" + UrlEncoder.Default.Encode("http://example.com/signin-facebook"), location);
@@ -298,7 +298,7 @@ public class FacebookTests : RemoteAuthenticationTests<FacebookOptions>
         var transaction = await server.SendAsync("http://example.com/challenge");
         Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
         var location = transaction.Response.Headers.Location.AbsoluteUri;
-        Assert.Contains("https://www.facebook.com/v21.0/dialog/oauth", location);
+        Assert.Contains("https://www.facebook.com/v22.0/dialog/oauth", location);
         Assert.Contains("response_type=code", location);
         Assert.Contains("client_id=", location);
         Assert.Contains("redirect_uri=", location);
@@ -388,7 +388,7 @@ public class FacebookTests : RemoteAuthenticationTests<FacebookOptions>
                         {
                             Sender = req =>
                             {
-                                if (req.RequestUri.AbsoluteUri == "https://graph.facebook.com/v21.0/oauth/access_token")
+                                if (req.RequestUri.AbsoluteUri == "https://graph.facebook.com/v22.0/oauth/access_token")
                                 {
                                     var body = req.Content.ReadAsStringAsync().Result;
                                     var form = new FormReader(body);
@@ -407,7 +407,7 @@ public class FacebookTests : RemoteAuthenticationTests<FacebookOptions>
                                         token_type = "Bearer",
                                     });
                                 }
-                                else if (req.RequestUri.GetComponents(UriComponents.SchemeAndServer | UriComponents.Path, UriFormat.UriEscaped) == "https://graph.facebook.com/v21.0/me")
+                                else if (req.RequestUri.GetComponents(UriComponents.SchemeAndServer | UriComponents.Path, UriFormat.UriEscaped) == "https://graph.facebook.com/v22.0/me")
                                 {
                                     return ReturnJsonResponse(new
                                     {
@@ -433,7 +433,7 @@ public class FacebookTests : RemoteAuthenticationTests<FacebookOptions>
         var transaction = await server.SendAsync("https://example.com/challenge");
         Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
         var locationUri = transaction.Response.Headers.Location;
-        Assert.StartsWith("https://www.facebook.com/v21.0/dialog/oauth", locationUri.AbsoluteUri);
+        Assert.StartsWith("https://www.facebook.com/v22.0/dialog/oauth", locationUri.AbsoluteUri);
 
         var queryParams = QueryHelpers.ParseQuery(locationUri.Query);
         Assert.False(string.IsNullOrEmpty(queryParams["code_challenge"]));


### PR DESCRIPTION
# Upgrade Facebook Graph API version to v22.0

Currently, ASP.NET Core uses version v14.0 of the Facebook Graph API for authentication. This version of the API is no longer supported by Facebook, and should be upgraded to v22.0.

## Description

Version v14.0 of the Graph API was supported [until September 17, 2024](https://developers.facebook.com/docs/graph-api/changelog/version14.0/). We should be able to safely upgrade to v22.0, the latest version, since there are no documented changes to the _authorization_, _token_ or _user information_ endpoints between these versions.

While this contributes towards #4684, it does not completely fix it, since the scope of that issue is broader than just Facebook.
