### PR TITLE
Add a new UseKestel API to the WebApplicationFactory

### DIFF
--- a/src/Mvc/Mvc.Testing/src/Microsoft.AspNetCore.Mvc.Testing.csproj
+++ b/src/Mvc/Mvc.Testing/src/Microsoft.AspNetCore.Mvc.Testing.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.TestHost" />
     <Reference Include="Microsoft.AspNetCore.Mvc.Core" />
+    <Reference Include="Microsoft.AspNetCore.Server.Kestrel" />
     <Reference Include="Microsoft.Extensions.DependencyModel" />
     <Reference Include="Microsoft.Extensions.Hosting" />
     <Reference Include="Microsoft.Extensions.HostFactoryResolver.Sources" />

--- a/src/Mvc/Mvc.Testing/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.Testing/src/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
 #nullable enable
 *REMOVED*Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.Server.get -> Microsoft.AspNetCore.TestHost.TestServer!
+Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.Initialize() -> void
 Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.Server.get -> Microsoft.AspNetCore.TestHost.TestServer?
 Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.UseKestrel() -> void
-virtual Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.CreateHandler() -> System.Net.Http.HttpMessageHandler!

--- a/src/Mvc/Mvc.Testing/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.Testing/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 #nullable enable
+*REMOVED*Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.Server.get -> Microsoft.AspNetCore.TestHost.TestServer!
+Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.Server.get -> Microsoft.AspNetCore.TestHost.TestServer?
+Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.UseKestrel() -> void
+virtual Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.CreateHandler() -> System.Net.Http.HttpMessageHandler!

--- a/src/Mvc/Mvc.Testing/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.Testing/src/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
 #nullable enable
-*REMOVED*Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.Server.get -> Microsoft.AspNetCore.TestHost.TestServer!
-Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.Initialize() -> void
-Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.Server.get -> Microsoft.AspNetCore.TestHost.TestServer?
+Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.StartServer() -> void
 Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.UseKestrel() -> void
+Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.UseKestrel(int port) -> void
+Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>.UseKestrel(System.Action<Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions!>! configureKestrelOptions) -> void

--- a/src/Mvc/Mvc.Testing/src/Resources.resx
+++ b/src/Mvc/Mvc.Testing/src/Resources.resx
@@ -127,7 +127,10 @@
     <value>Can't find '{0}'. This file is required for functional tests to run properly. There should be a copy of the file on your source project bin folder. If that is not the case, make sure that the property PreserveCompilationContext is set to true on your project file. E.g '&lt;PreserveCompilationContext&gt;true&lt;/PreserveCompilationContext&gt;'. For functional tests to work they need to either run from the build output folder or the {1} file from your application's output directory must be copied to the folder where the tests are running on. A common cause for this error is having shadow copying enabled when the tests run.</value>
   </data>
   <data name="ServerNotInitialized" xml:space="preserve">
-    <value>Server hasn't been initialized yet. Plase intialized the server first before trying to create a client.</value>
+    <value>Server hasn't been initialized yet. Please initialize the server first before trying to create a client.</value>
+  </data>
+  <data name="TestServerNotSupportedWhenUsingKestrel" xml:space="preserve">
+    <value>Accessing the `Server` property isn't supported when using Kestrel server.</value>
   </data>
   <data name="UseKestrelCanBeCalledBeforeInitialization" xml:space="preserve">
     <value>UseKestrel should be called before server initialization. Calling UseKestrel after the server was initialized will have no effect.</value>

--- a/src/Mvc/Mvc.Testing/src/Resources.resx
+++ b/src/Mvc/Mvc.Testing/src/Resources.resx
@@ -129,4 +129,7 @@
   <data name="ServerNotInitialized" xml:space="preserve">
     <value>Server hasn't been initialized yet. Plase intialized the server first before trying to create a client.</value>
   </data>
+  <data name="UseKestrelCanBeCalledBeforeInitialization" xml:space="preserve">
+    <value>UseKestrel should be called before server initialization. Calling UseKestrel after the server was initialized will have no effect.</value>
+  </data>
 </root>

