### PR TITLE
Use trim-safe ValidationContext constructor and update RuntimeParameterInfoResolver

### DIFF
--- a/src/Http/Http.Abstractions/src/Validation/RuntimeValidatableParameterInfoResolver.cs
+++ b/src/Http/Http.Abstractions/src/Validation/RuntimeValidatableParameterInfoResolver.cs
@@ -27,6 +27,15 @@ internal sealed class RuntimeValidatableParameterInfoResolver : IValidatableInfo
         var validationAttributes = parameterInfo
             .GetCustomAttributes<ValidationAttribute>()
             .ToArray();
+
+        // If there are no validation attributes and this type is not a complex type
+        // we don't need to validate it. Complex types without attributes are still
+        // validatable because we want to run the validations on the properties.
+        if (validationAttributes.Length == 0 && !IsClass(parameterInfo.ParameterType))
+        {
+            validatableInfo = null;
+            return false;
+        }
         validatableInfo = new RuntimeValidatableParameterInfo(
             parameterType: parameterInfo.ParameterType,
             name: parameterInfo.Name,
@@ -47,7 +56,7 @@ internal sealed class RuntimeValidatableParameterInfoResolver : IValidatableInfo
         return parameterInfo.Name!;
     }
 
-    private sealed class RuntimeValidatableParameterInfo(
+    internal sealed class RuntimeValidatableParameterInfo(
         Type parameterType,
         string name,
         string displayName,
@@ -57,5 +66,32 @@ internal sealed class RuntimeValidatableParameterInfoResolver : IValidatableInfo
         protected override ValidationAttribute[] GetValidationAttributes() => _validationAttributes;
 
         private readonly ValidationAttribute[] _validationAttributes = validationAttributes;
+    }
+
+    private static bool IsClass(Type type)
+    {
+        // Skip primitives, enums, and common built-in types that don't need validation
+        // if they don't have attributes
+        if (type.IsPrimitive ||
+            type.IsEnum ||
+            type == typeof(string) ||
+            type == typeof(decimal) ||
+            type == typeof(DateTime) ||
+            type == typeof(DateTimeOffset) ||
+            type == typeof(TimeOnly) ||
+            type == typeof(DateOnly) ||
+            type == typeof(TimeSpan) ||
+            type == typeof(Guid))
+        {
+            return false;
+        }
+
+        // Check if the underlying type in a nullable is valid
+        if (Nullable.GetUnderlyingType(type) is { } nullableType)
+        {
+            return IsClass(nullableType);
+        }
+
+        return type.IsClass;
     }
 }

--- a/src/Http/Http.Abstractions/src/Validation/RuntimeValidatableParameterInfoResolver.cs
+++ b/src/Http/Http.Abstractions/src/Validation/RuntimeValidatableParameterInfoResolver.cs
@@ -3,8 +3,10 @@
 
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
+using System.IO.Pipelines;
 using System.Linq;
 using System.Reflection;
+using System.Security.Claims;
 
 namespace Microsoft.AspNetCore.Http.Validation;
 
@@ -70,8 +72,8 @@ internal sealed class RuntimeValidatableParameterInfoResolver : IValidatableInfo
 
     private static bool IsClass(Type type)
     {
-        // Skip primitives, enums, and common built-in types that don't need validation
-        // if they don't have attributes
+        // Skip primitives, enums, common built-in types, and types that are specially
+        // handled by RDF/RDG that don't need validation if they don't have attributes
         if (type.IsPrimitive ||
             type.IsEnum ||
             type == typeof(string) ||
@@ -81,7 +83,17 @@ internal sealed class RuntimeValidatableParameterInfoResolver : IValidatableInfo
             type == typeof(TimeOnly) ||
             type == typeof(DateOnly) ||
             type == typeof(TimeSpan) ||
-            type == typeof(Guid))
+            type == typeof(Guid) ||
+            type == typeof(IFormFile) ||
+            type == typeof(IFormFileCollection) ||
+            type == typeof(IFormCollection) ||
+            type == typeof(HttpContext) ||
+            type == typeof(HttpRequest) ||
+            type == typeof(HttpResponse) ||
+            type == typeof(ClaimsPrincipal) ||
+            type == typeof(CancellationToken) ||
+            type == typeof(Stream) ||
+            type == typeof(PipeReader))
         {
             return false;
         }

