### PR TITLE
Fixed the issue

### DIFF
--- a/src/Mvc/Mvc.Core/src/ApplicationModels/DefaultApplicationModelProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ApplicationModels/DefaultApplicationModelProvider.cs
@@ -356,7 +356,11 @@ internal class DefaultApplicationModelProvider : IApplicationModelProvider
         return actionModel;
     }
 
-    [UnconditionalSuppressMessage("AssemblyLoadTrimming", "IL2026:RequiresUnreferencedCode",
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "The method utilizes reflection to get information about the return type of an action")]
+    [UnconditionalSuppressMessage("Trimming", "IL2060",
+        Justification = "The method utilizes reflection to get information about the return type of an action")]
+    [UnconditionalSuppressMessage("Trimming", "IL2072",
         Justification = "The method utilizes reflection to get information about the return type of an action")]
     internal static void AddReturnTypeMetadata(IList<SelectorModel> selectors, MethodInfo methodInfo)
     {

--- a/src/Mvc/Mvc.Core/src/ApplicationModels/DefaultApplicationModelProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ApplicationModels/DefaultApplicationModelProvider.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using Microsoft.AspNetCore.Http;
@@ -356,12 +355,6 @@ internal class DefaultApplicationModelProvider : IApplicationModelProvider
         return actionModel;
     }
 
