### PR TITLE
[Blazor] Avoid defining webassembly.js as a framework asset

### DIFF
--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -599,7 +599,7 @@ stages:
           displayName: Update submodules
         - script: ./restore.cmd
           displayName: Run restore.cmd
-        - powershell: ./eng/build.ps1 -all -noBuildJava -noBuildNodeJS "-WarnAsError:false"
+        - powershell: ./eng/build.ps1 --binaryLog -all -noBuildJava -noBuildNodeJS "-WarnAsError:false"
           displayName: Build (No NodeJS)
         - script: npm run build
           displayName: Build JS

--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -599,7 +599,7 @@ stages:
           displayName: Update submodules
         - script: ./restore.cmd
           displayName: Run restore.cmd
-        - powershell: ./eng/build.ps1 --binaryLog -all -noBuildJava -noBuildNodeJS "-WarnAsError:false"
+        - powershell: ./eng/build.ps1 -all -noBuildJava -noBuildNodeJS "-WarnAsError:false"
           displayName: Build (No NodeJS)
         - script: npm run build
           displayName: Build JS

--- a/src/Assets/build/Microsoft.AspNetCore.App.Internal.Assets.targets
+++ b/src/Assets/build/Microsoft.AspNetCore.App.Internal.Assets.targets
@@ -23,6 +23,7 @@
     <ItemGroup Condition="'$(UsingMicrosoftNETSdkWeb)' == 'true' AND '$(UseBlazorFrameworkDebugAssets)' == 'true'">
       <_FrameworkStaticWebAssetCandidate Include="$(BlazorFrameworkStaticWebAssetRoot)\blazor.web.js.map">
         <RelativePath>_framework/blazor.web.js.map</RelativePath>
+      </_FrameworkStaticWebAssetCandidate>
       <_FrameworkStaticWebAssetCandidate Include="$(BlazorFrameworkStaticWebAssetRoot)\blazor.server.js.map">
         <RelativePath>_framework/blazor.server.js.map</RelativePath>
       </_FrameworkStaticWebAssetCandidate>

--- a/src/Assets/build/Microsoft.AspNetCore.App.Internal.Assets.targets
+++ b/src/Assets/build/Microsoft.AspNetCore.App.Internal.Assets.targets
@@ -21,8 +21,11 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(UsingMicrosoftNETSdkWeb)' == 'true' AND '$(UseBlazorFrameworkDebugAssets)' == 'true'">
-      <_FrameworkStaticWebAssetCandidate Include="$(BlazorFrameworkStaticWebAssetRoot)\blazor.web.js.map" />
-      <_FrameworkStaticWebAssetCandidate Include="$(BlazorFrameworkStaticWebAssetRoot)\blazor.server.js.map" />
+      <_FrameworkStaticWebAssetCandidate Include="$(BlazorFrameworkStaticWebAssetRoot)\blazor.web.js.map">
+        <RelativePath>_framework/blazor.web.js.map</RelativePath>
+      <_FrameworkStaticWebAssetCandidate Include="$(BlazorFrameworkStaticWebAssetRoot)\blazor.server.js.map">
+        <RelativePath>_framework/blazor.server.js.map</RelativePath>
+      </_FrameworkStaticWebAssetCandidate>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Assets/build/Microsoft.AspNetCore.App.Internal.Assets.targets
+++ b/src/Assets/build/Microsoft.AspNetCore.App.Internal.Assets.targets
@@ -12,25 +12,17 @@
 
   <Target Name="_AddBlazorFrameworkStaticWebAssets" Condition="'$(OutputType)' == 'Exe'">
     <ItemGroup Condition="'$(UsingMicrosoftNETSdkWeb)' == 'true'">
-      <_FrameworkStaticWebAssetCandidate Include="$(BlazorFrameworkStaticWebAssetRoot)\blazor.web.js" />
-      <_FrameworkStaticWebAssetCandidate Include="$(BlazorFrameworkStaticWebAssetRoot)\blazor.server.js" />
+      <_FrameworkStaticWebAssetCandidate Include="$(BlazorFrameworkStaticWebAssetRoot)\blazor.web.js">
+        <RelativePath>_framework/blazor.web.js</RelativePath>
+      </_FrameworkStaticWebAssetCandidate>
+      <_FrameworkStaticWebAssetCandidate Include="$(BlazorFrameworkStaticWebAssetRoot)\blazor.server.js">
+        <RelativePath>_framework/blazor.server.js</RelativePath>
+      </_FrameworkStaticWebAssetCandidate>
     </ItemGroup>
 
     <ItemGroup Condition="'$(UsingMicrosoftNETSdkWeb)' == 'true' AND '$(UseBlazorFrameworkDebugAssets)' == 'true'">
       <_FrameworkStaticWebAssetCandidate Include="$(BlazorFrameworkStaticWebAssetRoot)\blazor.web.js.map" />
       <_FrameworkStaticWebAssetCandidate Include="$(BlazorFrameworkStaticWebAssetRoot)\blazor.server.js.map" />
