### PR TITLE
Only generate specified document (#59097)

### DIFF
--- a/src/Tools/GetDocumentInsider/src/Commands/GetDocumentCommandWorker.cs
+++ b/src/Tools/GetDocumentInsider/src/Commands/GetDocumentCommandWorker.cs
@@ -254,17 +254,23 @@ internal sealed class GetDocumentCommandWorker
             return false;
         }
 
-        // If an explicit document name is provided, then generate only that document.
+        // Get document names
         var documentNames = (IEnumerable<string>)InvokeMethod(getDocumentsMethod, service, _getDocumentsArguments);
         if (documentNames == null)
         {
             return false;
         }
 
-        if (!string.IsNullOrEmpty(_context.DocumentName) && !documentNames.Contains(_context.DocumentName))
+        // If an explicit document name is provided, then generate only that document.
+        if (!string.IsNullOrEmpty(_context.DocumentName))
         {
-            _reporter.WriteError(Resources.FormatDocumentNotFound(_context.DocumentName));
-            return false;
+            if (!documentNames.Contains(_context.DocumentName))
+            {
+                _reporter.WriteError(Resources.FormatDocumentNotFound(_context.DocumentName));
+                return false;
+            }
+
+            documentNames = [_context.DocumentName];
         }
 
         if (!string.IsNullOrWhiteSpace(_context.FileName) && !Regex.IsMatch(_context.FileName, "^([A-Za-z0-9-_]+)$"))

--- a/src/Tools/GetDocumentInsider/tests/GetDocumentTests.cs
+++ b/src/Tools/GetDocumentInsider/tests/GetDocumentTests.cs
@@ -113,7 +113,14 @@ public class GetDocumentTests(ITestOutputHelper output)
         ], new GetDocumentCommand(_console), throwOnUnexpectedArg: false);
 
         // Assert
-        var document = new OpenApiStreamReader().Read(File.OpenRead(Path.Combine(outputPath.FullName, "Sample_internal.json")), out var diagnostic);
+        var expectedDocumentPath = Path.Combine(outputPath.FullName, "Sample_internal.json");
+
+        // There should only be one document when document name is specified
+        var documentNames = Directory.GetFiles(outputPath.FullName).Where(documentName => documentName.EndsWith(".json", StringComparison.Ordinal)).ToList();
+        Assert.Single(documentNames);
+        Assert.Contains(expectedDocumentPath, documentNames);
+
+        var document = new OpenApiStreamReader().Read(File.OpenRead(Path.Combine(outputPath.FullName, expectedDocumentPath)), out var diagnostic);
         Assert.Empty(diagnostic.Errors);
         Assert.Equal(OpenApiSpecVersion.OpenApi3_0, diagnostic.SpecificationVersion);
         // Document name in the title gives us a clue that the correct document was actually resolved


### PR DESCRIPTION
# Respect --document-name flag and only generate the specified document

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

Adjusted the unit test for the `--document--name` flag to include a check for the number of files, at which point it started to fail. Then, I updated the logic in `GetDocumentCommandWorker` to filter the `documentNames` list down to just the specified document name if only and only if the `--document-name` flag is provided.

Fixes #59097
