### PR TITLE
InputNumber formatting for decimal numbers

### DIFF
--- a/src/Components/Components/src/BindConverter.cs
+++ b/src/Components/Components/src/BindConverter.cs
@@ -259,10 +259,15 @@ public static class BindConverter
     /// </param>
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
-    public static string? FormatValue(double value, CultureInfo? culture = null) => FormatDoubleValueCore(value, culture);
+    public static string? FormatValue(double value, CultureInfo? culture = null, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format = null) => FormatDoubleValueCore(value, culture, format);
 
-    private static string FormatDoubleValueCore(double value, CultureInfo? culture)
+    private static string FormatDoubleValueCore(double value, CultureInfo? culture, string? format)
     {
+        if (format != null)
+        {
+            return value.ToString(format, culture ?? CultureInfo.CurrentCulture);
+        }
+
         return value.ToString(culture ?? CultureInfo.CurrentCulture);
     }
 
@@ -275,13 +280,18 @@ public static class BindConverter
     /// </param>
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
-    public static string? FormatValue(double? value, CultureInfo? culture = null) => FormatNullableDoubleValueCore(value, culture);
+    public static string? FormatValue(double? value, CultureInfo? culture = null, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format = null) => FormatNullableDoubleValueCore(value, culture, format);
 
-    private static string? FormatNullableDoubleValueCore(double? value, CultureInfo? culture)
+    private static string? FormatNullableDoubleValueCore(double? value, CultureInfo? culture, string? format)
     {
         if (value == null)
         {
             return null;
+        }
+
+        if (format != null)
+        {
+            return value.ToString(format, culture ?? CultureInfo.CurrentCulture);
         }
 
         return value.Value.ToString(culture ?? CultureInfo.CurrentCulture);

--- a/src/Components/Components/src/BindConverter.cs
+++ b/src/Components/Components/src/BindConverter.cs
@@ -306,10 +306,15 @@ public static class BindConverter
     /// </param>
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
-    public static string FormatValue(decimal value, CultureInfo? culture = null) => FormatDecimalValueCore(value, culture);
+    public static string FormatValue(decimal value, CultureInfo? culture = null, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format = null) => FormatDecimalValueCore(value, culture, format);
 
-    private static string FormatDecimalValueCore(decimal value, CultureInfo? culture)
+    private static string FormatDecimalValueCore(decimal value, CultureInfo? culture, string? format)
     {
+        if (format != null)
+        {
+            return value.ToString(format, culture ?? CultureInfo.CurrentCulture);
+        }
+
         return value.ToString(culture ?? CultureInfo.CurrentCulture);
     }
 
@@ -319,16 +324,22 @@ public static class BindConverter
     /// <param name="value">The value to format.</param>
     /// <param name="culture">
     /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
+    /// The <see cref="StringSyntaxAttribute.NumericFormat)"/> to use while formatting.
     /// </param>
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
-    public static string? FormatValue(decimal? value, CultureInfo? culture = null) => FormatNullableDecimalValueCore(value, culture);
+    public static string? FormatValue(decimal? value, CultureInfo? culture = null, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format = null) => FormatNullableDecimalValueCore(value, culture, format);
 
-    private static string? FormatNullableDecimalValueCore(decimal? value, CultureInfo? culture)
+    private static string? FormatNullableDecimalValueCore(decimal? value, CultureInfo? culture, string? format)
     {
         if (value == null)
         {
             return null;
+        }
+
+        if (format != null)
+        {
+            return value.ToString(format, culture ?? CultureInfo.CurrentCulture);
         }
 
         return value.Value.ToString(culture ?? CultureInfo.CurrentCulture);

--- a/src/Components/Components/src/BindConverter.cs
+++ b/src/Components/Components/src/BindConverter.cs
@@ -329,7 +329,6 @@ public static class BindConverter
     /// <param name="value">The value to format.</param>
     /// <param name="culture">
     /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
-    /// The <see cref="StringSyntaxAttribute.NumericFormat)"/> to use while formatting.
     /// </param>
     /// <param name="format">The format to use. Provided to <see cref="decimal.ToString(string, IFormatProvider)"/>.</param>
     /// <returns>The formatted value.</returns>

--- a/src/Components/Components/src/BindConverter.cs
+++ b/src/Components/Components/src/BindConverter.cs
@@ -212,10 +212,15 @@ public static class BindConverter
     /// </param>
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
-    public static string FormatValue(float value, CultureInfo? culture = null) => FormatFloatValueCore(value, culture);
+    public static string FormatValue(float value, CultureInfo? culture = null, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format = null) => FormatFloatValueCore(value, culture, format);
 
-    private static string FormatFloatValueCore(float value, CultureInfo? culture)
+    private static string FormatFloatValueCore(float value, CultureInfo? culture, string? format)
     {
+        if (format != null)
+        {
+            return value.ToString(format, culture ?? CultureInfo.CurrentCulture);
+        }
+
         return value.ToString(culture ?? CultureInfo.CurrentCulture);
     }
 
@@ -228,13 +233,18 @@ public static class BindConverter
     /// </param>
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
-    public static string? FormatValue(float? value, CultureInfo? culture = null) => FormatNullableFloatValueCore(value, culture);
+    public static string? FormatValue(float? value, CultureInfo? culture = null, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format = null) => FormatNullableFloatValueCore(value, culture, format);
 
-    private static string? FormatNullableFloatValueCore(float? value, CultureInfo? culture)
+    private static string? FormatNullableFloatValueCore(float? value, CultureInfo? culture, string? format)
     {
         if (value == null)
         {
             return null;
+        }
+
+        if (format != null)
+        {
+            return value.ToString(format, culture ?? CultureInfo.CurrentCulture);
         }
 
         return value.Value.ToString(culture ?? CultureInfo.CurrentCulture);

--- a/src/Components/Components/src/BindConverter.cs
+++ b/src/Components/Components/src/BindConverter.cs
@@ -246,7 +246,7 @@ public static class BindConverter
 
         if (format != null)
         {
-            return value.ToString(format, culture ?? CultureInfo.CurrentCulture);
+            return value.Value.ToString(format, culture ?? CultureInfo.CurrentCulture);
         }
 
         return value.Value.ToString(culture ?? CultureInfo.CurrentCulture);
@@ -295,7 +295,7 @@ public static class BindConverter
 
         if (format != null)
         {
-            return value.ToString(format, culture ?? CultureInfo.CurrentCulture);
+            return value.Value.ToString(format, culture ?? CultureInfo.CurrentCulture);
         }
 
         return value.Value.ToString(culture ?? CultureInfo.CurrentCulture);
@@ -344,7 +344,7 @@ public static class BindConverter
 
         if (format != null)
         {
-            return value.ToString(format, culture ?? CultureInfo.CurrentCulture);
+            return value.Value.ToString(format, culture ?? CultureInfo.CurrentCulture);
         }
 
         return value.Value.ToString(culture ?? CultureInfo.CurrentCulture);

--- a/src/Components/Components/src/BindConverter.cs
+++ b/src/Components/Components/src/BindConverter.cs
@@ -210,6 +210,7 @@ public static class BindConverter
     /// <param name="culture">
     /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
     /// </param>
+    /// <param name="format">The format to use. Provided to <see cref="float.ToString(string, IFormatProvider)"/>.</param>
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
     public static string FormatValue(float value, CultureInfo? culture = null, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format = null) => FormatFloatValueCore(value, culture, format);
@@ -231,6 +232,7 @@ public static class BindConverter
     /// <param name="culture">
     /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
     /// </param>
+    /// <param name="format">The format to use. Provided to <see cref="float.ToString(string, IFormatProvider)"/>.</param>
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
     public static string? FormatValue(float? value, CultureInfo? culture = null, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format = null) => FormatNullableFloatValueCore(value, culture, format);
@@ -257,6 +259,7 @@ public static class BindConverter
     /// <param name="culture">
     /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
     /// </param>
+    /// <param name="format">The format to use. Provided to <see cref="double.ToString(string, IFormatProvider)"/>.</param>
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
     public static string? FormatValue(double value, CultureInfo? culture = null, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format = null) => FormatDoubleValueCore(value, culture, format);
@@ -278,6 +281,7 @@ public static class BindConverter
     /// <param name="culture">
     /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
     /// </param>
+    /// <param name="format">The format to use. Provided to <see cref="double.ToString(string, IFormatProvider)"/>.</param>
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
     public static string? FormatValue(double? value, CultureInfo? culture = null, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format = null) => FormatNullableDoubleValueCore(value, culture, format);
@@ -304,6 +308,7 @@ public static class BindConverter
     /// <param name="culture">
     /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
     /// </param>
+    /// <param name="format">The format to use. Provided to <see cref="decimal.ToString(string, IFormatProvider)"/>.</param>
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
     public static string FormatValue(decimal value, CultureInfo? culture = null, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format = null) => FormatDecimalValueCore(value, culture, format);
@@ -326,6 +331,7 @@ public static class BindConverter
     /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
     /// The <see cref="StringSyntaxAttribute.NumericFormat)"/> to use while formatting.
     /// </param>
+    /// <param name="format">The format to use. Provided to <see cref="decimal.ToString(string, IFormatProvider)"/>.</param>
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
     public static string? FormatValue(decimal? value, CultureInfo? culture = null, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format = null) => FormatNullableDecimalValueCore(value, culture, format);

--- a/src/Components/Components/src/BindConverter.cs
+++ b/src/Components/Components/src/BindConverter.cs
@@ -1005,7 +1005,9 @@ public static class BindConverter
     }
 
     internal static BindParser<float> ConvertToFloat = ConvertToFloatCore;
+    internal static BindParserWithFormat<float> ConvertToFloatWithFormat = ConvertToFloatCore;
     internal static BindParser<float?> ConvertToNullableFloat = ConvertToNullableFloatCore;
+    internal static BindParserWithFormat<float?> ConvertToNullableFloatWithFormat = ConvertToNullableFloatCore;
 
     private static bool ConvertToFloatCore(object? obj, CultureInfo? culture, out float value)
     {
@@ -1082,7 +1084,9 @@ public static class BindConverter
     }
 
     internal static BindParser<double> ConvertToDoubleDelegate = ConvertToDoubleCore;
+    internal static BindParserWithFormat<double> ConvertToDoubleWithFormat = ConvertToDoubleCore;
     internal static BindParser<double?> ConvertToNullableDoubleDelegate = ConvertToNullableDoubleCore;
+    internal static BindParserWithFormat<double?> ConvertToNullableDoubleWithFormat = ConvertToNullableDoubleCore;
 
     private static bool ConvertToDoubleCore(object? obj, CultureInfo? culture, out double value)
     {
@@ -1159,7 +1163,9 @@ public static class BindConverter
     }
 
     internal static BindParser<decimal> ConvertToDecimal = ConvertToDecimalCore;
+    internal static BindParserWithFormat<decimal> ConvertToDecimalWithFormat = ConvertToDecimalCore;
     internal static BindParser<decimal?> ConvertToNullableDecimal = ConvertToNullableDecimalCore;
+    internal static BindParserWithFormat<decimal?> ConvertToNullableDecimalWithFormat = ConvertToNullableDecimalCore;
 
     private static bool ConvertToDecimalCore(object? obj, CultureInfo? culture, out decimal value)
     {

--- a/src/Components/Components/src/BindConverter.cs
+++ b/src/Components/Components/src/BindConverter.cs
@@ -223,7 +223,7 @@ public static class BindConverter
     /// <param name="format">The format to use. Provided to <see cref="float.ToString(string, IFormatProvider)"/>.</param>
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
-    public static string FormatValue(float value, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string format, CultureInfo? culture = null) => FormatFloatValueCore(value, culture, format);
+    public static string FormatValue(float value, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format, CultureInfo? culture = null) => FormatFloatValueCore(value, culture, format);
 
     private static string FormatFloatValueCore(float value, CultureInfo? culture, string? format)
     {
@@ -261,7 +261,7 @@ public static class BindConverter
     /// <param name="format">The format to use. Provided to <see cref="float.ToString(string, IFormatProvider)"/>.</param>
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
-    public static string? FormatValue(float? value, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string format, CultureInfo? culture = null) => FormatNullableFloatValueCore(value, culture, format);
+    public static string? FormatValue(float? value, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format, CultureInfo? culture = null) => FormatNullableFloatValueCore(value, culture, format);
 
     private static string? FormatNullableFloatValueCore(float? value, CultureInfo? culture, string? format)
     {
@@ -309,7 +309,7 @@ public static class BindConverter
     /// <param name="format">The format to use. Provided to <see cref="double.ToString(string, IFormatProvider)"/>.</param>
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
-    public static string? FormatValue(double value, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string format, CultureInfo? culture = null) => FormatDoubleValueCore(value, culture, format);
+    public static string? FormatValue(double value, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format, CultureInfo? culture = null) => FormatDoubleValueCore(value, culture, format);
 
     private static string FormatDoubleValueCore(double value, CultureInfo? culture, string? format)
     {
@@ -347,7 +347,7 @@ public static class BindConverter
     /// <param name="format">The format to use. Provided to <see cref="double.ToString(string, IFormatProvider)"/>.</param>
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
-    public static string? FormatValue(double? value, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string format, CultureInfo? culture = null) => FormatNullableDoubleValueCore(value, culture, format);
+    public static string? FormatValue(double? value, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format, CultureInfo? culture = null) => FormatNullableDoubleValueCore(value, culture, format);
 
     private static string? FormatNullableDoubleValueCore(double? value, CultureInfo? culture)
     {
@@ -395,7 +395,7 @@ public static class BindConverter
     /// <param name="format">The format to use. Provided to <see cref="decimal.ToString(string, IFormatProvider)"/>.</param>
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
-    public static string FormatValue(decimal value, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string format, CultureInfo? culture = null) => FormatDecimalValueCore(value, culture, format);
+    public static string FormatValue(decimal value, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format, CultureInfo? culture = null) => FormatDecimalValueCore(value, culture, format);
 
     private static string FormatDecimalValueCore(decimal value, CultureInfo? culture)
     {
@@ -433,7 +433,7 @@ public static class BindConverter
     /// <param name="format">The format to use. Provided to <see cref="decimal.ToString(string, IFormatProvider)"/>.</param>
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
-    public static string? FormatValue(decimal? value, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string format, CultureInfo? culture = null) => FormatNullableDecimalValueCore(value, culture, format);
+    public static string? FormatValue(decimal? value, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format, CultureInfo? culture = null) => FormatNullableDecimalValueCore(value, culture, format);
 
     private static string? FormatNullableDecimalValueCore(decimal? value, CultureInfo? culture)
     {
@@ -481,7 +481,7 @@ public static class BindConverter
     /// </param>
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
-    public static string FormatValue(DateTime value, [StringSyntax(StringSyntaxAttribute.DateTimeFormat)] string format, CultureInfo? culture = null) => FormatDateTimeValueCore(value, format, culture);
+    public static string FormatValue(DateTime value, [StringSyntax(StringSyntaxAttribute.DateTimeFormat)] string? format, CultureInfo? culture = null) => FormatDateTimeValueCore(value, format, culture);
 
     private static string FormatDateTimeValueCore(DateTime value, string? format, CultureInfo? culture)
     {

--- a/src/Components/Components/src/BindConverter.cs
+++ b/src/Components/Components/src/BindConverter.cs
@@ -1011,6 +1011,11 @@ public static class BindConverter
 
     private static bool ConvertToFloatCore(object? obj, CultureInfo? culture, out float value)
     {
+        return ConvertToFloatCore(obj, culture, format: null, out value);
+    }
+
+    private static bool ConvertToFloatCore(object? obj, CultureInfo? culture, out float value)
+    {
         var text = (string?)obj;
         if (string.IsNullOrEmpty(text))
         {
@@ -1035,6 +1040,11 @@ public static class BindConverter
     }
 
     private static bool ConvertToNullableFloatCore(object? obj, CultureInfo? culture, out float? value)
+    {
+        return ConvertToNullableFloatCore(obj, culture, format: null, out value);
+    }
+
+    private static bool ConvertToNullableFloatCore(object? obj, CultureInfo? culture, string? format, out float? value)
     {
         var text = (string?)obj;
         if (string.IsNullOrEmpty(text))
@@ -1090,6 +1100,11 @@ public static class BindConverter
 
     private static bool ConvertToDoubleCore(object? obj, CultureInfo? culture, out double value)
     {
+        return ConvertToDoubleCore(obj, culture, format: null, out value);
+    }
+
+    private static bool ConvertToDoubleCore(object? obj, CultureInfo? culture, string? format, out double value)
+    {
         var text = (string?)obj;
         if (string.IsNullOrEmpty(text))
         {
@@ -1114,6 +1129,11 @@ public static class BindConverter
     }
 
     private static bool ConvertToNullableDoubleCore(object? obj, CultureInfo? culture, out double? value)
+    {
+        return ConvertToNullableDoubleCore(obj, culture, format: null, out value);
+    }
+
+    private static bool ConvertToNullableDoubleCore(object? obj, CultureInfo? culture, string? format, out double? value)
     {
         var text = (string?)obj;
         if (string.IsNullOrEmpty(text))
@@ -1169,6 +1189,11 @@ public static class BindConverter
 
     private static bool ConvertToDecimalCore(object? obj, CultureInfo? culture, out decimal value)
     {
+        return ConvertToDecimalCore(obj, culture, format: null, out value);
+    }
+
+    private static bool ConvertToDecimalCore(object? obj, CultureInfo? culture, string? format, out decimal value)
+    {
         var text = (string?)obj;
         if (string.IsNullOrEmpty(text))
         {
@@ -1187,6 +1212,11 @@ public static class BindConverter
     }
 
     private static bool ConvertToNullableDecimalCore(object? obj, CultureInfo? culture, out decimal? value)
+    {
+        return ConvertToNullableDecimalCore(obj, culture, format: null, out value);
+    }
+
+    private static bool ConvertToNullableDecimalCore(object? obj, CultureInfo? culture, string? format, out decimal? value)
     {
         var text = (string?)obj;
         if (string.IsNullOrEmpty(text))

--- a/src/Components/Components/src/BindConverter.cs
+++ b/src/Components/Components/src/BindConverter.cs
@@ -223,7 +223,7 @@ public static class BindConverter
     /// <param name="format">The format to use. Provided to <see cref="float.ToString(string, IFormatProvider)"/>.</param>
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
-    public static string FormatValue(float value, CultureInfo? culture = null, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format = null) => FormatFloatValueCore(value, culture, format);
+    public static string FormatValue(float value, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string format, CultureInfo? culture = null) => FormatFloatValueCore(value, culture, format);
 
     private static string FormatFloatValueCore(float value, CultureInfo? culture, string? format)
     {
@@ -261,7 +261,7 @@ public static class BindConverter
     /// <param name="format">The format to use. Provided to <see cref="float.ToString(string, IFormatProvider)"/>.</param>
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
-    public static string? FormatValue(float? value, CultureInfo? culture = null, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format = null) => FormatNullableFloatValueCore(value, culture, format);
+    public static string? FormatValue(float? value, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string format, CultureInfo? culture = null) => FormatNullableFloatValueCore(value, culture, format);
 
     private static string? FormatNullableFloatValueCore(float? value, CultureInfo? culture, string? format)
     {
@@ -309,7 +309,7 @@ public static class BindConverter
     /// <param name="format">The format to use. Provided to <see cref="double.ToString(string, IFormatProvider)"/>.</param>
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
-    public static string? FormatValue(double value, CultureInfo? culture = null, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format = null) => FormatDoubleValueCore(value, culture, format);
+    public static string? FormatValue(double value, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string format, CultureInfo? culture = null) => FormatDoubleValueCore(value, culture, format);
 
     private static string FormatDoubleValueCore(double value, CultureInfo? culture, string? format)
     {
@@ -347,7 +347,7 @@ public static class BindConverter
     /// <param name="format">The format to use. Provided to <see cref="double.ToString(string, IFormatProvider)"/>.</param>
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
-    public static string? FormatValue(double? value, CultureInfo? culture = null, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format = null) => FormatNullableDoubleValueCore(value, culture, format);
+    public static string? FormatValue(double? value, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string format, CultureInfo? culture = null) => FormatNullableDoubleValueCore(value, culture, format);
 
     private static string? FormatNullableDoubleValueCore(double? value, CultureInfo? culture)
     {
@@ -395,7 +395,7 @@ public static class BindConverter
     /// <param name="format">The format to use. Provided to <see cref="decimal.ToString(string, IFormatProvider)"/>.</param>
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
-    public static string FormatValue(decimal value, CultureInfo? culture = null, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format = null) => FormatDecimalValueCore(value, culture, format);
+    public static string FormatValue(decimal value, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string format, CultureInfo? culture = null) => FormatDecimalValueCore(value, culture, format);
 
     private static string FormatDecimalValueCore(decimal value, CultureInfo? culture)
     {
@@ -433,7 +433,7 @@ public static class BindConverter
     /// <param name="format">The format to use. Provided to <see cref="decimal.ToString(string, IFormatProvider)"/>.</param>
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
-    public static string? FormatValue(decimal? value, CultureInfo? culture = null, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format = null) => FormatNullableDecimalValueCore(value, culture, format);
+    public static string? FormatValue(decimal? value, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string format, CultureInfo? culture = null) => FormatNullableDecimalValueCore(value, culture, format);
 
     private static string? FormatNullableDecimalValueCore(decimal? value, CultureInfo? culture)
     {

--- a/src/Components/Components/src/BindConverter.cs
+++ b/src/Components/Components/src/BindConverter.cs
@@ -24,7 +24,6 @@ public static class BindConverter
     private static readonly object BoxedFalse = false;
 
     private delegate object? BindFormatter<T>(T value, CultureInfo? culture);
-
     internal delegate bool BindParser<T>(object? obj, CultureInfo? culture, [MaybeNullWhen(false)] out T value);
     internal delegate bool BindParserWithFormat<T>(object? obj, CultureInfo? culture, string? format, [MaybeNullWhen(false)] out T value);
 
@@ -210,6 +209,17 @@ public static class BindConverter
     /// <param name="culture">
     /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
     /// </param>
+    /// <returns>The formatted value.</returns>
+    [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
+    public static string FormatValue(float value, CultureInfo? culture = null) => FormatFloatValueCore(value, culture, format: null);
+
+    /// <summary>
+    /// Formats the provided <paramref name="value"/> for inclusion in an attribute.
+    /// </summary>
+    /// <param name="value">The value to format.</param>
+    /// <param name="culture">
+    /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
+    /// </param>
     /// <param name="format">The format to use. Provided to <see cref="float.ToString(string, IFormatProvider)"/>.</param>
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
@@ -224,6 +234,22 @@ public static class BindConverter
 
         return value.ToString(culture ?? CultureInfo.CurrentCulture);
     }
+
+    private static string FormatFloatValueCore(float value, CultureInfo? culture)
+    {
+        return value.ToString(culture ?? CultureInfo.CurrentCulture);
+    }
+
+    /// <summary>
+    /// Formats the provided <paramref name="value"/> for inclusion in an attribute.
+    /// </summary>
+    /// <param name="value">The value to format.</param>
+    /// <param name="culture">
+    /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
+    /// </param>
+    /// <returns>The formatted value.</returns>
+    [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
+    public static string? FormatValue(float? value, CultureInfo? culture = null) => FormatNullableFloatValueCore(value, culture, format: null);
 
     /// <summary>
     /// Formats the provided <paramref name="value"/> for inclusion in an attribute.
@@ -252,6 +278,27 @@ public static class BindConverter
         return value.Value.ToString(culture ?? CultureInfo.CurrentCulture);
     }
 
+    private static string? FormatNullableFloatValueCore(float? value, CultureInfo? culture)
+    {
+        if (value == null)
+        {
+            return null;
+        }
+
+        return value.Value.ToString(culture ?? CultureInfo.CurrentCulture);
+    }
+
+    /// <summary>
+    /// Formats the provided <paramref name="value"/> for inclusion in an attribute.
+    /// </summary>
+    /// <param name="value">The value to format.</param>
+    /// <param name="culture">
+    /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
+    /// </param>
+    /// <returns>The formatted value.</returns>
+    [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
+    public static string? FormatValue(double value, CultureInfo? culture = null) => FormatDoubleValueCore(value, culture, format: null);
+
     /// <summary>
     /// Formats the provided <paramref name="value"/> for inclusion in an attribute.
     /// </summary>
@@ -274,6 +321,22 @@ public static class BindConverter
         return value.ToString(culture ?? CultureInfo.CurrentCulture);
     }
 
+    private static string FormatDoubleValueCore(double value, CultureInfo? culture)
+    {
+        return value.ToString(culture ?? CultureInfo.CurrentCulture);
+    }
+
+    /// <summary>
+    /// Formats the provided <paramref name="value"/> for inclusion in an attribute.
+    /// </summary>
+    /// <param name="value">The value to format.</param>
+    /// <param name="culture">
+    /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
+    /// </param>
+    /// <returns>The formatted value.</returns>
+    [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
+    public static string? FormatValue(double? value, CultureInfo? culture = null) => FormatNullableDoubleValueCore(value, culture, format: null);
+
     /// <summary>
     /// Formats the provided <paramref name="value"/> for inclusion in an attribute.
     /// </summary>
@@ -285,6 +348,16 @@ public static class BindConverter
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
     public static string? FormatValue(double? value, CultureInfo? culture = null, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format = null) => FormatNullableDoubleValueCore(value, culture, format);
+
+    private static string? FormatNullableDoubleValueCore(double? value, CultureInfo? culture)
+    {
+        if (value == null)
+        {
+            return null;
+        }
+
+        return value.Value.ToString(culture ?? CultureInfo.CurrentCulture);
+    }
 
     private static string? FormatNullableDoubleValueCore(double? value, CultureInfo? culture, string? format)
     {
@@ -308,10 +381,26 @@ public static class BindConverter
     /// <param name="culture">
     /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
     /// </param>
+    /// <returns>The formatted value.</returns>
+    [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
+    public static string FormatValue(decimal value, CultureInfo? culture = null) => FormatDecimalValueCore(value, culture, format: null);
+
+    /// <summary>
+    /// Formats the provided <paramref name="value"/> for inclusion in an attribute.
+    /// </summary>
+    /// <param name="value">The value to format.</param>
+    /// <param name="culture">
+    /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
+    /// </param>
     /// <param name="format">The format to use. Provided to <see cref="decimal.ToString(string, IFormatProvider)"/>.</param>
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
     public static string FormatValue(decimal value, CultureInfo? culture = null, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format = null) => FormatDecimalValueCore(value, culture, format);
+
+    private static string FormatDecimalValueCore(decimal value, CultureInfo? culture)
+    {
+        return value.ToString(culture ?? CultureInfo.CurrentCulture);
+    }
 
     private static string FormatDecimalValueCore(decimal value, CultureInfo? culture, string? format)
     {
@@ -330,10 +419,31 @@ public static class BindConverter
     /// <param name="culture">
     /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
     /// </param>
+    /// <returns>The formatted value.</returns>
+    [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
+    public static string? FormatValue(decimal? value, CultureInfo? culture = null) => FormatNullableDecimalValueCore(value, culture, format: null);
+
+    /// <summary>
+    /// Formats the provided <paramref name="value"/> as a <see cref="System.String"/>.
+    /// </summary>
+    /// <param name="value">The value to format.</param>
+    /// <param name="culture">
+    /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
+    /// </param>
     /// <param name="format">The format to use. Provided to <see cref="decimal.ToString(string, IFormatProvider)"/>.</param>
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
     public static string? FormatValue(decimal? value, CultureInfo? culture = null, [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format = null) => FormatNullableDecimalValueCore(value, culture, format);
+
+    private static string? FormatNullableDecimalValueCore(decimal? value, CultureInfo? culture)
+    {
+        if (value == null)
+        {
+            return null;
+        }
+
+        return value.Value.ToString(culture ?? CultureInfo.CurrentCulture);
+    }
 
     private static string? FormatNullableDecimalValueCore(decimal? value, CultureInfo? culture, string? format)
     {
@@ -1014,7 +1124,7 @@ public static class BindConverter
         return ConvertToFloatCore(obj, culture, format: null, out value);
     }
 
-    private static bool ConvertToFloatCore(object? obj, CultureInfo? culture, out float value)
+    private static bool ConvertToFloatCore(object? obj, CultureInfo? culture, string? format, out float value)
     {
         var text = (string?)obj;
         if (string.IsNullOrEmpty(text))

--- a/src/Components/Components/src/BindConverter.cs
+++ b/src/Components/Components/src/BindConverter.cs
@@ -481,7 +481,7 @@ public static class BindConverter
     /// </param>
     /// <returns>The formatted value.</returns>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
-    public static string FormatValue(DateTime value, [StringSyntax(StringSyntaxAttribute.DateTimeFormat)] string? format, CultureInfo? culture = null) => FormatDateTimeValueCore(value, format, culture);
+    public static string FormatValue(DateTime value, [StringSyntax(StringSyntaxAttribute.DateTimeFormat)] string format, CultureInfo? culture = null) => FormatDateTimeValueCore(value, format, culture);
 
     private static string FormatDateTimeValueCore(DateTime value, string? format, CultureInfo? culture)
     {

--- a/src/Components/Components/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Components/src/PublicAPI.Unshipped.txt
@@ -5,4 +5,3 @@ static Microsoft.AspNetCore.Components.BindConverter.FormatValue(double value, s
 static Microsoft.AspNetCore.Components.BindConverter.FormatValue(double? value, string? format, System.Globalization.CultureInfo? culture = null) -> string?
 static Microsoft.AspNetCore.Components.BindConverter.FormatValue(float value, string? format, System.Globalization.CultureInfo? culture = null) -> string!
 static Microsoft.AspNetCore.Components.BindConverter.FormatValue(float? value, string? format, System.Globalization.CultureInfo? culture = null) -> string?
-static Microsoft.AspNetCore.Components.BindConverter.FormatValue(System.DateTime value, string? format, System.Globalization.CultureInfo? culture = null) -> string!

--- a/src/Components/Components/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Components/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,7 @@
 #nullable enable
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(decimal value, string! format, System.Globalization.CultureInfo? culture = null) -> string!
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(decimal? value, string! format, System.Globalization.CultureInfo? culture = null) -> string?
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(double value, string! format, System.Globalization.CultureInfo? culture = null) -> string?
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(double? value, string! format, System.Globalization.CultureInfo? culture = null) -> string?
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(float value, string! format, System.Globalization.CultureInfo? culture = null) -> string!
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(float? value, string! format, System.Globalization.CultureInfo? culture = null) -> string?

--- a/src/Components/Components/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Components/src/PublicAPI.Unshipped.txt
@@ -1,7 +1,8 @@
 #nullable enable
-static Microsoft.AspNetCore.Components.BindConverter.FormatValue(decimal value, string! format, System.Globalization.CultureInfo? culture = null) -> string!
-static Microsoft.AspNetCore.Components.BindConverter.FormatValue(decimal? value, string! format, System.Globalization.CultureInfo? culture = null) -> string?
-static Microsoft.AspNetCore.Components.BindConverter.FormatValue(double value, string! format, System.Globalization.CultureInfo? culture = null) -> string?
-static Microsoft.AspNetCore.Components.BindConverter.FormatValue(double? value, string! format, System.Globalization.CultureInfo? culture = null) -> string?
-static Microsoft.AspNetCore.Components.BindConverter.FormatValue(float value, string! format, System.Globalization.CultureInfo? culture = null) -> string!
-static Microsoft.AspNetCore.Components.BindConverter.FormatValue(float? value, string! format, System.Globalization.CultureInfo? culture = null) -> string?
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(decimal value, string? format, System.Globalization.CultureInfo? culture = null) -> string!
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(decimal? value, string? format, System.Globalization.CultureInfo? culture = null) -> string?
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(double value, string? format, System.Globalization.CultureInfo? culture = null) -> string?
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(double? value, string? format, System.Globalization.CultureInfo? culture = null) -> string?
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(float value, string? format, System.Globalization.CultureInfo? culture = null) -> string!
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(float? value, string? format, System.Globalization.CultureInfo? culture = null) -> string?
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(System.DateTime value, string? format, System.Globalization.CultureInfo? culture = null) -> string!

--- a/src/Components/Components/test/BindConverterTest.cs
+++ b/src/Components/Components/test/BindConverterTest.cs
@@ -369,6 +369,75 @@ public class BindConverterTest
         Assert.Null(actual);
     }
 
+    [Theory]
+    [InlineData(1.1, "0.0#", "1.1")]        // Single decimal place with optional second
+    [InlineData(1500, "0.00", "1500.00")]    // Force two decimal places
+    [InlineData(1500, "0.##", "1500")]       // Remove unnecessary decimals
+    [InlineData(0, "0.00", "0.00")]          // Zero with fixed decimals
+    [InlineData(0, "0.##", "0")]             // Zero with optional decimals
+    [InlineData(-1.1, "0.0#", "-1.1")]       // Negative number with one decimal place
+    [InlineData(-1500, "0.00", "-1500.00")]  // Negative number with two fixed decimals
+    [InlineData(1.999, "0.0", "2.0")]        // Rounding up
+    [InlineData(1.111, "0.0", "1.1")]        // Rounding down
+    [InlineData(1234567.89, "N2", "1,234,567.89")] // Large number with thousands separator
+    [InlineData(1234567.89, "#,##0.00", "1,234,567.89")] // Explicit thousands separator format
+    [InlineData(0.1234, "0.00%", "12.34%")]  // Percentage formatting
+    [InlineData(0.12, "00.00", "00.12")]     // Fixed zero's with fixed decimals
+    [InlineData(1234567.89, "0.00", "1234567.89")]    // Fixed two decimals
+    public void FormatValue_Double_Format(double value, string format, string expected)
+    {
+        // Act
+        var actual = BindConverter.FormatValue(value, format, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData(1.1, "0.0#", "1.1")]        // Single decimal place with optional second
+    [InlineData(1500, "0.00", "1500.00")]    // Force two decimal places
+    [InlineData(1500, "0.##", "1500")]       // Remove unnecessary decimals
+    [InlineData(0, "0.00", "0.00")]          // Zero with fixed decimals
+    [InlineData(0, "0.##", "0")]             // Zero with optional decimals
+    [InlineData(-1.1, "0.0#", "-1.1")]       // Negative number with one decimal place
+    [InlineData(-1500, "0.00", "-1500.00")]  // Negative number with two fixed decimals
+    [InlineData(1.999, "0.0", "2.0")]        // Rounding up
+    [InlineData(1.111, "0.0", "1.1")]        // Rounding down
+    [InlineData(1234567.89, "N2", "1,234,567.89")] // Large number with thousands separator
+    [InlineData(1234567.89, "#,##0.00", "1,234,567.89")] // Explicit thousands separator format
+    [InlineData(0.1234, "0.00%", "12.34%")]  // Percentage formatting
+    [InlineData(0.12, "00.00", "00.12")]     // Fixed zero's with fixed decimals
+    public void FormatValue_Decimal_Format(decimal value, string format, string expected)
+    {
+        // Act
+        var actual = BindConverter.FormatValue(value, format, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData(1.1, "0.0#", "1.1")]        // Single decimal place with optional second
+    [InlineData(1500, "0.00", "1500.00")]    // Force two decimal places
+    [InlineData(1500, "0.##", "1500")]       // Remove unnecessary decimals
+    [InlineData(0, "0.00", "0.00")]          // Zero with fixed decimals
+    [InlineData(0, "0.##", "0")]             // Zero with optional decimals
+    [InlineData(-1.1, "0.0#", "-1.1")]       // Negative number with one decimal place
+    [InlineData(-1500, "0.00", "-1500.00")]  // Negative number with two fixed decimals
+    [InlineData(1.999, "0.0", "2.0")]        // Rounding up
+    [InlineData(1.111, "0.0", "1.1")]        // Rounding down
+    [InlineData(1234567.89, "N2", "1,234,567.88")] // Large number with thousands separator
+    [InlineData(0.1234, "0.00%", "12.34%")]  // Percentage formatting
+    [InlineData(0.12, "00.00", "00.12")]     // Fixed zero's with fixed decimals
+    public void FormatValue_Float_Format(float value, string format, string expected)
+    {
+        // Act
+        var actual = BindConverter.FormatValue(value, format, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
     private enum SomeLetters
     {
         A,

--- a/src/Components/Web/src/Forms/InputNumber.cs
+++ b/src/Components/Web/src/Forms/InputNumber.cs
@@ -107,13 +107,13 @@ public class InputNumber<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTy
                 return BindConverter.FormatValue(@short, CultureInfo.InvariantCulture);
 
             case float @float:
-                return BindConverter.FormatValue(@float, CultureInfo.InvariantCulture, Format);
+                return BindConverter.FormatValue(@float, Format, CultureInfo.InvariantCulture);
 
             case double @double:
-                return BindConverter.FormatValue(@double, CultureInfo.InvariantCulture, Format);
+                return BindConverter.FormatValue(@double, Format, CultureInfo.InvariantCulture);
 
             case decimal @decimal:
-                return BindConverter.FormatValue(@decimal, CultureInfo.InvariantCulture, Format);
+                return BindConverter.FormatValue(@decimal, Format, CultureInfo.InvariantCulture);
 
             default:
                 throw new InvalidOperationException($"Unsupported type {value.GetType()}");

--- a/src/Components/Web/src/Forms/InputNumber.cs
+++ b/src/Components/Web/src/Forms/InputNumber.cs
@@ -41,6 +41,11 @@ public class InputNumber<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTy
     [Parameter] public string ParsingErrorMessage { get; set; } = "The {0} field must be a number.";
 
     /// <summary>
+    /// Gets or sets the format to be used when displaying a number of types: <see cref="float"/> | <see cref="double"/> |  <see cref="decimal"/>.
+    /// </summary>
+    [Parameter] public string? Format { get; set; }
+
+    /// <summary>
     /// Gets or sets the associated <see cref="ElementReference"/>.
     /// <para>
     /// May be <see langword="null"/> if accessed before the component is rendered.
@@ -102,13 +107,13 @@ public class InputNumber<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTy
                 return BindConverter.FormatValue(@short, CultureInfo.InvariantCulture);
 
             case float @float:
-                return BindConverter.FormatValue(@float, CultureInfo.InvariantCulture);
+                return BindConverter.FormatValue(@float, CultureInfo.InvariantCulture, Format);
 
             case double @double:
-                return BindConverter.FormatValue(@double, CultureInfo.InvariantCulture);
+                return BindConverter.FormatValue(@double, CultureInfo.InvariantCulture, Format);
 
             case decimal @decimal:
-                return BindConverter.FormatValue(@decimal, CultureInfo.InvariantCulture);
+                return BindConverter.FormatValue(@decimal, CultureInfo.InvariantCulture, Format);
 
             default:
                 throw new InvalidOperationException($"Unsupported type {value.GetType()}");

--- a/src/Components/Web/src/Forms/InputNumber.cs
+++ b/src/Components/Web/src/Forms/InputNumber.cs
@@ -41,7 +41,7 @@ public class InputNumber<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTy
     [Parameter] public string ParsingErrorMessage { get; set; } = "The {0} field must be a number.";
 
     /// <summary>
-    /// Gets or sets the format to be used when displaying a number of types: <see cref="float"/> | <see cref="double"/> |  <see cref="decimal"/>.
+    /// Gets or sets the format to be used when displaying a number of types: <see cref="float"/>, <see cref="double"/>, <see cref="decimal"/>.
     /// </summary>
     [Parameter] public string? Format { get; set; }
 

--- a/src/Components/Web/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Web/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.Format.get -> string?
+Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.Format.set -> void

--- a/src/Components/Web/test/Forms/InputNumberTest.cs
+++ b/src/Components/Web/test/Forms/InputNumberTest.cs
@@ -20,21 +20,59 @@ public class InputNumberTest
         _testRenderer = new TestRenderer(services.BuildServiceProvider());
     }
 
+    [Theory]
+    [InlineData("1.1", "0.0#", "1.1")]                      // Single decimal place with optional second
+    [InlineData("1500", "0.00", "1500.00")]                 // Force two decimal places
+    [InlineData("1500", "0.0000", "1500.0000")]             // Force four decimal places
+    [InlineData("1500", "0.##", "1500")]                    // Remove unnecessary decimals
+    [InlineData("0", "0.00", "0.00")]                       // Zero with fixed decimals
+    [InlineData("0", "0.##", "0")]                          // Zero with optional decimals
+    [InlineData("-1.1", "0.0#", "-1.1")]                    // Negative number with one decimal place
+    [InlineData("-1500", "0.00", "-1500.00")]               // Negative number with two fixed decimals
+    [InlineData("1.999", "0.0", "2.0")]                     // Rounding up
+    [InlineData("1.111", "0.0", "1.1")]                     // Rounding down
+    [InlineData("1234567.89", "N2", "1,234,567.89")]        // Large number with thousands separator
+    [InlineData("1234567.89", "#,##0.00", "1,234,567.89")]  // Explicit thousands separator format
+    [InlineData("0.1234", "0.00%", "12.34%")]               // Percentage formatting
+    [InlineData("0.12", "00.00", "00.12")]                  // Fixed zero's with fixed decimals
+    [InlineData("1234567.89", "0.00", "1234567.89")]        // Fixed two decimals
+    public async Task FormatDoubles(string value, string format, string expected)
+    {
+        // Arrange
+        var model = new TestModel();
+        var rootComponent = new TestInputHostComponent<double, TestInputNumberComponent<double>>
+        {
+            EditContext = new EditContext(model),
+            ValueExpression = () => model.Double,
+            AdditionalAttributes = new Dictionary<string, object>
+            {
+                { "Format", format }
+            }
+        };
+        var inputComponent = await InputRenderer.RenderAndGetComponent(rootComponent);
+
+        // Act
+        inputComponent.CurrentValueAsString = value;
+
+        // Assert
+        Assert.Equal(expected, inputComponent.CurrentValueAsString);
+    }
+
     [Fact]
     public async Task ValidationErrorUsesDisplayAttributeName()
     {
         // Arrange
         var model = new TestModel();
-        var rootComponent = new TestInputHostComponent<int, TestInputNumberComponent>
+        var rootComponent = new TestInputHostComponent<int, TestInputNumberComponent<int>>
         {
             EditContext = new EditContext(model),
-            ValueExpression = () => model.SomeNumber,
+            ValueExpression = () => model.Int,
             AdditionalAttributes = new Dictionary<string, object>
-                {
-                    { "DisplayName", "Some number" }
-                }
+            {
+                { "DisplayName", "Some number" }
+            }
         };
-        var fieldIdentifier = FieldIdentifier.Create(() => model.SomeNumber);
+        var fieldIdentifier = FieldIdentifier.Create(() => model.Int);
         var inputComponent = await InputRenderer.RenderAndGetComponent(rootComponent);
 
         // Act
@@ -51,10 +89,10 @@ public class InputNumberTest
     {
         // Arrange
         var model = new TestModel();
-        var rootComponent = new TestInputHostComponent<int, TestInputNumberComponent>
+        var rootComponent = new TestInputHostComponent<int, TestInputNumberComponent<int>>
         {
             EditContext = new EditContext(model),
-            ValueExpression = () => model.SomeNumber,
+            ValueExpression = () => model.Int,
         };
 
         // Act
@@ -69,10 +107,10 @@ public class InputNumberTest
     {
         // Arrange
         var model = new TestModel();
-        var hostComponent = new TestInputHostComponent<int, TestInputNumberComponent>
+        var hostComponent = new TestInputHostComponent<int, TestInputNumberComponent<int>>
         {
             EditContext = new EditContext(model),
-            ValueExpression = () => model.SomeNumber,
+            ValueExpression = () => model.Int,
             AdditionalAttributes = new Dictionary<string, object>
             {
                 { "type", "range" }  // User-defined 'type' attribute to override default
@@ -93,21 +131,31 @@ public class InputNumberTest
         Assert.Equal("range", typeAttributeFrame.AttributeValue);
     }
 
-    private async Task<int> RenderAndGetTestInputNumberComponentIdAsync(TestInputHostComponent<int, TestInputNumberComponent> hostComponent)
+    private async Task<int> RenderAndGetTestInputNumberComponentIdAsync(TestInputHostComponent<int, TestInputNumberComponent<int>> hostComponent)
     {
         var hostComponentId = _testRenderer.AssignRootComponentId(hostComponent);
         await _testRenderer.RenderRootComponentAsync(hostComponentId);
         var batch = _testRenderer.Batches.Single();
-        return batch.GetComponentFrames<TestInputNumberComponent>().Single().ComponentId;
+        return batch.GetComponentFrames<TestInputNumberComponent<int>>().Single().ComponentId;
     }
 
     private class TestModel
     {
-        public int SomeNumber { get; set; }
+        public int Int { get; set; }
+        public double Double { get; set; }
+        public float Float { get; set; }
+        public decimal Decimal { get; set; }
     }
 
-    private class TestInputNumberComponent : InputNumber<int>
+    class TestInputNumberComponent<TValue> : InputNumber<TValue>
     {
+        public new TValue CurrentValue => base.CurrentValue;
+
+        public new string CurrentValueAsString
+        {
+            get => base.CurrentValueAsString;
+            set => base.CurrentValueAsString = value;
+        }
         public async Task SetCurrentValueAsStringAsync(string value)
         {
             // This is equivalent to the subclass writing to CurrentValueAsString


### PR DESCRIPTION
# InputNumber with formatting  (double, decimal, float)

Summary of the changes
`InputNumber` with formatting as in `0.00` or `#.00` etc.

## Description

In `<InputDate` we can choose how to format the date using the types. e.g. `mm/yyyy` etc. With `InputNumber` this is not possible to format decimal numbers. This PR intends to format the `InputNumber` with floating point numbers.


### Scope
The following are in scope:
- Types: 
   - `double`
   - `float`
   - `decimal`
- Components:
   - InputNumber

### API
```
<InputNumber @bind-Value="A" Format="0.00"/>
```
In this case the decimal will always have `2 trailing zero's`. 

```
<InputNumber @bind-Value="A" Format="0.0000"/>
```
In this case the decimal will always have `4 trailing zero's`. 

### Other possible formats:
| **Input Value**  | **Format String**  | **Expected Output**           | **Description** |
|------------------|------------------|------------------------------|----------------|
| `"1.1"`         | `"0.0#"`          | `"1.1"`                      | Single decimal place with optional second |
| `"1500"`        | `"0.00"`          | `"1500.00"`                  | Force two decimal places |
| `"1500"`        | `"0.0000"`        | `"1500.0000"`                | Force four decimal places |
| `"1500"`        | `"0.##"`          | `"1500"`                     | Remove unnecessary decimals |
| `"0"`           | `"0.00"`          | `"0.00"`                     | Zero with fixed decimals |
| `"0"`           | `"0.##"`          | `"0"`                        | Zero with optional decimals |
| `"-1.1"`        | `"0.0#"`          | `"-1.1"`                     | Negative number with one decimal place |
| `"-1500"`       | `"0.00"`          | `"-1500.00"`                 | Negative number with two fixed decimals |
| `"1.999"`       | `"0.0"`           | `"2.0"`                      | Rounding up |
| `"1.111"`       | `"0.0"`           | `"1.1"`                      | Rounding down |
| `"1234567.89"`  | `"N2"`            | `"1,234,567.89"`             | Large number with thousands separator |
| `"1234567.89"`  | `"#,##0.00"`      | `"1,234,567.89"`             | Explicit thousands separator format |
| `"0.1234"`      | `"0.00%"`         | `"12.34%"`                   | Percentage formatting |
| `"0.12"`        | `"00.00"`         | `"00.12"`                    | Fixed zero's with fixed decimals |
| `"1234567.89"`  | `"0.00"`          | `"1234567.89"`               | Fixed two decimals |


### Notes:
- However it will work in the tests but the `type="number"` on the input might stop us from showing thousand separators. since `1.000,01` won't show in the `type="number".` I don't think we want to change the type to `text` since we might break existing usage.  

Any idea's how to solve this problem are welcome. The other formats will work as expected.

### Idea's

Haven't tested it but using `inputmode` and `pattern` might accomplish the same: 

`<input type="text" pattern="^[0-9․,]+$" inputmode="decimal"/>`

### Other types
Note to self, `int`,`short` and `long` can also be used for thousand separators. 
e.g.
1.000 

Fixes #30567
