### PR TITLE
Update OSX helix queue

### DIFF
--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -48,7 +48,7 @@
         <HelixAvailableTargetQueue Include="$(HelixQueueArmDebian12)" Platform="Linux" />
 
         <!-- Mac -->
-        <HelixAvailableTargetQueue Include="OSX.1200.Amd64.Open" Platform="OSX" />
+        <HelixAvailableTargetQueue Include="OSX.15.Amd64.Open" Platform="OSX" />
 
         <!-- Windows -->
         <HelixAvailableTargetQueue Include="Windows.Amd64.Server2022.Open" Platform="Windows" />


### PR DESCRIPTION
The `aspnetcore-helix-matrix main` pipeline has been failing for a while with the following error:

```text
Helix queue osx.1200.amd64.open is set for estimated removal date of 2025-01-01. In most cases the queue will be removed permanently due to end-of-life; please contact dnceng for any questions or concerns, and we can help you decide how to proceed and discuss other options.
```

This PR updates the OSX helix queue to `OSX.15.Amd64.Open` to fix the failing pipeline.