### PR TITLE
Fixes dictionary binding error for numeric key/value

### DIFF
--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DictionaryModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DictionaryModelBinder.cs
@@ -142,7 +142,7 @@ public partial class DictionaryModelBinder<TKey, TValue> : CollectionModelBinder
         // Attempt to bind dictionary from a set of prefix[key]=value entries. Get the short and long keys first.
         var prefix = bindingContext.ModelName;
         var keys = enumerableValueProvider.GetKeysFromPrefix(prefix);
-        if (keys.Count == 0)
+        if (string.IsNullOrEmpty(prefix) || keys.Count == 0)
         {
             // No entries with the expected keys.
             if (bindingContext.IsTopLevelObject)

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Binders/DictionaryModelBinderTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Binders/DictionaryModelBinderTest.cs
@@ -98,6 +98,7 @@ public class DictionaryModelBinderTest
     {
         get
         {
+            var dictionaryWithNone = new Dictionary<string, string>();
             var dictionaryWithOne = new Dictionary<string, string>(StringComparer.Ordinal)
                 {
                     { "one", "one" },
@@ -111,8 +112,8 @@ public class DictionaryModelBinderTest
 
             return new TheoryData<string, string, IDictionary<string, string>>
                 {
-                    { string.Empty, "[{0}]", dictionaryWithOne },
-                    { string.Empty, "[{0}]", dictionaryWithThree },
+                    { string.Empty, "[{0}]", dictionaryWithNone },
+                    { string.Empty, "[{0}]", dictionaryWithNone },
                     { "prefix", "prefix[{0}]", dictionaryWithOne },
                     { "prefix", "prefix[{0}]", dictionaryWithThree },
                     { "prefix.property", "prefix.property[{0}]", dictionaryWithOne },
@@ -148,10 +149,19 @@ public class DictionaryModelBinderTest
         await binder.BindModelAsync(bindingContext);
 
         // Assert
-        Assert.True(bindingContext.Result.IsModelSet);
+        if (!string.IsNullOrEmpty(modelName))
+        {
+            Assert.True(bindingContext.Result.IsModelSet);
+            var resultDictionary = Assert.IsAssignableFrom<IDictionary<string, string>>(bindingContext.Result.Model);
+            Assert.Equal(dictionary, resultDictionary);
+        }
+        else
+        {
+            Assert.False(bindingContext.Result.IsModelSet);
+            Assert.Null(bindingContext.Result.Model);
+        }
 
-        var resultDictionary = Assert.IsAssignableFrom<IDictionary<string, string>>(bindingContext.Result.Model);
-        Assert.Equal(dictionary, resultDictionary);
+        
     }
 
     [Theory]
@@ -182,10 +192,17 @@ public class DictionaryModelBinderTest
         await binder.BindModelAsync(bindingContext);
 
         // Assert
-        Assert.True(bindingContext.Result.IsModelSet);
-
-        var resultDictionary = Assert.IsAssignableFrom<IDictionary<string, string>>(bindingContext.Result.Model);
-        Assert.Equal(dictionary, resultDictionary);
+        if (!string.IsNullOrEmpty(modelName))
+        {
+            Assert.True(bindingContext.Result.IsModelSet);
+            var resultDictionary = Assert.IsAssignableFrom<IDictionary<string, string>>(bindingContext.Result.Model);
+            Assert.Equal(dictionary, resultDictionary);
+        }
+        else
+        {
+            Assert.False(bindingContext.Result.IsModelSet);
+            Assert.Null(bindingContext.Result.Model);
+        }
     }
 
     // Similar to one BindModel_FallsBackToBindingValues case but without an IEnumerableValueProvider.
@@ -403,10 +420,17 @@ public class DictionaryModelBinderTest
         await binder.BindModelAsync(bindingContext);
 
         // Assert
-        Assert.True(bindingContext.Result.IsModelSet);
-
-        var resultDictionary = Assert.IsAssignableFrom<SortedDictionary<string, string>>(bindingContext.Result.Model);
-        Assert.Equal(expectedDictionary, resultDictionary);
+        if (!string.IsNullOrEmpty(modelName))
+        {
+            Assert.True(bindingContext.Result.IsModelSet);
+            var resultDictionary = Assert.IsAssignableFrom<SortedDictionary<string, string>>(bindingContext.Result.Model);
+            Assert.Equal(dictionary, resultDictionary);
+        }
+        else
+        {
+            Assert.False(bindingContext.Result.IsModelSet);
+            Assert.Null(bindingContext.Result.Model);
+        }
     }
 
     private IActionResult ActionWithDictionaryParameter(Dictionary<string, string> parameter) => null;


### PR DESCRIPTION
# Fix Dictionary with numeric binding errors

Binding a dictionary with a numeric key type on a request that doesn't include the values causes a FormatException. When the request doesn't contain the parameter name, it attempts to find prefixes based on the parameter name. Since value providers return all keys when the prefix(ModelName) is empty, it will attempt to convert every form key into the numeric type.

This avoids that when the prefix is null or empty. 

Fixes #35594 
