### PR TITLE
Don't send body in HEAD response when using PipeWriter.Advance before headers flushed

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
@@ -360,6 +360,7 @@ internal class Http1OutputProducer : IHttpOutputProducer, IDisposable
 
         writer.Commit();
 
+        Debug.Assert(responseBodyMode != ResponseBodyMode.Uninitialized);
         _responseBodyMode = responseBodyMode;
         WriteDataWrittenBeforeHeaders(ref writer);
         _unflushedBytes += writer.BytesCommitted;
@@ -544,7 +545,7 @@ internal class Http1OutputProducer : IHttpOutputProducer, IDisposable
         Debug.Assert(_completedSegments == null || _completedSegments.Count == 0);
         // Cleared in sequential address ascending order
         _currentMemoryPrefixBytes = 0;
-        _responseBodyMode = ResponseBodyMode.ContentLength;
+        _responseBodyMode = ResponseBodyMode.Uninitialized;
         _writeStreamSuffixCalled = false;
         _currentChunkMemoryUpdated = false;
         _startCalled = false;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
@@ -334,7 +334,7 @@ internal class Http1OutputProducer : IHttpOutputProducer, IDisposable
         writer.Commit();
     }
 
-    public void WriteResponseHeaders(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, bool appComplete, bool canWriteBody)
+    public void WriteResponseHeaders(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, bool appComplete)
     {
         lock (_contextLock)
         {
@@ -344,8 +344,6 @@ internal class Http1OutputProducer : IHttpOutputProducer, IDisposable
             {
                 return;
             }
-
-            _canWriteBody = canWriteBody;
 
             var buffer = _pipeWriter;
             var writer = new BufferWriter<PipeWriter>(buffer);
@@ -544,6 +542,11 @@ internal class Http1OutputProducer : IHttpOutputProducer, IDisposable
         }
     }
 
+    public void SetCanWriteBody(bool canWriteBody)
+    {
+        _canWriteBody = canWriteBody;
+    }
+
     public void Reset()
     {
         Debug.Assert(_currentSegmentOwner == null);
@@ -554,6 +557,7 @@ internal class Http1OutputProducer : IHttpOutputProducer, IDisposable
         _writeStreamSuffixCalled = false;
         _currentChunkMemoryUpdated = false;
         _startCalled = false;
+        _canWriteBody = true;
     }
 
     private ValueTask<FlushResult> WriteAsync(

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -999,7 +999,7 @@ internal abstract partial class HttpProtocol : IHttpResponseControl
 
         var responseHeaders = CreateResponseHeaders(appCompleted);
 
-        Output.WriteResponseHeaders(StatusCode, ReasonPhrase, responseHeaders, _autoChunk, appCompleted);
+        Output.WriteResponseHeaders(StatusCode, ReasonPhrase, responseHeaders, _autoChunk, appCompleted, canWriteBody: _canWriteResponseBody);
     }
 
     private void VerifyInitializeState(int firstWriteByteCount)
@@ -1645,7 +1645,7 @@ internal abstract partial class HttpProtocol : IHttpResponseControl
             {
                 if (data.Length == 0)
                 {
-                    Output.WriteResponseHeaders(StatusCode, ReasonPhrase, responseHeaders, _autoChunk, appCompleted: false);
+                    Output.WriteResponseHeaders(StatusCode, ReasonPhrase, responseHeaders, _autoChunk, appCompleted: false, canWriteBody: _canWriteResponseBody);
                     return Output.FlushAsync(cancellationToken);
                 }
 
@@ -1659,7 +1659,7 @@ internal abstract partial class HttpProtocol : IHttpResponseControl
         }
         else
         {
-            Output.WriteResponseHeaders(StatusCode, ReasonPhrase, responseHeaders, _autoChunk, appCompleted: false);
+            Output.WriteResponseHeaders(StatusCode, ReasonPhrase, responseHeaders, _autoChunk, appCompleted: false, canWriteBody: _canWriteResponseBody);
             HandleNonBodyResponseWrite();
             return Output.FlushAsync(cancellationToken);
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -999,7 +999,7 @@ internal abstract partial class HttpProtocol : IHttpResponseControl
 
         var responseHeaders = CreateResponseHeaders(appCompleted);
 
-        Output.WriteResponseHeaders(StatusCode, ReasonPhrase, responseHeaders, _autoChunk, appCompleted, canWriteBody: _canWriteResponseBody);
+        Output.WriteResponseHeaders(StatusCode, ReasonPhrase, responseHeaders, _autoChunk, appCompleted);
     }
 
     private void VerifyInitializeState(int firstWriteByteCount)
