### PR TITLE
Do a few tricks to shorten the intermediate output paths for the runtime packs

### DIFF
--- a/src/Framework/App.Ref/src/Directory.Build.props
+++ b/src/Framework/App.Ref/src/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <OutDirName Condition="'$(MSBuildProjectName)' == 'Microsoft.AspNetCore.App.Ref'">aspnetcore-ref</OutDirName>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
+</Project>

--- a/src/Framework/App.Runtime/src/Directory.Build.props
+++ b/src/Framework/App.Runtime/src/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <OutDirName Condition="'$(MSBuildProjectName)' == 'Microsoft.AspNetCore.App.Runtime'">aspnetcore-sfx</OutDirName>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
+</Project>

--- a/src/Framework/test/Microsoft.AspNetCore.App.UnitTests.csproj
+++ b/src/Framework/test/Microsoft.AspNetCore.App.UnitTests.csproj
@@ -16,7 +16,7 @@
       This depends on internal implementation details of the SharedFramework SDK and should be changed to use a supported mechanism
       to discover the runtime list.
     -->
-    <None Include="$(ArtifactsObjDir)Microsoft.AspNetCore.App.Runtime\$(Configuration)\$(DefaultNetCoreTargetFramework)\$(TargetRuntimeIdentifier)\RuntimeList.xml"
+    <None Include="$(ArtifactsObjDir)aspnetcore-sfx\$(Configuration)\$(TargetRuntimeIdentifier)\RuntimeList.xml"
         CopyToOutputDirectory="PreserveNewest" />
 
     <!-- Ignore aspnetcorev2_inprocess because tests expect only managed assemblies in this item group. -->


### PR DESCRIPTION
The Wix tooling can't handle long paths, which is blocking VMR integration. This change gets our paths to be short enough that even a long-named analyzer's resource DLL won't go past MAX_PATH in a VMR build.

Will unblock https://github.com/dotnet/sdk/pull/45430