-    </ItemGroup>
-
-    <PropertyGroup>
-      <_IncludeAssetsInBlazorWebAssemblyProject Condition="'$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true' AND '$(StaticWebAssetProjectMode)' != 'Default'">true</_IncludeAssetsInBlazorWebAssemblyProject>
-    </PropertyGroup>
-
-    <ItemGroup Condition="'$(_IncludeAssetsInBlazorWebAssemblyProject)' == 'true'">
-      <_FrameworkStaticWebAssetCandidate Include="$(BlazorFrameworkStaticWebAssetRoot)\blazor.webassembly.js" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(_IncludeAssetsInBlazorWebAssemblyProject)' == 'true' AND '$(UseBlazorFrameworkDebugAssets)' == 'true'">
-      <_FrameworkStaticWebAssetCandidate Include="$(BlazorFrameworkStaticWebAssetRoot)\blazor.webassembly.js.map" />
     </ItemGroup>
 
     <ItemGroup>
@@ -45,35 +37,14 @@
       Condition="'@(_MissingFrameworkStaticWebAssetCandidate->Count())' != '0'"
       Text="Framework asset '%(_MissingFrameworkStaticWebAssetCandidate.Identity)' could not be found and won't be included in the project." />
 
-    <PropertyGroup>
-      <_FrameworkAssetsPath>$(IntermediateOutputPath)frameworkassets</_FrameworkAssetsPath>
-    </PropertyGroup>
-
-    <MakeDir
-      Directories="$(_FrameworkAssetsPath)"
-      Condition="!EXISTS('$(_FrameworkAssetsPath)')" />
-
-    <Copy
-      SourceFiles="@(_FrameworkStaticWebAssetCandidate)"
-      DestinationFolder="$(_FrameworkAssetsPath)"
-      SkipUnchangedFiles="true">
-      <Output TaskParameter="CopiedFiles" ItemName="_CopiedFrameworkStaticWebAssetCandidate" />
-    </Copy>
-
-    <ItemGroup>
-      <_CopiedFrameworkStaticWebAssetCandidate>
-        <RelativePath>_framework\%(FileName)%(Extension)</RelativePath>
-        <ContentRoot>$(_FrameworkAssetsPath)</ContentRoot>
-      </_CopiedFrameworkStaticWebAssetCandidate>
-    </ItemGroup>
-
     <DefineStaticWebAssets
-      Condition="'@(_CopiedFrameworkStaticWebAssetCandidate->Count())' != '0'"
-      CandidateAssets="@(_CopiedFrameworkStaticWebAssetCandidate)"
+      Condition="'@(_FrameworkStaticWebAssetCandidate->Count())' != '0'"
+      CandidateAssets="@(_FrameworkStaticWebAssetCandidate)"
+      ContentRoot="$(BlazorFrameworkStaticWebAssetRoot)"
       SourceId="$(PackageId)"
       SourceType="Discovered"
       AssetKind="All"
-      AssetMode="All"
+      AssetMode="CurrentProject"
       AssetRole="Primary"
       FingerprintCandidates="true"
       BasePath="$(StaticWebAssetBasePath)">

--- a/src/Components/Directory.Build.targets
+++ b/src/Components/Directory.Build.targets
@@ -1,5 +1,5 @@
 ﻿<Project>
-  <PropertyGroup Condition="'$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true' and '$(BuildNodeJS)' == 'true'">
+  <PropertyGroup Condition="'$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true' and '$(BuildNodeJS)' != 'false'">
     <BlazorWebAssemblyJSPath
         Condition=" '$(Configuration)' == 'Debug' ">$(RepoRoot)src\Components\Web.JS\dist\Debug\blazor.webassembly.js</BlazorWebAssemblyJSPath>
     <BlazorWebAssemblyJSPath

