### PR TITLE
React to NuGet package pruning warnings

### DIFF
--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -86,7 +86,6 @@ and are generated based on the last package release.
     <LatestPackageReference Include="System.Net.Http.Json" />
     <LatestPackageReference Include="System.Net.Sockets" />
     <LatestPackageReference Include="System.Net.ServerSentEvents" />
-    <LatestPackageReference Include="System.Private.Uri" />
     <LatestPackageReference Include="System.Reflection.Metadata" />
     <LatestPackageReference Include="System.Runtime.InteropServices.RuntimeInformation" />
     <LatestPackageReference Include="System.Runtime.Caching" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -219,7 +219,6 @@
     <SystemComponentModelVersion>4.3.0</SystemComponentModelVersion>
     <SystemNetHttpVersion>4.3.4</SystemNetHttpVersion>
     <SystemNetSocketsVersion>4.3.0</SystemNetSocketsVersion>
-    <SystemPrivateUriVersion>4.3.2</SystemPrivateUriVersion>
     <SystemSecurityCryptographyX509CertificatesVersion>4.3.2</SystemSecurityCryptographyX509CertificatesVersion>
     <SystemRuntimeInteropServicesRuntimeInformationVersion>4.3.0</SystemRuntimeInteropServicesRuntimeInformationVersion>
     <SystemThreadingTasksExtensionsVersion>4.5.4</SystemThreadingTasksExtensionsVersion>

--- a/src/Azure/AzureAppServices.HostingStartup/src/Microsoft.AspNetCore.AzureAppServices.HostingStartup.csproj
+++ b/src/Azure/AzureAppServices.HostingStartup/src/Microsoft.AspNetCore.AzureAppServices.HostingStartup.csproj
@@ -13,7 +13,6 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.AzureAppServicesIntegration" />
     <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
-    <Reference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
+++ b/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
@@ -21,7 +21,6 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore" />
     <Reference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" />
-    <Reference Include="System.Text.Json" />
 
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Templating" PrivateAssets="All" Version="$(MicrosoftDotNetBuildTasksTemplatingVersion)" IsImplicitlyDefined="true" AllowExplicitReference="true" />
   </ItemGroup>

--- a/src/Components/test/testassets/BasicTestApp/BasicTestApp.csproj
+++ b/src/Components/test/testassets/BasicTestApp/BasicTestApp.csproj
@@ -28,7 +28,6 @@
     <Reference Include="Microsoft.AspNetCore.SignalR.Client" />
     <Reference Include="Microsoft.Extensions.Logging.Configuration" />
     <Reference Include="Newtonsoft.Json" />
-    <Reference Include="System.Private.Uri" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Features/JsonPatch/src/Microsoft.AspNetCore.JsonPatch.csproj
+++ b/src/Features/JsonPatch/src/Microsoft.AspNetCore.JsonPatch.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.CSharp" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
     <Reference Include="Newtonsoft.Json" />
   </ItemGroup>
 

--- a/src/Logging.AzureAppServices/src/Microsoft.Extensions.Logging.AzureAppServices.csproj
+++ b/src/Logging.AzureAppServices/src/Microsoft.Extensions.Logging.AzureAppServices.csproj
@@ -18,7 +18,7 @@
     <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
     <Reference Include="Microsoft.Extensions.Logging.Configuration" />
     <Reference Include="Microsoft.Extensions.Logging" />
-    <Reference Include="System.ValueTuple" />
+    <Reference Include="System.ValueTuple" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == '$(DefaultNetFxTargetFramework)' OR '$(MSBuildRestoreSessionId)' == ''">

--- a/src/Servers/IIS/IIS/perf/Microbenchmarks/IIS.Microbenchmarks.csproj
+++ b/src/Servers/IIS/IIS/perf/Microbenchmarks/IIS.Microbenchmarks.csproj
@@ -37,7 +37,6 @@
   <ItemGroup>
     <Reference Include="BenchmarkDotNet" />
     <Reference Include="Microsoft.AspNetCore.Server.IISIntegration" />
-    <Reference Include="System.Private.Uri" />
 
     <Compile Include="$(SharedSourceRoot)BenchmarkRunner\*.cs" />
   </ItemGroup>

--- a/src/Servers/IIS/IIS/samples/NativeIISSample/NativeIISSample.csproj
+++ b/src/Servers/IIS/IIS/samples/NativeIISSample/NativeIISSample.csproj
@@ -14,7 +14,6 @@
     <Reference Include="Microsoft.AspNetCore.Server.IIS" />
     <Reference Include="Microsoft.AspNetCore.Server.IISIntegration" />
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel" />
-    <Reference Include="System.Private.Uri" />
   </ItemGroup>
 
 </Project>