--- a/src/Http/Http.Abstractions/test/Validation/RuntimeValidatableParameterInfoResolverTests.cs
+++ b/src/Http/Http.Abstractions/test/Validation/RuntimeValidatableParameterInfoResolverTests.cs
@@ -53,7 +53,6 @@ public class RuntimeValidatableParameterInfoResolverTests
     [InlineData(typeof(HttpRequest))]
     [InlineData(typeof(HttpResponse))]
     [InlineData(typeof(CancellationToken))]
-
     public void TryGetValidatableParameterInfo_WithSimpleTypesAndNoAttributes_ReturnsFalse(Type parameterType)
     {
         var parameterInfo = GetParameter(parameterType);

--- a/src/Http/Http.Abstractions/test/Validation/RuntimeValidatableParameterInfoResolverTests.cs
+++ b/src/Http/Http.Abstractions/test/Validation/RuntimeValidatableParameterInfoResolverTests.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel.DataAnnotations;
+using System.IO.Pipelines;
 using System.Reflection;
+using System.Security.Claims;
 
 namespace Microsoft.AspNetCore.Http.Validation.Tests;
 
@@ -38,6 +40,20 @@ public class RuntimeValidatableParameterInfoResolverTests
     [InlineData(typeof(Guid))]
     [InlineData(typeof(decimal))]
     [InlineData(typeof(DayOfWeek))] // Enum
+    [InlineData(typeof(ClaimsPrincipal))]
+    [InlineData(typeof(PipeReader))]
+    [InlineData(typeof(DateTimeOffset))]
+    [InlineData(typeof(TimeOnly))]
+    [InlineData(typeof(DateOnly))]
+    [InlineData(typeof(TimeSpan))]
+    [InlineData(typeof(IFormFile))]
+    [InlineData(typeof(IFormFileCollection))]
+    [InlineData(typeof(IFormCollection))]
+    [InlineData(typeof(HttpContext))]
+    [InlineData(typeof(HttpRequest))]
+    [InlineData(typeof(HttpResponse))]
+    [InlineData(typeof(CancellationToken))]
+
     public void TryGetValidatableParameterInfo_WithSimpleTypesAndNoAttributes_ReturnsFalse(Type parameterType)
     {
         var parameterInfo = GetParameter(parameterType);

--- a/src/Http/Http.Abstractions/test/Validation/RuntimeValidatableParameterInfoResolverTests.cs
+++ b/src/Http/Http.Abstractions/test/Validation/RuntimeValidatableParameterInfoResolverTests.cs
@@ -1,0 +1,176 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+
+namespace Microsoft.AspNetCore.Http.Validation.Tests;
+
+public class RuntimeValidatableParameterInfoResolverTests
+{
+    private readonly RuntimeValidatableParameterInfoResolver _resolver = new();
+
+    [Fact]
+    public void TryGetValidatableTypeInfo_AlwaysReturnsFalse()
+    {
+        var result = _resolver.TryGetValidatableTypeInfo(typeof(string), out var validatableInfo);
+
+        Assert.False(result);
+        Assert.Null(validatableInfo);
+    }
+
+    [Fact]
+    public void TryGetValidatableParameterInfo_WithNullName_ThrowsInvalidOperationException()
+    {
+        var parameterInfo = new NullNameParameterInfo();
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            _resolver.TryGetValidatableParameterInfo(parameterInfo, out _));
+
+        Assert.Contains("without a name", exception.Message);
+    }
+
+    [Theory]
+    [InlineData(typeof(string))]
+    [InlineData(typeof(int))]
+    [InlineData(typeof(bool))]
+    [InlineData(typeof(DateTime))]
+    [InlineData(typeof(Guid))]
+    [InlineData(typeof(decimal))]
+    [InlineData(typeof(DayOfWeek))] // Enum
+    public void TryGetValidatableParameterInfo_WithSimpleTypesAndNoAttributes_ReturnsFalse(Type parameterType)
+    {
+        var parameterInfo = GetParameter(parameterType);
+
+        var result = _resolver.TryGetValidatableParameterInfo(parameterInfo, out var validatableInfo);
+
+        Assert.False(result);
+        Assert.Null(validatableInfo);
+    }
+
+    [Fact]
+    public void TryGetValidatableParameterInfo_WithClassTypeAndNoAttributes_ReturnsTrue()
+    {
+        var parameterInfo = GetParameter(typeof(TestClass));
+
+        var result = _resolver.TryGetValidatableParameterInfo(parameterInfo, out var validatableInfo);
+
+        Assert.True(result);
+        Assert.NotNull(validatableInfo);
+        var parameterValidatableInfo = Assert.IsType<RuntimeValidatableParameterInfoResolver.RuntimeValidatableParameterInfo>(validatableInfo);
+        Assert.Equal("testParam", parameterValidatableInfo.Name);
+        Assert.Equal("testParam", parameterValidatableInfo.DisplayName);
+    }
+
+    [Fact]
+    public void TryGetValidatableParameterInfo_WithSimpleTypeAndAttributes_ReturnsTrue()
+    {
+        var parameterInfo = typeof(TestController)
+            .GetMethod(nameof(TestController.MethodWithAttributedParam))!
+            .GetParameters()[0];
+
+        var result = _resolver.TryGetValidatableParameterInfo(parameterInfo, out var validatableInfo);
+
+        Assert.True(result);
+        Assert.NotNull(validatableInfo);
+        var parameterValidatableInfo = Assert.IsType<RuntimeValidatableParameterInfoResolver.RuntimeValidatableParameterInfo>(validatableInfo);
+        Assert.Equal("value", parameterValidatableInfo.Name);
+        Assert.Equal("value", parameterValidatableInfo.DisplayName);
+    }
+
+    [Fact]
+    public void TryGetValidatableParameterInfo_WithDisplayAttribute_UsesDisplayNameFromAttribute()
+    {
+        var parameterInfo = typeof(TestController)
+            .GetMethod(nameof(TestController.MethodWithDisplayAttribute))!
+            .GetParameters()[0];
+
+        var result = _resolver.TryGetValidatableParameterInfo(parameterInfo, out var validatableInfo);
+
+        Assert.True(result);
+        Assert.NotNull(validatableInfo);
+        var parameterValidatableInfo = Assert.IsType<RuntimeValidatableParameterInfoResolver.RuntimeValidatableParameterInfo>(validatableInfo);
+        Assert.Equal("value", parameterValidatableInfo.Name);
+        Assert.Equal("Custom Display Name", parameterValidatableInfo.DisplayName);
+    }
+
+    [Fact]
+    public void TryGetValidatableParameterInfo_WithDisplayAttributeWithNullName_UsesParameterName()
+    {
+        var parameterInfo = typeof(TestController)
+            .GetMethod(nameof(TestController.MethodWithNullDisplayName))!
+            .GetParameters()[0];
+
+        var result = _resolver.TryGetValidatableParameterInfo(parameterInfo, out var validatableInfo);
+
+        Assert.True(result);
+        Assert.NotNull(validatableInfo);
+        var parameterValidatableInfo = Assert.IsType<RuntimeValidatableParameterInfoResolver.RuntimeValidatableParameterInfo>(validatableInfo);
+        Assert.Equal("value", parameterValidatableInfo.Name);
+        Assert.Equal("value", parameterValidatableInfo.DisplayName);
+    }
+
+    [Fact]
+    public void TryGetValidatableParameterInfo_WithNullableValueType_ReturnsFalse()
+    {
+        var parameterInfo = GetParameter(typeof(int?));
+
+        var result = _resolver.TryGetValidatableParameterInfo(parameterInfo, out var validatableInfo);
+
+        Assert.False(result);
+        Assert.Null(validatableInfo);
+    }
+
+    [Fact]
+    public void TryGetValidatableParameterInfo_WithNullableReferenceType_ReturnsTrue()
+    {
+        var parameterInfo = GetNullableParameter(typeof(TestClass));
+
+        var result = _resolver.TryGetValidatableParameterInfo(parameterInfo, out var validatableInfo);
+
+        Assert.True(result);
+        Assert.NotNull(validatableInfo);
+        var parameterValidatableInfo = Assert.IsType<RuntimeValidatableParameterInfoResolver.RuntimeValidatableParameterInfo>(validatableInfo);
+        Assert.Equal("testParam", parameterValidatableInfo.Name);
+        Assert.Equal("testParam", parameterValidatableInfo.DisplayName);
+    }
+
+    private static ParameterInfo GetParameter(Type parameterType)
+    {
+        return typeof(TestParameterHolder)
+            .GetMethod(nameof(TestParameterHolder.Method))!
+            .MakeGenericMethod(parameterType)
+            .GetParameters()[0];
+    }
+
+    private static ParameterInfo GetNullableParameter(Type parameterType)
+    {
+        return typeof(TestParameterHolder)
+            .GetMethod(nameof(TestParameterHolder.MethodWithNullable))!
+            .MakeGenericMethod(parameterType)
+            .GetParameters()[0];
+    }
+
+    private class TestClass { }
+
+    private class TestParameterHolder
+    {
+        public void Method<T>(T testParam) { }
+        public void MethodWithNullable<T>(T? testParam) { }
+    }
+
+    private class TestController
+    {
+        public void MethodWithAttributedParam([Required] string value) { }
+
+        public void MethodWithDisplayAttribute([Display(Name = "Custom Display Name")][Required] string value) { }
+
+        public void MethodWithNullDisplayName([Display(Name = null)][Required] string value) { }
+    }
+
+    private class NullNameParameterInfo : ParameterInfo
+    {
+        public override string? Name => null;
+        public override Type ParameterType => typeof(string);
+    }
+}

--- a/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.ValidationsGenerator/Emitters/ValidationsGenerator.Emitter.cs
+++ b/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.ValidationsGenerator/Emitters/ValidationsGenerator.Emitter.cs
@@ -56,6 +56,7 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
     file sealed class GeneratedValidatablePropertyInfo : global::Microsoft.AspNetCore.Http.Validation.ValidatablePropertyInfo
     {
         public GeneratedValidatablePropertyInfo(
+            [param: global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)]
             global::System.Type containingType,
             global::System.Type propertyType,
             string name,
@@ -76,6 +77,7 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
     file sealed class GeneratedValidatableTypeInfo : global::Microsoft.AspNetCore.Http.Validation.ValidatableTypeInfo
     {
         public GeneratedValidatableTypeInfo(
+            [param: global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]
             global::System.Type type,
             ValidatablePropertyInfo[] members) : base(type, members) { }
     }

--- a/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidateComplexTypes#ValidatableInfoResolver.g.verified.cs
+++ b/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidateComplexTypes#ValidatableInfoResolver.g.verified.cs
@@ -28,6 +28,7 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
     file sealed class GeneratedValidatablePropertyInfo : global::Microsoft.AspNetCore.Http.Validation.ValidatablePropertyInfo
     {
         public GeneratedValidatablePropertyInfo(
+            [param: global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)]
             global::System.Type containingType,
             global::System.Type propertyType,
             string name,
@@ -48,6 +49,7 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
     file sealed class GeneratedValidatableTypeInfo : global::Microsoft.AspNetCore.Http.Validation.ValidatableTypeInfo
     {
         public GeneratedValidatableTypeInfo(
+            [param: global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]
             global::System.Type type,
             ValidatablePropertyInfo[] members) : base(type, members) { }
     }

--- a/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidateIValidatableObject#ValidatableInfoResolver.g.verified.cs
+++ b/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidateIValidatableObject#ValidatableInfoResolver.g.verified.cs
@@ -28,6 +28,7 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
     file sealed class GeneratedValidatablePropertyInfo : global::Microsoft.AspNetCore.Http.Validation.ValidatablePropertyInfo
     {
         public GeneratedValidatablePropertyInfo(
+            [param: global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)]
             global::System.Type containingType,
             global::System.Type propertyType,
             string name,
@@ -48,6 +49,7 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
     file sealed class GeneratedValidatableTypeInfo : global::Microsoft.AspNetCore.Http.Validation.ValidatableTypeInfo
     {
         public GeneratedValidatableTypeInfo(
+            [param: global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]
             global::System.Type type,
             ValidatablePropertyInfo[] members) : base(type, members) { }
     }

--- a/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidateParameters#ValidatableInfoResolver.g.verified.cs
+++ b/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidateParameters#ValidatableInfoResolver.g.verified.cs
@@ -28,6 +28,7 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
     file sealed class GeneratedValidatablePropertyInfo : global::Microsoft.AspNetCore.Http.Validation.ValidatablePropertyInfo
     {
         public GeneratedValidatablePropertyInfo(
+            [param: global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)]
             global::System.Type containingType,
             global::System.Type propertyType,
             string name,
@@ -48,6 +49,7 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
     file sealed class GeneratedValidatableTypeInfo : global::Microsoft.AspNetCore.Http.Validation.ValidatableTypeInfo
     {
         public GeneratedValidatableTypeInfo(
+            [param: global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]
             global::System.Type type,
             ValidatablePropertyInfo[] members) : base(type, members) { }
     }

--- a/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidatePolymorphicTypes#ValidatableInfoResolver.g.verified.cs
+++ b/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidatePolymorphicTypes#ValidatableInfoResolver.g.verified.cs
@@ -28,6 +28,7 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
     file sealed class GeneratedValidatablePropertyInfo : global::Microsoft.AspNetCore.Http.Validation.ValidatablePropertyInfo
     {
         public GeneratedValidatablePropertyInfo(
+            [param: global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)]
             global::System.Type containingType,
             global::System.Type propertyType,
             string name,
@@ -48,6 +49,7 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
     file sealed class GeneratedValidatableTypeInfo : global::Microsoft.AspNetCore.Http.Validation.ValidatableTypeInfo
     {
         public GeneratedValidatableTypeInfo(
+            [param: global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]
             global::System.Type type,
             ValidatablePropertyInfo[] members) : base(type, members) { }
     }

--- a/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidateRecursiveTypes#ValidatableInfoResolver.g.verified.cs
+++ b/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidateRecursiveTypes#ValidatableInfoResolver.g.verified.cs
@@ -28,6 +28,7 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
     file sealed class GeneratedValidatablePropertyInfo : global::Microsoft.AspNetCore.Http.Validation.ValidatablePropertyInfo
     {
         public GeneratedValidatablePropertyInfo(
+            [param: global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)]
             global::System.Type containingType,
             global::System.Type propertyType,
             string name,
@@ -48,6 +49,7 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
     file sealed class GeneratedValidatableTypeInfo : global::Microsoft.AspNetCore.Http.Validation.ValidatableTypeInfo
     {
         public GeneratedValidatableTypeInfo(
+            [param: global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]
             global::System.Type type,
             ValidatablePropertyInfo[] members) : base(type, members) { }
     }

--- a/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidateTypesWithAttribute#ValidatableInfoResolver.g.verified.cs
+++ b/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidateTypesWithAttribute#ValidatableInfoResolver.g.verified.cs
@@ -28,6 +28,7 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
     file sealed class GeneratedValidatablePropertyInfo : global::Microsoft.AspNetCore.Http.Validation.ValidatablePropertyInfo
     {
         public GeneratedValidatablePropertyInfo(
+            [param: global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)]
             global::System.Type containingType,
             global::System.Type propertyType,
             string name,
@@ -48,6 +49,7 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
     file sealed class GeneratedValidatableTypeInfo : global::Microsoft.AspNetCore.Http.Validation.ValidatableTypeInfo
     {
         public GeneratedValidatableTypeInfo(
+            [param: global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]
             global::System.Type type,
             ValidatablePropertyInfo[] members) : base(type, members) { }
     }

--- a/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.DoesNotEmitForExemptTypes#ValidatableInfoResolver.g.verified.cs
+++ b/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.DoesNotEmitForExemptTypes#ValidatableInfoResolver.g.verified.cs
@@ -28,6 +28,7 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
     file sealed class GeneratedValidatablePropertyInfo : global::Microsoft.AspNetCore.Http.Validation.ValidatablePropertyInfo
     {
         public GeneratedValidatablePropertyInfo(
+            [param: global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)]
             global::System.Type containingType,
             global::System.Type propertyType,
             string name,
@@ -48,6 +49,7 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
     file sealed class GeneratedValidatableTypeInfo : global::Microsoft.AspNetCore.Http.Validation.ValidatableTypeInfo
     {
         public GeneratedValidatableTypeInfo(
+            [param: global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]
             global::System.Type type,
             ValidatablePropertyInfo[] members) : base(type, members) { }
     }

--- a/src/Http/Routing/src/ValidationEndpointFilterFactory.cs
+++ b/src/Http/Routing/src/ValidationEndpointFilterFactory.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel.DataAnnotations;
-using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -11,8 +10,6 @@ namespace Microsoft.AspNetCore.Http.Validation;
 
 internal static class ValidationEndpointFilterFactory
 {
-    private const string ValidationContextJustification = "The DisplayName property is always statically initialized in the ValidationContext through this codepath.";
-
     public static EndpointFilterDelegate Create(EndpointFilterFactoryContext context, EndpointFilterDelegate next)
     {
         var parameters = context.MethodInfo.GetParameters();
@@ -60,7 +57,7 @@ internal static class ValidationEndpointFilterFactory
                 // initialize an explicit DisplayName. We can suppress the warning here.
                 // Eventually, this can be removed when the code is updated to
                 // use https://github.com/dotnet/runtime/issues/113134.
-                var validationContext = CreateValidationContext(argument, displayName, context.HttpContext.RequestServices);
+                var validationContext = new ValidationContext(argument, displayName, context.HttpContext.RequestServices, null);
                 validatableContext.ValidationContext = validationContext;
                 await validatableParameter.ValidateAsync(argument, validatableContext, context.HttpContext.RequestAborted);
             }
@@ -75,16 +72,6 @@ internal static class ValidationEndpointFilterFactory
             return await next(context);
         };
     }
-
-    /// <remarks>
-    /// ValidationContext is not trim-friendly in codepaths that don't
-    /// initialize an explicit DisplayName. We can suppress the warning here.
-    /// Eventually, this can be removed when the code is updated to
-    /// use https://github.com/dotnet/runtime/issues/113134.
-    /// </remarks>
-    [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = ValidationContextJustification)]
-    private static ValidationContext CreateValidationContext(object argument, string displayName, IServiceProvider serviceProvider)
-        => new(argument, serviceProvider, items: null) { DisplayName = displayName };
 
     private static string GetDisplayName(ParameterInfo parameterInfo)
     {

--- a/src/Http/Routing/src/ValidationEndpointFilterFactory.cs
+++ b/src/Http/Routing/src/ValidationEndpointFilterFactory.cs
@@ -54,7 +54,7 @@ internal static class ValidationEndpointFilterFactory
                     continue;
                 }
 
-                var validationContext = new ValidationContext(argument, displayName, context.HttpContext.RequestServices, null);
+                var validationContext = new ValidationContext(argument, displayName, context.HttpContext.RequestServices, items: null);
                 validatableContext.ValidationContext = validationContext;
                 await validatableParameter.ValidateAsync(argument, validatableContext, context.HttpContext.RequestAborted);
             }

--- a/src/Http/Routing/src/ValidationEndpointFilterFactory.cs
+++ b/src/Http/Routing/src/ValidationEndpointFilterFactory.cs
@@ -53,10 +53,7 @@ internal static class ValidationEndpointFilterFactory
                 {
                     continue;
                 }
-                // ValidationContext is not trim-friendly in codepaths that don't
-                // initialize an explicit DisplayName. We can suppress the warning here.
-                // Eventually, this can be removed when the code is updated to
-                // use https://github.com/dotnet/runtime/issues/113134.
+
                 var validationContext = new ValidationContext(argument, displayName, context.HttpContext.RequestServices, null);
                 validatableContext.ValidationContext = validationContext;
                 await validatableParameter.ValidateAsync(argument, validatableContext, context.HttpContext.RequestAborted);


### PR DESCRIPTION
- Use the new trim-safe ValidationContext constructor in the `ValidationEndpointFilterFactory` and remove suppressions.
- Update `RuntimeParameterInfoResolver` to skip parameters that have no validation attributes and won't have validatable types.