### PR TITLE
Remove unnecessary newline at the end of the webapiaot csproj

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/WebApiAot-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/WebApiAot-CSharp.csproj.in
@@ -14,6 +14,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="${MicrosoftAspNetCoreOpenApiVersion}" Condition="'$(EnableOpenAPI)' == 'True'" />
   </ItemGroup>
+  
   <!--#endif -->
-
 </Project>


### PR DESCRIPTION
# Remove unnecessary newline at the end of the webapiaot csproj

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

This PR removes a lingering newline at the end of the webapiaot csproj

## Description

In https://github.com/dotnet/aspnetcore/pull/60337 I added OpenAPI support to the `dotnet new webapiaot` template. This adds the `Microsoft.AspNetCore.OpenApi` package by default.

I just tested this locally by installing the `preview4` build. I saw that the `.csproj` has an extra newline at the end, before the `</project>` tag. The `dotnet new webapi` template doesn't have this, which means this is a bit inconsistent

I removed this extra newline in this PR to ensure both templates behave the same way.

Fixes #59564