-    [UnconditionalSuppressMessage("Trimming", "IL2026",
-        Justification = "The method utilizes reflection to get information about the return type of an action")]
-    [UnconditionalSuppressMessage("Trimming", "IL2060",
-        Justification = "The method utilizes reflection to get information about the return type of an action")]
-    [UnconditionalSuppressMessage("Trimming", "IL2072",
-        Justification = "The method utilizes reflection to get information about the return type of an action")]
     internal static void AddReturnTypeMetadata(IList<SelectorModel> selectors, MethodInfo methodInfo)
     {
         // Get metadata from return type

--- a/src/Mvc/Mvc.Core/src/Microsoft.AspNetCore.Mvc.Core.WarningSuppressions.xml
+++ b/src/Mvc/Mvc.Core/src/Microsoft.AspNetCore.Mvc.Core.WarningSuppressions.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <linker>
-  <assembly fullname="Microsoft.AspNetCore.Mvc.Core, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+  <assembly fullname="Microsoft.AspNetCore.Mvc.Core, Version=10.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
       <argument>IL2026</argument>
@@ -17,7 +17,7 @@
       <argument>ILLink</argument>
       <argument>IL2026</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.AspNetCore.Builder.MvcApplicationBuilderExtensions.&lt;&gt;c.&lt;UseMvcWithDefaultRoute&gt;b__1_0(Microsoft.AspNetCore.Routing.IRouteBuilder)</property>
+      <property name="Target">M:Microsoft.AspNetCore.Builder.MvcApplicationBuilderExtensions.&lt;&gt;c.{UseMvcWithDefaultRoute}b__1_0(Microsoft.AspNetCore.Routing.IRouteBuilder)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
@@ -36,6 +36,12 @@
       <argument>IL2026</argument>
       <property name="Scope">member</property>
       <property name="Target">M:Microsoft.AspNetCore.Mvc.AcceptedAtRouteResult.#ctor(System.String,System.Object,System.Object)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.AspNetCore.Mvc.ApplicationModels.DefaultApplicationModelProvider.AddReturnTypeMetadata(System.Collections.Generic.IList{Microsoft.AspNetCore.Mvc.ApplicationModels.SelectorModel},System.Reflection.MethodInfo)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
@@ -521,6 +527,12 @@
       <argument>ILLink</argument>
       <argument>IL2060</argument>
       <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.AspNetCore.Mvc.ApplicationModels.DefaultApplicationModelProvider.AddReturnTypeMetadata(System.Collections.Generic.IList{Microsoft.AspNetCore.Mvc.ApplicationModels.SelectorModel},System.Reflection.MethodInfo)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2060</argument>
+      <property name="Scope">member</property>
       <property name="Target">M:Microsoft.AspNetCore.Mvc.Infrastructure.AsyncEnumerableReader.TryGetReader(System.Type,System.Func{System.Object,System.Threading.CancellationToken,System.Threading.Tasks.Task{System.Collections.ICollection}}@)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
@@ -533,7 +545,7 @@
       <argument>ILLink</argument>
       <argument>IL2060</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.AspNetCore.Mvc.ModelBinding.Validation.DefaultCollectionValidationStrategy.&lt;&gt;c.&lt;GetEnumeratorForElementType&gt;b__5_0(System.Type)</property>
+      <property name="Target">M:Microsoft.AspNetCore.Mvc.ModelBinding.Validation.DefaultCollectionValidationStrategy.&lt;&gt;c.{GetEnumeratorForElementType}b__5_0(System.Type)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
@@ -557,7 +569,7 @@
       <argument>ILLink</argument>
       <argument>IL2067</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.AspNetCore.Mvc.Infrastructure.TypeActivatorCache.&lt;&gt;c.&lt;#ctor&gt;b__3_0(System.Type)</property>
+      <property name="Target">M:Microsoft.AspNetCore.Mvc.Infrastructure.TypeActivatorCache.&lt;&gt;c.{#ctor}b__3_0(System.Type)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
@@ -629,13 +641,19 @@
       <argument>ILLink</argument>
       <argument>IL2070</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.AspNetCore.Mvc.ModelBinding.Metadata.DefaultBindingMetadataProvider.&lt;GetRecordTypeConstructor&gt;g__IsRecordType|2_0(System.Type)</property>
+      <property name="Target">M:Microsoft.AspNetCore.Mvc.ModelBinding.Metadata.DefaultBindingMetadataProvider.{GetRecordTypeConstructor}g__IsRecordType|2_0(System.Type)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
       <argument>IL2070</argument>
       <property name="Scope">member</property>
       <property name="Target">M:Microsoft.AspNetCore.Mvc.ModelBinding.Metadata.DefaultBindingMetadataProvider.GetBoundConstructor(System.Type)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2072</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.AspNetCore.Mvc.ApplicationModels.DefaultApplicationModelProvider.AddReturnTypeMetadata(System.Collections.Generic.IList{Microsoft.AspNetCore.Mvc.ApplicationModels.SelectorModel},System.Reflection.MethodInfo)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>

--- a/src/Mvc/Mvc.Core/src/Microsoft.AspNetCore.Mvc.Core.WarningSuppressions.xml
+++ b/src/Mvc/Mvc.Core/src/Microsoft.AspNetCore.Mvc.Core.WarningSuppressions.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <linker>
-  <assembly fullname="Microsoft.AspNetCore.Mvc.Core, Version=10.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+  <assembly fullname="Microsoft.AspNetCore.Mvc.Core, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
       <argument>IL2026</argument>
@@ -41,7 +41,7 @@
       <argument>ILLink</argument>
       <argument>IL2026</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.AspNetCore.Mvc.ApplicationModels.DefaultApplicationModelProvider.AddReturnTypeMetadata(System.Collections.Generic.IList&lt;Microsoft.AspNetCore.Mvc.ApplicationModels.SelectorModel&gt;,System.Reflection.MethodInfo)</property>
+      <property name="Target">M:Microsoft.AspNetCore.Mvc.ApplicationModels.DefaultApplicationModelProvider.AddReturnTypeMetadata(System.Collections.Generic.IList{Microsoft.AspNetCore.Mvc.ApplicationModels.SelectorModel},System.Reflection.MethodInfo)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
@@ -527,7 +527,7 @@
       <argument>ILLink</argument>
       <argument>IL2060</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.AspNetCore.Mvc.ApplicationModels.DefaultApplicationModelProvider.AddReturnTypeMetadata(System.Collections.Generic.IList&lt;Microsoft.AspNetCore.Mvc.ApplicationModels.SelectorModel&gt;,System.Reflection.MethodInfo)</property>
+      <property name="Target">M:Microsoft.AspNetCore.Mvc.ApplicationModels.DefaultApplicationModelProvider.AddReturnTypeMetadata(System.Collections.Generic.IList{Microsoft.AspNetCore.Mvc.ApplicationModels.SelectorModel},System.Reflection.MethodInfo)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
@@ -653,7 +653,7 @@
       <argument>ILLink</argument>
       <argument>IL2072</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.AspNetCore.Mvc.ApplicationModels.DefaultApplicationModelProvider.AddReturnTypeMetadata(System.Collections.Generic.IList&lt;Microsoft.AspNetCore.Mvc.ApplicationModels.SelectorModel&gt;,System.Reflection.MethodInfo)</property>
+      <property name="Target">M:Microsoft.AspNetCore.Mvc.ApplicationModels.DefaultApplicationModelProvider.AddReturnTypeMetadata(System.Collections.Generic.IList{Microsoft.AspNetCore.Mvc.ApplicationModels.SelectorModel},System.Reflection.MethodInfo)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>

--- a/src/Mvc/Mvc.Core/src/Microsoft.AspNetCore.Mvc.Core.WarningSuppressions.xml
+++ b/src/Mvc/Mvc.Core/src/Microsoft.AspNetCore.Mvc.Core.WarningSuppressions.xml
@@ -17,7 +17,7 @@
       <argument>ILLink</argument>
       <argument>IL2026</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.AspNetCore.Builder.MvcApplicationBuilderExtensions.&lt;&gt;c.{UseMvcWithDefaultRoute}b__1_0(Microsoft.AspNetCore.Routing.IRouteBuilder)</property>
+      <property name="Target">M:Microsoft.AspNetCore.Builder.MvcApplicationBuilderExtensions.&lt;&gt;c.&lt;UseMvcWithDefaultRoute&gt;b__1_0(Microsoft.AspNetCore.Routing.IRouteBuilder)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
@@ -41,7 +41,7 @@
       <argument>ILLink</argument>
       <argument>IL2026</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.AspNetCore.Mvc.ApplicationModels.DefaultApplicationModelProvider.AddReturnTypeMetadata(System.Collections.Generic.IList{Microsoft.AspNetCore.Mvc.ApplicationModels.SelectorModel},System.Reflection.MethodInfo)</property>
+      <property name="Target">M:Microsoft.AspNetCore.Mvc.ApplicationModels.DefaultApplicationModelProvider.AddReturnTypeMetadata(System.Collections.Generic.IList&lt;Microsoft.AspNetCore.Mvc.ApplicationModels.SelectorModel&gt;,System.Reflection.MethodInfo)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
@@ -527,7 +527,7 @@
       <argument>ILLink</argument>
       <argument>IL2060</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.AspNetCore.Mvc.ApplicationModels.DefaultApplicationModelProvider.AddReturnTypeMetadata(System.Collections.Generic.IList{Microsoft.AspNetCore.Mvc.ApplicationModels.SelectorModel},System.Reflection.MethodInfo)</property>
+      <property name="Target">M:Microsoft.AspNetCore.Mvc.ApplicationModels.DefaultApplicationModelProvider.AddReturnTypeMetadata(System.Collections.Generic.IList&lt;Microsoft.AspNetCore.Mvc.ApplicationModels.SelectorModel&gt;,System.Reflection.MethodInfo)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
@@ -545,7 +545,7 @@
       <argument>ILLink</argument>
       <argument>IL2060</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.AspNetCore.Mvc.ModelBinding.Validation.DefaultCollectionValidationStrategy.&lt;&gt;c.{GetEnumeratorForElementType}b__5_0(System.Type)</property>
+      <property name="Target">M:Microsoft.AspNetCore.Mvc.ModelBinding.Validation.DefaultCollectionValidationStrategy.&lt;&gt;c.&lt;GetEnumeratorForElementType&gt;b__5_0(System.Type)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
@@ -569,7 +569,7 @@
       <argument>ILLink</argument>
       <argument>IL2067</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.AspNetCore.Mvc.Infrastructure.TypeActivatorCache.&lt;&gt;c.{#ctor}b__3_0(System.Type)</property>
+      <property name="Target">M:Microsoft.AspNetCore.Mvc.Infrastructure.TypeActivatorCache.&lt;&gt;c.&lt;#ctor&gt;b__3_0(System.Type)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
@@ -641,7 +641,7 @@
       <argument>ILLink</argument>
       <argument>IL2070</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.AspNetCore.Mvc.ModelBinding.Metadata.DefaultBindingMetadataProvider.{GetRecordTypeConstructor}g__IsRecordType|2_0(System.Type)</property>
+      <property name="Target">M:Microsoft.AspNetCore.Mvc.ModelBinding.Metadata.DefaultBindingMetadataProvider.&lt;GetRecordTypeConstructor&gt;g__IsRecordType|2_0(System.Type)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
@@ -653,7 +653,7 @@
       <argument>ILLink</argument>
       <argument>IL2072</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.AspNetCore.Mvc.ApplicationModels.DefaultApplicationModelProvider.AddReturnTypeMetadata(System.Collections.Generic.IList{Microsoft.AspNetCore.Mvc.ApplicationModels.SelectorModel},System.Reflection.MethodInfo)</property>
+      <property name="Target">M:Microsoft.AspNetCore.Mvc.ApplicationModels.DefaultApplicationModelProvider.AddReturnTypeMetadata(System.Collections.Generic.IList&lt;Microsoft.AspNetCore.Mvc.ApplicationModels.SelectorModel&gt;,System.Reflection.MethodInfo)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>

--- a/src/Mvc/Mvc.Core/src/Routing/ActionEndpointFactory.cs
+++ b/src/Mvc/Mvc.Core/src/Routing/ActionEndpointFactory.cs
@@ -543,12 +543,4 @@ internal sealed class ActionEndpointFactory
             return invoker!.InvokeAsync();
         };
     }
-
-    private sealed class InertEndpointBuilder : EndpointBuilder
-    {
-        public override Endpoint Build()
-        {
-            return new Endpoint(RequestDelegate, new EndpointMetadataCollection(Metadata), DisplayName);
-        }
-    }
 }

