### PR TITLE
Only build BuildAfterTargeting pack on win-x64

### DIFF
--- a/src/BuildAfterTargetingPack/BuildAfterTargetingPack.csproj
+++ b/src/BuildAfterTargetingPack/BuildAfterTargetingPack.csproj
@@ -42,7 +42,7 @@
   <!-- In VMR builds, only build on win-x64 -->
   <Target Name="BuildDelayedProjects"
       BeforeTargets="Build"
-      Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND AND ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64') "
+      Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64') "
       Returns="@(TargetPathWithTargetPlatformMoniker)">
     <MSBuild Projects="@(RequiresDelayedBuild)"
         BuildInParallel="$(BuildInParallel)"
@@ -53,13 +53,13 @@
     </MSBuild>
   </Target>
 
-  <Target Name="CleanDelayedProjects" BeforeTargets="Clean" Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND AND ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64') ">
+  <Target Name="CleanDelayedProjects" BeforeTargets="Clean" Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64') ">
     <MSBuild Projects="@(RequiresDelayedBuild)" BuildInParallel="$(BuildInParallel)" Targets="Clean" />
   </Target>
 
   <Target Name="CreateHelixPayloadDelayedProjects"
       BeforeTargets="CreateHelixPayload"
-      Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND AND ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64') "
+      Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64') "
       Returns="@(HelixWorkItem)">
     <MSBuild Projects="@(RequiresDelayedBuild)"
         BuildInParallel="$(BuildInParallel)"
@@ -77,19 +77,19 @@
     </MSBuild>
   </Target>
 
-  <Target Name="PackDelayedProjects" BeforeTargets="Pack" Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND AND ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64') ">
+  <Target Name="PackDelayedProjects" BeforeTargets="Pack" Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64') ">
     <MSBuild Projects="@(RequiresDelayedBuild)" BuildInParallel="$(BuildInParallel)" Targets="Pack" />
   </Target>
 
-  <Target Name="PublishDelayedProjects" BeforeTargets="Publish" Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND AND ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64') ">
+  <Target Name="PublishDelayedProjects" BeforeTargets="Publish" Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64') ">
     <MSBuild Projects="@(RequiresDelayedBuild)" BuildInParallel="$(BuildInParallel)" Targets="Publish" />
   </Target>
 
-  <Target Name="TestDelayedProjects" BeforeTargets="Test" Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND AND ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64') ">
+  <Target Name="TestDelayedProjects" BeforeTargets="Test" Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64') ">
     <MSBuild Projects="@(RequiresDelayedBuild)" BuildInParallel="$(BuildInParallel)" Targets="Test" />
   </Target>
 
-  <Target Name="VSTestDelayedProjects" BeforeTargets="VSTest" Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND AND ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64') ">
+  <Target Name="VSTestDelayedProjects" BeforeTargets="VSTest" Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64') ">
     <MSBuild Projects="@(RequiresDelayedBuild)" BuildInParallel="$(BuildInParallel)" Targets="VSTest" />
   </Target>
 

--- a/src/BuildAfterTargetingPack/BuildAfterTargetingPack.csproj
+++ b/src/BuildAfterTargetingPack/BuildAfterTargetingPack.csproj
@@ -39,9 +39,10 @@
   </ItemGroup>
 
   <!-- Cannot build in source-build because that does not create an App.Ref layout. -->
+  <!-- In VMR builds, only build on win-x64 -->
   <Target Name="BuildDelayedProjects"
       BeforeTargets="Build"
