### PR TITLE
Fix missing VMR assets in SiteExtensions packages

### DIFF
--- a/src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
+++ b/src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
@@ -19,6 +19,8 @@
     <IsShipping>true</IsShipping>
     <IsShipping Condition=" '$(PreReleaseVersionLabel)' == 'preview' ">false</IsShipping>
     <SiteExtensionsReferenceLayoutDir>$(ArtifactsObjDir)SiteExtensionsReferenceLayout/</SiteExtensionsReferenceLayoutDir>
+    <MicrosoftWebXdtExtensionsPath>$(ArtifactsBinDir)Microsoft.Web.Xdt.Extensions\$(Configuration)\net462\Microsoft.Web.Xdt.Extensions.dll</MicrosoftWebXdtExtensionsPath>
+    <MicrosoftWebXdtExtensionsPath Condition="'$(DotNetBuildPass)' == '2'">$(ArtifactsBinDir)Microsoft.Web.Xdt.Extensions\$(TargetArchitecture)\$(Configuration)\net462\Microsoft.Web.Xdt.Extensions.dll</MicrosoftWebXdtExtensionsPath>
 
     <!-- Grab packages LB.csproj should have just built. -->
     <RestoreAdditionalProjectSources>$(RestoreAdditionalProjectSources);$(ArtifactsNonShippingPackagesDir)</RestoreAdditionalProjectSources>
@@ -59,30 +61,27 @@
       BeforeTargets="Restore"
       Condition=" '$(DotNetBuildPass)' == '2' ">
 
-    <MSBuild Projects="..\..\..\LoggingBranch\LB.csproj"
-        BuildInParallel="$(BuildInParallel)"
-        Properties="Platform=x64;DisableTransitiveFrameworkReferences=true"
-        Targets="_VmrBuild" />
-    <MSBuild Projects="..\..\..\LoggingBranch\LB.csproj"
-        BuildInParallel="$(BuildInParallel)"
-        Properties="Platform=x86;TargetRid=win-x86;BaseOS=win-x86;TargetRuntimeIdentifier=win-x86;TargetArchitecture=x86;DisableTransitiveFrameworkReferences=true"
-        Targets="_VmrBuild" />
     <MSBuild Projects="..\..\..\Runtime\Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj"
-        BuildInParallel="$(BuildInParallel)"
+        BuildInParallel="false"
         Properties="Platform=x64"
         Targets="_VmrBuild" />
     <MSBuild Projects="..\..\..\Runtime\Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj"
-        BuildInParallel="$(BuildInParallel)"
+        BuildInParallel="false"
         Properties="Platform=x86;TargetRid=win-x86;BaseOS=win-x86;TargetRuntimeIdentifier=win-x86;TargetArchitecture=x86"
+        Targets="_VmrBuild" />
+    <MSBuild Projects="..\..\..\LoggingBranch\LB.csproj"
+        BuildInParallel="false"
+        Properties="Platform=x64;DisableTransitiveFrameworkReferences=true"
+        Targets="_VmrBuild" />
+    <MSBuild Projects="..\..\..\LoggingBranch\LB.csproj"
+        BuildInParallel="false"
+        Properties="Platform=x86;TargetRid=win-x86;BaseOS=win-x86;TargetRuntimeIdentifier=win-x86;TargetArchitecture=x86;DisableTransitiveFrameworkReferences=true"
         Targets="_VmrBuild" />
   </Target>
 
   <ItemGroup>
     <Content Include="applicationHost.xdt" />
     <Content Include="scmApplicationHost.xdt" />
-    <Content Include="$(ArtifactsBinDir)Microsoft.Web.Xdt.Extensions\$(Configuration)\$(DefaultNetFxTargetFramework)\Microsoft.Web.Xdt.Extensions.dll"
-        Condition="EXISTS('$(ArtifactsBinDir)Microsoft.Web.Xdt.Extensions\$(Configuration)\$(DefaultNetFxTargetFramework)\Microsoft.Web.Xdt.Extensions.dll')"
-        PackagePath="content" />
   </ItemGroup>
 
   <ItemGroup>
@@ -146,6 +145,9 @@
       <!-- Temporarily skip the common files -->
       <FilteredContentFilesToPack Include="@(ContentFilesToPack)" Condition="'%(RecursiveDir)' != ''" />
       <None Include="@(FilteredContentFilesToPack)" PackagePath="content\%(RecursiveDir)%(Filename)%(Extension)" Pack="true" />
