### PR TITLE
Add support for global conventions on WebApplication

### DIFF
--- a/src/DefaultBuilder/src/PublicAPI.Unshipped.txt
+++ b/src/DefaultBuilder/src/PublicAPI.Unshipped.txt
@@ -1,2 +1,2 @@
 #nullable enable
-Microsoft.AspNetCore.Builder.WebApplication.Conventions.get -> Microsoft.AspNetCore.Builder.IEndpointConventionBuilder!
+Microsoft.AspNetCore.Builder.WebApplication.EndpointConventions.get -> Microsoft.AspNetCore.Builder.IEndpointConventionBuilder!

--- a/src/DefaultBuilder/src/PublicAPI.Unshipped.txt
+++ b/src/DefaultBuilder/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Microsoft.AspNetCore.Builder.WebApplication.Conventions.get -> Microsoft.AspNetCore.Builder.IEndpointConventionBuilder!

--- a/src/DefaultBuilder/src/WebApplication.cs
+++ b/src/DefaultBuilder/src/WebApplication.cs
@@ -25,6 +25,7 @@ namespace Microsoft.AspNetCore.Builder;
 public sealed class WebApplication : IHost, IApplicationBuilder, IEndpointRouteBuilder, IAsyncDisposable
 {
     internal const string GlobalEndpointRouteBuilderKey = "__GlobalEndpointRouteBuilder";
+    internal const string GlobalRouteGroupBuilderKey = "__GlobalRouteGroupBuilder";
 
     private readonly IHost _host;
     private readonly GlobalEndpointRouteBuilder _globalEndpointRouteBuilder;
@@ -41,6 +42,7 @@ public sealed class WebApplication : IHost, IApplicationBuilder, IEndpointRouteB
         Logger = host.Services.GetRequiredService<ILoggerFactory>().CreateLogger(Environment.ApplicationName ?? nameof(WebApplication));
 
         Properties[GlobalEndpointRouteBuilderKey] = _globalEndpointRouteBuilder;
+        Properties[GlobalRouteGroupBuilderKey] = _globalRouteGroupBuilder;
     }
 
     /// <summary>
@@ -91,7 +93,7 @@ public sealed class WebApplication : IHost, IApplicationBuilder, IEndpointRouteB
     /// <summary>
     /// Gets the <see cref="IEndpointConventionBuilder"/> for the application.
     /// </summary>
-    public IEndpointConventionBuilder Conventions => _globalRouteGroupBuilder;
+    public IEndpointConventionBuilder EndpointConventions => _globalRouteGroupBuilder;
 
     internal ApplicationBuilder ApplicationBuilder { get; }
 
@@ -223,6 +225,7 @@ public sealed class WebApplication : IHost, IApplicationBuilder, IEndpointRouteB
         var newBuilder = ApplicationBuilder.New();
         // Remove the route builder so branched pipelines have their own routing world
         newBuilder.Properties.Remove(GlobalEndpointRouteBuilderKey);
+        newBuilder.Properties.Remove(GlobalRouteGroupBuilderKey);
         return newBuilder;
     }
 

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -411,6 +411,7 @@ public sealed class WebApplicationBuilder : IHostApplicationBuilder
         // by the WebApplication as the IEndpointRouteBuilder instance
         var globalRouteGroupBuilder = _builtApplication.Properties[WebApplication.GlobalEndpointRouteBuilderKey];
         app.Properties.Add(WebApplication.GlobalEndpointRouteBuilderKey, globalRouteGroupBuilder);
+        app.Properties.Add(WebApplication.GlobalRouteGroupBuilderKey, _builtApplication.Properties[WebApplication.GlobalRouteGroupBuilderKey]);
 
         // Only call UseRouting() if there are endpoints configured and UseRouting() wasn't called on the global route builder already
         if (_builtApplication.DataSources.Count > 0)

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -407,8 +407,10 @@ public sealed class WebApplicationBuilder : IHostApplicationBuilder
         // destination.Run(source)
         // destination.UseEndpoints()
 
