### PR TITLE
More thorough support for retrieving OpenAPI routes in a case-sensitive manner

### DIFF
--- a/src/OpenApi/src/Extensions/OpenApiEndpointRouteBuilderExtensions.cs
+++ b/src/OpenApi/src/Extensions/OpenApiEndpointRouteBuilderExtensions.cs
@@ -50,7 +50,7 @@ public static class OpenApiEndpointRouteBuilderExtensions
                 else
                 {
                     var document = await documentService.GetOpenApiDocumentAsync(context.RequestServices, context.RequestAborted);
-                    var documentOptions = options.Get(documentName);
+                    var documentOptions = options.Get(lowercasedDocumentName);
                     using var output = MemoryBufferWriter.Get();
                     using var writer = Utf8BufferTextWriter.Get(output);
                     try

--- a/src/OpenApi/src/Extensions/OpenApiEndpointRouteBuilderExtensions.cs
+++ b/src/OpenApi/src/Extensions/OpenApiEndpointRouteBuilderExtensions.cs
@@ -30,10 +30,12 @@ public static class OpenApiEndpointRouteBuilderExtensions
         var options = endpoints.ServiceProvider.GetRequiredService<IOptionsMonitor<OpenApiOptions>>();
         return endpoints.MapGet(pattern, async (HttpContext context, string documentName = OpenApiConstants.DefaultDocumentName) =>
             {
-                // We need to retrieve the document name in a case-insensitive manner
-                // to support case-insensitive document name resolution.
-                // Keyed Services are case-sensitive by default, which doesn't work well for document names in ASP.NET Core
-                // as routing in ASP.NET Core is case-insensitive by default.
+                // We need to retrieve the document name in a case-insensitive manner to support case-insensitive document name resolution.
+                // The document service is registered with a key equal to the document name, but in lowercase.
+                // The GetRequiredKeyedService() method is case-sensitive, which doesn't work well for OpenAPI document names here,
+                // as the document name is also used as the route to retrieve the document, so we need to ensure this is lowercased to achieve consistency with ASP.NET Core routing.
+                // The same goes for the document options below, which is also case-sensitive, and thus we need to pass in a case-insensitive document name.
+                // See OpenApiServiceCollectionExtensions.cs for more info.
                 var lowercasedDocumentName = documentName.ToLowerInvariant();
 
                 // It would be ideal to use the `HttpResponseStreamWriter` to

--- a/src/OpenApi/src/Extensions/OpenApiServiceCollectionExtensions.cs
+++ b/src/OpenApi/src/Extensions/OpenApiServiceCollectionExtensions.cs
@@ -106,6 +106,7 @@ public static class OpenApiServiceCollectionExtensions
     public static IServiceCollection AddOpenApi(this IServiceCollection services)
         => services.AddOpenApi(OpenApiConstants.DefaultDocumentName);
 
+    /// <param name="services">The <see cref="IServiceCollection"/> to register services onto.</param>
     /// <param name="documentName">Please ensure this is lowercased to prevent case-sensitive routing issues</param>
     /// <remarks>See https://github.com/dotnet/aspnetcore/issues/59175 for more information around the routing issue mentioned above</remarks>
     private static IServiceCollection AddOpenApiCore(this IServiceCollection services, string documentName)

--- a/src/OpenApi/src/Extensions/OpenApiServiceCollectionExtensions.cs
+++ b/src/OpenApi/src/Extensions/OpenApiServiceCollectionExtensions.cs
@@ -106,6 +106,8 @@ public static class OpenApiServiceCollectionExtensions
     public static IServiceCollection AddOpenApi(this IServiceCollection services)
         => services.AddOpenApi(OpenApiConstants.DefaultDocumentName);
 
+    /// <param name="documentName">Please ensure this is lowercased to prevent case-sensitive routing issues</param>
+    /// <remarks>See https://github.com/dotnet/aspnetcore/issues/59175 for more information around the routing issue mentioned above</remarks>
     private static IServiceCollection AddOpenApiCore(this IServiceCollection services, string documentName)
     {
         services.AddEndpointsApiExplorer();

--- a/src/OpenApi/src/Extensions/OpenApiServiceCollectionExtensions.cs
+++ b/src/OpenApi/src/Extensions/OpenApiServiceCollectionExtensions.cs
@@ -57,10 +57,9 @@ public static class OpenApiServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configureOptions);
 
-        // We need to store the document name in a case-insensitive manner
-        // to support case-insensitive document name resolution.
-        // Keyed Services are case-sensitive by default, which doesn't work well for document names in ASP.NET Core
-        // as routing in ASP.NET Core is case-insensitive by default.
+        // We need to register the document name in a case-insensitive manner to support case-insensitive document name resolution.
+        // The document name is used to store and retrieve keyed services and configuration options, which are all case-sensitive.
+        // To achieve parity with ASP.NET Core routing, which is case-insensitive, we need to ensure the document name is lowercased.
         var lowercasedDocumentName = documentName.ToLowerInvariant();
 
         services.AddOpenApiCore(lowercasedDocumentName);

--- a/src/OpenApi/src/Extensions/OpenApiServiceCollectionExtensions.cs
+++ b/src/OpenApi/src/Extensions/OpenApiServiceCollectionExtensions.cs
@@ -105,9 +105,6 @@ public static class OpenApiServiceCollectionExtensions
     public static IServiceCollection AddOpenApi(this IServiceCollection services)
         => services.AddOpenApi(OpenApiConstants.DefaultDocumentName);
 
-    /// <param name="services">The <see cref="IServiceCollection"/> to register services onto.</param>
-    /// <param name="documentName">Please ensure this is lowercased to prevent case-sensitive routing issues</param>
-    /// <remarks>See https://github.com/dotnet/aspnetcore/issues/59175 for more information around the routing issue mentioned above</remarks>
     private static IServiceCollection AddOpenApiCore(this IServiceCollection services, string documentName)
     {
         services.AddEndpointsApiExplorer();

--- a/src/OpenApi/src/Services/OpenApiDocumentProvider.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentProvider.cs
@@ -25,11 +25,7 @@ internal sealed class OpenApiDocumentProvider(IServiceProvider serviceProvider) 
     /// <param name="writer">A text writer associated with the document to write to.</param>
     public async Task GenerateAsync(string documentName, TextWriter writer)
     {
-        // We need to retrieve the document name in a case-insensitive manner to support case-insensitive document name resolution.
-        // The options are registered with a key equal to the document name, but in lowercase.
-        // The options monitor's Get() method is case-sensitive, which doesn't work well for OpenAPI document names here,
-        // as the document name is also used as the route to retrieve the document, so we need to ensure this is lowercased to achieve consistency with ASP.NET Core routing.
-        // See OpenApiServiceCollectionExtensions.cs for more info.
+        // See OpenApiServiceCollectionExtensions.cs to learn why we lowercase the document name
         var lowercasedDocumentName = documentName.ToLowerInvariant();
 
         var options = serviceProvider.GetRequiredService<IOptionsMonitor<OpenApiOptions>>();

--- a/src/OpenApi/src/Services/OpenApiDocumentProvider.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentProvider.cs
@@ -25,10 +25,17 @@ internal sealed class OpenApiDocumentProvider(IServiceProvider serviceProvider) 
     /// <param name="writer">A text writer associated with the document to write to.</param>
     public async Task GenerateAsync(string documentName, TextWriter writer)
     {
+        // We need to retrieve the document name in a case-insensitive manner to support case-insensitive document name resolution.
+        // The options are registered with a key equal to the document name, but in lowercase.
+        // The options monitor's Get() method is case-sensitive, which doesn't work well for OpenAPI document names here,
+        // as the document name is also used as the route to retrieve the document, so we need to ensure this is lowercased to achieve consistency with ASP.NET Core routing.
+        // See OpenApiServiceCollectionExtensions.cs for more info.
+        var lowercasedDocumentName = documentName.ToLowerInvariant();
+
         var options = serviceProvider.GetRequiredService<IOptionsMonitor<OpenApiOptions>>();
-        var namedOption = options.Get(documentName);
+        var namedOption = options.Get(lowercasedDocumentName);
         var resolvedOpenApiVersion = namedOption.OpenApiVersion;
-        await GenerateAsync(documentName, writer, resolvedOpenApiVersion);
+        await GenerateAsync(lowercasedDocumentName, writer, resolvedOpenApiVersion);
     }
 
     /// <summary>
@@ -40,10 +47,17 @@ internal sealed class OpenApiDocumentProvider(IServiceProvider serviceProvider) 
     /// <param name="openApiSpecVersion">The OpenAPI specification version to use when serializing the document.</param>
     public async Task GenerateAsync(string documentName, TextWriter writer, OpenApiSpecVersion openApiSpecVersion)
     {
+        // We need to retrieve the document name in a case-insensitive manner to support case-insensitive document name resolution.
+        // The document service is registered with a key equal to the document name, but in lowercase.
+        // The GetRequiredKeyedService() method is case-sensitive, which doesn't work well for OpenAPI document names here,
+        // as the document name is also used as the route to retrieve the document, so we need to ensure this is lowercased to achieve consistency with ASP.NET Core routing.
+        // See OpenApiServiceCollectionExtensions.cs for more info.
+        var lowercasedDocumentName = documentName.ToLowerInvariant();
+
         // Microsoft.OpenAPI does not provide async APIs for writing the JSON
         // document to a file. See https://github.com/microsoft/OpenAPI.NET/issues/421 for
         // more info.
-        var targetDocumentService = serviceProvider.GetRequiredKeyedService<OpenApiDocumentService>(documentName);
+        var targetDocumentService = serviceProvider.GetRequiredKeyedService<OpenApiDocumentService>(lowercasedDocumentName);
         using var scopedService = serviceProvider.CreateScope();
         var document = await targetDocumentService.GetOpenApiDocumentAsync(scopedService.ServiceProvider);
         var jsonWriter = new OpenApiJsonWriter(writer);

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Extensions/OpenApiEndpointRouteBuilderExtensionsTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Extensions/OpenApiEndpointRouteBuilderExtensionsTests.cs
@@ -181,12 +181,14 @@ public class OpenApiEndpointRouteBuilderExtensionsTests : OpenApiDocumentService
         Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
         var responseString = Encoding.UTF8.GetString(responseBodyStream.ToArray());
 
-        // When we receive an OpenAPI document, we use an OptionsMonitor to retrieve named options that equal the requested document name.
-        // This is case-sensitive. If the document doesn't exist, the options monitor return a default instance, in which the OpenAPI version is set to v3.
+        // When we receive an OpenAPI document, we use an OptionsMonitor to retrieve OpenAPI options which are stored with a key equal the requested document name.
+        // This key is case-sensitive. If the document doesn't exist, the options monitor return a default instance, in which the OpenAPI version is set to v3.
+        // This could cause bugs! You'd get your document, but depending on the casing you used in the document name you passed to the function, you'll receive different OpenAPI document versions.
+        // We want to prevent this from happening. Therefore:
         // By setting up a v2 document on the "casesensitive" route and requesting it on "CaseSensitive",
         // we can test that the we've configured the options monitor to retrieve the options in a case-insensitive manner.
         // If it is case-sensitive, it would return a default instance with OpenAPI version v3, which would cause this test to fail!
-        // However, if it would return the v2 instance, the test would pass!
+        // However, if it would return the v2 instance, which was configured on the lowercase - case-insensitive - documentname, the test would pass!
         // For more info, see OpenApiEndpointRouteBuilderExtensions.cs
         Assert.StartsWith("{\n  \"swagger\": \"2.0\"", responseString);
     }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentProviderTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentProviderTests.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.ApiDescriptions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.OpenApi;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers;
 using static Microsoft.AspNetCore.OpenApi.Tests.OpenApiOperationGeneratorTests;

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentProviderTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentProviderTests.cs
@@ -36,7 +36,7 @@ public class OpenApiDocumentProviderTests : OpenApiDocumentServiceTestBase
     {
         // Arrange
         var documentName = "CaseSensitive";
-        var serviceProvider = CreateServiceProvider(["casesensitive"]);
+        var serviceProvider = CreateServiceProvider(["casesensitive"], OpenApiSpecVersion.OpenApi2_0);
         var documentProvider = new OpenApiDocumentProvider(serviceProvider);
         var stringWriter = new StringWriter();
 
@@ -78,11 +78,7 @@ public class OpenApiDocumentProviderTests : OpenApiDocumentServiceTestBase
         // It's registered as "casesensitive" but we're passing in "CaseSensitive", which doesn't exist.
         // Therefore, if the test doesn't throw, we know it has passed correctly.
         // We still do a small check to validate the document, just in case. But the main test is that it doesn't throw.
-        ValidateOpenApiDocument(stringWriter, document =>
-        {
-            Assert.Equal($"{nameof(OpenApiDocumentProviderTests)} | {documentName}", document.Info.Title);
-            Assert.Equal("1.0.0", document.Info.Version);
-        });
+        ValidateOpenApiDocument(stringWriter, _ => { });
     }
 
     [Fact]
@@ -111,7 +107,7 @@ public class OpenApiDocumentProviderTests : OpenApiDocumentServiceTestBase
         action(document);
     }
 
-    private static IServiceProvider CreateServiceProvider(string[] documentNames)
+    private static IServiceProvider CreateServiceProvider(string[] documentNames, OpenApiSpecVersion openApiSpecVersion = OpenApiSpecVersion.OpenApi3_0)
     {
         var hostEnvironment = new HostEnvironment() { ApplicationName = nameof(OpenApiDocumentProviderTests) };
         var serviceProviderIsService = new ServiceProviderIsService();
@@ -121,7 +117,7 @@ public class OpenApiDocumentProviderTests : OpenApiDocumentServiceTestBase
             .AddSingleton(CreateApiDescriptionGroupCollectionProvider());
         foreach (var documentName in documentNames)
         {
-            serviceCollection.AddOpenApi(documentName);
+            serviceCollection.AddOpenApi(documentName, x => x.OpenApiVersion = openApiSpecVersion);
         }
         var serviceProvider = serviceCollection.BuildServiceProvider(validateScopes: true);
         return serviceProvider;

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentProviderTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentProviderTests.cs
@@ -70,6 +70,7 @@ public class OpenApiDocumentProviderTests : OpenApiDocumentServiceTestBase
         await documentProvider.GenerateAsync(documentName, stringWriter, OpenApiSpecVersion.OpenApi3_0);
 
         // Assert
+        var document = stringWriter.ToString();
 
         // If the Document Service is retrieved with a non-existent (case-sensitive) key, it would throw:
         // https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.serviceproviderkeyedserviceextensions.getrequiredkeyedservice?view=net-9.0-pp
@@ -79,6 +80,7 @@ public class OpenApiDocumentProviderTests : OpenApiDocumentServiceTestBase
         // Therefore, if the test doesn't throw, we know it has passed correctly.
         // We still do a small check to validate the document, just in case. But the main test is that it doesn't throw.
         ValidateOpenApiDocument(stringWriter, _ => { });
+        Assert.StartsWith("{\n  \"openapi\": \"3.0.1\"", document);
     }
 
     [Fact]


### PR DESCRIPTION
# More thorough support for retrieving OpenAPI routes in a case-sensitive manner

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

This PR fixes some oversights from #59199 around retrieving OpenAPI documents case-insensitively.

## Description

This PR modifies missed files from #59199 that use the registered document name as a key for retrieving services or options. This needs to be done case-insensitively to:

- Ensure documents can be retrieved correctly
  - Trying to retrieve services around OpenAPI documents that are registered with a differently cased document name, will result in an exception, which is not desired!
- Ensure documents are generated and retrieved with the correct OpenAPI version
  - If the configuration options are retrieved with an incorrectly cased document name argument, a default instance of `OpenApiOptions` is returned, which might contain different settings than what the user had configured.

This PR also adds some more comments and improves existing ones based on the previous PR around case-insensitive OpenAPI document names.

Fixes #59175 