### PR TITLE
Build projects that consume tool shims in pass 2

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -68,6 +68,13 @@
                       $(RepoRoot)src\Servers\IIS/IntegrationTesting.IIS\src\Microsoft.AspNetCore.Server.IntegrationTesting.IIS.csproj;
                       "
                       Condition=" '$(TargetOsName)' == 'win' and '$(DotNetBuild)' == 'true' and ('$(DotNetBuildPass)' == '' or '$(DotNetBuildPass)' == '1') " />
+
+    <!-- These projects requires inputs from x64, x86, and arm64 on Windows - therefore in the VMR, we build them in pass 2 -->
+    <ProjectToExclude Include="
+                      $(RepoRoot)src\Tools\dotnet-sql-cache\src\dotnet-sql-cache.csproj;
+                      $(RepoRoot)src\Tools\Microsoft.dotnet-openapi\src\Microsoft.dotnet-openapi.csproj;
+                      "
+                      Condition=" '$(TargetOsName)' == 'win' and '$(DotNetBuild)' == 'true' and ('$(DotNetBuildPass)' == '' or '$(DotNetBuildPass)' == '1') " />
   </ItemGroup>
 
   <Choose>
@@ -96,6 +103,13 @@
         </ProjectToBuild>
         <!-- Build SiteExtensions -->
         <ProjectToBuild Include="$(RepoRoot)src\SiteExtensions\LoggingAggregate\src\Microsoft.AspNetCore.AzureAppServices.SiteExtension\Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj">
+          <DotNetBuildPass>$(DotNetBuildPass)</DotNetBuildPass>
+        </ProjectToBuild>
+        <!-- Build tools projects that require multiple shims -->
+        <ProjectToBuild Include="$(RepoRoot)src\Tools\dotnet-sql-cache\src\dotnet-sql-cache.csproj" >
+          <DotNetBuildPass>$(DotNetBuildPass)</DotNetBuildPass>
+        </ProjectToBuild>
+        <ProjectToBuild Include="$(RepoRoot)src\Tools\Microsoft.dotnet-openapi\**\*.csproj" >
           <DotNetBuildPass>$(DotNetBuildPass)</DotNetBuildPass>
         </ProjectToBuild>
       </ItemGroup>

--- a/src/Tools/Directory.Build.targets
+++ b/src/Tools/Directory.Build.targets
@@ -1,9 +1,7 @@
 <Project>
   <PropertyGroup Condition=" '$(PackAsTool)' == 'true' ">
     <!-- Microsoft tool packages are required to target both x64 and x86. -->
-    <!-- In VMR builds we only use the current RID. -->
-    <PackAsToolShimRuntimeIdentifiers Condition=" '$(IsShippingPackage)' == 'true' AND '$(DotNetBuild)' != 'true' ">win-x64;win-x86</PackAsToolShimRuntimeIdentifiers>
-    <PackAsToolShimRuntimeIdentifiers Condition=" '$(IsShippingPackage)' == 'true' AND '$(DotNetBuild)' == 'true' AND '$(TargetOsName)' == 'win' ">$(TargetRid)</PackAsToolShimRuntimeIdentifiers>
+    <PackAsToolShimRuntimeIdentifiers Condition=" '$(IsShippingPackage)' == 'true' AND ('$(DotNetBuild)' != 'true' OR '$(TargetOsName)' == 'win')">win-x64;win-x86</PackAsToolShimRuntimeIdentifiers>
     <!-- None of the tool projects are project reference providers. -->
     <IsProjectReferenceProvider>false</IsProjectReferenceProvider>
     <!--


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/4944

We need to pack tool shims for all supported platforms which requires these two projects to be built in VMR's build-pass 2.

Verification build (internal): https://dev.azure.com/dnceng/internal/_build/results?buildId=2674425&view=results