### PR TITLE
1es-ify Localization pipeline

### DIFF
--- a/.azure/pipelines/localization.yml
+++ b/.azure/pipelines/localization.yml
@@ -41,13 +41,17 @@ extends:
   parameters:
     sdl:
       sourceAnalysisPool:
-        name: NetCore1ESPool-Svc-Internal
+        name: $(DncEngInternalBuildPool)
         image: 1es-windows-2022
         os: windows
       codeql:
         compiled:
           enabled: false
           justificationForDisabling: 'This is a test-only pipeline. The same product code is already scanned in the main pipeline (aspnetcore-ci)'
+    pool:
+      name: $(DncEngInternalBuildPool)
+      image: 1es-windows-2022
+      os: windows
 
     stages:
     - stage: build
@@ -56,7 +60,6 @@ extends:
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.Reason'], 'Manual'))) }}:
         - template: /eng/common/templates-official/job/onelocbuild.yml@self
           parameters:
-            agentOs: Windows
             CreatePr: ${{ or(ne(variables['Build.Reason'], 'Manual'), eq(parameters.createPr, 'true')) }}
             LclPackageId: 'LCL-JUNO-PROD-ASPNETCORE'
             LclSource: lclFilesFromPackage

--- a/.azure/pipelines/localization.yml
+++ b/.azure/pipelines/localization.yml
@@ -25,13 +25,39 @@ parameters:
 variables:
 - name: _TeamName
   value: AspNetCore
-- template: /eng/common/templates/variables/pool-providers.yml
+- template: /eng/common/templates-official/variables/pool-providers.yml@self
 
-jobs:
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.Reason'], 'Manual'))) }}:
-  - template: /eng/common/templates/job/onelocbuild.yml
-    parameters:
-      CreatePr: ${{ or(ne(variables['Build.Reason'], 'Manual'), eq(parameters.createPr, 'true')) }}
-      LclPackageId: 'LCL-JUNO-PROD-ASPNETCORE'
-      LclSource: lclFilesFromPackage
-      MirrorRepo: aspnetcore
+
+resources:
+  repositories:
+  # Repo: 1ESPipelineTemplates/1ESPipelineTemplates
+  - repository: 1esPipelines
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  parameters:
+    sdl:
+      sourceAnalysisPool:
+        name: NetCore1ESPool-Svc-Internal
+        image: 1es-windows-2022
+        os: windows
+      codeql:
+        compiled:
+          enabled: false
+          justificationForDisabling: 'This is a test-only pipeline. The same product code is already scanned in the main pipeline (aspnetcore-ci)'
+
+    stages:
+    - stage: build
+      displayName: Build
+      jobs:
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.Reason'], 'Manual'))) }}:
+        - template: /eng/common/templates-official/job/onelocbuild.yml@self
+          parameters:
+            agentOs: Windows
+            CreatePr: ${{ or(ne(variables['Build.Reason'], 'Manual'), eq(parameters.createPr, 'true')) }}
+            LclPackageId: 'LCL-JUNO-PROD-ASPNETCORE'
+            LclSource: lclFilesFromPackage
+            MirrorRepo: aspnetcore

--- a/.azure/pipelines/localization.yml
+++ b/.azure/pipelines/localization.yml
@@ -47,7 +47,7 @@ extends:
       codeql:
         compiled:
           enabled: false
-          justificationForDisabling: 'This is a test-only pipeline. The same product code is already scanned in the main pipeline (aspnetcore-ci)'
+          justificationForDisabling: "This pipeline doesn't build any code. The product code is already scanned in the main pipeline (aspnetcore-ci)"
     pool:
       name: $(DncEngInternalBuildPool)
       image: 1es-windows-2022


### PR DESCRIPTION
The loc pipeline has been broken for a long time because it was trying to run on a Linux agent. We should get it fully modernized by 1es-ifying it.

Test job here - we're currently at 99% localization coverage, so we can expect a small set of incoming changes, which we should consider backporting to 9.0: https://dev.azure.com/dnceng/internal/_build/results?buildId=2654452&view=results