### PR TITLE
Use the host version that corresponds with the LKG SDK

### DIFF
--- a/eng/tools/GenerateFiles/Directory.Build.props.in
+++ b/eng/tools/GenerateFiles/Directory.Build.props.in
@@ -3,6 +3,7 @@
     <DefaultNetCoreTargetFramework>${DefaultNetCoreTargetFramework}</DefaultNetCoreTargetFramework>
     <ArtifactsShippingPackagesDir>${ArtifactsShippingPackagesDir}</ArtifactsShippingPackagesDir>
     <TreatWarningsAsErrors Condition="'$(BuildingInsideVisualStudio)' != 'true'">true</TreatWarningsAsErrors>
+    <LibNetHostAppPackVersion Condition=" '$(LibNetHostAppPackVersion)' == '' ">${LibNetHostAppPackVersion}</LibNetHostAppPackVersion>
 
     <!-- Temporarily hardcoded to true -->
     <SuppressGenerateILCompilerExplicitPackageReferenceWarning>true</SuppressGenerateILCompilerExplicitPackageReferenceWarning>

--- a/eng/tools/GenerateFiles/GenerateFiles.csproj
+++ b/eng/tools/GenerateFiles/GenerateFiles.csproj
@@ -25,6 +25,7 @@
         MicrosoftNETCoreAppRefVersion=$(MicrosoftNETCoreAppRefVersion);
         MicrosoftNETCoreAppRuntimeVersion=$(MicrosoftNETCoreAppRuntimeVersion);
         MicrosoftPlaywrightCLIVersion=$(MicrosoftPlaywrightCLIVersion);
+        LibNetHostAppPackVersion=$(BundledNETCoreAppPackageVersion);
         SupportedRuntimeIdentifiers=$([MSBuild]::Escape($(SupportedRuntimeIdentifiers)));
         ArtifactsShippingPackagesDir=$(ArtifactsShippingPackagesDir)
       </_TemplateProperties>

--- a/src/Servers/IIS/Directory.Build.props
+++ b/src/Servers/IIS/Directory.Build.props
@@ -9,20 +9,20 @@
     <HostArch Condition="'$(Platform)' == 'Win32'">x86</HostArch>
     <HostArch Condition="'$(Platform)' == 'AnyCPU'">x64</HostArch>
     <HostArch Condition="'$(DotNetBuild)' == 'true'">$(TargetArchitecture)</HostArch>
-    <LibNetHostPath>$(NuGetPackageRoot)microsoft.netcore.app.host.win-$(HostArch)\$(MicrosoftNETCoreAppRefVersion)\runtimes\win-$(HostArch)\native</LibNetHostPath>
+    <LibNetHostPath>$(NuGetPackageRoot)microsoft.netcore.app.host.win-$(HostArch)\$(LibNetHostAppPackVersion)\runtimes\win-$(HostArch)\native</LibNetHostPath>
     <!-- This tools version MUST match the same version as runtime uses to compile libnethost.lib -->
     <PlatformToolsetVersion>143</PlatformToolsetVersion>
   </PropertyGroup>
 
   <!-- Platform is different during restore than during build. Therefore, restore everything when not building the product. -->
   <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.vcxproj' and '$(DotNetBuild)' != 'true'">
-    <PackageReference Include="Microsoft.NETCore.App.Host.win-x64" Version="[$(MicrosoftNETCoreAppRefVersion)]" PrivateAssets="all" ExcludeAssets="all" />
-    <PackageReference Include="Microsoft.NETCore.App.Host.win-x86" Version="[$(MicrosoftNETCoreAppRefVersion)]" PrivateAssets="all" ExcludeAssets="all" />
-    <PackageReference Include="Microsoft.NETCore.App.Host.win-arm64" Version="[$(MicrosoftNETCoreAppRefVersion)]" PrivateAssets="all" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.NETCore.App.Host.win-x64" Version="[$(LibNetHostAppPackVersion)]" PrivateAssets="all" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.NETCore.App.Host.win-x86" Version="[$(LibNetHostAppPackVersion)]" PrivateAssets="all" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.NETCore.App.Host.win-arm64" Version="[$(LibNetHostAppPackVersion)]" PrivateAssets="all" ExcludeAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.vcxproj' and '$(DotNetBuild)' == 'true'">
-    <PackageReference Include="Microsoft.NETCore.App.Host.win-$(TargetArchitecture)" Version="[$(MicrosoftNETCoreAppRefVersion)]" PrivateAssets="all" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.NETCore.App.Host.win-$(TargetArchitecture)" Version="[$(LibNetHostAppPackVersion)]" PrivateAssets="all" ExcludeAssets="all" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Don't use the live host but the one that is also redistributed in the .NET SDK. This is a small partial revert of https://github.com/dotnet/aspnetcore/commit/bac31da56136b05ffd8315a318d86b767e922218#diff-8df3cd354bc584349d04ad5675b33c042d8b99b741b8b95af394c55e0f5001bf

Unblocks https://github.com/dotnet/sdk/pull/47480