### PR TITLE
Blazor - rendering metrics

### DIFF
--- a/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
+++ b/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
@@ -23,6 +23,7 @@
     <Compile Include="$(SharedSourceRoot)Debugger\DictionaryItemDebugView.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)Debugger\DictionaryDebugView.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)UrlDecoder\UrlDecoder.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Metrics\MetricsConstants.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <Import Project="Microsoft.AspNetCore.Components.Routing.targets" />

--- a/src/Components/Components/src/RenderTree/Renderer.cs
+++ b/src/Components/Components/src/RenderTree/Renderer.cs
@@ -932,7 +932,7 @@ public abstract partial class Renderer : IDisposable, IAsyncDisposable
     {
         var componentState = renderQueueEntry.ComponentState;
         Log.RenderingComponent(_logger, componentState);
-        var startTime = ((bool)_renderingMetrics?.IsDurationEnabled()) ? Stopwatch.GetTimestamp() : 0;
+        var startTime = (_renderingMetrics != null && _renderingMetrics.IsDurationEnabled()) ? Stopwatch.GetTimestamp() : 0;
         _renderingMetrics?.RenderStart(componentState.Component.GetType().FullName);
         componentState.RenderIntoBatch(_batchBuilder, renderQueueEntry.RenderFragment, out var renderFragmentException);
         if (renderFragmentException != null)

--- a/src/Components/Components/src/RenderTree/Renderer.cs
+++ b/src/Components/Components/src/RenderTree/Renderer.cs
@@ -5,6 +5,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Metrics;
 using System.Linq;
 using Microsoft.AspNetCore.Components.HotReload;
 using Microsoft.AspNetCore.Components.Reflection;
@@ -24,6 +25,7 @@ namespace Microsoft.AspNetCore.Components.RenderTree;
 // dispatching events to them, and notifying when the user interface is being updated.
 public abstract partial class Renderer : IDisposable, IAsyncDisposable
 {
+    private readonly RenderingMetrics? _renderingMetrics;
     private readonly object _lockObject = new();
     private readonly IServiceProvider _serviceProvider;
     private readonly Dictionary<int, ComponentState> _componentStateById = new Dictionary<int, ComponentState>();
@@ -89,6 +91,9 @@ public abstract partial class Renderer : IDisposable, IAsyncDisposable
         // logger name in here as a string literal.
         _logger = loggerFactory.CreateLogger("Microsoft.AspNetCore.Components.RenderTree.Renderer");
         _componentFactory = new ComponentFactory(componentActivator, this);
+
+        var meterFactory = serviceProvider.GetService<IMeterFactory>();
+        _renderingMetrics = meterFactory != null ? new RenderingMetrics(meterFactory) : null;
 
         ServiceProviderCascadingValueSuppliers = serviceProvider.GetService<ICascadingValueSupplier>() is null
             ? Array.Empty<ICascadingValueSupplier>()
@@ -926,12 +931,15 @@ public abstract partial class Renderer : IDisposable, IAsyncDisposable
     {
         var componentState = renderQueueEntry.ComponentState;
         Log.RenderingComponent(_logger, componentState);
+        var startTime = _renderingMetrics != null ? Stopwatch.GetTimestamp() : 0;
+        _renderingMetrics?.RenderStart(componentState.Component.GetType().FullName);
         componentState.RenderIntoBatch(_batchBuilder, renderQueueEntry.RenderFragment, out var renderFragmentException);
         if (renderFragmentException != null)
         {
             // If this returns, the error was handled by an error boundary. Otherwise it throws.
             HandleExceptionViaErrorBoundary(renderFragmentException, componentState);
         }
+        _renderingMetrics?.RenderEnd(componentState.Component.GetType().FullName, renderFragmentException, startTime, Stopwatch.GetTimestamp());
 
         // Process disposal queue now in case it causes further component renders to be enqueued
         ProcessDisposalQueueInExistingBatch();

--- a/src/Components/Components/src/Rendering/RenderingMetrics.cs
+++ b/src/Components/Components/src/Rendering/RenderingMetrics.cs
@@ -18,6 +18,8 @@ internal sealed class RenderingMetrics : IDisposable
 
     public RenderingMetrics(IMeterFactory meterFactory)
     {
+        Debug.Assert(meterFactory != null);
+
         _meter = meterFactory.Create(MeterName);
 
         _renderTotalCounter = _meter.CreateCounter<long>(

--- a/src/Components/Components/src/Rendering/RenderingMetrics.cs
+++ b/src/Components/Components/src/Rendering/RenderingMetrics.cs
@@ -1,0 +1,91 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Components.Rendering;
+
+internal sealed class RenderingMetrics : IDisposable
+{
+    public const string MeterName = "Microsoft.AspNetCore.Components.Rendering";
+
+    private readonly Meter _meter;
+    private readonly Counter<long> _renderCounter;
+    private readonly Histogram<double> _renderDuration;
+
+    public RenderingMetrics(IMeterFactory meterFactory)
+    {
+        _meter = meterFactory.Create(MeterName);
+
+        _renderCounter = _meter.CreateCounter<long>(
+            "aspnetcore.components.rendering.count",
+            unit: "{render}",
+            description: "Number of component renders performed.");
+
+        _renderDuration = _meter.CreateHistogram<double>(
+            "aspnetcore.components.rendering.duration",
+            unit: "ms",
+            description: "Duration of component rendering operations per component.",
+            advice: new InstrumentAdvice<double> { HistogramBucketBoundaries = MetricsConstants.ShortSecondsBucketBoundaries });
+    }
+
+    public void RenderStart(string componentType)
+    {
+        var tags = new TagList();
+        tags = InitializeRequestTags(componentType, tags);
+
+        _renderCounter.Add(1, tags);
+    }
+
+    public void RenderEnd(string componentType, Exception? exception, long startTimestamp, long currentTimestamp)
+    {
+        var tags = new TagList();
+        tags = InitializeRequestTags(componentType, tags);
+
+        // Tags must match request start.
+        if (_renderCounter.Enabled)
+        {
+            _renderCounter.Add(-1, tags);
+        }
+
+        if (_renderDuration.Enabled)
+        {
+            if (exception != null)
+            {
+                TryAddTag(ref tags, "error.type", exception.GetType().FullName);
+            }
+
+            var duration = Stopwatch.GetElapsedTime(startTimestamp, currentTimestamp);
+            _renderDuration.Record(duration.TotalMilliseconds, tags);
+        }
+    }
+
+    private static TagList InitializeRequestTags(string componentType, TagList tags)
+    {
+        tags.Add("component.type", componentType);
+        return tags;
+    }
+
+    public bool IsEnabled() => _renderCounter.Enabled || _renderDuration.Enabled;
+
+    public void Dispose()
+    {
+        _meter.Dispose();
+    }
+
+    private static bool TryAddTag(ref TagList tags, string name, object? value)
+    {
+        for (var i = 0; i < tags.Count; i++)
+        {
+            if (tags[i].Key == name)
+            {
+                return false;
+            }
+        }
+
+        tags.Add(new KeyValuePair<string, object?>(name, value));
+        return true;
+    }
+}

--- a/src/Components/Components/test/Microsoft.AspNetCore.Components.Tests.csproj
+++ b/src/Components/Components/test/Microsoft.AspNetCore.Components.Tests.csproj
@@ -8,9 +8,11 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Components" />
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
+    <Reference Include="Microsoft.Extensions.Diagnostics.Testing" />
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(SharedSourceRoot)Metrics\TestMeterFactory.cs" LinkBase="shared" />
     <Compile Include="$(ComponentsSharedSourceRoot)test\**\*.cs" LinkBase="Helpers" />
   </ItemGroup>
 

--- a/src/Components/Components/test/Rendering/RenderingMetricsTest.cs
+++ b/src/Components/Components/test/Rendering/RenderingMetricsTest.cs
@@ -1,0 +1,238 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.InternalTesting;
+using Moq;
+
+namespace Microsoft.AspNetCore.Components.Rendering;
+
+public class RenderingMetricsTest
+{
+    private readonly TestMeterFactory _meterFactory;
+
+    public RenderingMetricsTest()
+    {
+        _meterFactory = new TestMeterFactory();
+    }
+
+    [Fact]
+    public void Constructor_CreatesMetersCorrectly()
+    {
+        // Arrange & Act
+        var renderingMetrics = new RenderingMetrics(_meterFactory);
+
+        // Assert
+        Assert.Single(_meterFactory.Meters);
+        Assert.Equal(RenderingMetrics.MeterName, _meterFactory.Meters[0].Name);
+    }
+
+    [Fact]
+    public void RenderStart_IncreasesCounters()
+    {
+        // Arrange
+        var renderingMetrics = new RenderingMetrics(_meterFactory);
+        using var totalCounter = new MetricCollector<long>(_meterFactory,
+            RenderingMetrics.MeterName, "aspnetcore.components.rendering.count");
+        using var activeCounter = new MetricCollector<long>(_meterFactory,
+            RenderingMetrics.MeterName, "aspnetcore.components.rendering.active_renders");
+
+        var componentType = "TestComponent";
+
+        // Act
+        renderingMetrics.RenderStart(componentType);
+
+        // Assert
+        var totalMeasurements = totalCounter.GetMeasurementSnapshot();
+        var activeMeasurements = activeCounter.GetMeasurementSnapshot();
+
+        Assert.Single(totalMeasurements);
+        Assert.Equal(1, totalMeasurements[0].Value);
+        Assert.Equal(componentType, totalMeasurements[0].Tags["component.type"]);
+
+        Assert.Single(activeMeasurements);
+        Assert.Equal(1, activeMeasurements[0].Value);
+        Assert.Equal(componentType, activeMeasurements[0].Tags["component.type"]);
+    }
+
+    [Fact]
+    public void RenderEnd_DecreasesActiveCounterAndRecordsDuration()
+    {
+        // Arrange
+        var renderingMetrics = new RenderingMetrics(_meterFactory);
+        using var activeCounter = new MetricCollector<long>(_meterFactory,
+            RenderingMetrics.MeterName, "aspnetcore.components.rendering.active_renders");
+        using var durationCollector = new MetricCollector<double>(_meterFactory,
+            RenderingMetrics.MeterName, "aspnetcore.components.rendering.duration");
+
+        var componentType = "TestComponent";
+
+        // Act
+        var startTime = Stopwatch.GetTimestamp();
+        Thread.Sleep(10); // Add a small delay to ensure a measurable duration
+        var endTime = Stopwatch.GetTimestamp();
+        renderingMetrics.RenderEnd(componentType, null, startTime, endTime);
+
+        // Assert
+        var activeMeasurements = activeCounter.GetMeasurementSnapshot();
+        var durationMeasurements = durationCollector.GetMeasurementSnapshot();
+
+        Assert.Single(activeMeasurements);
+        Assert.Equal(-1, activeMeasurements[0].Value);
+        Assert.Equal(componentType, activeMeasurements[0].Tags["component.type"]);
+
+        Assert.Single(durationMeasurements);
+        Assert.True(durationMeasurements[0].Value > 0);
+        Assert.Equal(componentType, durationMeasurements[0].Tags["component.type"]);
+    }
+
+    [Fact]
+    public void RenderEnd_AddsErrorTypeTag_WhenExceptionIsProvided()
+    {
+        // Arrange
+        var renderingMetrics = new RenderingMetrics(_meterFactory);
+        using var durationCollector = new MetricCollector<double>(_meterFactory,
+            RenderingMetrics.MeterName, "aspnetcore.components.rendering.duration");
+
+        var componentType = "TestComponent";
+        var exception = new InvalidOperationException("Test exception");
+
+        // Act
+        var startTime = Stopwatch.GetTimestamp();
+        Thread.Sleep(10);
+        var endTime = Stopwatch.GetTimestamp();
+        renderingMetrics.RenderEnd(componentType, exception, startTime, endTime);
+
+        // Assert
+        var durationMeasurements = durationCollector.GetMeasurementSnapshot();
+
+        Assert.Single(durationMeasurements);
+        Assert.True(durationMeasurements[0].Value > 0);
+        Assert.Equal(componentType, durationMeasurements[0].Tags["component.type"]);
+        Assert.Equal(exception.GetType().FullName, durationMeasurements[0].Tags["error.type"]);
+    }
+
+    [Fact]
+    public void IsDurationEnabled_ReturnsMeterEnabledState()
+    {
+        // Arrange
+        var renderingMetrics = new RenderingMetrics(_meterFactory);
+
+        // Create a collector to ensure the meter is enabled
+        using var durationCollector = new MetricCollector<double>(_meterFactory,
+            RenderingMetrics.MeterName, "aspnetcore.components.rendering.duration");
+
+        // Act & Assert
+        Assert.True(renderingMetrics.IsDurationEnabled());
+    }
+
+    [Fact]
+    public void FullRenderingLifecycle_RecordsAllMetricsCorrectly()
+    {
+        // Arrange
+        var renderingMetrics = new RenderingMetrics(_meterFactory);
+        using var totalCounter = new MetricCollector<long>(_meterFactory,
+            RenderingMetrics.MeterName, "aspnetcore.components.rendering.count");
+        using var activeCounter = new MetricCollector<long>(_meterFactory,
+            RenderingMetrics.MeterName, "aspnetcore.components.rendering.active_renders");
+        using var durationCollector = new MetricCollector<double>(_meterFactory,
+            RenderingMetrics.MeterName, "aspnetcore.components.rendering.duration");
+
+        var componentType = "TestComponent";
+
+        // Act - Simulating a full rendering lifecycle
+        var startTime = Stopwatch.GetTimestamp();
+
+        // 1. Component render starts
+        renderingMetrics.RenderStart(componentType);
+
+        // 2. Component render ends
+        Thread.Sleep(10); // Add a small delay to ensure a measurable duration
+        var endTime = Stopwatch.GetTimestamp();
+        renderingMetrics.RenderEnd(componentType, null, startTime, endTime);
+
+        // Assert
+        var totalMeasurements = totalCounter.GetMeasurementSnapshot();
+        var activeMeasurements = activeCounter.GetMeasurementSnapshot();
+        var durationMeasurements = durationCollector.GetMeasurementSnapshot();
+
+        // Total render count should have 1 measurement with value 1
+        Assert.Single(totalMeasurements);
+        Assert.Equal(1, totalMeasurements[0].Value);
+        Assert.Equal(componentType, totalMeasurements[0].Tags["component.type"]);
+
+        // Active render count should have 2 measurements (1 for start, -1 for end)
+        Assert.Equal(2, activeMeasurements.Count);
+        Assert.Equal(1, activeMeasurements[0].Value);
+        Assert.Equal(-1, activeMeasurements[1].Value);
+        Assert.Equal(componentType, activeMeasurements[0].Tags["component.type"]);
+        Assert.Equal(componentType, activeMeasurements[1].Tags["component.type"]);
+
+        // Duration should have 1 measurement with a positive value
+        Assert.Single(durationMeasurements);
+        Assert.True(durationMeasurements[0].Value > 0);
+        Assert.Equal(componentType, durationMeasurements[0].Tags["component.type"]);
+    }
+
+    [Fact]
+    public void MultipleRenders_TracksMetricsIndependently()
+    {
+        // Arrange
+        var renderingMetrics = new RenderingMetrics(_meterFactory);
+        using var totalCounter = new MetricCollector<long>(_meterFactory,
+            RenderingMetrics.MeterName, "aspnetcore.components.rendering.count");
+        using var activeCounter = new MetricCollector<long>(_meterFactory,
+            RenderingMetrics.MeterName, "aspnetcore.components.rendering.active_renders");
+        using var durationCollector = new MetricCollector<double>(_meterFactory,
+            RenderingMetrics.MeterName, "aspnetcore.components.rendering.duration");
+
+        var componentType1 = "TestComponent1";
+        var componentType2 = "TestComponent2";
+
+        // Act
+        // First component render
+        var startTime1 = Stopwatch.GetTimestamp();
+        renderingMetrics.RenderStart(componentType1);
+
+        // Second component render starts while first is still rendering
+        var startTime2 = Stopwatch.GetTimestamp();
+        renderingMetrics.RenderStart(componentType2);
+
+        // First component render ends
+        Thread.Sleep(5);
+        var endTime1 = Stopwatch.GetTimestamp();
+        renderingMetrics.RenderEnd(componentType1, null, startTime1, endTime1);
+
+        // Second component render ends
+        Thread.Sleep(5);
+        var endTime2 = Stopwatch.GetTimestamp();
+        renderingMetrics.RenderEnd(componentType2, null, startTime2, endTime2);
+
+        // Assert
+        var totalMeasurements = totalCounter.GetMeasurementSnapshot();
+        var activeMeasurements = activeCounter.GetMeasurementSnapshot();
+        var durationMeasurements = durationCollector.GetMeasurementSnapshot();
+
+        // Should have 2 total render counts (one for each component)
+        Assert.Equal(2, totalMeasurements.Count);
+        Assert.Contains(totalMeasurements, m => m.Value == 1 && m.Tags["component.type"] as string == componentType1);
+        Assert.Contains(totalMeasurements, m => m.Value == 1 && m.Tags["component.type"] as string == componentType2);
+
+        // Should have 4 active render counts (start and end for each component)
+        Assert.Equal(4, activeMeasurements.Count);
+        Assert.Contains(activeMeasurements, m => m.Value == 1 && m.Tags["component.type"] as string == componentType1);
+        Assert.Contains(activeMeasurements, m => m.Value == 1 && m.Tags["component.type"] as string == componentType2);
+        Assert.Contains(activeMeasurements, m => m.Value == -1 && m.Tags["component.type"] as string == componentType1);
+        Assert.Contains(activeMeasurements, m => m.Value == -1 && m.Tags["component.type"] as string == componentType2);
+
+        // Should have 2 duration measurements (one for each component)
+        Assert.Equal(2, durationMeasurements.Count);
+        Assert.Contains(durationMeasurements, m => m.Value > 0 && m.Tags["component.type"] as string == componentType1);
+        Assert.Contains(durationMeasurements, m => m.Value > 0 && m.Tags["component.type"] as string == componentType2);
+    }
+}

--- a/src/Components/Server/src/Circuits/CircuitFactory.cs
+++ b/src/Components/Server/src/Circuits/CircuitFactory.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.Metrics;
 using System.Linq;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Components.Infrastructure;
@@ -20,11 +21,13 @@ internal sealed partial class CircuitFactory : ICircuitFactory
     private readonly CircuitIdFactory _circuitIdFactory;
     private readonly CircuitOptions _options;
     private readonly ILogger _logger;
+    private readonly CircuitMetrics? _circuitMetrics;
 
     public CircuitFactory(
         IServiceScopeFactory scopeFactory,
         ILoggerFactory loggerFactory,
         CircuitIdFactory circuitIdFactory,
+        CircuitMetrics? circuitMetrics,
         IOptions<CircuitOptions> options)
     {
         _scopeFactory = scopeFactory;
@@ -32,6 +35,8 @@ internal sealed partial class CircuitFactory : ICircuitFactory
         _circuitIdFactory = circuitIdFactory;
         _options = options.Value;
         _logger = _loggerFactory.CreateLogger<CircuitFactory>();
+
+        _circuitMetrics = circuitMetrics;
     }
 
     public async ValueTask<CircuitHost> CreateCircuitHostAsync(
@@ -104,6 +109,7 @@ internal sealed partial class CircuitFactory : ICircuitFactory
             jsRuntime,
             navigationManager,
             circuitHandlers,
+            _circuitMetrics,
             _loggerFactory.CreateLogger<CircuitHost>());
         Log.CreatedCircuit(_logger, circuitHost);
 

--- a/src/Components/Server/src/Circuits/CircuitFactory.cs
+++ b/src/Components/Server/src/Circuits/CircuitFactory.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.Metrics;
 using System.Linq;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Components.Infrastructure;

--- a/src/Components/Server/src/Circuits/CircuitHost.cs
+++ b/src/Components/Server/src/Circuits/CircuitHost.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Diagnostics.Metrics;
 using System.Globalization;
 using System.Linq;
 using System.Security.Claims;

--- a/src/Components/Server/src/Circuits/CircuitHost.cs
+++ b/src/Components/Server/src/Circuits/CircuitHost.cs
@@ -50,7 +50,7 @@ internal partial class CircuitHost : IAsyncDisposable
         RemoteJSRuntime jsRuntime,
         RemoteNavigationManager navigationManager,
         CircuitHandler[] circuitHandlers,
-        CircuitMetrics circuitMetrics,
+        CircuitMetrics? circuitMetrics,
         ILogger logger)
     {
         CircuitId = circuitId;
@@ -235,7 +235,7 @@ internal partial class CircuitHost : IAsyncDisposable
     private async Task OnCircuitOpenedAsync(CancellationToken cancellationToken)
     {
         Log.CircuitOpened(_logger, CircuitId);
-        _startTime = ((bool)_circuitMetrics?.IsDurationEnabled()) ? Stopwatch.GetTimestamp() : 0;
+        _startTime = (_circuitMetrics != null && _circuitMetrics.IsDurationEnabled()) ? Stopwatch.GetTimestamp() : 0;
         _circuitMetrics?.OnCircuitOpened();
 
         Renderer.Dispatcher.AssertAccess();

--- a/src/Components/Server/src/Circuits/CircuitMetrics.cs
+++ b/src/Components/Server/src/Circuits/CircuitMetrics.cs
@@ -1,0 +1,108 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Components.Server.Circuits;
+
+internal sealed class CircuitMetrics : IDisposable
+{
+    public const string MeterName = "Microsoft.AspNetCore.Components.Server.Circuits";
+
+    private readonly Meter _meter;
+    private readonly Counter<long> _circuitTotalCounter;
+    private readonly UpDownCounter<long> _circuitActiveCounter;
+    private readonly UpDownCounter<long> _circuitConnectedCounter;
+    private readonly Histogram<double> _circuitDuration;
+
+    public CircuitMetrics(IMeterFactory meterFactory)
+    {
+        _meter = meterFactory.Create(MeterName);
+
+        _circuitTotalCounter = _meter.CreateCounter<long>(
+            "aspnetcore.components.circuits.count",
+            unit: "{circuits}",
+            description: "Number of active circuits.");
+
+        _circuitActiveCounter = _meter.CreateUpDownCounter<long>(
+            "aspnetcore.components.circuits.active_circuits",
+            unit: "{circuits}",
+            description: "Number of active circuits.");
+
+        _circuitConnectedCounter = _meter.CreateUpDownCounter<long>(
+            "aspnetcore.components.circuits.connected_circuits",
+            unit: "{circuits}",
+            description: "Number of disconnected circuits.");
+
+        _circuitDuration = _meter.CreateHistogram<double>(
+            "aspnetcore.components.circuits.duration",
+            unit: "s",
+            description: "Duration of circuit.",
+            advice: new InstrumentAdvice<double> { HistogramBucketBoundaries = MetricsConstants.VeryLongSecondsBucketBoundaries });
+    }
+
+    public void OnCircuitOpened()
+    {
+        var tags = new TagList();
+
+        if (_circuitActiveCounter.Enabled)
+        {
+            _circuitActiveCounter.Add(1, tags);
+        }
+        if (_circuitTotalCounter.Enabled)
+        {
+            _circuitTotalCounter.Add(1, tags);
+        }
+    }
+
+    public void OnConnectionUp()
+    {
+        var tags = new TagList();
+
+        if (_circuitConnectedCounter.Enabled)
+        {
+            _circuitConnectedCounter.Add(1, tags);
+        }
+    }
+
+    public void OnConnectionDown()
+    {
+        var tags = new TagList();
+
+        if (_circuitConnectedCounter.Enabled)
+        {
+            _circuitConnectedCounter.Add(-1, tags);
+        }
+    }
+
+    public void OnCircuitDown(long startTimestamp, long currentTimestamp)
+    {
+        // Tags must match request start.
+        var tags = new TagList();
+
+        if (_circuitActiveCounter.Enabled)
+        {
+            _circuitActiveCounter.Add(-1, tags);
+        }
+
+        if (_circuitConnectedCounter.Enabled)
+        {
+            _circuitConnectedCounter.Add(-1, tags);
+        }
+
+        if (_circuitDuration.Enabled)
+        {
+            var duration = Stopwatch.GetElapsedTime(startTimestamp, currentTimestamp);
+            _circuitDuration.Record(duration.TotalSeconds, tags);
+        }
+    }
+
+    public bool IsDurationEnabled() => _circuitDuration.Enabled;
+
+    public void Dispose()
+    {
+        _meter.Dispose();
+    }
+}

--- a/src/Components/Server/src/Circuits/CircuitMetrics.cs
+++ b/src/Components/Server/src/Circuits/CircuitMetrics.cs
@@ -19,6 +19,8 @@ internal sealed class CircuitMetrics : IDisposable
 
     public CircuitMetrics(IMeterFactory meterFactory)
     {
+        Debug.Assert(meterFactory != null);
+
         _meter = meterFactory.Create(MeterName);
 
         _circuitTotalCounter = _meter.CreateCounter<long>(

--- a/src/Components/Server/src/DependencyInjection/ComponentServiceCollectionExtensions.cs
+++ b/src/Components/Server/src/DependencyInjection/ComponentServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Metrics;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Forms;
@@ -60,6 +61,12 @@ public static class ComponentServiceCollectionExtensions
         // Here we add a bunch of services that don't vary in any way based on the
         // user's configuration. So even if the user has multiple independent server-side
         // Components entrypoints, this lot is the same and repeated registrations are a no-op.
+
+        services.TryAddSingleton(s =>
+        {
+            var meterFactory = s.GetService<IMeterFactory>();
+            return meterFactory != null ? new CircuitMetrics(meterFactory) : null;
+        });
         services.TryAddSingleton<ICircuitFactory, CircuitFactory>();
         services.TryAddSingleton<ICircuitHandleRegistry, CircuitHandleRegistry>();
         services.TryAddSingleton<RootTypeCache>();

--- a/src/Components/Server/src/Microsoft.AspNetCore.Components.Server.csproj
+++ b/src/Components/Server/src/Microsoft.AspNetCore.Components.Server.csproj
@@ -26,7 +26,8 @@
 
     <Compile Include="$(SharedSourceRoot)ValueStopwatch\*.cs" />
     <Compile Include="$(SharedSourceRoot)LinkerFlags.cs" LinkBase="Shared" />
-    <Compile Include="$(SharedSourceRoot)\PooledArrayBufferWriter.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)PooledArrayBufferWriter.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Metrics\MetricsConstants.cs" LinkBase="Shared" />
 
     <!-- Add a project dependency without reference output assemblies to enforce build order -->
     <!-- Applying workaround for https://github.com/microsoft/msbuild/issues/2661 and https://github.com/dotnet/sdk/issues/952 -->

--- a/src/Components/Server/test/Circuits/CircuitMetricsTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitMetricsTest.cs
@@ -1,0 +1,204 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.JSInterop;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.InternalTesting;
+using Moq;
+
+namespace Microsoft.AspNetCore.Components.Server.Circuits;
+
+public class CircuitMetricsTest
+{
+    private readonly TestMeterFactory _meterFactory;
+
+    public CircuitMetricsTest()
+    {
+        _meterFactory = new TestMeterFactory();
+    }
+
+    [Fact]
+    public void Constructor_CreatesMetersCorrectly()
+    {
+        // Arrange & Act
+        var circuitMetrics = new CircuitMetrics(_meterFactory);
+
+        // Assert
+        Assert.Single(_meterFactory.Meters);
+        Assert.Equal(CircuitMetrics.MeterName, _meterFactory.Meters[0].Name);
+    }
+
+    [Fact]
+    public void OnCircuitOpened_IncreasesCounters()
+    {
+        // Arrange
+        var circuitMetrics = new CircuitMetrics(_meterFactory);
+        using var activeTotalCounter = new MetricCollector<long>(_meterFactory,
+            CircuitMetrics.MeterName, "aspnetcore.components.circuits.count");
+        using var activeCircuitCounter = new MetricCollector<long>(_meterFactory,
+            CircuitMetrics.MeterName, "aspnetcore.components.circuits.active_circuits");
+
+        // Act
+        circuitMetrics.OnCircuitOpened();
+
+        // Assert
+        var totalMeasurements = activeTotalCounter.GetMeasurementSnapshot();
+        var activeMeasurements = activeCircuitCounter.GetMeasurementSnapshot();
+
+        Assert.Single(totalMeasurements);
+        Assert.Equal(1, totalMeasurements[0].Value);
+
+        Assert.Single(activeMeasurements);
+        Assert.Equal(1, activeMeasurements[0].Value);
+    }
+
+    [Fact]
+    public void OnConnectionUp_IncreasesConnectedCounter()
+    {
+        // Arrange
+        var circuitMetrics = new CircuitMetrics(_meterFactory);
+        using var connectedCircuitCounter = new MetricCollector<long>(_meterFactory,
+            CircuitMetrics.MeterName, "aspnetcore.components.circuits.connected_circuits");
+
+        // Act
+        circuitMetrics.OnConnectionUp();
+
+        // Assert
+        var measurements = connectedCircuitCounter.GetMeasurementSnapshot();
+
+        Assert.Single(measurements);
+        Assert.Equal(1, measurements[0].Value);
+    }
+
+    [Fact]
+    public void OnConnectionDown_DecreasesConnectedCounter()
+    {
+        // Arrange
+        var circuitMetrics = new CircuitMetrics(_meterFactory);
+        using var connectedCircuitCounter = new MetricCollector<long>(_meterFactory,
+            CircuitMetrics.MeterName, "aspnetcore.components.circuits.connected_circuits");
+
+        // Act
+        circuitMetrics.OnConnectionDown();
+
+        // Assert
+        var measurements = connectedCircuitCounter.GetMeasurementSnapshot();
+
+        Assert.Single(measurements);
+        Assert.Equal(-1, measurements[0].Value);
+    }
+
+    [Fact]
+    public void OnCircuitDown_UpdatesCountersAndRecordsDuration()
+    {
+        // Arrange
+        var circuitMetrics = new CircuitMetrics(_meterFactory);
+        using var activeCircuitCounter = new MetricCollector<long>(_meterFactory,
+            CircuitMetrics.MeterName, "aspnetcore.components.circuits.active_circuits");
+        using var connectedCircuitCounter = new MetricCollector<long>(_meterFactory,
+            CircuitMetrics.MeterName, "aspnetcore.components.circuits.connected_circuits");
+        using var circuitDurationCollector = new MetricCollector<double>(_meterFactory,
+            CircuitMetrics.MeterName, "aspnetcore.components.circuits.duration");
+
+        // Act
+        var startTime = Stopwatch.GetTimestamp();
+        Thread.Sleep(10); // Add a small delay to ensure a measurable duration
+        var endTime = Stopwatch.GetTimestamp();
+        circuitMetrics.OnCircuitDown(startTime, endTime);
+
+        // Assert
+        var activeMeasurements = activeCircuitCounter.GetMeasurementSnapshot();
+        var connectedMeasurements = connectedCircuitCounter.GetMeasurementSnapshot();
+        var durationMeasurements = circuitDurationCollector.GetMeasurementSnapshot();
+
+        Assert.Single(activeMeasurements);
+        Assert.Equal(-1, activeMeasurements[0].Value);
+
+        Assert.Single(connectedMeasurements);
+        Assert.Equal(-1, connectedMeasurements[0].Value);
+
+        Assert.Single(durationMeasurements);
+        Assert.True(durationMeasurements[0].Value > 0);
+    }
+
+    [Fact]
+    public void IsDurationEnabled_ReturnsMeterEnabledState()
+    {
+        // Arrange
+        var circuitMetrics = new CircuitMetrics(_meterFactory);
+
+        // Create a collector to ensure the meter is enabled
+        using var circuitDurationCollector = new MetricCollector<double>(_meterFactory,
+            CircuitMetrics.MeterName, "aspnetcore.components.circuits.duration");
+
+        // Act & Assert
+        Assert.True(circuitMetrics.IsDurationEnabled());
+    }
+
+    [Fact]
+    public void FullCircuitLifecycle_RecordsAllMetricsCorrectly()
+    {
+        // Arrange
+        var circuitMetrics = new CircuitMetrics(_meterFactory);
+        using var totalCounter = new MetricCollector<long>(_meterFactory,
+            CircuitMetrics.MeterName, "aspnetcore.components.circuits.count");
+        using var activeCircuitCounter = new MetricCollector<long>(_meterFactory,
+            CircuitMetrics.MeterName, "aspnetcore.components.circuits.active_circuits");
+        using var connectedCircuitCounter = new MetricCollector<long>(_meterFactory,
+            CircuitMetrics.MeterName, "aspnetcore.components.circuits.connected_circuits");
+        using var circuitDurationCollector = new MetricCollector<double>(_meterFactory,
+            CircuitMetrics.MeterName, "aspnetcore.components.circuits.duration");
+
+        // Act - Simulating a full circuit lifecycle
+        var startTime = Stopwatch.GetTimestamp();
+
+        // 1. Circuit opens
+        circuitMetrics.OnCircuitOpened();
+
+        // 2. Connection established
+        circuitMetrics.OnConnectionUp();
+
+        // 3. Connection drops
+        circuitMetrics.OnConnectionDown();
+
+        // 4. Connection re-established
+        circuitMetrics.OnConnectionUp();
+
+        // 5. Circuit closes
+        Thread.Sleep(10); // Add a small delay to ensure a measurable duration
+        var endTime = Stopwatch.GetTimestamp();
+        circuitMetrics.OnCircuitDown(startTime, endTime);
+
+        // Assert
+        var totalMeasurements = totalCounter.GetMeasurementSnapshot();
+        var activeMeasurements = activeCircuitCounter.GetMeasurementSnapshot();
+        var connectedMeasurements = connectedCircuitCounter.GetMeasurementSnapshot();
+        var durationMeasurements = circuitDurationCollector.GetMeasurementSnapshot();
+
+        // Total circuit count should have 1 measurement with value 1
+        Assert.Single(totalMeasurements);
+        Assert.Equal(1, totalMeasurements[0].Value);
+
+        // Active circuit count should have 2 measurements (1 for open, -1 for close)
+        Assert.Equal(2, activeMeasurements.Count);
+        Assert.Equal(1, activeMeasurements[0].Value);
+        Assert.Equal(-1, activeMeasurements[1].Value);
+
+        // Connected circuit count should have 4 measurements (connecting, disconnecting, reconnecting, closing)
+        Assert.Equal(4, connectedMeasurements.Count);
+        Assert.Equal(1, connectedMeasurements[0].Value);
+        Assert.Equal(-1, connectedMeasurements[1].Value);
+        Assert.Equal(1, connectedMeasurements[2].Value);
+        Assert.Equal(-1, connectedMeasurements[3].Value);
+
+        // Duration should have 1 measurement with a positive value
+        Assert.Single(durationMeasurements);
+        Assert.True(durationMeasurements[0].Value > 0);
+    }
+}

--- a/src/Components/Server/test/Circuits/TestCircuitHost.cs
+++ b/src/Components/Server/test/Circuits/TestCircuitHost.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.Metrics;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -13,8 +15,8 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits;
 
 internal class TestCircuitHost : CircuitHost
 {
-    private TestCircuitHost(CircuitId circuitId, AsyncServiceScope scope, CircuitOptions options, CircuitClientProxy client, RemoteRenderer renderer, IReadOnlyList<ComponentDescriptor> descriptors, RemoteJSRuntime jsRuntime, RemoteNavigationManager navigationManager, CircuitHandler[] circuitHandlers, ILogger logger)
-        : base(circuitId, scope, options, client, renderer, descriptors, jsRuntime, navigationManager, circuitHandlers, logger)
+    private TestCircuitHost(CircuitId circuitId, AsyncServiceScope scope, CircuitOptions options, CircuitClientProxy client, RemoteRenderer renderer, IReadOnlyList<ComponentDescriptor> descriptors, RemoteJSRuntime jsRuntime, RemoteNavigationManager navigationManager, CircuitHandler[] circuitHandlers, CircuitMetrics circuitMetrics, ILogger logger)
+        : base(circuitId, scope, options, client, renderer, descriptors, jsRuntime, navigationManager, circuitHandlers, circuitMetrics, logger)
     {
     }
 
@@ -35,6 +37,7 @@ internal class TestCircuitHost : CircuitHost
             .Setup(services => services.GetService(typeof(IJSRuntime)))
             .Returns(jsRuntime);
         var serverComponentDeserializer = Mock.Of<IServerComponentDeserializer>();
+        var circuitMetrics = new CircuitMetrics(new TestMeterFactory());
 
         if (remoteRenderer == null)
         {
@@ -60,6 +63,7 @@ internal class TestCircuitHost : CircuitHost
             jsRuntime,
             navigationManager,
             handlers,
+            circuitMetrics,
             NullLogger<CircuitHost>.Instance);
     }
 }

--- a/src/Components/Server/test/Microsoft.AspNetCore.Components.Server.Tests.csproj
+++ b/src/Components/Server/test/Microsoft.AspNetCore.Components.Server.Tests.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Components.Server" />
     <Reference Include="Microsoft.AspNetCore.Html.Abstractions" />
+    <Reference Include="Microsoft.Extensions.Diagnostics.Testing" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -14,6 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(SharedSourceRoot)Metrics\TestMeterFactory.cs" LinkBase="shared" />
+
     <Compile Include="$(SignalRTestBase)HubMessageHelpers.cs" LinkBase="BlazorPack" />
     <Compile Include="$(SignalRTestBase)MessagePackHubProtocolTestBase.cs" LinkBase="BlazorPack" />
     <Compile Include="$(SignalRTestBase)TestBinder.cs" LinkBase="BlazorPack" />

--- a/src/Shared/Metrics/MetricsConstants.cs
+++ b/src/Shared/Metrics/MetricsConstants.cs
@@ -10,4 +10,7 @@ internal static class MetricsConstants
 
     // Not based on a standard. Larger bucket sizes for longer lasting operations, e.g. HTTP connection duration. See https://github.com/open-telemetry/semantic-conventions/issues/336
     public static readonly IReadOnlyList<double> LongSecondsBucketBoundaries = [0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120, 300];
+
+    // For Blazor/signalR sessions, which can last a long time.
+    public static readonly IReadOnlyList<double> VeryLongSecondsBucketBoundaries = [0.5, 1, 2, 5, 10, 30, 60, 120, 300, 600, 1500, 60*60, 2 * 60 * 60, 4 * 60 * 60];
 }


### PR DESCRIPTION
# Blazor - rendering metrics

new `Microsoft.AspNetCore.Components.Rendering` meter
- has `component.type` which is `GetType().FullName` of the component being rendered
- `aspnetcore.components.rendering.count`  
    - this is total count, always growing. The viewer could calculate "component render/minute"
- `aspnetcore.components.rendering.duration` 
    - per component

new `Microsoft.AspNetCore.Components.Server.Circuits` meter
- `aspnetcore.components.circuits.count` 
    - this is total count, always growing. The viewer could calculate "new circuits/minute"
- `aspnetcore.components.circuits.active_circuits` 
    - in server memory
- `aspnetcore.components.circuits.connected_circuits` 
    - with connected signalR
- `aspnetcore.components.circuits.duration` 
    - from creation until GC


# How to enable with OpenTelemetry/Aspire

```cs
builder.Services.ConfigureOpenTelemetryMeterProvider(meterProvider =>
{
    meterProvider.AddMeter("Microsoft.AspNetCore.Components.Rendering");
    meterProvider.AddMeter("Microsoft.AspNetCore.Components.Server.Circuits");
});
```

Fixes https://github.com/dotnet/aspnetcore/issues/53613


![image](https://github.com/user-attachments/assets/46ea942c-7687-4b11-a0a4-d151632c5342)

