### PR TITLE
Apply HeadersLengthLimit to preamble in MultipartReader

### DIFF
--- a/src/Http/WebUtilities/src/MultipartBoundary.cs
+++ b/src/Http/WebUtilities/src/MultipartBoundary.cs
@@ -10,11 +10,11 @@ internal sealed class MultipartBoundary
     private readonly byte[] _boundaryBytes;
     private bool _expectLeadingCrlf;
 
-    public MultipartBoundary(string boundary, bool expectLeadingCrlf = true)
+    public MultipartBoundary(string boundary)
     {
         ArgumentNullException.ThrowIfNull(boundary);
 
-        _expectLeadingCrlf = expectLeadingCrlf;
+        _expectLeadingCrlf = false;
         _boundaryBytes = Encoding.UTF8.GetBytes("\r\n--" + boundary);
 
         FinalBoundaryLength = BoundaryBytes.Length + 2; // Include the final '--' terminator.

--- a/src/Http/WebUtilities/src/MultipartBoundary.cs
+++ b/src/Http/WebUtilities/src/MultipartBoundary.cs
@@ -25,6 +25,12 @@ internal sealed class MultipartBoundary
         _expectLeadingCrlf = true;
     }
 
+    // Lets us throw a more specific error from MultipartReaderStream when reading any preamble data.
+    public bool BeforeFirstBoundary()
+    {
+        return !_expectLeadingCrlf;
+    }
+
     // Return either "--{boundary}" or "\r\n--{boundary}" depending on if we're looking for the end of a section
     public ReadOnlySpan<byte> BoundaryBytes => _boundaryBytes.AsSpan(_expectLeadingCrlf ? 0 : 2);
 

--- a/src/Http/WebUtilities/src/MultipartReader.cs
+++ b/src/Http/WebUtilities/src/MultipartReader.cs
@@ -56,7 +56,7 @@ public class MultipartReader
         }
         _stream = new BufferedReadStream(stream, bufferSize);
         boundary = HeaderUtilities.RemoveQuotes(new StringSegment(boundary)).ToString();
-        _boundary = new MultipartBoundary(boundary, false);
+        _boundary = new MultipartBoundary(boundary);
     }
 
     /// <summary>
@@ -83,12 +83,9 @@ public class MultipartReader
     /// <returns></returns>
     public async Task<MultipartSection?> ReadNextSectionAsync(CancellationToken cancellationToken = new CancellationToken())
     {
-        if (_currentStream == null)
-        {
-            // Only occurs on first call
-            // This stream will drain any preamble data and remove the first boundary marker.
-            _currentStream = new MultipartReaderStream(_stream, _boundary) { LengthLimit = HeadersLengthLimit };
-        }
+        // Only occurs on first call
+        // This stream will drain any preamble data and remove the first boundary marker.
+        _currentStream ??= new MultipartReaderStream(_stream, _boundary) { LengthLimit = HeadersLengthLimit };
 
         // Drain the prior section.
         await _currentStream.DrainAsync(cancellationToken);

--- a/src/Http/WebUtilities/src/MultipartReader.cs
+++ b/src/Http/WebUtilities/src/MultipartReader.cs
@@ -27,7 +27,7 @@ public class MultipartReader
 
     private readonly BufferedReadStream _stream;
     private readonly MultipartBoundary _boundary;
-    private MultipartReaderStream _currentStream;
+    private MultipartReaderStream? _currentStream;
 
     /// <summary>
     /// Initializes a new instance of <see cref="MultipartReader"/>.
@@ -57,9 +57,6 @@ public class MultipartReader
         _stream = new BufferedReadStream(stream, bufferSize);
         boundary = HeaderUtilities.RemoveQuotes(new StringSegment(boundary)).ToString();
         _boundary = new MultipartBoundary(boundary, false);
-        // This stream will drain any preamble data and remove the first boundary marker.
-        // TODO: HeadersLengthLimit can't be modified until after the constructor.
-        _currentStream = new MultipartReaderStream(_stream, _boundary) { LengthLimit = HeadersLengthLimit };
     }
 
     /// <summary>
@@ -86,6 +83,13 @@ public class MultipartReader
     /// <returns></returns>
     public async Task<MultipartSection?> ReadNextSectionAsync(CancellationToken cancellationToken = new CancellationToken())
     {
+        if (_currentStream == null)
+        {
+            // Only occurs on first call
+            // This stream will drain any preamble data and remove the first boundary marker.
+            _currentStream = new MultipartReaderStream(_stream, _boundary) { LengthLimit = HeadersLengthLimit };
+        }
+
         // Drain the prior section.
         await _currentStream.DrainAsync(cancellationToken);
         // If we're at the end return null

--- a/src/Http/WebUtilities/src/MultipartReaderStream.cs
+++ b/src/Http/WebUtilities/src/MultipartReaderStream.cs
@@ -145,16 +145,18 @@ internal sealed class MultipartReaderStream : Stream
         if (_observedLength < _position)
         {
             _observedLength = _position;
-            if (LengthLimit.HasValue && _observedLength > LengthLimit.GetValueOrDefault())
+            if (LengthLimit.HasValue &&
+                LengthLimit.GetValueOrDefault() is var lengthLimit &&
+                _observedLength > lengthLimit)
             {
                 // If we hit the limit before the first boundary then we're using the header length limit, not the body length limit.
                 if (_boundary.BeforeFirstBoundary())
                 {
-                    throw new InvalidDataException($"Multipart header length limit {LengthLimit.GetValueOrDefault()} exceeded. Too much data before the first boundary.");
+                    throw new InvalidDataException($"Multipart header length limit {lengthLimit} exceeded. Too much data before the first boundary.");
                 }
                 else
                 {
-                    throw new InvalidDataException($"Multipart body length limit {LengthLimit.GetValueOrDefault()} exceeded.");
+                    throw new InvalidDataException($"Multipart body length limit {lengthLimit} exceeded.");
                 }
             }
         }

--- a/src/Http/WebUtilities/src/MultipartReaderStream.cs
+++ b/src/Http/WebUtilities/src/MultipartReaderStream.cs
@@ -147,7 +147,15 @@ internal sealed class MultipartReaderStream : Stream
             _observedLength = _position;
             if (LengthLimit.HasValue && _observedLength > LengthLimit.GetValueOrDefault())
             {
-                throw new InvalidDataException($"Multipart body length limit {LengthLimit.GetValueOrDefault()} exceeded.");
+                // If we hit the limit before the first boundary then we're using the header length limit, not the body length limit.
+                if (_boundary.BeforeFirstBoundary())
+                {
+                    throw new InvalidDataException($"Multipart header length limit {LengthLimit.GetValueOrDefault()} exceeded. Too much data before the first boundary.");
+                }
+                else
+                {
+                    throw new InvalidDataException($"Multipart body length limit {LengthLimit.GetValueOrDefault()} exceeded.");
+                }
             }
         }
         return read;


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/50252
Helps with https://github.com/dotnet/aspnetcore/issues/58233

The `HeadersLengthLimit` on `MultipartReader` now applies to the inner stream on first read. What this means is that if the request has any preamble data (data before the first boundary), the `HeadersLengthLimit` will now be applied to that preamble data. Before it was hardcoded to the default value of 16kb and not modifiable before being used.