@@ -1162,6 +1162,7 @@ internal abstract partial class HttpProtocol : IHttpResponseControl
 
         // Set whether response can have body
         _canWriteResponseBody = CanWriteResponseBody();
+        Output.SetCanWriteBody(_canWriteResponseBody);
 
         if (!_canWriteResponseBody && hasTransferEncoding)
         {
@@ -1645,7 +1646,7 @@ internal abstract partial class HttpProtocol : IHttpResponseControl
             {
                 if (data.Length == 0)
                 {
-                    Output.WriteResponseHeaders(StatusCode, ReasonPhrase, responseHeaders, _autoChunk, appCompleted: false, canWriteBody: _canWriteResponseBody);
+                    Output.WriteResponseHeaders(StatusCode, ReasonPhrase, responseHeaders, _autoChunk, appCompleted: false);
                     return Output.FlushAsync(cancellationToken);
                 }
 
@@ -1659,7 +1660,7 @@ internal abstract partial class HttpProtocol : IHttpResponseControl
         }
         else
         {
-            Output.WriteResponseHeaders(StatusCode, ReasonPhrase, responseHeaders, _autoChunk, appCompleted: false, canWriteBody: _canWriteResponseBody);
+            Output.WriteResponseHeaders(StatusCode, ReasonPhrase, responseHeaders, _autoChunk, appCompleted: false);
             HandleNonBodyResponseWrite();
             return Output.FlushAsync(cancellationToken);
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/IHttpOutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/IHttpOutputProducer.cs
@@ -13,7 +13,7 @@ internal interface IHttpOutputProducer
     ValueTask<FlushResult> WriteChunkAsync(ReadOnlySpan<byte> data, CancellationToken cancellationToken);
     ValueTask<FlushResult> FlushAsync(CancellationToken cancellationToken);
     ValueTask<FlushResult> Write100ContinueAsync();
-    void WriteResponseHeaders(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, bool appCompleted);
+    void WriteResponseHeaders(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, bool appCompleted, bool canWriteBody);
     // This takes ReadOnlySpan instead of ReadOnlyMemory because it always synchronously copies data before flushing.
     ValueTask<FlushResult> WriteDataToPipeAsync(ReadOnlySpan<byte> data, CancellationToken cancellationToken);
     // Test hook

--- a/src/Servers/Kestrel/Core/src/Internal/Http/IHttpOutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/IHttpOutputProducer.cs
@@ -13,7 +13,7 @@ internal interface IHttpOutputProducer
     ValueTask<FlushResult> WriteChunkAsync(ReadOnlySpan<byte> data, CancellationToken cancellationToken);
     ValueTask<FlushResult> FlushAsync(CancellationToken cancellationToken);
     ValueTask<FlushResult> Write100ContinueAsync();
-    void WriteResponseHeaders(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, bool appCompleted, bool canWriteBody);
+    void WriteResponseHeaders(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, bool appCompleted);
     // This takes ReadOnlySpan instead of ReadOnlyMemory because it always synchronously copies data before flushing.
     ValueTask<FlushResult> WriteDataToPipeAsync(ReadOnlySpan<byte> data, CancellationToken cancellationToken);
     // Test hook
@@ -28,4 +28,6 @@ internal interface IHttpOutputProducer
     ValueTask<FlushResult> FirstWriteAsync(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, ReadOnlySpan<byte> data, CancellationToken cancellationToken);
     ValueTask<FlushResult> FirstWriteChunkedAsync(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, ReadOnlySpan<byte> data, CancellationToken cancellationToken);
     void Reset();
+    // Only used by Http1OutputProducer for non-body responses
+    void SetCanWriteBody(bool canWriteBody) { }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/IHttpOutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/IHttpOutputProducer.cs
@@ -32,6 +32,7 @@ internal interface IHttpOutputProducer
 
 internal enum ResponseBodyMode
 {
+    Uninitialized,
     Disabled,
     Chunked,
     ContentLength

--- a/src/Servers/Kestrel/Core/src/Internal/Http/IHttpOutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/IHttpOutputProducer.cs
@@ -13,7 +13,7 @@ internal interface IHttpOutputProducer
     ValueTask<FlushResult> WriteChunkAsync(ReadOnlySpan<byte> data, CancellationToken cancellationToken);
     ValueTask<FlushResult> FlushAsync(CancellationToken cancellationToken);
     ValueTask<FlushResult> Write100ContinueAsync();
-    void WriteResponseHeaders(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, bool appCompleted);
+    void WriteResponseHeaders(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, ResponseBodyMode responseBodyMode, bool appCompleted);
     // This takes ReadOnlySpan instead of ReadOnlyMemory because it always synchronously copies data before flushing.
     ValueTask<FlushResult> WriteDataToPipeAsync(ReadOnlySpan<byte> data, CancellationToken cancellationToken);
     // Test hook
@@ -25,9 +25,14 @@ internal interface IHttpOutputProducer
     Memory<byte> GetMemory(int sizeHint = 0);
     void CancelPendingFlush();
     void Stop();
-    ValueTask<FlushResult> FirstWriteAsync(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, ReadOnlySpan<byte> data, CancellationToken cancellationToken);
-    ValueTask<FlushResult> FirstWriteChunkedAsync(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, ReadOnlySpan<byte> data, CancellationToken cancellationToken);
+    ValueTask<FlushResult> FirstWriteAsync(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, ResponseBodyMode responseBodyMode, ReadOnlySpan<byte> data, CancellationToken cancellationToken);
+    ValueTask<FlushResult> FirstWriteChunkedAsync(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, ResponseBodyMode responseBodyMode, ReadOnlySpan<byte> data, CancellationToken cancellationToken);
     void Reset();
-    // Only used by Http1OutputProducer for non-body responses
-    void SetCanWriteBody(bool canWriteBody) { }
+}
+
+internal enum ResponseBodyMode
+{
+    Disabled,
+    Chunked,
+    ContentLength
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
@@ -358,7 +358,7 @@ internal sealed class Http2OutputProducer : IHttpOutputProducer, IHttpOutputAbor
         }
     }
 
-    public void WriteResponseHeaders(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, bool appCompleted)
+    public void WriteResponseHeaders(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, ResponseBodyMode responseBodyMode, bool appCompleted)
     {
         lock (_dataWriterLock)
         {
@@ -552,11 +552,11 @@ internal sealed class Http2OutputProducer : IHttpOutputProducer, IHttpOutputAbor
         }
     }
 
-    public ValueTask<FlushResult> FirstWriteAsync(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, ReadOnlySpan<byte> data, CancellationToken cancellationToken)
+    public ValueTask<FlushResult> FirstWriteAsync(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, ResponseBodyMode responseBodyMode, ReadOnlySpan<byte> data, CancellationToken cancellationToken)
     {
         lock (_dataWriterLock)
         {
-            WriteResponseHeaders(statusCode, reasonPhrase, responseHeaders, autoChunk, appCompleted: false);
+            WriteResponseHeaders(statusCode, reasonPhrase, responseHeaders, responseBodyMode, appCompleted: false);
 
             return WriteDataToPipeAsync(data, cancellationToken);
         }
@@ -567,7 +567,7 @@ internal sealed class Http2OutputProducer : IHttpOutputProducer, IHttpOutputAbor
         throw new NotImplementedException();
     }
 
-    public ValueTask<FlushResult> FirstWriteChunkedAsync(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, ReadOnlySpan<byte> data, CancellationToken cancellationToken)
+    public ValueTask<FlushResult> FirstWriteChunkedAsync(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, ResponseBodyMode responseBodyMode, ReadOnlySpan<byte> data, CancellationToken cancellationToken)
     {
         throw new NotImplementedException();
     }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
@@ -358,8 +358,7 @@ internal sealed class Http2OutputProducer : IHttpOutputProducer, IHttpOutputAbor
         }
     }
 
