### PR TITLE
Enable SiteExtensions build in VMR Pass 2

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -83,13 +83,19 @@
         </ProjectToBuild>
       </ItemGroup>
     </When>
+    <!-- Projects to build in VMR build pass 2 -->
     <When Condition="'$(DotNetBuildPass)' == '2'">
       <ItemGroup Condition=" '$(DotNetBuild)' == 'true' AND '$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64' ">
+        <!-- Build Hosting Bundle -->
         <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\WindowsHostingBundle\WindowsHostingBundle.wixproj">
           <AdditionalProperties>Platform=x86</AdditionalProperties>
           <DotNetBuildPass>$(DotNetBuildPass)</DotNetBuildPass>
         </ProjectToBuild>
         <ProjectToBuild Include="$(RepoRoot)src\Servers\IIS/IntegrationTesting.IIS\src\Microsoft.AspNetCore.Server.IntegrationTesting.IIS.csproj" >
+          <DotNetBuildPass>$(DotNetBuildPass)</DotNetBuildPass>
+        </ProjectToBuild>
+        <!-- Build SiteExtensions -->
+        <ProjectToBuild Include="$(RepoRoot)src\SiteExtensions\LoggingAggregate\src\Microsoft.AspNetCore.AzureAppServices.SiteExtension\Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj">
           <DotNetBuildPass>$(DotNetBuildPass)</DotNetBuildPass>
         </ProjectToBuild>
       </ItemGroup>

--- a/eng/Common.props
+++ b/eng/Common.props
@@ -31,4 +31,10 @@
   <PropertyGroup>
     <BuildNative Condition=" '$(BuildNative)' == '' ">false</BuildNative>
   </PropertyGroup>
+
+  <!-- Don't restore w/ nuget.targets in VMR pass 2 -->
+  <!-- This allows us to hook targets before Restore in the SiteExtensions build -->
+  <PropertyGroup Condition=" '$(DotNetBuildPass)' == '2' " >
+    <RestoreUsingNuGetTargets>false</RestoreUsingNuGetTargets>
+  </PropertyGroup>
 </Project>

--- a/src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
+++ b/src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
@@ -18,6 +18,7 @@
     <IsPackable>true</IsPackable>
     <IsShipping>true</IsShipping>
     <IsShipping Condition=" '$(PreReleaseVersionLabel)' == 'preview' ">false</IsShipping>
+    <SiteExtensionsReferenceLayoutDir>$(ArtifactsObjDir)SiteExtensionsReferenceLayout/</SiteExtensionsReferenceLayoutDir>
 
     <!-- Grab packages LB.csproj should have just built. -->
     <RestoreAdditionalProjectSources>$(RestoreAdditionalProjectSources);$(ArtifactsNonShippingPackagesDir)</RestoreAdditionalProjectSources>
@@ -38,14 +39,43 @@
       UpdateLatestPackageReferences for the hard way.
     -->
     <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension.$(AspNetCoreMajorMinorVersion).x64"
-        Condition=" '$(IsShipping)' == 'false' "
+        Condition=" '$(IsShipping)' == 'false' AND '$(DotNetBuild)' != 'true'"
         PrivateAssets="All"
         Version="$(PackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension.$(AspNetCoreMajorMinorVersion).x86"
-        Condition=" '$(IsShipping)' == 'false' "
+        Condition=" '$(IsShipping)' == 'false' AND '$(DotNetBuild)' != 'true'"
         PrivateAssets="All"
         Version="$(PackageVersion)" />
+
+    <_SiteExtensionsReference Include="$(ArtifactsNonShippingPackagesDir)Microsoft.AspNetCore.AzureAppServices.SiteExtension.$(AspNetCoreMajorMinorVersion).x64.$(PackageVersion).nupkg"
+        Name="Microsoft.AspNetCore.AzureAppServices.SiteExtension.$(AspNetCoreMajorMinorVersion).x64"
+        Condition=" '$(IsShipping)' == 'false' AND '$(DotNetBuild)' == 'true'" />
+    <_SiteExtensionsReference Include="$(ArtifactsNonShippingPackagesDir)Microsoft.AspNetCore.AzureAppServices.SiteExtension.$(AspNetCoreMajorMinorVersion).x86.$(PackageVersion).nupkg"
+        Name="Microsoft.AspNetCore.AzureAppServices.SiteExtension.$(AspNetCoreMajorMinorVersion).x86"
+        Condition=" '$(IsShipping)' == 'false' AND '$(DotNetBuild)' == 'true'" />
   </ItemGroup>
