### PR TITLE
Move DotNetBuild.props logic into repo

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -107,6 +107,8 @@
 
     <IncludeSymbols>true</IncludeSymbols>
     <DefaultNetFxTargetFramework>net462</DefaultNetFxTargetFramework>
+
+    <CrossgenOutput Condition="'$(DotNetBuildUseMonoRuntime)' == 'true'">false</CrossgenOutput>
   </PropertyGroup>
 
   <!-- Warnings and errors -->

--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -5,7 +5,6 @@
   <PropertyGroup>
     <GitHubRepositoryName>aspnetcore</GitHubRepositoryName>
     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
-    <SourceBuildTargetFrameworkFilter>netstandard2.0%3bnetstandard2.1%3bnetcoreapp2.1%3bnetcoreapp3.1%3bnet5.0%3bnet6.0%3bnet7.0%3bnet8.0%3bnet9.0%3bnet10.0</SourceBuildTargetFrameworkFilter>
   </PropertyGroup>
 
   <!--
@@ -58,14 +57,6 @@
       WorkingDirectory="$(InnerSourceBuildRepoRoot)"
       EnvironmentVariables="@(InnerBuildEnv)"
       Condition="'$(OS)' == 'Windows_NT'" />
-  </Target>
-
-  <Target Name="CustomizeInnerBuildArgs"
-          BeforeTargets="GetSourceBuildCommandConfiguration">
-
-    <PropertyGroup>
-      <InnerBuildArgs Condition="'$(DotNetBuildUseMonoRuntime)' == 'true'">$(InnerBuildArgs) /p:CrossgenOutput=false</InnerBuildArgs>
-    </PropertyGroup>
   </Target>
 
   <Target Name="GetAspnetcoreCategorizedIntermediateNupkgContents"

--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -7,6 +7,20 @@
     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
   </PropertyGroup>
 
+  <!--
+    Remove inner source .globalconfig file as both the inner and outer config files get loaded and cause a conflict.
+    Leaving the inner will cause all conflicting settings to be ignored.
+    https://learn.microsoft.com/dotnet/fundamentals/code-analysis/configuration-files#general-options.
+    This only needs to be done if there is an inner clone.
+  -->
+  <Target Name="RemoveInnerGlobalConfig"
+          DependsOnTargets="PrepareInnerSourceBuildRepoRoot"
+          BeforeTargets="RunInnerSourceBuildCommand"
+          Condition="'$(DotNetBuildOrchestrator)' != 'true'">
+
+    <Delete Files="$(InnerSourceBuildRepoRoot).globalconfig" />
+  </Target>
+
   <!-- Build RepoTasks - this is normally triggered via the build script but the inner ArPow source-build is run via msbuild.
        https://github.com/dotnet/source-build/issues/3807 -->
   <Target Name="BuildRepoTasks"

--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -7,20 +7,6 @@
     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
   </PropertyGroup>
 
-  <!--
-    Remove inner source .globalconfig file as both the inner and outer config files get loaded and cause a conflict.
-    Leaving the inner will cause all conflicting settings to be ignored.
-    https://learn.microsoft.com/dotnet/fundamentals/code-analysis/configuration-files#general-options.
-    This only needs to be done if there is an inner clone.
-  -->
-  <Target Name="RemoveInnerGlobalConfig"
-          DependsOnTargets="PrepareInnerSourceBuildRepoRoot"
-          BeforeTargets="RunInnerSourceBuildCommand"
-          Condition="'$(DotNetBuildOrchestrator)' != 'true'">
-
-    <Delete Files="$(InnerSourceBuildRepoRoot).globalconfig" />
-  </Target>
-
   <!-- Build RepoTasks - this is normally triggered via the build script but the inner ArPow source-build is run via msbuild.
        https://github.com/dotnet/source-build/issues/3807 -->
   <Target Name="BuildRepoTasks"
@@ -73,45 +59,6 @@
       <IntermediateNupkgArtifactFile Include="$(InstallersArtifactsDir)aspnetcore-runtime-*.msi" />
       <IntermediateNupkgArtifactFile Include="$(InstallersArtifactsDir)aspnetcore-runtime-*.pkg" />
     </ItemGroup>
-  </Target>
-
-  <Target Name="RestoreNpmPackages"
-          Condition="'$(BuildNodeJS)' == 'true' and '$(DotNetBuildSourceOnly)' == 'true'"
-          BeforeTargets="RunInnerSourceBuildCommand">
-
-    <Message Text="Checking node version..." Importance="high" />
-    <Exec
-      Command="node --version"
-      WorkingDirectory="$(InnerSourceBuildRepoRoot)" />
-
-    <Message Text="Checking npm version..." Importance="high" />
-    <Exec
-      Command="npm --version"
-      WorkingDirectory="$(InnerSourceBuildRepoRoot)" />
-
-    <PropertyGroup>
-      <!-- Disable installing puppeteer browsers when running in source build -->
-      <_AdditionalEnvironmentVariable Condition="$(DotNetBuildSourceOnly) == 'true'">PUPPETEER_SKIP_DOWNLOAD=1</_AdditionalEnvironmentVariable>
-    </PropertyGroup>
-
-    <Exec
-      Command="npm ci"
-      WorkingDirectory="$(InnerSourceBuildRepoRoot)"
-      EnvironmentVariables="$(_AdditionalEnvironmentVariable)" />
-
-  </Target>
-
-  <Target Name="BuildNpmFiles"
-          Condition="'$(BuildNodeJS)' == 'true' and '$(DotNetBuildSourceOnly)' == 'true'"
-          DependsOnTargets="RestoreNpmPackages"
-          BeforeTargets="RunInnerSourceBuildCommand">
-
-    <Message Text="Building Node JS files..." Importance="high" />
-
-    <Exec
-      Command="npm run build"
-      WorkingDirectory="$(InnerSourceBuildRepoRoot)" />
-
   </Target>
 
 </Project>


### PR DESCRIPTION
- Remove the TargetFrameworkFilter which isn't necessary as defined centrally by Arcade with the same value.
- Remove the npm target which never runs in source-build: https://github.com/dotnet/aspnetcore/blob/9878dd936896961042bafad5392576db1ee2052b/eng/Common.props#L17
- Move the `CrossgenOutput` property condition into the repo.