### PR TITLE
Fix installer package versioning

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -278,9 +278,9 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <!-- Set the arcade before common targets so we compute ExcludeFromBuild before arcade uses it. -->
-    <CustomBeforeMicrosoftCommonTargets>$(MSBuildThisFileDirectory)Directory.Build.BeforeCommonTargets.targets</CustomBeforeMicrosoftCommonTargets>
-    <CustomBeforeMicrosoftCommonCrossTargetingTargets>$(MSBuildThisFileDirectory)Directory.Build.BeforeCommonTargets.targets</CustomBeforeMicrosoftCommonCrossTargetingTargets>
+    <!-- Set the before common targets so we compute ExcludeFromBuild before arcade uses it. -->
+    <CustomBeforeMicrosoftCommonTargets>$(MSBuildThisFileDirectory)Directory.Build.BeforeCommonTargets.targets;$(CustomBeforeMicrosoftCommonTargets)</CustomBeforeMicrosoftCommonTargets>
+    <CustomBeforeMicrosoftCommonCrossTargetingTargets>$(MSBuildThisFileDirectory)Directory.Build.BeforeCommonTargets.targets;$(CustomBeforeMicrosoftCommonCrossTargetingTargets)</CustomBeforeMicrosoftCommonCrossTargetingTargets>
   </PropertyGroup>
 
   <Import Project="eng\Workarounds.props" />

--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.sfxproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.sfxproj
@@ -32,7 +32,7 @@
 
     <!-- Needed some creativity to convert the PackageVersion M.N.P-PreReleaseVersionLabel-Build to the installer version M.N.P~PreReleaseVersionLabel-Build, The conditional handles stabilized builds -->
     <DotnetRuntimeDependencyVersion>$(MicrosoftNETCoreAppRefVersion)</DotnetRuntimeDependencyVersion>
-    <DotnetRuntimeDependencyVersion Condition="$(DotnetTargetingPackDependencyVersion.Contains('-'))">$(DotnetTargetingPackDependencyVersion.Substring(0, $(DotnetTargetingPackDependencyVersion.IndexOf('-'))))~$(DotnetTargetingPackDependencyVersion.Substring($([MSBuild]::Add($(DotnetTargetingPackDependencyVersion.IndexOf('-')), 1))))</DotnetRuntimeDependencyVersion>
+    <DotnetRuntimeDependencyVersion Condition="$(DotnetRuntimeDependencyVersion.Contains('-'))">$(DotnetRuntimeDependencyVersion.Substring(0, $(DotnetRuntimeDependencyVersion.IndexOf('-'))))~$(DotnetRuntimeDependencyVersion.Substring($([MSBuild]::Add($(DotnetRuntimeDependencyVersion.IndexOf('-')), 1))))</DotnetRuntimeDependencyVersion>
     <DotnetRuntimeDependencyMajorMinorVersion>$(MicrosoftNETCoreAppRefVersion.Split('.')[0]).$(MicrosoftNETCoreAppRefVersion.Split('.')[1])</DotnetRuntimeDependencyMajorMinorVersion>
 
     <!-- Setting this suppresses getting documentation .xml files in the shared runtime output. -->

--- a/src/Tools/Directory.Build.targets
+++ b/src/Tools/Directory.Build.targets
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup Condition=" '$(PackAsTool)' == 'true' ">
     <!-- Microsoft tool packages are required to target both x64 and x86. -->
-    <PackAsToolShimRuntimeIdentifiers Condition=" '$(IsShippingPackage)' == 'true' AND '$(DotNetBuildSourceOnly)' != 'true' ">win-x64;win-x86</PackAsToolShimRuntimeIdentifiers>
+    <PackAsToolShimRuntimeIdentifiers Condition=" '$(IsShippingPackage)' == 'true' AND '$(TargetOsName)' == 'win' ">win-x64;win-x86</PackAsToolShimRuntimeIdentifiers>
     <!-- None of the tool projects are project reference providers. -->
     <IsProjectReferenceProvider>false</IsProjectReferenceProvider>
     <!--


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/4895

Changes in `src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.sfxproj` are fixing package dependency versions.

Changes in `Directory.Build.props` are fixing package versions, to allow inclusion of prerelease version suffix. `VersionSuffix` is used in packaging infra: https://github.com/dotnet/arcade/blob/ae3c938af5df4a2db45ded37dd05608ce59d8e5e/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.build.targets#L36

However due to a bug in `Directory.Build.Props`, arcade's `BeforeCommonTargets.targets` are not imported early enough - see https://github.com/dotnet/source-build/issues/4895#issuecomment-2659850271. The fix is to preserve the existing values of `CustomBeforeMicrosoftCommonTargets` and `CustomBeforeMicrosoftCommonCrossTargetingTargets` properties, and prepend the custom targets used by this repo.

Due to the above change in `Directory.Build.Props` some projects are only now evaluating all arcade properties correctly, which caused a build issue in two shipping tools projects (Microsoft.dotnet-openapi.csproj and dotnet-sql-cache.csproj), due to `PackAsToolShimRuntimeIdentifier` being assigned Windows runtime identifiers in Linux builds - which of course won't work.

Therefore I have also had to make a third change, in `src/Tools/Directory.Build.targets` to fix the evaluation of `PackAsToolShimRuntimeIdentifiers` in tools projects.