### PR TITLE
Abstract away the TestServer dependency from WebApplicationBuilder

### DIFF
--- a/src/Hosting/TestHost/src/ITestServer.cs
+++ b/src/Hosting/TestHost/src/ITestServer.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net.Http;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+
+namespace Microsoft.AspNetCore.TestHost;
+
+/// <summary>
+/// A contract for a test server implementation.
+/// </summary>
+public interface ITestServer : IServer
+{
+    /// <summary>
+    /// Gets the web host associated with the test server.
+    /// </summary>
+    IWebHost Host { get; }
+
+    /// <summary>
+    /// Creates a new <see cref="HttpMessageHandler"/> for processing HTTP requests against the test server.
+    /// </summary>
+    /// <returns>A new <see cref="HttpMessageHandler"/> instance.</returns>
+    HttpMessageHandler CreateHandler();
+
+    /// <summary>
+    /// Creates a new <see cref="HttpClient"/> for processing HTTP requests against the test server.
+    /// </summary>
+    /// <returns></returns>
+    HttpClient CreateClient();
+}

--- a/src/Hosting/TestHost/src/PublicAPI.Unshipped.txt
+++ b/src/Hosting/TestHost/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 #nullable enable
+Microsoft.AspNetCore.TestHost.ITestServer
+Microsoft.AspNetCore.TestHost.ITestServer.CreateClient() -> System.Net.Http.HttpClient!
+Microsoft.AspNetCore.TestHost.ITestServer.CreateHandler() -> System.Net.Http.HttpMessageHandler!
+Microsoft.AspNetCore.TestHost.ITestServer.Host.get -> Microsoft.AspNetCore.Hosting.IWebHost!

--- a/src/Hosting/TestHost/src/TestServer.cs
+++ b/src/Hosting/TestHost/src/TestServer.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.TestHost;
 /// <summary>
 /// An <see cref="IServer"/> implementation for executing tests.
 /// </summary>
-public class TestServer : IServer
+public class TestServer : ITestServer
 {
     private readonly IWebHost? _hostInstance;
     private bool _disposed;

--- a/src/Identity/test/Identity.FunctionalTests/Infrastructure/ServerFactory.cs
+++ b/src/Identity/test/Identity.FunctionalTests/Infrastructure/ServerFactory.cs
@@ -63,9 +63,9 @@ public class ServerFactory<TStartup, TContext> : WebApplicationFactory<TStartup>
         return result;
     }
 
-    protected override ITestServer CreateServer(IWebHostBuilder builder)
+    protected override ITestServer CreateTestServer(IWebHostBuilder builder)
     {
-        var result = base.CreateServer(builder);
+        var result = base.CreateTestServer(builder);
         EnsureDatabaseCreated(result.Host.Services);
         return result;
     }

--- a/src/Identity/test/Identity.FunctionalTests/Infrastructure/ServerFactory.cs
+++ b/src/Identity/test/Identity.FunctionalTests/Infrastructure/ServerFactory.cs
@@ -63,7 +63,7 @@ public class ServerFactory<TStartup, TContext> : WebApplicationFactory<TStartup>
         return result;
     }
 