-        // Set the route builder so that UseRouting will use the WebApplication as the IEndpointRouteBuilder for route matching
-        app.Properties.Add(WebApplication.GlobalEndpointRouteBuilderKey, _builtApplication);
+        // Set the route builder so that UseRouting will use the RouteGroupBuilder managed
+        // by the WebApplication as the IEndpointRouteBuilder instance
+        var globalRouteGroupBuilder = _builtApplication.Properties[WebApplication.GlobalEndpointRouteBuilderKey];
+        app.Properties.Add(WebApplication.GlobalEndpointRouteBuilderKey, globalRouteGroupBuilder);
 
         // Only call UseRouting() if there are endpoints configured and UseRouting() wasn't called on the global route builder already
         if (_builtApplication.DataSources.Count > 0)

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/Microsoft.AspNetCore.Tests.csproj
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/Microsoft.AspNetCore.Tests.csproj
@@ -6,6 +6,10 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore" />
+    <Reference Include="Microsoft.AspNetCore.SignalR" />
+    <Reference Include="Microsoft.AspNetCore.Components.Endpoints" />
+    <Reference Include="Microsoft.AspNetCore.Mvc" />
+    <Reference Include="Microsoft.AspNetCore.Mvc.Core" />
     <Reference Include="Microsoft.AspNetCore.TestHost" />
     <Reference Include="Microsoft.AspNetCore.Authorization.Policy" />
     <Content Include="Microsoft.AspNetCore.TestHost.StaticWebAssets.xml" CopyToOutputDirectory="PreserveNewest" />

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationGlobalConventionTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationGlobalConventionTests.cs
@@ -1,0 +1,348 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApplicationParts;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.AspNetCore.Tests;
+
+public class WebApplicationGlobalConventionTests
+{
+    [Fact]
+    public async Task SupportsApplyingConventionsOnAllEndpoints()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        var app = builder.Build();
+
+        app.Conventions.WithMetadata(new EndpointGroupNameAttribute("global"));
+
+        app.MapGet("/1", () => "Hello, world!").WithName("One");
+        app.MapGet("/2", () => "Hello, world!").WithName("Two");
+
+        await app.StartAsync();
+
+        var endpointDataSource = app.Services.GetRequiredService<EndpointDataSource>();
+        Assert.Collection(endpointDataSource.Endpoints,
+            endpoint =>
+            {
+                var groupNameMetadata = endpoint.Metadata.GetMetadata<IEndpointGroupNameMetadata>();
+                var nameMetadata = endpoint.Metadata.GetMetadata<IEndpointNameMetadata>();
+                Assert.Equal("global", groupNameMetadata.EndpointGroupName);
+                Assert.Equal("One", nameMetadata.EndpointName);
+            },
+            endpoint =>
+            {
+                var groupNameMetadata = endpoint.Metadata.GetMetadata<IEndpointGroupNameMetadata>();
+                var nameMetadata = endpoint.Metadata.GetMetadata<IEndpointNameMetadata>();
+                Assert.Equal("global", groupNameMetadata.EndpointGroupName);
+                Assert.Equal("Two", nameMetadata.EndpointName);
+            }
+        );
+
+        await app.StopAsync();
+    }
+
+    [Fact]
+    public async Task LocalConventionsOverrideGlobalConventions()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        var app = builder.Build();
+
+        app.Conventions.WithMetadata(new EndpointGroupNameAttribute("one"));
+
+        var group = app.MapGroup("/hello")
+            .WithMetadata(new EndpointGroupNameAttribute("two"));
+
+        group.MapGet("/", () => "Hello world!")
+            .WithMetadata(new EndpointGroupNameAttribute("three"));
+
+        await app.StartAsync();
+
+        var endpointDataSource = app.Services.GetRequiredService<EndpointDataSource>();
+        Assert.Collection(endpointDataSource.Endpoints,
+            endpoint =>
+            {
+                var metadata = endpoint.Metadata.OfType<IEndpointGroupNameMetadata>();
+                Assert.Collection(metadata,
+                    metadata => Assert.Equal("one", metadata.EndpointGroupName),
+                    metadata => Assert.Equal("two", metadata.EndpointGroupName),
+                    metadata => Assert.Equal("three", metadata.EndpointGroupName));
+                var targetMetadata = endpoint.Metadata.GetMetadata<IEndpointGroupNameMetadata>();
+                Assert.Equal("three", targetMetadata.EndpointGroupName);
+            }
+        );
+
+        await app.StopAsync();
+    }
+
+    [Fact]
+    public async Task CanAccessCorrectBuilderInConvention()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        var app = builder.Build();
+
+        app.Conventions.Add(builder =>
+        {
+            if (builder is RouteEndpointBuilder { RoutePattern.RawText: "/1" })
+            {
+                builder.Metadata.Add(new EndpointGroupNameAttribute("global"));
+            }
+        });
+
+        app.MapGet("/1", () => "One");
+        app.MapGet("/2", () => " Two");
+
+        await app.StartAsync();
+
+        var endpointDataSource = app.Services.GetRequiredService<EndpointDataSource>();
+        Assert.Collection(endpointDataSource.Endpoints,
+            endpoint =>
+            {
+                var groupNameMetadata = endpoint.Metadata.GetMetadata<IEndpointGroupNameMetadata>();
+                Assert.Equal("global", groupNameMetadata.EndpointGroupName);
+            },
+            endpoint =>
+            {
+                var groupNameMetadata = endpoint.Metadata.GetMetadata<IEndpointGroupNameMetadata>();
+                Assert.Null(groupNameMetadata);
+
+            }
+        );
+
+        await app.StopAsync();
+    }
+
+    [Fact]
+    public async Task CanAccessCorrectServiceProviderInConvention()
+    {
+        IServiceProvider globalConventionServiceProvider = null;
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        var app = builder.Build();
+
+        app.Conventions.Add(builder =>
+        {
+            globalConventionServiceProvider = builder.ApplicationServices;
+        });
+
+        app.MapGet("/", () => "Hello, world!");
+
+        await app.StartAsync();
+
+        var endpointDataSource = app.Services.GetRequiredService<EndpointDataSource>();
+        Assert.NotEmpty(endpointDataSource.Endpoints);
+        Assert.Equal(app.Services, globalConventionServiceProvider);
+
+        await app.StopAsync();
+    }
+
+    [Fact]
+    public async Task BranchedPipelinesExemptFromGlobalConventions()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        var app = builder.Build();
+
+        app.Conventions.WithMetadata(new EndpointGroupNameAttribute("global"));
+
+        app.UseRouting();
+
+        app.MapGet("/1", () => "Hello, world!").WithName("One");
+
+        app.UseEndpoints(e =>
+        {
+            e.MapGet("/2", () => "Hello, world!").WithName("Two");
+        });
+
+        await app.StartAsync();
+
+        var endpointDataSource = app.Services.GetRequiredService<EndpointDataSource>();
+        Assert.Collection(endpointDataSource.Endpoints,
+            endpoint =>
+            {
+                var groupNameMetadata = endpoint.Metadata.GetMetadata<IEndpointGroupNameMetadata>();
+                var nameMetadata = endpoint.Metadata.GetMetadata<IEndpointNameMetadata>();
+                Assert.Equal("global", groupNameMetadata.EndpointGroupName);
+                Assert.Equal("One", nameMetadata.EndpointName);
+            },
+            endpoint =>
+            {
+                var groupNameMetadata = endpoint.Metadata.GetMetadata<IEndpointGroupNameMetadata>();
+                var nameMetadata = endpoint.Metadata.GetMetadata<IEndpointNameMetadata>();
+                Assert.Null(groupNameMetadata);
+                Assert.Equal("Two", nameMetadata.EndpointName);
+            }
+        );
+
+        await app.StopAsync();
+    }
+
+    [Fact]
+    public async Task SupportsGlobalConventionsOnRouteEndpoints()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+
+        builder.Services.AddSignalR();
+        builder.Services.AddRazorComponents();
+        builder.Services.AddControllers()
+            .ConfigureApplicationPartManager(apm =>
+                {
+                    apm.FeatureProviders.Clear();
+                    apm.FeatureProviders.Add(new TestControllerFeatureProvider());
+                });
+
+        var app = builder.Build();
+
+        app.Conventions.WithMetadata(new EndpointGroupNameAttribute("global"));
+
+        app.MapGet("/", () => "Hello, world!");
+        app.MapHub<TestHub>("/test-hub");
+        app.MapRazorComponents<TestComponent>();
+        app.MapControllers();
+
+        await app.StartAsync();
+
+        var endpointDataSource = app.Services.GetRequiredService<EndpointDataSource>();
+        Assert.Collection(endpointDataSource.Endpoints,
+            // Route handler endpoints
+            endpoint =>
+            {
+                var groupNameMetadata = endpoint.Metadata.GetMetadata<IEndpointGroupNameMetadata>();
+                Assert.Equal("global", groupNameMetadata.EndpointGroupName);
+            },
+            // SignalR produces two endpoints per hub
+            endpoint =>
+            {
+                var groupNameMetadata = endpoint.Metadata.GetMetadata<IEndpointGroupNameMetadata>();
+                Assert.Equal("global", groupNameMetadata.EndpointGroupName);
+            },
+            endpoint =>
+            {
+                var groupNameMetadata = endpoint.Metadata.GetMetadata<IEndpointGroupNameMetadata>();
+                Assert.Equal("global", groupNameMetadata.EndpointGroupName);
+            },
+            // Razor component endpoint
+            endpoint =>
+            {
+                var groupNameMetadata = endpoint.Metadata.GetMetadata<IEndpointGroupNameMetadata>();
+                Assert.Equal("global", groupNameMetadata.EndpointGroupName);
+            },
+            // MapController endpoint
+            endpoint =>
+            {
+                var groupNameMetadata = endpoint.Metadata.GetMetadata<IEndpointGroupNameMetadata>();
+                Assert.Equal("global", groupNameMetadata.EndpointGroupName);
+            },
+            // Controller-based endpoints
+            endpoint =>
+            {
+                var groupNameMetadata = endpoint.Metadata.GetMetadata<IEndpointGroupNameMetadata>();
+                Assert.Equal("global", groupNameMetadata.EndpointGroupName);
+            }
+        );
+
+        await app.StopAsync();
+    }
+
+    [Fact]
+    public async Task ThrowsExceptionOnNonRouteEndpointsAtTopLevel()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        var app = builder.Build();
+
+        app.Conventions.WithMetadata(new EndpointGroupNameAttribute("global"));
+
+        app.DataSources.Add(new CustomEndpointDataSource());
+
+        await app.StartAsync();
+
+        var endpointDataSource = app.Services.GetRequiredService<EndpointDataSource>();
+        var ex = Assert.Throws<NotSupportedException>(() => endpointDataSource.Endpoints);
+        Assert.Equal("MapGroup does not support custom Endpoint type 'Microsoft.AspNetCore.Tests.WebApplicationGlobalConventionTests+TestCustomEndpoint'. Only RouteEndpoints can be grouped.", ex.Message);
+
+        await app.StopAsync();
+    }
+
+    [Fact]
+    public async Task DoesNotThrowExceptionOnNonRouteEndpointsInBranchedPipeline()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        var app = builder.Build();
+
+        app.Conventions.WithMetadata(new EndpointGroupNameAttribute("global"));
+
+        app.UseRouting();
+
+        app.UseEndpoints(e =>
+        {
+            e.DataSources.Add(new CustomEndpointDataSource());
+        });
+
+        await app.StartAsync();
+
+        var endpointDataSource = app.Services.GetRequiredService<EndpointDataSource>();
+        Assert.Collection(endpointDataSource.Endpoints,
+            endpoint =>
+            {
+                var groupNameMetadata = endpoint.Metadata.GetMetadata<IEndpointGroupNameMetadata>();
+                Assert.Null(groupNameMetadata);
+            }
+        );
+
+        await app.StopAsync();
+    }
+
+    private class TestHub : Hub { }
+    private class TestComponent { }
+
+    private class TestController : Controller
+    {
+        [HttpGet("/")]
+        public void Index() { }
+    }
+
+    [ApiController]
+    private class MyApiController : ControllerBase
+    {
+        [HttpGet("other")]
+        public void Index() { }
+    }
+
+    private class TestControllerFeatureProvider : IApplicationFeatureProvider<ControllerFeature>
+    {
+        public void PopulateFeature(IEnumerable<ApplicationPart> parts, ControllerFeature feature)
+        {
+            feature.Controllers.Clear();
+            feature.Controllers.Add(typeof(TestController).GetTypeInfo());
+            feature.Controllers.Add(typeof(MyApiController).GetTypeInfo());
+        }
+    }
+
+    private sealed class TestCustomEndpoint : Endpoint
+    {
+        public TestCustomEndpoint() : base(null, null, null) { }
+    }
+
+    private sealed class CustomEndpointDataSource : EndpointDataSource
+    {
+        public override IReadOnlyList<Endpoint> Endpoints => [new TestCustomEndpoint()];
+        public override IChangeToken GetChangeToken() => NullChangeToken.Singleton;
+    }
+}

