### PR TITLE
Add reference to System.Security.Cryptography.Pkcs to RepoTasks

### DIFF
--- a/eng/tools/RepoTasks/RepoTasks.csproj
+++ b/eng/tools/RepoTasks/RepoTasks.csproj
@@ -21,6 +21,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackagingVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
+
+    <Reference Include="System.Security.Cryptography.Pkcs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net472'">


### PR DESCRIPTION
Fixes a CG alert

This pull request includes a minor update to the `RepoTasks.csproj` file. The change adds a reference to the `System.Security.Cryptography.Pkcs` library, likely to enable cryptographic operations involving PKCS standards.