### PR TITLE
Handle langword for see elements

### DIFF
--- a/src/OpenApi/gen/XmlComments/XmlComment.cs
+++ b/src/OpenApi/gen/XmlComments/XmlComment.cs
@@ -203,10 +203,10 @@ internal sealed partial class XmlComment
     }
 
     /// <summary>
-    /// Resolves the links in the XML documentation into type names.
+    /// Resolves the links in the XML documentation into language keywords.
     /// </summary>
     /// <param name="node">The target node to process crefs in.</param>
-    /// <param name="elementName">The node type to process crefs for, can be `see` or `seealso`.</param>
+    /// <param name="elementName">The node type to process langwords for, can be `see` or `seealso`.</param>
     private static void ResolveLangKeyword(XNode node, string elementName)
     {
         if (node == null || string.IsNullOrEmpty(elementName))

--- a/src/OpenApi/gen/XmlComments/XmlComment.cs
+++ b/src/OpenApi/gen/XmlComments/XmlComment.cs
@@ -35,8 +35,11 @@ internal sealed partial class XmlComment
         // Transform triple slash comment
         var doc = XDocument.Parse(xml, LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo);
 
-        ResolveCrefLink(compilation, doc, $"//{DocumentationCommentXmlNames.SeeAlsoElementName}[@cref]");
-        ResolveCrefLink(compilation, doc, $"//{DocumentationCommentXmlNames.SeeElementName}[@cref]");
+        ResolveCrefLink(compilation, doc, DocumentationCommentXmlNames.SeeAlsoElementName);
+        ResolveCrefLink(compilation, doc, DocumentationCommentXmlNames.SeeElementName);
+
+        ResolveLangKeyword(doc, DocumentationCommentXmlNames.SeeElementName);
+
         // Resolve <list> and <item> tags into bullets
         ResolveListTags(doc);
         // Resolve <code> tags into code blocks
@@ -171,18 +174,20 @@ internal sealed partial class XmlComment
     /// </summary>
     /// <param name="compilation">The compilation to resolve type symbol declarations from.</param>
     /// <param name="node">The target node to process crefs in.</param>
-    /// <param name="nodeSelector">The node type to process crefs for, can be `see` or `seealso`.</param>
-    private static void ResolveCrefLink(Compilation compilation, XNode node, string nodeSelector)
+    /// <param name="elementName">The node type to process crefs for, can be `see` or `seealso`.</param>
+    private static void ResolveCrefLink(Compilation compilation, XNode node, string elementName)
     {
-        if (node == null || string.IsNullOrEmpty(nodeSelector))
+        if (node == null || string.IsNullOrEmpty(elementName))
         {
             return;
         }
 
-        var nodes = node.XPathSelectElements(nodeSelector + "[@cref]").ToArray();
+        var attributeName = DocumentationCommentXmlNames.CrefAttributeName;
+
+        var nodes = node.XPathSelectElements($"//{elementName}[@{attributeName}]").ToArray();
         foreach (var item in nodes)
         {
-            var cref = item.Attribute(DocumentationCommentXmlNames.CrefAttributeName).Value;
+            var cref = item.Attribute(attributeName).Value;
             if (string.IsNullOrEmpty(cref))
             {
                 continue;
@@ -194,6 +199,33 @@ internal sealed partial class XmlComment
                 var type = symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
                 item.ReplaceWith(new XText(type));
             }
+        }
+    }
+
+    /// <summary>
+    /// Resolves the links in the XML documentation into type names.
+    /// </summary>
+    /// <param name="node">The target node to process crefs in.</param>
+    /// <param name="elementName">The node type to process crefs for, can be `see` or `seealso`.</param>
+    private static void ResolveLangKeyword(XNode node, string elementName)
+    {
+        if (node == null || string.IsNullOrEmpty(elementName))
+        {
+            return;
+        }
+
+        var attributeName = DocumentationCommentXmlNames.LangwordAttributeName;
+
+        var nodes = node.XPathSelectElements($"//{elementName}[@{attributeName}]").ToArray();
+        foreach (var item in nodes)
+        {
+            var langword = item.Attribute(attributeName).Value;
+            if (string.IsNullOrEmpty(langword))
+            {
+                continue;
+            }
+
+            item.ReplaceWith(new XText($"`{langword}`"));
         }
     }
 

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.SourceGenerators.Tests/CompletenessTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.SourceGenerators.Tests/CompletenessTests.cs
@@ -464,6 +464,7 @@ public class DisposableType : IDisposable
     /// <param name="disposing">
     /// <see langword="true" /> to release both managed and unmanaged resources;
     /// <see langword="false" /> to release only unmanaged resources.
+    /// <see langword="null" /> to indicate a no-op.
     /// </param>
     protected virtual void Dispose(bool disposing)
     {

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.SourceGenerators.Tests/CompletenessTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.SourceGenerators.Tests/CompletenessTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Http;
-using Microsoft.OpenApi.Models;
 
 namespace Microsoft.AspNetCore.OpenApi.SourceGenerators.Tests;
 

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.SourceGenerators.Tests/CompletenessTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.SourceGenerators.Tests/CompletenessTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Http;
+using Microsoft.OpenApi.Models;
 
 namespace Microsoft.AspNetCore.OpenApi.SourceGenerators.Tests;
 
@@ -435,6 +436,39 @@ public class ParamsAndParamRefs
     public static T GetGenericValue<T>(T para)
     {
         return para;
+    }
+}
+
+/// <summary>
+/// A class that implements the <see cref="IDisposable"/> interface.
+/// </summary>
+public class DisposableType : IDisposable
+{
+    /// <summary>
+    /// Finalizes an instance of the <see cref="DisposableType"/> class.
+    /// </summary>
+    ~DisposableType()
+    {
+        Dispose(false);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+    /// </summary>
+    /// <param name="disposing">
+    /// <see langword="true" /> to release both managed and unmanaged resources;
+    /// <see langword="false" /> to release only unmanaged resources.
+    /// </param>
+    protected virtual void Dispose(bool disposing)
+    {
+        // No-op
     }
 }
 """;

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.SourceGenerators.Tests/snapshots/CompletenessTests.SupportsAllXmlTagsOnSchemas#OpenApiXmlCommentSupport.generated.verified.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.SourceGenerators.Tests/snapshots/CompletenessTests.SupportsAllXmlTagsOnSchemas#OpenApiXmlCommentSupport.generated.verified.cs
@@ -148,7 +148,8 @@ generic type, or the type parameter.", null, null, false, null, null, null));
 generic types to open generics for use in
 typeof expressions.", null, null, null, null, false, null, null, null));
             cache.Add(@"T:ParamsAndParamRefs", new XmlComment(@"This shows examples of typeparamref and typeparam tags", null, null, null, null, false, null, null, null));
-            cache.Add(@"P:ExampleClass.Label", new XmlComment(null, null, @"    The string? ExampleClass.Label is a <see langword=""string"" />
+            cache.Add(@"T:DisposableType", new XmlComment(@"A class that implements the IDisposable interface.", null, null, null, null, false, null, null, null));
+            cache.Add(@"P:ExampleClass.Label", new XmlComment(null, null, @"    The string? ExampleClass.Label is a `string`
     that you use for a label.
     Note that there isn't a way to provide a ""cref"" to
 each accessor, only to the property itself.", null, @"The `Label` property represents a label
@@ -191,6 +192,7 @@ type parameter inside.", null, null, null, null, false, null, null, null));
 method as a cref attribute.
 The parameter and return value are both of an arbitrary type,
 T", null, null, false, null, null, null));
+            cache.Add(@"M:DisposableType.Dispose", new XmlComment(null, null, null, null, null, false, null, null, null));
 
             return cache;
         }


### PR DESCRIPTION
# Handle `langword` for `see` elements

Handle `<see langword="value" />` references in XML documentation as inline code.

## Description

Extract the value from `langword` on `see` references and emit as inline code.

For example `<see langword="true" />` becomes ````true````.

Questions:

1. Should it also handle `seealso`?
2. ~~Do we output verbatim, or map the keywords to something? (e.g. C# `null` to `null` but VB `Nothing` to `null`)~~

Fixes #61042.
