### PR TITLE
Fix up publishing of installers built with shared tooling

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -259,13 +259,6 @@
         <InstallerProject Include="$(RepoRoot)src\Installers\Windows\WindowsHostingBundle\WindowsHostingBundle.wixproj" AdditionalProperties="Platform=x86" />
       </ItemGroup>
 
-      <ItemGroup Condition="'$(TargetRuntimeIdentifier)' == 'linux-x64' OR '$(TargetRuntimeIdentifier)' == 'linux-arm64'">
-        <InstallerProject Condition=" '$(LinuxInstallerType)' == 'deb' "
-                        Include="$(RepoRoot)src\Installers\Debian\**\*.*proj" />
-        <InstallerProject Condition=" '$(LinuxInstallerType)' == 'rpm' "
-                        Include="$(RepoRoot)src\Installers\Rpm\**\*.*proj" />
-      </ItemGroup>
-
       <ItemGroup>
         <ProjectToBuild Condition=" '$(BuildInstallers)' == 'true'" Include="@(InstallerProject)" BuildStep="installer" />
       </ItemGroup>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -34,11 +34,15 @@
     <_InstallersToPublish Include="$(ArtifactsDir)packages\**\*.deb" UploadPathSegment="Runtime" ChecksumPath="%(FullPath).sha512" />
     <_InstallersToPublish Include="$(ArtifactsDir)packages\**\*.rpm" UploadPathSegment="Runtime" ChecksumPath="%(FullPath).sha512" />
     <_InstallersToPublish Include="$(ArtifactsDir)packages\**\*.tar.gz" UploadPathSegment="Runtime" ChecksumPath="%(FullPath).sha512" />
-    <_InstallersToPublish Include="$(ArtifactsDir)packages\**\*.zip" UploadPathSegment="Runtime" />
+    <_InstallersToPublish Include="$(ArtifactsDir)packages\**\*.exe" UploadPathSegment="Runtime" ChecksumPath="%(FullPath).sha512" />
+    <_InstallersToPublish Include="$(ArtifactsDir)packages\**\*.msi" UploadPathSegment="Runtime" ChecksumPath="%(FullPath).sha512" />
+    <_InstallersToPublish Include="$(ArtifactsDir)packages\**\*.zip" UploadPathSegment="Runtime">
+      <!-- Exclude wixpack.zip files from checksum generation -->
+      <ChecksumPath Condition="$([System.String]::Copy('%(Filename)%(Extension)').EndsWith('.wixpack.zip')) != 'true'">%(FullPath).sha512</ChecksumPath>
+    </_InstallersToPublish>
 
     <_InstallersToPublish Include="$(ArtifactsDir)installers\**\*.exe" UploadPathSegment="Runtime" ChecksumPath="%(FullPath).sha512" />
     <_InstallersToPublish Include="$(ArtifactsDir)installers\**\*.msi" UploadPathSegment="Runtime" ChecksumPath="%(FullPath).sha512" />
-    <_InstallersToPublish Include="$(ArtifactsDir)installers\**\*.wixlib" UploadPathSegment="Runtime" ChecksumPath="%(FullPath).sha512" />
     <_InstallersToPublish Include="$(ArtifactsDir)installers\**\*.zip" UploadPathSegment="Runtime">
       <!-- Exclude wixpack.zip files from checksum generation -->
       <ChecksumPath Condition="$([System.String]::Copy('%(Filename)%(Extension)').EndsWith('.wixpack.zip')) != 'true'">%(FullPath).sha512</ChecksumPath>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -49,6 +49,7 @@
     </_InstallersToPublish>
 
     <!-- Remove wixpacks if not doing post-build signing, since they are not needed -->
+    <_InstallersToPublish Remove="$(ArtifactsDir)packages\**\*.wixpack.zip" Condition="'$(PostBuildSign)' != 'true'" />
     <_InstallersToPublish Remove="$(ArtifactsDir)installers\**\*.wixpack.zip" Condition="'$(PostBuildSign)' != 'true'" />
 
     <Artifact Include="@(_InstallersToPublish)">


### PR DESCRIPTION
Fix publishing of Windows installers that are produced with the shared tooling