### PR TITLE
Attempted fix on flaky counter tests

### DIFF
--- a/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
@@ -40,9 +40,9 @@ public class HostingApplicationDiagnosticsTests : LoggedTest
         using CancellationTokenSource timeoutTokenSource = new CancellationTokenSource(timeout);
         timeoutTokenSource.Token.Register(() => Logger.LogError("Timeout while waiting for counter value."));
 
-        var totalRequestValues = eventListener.GetCounterValues("total-requests", timeoutTokenSource.Token).GetAsyncEnumerator();
-        var currentRequestValues = eventListener.GetCounterValues("current-requests", timeoutTokenSource.Token).GetAsyncEnumerator();
-        var failedRequestValues = eventListener.GetCounterValues("failed-requests", timeoutTokenSource.Token).GetAsyncEnumerator();
+        var totalRequestValues = eventListener.GetCounterValues("total-requests", timeoutTokenSource.Token);
+        var currentRequestValues = eventListener.GetCounterValues("current-requests", timeoutTokenSource.Token);
+        var failedRequestValues = eventListener.GetCounterValues("failed-requests", timeoutTokenSource.Token);
 
         eventListener.EnableEvents(hostingEventSource, EventLevel.Informational, EventKeywords.None,
             new Dictionary<string, string>
@@ -69,18 +69,18 @@ public class HostingApplicationDiagnosticsTests : LoggedTest
         var context1 = hostingApplication1.CreateContext(features1);
         var context2 = hostingApplication2.CreateContext(features2);
 
-        await totalRequestValues.WaitForValueAsync(2);
-        await currentRequestValues.WaitForValueAsync(2);
-        await failedRequestValues.WaitForValueAsync(0);
+        await WaitForCounterValue(totalRequestValues, expectedValue: 2, Logger);
+        await WaitForCounterValue(currentRequestValues, expectedValue: 2, Logger);
+        await WaitForCounterValue(failedRequestValues, expectedValue: 0, Logger);
 
         Logger.LogInformation(nameof(HostingApplication.DisposeContext));
 
         hostingApplication1.DisposeContext(context1, null);
         hostingApplication2.DisposeContext(context2, null);
 
-        await totalRequestValues.WaitForValueAsync(2);
-        await currentRequestValues.WaitForValueAsync(0);
-        await failedRequestValues.WaitForValueAsync(0);
+        await WaitForCounterValue(totalRequestValues, expectedValue: 2, Logger);
+        await WaitForCounterValue(currentRequestValues, expectedValue: 0, Logger);
+        await WaitForCounterValue(failedRequestValues, expectedValue: 0, Logger);
 
         Assert.Collection(activeRequestsCollector1.GetMeasurementSnapshot(),
             m => Assert.Equal(1, m.Value),
@@ -100,9 +100,9 @@ public class HostingApplicationDiagnosticsTests : LoggedTest
         context1 = hostingApplication1.CreateContext(features1);
         context2 = hostingApplication2.CreateContext(features2);
 
-        await totalRequestValues.WaitForValueAsync(4);
-        await currentRequestValues.WaitForValueAsync(2);
-        await failedRequestValues.WaitForValueAsync(0);
+        await WaitForCounterValue(totalRequestValues, expectedValue: 4, Logger);
+        await WaitForCounterValue(currentRequestValues, expectedValue: 2, Logger);
+        await WaitForCounterValue(failedRequestValues, expectedValue: 0, Logger);
 
         context1.HttpContext.Response.StatusCode = StatusCodes.Status500InternalServerError;
         context2.HttpContext.Response.StatusCode = StatusCodes.Status500InternalServerError;
@@ -112,9 +112,9 @@ public class HostingApplicationDiagnosticsTests : LoggedTest
         hostingApplication1.DisposeContext(context1, null);
         hostingApplication2.DisposeContext(context2, null);
 
-        await totalRequestValues.WaitForValueAsync(4);
-        await currentRequestValues.WaitForValueAsync(0);
-        await failedRequestValues.WaitForValueAsync(2);
+        await WaitForCounterValue(totalRequestValues, expectedValue: 4, Logger);
+        await WaitForCounterValue(currentRequestValues, expectedValue: 0, Logger);
+        await WaitForCounterValue(failedRequestValues, expectedValue: 2, Logger);
 
         Assert.Collection(activeRequestsCollector1.GetMeasurementSnapshot(),
             m => Assert.Equal(1, m.Value),
@@ -132,6 +132,11 @@ public class HostingApplicationDiagnosticsTests : LoggedTest
         Assert.Collection(requestDurationCollector2.GetMeasurementSnapshot(),
             m => Assert.True(m.Value > 0),
             m => Assert.True(m.Value > 0));
+    }
+
+    private static async Task WaitForCounterValue(CounterValues values, double expectedValue, ILogger logger)
+    {
+        await values.Values.WaitForValueAsync(expectedValue, values.CounterName, logger);
     }
 
     [Fact]

--- a/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
@@ -69,7 +69,7 @@ public class HostingApplicationDiagnosticsTests : LoggedTest
         var context1 = hostingApplication1.CreateContext(features1);
         var context2 = hostingApplication2.CreateContext(features2);
 
-        await totalRequestValues.WaitForSumValueAsync(2);
+        await totalRequestValues.WaitForValueAsync(2);
         await currentRequestValues.WaitForValueAsync(2);
         await failedRequestValues.WaitForValueAsync(0);
 
@@ -78,7 +78,7 @@ public class HostingApplicationDiagnosticsTests : LoggedTest
         hostingApplication1.DisposeContext(context1, null);
         hostingApplication2.DisposeContext(context2, null);
 
-        await totalRequestValues.WaitForSumValueAsync(2);
+        await totalRequestValues.WaitForValueAsync(2);
         await currentRequestValues.WaitForValueAsync(0);
         await failedRequestValues.WaitForValueAsync(0);
 
@@ -100,7 +100,7 @@ public class HostingApplicationDiagnosticsTests : LoggedTest
         context1 = hostingApplication1.CreateContext(features1);
         context2 = hostingApplication2.CreateContext(features2);
 
-        await totalRequestValues.WaitForSumValueAsync(4);
+        await totalRequestValues.WaitForValueAsync(4);
         await currentRequestValues.WaitForValueAsync(2);
         await failedRequestValues.WaitForValueAsync(0);
 
@@ -112,7 +112,7 @@ public class HostingApplicationDiagnosticsTests : LoggedTest
         hostingApplication1.DisposeContext(context1, null);
         hostingApplication2.DisposeContext(context2, null);
 
-        await totalRequestValues.WaitForSumValueAsync(4);
+        await totalRequestValues.WaitForValueAsync(4);
         await currentRequestValues.WaitForValueAsync(0);
         await failedRequestValues.WaitForValueAsync(2);
 

--- a/src/Hosting/Hosting/test/Internal/AsyncEnumerableExtensions.cs
+++ b/src/Hosting/Hosting/test/Internal/AsyncEnumerableExtensions.cs
@@ -2,12 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Numerics;
+using Microsoft.Extensions.Logging;
 
 namespace System.Collections.Generic;
 
 internal static class AsyncEnumerableExtensions
 {
-    public static async Task WaitForValueAsync<T>(this IAsyncEnumerator<T> values, T expectedValue) where T : INumber<T>
+    public static async Task WaitForValueAsync<T>(this IAsyncEnumerator<T> values, T expectedValue, string operationName, ILogger logger) where T : INumber<T>
     {
         T value = T.Zero;
         try
@@ -17,8 +18,11 @@ internal static class AsyncEnumerableExtensions
                 value = values.Current;
                 if (value == expectedValue)
                 {
+                    logger.LogDebug("Operation {OperationName} completed with value {Value}.", operationName, value);
                     return;
                 }
+
+                logger.LogDebug("Operation {OperationName} expected {ExpectedValue} but got {Value}.", operationName, expectedValue, value);
             }
 
             throw new InvalidOperationException("Data ended without match.");
@@ -26,28 +30,6 @@ internal static class AsyncEnumerableExtensions
         catch (Exception ex)
         {
             throw new InvalidOperationException($"Results ended with final value of {value}. Expected value of {expectedValue}.", ex);
-        }
-    }
-
-    public static async Task WaitForSumValueAsync<T>(this IAsyncEnumerator<T> values, T expectedValue) where T: INumber<T>
-    {
-        T value = T.Zero;
-        try
-        {
-            while (await values.MoveNextAsync())
-            {
-                value += values.Current;
-                if (value == expectedValue)
-                {
-                    return;
-                }
-            }
-
-            throw new InvalidOperationException("Data ended without match.");
-        }
-        catch (Exception ex)
-        {
-            throw new InvalidOperationException($"Results ended with final sum value of {value}. Expected sum value of {expectedValue}.", ex);
         }
     }
 }

--- a/src/Hosting/Hosting/test/Internal/HostingEventSourceTests.cs
+++ b/src/Hosting/Hosting/test/Internal/HostingEventSourceTests.cs
@@ -207,21 +207,21 @@ public class HostingEventSourceTests : LoggedTest
         Logger.LogInformation(nameof(HostingEventSource.RequestStart));
         hostingEventSource.RequestStart("GET", "/");
 
-        await totalRequestValues.WaitForSumValueAsync(1);
+        await totalRequestValues.WaitForValueAsync(1);
         await currentRequestValues.WaitForValueAsync(1);
         await failedRequestValues.WaitForValueAsync(0);
 
         Logger.LogInformation(nameof(HostingEventSource.RequestStop));
         hostingEventSource.RequestStop();
 
-        await totalRequestValues.WaitForSumValueAsync(1);
+        await totalRequestValues.WaitForValueAsync(1);
         await currentRequestValues.WaitForValueAsync(0);
         await failedRequestValues.WaitForValueAsync(0);
 
         Logger.LogInformation(nameof(HostingEventSource.RequestStart));
         hostingEventSource.RequestStart("POST", "/");
 
-        await totalRequestValues.WaitForSumValueAsync(2);
+        await totalRequestValues.WaitForValueAsync(2);
         await currentRequestValues.WaitForValueAsync(1);
         await failedRequestValues.WaitForValueAsync(0);
 
@@ -230,7 +230,7 @@ public class HostingEventSourceTests : LoggedTest
         Logger.LogInformation(nameof(HostingEventSource.RequestStop));
         hostingEventSource.RequestStop();
 
-        await totalRequestValues.WaitForSumValueAsync(2);
+        await totalRequestValues.WaitForValueAsync(2);
         await currentRequestValues.WaitForValueAsync(0);
         await failedRequestValues.WaitForValueAsync(1);
     }