+      <Content Include="$(MicrosoftWebXdtExtensionsPath)"
+            Condition="EXISTS('$(MicrosoftWebXdtExtensionsPath)')"
+            PackagePath="content" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
+++ b/src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
@@ -147,9 +147,7 @@
       <!-- Temporarily skip the common files -->
       <FilteredContentFilesToPack Include="@(ContentFilesToPack)" Condition="'%(RecursiveDir)' != ''" />
       <None Include="@(FilteredContentFilesToPack)" PackagePath="content\%(RecursiveDir)%(Filename)%(Extension)" Pack="true" />
-      <Content Include="$(MicrosoftWebXdtExtensionsPath)"
-            Condition="EXISTS('$(MicrosoftWebXdtExtensionsPath)')"
-            PackagePath="content" />
+      <Content Include="$(MicrosoftWebXdtExtensionsPath)" PackagePath="content" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
+++ b/src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
@@ -128,6 +128,8 @@
         OverwriteReadOnlyFiles="true"
         Condition="'$(DotNetBuild)' == 'true'" />
 
+    <Error Condition="!Exists('$(MicrosoftWebXdtExtensionsPath)')" Text="Microsoft.Web.Xdt.Extensions.dll should be available for SiteExtensions .nupkg, but isn't." />
+
     <ItemGroup>
       <!--
         The x64 & x86 SiteExtension packages have identical deps.json files. We include only the x64 files to

--- a/src/SiteExtensions/Runtime/Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj
+++ b/src/SiteExtensions/Runtime/Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj
@@ -14,6 +14,9 @@
     <DotNetUnpackFolder>$(RedistSharedFrameworkLayoutRoot)</DotNetUnpackFolder>
     <IsPackable>true</IsPackable>
     <NoSemVer20>true</NoSemVer20>
+    <CrossArchitectureInstallerBasePathNormalized>$([MSBuild]::NormalizeDirectory('$(CrossArchitectureInstallerBasePath)', 'aspnetcore', 'Runtime'))</CrossArchitectureInstallerBasePathNormalized>
+    <MicrosoftWebXdtExtensionsPath>$(ArtifactsBinDir)Microsoft.Web.Xdt.Extensions\$(Configuration)\net462\Microsoft.Web.Xdt.Extensions.dll</MicrosoftWebXdtExtensionsPath>
+    <MicrosoftWebXdtExtensionsPath Condition="'$(DotNetBuildPass)' == '2'">$(ArtifactsBinDir)Microsoft.Web.Xdt.Extensions\$(Platform)\$(Configuration)\net462\Microsoft.Web.Xdt.Extensions.dll</MicrosoftWebXdtExtensionsPath>
   </PropertyGroup>
 
   <Import Project="..\..\..\src\Servers\IIS\build\assets.props" />
@@ -22,9 +25,6 @@
     <Content Include="applicationHost.xdt" />
     <Content Include="scmApplicationHost.xdt" />
     <Content Include="install.cmd" />
-    <Content Include="$(ArtifactsBinDir)Microsoft.Web.Xdt.Extensions\$(Configuration)\net462\Microsoft.Web.Xdt.Extensions.dll"
-        Condition="EXISTS('$(ArtifactsBinDir)Microsoft.Web.Xdt.Extensions\$(Configuration)\net462\Microsoft.Web.Xdt.Extensions.dll')"
-        PackagePath="content" />
   </ItemGroup>
 
   <ItemGroup>
@@ -47,11 +47,25 @@
 
   <Target Name="ResolveReferenceItemsForPackage" DependsOnTargets="ResolveReferences" BeforeTargets="_GetPackageFiles">
     <ItemGroup>
