### PR TITLE
Fix double line in APIReviewPrinciples.md for markdownlint

### DIFF
--- a/docs/APIReviewPrinciples.md
+++ b/docs/APIReviewPrinciples.md
@@ -6,7 +6,6 @@ The primary goal of this document is to provide a reference for our team and con
 
 We encourage you to refer to this document regularly and contribute to its evolution as we continue to refine our API review process. We also encourage you to follow the [.NET framework design guidelines](https://learn.microsoft.com/dotnet/standard/design-guidelines/) for more general guidance not specific to the dotnet/aspnetcore repository.
 
-
 ## Principles
 - Principle 1
 


### PR DESCRIPTION
https://github.com/dotnet/aspnetcore/pull/59883 failed because of double blank lines reported by markdownlint:

```
Error: docs/APIReviewPrinciples.md:9 MD012/no-multiple-blanks Multiple consecutive blank lines [Expected: 1; Actual: 2]
Error: Process completed with exit code 1.
```

File was recently added here: https://github.com/dotnet/aspnetcore/pull/59880

I don't know why lint didn't complain on the PR but did complain on the dependency update 🤷 Edit: It did fail on the PR it was added, but it's not a required check.

cc @mkArtakMSFT 