### PR TITLE
Refactoring DiagnosticDescriptors.cs files

### DIFF
--- a/src/Components/Analyzers/src/DiagnosticDescriptors.cs
+++ b/src/Components/Analyzers/src/DiagnosticDescriptors.cs
@@ -8,65 +8,70 @@ namespace Microsoft.AspNetCore.Components.Analyzers;
 [System.Diagnostics.CodeAnalysis.SuppressMessage("MicrosoftCodeAnalysisReleaseTracking", "RS2008:Enable analyzer release tracking")]
 internal static class DiagnosticDescriptors
 {
-    public static readonly DiagnosticDescriptor ComponentParameterSettersShouldBePublic = new DiagnosticDescriptor(
+    private const string Encapsulation = "Encapsulation";
+    private const string Usage = "Usage";
+
+    private static LocalizableResourceString CreateLocalizableResourceString(string resource) => new(resource, Resources.ResourceManager, typeof(Resources));
+
+    public static readonly DiagnosticDescriptor ComponentParameterSettersShouldBePublic = new(
         "BL0001",
-        new LocalizableResourceString(nameof(Resources.ComponentParameterSettersShouldBePublic_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.ComponentParameterSettersShouldBePublic_Format), Resources.ResourceManager, typeof(Resources)),
-        "Encapsulation",
+        CreateLocalizableResourceString(nameof(Resources.ComponentParameterSettersShouldBePublic_Title)),
+        CreateLocalizableResourceString(nameof(Resources.ComponentParameterSettersShouldBePublic_Format)),
+        Encapsulation,
         DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: new LocalizableResourceString(nameof(Resources.ComponentParameterSettersShouldBePublic_Description), Resources.ResourceManager, typeof(Resources)));
+        description: CreateLocalizableResourceString(nameof(Resources.ComponentParameterSettersShouldBePublic_Description)));
 
-    public static readonly DiagnosticDescriptor ComponentParameterCaptureUnmatchedValuesMustBeUnique = new DiagnosticDescriptor(
+    public static readonly DiagnosticDescriptor ComponentParameterCaptureUnmatchedValuesMustBeUnique = new(
         "BL0002",
-        new LocalizableResourceString(nameof(Resources.ComponentParameterCaptureUnmatchedValuesMustBeUnique_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.ComponentParameterCaptureUnmatchedValuesMustBeUnique_Format), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.ComponentParameterCaptureUnmatchedValuesMustBeUnique_Title)),
+        CreateLocalizableResourceString(nameof(Resources.ComponentParameterCaptureUnmatchedValuesMustBeUnique_Format)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: new LocalizableResourceString(nameof(Resources.ComponentParameterCaptureUnmatchedValuesMustBeUnique_Description), Resources.ResourceManager, typeof(Resources)));
+        description: CreateLocalizableResourceString(nameof(Resources.ComponentParameterCaptureUnmatchedValuesMustBeUnique_Description)));
 
-    public static readonly DiagnosticDescriptor ComponentParameterCaptureUnmatchedValuesHasWrongType = new DiagnosticDescriptor(
+    public static readonly DiagnosticDescriptor ComponentParameterCaptureUnmatchedValuesHasWrongType = new(
         "BL0003",
-        new LocalizableResourceString(nameof(Resources.ComponentParameterCaptureUnmatchedValuesHasWrongType_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.ComponentParameterCaptureUnmatchedValuesHasWrongType_Format), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.ComponentParameterCaptureUnmatchedValuesHasWrongType_Title)),
+        CreateLocalizableResourceString(nameof(Resources.ComponentParameterCaptureUnmatchedValuesHasWrongType_Format)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: new LocalizableResourceString(nameof(Resources.ComponentParameterCaptureUnmatchedValuesHasWrongType_Description), Resources.ResourceManager, typeof(Resources)));
+        description: CreateLocalizableResourceString(nameof(Resources.ComponentParameterCaptureUnmatchedValuesHasWrongType_Description)));
 
-    public static readonly DiagnosticDescriptor ComponentParametersShouldBePublic = new DiagnosticDescriptor(
+    public static readonly DiagnosticDescriptor ComponentParametersShouldBePublic = new(
         "BL0004",
-        new LocalizableResourceString(nameof(Resources.ComponentParameterShouldBePublic_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.ComponentParameterShouldBePublic_Format), Resources.ResourceManager, typeof(Resources)),
-        "Encapsulation",
+        CreateLocalizableResourceString(nameof(Resources.ComponentParameterShouldBePublic_Title )),
+        CreateLocalizableResourceString(nameof(Resources.ComponentParameterShouldBePublic_Format)),
+        Encapsulation,
         DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: new LocalizableResourceString(nameof(Resources.ComponentParametersShouldBePublic_Description), Resources.ResourceManager, typeof(Resources)));
+        description: CreateLocalizableResourceString(nameof(Resources.ComponentParametersShouldBePublic_Description)));
 
-    public static readonly DiagnosticDescriptor ComponentParametersShouldNotBeSetOutsideOfTheirDeclaredComponent = new DiagnosticDescriptor(
+    public static readonly DiagnosticDescriptor ComponentParametersShouldNotBeSetOutsideOfTheirDeclaredComponent = new(
         "BL0005",
-        new LocalizableResourceString(nameof(Resources.ComponentParameterShouldNotBeSetOutsideOfTheirDeclaredComponent_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.ComponentParameterShouldNotBeSetOutsideOfTheirDeclaredComponent_Format), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.ComponentParameterShouldNotBeSetOutsideOfTheirDeclaredComponent_Title  )),
+        CreateLocalizableResourceString(nameof(Resources.ComponentParameterShouldNotBeSetOutsideOfTheirDeclaredComponent_Format)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: new LocalizableResourceString(nameof(Resources.ComponentParameterShouldNotBeSetOutsideOfTheirDeclaredComponent_Description), Resources.ResourceManager, typeof(Resources)));
+        description: CreateLocalizableResourceString(nameof(Resources.ComponentParameterShouldNotBeSetOutsideOfTheirDeclaredComponent_Description)));
 
-    public static readonly DiagnosticDescriptor DoNotUseRenderTreeTypes = new DiagnosticDescriptor(
+    public static readonly DiagnosticDescriptor DoNotUseRenderTreeTypes = new(
         "BL0006",
-        new LocalizableResourceString(nameof(Resources.DoNotUseRenderTreeTypes_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.DoNotUseRenderTreeTypes_Description), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.DoNotUseRenderTreeTypes_Title)),
+        CreateLocalizableResourceString(nameof(Resources.DoNotUseRenderTreeTypes_Description)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: new LocalizableResourceString(nameof(Resources.DoNotUseRenderTreeTypes_Description), Resources.ResourceManager, typeof(Resources)));
+        description: CreateLocalizableResourceString(nameof(Resources.DoNotUseRenderTreeTypes_Description)));
 
     public static readonly DiagnosticDescriptor ComponentParametersShouldBeAutoProperties = new(
         "BL0007",
-        new LocalizableResourceString(nameof(Resources.ComponentParametersShouldBeAutoProperties_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.ComponentParametersShouldBeAutoProperties_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.ComponentParametersShouldBeAutoProperties_Title)),
+        CreateLocalizableResourceString(nameof(Resources.ComponentParametersShouldBeAutoProperties_Message)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
 }

--- a/src/Components/Analyzers/src/DiagnosticDescriptors.cs
+++ b/src/Components/Analyzers/src/DiagnosticDescriptors.cs
@@ -42,7 +42,7 @@ internal static class DiagnosticDescriptors
 
     public static readonly DiagnosticDescriptor ComponentParametersShouldBePublic = new(
         "BL0004",
-        CreateLocalizableResourceString(nameof(Resources.ComponentParameterShouldBePublic_Title )),
+        CreateLocalizableResourceString(nameof(Resources.ComponentParameterShouldBePublic_Title)),
         CreateLocalizableResourceString(nameof(Resources.ComponentParameterShouldBePublic_Format)),
         Encapsulation,
         DiagnosticSeverity.Error,
@@ -51,7 +51,7 @@ internal static class DiagnosticDescriptors
 
     public static readonly DiagnosticDescriptor ComponentParametersShouldNotBeSetOutsideOfTheirDeclaredComponent = new(
         "BL0005",
-        CreateLocalizableResourceString(nameof(Resources.ComponentParameterShouldNotBeSetOutsideOfTheirDeclaredComponent_Title  )),
+        CreateLocalizableResourceString(nameof(Resources.ComponentParameterShouldNotBeSetOutsideOfTheirDeclaredComponent_Title)),
         CreateLocalizableResourceString(nameof(Resources.ComponentParameterShouldNotBeSetOutsideOfTheirDeclaredComponent_Format)),
         Usage,
         DiagnosticSeverity.Warning,

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
@@ -8,238 +8,244 @@ namespace Microsoft.AspNetCore.Analyzers;
 [System.Diagnostics.CodeAnalysis.SuppressMessage("MicrosoftCodeAnalysisReleaseTracking", "RS2008:Enable analyzer release tracking")]
 internal static class DiagnosticDescriptors
 {
+    private const string Security = "Security";
+    private const string Usage = "Usage";
+    private const string AnalyzersLink = "https://aka.ms/aspnet/analyzers";
+
+    private static LocalizableResourceString CreateLocalizableResourceString(string resource) => new(resource, Resources.ResourceManager, typeof(Resources));
+    
     internal static readonly DiagnosticDescriptor DoNotUseModelBindingAttributesOnRouteHandlerParameters = new(
         "ASP0003",
-        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotUseModelBindingAttributesOnRouteHandlerParameters_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotUseModelBindingAttributesOnRouteHandlerParameters_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_DoNotUseModelBindingAttributesOnRouteHandlerParameters_Title)),
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_DoNotUseModelBindingAttributesOnRouteHandlerParameters_Message)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri: "https://aka.ms/aspnet/analyzers");
+        helpLinkUri: AnalyzersLink);
 
     internal static readonly DiagnosticDescriptor DoNotReturnActionResultsFromRouteHandlers = new(
         "ASP0004",
-        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotReturnActionResultsFromRouteHandlers_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotReturnActionResultsFromRouteHandlers_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_DoNotReturnActionResultsFromRouteHandlers_Title)),
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_DoNotReturnActionResultsFromRouteHandlers_Message)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri: "https://aka.ms/aspnet/analyzers");
+        helpLinkUri: AnalyzersLink);
 
     internal static readonly DiagnosticDescriptor DetectMisplacedLambdaAttribute = new(
         "ASP0005",
-        new LocalizableResourceString(nameof(Resources.Analyzer_DetectMisplacedLambdaAttribute_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.Analyzer_DetectMisplacedLambdaAttribute_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_DetectMisplacedLambdaAttribute_Title)),
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_DetectMisplacedLambdaAttribute_Message)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri: "https://aka.ms/aspnet/analyzers");
+        helpLinkUri: AnalyzersLink);
 
     internal static readonly DiagnosticDescriptor DoNotUseNonLiteralSequenceNumbers = new(
         "ASP0006",
-        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotUseNonLiteralSequenceNumbers_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotUseNonLiteralSequenceNumbers_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_DoNotUseNonLiteralSequenceNumbers_Title)),
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_DoNotUseNonLiteralSequenceNumbers_Message)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri: "https://aka.ms/aspnet/analyzers");
+        helpLinkUri: AnalyzersLink);
 
     internal static readonly DiagnosticDescriptor DetectMismatchedParameterOptionality = new(
         "ASP0007",
-        new LocalizableResourceString(nameof(Resources.Analyzer_DetectMismatchedParameterOptionality_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.Analyzer_DetectMismatchedParameterOptionality_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_DetectMismatchedParameterOptionality_Title)),
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_DetectMismatchedParameterOptionality_Message)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri: "https://aka.ms/aspnet/analyzers");
+        helpLinkUri: AnalyzersLink);
 
     internal static readonly DiagnosticDescriptor DoNotUseConfigureWebHostWithConfigureHostBuilder = new(
         "ASP0008",
-        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotUseConfigureWebHostWithConfigureHostBuilder_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotUseConfigureWebHostWithConfigureHostBuilder_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_DoNotUseConfigureWebHostWithConfigureHostBuilder_Title)),
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_DoNotUseConfigureWebHostWithConfigureHostBuilder_Message)),
+        Usage,
         DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        helpLinkUri: "https://aka.ms/aspnet/analyzers");
