### PR TITLE
`NavigateTo` does not scroll to the top in internal navigation to same url

### DIFF
--- a/src/Components/Web.JS/src/Services/NavigationManager.ts
+++ b/src/Components/Web.JS/src/Services/NavigationManager.ts
@@ -4,7 +4,7 @@
 import '@microsoft/dotnet-js-interop';
 import { resetScrollAfterNextBatch } from '../Rendering/Renderer';
 import { EventDelegator } from '../Rendering/Events/EventDelegator';
-import { attachEnhancedNavigationListener, getInteractiveRouterRendererId, handleClickForNavigationInterception, hasInteractiveRouter, hasProgrammaticEnhancedNavigationHandler, isSamePageWithHash, isWithinBaseUriSpace, performProgrammaticEnhancedNavigation, performScrollToElementOnTheSamePage, scrollToElement, setHasInteractiveRouter, toAbsoluteUri } from './NavigationUtils';
+import { attachEnhancedNavigationListener, getInteractiveRouterRendererId, handleClickForNavigationInterception, hasInteractiveRouter, hasProgrammaticEnhancedNavigationHandler, isForSamePath, isSamePageWithHash, isWithinBaseUriSpace, performProgrammaticEnhancedNavigation, performScrollToElementOnTheSamePage, scrollToElement, setHasInteractiveRouter, toAbsoluteUri } from './NavigationUtils';
 import { WebRendererId } from '../Rendering/WebRendererId';
 import { isRendererAttached } from '../Rendering/WebRendererInteropMethods';
 
@@ -169,7 +169,9 @@ async function performInternalNavigation(absoluteInternalHref: string, intercept
   // position, so reset it.
   // To avoid ugly flickering effects, we don't want to change the scroll position until
   // we render the new page. As a best approximation, wait until the next batch.
-  resetScrollAfterNextBatch();
+  if (!isForSamePath(absoluteInternalHref, location.href)) {
+    resetScrollAfterNextBatch();
+  }
 
   saveToBrowserHistory(absoluteInternalHref, replace, state);
 

--- a/src/Components/test/testassets/BasicTestApp/RouterTest/ProgrammaticNavigationCases.razor
+++ b/src/Components/test/testassets/BasicTestApp/RouterTest/ProgrammaticNavigationCases.razor
@@ -3,6 +3,22 @@
 
 <div id="test-info">This page has test cases for programmatic navigation.</div>
 
+<style>
+.sticky-top {
+    position: -webkit-sticky;
+    position: sticky;
+    top: 0;
+    z-index: 1020;
+    background-color: white;
+}
+</style>
+
+<div class="sticky-top">
+    <button id="do-self-navigate" @onclick="SelfNavigate">Navigate to Self</button>
+    <button id="do-self-navigate-with-query" @onclick="SelfNavigateWithQuery">Navigate to Self With Query</button>
+    <button id="do-self-navigate-to-fragment" @onclick="SelfNavigateWithFragment">Navigate to Self with Fragment</button>
+</div>
+
 <button id="do-other-navigation" @onclick="@(() => NavigationManager.NavigateTo("Other", new NavigationOptions()))">
     Programmatic navigation (NavigationOptions overload)
 </button>
@@ -34,3 +50,46 @@
 <button id="do-other-navigation-state-replacehistoryentry" @onclick="@(() => NavigationManager.NavigateTo("Other", new NavigationOptions { HistoryEntryState = "state", ReplaceHistoryEntry = true }))">
     Programmatic navigation (NavigationOptions overload) with replace and state
 </button>
+
+<div>
+    @foreach (var i in Enumerable.Range(0, 200))
+    {
+        <p>before fragment: @i</p>
+    }
+
+    <div id="fragment">
+        Middle section
+    </div>
+
+    @foreach (var i in Enumerable.Range(0, 200))
+    {
+        <p>after fragment: @i</p>
+    }
+</div>
+
+@code
+{
+    private void SelfNavigate()
+    {
+        NavigationManager.NavigateTo(NavigationManager.Uri.ToString(), false);
+    }
+
+    private void SelfNavigateWithQuery()
+    {
+        var newUri = new UriBuilder(NavigationManager.Uri)
+        {
+            Query = $"random={Random.Shared.Next()}"
+        };
+        NavigationManager.NavigateTo(newUri.ToString(), false);
+    }
+
+    private void SelfNavigateWithFragment()
+    {
+        var newUri = new UriBuilder(NavigationManager.Uri)
+        {
+            Fragment = "fragment"
+        };
+        NavigationManager.NavigateTo(newUri.ToString(), false);
+    }
+
+}


### PR DESCRIPTION
# `NavigateTo` does not scroll to the top in internal navigation to same url

## Description
If we use `NavigateTo` with same url as the current one or with only query appended, the navigation action finishes with setting the scroll at the top of the page. It happens even if we were not forcing the external navigation (setting `forceLoad=false`).

The change:
Now, we are conditioning the scroll action with the check if internal navigation is not happening for the same path. `isForSamePath` compares ignoring queries.

Fixes #40190
