### PR TITLE
Fixes a bug with form file binding when binding file name with index to an indexable collection

### DIFF
--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/FormFileModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/FormFileModelBinder.cs
@@ -150,7 +150,8 @@ public partial class FormFileModelBinder : IModelBinder
                     continue;
                 }
 
-                if (file.Name.Equals(modelName, StringComparison.OrdinalIgnoreCase))
+                if (file.Name.Equals(modelName, StringComparison.OrdinalIgnoreCase) ||
+                    file.Name.StartsWith($"{modelName}[", StringComparison.OrdinalIgnoreCase))
                 {
                     postedFiles.Add(file);
                 }

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Binders/FormFileModelBinderTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Binders/FormFileModelBinderTest.cs
@@ -221,7 +221,7 @@ public class FormFileModelBinderTest
     }
 
     [Fact]
-    public async Task FormFileModelBinder_SingleFileWithinIndexableCollection_BindSuccessful()
+    public async Task FormFileModelBinder_SingleFileWithIndexer_BindSuccessful()
     {
         // Arrange
         var formFiles = new FormFileCollection
@@ -285,7 +285,7 @@ public class FormFileModelBinderTest
     }
 
     [Fact]
-    public async Task FormFileModelBinder_MultipleFilesWithinIndexableCollection_BindSuccessful()
+    public async Task FormFileModelBinder_MultipleFilesWithIndexersWithinIndexableCollection_BindSuccessful()
     {
         // Arrange
         var formFiles = new FormFileCollection

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Binders/FormFileModelBinderTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Binders/FormFileModelBinderTest.cs
@@ -252,6 +252,39 @@ public class FormFileModelBinderTest
     }
 
     [Fact]
+    public async Task FormFileModelBinder_MultipleFilesWithIndexersWithinSingleFormFile_BindSuccessful_OnlyFirstFileIsBound()
+    {
+        // Arrange
+        var formFiles = new FormFileCollection
+            {
+                GetMockFormFile("file[0]", "file1.txt"),
+                GetMockFormFile("file[1]", "file2.txt")
+            };
+        var httpContext = GetMockHttpContext(GetMockFormCollection(formFiles));
+
+        var bindingContext = DefaultModelBindingContext.CreateBindingContext(
+            new ActionContext { HttpContext = httpContext },
+            Mock.Of<IValueProvider>(),
+            new EmptyModelMetadataProvider().GetMetadataForType(typeof(IFormFile)),
+            bindingInfo: null,
+            modelName: "file");
+
+        var binder = new FormFileModelBinder(NullLoggerFactory.Instance);
+
+        // Act
+        await binder.BindModelAsync(bindingContext);
+
+        // Assert
+        Assert.True(bindingContext.Result.IsModelSet);
+
+        var entry = bindingContext.ValidationState[bindingContext.Result.Model];
+        Assert.False(entry.SuppressValidation);
+        Assert.Equal("file", entry.Key);
+        Assert.Equal(formFiles[0], bindingContext.Result.Model);
+        Assert.Null(entry.Metadata);
+    }
+
+    [Fact]
     public async Task FormFileModelBinder_MultipleFilesWithinIndexableCollection_BindSuccessful()
     {
         // Arrange

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Binders/FormFileModelBinderTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Binders/FormFileModelBinderTest.cs
@@ -226,7 +226,7 @@ public class FormFileModelBinderTest
         // Arrange
         var formFiles = new FormFileCollection
             {
-                GetMockFormFile("files[0]", "file1.txt")
+                GetMockFormFile("file[0]", "file1.txt")
             };
         var httpContext = GetMockHttpContext(GetMockFormCollection(formFiles));
 
@@ -235,7 +235,7 @@ public class FormFileModelBinderTest
             Mock.Of<IValueProvider>(),
             new EmptyModelMetadataProvider().GetMetadataForType(typeof(IFormFile)),
             bindingInfo: null,
-            modelName: "files");
+            modelName: "file");
 
         var binder = new FormFileModelBinder(NullLoggerFactory.Instance);
 
@@ -247,7 +247,7 @@ public class FormFileModelBinderTest
 
         var entry = bindingContext.ValidationState[bindingContext.Result.Model];
         Assert.False(entry.SuppressValidation);
-        Assert.Equal("files", entry.Key);
+        Assert.Equal("file", entry.Key);
         Assert.Null(entry.Metadata);
     }
 


### PR DESCRIPTION
# Fixes a bug with form file binding when binding file name with index to an indexable collection.

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Fixes a bug when binding form files with indexers.

## Description

When binding form files, we now check to see if the file name matches the model name even if it has an indexer within the form file name. Previously, form files would only bind if the file name matches the model name exactly.

Fixes #44398 