+        helpLinkUri: AnalyzersLink);
 
     internal static readonly DiagnosticDescriptor DoNotUseConfigureWithConfigureWebHostBuilder = new(
         "ASP0009",
-        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotUseConfigureWithConfigureWebHostBuilder_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotUseConfigureWithConfigureWebHostBuilder_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_DoNotUseConfigureWithConfigureWebHostBuilder_Title)),
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_DoNotUseConfigureWithConfigureWebHostBuilder_Message)),
+        Usage,
         DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        helpLinkUri: "https://aka.ms/aspnet/analyzers");
+        helpLinkUri: AnalyzersLink);
 
     internal static readonly DiagnosticDescriptor DoNotUseUseStartupWithConfigureWebHostBuilder = new(
         "ASP0010",
-        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotUseUseStartupWithConfigureWebHostBuilder_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotUseUseStartupWithConfigureWebHostBuilder_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_DoNotUseUseStartupWithConfigureWebHostBuilder_Title)),
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_DoNotUseUseStartupWithConfigureWebHostBuilder_Message)),
+        Usage,
         DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        helpLinkUri: "https://aka.ms/aspnet/analyzers");
+        helpLinkUri: AnalyzersLink);
 
     internal static readonly DiagnosticDescriptor DoNotUseHostConfigureLogging = new(
         "ASP0011",
-        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotUseHostConfigureLogging_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotUseHostConfigureLogging_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_DoNotUseHostConfigureLogging_Title)),
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_DoNotUseHostConfigureLogging_Message)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri: "https://aka.ms/aspnet/analyzers");
+        helpLinkUri: AnalyzersLink);
 
     internal static readonly DiagnosticDescriptor DoNotUseHostConfigureServices = new(
         "ASP0012",
-        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotUseHostConfigureServices_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotUseHostConfigureServices_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_DoNotUseHostConfigureServices_Title)),
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_DoNotUseHostConfigureServices_Message)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri: "https://aka.ms/aspnet/analyzers");
+        helpLinkUri: AnalyzersLink);
 
     internal static readonly DiagnosticDescriptor DisallowConfigureAppConfigureHostBuilder = new(
         "ASP0013",
-        new LocalizableResourceString(nameof(Resources.Analyzer_DisallowConfigureAppConfigureHostBuilder_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.Analyzer_DisallowConfigureAppConfigureHostBuilder_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_DisallowConfigureAppConfigureHostBuilder_Title)),
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_DisallowConfigureAppConfigureHostBuilder_Message)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri: "https://aka.ms/aspnet/analyzers");
+        helpLinkUri: AnalyzersLink);
 
     internal static readonly DiagnosticDescriptor UseTopLevelRouteRegistrationsInsteadOfUseEndpoints = new(
         "ASP0014",
-        new LocalizableResourceString(nameof(Resources.Analyzer_UseTopLevelRouteRegistrationsInsteadOfUseEndpoints_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.Analyzer_UseTopLevelRouteRegistrationsInsteadOfUseEndpoints_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_UseTopLevelRouteRegistrationsInsteadOfUseEndpoints_Title)),
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_UseTopLevelRouteRegistrationsInsteadOfUseEndpoints_Message)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri: "https://aka.ms/aspnet/analyzers");
+        helpLinkUri: AnalyzersLink);
 
     internal static readonly DiagnosticDescriptor UseHeaderDictionaryPropertiesInsteadOfIndexer = new(
         "ASP0015",
-        new LocalizableResourceString(nameof(Resources.Analyzer_HeaderDictionaryIndexer_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.Analyzer_HeaderDictionaryIndexer_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_HeaderDictionaryIndexer_Title)),
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_HeaderDictionaryIndexer_Message)),
+        Usage,
         DiagnosticSeverity.Info,
         isEnabledByDefault: true,