+
+  <Target Name="BuildSiteExtensionInputs"
+      BeforeTargets="Restore"
+      Condition=" '$(DotNetBuildPass)' == '2' ">
+
+    <MSBuild Projects="..\..\..\LoggingBranch\LB.csproj"
+        BuildInParallel="$(BuildInParallel)"
+        Properties="Platform=x64;DisableTransitiveFrameworkReferences=true"
+        Targets="_VmrBuild" />
+    <MSBuild Projects="..\..\..\LoggingBranch\LB.csproj"
+        BuildInParallel="$(BuildInParallel)"
+        Properties="Platform=x86;TargetRid=win-x86;BaseOS=win-x86;TargetRuntimeIdentifier=win-x86;TargetArchitecture=x86;DisableTransitiveFrameworkReferences=true"
+        Targets="_VmrBuild" />
+    <MSBuild Projects="..\..\..\Runtime\Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj"
+        BuildInParallel="$(BuildInParallel)"
+        Properties="Platform=x64"
+        Targets="_VmrBuild" />
+    <MSBuild Projects="..\..\..\Runtime\Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj"
+        BuildInParallel="$(BuildInParallel)"
+        Properties="Platform=x86;TargetRid=win-x86;BaseOS=win-x86;TargetRuntimeIdentifier=win-x86;TargetArchitecture=x86"
+        Targets="_VmrBuild" />
+  </Target>
 
   <ItemGroup>
     <Content Include="applicationHost.xdt" />
@@ -68,14 +98,14 @@
   -->
   <Target Name="UpdateLatestPackageReferences"
       BeforeTargets="CollectPackageReferences;ResolveAssemblyReferencesDesignTime;ResolveAssemblyReferences"
-      Condition=" '$(IsShipping)' == 'true' ">
+      Condition=" '$(IsShipping)' == 'true'">
     <!-- This target is defined in eng/targets/Packaging.targets and included in every C# and F# project. -->
     <MSBuild Projects="$(RepoRoot)src\SiteExtensions\LoggingBranch\LB.csproj"
         Targets="_GetPackageVersionInfo">
       <Output TaskParameter="TargetOutputs" ItemName="_ResolvedPackageVersionInfo" />
     </MSBuild>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(DotNetBuild)' != 'true'">
       <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension.$(AspNetCoreMajorMinorVersion).x64"
           PrivateAssets="All"
           Version="%(_ResolvedPackageVersionInfo.PackageVersion)" />
@@ -83,9 +113,22 @@
           PrivateAssets="All"
           Version="%(_ResolvedPackageVersionInfo.PackageVersion)" />
     </ItemGroup>
+
+    <ItemGroup Condition="'$(DotNetBuild)' == 'true'">
+      <_SiteExtensionsReference Include="$(ArtifactsNonShippingPackagesDir)Microsoft.AspNetCore.AzureAppServices.SiteExtension.$(AspNetCoreMajorMinorVersion).x64.%(_ResolvedPackageVersionInfo.PackageVersion).nupkg" 
+          Name="Microsoft.AspNetCore.AzureAppServices.SiteExtension.$(AspNetCoreMajorMinorVersion).x64" />
+      <_SiteExtensionsReference Include="$(ArtifactsNonShippingPackagesDir)Microsoft.AspNetCore.AzureAppServices.SiteExtension.$(AspNetCoreMajorMinorVersion).x86.%(_ResolvedPackageVersionInfo.PackageVersion).nupkg"
+          Name="Microsoft.AspNetCore.AzureAppServices.SiteExtension.$(AspNetCoreMajorMinorVersion).x86" />
+    </ItemGroup>
   </Target>
 
   <Target Name="AddContent" BeforeTargets="_GetPackageFiles">
+    <Unzip
+        SourceFiles="@(_SiteExtensionsReference)"
+        DestinationFolder="$(SiteExtensionsReferenceLayoutDir)%(Name)"
+        OverwriteReadOnlyFiles="true"
+        Condition="'$(DotNetBuild)' == 'true'" />
+
     <ItemGroup>
       <!--
         The x64 & x86 SiteExtension packages have identical deps.json files. We include only the x64 files to
@@ -93,12 +136,16 @@
       -->
       <ContentFilesToPack
           Include="$(NugetPackageRoot)\%(PackageReference.Identity)\%(PackageReference.Version)\content\**\*.*"
