### PR TITLE
Update Selenium and Playwright dependencies 2025-01-29

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -319,8 +319,8 @@
     <MicrosoftPlaywrightVersion>1.49.0</MicrosoftPlaywrightVersion>
     <PollyExtensionsHttpVersion>3.0.0</PollyExtensionsHttpVersion>
     <PollyVersion>7.2.4</PollyVersion>
-    <SeleniumSupportVersion>4.27.0</SeleniumSupportVersion>
-    <SeleniumWebDriverVersion>4.27.0</SeleniumWebDriverVersion>
+    <SeleniumSupportVersion>4.28.0</SeleniumSupportVersion>
+    <SeleniumWebDriverVersion>4.28.0</SeleniumWebDriverVersion>
     <SerilogExtensionsLoggingVersion>1.4.0</SerilogExtensionsLoggingVersion>
     <SerilogSinksFileVersion>4.0.0</SerilogSinksFileVersion>
     <StackExchangeRedisVersion>2.7.27</StackExchangeRedisVersion>


### PR DESCRIPTION
[Infrastructure] Update Selenium and Playwright dependencies 2025-01-29
* Updated Playwright version to 1.49.0
* Updated Selenium version to 4.28.0
* Updated Selenium version to 4.28.0
Please see the [MirroringPackages.md](https://github.com/dotnet/arcade/blob/main/Documentation/MirroringPackages.md) document in the [dotnet/arcade](https://github.com/dotnet/arcade) repository for information on how to mirror these packages on the MS NuGet feed.