-        helpLinkUri: "https://aka.ms/aspnet/analyzers");
+        helpLinkUri: AnalyzersLink);
 
     internal static readonly DiagnosticDescriptor DoNotReturnValueFromRequestDelegate = new(
         "ASP0016",
-        new LocalizableResourceString(nameof(Resources.Analyzer_RequestDelegateReturnValue_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.Analyzer_RequestDelegateReturnValue_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_RequestDelegateReturnValue_Title)),
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_RequestDelegateReturnValue_Message)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri: "https://aka.ms/aspnet/analyzers");
+        helpLinkUri: AnalyzersLink);
 
     internal static readonly DiagnosticDescriptor RoutePatternIssue = new(
         "ASP0017",
-        new LocalizableResourceString(nameof(Resources.Analyzer_RouteIssue_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.Analyzer_RouteIssue_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_RouteIssue_Title)),
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_RouteIssue_Message)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri: "https://aka.ms/aspnet/analyzers");
+        helpLinkUri: AnalyzersLink);
 
     internal static readonly DiagnosticDescriptor RoutePatternUnusedParameter = new(
         "ASP0018",
-        new LocalizableResourceString(nameof(Resources.Analyzer_UnusedParameter_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.Analyzer_UnusedParameter_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_UnusedParameter_Title)),
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_UnusedParameter_Message)),
+        Usage,
         DiagnosticSeverity.Info,
         isEnabledByDefault: true,
-        helpLinkUri: "https://aka.ms/aspnet/analyzers");
+        helpLinkUri: AnalyzersLink);
 
     internal static readonly DiagnosticDescriptor DoNotUseIHeaderDictionaryAdd = new(
         "ASP0019",
-        new LocalizableResourceString(nameof(Resources.Analyzer_HeaderDictionaryAdd_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.Analyzer_HeaderDictionaryAdd_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_HeaderDictionaryAdd_Title)),
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_HeaderDictionaryAdd_Message)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri: "https://aka.ms/aspnet/analyzers");
+        helpLinkUri: AnalyzersLink);
 
     internal static readonly DiagnosticDescriptor RouteParameterComplexTypeIsNotParsable = new(
         "ASP0020",
-        new LocalizableResourceString(nameof(Resources.Analyzer_RouteParameterComplexTypeIsNotParsable_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.Analyzer_RouteParameterComplexTypeIsNotParsable_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_RouteParameterComplexTypeIsNotParsable_Title)),
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_RouteParameterComplexTypeIsNotParsable_Message)),
+        Usage,
         DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        helpLinkUri: "https://aka.ms/aspnet/analyzers");
