### PR TITLE
Caching SERedis critical bugfix; defer HC metadata detection because of DI cycle

### DIFF
--- a/src/Caching/StackExchangeRedis/src/RedisCache.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCache.cs
@@ -53,7 +53,7 @@ public partial class RedisCache : IBufferDistributedCache, IDisposable
     private long _firstErrorTimeTicks;
     private long _previousErrorTimeTicks;
 
-    internal bool HybridCacheActive { get; set; }
+    internal virtual bool IsHybridCacheActive() => false;
 
     // StackExchange.Redis will also be trying to reconnect internally,
     // so limit how often we recreate the ConnectionMultiplexer instance
@@ -378,7 +378,7 @@ public partial class RedisCache : IBufferDistributedCache, IDisposable
             connection.AddLibraryNameSuffix("aspnet");
             connection.AddLibraryNameSuffix("DC");
 
-            if (HybridCacheActive)
+            if (IsHybridCacheActive())
             {
                 connection.AddLibraryNameSuffix("HC");
             }

--- a/src/Caching/StackExchangeRedis/src/RedisCacheImpl.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCacheImpl.cs
@@ -11,19 +11,20 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis;
 
 internal sealed class RedisCacheImpl : RedisCache
 {
+    private readonly IServiceProvider _services;
+
+    internal override bool IsHybridCacheActive()
+        => _services.GetService<HybridCache>() is not null;
+
     public RedisCacheImpl(IOptions<RedisCacheOptions> optionsAccessor, ILogger<RedisCache> logger, IServiceProvider services)
         : base(optionsAccessor, logger)
     {
-        HybridCacheActive = IsHybridCacheDefined(services);
+        _services = services; // important: do not check for HybridCache here due to dependency - creates a cycle
     }
 
     public RedisCacheImpl(IOptions<RedisCacheOptions> optionsAccessor, IServiceProvider services)
         : base(optionsAccessor)
     {
-        HybridCacheActive = IsHybridCacheDefined(services);
+        _services = services; // important: do not check for HybridCache here due to dependency - creates a cycle
     }
-
-    // HybridCache optionally uses IDistributedCache; if we're here, then *we are* the DC
-    private static bool IsHybridCacheDefined(IServiceProvider services)
-        => services.GetService<HybridCache>() is not null;
 }

--- a/src/Caching/StackExchangeRedis/test/CacheServiceExtensionsTests.cs
+++ b/src/Caching/StackExchangeRedis/test/CacheServiceExtensionsTests.cs
@@ -8,10 +8,12 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -142,16 +144,46 @@ public class CacheServiceExtensionsTests
         services.AddStackExchangeRedisCache(options => { });
         if (hybridCacheActive)
         {
-            services.TryAddSingleton<HybridCache>(new DummyHybridCache());
+            services.AddMemoryCache();
+            services.TryAddSingleton<HybridCache, DummyHybridCache>();
         }
 
         using var provider = services.BuildServiceProvider();
         var cache = Assert.IsAssignableFrom<RedisCache>(provider.GetRequiredService<IDistributedCache>());
-        Assert.Equal(hybridCacheActive, cache.HybridCacheActive);
+        Assert.Equal(hybridCacheActive, cache.IsHybridCacheActive());
     }
 
     sealed class DummyHybridCache : HybridCache
     {
+        // emulate the layout from HybridCache in dotnet/extensions
+        public DummyHybridCache(IOptions<HybridCacheOptions> options, IServiceProvider services)
+        {
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            var l1 = services.GetRequiredService<IMemoryCache>();
+            _ = options.Value;
+            var logger = services.GetService<ILoggerFactory>()?.CreateLogger(typeof(HybridCache)) ?? NullLogger.Instance;
+            // var clock = services.GetService<TimeProvider>() ?? TimeProvider.System;
+            var l2 = services.GetService<IDistributedCache>(); // note optional
+
+            // ignore L2 if it is really just the same L1, wrapped
+            // (note not just an "is" test; if someone has a custom subclass, who knows what it does?)
+            if (l2 is not null
+                && l2.GetType() == typeof(MemoryDistributedCache)
+                && l1.GetType() == typeof(MemoryCache))
+            {
+                l2 = null;
+            }
+
+            IHybridCacheSerializerFactory[] factories = services.GetServices<IHybridCacheSerializerFactory>().ToArray();
+            Array.Reverse(factories);
+        }
+
+        public class HybridCacheOptions { }
+
         public override ValueTask<T> GetOrCreateAsync<TState, T>(string key, TState state, Func<TState, CancellationToken, ValueTask<T>> factory, HybridCacheEntryOptions options = null, IEnumerable<string> tags = null, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
 


### PR DESCRIPTION
# Caching SERedis critical bugfix; defer HC metadata detection because of DI cycle

fix #60894

Existing `HybridCache` metadata detection can create a DI cycle, infinite loop and eventual stack-overflow

Fix this by deferring detection until after construction.

Workaround for now is simply not to use 9.0.3:

``` diff
- <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.3" />
+ <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.2" />
```