### PR TITLE
Associate tagged keys with entries so replacements are not evicted

### DIFF
--- a/src/Middleware/OutputCaching/src/Memory/MemoryOutputCacheStore.cs
+++ b/src/Middleware/OutputCaching/src/Memory/MemoryOutputCacheStore.cs
@@ -136,13 +136,12 @@ internal sealed class MemoryOutputCacheStore : IOutputCacheStore
     {
         Debug.Assert(state != null);
 
-        var stateTuple = ((string[] tags, Guid entryId))state;
-        var tags = stateTuple.tags;
-        var entryId = stateTuple.entryId;
+        var (tags, entryId) = ((string[] tags, Guid entryId))state;
 
         Debug.Assert(tags != null);
         Debug.Assert(tags.Length > 0);
         Debug.Assert(key is string);
+        Debug.Assert(entryId != Guid.Empty);
 
         lock (_tagsLock)
         {

--- a/src/Middleware/OutputCaching/src/Memory/MemoryOutputCacheStore.cs
+++ b/src/Middleware/OutputCaching/src/Memory/MemoryOutputCacheStore.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.Extensions.Caching.Memory;
 
 namespace Microsoft.AspNetCore.OutputCaching.Memory;
@@ -9,7 +10,7 @@ namespace Microsoft.AspNetCore.OutputCaching.Memory;
 internal sealed class MemoryOutputCacheStore : IOutputCacheStore
 {
     private readonly MemoryCache _cache;
-    private readonly Dictionary<string, HashSet<string>> _taggedEntries = new();
+    private readonly Dictionary<string, HashSet<Tuple<string,string>>> _taggedEntries = new();
     private readonly object _tagsLock = new();
 
     internal MemoryOutputCacheStore(MemoryCache cache)
@@ -20,7 +21,7 @@ internal sealed class MemoryOutputCacheStore : IOutputCacheStore
     }
 
     // For testing
-    internal Dictionary<string, HashSet<string>> TaggedEntries => _taggedEntries;
+    internal Dictionary<string, HashSet<string>> TaggedEntries => _taggedEntries.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Select(t => t.Item1).ToHashSet());
 
     public ValueTask EvictByTagAsync(string tag, CancellationToken cancellationToken)
     {
@@ -40,9 +41,9 @@ internal sealed class MemoryOutputCacheStore : IOutputCacheStore
                     while (i > 0)
                     {
                         var oldCount = keys.Count;
-                        foreach (var key in keys)
+                        foreach (var tuple in keys)
                         {
-                            _cache.Remove(key);
+                            _cache.Remove(tuple.Item1);
                             i--;
                             if (oldCount != keys.Count)
                             {
@@ -74,6 +75,8 @@ internal sealed class MemoryOutputCacheStore : IOutputCacheStore
         ArgumentNullException.ThrowIfNull(key);
         ArgumentNullException.ThrowIfNull(value);
 
+        var entryId = Guid.NewGuid().ToString();
+
         if (tags != null)
         {
             // Lock with SetEntry() to prevent EvictByTagAsync() from trying to remove a tag whose entry hasn't been added yet.
@@ -90,27 +93,27 @@ internal sealed class MemoryOutputCacheStore : IOutputCacheStore
 
                     if (!_taggedEntries.TryGetValue(tag, out var keys))
                     {
-                        keys = new HashSet<string>();
+                        keys = new HashSet<Tuple<string, string>>();
                         _taggedEntries[tag] = keys;
                     }
 
                     Debug.Assert(keys != null);
 
-                    keys.Add(key);
+                    keys.Add(Tuple.Create(key, entryId));
                 }
 
-                SetEntry(key, value, tags, validFor);
+                SetEntry(key, value, tags, validFor, entryId);
             }
         }
         else
         {
-            SetEntry(key, value, tags, validFor);
+            SetEntry(key, value, tags, validFor, entryId);
         }
 
         return ValueTask.CompletedTask;
     }
 
-    void SetEntry(string key, byte[] value, string[]? tags, TimeSpan validFor)
+    private void SetEntry(string key, byte[] value, string[]? tags, TimeSpan validFor, string entryId)
     {
         Debug.Assert(key != null);
 
@@ -123,7 +126,7 @@ internal sealed class MemoryOutputCacheStore : IOutputCacheStore
         if (tags != null && tags.Length > 0)
         {
             // Remove cache keys from tag lists when the entry is evicted
-            options.RegisterPostEvictionCallback(RemoveFromTags, tags);
+            options.RegisterPostEvictionCallback(RemoveFromTags, Tuple.Create(tags, entryId));
         }
 
         _cache.Set(key, value, options);
@@ -131,11 +134,14 @@ internal sealed class MemoryOutputCacheStore : IOutputCacheStore
 
     void RemoveFromTags(object key, object? value, EvictionReason reason, object? state)
     {
-        var tags = state as string[];
+        var stateTuple = state as Tuple<string[], string>;
+        string[]? tags = stateTuple?.Item1;
+        string? entryId = stateTuple?.Item2;
 
         Debug.Assert(tags != null);
         Debug.Assert(tags.Length > 0);
         Debug.Assert(key is string);
+        Debug.Assert(entryId != null);
 
         lock (_tagsLock)
         {
@@ -143,7 +149,7 @@ internal sealed class MemoryOutputCacheStore : IOutputCacheStore
             {
                 if (_taggedEntries.TryGetValue(tag, out var tagged))
                 {
-                    tagged.Remove((string)key);
+                    tagged.Remove(Tuple.Create((string) key, entryId));
 
                     // Remove the collection if there is no more keys in it
                     if (tagged.Count == 0)

--- a/src/Middleware/OutputCaching/src/Memory/MemoryOutputCacheStore.cs
+++ b/src/Middleware/OutputCaching/src/Memory/MemoryOutputCacheStore.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.OutputCaching.Memory;
 internal sealed class MemoryOutputCacheStore : IOutputCacheStore
 {
     private readonly MemoryCache _cache;
-    private readonly Dictionary<string, HashSet<(string Key, Guid EntryId)>> _taggedEntries = [];
+    private readonly Dictionary<string, HashSet<TaggedEntry>> _taggedEntries = [];
     private readonly object _tagsLock = new();
 
     internal MemoryOutputCacheStore(MemoryCache cache)
@@ -93,13 +93,13 @@ internal sealed class MemoryOutputCacheStore : IOutputCacheStore
 
                     if (!_taggedEntries.TryGetValue(tag, out var keys))
                     {
-                        keys = new HashSet<(string, Guid)>();
+                        keys = new HashSet<TaggedEntry>();
                         _taggedEntries[tag] = keys;
                     }
 
                     Debug.Assert(keys != null);
 
-                    keys.Add((key, entryId));
+                    keys.Add(new TaggedEntry(key, entryId));
                 }
 
                 SetEntry(key, value, tags, validFor, entryId);
@@ -149,7 +149,7 @@ internal sealed class MemoryOutputCacheStore : IOutputCacheStore
             {
                 if (_taggedEntries.TryGetValue(tag, out var tagged))
                 {
-                    tagged.Remove((Key: (string)key, entryId));
+                    tagged.Remove(new TaggedEntry((string)key, entryId));
 
                     // Remove the collection if there is no more keys in it
                     if (tagged.Count == 0)
@@ -160,4 +160,6 @@ internal sealed class MemoryOutputCacheStore : IOutputCacheStore
             }
         }
     }
+
+    private record TaggedEntry(string Key, Guid EntryId);
 }

--- a/src/Middleware/OutputCaching/src/Memory/MemoryOutputCacheStore.cs
+++ b/src/Middleware/OutputCaching/src/Memory/MemoryOutputCacheStore.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.OutputCaching.Memory;
 internal sealed class MemoryOutputCacheStore : IOutputCacheStore
 {
     private readonly MemoryCache _cache;
-    private readonly Dictionary<string, HashSet<ValueTuple<string,Guid>>> _taggedEntries = new();
+    private readonly Dictionary<string, HashSet<ValueTuple<string,Guid>>> _taggedEntries = [];
     private readonly object _tagsLock = new();
 
     internal MemoryOutputCacheStore(MemoryCache cache)

--- a/src/Middleware/OutputCaching/test/MemoryOutputCacheStoreTests.cs
+++ b/src/Middleware/OutputCaching/test/MemoryOutputCacheStoreTests.cs
@@ -197,6 +197,43 @@ public class MemoryOutputCacheStoreTests
         Assert.Single(tag2s);
     }
 
+    [Fact]
+    public async Task ReplacedEntries_AreNotRemovedFromTags()
+    {
+        var testClock = new TestMemoryOptionsClock { UtcNow = DateTimeOffset.UtcNow };
+        var cache = new MemoryCache(new MemoryCacheOptions { SizeLimit = 1000, Clock = testClock, ExpirationScanFrequency = TimeSpan.FromMilliseconds(1) });
+        var store = new MemoryOutputCacheStore(cache);
+        var value = "abc"u8.ToArray();
+
+        await store.SetAsync("a", value, new[] { "tag1", "tag2" }, TimeSpan.FromMilliseconds(5), default);
+        await store.SetAsync("a", value, new[] { "tag1" }, TimeSpan.FromMilliseconds(20), default);
+
+        testClock.Advance(TimeSpan.FromMilliseconds(10));
+
+        // Background expiration checks are triggered by misc cache activity.
+        _ = cache.Get("a");
+
+        var resulta = await store.GetAsync("a", default);
+
+        Assert.NotNull(resulta);
+
+        HashSet<string> tag1s, tag2s;
+
+        // Wait for the hashset to be removed as it happens on a separate thread
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        while (store.TaggedEntries.TryGetValue("tag2", out tag2s) && !cts.IsCancellationRequested)
+        {
+            await Task.Yield();
+        }
+
+        store.TaggedEntries.TryGetValue("tag1", out tag1s);
+
+        Assert.Null(tag2s);
+        Assert.Single(tag1s);
+    }
+
     [Theory]
     [InlineData(null)]
     public async Task Store_Throws_OnInvalidTag(string tag)

--- a/src/Middleware/OutputCaching/test/MemoryOutputCacheStoreTests.cs
+++ b/src/Middleware/OutputCaching/test/MemoryOutputCacheStoreTests.cs
@@ -219,7 +219,7 @@ public class MemoryOutputCacheStoreTests
 
         HashSet<string> tag1s, tag2s;
 
-        // Wait for the hashset to be removed as it happens on a separate thread
+        // Wait for the tag2 HashSet to be removed by the background expiration thread.
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 

--- a/src/Middleware/OutputCaching/test/MemoryOutputCacheStoreTests.cs
+++ b/src/Middleware/OutputCaching/test/MemoryOutputCacheStoreTests.cs
@@ -210,7 +210,7 @@ public class MemoryOutputCacheStoreTests
 
         testClock.Advance(TimeSpan.FromMilliseconds(10));
 
-        // Background expiration checks are triggered by misc cache activity.
+        // Trigger background expiration by accessing the cache.
         _ = cache.Get("a");
 
         var resulta = await store.GetAsync("a", default);


### PR DESCRIPTION
# Associate tagged keys with entries so replacements are not evicted

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

`MemoryOutputCacheStore` will now only remove tags from the associated eviction, rather than all tags associated with the key.

## Description

A previous PR (https://github.com/dotnet/aspnetcore/pull/43728) fixed a memory leak by removing tags upon eviction from the `MemoryOutputCacheStore`. 

That fix created a bug where if an entry is replaced rather than evicted via timeout, the tags associated with the replacement would erroneously be deleted and the new entry would have no tags.

This PR associates each tag with a specific entry. When the PostEvictionCallback is run, only the associated tags with that specific eviction will be removed.

I based this on release/8.0 branch, I assume it can be merged into `release/8.0`, `release/9.0`, and `main`.

Fixes #61524