+      <AspNetRuntimeArchive 
+          Include="$(CrossArchitectureInstallerBasePathNormalized)**\$(RuntimeInstallerBaseName)-*-win-$(Platform).zip"
+          Exclude="$(CrossArchitectureInstallerBasePathNormalized)**\$(RuntimeInstallerBaseName)-composite*" />
+    </ItemGroup>
+
+    <Unzip
+        SourceFiles="@(AspNetRuntimeArchive)"
+        DestinationFolder="$(DotNetUnpackFolder)"
+        OverwriteReadOnlyFiles="true"
+        Condition="'$(DotNetBuildPass)' == '2'" />
+    <ItemGroup>
       <Content Include="$(DotNetUnpackFolder)\**\*.*" Exclude="$(DotNetUnpackFolder)\**\.*" PackagePath="content\%(RecursiveDir)" />
       <Content Include="%(ShimComponents.DllLocation)"
             Pack="true"
             Condition="'%(ShimComponents.Platform)' == '$(TargetArchitecture)'"
             PackagePath="content\ancm\%(ShimComponents.TempSubfolder)" />
+      <Content Include="$(MicrosoftWebXdtExtensionsPath)"
+            Condition="EXISTS('$(MicrosoftWebXdtExtensionsPath)')"
+            PackagePath="content" />
     </ItemGroup>
   </Target>
 

--- a/src/SiteExtensions/Runtime/Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj
+++ b/src/SiteExtensions/Runtime/Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj
@@ -57,7 +57,10 @@
         DestinationFolder="$(DotNetUnpackFolder)"
         OverwriteReadOnlyFiles="true"
         Condition="'$(DotNetBuildPass)' == '2'" />
+
     <Error Condition="!Exists('$(DotNetUnpackFolder)')" Text="AspNetCore Shared Framework layout should be available for AspNetCoreRuntime .nupkg, but isn't." />
+    <Error Condition="!Exists('$(MicrosoftWebXdtExtensionsPath)')" Text="Microsoft.Web.Xdt.Extensions.dll should be available for AspNetCoreRuntime .nupkg, but isn't." />
+
     <ItemGroup>
       <Content Include="$(DotNetUnpackFolder)\**\*.*" Exclude="$(DotNetUnpackFolder)\**\.*" PackagePath="content\%(RecursiveDir)" />
       <Content Include="%(ShimComponents.DllLocation)"

--- a/src/SiteExtensions/Runtime/Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj
+++ b/src/SiteExtensions/Runtime/Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj
@@ -57,6 +57,7 @@
         DestinationFolder="$(DotNetUnpackFolder)"
         OverwriteReadOnlyFiles="true"
         Condition="'$(DotNetBuildPass)' == '2'" />
+    <Error Condition="!Exists('$(DotNetUnpackFolder)')" Text="AspNetCore Shared Framework layout should be available for AspNetCoreRuntime .nupkg, but isn't." />
     <ItemGroup>
       <Content Include="$(DotNetUnpackFolder)\**\*.*" Exclude="$(DotNetUnpackFolder)\**\.*" PackagePath="content\%(RecursiveDir)" />
       <Content Include="%(ShimComponents.DllLocation)"

--- a/src/SiteExtensions/Runtime/Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj
+++ b/src/SiteExtensions/Runtime/Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj
@@ -67,9 +67,7 @@
             Pack="true"
             Condition="'%(ShimComponents.Platform)' == '$(TargetArchitecture)'"
             PackagePath="content\ancm\%(ShimComponents.TempSubfolder)" />
-      <Content Include="$(MicrosoftWebXdtExtensionsPath)"
-            Condition="EXISTS('$(MicrosoftWebXdtExtensionsPath)')"
-            PackagePath="content" />
+      <Content Include="$(MicrosoftWebXdtExtensionsPath)" PackagePath="content" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Should fix https://github.com/dotnet/aspnetcore/issues/61185, https://github.com/dotnet/aspnetcore/issues/61187. 

Current test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2674842&view=results

After this change:

> Issues: 1217
Baselined issues: 837
Detailed issue counts by type:
  MissingShipping: Issues w/o Baseline = 338, Baselined issues = 96
  MissingNonShipping: Issues w/o Baseline = 114, Baselined issues = 0
  MisclassifiedAsset: Issues w/o Baseline = 2, Baselined issues = 0
  AssemblyVersionMismatch: Issues w/o Baseline = 5, Baselined issues = 741
  MissingPackageContent: Issues w/o Baseline = 435, Baselined issues = 0
  ExtraPackageContent: Issues w/o Baseline = 9, Baselined issues = 0
  PackageMetadataDifference: Issues w/o Baseline = 237, Baselined issues = 0
  PackageTFMs: Issues w/o Baseline = 1, Baselined issues = 0
  PackageDependencies: Issues w/o Baseline = 76, Baselined issues = 0