--- a/src/Mvc/Mvc.Core/src/Routing/InertEndpointBuilder.cs
+++ b/src/Mvc/Mvc.Core/src/Routing/InertEndpointBuilder.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Mvc.Routing;
+
+internal sealed class InertEndpointBuilder : EndpointBuilder
+{
+    public override Endpoint Build()
+    {
+        return new Endpoint(RequestDelegate, new EndpointMetadataCollection(Metadata), DisplayName);
+    }
+}

--- a/src/Mvc/Mvc.Core/test/Microsoft.AspNetCore.Mvc.Core.Test.csproj
+++ b/src/Mvc/Mvc.Core/test/Microsoft.AspNetCore.Mvc.Core.Test.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <Reference Include="FSharp.Core" />
     <Reference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
+    <Reference Include="Microsoft.AspNetCore.Http.Results" />
     <ProjectReference Include="..\..\shared\Mvc.Core.TestCommon\Microsoft.AspNetCore.Mvc.Core.TestCommon.csproj" />
     <ProjectReference Include="..\..\shared\Mvc.TestDiagnosticListener\Microsoft.AspNetCore.Mvc.TestDiagnosticListener.csproj" />
 

--- a/src/Mvc/test/Mvc.FunctionalTests/ApiExplorerTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/ApiExplorerTest.cs
@@ -11,6 +11,11 @@ using Newtonsoft.Json;
 using Microsoft.Extensions.Logging;
 using System.Reflection;
 using Xunit.Abstractions;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests;
 
