### PR TITLE
Use NormalizeDirectory consistently in SiteExtensions D.B.P

### DIFF
--- a/src/SiteExtensions/Directory.Build.props
+++ b/src/SiteExtensions/Directory.Build.props
@@ -2,21 +2,11 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup>
-    <MicrosoftWebXdtExtensionsPath>
-      $([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'Microsoft.Web.Xdt.Extensions', '$(Configuration)', 'net462', 'Microsoft.Web.Xdt.Extensions.dll'))
-    </MicrosoftWebXdtExtensionsPath>
-    <MicrosoftWebXdtExtensionsPath Condition="'$(DotNetBuildPass)' == '2'">
-      $([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'Microsoft.Web.Xdt.Extensions', '$(TargetArchitecture)', '$(Configuration)', 'net462', 'Microsoft.Web.Xdt.Extensions.dll'))
-    </MicrosoftWebXdtExtensionsPath>
-    <BaseIntermediateOutputPath Condition="'$(DotNetBuildPass)' == '2'">
-      $([MSBuild]::NormalizeDirectory('$(BaseIntermediateOutputPath)', '$(TargetArchitecture)'))
-    </BaseIntermediateOutputPath>
-    <IntermediateOutputPath Condition="'$(PlatformName)' == 'AnyCPU' AND '$(DotNetBuildPass)' == '2'">
-      $([MSBuild]::NormalizeDirectory('$(BaseIntermediateOutputPath)', '$(Configuration)'))
-    </IntermediateOutputPath>
-    <IntermediateOutputPath Condition="'$(PlatformName)' != 'AnyCPU' AND '$(DotNetBuildPass)' == '2'">
-      $([MSBuild]::NormalizeDirectory('$(BaseIntermediateOutputPath)', '$(PlatformName)', '$(Configuration)'))
-    </IntermediateOutputPath>
+    <MicrosoftWebXdtExtensionsPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'Microsoft.Web.Xdt.Extensions', '$(Configuration)', 'net462', 'Microsoft.Web.Xdt.Extensions.dll'))</MicrosoftWebXdtExtensionsPath>
+    <MicrosoftWebXdtExtensionsPath Condition="'$(DotNetBuildPass)' == '2'">$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'Microsoft.Web.Xdt.Extensions', '$(TargetArchitecture)', '$(Configuration)', 'net462', 'Microsoft.Web.Xdt.Extensions.dll'))</MicrosoftWebXdtExtensionsPath>
+    <BaseIntermediateOutputPath Condition="'$(DotNetBuildPass)' == '2'">$([MSBuild]::NormalizeDirectory('$(BaseIntermediateOutputPath)', '$(TargetArchitecture)'))</BaseIntermediateOutputPath>
+    <IntermediateOutputPath Condition="'$(PlatformName)' == 'AnyCPU' AND '$(DotNetBuildPass)' == '2'">$([MSBuild]::NormalizeDirectory('$(BaseIntermediateOutputPath)', '$(Configuration)'))</IntermediateOutputPath>
+    <IntermediateOutputPath Condition="'$(PlatformName)' != 'AnyCPU' AND '$(DotNetBuildPass)' == '2'">$([MSBuild]::NormalizeDirectory('$(BaseIntermediateOutputPath)', '$(PlatformName)', '$(Configuration)'))</IntermediateOutputPath>
   </PropertyGroup>
 
 </Project>

