### PR TITLE
Build Windows local test job in official builds

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -657,6 +657,7 @@ extends:
                       -NoRestore
                       -NoBuild
                       -NoBuildDeps
+                      -NoBuildRepoTasks
                       -configuration Release
                       -bl
                       -ci

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -632,43 +632,42 @@ extends:
               includeForks: true
 
         # Local development validation
-        - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
-          - template: .azure/pipelines/jobs/default-build.yml@self
-            parameters:
-              jobName: Local_Windows
-              jobDisplayName: 'Test: Windows local development validation'
-              agentOs: Windows
-              isAzDOTestingJob: true
-              timeoutInMinutes: 240
-              steps:
-              - script: git submodule update --init
-                displayName: Update submodules
-              - script: ./restore.cmd
-                displayName: Run restore.cmd
-              - powershell: ./eng/build.ps1 -all -noBuildJava -noBuildNodeJS "-WarnAsError:false"
-                displayName: Build (No NodeJS)
-              - script: npm run build
-                displayName: Build JS
-              - script: ./eng/build.cmd -all -noBuildJava -pack -c Debug
-                displayName: Build (Debug)
-              - script: ./eng/build.cmd -all -noBuildJava -pack -c Release
-                displayName: Build (Release)
-              - script: ./src/ProjectTemplates/build.cmd
-                        -test
-                        -NoRestore
-                        -NoBuild
-                        -NoBuildDeps
-                        -configuration Release
-                        -bl
-                displayName: Run project template tests
-              - powershell: . ./activate.ps1; ./src/ProjectTemplates/scripts/Run-BlazorWeb-Locally.ps1 -Verbose
-                displayName: Run Blazor web app test script
+        - template: .azure/pipelines/jobs/default-build.yml@self
+          parameters:
+            jobName: Local_Windows
+            jobDisplayName: 'Test: Windows local development validation'
+            agentOs: Windows
+            isAzDOTestingJob: true
+            timeoutInMinutes: 240
+            steps:
+            - script: git submodule update --init
+              displayName: Update submodules
+            - script: ./restore.cmd
+              displayName: Run restore.cmd
+            - powershell: ./eng/build.ps1 -all -noBuildJava -noBuildNodeJS "-WarnAsError:false"
+              displayName: Build (No NodeJS)
+            - script: npm run build
+              displayName: Build JS
+            - script: ./eng/build.cmd -all -noBuildJava -pack -c Debug
+              displayName: Build (Debug)
+            - script: ./eng/build.cmd -all -noBuildJava -pack -c Release
+              displayName: Build (Release)
+            - script: ./src/ProjectTemplates/build.cmd
+                      -test
+                      -NoRestore
+                      -NoBuild
+                      -NoBuildDeps
+                      -configuration Release
+                      -bl
+              displayName: Run project template tests
+            - powershell: . ./activate.ps1; ./src/ProjectTemplates/scripts/Run-BlazorWeb-Locally.ps1 -Verbose
+              displayName: Run Blazor web app test script
 
-              artifacts:
-              - name: Local_Windows_x64_Logs_Attempt_$(System.JobAttempt)
-                path: artifacts/log/
-                publishOnError: true
-                includeForks: true
+            artifacts:
+            - name: Local_Windows_x64_Logs_Attempt_$(System.JobAttempt)
+              path: artifacts/log/
+              publishOnError: true
+              includeForks: true
 
       # Source build
       - template: /eng/common/templates-official/job/source-build.yml@self

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -632,42 +632,43 @@ extends:
               includeForks: true
 
         # Local development validation
