### PR TITLE
Add default implementation to OpenAPI's new Description property to prevent a breaking change

### DIFF
--- a/src/Http/Http.Abstractions/src/Metadata/IProducesResponseTypeMetadata.cs
+++ b/src/Http/Http.Abstractions/src/Metadata/IProducesResponseTypeMetadata.cs
@@ -21,7 +21,7 @@ public interface IProducesResponseTypeMetadata
     /// <summary>
     /// Gets the description of the response.
     /// </summary>
-    string? Description { get; }
+    string? Description { get; } = null;
 
     /// <summary>
     /// Gets the content types supported by the metadata.

--- a/src/Http/Http.Abstractions/src/Metadata/IProducesResponseTypeMetadata.cs
+++ b/src/Http/Http.Abstractions/src/Metadata/IProducesResponseTypeMetadata.cs
@@ -21,7 +21,7 @@ public interface IProducesResponseTypeMetadata
     /// <summary>
     /// Gets the description of the response.
     /// </summary>
-    string? Description { get; } = null;
+    string? Description => null;
 
     /// <summary>
     /// Gets the content types supported by the metadata.

--- a/src/Mvc/Mvc.Core/src/ApiExplorer/IApiResponseMetadataProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ApiExplorer/IApiResponseMetadataProvider.cs
@@ -20,7 +20,7 @@ public interface IApiResponseMetadataProvider : IFilterMetadata
     /// <summary>
     /// Gets the description of the response.
     /// </summary>
-    string? Description { get; }
+    string? Description => null;
 
     /// <summary>
     /// Gets the HTTP status code of the response.


### PR DESCRIPTION
# Add default implementation to OpenAPI's new Description property to prevent a breaking change

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

This PR adds a default implementation to `IProducesResponseTypeMetadata.Description` and `IApiResponseMetadataProvider.Description` to prevent breaking changes.

## Description

In #58193 I added a `Description` property to `IProducesResponseType`, `IApiResponseMetadataProvider`, attributes and some other spots to allow developers to easily set response descriptions. 

The linked issue tries to cast their own class implementation to `IProducesResponseType`. Because they don't have `Description`, an exception is thrown.

This issue is fixed by adding a default implementation of this property.

Fixes #59804
