### PR TITLE
Quarantine `EnhancedNavigationScrollBehavesSameAsBrowserOnBackwardsForwardsAction`

### DIFF
--- a/src/Components/test/E2ETest/ServerRenderingTests/EnhancedNavigationTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/EnhancedNavigationTest.cs
@@ -722,10 +722,10 @@ public class EnhancedNavigationTest : ServerTestBase<BasicTestAppServerSiteFixtu
     }
 
     [Theory]
-    [InlineData(false, false, false)] // https://github.com/dotnet/aspnetcore/issues/60875
+    // [InlineData(false, false, false)] // https://github.com/dotnet/aspnetcore/issues/60875
     [InlineData(false, true, false)]
-    [InlineData(true, true, false)] // https://github.com/dotnet/aspnetcore/issues/60875
-    [InlineData(true, false, false)]
+    // [InlineData(true, true, false)] // https://github.com/dotnet/aspnetcore/issues/60875
+    // [InlineData(true, false, false)] // https://github.com/dotnet/aspnetcore/issues/60875
     // [InlineData(false, false, true)] programmatic navigation doesn't work without enhanced navigation
     [InlineData(false, true, true)]
     [InlineData(true, true, true)]

--- a/src/Components/test/E2ETest/ServerRenderingTests/EnhancedNavigationTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/EnhancedNavigationTest.cs
@@ -724,7 +724,7 @@ public class EnhancedNavigationTest : ServerTestBase<BasicTestAppServerSiteFixtu
     [Theory]
     // [InlineData(false, false, false)] // https://github.com/dotnet/aspnetcore/issues/60875
     [InlineData(false, true, false)]
-    // [InlineData(true, true, false)] // https://github.com/dotnet/aspnetcore/issues/60875
+    [InlineData(true, true, false)]
     // [InlineData(true, false, false)] // https://github.com/dotnet/aspnetcore/issues/60875
     // [InlineData(false, false, true)] programmatic navigation doesn't work without enhanced navigation
     [InlineData(false, true, true)]


### PR DESCRIPTION
This test seems to be [flaky](https://dev.azure.com/dnceng-public/public/_build/results?buildId=995809&view=ms.vss-test-web.build-test-results-tab&runId=26578780&resultId=101078&paneView=history).

This PR comments out the argument combination I've observed to be problematic.
It also comments out other argument combinations that link to a GitHub issue but weren't already commented out. I assume these were meant to be disabled but were left enabled by accident.

Contributes to https://github.com/dotnet/aspnetcore/issues/60875