### PR TITLE
Fix: Inconsistent certificate chain handling between endpoint and default configuration

### DIFF
--- a/src/Servers/Kestrel/Core/src/IHttpsConfigurationService.cs
+++ b/src/Servers/Kestrel/Core/src/IHttpsConfigurationService.cs
@@ -90,11 +90,19 @@ internal interface IHttpsConfigurationService
 internal readonly struct CertificateAndConfig
 {
     public readonly X509Certificate2 Certificate;
+    public readonly X509Certificate2Collection CertificateChain;
     public readonly CertificateConfig CertificateConfig;
 
     public CertificateAndConfig(X509Certificate2 certificate, CertificateConfig certificateConfig)
     {
         Certificate = certificate;
         CertificateConfig = certificateConfig;
+        CertificateChain = [];
+    }
+
+    public CertificateAndConfig(X509Certificate2 certificate, CertificateConfig certificateConfig, X509Certificate2Collection certificateChain){
+        Certificate = certificate;
+        CertificateConfig = certificateConfig;
+        CertificateChain = certificateChain;
     }
 }

--- a/src/Servers/Kestrel/Core/src/IHttpsConfigurationService.cs
+++ b/src/Servers/Kestrel/Core/src/IHttpsConfigurationService.cs
@@ -100,7 +100,8 @@ internal readonly struct CertificateAndConfig
         CertificateChain = [];
     }
 