--- a/src/Components/Directory.Build.targets
+++ b/src/Components/Directory.Build.targets
@@ -1,11 +1,11 @@
 ﻿<Project>
-  <PropertyGroup Condition="'$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true'">
+  <PropertyGroup Condition="'$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true' and '$(BuildNodeJS)' == 'true'">
     <BlazorWebAssemblyJSPath
         Condition=" '$(Configuration)' == 'Debug' ">$(RepoRoot)src\Components\Web.JS\dist\Debug\blazor.webassembly.js</BlazorWebAssemblyJSPath>
     <BlazorWebAssemblyJSPath
         Condition=" '$(Configuration)' != 'Debug' ">$(RepoRoot)src\Components\Web.JS\dist\Release\blazor.webassembly.js</BlazorWebAssemblyJSPath>
     <BlazorWebAssemblyJSMapPath>$(BlazorWebAssemblyJSPath).map</BlazorWebAssemblyJSMapPath>
   </PropertyGroup>
-  
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.targets))\Directory.Build.targets" />
 </Project>

--- a/src/Components/Directory.Build.targets
+++ b/src/Components/Directory.Build.targets
@@ -1,3 +1,11 @@
 ﻿<Project>
+  <PropertyGroup Condition="'$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true'">
+    <BlazorWebAssemblyJSPath
+        Condition=" '$(Configuration)' == 'Debug' ">$(RepoRoot)src\Components\Web.JS\dist\Debug\blazor.webassembly.js</BlazorWebAssemblyJSPath>
+    <BlazorWebAssemblyJSPath
+        Condition=" '$(Configuration)' != 'Debug' ">$(RepoRoot)src\Components\Web.JS\dist\Release\blazor.webassembly.js</BlazorWebAssemblyJSPath>
+    <BlazorWebAssemblyJSMapPath>$(BlazorWebAssemblyJSPath).map</BlazorWebAssemblyJSMapPath>
+  </PropertyGroup>
+  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.targets))\Directory.Build.targets" />
 </Project>

--- a/src/Components/WebAssembly/WebAssembly/src/Microsoft.AspNetCore.Components.WebAssembly.csproj
+++ b/src/Components/WebAssembly/WebAssembly/src/Microsoft.AspNetCore.Components.WebAssembly.csproj
@@ -52,7 +52,13 @@
     <InternalsVisibleTo Include="BasicTestApp" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <BlazorWebAssemblyJSFile Condition=" '$(Configuration)' == 'Debug' ">..\..\..\Web.JS\dist\Debug\blazor.webassembly.js</BlazorWebAssemblyJSFile>
+    <BlazorWebAssemblyJSFile Condition=" '$(Configuration)' != 'Debug' ">..\..\..\Web.JS\dist\Release\blazor.webassembly.js</BlazorWebAssemblyJSFile>
+  </PropertyGroup>
+
   <ItemGroup>
+    <Content Include="$(BlazorWebAssemblyJSFile)" Pack="true" PackagePath="build\$(DefaultNetCoreTargetFramework)\" LinkBase="build\$(DefaultNetCoreTargetFramework)\" />  
     <Content Include="targets\*.props" Pack="true" PackagePath="build\$(DefaultNetCoreTargetFramework)\" />
   </ItemGroup>
 

--- a/src/Components/WebAssembly/WebAssembly/src/targets/Microsoft.AspNetCore.Components.WebAssembly.props
+++ b/src/Components/WebAssembly/WebAssembly/src/targets/Microsoft.AspNetCore.Components.WebAssembly.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
+    <BlazorWebAssemblyJSPath>$(MSBuildThisFileDirectory)blazor.webassembly.js</BlazorWebAssemblyJSPath>
     <BlazorRoutingEnableRegexConstraint Condition="'$(BlazorRoutingEnableRegexConstraint)' == ''">false</BlazorRoutingEnableRegexConstraint>
   </PropertyGroup>
 


### PR DESCRIPTION
* The only assets that need to go into the `.Internal.Assets` package are `blazor.web.js` and `blazor.server.js`.
* `blazor.webassembly.js` should continue shipping as a package.

We should look into making `blazor.webassembly.js` a regular static web asset, instead of the custom dance that happens now.

This change is in reaction to an issue we are seeing in a dependency update PR where blazor.webassembly.js is getting included twice.

Once by `_ResolveBlazorFrameworkAssets` and another one by `_ResolveBlazorWasmOutputs`.