### PR TITLE
Fix condition for if installers are shipping

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -97,8 +97,8 @@
 
     <Artifact Include="@(_InstallersToPublish)" Kind="Blob">
       <!-- Working around msbuild not being able to negate the result of Contains() outside of targets -->
-      <IsShipping Condition="$([System.String]::Copy('%(Filename)').ToLowerInvariant().Contains('internal')) == 'True'">false</IsShipping>
-      <IsShipping Condition="$([System.String]::Copy('%(Filename)').ToLowerInvariant().Contains('internal')) != 'True'">true</IsShipping>
+      <IsShipping Condition="$([System.String]::Copy('%(RecursiveDir)').StartsWith('Shipping')) != 'true'">false</IsShipping>
+      <IsShipping Condition="$([System.String]::Copy('%(RecursiveDir)').StartsWith('Shipping')) == 'true'">true</IsShipping>
     </Artifact>
   </ItemGroup>
 

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -96,9 +96,9 @@
     </_InstallersToPublish>
 
     <Artifact Include="@(_InstallersToPublish)" Kind="Blob">
-      <!-- Working around msbuild not being able to negate the result of Contains() outside of targets -->
-      <IsShipping Condition="$([System.String]::Copy('%(RecursiveDir)').StartsWith('Shipping')) != 'true'">false</IsShipping>
-      <IsShipping Condition="$([System.String]::Copy('%(RecursiveDir)').StartsWith('Shipping')) == 'true'">true</IsShipping>
+      <IsShipping>true</IsShipping>
+      <IsShipping Condition="$([System.String]::Copy('%(RecursiveDir)').StartsWith('NonShipping'))">false</IsShipping>
+      <IsShipping Condition="$([System.String]::Copy('%(Filename)').ToLowerInvariant().Contains('wixpack.zip'))">false</IsShipping>
     </Artifact>
   </ItemGroup>
 


### PR DESCRIPTION
We no longer produce any `-internal` archives - In the non-hosting bundle case, we can rely on the `Shipping` or `NonShipping` dir, but for assets in the hosting bundle build, we have to manually mark wixpacks as NonShipping