### PR TITLE
Http/3 Partial Frame support

### DIFF
--- a/src/Components/test/E2ETest/ServerRenderingTests/EnhancedNavigationTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/EnhancedNavigationTest.cs
@@ -717,7 +717,7 @@ public class EnhancedNavigationTest : ServerTestBase<BasicTestAppServerSiteFixtu
         AssertWeAreOnNextPage();
         WaitStreamingRendersFullPage(enableStreaming);
         AssertEnhancedNavigation(useEnhancedNavigation, elementForStalenessCheckOnNextPage);
-        var expectedFragmentScrollPosition = fragmentScrollPosition - 1;
+        var expectedFragmentScrollPosition = fragmentScrollPosition;
         Assert.Equal(expectedFragmentScrollPosition, Browser.GetScrollY());
     }
 

--- a/src/Servers/Kestrel/Core/src/CoreStrings.resx
+++ b/src/Servers/Kestrel/Core/src/CoreStrings.resx
@@ -737,4 +737,7 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
   <data name="NeedHttpsConfigurationToBindHttpsAddresses" xml:space="preserve">
     <value>Call UseKestrelHttpsConfiguration() on IWebHostBuilder to automatically enable HTTPS when an https:// address is used.</value>
   </data>
+  <data name="Http3ControlStreamFrameTooLarge" xml:space="preserve">
+    <value>The client sent a {frameType} frame to a control stream that was too large.</value>
+  </data>
 </root>

--- a/src/Servers/Kestrel/Core/src/Http3Limits.cs
+++ b/src/Servers/Kestrel/Core/src/Http3Limits.cs
@@ -37,7 +37,7 @@ public class Http3Limits
     /// <summary>
     /// Indicates the size of the maximum allowed size of a request header field sequence. This limit applies to both name and value sequences in their compressed and uncompressed representations.
     /// <para>