@@ -1563,6 +1568,26 @@ public class ApiExplorerTest : LoggedTest
         Assert.Contains(TestSink.Writes, w => w.LoggerName.Equals("Microsoft.AspNetCore.Mvc.ApiExplorer.ApiDescriptionGroupCollectionProvider", StringComparison.Ordinal));
         Assert.Contains(TestSink.Writes, w => w.Message.Equals("Executing API description provider 'DefaultApiDescriptionProvider' from assembly Microsoft.AspNetCore.Mvc.ApiExplorer v10.0.0.0.", StringComparison.Ordinal));
         Assert.Contains(TestSink.Writes, w => w.Message.Equals("Executing API description provider 'JsonPatchOperationsArrayProvider' from assembly Microsoft.AspNetCore.Mvc.NewtonsoftJson v42.42.42.42.", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ApiExplorer_BuildsMetadataForActionWithTypedResult()
+    {
+        var apiDescCollectionProvider = Factory.Server.Services.GetService<IApiDescriptionGroupCollectionProvider>();
+        var testGroupName = nameof(ApiExplorerWithTypedResultController).Replace("Controller", string.Empty);
+        var group = apiDescCollectionProvider.ApiDescriptionGroups.Items.Where(i => i.GroupName == testGroupName).SingleOrDefault();
+        Assert.NotNull(group);
+        var apiDescription = Assert.Single<ApiDescription>(group.Items);
+
+        var responseType = Assert.Single(apiDescription.SupportedResponseTypes);
+        Assert.Equal(StatusCodes.Status200OK, responseType.StatusCode);
+        Assert.Equal(typeof(Product), responseType.Type);
+
+        Assert.NotNull(apiDescription.ActionDescriptor.EndpointMetadata);
+        var producesResponseTypeMetadata = apiDescription.ActionDescriptor.EndpointMetadata.OfType<ProducesResponseTypeMetadata>().SingleOrDefault();
+        Assert.NotNull(producesResponseTypeMetadata);
+        Assert.Equal(StatusCodes.Status200OK, producesResponseTypeMetadata.StatusCode);
+        Assert.Equal(typeof(Product), producesResponseTypeMetadata.Type);
     }
 
     private IEnumerable<string> GetSortedMediaTypes(ApiExplorerResponseType apiResponseType)

--- a/src/Mvc/test/WebSites/ApiExplorerWebSite/ApiExplorerWebSite.csproj
+++ b/src/Mvc/test/WebSites/ApiExplorerWebSite/ApiExplorerWebSite.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Mvc" />
     <Reference Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" />
+    <Reference Include="Microsoft.AspNetCore.Http.Results" />
     <Reference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
 
     <Reference Include="Microsoft.AspNetCore.Server.IISIntegration" />

--- a/src/Mvc/test/WebSites/ApiExplorerWebSite/Controllers/ApiExplorerWithTypedResultController.cs
+++ b/src/Mvc/test/WebSites/ApiExplorerWebSite/Controllers/ApiExplorerWithTypedResultController.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ApiExplorerWebSite;
+
+[Route("ApiExplorerWithTypedResult/[Action]")]
+public class ApiExplorerWithTypedResultController : Controller
+{
+    [HttpGet]
+    public Ok<Product> GetProduct() => TypedResults.Ok(new Product { Name = "Test product" });
+}

--- a/src/OpenApi/sample/Controllers/TestController.cs
+++ b/src/OpenApi/sample/Controllers/TestController.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 
 [ApiController]
@@ -15,6 +16,13 @@ public class TestController : ControllerBase
     public string GetByIdAndName(RouteParamsContainer paramsContainer)
     {
         return paramsContainer.Id + "_" + paramsContainer.Name;
+    }
+
+    [HttpGet]
+    [Route("/gettypedresult")]
+    public Ok<MvcTodo> GetTypedResult()
+    {
+        return TypedResults.Ok(new MvcTodo("Title", "Description", true));
     }
 
     [HttpPost]

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=controllers.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=controllers.verified.txt
@@ -54,6 +54,25 @@
         }
       }
     },
