### PR TITLE
[Blazor] Generate Link headers based on StaticWebAssets manifest properties

### DIFF
--- a/src/Components/Endpoints/src/Builder/ResourceCollectionConvention.cs
+++ b/src/Components/Endpoints/src/Builder/ResourceCollectionConvention.cs
@@ -49,6 +49,7 @@ internal class ResourceCollectionConvention(ResourceCollectionResolver resolver)
         if (_collection != null && _collectionImportMap != null)
         {
             eb.Metadata.Add(_collection);
+            eb.Metadata.Add(new ResourcePreloadCollection(_collection));
 
             if (_collectionUrl != null)
             {

--- a/src/Components/Endpoints/src/Builder/ResourcePreloadCollection.cs
+++ b/src/Components/Endpoints/src/Builder/ResourcePreloadCollection.cs
@@ -13,80 +13,86 @@ internal class ResourcePreloadCollection
 
     public ResourcePreloadCollection(ResourceAssetCollection assets)
     {
-        if (assets != null)
+        var headerBuilder = new StringBuilder();
+        var headers = new Dictionary<string, List<(int Order, string Value)>>();
+        foreach (var asset in assets)
         {
-            var headers = new List<(string? Group, int Order, string Value)>();
-            foreach (var asset in assets)
+            if (asset.Properties == null)
             {
-                if (asset.Properties == null)
-                {
-                    continue;
-                }
+                continue;
+            }
 
-                // Use preloadgroup=webassembly to identify assets that should to be preloaded
-                string? group = null;
-                foreach (var property in asset.Properties)
+            // Use preloadgroup property to identify assets that should be preloaded
+            string? group = null;
+            foreach (var property in asset.Properties)
+            {
+                if (property.Name.Equals("preloadgroup", StringComparison.OrdinalIgnoreCase))
                 {
-                    if (property.Name.Equals("preloadgroup", StringComparison.OrdinalIgnoreCase))
-                    {
-                        group = property.Value ?? string.Empty;
-                        break;
-                    }
-                }
-
-                if (group == null)
-                {
-                    continue;
-                }
-
-                var header = new StringBuilder();
-                header.Append('<');
-                header.Append(asset.Url);
-                header.Append('>');
-
-                int order = 0;
-                foreach (var property in asset.Properties)
-                {
-                    if (property.Name.Equals("preloadrel", StringComparison.OrdinalIgnoreCase))
-                    {
-                        header.Append("; rel=").Append(property.Value);
-                    }
-                    else if (property.Name.Equals("preloadas", StringComparison.OrdinalIgnoreCase))
-                    {
-                        header.Append("; as=").Append(property.Value);
-                    }
-                    else if (property.Name.Equals("preloadpriority", StringComparison.OrdinalIgnoreCase))
-                    {
-                        header.Append("; fetchpriority=").Append(property.Value);
-                    }
-                    else if (property.Name.Equals("preloadcrossorigin", StringComparison.OrdinalIgnoreCase))
-                    {
-                        header.Append("; crossorigin=").Append(property.Value);
-                    }
-                    else if (property.Name.Equals("integrity", StringComparison.OrdinalIgnoreCase))
-                    {
-                        header.Append("; integrity=\"").Append(property.Value).Append('"');
-                    }
-                    else if (property.Name.Equals("preloadorder", StringComparison.OrdinalIgnoreCase))
-                    {
-                        if (!int.TryParse(property.Value, out order))
-                        {
-                            order = 0;
-                        }
-                    }
-                }
-
-                if (header != null)
-                {
-                    headers.Add((group, order, header.ToString()));
+                    group = property.Value ?? string.Empty;
+                    break;
                 }
             }
 
-            foreach (var group in headers.GroupBy(h => h.Group))
+            if (group == null)
             {
-                _storage[group.Key ?? string.Empty] = group.OrderBy(h => h.Order).Select(h => h.Value).ToArray();
+                continue;
+            }
+
+            var header = CreateHeader(headerBuilder, asset.Url, asset.Properties);
+            if (!headers.TryGetValue(group, out var groupHeaders))
+            {
+                groupHeaders = headers[group] = new List<(int Order, string Value)>();
+            }
+
+            groupHeaders.Add(header);
+        }
+
+        foreach (var group in headers)
+        {
+            _storage[group.Key ?? string.Empty] = group.Value.OrderBy(h => h.Order).Select(h => h.Value).ToArray();
+        }
+    }
+
+    private static (int order, string header) CreateHeader(StringBuilder headerBuilder, string url, IEnumerable<ResourceAssetProperty> properties)
+    {
+        headerBuilder.Clear();
+        headerBuilder.Append('<');
+        headerBuilder.Append(url);
+        headerBuilder.Append('>');
+
+        int order = 0;
+        foreach (var property in properties)
+        {
+            if (property.Name.Equals("preloadrel", StringComparison.OrdinalIgnoreCase))
+            {
+                headerBuilder.Append("; rel=").Append(property.Value);
+            }
+            else if (property.Name.Equals("preloadas", StringComparison.OrdinalIgnoreCase))
+            {
+                headerBuilder.Append("; as=").Append(property.Value);
+            }
+            else if (property.Name.Equals("preloadpriority", StringComparison.OrdinalIgnoreCase))
+            {
+                headerBuilder.Append("; fetchpriority=").Append(property.Value);
+            }
+            else if (property.Name.Equals("preloadcrossorigin", StringComparison.OrdinalIgnoreCase))
+            {
+                headerBuilder.Append("; crossorigin=").Append(property.Value);
+            }
+            else if (property.Name.Equals("integrity", StringComparison.OrdinalIgnoreCase))
+            {
+                headerBuilder.Append("; integrity=\"").Append(property.Value).Append('"');
+            }
+            else if (property.Name.Equals("preloadorder", StringComparison.OrdinalIgnoreCase))
+            {
+                if (!int.TryParse(property.Value, out order))
+                {
+                    order = 0;
+                }
             }
         }
+
+        return (order, headerBuilder.ToString());
     }
 
     public bool TryGetLinkHeaders(string group, out StringValues linkHeaders)

--- a/src/Components/Endpoints/src/Builder/ResourcePreloadCollection.cs
+++ b/src/Components/Endpoints/src/Builder/ResourcePreloadCollection.cs
@@ -15,7 +15,7 @@ internal class ResourcePreloadCollection
     {
         if (assets != null)
         {
-            var headers = new List<(string? Group, string? Order, string Value)>();
+            var headers = new List<(string? Group, int Order, string Value)>();
             foreach (var asset in assets)
             {
                 if (asset.Properties == null)
@@ -44,7 +44,7 @@ internal class ResourcePreloadCollection
                 header.Append(asset.Url);
                 header.Append('>');
 
-                string? order = null;
+                int order = 0;
                 foreach (var property in asset.Properties)
                 {
                     if (property.Name.Equals("preloadrel", StringComparison.OrdinalIgnoreCase))
@@ -69,7 +69,10 @@ internal class ResourcePreloadCollection
                     }
                     else if (property.Name.Equals("preloadorder", StringComparison.OrdinalIgnoreCase))
                     {
-                        order = property.Value;
+                        if (!int.TryParse(property.Value, out order))
+                        {
+                            order = 0;
+                        }
                     }
                 }
 

--- a/src/Components/Endpoints/src/Builder/ResourcePreloadCollection.cs
+++ b/src/Components/Endpoints/src/Builder/ResourcePreloadCollection.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
+using System.Text;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Components.Endpoints;
@@ -23,45 +24,48 @@ internal class ResourcePreloadCollection
                 }
 
                 // Use preloadgroup=webassembly to identify assets that should to be preloaded
-                string? header = null;
                 string? group = null;
                 foreach (var property in asset.Properties)
                 {
                     if (property.Name.Equals("preloadgroup", StringComparison.OrdinalIgnoreCase))
                     {
-                        group = property.Value;
-                        header = $"<{asset.Url}>";
+                        group = property.Value ?? string.Empty;
                         break;
                     }
                 }
 
-                if (header == null)
+                if (group == null)
                 {
                     continue;
                 }
+
+                var header = new StringBuilder();
+                header.Append('<');
+                header.Append(asset.Url);
+                header.Append('>');
 
                 string? order = null;
                 foreach (var property in asset.Properties)
                 {
                     if (property.Name.Equals("preloadrel", StringComparison.OrdinalIgnoreCase))
                     {
-                        header = String.Concat(header, "; rel=", property.Value);
+                        header.Append("; rel=").Append(property.Value);
                     }
                     else if (property.Name.Equals("preloadas", StringComparison.OrdinalIgnoreCase))
                     {
-                        header = String.Concat(header, "; as=", property.Value);
+                        header.Append("; as=").Append(property.Value);
                     }
                     else if (property.Name.Equals("preloadpriority", StringComparison.OrdinalIgnoreCase))
                     {
-                        header = String.Concat(header, "; fetchpriority=", property.Value);
+                        header.Append("; fetchpriority=").Append(property.Value);
                     }
                     else if (property.Name.Equals("preloadcrossorigin", StringComparison.OrdinalIgnoreCase))
                     {
-                        header = String.Concat(header, "; crossorigin=", property.Value);
+                        header.Append("; crossorigin=").Append(property.Value);
                     }
                     else if (property.Name.Equals("integrity", StringComparison.OrdinalIgnoreCase))
                     {
-                        header = String.Concat(header, "; integrity=\"", property.Value, "\"");
+                        header.Append("; integrity=\"").Append(property.Value).Append('"');
                     }
                     else if (property.Name.Equals("preloadorder", StringComparison.OrdinalIgnoreCase))
                     {
@@ -71,7 +75,7 @@ internal class ResourcePreloadCollection
 
                 if (header != null)
                 {
-                    headers.Add((group, order, header));
+                    headers.Add((group, order, header.ToString()));
                 }
             }
 

--- a/src/Components/Endpoints/src/Builder/ResourcePreloadCollection.cs
+++ b/src/Components/Endpoints/src/Builder/ResourcePreloadCollection.cs
@@ -1,0 +1,84 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.AspNetCore.Components.Endpoints;
+
+internal class ResourcePreloadCollection
+{
+    private readonly Dictionary<string?, StringValues> _storage = new();
+
+    public ResourcePreloadCollection(ResourceAssetCollection assets)
+    {
+        if (assets != null)
+        {
+            var headers = new List<(string? Order, string Value)>();
+            foreach (var asset in assets)
+            {
+                if (asset.Properties == null)
+                {
+                    continue;
+                }
+
+                // Use preloadgroup=webassembly to identify assets that should to be preloaded
+                string? header = null;
+                string? group = null;
+                foreach (var property in asset.Properties)
+                {
+                    if (property.Name.Equals("preloadgroup", StringComparison.OrdinalIgnoreCase))
+                    {
+                        group = property.Value;
+                        header = $"<{asset.Url}>";
+                        break;
+                    }
+                }
+
+                if (header == null)
+                {
+                    continue;
+                }
+
+                string? order = null;
+                foreach (var property in asset.Properties)
+                {
+                    if (property.Name.Equals("preloadrel", StringComparison.OrdinalIgnoreCase))
+                    {
+                        header = String.Concat(header, "; rel=", property.Value);
+                    }
+                    else if (property.Name.Equals("preloadas", StringComparison.OrdinalIgnoreCase))
+                    {
+                        header = String.Concat(header, "; as=", property.Value);
+                    }
+                    else if (property.Name.Equals("preloadpriority", StringComparison.OrdinalIgnoreCase))
+                    {
+                        header = String.Concat(header, "; fetchpriority=", property.Value);
+                    }
+                    else if (property.Name.Equals("preloadcrossorigin", StringComparison.OrdinalIgnoreCase))
+                    {
+                        header = String.Concat(header, "; crossorigin=", property.Value);
+                    }
+                    else if (property.Name.Equals("integrity", StringComparison.OrdinalIgnoreCase))
+                    {
+                        header = String.Concat(header, "; integrity=\"", property.Value, "\"");
+                    }
+                    else if (property.Name.Equals("preloadorder", StringComparison.OrdinalIgnoreCase))
+                    {
+                        order = property.Value;
+                    }
+                }
+
+                if (header != null)
+                {
+                    headers.Add((order, header));
+                }
+            }
+
+            headers.Sort((a, b) => string.Compare(a.Order, b.Order, StringComparison.InvariantCulture));
+        }
+    }
+
+    public bool TryGetLinkHeaders(string group, out StringValues linkHeaders)
+        => _storage.TryGetValue(group, out linkHeaders);
+}

--- a/src/Components/Endpoints/src/Builder/ResourcePreloadCollection.cs
+++ b/src/Components/Endpoints/src/Builder/ResourcePreloadCollection.cs
@@ -8,13 +8,13 @@ namespace Microsoft.AspNetCore.Components.Endpoints;
 
 internal class ResourcePreloadCollection
 {
-    private readonly Dictionary<string?, StringValues> _storage = new();
+    private readonly Dictionary<string, StringValues> _storage = new();
 
     public ResourcePreloadCollection(ResourceAssetCollection assets)
     {
         if (assets != null)
         {
-            var headers = new List<(string? Order, string Value)>();
+            var headers = new List<(string? Group, string? Order, string Value)>();
             foreach (var asset in assets)
             {
                 if (asset.Properties == null)
@@ -71,11 +71,14 @@ internal class ResourcePreloadCollection
 
                 if (header != null)
                 {
-                    headers.Add((order, header));
+                    headers.Add((group, order, header));
                 }
             }
 
-            headers.Sort((a, b) => string.Compare(a.Order, b.Order, StringComparison.InvariantCulture));
+            foreach (var group in headers.GroupBy(h => h.Group))
+            {
+                _storage[group.Key ?? string.Empty] = group.OrderBy(h => h.Order).Select(h => h.Value).ToArray();
+            }
         }
     }
 

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Streaming.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Streaming.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Linq;
-using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Encodings.Web;

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Streaming.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Streaming.cs
@@ -332,13 +332,13 @@ internal partial class EndpointHtmlRenderer
                     continue;
                 }
 
-                // Use preloadrel to identify assets that should to be preloaded
+                // Use preloadgroup=webassembly to identify assets that should to be preloaded
                 string? header = null;
                 foreach (var property in asset.Properties)
                 {
-                    if (property.Name.Equals("preloadrel", StringComparison.OrdinalIgnoreCase))
+                    if (property.Name.Equals("preloadgroup", StringComparison.OrdinalIgnoreCase) && property.Value.Equals("webassembly", StringComparison.OrdinalIgnoreCase))
                     {
-                        header = String.Concat($"<{asset.Url}>", "; rel=", property.Value);
+                        header = $"<{asset.Url}>";
                         break;
                     }
                 }
@@ -351,7 +351,11 @@ internal partial class EndpointHtmlRenderer
                 string? order = null;
                 foreach (var property in asset.Properties)
                 {
-                    if (property.Name.Equals("preloadas", StringComparison.OrdinalIgnoreCase))
+                    if (property.Name.Equals("preloadrel", StringComparison.OrdinalIgnoreCase))
+                    {
+                        header = String.Concat(header, "; rel=", property.Value);
+                    }
+                    else if (property.Name.Equals("preloadas", StringComparison.OrdinalIgnoreCase))
                     {
                         header = String.Concat(header, "; as=", property.Value);
                     }

--- a/src/Components/Endpoints/test/EndpointHtmlRendererTest.cs
+++ b/src/Components/Endpoints/test/EndpointHtmlRendererTest.cs
@@ -81,38 +81,40 @@ public class EndpointHtmlRendererTest
             new Endpoint(
                 ctx => Task.CompletedTask,
                 new EndpointMetadataCollection([
-                    new ResourceAssetCollection([
-                        new ResourceAsset("second.js", [
-                            new ResourceAssetProperty("preloadrel", "preload"),
-                            new ResourceAssetProperty("preloadas", "script"),
-                            new ResourceAssetProperty("preloadpriority", "high"),
-                            new ResourceAssetProperty("preloadcrossorigin", "anonymous"),
-                            new ResourceAssetProperty("integrity", "abcd"),
-                            new ResourceAssetProperty("preloadorder", "2"),
-                            new ResourceAssetProperty("preloadgroup", "webassembly")
-                        ]),
-                        new ResourceAsset("first.js", [
-                            new ResourceAssetProperty("preloadrel", "preload"),
-                            new ResourceAssetProperty("preloadas", "script"),
-                            new ResourceAssetProperty("preloadpriority", "high"),
-                            new ResourceAssetProperty("preloadcrossorigin", "anonymous"),
-                            new ResourceAssetProperty("integrity", "abcd"),
-                            new ResourceAssetProperty("preloadorder", "1"),
-                            new ResourceAssetProperty("preloadgroup", "webassembly")
-                        ]),
-                        new ResourceAsset("preload-nowebassembly.js", [
-                            new ResourceAssetProperty("preloadrel", "preload"),
-                            new ResourceAssetProperty("preloadas", "script"),
-                            new ResourceAssetProperty("preloadpriority", "high"),
-                            new ResourceAssetProperty("preloadcrossorigin", "anonymous"),
-                            new ResourceAssetProperty("integrity", "abcd"),
-                            new ResourceAssetProperty("preloadorder", "1"),
-                            new ResourceAssetProperty("preloadgroup", "abcd")
-                        ]),
-                        new ResourceAsset("nopreload.js", [
-                            new ResourceAssetProperty("integrity", "abcd")
+                    new ResourcePreloadCollection(
+                        new ResourceAssetCollection([
+                            new ResourceAsset("second.js", [
+                                new ResourceAssetProperty("preloadrel", "preload"),
+                                new ResourceAssetProperty("preloadas", "script"),
+                                new ResourceAssetProperty("preloadpriority", "high"),
+                                new ResourceAssetProperty("preloadcrossorigin", "anonymous"),
+                                new ResourceAssetProperty("integrity", "abcd"),
+                                new ResourceAssetProperty("preloadorder", "2"),
+                                new ResourceAssetProperty("preloadgroup", "webassembly")
+                            ]),
+                            new ResourceAsset("first.js", [
+                                new ResourceAssetProperty("preloadrel", "preload"),
+                                new ResourceAssetProperty("preloadas", "script"),
+                                new ResourceAssetProperty("preloadpriority", "high"),
+                                new ResourceAssetProperty("preloadcrossorigin", "anonymous"),
+                                new ResourceAssetProperty("integrity", "abcd"),
+                                new ResourceAssetProperty("preloadorder", "1"),
+                                new ResourceAssetProperty("preloadgroup", "webassembly")
+                            ]),
+                            new ResourceAsset("preload-nowebassembly.js", [
+                                new ResourceAssetProperty("preloadrel", "preload"),
+                                new ResourceAssetProperty("preloadas", "script"),
+                                new ResourceAssetProperty("preloadpriority", "high"),
+                                new ResourceAssetProperty("preloadcrossorigin", "anonymous"),
+                                new ResourceAssetProperty("integrity", "abcd"),
+                                new ResourceAssetProperty("preloadorder", "1"),
+                                new ResourceAssetProperty("preloadgroup", "abcd")
+                            ]),
+                            new ResourceAsset("nopreload.js", [
+                                new ResourceAssetProperty("integrity", "abcd")
+                            ])
                         ])
-                    ])
+                    )
                 ]),
                 "TestEndpoint"
             )

--- a/src/Components/Endpoints/test/EndpointHtmlRendererTest.cs
+++ b/src/Components/Endpoints/test/EndpointHtmlRendererTest.cs
@@ -88,7 +88,8 @@ public class EndpointHtmlRendererTest
                             new ResourceAssetProperty("preloadpriority", "high"),
                             new ResourceAssetProperty("preloadcrossorigin", "anonymous"),
                             new ResourceAssetProperty("integrity", "abcd"),
-                            new ResourceAssetProperty("preloadorder", "2")
+                            new ResourceAssetProperty("preloadorder", "2"),
+                            new ResourceAssetProperty("preloadgroup", "webassembly")
                         ]),
                         new ResourceAsset("first.js", [
                             new ResourceAssetProperty("preloadrel", "preload"),
@@ -96,7 +97,17 @@ public class EndpointHtmlRendererTest
                             new ResourceAssetProperty("preloadpriority", "high"),
                             new ResourceAssetProperty("preloadcrossorigin", "anonymous"),
                             new ResourceAssetProperty("integrity", "abcd"),
-                            new ResourceAssetProperty("preloadorder", "1")
+                            new ResourceAssetProperty("preloadorder", "1"),
+                            new ResourceAssetProperty("preloadgroup", "webassembly")
+                        ]),
+                        new ResourceAsset("preload-nowebassembly.js", [
+                            new ResourceAssetProperty("preloadrel", "preload"),
+                            new ResourceAssetProperty("preloadas", "script"),
+                            new ResourceAssetProperty("preloadpriority", "high"),
+                            new ResourceAssetProperty("preloadcrossorigin", "anonymous"),
+                            new ResourceAssetProperty("integrity", "abcd"),
+                            new ResourceAssetProperty("preloadorder", "1"),
+                            new ResourceAssetProperty("preloadgroup", "abcd")
                         ]),
                         new ResourceAsset("nopreload.js", [
                             new ResourceAssetProperty("integrity", "abcd")

--- a/src/Components/Endpoints/test/EndpointHtmlRendererTest.cs
+++ b/src/Components/Endpoints/test/EndpointHtmlRendererTest.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Net.Http;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -69,6 +68,65 @@ public class EndpointHtmlRendererTest
         Assert.Equal(typeof(SimpleComponent).Assembly.GetName().Name, marker.Assembly);
         Assert.Equal(typeof(SimpleComponent).FullName, marker.TypeName);
         Assert.Empty(httpContext.Items);
+    }
+
+    [Fact]
+    public async Task CanPreload_WebAssembly_ResourceAssets()
+    {
+        // Arrange
+        var httpContext = GetHttpContext();
+        var writer = new StringWriter();
+
+        httpContext.SetEndpoint(
+            new Endpoint(
+                ctx => Task.CompletedTask,
+                new EndpointMetadataCollection([
+                    new ResourceAssetCollection([
+                        new ResourceAsset("second.js", [
+                            new ResourceAssetProperty("preloadrel", "preload"),
+                            new ResourceAssetProperty("preloadas", "script"),
+                            new ResourceAssetProperty("preloadpriority", "high"),
+                            new ResourceAssetProperty("preloadcrossorigin", "anonymous"),
+                            new ResourceAssetProperty("integrity", "abcd"),
+                            new ResourceAssetProperty("preloadorder", "2")
+                        ]),
+                        new ResourceAsset("first.js", [
+                            new ResourceAssetProperty("preloadrel", "preload"),
+                            new ResourceAssetProperty("preloadas", "script"),
+                            new ResourceAssetProperty("preloadpriority", "high"),
+                            new ResourceAssetProperty("preloadcrossorigin", "anonymous"),
+                            new ResourceAssetProperty("integrity", "abcd"),
+                            new ResourceAssetProperty("preloadorder", "1")
+                        ]),
+                        new ResourceAsset("nopreload.js", [
+                            new ResourceAssetProperty("integrity", "abcd")
+                        ])
+                    ])
+                ]),
+                "TestEndpoint"
+            )
+        );
+
+        // Act
+        var result = await renderer.PrerenderComponentAsync(httpContext, typeof(SimpleComponent), new InteractiveWebAssemblyRenderMode(prerender: false), ParameterView.Empty);
+        await renderer.Dispatcher.InvokeAsync(() => result.WriteTo(writer, HtmlEncoder.Default));
+
+        // Assert
+        Assert.Equal(2, httpContext.Response.Headers.Link.Count);
+
+        var firstPreloadLink = httpContext.Response.Headers.Link[0];
+        Assert.Contains("<first.js>", firstPreloadLink);
+        Assert.Contains("rel=preload", firstPreloadLink);
+        Assert.Contains("as=script", firstPreloadLink);
+        Assert.Contains("fetchpriority=high", firstPreloadLink);
+        Assert.Contains("integrity=\"abcd\"", firstPreloadLink);
+
+        var secondPreloadLink = httpContext.Response.Headers.Link[1];
+        Assert.Contains("<second.js>", secondPreloadLink);
+        Assert.Contains("rel=preload", secondPreloadLink);
+        Assert.Contains("as=script", secondPreloadLink);
+        Assert.Contains("fetchpriority=high", secondPreloadLink);
+        Assert.Contains("integrity=\"abcd\"", secondPreloadLink);
     }
 
     [Fact]

--- a/src/Shared/Components/ResourceCollectionResolver.cs
+++ b/src/Shared/Components/ResourceCollectionResolver.cs
@@ -46,6 +46,7 @@ internal class ResourceCollectionResolver(IEndpointRouteBuilder endpoints)
             string? preloadAs = null;
             string? preloadPriority = null;
             string? preloadCrossorigin = null;
+            string? preloadOrder = null;
 #else
             string label = null;
             string integrity = null;
@@ -53,6 +54,7 @@ internal class ResourceCollectionResolver(IEndpointRouteBuilder endpoints)
             string preloadAs = null;
             string preloadPriority = null;
             string preloadCrossorigin = null;
+            string preloadOrder = null;
 #endif
 
             // If there's a selector this means that this is an alternative representation for a resource, so skip it.
@@ -92,9 +94,14 @@ internal class ResourceCollectionResolver(IEndpointRouteBuilder endpoints)
                         preloadCrossorigin = property.Value;
                         foundProperties++;
                     }
+                    else if (property.Name.Equals("preloadorder", StringComparison.OrdinalIgnoreCase))
+                    {
+                        preloadOrder = property.Value;
+                        foundProperties++;
+                    }
                 }
 
-                AddResource(resources, descriptor, label, integrity, preloadRel, preloadAs, preloadPriority, preloadCrossorigin, foundProperties);
+                AddResource(resources, descriptor, label, integrity, preloadRel, preloadAs, preloadPriority, preloadCrossorigin, preloadOrder, foundProperties);
             }
         }
 
@@ -128,6 +135,7 @@ internal class ResourceCollectionResolver(IEndpointRouteBuilder endpoints)
         string? preloadAs,
         string? preloadPriority,
         string? preloadCrossorigin,
+        string? preloadOrder,
 #else
         string label,
         string integrity,
@@ -135,6 +143,7 @@ internal class ResourceCollectionResolver(IEndpointRouteBuilder endpoints)
         string preloadAs,
         string preloadPriority,
         string preloadCrossorigin,
+        string preloadOrder,
 #endif
     int foundProperties)
     {
@@ -165,6 +174,10 @@ internal class ResourceCollectionResolver(IEndpointRouteBuilder endpoints)
             if (preloadCrossorigin != null)
             {
                 properties[index++] = new ResourceAssetProperty("preloadcrossorigin", preloadCrossorigin);
+            }
+            if (preloadOrder != null)
+            {
+                properties[index++] = new ResourceAssetProperty("preloadorder", preloadOrder);
             }
 
             resources.Add(new ResourceAsset(descriptor.Route, properties));

--- a/src/Shared/Components/ResourceCollectionResolver.cs
+++ b/src/Shared/Components/ResourceCollectionResolver.cs
@@ -42,9 +42,17 @@ internal class ResourceCollectionResolver(IEndpointRouteBuilder endpoints)
 #if !MVC_VIEWFEATURES
             string? label = null;
             string? integrity = null;
+            string? preloadRel = null;
+            string? preloadAs = null;
+            string? preloadPriority = null;
+            string? preloadCrossorigin = null;
 #else
             string label = null;
             string integrity = null;
+            string preloadRel = null;
+            string preloadAs = null;
+            string preloadPriority = null;
+            string preloadCrossorigin = null;
 #endif
 
             // If there's a selector this means that this is an alternative representation for a resource, so skip it.
@@ -59,15 +67,34 @@ internal class ResourceCollectionResolver(IEndpointRouteBuilder endpoints)
                         label = property.Value;
                         foundProperties++;
                     }
-
                     else if (property.Name.Equals("integrity", StringComparison.OrdinalIgnoreCase))
                     {
                         integrity = property.Value;
                         foundProperties++;
                     }
+                    else if (property.Name.Equals("preloadrel", StringComparison.OrdinalIgnoreCase))
+                    {
+                        preloadRel = property.Value;
+                        foundProperties++;
+                    }
+                    else if (property.Name.Equals("preloadas", StringComparison.OrdinalIgnoreCase))
+                    {
+                        preloadAs = property.Value;
+                        foundProperties++;
+                    }
+                    else if (property.Name.Equals("preloadpriority", StringComparison.OrdinalIgnoreCase))
+                    {
+                        preloadPriority = property.Value;
+                        foundProperties++;
+                    }
+                    else if (property.Name.Equals("preloadcrossorigin", StringComparison.OrdinalIgnoreCase))
+                    {
+                        preloadCrossorigin = property.Value;
+                        foundProperties++;
+                    }
                 }
 