-    /// Value must be greater than 0, defaults to 2^14 (16,384).
+    /// Value must be greater than 0, defaults to 2^15 (32,768).
     /// </para>
     /// </summary>
     public int MaxRequestHeaderFieldSize

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Frames/Http3RawFrame.Data.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Frames/Http3RawFrame.Data.cs
@@ -7,7 +7,7 @@ internal partial class Http3RawFrame
 {
     public void PrepareData()
     {
-        Length = 0;
+        RemainingLength = 0;
         Type = Http3FrameType.Data;
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Frames/Http3RawFrame.GoAway.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Frames/Http3RawFrame.GoAway.cs
@@ -7,7 +7,7 @@ internal partial class Http3RawFrame
 {
     public void PrepareGoAway()
     {
-        Length = 0;
+        RemainingLength = 0;
         Type = Http3FrameType.GoAway;
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Frames/Http3RawFrame.Headers.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Frames/Http3RawFrame.Headers.cs
@@ -7,7 +7,7 @@ internal partial class Http3RawFrame
 {
     public void PrepareHeaders()
     {
-        Length = 0;
+        RemainingLength = 0;
         Type = Http3FrameType.Headers;
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Frames/Http3RawFrame.Settings.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Frames/Http3RawFrame.Settings.cs
@@ -7,7 +7,7 @@ internal partial class Http3RawFrame
 {
     public void PrepareSettings()
     {
-        Length = 0;
+        RemainingLength = 0;
         Type = Http3FrameType.Settings;
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Frames/Http3RawFrame.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Frames/Http3RawFrame.cs
@@ -9,7 +9,7 @@ namespace System.Net.Http;
 internal partial class Http3RawFrame
 #pragma warning restore CA1852 // Seal internal types
 {
-    public long Length { get; set; }
+    public long RemainingLength { get; set; }
 
     public Http3FrameType Type { get; internal set; }
 
@@ -17,6 +17,6 @@ internal partial class Http3RawFrame
 
     public override string ToString()
     {
-        return $"{FormattedType} Length: {Length}";
+        return $"{FormattedType} Length: {RemainingLength}";
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3PendingStream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3PendingStream.cs
@@ -60,8 +60,7 @@ internal sealed class Http3PendingStream
 
                 if (!readableBuffer.IsEmpty)
                 {
-                    var value = VariableLengthIntegerHelper.GetInteger(readableBuffer, out consumed, out _);
-                    if (value != -1)
+                    if (VariableLengthIntegerHelper.TryGetInteger(readableBuffer, out consumed, out var value))
                     {
                         if (!advanceOn.HasValue || value == (long)advanceOn)
                         {

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.Http3.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.Http3.cs
@@ -37,7 +37,7 @@ internal sealed partial class KestrelTrace : ILogger
     {
         if (_http3Logger.IsEnabled(LogLevel.Trace))
         {
-            Http3Log.Http3FrameReceived(_http3Logger, connectionId, Http3Formatting.ToFormattedType(frame.Type), streamId, frame.Length);
+            Http3Log.Http3FrameReceived(_http3Logger, connectionId, Http3Formatting.ToFormattedType(frame.Type), streamId, frame.RemainingLength);
         }
     }
 
@@ -45,7 +45,7 @@ internal sealed partial class KestrelTrace : ILogger
     {
         if (_http3Logger.IsEnabled(LogLevel.Trace))
         {
-            Http3Log.Http3FrameSending(_http3Logger, connectionId, Http3Formatting.ToFormattedType(frame.Type), streamId, frame.Length);
+            Http3Log.Http3FrameSending(_http3Logger, connectionId, Http3Formatting.ToFormattedType(frame.Type), streamId, frame.RemainingLength);
         }
     }
 

--- a/src/Servers/Kestrel/Core/test/VariableIntHelperTests.cs
+++ b/src/Servers/Kestrel/Core/test/VariableIntHelperTests.cs
@@ -14,7 +14,8 @@ public class VariableIntHelperTests
     [MemberData(nameof(IntegerData))]
     public void CheckDecoding(long expected, byte[] input)
     {
-        var decoded = VariableLengthIntegerHelper.GetInteger(new ReadOnlySequence<byte>(input), out _, out _);
+        var result = VariableLengthIntegerHelper.TryGetInteger(new ReadOnlySequence<byte>(input), out _, out var decoded);
+        Assert.True(result);
         Assert.Equal(expected, decoded);
     }
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Globalization;
+using System.IO.Pipelines;
 using System.Net.Http;
 using System.Runtime.ExceptionServices;
 using System.Text;
@@ -11,8 +13,8 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Internal;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3;
-using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests;
@@ -1977,7 +1979,7 @@ public class Http3StreamTests : Http3TestBase
         var trailers = new[]
         {
                 new KeyValuePair<string, string>("TestName", "TestValue"),
-            };
+        };
         var requestStream = await Http3Api.InitializeConnectionAndStreamsAsync(async c =>
         {
             await c.Request.Body.DrainAsync(default);
@@ -2368,6 +2370,21 @@ public class Http3StreamTests : Http3TestBase
         };
 
         return HEADERS_Received_InvalidHeaderFields_StreamError(headers, CoreStrings.BadRequest_HeadersExceedMaxTotalSize, Http3ErrorCode.RequestRejected);
+    }
+
+    [Fact]
+    public Task HEADERS_Received_HeaderValueOverLimit_ConnectionError()
+    {
+        var limit = _serviceContext.ServerOptions.Limits.Http3.MaxRequestHeaderFieldSize;
+        // Single header value exceeds limit
+        var headers = new[]
+        {
+            new KeyValuePair<string, string>("a", new string('a', limit + 1)),
+        };
+
+        return HEADERS_Received_InvalidHeaderFields_StreamError(headers,
+            SR.Format(SR.net_http_headers_exceeded_length, limit),
+            Http3ErrorCode.InternalError);
     }
 
     [Fact]
@@ -2999,5 +3016,297 @@ public class Http3StreamTests : Http3TestBase
             await context.Response.CompleteAsync();
             context.Response.BodyWriter.Advance(memory.Length);
         }, headers);
+    }
+
+    [Fact]
+    public async Task ControlStream_CloseBeforeSendingSettings()
+    {
+        await Http3Api.InitializeConnectionAsync(_noopApplication);
+
+        var outboundcontrolStream = await Http3Api.CreateControlStream();
+
+        await outboundcontrolStream.EndStreamAsync();
+
+        await outboundcontrolStream.ReceiveEndAsync();
+    }
+
+    [Fact]
+    public async Task ControlStream_PartialFrameThenClose()
+    {
+        await Http3Api.InitializeConnectionAsync(_noopApplication);
+
+        var outboundcontrolStream = await Http3Api.CreateControlStream();
+
+        var settings = new List<Http3PeerSetting>
+        {
+            new Http3PeerSetting(Internal.Http3.Http3SettingType.MaxFieldSectionSize, 100),
+            new Http3PeerSetting(Internal.Http3.Http3SettingType.EnableWebTransport, 1),
+            new Http3PeerSetting(Internal.Http3.Http3SettingType.H3Datagram, 1)
+        };
+        var len = Http3FrameWriter.CalculateSettingsSize(settings);
+
+        Http3FrameWriter.WriteHeader(Http3FrameType.Settings, len, outboundcontrolStream.Pair.Application.Output);
+
+        var parameterLength = VariableLengthIntegerHelper.WriteInteger(outboundcontrolStream.Pair.Application.Output.GetSpan(), (long)Internal.Http3.Http3SettingType.MaxFieldSectionSize);
+        outboundcontrolStream.Pair.Application.Output.Advance(parameterLength);
+        await outboundcontrolStream.Pair.Application.Output.FlushAsync();
+
+        await outboundcontrolStream.EndStreamAsync();
+
+        await outboundcontrolStream.ReceiveEndAsync();
+    }
+
+    [Fact]
+    public async Task SendDataObservesBackpressureFromApp()
+    {
+        var headers = new[]
+        {
+            new KeyValuePair<string, string>(InternalHeaderNames.Method, "Custom"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Path, "/"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Scheme, "http"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Authority, "localhost:80"),
+        };
+
+        // Http3Stream hardcodes a 64k size for the RequestBodyPipe there is also the transport Pipe which we can influence with MaxRequestBufferSize
+        // So we need to send enough to fill up the 64k Pipe as well as the 100 byte Pipe.
+        var sendSize = 1024 * 65;
+        _serviceContext.ServerOptions.Limits.MaxRequestBufferSize = 100;
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var startedReadingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var requestStream = await Http3Api.InitializeConnectionAndStreamsAsync(async c =>
+        {
+            // Read a single byte to make sure data has gotten here before we start verifying backpressure in the test code
+            var res = await c.Request.BodyReader.ReadAsync();
+            Assert.Equal(sendSize, res.Buffer.Length);
+            c.Request.BodyReader.AdvanceTo(res.Buffer.Slice(1).Start);
+            startedReadingTcs.SetResult();
+
+            await tcs.Task;
+            res = await c.Request.BodyReader.ReadAsync();
+            Assert.Equal(sendSize - 1, res.Buffer.Length);
+            c.Request.BodyReader.AdvanceTo(res.Buffer.End);
+        }, headers);
+
+        var sendTask = requestStream.SendDataAsync(Encoding.ASCII.GetBytes(new string('a', sendSize)));
+
+        // Wait for "app" code to start reading to ensure it has gotten bytes before we start verifying backpressure
+        await startedReadingTcs.Task;
+        Assert.False(sendTask.IsCompleted);
+        tcs.SetResult();
+
+        await sendTask;
+
+        var responseHeaders = await requestStream.ExpectHeadersAsync();
+        Assert.Equal("200", responseHeaders[InternalHeaderNames.Status]);
+
+        await requestStream.ExpectReceiveEndOfStream();
+    }
+
+    [Fact]
+    public async Task Request_FrameParsingSingleByteAtATimeWorks()
+    {
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var total = 0;
+        var trailerValue = string.Empty;
+        await Http3Api.InitializeConnectionAsync(async context =>
+        {
+            var buffer = new byte[100];
+            var read = await context.Request.Body.ReadAsync(buffer, 0, buffer.Length);
+            var captureTcs = tcs;
+            tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            captureTcs.SetResult();
+            Assert.Equal(1, read);
+            total = read;
+            while (read > 0)
+            {
+                read = await context.Request.Body.ReadAsync(buffer, total, buffer.Length - total);
+                captureTcs = tcs;
+                tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                captureTcs.SetResult();
+                total += read;
+                if (read == 0)
+                {
+                    break;
+                }
+                Assert.Equal(1, read);
+            }
+
+            trailerValue = context.Request.GetTrailer("TestName");
+        });
+
+        // Use Inline scheduling and buffer size of 1 to guarantee each write will wait for the parsing loop to complete before writing more data
+        _serviceContext.ServerOptions.Limits.MaxRequestBufferSize = 1;
+        var stream = await Http3Api.CreateRequestStream(headers: [], clientWriterScheduler: PipeScheduler.Inline);
+
+        // Use local pipe to write frames so we can get the entire buffer in order to write it one byte at a time
+        var bufferPipe = new Pipe();
+        Http3FrameWriter.WriteHeader(Http3FrameType.Headers, frameLength: 38, bufferPipe.Writer);
+
+        var headersTotalSize = 0;
+        var headers = new Http3HeadersEnumerator();
+        headers.Initialize(new Dictionary<string, StringValues>() {
+            { InternalHeaderNames.Method, "POST" },
+            { InternalHeaderNames.Path, "/" },
+            { InternalHeaderNames.Scheme, "http" }, });
+
+        var mem = bufferPipe.Writer.GetMemory();
+        var done = QPackHeaderWriter.BeginEncodeHeaders(headers, mem.Span, ref headersTotalSize, out var length);
+        Assert.True(done);
+        bufferPipe.Writer.Advance(length);
+        await bufferPipe.Writer.FlushAsync();
+
+        // Write header frame one byte at a time
+        await WriteOneByteAtATime(bufferPipe.Reader, stream.Pair.Application.Output);
+
+        Http3FrameWriter.WriteHeader(Http3FrameType.Data, frameLength: 12, bufferPipe.Writer);
+        await bufferPipe.Writer.FlushAsync();
+
+        // Write data header one byte at a time
+        await WriteOneByteAtATime(bufferPipe.Reader, stream.Pair.Application.Output);
+
+        bufferPipe.Writer.Write(new byte[12]);
+        await bufferPipe.Writer.FlushAsync();
+
+        // Write data in data frame one byte at a time
+        // Don't use WriteOneByteAtATime() as we want to wait on the TCS after every flush to make sure app code consumed the data
+        // before we send another byte
+        var res = await bufferPipe.Reader.ReadAsync();
+        for (var i = 0; i < res.Buffer.Length; i++)
+        {
+            mem = stream.Pair.Application.Output.GetMemory();
+            mem.Span[0] = res.Buffer.Slice(i).FirstSpan[0];
+            stream.Pair.Application.Output.Advance(1);
+            // Use TCS to make sure app can read data before we send more
+            var capturedTcs = tcs;
+            await stream.Pair.Application.Output.FlushAsync();
+            await capturedTcs.Task;
+        }
+        bufferPipe.Reader.AdvanceTo(res.Buffer.End);
+
+        var trailers = new Http3HeadersEnumerator();
+        trailers.Initialize(new Dictionary<string, StringValues>()
+        {
+            { "TestName", "TestValue" }
+        });
+
+        Http3FrameWriter.WriteHeader(Http3FrameType.Headers, frameLength: 22, bufferPipe.Writer);
+        mem = bufferPipe.Writer.GetMemory();
+        done = QPackHeaderWriter.BeginEncodeHeaders(trailers, mem.Span, ref headersTotalSize, out length);
+        Assert.True(done);
+        bufferPipe.Writer.Advance(length);
+        await bufferPipe.Writer.FlushAsync();
+
+        // Write trailer frame one byte at a time
+        await WriteOneByteAtATime(bufferPipe.Reader, stream.Pair.Application.Output);
+
+        await stream.EndStreamAsync();
+
+        var responseHeaders = await stream.ExpectHeadersAsync();
+        Assert.Equal(3, responseHeaders.Count);
+        Assert.Contains("date", responseHeaders.Keys, StringComparer.OrdinalIgnoreCase);
+        Assert.Equal("200", responseHeaders[InternalHeaderNames.Status]);
+        Assert.Equal("0", responseHeaders["content-length"]);
+
+        await stream.ExpectReceiveEndOfStream();
+
+        Assert.Equal(12, total);
+        Assert.Equal("TestValue", trailerValue);
+    }
+
+    [Fact]
+    public async Task Control_FrameParsingSingleByteAtATimeWorks()
+    {
+        await Http3Api.InitializeConnectionAsync(_noopApplication);
+
+        // Use Inline scheduling and buffer size of 1 to guarantee each write will wait for the parsing loop to complete before writing more data
+        _serviceContext.ServerOptions.Limits.MaxRequestBufferSize = 1;
+        var outboundcontrolStream = await Http3Api.CreateControlStream(clientWriterScheduler: PipeScheduler.Inline);
+
+        // Use local pipe to write frames so we can get the entire buffer in order to write it one byte at a time
+        var bufferPipe = new Pipe();
+
+        var settings = new List<Http3PeerSetting>
+        {
+            new Http3PeerSetting(Internal.Http3.Http3SettingType.MaxFieldSectionSize, 100),
+            new Http3PeerSetting(Internal.Http3.Http3SettingType.EnableWebTransport, 1),
+            new Http3PeerSetting(Internal.Http3.Http3SettingType.H3Datagram, 1)
+        };
+        var len = Http3FrameWriter.CalculateSettingsSize(settings);
+
+        Http3FrameWriter.WriteHeader(Http3FrameType.Settings, len, bufferPipe.Writer);
+        var mem = bufferPipe.Writer.GetMemory();
+        Http3FrameWriter.WriteSettings(settings, mem.Span);
+
+        bufferPipe.Writer.Advance(len);
+        await bufferPipe.Writer.FlushAsync();
+
+        // Write Settings frame one byte at a time
+        await WriteOneByteAtATime(bufferPipe.Reader, outboundcontrolStream.Pair.Application.Output);
+
+        var fieldSetting = await Http3Api.ServerReceivedSettingsReader.ReadAsync().DefaultTimeout();
+
+        Assert.Equal(Internal.Http3.Http3SettingType.MaxFieldSectionSize, fieldSetting.Key);
+        Assert.Equal(100, fieldSetting.Value);
+
+        fieldSetting = await Http3Api.ServerReceivedSettingsReader.ReadAsync().DefaultTimeout();
+        Assert.Equal(Internal.Http3.Http3SettingType.EnableWebTransport, fieldSetting.Key);
+        Assert.Equal(1, fieldSetting.Value);
+
+        fieldSetting = await Http3Api.ServerReceivedSettingsReader.ReadAsync().DefaultTimeout();
+        Assert.Equal(Internal.Http3.Http3SettingType.H3Datagram, fieldSetting.Key);
+        Assert.Equal(1, fieldSetting.Value);
+
+        // Frames must be well-formed otherwise we close the connection with a frame error
+        Http3FrameWriter.WriteHeader(Http3FrameType.CancelPush, frameLength: 2, bufferPipe.Writer);
+        var idLength = VariableLengthIntegerHelper.WriteInteger(bufferPipe.Writer.GetSpan(), longToEncode: 1026);
+        bufferPipe.Writer.Advance(idLength);
+        await bufferPipe.Writer.FlushAsync();
+
+        // Write CancelPush frame one byte at a time
+        await WriteOneByteAtATime(bufferPipe.Reader, outboundcontrolStream.Pair.Application.Output);
+
+        // Frames must be well-formed otherwise we close the connection with a frame error
+        Http3FrameWriter.WriteHeader(Http3FrameType.GoAway, frameLength: 4, bufferPipe.Writer);
+        idLength = VariableLengthIntegerHelper.WriteInteger(bufferPipe.Writer.GetSpan(), longToEncode: 100026);
+        bufferPipe.Writer.Advance(idLength);
+        await bufferPipe.Writer.FlushAsync();
+
+        try
+        {
+            // Write GoAway frame one byte at a time
+            await WriteOneByteAtATime(bufferPipe.Reader, outboundcontrolStream.Pair.Application.Output);
+        }
+        // As soon as the GOAWAY frame identifier is processed we initiate the connection close process.
+        // That means it's possible to still be writing to the stream when we close the
+        // connection which would result in an exception. We'll just ignore the exception in this case.
+        catch (Exception) { }
+
+        await outboundcontrolStream.EndStreamAsync();
+
+        // Check that connection is closed.
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Http3Api.MultiplexedConnectionContext.ConnectionClosed.Register(() => tcs.TrySetResult());
+        await tcs.Task;
+
+        await outboundcontrolStream.ReceiveEndAsync();
+    }
+
+    private async Task WriteOneByteAtATime(PipeReader reader, PipeWriter writer)
+    {
+        var res = await reader.ReadAsync();
+        try
+        {
+            for (var i = 0; i < res.Buffer.Length; i++)
+            {
+                var mem = writer.GetMemory();
+                mem.Span[0] = res.Buffer.Slice(i).FirstSpan[0];
+                writer.Advance(1);
+                await writer.FlushAsync();
+            }
+        }
+        finally
+        {
+            reader.AdvanceTo(res.Buffer.End);
+        }
     }
 }

--- a/src/Shared/runtime/Http3/Helpers/VariableLengthIntegerHelper.cs
+++ b/src/Shared/runtime/Http3/Helpers/VariableLengthIntegerHelper.cs
@@ -128,19 +128,19 @@ namespace System.Net.Http
             }
         }
 
-        public static long GetInteger(in ReadOnlySequence<byte> buffer, out SequencePosition consumed, out SequencePosition examined)
+        // If callsite has 'examined', set it to buffer.End if the integer wasn't successfully read, otherwise set examined = consumed.
+        public static bool TryGetInteger(in ReadOnlySequence<byte> buffer, out SequencePosition consumed, out long integer)
         {
             var reader = new SequenceReader<byte>(buffer);
-            if (TryRead(ref reader, out long value))
+            if (TryRead(ref reader, out integer))
             {
-                consumed = examined = buffer.GetPosition(reader.Consumed);
-                return value;
+                consumed = buffer.GetPosition(reader.Consumed);
+                return true;
             }
             else
             {
-                consumed = default;
-                examined = buffer.End;
-                return -1;
+                consumed = buffer.Start;
+                return false;
             }
         }
 

--- a/src/Shared/test/Shared.Tests/runtime/Http3/VariableLengthIntegerHelperTests.cs
+++ b/src/Shared/test/Shared.Tests/runtime/Http3/VariableLengthIntegerHelperTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -223,12 +223,12 @@ namespace Common.Tests.Tests.System.Net.aspnetcore.Http3
             MemorySegment<byte> memorySegment2 = memorySegment1.Append(new byte[] { 0, 0, 0, 0, 0, 0, 2 });
             ReadOnlySequence<byte> readOnlySequence = new ReadOnlySequence<byte>(
                 memorySegment1, 0, memorySegment2, memorySegment2.Memory.Length);
-            long result = VariableLengthIntegerHelper.GetInteger(readOnlySequence,
-                out SequencePosition consumed, out SequencePosition examined);
+            bool result = VariableLengthIntegerHelper.TryGetInteger(readOnlySequence,
+                out SequencePosition consumed, out long integer);
 
-            Assert.Equal(2, result);
+            Assert.True(result);
+            Assert.Equal(2, integer);
             Assert.Equal(7, consumed.GetInteger());
-            Assert.Equal(7, examined.GetInteger());
         }
 
         [Fact]
@@ -238,12 +238,11 @@ namespace Common.Tests.Tests.System.Net.aspnetcore.Http3
             MemorySegment<byte> memorySegment2 = memorySegment1.Append(new byte[] { 0, 0, 0, 0, 0, 2 });
             ReadOnlySequence<byte> readOnlySequence = new ReadOnlySequence<byte>(
                 memorySegment1, 0, memorySegment2, memorySegment2.Memory.Length);
-            long result = VariableLengthIntegerHelper.GetInteger(readOnlySequence,
-                out SequencePosition consumed, out SequencePosition examined);
+            bool result = VariableLengthIntegerHelper.TryGetInteger(readOnlySequence,
+                out SequencePosition consumed, out long integer);
 
-            Assert.Equal(-1, result);
+            Assert.False(result);
             Assert.Equal(0, consumed.GetInteger());
-            Assert.Equal(6, examined.GetInteger());
         }
 
         [Fact]


### PR DESCRIPTION
Support partial frames for HTTP/3 in Kestrel.

We incrementally parse frames as they come in.
