### PR TITLE
Clarify meaning of the group name specified in WithGroupName

### DIFF
--- a/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
@@ -112,10 +112,9 @@ public static class RoutingEndpointConventionBuilderExtensions
     }
 
     /// <summary>
-    /// Sets the <see cref="EndpointGroupNameAttribute"/> for all endpoints produced
-    /// on the target <see cref="IEndpointConventionBuilder"/> given the <paramref name="endpointGroupName" />.
-    /// The <see cref="IEndpointGroupNameMetadata" /> on the endpoint is used to set the endpoint's
-    /// GroupName in the OpenAPI specification.
+    /// Sets the <see cref="IEndpointGroupNameMetadata"/> with the given <paramref name="endpointGroupName"/>
+    /// in the endpoint <see cref="Http.Endpoint.Metadata"/> for all endpoints produced on the target
+    /// <see cref="IEndpointConventionBuilder"/>.
     /// </summary>
     /// <param name="builder">The <see cref="IEndpointConventionBuilder"/>.</param>
     /// <param name="endpointGroupName">The endpoint group name.</param>


### PR DESCRIPTION
This PR makes a small change to the description of the value passed to `WithGroupName` to explain how it is used in OpenAPI document generation. The prior text was inaccurate because there is no "GroupName" in the OpenAPI specification.