-    protected override TestServer CreateServer(IWebHostBuilder builder)
+    protected override ITestServer CreateServer(IWebHostBuilder builder)
     {
         var result = base.CreateServer(builder);
         EnsureDatabaseCreated(result.Host.Services);

--- a/src/Mvc/Mvc.Testing.Tasks/src/GenerateMvcTestManifestTask.cs
+++ b/src/Mvc/Mvc.Testing.Tasks/src/GenerateMvcTestManifestTask.cs
@@ -1,8 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.Serialization.Json;
 using System.Text;
 using Microsoft.Build.Framework;
@@ -33,11 +35,14 @@ public class GenerateMvcTestManifestTask : Task
     {
         using var fileStream = File.Create(ManifestPath);
         var output = new Dictionary<string, string>();
+        var manifestDirectory = Path.GetDirectoryName(ManifestPath);
+
         foreach (var project in Projects)
         {
             var contentRoot = project.GetMetadata("ContentRoot");
             var assemblyName = project.GetMetadata("Identity");
-            output[assemblyName] = contentRoot;
+            var relativeContentRoot = GetRelativePath(manifestDirectory, contentRoot);
+            output[assemblyName] = relativeContentRoot;
         }
 
         var serializer = new DataContractJsonSerializer(typeof(Dictionary<string, string>), new DataContractJsonSerializerSettings
@@ -48,5 +53,45 @@ public class GenerateMvcTestManifestTask : Task
         serializer.WriteObject(writer, output);
 
         return !Log.HasLoggedErrors;
+    }
+
+    private static string GetRelativePath(string? relativeTo, string path)
+    {
+        if (string.IsNullOrEmpty(relativeTo))
+        {
+            return path;
+        }
+
+        // Ensure the paths are absolute
+        string absoluteRelativeTo = Path.GetFullPath(relativeTo);
+        string absolutePath = Path.GetFullPath(path);
+
+        // Split the paths into their components
+        string[] relativeToParts = absoluteRelativeTo.TrimEnd(Path.DirectorySeparatorChar).Split(Path.DirectorySeparatorChar);
+        string[] pathParts = absolutePath.TrimEnd(Path.DirectorySeparatorChar).Split(Path.DirectorySeparatorChar);
+
+        // Find the common base path length
+        int commonLength = 0;
+        while (commonLength < relativeToParts.Length && commonLength < pathParts.Length &&
+               string.Equals(relativeToParts[commonLength], pathParts[commonLength], StringComparison.OrdinalIgnoreCase))
+        {
+            commonLength++;
+        }
+
+        // Calculate the number of directories to go up from the relativeTo path
+        int upDirectories = relativeToParts.Length - commonLength;
+
+        // Build the relative path
+        string relativePath = string.Join(Path.DirectorySeparatorChar.ToString(), new string[upDirectories].Select(_ => "..").ToArray());
+        if (commonLength < pathParts.Length)
+        {
+            if (relativePath.Length > 0)
+            {
+                relativePath += Path.DirectorySeparatorChar;
+            }
+            relativePath += string.Join(Path.DirectorySeparatorChar.ToString(), pathParts.Skip(commonLength));
+        }
+
+        return relativePath;
     }
 }

--- a/src/Mvc/Mvc.Testing/src/PublicAPI.Shipped.txt
+++ b/src/Mvc/Mvc.Testing/src/PublicAPI.Shipped.txt
@@ -16,6 +16,7 @@ Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.CreateDefaul
 Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.CreateDefaultClient(System.Uri! baseAddress, params System.Net.Http.DelegatingHandler![]! handlers) -> System.Net.Http.HttpClient!
 Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.Dispose() -> void
 Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.Factories.get -> System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint!>!>!
+Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.Server.get -> Microsoft.AspNetCore.TestHost.TestServer!
 Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.WebApplicationFactory() -> void
 Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.WithWebHostBuilder(System.Action<Microsoft.AspNetCore.Hosting.IWebHostBuilder!>! configuration) -> Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint!>!
 Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions
@@ -40,6 +41,7 @@ virtual Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.Conf
 virtual Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.ConfigureWebHost(Microsoft.AspNetCore.Hosting.IWebHostBuilder! builder) -> void
 virtual Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.CreateHost(Microsoft.Extensions.Hosting.IHostBuilder! builder) -> Microsoft.Extensions.Hosting.IHost!
 virtual Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.CreateHostBuilder() -> Microsoft.Extensions.Hosting.IHostBuilder?
+virtual Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.CreateServer(Microsoft.AspNetCore.Hosting.IWebHostBuilder! builder) -> Microsoft.AspNetCore.TestHost.TestServer!
 virtual Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.CreateWebHostBuilder() -> Microsoft.AspNetCore.Hosting.IWebHostBuilder?
 virtual Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.Dispose(bool disposing) -> void
 virtual Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.DisposeAsync() -> System.Threading.Tasks.ValueTask

--- a/src/Mvc/Mvc.Testing/src/PublicAPI.Shipped.txt
+++ b/src/Mvc/Mvc.Testing/src/PublicAPI.Shipped.txt
@@ -16,7 +16,6 @@ Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.CreateDefaul
 Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.CreateDefaultClient(System.Uri! baseAddress, params System.Net.Http.DelegatingHandler![]! handlers) -> System.Net.Http.HttpClient!
 Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.Dispose() -> void
 Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.Factories.get -> System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint!>!>!
-Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.Server.get -> Microsoft.AspNetCore.TestHost.TestServer!
 Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.WebApplicationFactory() -> void
 Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.WithWebHostBuilder(System.Action<Microsoft.AspNetCore.Hosting.IWebHostBuilder!>! configuration) -> Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint!>!
 Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions
@@ -41,7 +40,6 @@ virtual Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.Conf
 virtual Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.ConfigureWebHost(Microsoft.AspNetCore.Hosting.IWebHostBuilder! builder) -> void
 virtual Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.CreateHost(Microsoft.Extensions.Hosting.IHostBuilder! builder) -> Microsoft.Extensions.Hosting.IHost!
 virtual Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.CreateHostBuilder() -> Microsoft.Extensions.Hosting.IHostBuilder?
-virtual Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.CreateServer(Microsoft.AspNetCore.Hosting.IWebHostBuilder! builder) -> Microsoft.AspNetCore.TestHost.TestServer!
 virtual Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.CreateWebHostBuilder() -> Microsoft.AspNetCore.Hosting.IWebHostBuilder?
 virtual Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.Dispose(bool disposing) -> void
 virtual Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.DisposeAsync() -> System.Threading.Tasks.ValueTask

--- a/src/Mvc/Mvc.Testing/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.Testing/src/PublicAPI.Unshipped.txt
@@ -1,5 +1,8 @@
 #nullable enable
 Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.Initialize() -> void
+*REMOVED*Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.Server.get -> Microsoft.AspNetCore.TestHost.TestServer!
 Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.Server.get -> Microsoft.AspNetCore.TestHost.TestServer?
 Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.TestServer.get -> Microsoft.AspNetCore.TestHost.ITestServer?
+*REMOVED*virtual Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.CreateServer(Microsoft.AspNetCore.Hosting.IWebHostBuilder! builder) -> Microsoft.AspNetCore.TestHost.TestServer!
 virtual Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.CreateServer(Microsoft.AspNetCore.Hosting.IWebHostBuilder! builder) -> Microsoft.AspNetCore.TestHost.ITestServer!
+

--- a/src/Mvc/Mvc.Testing/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.Testing/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 #nullable enable
+Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.Initialize() -> void
+Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.Server.get -> Microsoft.AspNetCore.TestHost.TestServer?
+Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.TestServer.get -> Microsoft.AspNetCore.TestHost.ITestServer?
+virtual Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.CreateServer(Microsoft.AspNetCore.Hosting.IWebHostBuilder! builder) -> Microsoft.AspNetCore.TestHost.ITestServer!

--- a/src/Mvc/Mvc.Testing/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.Testing/src/PublicAPI.Unshipped.txt
@@ -3,6 +3,5 @@ Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.Initialize()
 *REMOVED*Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.Server.get -> Microsoft.AspNetCore.TestHost.TestServer!
 Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.Server.get -> Microsoft.AspNetCore.TestHost.TestServer?
 Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.TestServer.get -> Microsoft.AspNetCore.TestHost.ITestServer?
-*REMOVED*virtual Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.CreateServer(Microsoft.AspNetCore.Hosting.IWebHostBuilder! builder) -> Microsoft.AspNetCore.TestHost.TestServer!
-virtual Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.CreateServer(Microsoft.AspNetCore.Hosting.IWebHostBuilder! builder) -> Microsoft.AspNetCore.TestHost.ITestServer!
+virtual Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.CreateTestServer(Microsoft.AspNetCore.Hosting.IWebHostBuilder! builder) -> Microsoft.AspNetCore.TestHost.ITestServer!
 

--- a/src/Mvc/Mvc.Testing/src/Resources.resx
+++ b/src/Mvc/Mvc.Testing/src/Resources.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -119,6 +119,9 @@
   </resheader>
   <data name="InvalidAssemblyEntryPoint" xml:space="preserve">
     <value>The provided Type '{0}' does not belong to an assembly with an entry point. A common cause for this error is providing a Type from a class library.</value>
+  </data>
+  <data name="InvalidTestServerConfiguration" xml:space="preserve">
+    <value>The host doesn't contain a valid ITestServer configuration.</value>
   </data>
   <data name="MissingBuilderMethod" xml:space="preserve">
     <value>No method 'public static {0} CreateHostBuilder(string[] args)' or 'public static {1} CreateWebHostBuilder(string[] args)' found on '{2}'. Alternatively, {3} can be extended and '{4}' or '{5}' can be overridden to provide your own instance.</value>

--- a/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
+++ b/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
@@ -246,17 +246,23 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
             return;
         }
 