+        helpLinkUri: AnalyzersLink);
 
     internal static readonly DiagnosticDescriptor BindAsyncSignatureMustReturnValueTaskOfT = new(
         "ASP0021",
-        new LocalizableResourceString(nameof(Resources.Analyzer_BindAsyncSignatureMustReturnValueTaskOfT_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.Analyzer_BindAsyncSignatureMustReturnValueTaskOfT_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_BindAsyncSignatureMustReturnValueTaskOfT_Title)),
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_BindAsyncSignatureMustReturnValueTaskOfT_Message)),
+        Usage,
         DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        helpLinkUri: "https://aka.ms/aspnet/analyzers");
+        helpLinkUri: AnalyzersLink);
 
     internal static readonly DiagnosticDescriptor AmbiguousRouteHandlerRoute = new(
         "ASP0022",
-        new LocalizableResourceString(nameof(Resources.Analyzer_AmbiguousRouteHandlerRoute_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.Analyzer_AmbiguousRouteHandlerRoute_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_AmbiguousRouteHandlerRoute_Title)),
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_AmbiguousRouteHandlerRoute_Message)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri: "https://aka.ms/aspnet/analyzers");
+        helpLinkUri: AnalyzersLink);
 
     internal static readonly DiagnosticDescriptor AmbiguousActionRoute = new(
         "ASP0023",
-        new LocalizableResourceString(nameof(Resources.Analyzer_AmbiguousActionRoute_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.Analyzer_AmbiguousActionRoute_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_AmbiguousActionRoute_Title)),
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_AmbiguousActionRoute_Message)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri: "https://aka.ms/aspnet/analyzers");
+        helpLinkUri: AnalyzersLink);
 
     internal static readonly DiagnosticDescriptor AtMostOneFromBodyAttribute = new(
         "ASP0024",
-        new LocalizableResourceString(nameof(Resources.Analyzer_MultipleFromBody_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.Analyzer_MultipleFromBody_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_MultipleFromBody_Title)),
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_MultipleFromBody_Message)),
+        Usage,
         DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        helpLinkUri: "https://aka.ms/aspnet/analyzers");
+        helpLinkUri: AnalyzersLink);
 
     internal static readonly DiagnosticDescriptor UseAddAuthorizationBuilder = new(
         "ASP0025",
-        new LocalizableResourceString(nameof(Resources.Analyzer_UseAddAuthorizationBuilder_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.Analyzer_UseAddAuthorizationBuilder_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_UseAddAuthorizationBuilder_Title)),
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_UseAddAuthorizationBuilder_Message)),
+        Usage,
         DiagnosticSeverity.Info,
         isEnabledByDefault: true,
-        helpLinkUri: "https://aka.ms/aspnet/analyzers");
+        helpLinkUri: AnalyzersLink);
 
     internal static readonly DiagnosticDescriptor OverriddenAuthorizeAttribute = new(
         "ASP0026",
-        new LocalizableResourceString(nameof(Resources.Analyzer_OverriddenAuthorizeAttribute_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.Analyzer_OverriddenAuthorizeAttribute_Message), Resources.ResourceManager, typeof(Resources)),
-        "Security",
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_OverriddenAuthorizeAttribute_Title)),
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_OverriddenAuthorizeAttribute_Message)),
+        Security,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        helpLinkUri: "https://aka.ms/aspnet/analyzers");
+        helpLinkUri: AnalyzersLink);
 
     internal static readonly DiagnosticDescriptor PublicPartialProgramClassNotRequired = new(
         "ASP0027",
-        new LocalizableResourceString(nameof(Resources.Analyzer_PublicPartialProgramClass_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.Analyzer_PublicPartialProgramClass_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_PublicPartialProgramClass_Title)),
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_PublicPartialProgramClass_Message)),
+        Usage,
         DiagnosticSeverity.Info,
         isEnabledByDefault: true,
-        helpLinkUri: "https://aka.ms/aspnet/analyzers",
+        helpLinkUri: AnalyzersLink,
         customTags: WellKnownDiagnosticTags.Unnecessary);
 
     internal static readonly DiagnosticDescriptor KestrelShouldListenOnIPv6AnyInsteadOfIpAny = new(
         "ASP0028",
-        new LocalizableResourceString(nameof(Resources.Analyzer_KestrelShouldListenOnIPv6AnyInsteadOfIpAny_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.Analyzer_KestrelShouldListenOnIPv6AnyInsteadOfIpAny_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_KestrelShouldListenOnIPv6AnyInsteadOfIpAny_Title)),
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_KestrelShouldListenOnIPv6AnyInsteadOfIpAny_Message)),
+        Usage,
         DiagnosticSeverity.Info,
         isEnabledByDefault: true,
-        helpLinkUri: "https://aka.ms/aspnet/analyzers");
+        helpLinkUri: AnalyzersLink);
 }