--- a/src/Mvc/Mvc.Testing/src/Resources.resx
+++ b/src/Mvc/Mvc.Testing/src/Resources.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -125,5 +125,8 @@
   </data>
   <data name="MissingDepsFile" xml:space="preserve">
     <value>Can't find '{0}'. This file is required for functional tests to run properly. There should be a copy of the file on your source project bin folder. If that is not the case, make sure that the property PreserveCompilationContext is set to true on your project file. E.g '&lt;PreserveCompilationContext&gt;true&lt;/PreserveCompilationContext&gt;'. For functional tests to work they need to either run from the build output folder or the {1} file from your application's output directory must be copied to the folder where the tests are running on. A common cause for this error is having shadow copying enabled when the tests run.</value>
+  </data>
+  <data name="ServerNotInitialized" xml:space="preserve">
+    <value>Server hasn't been initialized yet. Plase intialized the server first before trying to create a client.</value>
   </data>
 </root>

--- a/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
+++ b/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
@@ -111,6 +111,11 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
     }
 
     /// <summary>
+    /// Helps determine if the `StartServer` method has been called already.
+    /// </summary>
+    private bool ServerStarted => _webHost != null || _host != null || _server != null;
+
+    /// <summary>
     /// Gets the <see cref="IReadOnlyList{WebApplicationFactory}"/> of factories created from this factory
     /// by further customizing the <see cref="IWebHostBuilder"/> when calling
     /// <see cref="WebApplicationFactory{TEntryPoint}.WithWebHostBuilder(Action{IWebHostBuilder})"/>.
@@ -239,7 +244,7 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
     /// <exception cref="InvalidOperationException">Thrown if the provided <typeparamref name="TEntryPoint"/> type has no factory method.</exception>
     public void StartServer()
     {
-        if (_webHost != null || _host != null)
+        if (ServerStarted)
         {
             return;
         }

--- a/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
+++ b/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
@@ -572,11 +572,7 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
         return client;
     }
 
