### PR TITLE
Increase Grpc InteropTests timeout

### DIFF
--- a/src/Grpc/Interop/test/InteropTests/InteropTests.cs
+++ b/src/Grpc/Interop/test/InteropTests/InteropTests.cs
@@ -11,7 +11,7 @@ namespace InteropTests;
 // Tests are separate methods so that they can be quarantined separately.
 public class InteropTests
 {
-    private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(60);
     private readonly string _clientPath = Path.Combine(Directory.GetCurrentDirectory(), "InteropClient", "InteropClient.dll");
     private readonly string _serverPath = Path.Combine(Directory.GetCurrentDirectory(), "InteropWebsite", "InteropWebsite.dll");
     private readonly ITestOutputHelper _output;


### PR DESCRIPTION
These tests have started timing out suddenly and they show zero server output. Seems the machines got slower or something, increasing the timeout as they shouldn't be failing in this way.