--- a/src/Servers/IIS/IIS/test/IIS.Tests/IIS.Tests.csproj
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/IIS.Tests.csproj
@@ -21,7 +21,6 @@
     <Reference Include="Microsoft.AspNetCore.Server.IIS" />
     <Reference Include="Microsoft.Extensions.Logging" />
     <Reference Include="System.Diagnostics.EventLog" />
-    <Reference Include="System.Private.Uri" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Servers/IIS/IIS/test/testassets/InProcessNewShimWebSite/InProcessNewShimWebSite.csproj
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessNewShimWebSite/InProcessNewShimWebSite.csproj
@@ -59,9 +59,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" >
       <AllowExplicitReference>true</AllowExplicitReference>
     </PackageReference>
-    <PackageReference Include="System.Private.Uri" Version="4.3.2" >
-      <AllowExplicitReference>true</AllowExplicitReference>
-    </PackageReference>
     <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" >
       <AllowExplicitReference>true</AllowExplicitReference>
     </PackageReference>

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/InProcessWebSite.csproj
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/InProcessWebSite.csproj
@@ -34,7 +34,6 @@
     <Reference Include="Microsoft.Extensions.Configuration.Json" />
     <Reference Include="Microsoft.Extensions.Hosting" />
     <Reference Include="Microsoft.Extensions.Logging.Console" />
-    <Reference Include="System.Private.Uri" />
     <Reference Include="xunit.assert" />
   </ItemGroup>
 </Project>

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/Microsoft.AspNetCore.Server.IntegrationTesting.IIS.csproj
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/Microsoft.AspNetCore.Server.IntegrationTesting.IIS.csproj
@@ -70,9 +70,6 @@
 
     <Reference Include="Microsoft.NETCore.Windows.ApiSets" />
     <Reference Include="Microsoft.Web.Administration" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Security.Cryptography.X509Certificates" />
-    <Reference Include="System.Security.Principal.Windows" />
     <Reference Include="System.ServiceProcess.ServiceController" />
   </ItemGroup>
 

--- a/src/SignalR/clients/csharp/Client.Core/src/Microsoft.AspNetCore.SignalR.Client.Core.csproj
+++ b/src/SignalR/clients/csharp/Client.Core/src/Microsoft.AspNetCore.SignalR.Client.Core.csproj
@@ -33,7 +33,7 @@
     <Reference Include="Microsoft.AspNetCore.SignalR.Protocols.Json" />
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
     <Reference Include="Microsoft.Extensions.Logging" />
-    <Reference Include="System.Threading.Channels" />
+    <Reference Include="System.Threading.Channels" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != '$(DefaultNetCoreTargetFramework)'">

--- a/src/Testing/src/Microsoft.AspNetCore.InternalTesting.csproj
+++ b/src/Testing/src/Microsoft.AspNetCore.InternalTesting.csproj
@@ -28,7 +28,7 @@
     <Reference Include="Microsoft.Extensions.Logging" />
     <Reference Include="Serilog.Extensions.Logging" />
     <Reference Include="Serilog.Sinks.File" />
-    <Reference Include="System.ValueTuple" />
+    <Reference Include="System.ValueTuple" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
 
     <!--
       This intentionally does not reference 'xunit', 'xunit.core', or any runner packages.

--- a/src/Tools/GetDocumentInsider/src/GetDocument.Insider.csproj
+++ b/src/Tools/GetDocumentInsider/src/GetDocument.Insider.csproj
@@ -19,7 +19,7 @@
     <Reference Include="Microsoft.Extensions.Hosting.Abstractions" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <Reference Include="System.Diagnostics.DiagnosticSource" />
   </ItemGroup>
 

--- a/src/Tools/Microsoft.dotnet-openapi/src/Microsoft.dotnet-openapi.csproj
+++ b/src/Tools/Microsoft.dotnet-openapi/src/Microsoft.dotnet-openapi.csproj
@@ -17,8 +17,6 @@
   <ItemGroup>
     <Reference Include="Microsoft.Build" ExcludeAssets="runtime" />
     <Reference Include="Microsoft.Build.Locator" />
-    <Reference Include="System.Private.Uri" />
-    <Reference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tools/dotnet-sql-cache/src/dotnet-sql-cache.csproj
+++ b/src/Tools/dotnet-sql-cache/src/dotnet-sql-cache.csproj
@@ -16,9 +16,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.Data.SqlClient" />
     <Reference Include="Azure.Identity" />
-    <Reference Include="System.Private.Uri" />
     <Reference Include="System.Runtime.Caching" />
-    <Reference Include="System.Text.Json" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/sdk/pull/46829

NuGet added a new feature that automatically prunes package and project references that are provided by the shared framework that is targeted.

Resolve warnings that get emitted when building non-source-only.
