### PR TITLE
Avoid IISHttpServer close race on construction

### DIFF
--- a/src/Servers/IIS/IIS/src/Core/IISHttpServer.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpServer.cs
@@ -28,7 +28,7 @@ internal sealed class IISHttpServer : IServer
     private readonly IISServerOptions _options;
     private readonly IISNativeApplication _nativeApplication;
     private readonly ServerAddressesFeature _serverAddressesFeature;
-    private readonly string? _virtualPath;
+    private string? _virtualPath;
 
     private readonly TaskCompletionSource _shutdownSignal = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
     private bool? _websocketAvailable;
@@ -69,8 +69,6 @@ internal sealed class IISHttpServer : IServer
         _logger = logger;
         _options = options.Value;
         _serverAddressesFeature = new ServerAddressesFeature();
-        var iisConfigData = NativeMethods.HttpGetApplicationProperties();
-        _virtualPath = iisConfigData.pwzVirtualApplicationPath;
 
         if (_options.ForwardWindowsAuthentication)
         {
@@ -105,6 +103,9 @@ internal sealed class IISHttpServer : IServer
             &OnRequestsDrained,
             (IntPtr)_httpServerHandle,
             (IntPtr)_httpServerHandle);
+
+        var iisConfigData = NativeMethods.HttpGetApplicationProperties();
+        _virtualPath = iisConfigData.pwzVirtualApplicationPath;
 
         _serverAddressesFeature.Addresses = _options.ServerAddresses;
 

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/AppOfflineIISExpressTests.cs
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/AppOfflineIISExpressTests.cs
@@ -19,6 +19,7 @@ public class AppOfflineIISExpressTests : IISFunctionalTestBase
     }
 
     [ConditionalFact]
+    [Repeat(100)]
     public async Task AppOfflineDroppedWhileSiteStarting_SiteShutsDown_InProcess()
     {
         // This test often hits a race between debug logging and stdout redirection closing the handle

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/AppOfflineIISExpressTests.cs
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/AppOfflineIISExpressTests.cs
@@ -19,7 +19,7 @@ public class AppOfflineIISExpressTests : IISFunctionalTestBase
     }
 
     [ConditionalFact]
-    [Repeat(100)]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/60482")]
     public async Task AppOfflineDroppedWhileSiteStarting_SiteShutsDown_InProcess()
     {
         // This test often hits a race between debug logging and stdout redirection closing the handle

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/AppOfflineIISExpressTests.cs
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/AppOfflineIISExpressTests.cs
@@ -56,8 +56,8 @@ public class AppOfflineIISExpressTests : IISFunctionalTestBase
                 {
                     // For IISExpress, we need to catch the exception because IISExpress will not restart a process if it crashed.
                     // RemoveAppOffline will fail due to a bad request exception as the server is down.
-                    Assert.Contains(TestSink.Writes, context => context.Message.Contains("Drained all requests, notifying managed."));
                     deploymentResult.AssertWorkerProcessStop();
+                    Assert.Contains(TestSink.Writes, context => context.Message.Contains("Drained all requests, notifying managed."));
                     return;
                 }
             }


### PR DESCRIPTION
Avoid throwing in IISHttpServer.ctor by moving the native call into `IServer.StartAsync`, also setting up native to managed callbacks before doing anything else so that if there are any errors native can still tell managed it's shutting down.

The `NativeMethods.HttpGetApplicationProperties()` call can throw if the native side is shutting down while the managed side is starting up.

Quarantine test tracking: https://github.com/dotnet/aspnetcore/issues/60482