### PR TITLE
[release/8.0] Fix Kestrel host header mismatch handling when port in Url

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -625,12 +625,15 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
             // authority component, excluding any userinfo subcomponent and its "@"
             // delimiter.
 
+            // Accessing authority always allocates, store it in a local to only allocate once
+            var authority = _absoluteRequestTarget!.Authority;
+
             // System.Uri doesn't not tell us if the port was in the original string or not.
             // When IsDefaultPort = true, we will allow Host: with or without the default port
-            if (hostText != _absoluteRequestTarget!.Authority)
+            if (hostText != authority)
             {
                 if (!_absoluteRequestTarget.IsDefaultPort
-                    || hostText != $"{_absoluteRequestTarget.Authority}:{_absoluteRequestTarget.Port}")
+                    || hostText != $"{authority}:{_absoluteRequestTarget.Port}")
                 {
                     if (_context.ServiceContext.ServerOptions.AllowHostHeaderOverride)
                     {
@@ -639,7 +642,7 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
                         // see: https://datatracker.ietf.org/doc/html/rfc2616/#section-14.23
                         // A "host" without any trailing port information implies the default
                         // port for the service requested (e.g., "80" for an HTTP URL).
-                        hostText = _absoluteRequestTarget.Authority;
+                        hostText = authority;
                         HttpRequestHeaders.HeaderHost = hostText;
                     }
                     else

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -3,7 +3,6 @@
 
 using System.Buffers;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO.Pipelines;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
@@ -631,11 +630,16 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
             if (hostText != _absoluteRequestTarget!.Authority)
             {
                 if (!_absoluteRequestTarget.IsDefaultPort
-                    || hostText != _absoluteRequestTarget.Authority + ":" + _absoluteRequestTarget.Port.ToString(CultureInfo.InvariantCulture))
+                    || hostText != $"{_absoluteRequestTarget.Authority}:{_absoluteRequestTarget.Port}")
                 {
                     if (_context.ServiceContext.ServerOptions.AllowHostHeaderOverride)
                     {
-                        hostText = _absoluteRequestTarget.Authority + ":" + _absoluteRequestTarget.Port.ToString(CultureInfo.InvariantCulture);
+                        // No need to include the port here, it's either already in the Authority
+                        // or it's the default port
+                        // see: https://datatracker.ietf.org/doc/html/rfc2616/#section-14.23
+                        // A "host" without any trailing port information implies the default
+                        // port for the service requested (e.g., "80" for an HTTP URL).
+                        hostText = _absoluteRequestTarget.Authority;
                         HttpRequestHeaders.HeaderHost = hostText;
                     }
                     else

--- a/src/Servers/Kestrel/shared/test/HttpParsingData.cs
+++ b/src/Servers/Kestrel/shared/test/HttpParsingData.cs
@@ -497,8 +497,10 @@ public class HttpParsingData
                     { "GET /pub/WWW/", "www.example.org" },
                     { "GET http://localhost/", "localhost" },
                     { "GET http://localhost:80/", "localhost:80" },
+                    { "GET http://localhost:80/", "localhost" },
                     { "GET https://localhost/", "localhost" },
                     { "GET https://localhost:443/", "localhost:443" },
+                    { "GET https://localhost:443/", "localhost" },
                     { "CONNECT asp.net:80", "asp.net:80" },
                     { "CONNECT asp.net:443", "asp.net:443" },
                     { "CONNECT user-images.githubusercontent.com:443", "user-images.githubusercontent.com:443" },
@@ -534,9 +536,12 @@ public class HttpParsingData
                 data.Add("CONNECT contoso.com", host);
             }
 
-            // port mismatch when target contains port
+            // port mismatch when target contains default https port
             data.Add("GET https://contoso.com:443/", "contoso.com:5000");
             data.Add("CONNECT contoso.com:443", "contoso.com:5000");
+
+            // port mismatch when target contains default http port
+            data.Add("GET http://contoso.com:80/", "contoso.com:5000");
 
             return data;
         }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
@@ -142,9 +142,12 @@ public class BadHttpRequestTests : LoggedTest
     }
 
     [Theory]
-    [InlineData("Host: www.foo.comConnection: keep-alive")] // Corrupted - missing line-break
-    [InlineData("Host: www.notfoo.com")] // Syntactically correct but not matching
-    public async Task CanOptOutOfBadRequestIfHostHeaderDoesNotMatchRequestTarget(string hostHeader)
+    [InlineData("http://www.foo.com", "Host: www.foo.comConnection: keep-alive", "www.foo.com")] // Corrupted - missing line-break
+    [InlineData("http://www.foo.com/", "Host: www.notfoo.com", "www.foo.com")] // Syntactically correct but not matching
+    [InlineData("http://www.foo.com:80", "Host: www.notfoo.com", "www.foo.com")] // Explicit default port in request string
+    [InlineData("http://www.foo.com:5129", "Host: www.foo.com", "www.foo.com:5129")] // Non-default port in request string
+    [InlineData("http://www.foo.com:5129", "Host: www.foo.com:5128", "www.foo.com:5129")] // Different port in host header
+    public async Task CanOptOutOfBadRequestIfHostHeaderDoesNotMatchRequestTarget(string requestString, string hostHeader, string expectedHost)
     {
         var receivedHost = StringValues.Empty;
         await using var server = new TestServer(context =>
@@ -157,14 +160,17 @@ public class BadHttpRequestTests : LoggedTest
             {
                 AllowHostHeaderOverride = true,
             }
-        });
-        using var client = server.CreateConnection();
+        }))
+        {
+            using (var client = server.CreateConnection())
+            {
+                await client.SendAll($"GET {requestString} HTTP/1.1\r\n{hostHeader}\r\n\r\n");
 
-        await client.SendAll($"GET http://www.foo.com/api/data HTTP/1.1\r\n{hostHeader}\r\n\r\n");
+                await client.Receive("HTTP/1.1 200 OK");
+            }
+        }
 
-        await client.Receive("HTTP/1.1 200 OK");
-
-        Assert.Equal("www.foo.com:80", receivedHost);
+        Assert.Equal(expectedHost, receivedHost);
     }
 
     [Fact]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
@@ -160,15 +160,12 @@ public class BadHttpRequestTests : LoggedTest
             {
                 AllowHostHeaderOverride = true,
             }
-        }))
-        {
-            using (var client = server.CreateConnection())
-            {
-                await client.SendAll($"GET {requestString} HTTP/1.1\r\n{hostHeader}\r\n\r\n");
+        });
+        using var client = server.CreateConnection();
 
-                await client.Receive("HTTP/1.1 200 OK");
-            }
-        }
+        await client.SendAll($"GET {requestString} HTTP/1.1\r\n{hostHeader}\r\n\r\n");
+
+        await client.Receive("HTTP/1.1 200 OK");
 
         Assert.Equal(expectedHost, receivedHost);
     }


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspnetcore/pull/59352

# Fix Kestrel host header mismatch handling when port in Url

## Description

Fixes some validation of host headers in Kestrel if a non-default port is included in the request url.

## Customer Impact

Valid requests will result in a 400 error response if they hit this case.
An internal partner team is hitting this currently.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Small bug fix with additional unit test coverage to make sure it works and doesn't regress in the future.

## Verification

- [ ] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
