### PR TITLE
Readd DiagnosticSource to KestrelServerImpl

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
@@ -39,8 +39,9 @@ internal sealed class KestrelServerImpl : IServer
         IEnumerable<IMultiplexedConnectionListenerFactory> multiplexedFactories,
         IHttpsConfigurationService httpsConfigurationService,
         ILoggerFactory loggerFactory,
+        DiagnosticSource diagnosticSource,
         KestrelMetrics metrics)
-        : this(transportFactories, multiplexedFactories, httpsConfigurationService, CreateServiceContext(options, loggerFactory, diagnosticSource: null, metrics))
+        : this(transportFactories, multiplexedFactories, httpsConfigurationService, CreateServiceContext(options, loggerFactory, diagnosticSource, metrics))
     {
     }
 
@@ -111,7 +112,8 @@ internal sealed class KestrelServerImpl : IServer
 
     public KestrelServerOptions Options => ServiceContext.ServerOptions;
 
-    private ServiceContext ServiceContext { get; }
+    // Internal for testing
+    internal ServiceContext ServiceContext { get; }
 
     private KestrelTrace Trace => ServiceContext.Log;
 

--- a/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
@@ -39,7 +39,7 @@ internal sealed class KestrelServerImpl : IServer
         IEnumerable<IMultiplexedConnectionListenerFactory> multiplexedFactories,
         IHttpsConfigurationService httpsConfigurationService,
         ILoggerFactory loggerFactory,
-        DiagnosticSource diagnosticSource,
+        DiagnosticSource? diagnosticSource,
         KestrelMetrics metrics)
         : this(transportFactories, multiplexedFactories, httpsConfigurationService, CreateServiceContext(options, loggerFactory, diagnosticSource, metrics))
     {

--- a/src/Servers/Kestrel/Core/src/KestrelServer.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServer.cs
@@ -36,6 +36,7 @@ public class KestrelServer : IServer
             Array.Empty<IMultiplexedConnectionListenerFactory>(),
             new SimpleHttpsConfigurationService(),
             loggerFactory,
+            diagnosticSource: null,
             new KestrelMetrics(new DummyMeterFactory()));
     }
 

--- a/src/Servers/Kestrel/Core/test/KestrelServerTests.cs
+++ b/src/Servers/Kestrel/Core/test/KestrelServerTests.cs
@@ -309,6 +309,7 @@ public class KestrelServerTests
             multiplexedFactories,
             httpsConfigurationService,
             loggerFactory ?? new LoggerFactory(new[] { new KestrelTestLoggerProvider() }),
+            diagnosticSource: null,
             metrics ?? new KestrelMetrics(new TestMeterFactory()));
     }
 

--- a/src/Servers/Kestrel/Kestrel/test/WebHostBuilderKestrelExtensionsTests.cs
+++ b/src/Servers/Kestrel/Kestrel/test/WebHostBuilderKestrelExtensionsTests.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using System.IO.Pipelines;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets;
 using Microsoft.Extensions.DependencyInjection;
@@ -107,6 +109,11 @@ public class WebHostBuilderKestrelExtensionsTests
             .UseKestrel()
             .Configure(app => { });
 
-        Assert.IsType<KestrelServerImpl>(hostBuilder.Build().Services.GetService<IServer>());
+        var server = Assert.IsType<KestrelServerImpl>(hostBuilder.Build().Services.GetService<IServer>());
+
+        Assert.NotNull(server.ServiceContext.DiagnosticSource);
+        Assert.IsType<KestrelMetrics>(server.ServiceContext.Metrics);
+        Assert.Equal(PipeScheduler.ThreadPool, server.ServiceContext.Scheduler);
+        Assert.Equal(TimeProvider.System, server.ServiceContext.TimeProvider);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/58911

Regressed in https://github.com/dotnet/aspnetcore/pull/46834. Added a little bit more test coverage by checking some properties on `KestrelServerImpl`.