### PR TITLE
[Blazor] Updates the itemgroup name to avoid conflicts

### DIFF
--- a/src/Components/WebView/WebView/src/build/Microsoft.AspNetCore.Components.WebView.props
+++ b/src/Components/WebView/WebView/src/build/Microsoft.AspNetCore.Components.WebView.props
@@ -44,11 +44,11 @@
       AssetRole="Primary"
       FingerprintCandidates="true"
       BasePath="/">
-      <Output TaskParameter="Assets" ItemName="_FrameworkStaticWebAsset" />
+      <Output TaskParameter="Assets" ItemName="_WebViewFrameworkStaticWebAsset" />
     </DefineStaticWebAssets>
 
     <ItemGroup>
-      <StaticWebAsset Include="@(_FrameworkStaticWebAsset)" />
+      <StaticWebAsset Include="@(_WebViewFrameworkStaticWebAsset)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
* `microsoft.aspnetcore.app.internal.assets` has code to include assets in the previous item group that are included as static web assets, so it was getting included twice, once for the MSBuild in the package and another for the msbuild in the `microsoft.aspnetcore.app.internal.assets` package.
* Changing the item group so that they don't conflict addresses the issue.
* We still need to determine why `microsoft.aspnetcore.app.internal.assets` is getting imported.