-        var fromFile = File.Exists("MvcTestingAppManifest.json");
-        var contentRoot = fromFile ? GetContentRootFromFile("MvcTestingAppManifest.json") : GetContentRootFromAssembly();
+        string? contentRoot = null;
+        if (File.Exists("MvcTestingAppManifest.json"))
+        {
+            var manifestContentRoot = GetContentRootFromFile("MvcTestingAppManifest.json");
+            if (manifestContentRoot is not null && Directory.Exists(manifestContentRoot))
+            {
+                contentRoot = manifestContentRoot;
+            }
+        }
 
-        if (contentRoot != null)
+        contentRoot ??= GetContentRootFromAssembly();
+        if (contentRoot is null || !Directory.Exists(contentRoot))
         {
-            builder.UseContentRoot(contentRoot);
+            contentRoot = AppContext.BaseDirectory;
         }
-        else
-        {
-            builder.UseSolutionRelativeContentRoot(typeof(TEntryPoint).Assembly.GetName().Name!);
-        }
+
+        builder.UseContentRoot(contentRoot);
     }
 
     private static string? GetContentRootFromFile(string file)

--- a/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
+++ b/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
@@ -22,9 +22,9 @@ namespace Microsoft.AspNetCore.Mvc.Testing;
 /// </summary>
 /// <typeparam name="TEntryPoint">A type in the entry point assembly of the application.
 /// Typically the Startup or Program classes can be used.</typeparam>
