### PR TITLE
Redis distributed cache: add HybridCache usage signal

### DIFF
--- a/src/Caching/StackExchangeRedis/src/RedisCache.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCache.cs
@@ -53,6 +53,8 @@ public partial class RedisCache : IBufferDistributedCache, IDisposable
     private long _firstErrorTimeTicks;
     private long _previousErrorTimeTicks;
 
+    internal bool HybridCacheActive { get; set; }
+
     // StackExchange.Redis will also be trying to reconnect internally,
     // so limit how often we recreate the ConnectionMultiplexer instance
     // in an attempt to reconnect
@@ -375,6 +377,11 @@ public partial class RedisCache : IBufferDistributedCache, IDisposable
         {
             connection.AddLibraryNameSuffix("aspnet");
             connection.AddLibraryNameSuffix("DC");
+
+            if (HybridCacheActive)
+            {
+                connection.AddLibraryNameSuffix("HC");
+            }
         }
         catch (Exception ex)
         {

--- a/src/Caching/StackExchangeRedis/src/RedisCacheImpl.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCacheImpl.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -8,13 +11,19 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis;
 
 internal sealed class RedisCacheImpl : RedisCache
 {
-    public RedisCacheImpl(IOptions<RedisCacheOptions> optionsAccessor, ILogger<RedisCache> logger)
+    public RedisCacheImpl(IOptions<RedisCacheOptions> optionsAccessor, ILogger<RedisCache> logger, IServiceProvider services)
         : base(optionsAccessor, logger)
     {
+        HybridCacheActive = IsHybridCacheDefined(services);
     }
 
-    public RedisCacheImpl(IOptions<RedisCacheOptions> optionsAccessor)
+    public RedisCacheImpl(IOptions<RedisCacheOptions> optionsAccessor, IServiceProvider services)
         : base(optionsAccessor)
     {
+        HybridCacheActive = IsHybridCacheDefined(services);
     }
+
+    // HybridCache optionally uses IDistributedCache; if we're here, then *we are* the DC
+    private static bool IsHybridCacheDefined(IServiceProvider services)
+        => services.GetService<HybridCache>() is not null;
 }


### PR DESCRIPTION
We already use `"DC"` and `"OC"` markers on RESP connections to provide a non-intrusive signal that Distributed Cache and Output Cache are being used; since `HybridCache` is a feature on top of `IDistributedCache`, here we add an additional `"HC"` token to indicate that a RESP connection is being used for `HybridCache`.

We do this by using `IServiceProvider` (changing the `internal RedisCacheImpl(...)` constructors) to detect `HybridCache` as a service. We don't need it to be the official `HybridCache` specifically (as in `.AddHybridCache()`) - just that a `HybridCache` exists. There are no public API or dependency changes required.

Note: we will also want to backport this