### PR TITLE
Fix preserving messages for stateful reconnect with backplane

### DIFF
--- a/src/SignalR/common/Shared/MessageBuffer.cs
+++ b/src/SignalR/common/Shared/MessageBuffer.cs
@@ -121,7 +121,7 @@ internal sealed class MessageBuffer : IDisposable
 
     public ValueTask<FlushResult> WriteAsync(SerializedHubMessage hubMessage, CancellationToken cancellationToken)
     {
-        // Default to HubInvocationMessage as that's the only type we use SerializedHubMessage for currently. Should harden this in the future.
+        // Default to HubInvocationMessage as that's the only type we use SerializedHubMessage for currently when Message is null. Should harden this in the future.
         return WriteAsyncCore(hubMessage.Message?.GetType() ?? typeof(HubInvocationMessage), hubMessage.GetSerializedMessage(_protocol), cancellationToken);
     }
 

--- a/src/SignalR/common/Shared/MessageBuffer.cs
+++ b/src/SignalR/common/Shared/MessageBuffer.cs
@@ -121,15 +121,16 @@ internal sealed class MessageBuffer : IDisposable
 
     public ValueTask<FlushResult> WriteAsync(SerializedHubMessage hubMessage, CancellationToken cancellationToken)
     {
-        return WriteAsyncCore(hubMessage.Message!, hubMessage.GetSerializedMessage(_protocol), cancellationToken);
+        // Default to HubInvocationMessage as that's the only type we use SerializedHubMessage for currently. Should harden this in the future.
+        return WriteAsyncCore(hubMessage.Message?.GetType() ?? typeof(HubInvocationMessage), hubMessage.GetSerializedMessage(_protocol), cancellationToken);
     }
 
     public ValueTask<FlushResult> WriteAsync(HubMessage hubMessage, CancellationToken cancellationToken)
     {
-        return WriteAsyncCore(hubMessage, _protocol.GetMessageBytes(hubMessage), cancellationToken);
+        return WriteAsyncCore(hubMessage.GetType(), _protocol.GetMessageBytes(hubMessage), cancellationToken);
     }
 
-    private async ValueTask<FlushResult> WriteAsyncCore(HubMessage hubMessage, ReadOnlyMemory<byte> messageBytes, CancellationToken cancellationToken)
+    private async ValueTask<FlushResult> WriteAsyncCore(Type hubMessageType, ReadOnlyMemory<byte> messageBytes, CancellationToken cancellationToken)
     {
         // TODO: Add backpressure based on message count
         if (_bufferedByteCount > _bufferLimit)
@@ -158,7 +159,7 @@ internal sealed class MessageBuffer : IDisposable
         await _writeLock.WaitAsync(cancellationToken: default).ConfigureAwait(false);
         try
         {
-            if (hubMessage is HubInvocationMessage invocationMessage)
+            if (typeof(HubInvocationMessage).IsAssignableFrom(hubMessageType))
             {
                 _totalMessageCount++;
                 _bufferedByteCount += messageBytes.Length;

--- a/src/SignalR/server/Core/src/SerializedHubMessage.cs
+++ b/src/SignalR/server/Core/src/SerializedHubMessage.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using Microsoft.AspNetCore.SignalR.Protocol;
 
 namespace Microsoft.AspNetCore.SignalR;
@@ -40,6 +41,8 @@ public class SerializedHubMessage
     /// <param name="message">The hub message for the cache. This will be serialized with an <see cref="IHubProtocol"/> in <see cref="GetSerializedMessage"/> to get the message's serialized representation.</param>
     public SerializedHubMessage(HubMessage message)
     {
+        // Type currently only used for invocation messages, we should probably refactor it to be explicit about that e.g. new property for message type?
+        Debug.Assert(message.GetType().IsAssignableTo(typeof(HubInvocationMessage)));
         Message = message;
     }
 

--- a/src/SignalR/server/StackExchangeRedis/test/Startup.cs
+++ b/src/SignalR/server/StackExchangeRedis/test/Startup.cs
@@ -33,6 +33,7 @@ public class Startup
         app.UseEndpoints(endpoints =>
         {
             endpoints.MapHub<EchoHub>("/echo");
+            endpoints.MapHub<StatefulHub>("/stateful", o => o.AllowStatefulReconnects = true);
         });
     }
 

--- a/src/SignalR/server/StackExchangeRedis/test/StatefulHub.cs
+++ b/src/SignalR/server/StackExchangeRedis/test/StatefulHub.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.SignalR.StackExchangeRedis.Tests;
+
+public class StatefulHub : Hub
+{
+    public Task SendToAll(string message)
+    {
+        return Clients.All.SendAsync("SendToAll", message);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/55575

Changed `MessageBuffer.WriteAsync` methods to use the hub message type since that's the only information we're using in the method. And updated the `SerializedHubMessage` usage to assume we're sending a `HubInvocationMessage` since that's the only message type we currently use with `SerializedHubMessage`.

Updated tests:
* [`src/SignalR/server/SignalR/test/Microsoft.AspNetCore.SignalR.Tests/Internal/MessageBufferTests.cs`](diffhunk://#diff-a2a124e86f8258d8976412c33c8dcb74c6815ae284e3d6eb31c66c2ea258c4edR173-R228): Added a regression test to ensure unacknowledged serialized messages are resent on reconnect.

* [`src/SignalR/server/StackExchangeRedis/test/RedisEndToEnd.cs`](diffhunk://#diff-91d56b5d60716bde43cc90862fd23895195c4effe5fe6fc3365f34e38583f8e6L216-R312): Added a new E2E stateful reconnect test to verify that messages are preserved during reconnects and introduced a `WebSocketWrapper` class to simulate ungraceful closures. [[1]](diffhunk://#diff-91d56b5d60716bde43cc90862fd23895195c4effe5fe6fc3365f34e38583f8e6L216-R312) [[2]](diffhunk://#diff-91d56b5d60716bde43cc90862fd23895195c4effe5fe6fc3365f34e38583f8e6R326-R327) [[3]](diffhunk://#diff-91d56b5d60716bde43cc90862fd23895195c4effe5fe6fc3365f34e38583f8e6R356-R418)