### PR TITLE
Limit types that get converted to null for empty/null input in NullableConverter

### DIFF
--- a/src/Components/Endpoints/test/FormMapping/Converters/NullableConverterTests.cs
+++ b/src/Components/Endpoints/test/FormMapping/Converters/NullableConverterTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Microsoft.AspNetCore.Components.Endpoints.FormMapping;
 using Microsoft.Extensions.Primitives;
@@ -146,5 +147,95 @@ public class NullableConverterTests
         Assert.True(found);
         Assert.False(returnValue);
         Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryConvertValue_ForCustomParsableStruct_UsesParsableImplementation_ForEmptyString()
+    {
+        var culture = CultureInfo.GetCultureInfo("en-US");
+
+        var nullableConverter = new NullableConverter<ParsableTestStruct>(new ParsableConverter<ParsableTestStruct>());
+        var reader = new FormDataReader(default, culture, default);
+
+        var returnValue = nullableConverter.TryConvertValue(ref reader, string.Empty, out var result);
+
+        Assert.True(returnValue);
+        Assert.NotNull(result);
+        Assert.True(result.Value.WasEmptyOrNull);
+    }
+
+    [Fact]
+    public void TryConvertValue_ForCustomParsableStruct_UsesParsableImplementation_ForNull()
+    {
+        var culture = CultureInfo.GetCultureInfo("en-US");
+
+        var nullableConverter = new NullableConverter<ParsableTestStruct>(new ParsableConverter<ParsableTestStruct>());
+        var reader = new FormDataReader(default, culture, default);
+
+        var returnValue = nullableConverter.TryConvertValue(ref reader, null, out var result);
+
+        Assert.True(returnValue);
+        Assert.NotNull(result);
+        Assert.True(result.Value.WasEmptyOrNull);
+    }
+
+
+    [Fact]
+    public void TryConvertValue_ForCustomParsableStruct_UsesParsableImplementation_ForGoodValue()
+    {
+        var culture = CultureInfo.GetCultureInfo("en-US");
+
+        var nullableConverter = new NullableConverter<ParsableTestStruct>(new ParsableConverter<ParsableTestStruct>());
+        var reader = new FormDataReader(default, culture, default)
+        {
+            ErrorHandler = (_, __, ___) => { }
+        };
+
+        var returnValue = nullableConverter.TryConvertValue(ref reader, "good value", out var result);
+
+        Assert.True(returnValue);
+        Assert.False(result.Value.WasEmptyOrNull);
+    }
+
+    [Fact]
+    public void TryConvertValue_ForCustomParsableStruct_UsesParsableImplementation_ForBadValue()
+    {
+        var culture = CultureInfo.GetCultureInfo("en-US");
+
+        var nullableConverter = new NullableConverter<ParsableTestStruct>(new ParsableConverter<ParsableTestStruct>());
+        var reader = new FormDataReader(default, culture, default)
+        {
+            ErrorHandler = (_, __, ___) => { }
+        };
+
+        var returnValue = nullableConverter.TryConvertValue(ref reader, "bad value", out var result);
+
+        Assert.False(returnValue);
+    }
+
+    private struct ParsableTestStruct : IParsable<ParsableTestStruct>
+    {
+        public bool WasEmptyOrNull { get; set; }
+
+        public static ParsableTestStruct Parse(string s, IFormatProvider provider) => throw new NotImplementedException();
+
+        public static bool TryParse([NotNullWhen(true)] string s, IFormatProvider provider, [MaybeNullWhen(false)] out ParsableTestStruct result)
+        {
+            if (string.IsNullOrEmpty(s))
+            {
+                result = new ParsableTestStruct { WasEmptyOrNull = true };
+                return true;
+            }
+            else if (s == "good value")
+            {
+                result = new ParsableTestStruct { WasEmptyOrNull = false };
+                return true;
+            }
+            else
+            {
+                result = new();
+                return false;
+            }
+        }
     }
 }

--- a/src/Components/Endpoints/test/FormMapping/Converters/NullableConverterTests.cs
+++ b/src/Components/Endpoints/test/FormMapping/Converters/NullableConverterTests.cs
@@ -179,7 +179,6 @@ public class NullableConverterTests
         Assert.True(result.Value.WasEmptyOrNull);
     }
 
-
     [Fact]
     public void TryConvertValue_ForCustomParsableStruct_UsesParsableImplementation_ForGoodValue()
     {


### PR DESCRIPTION
Limits the nullable types for which empty string or null input gets converted to `null` in `NullableConverter`. After the change this only happens for types that either have `TypeCode != TypeCode.Object` or belong to a set of special supported types (currently `DateOnly`, `TimeOnly`, `DateTimeOffset`).

Other types get processed by the respective non-nullable converter as was the case before https://github.com/dotnet/aspnetcore/pull/52499. In particular, types implementing `IParsable` (with the exception of the types mentioned above) get converted using their `TryParse` method (via `ParsableConverter`) which means they can provide custom implementation for handling empty/null inputs.