### PR TITLE
[release/9.0] Pin to S.T.J 8.0.5 in Analyzers

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -41,8 +41,10 @@
     <UsagePattern IdentityGlob="Microsoft.DiaSymReader/*2.0.0*" />
 
     <!-- Transitive dependency of Roslyn dependencies. -->
-    <UsagePattern IdentityGlob="System.Text.Json/8.0.0*" />
     <UsagePattern IdentityGlob="System.Text.Encodings.Web/8.0.0*" />
+
+    <!-- Pinned to circumvent CG alert from Roslyn -->
+    <UsagePattern IdentityGlob="System.Text.Json/8.0.5*" />
 
     <!-- Transitive dependency of System.Security.Cryptography.Pkcs.5.0.*. -->
     <UsagePattern IdentityGlob="System.Formats.Asn1/6.0.0" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -205,6 +205,7 @@
     <!-- Build tool dependencies -->
     <MicrosoftVSSDKBuildToolsVersion>15.9.3032</MicrosoftVSSDKBuildToolsVersion>
     <RepoTasksSystemSecurityCryptographyXmlVersion>8.0.0</RepoTasksSystemSecurityCryptographyXmlVersion>
+    <AnalyzersSystemTextJsonVersion>8.0.5</AnalyzersSystemTextJsonVersion>
     <!-- Stable dotnet/corefx packages no longer updated for .NET Core 3 -->
     <MicrosoftCSharpVersion>4.7.0</MicrosoftCSharpVersion>
     <MicrosoftWin32RegistryVersion>5.0.0</MicrosoftWin32RegistryVersion>

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Microsoft.AspNetCore.App.Analyzers.csproj
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Microsoft.AspNetCore.App.Analyzers.csproj
@@ -9,11 +9,14 @@
     <RootNamespace>Microsoft.AspNetCore.Analyzers</RootNamespace>
     <SuppressNullableAttributesImport>true</SuppressNullableAttributesImport>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <DisablePackageReferenceRestrictions>true</DisablePackageReferenceRestrictions>
   </PropertyGroup>
 
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="All" />
     <Reference Include="Microsoft.CodeAnalysis.ExternalAccess.AspNetCore" />
+
+    <PackageReference Include="System.Text.Json" Version="$(AnalyzersSystemTextJsonVersion)" />
 
     <InternalsVisibleTo Include="Microsoft.AspNetCore.App.Analyzers.Test" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.App.CodeFixes" />


### PR DESCRIPTION
Fixes a CG alert. Roslyn isn't going to update to 8.0.5, so we should pin instead