### PR TITLE
[release/10.0-preview1] Do not remove wixpacks from items to sign

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -24,8 +24,6 @@
     <ItemsToSign Include="$(VisualStudioSetupOutputPath)**\*.vsix" />
     <ItemsToSign Include="$(ArtifactsDir)installers\$(Configuration)\**\*.exe" />
     <ItemsToSign Include="$(ArtifactsDir)installers\$(Configuration)\**\*.msi" />
-    <ItemsToSign Remove="$(ArtifactsDir)installers\$(Configuration)\**\*.wixpack.zip" />
-    <ItemsToSign Remove="$(ArtifactsPackagesDir)**\*.wixpack.zip" />
     <ItemsToSign Remove="$(ArtifactsPackagesDir)**\*symbols.nupkg" />
   </ItemGroup>
 


### PR DESCRIPTION
They need to be in the list so that they are identified as the pack for an msi or exe that can be unpacked, signed, and then used to re-create the msi/exe.
