### PR TITLE
Check length of TypeArguments before accessing via index 

### DIFF
--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DisallowNonParsableComplexTypesOnParameters.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DisallowNonParsableComplexTypesOnParameters.cs
@@ -30,7 +30,7 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            var parameterTypeSymbol = ResovleParameterTypeSymbol(handlerDelegateParameter);
+            var parameterTypeSymbol = ResolveParameterTypeSymbol(handlerDelegateParameter);
 
             // If this is null it means we aren't working with a named type symbol.
             if (parameterTypeSymbol == null)
@@ -113,7 +113,7 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        static INamedTypeSymbol? ResovleParameterTypeSymbol(IParameterSymbol parameterSymbol)
+        static INamedTypeSymbol? ResolveParameterTypeSymbol(IParameterSymbol parameterSymbol)
         {
             INamedTypeSymbol? parameterTypeSymbol = null;
 

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DisallowNonParsableComplexTypesOnParameters.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DisallowNonParsableComplexTypesOnParameters.cs
@@ -128,7 +128,8 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
             }
 
             // If it is nullable, unwrap it.
-            if (parameterTypeSymbol!.ConstructedFrom.SpecialType == SpecialType.System_Nullable_T)
+            if (parameterTypeSymbol!.ConstructedFrom.SpecialType == SpecialType.System_Nullable_T &&
+                parameterTypeSymbol.TypeArguments.Length > 0)
             {
                 parameterTypeSymbol = parameterTypeSymbol.TypeArguments[0] as INamedTypeSymbol;
             }

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DisallowNonParsableComplexTypesOnParameters.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DisallowNonParsableComplexTypesOnParameters.cs
@@ -127,7 +127,8 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
                 parameterTypeSymbol = namedTypeSymbol;
             }
 
-            // If it is nullable, unwrap it.
+            // If it is nullable and we have type arguments, unwrap it.
+            // The length check aims to alleviate AD0001 warnings when referencing methods in external class libraries that contain parameters
             if (parameterTypeSymbol!.ConstructedFrom.SpecialType == SpecialType.System_Nullable_T &&
                 parameterTypeSymbol.TypeArguments.Length > 0)
             {

--- a/src/Framework/AspNetCoreAnalyzers/test/RouteHandlers/DisallowNonParsableComplexTypesOnParametersTest.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteHandlers/DisallowNonParsableComplexTypesOnParametersTest.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Security.Policy;
 using Microsoft.CodeAnalysis.Testing;
 using VerifyCS = Microsoft.AspNetCore.Analyzers.Verifiers.CSharpAnalyzerVerifier<Microsoft.AspNetCore.Analyzers.RouteHandlers.RouteHandlerAnalyzer>;
 


### PR DESCRIPTION
## Description

- Added some safety around accessing TypeArguments via index in DisallowNonParsableComplexTypesOnParameters.cs
- Fixed a spelling mistake on ResolveParameterTypeSymbol
- Removed an unused using statement in the relevant test

Fixes #60719