### PR TITLE
Update runtime download paths to directly point to the blob store

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -234,10 +234,10 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <OfficialBaseURL>https://dotnetcli.azureedge.net/dotnet/</OfficialBaseURL>
+    <OfficialBaseURL>https://dotnetcli.blob.core.windows.net/dotnet/</OfficialBaseURL>
     <!-- Allow overriding the public base URL for Unified Build scenarios to pull assets from a local build. -->
-    <PublicBaseURL Condition="'$(PublicBaseURL)' == ''">https://dotnetbuilds.azureedge.net/public/</PublicBaseURL>
-    <InternalBaseURL>https://dotnetbuilds.azureedge.net/internal/</InternalBaseURL>
+    <PublicBaseURL Condition="'$(PublicBaseURL)' == ''">https://dotnetbuilds.blob.core.windows.net/public/</PublicBaseURL>
+    <InternalBaseURL>https://dotnetbuilds.blob.core.windows.net/internal/</InternalBaseURL>
     <!-- Allow overriding where installers are pulled in from previously completed jobs in Unified Build scenarios. -->
     <CrossArchitectureInstallerBasePath Condition="'$(CrossArchitectureInstallerBasePath)' == ''">$(ArtifactsShippingPackagesDir)</CrossArchitectureInstallerBasePath>
   </PropertyGroup>


### PR DESCRIPTION
Our CDN is changing, so update the URLs. Instead of pointing to the CDN, point to the underlying store like dotnet/sdk does.

See https://github.com/dotnet/core/issues/9671