### PR TITLE
MVC: Correct metadata type for formdata enum parameters

### DIFF
--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointModelMetadata.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointModelMetadata.cs
@@ -66,6 +66,6 @@ internal sealed class EndpointModelMetadata : ModelMetadata
             || underlyingType == typeof(decimal)
             || underlyingType == typeof(Guid)
             || underlyingType == typeof(Uri)
-            || underlyingType.IsAssignableTo(typeof(Enum)) ? type : typeof(string);
+            || underlyingType.IsEnum ? type : typeof(string);
     }
 }

--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointModelMetadata.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointModelMetadata.cs
@@ -65,6 +65,7 @@ internal sealed class EndpointModelMetadata : ModelMetadata
             || underlyingType == typeof(TimeSpan)
             || underlyingType == typeof(decimal)
             || underlyingType == typeof(Guid)
-            || underlyingType == typeof(Uri) ? type : typeof(string);
+            || underlyingType == typeof(Uri)
+            || underlyingType.IsAssignableTo(typeof(Enum)) ? type : typeof(string);
     }
 }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentServiceTestsBase.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentServiceTestsBase.cs
@@ -237,8 +237,11 @@ public abstract class OpenApiDocumentServiceTestBase
         action.RouteValues.Add("controller", "Test");
         action.RouteValues.Add("action", action.MethodInfo.Name);
         action.EndpointMetadata = [..action.MethodInfo.GetCustomAttributes()];
-        action.ActionConstraints = [new HttpMethodActionConstraint(
-            action.EndpointMetadata.OfType<IActionHttpMethodProvider>().SelectMany(a => a.HttpMethods).DefaultIfEmpty("GET")
+        action.ActionConstraints = [new HttpMethodActionConstraint(action
+            .EndpointMetadata
+            .OfType<IActionHttpMethodProvider>()
+            .SelectMany(a => a.HttpMethods)
+            .DefaultIfEmpty("GET")
         )];
         if (controllerType is not null)
         {

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentServiceTestsBase.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentServiceTestsBase.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Constraints;
@@ -235,8 +236,10 @@ public abstract class OpenApiDocumentServiceTestBase
         };
         action.RouteValues.Add("controller", "Test");
         action.RouteValues.Add("action", action.MethodInfo.Name);
-        action.ActionConstraints = [new HttpMethodActionConstraint(["GET"])];
         action.EndpointMetadata = [..action.MethodInfo.GetCustomAttributes()];
+        action.ActionConstraints = [new HttpMethodActionConstraint(
+            action.EndpointMetadata.OfType<IActionHttpMethodProvider>().SelectMany(a => a.HttpMethods).DefaultIfEmpty("GET")
+        )];
         if (controllerType is not null)
         {
             foreach (var attribute in controllerType.GetCustomAttributes())

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.RequestBodySchemas.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.RequestBodySchemas.cs
@@ -711,4 +711,51 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
         public IDictionary<string, Parent> SelfReferenceDictionary { get; set; } = new Dictionary<string, Parent>();
     }
 
+    /// <remarks>
+    /// Regression test for https://github.com/dotnet/aspnetcore/issues/61327
+    /// </remarks>
+    [Fact]
+    public async Task RespectsEnumDefaultValueInControllerFormParameters()
+    {
+        // Arrange
+        var actionDescriptor = CreateActionDescriptor(nameof(TestBodyController.FormPostWithOptionalEnumParam), typeof(TestBodyController));
+
+        // Assert
+        await VerifyOpenApiDocument(actionDescriptor, VerifyOptionalEnum);
+    }
+
+    [Fact]
+    public async Task RespectsEnumDefaultValueInMinimalApiFormParameters()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPost("/optionalEnum", ([FromForm(Name = "status")] Status status = Status.Approved) => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, VerifyOptionalEnum);
+    }
+
+    private void VerifyOptionalEnum(OpenApiDocument document)
+    {
+        var operation = document.Paths["/optionalEnum"].Operations[OperationType.Post];
+        var properties = operation.RequestBody.Content["application/x-www-form-urlencoded"].Schema.Properties;
+        var property = properties["status"];
+
+        Assert.NotNull(property);
+        Assert.Equal(3, property.Enum.Count);
+        Assert.Equal("Approved", property.Default.GetValue<string>());
+    }
+
+    [ApiController]
+    [Produces("application/json")]
+    public class TestBodyController
+    {
+        [Route("/optionalEnum")]
+        [HttpPost]
+        internal Status FormPostWithOptionalEnumParam(
+            [FromForm(Name = "status")] Status status = Status.Approved
+        ) => status;
+    }
 }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.RequestBodySchemas.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.RequestBodySchemas.cs
@@ -739,7 +739,7 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
 
     private void VerifyOptionalEnum(OpenApiDocument document)
     {
-        var operation = document.Paths["/optionalEnum"].Operations[OperationType.Post];
+        var operation = document.Paths["/optionalEnum"].Operations[HttpMethod.Post];
         var properties = operation.RequestBody.Content["application/x-www-form-urlencoded"].Schema.Properties;
         var property = properties["status"];
 


### PR DESCRIPTION
# MVC: Correct metadata type for formdata enum parameters

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

Fixes the type of enum parameters in the API explorer discovered from controller actions to not be forced as `string`, bringing them in line with other types that have defined conversions to/from string. This in turn fixes an exception in OpenAPI document generation. It also brings this behavior in line with the existing behavior of the same parameters discovered from minimal APIs.

Fixes #61327