--- a/src/SiteExtensions/Directory.Build.props
+++ b/src/SiteExtensions/Directory.Build.props
@@ -2,11 +2,21 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup>
-    <MicrosoftWebXdtExtensionsPath>$(ArtifactsBinDir)Microsoft.Web.Xdt.Extensions\$(Configuration)\net462\Microsoft.Web.Xdt.Extensions.dll</MicrosoftWebXdtExtensionsPath>
-    <MicrosoftWebXdtExtensionsPath Condition="'$(DotNetBuildPass)' == '2'">$(ArtifactsBinDir)Microsoft.Web.Xdt.Extensions\$(TargetArchitecture)\$(Configuration)\net462\Microsoft.Web.Xdt.Extensions.dll</MicrosoftWebXdtExtensionsPath>
-    <BaseIntermediateOutputPath Condition="'$(DotNetBuildPass)' == '2'">$([MSBuild]::NormalizeDirectory('$(BaseIntermediateOutputPath)', '$(TargetArchitecture)'))</BaseIntermediateOutputPath>
-    <IntermediateOutputPath Condition="'$(PlatformName)' == 'AnyCPU' AND '$(DotNetBuildPass)' == '2'">$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
-    <IntermediateOutputPath Condition="'$(PlatformName)' != 'AnyCPU' AND '$(DotNetBuildPass)' == '2'">$(BaseIntermediateOutputPath)$(PlatformName)\$(Configuration)\</IntermediateOutputPath>
+    <MicrosoftWebXdtExtensionsPath>
+      $([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'Microsoft.Web.Xdt.Extensions', '$(Configuration)', 'net462', 'Microsoft.Web.Xdt.Extensions.dll'))
+    </MicrosoftWebXdtExtensionsPath>
+    <MicrosoftWebXdtExtensionsPath Condition="'$(DotNetBuildPass)' == '2'">
+      $([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'Microsoft.Web.Xdt.Extensions', '$(TargetArchitecture)', '$(Configuration)', 'net462', 'Microsoft.Web.Xdt.Extensions.dll'))
+    </MicrosoftWebXdtExtensionsPath>
+    <BaseIntermediateOutputPath Condition="'$(DotNetBuildPass)' == '2'">
+      $([MSBuild]::NormalizeDirectory('$(BaseIntermediateOutputPath)', '$(TargetArchitecture)'))
+    </BaseIntermediateOutputPath>
+    <IntermediateOutputPath Condition="'$(PlatformName)' == 'AnyCPU' AND '$(DotNetBuildPass)' == '2'">
+      $([MSBuild]::NormalizeDirectory('$(BaseIntermediateOutputPath)', '$(Configuration)'))
+    </IntermediateOutputPath>
+    <IntermediateOutputPath Condition="'$(PlatformName)' != 'AnyCPU' AND '$(DotNetBuildPass)' == '2'">
+      $([MSBuild]::NormalizeDirectory('$(BaseIntermediateOutputPath)', '$(PlatformName)', '$(Configuration)'))
+    </IntermediateOutputPath>
   </PropertyGroup>
 
 </Project>

--- a/src/SiteExtensions/Directory.Build.props
+++ b/src/SiteExtensions/Directory.Build.props
@@ -2,8 +2,9 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup>
-    <MicrosoftWebXdtExtensionsPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'Microsoft.Web.Xdt.Extensions', '$(Configuration)', 'net462', 'Microsoft.Web.Xdt.Extensions.dll'))</MicrosoftWebXdtExtensionsPath>
-    <MicrosoftWebXdtExtensionsPath Condition="'$(DotNetBuildPass)' == '2'">$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'Microsoft.Web.Xdt.Extensions', '$(TargetArchitecture)', '$(Configuration)', 'net462', 'Microsoft.Web.Xdt.Extensions.dll'))</MicrosoftWebXdtExtensionsPath>
+    <MicrosoftWebXdtExtensionsDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'Microsoft.Web.Xdt.Extensions', '$(Configuration)', 'net462'))</MicrosoftWebXdtExtensionsDir>
+    <MicrosoftWebXdtExtensionsDir Condition="'$(DotNetBuildPass)' == '2'">$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'Microsoft.Web.Xdt.Extensions', '$(TargetArchitecture)', '$(Configuration)', 'net462'))</MicrosoftWebXdtExtensionsDir>
+    <MicrosoftWebXdtExtensionsPath>$(MicrosoftWebXdtExtensionsDir)Microsoft.Web.Xdt.Extensions.dll</MicrosoftWebXdtExtensionsPath>
     <BaseIntermediateOutputPath Condition="'$(DotNetBuildPass)' == '2'">$([MSBuild]::NormalizeDirectory('$(BaseIntermediateOutputPath)', '$(TargetArchitecture)'))</BaseIntermediateOutputPath>
     <IntermediateOutputPath Condition="'$(PlatformName)' == 'AnyCPU' AND '$(DotNetBuildPass)' == '2'">$([MSBuild]::NormalizeDirectory('$(BaseIntermediateOutputPath)', '$(Configuration)'))</IntermediateOutputPath>
     <IntermediateOutputPath Condition="'$(PlatformName)' != 'AnyCPU' AND '$(DotNetBuildPass)' == '2'">$([MSBuild]::NormalizeDirectory('$(BaseIntermediateOutputPath)', '$(PlatformName)', '$(Configuration)'))</IntermediateOutputPath>


### PR DESCRIPTION
We were calculating paths using 2 different methods in this file. NormalizeDirectory is better, so centralize on that. Generated by CoPilot!