-        - template: .azure/pipelines/jobs/default-build.yml@self
-          parameters:
-            jobName: Local_Windows
-            jobDisplayName: 'Test: Windows local development validation'
-            agentOs: Windows
-            isAzDOTestingJob: true
-            timeoutInMinutes: 240
-            steps:
-            - script: git submodule update --init
-              displayName: Update submodules
-            - script: ./restore.cmd
-              displayName: Run restore.cmd
-            - powershell: ./eng/build.ps1 -all -noBuildJava -noBuildNodeJS "-WarnAsError:false"
-              displayName: Build (No NodeJS)
-            - script: npm run build
-              displayName: Build JS
-            - script: ./eng/build.cmd -all -noBuildJava -pack -c Debug
-              displayName: Build (Debug)
-            - script: ./eng/build.cmd -all -noBuildJava -pack -c Release
-              displayName: Build (Release)
-            - script: ./src/ProjectTemplates/build.cmd
-                      -test
-                      -NoRestore
-                      -NoBuild
-                      -NoBuildDeps
-                      -configuration Release
-                      -bl
-              displayName: Run project template tests
-            - powershell: . ./activate.ps1; ./src/ProjectTemplates/scripts/Run-BlazorWeb-Locally.ps1 -Verbose
-              displayName: Run Blazor web app test script
+        - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+          - template: .azure/pipelines/jobs/default-build.yml@self
+            parameters:
+              jobName: Local_Windows
+              jobDisplayName: 'Test: Windows local development validation'
+              agentOs: Windows
+              isAzDOTestingJob: true
+              timeoutInMinutes: 240
+              steps:
+              - script: git submodule update --init
+                displayName: Update submodules
+              - script: ./restore.cmd
+                displayName: Run restore.cmd
+              - powershell: ./eng/build.ps1 -all -noBuildJava -noBuildNodeJS "-WarnAsError:false"
+                displayName: Build (No NodeJS)
+              - script: npm run build
+                displayName: Build JS
+              - script: ./eng/build.cmd -all -noBuildJava -pack -c Debug
+                displayName: Build (Debug)
+              - script: ./eng/build.cmd -all -noBuildJava -pack -c Release
+                displayName: Build (Release)
+              - script: ./src/ProjectTemplates/build.cmd
+                        -test
+                        -NoRestore
+                        -NoBuild
+                        -NoBuildDeps
+                        -configuration Release
+                        -bl
+                displayName: Run project template tests
+              - powershell: . ./activate.ps1; ./src/ProjectTemplates/scripts/Run-BlazorWeb-Locally.ps1 -Verbose
+                displayName: Run Blazor web app test script
 
-            artifacts:
-            - name: Local_Windows_x64_Logs_Attempt_$(System.JobAttempt)
-              path: artifacts/log/
-              publishOnError: true
-              includeForks: true
+              artifacts:
+              - name: Local_Windows_x64_Logs_Attempt_$(System.JobAttempt)
+                path: artifacts/log/
+                publishOnError: true
+                includeForks: true
 
       # Source build
       - template: /eng/common/templates-official/job/source-build.yml@self

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -534,32 +534,32 @@ extends:
           parameters:
             inputName: Linux_musl_arm64
 
+      - template: .azure/pipelines/jobs/default-build.yml@self
+        parameters:
+          jobName: Windows_Test
+          jobDisplayName: "Test: Windows Server x64"
+          agentOs: Windows
+          isAzDOTestingJob: true
+          # Just uploading artifacts/logs/ files can take 15 minutes. Doubling the cancel timeout for this job.
+          cancelTimeoutInMinutes: 30
+          buildArgs: -all -pack -test -binaryLog /p:SkipHelixReadyTests=true /p:SkipIISNewHandlerTests=true /p:SkipIISTests=true
+                     /p:SkipIISExpressTests=true /p:SkipIISNewShimTests=true /p:RunBlazorPlaywrightTemplateTests=true /p:DoNotCleanUpTemplates=true
+                     $(_InternalRuntimeDownloadArgs)
+          beforeBuild:
+          - powershell: "& ./src/Servers/IIS/tools/UpdateIISExpressCertificate.ps1; & ./src/Servers/IIS/tools/update_schema.ps1"
+            displayName: Setup IISExpress test certificates and schema
+          artifacts:
+          - name: Windows_Test_Logs_Attempt_$(System.JobAttempt)
+            path: artifacts/log/
+            publishOnError: true
+            includeForks: true
+          - name: Windows_Test_Results_Attempt_$(System.JobAttempt)
+            path: artifacts/TestResults/
+            publishOnError: true
+            includeForks: true
+
       - ${{ if and(ne(parameters.skipTests, 'true'), in(variables['Build.Reason'], 'PullRequest', 'Manual')) }}:
         # Test jobs
-        - template: .azure/pipelines/jobs/default-build.yml@self
-          parameters:
-            jobName: Windows_Test
-            jobDisplayName: "Test: Windows Server x64"
-            agentOs: Windows
-            isAzDOTestingJob: true
-            # Just uploading artifacts/logs/ files can take 15 minutes. Doubling the cancel timeout for this job.
-            cancelTimeoutInMinutes: 30
-            buildArgs: -all -pack -test -binaryLog /p:SkipHelixReadyTests=true /p:SkipIISNewHandlerTests=true /p:SkipIISTests=true
-                       /p:SkipIISExpressTests=true /p:SkipIISNewShimTests=true /p:RunTemplateTests=false /p:RunBlazorPlaywrightTemplateTests=true
-                       $(_InternalRuntimeDownloadArgs)
-            beforeBuild:
-            - powershell: "& ./src/Servers/IIS/tools/UpdateIISExpressCertificate.ps1; & ./src/Servers/IIS/tools/update_schema.ps1"
-              displayName: Setup IISExpress test certificates and schema
-            artifacts:
-            - name: Windows_Test_Logs_Attempt_$(System.JobAttempt)
-              path: artifacts/log/
-              publishOnError: true
-              includeForks: true
-            - name: Windows_Test_Results_Attempt_$(System.JobAttempt)
-              path: artifacts/TestResults/
-              publishOnError: true
-              includeForks: true
-
         - template: .azure/pipelines/jobs/default-build.yml@self
           parameters:
             jobName: MacOS_Test
