### PR TITLE
Fix incorrect path to included script file in Blazor project template

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/ReconnectModal.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/ReconnectModal.razor
@@ -1,4 +1,4 @@
-﻿<script type="module" src="@Assets["Layout/ReconnectModal.razor.js"]"></script>
+﻿<script type="module" src="@Assets["Components/Layout/ReconnectModal.razor.js"]"></script>
 
 <dialog id="components-reconnect-modal" data-nosnippet>
     <div class="components-reconnect-container">


### PR DESCRIPTION
The update to the Blazor project template made in https://github.com/dotnet/aspnetcore/pull/60376 contained an incorrect path to a script file, causing an 404 error when running an application created from that template.

Fixes [#3482](https://github.com/dotnet/AspNetCore-ManualTests/issues/3482)
