### PR TITLE
Package dotnet-getdocument from current TFM into top-level

### DIFF
--- a/src/Tools/Extensions.ApiDescription.Server/src/Microsoft.Extensions.ApiDescription.Server.nuspec
+++ b/src/Tools/Extensions.ApiDescription.Server/src/Microsoft.Extensions.ApiDescription.Server.nuspec
@@ -8,6 +8,7 @@
     $CommonFileElements$
     <file src="build\*" target="build" />
     <file src="buildMultiTargeting\*" target="buildMultiTargeting" />
+    <file src="$artifactsBinDir$\dotnet-getdocument\$configuration$\net10.0\publish\*.*" target="tools" />
     <file src="$artifactsBinDir$\GetDocument.Insider\$configuration$\net462\*.*" target="tools\net462" />
     <file src="$artifactsBinDir$\GetDocument.Insider\x86\$configuration$\net462\*.*" target="tools\net462-x86" />
     <file src="$artifactsBinDir$\GetDocument.Insider\$configuration$\net10.0\publish\*.*" target="tools\net10.0" />


### PR DESCRIPTION
Closes https://github.com/dotnet/aspnetcore/issues/60026.

In the previous PR, I removed the `netcoreapp2.0` target based on TFM instruction and removed the packaging of it in the top-level. I didn't realize that the MSBuild targets associated with this package were still being used by the `GetDocument` tool.

I'm packaging the net10-targeted build for this tool in the top-level nuspec file to ensure that the `dotnet-getdocument.dll` file is available in the `tools` directory. I think the net10 target is the correct one to use here since the TFM and package version are associated.

It would be good to squeeze this in before the 10-preview1 cut-off later today.