### PR TITLE
Add location.reload on rejected Blazor reconnection to ReconnectModal…

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/ReconnectModal.razor.js
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/ReconnectModal.razor.js
@@ -12,6 +12,8 @@ function handleReconnectStateChanged(event) {
         reconnectModal.close();
     } else if (event.detail.state === "failed") {
         document.addEventListener("visibilitychange", retryWhenDocumentBecomesVisible);
+    } else if (event.detail.state === "rejected") {
+        location.reload();
     }
 }
 


### PR DESCRIPTION
As reported [here](https://github.com/dotnet/AspNetCore-ManualTests/issues/3489) with the new reconnection UI component in the Blazor project template, the client does not automatically reconnect after a developer stops and restarts the app (e.g. in Visual Studio or using dotnet CLI) without closing or refreshing the browser tab.

I tested it in .NET 9 and found that this workflow never worked with customized reconnection UI.

I investigated the differences in implementation of `UserSpecifiedDisplay` (used when user has customized reconnection UI) and `DefaultReconnectDisplay` (used otherwise) and found that the latter has additional call to `location.reload` when it gets rejected by the Blazor server during reconnection attempt. This is what happens when another instance of the app restarts on the same port. The reload is what enables the development workflow described in the issue.

I added such call to the `ReconnectModal` component to match the expected behavior.

Fixes https://github.com/dotnet/AspNetCore-ManualTests/issues/3489