### PR TITLE
Apply schema transformer to AdditionalProperties

### DIFF
--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -212,7 +212,13 @@ internal sealed class OpenApiSchemaService(
                 }
             }
         }
-    }
+
+        if (schema is { AdditionalPropertiesAllowed: true, AdditionalProperties: not null } && jsonTypeInfo.ElementType is not null) 
+		{
+            var elementTypeInfo = _jsonSerializerOptions.GetTypeInfo(jsonTypeInfo.ElementType);
+            await InnerApplySchemaTransformersAsync(schema.AdditionalProperties, elementTypeInfo, null, context, transformer, cancellationToken);
+        }
+	}
 
     private JsonNode CreateSchema(OpenApiSchemaKey key)
         => JsonSchemaExporter.GetJsonSchemaAsNode(_jsonSerializerOptions, key.Type, _configuration);

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/SchemaTransformerTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/SchemaTransformerTests.cs
@@ -444,6 +444,7 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
 
         builder.MapGet("/list", () => new List<int> { 1, 2, 3, 4 });
         builder.MapGet("/single", () => 1);
+        builder.MapGet("/dictionary", () => new Dictionary<string, int> {{ "key", 1 }});
 
         var options = new OpenApiOptions();
         options.AddSchemaTransformer((schema, context, cancellationToken) =>
@@ -469,7 +470,13 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
             getOperation = path.Operations[OperationType.Get];
             responseSchema = getOperation.Responses["200"].Content["application/json"].Schema.GetEffective(document);
             Assert.Equal("modified-number-format", responseSchema.Format);
-        });
+
+            // Assert that the schema represent dictionary values has been modified
+            path = document.Paths["/dictionary"];
+            getOperation = path.Operations[OperationType.Get];
+            responseSchema = getOperation.Responses["200"].Content["application/json"].Schema.GetEffective(document);
+            Assert.Equal("modified-number-format", responseSchema.AdditionalProperties.Format);
+		});
     }
 
     [Fact]


### PR DESCRIPTION
# Apply schema transformer to AdditionalProperties

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Applied `InnerApplySchemaTransformersAsync` to `AdditionalProperties` where `AdditionalPropertiesAllowed` and `jsonTypeInfo` has an `ElementType`

## Description

Fixed schema generation for `AdditionalProperties`, the result of a dictionary value type.

Fixes #59616 
