### PR TITLE
Fix SkipOnHelix skipping tests that had `';'` at the end of the Queues list

### DIFF
--- a/src/Testing/src/xunit/SkipOnHelixAttribute.cs
+++ b/src/Testing/src/xunit/SkipOnHelixAttribute.cs
@@ -68,7 +68,8 @@ public class SkipOnHelixAttribute : Attribute, ITestCondition
 
         // We have "QueueName" and "QueueName.Open" queues for internal and public builds
         // If we want to skip the test in the public queue, we want to skip it in the internal queue, and vice versa
-        return Queues.ToLowerInvariant().Split(';').Any(q => q.Equals(targetQueue, StringComparison.Ordinal) || q.StartsWith(targetQueue, StringComparison.Ordinal) || 
+        return Queues.ToLowerInvariant().Split([';'], StringSplitOptions.RemoveEmptyEntries)
+            .Any(q => q.Equals(targetQueue, StringComparison.Ordinal) || q.StartsWith(targetQueue, StringComparison.Ordinal) || 
             targetQueue.StartsWith(q, StringComparison.Ordinal));
     }
 


### PR DESCRIPTION
For example, https://github.com/dotnet/aspnetcore/blob/9660fb48ce586117945d844c56166fe420f90d62/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/ApplicationInitializationTests.cs#L32 is completely skipped on CI due to this bug.