### PR TITLE
Revert "Sign Mariner rpms with Mariner cert"

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -15,10 +15,6 @@
     <FileSignInfo Include="Mono.Cecil.Mdb.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Mono.Cecil.Pdb.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Mono.Cecil.Rocks.dll" CertificateName="3PartySHA2" />
-    
-    <!-- Ensure that azl files get the mariner cert -->
-    <AzureLinuxRPM Include="$(ArtifactsPackagesDir)**/*-azl-*.rpm" />
-    <FileSignInfo Include="@(AzureLinuxRPM->'%(Filename)%(Extension)')" CertificateName="LinuxSignMariner" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Reverts dotnet/aspnetcore#61262

This got [upstreamed into arcade](https://github.com/dotnet/arcade/commit/c614b14e5dfd8953450c293472d50078f0497adb) and is now causing VMR official build failures