### PR TITLE
Rename `DisableMatchAllIgnoresLeftUriPart` to `EnableMatchAllForQueryStringAndFragmentSwitchKey`

### DIFF
--- a/src/Components/Web/src/Routing/NavLink.cs
+++ b/src/Components/Web/src/Routing/NavLink.cs
@@ -12,8 +12,8 @@ namespace Microsoft.AspNetCore.Components.Routing;
 /// </summary>
 public class NavLink : ComponentBase, IDisposable
 {
-    private const string DisableMatchAllIgnoresLeftUriPartSwitchKey = "Microsoft.AspNetCore.Components.Routing.NavLink.DisableMatchAllIgnoresLeftUriPart";
-    private static readonly bool _disableMatchAllIgnoresLeftUriPart = AppContext.TryGetSwitch(DisableMatchAllIgnoresLeftUriPartSwitchKey, out var switchValue) && switchValue;
+    private const string EnableMatchAllForQueryStringAndFragmentSwitchKey = "Microsoft.AspNetCore.Components.Routing.NavLink.EnableMatchAllForQueryStringAndFragment";
+    private static readonly bool _enableMatchAllForQueryStringAndFragment = AppContext.TryGetSwitch(EnableMatchAllForQueryStringAndFragmentSwitchKey, out var switchValue) && switchValue;
 
     private const string DefaultActiveClass = "active";
 
@@ -133,7 +133,7 @@ public class NavLink : ComponentBase, IDisposable
             return true;
         }
 
-        if (_disableMatchAllIgnoresLeftUriPart || Match != NavLinkMatch.All)
+        if (_enableMatchAllForQueryStringAndFragment || Match != NavLinkMatch.All)
         {
             return false;
         }


### PR DESCRIPTION
The original switch name was not in line with its function. We are ignoring the right part of the uri, not the left one. This PR changes the name for a simplified version, proposed by @guardrex. [Reference]( https://github.com/dotnet/AspNetCore.Docs/pull/34966#issuecomment-2729452934).