-                AddResource(resources, descriptor, label, integrity, foundProperties);
+                AddResource(resources, descriptor, label, integrity, preloadRel, preloadAs, preloadPriority, preloadCrossorigin, foundProperties);
             }
         }
 
@@ -97,11 +124,19 @@ internal class ResourceCollectionResolver(IEndpointRouteBuilder endpoints)
 #if !MVC_VIEWFEATURES
         string? label,
         string? integrity,
+        string? preloadRel,
+        string? preloadAs,
+        string? preloadPriority,
+        string? preloadCrossorigin,
 #else
         string label,
         string integrity,
+        string preloadRel,
+        string preloadAs,
+        string preloadPriority,
+        string preloadCrossorigin,
 #endif
-        int foundProperties)
+    int foundProperties)
     {
         if (label != null || integrity != null)
         {
@@ -114,6 +149,22 @@ internal class ResourceCollectionResolver(IEndpointRouteBuilder endpoints)
             if (integrity != null)
             {
                 properties[index++] = new ResourceAssetProperty("integrity", integrity);
+            }
+            if (preloadRel != null)
+            {
+                properties[index++] = new ResourceAssetProperty("preloadrel", preloadRel);
+            }
+            if (preloadAs != null)
+            {
+                properties[index++] = new ResourceAssetProperty("preloadas", preloadAs);
+            }
+            if (preloadPriority != null)
+            {
+                properties[index++] = new ResourceAssetProperty("preloadpriority", preloadPriority);
+            }
+            if (preloadCrossorigin != null)
+            {
+                properties[index++] = new ResourceAssetProperty("preloadcrossorigin", preloadCrossorigin);
             }
 
             resources.Add(new ResourceAsset(descriptor.Route, properties));

--- a/src/Shared/Components/ResourceCollectionResolver.cs
+++ b/src/Shared/Components/ResourceCollectionResolver.cs
@@ -47,6 +47,7 @@ internal class ResourceCollectionResolver(IEndpointRouteBuilder endpoints)
             string? preloadPriority = null;
             string? preloadCrossorigin = null;
             string? preloadOrder = null;
+            string? preloadGroup = null;
 #else
             string label = null;
             string integrity = null;
@@ -55,6 +56,7 @@ internal class ResourceCollectionResolver(IEndpointRouteBuilder endpoints)
             string preloadPriority = null;
             string preloadCrossorigin = null;
             string preloadOrder = null;
+            string preloadGroup = null;
 #endif
 
             // If there's a selector this means that this is an alternative representation for a resource, so skip it.
@@ -99,9 +101,14 @@ internal class ResourceCollectionResolver(IEndpointRouteBuilder endpoints)
                         preloadOrder = property.Value;
                         foundProperties++;
                     }
+                    else if (property.Name.Equals("preloadgroup", StringComparison.OrdinalIgnoreCase))
+                    {
+                        preloadGroup = property.Value;
+                        foundProperties++;
+                    }
                 }
 
