### PR TITLE
Fix HttpLoggingMiddleware Request/Response bodies logging in case of stream being closed by a subsequent middleware

### DIFF
--- a/src/Middleware/HttpLogging/src/ResponseBufferingStream.cs
+++ b/src/Middleware/HttpLogging/src/ResponseBufferingStream.cs
@@ -19,6 +19,7 @@ internal sealed class ResponseBufferingStream : BufferingStream, IHttpResponseBo
     private readonly HttpLoggingOptions _options;
     private readonly IHttpLoggingInterceptor[] _interceptors;
     private bool _logBody;
+    private bool _hasLogged;
     private Encoding? _encoding;
     private string? _bodyBeforeClose;
 
@@ -182,6 +183,7 @@ internal sealed class ResponseBufferingStream : BufferingStream, IHttpResponseBo
         {
             var responseBody = GetStringInternal();
             _logger.ResponseBody(responseBody);
+            _hasLogged = true;
         }
     }
 
@@ -190,6 +192,7 @@ internal sealed class ResponseBufferingStream : BufferingStream, IHttpResponseBo
         if (_logBody)
         {
             logContext.AddParameter("ResponseBody", GetStringInternal());
+            _hasLogged = true;
         }
     }
 
@@ -203,7 +206,7 @@ internal sealed class ResponseBufferingStream : BufferingStream, IHttpResponseBo
 
     public override void Close()
     {
-        if (_logBody)
+        if (_logBody && !_hasLogged)
         {
             // Subsequent middleware can close the response stream after writing its body
             // Preserving the body for the final GetStringInternal() call.

--- a/src/Middleware/HttpLogging/test/HttpLoggingMiddlewareTests.cs
+++ b/src/Middleware/HttpLogging/test/HttpLoggingMiddlewareTests.cs
@@ -406,7 +406,7 @@ public class HttpLoggingMiddlewareTests : LoggedTest
                 // (1) The subsequent middleware reads right up to the buffer size (guided by the ContentLength header)
                 while (contentLengthBytesLeft > 0)
                 {
-                    var res = await c.Request.Body.ReadAsync(arr, 0, (int)Math.Min(arr.Length, contentLengthBytesLeft));
+                    var res = await c.Request.Body.ReadAsync(arr, 0, arr.Length);
                     contentLengthBytesLeft -= res;
                     if (res == 0)
                     {
@@ -1669,6 +1669,73 @@ public class HttpLoggingMiddlewareTests : LoggedTest
         Assert.Equal("RequestBody: test", lines[i++]);
         Assert.Equal("RequestBodyStatus: [Completed]", lines[i++]);
         Assert.StartsWith("Duration: ", lines[i++]);
+        Assert.Equal(lines.Length, i);
+    }
+
+    [Theory]
+    [InlineData(HttpLoggingFields.RequestBody | HttpLoggingFields.ResponseBody, true, true)]
+    [InlineData(HttpLoggingFields.RequestBody, true, false)]
+    [InlineData(HttpLoggingFields.ResponseBody, false, true)]
+    public async Task CombineLogsWithStreamCloseWorks(HttpLoggingFields fields, bool hasRequestBody, bool hasResponseBody)
+    {
+        var options = CreateOptionsAccessor();
+        options.CurrentValue.LoggingFields = fields;
+        options.CurrentValue.CombineLogs = true;
+
+        var middleware = CreateMiddleware(
+            async c =>
+            {
+                var arr = new byte[4096];
+                var contentLengthBytesLeft = c.Request.Body.Length;
+
+                // (1) The subsequent middleware reads right up to the buffer size (guided by the ContentLength header)
+                while (contentLengthBytesLeft > 0)
+                {
+                    var res = await c.Request.Body.ReadAsync(arr, 0, arr.Length);
+                    contentLengthBytesLeft -= res;
+                    if (res == 0)
+                    {
+                        break;
+                    }
+                }
+
+                // (2) The subsequent middleware closes the request stream after its consumption
+                c.Request.Body.Close();
+
+
+                c.Response.ContentType = "text/plain";
+
+                // (3) The subsequent middleware writes its response
+                await c.Response.WriteAsync("test response");
+
+                // (4) The subsequent middleware closes the response stream after it has completed writing to it
+                c.Response.Body.Close();
+            },
+            options);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.ContentType = "text/plain";
+        var requestBodyBuffer = Encoding.UTF8.GetBytes("test request");
+        httpContext.Request.Body = new MemoryStream(requestBodyBuffer);
+        httpContext.Request.ContentLength = requestBodyBuffer.Length;
+
+        await middleware.Invoke(httpContext);
+
+        var lines = Assert.Single(TestSink.Writes.Where(w => w.LogLevel >= LogLevel.Information)).Message.Split(Environment.NewLine);
+        var i = 0;
+        Assert.Equal("Request and Response:", lines[i++]);
+        if (fields.HasFlag(HttpLoggingFields.RequestBody))
+        {
+            Assert.Equal("RequestBody: test request", lines[i++]);
+            // Here we expect "Only partially consumed by app" status as the middleware reads request body right to its end,
+            // but never further as it follows the ContentLength header. From logging middleware perspective it looks like
+            // a partial consumption as it can't know for sure if it has been drained to the end or not.
+            Assert.Equal("RequestBodyStatus: [Only partially consumed by app]", lines[i++]);
+        }
+        if (fields.HasFlag(HttpLoggingFields.ResponseBody))
+        {
+            Assert.Equal("ResponseBody: test response", lines[i++]);
+        }
         Assert.Equal(lines.Length, i);
     }
 

--- a/src/Middleware/HttpLogging/test/HttpLoggingMiddlewareTests.cs
+++ b/src/Middleware/HttpLogging/test/HttpLoggingMiddlewareTests.cs
@@ -1673,10 +1673,10 @@ public class HttpLoggingMiddlewareTests : LoggedTest
     }
 
     [Theory]
-    [InlineData(HttpLoggingFields.RequestBody | HttpLoggingFields.ResponseBody, true, true)]
-    [InlineData(HttpLoggingFields.RequestBody, true, false)]
-    [InlineData(HttpLoggingFields.ResponseBody, false, true)]
-    public async Task CombineLogsWithStreamCloseWorks(HttpLoggingFields fields, bool hasRequestBody, bool hasResponseBody)
+    [InlineData(HttpLoggingFields.RequestBody | HttpLoggingFields.ResponseBody)]
+    [InlineData(HttpLoggingFields.RequestBody)]
+    [InlineData(HttpLoggingFields.ResponseBody)]
+    public async Task CombineLogsWithStreamCloseWorks(HttpLoggingFields fields)
     {
         var options = CreateOptionsAccessor();
         options.CurrentValue.LoggingFields = fields;
@@ -1701,7 +1701,6 @@ public class HttpLoggingMiddlewareTests : LoggedTest
 
                 // (2) The subsequent middleware closes the request stream after its consumption
                 c.Request.Body.Close();
-
 
                 c.Response.ContentType = "text/plain";
 


### PR DESCRIPTION
# Fix HttpLoggingMiddleware Request/Response bodies logging in case of stream being closed by a subsequent middleware (#61489)

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Preserve buffer contents until it is consumed by the `HttpLoggingMiddleware`

## Description

Fixes #61489

When the subsequent middleware closes request/response stream, the `BufferingStream` calls `Reset` which leads to an empty body being logged.

The request stream might be closed if the subsequent middleware follows the `ContentLength` header to sense the end of the stream (instead of reading it to the end).

The response stream might be closed without any additional preconditions, just because the subsequent middleware decided to do so.

A real-life example of such a middleware is `CoreWCF` `BasicHttpBinding`: [inputStream.Close](https://github.com/CoreWCF/CoreWCF/blob/067f83b490332120f45ec9064dd7d1fa555ba65d/src/CoreWCF.Http/src/CoreWCF/Channels/HttpChannelHelpers.cs#L151), [_outputStream.Close](https://github.com/CoreWCF/CoreWCF/blob/067f83b490332120f45ec9064dd7d1fa555ba65d/src/CoreWCF.Http/src/CoreWCF/Channels/HttpChannelHelpers.cs#L544)