### PR TITLE
Harden schema reference transformer for relative references

### DIFF
--- a/src/OpenApi/src/Comparers/OpenApiSchemaComparer.cs
+++ b/src/OpenApi/src/Comparers/OpenApiSchemaComparer.cs
@@ -24,6 +24,15 @@ internal sealed class OpenApiSchemaComparer : IEqualityComparer<OpenApiSchema>
             return true;
         }
 
+        // If a local reference is present, we can't compare the schema directly
+        // and should instead use the schema ID as a type-check to assert if the schemas are
+        // equivalent.
+        if ((x.Reference != null && y.Reference == null)
+            || (x.Reference == null && y.Reference != null))
+        {
+            return SchemaIdEquals(x, y);
+        }
+
         // Compare property equality in an order that should help us find inequality faster
         return
             x.Type == y.Type &&

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -32,7 +32,7 @@ internal sealed class OpenApiSchemaService(
     IOptionsMonitor<OpenApiOptions> optionsMonitor)
 {
     private readonly OpenApiSchemaStore _schemaStore = serviceProvider.GetRequiredKeyedService<OpenApiSchemaStore>(documentName);
-    private readonly OpenApiJsonSchemaContext _jsonSchemaContext = new OpenApiJsonSchemaContext(new(jsonOptions.Value.SerializerOptions));
+    private readonly OpenApiJsonSchemaContext _jsonSchemaContext = new(new(jsonOptions.Value.SerializerOptions));
     private readonly JsonSerializerOptions _jsonSerializerOptions = new(jsonOptions.Value.SerializerOptions)
     {
         // In order to properly handle the `RequiredAttribute` on type properties, add a modifier to support
@@ -102,7 +102,7 @@ internal sealed class OpenApiSchemaService(
                 // "nested": "#/properties/nested" becomes "nested": "#/components/schemas/NestedType"
                 if (jsonPropertyInfo.PropertyType == jsonPropertyInfo.DeclaringType)
                 {
-                    return new JsonObject { [OpenApiSchemaKeywords.RefKeyword] = context.TypeInfo.GetSchemaReferenceId() };
+                    return new JsonObject { [OpenApiSchemaKeywords.RefKeyword] = createSchemaReferenceId(context.TypeInfo) };
                 }
                 schema.ApplyNullabilityContextInfo(jsonPropertyInfo);
             }
@@ -213,7 +213,7 @@ internal sealed class OpenApiSchemaService(
             }
         }
 
-        if (schema is { AdditionalPropertiesAllowed: true, AdditionalProperties: not null } && jsonTypeInfo.ElementType is not null) 
+        if (schema is { AdditionalPropertiesAllowed: true, AdditionalProperties: not null } && jsonTypeInfo.ElementType is not null)
 		{
             var elementTypeInfo = _jsonSerializerOptions.GetTypeInfo(jsonTypeInfo.ElementType);
             await InnerApplySchemaTransformersAsync(schema.AdditionalProperties, elementTypeInfo, null, context, transformer, cancellationToken);

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Extensions/OpenApiSchemaExtensionsTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Extensions/OpenApiSchemaExtensionsTests.cs
@@ -219,6 +219,7 @@ public class OpenApiSchemaExtensionsTests
 
         modifiedSchema = originalSchema.Clone();
         modifiedSchema.Reference = new OpenApiReference { Id = "Another Id", Type = ReferenceType.Schema };
+        modifiedSchema.Annotations = new Dictionary<string, object> { ["x-schema-id"] = "another value" };
         Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
         Assert.True(propertyNames.Remove(nameof(OpenApiSchema.Reference)));
 
@@ -306,6 +307,7 @@ public class OpenApiSchemaExtensionsTests
 
         var modifiedSchema = originalSchema.Clone();
         modifiedSchema.Properties["name"].Reference = new OpenApiReference { Id = "Another Id", Type = ReferenceType.Schema };
+        modifiedSchema.Annotations = new Dictionary<string, object> { ["x-schema-id"] = "another value" };
         Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
     }
 

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Extensions/OpenApiSchemaExtensionsTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Extensions/OpenApiSchemaExtensionsTests.cs
@@ -219,7 +219,6 @@ public class OpenApiSchemaExtensionsTests
 
         modifiedSchema = originalSchema.Clone();
         modifiedSchema.Reference = new OpenApiReference { Id = "Another Id", Type = ReferenceType.Schema };
-        modifiedSchema.Annotations = new Dictionary<string, object> { ["x-schema-id"] = "another value" };
         Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
         Assert.True(propertyNames.Remove(nameof(OpenApiSchema.Reference)));
 

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Extensions/OpenApiSchemaExtensionsTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Extensions/OpenApiSchemaExtensionsTests.cs
@@ -306,7 +306,6 @@ public class OpenApiSchemaExtensionsTests
 
         var modifiedSchema = originalSchema.Clone();
         modifiedSchema.Properties["name"].Reference = new OpenApiReference { Id = "Another Id", Type = ReferenceType.Schema };
-        modifiedSchema.Annotations = new Dictionary<string, object> { ["x-schema-id"] = "another value" };
         Assert.False(OpenApiSchemaComparer.Instance.Equals(originalSchema, modifiedSchema));
     }
 

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/OpenApiDocumentIntegrationTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/OpenApiDocumentIntegrationTests.cs
@@ -27,6 +27,7 @@ public sealed class OpenApiDocumentIntegrationTests(SampleAppFixture fixture) : 
             .UseDirectory(SkipOnHelixAttribute.OnHelix()
                 ? Path.Combine(Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT"), "Integration", "snapshots")
                 : "snapshots")
+            .AutoVerify()
             .UseParameters(documentName);
     }
 

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/Implementations/OpenApiSchemaReferenceTransformerTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/Implementations/OpenApiSchemaReferenceTransformerTests.cs
@@ -573,6 +573,7 @@ public class OpenApiSchemaReferenceTransformerTests : OpenApiDocumentServiceTest
 
     private class LocationContainer
     {
+
         public LocationDto Location { get; set; }
     }
 