-    // canWriteBody is ignored as we don't have chunked bodies in HTTP/2 and so writing headers is not affected by canWriteBody
-    public void WriteResponseHeaders(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, bool appCompleted, bool canWriteBody)
+    public void WriteResponseHeaders(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, bool appCompleted)
     {
         lock (_dataWriterLock)
         {
@@ -557,8 +556,7 @@ internal sealed class Http2OutputProducer : IHttpOutputProducer, IHttpOutputAbor
     {
         lock (_dataWriterLock)
         {
-            // canWriteBody is hardcoded to true as we don't have chunked bodies in HTTP/2 and so writing headers is not affected by canWriteBody
-            WriteResponseHeaders(statusCode, reasonPhrase, responseHeaders, autoChunk, appCompleted: false, canWriteBody: true);
+            WriteResponseHeaders(statusCode, reasonPhrase, responseHeaders, autoChunk, appCompleted: false);
 
             return WriteDataToPipeAsync(data, cancellationToken);
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
@@ -358,7 +358,8 @@ internal sealed class Http2OutputProducer : IHttpOutputProducer, IHttpOutputAbor
         }
     }
 
-    public void WriteResponseHeaders(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, bool appCompleted)
+    // canWriteBody is ignored as we don't have chunked bodies in HTTP/2 and so writing headers is not affected by canWriteBody
+    public void WriteResponseHeaders(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, bool appCompleted, bool canWriteBody)
     {
         lock (_dataWriterLock)
         {
@@ -556,7 +557,8 @@ internal sealed class Http2OutputProducer : IHttpOutputProducer, IHttpOutputAbor
     {
         lock (_dataWriterLock)
         {
-            WriteResponseHeaders(statusCode, reasonPhrase, responseHeaders, autoChunk, appCompleted: false);
+            // canWriteBody is hardcoded to true as we don't have chunked bodies in HTTP/2 and so writing headers is not affected by canWriteBody
+            WriteResponseHeaders(statusCode, reasonPhrase, responseHeaders, autoChunk, appCompleted: false, canWriteBody: true);
 
             return WriteDataToPipeAsync(data, cancellationToken);
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3OutputProducer.cs
@@ -149,17 +149,17 @@ internal sealed class Http3OutputProducer : IHttpOutputProducer, IHttpOutputAbor
         }
     }
 
-    public ValueTask<FlushResult> FirstWriteAsync(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, ReadOnlySpan<byte> data, CancellationToken cancellationToken)
+    public ValueTask<FlushResult> FirstWriteAsync(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, ResponseBodyMode responseBodyMode, ReadOnlySpan<byte> data, CancellationToken cancellationToken)
     {
         lock (_dataWriterLock)
         {
-            WriteResponseHeaders(statusCode, reasonPhrase, responseHeaders, autoChunk, appCompleted: false);
+            WriteResponseHeaders(statusCode, reasonPhrase, responseHeaders, responseBodyMode, appCompleted: false);
 
             return WriteDataToPipeAsync(data, cancellationToken);
         }
     }
 
-    public ValueTask<FlushResult> FirstWriteChunkedAsync(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, ReadOnlySpan<byte> data, CancellationToken cancellationToken)
+    public ValueTask<FlushResult> FirstWriteChunkedAsync(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, ResponseBodyMode responseBodyMode, ReadOnlySpan<byte> data, CancellationToken cancellationToken)
     {
         throw new NotImplementedException();
     }
@@ -375,7 +375,7 @@ internal sealed class Http3OutputProducer : IHttpOutputProducer, IHttpOutputAbor
         }
     }
 
-    public void WriteResponseHeaders(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, bool appCompleted)
+    public void WriteResponseHeaders(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, ResponseBodyMode responseBodyMode, bool appCompleted)
     {
         // appCompleted flag is not used here. The write FIN is sent via the transport and not via the frame.
         // Headers are written to buffer and flushed with a FIN when Http3FrameWriter.CompleteAsync is called

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3OutputProducer.cs
@@ -153,8 +153,7 @@ internal sealed class Http3OutputProducer : IHttpOutputProducer, IHttpOutputAbor
     {
         lock (_dataWriterLock)
         {
-            // canWriteBody is hardcoded to true as we don't have chunked bodies in HTTP/3 and so writing headers is not affected by canWriteBody
-            WriteResponseHeaders(statusCode, reasonPhrase, responseHeaders, autoChunk, appCompleted: false, canWriteBody: true);
+            WriteResponseHeaders(statusCode, reasonPhrase, responseHeaders, autoChunk, appCompleted: false);
 
             return WriteDataToPipeAsync(data, cancellationToken);
         }
@@ -376,8 +375,7 @@ internal sealed class Http3OutputProducer : IHttpOutputProducer, IHttpOutputAbor
         }
     }
 
-    // canWriteBody is ignored as we don't have chunked bodies in HTTP/3 and so writing headers is not affected by canWriteBody
-    public void WriteResponseHeaders(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, bool appCompleted, bool canWriteBody)
+    public void WriteResponseHeaders(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, bool appCompleted)
     {
         // appCompleted flag is not used here. The write FIN is sent via the transport and not via the frame.
         // Headers are written to buffer and flushed with a FIN when Http3FrameWriter.CompleteAsync is called

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3OutputProducer.cs
@@ -153,7 +153,8 @@ internal sealed class Http3OutputProducer : IHttpOutputProducer, IHttpOutputAbor
     {
         lock (_dataWriterLock)
         {
-            WriteResponseHeaders(statusCode, reasonPhrase, responseHeaders, autoChunk, appCompleted: false);
+            // canWriteBody is hardcoded to true as we don't have chunked bodies in HTTP/3 and so writing headers is not affected by canWriteBody
+            WriteResponseHeaders(statusCode, reasonPhrase, responseHeaders, autoChunk, appCompleted: false, canWriteBody: true);
 
             return WriteDataToPipeAsync(data, cancellationToken);
         }
@@ -375,7 +376,8 @@ internal sealed class Http3OutputProducer : IHttpOutputProducer, IHttpOutputAbor
         }
     }
 
-    public void WriteResponseHeaders(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, bool appCompleted)
+    // canWriteBody is ignored as we don't have chunked bodies in HTTP/3 and so writing headers is not affected by canWriteBody
+    public void WriteResponseHeaders(int statusCode, string? reasonPhrase, HttpResponseHeaders responseHeaders, bool autoChunk, bool appCompleted, bool canWriteBody)
     {
         // appCompleted flag is not used here. The write FIN is sent via the transport and not via the frame.
         // Headers are written to buffer and flushed with a FIN when Http3FrameWriter.CompleteAsync is called

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
@@ -1583,7 +1583,6 @@ public class ResponseTests : TestApplicationErrorLoggerLoggedTest
                 await connection.Receive(
                     "HTTP/1.1 200 OK",
                     $"Date: {server.Context.DateHeaderValue}",
-                    "Transfer-Encoding: chunked",
                     "",
                     "");
 
@@ -1674,7 +1673,6 @@ public class ResponseTests : TestApplicationErrorLoggerLoggedTest
                 await connection.Receive(
                     "HTTP/1.1 200 OK",
                     $"Date: {server.Context.DateHeaderValue}",
-                    "Transfer-Encoding: chunked",
                     "",
                     "");
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
@@ -1426,12 +1426,15 @@ public class ResponseTests : TestApplicationErrorLoggerLoggedTest
                     $"Date: {server.Context.DateHeaderValue}",
                     "",
                     "");
+
+                connection.ShutdownSend();
+                await connection.ReceiveEnd();
             }
         }
     }
 
     [Fact]