--- a/src/Http/Routing/src/EndpointDataSource.cs
+++ b/src/Http/Routing/src/EndpointDataSource.cs
@@ -36,11 +36,22 @@ public abstract class EndpointDataSource
     {
         // Only evaluate Endpoints once per call.
         var endpoints = Endpoints;
-        var wrappedEndpoints = new RouteEndpoint[endpoints.Count];
+        var wrappedEndpoints = new Endpoint[endpoints.Count];
 
         for (int i = 0; i < endpoints.Count; i++)
         {
             var endpoint = endpoints[i];
+
+            if (context.Conventions.Count == 0
+                && context.FinallyConventions.Count == 0
+                && endpoint is not RouteEndpoint)
+            {
+                // No conventions to apply, so just return the endpoints as-is. This supports
+                // scenarios where the endpoint is registered as part of the global route group
+                // handler on the WebApplication.
+                wrappedEndpoints[i] = endpoint;
+                continue;
+            }
 
             // Endpoint does not provide a RoutePattern but RouteEndpoint does. So it's impossible to apply a prefix for custom Endpoints.
             // Supporting arbitrary Endpoints just to add group metadata would require changing the Endpoint type breaking any real scenario.

--- a/src/Http/Routing/test/UnitTests/Builder/GroupTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/GroupTest.cs
@@ -298,12 +298,13 @@ public class GroupTest
     }
 
     [Fact]
-    public void GivenNonRouteEndpoint_ThrowsNotSupportedException()
+    public void GivenNonRouteEndpoint_WithConventions_ThrowsNotSupportedException()
     {
         var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(EmptyServiceProvider.Instance));
 
         var group = builder.MapGroup("/group");
-        ((IEndpointRouteBuilder)group).DataSources.Add(new TestCustomEndpintDataSource());
+        group.WithMetadata(new EndpointGroupNameAttribute("group"));
+        ((IEndpointRouteBuilder)group).DataSources.Add(new TestCustomEndpointDataSource());
 
         var dataSource = GetEndpointDataSource(builder);
         var ex = Assert.Throws<NotSupportedException>(() => dataSource.Endpoints);
@@ -311,6 +312,20 @@ public class GroupTest
             "MapGroup does not support custom Endpoint type 'Microsoft.AspNetCore.Builder.GroupTest+TestCustomEndpoint'. " +
             "Only RouteEndpoints can be grouped.",
             ex.Message);
