### PR TITLE
Ensure project.assets.json files are unique for SiteExtensions in VMR

### DIFF
--- a/src/SiteExtensions/Directory.Build.props
+++ b/src/SiteExtensions/Directory.Build.props
@@ -1,0 +1,10 @@
+<Project>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
+
+  <PropertyGroup>
+    <MicrosoftWebXdtExtensionsPath>$(ArtifactsBinDir)Microsoft.Web.Xdt.Extensions\$(Configuration)\net462\Microsoft.Web.Xdt.Extensions.dll</MicrosoftWebXdtExtensionsPath>
+    <MicrosoftWebXdtExtensionsPath Condition="'$(DotNetBuildPass)' == '2'">$(ArtifactsBinDir)Microsoft.Web.Xdt.Extensions\$(TargetArchitecture)\$(Configuration)\net462\Microsoft.Web.Xdt.Extensions.dll</MicrosoftWebXdtExtensionsPath>
+    <ProjectAssetsFile Condition="'$(ProjectAssetsFile)' == '' AND '$(DotNetBuildPass)' == '2'">$(MSBuildProjectExtensionsPath)/$(TargetArchitecture)/project.assets.json</ProjectAssetsFile>
+  </PropertyGroup>
+
+</Project>

--- a/src/SiteExtensions/Directory.Build.props
+++ b/src/SiteExtensions/Directory.Build.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <MicrosoftWebXdtExtensionsPath>$(ArtifactsBinDir)Microsoft.Web.Xdt.Extensions\$(Configuration)\net462\Microsoft.Web.Xdt.Extensions.dll</MicrosoftWebXdtExtensionsPath>
     <MicrosoftWebXdtExtensionsPath Condition="'$(DotNetBuildPass)' == '2'">$(ArtifactsBinDir)Microsoft.Web.Xdt.Extensions\$(TargetArchitecture)\$(Configuration)\net462\Microsoft.Web.Xdt.Extensions.dll</MicrosoftWebXdtExtensionsPath>
-    <ProjectAssetsFile Condition="'$(ProjectAssetsFile)' == '' AND '$(DotNetBuildPass)' == '2'">$(MSBuildProjectExtensionsPath)/$(TargetArchitecture)/project.assets.json</ProjectAssetsFile>
+    <ProjectAssetsFile Condition="'$(ProjectAssetsFile)' == '' AND '$(DotNetBuildPass)' == '2'">$(BaseIntermediateOutputPath)/$(TargetArchitecture)/project.assets.json</ProjectAssetsFile>
   </PropertyGroup>
 
 </Project>

--- a/src/SiteExtensions/Directory.Build.props
+++ b/src/SiteExtensions/Directory.Build.props
@@ -4,7 +4,9 @@
   <PropertyGroup>
     <MicrosoftWebXdtExtensionsPath>$(ArtifactsBinDir)Microsoft.Web.Xdt.Extensions\$(Configuration)\net462\Microsoft.Web.Xdt.Extensions.dll</MicrosoftWebXdtExtensionsPath>
     <MicrosoftWebXdtExtensionsPath Condition="'$(DotNetBuildPass)' == '2'">$(ArtifactsBinDir)Microsoft.Web.Xdt.Extensions\$(TargetArchitecture)\$(Configuration)\net462\Microsoft.Web.Xdt.Extensions.dll</MicrosoftWebXdtExtensionsPath>
