### PR TITLE
[Blazor] Explicitly opt-out from inlining boot config in tests

### DIFF
--- a/src/Components/WebAssembly/Directory.Build.props
+++ b/src/Components/WebAssembly/Directory.Build.props
@@ -4,4 +4,7 @@
     <!-- Avoid source build issues with WebAssembly -->
     <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
   </PropertyGroup>
+  <PropertyGroup>
+    <WasmInlineBootConfig>false</WasmInlineBootConfig>
+  </PropertyGroup>
 </Project>

--- a/src/Components/test/testassets/Directory.Build.props
+++ b/src/Components/test/testassets/Directory.Build.props
@@ -19,4 +19,7 @@
       <_Parameter2>true</_Parameter2>
     </AssemblyAttribute>
   </ItemGroup>
+  <PropertyGroup>
+    <WasmInlineBootConfig>false</WasmInlineBootConfig>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/77191
Pre-requisite for https://github.com/dotnet/runtime/pull/114686