-          Exclude="$(NugetPackageRoot)\Microsoft.AspNetCore.AzureAppServices.SiteExtension.*.x86\**\Microsoft.AspNetCore.AzureAppServices.HostingStartup.deps.json"/>
+          Exclude="$(NugetPackageRoot)\Microsoft.AspNetCore.AzureAppServices.SiteExtension.*.x86\**\Microsoft.AspNetCore.AzureAppServices.HostingStartup.deps.json" />
+
+      <ContentFilesToPack
+          Include="$(SiteExtensionsReferenceLayoutDir)\%(_SiteExtensionsReference.Name)\content\**\*.*"
+          Exclude="$(SiteExtensionsReferenceLayoutDir)\Microsoft.AspNetCore.AzureAppServices.SiteExtension.*.x86\**\Microsoft.AspNetCore.AzureAppServices.HostingStartup.deps.json"
+          Condition="'$(DotNetBuild)' == 'true'" />
 
       <!-- Temporarily skip the common files -->
       <FilteredContentFilesToPack Include="@(ContentFilesToPack)" Condition="'%(RecursiveDir)' != ''" />
       <None Include="@(FilteredContentFilesToPack)" PackagePath="content\%(RecursiveDir)%(Filename)%(Extension)" Pack="true" />
     </ItemGroup>
   </Target>
-
 </Project>

--- a/src/SiteExtensions/LoggingBranch/LB.csproj
+++ b/src/SiteExtensions/LoggingBranch/LB.csproj
@@ -24,10 +24,12 @@
   <ItemGroup>
     <HostingStartupRuntimeStoreTargets Include="$(DefaultNetCoreTargetFramework)" Runtime="$(TargetRuntimeIdentifier)" />
 
+    <!-- Make sure App.Ref layout is available - not necessary if this is Pass 2 of a VMR build -->
     <ProjectReference Include="..\..\Framework\App.Ref\src\Microsoft.AspNetCore.App.Ref.sfxproj"
       Private="false"
       ReferenceOutputAssembly="false"
-      SkipGetTargetFrameworkProperties="true" />
+      SkipGetTargetFrameworkProperties="true"
+      Condition="'$(DotNetBuildPass)' != '2'" />
   </ItemGroup>
 
   <!-- Cannot assume this project and Microsoft.AspNetCore.AzureAppServices.HostingStartup have the same package version. -->
@@ -42,4 +44,6 @@
       <HostingStartupPackageReference Include="%(_ResolvedPackageVersionInfo.PackageId)" Version="%(_ResolvedPackageVersionInfo.PackageVersion)" />
     </ItemGroup>
   </Target>
+
+  <Target Name="_VmrBuild" DependsOnTargets="Restore;Build;Pack" Condition=" '$(DotNetBuildPass)' == '2' " />
 </Project>

--- a/src/SiteExtensions/Runtime/Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj
+++ b/src/SiteExtensions/Runtime/Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj
@@ -34,10 +34,12 @@
       SkipGetTargetFrameworkProperties="true" />
 
     <!-- Make sure redist folder is built and ready -->
+    <!-- Not necessary if this is Pass 2 of a VMR build -->
     <ProjectReference Include="..\..\Framework\App.Runtime\src\aspnetcore-runtime.proj"
       Private="false"
       ReferenceOutputAssembly="false"
-      SkipGetTargetFrameworkProperties="true" />
+      SkipGetTargetFrameworkProperties="true"
+      Condition="'$(DotNetBuildPass)' != '2'" />
 
     <NativeProjectReference Include="$(RepoRoot)src\Servers\IIS\AspNetCoreModuleV2\AspNetCore\AspNetCore.vcxproj" Platform="$(TargetArchitecture)" />
     <NativeProjectReference Include="$(RepoRoot)src\Servers\IIS\AspNetCoreModuleV2\OutOfProcessRequestHandler\OutOfProcessRequestHandler.vcxproj" HandlerPath="2.0.0" Platform="$(TargetArchitecture)" />
@@ -56,5 +58,6 @@
   <Target Name="CopyFilesToOutputDirectory" />
   <Target Name="CoreCompile" />
   <Target Name="CreateManifestResourceNames" />
+  <Target Name="_VmrBuild" DependsOnTargets="Restore;Build;Pack" Condition=" '$(DotNetBuildPass)' == '2' " />
 
 </Project>


### PR DESCRIPTION
Should cover the rest of https://github.com/dotnet/aspnetcore/issues/60146

Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2666582&view=results

Had to do some msbuild trickery to get the build ordering correct - hooked a manual target named `_VmrBuild` into the SiteExtensions dependency projects, and disabled restoring w/ Nuget.Targets in pass 2 so I could hook targets before `Restore`