### PR TITLE
Do not use Wix targets to sign intermediates

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -166,8 +166,6 @@ jobs:
       - ${{ if eq(parameters.agentOs, 'macOS') }}:
         - script: sudo xcode-select -s /Applications/Xcode_15.2.0.app/Contents/Developer
           displayName: Use XCode 15.2.0
-      - checkout: self
-        clean: true
       - ${{ if and(eq(parameters.agentOs, 'Windows'), eq(parameters.isAzDOTestingJob, true)) }}:
         - powershell: ./eng/scripts/InstallProcDump.ps1
           displayName: Install ProcDump
@@ -393,8 +391,6 @@ jobs:
       - ${{ if eq(parameters.agentOs, 'macOS') }}:
         - script: sudo xcode-select -s /Applications/Xcode_15.2.0.app/Contents/Developer
           displayName: Use XCode 15.2.0
-      - checkout: self
-        clean: true
       - ${{ if and(eq(parameters.agentOs, 'Windows'), eq(parameters.isAzDOTestingJob, true)) }}:
         - powershell: ./eng/scripts/InstallProcDump.ps1
           displayName: Install ProcDump

--- a/eng/targets/Cpp.Common.props
+++ b/eng/targets/Cpp.Common.props
@@ -25,8 +25,4 @@
     <!-- If the following line is updated ensure that the /eng/scripts/vs.17.*.json files are updated to include the same version component too. -->
     <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
-
-  <Import Project="MicroBuild.Plugin.props" Condition="'$(MicroBuildSentinelFile)' == ''" />
-  <Import Project="$(MicroBuildPluginDirectory)\MicroBuild.Plugins.*\**\build\MicroBuild.Plugins.*.props" Condition=" '$(MicroBuildPluginDirectory)' != ''" />
-
 </Project>

--- a/eng/targets/Cpp.Common.props
+++ b/eng/targets/Cpp.Common.props
@@ -2,7 +2,7 @@
 <Project>
 
   <PropertyGroup>
-    <SignOutput Condition=" '$(SignType)' != '' ">true</SignOutput>
+    <SignOutput>false</SignOutput>
     <IsPackable>false</IsPackable>
 
     <!-- This maps the common MSBuild property name to equivalent C++ project properties.  -->

--- a/eng/targets/Wix.Common.props
+++ b/eng/targets/Wix.Common.props
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <SignOutput Condition=" '$(SignType)' != '' ">true</SignOutput>
+    <SignOutput>false</SignOutput>
     <DarkToolPath>$(WixExtDir)dark.exe</DarkToolPath>
   </PropertyGroup>
 

--- a/eng/targets/Wix.Common.props
+++ b/eng/targets/Wix.Common.props
@@ -27,8 +27,4 @@
     <SignOutput>false</SignOutput>
     <DarkToolPath>$(WixExtDir)dark.exe</DarkToolPath>
   </PropertyGroup>
-
-  <Import Project="MicroBuild.Plugin.props" Condition="'$(MicroBuildSentinelFile)' == ''" />
-  <Import Project="$(MicroBuildPluginDirectory)\MicroBuild.Plugins.*\**\build\MicroBuild.Plugins.*.props" Condition=" '$(MicroBuildPluginDirectory)' != ''" />
-
 </Project>


### PR DESCRIPTION
These are signed using signtool. The wix targets are significantly slower due to single-file-submissions