### PR TITLE
feat: Add method to retrieve current 2FA login provider

### DIFF
--- a/src/Identity/Core/src/PublicAPI.Unshipped.txt
+++ b/src/Identity/Core/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+virtual Microsoft.AspNetCore.Identity.SignInManager<TUser>.GetTwoFactorAuthenticationLoginProviderAsync() -> System.Threading.Tasks.Task<string?>!

--- a/src/Identity/Core/src/SignInManager.cs
+++ b/src/Identity/Core/src/SignInManager.cs
@@ -633,6 +633,25 @@ public class SignInManager<TUser> where TUser : class
     }
 
     /// <summary>
+    /// Retrieves the authentication provider associated with the current two-factor authentication login attempt.
+    /// </summary>
+    /// <returns>
+    /// A task that represents the asynchronous operation. The task result contains:
+    /// - The login provider name as a string if two-factor info exists
+    /// - null if no two-factor authentication info is found
+    /// </returns>
+    public virtual async Task<string?> GetTwoFactorAuthenticationLoginProviderAsync()
+    {
+        var info = await RetrieveTwoFactorInfoAsync();
+        if (info == null)
+        {
+            return null;
+        }
+
+        return info.LoginProvider;
+    }
+
+    /// <summary>
     /// Signs in a user via a previously registered third party login, as an asynchronous operation.
     /// </summary>
     /// <param name="loginProvider">The login provider to use.</param>


### PR DESCRIPTION
# Add method to retrieve current 2FA login provider

## Description
Adds a new method `GetTwoFactorAuthenticationLoginProviderAsync` to retrieve the authentication provider being used for the current two-factor authentication (2FA) login attempt.

Changes:
Implemented new async method to fetch the current 2FA login provider

Why:
- Enables authentication flows to determine which 2FA method is currently in use
- Allows UI/UX to be customized based on the active 2FA provider
- Helps with logging and debugging of 2FA-related issues
- Useful for scenarios where different handling is needed based on the provider type
