### PR TITLE
Fix use of ReconnectModal in Blazor templates with auto mode and global interactivity

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/.template.config/template.json
@@ -98,7 +98,10 @@
           "exclude": [
             "BlazorWeb-CSharp/Components/Layout/ReconnectModal.razor",
             "BlazorWeb-CSharp/Components/Layout/ReconnectModal.razor.css",
-            "BlazorWeb-CSharp/Components/Layout/ReconnectModal.razor.js"
+            "BlazorWeb-CSharp/Components/Layout/ReconnectModal.razor.js",
+            "BlazorWeb-CSharp.Client/Layout/ReconnectModal.razor",
+            "BlazorWeb-CSharp.Client/Layout/ReconnectModal.razor.css",
+            "BlazorWeb-CSharp.Client/Layout/ReconnectModal.razor.js"
           ]
         },
         {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/App.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/App.razor
@@ -39,6 +39,9 @@
     ##else
     <Routes @rendermode="InteractiveWebAssembly" />
     ##endif*@
+    @*#if (UseServer)  -->
+    <ReconnectModal />
+    ##endif*@
     <script src="@Assets["_framework/blazor.web.js"]"></script>
 </body>
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/MainLayout.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/MainLayout.razor
@@ -29,5 +29,6 @@
 </div>
 ##endif*@
 @*#if (UseServer)  -->
+
 <ReconnectModal />
 ##endif*@

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/MainLayout.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/MainLayout.razor
@@ -28,7 +28,3 @@
     <span class="dismiss">🗙</span>
 </div>
 ##endif*@
-@*#if (UseServer)  -->
-
-<ReconnectModal />
-##endif*@

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/ReconnectModal.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/ReconnectModal.razor
@@ -1,4 +1,8 @@
-﻿<script type="module" src="@Assets["Components/Layout/ReconnectModal.razor.js"]"></script>
+﻿@*#if (UseWebAssembly && InteractiveAtRoot) -->
+<script type="module" src="@Assets["Layout/ReconnectModal.razor.js"]"></script>
+##else
+<script type="module" src="@Assets["Components/Layout/ReconnectModal.razor.js"]"></script>
+##endif*@
 
 <dialog id="components-reconnect-modal" data-nosnippet>
     <div class="components-reconnect-container">

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/_Imports.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/_Imports.razor
@@ -13,4 +13,10 @@
 @*#if (UseWebAssembly) -->
 @using BlazorWeb_CSharp.Client
 ##endif*@
+@*#if (UseServer && UseWebAssembly && InteractiveAtRoot) -->
+@using BlazorWeb_CSharp.Client.Layout
+##endif*@
 @using BlazorWeb_CSharp.Components
+@*#if (UseServer && (!UseWebAssembly || !InteractiveAtRoot)) -->
+@using BlazorWeb_CSharp.Components.Layout
+##endif*@


### PR DESCRIPTION
Fixes two issues with `ReconnectModal` in the Blazor project template:

- Template configurations with options `--interactivity auto` and `--all-interactive` (aka global interactivity) use different file structure. This fixes the `ReconnectModal.razor.js` include path in this case, as reported in https://github.com/dotnet/AspNetCore-ManualTests/issues/3482 (after closing the original issue).
- Having the `<ReconnectModal>` element in `MainLayout.razor` does not work with global interactivity. This moves the element to `App.razor` and updates the import statements in `_Imports.razor` accordingly, so that the JS code setting up reconnection event handlers is executed properly in all modes.