### PR TITLE
Removed bound checks in SharedUrlHelper.IsLocalUrl and use JIT unrolling for checks

### DIFF
--- a/src/Shared/ResultsHelpers/SharedUrlHelper.cs
+++ b/src/Shared/ResultsHelpers/SharedUrlHelper.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Internal;
@@ -75,6 +76,7 @@ internal static class SharedUrlHelper
 
         return false;
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static bool HasControlCharacter(ReadOnlySpan<char> readOnlySpan)
         {
             // URLs may not contain ASCII control characters.

--- a/src/Shared/ResultsHelpers/SharedUrlHelper.cs
+++ b/src/Shared/ResultsHelpers/SharedUrlHelper.cs
@@ -37,40 +37,40 @@ internal static class SharedUrlHelper
             return false;
         }
 
+        var urlSpan = url.AsSpan();
+
         // Allows "/" or "/foo" but not "//" or "/\".
-        if (url[0] == '/')
+        if (urlSpan.StartsWith('/'))
         {
             // url is exactly "/"
-            if (url.Length == 1)
+            if (urlSpan.Length < 2)
             {
                 return true;
             }
 
             // url doesn't start with "//" or "/\"
-            if (url[1] != '/' && url[1] != '\\')
+            if (urlSpan[1] is not '/' and '\\')
             {
-                return !HasControlCharacter(url.AsSpan(1));
+                return !HasControlCharacter(urlSpan.Slice(1));
             }
 
             return false;
         }
 
         // Allows "~/" or "~/foo" but not "~//" or "~/\".
-        if (url[0] == '~' && url.Length > 1 && url[1] == '/')
+        if (urlSpan.StartsWith("~/"))
         {
             // url is exactly "~/"
-            if (url.Length == 2)
+            if (urlSpan.Length < 3)
             {
                 return true;
             }
 
             // url doesn't start with "~//" or "~/\"
-            if (url[2] != '/' && url[2] != '\\')
+            if (urlSpan[2] is not '/' and '\\')
             {
-                return !HasControlCharacter(url.AsSpan(2));
+                return !HasControlCharacter(urlSpan.Slice(2));
             }
-
-            return false;
         }
 
         return false;

--- a/src/Shared/ResultsHelpers/SharedUrlHelper.cs
+++ b/src/Shared/ResultsHelpers/SharedUrlHelper.cs
@@ -32,15 +32,15 @@ internal static class SharedUrlHelper
 
     internal static bool IsLocalUrl([NotNullWhen(true)] string? url)
     {
-        if (string.IsNullOrEmpty(url))
+        var urlSpan = url.AsSpan();
+
+        if (urlSpan.IsEmpty)
         {
             return false;
         }
 
-        var urlSpan = url.AsSpan();
-
         // Allows "/" or "/foo" but not "//" or "/\".
-        if (urlSpan.StartsWith('/'))
+        if (urlSpan[0] == '/')
         {
             // url is exactly "/"
             if (urlSpan.Length < 2)


### PR DESCRIPTION
The method is used for HTTP Redirects to check if the url is local or not.

The changes to the code are to help the JIT to elide the bound checks, and to collapse some checks (e.g. for '~' and '/') to only one check.

Benchmarking gives on my machine:
| Method  | Url   | Mean     | Error     | StdDev    | Ratio | RatioSD |
|-------- |------ |---------:|----------:|----------:|------:|--------:|
| **Default** | **/**     | **1.080 ns** | **0.0682 ns** | **0.1377 ns** |  **1.02** |    **0.19** |
| PR     | /     | 1.159 ns | 0.0334 ns | 0.0279 ns |  1.09 |    0.15 |
|         |       |          |           |           |       |         |
| **Default** | **/foo**  | **3.688 ns** | **0.1248 ns** | **0.3662 ns** |  **1.01** |    **0.14** |
| PR     | /foo  | 1.976 ns | 0.0816 ns | 0.1875 ns |  0.54 |    0.07 |
|         |       |          |           |           |       |         |
| **Default** | **~/bar** | **4.307 ns** | **0.1295 ns** | **0.1330 ns** |  **1.00** |    **0.04** |
| PR     | ~/bar | 1.687 ns | 0.0532 ns | 0.0444 ns |  0.39 |    0.02 |