### PR TITLE
Deduplicate assets produced on multiple build legs in the VMR to only be produced on the 'primary' build leg

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -12,10 +12,17 @@
                                        '$(PostBuildSign)' != 'true' and
                                        '$(DotNetBuildRepo)' != 'true'">false</EnableDefaultArtifacts>
 
-    <PublishInstallerBaseVersion Condition="'$(PublishInstallerBaseVersion)' == '' and
-                                            ('$(OS)' == 'Windows_NT' or '$(DotNetBuildOrchestrator)' == 'true')">true</PublishInstallerBaseVersion>
     <!-- This avoids creating VS.*.symbols.nupkg packages that are identical to the original package. -->
     <AutoGenerateSymbolPackages>false</AutoGenerateSymbolPackages>
+    <!--
+      Some assets are produced in all jobs, but only one job can publish them. We follow the following rules in that case:
+      - If we're building outside of the VMR, publish these assets from the Windows job.
+      - If we're building inside the VMR, publish these assets from whichever job is producing non-RID-specific artifacts.
+    -->
+    <PublishAllBuildsAssetsInThisJob Condition="('$(OS)' == 'Windows_NT' and '$(DotNetBuildOrchestrator)' != 'true')
+                                                or ('$(DotNetBuildOrchestrator)' == 'true' and '$(EnableDefaultRidSpecificArtifacts)' != 'true'
+                                                    and ('$(DotNetBuildPass)' == '' or '$(DotNetBuildPass)' == '1'))">true</PublishAllBuildsAssetsInThisJob>
+    <PublishInstallerBaseVersion Condition="'$(PublishInstallerBaseVersion)' == ''">$(PublishAllBuildsAssetsInThisJob)</PublishInstallerBaseVersion>
   </PropertyGroup>
 
   <!-- $(InstallersOutputPath), $(SymbolsOutputPath), and $(ChecksumExtensions) are not defined. Root Directory.Build.props is not imported. -->
@@ -24,10 +31,10 @@
     <FilesToPublishToSymbolServer Include="$(ArtifactsDir)symbols\**\*.pdb" />
 
     <!-- Prepare for _PublishInstallersAndChecksums target. -->
-    <_InstallersToPublish Include="$(ArtifactsDir)packages\**\*.jar" UploadPathSegment="jar" />
-    <_InstallersToPublish Include="$(ArtifactsDir)packages\**\*.pom" UploadPathSegment="jar" />
+    <_InstallersToPublish Include="$(ArtifactsDir)packages\**\*.jar" UploadPathSegment="jar" Condition="'$(PublishAllBuildsAssetsInThisJob)' == 'true'" />
+    <_InstallersToPublish Include="$(ArtifactsDir)packages\**\*.pom" UploadPathSegment="jar" Condition="'$(PublishAllBuildsAssetsInThisJob)' == 'true'" />
     <!-- All builds produce npm assets - only publish them once -->
-    <_InstallersToPublish Include="$(ArtifactsDir)packages\**\*.tgz" UploadPathSegment="npm" Condition="'$(OS)' == 'Windows_NT' or '$(DotNetBuildOrchestrator)' == 'true'" />
+    <_InstallersToPublish Include="$(ArtifactsDir)packages\**\*.tgz" UploadPathSegment="npm"  Condition="'$(PublishAllBuildsAssetsInThisJob)' == 'true'" />
     <_InstallersToPublish Include="$(ArtifactsDir)installers\**\*.version" UploadPathSegment="Runtime" Condition="'$(PublishInstallerBaseVersion)' == 'true'" />
 
     <!-- The following installers create checksums -->


### PR DESCRIPTION
# Deduplidate assets produced on multiple build legs in the VMR

As part of moving way from a "primary" vertical concept in the VMR, we need to deduplicate the Java and NPM assets that aspnetcore produces in the VMR builds. This PR provides that infrastructure.

## Description

Changes the version files, Java artifacts, and NPM artifacts to all be published in the VMR only when we're publishing all artifacts, not only RID-specific ones.

Contributes to https://github.com/dotnet/source-build/issues/4905
