### PR TITLE
Add more required publish args

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -362,6 +362,7 @@ extends:
             $(_ArcadePublishNonWindowsArg)
             -p:OnlyPackPlatformSpecificPackages=true
             $(_BuildArgs)
+            $(_PublishArgs)
             $(_InternalRuntimeDownloadArgs)
           artifacts:
           - name: Linux_x64_Logs_Attempt_$(System.JobAttempt)
@@ -421,6 +422,7 @@ extends:
             $(_ArcadePublishNonWindowsArg)
             -p:OnlyPackPlatformSpecificPackages=true
             $(_BuildArgs)
+            $(_PublishArgs)
             $(_InternalRuntimeDownloadArgs)
           artifacts:
           - name: Linux_arm64_Logs_Attempt_$(System.JobAttempt)


### PR DESCRIPTION
These publishing arguments were also not being passed down, which was breaking publishing on Linux x64/arm64.

Unblocks the official build
