### PR TITLE
[release/2.3] Enable signing for modules

### DIFF
--- a/build/RepositoryBuild.targets
+++ b/build/RepositoryBuild.targets
@@ -83,8 +83,6 @@
       <RepositoryBuildArguments>$(RepositoryBuildArguments) /p:BuildNumber=$(BuildNumber)</RepositoryBuildArguments>
       <RepositoryBuildArguments>$(RepositoryBuildArguments) /p:Configuration=$(Configuration)</RepositoryBuildArguments>
       <RepositoryBuildArguments>$(RepositoryBuildArguments) /p:IsFinalBuild=$(IsFinalBuild)</RepositoryBuildArguments>
-      <!-- We collect all output and code sign at the end. We don't need to code sign when we build each submodule. -->
-      <RepositoryBuildArguments>$(RepositoryBuildArguments) /p:DisableCodeSigning=true</RepositoryBuildArguments>
       <RepositoryBuildArguments>$(RepositoryBuildArguments) '/p:DotNetAssetRootAccessTokenSuffix=$(DotNetAssetRootAccessTokenSuffix)'</RepositoryBuildArguments>
       <RepositoryBuildArguments>$(RepositoryBuildArguments) '/p:DotNetAssetRootUrl=$(DotNetAssetRootUrl)'</RepositoryBuildArguments>
       <RepositoryBuildArguments Condition=" '$(SkipTestsDueToMissingSharedFx)' == 'true' ">$(RepositoryBuildArguments) /p:SkipAspNetCoreRuntimeInstall=true</RepositoryBuildArguments>


### PR DESCRIPTION
The current official build does not sign EFCore packages because they're from a submodule.

Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2620434&view=results