### PR TITLE
Fix crashing InMemory.FunctionalTests

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/TestTransport/InMemoryTransportConnection.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/TestTransport/InMemoryTransportConnection.cs
@@ -63,12 +63,10 @@ internal class InMemoryTransportConnection : TransportConnection
 
     public void OnClosed()
     {
-        if (_isClosed)
+        if (Interlocked.CompareExchange(ref _isClosed, true, false) == true)
         {
             return;
         }
-
-        _isClosed = true;
 
         ThreadPool.UnsafeQueueUserWorkItem(state =>
         {


### PR DESCRIPTION
InMemory.FunctionalTests has crashed before due to an exception in a background task. When the `InMemoryTransportConnection` is closed it queues a callback to the threadpool which sets a `TaskCompletionSource`. If the callback is queued more than once the TCS will be set multiple times which is an error and exceptions in threadpool items will crash the process.

Simple fix is to avoid queuing the threapool item multiple times by making our closed bool set/check an atomic operation.

One test that would hit this is
https://github.com/dotnet/aspnetcore/blob/f655a4a1cec91d2325b408142a8fe9f6d390c6f4/src/Servers/Kestrel/test/InMemory.FunctionalTests/ConnectionLimitTests.cs#L27
where it would dispose the connection from test code, while in parallel the app code would start cleaning up which would call `Abort`.