### PR TITLE
Fix overload resolution issue for Delegate and RequestDelegate

### DIFF
--- a/src/Http/Routing/src/Builder/EndpointRouteBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/EndpointRouteBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
@@ -227,6 +228,7 @@ public static class EndpointRouteBuilderExtensions
     /// <returns>A <see cref="RouteHandlerBuilder"/> that can be used to further customize the endpoint.</returns>
     [RequiresUnreferencedCode(MapEndpointUnreferencedCodeWarning)]
     [RequiresDynamicCode(MapEndpointDynamicCodeWarning)]
+    [OverloadResolutionPriority(1)]
     public static RouteHandlerBuilder MapGet(
         this IEndpointRouteBuilder endpoints,
         [StringSyntax("Route")] string pattern,
@@ -245,6 +247,7 @@ public static class EndpointRouteBuilderExtensions
     /// <returns>A <see cref="RouteHandlerBuilder"/> that can be used to further customize the endpoint.</returns>
     [RequiresUnreferencedCode(MapEndpointUnreferencedCodeWarning)]
     [RequiresDynamicCode(MapEndpointDynamicCodeWarning)]
+    [OverloadResolutionPriority(1)]
     public static RouteHandlerBuilder MapPost(
         this IEndpointRouteBuilder endpoints,
         [StringSyntax("Route")] string pattern,
@@ -263,6 +266,7 @@ public static class EndpointRouteBuilderExtensions
     /// <returns>A <see cref="RouteHandlerBuilder"/> that can be used to further customize the endpoint.</returns>
     [RequiresUnreferencedCode(MapEndpointUnreferencedCodeWarning)]
     [RequiresDynamicCode(MapEndpointDynamicCodeWarning)]
+    [OverloadResolutionPriority(1)]
     public static RouteHandlerBuilder MapPut(
         this IEndpointRouteBuilder endpoints,
         [StringSyntax("Route")] string pattern,
@@ -281,6 +285,7 @@ public static class EndpointRouteBuilderExtensions
     /// <returns>A <see cref="RouteHandlerBuilder"/> that can be used to further customize the endpoint.</returns>
     [RequiresUnreferencedCode(MapEndpointUnreferencedCodeWarning)]
     [RequiresDynamicCode(MapEndpointDynamicCodeWarning)]
+    [OverloadResolutionPriority(1)]
     public static RouteHandlerBuilder MapDelete(
         this IEndpointRouteBuilder endpoints,
         [StringSyntax("Route")] string pattern,
@@ -299,6 +304,7 @@ public static class EndpointRouteBuilderExtensions
     /// <returns>A <see cref="RouteHandlerBuilder"/> that can be used to further customize the endpoint.</returns>
     [RequiresUnreferencedCode(MapEndpointUnreferencedCodeWarning)]
     [RequiresDynamicCode(MapEndpointDynamicCodeWarning)]
+    [OverloadResolutionPriority(1)]
     public static RouteHandlerBuilder MapPatch(
         this IEndpointRouteBuilder endpoints,
         [StringSyntax("Route")] string pattern,
@@ -338,6 +344,7 @@ public static class EndpointRouteBuilderExtensions
     /// <returns>A <see cref="RouteHandlerBuilder"/> that can be used to further customize the endpoint.</returns>
     [RequiresUnreferencedCode(MapEndpointUnreferencedCodeWarning)]
     [RequiresDynamicCode(MapEndpointDynamicCodeWarning)]
+    [OverloadResolutionPriority(1)]
     public static RouteHandlerBuilder Map(
         this IEndpointRouteBuilder endpoints,
         [StringSyntax("Route")] string pattern,
@@ -413,6 +420,7 @@ public static class EndpointRouteBuilderExtensions
     /// </remarks>
     [RequiresUnreferencedCode(MapEndpointUnreferencedCodeWarning)]
     [RequiresDynamicCode(MapEndpointDynamicCodeWarning)]
+    [OverloadResolutionPriority(1)]
     public static RouteHandlerBuilder MapFallback(
         this IEndpointRouteBuilder endpoints,
         [StringSyntax("Route")] string pattern,

--- a/src/Http/Routing/src/Builder/FallbackEndpointRouteBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/FallbackEndpointRouteBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
 
 namespace Microsoft.AspNetCore.Builder;
 
@@ -74,7 +75,7 @@ public static class FallbackEndpointRouteBuilderExtensions
         ArgumentNullException.ThrowIfNull(pattern);
         ArgumentNullException.ThrowIfNull(requestDelegate);
 
-        var conventionBuilder = endpoints.Map(pattern, requestDelegate);
+        var conventionBuilder = endpoints.Map(RoutePatternFactory.Parse(pattern), requestDelegate);
         conventionBuilder.WithDisplayName("Fallback " + pattern);
         conventionBuilder.Add(b => ((RouteEndpointBuilder)b).Order = int.MaxValue);
         conventionBuilder.WithMetadata(FallbackMetadata.Instance);

--- a/src/Http/Routing/src/ShortCircuit/RouteShortCircuitEndpointRouteBuilderExtensions.cs
+++ b/src/Http/Routing/src/ShortCircuit/RouteShortCircuitEndpointRouteBuilderExtensions.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing.Patterns;
 
 namespace Microsoft.AspNetCore.Routing;
 
@@ -34,7 +35,7 @@ public static class RouteShortCircuitEndpointRouteBuilderExtensions
             {
                 route = $"{routePrefix}/{{**catchall}}";
             }
-            group.Map(route, _shortCircuitDelegate)
+            group.Map(RoutePatternFactory.Parse(route), _shortCircuitDelegate)
                 .ShortCircuit(statusCode)
                 .Add(endpoint =>
                 {

--- a/src/Middleware/HealthChecks/src/Builder/HealthCheckEndpointRouteBuilderExtensions.cs
+++ b/src/Middleware/HealthChecks/src/Builder/HealthCheckEndpointRouteBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
@@ -68,6 +69,6 @@ public static class HealthCheckEndpointRouteBuilderExtensions
            .UseMiddleware<HealthCheckMiddleware>(args)
            .Build();
 
-        return endpoints.Map(pattern, pipeline).WithDisplayName(DefaultDisplayName);
+        return endpoints.Map(RoutePatternFactory.Parse(pattern), pipeline).WithDisplayName(DefaultDisplayName);
     }
 }

--- a/src/SignalR/common/Http.Connections/src/ConnectionEndpointRouteBuilderExtensions.cs
+++ b/src/SignalR/common/Http.Connections/src/ConnectionEndpointRouteBuilderExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.Http.Connections.Internal;
 using Microsoft.AspNetCore.Http.Timeouts;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Builder;
@@ -99,7 +100,7 @@ public static class ConnectionEndpointRouteBuilderExtensions
         app.Run(c => dispatcher.ExecuteNegotiateAsync(c, options));
         var negotiateHandler = app.Build();
 
-        var negotiateBuilder = endpoints.Map(pattern + "/negotiate", negotiateHandler);
+        var negotiateBuilder = endpoints.Map(RoutePatternFactory.Parse(pattern + "/negotiate"), negotiateHandler);
         conventionBuilders.Add(negotiateBuilder);
         // Add the negotiate metadata so this endpoint can be identified
         negotiateBuilder.WithMetadata(_negotiateMetadata);
@@ -111,7 +112,7 @@ public static class ConnectionEndpointRouteBuilderExtensions
         app.Run(c => dispatcher.ExecuteAsync(c, options, connectionDelegate));
         var executehandler = app.Build();
 
-        var executeBuilder = endpoints.Map(pattern, executehandler);
+        var executeBuilder = endpoints.Map(RoutePatternFactory.Parse(pattern), executehandler);
         executeBuilder.WithMetadata(new DisableRequestTimeoutAttribute());
         conventionBuilders.Add(executeBuilder);
 


### PR DESCRIPTION
Test to try resolve the issue where the RequestDelegate overload is
chosen by the compiler instead of the Delegate overload by using the
OverloadResolutionPriority attribute. 

However, maybe this change will cause other unwanted side effects?