### PR TITLE
#59749 move TrimEnd after path normalization

### DIFF
--- a/src/Tools/Extensions.ApiDescription.Server/src/build/Microsoft.Extensions.ApiDescription.Server.targets
+++ b/src/Tools/Extensions.ApiDescription.Server/src/build/Microsoft.Extensions.ApiDescription.Server.targets
@@ -51,8 +51,7 @@
         Text="OpenAPI document generation is not supported when targeting netcoreapp2.0 or earlier. Disable the feature or move to a later target framework." />
 
     <PropertyGroup>
-      <_DotNetGetDocumentOutputPath>$(OpenApiDocumentsDirectory.TrimEnd('\'))</_DotNetGetDocumentOutputPath>
-      <_DotNetGetDocumentOutputPath>$([System.IO.Path]::GetFullPath('$(_DotNetGetDocumentOutputPath)'))</_DotNetGetDocumentOutputPath>
+      <_DotNetGetDocumentOutputPath>$([System.IO.Path]::GetFullPath('$(OpenApiDocumentsDirectory)').TrimEnd('\'))</_DotNetGetDocumentOutputPath>
       <_DotNetGetDocumentCommand>dotnet "$(MSBuildThisFileDirectory)../tools/dotnet-getdocument.dll" --assembly "$(TargetPath)"</_DotNetGetDocumentCommand>
       <_DotNetGetDocumentCommand>$(_DotNetGetDocumentCommand) --file-list "$(_OpenApiDocumentsCache)" --framework "$(TargetFrameworkMoniker)"</_DotNetGetDocumentCommand>
       <_DotNetGetDocumentCommand>$(_DotNetGetDocumentCommand) --output "$(_DotNetGetDocumentOutputPath)" --project "$(MSBuildProjectName)"</_DotNetGetDocumentCommand>


### PR DESCRIPTION
# Invocation of dotnet-getdocument.dll tool from Microsoft.Extensions.ApiDescription.Server.targets may result in trailing backslash and broken build on Windows

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description
Value of `OpenApiDocumentsDirectory` must be trimmed of trailing backslash on Windows _after_ path normalization.
`
OpenApiDocumentsDirectory = ../foo/` -> `Path.GetFullPath` (on Windows) ->` <rooted Path>\foo\` 

Move `TrimEnd('\')` to after path normalization, as a Linux style directory separator would not be trimmed, translated to windows style backslash by the path normalization done by GetFullPath if build runs on Windows. Resulting value in `_DotNetGetDocumentOutputPath` would still have trailing backslash and break the command line (on Windows). 

There seem to be some changes to this in past commits, moving the TrimEnd around. Looks like a regression.

Fixes #59749 (in this specific format)