-    /// <summary>
-    /// Creates a custom <see cref="HttpMessageHandler" /> for processing HTTP requests/responses with the test server.
-    /// </summary>
-
-    protected virtual HttpMessageHandler CreateHandler()
+    private HttpMessageHandler CreateHandler()
     {
         if (_useKestrel)
         {

--- a/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
+++ b/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
@@ -164,7 +164,7 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
     /// </summary>
     public void UseKestrel()
     {
-        if (_server != null || _webHost != null)
+        if (ServerStarted)
         {
             throw new InvalidOperationException(Resources.UseKestrelCanBeCalledBeforeInitialization);
         }

--- a/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
+++ b/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
@@ -85,7 +85,7 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
         {
             if (_useKestrel)
             {
-                throw new NotSupportedException();
+                throw new NotSupportedException(Resources.TestServerNotSupportedWhenUsingKestrel);
             }
 
             StartServer();

--- a/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
+++ b/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
@@ -78,7 +78,7 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
     {
         get
         {
-            EnsureServer();
+            Initialize();
             return _server;
         }
     }
@@ -90,7 +90,7 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
     {
         get
         {
-            EnsureServer();
+            Initialize();
             if (_useKestrel)
             {
                 return _webHost!.Services;
@@ -149,6 +149,11 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
     /// </summary>
     public void UseKestrel()
     {
+        if (_server != null || _webHost != null)
+        {
+            throw new InvalidOperationException(Resources.UseKestrelCanBeCalledBeforeInitialization);
+        }
+
         _useKestrel = true;
     }
 
@@ -159,7 +164,11 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
         return host;
     }
 
-    private void EnsureServer()
+    /// <summary>
+    /// Initializes the instance by configurating the host builder.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown if the provided <typeparamref name="TEntryPoint"/> type has no factory method.</exception>
+    public void Initialize()
     {
         if (_server != null || _webHost != null)
         {
@@ -533,7 +542,7 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
     /// <returns>The <see cref="HttpClient"/>.</returns>
     public HttpClient CreateDefaultClient(params DelegatingHandler[] handlers)
     {
-        EnsureServer();
+        Initialize();
 
         HttpClient client;
         if (handlers == null || handlers.Length == 0)
@@ -571,6 +580,8 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
 
         return client;
     }
+
+
 
     private HttpMessageHandler CreateHandler()
     {

--- a/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
+++ b/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
@@ -9,7 +9,6 @@ using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;

--- a/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
+++ b/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
@@ -581,8 +581,6 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
         return client;
     }
 
-
-
     private HttpMessageHandler CreateHandler()
     {
         if (_useKestrel)

--- a/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
+++ b/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
@@ -31,7 +31,7 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
     private IHost? _host;
     private Action<IWebHostBuilder> _configuration;
     private IWebHost? _webHost;
-    private Uri _webHostAddress;
+    private Uri? _webHostAddress;
     private readonly List<HttpClient> _clients = new();
     private readonly List<WebApplicationFactory<TEntryPoint>> _derivedFactories = new();
 
@@ -507,7 +507,7 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
 
         if (_useKestrel)
         {
-            // Have to do this, as the ClientOptions.BaseAddress will be set to poitn to the kestrel server,
+            // Have to do this, as the ClientOptions.BaseAddress will be set to point to the kestrel server,
             // and it may not match the original base address value.
             client.BaseAddress = ClientOptions.BaseAddress;
         }

--- a/src/Mvc/Mvc.Testing/src/WebApplicationFactoryClientOptions.cs
+++ b/src/Mvc/Mvc.Testing/src/WebApplicationFactoryClientOptions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
@@ -14,6 +14,8 @@ namespace Microsoft.AspNetCore.Mvc.Testing;
 /// </summary>
 public class WebApplicationFactoryClientOptions
 {
+    internal static readonly Uri DefaultBaseAddres = new Uri("http://localhost");
+
     /// <summary>
     /// Initializes a new instance of <see cref="WebApplicationFactoryClientOptions"/>.
     /// </summary>
@@ -35,7 +37,7 @@ public class WebApplicationFactoryClientOptions
     /// <see cref="WebApplicationFactory{TEntryPoint}.CreateClient(WebApplicationFactoryClientOptions)"/>.
     /// The default is <c>http://localhost</c>.
     /// </summary>
-    public Uri BaseAddress { get; set; } = new Uri("http://localhost");
+    public Uri BaseAddress { get; set; } = DefaultBaseAddres;
 
     /// <summary>
     /// Gets or sets whether or not <see cref="HttpClient"/> instances created by calling

--- a/src/Mvc/test/Mvc.FunctionalTests/KestrelBasedWapFactory.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/KestrelBasedWapFactory.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace Microsoft.AspNetCore.Mvc.FunctionalTests;
+
+public class KestrelBasedWapFactory : WebApplicationFactory<SimpleWebSite.Startup>
+{
+    public KestrelBasedWapFactory() : base()
+    {
+        this.UseKestrel();
+    }
+}

--- a/src/Mvc/test/Mvc.FunctionalTests/KestrelBasedWapFactory.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/KestrelBasedWapFactory.cs
@@ -9,6 +9,7 @@ public class KestrelBasedWapFactory : WebApplicationFactory<SimpleWebSite.Startu
 {
     public KestrelBasedWapFactory() : base()
     {
-        this.UseKestrel();
+        // Use dynamically assigned port to avoid test conflicts in CI.
+        this.UseKestrel(0);
     }
 }

--- a/src/Mvc/test/Mvc.FunctionalTests/KestrelBasedWebApplicationFactory.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/KestrelBasedWebApplicationFactory.cs
@@ -5,9 +5,9 @@ using Microsoft.AspNetCore.Mvc.Testing;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests;
 
-public class KestrelBasedWapFactory : WebApplicationFactory<SimpleWebSite.Startup>
+public class KestrelBasedWebApplicationFactory : WebApplicationFactory<SimpleWebSite.Startup>
 {
-    public KestrelBasedWapFactory() : base()
+    public KestrelBasedWebApplicationFactory() : base()
     {
         // Use dynamically assigned port to avoid test conflicts in CI.
         this.UseKestrel(0);

--- a/src/Mvc/test/Mvc.FunctionalTests/RealServerBackedIntegrationTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RealServerBackedIntegrationTests.cs
@@ -54,23 +54,4 @@ public class RealServerBackedIntegrationTests : IClassFixture<KestrelBasedWapFac
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
-
-    [Fact]
-    public async Task ServerReachableViaGenericHttpClient_OnSpecificPort()
-    {
-        // Arrange
-        var port = 7777;
-        var baseAddress = new Uri($"http://localhost:{port}");
-
-        // Act
-        Factory.UseKestrel(port);
-        Factory.StartServer();
-
-        using var client = new HttpClient() { BaseAddress = baseAddress };
-
-        using var response = await client.GetAsync("/");
-
-        // Assert
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-    }
 }

--- a/src/Mvc/test/Mvc.FunctionalTests/RealServerBackedIntegrationTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RealServerBackedIntegrationTests.cs
@@ -54,4 +54,23 @@ public class RealServerBackedIntegrationTests : IClassFixture<KestrelBasedWapFac
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
+
+    [Fact]
+    public async Task ServerReachableViaGenericHttpClient_OnSpecificPort()
+    {
+        // Arrange
+        var port = 7777;
+        var baseAddress = new Uri($"http://localhost:{port}");
+
+        // Act
+        Factory.UseKestrel(port);
+        Factory.StartServer();
+
+        using var client = new HttpClient() { BaseAddress = baseAddress };
+
+        using var response = await client.GetAsync("/");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
 }

--- a/src/Mvc/test/Mvc.FunctionalTests/RealServerBackedIntegrationTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RealServerBackedIntegrationTests.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace Microsoft.AspNetCore.Mvc.FunctionalTests;
+
+public class RealServerBackedIntegrationTests : IClassFixture<KestrelBasedWapFactory>
+{
+    public KestrelBasedWapFactory Factory { get; }
+
+    public RealServerBackedIntegrationTests(KestrelBasedWapFactory factory)
+    {
+        Factory = factory;
+    }
+
+    [Fact]
+    public async Task RetrievesDataFromRealServer()
+    {
+        // Arrange
+        var expectedMediaType = MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
+
+        // Act
+        var client = Factory.CreateClient();
+        var response = await client.GetAsync("/");
+        var responseContent = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(expectedMediaType, response.Content.Headers.ContentType);
+
+        Assert.Equal(5000, client.BaseAddress.Port);
+
+        Assert.Contains("first", responseContent);
+        Assert.Contains("second", responseContent);
+        Assert.Contains("wall", responseContent);
+        Assert.Contains("floor", responseContent);
+    }
+}

--- a/src/Mvc/test/Mvc.FunctionalTests/RealServerBackedIntegrationTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RealServerBackedIntegrationTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net;
+using System.Net.Http;
 using System.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests;
@@ -36,5 +37,21 @@ public class RealServerBackedIntegrationTests : IClassFixture<KestrelBasedWapFac
         Assert.Contains("second", responseContent);
         Assert.Contains("wall", responseContent);
         Assert.Contains("floor", responseContent);
+    }
+
+    [Fact]
+    public async Task ServerReachableViaGenericHttpClient()
+    {
+        // Arrange
+        var baseAddress = new Uri("http://localhost:5000");
+
+        // Act
+        using var factoryClient = Factory.CreateClient();
+        using var client = new HttpClient() { BaseAddress = factoryClient.BaseAddress };
+
+        using var response = await client.GetAsync("/");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 }

--- a/src/Mvc/test/Mvc.FunctionalTests/RealServerBackedIntegrationTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RealServerBackedIntegrationTests.cs
@@ -7,11 +7,11 @@ using System.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests;
 
-public class RealServerBackedIntegrationTests : IClassFixture<KestrelBasedWapFactory>
+public class RealServerBackedIntegrationTests : IClassFixture<KestrelBasedWebApplicationFactory>
 {
-    public KestrelBasedWapFactory Factory { get; }
+    public KestrelBasedWebApplicationFactory Factory { get; }
 
-    public RealServerBackedIntegrationTests(KestrelBasedWapFactory factory)
+    public RealServerBackedIntegrationTests(KestrelBasedWebApplicationFactory factory)
     {
         Factory = factory;
     }

--- a/src/Mvc/test/Mvc.FunctionalTests/RealServerBackedIntegrationTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RealServerBackedIntegrationTests.cs
@@ -31,8 +31,6 @@ public class RealServerBackedIntegrationTests : IClassFixture<KestrelBasedWapFac
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal(expectedMediaType, response.Content.Headers.ContentType);
 
-        Assert.Equal(5000, client.BaseAddress.Port);
-
         Assert.Contains("first", responseContent);
         Assert.Contains("second", responseContent);
         Assert.Contains("wall", responseContent);

--- a/src/Mvc/test/Mvc.FunctionalTests/RealServerWithCustomConfigurationIntegrationTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RealServerWithCustomConfigurationIntegrationTests.cs
@@ -7,13 +7,13 @@ using System.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests;
 
-public class RealServerWithCustomConfigurationIntegrationTests : IClassFixture<KestrelBasedWapFactory>
+public class RealServerWithCustomConfigurationIntegrationTests : IClassFixture<KestrelBasedWebApplicationFactory>
 {
     private int _optionsConfiguredCounter = 0;
 
-    public KestrelBasedWapFactory Factory { get; }
+    public KestrelBasedWebApplicationFactory Factory { get; }
 
-    public RealServerWithCustomConfigurationIntegrationTests(KestrelBasedWapFactory factory)
+    public RealServerWithCustomConfigurationIntegrationTests(KestrelBasedWebApplicationFactory factory)
     {
         Factory = factory;
         Factory.UseKestrel(options => { _optionsConfiguredCounter++; });

--- a/src/Mvc/test/Mvc.FunctionalTests/RealServerWithCustomConfigurationIntegrationTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RealServerWithCustomConfigurationIntegrationTests.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+namespace Microsoft.AspNetCore.Mvc.FunctionalTests;
+
+public class RealServerWithCustomConfigurationIntegrationTests : IClassFixture<KestrelBasedWapFactory>
+{
+    private int _optionsConfiguredCounter = 0;
+
+    public KestrelBasedWapFactory Factory { get; }
+
+    public RealServerWithCustomConfigurationIntegrationTests(KestrelBasedWapFactory factory)
+    {
+        Factory = factory;
+        Factory.UseKestrel(options => { _optionsConfiguredCounter++; });
+    }
+
+    [Fact]
+    public async Task ServerReachableViaGenericHttpClient()
+    {
+        // Arrange
+
+        // Act
+        Assert.Equal(0, _optionsConfiguredCounter);
+        Factory.StartServer();
+
+        using var client = Factory.CreateClient();
+
+        using var response = await client.GetAsync("/");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(1, _optionsConfiguredCounter);
+    }
+}

--- a/src/Mvc/test/Mvc.FunctionalTests/RealServerWithDynamicPortIntegrationTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RealServerWithDynamicPortIntegrationTests.cs
@@ -4,14 +4,15 @@
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using Microsoft.AspNetCore.Mvc.Testing;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests;
 
-public class RealServerWithDynamicPortIntegrationTests : IClassFixture<KestrelBasedWapFactory>
+public class RealServerWithDynamicPortIntegrationTests : IClassFixture<KestrelBasedWebApplicationFactory>
 {
-    public KestrelBasedWapFactory Factory { get; }
+    public KestrelBasedWebApplicationFactory Factory { get; }
 
-    public RealServerWithDynamicPortIntegrationTests(KestrelBasedWapFactory factory)
+    public RealServerWithDynamicPortIntegrationTests(KestrelBasedWebApplicationFactory factory)
     {
         Factory = factory;
 

--- a/src/Mvc/test/Mvc.FunctionalTests/RealServerWithDynamicPortIntegrationTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RealServerWithDynamicPortIntegrationTests.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+namespace Microsoft.AspNetCore.Mvc.FunctionalTests;
+
+public class RealServerWithDynamicPortIntegrationTests : IClassFixture<KestrelBasedWapFactory>
+{
+    public KestrelBasedWapFactory Factory { get; }
+
+    public RealServerWithDynamicPortIntegrationTests(KestrelBasedWapFactory factory)
+    {
+        Factory = factory;
+
+        // Use dynamic port
+        Factory.UseKestrel(0);
+    }
+
+    [Fact]
+    public async Task ServerReachableViaGenericHttpClient()
+    {
+        // Arrange
+        using var client = new HttpClient();
+        using var factoryClient = Factory.CreateClient();
+        client.BaseAddress = factoryClient.BaseAddress;
+
+        // Act
+        using var response = await client.GetAsync("/");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+}

--- a/src/Mvc/test/Mvc.FunctionalTests/RealServerWithSpecifiedPortBackedIntegrationTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RealServerWithSpecifiedPortBackedIntegrationTests.cs
@@ -7,13 +7,13 @@ using System.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests;
 
-public class RealServerWithSpecifiedPortBackedIntegrationTests : IClassFixture<KestrelBasedWapFactory>
+public class RealServerWithSpecifiedPortBackedIntegrationTests : IClassFixture<KestrelBasedWebApplicationFactory>
 {
     private const int ServerPort = 7777;
 
-    public KestrelBasedWapFactory Factory { get; }
+    public KestrelBasedWebApplicationFactory Factory { get; }
 
-    public RealServerWithSpecifiedPortBackedIntegrationTests(KestrelBasedWapFactory factory)
+    public RealServerWithSpecifiedPortBackedIntegrationTests(KestrelBasedWebApplicationFactory factory)
     {
         Factory = factory;
         Factory.UseKestrel(ServerPort);

--- a/src/Mvc/test/Mvc.FunctionalTests/RealServerWithSpecifiedPortBackedIntegrationTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RealServerWithSpecifiedPortBackedIntegrationTests.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+namespace Microsoft.AspNetCore.Mvc.FunctionalTests;
+
+public class RealServerWithSpecifiedPortBackedIntegrationTests : IClassFixture<KestrelBasedWapFactory>
+{
+    private const int ServerPort = 7777;
+
+    public KestrelBasedWapFactory Factory { get; }
+
+    public RealServerWithSpecifiedPortBackedIntegrationTests(KestrelBasedWapFactory factory)
+    {
+        Factory = factory;
+        Factory.UseKestrel(ServerPort);
+    }
+
+    [Fact]
+    public async Task ServerReachableViaGenericHttpClient_OnSpecificPort()
+    {
+        // Arrange
+        var baseAddress = new Uri($"http://localhost:{ServerPort}");
+
+        // Act
+        Factory.StartServer();
+
+        using var client = new HttpClient() { BaseAddress = baseAddress };
+
+        using var response = await client.GetAsync("/");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+}


### PR DESCRIPTION
- Added `UseKestrel(...)` APIs to the WebApplicationFactory<T> type. The API configures the WAF, so that later during initialization it will use Kestrel, instead of a TestServer for WebHostBuilder-based applications.
- Two different overloads (described in the API Proposal https://github.com/dotnet/aspnetcore/issues/60758) are added
- Renamed the `EnsureServer()` private method to `StartServer()` and made it public, so that consumers can call it directly, without the need of creating a client, as in many situations customers didn't need a client to interact with.


This is an alternative design to enabling real server usage with WebApplicationFactory, which was considered here: https://github.com/dotnet/aspnetcore/pull/60247

Fixes https://github.com/dotnet/aspnetcore/issues/4892

