### PR TITLE
Skip tests on internal queues too

### DIFF
--- a/src/Testing/src/xunit/SkipOnHelixAttribute.cs
+++ b/src/Testing/src/xunit/SkipOnHelixAttribute.cs
@@ -66,7 +66,9 @@ public class SkipOnHelixAttribute : Attribute, ITestCondition
             return true;
         }
 
-        return Queues.ToLowerInvariant().Split(';').Contains(targetQueue);
+        // We have "QueueName" and "QueueName.Open" queues for internal and public builds
+        // If we want to skip the test in the public queue, we want to skip it in the internal queue, and vice versa
+        return Queues.ToLowerInvariant().Split(';').Any(q => q.Equals(targetQueue) || q.StartsWith(targetQueue) || targetQueue.StartsWith(q));
     }
 
     public static bool OnHelix() => HelixHelper.OnHelix();

--- a/src/Testing/src/xunit/SkipOnHelixAttribute.cs
+++ b/src/Testing/src/xunit/SkipOnHelixAttribute.cs
@@ -68,7 +68,8 @@ public class SkipOnHelixAttribute : Attribute, ITestCondition
 
         // We have "QueueName" and "QueueName.Open" queues for internal and public builds
         // If we want to skip the test in the public queue, we want to skip it in the internal queue, and vice versa
-        return Queues.ToLowerInvariant().Split(';').Any(q => q.Equals(targetQueue) || q.StartsWith(targetQueue) || targetQueue.StartsWith(q));
+        return Queues.ToLowerInvariant().Split(';').Any(q => q.Equals(targetQueue, StringComparison.Ordinal) || q.StartsWith(targetQueue, StringComparison.Ordinal) || 
+            targetQueue.StartsWith(q, StringComparison.Ordinal));
     }
 
     public static bool OnHelix() => HelixHelper.OnHelix();


### PR DESCRIPTION
We run tests on internal queues sometimes (internal PRs, IdentityModel pipeline) - anywhere we skip a test on a specific public queue, we should skip it on the internal queue too.