-                AddResource(resources, descriptor, label, integrity, preloadRel, preloadAs, preloadPriority, preloadCrossorigin, preloadOrder, foundProperties);
+                AddResource(resources, descriptor, label, integrity, preloadRel, preloadAs, preloadPriority, preloadCrossorigin, preloadOrder, preloadGroup, foundProperties);
             }
         }
 
@@ -136,6 +143,7 @@ internal class ResourceCollectionResolver(IEndpointRouteBuilder endpoints)
         string? preloadPriority,
         string? preloadCrossorigin,
         string? preloadOrder,
+        string? preloadGroup,
 #else
         string label,
         string integrity,
@@ -144,6 +152,7 @@ internal class ResourceCollectionResolver(IEndpointRouteBuilder endpoints)
         string preloadPriority,
         string preloadCrossorigin,
         string preloadOrder,
+        string preloadGroup,
 #endif
     int foundProperties)
     {
@@ -178,6 +187,10 @@ internal class ResourceCollectionResolver(IEndpointRouteBuilder endpoints)
             if (preloadOrder != null)
             {
                 properties[index++] = new ResourceAssetProperty("preloadorder", preloadOrder);
+            }
+            if (preloadGroup != null)
+            {
+                properties[index++] = new ResourceAssetProperty("preloadgroup", preloadGroup);
             }
 
             resources.Add(new ResourceAsset(descriptor.Route, properties));


### PR DESCRIPTION
Use properties generated on StaticWebAsset endpoints to generate Link headers.
The endpoint selection will be part of WebAssembly SDK.

The StaticWebAsset endpoint properties are following
- `preloadgroup` is used to identify assets to preload during WebAssembly component pre-rendering
- `preloadrel` is translated to `rel` attribute and defines relationship (`preload` or `modulepreload` are values that will be used for runtime assets)
- `preloadas` is translated to `as` attribute and specifies the type of content being loaded (`script` or `fetch` are values that will be used for runtime assets)
- `preloadpriority` is translated to `fetchpriority` attribute, is optional, and specifies the priority
- `preloadcrossorigin` is translated to `crossorigin` attribute (`anonymous` is the value that will be used for runtime assets)
- `integrity` is translated to `integrity` attribute and specifies the integrity of the asset
- `preloadorder` is used to sort headers based on priority

<details>
<summary>Example headers</summary>

```
Link: <_framework/dotnet.356opavw5k.js>; rel=preload; integrity="sha256-6bkzR9FAbZfpGpeWcvro3Cdv5q7Q3lrAcECLjdbxMSo="; as=script; fetchpriority=high; crossorigin=anonymous
Link: <_framework/dotnet.native.xcldtrkobb.js>; rel=preload; integrity="sha256-YXbaINTFw/gbCm/ArwBij7UxWCce5uzsMTB7SOFGGRk="; as=script; fetchpriority=high; crossorigin=anonymous
Link: <_framework/dotnet.runtime.bx28vfxjlk.js>; rel=preload; integrity="sha256-MVTbSi9B/7ru3wD2oGurO6Kdq3jzzwpgPjXBZtvxa0E="; as=script; fetchpriority=high; crossorigin=anonymous
Link: <_framework/dotnet.native.w3oqpgq65o.wasm>; rel=preload; integrity="sha256-dOqfsmWHK5+n/l/CjWWXK73okrrdc9sosIkU8QIcD8s="; as=fetch; fetchpriority=high; crossorigin=anonymous
Link: <_framework/System.Private.CoreLib.87qgib2l06.wasm>; rel=preload; integrity="sha256-pKbvr+/okd1TAIi+LQWskI1w2zrpPicTVP6Rk2FUfxs="; as=fetch; fetchpriority=low; crossorigin=anonymous
Link: <_framework/System.Runtime.InteropServices.JavaScript.uyv1n2071u.wasm>; rel=preload; integrity="sha256-Ftdgt1xNeQcttseov2QUsvHr9/ckGemptorEmOa16iQ="; as=fetch; fetchpriority=low; crossorigin=anonymous
```

</details>

Contributes https://github.com/dotnet/aspnetcore/issues/58875