### PR TITLE
Prevent 503s from IIS after IISNativeApplication gets finalized

### DIFF
--- a/src/Servers/IIS/IIS/src/Core/IISHttpServer.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpServer.cs
@@ -132,7 +132,7 @@ internal sealed class IISHttpServer : IServer
         _disposed = true;
 
         // Block any more calls into managed from native as we are unloading.
-        _nativeApplication.StopCallsIntoManaged();
+        _nativeApplication.Stop();
         _shutdownSignal.TrySetResult();
 
         if (_httpServerHandle.IsAllocated)
@@ -141,7 +141,6 @@ internal sealed class IISHttpServer : IServer
         }
 
         _memoryPool.Dispose();
-        _nativeApplication.Dispose();
     }
 
     [UnmanagedCallersOnly]
@@ -261,7 +260,7 @@ internal sealed class IISHttpServer : IServer
                 return;
             }
 
-            server._nativeApplication.StopCallsIntoManaged();
+            server._nativeApplication.Stop();
             server._shutdownSignal.TrySetResult();
             server._cancellationTokenRegistration.Dispose();
         }

--- a/src/Servers/IIS/IIS/src/Core/IISNativeApplication.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISNativeApplication.cs
@@ -6,6 +6,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core;
 internal sealed class IISNativeApplication
 {
     private readonly NativeSafeHandle _nativeApplication;
+    private bool _hasRegisteredCallbacks;
     private readonly object _sync = new object();
 
     public IISNativeApplication(NativeSafeHandle nativeApplication)
@@ -24,14 +25,22 @@ internal sealed class IISNativeApplication
         }
     }
 
-    public void StopCallsIntoManaged()
+    public void Stop()
     {
         lock (_sync)
         {
-            if (!_nativeApplication.IsInvalid)
+            if (_nativeApplication.IsInvalid)
+            {
+                return;
+            }
+
+            if (_hasRegisteredCallbacks)
             {
                 NativeMethods.HttpStopCallsIntoManaged(_nativeApplication);
             }
+
+            _nativeApplication.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 
@@ -44,6 +53,8 @@ internal sealed class IISNativeApplication
         IntPtr pvRequestContext,
         IntPtr pvShutdownContext)
     {
+        _hasRegisteredCallbacks = true;
+
         NativeMethods.HttpRegisterCallbacks(
             _nativeApplication,
             requestCallback,
@@ -55,20 +66,9 @@ internal sealed class IISNativeApplication
             pvShutdownContext);
     }
 
-    public void Dispose()
-    {
-        lock (_sync)
-        {
-            GC.SuppressFinalize(this);
-
-            // Don't need to await here because pinvokes should never been called after disposing the safe handle.
-            _nativeApplication.Dispose();
-        }
-    }
-
     ~IISNativeApplication()
     {
         // If this finalize is invoked, try our best to block all calls into managed.
-        StopCallsIntoManaged();
+        Stop();
     }
 }


### PR DESCRIPTION
This was brought to my attention by https://github.com/dotnet/AspNetCore.Docs/pull/34492, but @Tratcher had already filed an issue for it. Both of these are based on the investigation at https://techcommunity.microsoft.com/blog/iis-support-blog/asp-net-core-503-server-has-been-shutdown/3830338.

@Tratcher's suggestion was to detect this situation and provide a better error, but so long as we haven't actually started the server, I don't think this needs to be an error case at all. We could consider making the server restartable, but I think that would require more drastic changes, and that's not something people try to do often.

What's more common is code like the following:

```csharp
var config = WebApplication.CreateBuilder().Configuration;
var someConfig = config["someConfig"];
```

While I would never recommend this, and would advocate for creating your own [ConfigurationManager](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.configuration.configurationmanager?view=net-9.0-pp) or `ConfigurationBuilder` from the appropriate source instead, this should not break IIS.

Fixes #48457
