### PR TITLE
Fix Handle Leak of ReadableJsonConfigurationProvider in FromStdInStrategy class

### DIFF
--- a/src/Tools/dotnet-user-secrets/src/Internal/SetCommand.cs
+++ b/src/Tools/dotnet-user-secrets/src/Internal/SetCommand.cs
@@ -61,7 +61,7 @@ Examples:
         public void Execute(CommandContext context)
         {
             // parses stdin with the same parser that Microsoft.Extensions.Configuration.Json would use
-            var provider = new ReadableJsonConfigurationProvider();
+            using var provider = new ReadableJsonConfigurationProvider();
             using (var stream = new MemoryStream())
             {
                 using (var writer = new StreamWriter(stream, Encoding.Unicode, 1024, true))


### PR DESCRIPTION
# Fix Handle Leak of ReadableJsonConfigurationProvider in FromStdInStrategy class

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

Add the `using` statement to ensure proper disposal.

Fixes #59260
##

Found by Linux Verification Center (linuxtesting.org) with SVACE.
