### PR TITLE
Make PublishAllBuildsAssetsInThisJob available in Signing.props

### DIFF
--- a/eng/Common.props
+++ b/eng/Common.props
@@ -37,4 +37,15 @@
   <PropertyGroup Condition=" '$(DotNetBuildPass)' == '2' " >
     <RestoreUsingNuGetTargets>false</RestoreUsingNuGetTargets>
   </PropertyGroup>
+
+  <PropertyGroup>
+      <!--
+      Some assets are produced in all jobs, but only one job can publish them. We follow the following rules in that case:
+      - If we're building outside of the VMR, publish these assets from the Windows job.
+      - If we're building inside the VMR, publish these assets from whichever job is producing non-RID-specific artifacts.
+    -->
+    <PublishAllBuildsAssetsInThisJob Condition="('$(OS)' == 'Windows_NT' and '$(DotNetBuildOrchestrator)' != 'true')
+                                                or ('$(DotNetBuildOrchestrator)' == 'true' and '$(EnableDefaultRidSpecificArtifacts)' != 'true'
+                                                    and ('$(DotNetBuildPass)' == '' or '$(DotNetBuildPass)' == '1'))">true</PublishAllBuildsAssetsInThisJob>
+  </PropertyGroup>
 </Project>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,4 +1,5 @@
 <Project>
+  <Import Project="Common.props" />
 
   <PropertyGroup>
     <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
@@ -14,16 +15,6 @@
 
     <!-- This avoids creating VS.*.symbols.nupkg packages that are identical to the original package. -->
     <AutoGenerateSymbolPackages>false</AutoGenerateSymbolPackages>
-
-    <!--
-      Some assets are produced in all jobs, but only one job can publish them. We follow the following rules in that case:
-      - If we're building outside of the VMR, publish these assets from the Windows job.
-      - If we're building inside the VMR, publish these assets from whichever job is producing non-RID-specific artifacts.
-    -->
-    <PublishAllBuildsAssetsInThisJob Condition="('$(OS)' == 'Windows_NT' and '$(DotNetBuildOrchestrator)' != 'true')
-                                                or ('$(DotNetBuildOrchestrator)' == 'true' and '$(EnableDefaultRidSpecificArtifacts)' != 'true'
-                                                    and ('$(DotNetBuildPass)' == '' or '$(DotNetBuildPass)' == '1'))">true</PublishAllBuildsAssetsInThisJob>
-    <PublishInstallerBaseVersion Condition="'$(PublishInstallerBaseVersion)' == ''">$(PublishAllBuildsAssetsInThisJob)</PublishInstallerBaseVersion>
   </PropertyGroup>
 
   <!-- $(InstallersOutputPath), $(SymbolsOutputPath), and $(ChecksumExtensions) are not defined. Root Directory.Build.props is not imported. -->

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,6 +1,4 @@
 <Project>
-  <Import Project="Common.props" />
-
   <PropertyGroup>
     <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
 


### PR DESCRIPTION
Fixes .jar's not getting signed