### PR TITLE
Consume `M.A.App.Internal.Assets` from the SDK during source build

### DIFF
--- a/eng/tools/GenerateFiles/Directory.Build.targets.in
+++ b/eng/tools/GenerateFiles/Directory.Build.targets.in
@@ -100,7 +100,7 @@
         Condition=" '%(TargetFramework)' == '${DefaultNetCoreTargetFramework}' ">${MicrosoftNETCoreAppRuntimeVersion}</WebAssemblySdkPackVersion>
     </KnownWebAssemblySdkPack>
 
-    <KnownAspNetCorePack Update="Microsoft.AspNetCore.App.Internal.Assets">
+    <KnownAspNetCorePack Update="Microsoft.AspNetCore.App.Internal.Assets" Condition=" '$(DotNetBuildSourceOnly)' != 'true' ">
       <AspNetCorePackVersion
         Condition=" '%(TargetFramework)' == '${DefaultNetCoreTargetFramework}' ">${MicrosoftAspNetCoreAppRuntimeVersion}</AspNetCorePackVersion>
     </KnownAspNetCorePack>


### PR DESCRIPTION
This should unblock https://github.com/dotnet/sdk/pull/45435