-    public async Task HeadResponseBodyNotWrittenWithAsyncWrite()
+    public async Task HeadResponseHeadersWrittenWithAsyncWriteBeforeAppCompletes()
     {
         var flushed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -1462,7 +1465,67 @@ public class ResponseTests : TestApplicationErrorLoggerLoggedTest
     }
 
     [Fact]
+    public async Task HeadResponseBodyNotWrittenWithAsyncWrite()
+    {
+        await using (var server = new TestServer(async httpContext =>
+        {
+            httpContext.Response.ContentLength = 12;
+            await httpContext.Response.WriteAsync("hello, world");
+        }, new TestServiceContext(LoggerFactory)))
+        {
+            using (var connection = server.CreateConnection())
+            {
+                await connection.Send(
+                    "HEAD / HTTP/1.1",
+                    "Host:",
+                    "",
+                    "");
+                await connection.Receive(
+                    "HTTP/1.1 200 OK",
+                    "Content-Length: 12",
+                    $"Date: {server.Context.DateHeaderValue}",
+                    "",
+                    "");
+
+                connection.ShutdownSend();
+                await connection.ReceiveEnd();
+            }
+        }
+    }
+
+    [Fact]
     public async Task HeadResponseBodyNotWrittenWithSyncWrite()
+    {
+        var serviceContext = new TestServiceContext(LoggerFactory) { ServerOptions = { AllowSynchronousIO = true } };
+
+        await using (var server = new TestServer(httpContext =>
+        {
+            httpContext.Response.ContentLength = 12;
+            httpContext.Response.Body.Write(Encoding.ASCII.GetBytes("hello, world"), 0, 12);
+            return Task.CompletedTask;
+        }, serviceContext))
+        {
+            using (var connection = server.CreateConnection())
+            {
+                await connection.Send(
+                    "HEAD / HTTP/1.1",
+                    "Host:",
+                    "",
+                    "");
+                await connection.Receive(
+                    "HTTP/1.1 200 OK",
+                    "Content-Length: 12",
+                    $"Date: {server.Context.DateHeaderValue}",
+                    "",
+                    "");
+                connection.ShutdownSend();
+                await connection.ReceiveEnd();
+            }
+        }
+    }
+
+    [Fact]
+    public async Task HeadResponseHeadersWrittenWithSyncWriteBeforeAppCompletes()
     {
         var flushed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -1471,7 +1534,7 @@ public class ResponseTests : TestApplicationErrorLoggerLoggedTest
         await using (var server = new TestServer(async httpContext =>
         {
             httpContext.Response.ContentLength = 12;
-            await httpContext.Response.BodyWriter.WriteAsync(new Memory<byte>(Encoding.ASCII.GetBytes("hello, world"), 0, 12));
+            httpContext.Response.Body.Write(Encoding.ASCII.GetBytes("hello, world"), 0, 12);
             await flushed.Task;
         }, serviceContext))
         {
@@ -1497,8 +1560,6 @@ public class ResponseTests : TestApplicationErrorLoggerLoggedTest
     [Fact]
     public async Task HeadResponseBodyNotWrittenWithAdvanceBeforeFlush()
     {
-        var flushed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-
         var serviceContext = new TestServiceContext(LoggerFactory) { ServerOptions = { AllowSynchronousIO = true } };
 
         await using (var server = new TestServer(async httpContext =>
@@ -1510,7 +1571,6 @@ public class ResponseTests : TestApplicationErrorLoggerLoggedTest
             }
             httpContext.Response.BodyWriter.Advance(span.Length);
             await httpContext.Response.BodyWriter.FlushAsync();
-            await flushed.Task;
         }, serviceContext))
         {
             using (var connection = server.CreateConnection())
@@ -1527,7 +1587,54 @@ public class ResponseTests : TestApplicationErrorLoggerLoggedTest
                     "",
                     "");
 
-                flushed.SetResult();
+                connection.ShutdownSend();
+                await connection.ReceiveEnd();
+            }
+        }
+    }
+
+    [Fact]
+    public async Task HeadResponseBodyNotWrittenWithAdvanceBeforeAndAfterFlush()
+    {
+        var serviceContext = new TestServiceContext(LoggerFactory) { ServerOptions = { AllowSynchronousIO = true } };
+
+        await using (var server = new TestServer(async httpContext =>
+        {
+            // Make response chunked
+            var span = httpContext.Response.BodyWriter.GetSpan(5);
+            for (var i = 0; i < span.Length; i++)
+            {
+                span[i] = (byte)'h';
+            }
+            httpContext.Response.BodyWriter.Advance(span.Length);
+            await httpContext.Response.BodyWriter.FlushAsync();
+
+            // Send after headers flushed
+            span = httpContext.Response.BodyWriter.GetSpan(5);
+            for (var i = 0; i < span.Length; i++)
+            {
+                span[i] = (byte)'h';
+            }
+            httpContext.Response.BodyWriter.Advance(span.Length);
+            await httpContext.Response.BodyWriter.FlushAsync();
+        }, serviceContext))
+        {
+            using (var connection = server.CreateConnection())
+            {
+                await connection.Send(
+                    "HEAD / HTTP/1.1",
+                    "Host:",
+                    "",
+                    "");
+                await connection.Receive(
+                    "HTTP/1.1 200 OK",
+                    $"Date: {server.Context.DateHeaderValue}",
+                    "Transfer-Encoding: chunked",
+                    "",
+                    "");
+
+                connection.ShutdownSend();
+                await connection.ReceiveEnd();
             }
         }
     }


