### PR TITLE
Fix OpenAPI server URLs for Aspire scenarios

### DIFF
--- a/src/OpenApi/src/Extensions/OpenApiEndpointRouteBuilderExtensions.cs
+++ b/src/OpenApi/src/Extensions/OpenApiEndpointRouteBuilderExtensions.cs
@@ -43,7 +43,7 @@ public static class OpenApiEndpointRouteBuilderExtensions
                 }
                 else
                 {
-                    var document = await documentService.GetOpenApiDocumentAsync(context.RequestServices, context.RequestAborted);
+                    var document = await documentService.GetOpenApiDocumentAsync(context.RequestServices, context.Request, context.RequestAborted);
                     var documentOptions = options.Get(documentName);
                     using var output = MemoryBufferWriter.Get();
                     using var writer = Utf8BufferTextWriter.Get(output);

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -199,7 +199,18 @@ internal sealed class OpenApiDocumentService(
     {
         if (httpRequest is not null)
         {
-            var serverUrl = UriHelper.BuildAbsolute(httpRequest.Scheme, httpRequest.Host, httpRequest.PathBase);
+            // Handle forwarded headers directly if present
+            var scheme = httpRequest.Headers.GetCommaSeparatedValues("X-Forwarded-Proto") is [var forwardedScheme, ..]
+                        ? forwardedScheme
+                        : httpRequest.Scheme;
+
+            var host = httpRequest.Headers.GetCommaSeparatedValues("X-Forwarded-Host") is [var forwardedHost, ..]
+                             ? forwardedHost
+                             : httpRequest.Host.Value;
+
+            var hostString = new HostString(host);
+            var serverUrl = UriHelper.BuildAbsolute(scheme, hostString, httpRequest.PathBase);
+
             return [new OpenApiServer { Url = serverUrl }];
         }
         else
@@ -207,6 +218,7 @@ internal sealed class OpenApiDocumentService(
             return GetDevelopmentOpenApiServers();
         }
     }
+
     private List<OpenApiServer> GetDevelopmentOpenApiServers()
     {
         if (hostEnvironment.IsDevelopment() &&

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -199,18 +199,7 @@ internal sealed class OpenApiDocumentService(
     {
         if (httpRequest is not null)
         {
-            // Handle forwarded headers directly if present
-            var scheme = httpRequest.Headers.GetCommaSeparatedValues("X-Forwarded-Proto") is [var forwardedScheme, ..]
-                        ? forwardedScheme
-                        : httpRequest.Scheme;
-
-            var host = httpRequest.Headers.GetCommaSeparatedValues("X-Forwarded-Host") is [var forwardedHost, ..]
-                             ? forwardedHost
-                             : httpRequest.Host.Value;
-
-            var hostString = new HostString(host);
-            var serverUrl = UriHelper.BuildAbsolute(scheme, hostString, httpRequest.PathBase);
-
+            var serverUrl = UriHelper.BuildAbsolute(httpRequest.Scheme, httpRequest.Host, httpRequest.PathBase);
             return [new OpenApiServer { Url = serverUrl }];
         }
         else
@@ -218,7 +207,6 @@ internal sealed class OpenApiDocumentService(
             return GetDevelopmentOpenApiServers();
         }
     }
-
     private List<OpenApiServer> GetDevelopmentOpenApiServers()
     {
         if (hostEnvironment.IsDevelopment() &&

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Servers.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Servers.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.Extensions.DependencyInjection;
@@ -10,6 +11,45 @@ using Moq;
 
 public partial class OpenApiDocumentServiceTests
 {
+    [Theory]
+    [InlineData("Development", "localhost:5001", "", "http", "http://localhost:5001/")]
+    [InlineData("Development", "example.com", "/api", "https", "https://example.com/api")]
+    [InlineData("Staging", "localhost:5002", "/v1", "http", "http://localhost:5002/v1")]
+    [InlineData("Staging", "api.example.com", "/base/path", "https", "https://api.example.com/base/path")]
+    [InlineData("Development", "localhost", "/", "http", "http://localhost/")]
+    public void GetOpenApiServers_FavorsHttpContextRequestOverServerAddress(string environment, string host, string pathBase, string scheme, string expectedUri)
+    {
+        // Arrange
+        var hostEnvironment = new HostingEnvironment
+        {
+            ApplicationName = "TestApplication",
+            EnvironmentName = environment
+        };
+        var docService = new OpenApiDocumentService(
+            "v1",
+            new Mock<IApiDescriptionGroupCollectionProvider>().Object,
+            hostEnvironment,
+            GetMockOptionsMonitor(),
+            new Mock<IKeyedServiceProvider>().Object,
+            new OpenApiTestServer(["http://localhost:5000"]));
+        var httpContext = new DefaultHttpContext()
+        {
+            Request =
+            {
+                Host = new HostString(host),
+                PathBase = pathBase,
+                Scheme = scheme
+
+            }
+        };
+
+        // Act
+        var servers = docService.GetOpenApiServers(httpContext.Request);
+
+        // Assert
+        Assert.Contains(expectedUri, servers.Select(s => s.Url));
+    }
+
     [Fact]
     public void GetOpenApiServers_HandlesServerAddressFeatureWithValues()
     {

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Servers.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Servers.cs
@@ -146,47 +146,4 @@ public partial class OpenApiDocumentServiceTests
         // Assert
         Assert.Empty(servers);
     }
-
-    [Theory]
-    [InlineData("https", "proxy-server.com", "https://proxy-server.com/original-path")]
-    [InlineData("http", "proxy:8080", "http://proxy:8080/original-path")]
-    [InlineData("https", "proxy.example.org", "https://proxy.example.org/original-path")]
-    public void GetOpenApiServers_HandlesForwardedHeaders(string forwardedProto, string forwardedHost, string expectedUrl)
-    {
-        // Arrange
-        var hostEnvironment = new HostingEnvironment
-        {
-            ApplicationName = "TestApplication",
-            EnvironmentName = "Production"
-        };
-        var docService = new OpenApiDocumentService(
-            "v1",
-            new Mock<IApiDescriptionGroupCollectionProvider>().Object,
-            hostEnvironment,
-            GetMockOptionsMonitor(),
-            new Mock<IKeyedServiceProvider>().Object,
-            new OpenApiTestServer(["http://localhost:5000"]));
-
-        var httpContext = new DefaultHttpContext()
-        {
-            Request =
-            {
-                // Original values that should be overridden by forwarded headers
-                Host = new HostString("localhost:5000"),
-                PathBase = "/original-path",
-                Scheme = "http"
-            }
-        };
-
-        // Add forwarded headers
-        httpContext.Request.Headers["X-Forwarded-Proto"] = forwardedProto;
-        httpContext.Request.Headers["X-Forwarded-Host"] = forwardedHost;
-
-        // Act
-        var servers = docService.GetOpenApiServers(httpContext.Request);
-
-        // Assert
-        var serverUrl = Assert.Single(servers).Url;
-        Assert.Equal(expectedUrl, serverUrl);
-    }
 }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Servers.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Servers.cs
@@ -146,4 +146,47 @@ public partial class OpenApiDocumentServiceTests
         // Assert
         Assert.Empty(servers);
     }
+
+    [Theory]
+    [InlineData("https", "proxy-server.com", "https://proxy-server.com/original-path")]
+    [InlineData("http", "proxy:8080", "http://proxy:8080/original-path")]
+    [InlineData("https", "proxy.example.org", "https://proxy.example.org/original-path")]
+    public void GetOpenApiServers_HandlesForwardedHeaders(string forwardedProto, string forwardedHost, string expectedUrl)
+    {
+        // Arrange
+        var hostEnvironment = new HostingEnvironment
+        {
+            ApplicationName = "TestApplication",
+            EnvironmentName = "Production"
+        };
+        var docService = new OpenApiDocumentService(
+            "v1",
+            new Mock<IApiDescriptionGroupCollectionProvider>().Object,
+            hostEnvironment,
+            GetMockOptionsMonitor(),
+            new Mock<IKeyedServiceProvider>().Object,
+            new OpenApiTestServer(["http://localhost:5000"]));
+
+        var httpContext = new DefaultHttpContext()
+        {
+            Request =
+            {
+                // Original values that should be overridden by forwarded headers
+                Host = new HostString("localhost:5000"),
+                PathBase = "/original-path",
+                Scheme = "http"
+            }
+        };
+
+        // Add forwarded headers
+        httpContext.Request.Headers["X-Forwarded-Proto"] = forwardedProto;
+        httpContext.Request.Headers["X-Forwarded-Host"] = forwardedHost;
+
+        // Act
+        var servers = docService.GetOpenApiServers(httpContext.Request);
+
+        // Assert
+        var serverUrl = Assert.Single(servers).Url;
+        Assert.Equal(expectedUrl, serverUrl);
+    }
 }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentServiceTestsBase.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentServiceTestsBase.cs
@@ -35,16 +35,16 @@ public abstract class OpenApiDocumentServiceTestBase
     {
         var documentService = CreateDocumentService(builder, openApiOptions);
         var scopedService = ((TestServiceProvider)builder.ServiceProvider).CreateScope();
-        var document = await documentService.GetOpenApiDocumentAsync(scopedService.ServiceProvider, cancellationToken);
+        var document = await documentService.GetOpenApiDocumentAsync(scopedService.ServiceProvider, null, cancellationToken);
         verifyOpenApiDocument(document);
     }
 
-    public static async Task VerifyOpenApiDocument(ActionDescriptor action, Action<OpenApiDocument> verifyOpenApiDocument)
+    public static async Task VerifyOpenApiDocument(ActionDescriptor action, Action<OpenApiDocument> verifyOpenApiDocument, CancellationToken cancellationToken = default)
     {
         var builder = CreateBuilder();
         var documentService = CreateDocumentService(builder, action);
         var scopedService = ((TestServiceProvider)builder.ServiceProvider).CreateScope();
-        var document = await documentService.GetOpenApiDocumentAsync(scopedService.ServiceProvider);
+        var document = await documentService.GetOpenApiDocumentAsync(scopedService.ServiceProvider, null);
         verifyOpenApiDocument(document);
     }
 


### PR DESCRIPTION
## Description

This PR supports respecting he X-Forwarded-Proto and X-Forwarded-Host headers when generating server URLs in OpenAPI documents. When these headers are present in the request, the OpenAPI document service will use them to generate the correct server URLs instead of using the original host and scheme values derived from the service configuration.

This is particularly useful in environments where the API is behind a proxy, load balancer, or gateway, allowing the generated OpenAPI document to correctly reference the public-facing URL rather than the internal service URL.

Fixes https://github.com/dotnet/aspnetcore/issues/57332

## Customer Impact

Without this change, documents served behind reverse proxies or forwarded endpoints do not reflect the correct service URl, particularly impact for the ASP.NET Core + Aspire scenario. While the issue is easy to workaround, we want a smoother experience with Aspire out-of-the-box.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

Low-risk, becase change as it only affects the generation of server URLs in OpenAPI documents and does not impact the actual API functionality. 

## Verification

- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A
