### PR TITLE
[Infrastructure] Avoid polluting the working set of files with changes after build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ UpgradeLog.htm
 .idea
 mono_crash.*.json
 mono_crash.*.blob
+package.json.bak

--- a/package-lock.json
+++ b/package-lock.json
@@ -18401,7 +18401,7 @@
     },
     "src/JSInterop/Microsoft.JSInterop.JS/src": {
       "name": "@microsoft/dotnet-js-interop",
-      "version": "9.0.0-dev",
+      "version": "10.0.0-dev",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^6.15.0",
@@ -18885,7 +18885,7 @@
     },
     "src/SignalR/clients/ts/signalr": {
       "name": "@microsoft/signalr",
-      "version": "5.0.0-dev",
+      "version": "10.0.0-dev",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -18897,7 +18897,7 @@
     },
     "src/SignalR/clients/ts/signalr-protocol-msgpack": {
       "name": "@microsoft/signalr-protocol-msgpack",
-      "version": "5.0.0-dev",
+      "version": "10.0.0-dev",
       "license": "MIT",
       "dependencies": {
         "@microsoft/signalr": "*",

--- a/src/JSInterop/Microsoft.JSInterop.JS/src/package.json
+++ b/src/JSInterop/Microsoft.JSInterop.JS/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/dotnet-js-interop",
-  "version": "9.0.0-dev",
+  "version": "10.0.0-dev",
   "description": "Provides abstractions and features for interop between .NET and JavaScript code.",
   "main": "dist/src/Microsoft.JSInterop.js",
   "types": "dist/src/Microsoft.JSInterop.d.ts",

--- a/src/SignalR/clients/ts/signalr-protocol-msgpack/package.json
+++ b/src/SignalR/clients/ts/signalr-protocol-msgpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/signalr-protocol-msgpack",
-  "version": "5.0.0-dev",
+  "version": "10.0.0-dev",
   "description": "MsgPack Protocol support for ASP.NET Core SignalR",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -41,7 +41,7 @@
     "src/**/*"
   ],
   "dependencies": {
-    "@microsoft/signalr": "*",
+    "@microsoft/signalr": ">=10.0.0-dev",
     "@msgpack/msgpack": "^2.7.0"
   },
   "overrides": {

--- a/src/SignalR/clients/ts/signalr/package.json
+++ b/src/SignalR/clients/ts/signalr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/signalr",
-  "version": "5.0.0-dev",
+  "version": "10.0.0-dev",
   "description": "ASP.NET Core SignalR Client",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",


### PR DESCRIPTION
* Adds an entry to `.gitignore` to ignore package.json.bak files generated during build
* Updates some package.json files that get modified during build to use the current version.