### PR TITLE
Add route string syntax for pattern in RouteHandlerServices.Map

### DIFF
--- a/src/Http/Routing/src/Builder/RouteHandlerServices.cs
+++ b/src/Http/Routing/src/Builder/RouteHandlerServices.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -32,7 +33,7 @@ public static class RouteHandlerServices
     /// <returns>The <see cref="RouteHandlerBuilder"/>>.</returns>
     public static RouteHandlerBuilder Map(
             IEndpointRouteBuilder endpoints,
-            string pattern,
+            [StringSyntax("Route")] string pattern,
             Delegate handler,
             IEnumerable<string>? httpMethods,
             Func<MethodInfo, RequestDelegateFactoryOptions?, RequestDelegateMetadataResult> populateMetadata,
@@ -62,7 +63,7 @@ public static class RouteHandlerServices
     /// <returns>The <see cref="RouteHandlerBuilder"/>>.</returns>
     public static RouteHandlerBuilder Map(
             IEndpointRouteBuilder endpoints,
-            string pattern,
+            [StringSyntax("Route")] string pattern,
             Delegate handler,
             IEnumerable<string>? httpMethods,
             Func<MethodInfo, RequestDelegateFactoryOptions?, RequestDelegateMetadataResult> populateMetadata,


### PR DESCRIPTION
# {PR title}

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Add route string syntax for pattern in RouteHandlerServices.Map. Just that.

Fixes #59939 
