### PR TITLE
Forwarded Headers Middleware: Ignore XForwardedHeaders from Unknown Proxy

### DIFF
--- a/src/Middleware/HttpOverrides/src/ForwardedHeadersMiddleware.cs
+++ b/src/Middleware/HttpOverrides/src/ForwardedHeadersMiddleware.cs
@@ -220,19 +220,19 @@ public class ForwardedHeadersMiddleware
         for (; entriesConsumed < sets.Length; entriesConsumed++)
         {
             var set = sets[entriesConsumed];
+            // For the first instance, allow remoteIp to be null for servers that don't support it natively.
+            if (currentValues.RemoteIpAndPort != null && checkKnownIps && !CheckKnownAddress(currentValues.RemoteIpAndPort.Address))
+            {
+                // Stop at the first unknown remote IP, but still apply changes processed so far.
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug(1, "Unknown proxy: {RemoteIpAndPort}", currentValues.RemoteIpAndPort);
+                }
+                break;
+            }
+
             if (checkFor)
             {
-                // For the first instance, allow remoteIp to be null for servers that don't support it natively.
-                if (currentValues.RemoteIpAndPort != null && checkKnownIps && !CheckKnownAddress(currentValues.RemoteIpAndPort.Address))
-                {
-                    // Stop at the first unknown remote IP, but still apply changes processed so far.
-                    if (_logger.IsEnabled(LogLevel.Debug))
-                    {
-                        _logger.LogDebug(1, "Unknown proxy: {RemoteIpAndPort}", currentValues.RemoteIpAndPort);
-                    }
-                    break;
-                }
-
                 if (IPEndPoint.TryParse(set.IpAndPortText, out var parsedEndPoint))
                 {
                     applyChanges = true;


### PR DESCRIPTION
# Forwarded Headers Middleware: Ignore XForwardedHeaders from Unknown Proxy

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Fixes a bug where, under some conditions, `XForwardedPrefix` , `XForwardedProto` and `XForwardedHost` headers could be tampered with.

## Description

This PR makes sure that XForwarded-Headers are only interpreted when they come from a known proxy. [As suggested by the documentation.](https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/proxy-load-balancer?view=aspnetcore-9.0).

If the `ForwardedHeaders.XForwardedFor` flag in `ForwardedHeadersOptions` isn't set. The `ForwardedHeadersMiddleware` doesn't check if the request comes from a known proxy.

This means that with the following `ForwardedHeadersOptions` (or any other combination where `ForwardedHeaders.XForwardedFor` is missing):
``` csharp
var options = new ForwardedHeadersOptions { ForwardedHeaders = ForwardedHeaders.XForwardedHost | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedPrefix };
_application.UseForwardedHeaders(options);
```

the respective `X-Forwarded`-headers will be always processed by the middleware which have some (security related?) side effects:

* `XForwardedPrefix` sets `context.Request.PathBase`
* `XForwardedProto` sets `context.Request.Scheme`
* `XForwardedHost` sets `context.Request.Host`

With `ForwardedHeadersOptions` set to `ForwardedHeaders.All` no side effects would have been executed.

Fixes #61449

This observation has been reported by me via the `MSRC`-Portal but was classified as a product bug. The following information may be related: https://github.com/aspnet/Announcements/issues/295