--- a/src/Hosting/Hosting/test/Internal/HostingEventSourceTests.cs
+++ b/src/Hosting/Hosting/test/Internal/HostingEventSourceTests.cs
@@ -193,9 +193,9 @@ public class HostingEventSourceTests : LoggedTest
         using var timeoutTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         timeoutTokenSource.Token.Register(() => Logger.LogError("Timeout while waiting for counter value."));
 
-        var totalRequestValues = eventListener.GetCounterValues("total-requests", timeoutTokenSource.Token).GetAsyncEnumerator();
-        var currentRequestValues = eventListener.GetCounterValues("current-requests", timeoutTokenSource.Token).GetAsyncEnumerator();
-        var failedRequestValues = eventListener.GetCounterValues("failed-requests", timeoutTokenSource.Token).GetAsyncEnumerator();
+        var totalRequestValues = eventListener.GetCounterValues("total-requests", timeoutTokenSource.Token);
+        var currentRequestValues = eventListener.GetCounterValues("current-requests", timeoutTokenSource.Token);
+        var failedRequestValues = eventListener.GetCounterValues("failed-requests", timeoutTokenSource.Token);
 
         eventListener.EnableEvents(hostingEventSource, EventLevel.Informational, EventKeywords.None,
             new Dictionary<string, string>
@@ -207,32 +207,37 @@ public class HostingEventSourceTests : LoggedTest
         Logger.LogInformation(nameof(HostingEventSource.RequestStart));
         hostingEventSource.RequestStart("GET", "/");
 
-        await totalRequestValues.WaitForValueAsync(1);
-        await currentRequestValues.WaitForValueAsync(1);
-        await failedRequestValues.WaitForValueAsync(0);
+        await WaitForCounterValue(totalRequestValues, expectedValue: 1, Logger);
+        await WaitForCounterValue(currentRequestValues, expectedValue: 1, Logger);
+        await WaitForCounterValue(failedRequestValues, expectedValue: 0, Logger);
 
         Logger.LogInformation(nameof(HostingEventSource.RequestStop));
         hostingEventSource.RequestStop();
 
-        await totalRequestValues.WaitForValueAsync(1);
-        await currentRequestValues.WaitForValueAsync(0);
-        await failedRequestValues.WaitForValueAsync(0);
+        await WaitForCounterValue(totalRequestValues, expectedValue: 1, Logger);
+        await WaitForCounterValue(currentRequestValues, expectedValue: 0, Logger);
+        await WaitForCounterValue(failedRequestValues, expectedValue: 0, Logger);
 
         Logger.LogInformation(nameof(HostingEventSource.RequestStart));
         hostingEventSource.RequestStart("POST", "/");
 
-        await totalRequestValues.WaitForValueAsync(2);
-        await currentRequestValues.WaitForValueAsync(1);
-        await failedRequestValues.WaitForValueAsync(0);
+        await WaitForCounterValue(totalRequestValues, expectedValue: 2, Logger);
+        await WaitForCounterValue(currentRequestValues, expectedValue: 1, Logger);
+        await WaitForCounterValue(failedRequestValues, expectedValue: 0, Logger);
 
         Logger.LogInformation(nameof(HostingEventSource.RequestFailed));
         hostingEventSource.RequestFailed();
         Logger.LogInformation(nameof(HostingEventSource.RequestStop));
         hostingEventSource.RequestStop();
 
-        await totalRequestValues.WaitForValueAsync(2);
-        await currentRequestValues.WaitForValueAsync(0);
-        await failedRequestValues.WaitForValueAsync(1);
+        await WaitForCounterValue(totalRequestValues, expectedValue: 2, Logger);
+        await WaitForCounterValue(currentRequestValues, expectedValue: 0, Logger);
+        await WaitForCounterValue(failedRequestValues, expectedValue: 1, Logger);
+    }
+
+    private static async Task WaitForCounterValue(CounterValues values, double expectedValue, ILogger logger)
+    {
+        await values.Values.WaitForValueAsync(expectedValue, values.CounterName, logger);
     }
 
     private static HostingEventSource GetHostingEventSource()

