### PR TITLE
Add avif MIME type

### DIFF
--- a/src/Components/WebView/WebView/src/FileExtensionContentTypeProvider.cs
+++ b/src/Components/WebView/WebView/src/FileExtensionContentTypeProvider.cs
@@ -58,6 +58,7 @@ internal sealed class FileExtensionContentTypeProvider : IContentTypeProvider
                 { ".atom", "application/atom+xml" },
                 { ".au", "audio/basic" },
                 { ".avi", "video/x-msvideo" },
+                { ".avif", "image/avif" },
                 { ".axs", "application/olescript" },
                 { ".bas", "text/plain" },
                 { ".bcpio", "application/x-bcpio" },

--- a/src/Middleware/StaticFiles/src/FileExtensionContentTypeProvider.cs
+++ b/src/Middleware/StaticFiles/src/FileExtensionContentTypeProvider.cs
@@ -52,6 +52,7 @@ public class FileExtensionContentTypeProvider : IContentTypeProvider
                 { ".atom", "application/atom+xml" },
                 { ".au", "audio/basic" },
                 { ".avi", "video/x-msvideo" },
+                { ".avif", "image/avif" },
                 { ".axs", "application/olescript" },
                 { ".bas", "text/plain" },
                 { ".bcpio", "application/x-bcpio" },


### PR DESCRIPTION
# Add avif MIME type

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

Add avif extension to list of files used by static file middleware.

## Description

This is a common image format supported by all major browsers now[^1], adding it will make it easier for people to use this format.

There's a couple `Http.config` files used in unit tests where this wasn't added. I didn't bother since `webp` wasn't in there, but I can add them if needed.

Fixes #39984

[^1]: https://caniuse.com/avif
