### PR TITLE
Update xcopy-msbuild to latest available version

### DIFF
--- a/global.json
+++ b/global.json
@@ -21,7 +21,7 @@
         "Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
       ]
     },
-    "xcopy-msbuild": "17.8.5"
+    "xcopy-msbuild": "17.13.0"
   },
   "native-tools": {
     "jdk": "latest"


### PR DESCRIPTION
# Update xcopy-msbuild to latest available version

Updated `xcopy-msbuild` in `global.json` to the latest available version on dotnet-eng

Fixes #60665 