### PR TITLE
Add partitioned to cookie for SignalR browser testing

### DIFF
--- a/src/SignalR/clients/ts/FunctionalTests/Startup.cs
+++ b/src/SignalR/clients/ts/FunctionalTests/Startup.cs
@@ -184,9 +184,11 @@ public class Startup
                 {
                     cookieOptions.SameSite = Microsoft.AspNetCore.Http.SameSiteMode.None;
                     cookieOptions.Secure = true;
+                    cookieOptions.Extensions.Add("partitioned"); // Required by Chromium
 
                     expiredCookieOptions.SameSite = Microsoft.AspNetCore.Http.SameSiteMode.None;
                     expiredCookieOptions.Secure = true;
+                    cookieOptions.Extensions.Add("partitioned"); // Required by Chromium
                 }
                 context.Response.Cookies.Append("testCookie", "testValue", cookieOptions);
                 context.Response.Cookies.Append("testCookie2", "testValue2", cookieOptions);

--- a/src/SignalR/clients/ts/FunctionalTests/Startup.cs
+++ b/src/SignalR/clients/ts/FunctionalTests/Startup.cs
@@ -188,7 +188,7 @@ public class Startup
 
                     expiredCookieOptions.SameSite = Microsoft.AspNetCore.Http.SameSiteMode.None;
                     expiredCookieOptions.Secure = true;
-                    cookieOptions.Extensions.Add("partitioned"); // Required by Chromium
+                    expiredCookieOptions.Extensions.Add("partitioned"); // Required by Chromium
                 }
                 context.Response.Cookies.Append("testCookie", "testValue", cookieOptions);
                 context.Response.Cookies.Append("testCookie2", "testValue2", cookieOptions);


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspnetcore/pull/57997
Test only change.