-/// <remarks>The default behavior of the <see cref="CreateServer(IWebHostBuilder)"/> implementation
+/// <remarks>The default behavior of the <see cref="CreateTestServer(IWebHostBuilder)"/> implementation
 /// creates a new <see cref="TestHost.TestServer"/> instance as an in-memory server to utilize for testing.
-/// If the developers wants, they can override the <see cref="CreateServer(IWebHostBuilder)"/> method to return a customer <see cref="ITestServer"/> implementation,
+/// If the developers wants, they can override the <see cref="CreateTestServer(IWebHostBuilder)"/> method to return a customer <see cref="ITestServer"/> implementation,
 /// and provide an adapter over a real web server, if needed. If done so, the <see cref="CreateClient()"/> and similar methods will
 /// create <see cref="HttpClient"/> instances configured to interact with the provided test server instead.</remarks>
 public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDisposable where TEntryPoint : class
@@ -86,7 +86,7 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
     }
 
     /// <summary>
-    /// Gets the <see cref="ITestServer"/> instance created by the underyling <see cref="CreateServer(IWebHostBuilder)"/> call.
+    /// Gets the <see cref="ITestServer"/> instance created by the underyling <see cref="CreateTestServer(IWebHostBuilder)"/> call.
     /// </summary>
     public ITestServer? TestServer
     {
@@ -136,7 +136,7 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
     {
         var factory = new DelegatedWebApplicationFactory(
             ClientOptions,
-            CreateServer,
+            CreateTestServer,
             CreateHost,
             CreateWebHostBuilder,
             CreateHostBuilder,
@@ -218,7 +218,7 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
         {
             SetContentRoot(builder);
             _configuration(builder);
-            _server = CreateServer(builder);
+            _server = CreateTestServer(builder);
         }
     }
 
@@ -457,12 +457,25 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
     /// <param name="builder">The <see cref="IWebHostBuilder"/> used to
     /// create the server.</param>
     /// <returns>The <see cref="TestServer"/> with the bootstrapped application.</returns>
-    protected virtual ITestServer CreateServer(IWebHostBuilder builder) => new TestServer(builder);
+    [Obsolete("This method is obsolete. Consider utilizing the CreateTestServer method instead.")]
+    protected virtual TestServer CreateServer(IWebHostBuilder builder) => new TestServer(builder);
+
+    /// <summary>
+    /// Creates the <see cref="ITestServer"/> with the bootstrapped application in <paramref name="builder"/>.
+    /// This is only called for applications using <see cref="IWebHostBuilder"/>. Applications based on
+    /// <see cref="IHostBuilder"/> will use <see cref="CreateHost"/> instead.
+    /// </summary>
+    /// <param name="builder">The <see cref="IWebHostBuilder"/> used to
+    /// create the server.</param>
+    /// <returns>The <see cref="ITestServer"/> with the bootstrapped application.</returns>
+#pragma warning disable CS0618 // Type or member is obsolete
+    protected virtual ITestServer CreateTestServer(IWebHostBuilder builder) => CreateServer(builder);
+#pragma warning restore CS0618 // Type or member is obsolete
 
     /// <summary>
     /// Creates the <see cref="IHost"/> with the bootstrapped application in <paramref name="builder"/>.
     /// This is only called for applications using <see cref="IHostBuilder"/>. Applications based on
-    /// <see cref="IWebHostBuilder"/> will use <see cref="CreateServer"/> instead.
+    /// <see cref="IWebHostBuilder"/> will use <see cref="CreateTestServer"/> instead.
     /// </summary>
     /// <param name="builder">The <see cref="IHostBuilder"/> used to create the host.</param>
     /// <returns>The <see cref="IHost"/> with the bootstrapped application.</returns>
@@ -664,7 +677,7 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
             _configuration = configureWebHost;
         }
 
-        protected override ITestServer CreateServer(IWebHostBuilder builder) => _createServer(builder);
+        protected override ITestServer CreateTestServer(IWebHostBuilder builder) => _createServer(builder);
 
         protected override IHost CreateHost(IHostBuilder builder) => _createHost(builder);
 

--- a/src/Mvc/test/Mvc.FunctionalTests/ApiExplorerTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/ApiExplorerTest.cs
@@ -1573,7 +1573,7 @@ public class ApiExplorerTest : LoggedTest
     [Fact]
     public void ApiExplorer_BuildsMetadataForActionWithTypedResult()
     {
-        var apiDescCollectionProvider = Factory.Server.Services.GetService<IApiDescriptionGroupCollectionProvider>();
+        var apiDescCollectionProvider = Factory.Services.GetService<IApiDescriptionGroupCollectionProvider>();
         var testGroupName = nameof(ApiExplorerWithTypedResultController).Replace("Controller", string.Empty);
         var group = apiDescCollectionProvider.ApiDescriptionGroups.Items.Where(i => i.GroupName == testGroupName).SingleOrDefault();
         Assert.NotNull(group);

--- a/src/Mvc/test/Mvc.FunctionalTests/ComponentRenderingFunctionalTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/ComponentRenderingFunctionalTests.cs
@@ -198,7 +198,7 @@ public class ComponentRenderingFunctionalTests : LoggedTest
 
         // We configure the inner handler with a handler to this TestServer instance so that calls to the
         // server can get routed properly.
-        loopHandler.InnerHandler = fixture.Server.CreateHandler();
+        loopHandler.InnerHandler = fixture.TestServer.CreateHandler();
 
         void ConfigureTestWeatherForecastService(IServiceCollection services) =>
             // We configure the test service here with an HttpClient that uses this loopback handler to talk

--- a/src/Mvc/test/Mvc.FunctionalTests/Infrastructure/MvcTestFixture.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/Infrastructure/MvcTestFixture.cs
@@ -42,7 +42,7 @@ public class MvcTestFixture<TStartup> : WebApplicationFactory<TStartup>
                 });
     }
 