+    }
+
+    [Fact]
+    public void GivenNonRouteEndpoint_WithNoConventions_ReturnsEndpointAsIs()
+    {
+        var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(EmptyServiceProvider.Instance));
+
+        var group = builder.MapGroup("/group");
+        ((IEndpointRouteBuilder)group).DataSources.Add(new TestCustomEndpointDataSource());
+
+        var dataSource = GetEndpointDataSource(builder);
+        var endpoint = Assert.Single(dataSource.Endpoints);
+
+        Assert.IsType<TestCustomEndpoint>(endpoint);
     }
 
     [Fact]
@@ -388,7 +403,7 @@ public class GroupTest
         public TestCustomEndpoint() : base(null, null, null) { }
     }
 
-    private sealed class TestCustomEndpintDataSource : EndpointDataSource
+    private sealed class TestCustomEndpointDataSource : EndpointDataSource
     {
         public override IReadOnlyList<Endpoint> Endpoints => new[] { new TestCustomEndpoint() };
         public override IChangeToken GetChangeToken() => throw new NotImplementedException();


### PR DESCRIPTION
Implements https://github.com/dotnet/aspnetcore/issues/59755.

This pull request introduces changes to the `WebApplication` class and its associated components to support global endpoint conventions.

Changes include:

* Replaced the internal `_dataSources` list with `GlobalEndpointRouteBuilder` and `RouteGroupBuilder` to create an implicit global route group for all endpoints (`src/DefaultBuilder/src/WebApplication.cs`).
* Added a new `Conventions` property to expose `IEndpointConventionBuilder` for the application (`src/DefaultBuilder/src/WebApplication.cs`) that maps to underlying `RouteGroupBuilder`
* Added test cases in `WebApplicationGlobalConventionTests` to verify the application of global conventions on endpoints (`src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationGlobalConventionTests.cs`).

Wait to review + merge until attached API proposal is reviewed.