### PR TITLE
[Blazor] Remove explicit WasmBootConfigFileName from tests

### DIFF
--- a/src/Components/WebAssembly/Directory.Build.props
+++ b/src/Components/WebAssembly/Directory.Build.props
@@ -4,8 +4,4 @@
     <!-- Avoid source build issues with WebAssembly -->
     <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
   </PropertyGroup>
-
-  <PropertyGroup>
-    <WasmBootConfigFileName>dotnet.boot.js</WasmBootConfigFileName>
-  </PropertyGroup>
 </Project>

--- a/src/Components/WebAssembly/testassets/CustomBasePathApp/wwwroot/index.html
+++ b/src/Components/WebAssembly/testassets/CustomBasePathApp/wwwroot/index.html
@@ -9,7 +9,6 @@
 </head>
 <body>
     <app>Loading...</app>
-    <script>window["__DOTNET_INTERNAL_BOOT_CONFIG_SRC"] = "dotnet.boot.js";</script>
     <script src="_framework/blazor.webassembly.js"></script>
 </body>
 </html>

--- a/src/Components/WebAssembly/testassets/HostedInAspNet.Client/wwwroot/index.html
+++ b/src/Components/WebAssembly/testassets/HostedInAspNet.Client/wwwroot/index.html
@@ -7,7 +7,6 @@
 <body>
     <app>Loading...</app>
     <script src="customJsFileForTests.js"></script>
-    <script>window["__DOTNET_INTERNAL_BOOT_CONFIG_SRC"] = "dotnet.boot.js";</script>
     <script src="_framework/blazor.webassembly.js" autostart="false"></script>
 
     <!--

--- a/src/Components/WebAssembly/testassets/StandaloneApp/wwwroot/index.html
+++ b/src/Components/WebAssembly/testassets/StandaloneApp/wwwroot/index.html
@@ -19,7 +19,6 @@
         <a class="dismiss">🗙</a>
     </div>
 
