### PR TITLE
[release/8.0] Pin to S.T.J 8.0.5 in Analyzers

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -200,6 +200,7 @@
     <MicrosoftVSSDKBuildToolsVersion>15.9.3032</MicrosoftVSSDKBuildToolsVersion>
     <!-- Manually updated version from 6.0.0 to address CVE-2021-43877 -->
     <RepoTasksSystemSecurityCryptographyXmlVersion>6.0.1</RepoTasksSystemSecurityCryptographyXmlVersion>
+    <AnalyzersSystemTextJsonVersion>8.0.5</AnalyzersSystemTextJsonVersion>
     <!-- Stable dotnet/corefx packages no longer updated for .NET Core 3 -->
     <MicrosoftCSharpVersion>4.7.0</MicrosoftCSharpVersion>
     <MicrosoftWin32RegistryVersion>5.0.0</MicrosoftWin32RegistryVersion>

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Microsoft.AspNetCore.App.Analyzers.csproj
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Microsoft.AspNetCore.App.Analyzers.csproj
@@ -9,11 +9,14 @@
     <RootNamespace>Microsoft.AspNetCore.Analyzers</RootNamespace>
     <SuppressNullableAttributesImport>true</SuppressNullableAttributesImport>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <DisablePackageReferenceRestrictions>true</DisablePackageReferenceRestrictions>
   </PropertyGroup>
 
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="All" />
     <Reference Include="Microsoft.CodeAnalysis.ExternalAccess.AspNetCore" />
+
+    <PackageReference Include="System.Text.Json" Version="$(AnalyzersSystemTextJsonVersion)" />
 
     <InternalsVisibleTo Include="Microsoft.AspNetCore.App.Analyzers.Test" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.App.CodeFixes" />


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspnetcore/pull/59776

Fixes a CG alert. Roslyn isn't going to update to 8.0.5, so we should pin instead