### PR TITLE
Revert "Update .NET build URLs"

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -79,14 +79,14 @@ variables:
 - name: WindowsArm64InstallersLogArgs
   value: /bl:artifacts/log/Release/Build.Installers.Arm64.binlog
 - name: _InternalRuntimeDownloadArgs
-  value: -RuntimeSourceFeed https://ci.dot.net/internal
+  value: -RuntimeSourceFeed https://dotnetbuilds.blob.core.windows.net/internal
          -RuntimeSourceFeedKey $(dotnetbuilds-internal-container-read-token-base64)
          /p:DotNetAssetRootAccessTokenSuffix='$(dotnetbuilds-internal-container-read-token-base64)'
 # The code signing doesn't use the aspnet build scripts, so the msbuild parameters have to be passed directly. This
 # is awkward but necessary because the eng/common/ build scripts don't add the msbuild properties automatically.
 - name: _InternalRuntimeDownloadCodeSignArgs
   value: $(_InternalRuntimeDownloadArgs)
-         /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal
+         /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal
          /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
 - group: DotNet-HelixApi-Access
 - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -234,10 +234,10 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <OfficialBaseURL>https://builds.dotnet.microsoft.com/dotnet/</OfficialBaseURL>
+    <OfficialBaseURL>https://dotnetcli.blob.core.windows.net/dotnet/</OfficialBaseURL>
     <!-- Allow overriding the public base URL for Unified Build scenarios to pull assets from a local build. -->
-    <PublicBaseURL Condition="'$(PublicBaseURL)' == ''">https://ci.dot.net/public/</PublicBaseURL>
-    <InternalBaseURL>https://ci.dot.net/internal/</InternalBaseURL>
+    <PublicBaseURL Condition="'$(PublicBaseURL)' == ''">https://dotnetbuilds.blob.core.windows.net/public/</PublicBaseURL>
+    <InternalBaseURL>https://dotnetbuilds.blob.core.windows.net/internal/</InternalBaseURL>
     <!-- Allow overriding where installers are pulled in from previously completed jobs in Unified Build scenarios. -->
     <AddVersionToCrossArchitectureInstallerBasePath Condition="'$(CrossArchitectureInstallerBasePath)' != ''">true</AddVersionToCrossArchitectureInstallerBasePath>
     <CrossArchitectureInstallerBasePath Condition="'$(CrossArchitectureInstallerBasePath)' == ''">$(ArtifactsShippingPackagesDir)</CrossArchitectureInstallerBasePath>

--- a/eng/common/core-templates/steps/source-build.yml
+++ b/eng/common/core-templates/steps/source-build.yml
@@ -37,7 +37,7 @@ steps:
     # in the default public locations.
     internalRuntimeDownloadArgs=
     if [ '$(dotnetbuilds-internal-container-read-token-base64)' != '$''(dotnetbuilds-internal-container-read-token-base64)' ]; then
-      internalRuntimeDownloadArgs='/p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64) --runtimesourcefeed https://ci.dot.net/internal --runtimesourcefeedkey $(dotnetbuilds-internal-container-read-token-base64)'
+      internalRuntimeDownloadArgs='/p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64) --runtimesourcefeed https://dotnetbuilds.blob.core.windows.net/internal --runtimesourcefeedkey $(dotnetbuilds-internal-container-read-token-base64)'
     fi
 
     buildConfig=Release

--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -58,12 +58,12 @@
       <PackageType>runtime</PackageType>
     </AdditionalDotNetPackage>
 
-    <AdditionalDotNetPackageFeed Include="https://ci.dot.net/internal"
+    <AdditionalDotNetPackageFeed Include="https://dotnetbuilds.blob.core.windows.net/internal"
                                  Condition="'$(SYSTEM_TEAMPROJECT)' == 'internal'">
       <SasToken>$([System.Environment]::GetEnvironmentVariable('DotNetBuildsInternalReadSasToken'))</SasToken>
     </AdditionalDotNetPackageFeed>
 
-    <AdditionalDotNetPackageFeed Include="https://ci.dot.net/internal"
+    <AdditionalDotNetPackageFeed Include="https://dotnetbuilds.blob.core.windows.net/internal"
                                  Condition="'$(SYSTEM_TEAMPROJECT)' == 'internal'">
       <SasToken>$([System.Environment]::GetEnvironmentVariable('DotNetBuildsInternalReadSasToken'))</SasToken>
     </AdditionalDotNetPackageFeed>


### PR DESCRIPTION
Reverts dotnet/aspnetcore#60265 - CI is broken on Mac with the new URLs