### PR TITLE
[release/9.0] [Blazor] Fix custom elements JS assets not being included in build output

### DIFF
--- a/src/Components/CustomElements/src/Microsoft.AspNetCore.Components.CustomElements.csproj
+++ b/src/Components/CustomElements/src/Microsoft.AspNetCore.Components.CustomElements.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
@@ -18,7 +18,7 @@
     </ResolveStaticWebAssetsInputsDependsOn>
   </PropertyGroup>
 
-  <Target Name="IncludeCompileJsOutput" BeforeTargets="ResolveJSModuleStaticWebAssets">
+  <Target Name="IncludeCompileJsOutput" BeforeTargets="ResolveJSModuleStaticWebAssets;ResolveJsInitializerModuleStaticWebAssets">
     <ItemGroup>
       <_JsBuildOutput Include="$(InteropWorkingDir)dist\$(Configuration)\**" Exclude="$(InteropWorkingDir)dist\.gitignore" />
     </ItemGroup>


### PR DESCRIPTION
# Fix custom elements JS assets not being included in build output

This update addresses an issue where JS assets providing functionality for the `Microsoft.AspNetCore.Components.CustomElements` package were not correctly built, causing the extension method `RootComponentMappingCollection.RegisterCustomElement()` to throw an exception.

## Description

The MSBuild logic to include JS assets in the `Microsoft.AspNetCore.Components.CustomElements` package stopped working because the target that adds JS assets started running too late in the build process (after the `ResolveJSModuleStaticWebAssets` target). Although the reasons for the change in target ordering are unknown, the fix is to explicitly run the target before `ResolveJSModuleStaticWebAssets`.

This bug was discovered during the investigation of failures in our automated Blazor E2E tests.

Fixes https://github.com/dotnet/aspnetcore/issues/60859

## Customer Impact

If this bug is left unfixed, calls to `RegisterCustomElement()` will throw an exception, preventing Blazor WebAssembly functionality from working. In a Blazor Web App, this may cause partial or complete loss of app functionality, and in Blazor WebAssembly apps, complete loss of app functionality.

However, note that this issue would only affect Blazor apps using the `Microsoft.AspNetCore.Components.CustomElements` package. The primary purpose of the package is to expose Blazor components as custom elements that can be rendered from a JavaScript-based UI library.

We don't have any customer data on the bug because a version of the package with the bug has not shipped. Version 9.0.3 would have included the bug, so we're going to skip shipping version 9.0.3 of this package and get this bug fixed for version 9.0.4.

## Regression?

- [X] Yes
- [ ] No

Regressed from `Microsoft.AspNetCore.Components.CustomElements` version 9.0.2.

## Risk

- [ ] High
- [ ] Medium
- [X] Low

The fix is simple and was applied back in October 2024 on the `main` branch.

## Verification

- [X] Manual (required)
- [X] Automated

Automated E2E tests caught this bug an SDK update PR targeting `main` because the `components-e2e` pipeline is a required check in `main`. However, since that pipeline was not required for `release` branches, this issue slipped through the cracks for `release/9.0`. This has been fixed, and the `components-e2e` pipeline is now a required check for `release` branches.

## Packaging Changes Reviewed?

- [ ] Yes
- [ ] No
- [X] N/A