@@ -632,43 +632,42 @@ extends:
               includeForks: true
 
         # Local development validation
-        - template: .azure/pipelines/jobs/default-build.yml@self
-          parameters:
-            jobName: Local_Windows
-            jobDisplayName: 'Test: Windows local development validation'
-            agentOs: Windows
-            isAzDOTestingJob: true
-            timeoutInMinutes: 240
-            steps:
-            - script: git submodule update --init
-              displayName: Update submodules
-            - script: ./restore.cmd
-              displayName: Run restore.cmd
-            - powershell: ./eng/build.ps1 -all -noBuildJava -noBuildNodeJS "-WarnAsError:false"
-              displayName: Build (No NodeJS)
-            - script: npm run build
-              displayName: Build JS
-            - script: ./eng/build.cmd -all -noBuildJava -pack -c Debug /p:ContinuousIntegrationBuild=true
-              displayName: Build (Debug)
-            - script: ./eng/build.cmd -all -noBuildJava -pack -c Release /p:ContinuousIntegrationBuild=true
-              displayName: Build (Release)
-            - script: ./src/ProjectTemplates/build.cmd
-                      -test
-                      -NoRestore
-                      -NoBuild
-                      -NoBuildDeps
-                      -configuration Release
-                      -bl
-                      /p:ContinuousIntegrationBuild=true
-              displayName: Run project template tests
-            - powershell: . ./activate.ps1; ./src/ProjectTemplates/scripts/Run-BlazorWeb-Locally.ps1 -Verbose
-              displayName: Run Blazor web app test script
+        - ${{ if in(variables['Build.Reason'], 'PullRequest', 'Manual') }}:
+          - template: .azure/pipelines/jobs/default-build.yml@self
+            parameters:
+              jobName: Local_Windows
+              jobDisplayName: 'Test: Windows local development validation'
+              agentOs: Windows
+              isAzDOTestingJob: true
+              timeoutInMinutes: 240
+              steps:
+              - script: git submodule update --init
+                displayName: Update submodules
+              - script: ./restore.cmd
+                displayName: Run restore.cmd
+              - script: ./eng/build.cmd -all -noBuildJava -noBuildNodeJS
+                displayName: Build (No NodeJS)
+              - script: npm run build
+                displayName: Build JS
+              - script: ./eng/build.cmd -all -noBuildJava -pack -c Debug
+                displayName: Build (Debug)
+              - script: ./eng/build.cmd -all -noBuildJava -pack -c Release
+                displayName: Build (Release)
+              - script: ./src/ProjectTemplates/build.cmd
+                        -test
+                        -NoRestore
+                        -NoBuild
+                        -NoBuildDeps
+                        -configuration Release
+                displayName: Run project template tests
+              - powershell: . ./activate.ps1; ./src/ProjectTemplates/scripts/Run-BlazorWeb-Locally.ps1 -Verbose
+                displayName: Run Blazor web app test script
 
-            artifacts:
-            - name: Local_Windows_x64_Logs_Attempt_$(System.JobAttempt)
-              path: artifacts/log/
-              publishOnError: true
-              includeForks: true
+              artifacts:
+              - name: Local_Windows_x64_Logs_Attempt_$(System.JobAttempt)
+                path: artifacts/log/
+                publishOnError: true
+                includeForks: true
 
       # Source build
       - template: /eng/common/templates-official/job/source-build.yml@self

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -644,7 +644,7 @@ extends:
               displayName: Update submodules
             - script: ./restore.cmd
               displayName: Run restore.cmd
-            - script: ./eng/build.cmd -all -noBuildJava -noBuildNodeJS "-WarnAsError:false"
+            - powershell: ./eng/build.ps1 -all -noBuildJava -noBuildNodeJS "-WarnAsError:false"
               displayName: Build (No NodeJS)
             - script: npm run build
               displayName: Build JS

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -657,10 +657,9 @@ extends:
                       -NoRestore
                       -NoBuild
                       -NoBuildDeps
-                      -NoBuildRepoTasks
                       -configuration Release
                       -bl
