### PR TITLE
React to NuGet package pruning warnings

### DIFF
--- a/src/Components/Server/src/Microsoft.AspNetCore.Components.Server.csproj
+++ b/src/Components/Server/src/Microsoft.AspNetCore.Components.Server.csproj
@@ -22,7 +22,7 @@
     <Reference Include="Microsoft.Extensions.Caching.Memory" />
     <Reference Include="Microsoft.Extensions.Logging" />
     <!-- Required for S.T.J source generation -->
-    <Reference Include="System.Text.Json" PrivateAssets="All" />
+    <Reference Include="System.Text.Json" PrivateAssets="All" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
 
     <Compile Include="$(SharedSourceRoot)ValueStopwatch\*.cs" />
     <Compile Include="$(SharedSourceRoot)LinkerFlags.cs" LinkBase="Shared" />

--- a/src/Tools/dotnet-user-jwts/src/dotnet-user-jwts.csproj
+++ b/src/Tools/dotnet-user-jwts/src/dotnet-user-jwts.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <Reference Include="System.IdentityModel.Tokens.Jwt" />
-    <Reference Include="System.Text.Json" />
+    <Reference Include="System.Text.Json" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
     <Reference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <Reference Include="Microsoft.Extensions.Configuration" />
     <Reference Include="Microsoft.Extensions.Configuration.Binder" />

--- a/src/Tools/dotnet-user-secrets/src/dotnet-user-secrets.csproj
+++ b/src/Tools/dotnet-user-secrets/src/dotnet-user-secrets.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <Reference Include="Newtonsoft.Json" />
-    <Reference Include="System.Text.Json" />
+    <Reference Include="System.Text.Json" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
     <Reference Include="Microsoft.Extensions.Configuration.UserSecrets" />
   </ItemGroup>
 


### PR DESCRIPTION
Contributes to https://github.com/dotnet/sdk/pull/46642

NuGet added a new feature that automatically prunes package and project references that are provided by the shared framework that is targeted.

Resolve the 3 warnings that got emitted when source-building the repository.