### PR DESCRIPTION
Bug exposed/introduced by https://github.com/dotnet/aspnetcore/pull/8199

Fixes https://github.com/dotnet/aspnetcore/issues/59691

Reason this hasn't been found in the >5 years since the bug was introduced is that it requires using `PipeWriter.GetMemory(...)` + `PipeWriter.Advance(...)` before flushing the headers and using a HEAD request at the same time. This is very uncommon except for in .NET 9 where we made writing JSON responses use the `PipeWriter` which uses the `GetMemory` + `Advance` path.

The fix is to pass the `canWriteBody` parameter to `WriteDataWrittenBeforeHeaders` and only copy the bytes from previous `GetMemory` + `Advance` calls to the body if `canWriteBody` is true.

Edit: Removed `Transfer-Encoding: chunked` header from non-body responses.
~~**One additional change we might want to consider here**, is removing the `Transfer-Encoding: chunked` header from the HEAD response. We have [TransferEncodingNotSetOnHeadResponse](https://github.com/dotnet/aspnetcore/blob/1a23df0f96175d51940aec9306db3460d484da4d/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs#L875) and [ManuallySettingTransferEncodingThrowsForHeadResponse](https://github.com/dotnet/aspnetcore/blob/1a23df0f96175d51940aec9306db3460d484da4d/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTests.cs#L628) which show us explicitly not letting the transfer encoding exist on a HEAD response, however according to the RFC 7231 section 4.3.2~~
> ~~The server SHOULD send the same
   header fields in response to a HEAD request as it would have sent if
   the request had been a GET, except that the payload header fields
   ([Section 3.3](https://www.rfc-editor.org/rfc/rfc7231#section-3.3)) MAY be omitted.~~

~~And https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding~~
> ~~When present on a response to a [HEAD](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/HEAD) request that has no body, it indicates the value that would have applied to the corresponding [GET](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/GET) message.~~

~~Both of which indicate it is perfectly fine to include the Transfer-Encoding header.~~

~~Looking at the history of why we added this restriction to Kestrel, we find https://github.com/aspnet/KestrelHttpServer/issues/952 which was about a browser request hanging when accessing an endpoint that responded with another non-body response in the form of a 304 and we just added the restriction to HEAD response as well since it is a non-body response.~~