--- a/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator/DiagnosticDescriptors.cs
+++ b/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator/DiagnosticDescriptors.cs
@@ -7,121 +7,124 @@ namespace Microsoft.AspNetCore.Http.RequestDelegateGenerator;
 
 internal static class DiagnosticDescriptors
 {
+    private const string Usage = "Usage";
+
+    private static LocalizableResourceString CreateLocalizableResourceString(string resource) => new(resource, Resources.ResourceManager, typeof(Resources));
     private static string GetHelpLinkUrl(string id) => $"https://learn.microsoft.com/aspnet/core/fundamentals/aot/request-delegate-generator/diagnostics/{id}";
 
     public static DiagnosticDescriptor UnableToResolveRoutePattern { get; } = new(
         "RDG001",
-        new LocalizableResourceString(nameof(Resources.UnableToResolveRoutePattern_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.UnableToResolveRoutePattern_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.UnableToResolveRoutePattern_Title)),
+        CreateLocalizableResourceString(nameof(Resources.UnableToResolveRoutePattern_Message)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         helpLinkUri: GetHelpLinkUrl("RDG001"));
 
     public static DiagnosticDescriptor UnableToResolveMethod { get; } = new(
         "RDG002",
-        new LocalizableResourceString(nameof(Resources.UnableToResolveMethod_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.UnableToResolveMethod_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.UnableToResolveMethod_Title)),
+        CreateLocalizableResourceString(nameof(Resources.UnableToResolveMethod_Message)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         helpLinkUri: GetHelpLinkUrl("RDG002"));
 
     public static DiagnosticDescriptor UnableToResolveParameterDescriptor { get; } = new(
         "RDG003",
-        new LocalizableResourceString(nameof(Resources.UnableToResolveParameter_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.UnableToResolveParameter_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.UnableToResolveParameter_Title)),
+        CreateLocalizableResourceString(nameof(Resources.UnableToResolveParameter_Message)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         helpLinkUri: GetHelpLinkUrl("RDG003"));
 
     public static DiagnosticDescriptor UnableToResolveAnonymousReturnType { get; } = new(
         "RDG004",
-        new LocalizableResourceString(nameof(Resources.UnableToResolveAnonymousReturnType_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.UnableToResolveAnonymousReturnType_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.UnableToResolveAnonymousReturnType_Title)),
+        CreateLocalizableResourceString(nameof(Resources.UnableToResolveAnonymousReturnType_Message)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         helpLinkUri: GetHelpLinkUrl("RDG004"));
 
     public static DiagnosticDescriptor InvalidAsParametersAbstractType { get; } = new(
         "RDG005",
-        new LocalizableResourceString(nameof(Resources.InvalidAsParametersAbstractType_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.InvalidAsParametersAbstractType_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.InvalidAsParametersAbstractType_Title)),
+        CreateLocalizableResourceString(nameof(Resources.InvalidAsParametersAbstractType_Message)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         helpLinkUri: GetHelpLinkUrl("RDG005"));
 
     public static DiagnosticDescriptor InvalidAsParametersSignature { get; } = new(
         "RDG006",
-        new LocalizableResourceString(nameof(Resources.InvalidAsParametersSignature_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.InvalidAsParametersSignature_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.InvalidAsParametersSignature_Title)),
+        CreateLocalizableResourceString(nameof(Resources.InvalidAsParametersSignature_Message)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         helpLinkUri: GetHelpLinkUrl("RDG006"));
 
     public static DiagnosticDescriptor InvalidAsParametersNoConstructorFound { get; } = new(
         "RDG007",
-        new LocalizableResourceString(nameof(Resources.InvalidAsParametersNoConstructorFound_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.InvalidAsParametersNoConstructorFound_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.InvalidAsParametersNoConstructorFound_Title)),
+        CreateLocalizableResourceString(nameof(Resources.InvalidAsParametersNoConstructorFound_Message)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         helpLinkUri: GetHelpLinkUrl("RDG007"));
 
     public static DiagnosticDescriptor InvalidAsParametersSingleConstructorOnly { get; } = new(
         "RDG008",
-        new LocalizableResourceString(nameof(Resources.InvalidAsParametersSingleConstructorOnly_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.InvalidAsParametersSingleConstructorOnly_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.InvalidAsParametersSingleConstructorOnly_Title)),
+        CreateLocalizableResourceString(nameof(Resources.InvalidAsParametersSingleConstructorOnly_Message)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         helpLinkUri: GetHelpLinkUrl("RDG008"));
 
     public static DiagnosticDescriptor InvalidAsParametersNested { get; } = new(
         "RDG009",
-        new LocalizableResourceString(nameof(Resources.InvalidAsParametersNested_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.InvalidAsParametersNested_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.InvalidAsParametersNested_Title)),
+        CreateLocalizableResourceString(nameof(Resources.InvalidAsParametersNested_Message)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         helpLinkUri: GetHelpLinkUrl("RDG009"));
 
     public static DiagnosticDescriptor InvalidAsParametersNullable { get; } = new(
         "RDG010",
-        new LocalizableResourceString(nameof(Resources.InvalidAsParametersNullable_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.InvalidAsParametersNullable_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.InvalidAsParametersNullable_Title)),
+        CreateLocalizableResourceString(nameof(Resources.InvalidAsParametersNullable_Message)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         helpLinkUri: GetHelpLinkUrl("RDG010"));
 
     public static DiagnosticDescriptor TypeParametersNotSupported { get; } = new(
         "RDG011",
-        new LocalizableResourceString(nameof(Resources.TypeParametersNotSupported_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.TypeParametersNotSupported_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.TypeParametersNotSupported_Title)),
+        CreateLocalizableResourceString(nameof(Resources.TypeParametersNotSupported_Message)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         helpLinkUri: GetHelpLinkUrl("RDG011"));
 
     public static DiagnosticDescriptor InaccessibleTypesNotSupported { get; } = new(
         "RDG012",
-        new LocalizableResourceString(nameof(Resources.InaccessibleTypesNotSupported_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.InaccessibleTypesNotSupported_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.InaccessibleTypesNotSupported_Title)),
+        CreateLocalizableResourceString(nameof(Resources.InaccessibleTypesNotSupported_Message)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         helpLinkUri: GetHelpLinkUrl("RDG012"));
 
     public static DiagnosticDescriptor KeyedAndNotKeyedServiceAttributesNotSupported { get; } = new(
         "RDG013",
-        new LocalizableResourceString(nameof(Resources.KeyedAndNotKeyedServiceAttributesNotSupported_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.KeyedAndNotKeyedServiceAttributesNotSupported_Message), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.KeyedAndNotKeyedServiceAttributesNotSupported_Title)),
+        CreateLocalizableResourceString(nameof(Resources.KeyedAndNotKeyedServiceAttributesNotSupported_Message)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         helpLinkUri: GetHelpLinkUrl("RDG013"));

--- a/src/Mvc/Mvc.Analyzers/src/DiagnosticDescriptors.cs
+++ b/src/Mvc/Mvc.Analyzers/src/DiagnosticDescriptors.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.CodeAnalysis;
@@ -8,12 +8,15 @@ namespace Microsoft.AspNetCore.Mvc.Analyzers;
 [System.Diagnostics.CodeAnalysis.SuppressMessage("MicrosoftCodeAnalysisReleaseTracking", "RS2008:Enable analyzer release tracking")]
 public static class DiagnosticDescriptors
 {
+    private const string Naming = "Naming";
+    private const string Usage = "Usage";
+
     public static readonly DiagnosticDescriptor MVC1000_HtmlHelperPartialShouldBeAvoided =
         new DiagnosticDescriptor(
             "MVC1000",
             "Use of IHtmlHelper.{0} should be avoided",
             "Use of IHtmlHelper.{0} may result in application deadlocks. Consider using <partial> Tag Helper or IHtmlHelper.{0}Async.",
-            "Usage",
+            Usage,
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
@@ -22,7 +25,7 @@ public static class DiagnosticDescriptors
             "MVC1001",
             "Filters cannot be applied to page handler methods",
             "'{0}' cannot be applied to Razor Page handler methods. It may be applied either to the Razor Page model or applied globally.",
-            "Usage",
+            Usage,
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
@@ -31,7 +34,7 @@ public static class DiagnosticDescriptors
             "MVC1002",
             "Route attributes cannot be applied to page handler methods",
             "'{0}' cannot be applied to Razor Page handler methods. Routes for Razor Pages must be declared using the @page directive or using conventions.",
-            "Usage",
+            Usage,
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
@@ -40,7 +43,7 @@ public static class DiagnosticDescriptors
             "MVC1003",
             "Route attributes cannot be applied to page models",
             "'{0}' cannot be applied to a Razor Page model. Routes for Razor Pages must be declared using the @page directive or using conventions.",
-            "Usage",
+            Usage,
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
@@ -50,7 +53,7 @@ public static class DiagnosticDescriptors
             "Rename model bound parameter",
             "Property on type '{0}' has the same name as parameter '{1}'. This may result in incorrect model binding. " +
             "Consider renaming the parameter or the property to avoid conflicts. If the type '{0}' has a custom type converter or custom model binder, you can suppress this message.",
-            "Naming",
+            Naming,
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
             helpLinkUri: "https://aka.ms/AA20pbc");
@@ -62,7 +65,7 @@ public static class DiagnosticDescriptors
             "MVC1006",
             "Methods containing TagHelpers must be async and return Task",
             "The method contains a TagHelper and therefore must be async and return a Task. For instance, usage of ~/ typically results in a TagHelper and requires an async Task returning parent method.",
-            "Usage",
+            Usage,
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 }

--- a/src/Mvc/Mvc.Api.Analyzers/src/ApiDiagnosticDescriptors.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/src/ApiDiagnosticDescriptors.cs
@@ -8,12 +8,14 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers;
 [System.Diagnostics.CodeAnalysis.SuppressMessage("MicrosoftCodeAnalysisReleaseTracking", "RS2008:Enable analyzer release tracking")]
 internal static class ApiDiagnosticDescriptors
 {
+    public const string Usage = "Usage";
+
     public static readonly DiagnosticDescriptor API1000_ActionReturnsUndocumentedStatusCode =
         new DiagnosticDescriptor(
             "API1000",
             "Action returns undeclared status code",
             "Action method returns undeclared status code '{0}'",
-            "Usage",
+            Usage,
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
@@ -22,7 +24,7 @@ internal static class ApiDiagnosticDescriptors
             "API1001",
             "Action returns undeclared success result",
             "Action method returns a success result without a corresponding ProducesResponseType",
-            "Usage",
+            Usage,
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
@@ -31,7 +33,7 @@ internal static class ApiDiagnosticDescriptors
             "API1002",
             "Action documents status code that is not returned",
             "Action method documents status code '{0}' without a corresponding return type",
-            "Usage",
+            Usage,
             DiagnosticSeverity.Info,
             isEnabledByDefault: false);
 
@@ -40,7 +42,7 @@ internal static class ApiDiagnosticDescriptors
             "API1003",
             "Action methods on ApiController instances do not require explicit model validation check",
             "Action methods on ApiController instances do not require explicit model validation check",
-            "Usage",
+            Usage,
             DiagnosticSeverity.Info,
             isEnabledByDefault: true,
             customTags: new[] { WellKnownDiagnosticTags.Unnecessary });

--- a/src/Mvc/Mvc.Api.Analyzers/src/ApiDiagnosticDescriptors.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/src/ApiDiagnosticDescriptors.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers;
 [System.Diagnostics.CodeAnalysis.SuppressMessage("MicrosoftCodeAnalysisReleaseTracking", "RS2008:Enable analyzer release tracking")]
 internal static class ApiDiagnosticDescriptors
 {
-    public const string Usage = "Usage";
+    private const string Usage = "Usage";
 
     public static readonly DiagnosticDescriptor API1000_ActionReturnsUndocumentedStatusCode =
         new DiagnosticDescriptor(

--- a/src/SignalR/clients/csharp/Client.SourceGenerator/src/DiagnosticDescriptors.cs
+++ b/src/SignalR/clients/csharp/Client.SourceGenerator/src/DiagnosticDescriptors.cs
@@ -7,6 +7,8 @@ namespace Microsoft.AspNetCore.SignalR.Client.SourceGenerator;
 
 internal static class DiagnosticDescriptors
 {
+    private const string SignalRClientSourceGeneratorCategory = "SignalR.Client.SourceGenerator";
+
     // Ranges
     // SSG0000-0099: HubServerProxyGenerator
     // SSG0100-0199: HubClientProxyGenerator
@@ -15,7 +17,7 @@ internal static class DiagnosticDescriptors
         id: "SSG0000",
         title: "Non-interface generic type argument",
         messageFormat: "Only interfaces are accepted. '{0}' is not an interface.",
-        category: "SignalR.Client.SourceGenerator",
+        category: SignalRClientSourceGeneratorCategory,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
@@ -23,7 +25,7 @@ internal static class DiagnosticDescriptors
         id: "SSG0001",
         title: "Unsupported return type",
         messageFormat: "'{0}' has a return type of '{1}' but only Task, ValueTask, Task<T> and ValueTask<T> are supported for source generation.",
-        category: "SignalR.Client.SourceGenerator",
+        category: SignalRClientSourceGeneratorCategory,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
 
@@ -31,7 +33,7 @@ internal static class DiagnosticDescriptors
         id: "SSG0002",
         title: "Too many HubServerProxy attributed methods",
         messageFormat: "There can only be one HubServerProxy attributed method.",
-        category: "SignalR.Client.SourceGenerator",
+        category: SignalRClientSourceGeneratorCategory,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
@@ -39,7 +41,7 @@ internal static class DiagnosticDescriptors
         id: "SSG0003",
         title: "HubServerProxy attributed method has bad accessibility",
         messageFormat: "HubServerProxy attributed method may only have an accessibility of public, internal, protected, protected internal or private.",
-        category: "SignalR.Client.SourceGenerator",
+        category: SignalRClientSourceGeneratorCategory,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
@@ -47,7 +49,7 @@ internal static class DiagnosticDescriptors
         id: "SSG0004",
         title: "HubServerProxy attributed method is not partial",
         messageFormat: "HubServerProxy attributed method must be partial.",
-        category: "SignalR.Client.SourceGenerator",
+        category: SignalRClientSourceGeneratorCategory,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
@@ -55,7 +57,7 @@ internal static class DiagnosticDescriptors
         id: "SSG0005",
         title: "HubServerProxy attributed method is not an extension method",
         messageFormat: "HubServerProxy attributed method must be an extension method for HubConnection.",
-        category: "SignalR.Client.SourceGenerator",
+        category: SignalRClientSourceGeneratorCategory,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
@@ -63,7 +65,7 @@ internal static class DiagnosticDescriptors
         id: "SSG0006",
         title: "HubServerProxy attributed method has bad number of type arguments",
         messageFormat: "HubServerProxy attributed method must have exactly one type argument.",
-        category: "SignalR.Client.SourceGenerator",
+        category: SignalRClientSourceGeneratorCategory,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
@@ -71,7 +73,7 @@ internal static class DiagnosticDescriptors
         id: "SSG0007",
         title: "HubServerProxy attributed method type argument and return type does not match",
         messageFormat: "HubServerProxy attributed method must have the same type argument and return type.",
-        category: "SignalR.Client.SourceGenerator",
+        category: SignalRClientSourceGeneratorCategory,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
@@ -79,7 +81,7 @@ internal static class DiagnosticDescriptors
         id: "SSG0008",
         title: "HubServerProxy attributed method has bad number of arguments",
         messageFormat: "HubServerProxy attributed method must have exactly one argument which must be of type HubConnection.",
-        category: "SignalR.Client.SourceGenerator",
+        category: SignalRClientSourceGeneratorCategory,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
@@ -87,7 +89,7 @@ internal static class DiagnosticDescriptors
         id: "SSG0009",
         title: "HubServerProxy attributed method has argument of wrong type",
         messageFormat: "HubServerProxy attributed method must have exactly one argument which must be of type HubConnection.",
-        category: "SignalR.Client.SourceGenerator",
+        category: SignalRClientSourceGeneratorCategory,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
@@ -97,7 +99,7 @@ internal static class DiagnosticDescriptors
         id: "SSG0100",
         title: "Unsupported return type",
         messageFormat: "'{0}' has a return type of '{1}' but only void and Task are supported for callback methods.",
-        category: "SignalR.Client.SourceGenerator",
+        category: SignalRClientSourceGeneratorCategory,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
 
@@ -105,7 +107,7 @@ internal static class DiagnosticDescriptors
         id: "SSG0102",
         title: "Too many HubClientProxy attributed methods",
         messageFormat: "There can only be one HubClientProxy attributed method.",
-        category: "SignalR.Client.SourceGenerator",
+        category: SignalRClientSourceGeneratorCategory,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
@@ -113,7 +115,7 @@ internal static class DiagnosticDescriptors
         id: "SSG0103",
         title: "HubClientProxy attributed method has bad accessibility",
         messageFormat: "HubClientProxy attributed method may only have an accessibility of public, internal, protected, protected internal or private.",
-        category: "SignalR.Client.SourceGenerator",
+        category: SignalRClientSourceGeneratorCategory,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
@@ -121,7 +123,7 @@ internal static class DiagnosticDescriptors
         id: "SSG0104",
         title: "HubClientProxy attributed method is not partial",
         messageFormat: "HubClientProxy attributed method must be partial.",
-        category: "SignalR.Client.SourceGenerator",
+        category: SignalRClientSourceGeneratorCategory,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
@@ -129,7 +131,7 @@ internal static class DiagnosticDescriptors
         id: "SSG0105",
         title: "HubClientProxy attributed method is not an extension method",
         messageFormat: "HubClientProxy attributed method must be an extension method for HubConnection.",
-        category: "SignalR.Client.SourceGenerator",
+        category: SignalRClientSourceGeneratorCategory,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
@@ -137,7 +139,7 @@ internal static class DiagnosticDescriptors
         id: "SSG0106",
         title: "HubClientProxy attributed method has bad number of type arguments",
         messageFormat: "HubClientProxy attributed method must have exactly one type argument.",
-        category: "SignalR.Client.SourceGenerator",
+        category: SignalRClientSourceGeneratorCategory,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
@@ -145,7 +147,7 @@ internal static class DiagnosticDescriptors
         id: "SSG0107",
         title: "HubClientProxy attributed method type argument and return type does not match",
         messageFormat: "HubClientProxy attributed method must have the same type argument and return type.",
-        category: "SignalR.Client.SourceGenerator",
+        category: SignalRClientSourceGeneratorCategory,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
@@ -153,7 +155,7 @@ internal static class DiagnosticDescriptors
         id: "SSG0108",
         title: "HubClientProxy attributed method has bad number of arguments",
         messageFormat: "HubClientProxy attributed method must have exactly two arguments.",
-        category: "SignalR.Client.SourceGenerator",
+        category: SignalRClientSourceGeneratorCategory,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
@@ -161,7 +163,7 @@ internal static class DiagnosticDescriptors
         id: "SSG0109",
         title: "HubClientProxy attributed method has first argument of wrong type",
         messageFormat: "HubClientProxy attributed method must have its first argument type be HubConnection.",
-        category: "SignalR.Client.SourceGenerator",
+        category: SignalRClientSourceGeneratorCategory,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
@@ -169,7 +171,7 @@ internal static class DiagnosticDescriptors
         id: "SSG0110",
         title: "HubClientProxy attributed method has wrong return type",
         messageFormat: "HubClientProxy attributed method must have a return type of IDisposable.",
-        category: "SignalR.Client.SourceGenerator",
+        category: SignalRClientSourceGeneratorCategory,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 }

--- a/src/Tools/SDK-Analyzers/Components/src/DiagnosticDescriptors.cs
+++ b/src/Tools/SDK-Analyzers/Components/src/DiagnosticDescriptors.cs
@@ -8,61 +8,66 @@ namespace Microsoft.AspNetCore.Components.Analyzers;
 [System.Diagnostics.CodeAnalysis.SuppressMessage("MicrosoftCodeAnalysisReleaseTracking", "RS2008:Enable analyzer release tracking")]
 internal static class DiagnosticDescriptors
 {
+    private const string Encapsulation = "Encapsulation";
+    private const string Usage = "Usage";
+
+    private static LocalizableResourceString CreateLocalizableResourceString(string resource) => new(resource, Resources.ResourceManager, typeof(Resources));
+
     // Note: The Razor Compiler (including Components features) use the RZ prefix for diagnostics, so there's currently
     // no change of clashing between that and the BL prefix used here.
     //
     // Tracking https://github.com/dotnet/aspnetcore/issues/10382 to rationalize this
     public static readonly DiagnosticDescriptor ComponentParameterSettersShouldBePublic = new DiagnosticDescriptor(
         "BL0001",
-        new LocalizableResourceString(nameof(Resources.ComponentParameterSettersShouldBePublic_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.ComponentParameterSettersShouldBePublic_Format), Resources.ResourceManager, typeof(Resources)),
-        "Encapsulation",
+        CreateLocalizableResourceString(nameof(Resources.ComponentParameterSettersShouldBePublic_Title)),
+        CreateLocalizableResourceString(nameof(Resources.ComponentParameterSettersShouldBePublic_Format)),
+        Encapsulation,
         DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: new LocalizableResourceString(nameof(Resources.ComponentParameterSettersShouldBePublic_Description), Resources.ResourceManager, typeof(Resources)));
+        description: CreateLocalizableResourceString(nameof(Resources.ComponentParameterSettersShouldBePublic_Description)));
 
     public static readonly DiagnosticDescriptor ComponentParameterCaptureUnmatchedValuesMustBeUnique = new DiagnosticDescriptor(
         "BL0002",
-        new LocalizableResourceString(nameof(Resources.ComponentParameterCaptureUnmatchedValuesMustBeUnique_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.ComponentParameterCaptureUnmatchedValuesMustBeUnique_Format), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.ComponentParameterCaptureUnmatchedValuesMustBeUnique_Title)),
+        CreateLocalizableResourceString(nameof(Resources.ComponentParameterCaptureUnmatchedValuesMustBeUnique_Format)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: new LocalizableResourceString(nameof(Resources.ComponentParameterCaptureUnmatchedValuesMustBeUnique_Description), Resources.ResourceManager, typeof(Resources)));
+        description: CreateLocalizableResourceString(nameof(Resources.ComponentParameterCaptureUnmatchedValuesMustBeUnique_Description)));
 
     public static readonly DiagnosticDescriptor ComponentParameterCaptureUnmatchedValuesHasWrongType = new DiagnosticDescriptor(
         "BL0003",
-        new LocalizableResourceString(nameof(Resources.ComponentParameterCaptureUnmatchedValuesHasWrongType_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.ComponentParameterCaptureUnmatchedValuesHasWrongType_Format), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.ComponentParameterCaptureUnmatchedValuesHasWrongType_Title)),
+        CreateLocalizableResourceString(nameof(Resources.ComponentParameterCaptureUnmatchedValuesHasWrongType_Format)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: new LocalizableResourceString(nameof(Resources.ComponentParameterCaptureUnmatchedValuesHasWrongType_Description), Resources.ResourceManager, typeof(Resources)));
+        description: CreateLocalizableResourceString(nameof(Resources.ComponentParameterCaptureUnmatchedValuesHasWrongType_Description)));
 
     public static readonly DiagnosticDescriptor ComponentParametersShouldBePublic = new DiagnosticDescriptor(
         "BL0004",
-        new LocalizableResourceString(nameof(Resources.ComponentParameterShouldBePublic_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.ComponentParameterShouldBePublic_Format), Resources.ResourceManager, typeof(Resources)),
-        "Encapsulation",
+        CreateLocalizableResourceString(nameof(Resources.ComponentParameterShouldBePublic_Title)),
+        CreateLocalizableResourceString(nameof(Resources.ComponentParameterShouldBePublic_Format)),
+        Encapsulation,
         DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: new LocalizableResourceString(nameof(Resources.ComponentParametersShouldBePublic_Description), Resources.ResourceManager, typeof(Resources)));
+        description: CreateLocalizableResourceString(nameof(Resources.ComponentParametersShouldBePublic_Description)));
 
     public static readonly DiagnosticDescriptor ComponentParametersShouldNotBeSetOutsideOfTheirDeclaredComponent = new DiagnosticDescriptor(
         "BL0005",
-        new LocalizableResourceString(nameof(Resources.ComponentParameterShouldNotBeSetOutsideOfTheirDeclaredComponent_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.ComponentParameterShouldNotBeSetOutsideOfTheirDeclaredComponent_Format), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.ComponentParameterShouldNotBeSetOutsideOfTheirDeclaredComponent_Title)),
+        CreateLocalizableResourceString(nameof(Resources.ComponentParameterShouldNotBeSetOutsideOfTheirDeclaredComponent_Format)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: new LocalizableResourceString(nameof(Resources.ComponentParameterShouldNotBeSetOutsideOfTheirDeclaredComponent_Description), Resources.ResourceManager, typeof(Resources)));
+        description: CreateLocalizableResourceString(nameof(Resources.ComponentParameterShouldNotBeSetOutsideOfTheirDeclaredComponent_Description)));
 
     public static readonly DiagnosticDescriptor DoNotUseRenderTreeTypes = new DiagnosticDescriptor(
         "BL0006",
-        new LocalizableResourceString(nameof(Resources.DoNotUseRenderTreeTypes_Title), Resources.ResourceManager, typeof(Resources)),
-        new LocalizableResourceString(nameof(Resources.DoNotUseRenderTreeTypes_Description), Resources.ResourceManager, typeof(Resources)),
-        "Usage",
+        CreateLocalizableResourceString(nameof(Resources.DoNotUseRenderTreeTypes_Title)),
+        CreateLocalizableResourceString(nameof(Resources.DoNotUseRenderTreeTypes_Description)),
+        Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: new LocalizableResourceString(nameof(Resources.DoNotUseRenderTreeTypes_Description), Resources.ResourceManager, typeof(Resources)));
+        description: CreateLocalizableResourceString(nameof(Resources.DoNotUseRenderTreeTypes_Description)));
 }


### PR DESCRIPTION
## Description

I have refactored seven of the `DiagnosticDescriptor.cs` files following the points below

- Use constants to maintain consistency between descriptors where applicable
- Use a helper method when creating a `LocalizableResourceString` to make code more concise

Fixes #60831
