### PR TITLE
Fix for PackAsToolShimRuntimeIdentifiers property in VMR builds

### DIFF
--- a/src/Tools/Directory.Build.targets
+++ b/src/Tools/Directory.Build.targets
@@ -1,7 +1,9 @@
 <Project>
   <PropertyGroup Condition=" '$(PackAsTool)' == 'true' ">
     <!-- Microsoft tool packages are required to target both x64 and x86. -->
-    <PackAsToolShimRuntimeIdentifiers Condition=" '$(IsShippingPackage)' == 'true' AND '$(TargetOsName)' == 'win' ">win-x64;win-x86</PackAsToolShimRuntimeIdentifiers>
+    <!-- In VMR builds we only use the current RID. -->
+    <PackAsToolShimRuntimeIdentifiers Condition=" '$(IsShippingPackage)' == 'true' AND '$(DotNetBuild)' != 'true' ">win-x64;win-x86</PackAsToolShimRuntimeIdentifiers>
+    <PackAsToolShimRuntimeIdentifiers Condition=" '$(IsShippingPackage)' == 'true' AND '$(DotNetBuild)' == 'true' AND '$(TargetOsName)' == 'win' ">$(TargetRid)</PackAsToolShimRuntimeIdentifiers>
     <!-- None of the tool projects are project reference providers. -->
     <IsProjectReferenceProvider>false</IsProjectReferenceProvider>
     <!--


### PR DESCRIPTION
Fixes the VMR issue in `aspnetcore` flow: https://github.com/dotnet/sdk/pull/46926#issuecomment-2669375880

In VMR build we only have one package version, matching the `TargetRid`.

Otherwise we're getting these types of errors - this is in x64 build:
```
src\aspnetcore\src\Tools\Microsoft.dotnet-openapi\src\Microsoft.dotnet-openapi.csproj(0,0): error NU1102:
 (NETCORE_ENGINEERING_TELEMETRY=Restore) Unable to find package Microsoft.NETCore.App.Host.win-x86 with version (= 10.0.0-ci)
  - Found 1458 version(s) in dotnet8 [ Nearest version: 8.0.0-rtm.23523.3 ]
  - Found 1417 version(s) in dotnet9 [ Nearest version: 9.0.0-rtm.24516.5 ]
```