### PR TITLE
Migrate off of Debian 11

### DIFF
--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <HelixQueueAlmaLinux8>(AlmaLinux.8.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:almalinux-8-helix-amd64</HelixQueueAlmaLinux8>
     <HelixQueueAlpine317>(Alpine.317.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.17-helix-amd64</HelixQueueAlpine317>
-    <HelixQueueDebian11>(Debian.11.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64</HelixQueueDebian11>
+    <HelixQueueDebian11>(Debian.12.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-amd64</HelixQueueDebian11>
     <HelixQueueFedora38>(Fedora.38.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-38-helix</HelixQueueFedora38>
     <HelixQueueMariner>(Mariner)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-1.0-helix</HelixQueueMariner>
     <HelixQueueArmDebian12>(Debian.12.Arm64.Open)ubuntu.2204.armarch.open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-arm64v8</HelixQueueArmDebian12>
@@ -17,7 +17,7 @@
     <HelixAvailablePlatform Include="OSX" />
     <HelixAvailablePlatform Include="Linux" />
   </ItemGroup>
-
+<!--  -->
   <!--
     Usually do not need to check $(_UseHelixOpenQueues), $(RunQuarantinedTests) or $(IsWindowsOnlyTest).
     $(_UseHelixOpenQueues) handling in helix.proj and Helix.targets is sufficient. We have no quarantined queues

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <HelixQueueAlmaLinux8>(AlmaLinux.8.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:almalinux-8-helix-amd64</HelixQueueAlmaLinux8>
     <HelixQueueAlpine317>(Alpine.317.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.17-helix-amd64</HelixQueueAlpine317>
-    <HelixQueueDebian11>(Debian.12.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-amd64</HelixQueueDebian11>
-    <HelixQueueFedora38>(Fedora.38.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-38-helix</HelixQueueFedora38>
-    <HelixQueueMariner>(Mariner)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-1.0-helix</HelixQueueMariner>
+    <HelixQueueDebian12>(Debian.12.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-amd64</HelixQueueDebian12>
+    <HelixQueueFedora40>(Fedora.40.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-40-helix</HelixQueueFedora40>
+    <HelixQueueMariner>(Mariner)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-helix</HelixQueueMariner>
     <HelixQueueArmDebian12>(Debian.12.Arm64.Open)ubuntu.2204.armarch.open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-arm64v8</HelixQueueArmDebian12>
 
     <!-- Do not attempt to override global property. -->
@@ -43,8 +43,8 @@
 
         <!-- Containers -->
         <HelixAvailableTargetQueue Include="$(HelixQueueAlpine317)" Platform="Linux" />
-        <HelixAvailableTargetQueue Include="$(HelixQueueDebian11)" Platform="Linux" />
-        <HelixAvailableTargetQueue Include="$(HelixQueueFedora38)" Platform="Linux" />
+        <HelixAvailableTargetQueue Include="$(HelixQueueDebian12)" Platform="Linux" />
+        <HelixAvailableTargetQueue Include="$(HelixQueueFedora40)" Platform="Linux" />
         <HelixAvailableTargetQueue Include="$(HelixQueueMariner)" Platform="Linux" />
         <HelixAvailableTargetQueue Include="$(HelixQueueArmDebian12)" Platform="Linux" />
 

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -17,7 +17,7 @@
     <HelixAvailablePlatform Include="OSX" />
     <HelixAvailablePlatform Include="Linux" />
   </ItemGroup>
-<!--  -->
+
   <!--
     Usually do not need to check $(_UseHelixOpenQueues), $(RunQuarantinedTests) or $(IsWindowsOnlyTest).
     $(_UseHelixOpenQueues) handling in helix.proj and Helix.targets is sufficient. We have no quarantined queues

--- a/eng/targets/Helix.targets
+++ b/eng/targets/Helix.targets
@@ -18,8 +18,8 @@
     <SkipHelixQueues>
       $(HelixQueueAlmaLinux8);
       $(HelixQueueAlpine316);
-      $(HelixQueueDebian11);
-      $(HelixQueueFedora34);
+      $(HelixQueueDebian12);
+      $(HelixQueueFedora40);
       $(HelixQueueMariner);
       Ubuntu.2004.Amd64.Open;
     </SkipHelixQueues>


### PR DESCRIPTION
aspnetcore references a Debian 11 image that is EOL (see https://github.com/dotnet/core/issues/9625):
Branch: release/8.0
https://github.com/dotnet/aspnetcore/blob/dc3b2086feef8e62771254fdfded9d9d8a05346f/eng/targets/Helix.Common.props#L6
https://github.com/dotnet/aspnetcore/blob/e76fa91013f223a6300ac046b0e0839ef9601ccc/eng/targets/Helix.Common.props#L7
https://github.com/dotnet/aspnetcore/blob/e76fa91013f223a6300ac046b0e0839ef9601ccc/eng/targets/Helix.Common.props#L46
https://github.com/dotnet/aspnetcore/blob/e76fa91013f223a6300ac046b0e0839ef9601ccc/eng/targets/Helix.Common.props#L47
https://github.com/dotnet/aspnetcore/blob/e76fa91013f223a6300ac046b0e0839ef9601ccc/eng/targets/Helix.targets#L21
https://github.com/dotnet/aspnetcore/blob/e76fa91013f223a6300ac046b0e0839ef9601ccc/eng/targets/Helix.targets#L22

Update Debian11 -> 12 and Fedora 38 -> 40