### PR TITLE
update community-triager list

### DIFF
--- a/docs/area-owners.md
+++ b/docs/area-owners.md
@@ -46,4 +46,3 @@ While not necessarily associated with a specific area, these community members h
 - [@Kahbazi](https://github.com/Kahbazi)
 - [@marinasundstrom](https://github.com/marinasundstrom)
 - [@martincostello](https://github.com/martincostello)
-

--- a/docs/area-owners.md
+++ b/docs/area-owners.md
@@ -38,9 +38,12 @@ The **dotnet/runtime** repo has [its own list](https://github.com/dotnet/runtime
 
 While not necessarily associated with a specific area, these community members have the power to assist with routing and labeling issues and pull requests, and have been recognized for being consistently knowledgeable about and helpful in this repo:
 
+- [@Andrzej-W](https://github.com/Andrzej-W)
+- [@davidacker](https://github.com/davidacker)
 - [@egil](https://github.com/egil)
 - [@gfoidl](https://github.com/gfoidl)
 - [@hishamco](https://github.com/hishamco)
 - [@Kahbazi](https://github.com/Kahbazi)
 - [@marinasundstrom](https://github.com/marinasundstrom)
 - [@martincostello](https://github.com/martincostello)
+


### PR DESCRIPTION
syncing with https://github.com/orgs/dotnet/teams/aspnet-community-triagers (folks who can fix labels and are generally key community members)