### PR TITLE
Bundle the .NET Runtime in the archives in the VMR as well

### DIFF
--- a/src/Framework/App.Runtime/src/aspnetcore-runtime-composite.proj
+++ b/src/Framework/App.Runtime/src/aspnetcore-runtime-composite.proj
@@ -32,7 +32,7 @@
     <DotNetRuntimeArchive>$(BaseIntermediateOutputPath)$(DotNetRuntimeArchiveFileName)</DotNetRuntimeArchive>
   </PropertyGroup>
 
-  <Target Name="_DownloadAndExtractDotNetRuntime" Condition="'$(DotNetBuild)' != 'true'" Returns="$(DotNetRuntimeArchive)">
+  <Target Name="_DownloadAndExtractDotNetRuntime" Returns="$(DotNetRuntimeArchive)">
     <ItemGroup>
       <UrisToDownload Include="@(RemoteAssetBaseURL->'%(Identity)$(DotNetRuntimeDownloadPath)')" />
     </ItemGroup>
@@ -51,10 +51,10 @@
     <MakeDir Directories="$(OutputPath)" />
 
     <!-- Extract the dotnet-runtime archive -->
-    <Exec Condition="'$(ArchiveFormat)' == 'tar.gz' and '$(DotNetBuild)' != 'true'"
+    <Exec Condition="'$(ArchiveFormat)' == 'tar.gz'"
       Command="tar -xzf $(DotNetRuntimeArchive) -C $(OutputPath)" />
 
-    <Unzip Condition="'$(ArchiveFormat)' == 'zip' and '$(DotNetBuild)' != 'true'"
+    <Unzip Condition="'$(ArchiveFormat)' == 'zip'"
       SourceFiles="$(DotNetRuntimeArchive)"
       DestinationFolder="$(OutputPath)"
       OverwriteReadOnlyFiles="true" />

--- a/src/Framework/App.Runtime/src/aspnetcore-runtime.proj
+++ b/src/Framework/App.Runtime/src/aspnetcore-runtime.proj
@@ -35,7 +35,7 @@
     <DotNetRuntimeArchive>$(BaseIntermediateOutputPath)$(DotNetRuntimeArchiveFileName)</DotNetRuntimeArchive>
   </PropertyGroup>
 
-  <Target Name="_DownloadAndExtractDotNetRuntime" Condition="'$(DotNetBuild)' != 'true'" Returns="$(DotNetRuntimeArchive)">
+  <Target Name="_DownloadAndExtractDotNetRuntime" Returns="$(DotNetRuntimeArchive)">
     <ItemGroup>
       <UrisToDownload Include="@(RemoteAssetBaseURL->'%(Identity)$(DotNetRuntimeDownloadPath)')" />
     </ItemGroup>
@@ -54,10 +54,10 @@
     <MakeDir Directories="$(OutputPath)" />
 
     <!-- Extract the dotnet-runtime archive -->
-    <Exec Condition="'$(ArchiveFormat)' == 'tar.gz' and '$(DotNetBuild)' != 'true'"
+    <Exec Condition="'$(ArchiveFormat)' == 'tar.gz'"
       Command="tar -xzf $(DotNetRuntimeArchive) -C $(OutputPath)" />
 
-    <Unzip Condition="'$(ArchiveFormat)' == 'zip' and '$(DotNetBuild)' != 'true'"
+    <Unzip Condition="'$(ArchiveFormat)' == 'zip'"
       SourceFiles="$(DotNetRuntimeArchive)"
       DestinationFolder="$(OutputPath)"
       OverwriteReadOnlyFiles="true" />


### PR DESCRIPTION
We noticed that this was missing in the VMR, so do it there as well.

Running against CI first to see if in-repo SourceBuild has any impact here.