-                      -ci
+                      /p:ContinuousIntegrationBuild=true
               displayName: Run project template tests
             - powershell: . ./activate.ps1; ./src/ProjectTemplates/scripts/Run-BlazorWeb-Locally.ps1 -Verbose
               displayName: Run Blazor web app test script

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -632,42 +632,42 @@ extends:
               includeForks: true
 
         # Local development validation
-        - ${{ if in(variables['Build.Reason'], 'PullRequest', 'Manual') }}:
-          - template: .azure/pipelines/jobs/default-build.yml@self
-            parameters:
-              jobName: Local_Windows
-              jobDisplayName: 'Test: Windows local development validation'
-              agentOs: Windows
-              isAzDOTestingJob: true
-              timeoutInMinutes: 240
-              steps:
-              - script: git submodule update --init
-                displayName: Update submodules
-              - script: ./restore.cmd
-                displayName: Run restore.cmd
-              - script: ./eng/build.cmd -all -noBuildJava -noBuildNodeJS
-                displayName: Build (No NodeJS)
-              - script: npm run build
-                displayName: Build JS
-              - script: ./eng/build.cmd -all -noBuildJava -pack -c Debug
-                displayName: Build (Debug)
-              - script: ./eng/build.cmd -all -noBuildJava -pack -c Release
-                displayName: Build (Release)
-              - script: ./src/ProjectTemplates/build.cmd
-                        -test
-                        -NoRestore
-                        -NoBuild
-                        -NoBuildDeps
-                        -configuration Release
-                displayName: Run project template tests
-              - powershell: . ./activate.ps1; ./src/ProjectTemplates/scripts/Run-BlazorWeb-Locally.ps1 -Verbose
-                displayName: Run Blazor web app test script
+        - template: .azure/pipelines/jobs/default-build.yml@self
+          parameters:
+            jobName: Local_Windows
+            jobDisplayName: 'Test: Windows local development validation'
+            agentOs: Windows
+            isAzDOTestingJob: true
+            timeoutInMinutes: 240
+            steps:
+            - script: git submodule update --init
+              displayName: Update submodules
+            - script: ./restore.cmd
+              displayName: Run restore.cmd
+            - script: ./eng/build.cmd -all -noBuildJava -noBuildNodeJS "-WarnAsError:false"
+              displayName: Build (No NodeJS)
+            - script: npm run build
+              displayName: Build JS
+            - script: ./eng/build.cmd -all -noBuildJava -pack -c Debug
+              displayName: Build (Debug)
+            - script: ./eng/build.cmd -all -noBuildJava -pack -c Release
+              displayName: Build (Release)
+            - script: ./src/ProjectTemplates/build.cmd
+                      -test
+                      -NoRestore
+                      -NoBuild
+                      -NoBuildDeps
+                      -configuration Release
+                      -bl
+              displayName: Run project template tests
+            - powershell: . ./activate.ps1; ./src/ProjectTemplates/scripts/Run-BlazorWeb-Locally.ps1 -Verbose
+              displayName: Run Blazor web app test script
 
-              artifacts:
-              - name: Local_Windows_x64_Logs_Attempt_$(System.JobAttempt)
-                path: artifacts/log/
-                publishOnError: true
-                includeForks: true
+            artifacts:
+            - name: Local_Windows_x64_Logs_Attempt_$(System.JobAttempt)
+              path: artifacts/log/
+              publishOnError: true
+              includeForks: true
 
       # Source build
       - template: /eng/common/templates-official/job/source-build.yml@self

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -648,9 +648,9 @@ extends:
               displayName: Build (No NodeJS)
             - script: npm run build
               displayName: Build JS
-            - script: ./eng/build.cmd -all -noBuildJava -pack -c Debug
+            - script: ./eng/build.cmd -all -noBuildJava -pack -c Debug /p:ContinuousIntegrationBuild=true
               displayName: Build (Debug)
-            - script: ./eng/build.cmd -all -noBuildJava -pack -c Release
+            - script: ./eng/build.cmd -all -noBuildJava -pack -c Release /p:ContinuousIntegrationBuild=true
               displayName: Build (Release)
             - script: ./src/ProjectTemplates/build.cmd
                       -test

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -659,6 +659,7 @@ extends:
                       -NoBuildDeps
                       -configuration Release
                       -bl
+                      -ci
               displayName: Run project template tests
             - powershell: . ./activate.ps1; ./src/ProjectTemplates/scripts/Run-BlazorWeb-Locally.ps1 -Verbose
               displayName: Run Blazor web app test script

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -119,7 +119,7 @@
     <IsPackable Condition="'$(IsPackable)' == '' ">false</IsPackable>
 
     <BuildHelixPayload Condition="'$(BuildHelixPayload)' == '' AND $(IsTestProject) ">true</BuildHelixPayload>