-      Condition=" '$(DotNetBuildSourceOnly)' != 'true' "
+      Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND ('$(DotNetBuild)' != 'true' OR ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64')) "
       Returns="@(TargetPathWithTargetPlatformMoniker)">
     <MSBuild Projects="@(RequiresDelayedBuild)"
         BuildInParallel="$(BuildInParallel)"
@@ -52,13 +53,13 @@
     </MSBuild>
   </Target>
 
-  <Target Name="CleanDelayedProjects" BeforeTargets="Clean" Condition=" '$(DotNetBuildSourceOnly)' != 'true' ">
+  <Target Name="CleanDelayedProjects" BeforeTargets="Clean" Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND ('$(DotNetBuild)' != 'true' OR ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64')) ">
     <MSBuild Projects="@(RequiresDelayedBuild)" BuildInParallel="$(BuildInParallel)" Targets="Clean" />
   </Target>
 
   <Target Name="CreateHelixPayloadDelayedProjects"
       BeforeTargets="CreateHelixPayload"
-      Condition=" '$(DotNetBuildSourceOnly)' != 'true' "
+      Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND ('$(DotNetBuild)' != 'true' OR ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64')) "
       Returns="@(HelixWorkItem)">
     <MSBuild Projects="@(RequiresDelayedBuild)"
         BuildInParallel="$(BuildInParallel)"
@@ -76,19 +77,19 @@
     </MSBuild>
   </Target>
 
-  <Target Name="PackDelayedProjects" BeforeTargets="Pack" Condition=" '$(DotNetBuildSourceOnly)' != 'true' ">
+  <Target Name="PackDelayedProjects" BeforeTargets="Pack" Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND ('$(DotNetBuild)' != 'true' OR ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64')) ">
     <MSBuild Projects="@(RequiresDelayedBuild)" BuildInParallel="$(BuildInParallel)" Targets="Pack" />
   </Target>
 
-  <Target Name="PublishDelayedProjects" BeforeTargets="Publish" Condition=" '$(DotNetBuildSourceOnly)' != 'true' ">
+  <Target Name="PublishDelayedProjects" BeforeTargets="Publish" Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND ('$(DotNetBuild)' != 'true' OR ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64')) ">
     <MSBuild Projects="@(RequiresDelayedBuild)" BuildInParallel="$(BuildInParallel)" Targets="Publish" />
   </Target>
 
-  <Target Name="TestDelayedProjects" BeforeTargets="Test" Condition=" '$(DotNetBuildSourceOnly)' != 'true' ">
+  <Target Name="TestDelayedProjects" BeforeTargets="Test" Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND ('$(DotNetBuild)' != 'true' OR ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64')) ">
     <MSBuild Projects="@(RequiresDelayedBuild)" BuildInParallel="$(BuildInParallel)" Targets="Test" />
   </Target>
 
-  <Target Name="VSTestDelayedProjects" BeforeTargets="VSTest" Condition=" '$(DotNetBuildSourceOnly)' != 'true' ">
+  <Target Name="VSTestDelayedProjects" BeforeTargets="VSTest" Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND ('$(DotNetBuild)' != 'true' OR ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64')) ">
     <MSBuild Projects="@(RequiresDelayedBuild)" BuildInParallel="$(BuildInParallel)" Targets="VSTest" />
   </Target>
 

--- a/src/BuildAfterTargetingPack/BuildAfterTargetingPack.csproj
+++ b/src/BuildAfterTargetingPack/BuildAfterTargetingPack.csproj
@@ -39,7 +39,7 @@
   </ItemGroup>
 
   <!-- Cannot build in source-build because that does not create an App.Ref layout. -->
-  <!-- In VMR builds, only build on win-x64 -->
+  <!-- Only build on win-x64 -->
   <Target Name="BuildDelayedProjects"
       BeforeTargets="Build"
       Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64') "

--- a/src/BuildAfterTargetingPack/BuildAfterTargetingPack.csproj
+++ b/src/BuildAfterTargetingPack/BuildAfterTargetingPack.csproj
@@ -42,7 +42,7 @@
   <!-- In VMR builds, only build on win-x64 -->
   <Target Name="BuildDelayedProjects"
       BeforeTargets="Build"
-      Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND ('$(DotNetBuild)' != 'true' OR ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64')) "
+      Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND AND ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64') "
       Returns="@(TargetPathWithTargetPlatformMoniker)">
     <MSBuild Projects="@(RequiresDelayedBuild)"
         BuildInParallel="$(BuildInParallel)"
@@ -53,13 +53,13 @@
     </MSBuild>
   </Target>
 
-  <Target Name="CleanDelayedProjects" BeforeTargets="Clean" Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND ('$(DotNetBuild)' != 'true' OR ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64')) ">
+  <Target Name="CleanDelayedProjects" BeforeTargets="Clean" Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND AND ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64') ">
     <MSBuild Projects="@(RequiresDelayedBuild)" BuildInParallel="$(BuildInParallel)" Targets="Clean" />
   </Target>
 
   <Target Name="CreateHelixPayloadDelayedProjects"
       BeforeTargets="CreateHelixPayload"
-      Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND ('$(DotNetBuild)' != 'true' OR ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64')) "
+      Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND AND ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64') "
       Returns="@(HelixWorkItem)">
     <MSBuild Projects="@(RequiresDelayedBuild)"
         BuildInParallel="$(BuildInParallel)"
@@ -77,19 +77,19 @@
     </MSBuild>
   </Target>
 
-  <Target Name="PackDelayedProjects" BeforeTargets="Pack" Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND ('$(DotNetBuild)' != 'true' OR ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64')) ">
+  <Target Name="PackDelayedProjects" BeforeTargets="Pack" Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND AND ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64') ">
     <MSBuild Projects="@(RequiresDelayedBuild)" BuildInParallel="$(BuildInParallel)" Targets="Pack" />
   </Target>
 
-  <Target Name="PublishDelayedProjects" BeforeTargets="Publish" Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND ('$(DotNetBuild)' != 'true' OR ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64')) ">
+  <Target Name="PublishDelayedProjects" BeforeTargets="Publish" Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND AND ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64') ">
     <MSBuild Projects="@(RequiresDelayedBuild)" BuildInParallel="$(BuildInParallel)" Targets="Publish" />
   </Target>
 
-  <Target Name="TestDelayedProjects" BeforeTargets="Test" Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND ('$(DotNetBuild)' != 'true' OR ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64')) ">
+  <Target Name="TestDelayedProjects" BeforeTargets="Test" Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND AND ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64') ">
     <MSBuild Projects="@(RequiresDelayedBuild)" BuildInParallel="$(BuildInParallel)" Targets="Test" />
   </Target>
 
-  <Target Name="VSTestDelayedProjects" BeforeTargets="VSTest" Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND ('$(DotNetBuild)' != 'true' OR ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64')) ">
+  <Target Name="VSTestDelayedProjects" BeforeTargets="VSTest" Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND AND ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64') ">
     <MSBuild Projects="@(RequiresDelayedBuild)" BuildInParallel="$(BuildInParallel)" Targets="VSTest" />
   </Target>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/60530. This project just produces some .nupkg's, and doesn't build anything for the sharedFx/Ref pack. We can be certain that it never will, because by definition it builds after the targeting pack.

BuildAfterTargetingPack.csproj introduces flakiness into the build because it sometimes causes a race condition that leads to file conflicts - therefore we should build it as infrequently as possible (only on win-x64).

Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2652111&view=results