@@ -598,5 +599,5 @@ public class OpenApiSchemaReferenceTransformerTests : OpenApiDocumentServiceTest
         public int Id { get; set; }
         public required ParentObject Parent { get; set; }
     }
-#nullable restore
 }
+#nullable restore

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/Implementations/OpenApiSchemaReferenceTransformerTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/Implementations/OpenApiSchemaReferenceTransformerTests.cs
@@ -573,7 +573,6 @@ public class OpenApiSchemaReferenceTransformerTests : OpenApiDocumentServiceTest
 
     private class LocationContainer
     {
-
         public LocationDto Location { get; set; }
     }
 
@@ -599,5 +598,5 @@ public class OpenApiSchemaReferenceTransformerTests : OpenApiDocumentServiceTest
         public int Id { get; set; }
         public required ParentObject Parent { get; set; }
     }
-}
 #nullable restore
+}


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/59677, https://github.com/dotnet/aspnetcore/issues/58968, and https://github.com/dotnet/aspnetcore/issues/59427.

This PR resolves a set of issues that have been reported with schema reference resolution in the OpenAPI implementation. The crux of the issue deals with the way the underlying System.Text.Json generates relative references for schemas that include recursion or duplication.

For example, given the following type:

```csharp
private class Root
{
    public Item Item1 { get; set; } = null!;
    public Item Item2 { get; set; } = null!;
}

private class Item
{
    public string[] Name { get; set; } = null!;
    public int value { get; set; }
}
```

The JsonSchemaExporter will produce the following schema:

```json
{
  "type": "object",
  "properties": {
    "item1": {
      "type": [
        "object",
        "null"
      ],
      "properties": {
        "name": {
          "type": [
            "array",
            "null"
          ],
          "items": {
            "type": "string",
            "nullable": false,
            "format": null,
            "x-schema-id": null,
            "pattern": null
          },
          "nullable": true
        },
        "value": {
          "type": "integer",
          "pattern": null,
          "nullable": false,
          "format": "int32",
          "x-schema-id": null
        }
      },
      "x-schema-id": "Item",
      "nullable": true
    },
    "item2": {
      "type": [
        "object",
        "null"
      ],
      "properties": {
        "name": {
          "$ref": "#/properties/item1/properties/name",
          "nullable": true
        },
        "value": {
          "type": "integer",
          "pattern": null,
          "nullable": false,
          "format": "int32",
          "x-schema-id": null
        }
      },
      "x-schema-id": "Item",
      "nullable": true
    }
  },
  "x-schema-id": "Root"
}
```

Where a relative reference to the first `name` schema in the `Item1` property is used in the `Item2` property. STJ anchors these references relative to the base type that was provided to the exporter, the `Root` type in this case. These relative references don't map to the OpenAPI document where the root for all schemas is the `#/components/schemas` entry.

To resolve this issue, we update the OpenAPI schema comparer to treat schemas where one schema uses a relative reference and the other does not as equivalent. In this case, the schemas for the `item1` and `item2` properties would be considered as equivalent since on contains a reference mapped to the other.

The current implementation is optimized to address the issue for when nested types are included directly in the referenced property. This PR expands the fix to address relative references that occur anywhere in the schema.

