### PR TITLE
Only build MSIs that aren't also built in BuildPass2 during BuildPass1

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -254,13 +254,12 @@
         <InstallerProject Include="$(RepoRoot)src\Installers\Windows\WindowsHostingBundle\WindowsHostingBundle.wixproj" AdditionalProperties="Platform=x86" />
       </ItemGroup>
 
-      <!-- In a vertical build, only build the MSIs for the current vertical in the first pass and build the hosting bundle in the second pass -->
+      <!--
+        In a vertical build, only build the MSIs for the current vertical that aren't used in the hosting bundle in the first pass
+        and build the hosting bundle and its dependencies in the second pass.
+      -->
       <ItemGroup Condition="'$(DotNetBuild)' == 'true' and ('$(DotNetBuildPass)' == '' or '$(DotNetBuildPass)' == '1') and '$(_BuildWindowsInstallers)' == 'true'">
-        <!-- Build the ANCM custom action -->
-        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\CustomAction\aspnetcoreCA.vcxproj" AdditionalProperties="Platform=$(_VcxTargetPlatform)" />
-        <!-- Build the ANCM msis -->
         <InstallerProject Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\ANCMIISExpressV2\AncmIISExpressV2.wixproj" AdditionalProperties="Platform=$(TargetArchitecture)" />
-        <InstallerProject Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\ANCMV2\ANCMV2.wixproj" AdditionalProperties="Platform=$(TargetArchitecture)" />
       </ItemGroup>
 
       <ItemGroup>


### PR DESCRIPTION
Today, the VMR produces duplicates of these MSIs (and the corresponding VS insertion packages) on each BuildPass1 vertical (explicitly referenced from Build.props) and during the BuildPass2 vertical (transitively referenced via the hosting bundle). Remove the duplication by only building them in BuildPass2 via the hosting bundle.

Related: https://github.com/dotnet/aspnetcore/issues/59865