### PR TITLE
Api proposal fix for `NavLink.ShouldMatch`

### DIFF
--- a/src/Components/Web/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Web/src/PublicAPI.Unshipped.txt
@@ -1,2 +1,2 @@
 #nullable enable
-virtual Microsoft.AspNetCore.Components.Routing.NavLink.ShouldMatch(string! currentUriAbsolute) -> bool
+virtual Microsoft.AspNetCore.Components.Routing.NavLink.ShouldMatch(string! uriAbsolute) -> bool

--- a/src/Components/Web/src/Routing/NavLink.cs
+++ b/src/Components/Web/src/Routing/NavLink.cs
@@ -111,24 +111,24 @@ public class NavLink : ComponentBase, IDisposable
     /// <summary>
     /// Determines whether the current URI should match the link.
     /// </summary>
-    /// <param name="currentUriAbsolute">The absolute URI of the current location.</param>
+    /// <param name="uriAbsolute">The absolute URI of the current location.</param>
     /// <returns>True if the link should be highlighted as active; otherwise, false.</returns>
-    protected virtual bool ShouldMatch(string currentUriAbsolute)
+    protected virtual bool ShouldMatch(string uriAbsolute)
     {
         if (_hrefAbsolute == null)
         {
             return false;
         }
 
-        var currentUriAbsoluteSpan = currentUriAbsolute.AsSpan();
+        var uriAbsoluteSpan = uriAbsolute.AsSpan();
         var hrefAbsoluteSpan = _hrefAbsolute.AsSpan();
-        if (EqualsHrefExactlyOrIfTrailingSlashAdded(currentUriAbsoluteSpan, hrefAbsoluteSpan))
+        if (EqualsHrefExactlyOrIfTrailingSlashAdded(uriAbsoluteSpan, hrefAbsoluteSpan))
         {
             return true;
         }
 
         if (Match == NavLinkMatch.Prefix
-            && IsStrictlyPrefixWithSeparator(currentUriAbsolute, _hrefAbsolute))
+            && IsStrictlyPrefixWithSeparator(uriAbsolute, _hrefAbsolute))
         {
             return true;
         }
@@ -138,7 +138,7 @@ public class NavLink : ComponentBase, IDisposable
             return false;
         }
 
-        var uriWithoutQueryAndFragment = GetUriIgnoreQueryAndFragment(currentUriAbsoluteSpan);
+        var uriWithoutQueryAndFragment = GetUriIgnoreQueryAndFragment(uriAbsoluteSpan);
         if (EqualsHrefExactlyOrIfTrailingSlashAdded(uriWithoutQueryAndFragment, hrefAbsoluteSpan))
         {
             return true;


### PR DESCRIPTION
# Rename `currentUriAbsolute` to `uriAbsolute`

## Description

Applying the change from API review. To keep the local variables in line with the rename, `currentUriAbsoluteSpan` -> `uriAbsoluteSpan` was done as well.

Fixes #61137
