### PR TITLE
Fix flaky SignalR test: RequestTimeoutDisabledWhenConnected

### DIFF
--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -3505,6 +3505,8 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
                 {
                     services.AddConnections();
 
+                    services.AddSingleton<TestConnectionHandler>();
+
                     // Since tests run in parallel, it's possible multiple servers will startup,
                     // we use an ephemeral key provider and repository to avoid filesystem contention issues
                     services.AddSingleton<IDataProtectionProvider, EphemeralDataProtectionProvider>();
@@ -3549,6 +3551,8 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
                 LoggerFactory);
 
             await connection.StartAsync();
+
+            await host.Services.GetRequiredService<TestConnectionHandler>().Started;
 
             var negotiateResponse = NegotiateProtocol.ParseResponse(stream.ToArray());
 


### PR DESCRIPTION
`await connection.StartAsync();` only waits for the connection headers to be written, which means there is a race between the connection starting and the test checking if the request timeout feature was disabled. To fix this, I added writing and reading to the connection to make sure everything is fully set up on the connection before testing the feature.