-    <ProjectAssetsFile Condition="'$(ProjectAssetsFile)' == '' AND '$(DotNetBuildPass)' == '2'">$(BaseIntermediateOutputPath)/$(TargetArchitecture)/project.assets.json</ProjectAssetsFile>
+    <BaseIntermediateOutputPath Condition="'$(DotNetBuildPass)' == '2'">$([MSBuild]::NormalizeDirectory('$(BaseIntermediateOutputPath)', '$(TargetArchitecture)'))</BaseIntermediateOutputPath>
+    <IntermediateOutputPath Condition="'$(PlatformName)' == 'AnyCPU' AND '$(DotNetBuildPass)' == '2'">$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
+    <IntermediateOutputPath Condition="'$(PlatformName)' != 'AnyCPU' AND '$(DotNetBuildPass)' == '2'">$(BaseIntermediateOutputPath)$(PlatformName)\$(Configuration)\</IntermediateOutputPath>
   </PropertyGroup>
 
 </Project>

--- a/src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
+++ b/src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
@@ -19,8 +19,6 @@
     <IsShipping>true</IsShipping>
     <IsShipping Condition=" '$(PreReleaseVersionLabel)' == 'preview' ">false</IsShipping>
     <SiteExtensionsReferenceLayoutDir>$(ArtifactsObjDir)SiteExtensionsReferenceLayout/</SiteExtensionsReferenceLayoutDir>
-    <MicrosoftWebXdtExtensionsPath>$(ArtifactsBinDir)Microsoft.Web.Xdt.Extensions\$(Configuration)\net462\Microsoft.Web.Xdt.Extensions.dll</MicrosoftWebXdtExtensionsPath>
-    <MicrosoftWebXdtExtensionsPath Condition="'$(DotNetBuildPass)' == '2'">$(ArtifactsBinDir)Microsoft.Web.Xdt.Extensions\$(TargetArchitecture)\$(Configuration)\net462\Microsoft.Web.Xdt.Extensions.dll</MicrosoftWebXdtExtensionsPath>
 
     <!-- Grab packages LB.csproj should have just built. -->
     <RestoreAdditionalProjectSources>$(RestoreAdditionalProjectSources);$(ArtifactsNonShippingPackagesDir)</RestoreAdditionalProjectSources>

--- a/src/SiteExtensions/Runtime/Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj
+++ b/src/SiteExtensions/Runtime/Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj
@@ -15,8 +15,6 @@
     <IsPackable>true</IsPackable>
     <NoSemVer20>true</NoSemVer20>
     <CrossArchitectureInstallerBasePathNormalized>$([MSBuild]::NormalizeDirectory('$(CrossArchitectureInstallerBasePath)', 'aspnetcore', 'Runtime'))</CrossArchitectureInstallerBasePathNormalized>
-    <MicrosoftWebXdtExtensionsPath>$(ArtifactsBinDir)Microsoft.Web.Xdt.Extensions\$(Configuration)\net462\Microsoft.Web.Xdt.Extensions.dll</MicrosoftWebXdtExtensionsPath>
-    <MicrosoftWebXdtExtensionsPath Condition="'$(DotNetBuildPass)' == '2'">$(ArtifactsBinDir)Microsoft.Web.Xdt.Extensions\$(Platform)\$(Configuration)\net462\Microsoft.Web.Xdt.Extensions.dll</MicrosoftWebXdtExtensionsPath>
   </PropertyGroup>
 
   <Import Project="..\..\..\src\Servers\IIS\build\assets.props" />


### PR DESCRIPTION
Should fix errors like:

>     D:\a\_work\1\s\.dotnet\sdk\10.0.100-preview.4.25177.22\Sdks\Microsoft.NET.Sdk\targets\Microsoft.PackageDependencyResolution.targets(266,5): error NETSDK1047: Assets file 'D:\a\_work\1\s\src\aspnetcore\artifacts\obj\Microsoft.AspNetCore.Runtime.SiteExtension\project.assets.json' doesn't have a target for 'net462/win-x86'. Ensure that restore has run and that you have included 'net462' in the TargetFrameworks for your project. You may also need to include 'win-x86' in your project's RuntimeIdentifiers. [D:\a\_work\1\s\src\aspnetcore\src\SiteExtensions\Runtime\Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj]

https://dev.azure.com/dnceng/internal/_build/results?buildId=2683453&view=results