### PR TITLE
Unquarantine EventCountersAndMetricsValues and VerifyCountersFireWithCorrectValues

### DIFF
--- a/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
@@ -22,7 +22,6 @@ namespace Microsoft.AspNetCore.Hosting.Tests;
 public class HostingApplicationDiagnosticsTests : LoggedTest
 {
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/57259")]
     public async Task EventCountersAndMetricsValues()
     {
         // Arrange

--- a/src/Hosting/Hosting/test/Internal/HostingEventSourceTests.cs
+++ b/src/Hosting/Hosting/test/Internal/HostingEventSourceTests.cs
@@ -176,7 +176,6 @@ public class HostingEventSourceTests : LoggedTest
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/57259")]
     public async Task VerifyCountersFireWithCorrectValues()
     {
         // Arrange


### PR DESCRIPTION
Fixes #57259

I've checked and EventCountersAndMetricsValues and VerifyCountersFireWithCorrectValues both seem to have passed 289 out of 289 times in the last 30 days, and were flagged `test-fixed` over 30 days ago, so I think they qualify for unquarantining.

@JamesNK, I think you fixed these. Are you happy for them to be unquarantined now?