--- a/src/Hosting/Hosting/test/Microsoft.AspNetCore.Hosting.Tests.csproj
+++ b/src/Hosting/Hosting/test/Microsoft.AspNetCore.Hosting.Tests.csproj
@@ -11,6 +11,7 @@
     <Compile Include="$(SharedSourceRoot)EventSource.Testing\TestCounterListener.cs" />
     <Compile Include="$(SharedSourceRoot)SyncPoint\SyncPoint.cs" />
     <Compile Include="$(SharedSourceRoot)Metrics\TestMeterFactory.cs" LinkBase="shared" />
+    <Compile Include="$(SharedSourceRoot)AsyncEnumerableExtensions.cs" LinkBase="shared" />
     <Content Include="testroot\**\*" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
     <Content Include="Microsoft.AspNetCore.Hosting.StaticWebAssets.xml" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/src/Middleware/ConcurrencyLimiter/test/Microsoft.AspNetCore.ConcurrencyLimiter.Tests.csproj
+++ b/src/Middleware/ConcurrencyLimiter/test/Microsoft.AspNetCore.ConcurrencyLimiter.Tests.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)EventSource.Testing\TestCounterListener.cs" />
     <Compile Include="$(SharedSourceRoot)EventSource.Testing\TestEventListener.cs" />
+    <Compile Include="$(SharedSourceRoot)AsyncEnumerableExtensions.cs" LinkBase="shared" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Shared/AsyncEnumerableExtensions.cs
+++ b/src/Shared/AsyncEnumerableExtensions.cs
@@ -4,7 +4,7 @@
 using System.Numerics;
 using Microsoft.Extensions.Logging;
 
-namespace System.Collections.Generic;
+namespace Microsoft.AspNetCore.InternalTesting;
 
 internal static class AsyncEnumerableExtensions
 {


### PR DESCRIPTION
I noticed that https://github.com/dotnet/aspnetcore/issues/57259 is still flaky after the latest changes. 4 failures in the last 30 days.

For some reason I thought it would be a good idea to sum the results from the total request counter. This doesn't make any sense 🤷 Maybe I was thinking of RPS counter when I did it. Total request counter is pre-summed so change the test back to test the latest value.

I've also made a change to improve logging and debugging the counter methods.