+    "/gettypedresult": {
+      "get": {
+        "tags": [
+          "Test"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MvcTodo"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/forms": {
       "post": {
         "tags": [
@@ -83,6 +102,29 @@
         "responses": {
           "200": {
             "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "MvcTodo": {
+        "required": [
+          "title",
+          "description",
+          "isCompleted"
+        ],
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "isCompleted": {
+            "type": "boolean"
           }
         }
       }

--- a/src/Shared/EndpointMetadataPopulator.cs
+++ b/src/Shared/EndpointMetadataPopulator.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Http;
 internal static class EndpointMetadataPopulator
 {
     private static readonly MethodInfo PopulateMetadataForParameterMethod = typeof(EndpointMetadataPopulator).GetMethod(nameof(PopulateMetadataForParameter), BindingFlags.NonPublic | BindingFlags.Static)!;
-    private static readonly MethodInfo PopulateMetadataForEndpointMethod = typeof(EndpointMetadataPopulator).GetMethod(nameof(PopulateMetadataForEndpoint), BindingFlags.NonPublic | BindingFlags.Static)!;
+    internal static readonly MethodInfo PopulateMetadataForEndpointMethod = typeof(EndpointMetadataPopulator).GetMethod(nameof(PopulateMetadataForEndpoint), BindingFlags.NonPublic | BindingFlags.Static)!;
 
     public static void PopulateMetadata(MethodInfo methodInfo, EndpointBuilder builder, IEnumerable<ParameterInfo>? parameters = null)
     {


### PR DESCRIPTION
# Include typed result metadata in the action descriptors for MVC Controller actions

## Description

The endpoint metadata wasn't being captured in ActionModel during the ApplicationModel creation. This is addressed by the change in the DefaultApplicationModelProvider class. The metadata is now being extracted based on the return type of the action and then the selectors associated with the action are populated with that metadata, as that's what is being used later on for populating the ActionDescriptor's EndpointMetadata.

Fixes #44988 
