### PR TITLE
Fix: Mark catch-all route parameters as optional (#60392)

### DIFF
--- a/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
@@ -317,9 +317,12 @@ public class DefaultApiDescriptionProvider : IApiDescriptionProvider
 
             if (parameter.Source == BindingSource.Path && parameter.RouteInfo != null)
             {
-                // If the route template contains a catch-all parameter marker ("{**"), treat it as optional.
-                var template = context.ActionDescriptor.AttributeRouteInfo?.Template;
-                if (!string.IsNullOrEmpty(template) && template.Contains("{**"))
+                // Locate the corresponding route parameter metadata.
+                var routeParam = context.RouteParameters
+                    .FirstOrDefault(rp => string.Equals(rp.Name, parameter.Name, StringComparison.OrdinalIgnoreCase));
+
+                // If the parameter is defined as a catch-all, mark it as optional.
+                if (routeParam != null && routeParam.IsCatchAll)
                 {
                     parameter.IsRequired = false;
                 }

--- a/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
@@ -315,9 +315,18 @@ public class DefaultApiDescriptionProvider : IApiDescriptionProvider
                 parameter.IsRequired = true;
             }
 
-            if (parameter.Source == BindingSource.Path && parameter.RouteInfo != null && !parameter.RouteInfo.IsOptional)
+            if (parameter.Source == BindingSource.Path && parameter.RouteInfo != null)
             {
-                parameter.IsRequired = true;
+                // If the route template contains a catch-all parameter marker ("{**"), treat it as optional.
+                var template = context.ActionDescriptor.AttributeRouteInfo?.Template;
+                if (!string.IsNullOrEmpty(template) && template.Contains("{**"))
+                {
+                    parameter.IsRequired = false;
+                }
+                else if (!parameter.RouteInfo.IsOptional)
+                {
+                    parameter.IsRequired = true;
+                }
             }
         }
     }

--- a/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
@@ -33,6 +33,23 @@ namespace Microsoft.AspNetCore.Mvc.Description;
 public class DefaultApiDescriptionProviderTest
 {
     [Fact]
+    public void CatchAllParameter_IsReportedAsOptional()
+    {
+        // Arrange: Create an action descriptor with a catch-all route template.
+        var action = CreateActionDescriptor();
+        action.AttributeRouteInfo = new AttributeRouteInfo { Template = "{**catchAllParameter}" };
+
+        // Act: Get the API descriptions using the existing helper.
+        var descriptions = GetApiDescriptions(action);
+
+        // Assert: There should be one description, with one parameter named "catchAllParameter"
+        // and its IsRequired property should be false.
+        var description = Assert.Single(descriptions);
+        var parameter = Assert.Single(description.ParameterDescriptions, p => p.Name == "catchAllParameter");
+        Assert.False(parameter.IsRequired);
+    }
+
+    [Fact]
     public void GetApiDescription_IgnoresNonControllerActionDescriptor()
     {
         // Arrange

--- a/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
@@ -33,20 +33,33 @@ namespace Microsoft.AspNetCore.Mvc.Description;
 public class DefaultApiDescriptionProviderTest
 {
     [Fact]
-    public void CatchAllParameter_IsReportedAsOptional()
+    public void OnlyCatchAllParameter_IsReportedAsOptional()
     {
-        // Arrange: Create an action descriptor with a catch-all route template.
+        // Arrange: Create an action descriptor with a multi-parameter route template.
         var action = CreateActionDescriptor();
-        action.AttributeRouteInfo = new AttributeRouteInfo { Template = "{**catchAllParameter}" };
+        action.AttributeRouteInfo = new AttributeRouteInfo
+        {
+            Template = "/products/{category}/items/{group}/inventory/{**any}"
+        };
 
         // Act: Get the API descriptions using the existing helper.
         var descriptions = GetApiDescriptions(action);
 
-        // Assert: There should be one description, with one parameter named "catchAllParameter"
-        // and its IsRequired property should be false.
+        // Assert: Only the 'any' parameter should be optional.
         var description = Assert.Single(descriptions);
-        var parameter = Assert.Single(description.ParameterDescriptions, p => p.Name == "catchAllParameter");
-        Assert.False(parameter.IsRequired);
+        var categoryParameter = Assert.Single(description.ParameterDescriptions,
+            p => string.Equals(p.Name, "category", StringComparison.OrdinalIgnoreCase));
+        var groupParameter = Assert.Single(description.ParameterDescriptions,
+            p => string.Equals(p.Name, "group", StringComparison.OrdinalIgnoreCase));
+        var anyParameter = Assert.Single(description.ParameterDescriptions,
+            p => string.Equals(p.Name, "any", StringComparison.OrdinalIgnoreCase));
+
+        // The non-catch-all parameters should be required.
+        Assert.True(categoryParameter.IsRequired);
+        Assert.True(groupParameter.IsRequired);
+
+        // The catch-all parameter should be optional.
+        Assert.False(anyParameter.IsRequired);
     }
 
     [Fact]


### PR DESCRIPTION
# Fix: Catch-All Route Parameters Incorrectly Marked as Required in ApiExplorer

## Description

This pull request addresses an issue in ASP.NET Core’s `ApiExplorer` where catch-all route parameters (e.g., `{**catchAllParameter}`) are erroneously marked as required, despite being optional in practice. At runtime, catch-all parameters match all values—including empty strings—so they should be considered optional. This discrepancy results in misleading API metadata, negatively impacting API documentation and client generation.

## Changes Made

- Added a new unit test in `DefaultApiDescriptionProviderTest` to validate that catch-all route parameters are reported as optional.
- Followed a **Test-Driven Development (TDD)** approach: the test initially failed (confirming the bug) and then served as a baseline for the fix.
- Updated the `ProcessIsRequired` method in `DefaultApiDescriptionProvider`:
  - Now examines the route template for a catch-all marker (`{**`).
  - If a catch-all marker is detected, the parameter’s `IsRequired` property is set to `false`.
  - Otherwise, the existing behavior is maintained.
- Ensures that `ApiExplorer` metadata aligns with actual routing semantics.

## Testing

- The new unit test confirms that when a controller action defines a catch-all route parameter, it is correctly marked as optional.
- The complete test suite was executed to verify that the changes do not negatively impact other aspects of `ApiExplorer` functionality.

## Impact

- This change is **limited to API metadata generation logic** and does **not** affect the runtime behavior of existing applications.
- By accurately reflecting the optional nature of catch-all parameters, this fix improves:
  - The quality of generated API documentation (e.g., OpenAPI/Swagger).
  - The reliability of client libraries and automated testing tools by minimizing potential errors.
