### PR TITLE
Fix publishing from new linux legs

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -361,7 +361,9 @@ extends:
             --no-build-java
             $(_ArcadePublishNonWindowsArg)
             -p:OnlyPackPlatformSpecificPackages=true
+            -p:AssetManifestFileName=aspnetcore-Linux_x64.xml
             $(_BuildArgs)
+            $(_PublishArgs)
             $(_InternalRuntimeDownloadArgs)
           artifacts:
           - name: Linux_x64_Logs_Attempt_$(System.JobAttempt)
@@ -420,7 +422,9 @@ extends:
             --no-build-java
             $(_ArcadePublishNonWindowsArg)
             -p:OnlyPackPlatformSpecificPackages=true
+            -p:AssetManifestFileName=aspnetcore-Linux_arm64.xml
             $(_BuildArgs)
+            $(_PublishArgs)
             $(_InternalRuntimeDownloadArgs)
           artifacts:
           - name: Linux_arm64_Logs_Attempt_$(System.JobAttempt)


### PR DESCRIPTION
Fixes failing official builds: https://dnceng.visualstudio.com/internal/_build?definitionId=21&_a=summary
Regressed with https://github.com/dotnet/aspnetcore/commit/79494219cbc4f10a0b8ea7f77859e97a5768fbac
Unblocks https://github.com/dotnet/sdk/pull/45347