### PR TITLE
Migrate off of Fedora 38

### DIFF
--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -4,7 +4,7 @@
     <HelixQueueAlmaLinux8>(AlmaLinux.8.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:almalinux-8-helix-amd64</HelixQueueAlmaLinux8>
     <HelixQueueAlpine318>(Alpine.318.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.18-helix-amd64</HelixQueueAlpine318>
     <HelixQueueDebian12>(Debian.12.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-amd64</HelixQueueDebian12>
-    <HelixQueueFedora38>(Fedora.38.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-38-helix</HelixQueueFedora38>
+    <HelixQueueFedora40>(Fedora.40.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-40-helix</HelixQueueFedora40>
     <HelixQueueMariner>(Mariner)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-helix-amd64</HelixQueueMariner>
     <HelixQueueArmDebian12>(Debian.12.Arm64.Open)ubuntu.2204.armarch.open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-arm64v8</HelixQueueArmDebian12>
 
@@ -44,7 +44,7 @@
         <!-- Containers -->
         <HelixAvailableTargetQueue Include="$(HelixQueueAlpine318)" Platform="Linux" />
         <HelixAvailableTargetQueue Include="$(HelixQueueDebian12)" Platform="Linux" />
-        <HelixAvailableTargetQueue Include="$(HelixQueueFedora38)" Platform="Linux" />
+        <HelixAvailableTargetQueue Include="$(HelixQueueFedora40)" Platform="Linux" />
         <HelixAvailableTargetQueue Include="$(HelixQueueMariner)" Platform="Linux" />
         <HelixAvailableTargetQueue Include="$(HelixQueueArmDebian12)" Platform="Linux" />
 

--- a/eng/targets/Helix.targets
+++ b/eng/targets/Helix.targets
@@ -19,7 +19,7 @@
       $(HelixQueueAlmaLinux8);
       $(HelixQueueAlpine318);
       $(HelixQueueDebian12);
-      $(HelixQueueFedora38);
+      $(HelixQueueFedora40);
       $(HelixQueueMariner);
       Ubuntu.2004.Amd64.Open;
     </SkipHelixQueues>


### PR DESCRIPTION
aspnetcore references a Fedora 38 image that is EOL (see https://github.com/dotnet/core/issues/9625):
branch release/9.0:

https://github.com/dotnet/aspnetcore/blob/401ae7cb55f1460e038f7f8be0e8c782bfeec1ef/eng/targets/Helix.Common.props#L7

https://github.com/dotnet/aspnetcore/blob/401ae7cb55f1460e038f7f8be0e8c782bfeec1ef/eng/targets/Helix.Common.props#L47

https://github.com/dotnet/aspnetcore/blob/401ae7cb55f1460e038f7f8be0e8c782bfeec1ef/eng/targets/Helix.targets#L22
Update Fedora 38 -> 40