-    <script>window["__DOTNET_INTERNAL_BOOT_CONFIG_SRC"] = "dotnet.boot.js";</script>
     <script src="_framework/blazor.webassembly.js" autostart="false"></script>
     <script>
         (function(){

--- a/src/Components/WebAssembly/testassets/ThreadingApp.Server/Components/App.razor
+++ b/src/Components/WebAssembly/testassets/ThreadingApp.Server/Components/App.razor
@@ -19,7 +19,6 @@
         <a class="dismiss">🗙</a>
     </div>
 
-    <script>window["__DOTNET_INTERNAL_BOOT_CONFIG_SRC"] = "dotnet.boot.js";</script>
     <script src="@Assets["_framework/blazor.web.js"]"></script>
 </body>
 

--- a/src/Components/WebAssembly/testassets/ThreadingApp/wwwroot/index.html
+++ b/src/Components/WebAssembly/testassets/ThreadingApp/wwwroot/index.html
@@ -18,7 +18,6 @@
         <a class="dismiss">🗙</a>
     </div>
 
-    <script>window["__DOTNET_INTERNAL_BOOT_CONFIG_SRC"] = "dotnet.boot.js";</script>
     <script src="_framework/blazor.webassembly.js" autostart="false"></script>
     <script>
         (function(){

--- a/src/Components/WebAssembly/testassets/Wasm.Prerendered.Server/Pages/_Layout.cshtml
+++ b/src/Components/WebAssembly/testassets/Wasm.Prerendered.Server/Pages/_Layout.cshtml
@@ -13,7 +13,6 @@
 <body>
     @RenderBody()
 
-    <script>window["__DOTNET_INTERNAL_BOOT_CONFIG_SRC"] = "dotnet.boot.js";</script>
     <script src="_framework/blazor.webassembly.js" autostart="false"></script>
     <script>
         function start() {

--- a/src/Components/test/testassets/BasicTestApp/wwwroot/index.html
+++ b/src/Components/test/testassets/BasicTestApp/wwwroot/index.html
@@ -53,7 +53,6 @@
             return Blazor.runtime.runtimeBuildInfo.buildConfiguration;
         }
     </script>
-    <script>window["__DOTNET_INTERNAL_BOOT_CONFIG_SRC"] = "dotnet.boot.js";</script>
     <script src="_framework/blazor.webassembly.js" autostart="false"></script>
 
     <script>

--- a/src/Components/test/testassets/Components.TestServer/Pages/Client/MultipleComponentsLayout.cshtml
+++ b/src/Components/test/testassets/Components.TestServer/Pages/Client/MultipleComponentsLayout.cshtml
@@ -33,7 +33,6 @@
 
     <button id="load-boot-script" onclick="start()">Load boot script</button>
 
-    <script>window["__DOTNET_INTERNAL_BOOT_CONFIG_SRC"] = "dotnet.boot.js";</script>
     <script src="_framework/blazor.webassembly.js" autostart="false"></script>
     <script src="js/jsRootComponentInitializers.js"></script>
     <script>

--- a/src/Components/test/testassets/Components.TestServer/Pages/SaveState.cshtml
+++ b/src/Components/test/testassets/Components.TestServer/Pages/SaveState.cshtml
@@ -128,7 +128,6 @@
     }
     else
     {
-        <script>window["__DOTNET_INTERNAL_BOOT_CONFIG_SRC"] = "dotnet.boot.js";</script>
         <script src="_framework/blazor.webassembly.js" autostart="false"></script>
     }
 

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/App.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/App.razor
@@ -23,7 +23,6 @@
             elementToFocus.focus();
         }
     </script>
-    <script>window["__DOTNET_INTERNAL_BOOT_CONFIG_SRC"] = "dotnet.boot.js";</script>
     <script src="@Assets["_framework/blazor.web.js"]" autostart="false" suppress-error="BL9992"></script>
     <script src="_content/TestContentPackage/counterInterop.js"></script>
     <script src="js/circuitContextTest.js"></script>

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/GlobalInteractivityApp.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/GlobalInteractivityApp.razor
@@ -7,7 +7,6 @@
 </head>
 <body>
     <Components.WasmMinimal.Routes @rendermode="@PageRenderMode" />
-    <script>window["__DOTNET_INTERNAL_BOOT_CONFIG_SRC"] = "dotnet.boot.js";</script>
     <script src="@Assets["_framework/blazor.web.js"]" autostart="false"></script>
     <script>
         Blazor.start({

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/NamedFormContextNoFormContextApp.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/NamedFormContextNoFormContextApp.razor
@@ -10,7 +10,6 @@
 <body>
     <h1 id="ready">Form test cases</h1>
     <NamedFormContextNoFormContextLayout />
-    <script>window["__DOTNET_INTERNAL_BOOT_CONFIG_SRC"] = "dotnet.boot.js";</script>
     <script src="@Assets["_framework/blazor.web.js"]" suppress-error="BL9992"></script>
 </body>
 </html>

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/RemoteAuthenticationApp.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/RemoteAuthenticationApp.razor
@@ -10,7 +10,6 @@
 
 <body>
     <Components.WasmRemoteAuthentication.Routes @rendermode="new InteractiveWebAssemblyRenderMode(prerender: false)" />
-    <script>window["__DOTNET_INTERNAL_BOOT_CONFIG_SRC"] = "dotnet.boot.js";</script>
     <script src="@Assets["_framework/blazor.web.js"]" autostart="false"></script>
     <script src="_content/Microsoft.AspNetCore.Components.WebAssembly.Authentication/AuthenticationService.js"></script>
     <script>

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Root.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Root.razor
@@ -11,7 +11,6 @@
 <body>
     <ServerApp @rendermode="@RenderMode.InteractiveServer" />
 
-    <script>window["__DOTNET_INTERNAL_BOOT_CONFIG_SRC"] = "dotnet.boot.js";</script>
     <script src="@Assets["_framework/blazor.web.js"]" autostart="false"></script>
     <script>
         const suppressEnhancedNavigation = sessionStorage.getItem('suppress-enhanced-navigation') === 'true';

--- a/src/Components/test/testassets/Directory.Build.props
+++ b/src/Components/test/testassets/Directory.Build.props
@@ -19,8 +19,4 @@
       <_Parameter2>true</_Parameter2>
     </AssemblyAttribute>
   </ItemGroup>
-
-  <PropertyGroup>
-    <WasmBootConfigFileName>dotnet.boot.js</WasmBootConfigFileName>
-  </PropertyGroup>
 </Project>

--- a/src/Components/test/testassets/GlobalizationWasmApp/wwwroot/index.html
+++ b/src/Components/test/testassets/GlobalizationWasmApp/wwwroot/index.html
@@ -7,7 +7,6 @@
 <body>
     <div id="blazor-error-ui">Error</div>
     <app>Loading...</app>
-    <script>window["__DOTNET_INTERNAL_BOOT_CONFIG_SRC"] = "dotnet.boot.js";</script>
     <script src="_framework/blazor.webassembly.js" autostart="false"></script>
     <script>
         (function(){


### PR DESCRIPTION
The change to have dotnet.boot.js as a default boot config flown from runtime to aspnetcore. We can remove the explicit configuration from all tests.

Contributes to https://github.com/dotnet/aspnetcore/issues/59456