### PR TITLE
Fix template test scripts

### DIFF
--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -615,7 +615,7 @@ stages:
                   -configuration Release
                   -bl
           displayName: Run project template tests
-        - powershell: ./src/ProjectTemplates/scripts/Run-BlazorWeb-Locally.ps1 -Verbose
+        - powershell: . ./activate.ps1; ./src/ProjectTemplates/scripts/Run-BlazorWeb-Locally.ps1 -Verbose
           displayName: Run Blazor web app test script
 
         artifacts:

--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -615,6 +615,8 @@ stages:
                   -configuration Release
                   -bl
           displayName: Run project template tests
+        - script: ./src/ProjectTemplates/scripts/Run-BlazorWeb-Locally.ps1
+          displayName: Run Blazor web app test script
 
         artifacts:
         - name: Local_Windows_x64_Logs_Attempt_$(System.JobAttempt)

--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -615,7 +615,7 @@ stages:
                   -configuration Release
                   -bl
           displayName: Run project template tests
-        - script: ./src/ProjectTemplates/scripts/Run-BlazorWeb-Locally.ps1
+        - powershell: ./src/ProjectTemplates/scripts/Run-BlazorWeb-Locally.ps1
           displayName: Run Blazor web app test script
 
         artifacts:

--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -615,7 +615,7 @@ stages:
                   -configuration Release
                   -bl
           displayName: Run project template tests
-        - powershell: ./src/ProjectTemplates/scripts/Run-BlazorWeb-Locally.ps1
+        - powershell: ./src/ProjectTemplates/scripts/Run-BlazorWeb-Locally.ps1 -Verbose
           displayName: Run Blazor web app test script
 
         artifacts:

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -664,7 +664,7 @@ extends:
                         -NoBuildDeps
                         -configuration Release
                 displayName: Run project template tests
-              - script: ./src/ProjectTemplates/scripts/Run-BlazorWeb-Locally.ps1
+              - powershell: ./src/ProjectTemplates/scripts/Run-BlazorWeb-Locally.ps1
                 displayName: Run Blazor web app test script
 
               artifacts:

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -664,7 +664,7 @@ extends:
                         -NoBuildDeps
                         -configuration Release
                 displayName: Run project template tests
-              - powershell: ./src/ProjectTemplates/scripts/Run-BlazorWeb-Locally.ps1
+              - powershell: ./src/ProjectTemplates/scripts/Run-BlazorWeb-Locally.ps1 -Verbose
                 displayName: Run Blazor web app test script
 
               artifacts:

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -664,6 +664,8 @@ extends:
                         -NoBuildDeps
                         -configuration Release
                 displayName: Run project template tests
+              - script: ./src/ProjectTemplates/scripts/Run-BlazorWeb-Locally.ps1
+                displayName: Run Blazor web app test script
 
               artifacts:
               - name: Local_Windows_x64_Logs_Attempt_$(System.JobAttempt)

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -664,7 +664,7 @@ extends:
                         -NoBuildDeps
                         -configuration Release
                 displayName: Run project template tests
-              - powershell: ./src/ProjectTemplates/scripts/Run-BlazorWeb-Locally.ps1 -Verbose
+              - powershell: . ./activate.ps1; ./src/ProjectTemplates/scripts/Run-BlazorWeb-Locally.ps1 -Verbose
                 displayName: Run Blazor web app test script
 
               artifacts:

--- a/src/ProjectTemplates/scripts/Run-BlazorWasm-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-BlazorWasm-Locally.ps1
@@ -73,7 +73,7 @@ if ($UseProgramMain) {
     $templateArguments += "--use-program-main"
 }
 
-Import-Module -Name .\Test-Template.psm1;
+Import-Module -Name "$PSScriptRoot/Test-Template.psm1";
 
 Test-Template `
     -TemplateName "MyBlazorWasmApp" `

--- a/src/ProjectTemplates/scripts/Run-BlazorWeb-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-BlazorWeb-Locally.ps1
@@ -78,7 +78,7 @@
         $templateArguments += "--use-program-main"
     }
 
-    Import-Module -Name .\Test-Template.psm1;
+    Import-Module -Name "$PSScriptRoot/Test-Template.psm1";
 
     Test-Template `
         -TemplateName "MyBlazorApp" `

--- a/src/ProjectTemplates/scripts/Run-Razor-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-Razor-Locally.ps1
@@ -48,7 +48,7 @@ if ($UseProgramMain) {
     $templateArguments += "--use-program-main"
 }
 
-Import-Module -Name .\Test-Template.psm1;
+Import-Module -Name "$PSScriptRoot/Test-Template.psm1";
 
 Test-Template `
     -TemplateName "MyWebApp" `

--- a/src/ProjectTemplates/scripts/Run-Starterweb-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-Starterweb-Locally.ps1
@@ -48,7 +48,7 @@ if ($UseProgramMain) {
     $templateArguments += "--use-program-main"
 }
 
-Import-Module -Name .\Test-Template.psm1;
+Import-Module -Name "$PSScriptRoot/Test-Template.psm1";
 
 Test-Template `
     -TemplateName "MyMvcApp" `

--- a/src/ProjectTemplates/scripts/Test-Template.psm1
+++ b/src/ProjectTemplates/scripts/Test-Template.psm1
@@ -25,7 +25,7 @@ function Test-Template {
     }
 
     Write-Verbose "Patching Microsoft.AspNetCore.App";
-    $builtRuntime = Resolve-Path "$PSScriptRoot/../../../artifacts/installers/$Configuration/aspnetcore-runtime-*-dev-win-x64.zip";
+    $builtRuntime = Resolve-Path "$PSScriptRoot/../../../artifacts/packages/$Configuration/Shipping/aspnetcore-runtime-*-dev-win-x64.zip" | Where-Object { $_ -match "aspnetcore-runtime-[0-9.]+-dev-win-x64.zip" };
     Write-Verbose "Patching Microsoft.AspNetCore.App from $builtRuntime";
     Remove-Item "$PSScriptRoot/.runtime" -Recurse -ErrorAction Ignore;
     Expand-Archive -Path $builtRuntime -DestinationPath "$PSScriptRoot/.runtime" -Force;


### PR DESCRIPTION
The location of `aspnetcore-runtime-*-dev-win-x64.zip` recently changed from the `installers` folder to the `packages` folder. This broke some of the template test scripts, so this PR:
* Fixes the test scripts to use the new path
* Adds a new step in the "Windows local development validation" pipeline to verify that the `Run-BlazorWeb-Locally` script executes successfully