### PR TITLE
update message for "dotnet dev-cert https --trust"

### DIFF
--- a/src/Tools/dotnet-dev-certs/src/Program.cs
+++ b/src/Tools/dotnet-dev-certs/src/Program.cs
@@ -98,7 +98,7 @@ internal sealed class Program
 
                 CommandOption trust = null;
                 trust = c.Option("-t|--trust",
-                    "Trust the certificate on the current platform, creating one if necessary. When combined with the --check option, validates that the certificate is trusted.",
+                    "When not combined with the --check option, trusts the certificate on the current platform, creating one if necessary. When combined with the --check option, validates that there is a certificate and it is trusted.",
                     CommandOptionType.NoValue);
 
                 var verbose = c.Option("-v|--verbose",

--- a/src/Tools/dotnet-dev-certs/src/Program.cs
+++ b/src/Tools/dotnet-dev-certs/src/Program.cs
@@ -98,7 +98,8 @@ internal sealed class Program
 
                 CommandOption trust = null;
                 trust = c.Option("-t|--trust",
-                    "When not combined with the --check option, trusts the certificate on the current platform, creating one if necessary. When combined with the --check option, validates that there is a certificate and it is trusted.",
+                    "When not combined with the --check option, trusts the certificate on the current platform, creating one if necessary.\n" +
+                    "                     When combined with the --check option, validates that there is a certificate and it is trusted.",
                     CommandOptionType.NoValue);
 
                 var verbose = c.Option("-v|--verbose",

--- a/src/Tools/dotnet-dev-certs/src/Program.cs
+++ b/src/Tools/dotnet-dev-certs/src/Program.cs
@@ -98,7 +98,7 @@ internal sealed class Program
 
                 CommandOption trust = null;
                 trust = c.Option("-t|--trust",
-                    "Trust the certificate on the current platform. When combined with the --check option, validates that the certificate is trusted.",
+                    "Trust the certificate on the current platform, creating one if necessary. When combined with the --check option, validates that the certificate is trusted.",
                     CommandOptionType.NoValue);
 
                 var verbose = c.Option("-v|--verbose",


### PR DESCRIPTION
I noticed it creates one if not present (eg., you did --clean) but the help message did not show how to create one.