### PR TITLE
Dispose CTS when the Stream is claimed or timeout occurs

### DIFF
--- a/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
+++ b/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
@@ -18,7 +18,7 @@ internal partial class RemoteJSRuntime : JSRuntime
     private readonly CircuitOptions _options;
     private readonly ILogger<RemoteJSRuntime> _logger;
     private CircuitClientProxy _clientProxy;
-    private readonly ConcurrentDictionary<long, DotNetStreamReference> _pendingDotNetToJSStreams = new();
+    private readonly ConcurrentDictionary<long, CancelableDotNetStreamReference> _pendingDotNetToJSStreams = new();
     private bool _permanentlyDisconnected;
     private readonly long _maximumIncomingBytes;
     private int _byteArraysToBeRevivedTotalBytes;
@@ -152,7 +152,8 @@ internal partial class RemoteJSRuntime : JSRuntime
 
     protected override async Task TransmitStreamAsync(long streamId, DotNetStreamReference dotNetStreamReference)
     {
-        if (!_pendingDotNetToJSStreams.TryAdd(streamId, dotNetStreamReference))
+        var cancelableStreamReference = new CancelableDotNetStreamReference(dotNetStreamReference);
+        if (_pendingDotNetToJSStreams.TryAdd(streamId, cancelableStreamReference))
         {
             throw new ArgumentException($"The stream {streamId} is already pending.");
         }
@@ -160,13 +161,18 @@ internal partial class RemoteJSRuntime : JSRuntime
         // SignalR only supports streaming being initiated from the JS side, so we have to ask it to
         // start the stream. We'll give it a maximum of 10 seconds to do so, after which we give up
         // and discard it.
-        var cancellationToken = new CancellationTokenSource(TimeSpan.FromSeconds(10)).Token;
-        cancellationToken.Register(() =>
+        CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromSeconds(10));
+
+        // Store CTS to dispose later.
+        cancelableStreamReference.CancellationTokenSource = cancellationTokenSource;
+
+        cancellationTokenSource.Token.Register(() =>
         {
             // If by now the stream hasn't been claimed for sending, stop tracking it
-            if (_pendingDotNetToJSStreams.TryRemove(streamId, out var timedOutStream) && !timedOutStream.LeaveOpen)
+            if (_pendingDotNetToJSStreams.TryRemove(streamId, out var timedOutCancelableStreamReference))
             {
-                timedOutStream.Stream.Dispose();
+                timedOutCancelableStreamReference.StreamReference.Dispose();
+                timedOutCancelableStreamReference.CancellationTokenSource?.Dispose();
             }
         });
 
@@ -175,8 +181,13 @@ internal partial class RemoteJSRuntime : JSRuntime
 
     public bool TryClaimPendingStreamForSending(long streamId, out DotNetStreamReference pendingStream)
     {
-        if (_pendingDotNetToJSStreams.TryRemove(streamId, out pendingStream))
+        if (_pendingDotNetToJSStreams.TryRemove(streamId, out var cancelableStreamReference))
         {
+            pendingStream = cancelableStreamReference.StreamReference;
+
+            // Dispose CTS for claimed Stream.
+            cancelableStreamReference.CancellationTokenSource?.Dispose();
+
             return true;
         }
 
@@ -192,6 +203,18 @@ internal partial class RemoteJSRuntime : JSRuntime
 
     protected override async Task<Stream> ReadJSDataAsStreamAsync(IJSStreamReference jsStreamReference, long totalLength, CancellationToken cancellationToken = default)
         => await RemoteJSDataStream.CreateRemoteJSDataStreamAsync(this, jsStreamReference, totalLength, _maximumIncomingBytes, _options.JSInteropDefaultCallTimeout, cancellationToken);
+
+    private class CancelableDotNetStreamReference
+    {
+        public CancelableDotNetStreamReference(DotNetStreamReference streamReference)
+        {
+            StreamReference = streamReference;
+        }
+
+        public CancellationTokenSource? CancellationTokenSource { get; set; }
+
+        public DotNetStreamReference StreamReference { get; }
+    }
 
     public static partial class Log
     {

--- a/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
+++ b/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
@@ -153,7 +153,7 @@ internal partial class RemoteJSRuntime : JSRuntime
     protected override async Task TransmitStreamAsync(long streamId, DotNetStreamReference dotNetStreamReference)
     {
         var cancelableStreamReference = new CancelableDotNetStreamReference(dotNetStreamReference);
-        if (_pendingDotNetToJSStreams.TryAdd(streamId, cancelableStreamReference))
+        if (!_pendingDotNetToJSStreams.TryAdd(streamId, cancelableStreamReference))
         {
             throw new ArgumentException($"The stream {streamId} is already pending.");
         }


### PR DESCRIPTION
# Dispose CTS when the Stream is claimed or timeout occurs

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Store the `CancellationTokenSource` to dispose when the `DotNetStreamReference` is claimed or timeout occurs.

Fixes #59263 
