### PR TITLE
Update Chrome download link and disable TerminalLogger for Helix tests

### DIFF
--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -570,11 +570,13 @@ stages:
         # Build the shared framework
         - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -nobl -all -pack -arch x64
                   /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
+                  /p:VsTestUseMSBuildOutput=false
           displayName: Build shared fx
         # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
         - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -nobl -all -noBuildRepoTasks -noBuildNative -noBuild -test
                   -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true
                   /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
+                  /p:VsTestUseMSBuildOutput=false
           displayName: Run build.cmd helix target
           env:
             HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues

--- a/eng/scripts/InstallGoogleChrome.ps1
+++ b/eng/scripts/InstallGoogleChrome.ps1
@@ -1,4 +1,4 @@
 $InstallerPath = "$env:Temp\chrome_installer.exe";
-& $PSScriptRoot\Download.ps1 "http://dl.google.com/chrome/install/375.126/chrome_installer.exe" $InstallerPath
+& $PSScriptRoot\Download.ps1 "http://dl.google.com/chrome/install/latest/chrome_installer.exe" $InstallerPath
 Start-Process -FilePath $InstallerPath -Args "/silent /install" -Verb RunAs -Wait;
 Remove-Item $InstallerPath

--- a/eng/scripts/InstallGoogleChrome.ps1
+++ b/eng/scripts/InstallGoogleChrome.ps1
@@ -1,4 +1,4 @@
 $InstallerPath = "$env:Temp\chrome_installer.exe";
-& $PSScriptRoot\Download.ps1 "http://dl.google.com/chrome/install/latest/chrome_installer.exe" $InstallerPath
+& $PSScriptRoot\Download.ps1 "https://dl.google.com/chrome/install/latest/chrome_installer.exe" $InstallerPath
 Start-Process -FilePath $InstallerPath -Args "/silent /install" -Verb RunAs -Wait;
 Remove-Item $InstallerPath


### PR DESCRIPTION
We've been seeing Helix timeouts recently, and the logs are very large (~2MB **per test**). This seems to be caused by the chattiness of the new TerminalLogger.

I'm going to try disabling the TerminalLogger to make the failures easier to debug. We already did this for the `components-e2e` pipeline a while ago in https://github.com/dotnet/aspnetcore/pull/54556.

The chrome download link also seems to have broken. This PR updates the link.