-    public CertificateAndConfig(X509Certificate2 certificate, CertificateConfig certificateConfig, X509Certificate2Collection certificateChain){
+    public CertificateAndConfig(X509Certificate2 certificate, CertificateConfig certificateConfig, X509Certificate2Collection certificateChain)
+    {
         Certificate = certificate;
         CertificateConfig = certificateConfig;
         CertificateChain = certificateChain;

--- a/src/Servers/Kestrel/Core/src/IHttpsConfigurationService.cs
+++ b/src/Servers/Kestrel/Core/src/IHttpsConfigurationService.cs
@@ -94,10 +94,11 @@ internal readonly struct CertificateAndConfig
     public readonly CertificateConfig CertificateConfig;
 
     public CertificateAndConfig(X509Certificate2 certificate, CertificateConfig certificateConfig)
+        : this(
+            certificate,
+            certificateConfig,
+            [])
     {
-        Certificate = certificate;
-        CertificateConfig = certificateConfig;
-        CertificateChain = [];
     }
 
     public CertificateAndConfig(X509Certificate2 certificate, CertificateConfig certificateConfig, X509Certificate2Collection certificateChain)

--- a/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
@@ -77,6 +77,7 @@ public class KestrelConfigurationLoader
     private CertificateConfig? DefaultCertificateConfig { get; set; }
     internal X509Certificate2? DefaultCertificate { get; set; }
 
+    internal X509Certificate2Collection? DefaultCertificateChain {get; set;}
     /// <summary>
     /// Specifies a configuration Action to run when an endpoint with the given name is loaded from configuration.
     /// </summary>
@@ -345,12 +346,14 @@ public class KestrelConfigurationLoader
 
         DefaultCertificateConfig = null;
         DefaultCertificate = null;
+        DefaultCertificateChain = null;
 
         ConfigurationReader = new ConfigurationReader(Configuration);
 
         if (_httpsConfigurationService.IsInitialized && _httpsConfigurationService.LoadDefaultCertificate(ConfigurationReader) is CertificateAndConfig certPair)
         {
             DefaultCertificate = certPair.Certificate;
+            DefaultCertificateChain = certPair.CertificateChain;
             DefaultCertificateConfig = certPair.CertificateConfig;
         }
 

--- a/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
@@ -79,7 +79,6 @@ public class KestrelConfigurationLoader
 
     internal X509Certificate2Collection? DefaultCertificateChain { get; set; }
 
-
     /// <summary>
     /// Specifies a configuration Action to run when an endpoint with the given name is loaded from configuration.
     /// </summary>

--- a/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
@@ -78,6 +78,7 @@ public class KestrelConfigurationLoader
     internal X509Certificate2? DefaultCertificate { get; set; }
 
     internal X509Certificate2Collection? DefaultCertificateChain { get; set; }
+
     /// <summary>
     /// Specifies a configuration Action to run when an endpoint with the given name is loaded from configuration.
     /// </summary>

--- a/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
@@ -77,7 +77,7 @@ public class KestrelConfigurationLoader
     private CertificateConfig? DefaultCertificateConfig { get; set; }
     internal X509Certificate2? DefaultCertificate { get; set; }
 
-    internal X509Certificate2Collection? DefaultCertificateChain {get; set;}
+    internal X509Certificate2Collection? DefaultCertificateChain { get; set; }
     /// <summary>
     /// Specifies a configuration Action to run when an endpoint with the given name is loaded from configuration.
     /// </summary>

--- a/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
@@ -79,6 +79,7 @@ public class KestrelConfigurationLoader
 
     internal X509Certificate2Collection? DefaultCertificateChain { get; set; }
 
+
     /// <summary>
     /// Specifies a configuration Action to run when an endpoint with the given name is loaded from configuration.
     /// </summary>

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -303,6 +303,9 @@ public class KestrelServerOptions
         if (ConfigurationLoader?.DefaultCertificate is X509Certificate2 certificateFromLoader)
         {
             httpsOptions.ServerCertificate = certificateFromLoader;
+            if (ConfigurationLoader?.DefaultCertificateChain is X509Certificate2Collection certificateChainFromLoader){
+                httpsOptions.ServerCertificateChain = certificateChainFromLoader;
+            }
             return;
         }
 

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -303,7 +303,8 @@ public class KestrelServerOptions
         if (ConfigurationLoader?.DefaultCertificate is X509Certificate2 certificateFromLoader)
         {
             httpsOptions.ServerCertificate = certificateFromLoader;
-            if (ConfigurationLoader?.DefaultCertificateChain is X509Certificate2Collection certificateChainFromLoader){
+            if (ConfigurationLoader?.DefaultCertificateChain is X509Certificate2Collection certificateChainFromLoader)
+            {
                 httpsOptions.ServerCertificateChain = certificateChainFromLoader;
             }
             return;

--- a/src/Servers/Kestrel/Core/src/TlsConfigurationLoader.cs
+++ b/src/Servers/Kestrel/Core/src/TlsConfigurationLoader.cs
@@ -131,8 +131,9 @@ internal sealed class TlsConfigurationLoader
             var (defaultCert, defaultCertChain) = _certificateConfigLoader.LoadCertificate(defaultCertConfig, "Default");
             if (defaultCert != null)
             {
-                if(defaultCertChain != null){
-                    return new CertificateAndConfig(defaultCert,defaultCertConfig,defaultCertChain);
+                if (defaultCertChain != null)
+                {
+                    return new CertificateAndConfig(defaultCert, defaultCertConfig, defaultCertChain);
                 }
                 return new CertificateAndConfig(defaultCert, defaultCertConfig);
             }

--- a/src/Servers/Kestrel/Core/src/TlsConfigurationLoader.cs
+++ b/src/Servers/Kestrel/Core/src/TlsConfigurationLoader.cs
@@ -128,9 +128,12 @@ internal sealed class TlsConfigurationLoader
     {
         if (configurationReader.Certificates.TryGetValue("Default", out var defaultCertConfig))
         {
-            var (defaultCert, _ /* cert chain */) = _certificateConfigLoader.LoadCertificate(defaultCertConfig, "Default");
+            var (defaultCert, defaultCertChain) = _certificateConfigLoader.LoadCertificate(defaultCertConfig, "Default");
             if (defaultCert != null)
             {
+                if(defaultCertChain != null){
+                    return new CertificateAndConfig(defaultCert,defaultCertConfig,defaultCertChain);
+                }
                 return new CertificateAndConfig(defaultCert, defaultCertConfig);
             }
         }

--- a/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
+++ b/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
@@ -205,7 +205,7 @@ public class KestrelConfigurationLoaderTests
         var config = new ConfigurationBuilder().AddInMemoryCollection(new[]
         {
             new KeyValuePair<string, string>("Endpoints:End1:Url", "https://*:5001"),
-            new KeyValuePair<string,string>("Certificates:Default:Path",testCertPath)
+            new KeyValuePair<string,string>("Certificates:Default:Path", testCertPath)
         }).Build();
 
         serverOptions.Configure(config)

--- a/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
+++ b/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
@@ -197,6 +197,33 @@ public class KestrelConfigurationLoaderTests
     }
 
     [Fact]
+    public void ConfigureDefaultCertificatePathLoadsChain()
+    {
+        var serverOptions = CreateServerOptions();
+        var testCertPath = TestResources.GetCertPath("leaf.com.crt");
+        var ran1 = false;
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new[]
+        {
+            new KeyValuePair<string, string>("Endpoints:End1:Url", "https://*:5001"),
+            new KeyValuePair<string,string>("Certificates:Default:Path",testCertPath)
+        }).Build();
+
+        serverOptions.Configure(config)
+            .Endpoint("End1", opt =>
+            {
+                ran1 = true;
+                Assert.True(opt.IsHttps);
+                Assert.NotNull(opt.HttpsOptions.ServerCertificate);
+                Assert.NotNull(opt.HttpsOptions.ServerCertificateChain);
+                Assert.Equal(2, opt.HttpsOptions.ServerCertificateChain.Count);
+            }).Load();
+
+        Assert.True(ran1);
+
+        Assert.True(serverOptions.ConfigurationBackedListenOptions[0].IsTls);
+    }
+
+    [Fact]
     public void ConfigureEndpointDefaultCanEnableHttps()
     {
         var serverOptions = CreateServerOptions();


### PR DESCRIPTION
# Fix: Inconsistent certificate chain handling between endpoint and default configuration

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Changes Kestrel configuration to process default certificate loading configurations the same as per endpoint configurations. With this change, certificates specified in the default configuration section will have their chains presented on the server even if their intermediates are not present in the system certificate store.

## Description
### IHttpsConfigurationService.cs:
- Changed to add the `CertificateChain` property onto the internal `CertificateAndConfig` struct, necessary for passing cert chain from `TlsConfigurationLoader` to `KestrelConfigurationLoader`.

### TlsConfigurationLoader.cs:
- Changed to use the certificate chain from the loaded default certificate to return a `CertificateAndConfig` object with the chain specified if the chain is not null.

### KestrelConfigurationLoader.cs:
- Changed to add an internal `DefaultCertificateChain` property for specifying the default certificate chain to load on endpoints in `KestrelServerOptions.ApplyDefaultCertificate`.

### KestrelServerOptions.cs:
- Changed to get the default certificate chain specified in `KestrelConfigurationLoader` and set the `ServerCertificateChain` property on the `httpsOptions` for an endpoint.

Fixes #60709
