### PR TITLE
Avoid logging bad requests as application errors if the connection was aborted

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -702,7 +702,15 @@ internal abstract partial class HttpProtocol : IHttpResponseControl
                 // This has to be caught here so StatusCode is set properly before disposing the HttpContext
                 // (DisposeContext logs StatusCode).
                 SetBadRequestState(ex);
-                ReportApplicationError(ex);
+
+                if (!_connectionAborted)
+                {
+                    // Only report bad requests as error-level logs here if the connection hasn't been aborted. This
+                    // prevents noise in the logs for common types of client errors, and we already have a mechanism
+                    // for logging these at a higher level if needed by increasing the log level for
+                    // "Microsoft.AspNetCore.Server.Kestrel.BadRequests".
+                    ReportApplicationError(ex);
+                }
             }
             catch (Exception ex)
             {

--- a/src/Servers/Kestrel/test/FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/RequestTests.cs
@@ -417,19 +417,18 @@ public class RequestTests : LoggedTest
                 && context.EventId == badRequestEventId
                 && context.LogLevel == LogLevel.Debug)
             {
-                badRequestLogged.SetResult();
+                badRequestLogged.TrySetResult();
             }
             else if (context.LoggerName == "Microsoft.AspNetCore.Server.Kestrel"
                     && context.EventId.Id == appErrorEventId
                     && context.LogLevel > LogLevel.Debug)
             {
-                appErrorLogged.SetResult();
+                appErrorLogged.TrySetResult();
             }
             else if (context.LoggerName == "Microsoft.AspNetCore.Server.Kestrel.Connections"
-                    && context.EventId == connectionStopEventId
-                    && context.Message.Contains("stopped."))
+                    && context.EventId == connectionStopEventId)
             {
-                connectionStoppedLogged.SetResult();
+                connectionStoppedLogged.TrySetResult();
             }
         };
 

--- a/src/Servers/Kestrel/test/FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/RequestTests.cs
@@ -32,7 +32,6 @@ using Newtonsoft.Json.Linq;
 using Xunit;
 using Microsoft.Extensions.Diagnostics.Metrics.Testing;
 using System.Diagnostics.Metrics;
-using System.Linq.Expressions;
 
 #if SOCKETS
 namespace Microsoft.AspNetCore.Server.Kestrel.Sockets.FunctionalTests;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ChunkedRequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ChunkedRequestTests.cs
@@ -740,6 +740,9 @@ public class ChunkedRequestTests : LoggedTest
                     "",
                     "");
             }
+
+            // The 400 response should have been logged by default at Error level since the connection wasn't aborted when the bad request was handled.
+            Assert.Contains(TestSink.Writes, w => w.LoggerName == "Microsoft.AspNetCore.Server.Kestrel" && w.EventId.Id == 13 && w.LogLevel > LogLevel.Debug);
         }
     }
 


### PR DESCRIPTION
Change the behavior in Kestrel's request processing logic so that bad requests are only logged as errors if the connection has not been aborted. This reduces noise in the logs for common client errors.

We already expose bad request information via `Microsoft.AspNetCore.Server.Kestrel.BadRequests` so anyone who is interested in seeing all of this already has a mechanism for doing so, and we don't show scary "fail" messages to people who don't care.

This issue has been a source of great frustration for years now (https://github.com/dotnet/aspnetcore/issues/23949), and generally, there's nothing the server dev can do when there's an unexpected client behavior (e.g. aborting a connection before completing a request) so this seems like a sane default.

Fix https://github.com/dotnet/aspnetcore/issues/23949