### PR TITLE
Fix SFX issues causing sdk injestion failures

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -359,6 +359,7 @@ extends:
             --all
             --build-installers
             --no-build-java
+            $(_ArcadePublishNonWindowsArg)
             -p:OnlyPackPlatformSpecificPackages=true
             $(_BuildArgs)
             $(_InternalRuntimeDownloadArgs)
@@ -417,6 +418,7 @@ extends:
             --all
             --build-installers
             --no-build-java
+            $(_ArcadePublishNonWindowsArg)
             -p:OnlyPackPlatformSpecificPackages=true
             $(_BuildArgs)
             $(_InternalRuntimeDownloadArgs)

--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.Composite.sfxproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.Composite.sfxproj
@@ -77,7 +77,7 @@
     <NativePlatform Condition=" '$(NativePlatform)' == 'x86' ">Win32</NativePlatform>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Condition=" '$(UseIisNativeAssets)' == 'true' AND $(BuildNative) "
+    <ProjectReference Condition=" '$(UseIisNativeAssets)' == 'true' AND $(BuildNative)  AND '$(MSBuildRestoreSessionId)' == ''"
         Include="$(RepoRoot)src\Servers\IIS\AspNetCoreModuleV2\InProcessRequestHandler\InProcessRequestHandler.vcxproj">
       <SetPlatform>Platform=$(NativePlatform)</SetPlatform>
       <!-- A custom item group to be used in targets later.  -->

--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.sfxproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.sfxproj
@@ -71,7 +71,7 @@
     <NativePlatform Condition=" '$(NativePlatform)' == 'x86' ">Win32</NativePlatform>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Condition=" '$(UseIisNativeAssets)' == 'true' AND $(BuildNative) "
+    <ProjectReference Condition=" '$(UseIisNativeAssets)' == 'true' AND $(BuildNative) AND '$(MSBuildRestoreSessionId)' == ''"
         Include="$(RepoRoot)src\Servers\IIS\AspNetCoreModuleV2\InProcessRequestHandler\InProcessRequestHandler.vcxproj">
       <SetPlatform>Platform=$(NativePlatform)</SetPlatform>
       <OutputItemType>NativeRuntimeAsset</OutputItemType>


### PR DESCRIPTION
Unblocks https://github.com/dotnet/sdk/pull/45347

When simplifying the official build YAML, I missed adding the publish argument explicitly for Linux x64/arm64 jobs. Add that flag back.

When building the repo all-up on Windows in one invocation (only done in the VMR), the project reference from the sfxproj to the native project causes issues during Restore. Exclude the reference during restore evaluation.