-    protected override ITestServer CreateServer(IWebHostBuilder builder)
+    protected override ITestServer CreateTestServer(IWebHostBuilder builder)
     {
         var originalCulture = CultureInfo.CurrentCulture;
         var originalUICulture = CultureInfo.CurrentUICulture;
@@ -50,7 +50,7 @@ public class MvcTestFixture<TStartup> : WebApplicationFactory<TStartup>
         {
             CultureInfo.CurrentCulture = new CultureInfo("en-GB");
             CultureInfo.CurrentUICulture = new CultureInfo("en-US");
-            return base.CreateServer(builder);
+            return base.CreateTestServer(builder);
         }
         finally
         {

--- a/src/Mvc/test/Mvc.FunctionalTests/Infrastructure/MvcTestFixture.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/Infrastructure/MvcTestFixture.cs
@@ -42,7 +42,7 @@ public class MvcTestFixture<TStartup> : WebApplicationFactory<TStartup>
                 });
     }
 
-    protected override TestServer CreateServer(IWebHostBuilder builder)
+    protected override ITestServer CreateServer(IWebHostBuilder builder)
     {
         var originalCulture = CultureInfo.CurrentCulture;
         var originalUICulture = CultureInfo.CurrentUICulture;

--- a/src/Mvc/test/Mvc.FunctionalTests/TestingInfrastructureInheritanceTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/TestingInfrastructureInheritanceTests.cs
@@ -157,10 +157,10 @@ public class TestingInfrastructureInheritanceTests
             base.ConfigureWebHost(builder);
         }
 
