### PR TITLE
Update nightly build links to 10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ This table includes links to download the latest builds of the ASP.NET Core Shar
 
 | Platform | Shared Framework (Installer) | Shared Framework (Binaries) | Hosting Bundle (Installer) |
 | :--------- | :----------: | :----------: | :----------: |
-| **Windows x64** | [Installer](https://aka.ms/dotnet/9.0/daily/aspnetcore-runtime-win-x64.exe) | [Binaries](https://aka.ms/dotnet/9.0/daily/aspnetcore-runtime-win-x64.zip) | [Installer](https://aka.ms/dotnet/9.0/daily/dotnet-hosting-win.exe) |
-| **Windows x86** | [Installer](https://aka.ms/dotnet/9.0/daily/aspnetcore-runtime-win-x86.exe) | [Binaries](https://aka.ms/dotnet/9.0/daily/aspnetcore-runtime-win-x86.zip) | [Installer](https://aka.ms/dotnet/9.0/daily/dotnet-hosting-win.exe) |
-| **Windows arm64** | [Installer](https://aka.ms/dotnet/9.0/daily/aspnetcore-runtime-win-arm64.exe) | [Binaries](https://aka.ms/dotnet/9.0/daily/aspnetcore-runtime-win-arm64.zip) | [Installer](https://aka.ms/dotnet/9.0/daily/dotnet-hosting-win.exe) |
-| **macOS x64** | **N/A** | [Binaries](https://aka.ms/dotnet/9.0/daily/aspnetcore-runtime-osx-x64.tar.gz) | **N/A** |
-| **macOS arm64** | **N/A** | [Binaries](https://aka.ms/dotnet/9.0/daily/aspnetcore-runtime-osx-arm64.tar.gz) | **N/A** |
-| **Linux x64** | [Deb Installer](https://aka.ms/dotnet/9.0/daily/aspnetcore-runtime-x64.deb) - [RPM Installer](https://aka.ms/dotnet/9.0/daily/aspnetcore-runtime-x64.rpm) | [Binaries](https://aka.ms/dotnet/9.0/daily/aspnetcore-runtime-linux-x64.tar.gz) | **N/A** |
-| **Linux arm** | **N/A** | [Binaries](https://aka.ms/dotnet/9.0/daily/aspnetcore-runtime-linux-arm.tar.gz) | **N/A** |
-| **Linux arm64** | [RPM Installer](https://aka.ms/dotnet/9.0/daily/aspnetcore-runtime-aarch64.rpm) | [Binaries](https://aka.ms/dotnet/9.0/daily/aspnetcore-runtime-linux-arm64.tar.gz) | **N/A** |
-| **Linux-musl-x64** | **N/A** | [Binaries](https://aka.ms/dotnet/9.0/daily/aspnetcore-runtime-linux-musl-x64.tar.gz) | **N/A** |
-| **Linux-musl-arm** | **N/A** | [Binaries](https://aka.ms/dotnet/9.0/daily/aspnetcore-runtime-linux-musl-arm.tar.gz) | **N/A** |
-| **Linux-musl-arm64** | **N/A** | [Binaries](https://aka.ms/dotnet/9.0/daily/aspnetcore-runtime-linux-musl-arm64.tar.gz) | **N/A** |
+| **Windows x64** | [Installer](https://aka.ms/dotnet/10.0/daily/aspnetcore-runtime-win-x64.exe) | [Binaries](https://aka.ms/dotnet/10.0/daily/aspnetcore-runtime-win-x64.zip) | [Installer](https://aka.ms/dotnet/10.0/daily/dotnet-hosting-win.exe) |
+| **Windows x86** | [Installer](https://aka.ms/dotnet/10.0/daily/aspnetcore-runtime-win-x86.exe) | [Binaries](https://aka.ms/dotnet/10.0/daily/aspnetcore-runtime-win-x86.zip) | [Installer](https://aka.ms/dotnet/10.0/daily/dotnet-hosting-win.exe) |
+| **Windows arm64** | [Installer](https://aka.ms/dotnet/10.0/daily/aspnetcore-runtime-win-arm64.exe) | [Binaries](https://aka.ms/dotnet/10.0/daily/aspnetcore-runtime-win-arm64.zip) | [Installer](https://aka.ms/dotnet/10.0/daily/dotnet-hosting-win.exe) |
+| **macOS x64** | **N/A** | [Binaries](https://aka.ms/dotnet/10.0/daily/aspnetcore-runtime-osx-x64.tar.gz) | **N/A** |
+| **macOS arm64** | **N/A** | [Binaries](https://aka.ms/dotnet/10.0/daily/aspnetcore-runtime-osx-arm64.tar.gz) | **N/A** |
+| **Linux x64** | [Deb Installer](https://aka.ms/dotnet/10.0/daily/aspnetcore-runtime-x64.deb) - [RPM Installer](https://aka.ms/dotnet/10.0/daily/aspnetcore-runtime-x64.rpm) | [Binaries](https://aka.ms/dotnet/10.0/daily/aspnetcore-runtime-linux-x64.tar.gz) | **N/A** |
+| **Linux arm** | **N/A** | [Binaries](https://aka.ms/dotnet/10.0/daily/aspnetcore-runtime-linux-arm.tar.gz) | **N/A** |
+| **Linux arm64** | [RPM Installer](https://aka.ms/dotnet/10.0/daily/aspnetcore-runtime-aarch64.rpm) | [Binaries](https://aka.ms/dotnet/10.0/daily/aspnetcore-runtime-linux-arm64.tar.gz) | **N/A** |
+| **Linux-musl-x64** | **N/A** | [Binaries](https://aka.ms/dotnet/10.0/daily/aspnetcore-runtime-linux-musl-x64.tar.gz) | **N/A** |
+| **Linux-musl-arm** | **N/A** | [Binaries](https://aka.ms/dotnet/10.0/daily/aspnetcore-runtime-linux-musl-arm.tar.gz) | **N/A** |
+| **Linux-musl-arm64** | **N/A** | [Binaries](https://aka.ms/dotnet/10.0/daily/aspnetcore-runtime-linux-musl-arm64.tar.gz) | **N/A** |


### PR DESCRIPTION
This pull request updates the download links for the ASP.NET Core Shared Framework and Hosting Bundle in the `README.md` file to point to the latest version 10.0 builds.

Changes to download links:

* Updated download links for all platforms (Windows x64, Windows x86, Windows arm64, macOS x64, macOS arm64, Linux x64, Linux arm, Linux arm64, Linux-musl-x64, Linux-musl-arm, Linux-musl-arm64) to point to the version 10.0 builds.