### PR TITLE
[Blazor] Add preload placeholder to blazorwasm template

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/wwwroot/index.html
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/wwwroot/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ComponentsWebAssembly-CSharp</title>
     <base href="/" />
+    <link rel="preload" id="webassembly" />
     <!--#if SampleContent -->
     <link rel="stylesheet" href="lib/bootstrap/dist/css/bootstrap.min.css" />
     <!--#endif -->


### PR DESCRIPTION
Add placeholder that `OverrideHtmlAssetPlaceholders=true` feature overrides with link elements to WebAssembly assets to preload.

Contributes to https://github.com/dotnet/aspnetcore/issues/58875