-        protected override ITestServer CreateServer(IWebHostBuilder builder)
+        protected override ITestServer CreateTestServer(IWebHostBuilder builder)
         {
             CreateServerCalled = true;
-            return base.CreateServer(builder);
+            return base.CreateTestServer(builder);
         }
 
         protected override IHost CreateHost(IHostBuilder builder)

--- a/src/Mvc/test/Mvc.FunctionalTests/TestingInfrastructureInheritanceTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/TestingInfrastructureInheritanceTests.cs
@@ -141,7 +141,7 @@ public class TestingInfrastructureInheritanceTests
             base.ConfigureWebHost(builder);
         }
 
-        protected override TestServer CreateServer(IWebHostBuilder builder)
+        protected override ITestServer CreateServer(IWebHostBuilder builder)
         {
             CreateServerCalled = true;
             return base.CreateServer(builder);

--- a/src/Mvc/test/Mvc.FunctionalTests/TestingInfrastructureInheritanceTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/TestingInfrastructureInheritanceTests.cs
@@ -27,8 +27,13 @@ public class TestingInfrastructureInheritanceTests
         Assert.Equal(new[] { "ConfigureWebHost", "Customization", "FurtherCustomization" }, factory.ConfigureWebHostCalled.ToArray());
         Assert.True(factory.CreateServerCalled);
         Assert.True(factory.CreateWebHostBuilderCalled);
-        // GetTestAssemblies is not called when reading content roots from MvcAppManifest
-        Assert.False(factory.GetTestAssembliesCalled);
+
+        // When run locally on the developer machine, the test manifest will be generated,
+        // and the content root will be read from the manifest file.
+        // However, when run in CI, the relative path in the metadata will not exist,
+        // and the content root lookup logic will probe the test assemblies too.
+        //Assert.False(factory.GetTestAssembliesCalled);
+
         Assert.True(factory.CreateHostBuilderCalled);
         Assert.False(factory.CreateHostCalled);
     }
@@ -45,7 +50,13 @@ public class TestingInfrastructureInheritanceTests
 
         // Assert
         Assert.Equal(new[] { "ConfigureWebHost", "Customization", "FurtherCustomization" }, factory.ConfigureWebHostCalled.ToArray());
-        Assert.False(factory.GetTestAssembliesCalled);
+
+        // When run locally on the developer machine, the test manifest will be generated,
+        // and the content root will be read from the manifest file.
+        // However, when run in CI, the relative path in the metadata will not exist,
+        // and the content root lookup logic will probe the test assemblies too.
+        //Assert.False(factory.GetTestAssembliesCalled);
+
         Assert.True(factory.CreateHostBuilderCalled);
         Assert.True(factory.CreateHostCalled);
         Assert.False(factory.CreateServerCalled);
@@ -128,7 +139,12 @@ public class TestingInfrastructureInheritanceTests
 
     private class CustomizedFactory<TEntryPoint> : WebApplicationFactory<TEntryPoint> where TEntryPoint : class
     {
+        // GetTestAssemblies is not called when reading content roots from MvcAppManifest,
+        // and the content root specified in the manifest is a path that exists.
+        // Otherwise, the WebApplicationFactory will try to look for the referenced assemblies which have
+        // `WebApplicationFactoryContentRootAttribute` applied to them, to extract the content root path from that metadata.
         public bool GetTestAssembliesCalled { get; private set; }
+
         public bool CreateWebHostBuilderCalled { get; private set; }
         public bool CreateHostBuilderCalled { get; private set; }
         public bool CreateServerCalled { get; private set; }


### PR DESCRIPTION
## Description
- Replaces (avoiding breaking changes the TestServer dependency with a new ITestServer abstraction in the WebApplicationFactory.
- Updated the WebApplicationFactory to depend on the ITestServer abstraction
- Updated the GenerateMvcTestManifestTask to generate relative contentRoot paths in test manifests.

## Validation
How do I know if this change didn't break something? Well, at first it did and many integration tests in the repo started failing. So these, naturally become a validation ground for this change.

Fixes https://github.com/dotnet/aspnetcore/issues/4892