-    <SkipTests Condition="'$(SkipHelixReadyTests)' == 'true' AND '$(BuildHelixPayload)' == 'true'">true</SkipTests>
+    <SkipTests Condition="'$(SkipTests)' == '' AND '$(SkipHelixReadyTests)' == 'true' AND '$(BuildHelixPayload)' == 'true'">true</SkipTests>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/eng/RequiresDelayedBuildProjects.props
+++ b/eng/RequiresDelayedBuildProjects.props
@@ -22,6 +22,10 @@
     <RequiresDelayedBuild Include="$(RepoRoot)src\Grpc\JsonTranscoding\test\testassets\Sandbox\Sandbox.csproj" />
     <RequiresDelayedBuild Include="$(RepoRoot)src\OpenApi\test\Microsoft.AspNetCore.OpenApi.NativeAotTests\Microsoft.AspNetCore.OpenApi.NativeAotTests.proj" />
     <RequiresDelayedBuild Include="$(RepoRoot)src\ProjectTemplates\test\Templates.Blazor.Tests\Templates.Blazor.Tests.csproj" />
+    <RequiresDelayedBuild Include="$(RepoRoot)src\ProjectTemplates\test\Templates.Blazor.WebAssembly.Auth.Tests\Templates.Blazor.WebAssembly.Auth.Tests.csproj" />
+    <RequiresDelayedBuild Include="$(RepoRoot)src\ProjectTemplates\test\Templates.Blazor.WebAssembly.Tests\Templates.Blazor.WebAssembly.Tests.csproj" />
+    <RequiresDelayedBuild Include="$(RepoRoot)src\ProjectTemplates\test\Templates.Mvc.Tests\Templates.Mvc.Tests.csproj" />
+    <RequiresDelayedBuild Include="$(RepoRoot)src\ProjectTemplates\test\Templates.Tests\Templates.Tests.csproj" />
     <RequiresDelayedBuild Include="$(RepoRoot)src\SignalR\server\SignalR\test\Microsoft.AspNetCore.SignalR.TrimmingTests\Microsoft.AspNetCore.SignalR.TrimmingTests.proj" />
     <RequiresDelayedBuild Include="$(RepoRoot)eng\Npm.Workspace.FunctionalTests.nodeproj" />
   </ItemGroup>

--- a/src/ProjectTemplates/Shared/Project.cs
+++ b/src/ProjectTemplates/Shared/Project.cs
@@ -429,7 +429,7 @@ public class Project : IDisposable
         var continuousIntegrationBuild = typeof(ProjectFactoryFixture).Assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
             .Single(attribute => attribute.Key == "ContinuousIntegrationBuild")
             .Value;
