### PR TITLE
Use Markdown alert in Contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,8 @@ Start a discussion on the [repository issue tracker](https://github.com/dotnet/a
 
 ## Bugs and feature requests?
 
-❗ **IMPORTANT: If you want to report a security-related issue, please see the `Reporting security issues and bugs` section below.**
+> [!IMPORTANT]
+> **If you want to report a security-related issue, please see the `Reporting security issues and bugs` section below.**
 
 Before reporting a new issue, try to find an existing issue if one already exists. If it already exists, upvote (👍) it. Also, consider adding a comment with your unique scenarios and requirements related to that issue.  Upvotes and clear details on the issue's impact help us prioritize the most important issues to be worked on sooner rather than later. If you can't find one, that's okay, we'd rather get a duplicate report than none.
 


### PR DESCRIPTION
# Use Markdown alert

Use GitHub markdown alert.

## Description

Use a [GitHub native alert](https://github.com/orgs/community/discussions/16925) to improve the rendering of the note in the contributing guide. I noticed this while watching [yesterday's ASP.NET Core Community Standup](https://www.youtube.com/watch?v=Hy36hLZFGGU&list=PLdo4fOcmZ0oX-DBuRG4u58ZTAJgBAeQ-t&index=1).

### Before

![image](https://github.com/user-attachments/assets/3ababb2c-2451-41cd-9c78-2609cc9b622d)

### After

![image](https://github.com/user-attachments/assets/c36d0b54-f724-4d08-a384-948185ef71fe)
