### PR TITLE
Add restore config file param

### DIFF
--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -32,7 +32,7 @@
       <_AdditionalRepoTaskBuildArgs />
       <_AdditionalRepoTaskBuildArgs Condition="'$(DotNetRuntimeSourceFeed)' != ''" >$(_AdditionalRepoTaskBuildArgs) --runtimesourcefeed $(DotNetRuntimeSourceFeed)</_AdditionalRepoTaskBuildArgs>
       <_AdditionalRepoTaskBuildArgs Condition="'$(DotNetRuntimeSourceFeedKey)' != ''" >$(_AdditionalRepoTaskBuildArgs) --runtimesourcefeedkey $(DotNetRuntimeSourceFeedKey)</_AdditionalRepoTaskBuildArgs>
-      <_AdditionalRepoTaskBuildArgs Condition="'$(RestoreConfigFile)' != ''" >$(_AdditionalRepoTaskBuildArgs) /p:RestoreConfigFile=$(RestoreConfigFile)</_AdditionalRepoTaskBuildArgs>
+      <_AdditionalRepoTaskBuildArgs Condition="'$(RestoreConfigFile)' != ''" >$(_AdditionalRepoTaskBuildArgs) --restore-config-file $(RestoreConfigFile)</_AdditionalRepoTaskBuildArgs>
     </PropertyGroup>
 
     <ItemGroup>

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -199,7 +199,7 @@ param(
     [Alias('DotNetRuntimeSourceFeedKey')]
     [string]$RuntimeSourceFeedKey,
 
-    [string]$RestoreConfigFile
+    [string]$RestoreConfigFile,
 
     # Capture the rest
     [Parameter(ValueFromRemainingArguments = $true)]

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -99,6 +99,9 @@ Additional feed that can be used when downloading .NET runtimes and SDKs
 .PARAMETER RuntimeSourceFeedKey
 Key for feed that can be used when downloading .NET runtimes and SDKs
 
+.PARAMETER RestoreConfigFile
+NuGet.config that should be passed to build commands (via /p:RestoreConfigFile)
+
 .EXAMPLE
 Building both native and managed projects.
 
@@ -196,6 +199,8 @@ param(
     [Alias('DotNetRuntimeSourceFeedKey')]
     [string]$RuntimeSourceFeedKey,
 
+    [string]$RestoreConfigFile
+
     # Capture the rest
     [Parameter(ValueFromRemainingArguments = $true)]
     [string[]]$MSBuildArguments
@@ -286,6 +291,12 @@ if ($RuntimeSourceFeed -or $RuntimeSourceFeedKey) {
     $MSBuildArguments += $runtimeFeedKeyArg
     $ToolsetBuildArguments += $runtimeFeedArg
     $ToolsetBuildArguments += $runtimeFeedKeyArg
+}
+
+if ($RestoreConfigFile) {
+    $restoreConfigFileArg = "/p:RestoreConfigFile=$RestoreConfigFile"
+    $MSBuildArguments += $restoreConfigFileArg
+    $ToolsetBuildArguments += $restoreConfigFileArg
 }
 
 # Split build categories between dotnet msbuild and desktop msbuild. Use desktop msbuild as little as possible.

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -35,6 +35,7 @@ target_arch='x64'
 configuration=''
 runtime_source_feed=''
 runtime_source_feed_key=''
+restore_config_file=''
 
 if [ "$(uname)" = "Darwin" ]; then
     target_os_name='osx'
@@ -87,6 +88,8 @@ Options:
 
     --runtime-source-feed             Additional feed that can be used when downloading .NET runtimes and SDKs
     --runtime-source-feed-key         Key for feed that can be used when downloading .NET runtimes and SDKs
+
+    --restore-config-file             NuGet.config file to use when building the repository
 
 Description:
     This build script installs required tools and runs an MSBuild command on this repository
@@ -242,6 +245,11 @@ while [[ $# -gt 0 ]]; do
             [ -z "${1:-}" ] && __error "Missing value for parameter --runtime-source-feed-key" && __usage
             runtime_source_feed_key="${1:-}"
             ;;
+        -restore-config-file|-restoreconfigfile)
+            shift
+            [ -z "${1:-}" ] && __error "Missing value for parameter --restore-config-file" && __usage
+            restore_config_file="${1:-}"
+            ;;
         *)
             msbuild_args[${#msbuild_args[*]}]="$1"
             ;;
@@ -328,6 +336,12 @@ if [ ! -z "$runtime_source_feed$runtime_source_feed_key" ]; then
     msbuild_args[${#msbuild_args[*]}]=$runtimeFeedKeyArg
     toolset_build_args[${#toolset_build_args[*]}]=$runtimeFeedArg
     toolset_build_args[${#toolset_build_args[*]}]=$runtimeFeedKeyArg
+fi
+
+if [ ! -z "$restore_config_file" ]; then
+    restoreConfigFileArg="/p:RestoreConfigFile=$restore_config_file"
+    msbuild_args[${#msbuild_args[*]}]=$restoreConfigFileArg
+    toolset_build_args[${#toolset_build_args[*]}]=$restoreConfigFileArg
 fi
 
 # Initialize global variables need to be set before the import of Arcade is imported


### PR DESCRIPTION
Add a parameter to the build scripts which translates into /p:RestoreConfigFile=<nuget config>. This is useful so that we can pass this parameter in UB rather than as a /p. /p: parameters do not get passed to initial repo build task invocations. but we do want a restore config file parameter to be set.