-        if (string.Equals(continuousIntegrationBuild, "false", StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(continuousIntegrationBuild, "true", StringComparison.OrdinalIgnoreCase))
         {
             DeleteOutputDirectory();
         }

--- a/src/ProjectTemplates/Shared/Project.cs
+++ b/src/ProjectTemplates/Shared/Project.cs
@@ -45,10 +45,6 @@ public class Project : IDisposable
             .Value
         : Environment.GetEnvironmentVariable("DotNetEfFullPath");
 
-    private static bool ContinuousIntegrationBuild => (string.Equals(typeof(ProjectFactoryFixture).Assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
-            .Single(attribute => attribute.Key == "ContinuousIntegrationBuild")
-            .Value), "true", StringComparison.OrdinalIgnoreCase);
-
     public string ProjectName { get; set; }
     public string ProjectArguments { get; set; }
     public string ProjectGuid { get; set; }
@@ -430,7 +426,10 @@ public class Project : IDisposable
 
     public void Dispose()
     {
-        if (ContinuousIntegrationBuild)
+        var continuousIntegrationBuild = typeof(ProjectFactoryFixture).Assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
+            .Single(attribute => attribute.Key == "ContinuousIntegrationBuild")
+            .Value;
+        if (string.Equals(continuousIntegrationBuild, "true", StringComparison.OrdinalIgnoreCase))
         {
             DeleteOutputDirectory();
         }

--- a/src/ProjectTemplates/Shared/Project.cs
+++ b/src/ProjectTemplates/Shared/Project.cs
@@ -429,7 +429,7 @@ public class Project : IDisposable
         var continuousIntegrationBuild = typeof(ProjectFactoryFixture).Assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
             .Single(attribute => attribute.Key == "ContinuousIntegrationBuild")
             .Value;
-        if (string.Equals(continuousIntegrationBuild, "true", StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(continuousIntegrationBuild, "false", StringComparison.OrdinalIgnoreCase))
         {
             DeleteOutputDirectory();
         }

--- a/src/ProjectTemplates/Shared/Project.cs
+++ b/src/ProjectTemplates/Shared/Project.cs
@@ -426,10 +426,10 @@ public class Project : IDisposable
 
     public void Dispose()
     {
-        var continuousIntegrationBuild = typeof(ProjectFactoryFixture).Assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
-            .Single(attribute => attribute.Key == "ContinuousIntegrationBuild")
+        var doNotCleanUpTemplates = typeof(ProjectFactoryFixture).Assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
+            .Single(attribute => attribute.Key == "DoNotCleanUpTemplates")
             .Value;
-        if (string.Equals(continuousIntegrationBuild, "true", StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(doNotCleanUpTemplates, "false", StringComparison.OrdinalIgnoreCase))
         {
             DeleteOutputDirectory();
         }

--- a/src/ProjectTemplates/Shared/Project.cs
+++ b/src/ProjectTemplates/Shared/Project.cs
@@ -45,6 +45,10 @@ public class Project : IDisposable
             .Value
         : Environment.GetEnvironmentVariable("DotNetEfFullPath");
 
+    private bool ContinuousIntegrationBuild => (string.Equals(typeof(ProjectFactoryFixture).Assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
+            .Single(attribute => attribute.Key == "ContinuousIntegrationBuild")
+            .Value), "true", StringComparison.OrdinalIgnoreCase);
+
     public string ProjectName { get; set; }
     public string ProjectArguments { get; set; }
     public string ProjectGuid { get; set; }
@@ -426,7 +430,10 @@ public class Project : IDisposable
 
     public void Dispose()
     {
-        DeleteOutputDirectory();
+        if (ContinuousIntegrationBuild)
+        {
+            DeleteOutputDirectory();
+        }
     }
 
     public void DeleteOutputDirectory()

--- a/src/ProjectTemplates/Shared/Project.cs
+++ b/src/ProjectTemplates/Shared/Project.cs
@@ -45,7 +45,7 @@ public class Project : IDisposable
             .Value
         : Environment.GetEnvironmentVariable("DotNetEfFullPath");
 
-    private bool ContinuousIntegrationBuild => (string.Equals(typeof(ProjectFactoryFixture).Assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
+    private static bool ContinuousIntegrationBuild => (string.Equals(typeof(ProjectFactoryFixture).Assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
             .Single(attribute => attribute.Key == "ContinuousIntegrationBuild")
             .Value), "true", StringComparison.OrdinalIgnoreCase);
 

--- a/src/ProjectTemplates/TestInfrastructure/PrepareForTest.targets
+++ b/src/ProjectTemplates/TestInfrastructure/PrepareForTest.targets
@@ -20,6 +20,10 @@
       <_Parameter1>ContinuousIntegrationBuild</_Parameter1>
       <_Parameter2>true</_Parameter2>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition="'$(ContinuousIntegrationBuild)' != 'true'">
+      <_Parameter1>ContinuousIntegrationBuild</_Parameter1>
+      <_Parameter2>false</_Parameter2>
+    </AssemblyAttribute>
   </ItemGroup>
 
     <Target Name="GenerateTesDevCert" BeforeTargets="AssignTargetPaths">

--- a/src/ProjectTemplates/TestInfrastructure/PrepareForTest.targets
+++ b/src/ProjectTemplates/TestInfrastructure/PrepareForTest.targets
@@ -101,7 +101,7 @@
          get cached results and changes show up.
     -->
 
-    <Message Importance="high" Text="ContinuousIntegrationBuild: $(ContinuousIntegrationBuild)" />
+    <Message Importance="high" Text="DoNotCleanUpTemplates: $(DoNotCleanUpTemplates)" />
 
     <ItemGroup>
       <_ExistingFilesFromLastRun Include="$(TestTemplateCreationFolder)**\*" />

--- a/src/ProjectTemplates/TestInfrastructure/PrepareForTest.targets
+++ b/src/ProjectTemplates/TestInfrastructure/PrepareForTest.targets
@@ -20,8 +20,12 @@
       <_Parameter1>ContinuousIntegrationBuild</_Parameter1>
       <_Parameter2>true</_Parameter2>
     </AssemblyAttribute>
-    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition="'$(ContinuousIntegrationBuild)' != 'true'">
-      <_Parameter1>ContinuousIntegrationBuild</_Parameter1>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition="'$(DoNotCleanUpTemplates)' == 'true'">
+      <_Parameter1>DoNotCleanUpTemplates</_Parameter1>
+      <_Parameter2>true</_Parameter2>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition="'$(DoNotCleanUpTemplates)' != 'true'">
+      <_Parameter1>DoNotCleanUpTemplates</_Parameter1>
       <_Parameter2>false</_Parameter2>
     </AssemblyAttribute>
   </ItemGroup>

--- a/src/ProjectTemplates/TestInfrastructure/PrepareForTest.targets
+++ b/src/ProjectTemplates/TestInfrastructure/PrepareForTest.targets
@@ -101,8 +101,6 @@
          get cached results and changes show up.
     -->
 
-    <Message Importance="high" Text="DoNotCleanUpTemplates: $(DoNotCleanUpTemplates)" />
-
     <ItemGroup>
       <_ExistingFilesFromLastRun Include="$(TestTemplateCreationFolder)**\*" />
     </ItemGroup>

--- a/src/ProjectTemplates/TestInfrastructure/PrepareForTest.targets
+++ b/src/ProjectTemplates/TestInfrastructure/PrepareForTest.targets
@@ -97,6 +97,8 @@
          get cached results and changes show up.
     -->
 
+    <Message Importance="high" Text="ContinuousIntegrationBuild: $(ContinuousIntegrationBuild)" />
+
     <ItemGroup>
       <_ExistingFilesFromLastRun Include="$(TestTemplateCreationFolder)**\*" />
     </ItemGroup>

--- a/src/ProjectTemplates/test/Templates.Blazor.Tests/Templates.Blazor.Tests.csproj
+++ b/src/ProjectTemplates/test/Templates.Blazor.Tests/Templates.Blazor.Tests.csproj
@@ -9,6 +9,7 @@
     <RunTemplateTests Condition="'$(RunTemplateTests)' == ''">true</RunTemplateTests>
     <RunBlazorPlaywrightTemplateTests Condition="'$(RunBlazorPlaywrightTemplateTests)' == ''">$(RunTemplateTests)</RunBlazorPlaywrightTemplateTests>
     <SkipTests Condition="'$(RunBlazorPlaywrightTemplateTests)' != 'true'">true</SkipTests>
+    <SkipTests Condition="'$(RunBlazorPlaywrightTemplateTests)' == 'true'">false</SkipTests>
     <BuildHelixPayload Condition="'$(RunBlazorPlaywrightTemplateTests)' != 'true'">false</BuildHelixPayload>
 
     <BaseOutputPath />

--- a/src/ProjectTemplates/test/Templates.Blazor.WebAssembly.Auth.Tests/Templates.Blazor.WebAssembly.Auth.Tests.csproj
+++ b/src/ProjectTemplates/test/Templates.Blazor.WebAssembly.Auth.Tests/Templates.Blazor.WebAssembly.Auth.Tests.csproj
@@ -7,6 +7,8 @@
     <TestGroupName>ProjectTemplates.Blazor.WebAssembly.Auth.Tests</TestGroupName>
     <DefineConstants>$(DefineConstants);XPLAT</DefineConstants>
 
+    <RequiresDelayedBuild>true</RequiresDelayedBuild>
+
     <RunTemplateTests Condition="'$(RunTemplateTests)' == ''">true</RunTemplateTests>
     <SkipTests Condition="'$(RunTemplateTests)' != 'true'">true</SkipTests>
     <SkipTests Condition="'$(RunTemplateTests)' == 'true'">false</SkipTests>

--- a/src/ProjectTemplates/test/Templates.Blazor.WebAssembly.Auth.Tests/Templates.Blazor.WebAssembly.Auth.Tests.csproj
+++ b/src/ProjectTemplates/test/Templates.Blazor.WebAssembly.Auth.Tests/Templates.Blazor.WebAssembly.Auth.Tests.csproj
@@ -9,6 +9,7 @@
 
     <RunTemplateTests Condition="'$(RunTemplateTests)' == ''">true</RunTemplateTests>
     <SkipTests Condition="'$(RunTemplateTests)' != 'true'">true</SkipTests>
+    <SkipTests Condition="'$(RunTemplateTests)' == 'true'">false</SkipTests>
     <BuildHelixPayload Condition="'$(RunTemplateTests)' != 'true'">false</BuildHelixPayload>
 
     <BaseOutputPath />

--- a/src/ProjectTemplates/test/Templates.Blazor.WebAssembly.Tests/Templates.Blazor.WebAssembly.Tests.csproj
+++ b/src/ProjectTemplates/test/Templates.Blazor.WebAssembly.Tests/Templates.Blazor.WebAssembly.Tests.csproj
@@ -7,6 +7,8 @@
     <TestGroupName>ProjectTemplates.Blazor.WebAssembly.Tests</TestGroupName>
     <DefineConstants>$(DefineConstants);XPLAT</DefineConstants>
 
+    <RequiresDelayedBuild>true</RequiresDelayedBuild>
+
     <RunTemplateTests Condition="'$(RunTemplateTests)' == ''">true</RunTemplateTests>
     <SkipTests Condition="'$(RunTemplateTests)' != 'true'">true</SkipTests>
     <SkipTests Condition="'$(RunTemplateTests)' == 'true'">false</SkipTests>

--- a/src/ProjectTemplates/test/Templates.Blazor.WebAssembly.Tests/Templates.Blazor.WebAssembly.Tests.csproj
+++ b/src/ProjectTemplates/test/Templates.Blazor.WebAssembly.Tests/Templates.Blazor.WebAssembly.Tests.csproj
@@ -9,6 +9,7 @@
 
     <RunTemplateTests Condition="'$(RunTemplateTests)' == ''">true</RunTemplateTests>
     <SkipTests Condition="'$(RunTemplateTests)' != 'true'">true</SkipTests>
+    <SkipTests Condition="'$(RunTemplateTests)' == 'true'">false</SkipTests>
     <BuildHelixPayload Condition="'$(RunTemplateTests)' != 'true'">false</BuildHelixPayload>
 
     <BaseOutputPath />

--- a/src/ProjectTemplates/test/Templates.Mvc.Tests/Templates.Mvc.Tests.csproj
+++ b/src/ProjectTemplates/test/Templates.Mvc.Tests/Templates.Mvc.Tests.csproj
@@ -7,6 +7,8 @@
     <TestGroupName>ProjectTemplates.Mvc.Tests</TestGroupName>
     <DefineConstants>$(DefineConstants);XPLAT</DefineConstants>
 
+    <RequiresDelayedBuild>true</RequiresDelayedBuild>
+
     <RunTemplateTests Condition="'$(RunTemplateTests)' == ''">true</RunTemplateTests>
     <SkipTests Condition="'$(RunTemplateTests)' != 'true'">true</SkipTests>
     <SkipTests Condition="'$(RunTemplateTests)' == 'true'">false</SkipTests>

--- a/src/ProjectTemplates/test/Templates.Mvc.Tests/Templates.Mvc.Tests.csproj
+++ b/src/ProjectTemplates/test/Templates.Mvc.Tests/Templates.Mvc.Tests.csproj
@@ -9,6 +9,7 @@
 
     <RunTemplateTests Condition="'$(RunTemplateTests)' == ''">true</RunTemplateTests>
     <SkipTests Condition="'$(RunTemplateTests)' != 'true'">true</SkipTests>
+    <SkipTests Condition="'$(RunTemplateTests)' == 'true'">false</SkipTests>
     <BuildHelixPayload Condition="'$(RunTemplateTests)' != 'true'">false</BuildHelixPayload>
 
     <BaseOutputPath />

--- a/src/ProjectTemplates/test/Templates.Tests/Templates.Tests.csproj
+++ b/src/ProjectTemplates/test/Templates.Tests/Templates.Tests.csproj
@@ -7,6 +7,8 @@
     <TestGroupName>ProjectTemplates.Tests</TestGroupName>
     <DefineConstants>$(DefineConstants);XPLAT</DefineConstants>
 
+    <RequiresDelayedBuild>true</RequiresDelayedBuild>
+
     <RunTemplateTests Condition="'$(RunTemplateTests)' == ''">true</RunTemplateTests>
     <SkipTests Condition="'$(RunTemplateTests)' != 'true'">true</SkipTests>
     <SkipTests Condition="'$(RunTemplateTests)' == 'true'">false</SkipTests>

--- a/src/ProjectTemplates/test/Templates.Tests/Templates.Tests.csproj
+++ b/src/ProjectTemplates/test/Templates.Tests/Templates.Tests.csproj
@@ -9,6 +9,7 @@
 
     <RunTemplateTests Condition="'$(RunTemplateTests)' == ''">true</RunTemplateTests>
     <SkipTests Condition="'$(RunTemplateTests)' != 'true'">true</SkipTests>
+    <SkipTests Condition="'$(RunTemplateTests)' == 'true'">false</SkipTests>
     <BuildHelixPayload Condition="'$(RunTemplateTests)' != 'true'">false</BuildHelixPayload>
 
     <BaseOutputPath />


### PR DESCRIPTION
Allows us to build our templates in the internal project, so that they can be tracked by CG. Fixes https://github.com/dotnet/aspnetcore/issues/61518.

Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2688844&view=results