### PR TITLE
OpenAPI: merge multiple body content types into one operation

### DIFF
--- a/src/OpenApi/sample/Controllers/XmlController.cs
+++ b/src/OpenApi/sample/Controllers/XmlController.cs
@@ -22,7 +22,7 @@ public class XmlController : ControllerBase
 
     /// <param name="name">The name of the person.</param>
     /// <response code="200">Returns the greeting.</response>
-    [HttpGet]
+    [HttpGet("{name}")]
     public string Get1(string name)
     {
         return $"Hello, {name}!";

--- a/src/OpenApi/src/PublicAPI.Unshipped.txt
+++ b/src/OpenApi/src/PublicAPI.Unshipped.txt
@@ -19,6 +19,8 @@ Microsoft.AspNetCore.OpenApi.OpenApiDocumentTransformerContext.GetOrCreateSchema
 Microsoft.AspNetCore.OpenApi.OpenApiOperationTransformerContext.Document.get -> Microsoft.OpenApi.OpenApiDocument?
 Microsoft.AspNetCore.OpenApi.OpenApiOperationTransformerContext.Document.init -> void
 Microsoft.AspNetCore.OpenApi.OpenApiOperationTransformerContext.GetOrCreateSchemaAsync(System.Type! type, Microsoft.AspNetCore.Mvc.ApiExplorer.ApiParameterDescription? parameterDescription = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.OpenApi.OpenApiSchema!>!
+Microsoft.AspNetCore.OpenApi.OpenApiOperationTransformerContext.AllDescriptions.get -> System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Mvc.ApiExplorer.ApiDescription!>!
+Microsoft.AspNetCore.OpenApi.OpenApiOperationTransformerContext.AllDescriptions.init -> void
 Microsoft.AspNetCore.OpenApi.OpenApiSchemaTransformerContext.Document.get -> Microsoft.OpenApi.OpenApiDocument?
 Microsoft.AspNetCore.OpenApi.OpenApiSchemaTransformerContext.Document.init -> void
 Microsoft.AspNetCore.OpenApi.OpenApiSchemaTransformerContext.GetOrCreateSchemaAsync(System.Type! type, Microsoft.AspNetCore.Mvc.ApiExplorer.ApiParameterDescription? parameterDescription = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.OpenApi.OpenApiSchema!>!

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -286,7 +286,7 @@ internal sealed class OpenApiDocumentService(
             {
                 DocumentName = documentName,
                 Description = description,
-                AllDescriptions = [.. allDescriptions],
+                AllDescriptions = allDescriptions,
                 ApplicationServices = scopedServiceProvider,
                 Document = document,
                 SchemaTransformers = schemaTransformers

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -269,9 +269,16 @@ internal sealed class OpenApiDocumentService(
         CancellationToken cancellationToken)
     {
         var operations = new Dictionary<HttpMethod, OpenApiOperation>();
-        foreach (var description in descriptions)
+        foreach (var httpMethodDescriptions in descriptions.GroupBy(d => d.GetHttpMethod()))
         {
-            var operation = await GetOperationAsync(description, document, scopedServiceProvider, schemaTransformers, cancellationToken);
+            // `description` is the first description for a given Route + HttpMethod.
+            // There may be additional descriptions if the endpoint has additional definitions
+            // with different [Consumes] definitions. We merge in the bodies of these additional endpoints,
+            // but currently don't merge any other parts of the definition.
+            IReadOnlyList<ApiDescription> allDescriptions = [.. httpMethodDescriptions];
+            var description = allDescriptions.First();
+
+            var operation = await GetOperationAsync(allDescriptions, document, scopedServiceProvider, schemaTransformers, cancellationToken);
             operation.Metadata ??= new Dictionary<string, object>();
             operation.Metadata.Add(OpenApiConstants.DescriptionId, description.ActionDescriptor.Id);
 
@@ -279,6 +286,7 @@ internal sealed class OpenApiDocumentService(
             {
                 DocumentName = documentName,
                 Description = description,
+                AllDescriptions = [.. allDescriptions],
                 ApplicationServices = scopedServiceProvider,
                 Document = document,
                 SchemaTransformers = schemaTransformers
@@ -286,7 +294,7 @@ internal sealed class OpenApiDocumentService(
 
             _operationTransformerContextCache.TryAdd(description.ActionDescriptor.Id, operationContext);
 
-            if (description.GetHttpMethod() is not { } method)
+            if (httpMethodDescriptions.Key is not { } method)
             {
                 // Skip unsupported HTTP methods
                 continue;
@@ -303,8 +311,9 @@ internal sealed class OpenApiDocumentService(
 
             // Apply any endpoint-specific operation transformers registered via
             // the AddOpenApiOperationTransformer extension method.
-            var endpointOperationTransformers = description.ActionDescriptor.EndpointMetadata
-                .OfType<DelegateOpenApiOperationTransformer>();
+            var endpointOperationTransformers = allDescriptions
+                .SelectMany(d => d.ActionDescriptor.EndpointMetadata
+                    .OfType<DelegateOpenApiOperationTransformer>());
             foreach (var endpointOperationTransformer in endpointOperationTransformers)
             {
                 await endpointOperationTransformer.TransformAsync(operation, operationContext, cancellationToken);
@@ -314,12 +323,13 @@ internal sealed class OpenApiDocumentService(
     }
 
     private async Task<OpenApiOperation> GetOperationAsync(
-        ApiDescription description,
+        IReadOnlyList<ApiDescription> descriptions,
         OpenApiDocument document,
         IServiceProvider scopedServiceProvider,
         IOpenApiSchemaTransformer[] schemaTransformers,
         CancellationToken cancellationToken)
     {
+        var description = descriptions.First();
         var tags = GetTags(description, document);
         var operation = new OpenApiOperation
         {
@@ -328,9 +338,31 @@ internal sealed class OpenApiDocumentService(
             Description = GetDescription(description),
             Responses = await GetResponsesAsync(document, description, scopedServiceProvider, schemaTransformers, cancellationToken),
             Parameters = await GetParametersAsync(document, description, scopedServiceProvider, schemaTransformers, cancellationToken),
-            RequestBody = await GetRequestBodyAsync(document, description, scopedServiceProvider, schemaTransformers, cancellationToken),
             Tags = tags,
         };
+
+        foreach (var bodyDescription in descriptions)
+        {
+            var requestBody = await GetRequestBodyAsync(document, bodyDescription, scopedServiceProvider, schemaTransformers, cancellationToken);
+            if (operation.RequestBody is null)
+            {
+                operation.RequestBody = requestBody;
+            }
+            else if (requestBody is not null)
+            {
+                // Merge additional accepted content types that are defined by additional endpoint descriptions.
+                // `RequestBody.Content` produced by `GetRequestBodyAsync` is never null.
+                var existingContent = operation.RequestBody.Content!;
+                foreach (var additionalContent in requestBody.Content!)
+                {
+                    if (!existingContent.ContainsKey(additionalContent.Key))
+                    {
+                        existingContent.Add(additionalContent);
+                    }
+                }
+            }
+        }
+
         return operation;
     }
 

--- a/src/OpenApi/src/Transformers/OpenApiOperationTransformerContext.cs
+++ b/src/OpenApi/src/Transformers/OpenApiOperationTransformerContext.cs
@@ -17,9 +17,14 @@ public sealed class OpenApiOperationTransformerContext
     public required string DocumentName { get; init; }
 
     /// <summary>
-    /// Gets the API description associated with target operation.
+    /// Gets the primary API description associated with target operation.
     /// </summary>
     public required ApiDescription Description { get; init; }
+
+    /// <summary>
+    /// Gets all API descriptions that were merged to create the target operation.
+    /// </summary>
+    public required IReadOnlyList<ApiDescription> AllDescriptions { get; init; }
 
     /// <summary>
     /// Gets the application services associated with the current document the target operation is in.

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=xml.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=xml.verified.txt
@@ -149,19 +149,11 @@
         "tags": [
           "Xml"
         ],
-        "parameters": [
-          {
-            "name": "name",
-            "in": "query",
-            "description": "The name of the person.",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "summary": "A summary of the action.",
+        "description": "A description of the action.",
         "responses": {
           "200": {
-            "description": "Returns the greeting.",
+            "description": "OK",
             "content": {
               "text/plain": {
                 "schema": {
@@ -210,6 +202,46 @@
         "responses": {
           "200": {
             "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/Xml/{name}": {
+      "get": {
+        "tags": [
+          "Xml"
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The name of the person.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the greeting.",
             "content": {
               "text/plain": {
                 "schema": {

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=xml.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=xml.verified.txt
@@ -149,19 +149,11 @@
         "tags": [
           "Xml"
         ],
-        "parameters": [
-          {
-            "name": "name",
-            "in": "query",
-            "description": "The name of the person.",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "summary": "A summary of the action.",
+        "description": "A description of the action.",
         "responses": {
           "200": {
-            "description": "Returns the greeting.",
+            "description": "OK",
             "content": {
               "text/plain": {
                 "schema": {
@@ -210,6 +202,46 @@
         "responses": {
           "200": {
             "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/Xml/{name}": {
+      "get": {
+        "tags": [
+          "Xml"
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The name of the person.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the greeting.",
             "content": {
               "text/plain": {
                 "schema": {

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentLocalizationTests.VerifyOpenApiDocumentIsInvariant.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentLocalizationTests.VerifyOpenApiDocumentIsInvariant.verified.txt
@@ -448,19 +448,11 @@
         "tags": [
           "Xml"
         ],
-        "parameters": [
-          {
-            "name": "name",
-            "in": "query",
-            "description": "The name of the person.",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "summary": "A summary of the action.",
+        "description": "A description of the action.",
         "responses": {
           "200": {
-            "description": "Returns the greeting.",
+            "description": "OK",
             "content": {
               "text/plain": {
                 "schema": {
@@ -509,6 +501,46 @@
         "responses": {
           "200": {
             "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/Xml/{name}": {
+      "get": {
+        "tags": [
+          "Xml"
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The name of the person.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the greeting.",
             "content": {
               "text/plain": {
                 "schema": {


### PR DESCRIPTION
# OpenAPI: merge multiple body content types for the same path/method

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

This change merges multiple body content types into one operation definition in the OpenAPI document when there are multiple endpoints with the same path and HTTP method but different Consumes attributes.

The previous behavior would clobber existing operations in this scenario such that the last defined operation wins.

Fixes #58329 
