### PR TITLE
Add IMemoryPoolFactory and cleanup memory pool while idle

### DIFF
--- a/src/Servers/Connections.Abstractions/src/IMemoryPoolFactory.cs
+++ b/src/Servers/Connections.Abstractions/src/IMemoryPoolFactory.cs
@@ -8,11 +8,11 @@ namespace Microsoft.AspNetCore.Connections;
 /// <summary>
 /// 
 /// </summary>
-public interface IMemoryPoolFactory
+public interface IMemoryPoolFactory<T>
 {
     /// <summary>
     /// 
     /// </summary>
     /// <returns></returns>
-    MemoryPool<byte> CreatePool();
+    MemoryPool<T> Create();
 }

--- a/src/Servers/Connections.Abstractions/src/IMemoryPoolFactory.cs
+++ b/src/Servers/Connections.Abstractions/src/IMemoryPoolFactory.cs
@@ -6,13 +6,13 @@ using System.Buffers;
 namespace Microsoft.AspNetCore.Connections;
 
 /// <summary>
-/// 
+/// Interface for creating memory pools.
 /// </summary>
 public interface IMemoryPoolFactory<T>
 {
     /// <summary>
-    /// 
+    /// Creates a new instance of a memory pool.
     /// </summary>
-    /// <returns></returns>
+    /// <returns>A new memory pool instance.</returns>
     MemoryPool<T> Create();
 }

--- a/src/Servers/Connections.Abstractions/src/IMemoryPoolFactory.cs
+++ b/src/Servers/Connections.Abstractions/src/IMemoryPoolFactory.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+
+namespace Microsoft.AspNetCore.Connections;
+
+/// <summary>
+/// 
+/// </summary>
+public interface IMemoryPoolFactory
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <returns></returns>
+    MemoryPool<byte> CreatePool();
+}

--- a/src/Servers/Connections.Abstractions/src/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Servers/Connections.Abstractions/src/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,3 @@
 #nullable enable
-Microsoft.AspNetCore.Connections.IMemoryPoolFactory
-Microsoft.AspNetCore.Connections.IMemoryPoolFactory.CreatePool() -> System.Buffers.MemoryPool<byte>!
+Microsoft.AspNetCore.Connections.IMemoryPoolFactory<T>
+Microsoft.AspNetCore.Connections.IMemoryPoolFactory<T>.Create() -> System.Buffers.MemoryPool<T>!

--- a/src/Servers/Connections.Abstractions/src/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Servers/Connections.Abstractions/src/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.AspNetCore.Connections.IMemoryPoolFactory
+Microsoft.AspNetCore.Connections.IMemoryPoolFactory.CreatePool() -> System.Buffers.MemoryPool<byte>!

--- a/src/Servers/Connections.Abstractions/src/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Servers/Connections.Abstractions/src/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,3 +1,3 @@
 #nullable enable
-Microsoft.AspNetCore.Connections.IMemoryPoolFactory
-Microsoft.AspNetCore.Connections.IMemoryPoolFactory.CreatePool() -> System.Buffers.MemoryPool<byte>!
+Microsoft.AspNetCore.Connections.IMemoryPoolFactory<T>
+Microsoft.AspNetCore.Connections.IMemoryPoolFactory<T>.Create() -> System.Buffers.MemoryPool<T>!

--- a/src/Servers/Connections.Abstractions/src/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Servers/Connections.Abstractions/src/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.AspNetCore.Connections.IMemoryPoolFactory
+Microsoft.AspNetCore.Connections.IMemoryPoolFactory.CreatePool() -> System.Buffers.MemoryPool<byte>!

--- a/src/Servers/Connections.Abstractions/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Servers/Connections.Abstractions/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,3 @@
 #nullable enable
-Microsoft.AspNetCore.Connections.IMemoryPoolFactory
-Microsoft.AspNetCore.Connections.IMemoryPoolFactory.CreatePool() -> System.Buffers.MemoryPool<byte>!
+Microsoft.AspNetCore.Connections.IMemoryPoolFactory<T>
+Microsoft.AspNetCore.Connections.IMemoryPoolFactory<T>.Create() -> System.Buffers.MemoryPool<T>!

--- a/src/Servers/Connections.Abstractions/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Servers/Connections.Abstractions/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.AspNetCore.Connections.IMemoryPoolFactory
+Microsoft.AspNetCore.Connections.IMemoryPoolFactory.CreatePool() -> System.Buffers.MemoryPool<byte>!

--- a/src/Servers/Connections.Abstractions/src/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/Servers/Connections.Abstractions/src/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,3 +1,3 @@
 #nullable enable
-Microsoft.AspNetCore.Connections.IMemoryPoolFactory
-Microsoft.AspNetCore.Connections.IMemoryPoolFactory.CreatePool() -> System.Buffers.MemoryPool<byte>!
+Microsoft.AspNetCore.Connections.IMemoryPoolFactory<T>
+Microsoft.AspNetCore.Connections.IMemoryPoolFactory<T>.Create() -> System.Buffers.MemoryPool<T>!

--- a/src/Servers/Connections.Abstractions/src/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/Servers/Connections.Abstractions/src/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.AspNetCore.Connections.IMemoryPoolFactory
+Microsoft.AspNetCore.Connections.IMemoryPoolFactory.CreatePool() -> System.Buffers.MemoryPool<byte>!

--- a/src/Servers/HttpSys/src/HttpSysListener.cs
+++ b/src/Servers/HttpSys/src/HttpSysListener.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpSys.Internal;
 using Microsoft.AspNetCore.WebUtilities;
@@ -33,7 +34,14 @@ internal sealed partial class HttpSysListener : IDisposable
     // 0.5 seconds per request.  Respond with a 400 Bad Request.
     private const int UnknownHeaderLimit = 1000;
 
-    internal MemoryPool<byte> MemoryPool { get; } = PinnedBlockMemoryPoolFactory.Create();
+    internal sealed class DummyMeterFactory : IMeterFactory
+    {
+        public Meter Create(MeterOptions options) => new Meter(options);
+
+        public void Dispose() { }
+    }
+
+    internal MemoryPool<byte> MemoryPool { get; } = PinnedBlockMemoryPoolFactory.Create(new DummyMeterFactory());
 
     private volatile State _state; // m_State is set only within lock blocks, but often read outside locks.
 

--- a/src/Servers/HttpSys/src/HttpSysListener.cs
+++ b/src/Servers/HttpSys/src/HttpSysListener.cs
@@ -3,7 +3,6 @@
 
 using System.Buffers;
 using System.Diagnostics;
-using System.Diagnostics.Metrics;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpSys.Internal;
@@ -34,13 +33,6 @@ internal sealed partial class HttpSysListener : IDisposable
     // with hash collisions will cause the server to consume excess CPU.  1000 headers limits CPU time to under
     // 0.5 seconds per request.  Respond with a 400 Bad Request.
     private const int UnknownHeaderLimit = 1000;
-
-    internal sealed class NoopMeterFactory : IMeterFactory
-    {
-        public Meter Create(MeterOptions options) => new Meter(options);
-
-        public void Dispose() { }
-    }
 
     internal MemoryPool<byte> MemoryPool { get; }
 

--- a/src/Servers/HttpSys/src/MessagePump.cs
+++ b/src/Servers/HttpSys/src/MessagePump.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http.Features;
@@ -27,12 +28,13 @@ internal sealed partial class MessagePump : IServer, IServerDelegationFeature
 
     private readonly ServerAddressesFeature _serverAddresses;
 
-    public MessagePump(IOptions<HttpSysOptions> options, ILoggerFactory loggerFactory, IAuthenticationSchemeProvider authentication)
+    public MessagePump(IOptions<HttpSysOptions> options, IMemoryPoolFactory<byte> memoryPoolFactory,
+        ILoggerFactory loggerFactory, IAuthenticationSchemeProvider authentication)
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(loggerFactory);
         _options = options.Value;
-        Listener = new HttpSysListener(_options, loggerFactory);
+        Listener = new HttpSysListener(_options, memoryPoolFactory, loggerFactory);
         _logger = loggerFactory.CreateLogger<MessagePump>();
 
         if (_options.Authentication.Schemes != AuthenticationSchemes.None)

--- a/src/Servers/HttpSys/src/WebHostBuilderHttpSysExtensions.cs
+++ b/src/Servers/HttpSys/src/WebHostBuilderHttpSysExtensions.cs
@@ -1,10 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Runtime.Versioning;
+using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Server.HttpSys;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Hosting;
@@ -45,6 +48,8 @@ public static class WebHostBuilderHttpSysExtensions
                 };
             });
             services.AddAuthenticationCore();
+
+            services.TryAddSingleton<IMemoryPoolFactory<byte>, DefaultMemoryPoolFactory>();
         });
     }
 

--- a/src/Servers/HttpSys/src/WebHostBuilderHttpSysExtensions.cs
+++ b/src/Servers/HttpSys/src/WebHostBuilderHttpSysExtensions.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Buffers;
 using System.Runtime.Versioning;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Hosting.Server;

--- a/src/Servers/HttpSys/test/FunctionalTests/Listener/ServerTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Listener/ServerTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Buffers;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -132,7 +133,7 @@ public class ServerTests
 
         var options = new HttpSysOptions();
         options.UrlPrefixes.Add(address1);
-        using var listener = new HttpSysListener(options, new LoggerFactory());
+        using var listener = new HttpSysListener(options, new DefaultMemoryPoolFactory(), new LoggerFactory());
 
         var exception = Assert.Throws<HttpSysException>(() => listener.Start());
 

--- a/src/Servers/HttpSys/test/FunctionalTests/Listener/Utilities.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Listener/Utilities.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Buffers;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.HttpSys.Internal;
 using Microsoft.Extensions.Logging;
@@ -47,7 +48,7 @@ internal static class Utilities
                 var options = new HttpSysOptions();
                 options.UrlPrefixes.Add(prefix);
                 options.RequestQueueName = prefix.Port; // Convention for use with CreateServerOnExistingQueue
-                var listener = new HttpSysListener(options, new LoggerFactory());
+                var listener = new HttpSysListener(options, new DefaultMemoryPoolFactory(), new LoggerFactory());
                 try
                 {
                     listener.Start();
@@ -76,7 +77,7 @@ internal static class Utilities
 
     internal static HttpSysListener CreateServer(string scheme, string host, int port, string path)
     {
-        var listener = new HttpSysListener(new HttpSysOptions(), new LoggerFactory());
+        var listener = new HttpSysListener(new HttpSysOptions(), new DefaultMemoryPoolFactory(), new LoggerFactory());
         listener.Options.UrlPrefixes.Add(UrlPrefix.Create(scheme, host, port, path));
         listener.Start();
         return listener;
@@ -86,7 +87,7 @@ internal static class Utilities
     {
         var options = new HttpSysOptions();
         configureOptions(options);
-        var listener = new HttpSysListener(options, new LoggerFactory());
+        var listener = new HttpSysListener(options, new DefaultMemoryPoolFactory(), new LoggerFactory());
         listener.Start();
         return listener;
     }

--- a/src/Servers/HttpSys/test/FunctionalTests/Utilities.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Utilities.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Buffers;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -112,13 +113,13 @@ internal static class Utilities
     }
 
     internal static MessagePump CreatePump(ILoggerFactory loggerFactory)
-        => new MessagePump(Options.Create(new HttpSysOptions()), loggerFactory ?? new LoggerFactory(), new AuthenticationSchemeProvider(Options.Create(new AuthenticationOptions())));
+        => new MessagePump(Options.Create(new HttpSysOptions()), new DefaultMemoryPoolFactory(), loggerFactory ?? new LoggerFactory(), new AuthenticationSchemeProvider(Options.Create(new AuthenticationOptions())));
 
     internal static MessagePump CreatePump(Action<HttpSysOptions> configureOptions, ILoggerFactory loggerFactory)
     {
         var options = new HttpSysOptions();
         configureOptions(options);
-        return new MessagePump(Options.Create(options), loggerFactory ?? new LoggerFactory(), new AuthenticationSchemeProvider(Options.Create(new AuthenticationOptions())));
+        return new MessagePump(Options.Create(options), new DefaultMemoryPoolFactory(), loggerFactory ?? new LoggerFactory(), new AuthenticationSchemeProvider(Options.Create(new AuthenticationOptions())));
     }
 
     internal static IServer CreateDynamicHttpServer(string basePath, out string root, out string baseAddress, Action<HttpSysOptions> configureOptions, RequestDelegate app, ILoggerFactory loggerFactory)

--- a/src/Servers/HttpSys/test/NonHelixTests/Utilities.cs
+++ b/src/Servers/HttpSys/test/NonHelixTests/Utilities.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
@@ -31,13 +32,13 @@ internal static class Utilities
     }
 
     internal static MessagePump CreatePump(ILoggerFactory loggerFactory = null)
-        => new MessagePump(Options.Create(new HttpSysOptions()), loggerFactory ?? new LoggerFactory(), new AuthenticationSchemeProvider(Options.Create(new AuthenticationOptions())));
+        => new MessagePump(Options.Create(new HttpSysOptions()), new DefaultMemoryPoolFactory(), loggerFactory ?? new LoggerFactory(), new AuthenticationSchemeProvider(Options.Create(new AuthenticationOptions())));
 
     internal static MessagePump CreatePump(Action<HttpSysOptions> configureOptions, ILoggerFactory loggerFactory = null)
     {
         var options = new HttpSysOptions();
         configureOptions(options);
-        return new MessagePump(Options.Create(options), loggerFactory ?? new LoggerFactory(), new AuthenticationSchemeProvider(Options.Create(new AuthenticationOptions())));
+        return new MessagePump(Options.Create(options), new DefaultMemoryPoolFactory(), loggerFactory ?? new LoggerFactory(), new AuthenticationSchemeProvider(Options.Create(new AuthenticationOptions())));
     }
 
     internal static IServer CreateDynamicHttpServer(string basePath, out string root, out string baseAddress, Action<HttpSysOptions> configureOptions, RequestDelegate app)

--- a/src/Servers/IIS/IIS/src/Core/IISHttpServer.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpServer.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
@@ -18,10 +19,17 @@ namespace Microsoft.AspNetCore.Server.IIS.Core;
 
 internal sealed class IISHttpServer : IServer
 {
+    internal sealed class DummyMeterFactory : IMeterFactory
+    {
+        public Meter Create(MeterOptions options) => new Meter(options);
+
+        public void Dispose() { }
+    }
+
     private const string WebSocketVersionString = "WEBSOCKET_VERSION";
 
     private IISContextFactory? _iisContextFactory;
-    private readonly MemoryPool<byte> _memoryPool = new PinnedBlockMemoryPool();
+    private readonly MemoryPool<byte> _memoryPool = new PinnedBlockMemoryPool(new DummyMeterFactory());
     private GCHandle _httpServerHandle;
     private readonly IHostApplicationLifetime _applicationLifetime;
     private readonly ILogger<IISHttpServer> _logger;

--- a/src/Servers/IIS/IIS/src/WebHostBuilderIISExtensions.cs
+++ b/src/Servers/IIS/IIS/src/WebHostBuilderIISExtensions.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Buffers;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Hosting.Server;

--- a/src/Servers/IIS/IIS/src/WebHostBuilderIISExtensions.cs
+++ b/src/Servers/IIS/IIS/src/WebHostBuilderIISExtensions.cs
@@ -1,11 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Server.IIS;
 using Microsoft.AspNetCore.Server.IIS.Core;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.AspNetCore.Hosting;
 
@@ -53,6 +56,8 @@ public static class WebHostBuilderIISExtensions
                             options.IisMaxRequestSizeLimit = iisConfigData.maxRequestBodySize;
                         }
                     );
+
+                    services.TryAddSingleton<IMemoryPoolFactory<byte>, DefaultMemoryPoolFactory>();
                 });
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/PinnedBlockMemoryPoolFactory.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/PinnedBlockMemoryPoolFactory.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
+
+internal sealed class PinnedBlockMemoryPoolFactory : IMemoryPoolFactory, IHeartbeatHandler
+{
+    private readonly IMeterFactory _meterFactory;
+    private readonly ConcurrentDictionary<PinnedBlockMemoryPool, PinnedBlockMemoryPool> _pools = new();
+
+    public PinnedBlockMemoryPoolFactory(IMeterFactory meterFactory)
+    {
+        _meterFactory = meterFactory;
+    }
+
+    public MemoryPool<byte> CreatePool()
+    {
+        // TODO: wire up PinnedBlockMemoryPool's dispose to remove from _pools
+        var pool = new PinnedBlockMemoryPool(_meterFactory);
+
+        _pools.TryAdd(pool, pool);
+
+#if DEBUG
+        return new DiagnosticMemoryPool(pool);
+#else
+        return pool;
+#endif
+    }
+
+    public void OnHeartbeat()
+    {
+        foreach (var pool in _pools)
+        {
+            pool.Value.PerformEviction();
+        }
+    }
+}

--- a/src/Servers/Kestrel/Core/src/Internal/PinnedBlockMemoryPoolFactory.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/PinnedBlockMemoryPoolFactory.cs
@@ -24,12 +24,13 @@ internal sealed class PinnedBlockMemoryPoolFactory : IMemoryPoolFactory<byte>, I
     public MemoryPool<byte> Create()
     {
         var pool = new PinnedBlockMemoryPool(_meterFactory);
+
+        _pools.TryAdd(pool, pool);
+
         pool.DisposeCallback = (self) =>
         {
             _pools.TryRemove(self, out _);
         };
-
-        _pools.TryAdd(pool, pool);
 
         return pool;
     }

--- a/src/Servers/Kestrel/Core/src/Internal/PinnedBlockMemoryPoolFactory.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/PinnedBlockMemoryPoolFactory.cs
@@ -27,10 +27,10 @@ internal sealed class PinnedBlockMemoryPoolFactory : IMemoryPoolFactory<byte>, I
 
         _pools.TryAdd(pool, pool);
 
-        pool.DisposeCallback = (self) =>
+        pool.OnPoolDisposed(static (state, self) =>
         {
-            _pools.TryRemove(self, out _);
-        };
+            ((ConcurrentDictionary<PinnedBlockMemoryPool, PinnedBlockMemoryPool>)state!).TryRemove(self, out _);
+        }, _pools);
 
         return pool;
     }

--- a/src/Servers/Kestrel/Core/src/Internal/PinnedBlockMemoryPoolFactory.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/PinnedBlockMemoryPoolFactory.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 
-internal sealed class PinnedBlockMemoryPoolFactory : IMemoryPoolFactory, IHeartbeatHandler
+internal sealed class PinnedBlockMemoryPoolFactory : IMemoryPoolFactory<byte>, IHeartbeatHandler
 {
     private readonly IMeterFactory _meterFactory;
     private readonly ConcurrentDictionary<PinnedBlockMemoryPool, PinnedBlockMemoryPool> _pools = new();
@@ -19,7 +19,7 @@ internal sealed class PinnedBlockMemoryPoolFactory : IMemoryPoolFactory, IHeartb
         _meterFactory = meterFactory;
     }
 
-    public MemoryPool<byte> CreatePool()
+    public MemoryPool<byte> Create()
     {
         // TODO: wire up PinnedBlockMemoryPool's dispose to remove from _pools
         var pool = new PinnedBlockMemoryPool(_meterFactory);

--- a/src/Servers/Kestrel/Core/src/Internal/PinnedBlockMemoryPoolFactory.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/PinnedBlockMemoryPoolFactory.cs
@@ -6,25 +6,28 @@ using System.Collections.Concurrent;
 using System.Diagnostics.Metrics;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 
 internal sealed class PinnedBlockMemoryPoolFactory : IMemoryPoolFactory<byte>, IHeartbeatHandler
 {
     private readonly IMeterFactory _meterFactory;
+    private readonly ILogger? _logger;
     private readonly TimeProvider _timeProvider;
     // micro-optimization: Using nuint as the value type to avoid GC write barriers; could replace with ConcurrentHashSet if that becomes available
     private readonly ConcurrentDictionary<PinnedBlockMemoryPool, nuint> _pools = new();
 
-    public PinnedBlockMemoryPoolFactory(IMeterFactory meterFactory, TimeProvider? timeProvider = null)
+    public PinnedBlockMemoryPoolFactory(IMeterFactory meterFactory, TimeProvider? timeProvider = null, ILogger<PinnedBlockMemoryPoolFactory>? logger = null)
     {
         _timeProvider = timeProvider ?? TimeProvider.System;
         _meterFactory = meterFactory;
+        _logger = logger;
     }
 
     public MemoryPool<byte> Create()
     {
-        var pool = new PinnedBlockMemoryPool(_meterFactory);
+        var pool = new PinnedBlockMemoryPool(_meterFactory, _logger);
 
         _pools.TryAdd(pool, nuint.Zero);
 

--- a/src/Servers/Kestrel/Core/src/KestrelServer.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServer.cs
@@ -37,7 +37,8 @@ public class KestrelServer : IServer
             new SimpleHttpsConfigurationService(),
             loggerFactory,
             diagnosticSource: null,
-            new KestrelMetrics(new DummyMeterFactory()));
+            new KestrelMetrics(new DummyMeterFactory()),
+            heartbeatHandlers: []);
     }
 
     /// <inheritdoc />

--- a/src/Servers/Kestrel/Core/src/Microsoft.AspNetCore.Server.Kestrel.Core.csproj
+++ b/src/Servers/Kestrel/Core/src/Microsoft.AspNetCore.Server.Kestrel.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Core components of ASP.NET Core Kestrel cross-platform web server.</Description>
@@ -37,6 +37,7 @@
     <Compile Include="$(SharedSourceRoot)Obsoletions.cs" LinkBase="Shared" />
     <Compile Include="$(RepoRoot)src\Shared\TaskToApm.cs" Link="Internal\TaskToApm.cs" />
     <Compile Include="$(SharedSourceRoot)Metrics\MetricsExtensions.cs" />
+    <Compile Include="$(RepoRoot)src\Shared\Buffers.MemoryPool\*.cs" LinkBase="MemoryPool" />
   </ItemGroup>
 
   <ItemGroup>
@@ -70,6 +71,7 @@
     <InternalsVisibleTo Include="Sockets.FunctionalTests" />
     <InternalsVisibleTo Include="Quic.FunctionalTests" />
     <InternalsVisibleTo Include="InMemory.FunctionalTests" />
+    <InternalsVisibleTo Include="Interop.FunctionalTests" />
     <InternalsVisibleTo Include="Sockets.BindTests" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.Server.Kestrel" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.Server.Kestrel.Core.Tests" />

--- a/src/Servers/Kestrel/Core/src/Microsoft.AspNetCore.Server.Kestrel.Core.csproj
+++ b/src/Servers/Kestrel/Core/src/Microsoft.AspNetCore.Server.Kestrel.Core.csproj
@@ -71,7 +71,6 @@
     <InternalsVisibleTo Include="Sockets.FunctionalTests" />
     <InternalsVisibleTo Include="Quic.FunctionalTests" />
     <InternalsVisibleTo Include="InMemory.FunctionalTests" />
-    <InternalsVisibleTo Include="Interop.FunctionalTests" />
     <InternalsVisibleTo Include="Sockets.BindTests" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.Server.Kestrel" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.Server.Kestrel.Core.Tests" />

--- a/src/Servers/Kestrel/Core/test/DiagnosticMemoryPoolTests.cs
+++ b/src/Servers/Kestrel/Core/test/DiagnosticMemoryPoolTests.cs
@@ -1,10 +1,11 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Buffers;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore;
 using Xunit;
 
 namespace Microsoft.Extensions.Internal.Test;

--- a/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTestsBase.cs
+++ b/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTestsBase.cs
@@ -31,7 +31,7 @@ public class Http1ConnectionTestsBase : LoggedTest, IDisposable
     {
         base.Initialize(context, methodInfo, testMethodArguments, testOutputHelper);
 
-        _pipelineFactory = System.Buffers.PinnedBlockMemoryPoolFactory.Create();
+        _pipelineFactory = TestMemoryPoolFactory.Create();
         var options = new PipeOptions(_pipelineFactory, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false);
         var pair = DuplexPipe.CreateConnectionPair(options, options);
 

--- a/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTestsBase.cs
+++ b/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTestsBase.cs
@@ -31,7 +31,7 @@ public class Http1ConnectionTestsBase : LoggedTest, IDisposable
     {
         base.Initialize(context, methodInfo, testMethodArguments, testOutputHelper);
 
-        _pipelineFactory = PinnedBlockMemoryPoolFactory.Create();
+        _pipelineFactory = System.Buffers.PinnedBlockMemoryPoolFactory.Create();
         var options = new PipeOptions(_pipelineFactory, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false);
         var pair = DuplexPipe.CreateConnectionPair(options, options);
 

--- a/src/Servers/Kestrel/Core/test/Http1/Http1OutputProducerTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http1/Http1OutputProducerTests.cs
@@ -22,7 +22,7 @@ public class Http1OutputProducerTests : IDisposable
 
     public Http1OutputProducerTests()
     {
-        _memoryPool = PinnedBlockMemoryPoolFactory.Create();
+        _memoryPool = TestMemoryPoolFactory.Create();
     }
 
     public void Dispose()

--- a/src/Servers/Kestrel/Core/test/HttpResponseHeadersTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpResponseHeadersTests.cs
@@ -21,7 +21,7 @@ public class HttpResponseHeadersTests
     [Fact]
     public void InitialDictionaryIsEmpty()
     {
-        using (var memoryPool = PinnedBlockMemoryPoolFactory.Create())
+        using (var memoryPool = TestMemoryPoolFactory.Create())
         {
             var options = new PipeOptions(memoryPool, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false);
             var pair = DuplexPipe.CreateConnectionPair(options, options);

--- a/src/Servers/Kestrel/Core/test/KestrelServerTests.cs
+++ b/src/Servers/Kestrel/Core/test/KestrelServerTests.cs
@@ -310,7 +310,8 @@ public class KestrelServerTests
             httpsConfigurationService,
             loggerFactory ?? new LoggerFactory(new[] { new KestrelTestLoggerProvider() }),
             diagnosticSource: null,
-            metrics ?? new KestrelMetrics(new TestMeterFactory()));
+            metrics ?? new KestrelMetrics(new TestMeterFactory()),
+            heartbeatHandlers: []);
     }
 
     [Fact]

--- a/src/Servers/Kestrel/Core/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests.csproj
+++ b/src/Servers/Kestrel/Core/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests.csproj
@@ -14,7 +14,6 @@
     <Compile Include="$(KestrelSharedSourceRoot)KnownHeaders.cs" LinkBase="shared" />
     <Compile Include="$(KestrelSharedSourceRoot)\HPackHeaderWriter.cs" Link="Http2\HPackHeaderWriter.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)\Http2HeadersEnumerator.cs" Link="Http2\Http2HeadersEnumerator.cs" />
-    <Compile Include="$(RepoRoot)src\Shared\Buffers.MemoryPool\*.cs" LinkBase="MemoryPool" />
     <Compile Include="$(KestrelSharedSourceRoot)\CorrelationIdGenerator.cs" Link="Internal\CorrelationIdGenerator.cs" />
     <Compile Include="$(SharedSourceRoot)test\Shared.Tests\runtime\Http2\*.cs" LinkBase="Shared\runtime\Http2" />
     <Compile Include="$(SharedSourceRoot)test\Shared.Tests\runtime\Http3\*.cs" LinkBase="Shared\runtime\Http3" />

--- a/src/Servers/Kestrel/Core/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests.csproj
+++ b/src/Servers/Kestrel/Core/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests.csproj
@@ -28,6 +28,7 @@
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
     <Reference Include="Microsoft.Extensions.FileProviders.Physical" />
     <Reference Include="Microsoft.Extensions.Logging" />
+    <Reference Include="Microsoft.Extensions.Diagnostics.Testing" />
     <Reference Include="Microsoft.Extensions.TimeProvider.Testing" />
   </ItemGroup>
 </Project>

--- a/src/Servers/Kestrel/Core/test/PinnedBlockMemoryPoolFactoryTests.cs
+++ b/src/Servers/Kestrel/Core/test/PinnedBlockMemoryPoolFactoryTests.cs
@@ -1,0 +1,107 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Reflection;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests;
+
+public class PinnedBlockMemoryPoolFactoryTests
+{
+    [Fact]
+    public void CreatePool()
+    {
+        var factory = new PinnedBlockMemoryPoolFactory(new TestMeterFactory());
+        var pool = factory.Create();
+        Assert.NotNull(pool);
+        Assert.IsType<PinnedBlockMemoryPool>(pool);
+    }
+
+    [Fact]
+    public void CreateMultiplePools()
+    {
+        var factory = new PinnedBlockMemoryPoolFactory(new TestMeterFactory());
+        var pool1 = factory.Create();
+        var pool2 = factory.Create();
+
+        Assert.NotNull(pool1);
+        Assert.NotNull(pool2);
+        Assert.NotSame(pool1, pool2);
+    }
+
+    [Fact]
+    public void DisposePoolRemovesFromFactory()
+    {
+        var factory = new PinnedBlockMemoryPoolFactory(new TestMeterFactory());
+        var pool = factory.Create();
+        Assert.NotNull(pool);
+
+        var dict = (ConcurrentDictionary<PinnedBlockMemoryPool, PinnedBlockMemoryPool>)(typeof(PinnedBlockMemoryPoolFactory)
+            .GetField("_pools", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?.GetValue(factory));
+        Assert.Single(dict);
+
+        pool.Dispose();
+        Assert.Empty(dict);
+    }
+
+    [Fact]
+    public async Task FactoryHeartbeatWorks()
+    {
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow.AddDays(1));
+        var factory = new PinnedBlockMemoryPoolFactory(new TestMeterFactory(), timeProvider);
+
+        // Use 2 pools to make sure they all get triggered by the heartbeat
+        var pool = Assert.IsType<PinnedBlockMemoryPool>(factory.Create());
+        var pool2 = Assert.IsType<PinnedBlockMemoryPool>(factory.Create());
+
+        var blocks = new List<IMemoryOwner<byte>>();
+        for (var i = 0; i < 10000; i++)
+        {
+            blocks.Add(pool.Rent());
+            blocks.Add(pool2.Rent());
+        }
+
+        foreach (var block in blocks)
+        {
+            block.Dispose();
+        }
+        blocks.Clear();
+
+        // First eviction pass likely won't do anything since the pool was just very active
+        factory.OnHeartbeat();
+
+        var previousCount = pool.BlockCount();
+        var previousCount2 = pool2.BlockCount();
+        timeProvider.Advance(TimeSpan.FromSeconds(10));
+        factory.OnHeartbeat();
+
+        await VerifyPoolEviction(pool, previousCount);
+        await VerifyPoolEviction(pool2, previousCount2);
+
+        timeProvider.Advance(TimeSpan.FromSeconds(10));
+
+        previousCount = pool.BlockCount();
+        previousCount2 = pool2.BlockCount();
+        factory.OnHeartbeat();
+
+        await VerifyPoolEviction(pool, previousCount);
+        await VerifyPoolEviction(pool2, previousCount2);
+
+        static async Task VerifyPoolEviction(PinnedBlockMemoryPool pool, int previousCount)
+        {
+            var maxWait = TimeSpan.FromSeconds(5);
+            while (pool.BlockCount() > previousCount - (previousCount / 30) && maxWait > TimeSpan.Zero)
+            {
+                await Task.Delay(50);
+                maxWait -= TimeSpan.FromMilliseconds(50);
+            }
+
+            Assert.InRange(pool.BlockCount(), previousCount - (previousCount / 10), previousCount - (previousCount / 30));
+        }
+    }
+}

--- a/src/Servers/Kestrel/Core/test/PinnedBlockMemoryPoolFactoryTests.cs
+++ b/src/Servers/Kestrel/Core/test/PinnedBlockMemoryPoolFactoryTests.cs
@@ -94,6 +94,10 @@ public class PinnedBlockMemoryPoolFactoryTests
 
         static async Task VerifyPoolEviction(PinnedBlockMemoryPool pool, int previousCount)
         {
+            // Because the eviction happens on a thread pool thread, we need to wait for it to complete
+            // and the only way to do that (without adding a test hook in the pool code) is to delay.
+            // But we don't want to add an arbitrary delay, so we do a short delay with block count checks
+            // to reduce the wait time.
             var maxWait = TimeSpan.FromSeconds(5);
             while (pool.BlockCount() > previousCount - (previousCount / 30) && maxWait > TimeSpan.Zero)
             {
@@ -101,6 +105,8 @@ public class PinnedBlockMemoryPoolFactoryTests
                 maxWait -= TimeSpan.FromMilliseconds(50);
             }
 
+            // Assert that the block count has decreased by 3.3-10%.
+            // This relies on the current implementation of eviction logic which may change in the future.
             Assert.InRange(pool.BlockCount(), previousCount - (previousCount / 10), previousCount - (previousCount / 30));
         }
     }

--- a/src/Servers/Kestrel/Core/test/PinnedBlockMemoryPoolFactoryTests.cs
+++ b/src/Servers/Kestrel/Core/test/PinnedBlockMemoryPoolFactoryTests.cs
@@ -40,7 +40,7 @@ public class PinnedBlockMemoryPoolFactoryTests
         var pool = factory.Create();
         Assert.NotNull(pool);
 
-        var dict = (ConcurrentDictionary<PinnedBlockMemoryPool, PinnedBlockMemoryPool>)(typeof(PinnedBlockMemoryPoolFactory)
+        var dict = (ConcurrentDictionary<PinnedBlockMemoryPool, nuint>)(typeof(PinnedBlockMemoryPoolFactory)
             .GetField("_pools", BindingFlags.NonPublic | BindingFlags.Instance)
             ?.GetValue(factory));
         Assert.Single(dict);

--- a/src/Servers/Kestrel/Core/test/PinnedBlockMemoryPoolTests.cs
+++ b/src/Servers/Kestrel/Core/test/PinnedBlockMemoryPoolTests.cs
@@ -1,8 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
-using Xunit;
 
 namespace Microsoft.Extensions.Internal.Test;
 
@@ -24,5 +23,201 @@ public class PinnedBlockMemoryPoolTests : MemoryPoolTests
         var memoryPool = CreatePool();
         var block = memoryPool.Rent();
         memoryPool.Dispose();
+    }
+
+    [Fact]
+    public void CanEvictBlocks()
+    {
+        using var memoryPool = new PinnedBlockMemoryPool();
+
+        var block = memoryPool.Rent();
+        block.Dispose();
+        Assert.Equal(1, memoryPool.BlockCount());
+
+        // First eviction does nothing because we double counted the initial rent due to it needing to allocate
+        memoryPool.PerformEviction();
+        Assert.Equal(1, memoryPool.BlockCount());
+
+        memoryPool.PerformEviction();
+        Assert.Equal(0, memoryPool.BlockCount());
+    }
+
+    [Fact]
+    public void EvictsSmallAmountOfBlocksWhenTrafficIsTheSame()
+    {
+        using var memoryPool = new PinnedBlockMemoryPool();
+
+        var blocks = new List<IMemoryOwner<byte>>();
+        for (var i = 0; i < 10000; i++)
+        {
+            blocks.Add(memoryPool.Rent());
+        }
+        Assert.Equal(0, memoryPool.BlockCount());
+        memoryPool.PerformEviction();
+
+        foreach (var block in blocks)
+        {
+            block.Dispose();
+        }
+        blocks.Clear();
+        Assert.Equal(10000, memoryPool.BlockCount());
+        memoryPool.PerformEviction();
+
+        var originalCount = memoryPool.BlockCount();
+        for (var j = 0; j < 100; j++)
+        {
+            var previousCount = memoryPool.BlockCount();
+            // Rent and return at the same rate
+            for (var i = 0; i < 100; i++)
+            {
+                blocks.Add(memoryPool.Rent());
+            }
+            foreach (var block in blocks)
+            {
+                block.Dispose();
+            }
+            blocks.Clear();
+
+            Assert.Equal(previousCount, memoryPool.BlockCount());
+
+            // Eviction while rent+return is the same
+            memoryPool.PerformEviction();
+            Assert.InRange(memoryPool.BlockCount(), previousCount - (previousCount / 100), previousCount - 1);
+        }
+
+        Assert.True(memoryPool.BlockCount() <= originalCount - 100, "Evictions should have removed some blocks");
+    }
+
+    [Fact]
+    public void DoesNotEvictBlocksWhenActive()
+    {
+        using var memoryPool = new PinnedBlockMemoryPool();
+
+        var blocks = new List<IMemoryOwner<byte>>();
+        for (var i = 0; i < 10000; i++)
+        {
+            blocks.Add(memoryPool.Rent());
+        }
+        Assert.Equal(0, memoryPool.BlockCount());
+        memoryPool.PerformEviction();
+
+        foreach (var block in blocks)
+        {
+            block.Dispose();
+        }
+        blocks.Clear();
+        Assert.Equal(10000, memoryPool.BlockCount());
+        memoryPool.PerformEviction();
+        var previousCount = memoryPool.BlockCount();
+
+        // Simulate active usage, rent without returning
+        for (var i = 0; i < 100; i++)
+        {
+            blocks.Add(memoryPool.Rent());
+        }
+        previousCount -= 100;
+
+        // Eviction while pool is actively used should not remove blocks
+        memoryPool.PerformEviction();
+        Assert.Equal(previousCount, memoryPool.BlockCount());
+    }
+
+    [Fact]
+    public void EvictsBlocksGraduallyWhenIdle()
+    {
+        using var memoryPool = new PinnedBlockMemoryPool();
+
+        var blocks = new List<IMemoryOwner<byte>>();
+        for (var i = 0; i < 10000; i++)
+        {
+            blocks.Add(memoryPool.Rent());
+        }
+        Assert.Equal(0, memoryPool.BlockCount());
+        memoryPool.PerformEviction();
+
+        foreach (var block in blocks)
+        {
+            block.Dispose();
+        }
+        blocks.Clear();
+        Assert.Equal(10000, memoryPool.BlockCount());
+        // Eviction after returning everything to reset internal counters
+        memoryPool.PerformEviction();
+
+        // Eviction should happen gradually over multiple calls
+        for (var i = 0; i < 10; i++)
+        {
+            var previousCount = memoryPool.BlockCount();
+            memoryPool.PerformEviction();
+            // Eviction while idle should remove 10-30% of blocks
+            Assert.InRange(memoryPool.BlockCount(), previousCount - (previousCount / 10), previousCount - (previousCount / 30));
+        }
+
+        // Ensure all blocks are evicted eventually
+        var count = memoryPool.BlockCount();
+        do
+        {
+            count = memoryPool.BlockCount();
+            memoryPool.PerformEviction();
+        }
+        // Make sure the loop makes forward progress
+        while (count != 0 && count != memoryPool.BlockCount());
+
+        Assert.Equal(0, memoryPool.BlockCount());
+    }
+
+    [Fact]
+    public async Task EvictionsAreScheduled()
+    {
+        using var memoryPool = new PinnedBlockMemoryPool();
+
+        var blocks = new List<IMemoryOwner<byte>>();
+        for (var i = 0; i < 10000; i++)
+        {
+            blocks.Add(memoryPool.Rent());
+        }
+        Assert.Equal(0, memoryPool.BlockCount());
+
+        foreach (var block in blocks)
+        {
+            block.Dispose();
+        }
+        blocks.Clear();
+        Assert.Equal(10000, memoryPool.BlockCount());
+        // Eviction after returning everything to reset internal counters
+        memoryPool.PerformEviction();
+
+        Assert.Equal(10000, memoryPool.BlockCount());
+
+        var previousCount = memoryPool.BlockCount();
+
+        // Scheduling only works every 10 seconds and is initialized to UtcNow + 10 when the pool is constructed
+        Assert.False(memoryPool.TryScheduleEviction(DateTime.UtcNow));
+
+        Assert.True(memoryPool.TryScheduleEviction(DateTime.UtcNow.AddSeconds(10)));
+
+        var maxWait = TimeSpan.FromSeconds(5);
+        while (memoryPool.BlockCount() > previousCount - (previousCount / 30) && maxWait > TimeSpan.Zero)
+        {
+            await Task.Delay(50);
+            maxWait -= TimeSpan.FromMilliseconds(50);
+        }
+
+        Assert.InRange(memoryPool.BlockCount(), previousCount - (previousCount / 10), previousCount - (previousCount / 30));
+
+        // Since we scheduled successfully, we now need to wait 10 seconds to schedule again.
+        Assert.False(memoryPool.TryScheduleEviction(DateTime.UtcNow.AddSeconds(10)));
+
+        previousCount = memoryPool.BlockCount();
+        Assert.True(memoryPool.TryScheduleEviction(DateTime.UtcNow.AddSeconds(20)));
+
+        maxWait = TimeSpan.FromSeconds(5);
+        while (memoryPool.BlockCount() > previousCount - (previousCount / 30) && maxWait > TimeSpan.Zero)
+        {
+            await Task.Delay(50);
+            maxWait -= TimeSpan.FromMilliseconds(50);
+        }
+
+        Assert.InRange(memoryPool.BlockCount(), previousCount - (previousCount / 10), previousCount - (previousCount / 30));
     }
 }

--- a/src/Servers/Kestrel/Core/test/PipelineExtensionTests.cs
+++ b/src/Servers/Kestrel/Core/test/PipelineExtensionTests.cs
@@ -16,7 +16,7 @@ public class PipelineExtensionTests : IDisposable
     private const int _ulongMaxValueLength = 20;
 
     private readonly Pipe _pipe;
-    private readonly MemoryPool<byte> _memoryPool = PinnedBlockMemoryPoolFactory.Create();
+    private readonly MemoryPool<byte> _memoryPool = TestMemoryPoolFactory.Create();
 
     public PipelineExtensionTests()
     {

--- a/src/Servers/Kestrel/Core/test/StartLineTests.cs
+++ b/src/Servers/Kestrel/Core/test/StartLineTests.cs
@@ -515,7 +515,7 @@ public class StartLineTests : IDisposable
 
     public StartLineTests()
     {
-        MemoryPool = PinnedBlockMemoryPoolFactory.Create();
+        MemoryPool = TestMemoryPoolFactory.Create();
         var options = new PipeOptions(MemoryPool, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false);
         var pair = DuplexPipe.CreateConnectionPair(options, options);
         Transport = pair.Transport;

--- a/src/Servers/Kestrel/Core/test/TestHelpers/TestInput.cs
+++ b/src/Servers/Kestrel/Core/test/TestHelpers/TestInput.cs
@@ -24,7 +24,7 @@ class TestInput : IDisposable
 
     public TestInput(KestrelTrace log = null, ITimeoutControl timeoutControl = null)
     {
-        _memoryPool = PinnedBlockMemoryPoolFactory.Create();
+        _memoryPool = System.Buffers.PinnedBlockMemoryPoolFactory.Create();
         var options = new PipeOptions(pool: _memoryPool, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false);
         var pair = DuplexPipe.CreateConnectionPair(options, options);
         Transport = pair.Transport;

--- a/src/Servers/Kestrel/Core/test/TestHelpers/TestInput.cs
+++ b/src/Servers/Kestrel/Core/test/TestHelpers/TestInput.cs
@@ -24,7 +24,7 @@ class TestInput : IDisposable
 
     public TestInput(KestrelTrace log = null, ITimeoutControl timeoutControl = null)
     {
-        _memoryPool = System.Buffers.PinnedBlockMemoryPoolFactory.Create();
+        _memoryPool = TestMemoryPoolFactory.Create();
         var options = new PipeOptions(pool: _memoryPool, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false);
         var pair = DuplexPipe.CreateConnectionPair(options, options);
         Transport = pair.Transport;

--- a/src/Servers/Kestrel/Kestrel/src/WebHostBuilderKestrelExtensions.cs
+++ b/src/Servers/Kestrel/Kestrel/src/WebHostBuilderKestrelExtensions.cs
@@ -91,7 +91,7 @@ public static class WebHostBuilderKestrelExtensions
 
             services.AddSingleton<PinnedBlockMemoryPoolFactory>();
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IHeartbeatHandler, PinnedBlockMemoryPoolFactory>(sp => sp.GetRequiredService<PinnedBlockMemoryPoolFactory>()));
-            services.AddSingleton<IMemoryPoolFactory>(sp => sp.GetRequiredService<PinnedBlockMemoryPoolFactory>());
+            services.AddSingleton<IMemoryPoolFactory<byte>>(sp => sp.GetRequiredService<PinnedBlockMemoryPoolFactory>());
         });
 
         if (OperatingSystem.IsWindows())

--- a/src/Servers/Kestrel/Kestrel/src/WebHostBuilderKestrelExtensions.cs
+++ b/src/Servers/Kestrel/Kestrel/src/WebHostBuilderKestrelExtensions.cs
@@ -81,9 +81,6 @@ public static class WebHostBuilderKestrelExtensions
         hostBuilder.UseSockets();
         hostBuilder.ConfigureServices(services =>
         {
-            // Don't override an already-configured transport
-            //services.TryAddSingleton<IConnectionListenerFactory, SocketTransportFactory>();
-
             services.AddTransient<IConfigureOptions<KestrelServerOptions>, KestrelServerOptionsSetup>();
             services.AddSingleton<IHttpsConfigurationService, HttpsConfigurationService>();
             services.AddSingleton<IServer, KestrelServerImpl>();

--- a/src/Servers/Kestrel/Kestrel/src/WebHostBuilderKestrelExtensions.cs
+++ b/src/Servers/Kestrel/Kestrel/src/WebHostBuilderKestrelExtensions.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
-using Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
@@ -79,10 +78,11 @@ public static class WebHostBuilderKestrelExtensions
     /// </returns>
     public static IWebHostBuilder UseKestrelCore(this IWebHostBuilder hostBuilder)
     {
+        hostBuilder.UseSockets();
         hostBuilder.ConfigureServices(services =>
         {
             // Don't override an already-configured transport
-            services.TryAddSingleton<IConnectionListenerFactory, SocketTransportFactory>();
+            //services.TryAddSingleton<IConnectionListenerFactory, SocketTransportFactory>();
 
             services.AddTransient<IConfigureOptions<KestrelServerOptions>, KestrelServerOptionsSetup>();
             services.AddSingleton<IHttpsConfigurationService, HttpsConfigurationService>();

--- a/src/Servers/Kestrel/Kestrel/src/WebHostBuilderKestrelExtensions.cs
+++ b/src/Servers/Kestrel/Kestrel/src/WebHostBuilderKestrelExtensions.cs
@@ -88,6 +88,10 @@ public static class WebHostBuilderKestrelExtensions
             services.AddSingleton<IHttpsConfigurationService, HttpsConfigurationService>();
             services.AddSingleton<IServer, KestrelServerImpl>();
             services.AddSingleton<KestrelMetrics>();
+
+            services.AddSingleton<PinnedBlockMemoryPoolFactory>();
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IHeartbeatHandler, PinnedBlockMemoryPoolFactory>(sp => sp.GetRequiredService<PinnedBlockMemoryPoolFactory>()));
+            services.AddSingleton<IMemoryPoolFactory>(sp => sp.GetRequiredService<PinnedBlockMemoryPoolFactory>());
         });
 
         if (OperatingSystem.IsWindows())

--- a/src/Servers/Kestrel/Kestrel/test/Microsoft.AspNetCore.Server.Kestrel.Tests.csproj
+++ b/src/Servers/Kestrel/Kestrel/test/Microsoft.AspNetCore.Server.Kestrel.Tests.csproj
@@ -18,6 +18,7 @@
     <Content Include="$(KestrelRoot)Core\src\Internal\Infrastructure\HttpUtilities.Generated.cs" LinkBase="shared\GeneratedContent" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="$(KestrelSharedSourceRoot)\TransportConnection.Generated.cs" LinkBase="shared\GeneratedContent" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="$(KestrelSharedSourceRoot)\TransportMultiplexedConnection.Generated.cs" LinkBase="shared\GeneratedContent" CopyToOutputDirectory="PreserveNewest" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\TransportTestHelpers\NamedPipesSupportedAttribute.cs" Link="shared\TransportTestHelpers\NamedPipesSupportedAttribute.cs" />
 
     <ProjectReference Include="..\..\tools\CodeGenerator\CodeGenerator.csproj" />
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel" />

--- a/src/Servers/Kestrel/Kestrel/test/WebHostBuilderKestrelExtensionsTests.cs
+++ b/src/Servers/Kestrel/Kestrel/test/WebHostBuilderKestrelExtensionsTests.cs
@@ -1,13 +1,18 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.IO.Pipelines;
+using System.Reflection;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets;
 using Microsoft.Extensions.DependencyInjection;
@@ -115,10 +120,25 @@ public class WebHostBuilderKestrelExtensionsTests
         Assert.IsType<KestrelMetrics>(server.ServiceContext.Metrics);
         Assert.Equal(PipeScheduler.ThreadPool, server.ServiceContext.Scheduler);
         Assert.Equal(TimeProvider.System, server.ServiceContext.TimeProvider);
+
+        var handlers = (IHeartbeatHandler[])typeof(Heartbeat).GetField("_callbacks", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(server.ServiceContext.Heartbeat);
+        Assert.Collection(handlers,
+            handler =>
+            {
+                Assert.Equal(typeof(DateHeaderValueManager), handler.GetType());
+            },
+            handler =>
+            {
+                Assert.Equal(typeof(ConnectionManager), handler.GetType());
+            },
+            handler =>
+            {
+                Assert.Equal(typeof(PinnedBlockMemoryPoolFactory), handler.GetType());
+            });
     }
 
     [Fact]
-    public void MemoryPoolFactorySetCorrectly()
+    public void MemoryPoolFactorySetCorrectlyWithSockets()
     {
         var hostBuilder = new WebHostBuilder()
             .UseSockets()
@@ -144,5 +164,68 @@ public class WebHostBuilderKestrelExtensionsTests
         Assert.Null(host.Services.GetService<IMemoryPoolFactory<int>>());
 
         Assert.Same(memoryPoolFactory, host.Services.GetRequiredService<IOptions<SocketTransportOptions>>().Value.MemoryPoolFactory);
+    }
+
+    [Fact]
+    public void SocketsHasDefaultMemoryPool()
+    {
+        var hostBuilder = new WebHostBuilder()
+            .UseSockets()
+            .Configure(app => { });
+
+        var host = hostBuilder.Build();
+
+        var memoryPoolFactory = host.Services.GetRequiredService<IMemoryPoolFactory<byte>>();
+        Assert.IsNotType<PinnedBlockMemoryPoolFactory>(memoryPoolFactory);
+        Assert.Null(host.Services.GetService<IMemoryPoolFactory<int>>());
+
+        Assert.Same(memoryPoolFactory, host.Services.GetRequiredService<IOptions<SocketTransportOptions>>().Value.MemoryPoolFactory);
+    }
+
+    [ConditionalFact]
+    [NamedPipesSupported]
+    public void MemoryPoolFactorySetCorrectlyWithNamedPipes()
+    {
+        var hostBuilder = new WebHostBuilder()
+            .UseNamedPipes()
+            .UseKestrel()
+            .Configure(app => { });
+
+        var host = hostBuilder.Build();
+
+        var memoryPoolFactory = Assert.IsType<PinnedBlockMemoryPoolFactory>(host.Services.GetRequiredService<IMemoryPoolFactory<byte>>());
+        Assert.Null(host.Services.GetService<IMemoryPoolFactory<int>>());
+
+        Assert.Same(memoryPoolFactory, host.Services.GetRequiredService<IOptions<NamedPipeTransportOptions>>().Value.MemoryPoolFactory);
+
+        // Swap order of UseKestrel and UseNamedPipes
+        hostBuilder = new WebHostBuilder()
+            .UseKestrel()
+            .UseNamedPipes()
+            .Configure(app => { });
+
+        host = hostBuilder.Build();
+
+        memoryPoolFactory = Assert.IsType<PinnedBlockMemoryPoolFactory>(host.Services.GetRequiredService<IMemoryPoolFactory<byte>>());
+        Assert.Null(host.Services.GetService<IMemoryPoolFactory<int>>());
+
+        Assert.Same(memoryPoolFactory, host.Services.GetRequiredService<IOptions<NamedPipeTransportOptions>>().Value.MemoryPoolFactory);
+    }
+
+    [ConditionalFact]
+    [NamedPipesSupported]
+    public void NamedPipesHasDefaultMemoryPool()
+    {
+        var hostBuilder = new WebHostBuilder()
+            .UseNamedPipes()
+            .Configure(app => { });
+
+        var host = hostBuilder.Build();
+
+        var memoryPoolFactory = host.Services.GetRequiredService<IMemoryPoolFactory<byte>>();
+        Assert.IsNotType<PinnedBlockMemoryPoolFactory>(memoryPoolFactory);
+        Assert.Null(host.Services.GetService<IMemoryPoolFactory<int>>());
+
+        Assert.Same(memoryPoolFactory, host.Services.GetRequiredService<IOptions<NamedPipeTransportOptions>>().Value.MemoryPoolFactory);
     }
 }

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnectionListener.cs
@@ -40,7 +40,7 @@ internal sealed class NamedPipeConnectionListener : IConnectionListener
         _log = loggerFactory.CreateLogger("Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes");
         _endpoint = endpoint;
         _options = options;
-        _memoryPool = options.MemoryPoolFactory.CreatePool();
+        _memoryPool = options.MemoryPoolFactory.Create();
         _listeningToken = _listeningTokenSource.Token;
         // Have to create the pool here (instead of DI) because the pool is specific to an endpoint.
         _poolPolicy = new NamedPipeServerStreamPoolPolicy(endpoint, options);

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnectionListener.cs
@@ -40,7 +40,7 @@ internal sealed class NamedPipeConnectionListener : IConnectionListener
         _log = loggerFactory.CreateLogger("Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes");
         _endpoint = endpoint;
         _options = options;
-        _memoryPool = options.MemoryPoolFactory();
+        _memoryPool = options.MemoryPoolFactory.CreatePool();
         _listeningToken = _listeningTokenSource.Token;
         // Have to create the pool here (instead of DI) because the pool is specific to an endpoint.
         _poolPolicy = new NamedPipeServerStreamPoolPolicy(endpoint, options);

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.csproj
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.csproj
@@ -21,7 +21,7 @@
     <Compile Include="$(KestrelSharedSourceRoot)\TransportConnection.cs" Link="Internal\TransportConnection.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)\TransportConnection.Generated.cs" Link="Internal\TransportConnection.Generated.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)\TransportConnection.FeatureCollection.cs" Link="Internal\TransportConnection.FeatureCollection.cs" />
-    <Compile Include="$(KestrelSharedSourceRoot)\DefaultMemoryPoolFactory.cs" Link="Internal\DefaultMemoryPoolFactory.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)\DefaultSimpleMemoryPoolFactory.cs" Link="Internal\DefaultSimpleMemoryPoolFactory.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.csproj
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.csproj
@@ -21,6 +21,7 @@
     <Compile Include="$(KestrelSharedSourceRoot)\TransportConnection.cs" Link="Internal\TransportConnection.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)\TransportConnection.Generated.cs" Link="Internal\TransportConnection.Generated.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)\TransportConnection.FeatureCollection.cs" Link="Internal\TransportConnection.FeatureCollection.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)\DefaultMemoryPoolFactory.cs" Link="Internal\DefaultMemoryPoolFactory.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
@@ -117,5 +117,5 @@ public sealed class NamedPipeTransportOptions
         }
     }
 
-    internal IMemoryPoolFactory<byte> MemoryPoolFactory { get; set; } = DefaultMemoryPoolFactory.Instance;
+    internal IMemoryPoolFactory<byte> MemoryPoolFactory { get; set; } = DefaultSimpleMemoryPoolFactory.Instance;
 }

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.Diagnostics.Metrics;
 using System.IO.Pipes;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes;
@@ -116,5 +117,11 @@ public sealed class NamedPipeTransportOptions
         }
     }
 
-    internal Func<MemoryPool<byte>> MemoryPoolFactory { get; set; } = PinnedBlockMemoryPoolFactory.Create;
+    internal Func<MemoryPool<byte>> MemoryPoolFactory { get; set; } = () => PinnedBlockMemoryPoolFactory.Create(new DummyMeterFactory());
+    private sealed class DummyMeterFactory : IMeterFactory
+    {
+        public Meter Create(MeterOptions options) => new Meter(options);
+
+        public void Dispose() { }
+    }
 }

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
-using System.Diagnostics.Metrics;
 using System.IO.Pipes;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes;
@@ -117,11 +116,5 @@ public sealed class NamedPipeTransportOptions
         }
     }
 
-    internal Func<MemoryPool<byte>> MemoryPoolFactory { get; set; } = () => PinnedBlockMemoryPoolFactory.Create(new DummyMeterFactory());
-    private sealed class DummyMeterFactory : IMeterFactory
-    {
-        public Meter Create(MeterOptions options) => new Meter(options);
-
-        public void Dispose() { }
-    }
+    internal Func<MemoryPool<byte>> MemoryPoolFactory { get; set; } = () => PinnedBlockMemoryPoolFactory.Create();
 }

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
@@ -117,5 +117,5 @@ public sealed class NamedPipeTransportOptions
         }
     }
 
-    internal IMemoryPoolFactory MemoryPoolFactory { get; set; } = DefaultMemoryPoolFactory.Instance;
+    internal IMemoryPoolFactory<byte> MemoryPoolFactory { get; set; } = DefaultMemoryPoolFactory.Instance;
 }

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
@@ -1,8 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Buffers;
 using System.IO.Pipes;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Server.Kestrel.Internal;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes;
 
@@ -116,5 +117,5 @@ public sealed class NamedPipeTransportOptions
         }
     }
 
-    internal Func<MemoryPool<byte>> MemoryPoolFactory { get; set; } = () => PinnedBlockMemoryPoolFactory.Create();
+    internal IMemoryPoolFactory MemoryPoolFactory { get; set; } = DefaultMemoryPoolFactory.Instance;
 }

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/WebHostBuilderNamedPipeExtensions.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/WebHostBuilderNamedPipeExtensions.cs
@@ -35,8 +35,8 @@ public static class WebHostBuilderNamedPipeExtensions
             services.TryAddSingleton<ObjectPoolProvider, DefaultObjectPoolProvider>();
             services.AddSingleton<IConnectionListenerFactory, NamedPipeTransportFactory>();
 
-            services.TryAddSingleton<IMemoryPoolFactory, DefaultMemoryPoolFactory>();
-            services.AddOptions<NamedPipeTransportOptions>().Configure((NamedPipeTransportOptions options, IMemoryPoolFactory factory) =>
+            services.TryAddSingleton<IMemoryPoolFactory<byte>, DefaultMemoryPoolFactory>();
+            services.AddOptions<NamedPipeTransportOptions>().Configure((NamedPipeTransportOptions options, IMemoryPoolFactory<byte> factory) =>
             {
                 // Set the IMemoryPoolFactory from DI on NamedPipeTransportOptions. Usually this should be the PinnedBlockMemoryPoolFactory from UseKestrelCore.
                 options.MemoryPoolFactory = factory;

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/WebHostBuilderNamedPipeExtensions.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/WebHostBuilderNamedPipeExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Runtime.Versioning;
 using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Server.Kestrel.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.Internal;
 using Microsoft.Extensions.DependencyInjection;
@@ -33,7 +34,15 @@ public static class WebHostBuilderNamedPipeExtensions
         {
             services.TryAddSingleton<ObjectPoolProvider, DefaultObjectPoolProvider>();
             services.AddSingleton<IConnectionListenerFactory, NamedPipeTransportFactory>();
+
+            services.TryAddSingleton<IMemoryPoolFactory, DefaultMemoryPoolFactory>();
+            services.AddOptions<NamedPipeTransportOptions>().Configure((NamedPipeTransportOptions options, IMemoryPoolFactory factory) =>
+            {
+                // Set the IMemoryPoolFactory from DI on NamedPipeTransportOptions. Usually this should be the PinnedBlockMemoryPoolFactory from UseKestrelCore.
+                options.MemoryPoolFactory = factory;
+            });
         });
+
         return hostBuilder;
     }
 

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/WebHostBuilderNamedPipeExtensions.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/WebHostBuilderNamedPipeExtensions.cs
@@ -3,7 +3,6 @@
 
 using System.Runtime.Versioning;
 using Microsoft.AspNetCore.Connections;
-using Microsoft.AspNetCore.Server.Kestrel.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.Internal;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Servers/Kestrel/Transport.Sockets/src/Client/SocketConnectionFactory.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Client/SocketConnectionFactory.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.Diagnostics.Metrics;
 using System.IO.Pipelines;
 using System.Net;
 using System.Net.Sockets;
@@ -21,13 +22,13 @@ internal sealed class SocketConnectionFactory : IConnectionFactory, IAsyncDispos
     private readonly PipeOptions _outputOptions;
     private readonly SocketSenderPool _socketSenderPool;
 
-    public SocketConnectionFactory(IOptions<SocketTransportOptions> options, ILoggerFactory loggerFactory)
+    public SocketConnectionFactory(IOptions<SocketTransportOptions> options, ILoggerFactory loggerFactory, IMeterFactory meterFactory)
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
         _options = options.Value;
-        _memoryPool = options.Value.MemoryPoolFactory();
+        _memoryPool = options.Value.MemoryPoolFactory(meterFactory);
         _trace = loggerFactory.CreateLogger("Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Client");
 
         var maxReadBufferSize = _options.MaxReadBufferSize ?? 0;

--- a/src/Servers/Kestrel/Transport.Sockets/src/Client/SocketConnectionFactory.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Client/SocketConnectionFactory.cs
@@ -27,7 +27,7 @@ internal sealed class SocketConnectionFactory : IConnectionFactory, IAsyncDispos
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
         _options = options.Value;
-        _memoryPool = options.Value.MemoryPoolFactory.CreatePool();
+        _memoryPool = options.Value.MemoryPoolFactory.Create();
         _trace = loggerFactory.CreateLogger("Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Client");
 
         var maxReadBufferSize = _options.MaxReadBufferSize ?? 0;

--- a/src/Servers/Kestrel/Transport.Sockets/src/Client/SocketConnectionFactory.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Client/SocketConnectionFactory.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
-using System.Diagnostics.Metrics;
 using System.IO.Pipelines;
 using System.Net;
 using System.Net.Sockets;
@@ -22,13 +21,13 @@ internal sealed class SocketConnectionFactory : IConnectionFactory, IAsyncDispos
     private readonly PipeOptions _outputOptions;
     private readonly SocketSenderPool _socketSenderPool;
 
-    public SocketConnectionFactory(IOptions<SocketTransportOptions> options, ILoggerFactory loggerFactory, IMeterFactory meterFactory)
+    public SocketConnectionFactory(IOptions<SocketTransportOptions> options, ILoggerFactory loggerFactory)
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
         _options = options.Value;
-        _memoryPool = options.Value.MemoryPoolFactory(meterFactory);
+        _memoryPool = options.Value.MemoryPoolFactory.CreatePool();
         _trace = loggerFactory.CreateLogger("Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Client");
 
         var maxReadBufferSize = _options.MaxReadBufferSize ?? 0;

--- a/src/Servers/Kestrel/Transport.Sockets/src/Internal/DefaultMemoryPoolFactory.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Internal/DefaultMemoryPoolFactory.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using Microsoft.AspNetCore.Connections;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal;
+
+internal sealed class DefaultMemoryPoolFactory : IMemoryPoolFactory
+{
+    public static DefaultMemoryPoolFactory Instance { get; } = new DefaultMemoryPoolFactory();
+
+    public MemoryPool<byte> CreatePool()
+    {
+        return MemoryPool<byte>.Shared;
+    }
+}

--- a/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketConnection.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketConnection.cs
@@ -12,7 +12,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal;
 
 internal sealed partial class SocketConnection : TransportConnection
 {
-    private static readonly int MinAllocBufferSize = PinnedBlockMemoryPool.BlockSize / 2;
+    // PinnedBlockMemoryPool.BlockSize / 2
+    private const int MinAllocBufferSize = 4096 / 2;
 
     private readonly Socket _socket;
     private readonly ILogger _logger;

--- a/src/Servers/Kestrel/Transport.Sockets/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.csproj
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.csproj
@@ -17,7 +17,7 @@
     <Compile Include="$(KestrelSharedSourceRoot)\TransportConnection.cs" Link="Internal\TransportConnection.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)\TransportConnection.Generated.cs" Link="Internal\TransportConnection.Generated.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)\TransportConnection.FeatureCollection.cs" Link="Internal\TransportConnection.FeatureCollection.cs" />
-    <Compile Include="$(KestrelSharedSourceRoot)\DefaultMemoryPoolFactory.cs" Link="Internal\DefaultMemoryPoolFactory.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)\DefaultSimpleMemoryPoolFactory.cs" Link="Internal\DefaultSimpleMemoryPoolFactory.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Servers/Kestrel/Transport.Sockets/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.csproj
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.csproj
@@ -17,6 +17,7 @@
     <Compile Include="$(KestrelSharedSourceRoot)\TransportConnection.cs" Link="Internal\TransportConnection.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)\TransportConnection.Generated.cs" Link="Internal\TransportConnection.Generated.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)\TransportConnection.FeatureCollection.cs" Link="Internal\TransportConnection.FeatureCollection.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)\DefaultMemoryPoolFactory.cs" Link="Internal\DefaultMemoryPoolFactory.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Servers/Kestrel/Transport.Sockets/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.csproj
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.csproj
@@ -12,7 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="$(RepoRoot)src\Shared\Buffers.MemoryPool\*.cs" LinkBase="MemoryPool" />
     <Compile Include="$(KestrelSharedSourceRoot)\CorrelationIdGenerator.cs" Link="Internal\CorrelationIdGenerator.cs" />
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\DuplexPipe.cs" Link="Internal\DuplexPipe.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)\TransportConnection.cs" Link="Internal\TransportConnection.cs" />

--- a/src/Servers/Kestrel/Transport.Sockets/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Kestrel/Transport.Sockets/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportFactory.SocketTransportFactory(Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions!>! options, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory, System.Diagnostics.Metrics.IMeterFactory! meterFactory) -> void

--- a/src/Servers/Kestrel/Transport.Sockets/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Kestrel/Transport.Sockets/src/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
 #nullable enable
-Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportFactory.SocketTransportFactory(Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions!>! options, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory, System.Diagnostics.Metrics.IMeterFactory! meterFactory) -> void

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionContextFactory.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionContextFactory.cs
@@ -47,7 +47,7 @@ public sealed class SocketConnectionContextFactory : IDisposable
 
             for (var i = 0; i < _settingsCount; i++)
             {
-                var memoryPool = _options.MemoryPoolFactory(_options.MeterFactory);
+                var memoryPool = _options.MemoryPoolFactory.CreatePool();
                 var transportScheduler = options.UnsafePreferInlineScheduling ? PipeScheduler.Inline : new IOQueue();
 
                 _settings[i] = new QueueSettings()
@@ -62,7 +62,7 @@ public sealed class SocketConnectionContextFactory : IDisposable
         }
         else
         {
-            var memoryPool = _options.MemoryPoolFactory(_options.MeterFactory);
+            var memoryPool = _options.MemoryPoolFactory.CreatePool();
             var transportScheduler = options.UnsafePreferInlineScheduling ? PipeScheduler.Inline : PipeScheduler.ThreadPool;
 
             _settings = new QueueSettings[]

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionContextFactory.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionContextFactory.cs
@@ -47,7 +47,7 @@ public sealed class SocketConnectionContextFactory : IDisposable
 
             for (var i = 0; i < _settingsCount; i++)
             {
-                var memoryPool = _options.MemoryPoolFactory();
+                var memoryPool = _options.MemoryPoolFactory(_options.MeterFactory);
                 var transportScheduler = options.UnsafePreferInlineScheduling ? PipeScheduler.Inline : new IOQueue();
 
                 _settings[i] = new QueueSettings()
@@ -62,7 +62,7 @@ public sealed class SocketConnectionContextFactory : IDisposable
         }
         else
         {
-            var memoryPool = _options.MemoryPoolFactory();
+            var memoryPool = _options.MemoryPoolFactory(_options.MeterFactory);
             var transportScheduler = options.UnsafePreferInlineScheduling ? PipeScheduler.Inline : PipeScheduler.ThreadPool;
 
             _settings = new QueueSettings[]

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionContextFactory.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionContextFactory.cs
@@ -47,7 +47,7 @@ public sealed class SocketConnectionContextFactory : IDisposable
 
             for (var i = 0; i < _settingsCount; i++)
             {
-                var memoryPool = _options.MemoryPoolFactory.CreatePool();
+                var memoryPool = _options.MemoryPoolFactory.Create();
                 var transportScheduler = options.UnsafePreferInlineScheduling ? PipeScheduler.Inline : new IOQueue();
 
                 _settings[i] = new QueueSettings()
@@ -62,7 +62,7 @@ public sealed class SocketConnectionContextFactory : IDisposable
         }
         else
         {
-            var memoryPool = _options.MemoryPoolFactory.CreatePool();
+            var memoryPool = _options.MemoryPoolFactory.Create();
             var transportScheduler = options.UnsafePreferInlineScheduling ? PipeScheduler.Inline : PipeScheduler.ThreadPool;
 
             _settings = new QueueSettings[]

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionFactoryOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionFactoryOptions.cs
@@ -68,5 +68,5 @@ public class SocketConnectionFactoryOptions
     /// </remarks>
     public bool UnsafePreferInlineScheduling { get; set; }
 
-    internal IMemoryPoolFactory<byte> MemoryPoolFactory { get; set; } = DefaultMemoryPoolFactory.Instance;
+    internal IMemoryPoolFactory<byte> MemoryPoolFactory { get; set; } = DefaultSimpleMemoryPoolFactory.Instance;
 }

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionFactoryOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionFactoryOptions.cs
@@ -1,8 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Buffers;
-using System.Diagnostics.Metrics;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets;
 
@@ -14,9 +14,9 @@ public class SocketConnectionFactoryOptions
     /// <summary>
     /// Create a new instance.
     /// </summary>
-    public SocketConnectionFactoryOptions() { MeterFactory = new DummyMeterFactory(); }
+    public SocketConnectionFactoryOptions() { }
 
-    internal SocketConnectionFactoryOptions(SocketTransportOptions transportOptions, IMeterFactory meterFactory)
+    internal SocketConnectionFactoryOptions(SocketTransportOptions transportOptions)
     {
         IOQueueCount = transportOptions.IOQueueCount;
         WaitForDataBeforeAllocatingBuffer = transportOptions.WaitForDataBeforeAllocatingBuffer;
@@ -25,7 +25,6 @@ public class SocketConnectionFactoryOptions
         UnsafePreferInlineScheduling = transportOptions.UnsafePreferInlineScheduling;
         MemoryPoolFactory = transportOptions.MemoryPoolFactory;
         FinOnError = transportOptions.FinOnError;
-        MeterFactory = meterFactory;
     }
 
     // Opt-out flag for back compat. Remove in 9.0 (or make public).
@@ -69,13 +68,5 @@ public class SocketConnectionFactoryOptions
     /// </remarks>
     public bool UnsafePreferInlineScheduling { get; set; }
 
-    internal IMeterFactory MeterFactory { get; set; }
-    internal Func<IMeterFactory, MemoryPool<byte>> MemoryPoolFactory { get; set; } = PinnedBlockMemoryPoolFactory.Create;
-
-    internal sealed class DummyMeterFactory : IMeterFactory
-    {
-        public Meter Create(MeterOptions options) => new Meter(options);
-
-        public void Dispose() { }
-    }
+    internal IMemoryPoolFactory MemoryPoolFactory { get; set; } = DefaultMemoryPoolFactory.Instance;
 }

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionFactoryOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionFactoryOptions.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Connections;
-using Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal;
+using Microsoft.AspNetCore.Server.Kestrel.Internal;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets;
 

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionFactoryOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionFactoryOptions.cs
@@ -68,5 +68,5 @@ public class SocketConnectionFactoryOptions
     /// </remarks>
     public bool UnsafePreferInlineScheduling { get; set; }
 
-    internal IMemoryPoolFactory MemoryPoolFactory { get; set; } = DefaultMemoryPoolFactory.Instance;
+    internal IMemoryPoolFactory<byte> MemoryPoolFactory { get; set; } = DefaultMemoryPoolFactory.Instance;
 }

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionListener.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Diagnostics.Metrics;
 using System.Net;
 using System.Net.Sockets;
 using Microsoft.AspNetCore.Connections;
@@ -23,14 +22,13 @@ internal sealed class SocketConnectionListener : IConnectionListener
     internal SocketConnectionListener(
         EndPoint endpoint,
         SocketTransportOptions options,
-        ILoggerFactory loggerFactory,
-        IMeterFactory meterFactory)
+        ILoggerFactory loggerFactory)
     {
         EndPoint = endpoint;
         _options = options;
         var logger = loggerFactory.CreateLogger("Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets");
         _logger = logger;
-        _factory = new SocketConnectionContextFactory(new SocketConnectionFactoryOptions(options, meterFactory), logger);
+        _factory = new SocketConnectionContextFactory(new SocketConnectionFactoryOptions(options), logger);
     }
 
     internal void Bind()

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionListener.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using System.Net;
 using System.Net.Sockets;
 using Microsoft.AspNetCore.Connections;
@@ -22,13 +23,14 @@ internal sealed class SocketConnectionListener : IConnectionListener
     internal SocketConnectionListener(
         EndPoint endpoint,
         SocketTransportOptions options,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        IMeterFactory meterFactory)
     {
         EndPoint = endpoint;
         _options = options;
         var logger = loggerFactory.CreateLogger("Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets");
         _logger = logger;
-        _factory = new SocketConnectionContextFactory(new SocketConnectionFactoryOptions(options), logger);
+        _factory = new SocketConnectionContextFactory(new SocketConnectionFactoryOptions(options, meterFactory), logger);
     }
 
     internal void Bind()

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportFactory.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportFactory.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.Metrics;
 using System.Net;
 using System.Net.Sockets;
 using Microsoft.AspNetCore.Connections;
@@ -52,12 +51,5 @@ public sealed class SocketTransportFactory : IConnectionListenerFactory, IConnec
             FileHandleEndPoint _ => true,
             _ => false
         };
-    }
-
-    private sealed class DummyMeterFactory : IMeterFactory
-    {
-        public Meter Create(MeterOptions options) => new Meter(options);
-
-        public void Dispose() { }
     }
 }

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportFactory.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportFactory.cs
@@ -17,7 +17,6 @@ public sealed class SocketTransportFactory : IConnectionListenerFactory, IConnec
 {
     private readonly SocketTransportOptions _options;
     private readonly ILoggerFactory _logger;
-    private readonly IMeterFactory _meterFactory;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SocketTransportFactory"/> class.
@@ -26,26 +25,19 @@ public sealed class SocketTransportFactory : IConnectionListenerFactory, IConnec
     /// <param name="loggerFactory">The logger factory.</param>
     public SocketTransportFactory(
         IOptions<SocketTransportOptions> options,
-        ILoggerFactory loggerFactory) : this(options, loggerFactory, new DummyMeterFactory())
-    { }
-
-    public SocketTransportFactory(
-        IOptions<SocketTransportOptions> options,
-        ILoggerFactory loggerFactory,
-        IMeterFactory meterFactory)
+        ILoggerFactory loggerFactory)
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
         _options = options.Value;
         _logger = loggerFactory;
-        _meterFactory = meterFactory;
     }
 
     /// <inheritdoc />
     public ValueTask<IConnectionListener> BindAsync(EndPoint endpoint, CancellationToken cancellationToken = default)
     {
-        var transport = new SocketConnectionListener(endpoint, _options, _logger, _meterFactory);
+        var transport = new SocketConnectionListener(endpoint, _options, _logger);
         transport.Bind();
         return new ValueTask<IConnectionListener>(transport);
     }

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -1,11 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Buffers;
-using System.Diagnostics.Metrics;
 using System.Net;
 using System.Net.Sockets;
 using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets;
 
@@ -167,5 +166,5 @@ public class SocketTransportOptions
         return listenSocket;
     }
 
-    internal Func<IMeterFactory, MemoryPool<byte>> MemoryPoolFactory { get; set; } = PinnedBlockMemoryPoolFactory.Create;
+    internal IMemoryPoolFactory MemoryPoolFactory { get; set; } = DefaultMemoryPoolFactory.Instance;
 }

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.Diagnostics.Metrics;
 using System.Net;
 using System.Net.Sockets;
 using Microsoft.AspNetCore.Connections;
@@ -166,5 +167,5 @@ public class SocketTransportOptions
         return listenSocket;
     }
 
-    internal Func<MemoryPool<byte>> MemoryPoolFactory { get; set; } = System.Buffers.PinnedBlockMemoryPoolFactory.Create;
+    internal Func<IMeterFactory, MemoryPool<byte>> MemoryPoolFactory { get; set; } = PinnedBlockMemoryPoolFactory.Create;
 }

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -166,5 +166,5 @@ public class SocketTransportOptions
         return listenSocket;
     }
 
-    internal IMemoryPoolFactory MemoryPoolFactory { get; set; } = DefaultMemoryPoolFactory.Instance;
+    internal IMemoryPoolFactory<byte> MemoryPoolFactory { get; set; } = DefaultMemoryPoolFactory.Instance;
 }

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -166,5 +166,5 @@ public class SocketTransportOptions
         return listenSocket;
     }
 
-    internal IMemoryPoolFactory<byte> MemoryPoolFactory { get; set; } = DefaultMemoryPoolFactory.Instance;
+    internal IMemoryPoolFactory<byte> MemoryPoolFactory { get; set; } = DefaultSimpleMemoryPoolFactory.Instance;
 }

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -4,7 +4,7 @@
 using System.Net;
 using System.Net.Sockets;
 using Microsoft.AspNetCore.Connections;
-using Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal;
+using Microsoft.AspNetCore.Server.Kestrel.Internal;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets;
 

--- a/src/Servers/Kestrel/Transport.Sockets/src/WebHostBuilderSocketExtensions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/WebHostBuilderSocketExtensions.cs
@@ -29,8 +29,8 @@ public static class WebHostBuilderSocketExtensions
         {
             services.TryAddSingleton<IConnectionListenerFactory, SocketTransportFactory>();
 
-            services.TryAddSingleton<IMemoryPoolFactory, DefaultMemoryPoolFactory>();
-            services.AddOptions<SocketTransportOptions>().Configure((SocketTransportOptions options, IMemoryPoolFactory factory) =>
+            services.TryAddSingleton<IMemoryPoolFactory<byte>, DefaultMemoryPoolFactory>();
+            services.AddOptions<SocketTransportOptions>().Configure((SocketTransportOptions options, IMemoryPoolFactory<byte> factory) =>
             {
                 // Set the IMemoryPoolFactory from DI on SocketTransportOptions. Usually this should be the PinnedBlockMemoryPoolFactory from UseKestrelCore.
                 options.MemoryPoolFactory = factory;

--- a/src/Servers/Kestrel/Transport.Sockets/src/WebHostBuilderSocketExtensions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/WebHostBuilderSocketExtensions.cs
@@ -28,6 +28,7 @@ public static class WebHostBuilderSocketExtensions
         return hostBuilder.ConfigureServices(services =>
         {
             services.AddSingleton<IConnectionListenerFactory, SocketTransportFactory>();
+
             services.TryAddSingleton<IMemoryPoolFactory, DefaultMemoryPoolFactory>();
             services.AddOptions<SocketTransportOptions>().Configure((SocketTransportOptions options, IMemoryPoolFactory factory) =>
             {

--- a/src/Servers/Kestrel/Transport.Sockets/src/WebHostBuilderSocketExtensions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/WebHostBuilderSocketExtensions.cs
@@ -27,7 +27,7 @@ public static class WebHostBuilderSocketExtensions
     {
         return hostBuilder.ConfigureServices(services =>
         {
-            services.AddSingleton<IConnectionListenerFactory, SocketTransportFactory>();
+            services.TryAddSingleton<IConnectionListenerFactory, SocketTransportFactory>();
 
             services.TryAddSingleton<IMemoryPoolFactory, DefaultMemoryPoolFactory>();
             services.AddOptions<SocketTransportOptions>().Configure((SocketTransportOptions options, IMemoryPoolFactory factory) =>

--- a/src/Servers/Kestrel/Transport.Sockets/src/WebHostBuilderSocketExtensions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/WebHostBuilderSocketExtensions.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Server.Kestrel.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets;
-using Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -32,6 +32,7 @@ public static class WebHostBuilderSocketExtensions
             services.TryAddSingleton<IMemoryPoolFactory, DefaultMemoryPoolFactory>();
             services.AddOptions<SocketTransportOptions>().Configure((SocketTransportOptions options, IMemoryPoolFactory factory) =>
             {
+                // Set the IMemoryPoolFactory from DI on SocketTransportOptions. Usually this should be the PinnedBlockMemoryPoolFactory from UseKestrelCore.
                 options.MemoryPoolFactory = factory;
             });
         });

--- a/src/Servers/Kestrel/Transport.Sockets/src/WebHostBuilderSocketExtensions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/WebHostBuilderSocketExtensions.cs
@@ -29,7 +29,7 @@ public static class WebHostBuilderSocketExtensions
         {
             services.TryAddSingleton<IConnectionListenerFactory, SocketTransportFactory>();
 
-            services.TryAddSingleton<IMemoryPoolFactory<byte>, DefaultMemoryPoolFactory>();
+            services.TryAddSingleton<IMemoryPoolFactory<byte>, DefaultSimpleMemoryPoolFactory>();
             services.AddOptions<SocketTransportOptions>().Configure((SocketTransportOptions options, IMemoryPoolFactory<byte> factory) =>
             {
                 // Set the IMemoryPoolFactory from DI on SocketTransportOptions. Usually this should be the PinnedBlockMemoryPoolFactory from UseKestrelCore.

--- a/src/Servers/Kestrel/Transport.Sockets/src/WebHostBuilderSocketExtensions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/WebHostBuilderSocketExtensions.cs
@@ -3,7 +3,9 @@
 
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.AspNetCore.Hosting;
 
@@ -26,6 +28,11 @@ public static class WebHostBuilderSocketExtensions
         return hostBuilder.ConfigureServices(services =>
         {
             services.AddSingleton<IConnectionListenerFactory, SocketTransportFactory>();
+            services.TryAddSingleton<IMemoryPoolFactory, DefaultMemoryPoolFactory>();
+            services.AddOptions<SocketTransportOptions>().Configure((SocketTransportOptions options, IMemoryPoolFactory factory) =>
+            {
+                options.MemoryPoolFactory = factory;
+            });
         });
     }
 

--- a/src/Servers/Kestrel/perf/Microbenchmarks/ChunkWriterBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/ChunkWriterBenchmark.cs
@@ -20,7 +20,7 @@ public class ChunkWriterBenchmark
     [GlobalSetup]
     public void Setup()
     {
-        _memoryPool = PinnedBlockMemoryPoolFactory.Create();
+        _memoryPool = TestMemoryPoolFactory.Create();
         var pipe = new Pipe(new PipeOptions(_memoryPool));
         _reader = pipe.Reader;
         _writer = pipe.Writer;

--- a/src/Servers/Kestrel/perf/Microbenchmarks/HeaderCollectionBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/HeaderCollectionBenchmark.cs
@@ -324,7 +324,7 @@ public class HeaderCollectionBenchmark
     [IterationSetup]
     public void Setup()
     {
-        var memoryPool = PinnedBlockMemoryPoolFactory.Create();
+        var memoryPool = TestMemoryPoolFactory.Create();
         var options = new PipeOptions(memoryPool, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false);
         var pair = DuplexPipe.CreateConnectionPair(options, options);
 

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http1ConnectionBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http1ConnectionBenchmark.cs
@@ -27,7 +27,7 @@ public class Http1ConnectionBenchmark
     [GlobalSetup]
     public void Setup()
     {
-        var memoryPool = System.Buffers.PinnedBlockMemoryPoolFactory.Create();
+        var memoryPool = TestMemoryPoolFactory.Create();
         var options = new PipeOptions(memoryPool, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false);
         var pair = DuplexPipe.CreateConnectionPair(options, options);
 

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http1ConnectionBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http1ConnectionBenchmark.cs
@@ -27,7 +27,7 @@ public class Http1ConnectionBenchmark
     [GlobalSetup]
     public void Setup()
     {
-        var memoryPool = PinnedBlockMemoryPoolFactory.Create();
+        var memoryPool = System.Buffers.PinnedBlockMemoryPoolFactory.Create();
         var options = new PipeOptions(memoryPool, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false);
         var pair = DuplexPipe.CreateConnectionPair(options, options);
 

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http1ConnectionParsingOverheadBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http1ConnectionParsingOverheadBenchmark.cs
@@ -23,7 +23,7 @@ public class Http1ConnectionParsingOverheadBenchmark
     [IterationSetup]
     public void Setup()
     {
-        var memoryPool = System.Buffers.PinnedBlockMemoryPoolFactory.Create();
+        var memoryPool = TestMemoryPoolFactory.Create();
         var options = new PipeOptions(memoryPool, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false);
         var pair = DuplexPipe.CreateConnectionPair(options, options);
 

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http1ConnectionParsingOverheadBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http1ConnectionParsingOverheadBenchmark.cs
@@ -23,7 +23,7 @@ public class Http1ConnectionParsingOverheadBenchmark
     [IterationSetup]
     public void Setup()
     {
-        var memoryPool = PinnedBlockMemoryPoolFactory.Create();
+        var memoryPool = System.Buffers.PinnedBlockMemoryPoolFactory.Create();
         var options = new PipeOptions(memoryPool, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false);
         var pair = DuplexPipe.CreateConnectionPair(options, options);
 

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http1LargeWritingBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http1LargeWritingBenchmark.cs
@@ -28,7 +28,7 @@ public class Http1LargeWritingBenchmark
     [GlobalSetup]
     public void GlobalSetup()
     {
-        _memoryPool = PinnedBlockMemoryPoolFactory.Create();
+        _memoryPool = System.Buffers.PinnedBlockMemoryPoolFactory.Create();
         _http1Connection = MakeHttp1Connection();
         _consumeResponseBodyTask = ConsumeResponseBody();
     }

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http1LargeWritingBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http1LargeWritingBenchmark.cs
@@ -28,7 +28,7 @@ public class Http1LargeWritingBenchmark
     [GlobalSetup]
     public void GlobalSetup()
     {
-        _memoryPool = System.Buffers.PinnedBlockMemoryPoolFactory.Create();
+        _memoryPool = TestMemoryPoolFactory.Create();
         _http1Connection = MakeHttp1Connection();
         _consumeResponseBodyTask = ConsumeResponseBody();
     }

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http1ReadingBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http1ReadingBenchmark.cs
@@ -35,7 +35,7 @@ public class Http1ReadingBenchmark
     [GlobalSetup]
     public void GlobalSetup()
     {
-        _memoryPool = PinnedBlockMemoryPoolFactory.Create();
+        _memoryPool = System.Buffers.PinnedBlockMemoryPoolFactory.Create();
         _http1Connection = MakeHttp1Connection();
     }
 

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http1ReadingBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http1ReadingBenchmark.cs
@@ -35,7 +35,7 @@ public class Http1ReadingBenchmark
     [GlobalSetup]
     public void GlobalSetup()
     {
-        _memoryPool = System.Buffers.PinnedBlockMemoryPoolFactory.Create();
+        _memoryPool = TestMemoryPoolFactory.Create();
         _http1Connection = MakeHttp1Connection();
     }
 

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http1WritingBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http1WritingBenchmark.cs
@@ -35,7 +35,7 @@ public class Http1WritingBenchmark
     [GlobalSetup]
     public void GlobalSetup()
     {
-        _memoryPool = System.Buffers.PinnedBlockMemoryPoolFactory.Create();
+        _memoryPool = TestMemoryPoolFactory.Create();
         _http1Connection = MakeHttp1Connection();
         _consumeResponseBodyTask = ConsumeResponseBody();
     }

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http1WritingBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http1WritingBenchmark.cs
@@ -35,7 +35,7 @@ public class Http1WritingBenchmark
     [GlobalSetup]
     public void GlobalSetup()
     {
-        _memoryPool = PinnedBlockMemoryPoolFactory.Create();
+        _memoryPool = System.Buffers.PinnedBlockMemoryPoolFactory.Create();
         _http1Connection = MakeHttp1Connection();
         _consumeResponseBodyTask = ConsumeResponseBody();
     }

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http2/Http2ConnectionBenchmarkBase.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http2/Http2ConnectionBenchmarkBase.cs
@@ -43,7 +43,7 @@ public abstract class Http2ConnectionBenchmarkBase
 
     public virtual void GlobalSetup()
     {
-        _memoryPool = PinnedBlockMemoryPoolFactory.Create();
+        _memoryPool = TestMemoryPoolFactory.Create();
 
         var options = new PipeOptions(_memoryPool, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false);
 

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http2/Http2FrameWriterBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http2/Http2FrameWriterBenchmark.cs
@@ -24,7 +24,7 @@ public class Http2FrameWriterBenchmark
     [GlobalSetup]
     public void GlobalSetup()
     {
-        _memoryPool = PinnedBlockMemoryPoolFactory.Create();
+        _memoryPool = TestMemoryPoolFactory.Create();
 
         var options = new PipeOptions(_memoryPool, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false);
         _pipe = new Pipe(options);

--- a/src/Servers/Kestrel/perf/Microbenchmarks/HttpProtocolFeatureCollection.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/HttpProtocolFeatureCollection.cs
@@ -226,7 +226,7 @@ public class HttpProtocolFeatureCollection
 
     public HttpProtocolFeatureCollection()
     {
-        var memoryPool = PinnedBlockMemoryPoolFactory.Create();
+        var memoryPool = TestMemoryPoolFactory.Create();
         var options = new PipeOptions(memoryPool, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false);
         var pair = DuplexPipe.CreateConnectionPair(options, options);
 

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks.csproj
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks.csproj
@@ -18,7 +18,6 @@
     <Compile Include="$(KestrelSharedSourceRoot)test\PipeWriterHttp2FrameExtensions.cs" Link="Internal\PipeWriterHttp2FrameExtensions.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)\HPackHeaderWriter.cs" Link="Http2\HPackHeaderWriter.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)\Http2HeadersEnumerator.cs" Link="Http2\Http2HeadersEnumerator.cs" />
-    <Compile Include="$(RepoRoot)src\Shared\Buffers.MemoryPool\*.cs" LinkBase="MemoryPool" />
     <Compile Include="$(KestrelSharedSourceRoot)test\KestrelTestLoggerProvider.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)test\TestApplicationErrorLogger.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)test\TestHttp1Connection.cs" />

--- a/src/Servers/Kestrel/perf/Microbenchmarks/PipeThroughputBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/PipeThroughputBenchmark.cs
@@ -19,7 +19,7 @@ public class PipeThroughputBenchmark
     [IterationSetup]
     public void Setup()
     {
-        _memoryPool = PinnedBlockMemoryPoolFactory.Create();
+        _memoryPool = TestMemoryPoolFactory.Create();
         _pipe = new Pipe(new PipeOptions(_memoryPool));
     }
 

--- a/src/Servers/Kestrel/perf/Microbenchmarks/RequestParsingBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/RequestParsingBenchmark.cs
@@ -24,7 +24,7 @@ public class RequestParsingBenchmark
     [IterationSetup]
     public void Setup()
     {
-        _memoryPool = PinnedBlockMemoryPoolFactory.Create();
+        _memoryPool = System.Buffers.PinnedBlockMemoryPoolFactory.Create();
         var options = new PipeOptions(_memoryPool, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false);
         var pair = DuplexPipe.CreateConnectionPair(options, options);
 

--- a/src/Servers/Kestrel/perf/Microbenchmarks/RequestParsingBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/RequestParsingBenchmark.cs
@@ -24,7 +24,7 @@ public class RequestParsingBenchmark
     [IterationSetup]
     public void Setup()
     {
-        _memoryPool = System.Buffers.PinnedBlockMemoryPoolFactory.Create();
+        _memoryPool = TestMemoryPoolFactory.Create();
         var options = new PipeOptions(_memoryPool, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false);
         var pair = DuplexPipe.CreateConnectionPair(options, options);
 

--- a/src/Servers/Kestrel/perf/Microbenchmarks/ResponseHeaderCollectionBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/ResponseHeaderCollectionBenchmark.cs
@@ -172,7 +172,7 @@ public class ResponseHeaderCollectionBenchmark
     [IterationSetup]
     public void Setup()
     {
-        var memoryPool = PinnedBlockMemoryPoolFactory.Create();
+        var memoryPool = System.Buffers.PinnedBlockMemoryPoolFactory.Create();
         var options = new PipeOptions(memoryPool, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false);
         var pair = DuplexPipe.CreateConnectionPair(options, options);
 

--- a/src/Servers/Kestrel/perf/Microbenchmarks/ResponseHeaderCollectionBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/ResponseHeaderCollectionBenchmark.cs
@@ -172,7 +172,7 @@ public class ResponseHeaderCollectionBenchmark
     [IterationSetup]
     public void Setup()
     {
-        var memoryPool = System.Buffers.PinnedBlockMemoryPoolFactory.Create();
+        var memoryPool = TestMemoryPoolFactory.Create();
         var options = new PipeOptions(memoryPool, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false);
         var pair = DuplexPipe.CreateConnectionPair(options, options);
 

--- a/src/Servers/Kestrel/shared/DefaultMemoryPoolFactory.cs
+++ b/src/Servers/Kestrel/shared/DefaultMemoryPoolFactory.cs
@@ -6,11 +6,11 @@ using Microsoft.AspNetCore.Connections;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal;
 
-internal sealed class DefaultMemoryPoolFactory : IMemoryPoolFactory
+internal sealed class DefaultMemoryPoolFactory : IMemoryPoolFactory<byte>
 {
     public static DefaultMemoryPoolFactory Instance { get; } = new DefaultMemoryPoolFactory();
 
-    public MemoryPool<byte> CreatePool()
+    public MemoryPool<byte> Create()
     {
         return MemoryPool<byte>.Shared;
     }

--- a/src/Servers/Kestrel/shared/DefaultMemoryPoolFactory.cs
+++ b/src/Servers/Kestrel/shared/DefaultMemoryPoolFactory.cs
@@ -4,7 +4,7 @@
 using System.Buffers;
 using Microsoft.AspNetCore.Connections;
 
-namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal;
+namespace Microsoft.AspNetCore.Server.Kestrel.Internal;
 
 internal sealed class DefaultMemoryPoolFactory : IMemoryPoolFactory
 {

--- a/src/Servers/Kestrel/shared/DefaultSimpleMemoryPoolFactory.cs
+++ b/src/Servers/Kestrel/shared/DefaultSimpleMemoryPoolFactory.cs
@@ -6,9 +6,9 @@ using Microsoft.AspNetCore.Connections;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Internal;
 
-internal sealed class DefaultMemoryPoolFactory : IMemoryPoolFactory<byte>
+internal sealed class DefaultSimpleMemoryPoolFactory : IMemoryPoolFactory<byte>
 {
-    public static DefaultMemoryPoolFactory Instance { get; } = new DefaultMemoryPoolFactory();
+    public static DefaultSimpleMemoryPoolFactory Instance { get; } = new DefaultSimpleMemoryPoolFactory();
 
     public MemoryPool<byte> Create()
     {

--- a/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
+++ b/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers;
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using System.Globalization;
 using System.IO.Pipelines;
 using System.Net.Http;
@@ -70,11 +71,18 @@ internal class Http3InMemory
         }
     }
 
+    internal sealed class DummyMeterFactory : IMeterFactory
+    {
+        public Meter Create(MeterOptions options) => new Meter(options);
+
+        public void Dispose() { }
+    }
+
     internal ServiceContext _serviceContext;
     private FakeTimeProvider _fakeTimeProvider;
     internal HttpConnection _httpConnection;
     internal readonly TimeoutControl _timeoutControl;
-    internal readonly MemoryPool<byte> _memoryPool = PinnedBlockMemoryPoolFactory.Create();
+    internal readonly MemoryPool<byte> _memoryPool = PinnedBlockMemoryPoolFactory.Create(new DummyMeterFactory());
     internal readonly ConcurrentQueue<TestStreamContext> _streamContextPool = new ConcurrentQueue<TestStreamContext>();
     protected Task _connectionTask;
     internal ILogger Logger { get; }

--- a/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
+++ b/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
@@ -73,7 +73,7 @@ internal class Http3InMemory
     private FakeTimeProvider _fakeTimeProvider;
     internal HttpConnection _httpConnection;
     internal readonly TimeoutControl _timeoutControl;
-    internal readonly MemoryPool<byte> _memoryPool = System.Buffers.PinnedBlockMemoryPoolFactory.Create();
+    internal readonly MemoryPool<byte> _memoryPool = TestMemoryPoolFactory.Create();
     internal readonly ConcurrentQueue<TestStreamContext> _streamContextPool = new ConcurrentQueue<TestStreamContext>();
     protected Task _connectionTask;
     internal ILogger Logger { get; }

--- a/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
+++ b/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
@@ -73,7 +73,7 @@ internal class Http3InMemory
     private FakeTimeProvider _fakeTimeProvider;
     internal HttpConnection _httpConnection;
     internal readonly TimeoutControl _timeoutControl;
-    internal readonly MemoryPool<byte> _memoryPool = PinnedBlockMemoryPoolFactory.Create();
+    internal readonly MemoryPool<byte> _memoryPool = System.Buffers.PinnedBlockMemoryPoolFactory.Create();
     internal readonly ConcurrentQueue<TestStreamContext> _streamContextPool = new ConcurrentQueue<TestStreamContext>();
     protected Task _connectionTask;
     internal ILogger Logger { get; }

--- a/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
+++ b/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
@@ -1,11 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Buffers;
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Diagnostics.Metrics;
 using System.Globalization;
 using System.IO.Pipelines;
 using System.Net.Http;
@@ -71,18 +69,11 @@ internal class Http3InMemory
         }
     }
 
-    internal sealed class DummyMeterFactory : IMeterFactory
-    {
-        public Meter Create(MeterOptions options) => new Meter(options);
-
-        public void Dispose() { }
-    }
-
     internal ServiceContext _serviceContext;
     private FakeTimeProvider _fakeTimeProvider;
     internal HttpConnection _httpConnection;
     internal readonly TimeoutControl _timeoutControl;
-    internal readonly MemoryPool<byte> _memoryPool = PinnedBlockMemoryPoolFactory.Create(new DummyMeterFactory());
+    internal readonly MemoryPool<byte> _memoryPool = PinnedBlockMemoryPoolFactory.Create();
     internal readonly ConcurrentQueue<TestStreamContext> _streamContextPool = new ConcurrentQueue<TestStreamContext>();
     protected Task _connectionTask;
     internal ILogger Logger { get; }

--- a/src/Servers/Kestrel/shared/test/TestContextFactory.cs
+++ b/src/Servers/Kestrel/shared/test/TestContextFactory.cs
@@ -93,7 +93,7 @@ internal static class TestContextFactory
             connectionContext,
             serviceContext ?? CreateServiceContext(new KestrelServerOptions()),
             connectionFeatures ?? new FeatureCollection(),
-            memoryPool ?? PinnedBlockMemoryPoolFactory.Create(),
+            memoryPool ?? System.Buffers.PinnedBlockMemoryPoolFactory.Create(),
             localEndPoint,
             remoteEndPoint,
             metricsContext)

--- a/src/Servers/Kestrel/shared/test/TestContextFactory.cs
+++ b/src/Servers/Kestrel/shared/test/TestContextFactory.cs
@@ -93,7 +93,7 @@ internal static class TestContextFactory
             connectionContext,
             serviceContext ?? CreateServiceContext(new KestrelServerOptions()),
             connectionFeatures ?? new FeatureCollection(),
-            memoryPool ?? System.Buffers.PinnedBlockMemoryPoolFactory.Create(),
+            memoryPool ?? TestMemoryPoolFactory.Create(),
             localEndPoint,
             remoteEndPoint,
             metricsContext)

--- a/src/Servers/Kestrel/shared/test/TestContextFactory.cs
+++ b/src/Servers/Kestrel/shared/test/TestContextFactory.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
-using System.Diagnostics.Metrics;
 using System.IO.Pipelines;
 using System.Net;
 using Microsoft.AspNetCore.Connections;

--- a/src/Servers/Kestrel/shared/test/TestContextFactory.cs
+++ b/src/Servers/Kestrel/shared/test/TestContextFactory.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.Diagnostics.Metrics;
 using System.IO.Pipelines;
 using System.Net;
 using Microsoft.AspNetCore.Connections;
@@ -73,6 +74,13 @@ internal static class TestContextFactory
         return context;
     }
 
+    internal sealed class DummyMeterFactory : IMeterFactory
+    {
+        public Meter Create(MeterOptions options) => new Meter(options);
+
+        public void Dispose() { }
+    }
+
     public static HttpMultiplexedConnectionContext CreateHttp3ConnectionContext(
         MultiplexedConnectionContext connectionContext = null,
         ServiceContext serviceContext = null,
@@ -93,7 +101,7 @@ internal static class TestContextFactory
             connectionContext,
             serviceContext ?? CreateServiceContext(new KestrelServerOptions()),
             connectionFeatures ?? new FeatureCollection(),
-            memoryPool ?? PinnedBlockMemoryPoolFactory.Create(),
+            memoryPool ?? PinnedBlockMemoryPoolFactory.Create(new DummyMeterFactory()),
             localEndPoint,
             remoteEndPoint,
             metricsContext)

--- a/src/Servers/Kestrel/shared/test/TestContextFactory.cs
+++ b/src/Servers/Kestrel/shared/test/TestContextFactory.cs
@@ -74,13 +74,6 @@ internal static class TestContextFactory
         return context;
     }
 
-    internal sealed class DummyMeterFactory : IMeterFactory
-    {
-        public Meter Create(MeterOptions options) => new Meter(options);
-
-        public void Dispose() { }
-    }
-
     public static HttpMultiplexedConnectionContext CreateHttp3ConnectionContext(
         MultiplexedConnectionContext connectionContext = null,
         ServiceContext serviceContext = null,
@@ -101,7 +94,7 @@ internal static class TestContextFactory
             connectionContext,
             serviceContext ?? CreateServiceContext(new KestrelServerOptions()),
             connectionFeatures ?? new FeatureCollection(),
-            memoryPool ?? PinnedBlockMemoryPoolFactory.Create(new DummyMeterFactory()),
+            memoryPool ?? PinnedBlockMemoryPoolFactory.Create(),
             localEndPoint,
             remoteEndPoint,
             metricsContext)

--- a/src/Servers/Kestrel/shared/test/TestServiceContext.cs
+++ b/src/Servers/Kestrel/shared/test/TestServiceContext.cs
@@ -74,7 +74,7 @@ internal class TestServiceContext : ServiceContext
 
     public FakeTimeProvider FakeTimeProvider { get; set; }
 
-    public IMemoryPoolFactory<byte> MemoryPoolFactory { get; set; } = new WrappingMemoryPoolFactory(() => System.Buffers.PinnedBlockMemoryPoolFactory.Create());
+    public IMemoryPoolFactory<byte> MemoryPoolFactory { get; set; } = new WrappingMemoryPoolFactory(() => TestMemoryPoolFactory.Create());
 
     public string DateHeaderValue => DateHeaderValueManager.GetDateHeaderValues().String;
 

--- a/src/Servers/Kestrel/shared/test/TestServiceContext.cs
+++ b/src/Servers/Kestrel/shared/test/TestServiceContext.cs
@@ -74,11 +74,11 @@ internal class TestServiceContext : ServiceContext
 
     public FakeTimeProvider FakeTimeProvider { get; set; }
 
-    public IMemoryPoolFactory MemoryPoolFactory { get; set; } = new WrappingMemoryPoolFactory(() => System.Buffers.PinnedBlockMemoryPoolFactory.Create());
+    public IMemoryPoolFactory<byte> MemoryPoolFactory { get; set; } = new WrappingMemoryPoolFactory(() => System.Buffers.PinnedBlockMemoryPoolFactory.Create());
 
     public string DateHeaderValue => DateHeaderValueManager.GetDateHeaderValues().String;
 
-    internal sealed class WrappingMemoryPoolFactory : IMemoryPoolFactory
+    internal sealed class WrappingMemoryPoolFactory : IMemoryPoolFactory<byte>
     {
         private readonly Func<MemoryPool<byte>> _memoryPoolFactory;
 
@@ -87,6 +87,6 @@ internal class TestServiceContext : ServiceContext
             _memoryPoolFactory = memoryPoolFactory;
         }
 
-        public MemoryPool<byte> CreatePool() => _memoryPoolFactory();
+        public MemoryPool<byte> Create() => _memoryPoolFactory();
     }
 }

--- a/src/Servers/Kestrel/shared/test/TestServiceContext.cs
+++ b/src/Servers/Kestrel/shared/test/TestServiceContext.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
-using System.Diagnostics.Metrics;
 using System.IO.Pipelines;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Server.Kestrel.Core;

--- a/src/Servers/Kestrel/shared/test/TestServiceContext.cs
+++ b/src/Servers/Kestrel/shared/test/TestServiceContext.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.Diagnostics.Metrics;
 using System.IO.Pipelines;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
@@ -73,7 +74,14 @@ internal class TestServiceContext : ServiceContext
 
     public FakeTimeProvider FakeTimeProvider { get; set; }
 
-    public Func<MemoryPool<byte>> MemoryPoolFactory { get; set; } = System.Buffers.PinnedBlockMemoryPoolFactory.Create;
+    public Func<MemoryPool<byte>> MemoryPoolFactory { get; set; } = () => System.Buffers.PinnedBlockMemoryPoolFactory.Create(new DummyMeterFactory());
 
     public string DateHeaderValue => DateHeaderValueManager.GetDateHeaderValues().String;
+
+    internal sealed class DummyMeterFactory : IMeterFactory
+    {
+        public Meter Create(MeterOptions options) => new Meter(options);
+
+        public void Dispose() { }
+    }
 }

--- a/src/Servers/Kestrel/shared/test/TransportTestHelpers/DiagnosticMemoryPoolFactory.cs
+++ b/src/Servers/Kestrel/shared/test/TransportTestHelpers/DiagnosticMemoryPoolFactory.cs
@@ -10,7 +10,7 @@ using Microsoft.AspNetCore.Connections;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests;
 
-public class DiagnosticMemoryPoolFactory : IMemoryPoolFactory
+public class DiagnosticMemoryPoolFactory : IMemoryPoolFactory<byte>
 {
     private readonly bool _allowLateReturn;
 
@@ -25,7 +25,7 @@ public class DiagnosticMemoryPoolFactory : IMemoryPoolFactory
         _pools = new List<DiagnosticMemoryPool>();
     }
 
-    public MemoryPool<byte> CreatePool()
+    public MemoryPool<byte> Create()
     {
         lock (_pools)
         {

--- a/src/Servers/Kestrel/shared/test/TransportTestHelpers/DiagnosticMemoryPoolFactory.cs
+++ b/src/Servers/Kestrel/shared/test/TransportTestHelpers/DiagnosticMemoryPoolFactory.cs
@@ -6,10 +6,11 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests;
 
-public class DiagnosticMemoryPoolFactory
+public class DiagnosticMemoryPoolFactory : IMemoryPoolFactory
 {
     private readonly bool _allowLateReturn;
 
@@ -24,7 +25,7 @@ public class DiagnosticMemoryPoolFactory
         _pools = new List<DiagnosticMemoryPool>();
     }
 
-    public MemoryPool<byte> Create()
+    public MemoryPool<byte> CreatePool()
     {
         lock (_pools)
         {

--- a/src/Servers/Kestrel/shared/test/TransportTestHelpers/TestServer.cs
+++ b/src/Servers/Kestrel/shared/test/TransportTestHelpers/TestServer.cs
@@ -80,7 +80,7 @@ internal class TestServer : IAsyncDisposable, IStartup
                     {
                         if (context.MemoryPoolFactory != null)
                         {
-                            services.AddSingleton<IMemoryPoolFactory>(context.MemoryPoolFactory);
+                            services.AddSingleton<IMemoryPoolFactory<byte>>(context.MemoryPoolFactory);
                         }
                         services.AddSingleton<IStartup>(this);
                         services.AddSingleton(context.LoggerFactory);

--- a/src/Servers/Kestrel/shared/test/TransportTestHelpers/TestServer.cs
+++ b/src/Servers/Kestrel/shared/test/TransportTestHelpers/TestServer.cs
@@ -1,26 +1,19 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Net;
-using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Xunit;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests;
 
@@ -74,7 +67,7 @@ internal class TestServer : IAsyncDisposable, IStartup
         _app = app;
         Context = context;
 
-        _host = TransportSelector.GetHostBuilder(context.MemoryPoolFactory, context.ServerOptions.Limits.MaxRequestBufferSize)
+        _host = TransportSelector.GetHostBuilder(context.ServerOptions.Limits.MaxRequestBufferSize)
             .ConfigureWebHost(webHostBuilder =>
             {
                 webHostBuilder
@@ -85,6 +78,10 @@ internal class TestServer : IAsyncDisposable, IStartup
                     })
                     .ConfigureServices(services =>
                     {
+                        if (context.MemoryPoolFactory != null)
+                        {
+                            services.AddSingleton<IMemoryPoolFactory>(context.MemoryPoolFactory);
+                        }
                         services.AddSingleton<IStartup>(this);
                         services.AddSingleton(context.LoggerFactory);
                         services.AddSingleton<IHttpsConfigurationService, HttpsConfigurationService>();

--- a/src/Servers/Kestrel/test/FunctionalTests/Http2/ShutdownTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/Http2/ShutdownTests.cs
@@ -168,7 +168,7 @@ public class ShutdownTests : TestApplicationErrorLoggerLoggedTest
 
         var testContext = new TestServiceContext(LoggerFactory)
         {
-            MemoryPoolFactory = new TestServiceContext.WrappingMemoryPoolFactory(() => PinnedBlockMemoryPoolFactory.CreatePinnedBlockMemoryPool()),
+            MemoryPoolFactory = new TestServiceContext.WrappingMemoryPoolFactory(() => TestMemoryPoolFactory.CreatePinnedBlockMemoryPool()),
         };
 
         ThrowOnUngracefulShutdown = false;

--- a/src/Servers/Kestrel/test/FunctionalTests/Http2/ShutdownTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/Http2/ShutdownTests.cs
@@ -168,7 +168,7 @@ public class ShutdownTests : TestApplicationErrorLoggerLoggedTest
 
         var testContext = new TestServiceContext(LoggerFactory)
         {
-            MemoryPoolFactory = () => new PinnedBlockMemoryPool()
+            MemoryPoolFactory = new TestServiceContext.WrappingMemoryPoolFactory(() => PinnedBlockMemoryPoolFactory.CreatePinnedBlockMemoryPool()),
         };
 
         ThrowOnUngracefulShutdown = false;

--- a/src/Servers/Kestrel/test/FunctionalTests/MaxRequestBufferSizeTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/MaxRequestBufferSizeTests.cs
@@ -300,7 +300,7 @@ public class MaxRequestBufferSizeTests : LoggedTest
         bool useConnectionAdapter,
         TaskCompletionSource startReadingRequestBody,
         TaskCompletionSource clientFinishedSendingRequestBody,
-        IMemoryPoolFactory memoryPoolFactory = null)
+        IMemoryPoolFactory<byte> memoryPoolFactory = null)
     {
         var host = TransportSelector.GetHostBuilder(maxRequestBufferSize)
             .ConfigureWebHost(webHostBuilder =>
@@ -339,7 +339,7 @@ public class MaxRequestBufferSizeTests : LoggedTest
                     {
                         if (memoryPoolFactory != null)
                         {
-                            services.AddSingleton<IMemoryPoolFactory>(memoryPoolFactory);
+                            services.AddSingleton<IMemoryPoolFactory<byte>>(memoryPoolFactory);
                         }
                     })
                     .Configure(app => app.Run(async context =>

--- a/src/Servers/Kestrel/test/FunctionalTests/MaxRequestBufferSizeTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/MaxRequestBufferSizeTests.cs
@@ -1,23 +1,17 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Buffers;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Server.Kestrel.FunctionalTests;
 using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.AspNetCore.Server.Kestrel.FunctionalTests;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Xunit;
 
 #if SOCKETS
 namespace Microsoft.AspNetCore.Server.Kestrel.Sockets.FunctionalTests;
@@ -132,7 +126,7 @@ public class MaxRequestBufferSizeTests : LoggedTest
 
         var memoryPoolFactory = new DiagnosticMemoryPoolFactory(allowLateReturn: true);
 
-        using (var host = await StartHost(maxRequestBufferSize, data, connectionAdapter, startReadingRequestBody, clientFinishedSendingRequestBody, memoryPoolFactory.Create))
+        using (var host = await StartHost(maxRequestBufferSize, data, connectionAdapter, startReadingRequestBody, clientFinishedSendingRequestBody, memoryPoolFactory))
         {
             var port = host.GetPort();
             using (var socket = CreateSocket(port))
@@ -225,7 +219,7 @@ public class MaxRequestBufferSizeTests : LoggedTest
 
         var memoryPoolFactory = new DiagnosticMemoryPoolFactory(allowLateReturn: true);
 
-        using (var host = await StartHost(16 * 1024, data, false, startReadingRequestBody, clientFinishedSendingRequestBody, memoryPoolFactory.Create))
+        using (var host = await StartHost(16 * 1024, data, false, startReadingRequestBody, clientFinishedSendingRequestBody, memoryPoolFactory))
         {
             var port = host.GetPort();
             using (var socket = CreateSocket(port))
@@ -306,9 +300,9 @@ public class MaxRequestBufferSizeTests : LoggedTest
         bool useConnectionAdapter,
         TaskCompletionSource startReadingRequestBody,
         TaskCompletionSource clientFinishedSendingRequestBody,
-        Func<MemoryPool<byte>> memoryPoolFactory = null)
+        IMemoryPoolFactory memoryPoolFactory = null)
     {
-        var host = TransportSelector.GetHostBuilder(memoryPoolFactory, maxRequestBufferSize)
+        var host = TransportSelector.GetHostBuilder(maxRequestBufferSize)
             .ConfigureWebHost(webHostBuilder =>
             {
                 webHostBuilder
@@ -341,6 +335,13 @@ public class MaxRequestBufferSizeTests : LoggedTest
                         options.Limits.MaxRequestBodySize = _dataLength;
                     })
                     .UseContentRoot(Directory.GetCurrentDirectory())
+                    .ConfigureServices(services =>
+                    {
+                        if (memoryPoolFactory != null)
+                        {
+                            services.AddSingleton<IMemoryPoolFactory>(memoryPoolFactory);
+                        }
+                    })
                     .Configure(app => app.Run(async context =>
                     {
                         await startReadingRequestBody.Task.TimeoutAfter(TimeSpan.FromSeconds(120));

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -5,7 +5,6 @@ using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Diagnostics.Metrics;
 using System.Globalization;
 using System.IO.Pipelines;
 using System.Net.Http;
@@ -113,14 +112,7 @@ public class Http2TestBase : TestApplicationErrorLoggerLoggedTest, IDisposable, 
     protected static readonly byte[] _noData = new byte[0];
     protected static readonly byte[] _maxData = Encoding.ASCII.GetBytes(new string('a', Http2PeerSettings.MinAllowedMaxFrameSize));
 
-    internal sealed class DummyMeterFactory : IMeterFactory
-    {
-        public Meter Create(MeterOptions options) => new Meter(options);
-
-        public void Dispose() { }
-    }
-
-    private readonly MemoryPool<byte> _memoryPool = PinnedBlockMemoryPoolFactory.Create(new DummyMeterFactory());
+    private readonly MemoryPool<byte> _memoryPool = PinnedBlockMemoryPoolFactory.Create();
 
     internal readonly Http2PeerSettings _clientSettings = new Http2PeerSettings();
     internal readonly HPackDecoder _hpackDecoder;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -112,7 +112,7 @@ public class Http2TestBase : TestApplicationErrorLoggerLoggedTest, IDisposable, 
     protected static readonly byte[] _noData = new byte[0];
     protected static readonly byte[] _maxData = Encoding.ASCII.GetBytes(new string('a', Http2PeerSettings.MinAllowedMaxFrameSize));
 
-    private readonly MemoryPool<byte> _memoryPool = PinnedBlockMemoryPoolFactory.Create();
+    private readonly MemoryPool<byte> _memoryPool = System.Buffers.PinnedBlockMemoryPoolFactory.Create();
 
     internal readonly Http2PeerSettings _clientSettings = new Http2PeerSettings();
     internal readonly HPackDecoder _hpackDecoder;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -112,7 +112,7 @@ public class Http2TestBase : TestApplicationErrorLoggerLoggedTest, IDisposable, 
     protected static readonly byte[] _noData = new byte[0];
     protected static readonly byte[] _maxData = Encoding.ASCII.GetBytes(new string('a', Http2PeerSettings.MinAllowedMaxFrameSize));
 
-    private readonly MemoryPool<byte> _memoryPool = System.Buffers.PinnedBlockMemoryPoolFactory.Create();
+    private readonly MemoryPool<byte> _memoryPool = TestMemoryPoolFactory.Create();
 
     internal readonly Http2PeerSettings _clientSettings = new Http2PeerSettings();
     internal readonly HPackDecoder _hpackDecoder;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -5,6 +5,7 @@ using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using System.Globalization;
 using System.IO.Pipelines;
 using System.Net.Http;
@@ -112,7 +113,14 @@ public class Http2TestBase : TestApplicationErrorLoggerLoggedTest, IDisposable, 
     protected static readonly byte[] _noData = new byte[0];
     protected static readonly byte[] _maxData = Encoding.ASCII.GetBytes(new string('a', Http2PeerSettings.MinAllowedMaxFrameSize));
 
-    private readonly MemoryPool<byte> _memoryPool = PinnedBlockMemoryPoolFactory.Create();
+    internal sealed class DummyMeterFactory : IMeterFactory
+    {
+        public Meter Create(MeterOptions options) => new Meter(options);
+
+        public void Dispose() { }
+    }
+
+    private readonly MemoryPool<byte> _memoryPool = PinnedBlockMemoryPoolFactory.Create(new DummyMeterFactory());
 
     internal readonly Http2PeerSettings _clientSettings = new Http2PeerSettings();
     internal readonly HPackDecoder _hpackDecoder;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/InMemory.FunctionalTests.csproj
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/InMemory.FunctionalTests.csproj
@@ -17,7 +17,6 @@
     <Compile Include="$(KestrelSharedSourceRoot)test\Http3\*.cs" LinkBase="shared" />
     <Compile Include="$(KestrelSharedSourceRoot)\HPackHeaderWriter.cs" Link="Http2\HPackHeaderWriter.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)\Http2HeadersEnumerator.cs" Link="Http2\Http2HeadersEnumerator.cs" />
-    <Compile Include="$(RepoRoot)src\Shared\Buffers.MemoryPool\*.cs" LinkBase="MemoryPool" />
     <Compile Include="$(KestrelSharedSourceRoot)\CompletionPipeReader.cs" Link="Internal\CompletionPipeReader.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)\CompletionPipeWriter.cs" Link="Internal\CompletionPipeWriter.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)\ConnectionCompletion.cs" Link="Internal\ConnectionCompletion.cs" />

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/KestrelMetricsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/KestrelMetricsTests.cs
@@ -273,7 +273,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
 
         var serviceContext = new TestServiceContext(LoggerFactory, metrics: new KestrelMetrics(testMeterFactory))
         {
-            MemoryPoolFactory = new TestServiceContext.WrappingMemoryPoolFactory(() => PinnedBlockMemoryPoolFactory.CreatePinnedBlockMemoryPool()),
+            MemoryPoolFactory = new TestServiceContext.WrappingMemoryPoolFactory(() => System.Buffers.PinnedBlockMemoryPoolFactory.CreatePinnedBlockMemoryPool()),
             ShutdownTimeout = TimeSpan.Zero
         };
 
@@ -612,7 +612,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
         var serviceContext = new TestServiceContext(LoggerFactory, metrics: new KestrelMetrics(testMeterFactory))
         {
             ShutdownTimeout = TimeSpan.Zero,
-            MemoryPoolFactory = new TestServiceContext.WrappingMemoryPoolFactory(() => PinnedBlockMemoryPoolFactory.CreatePinnedBlockMemoryPool())
+            MemoryPoolFactory = new TestServiceContext.WrappingMemoryPoolFactory(() => System.Buffers.PinnedBlockMemoryPoolFactory.CreatePinnedBlockMemoryPool())
         };
 
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/KestrelMetricsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/KestrelMetricsTests.cs
@@ -612,7 +612,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
         var serviceContext = new TestServiceContext(LoggerFactory, metrics: new KestrelMetrics(testMeterFactory))
         {
             ShutdownTimeout = TimeSpan.Zero,
-            //MemoryPoolFactory = PinnedBlockMemoryPoolFactory.CreatePinnedBlockMemoryPool
+            MemoryPoolFactory = new TestServiceContext.WrappingMemoryPoolFactory(() => PinnedBlockMemoryPoolFactory.CreatePinnedBlockMemoryPool())
         };
 
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/KestrelMetricsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/KestrelMetricsTests.cs
@@ -273,7 +273,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
 
         var serviceContext = new TestServiceContext(LoggerFactory, metrics: new KestrelMetrics(testMeterFactory))
         {
-            MemoryPoolFactory = PinnedBlockMemoryPoolFactory.CreatePinnedBlockMemoryPool,
+            //MemoryPoolFactory = PinnedBlockMemoryPoolFactory.CreatePinnedBlockMemoryPool,
             ShutdownTimeout = TimeSpan.Zero
         };
 
@@ -612,7 +612,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
         var serviceContext = new TestServiceContext(LoggerFactory, metrics: new KestrelMetrics(testMeterFactory))
         {
             ShutdownTimeout = TimeSpan.Zero,
-            MemoryPoolFactory = PinnedBlockMemoryPoolFactory.CreatePinnedBlockMemoryPool
+            //MemoryPoolFactory = PinnedBlockMemoryPoolFactory.CreatePinnedBlockMemoryPool
         };
 
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/KestrelMetricsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/KestrelMetricsTests.cs
@@ -273,7 +273,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
 
         var serviceContext = new TestServiceContext(LoggerFactory, metrics: new KestrelMetrics(testMeterFactory))
         {
-            MemoryPoolFactory = new TestServiceContext.WrappingMemoryPoolFactory(() => System.Buffers.PinnedBlockMemoryPoolFactory.CreatePinnedBlockMemoryPool()),
+            MemoryPoolFactory = new TestServiceContext.WrappingMemoryPoolFactory(() => TestMemoryPoolFactory.CreatePinnedBlockMemoryPool()),
             ShutdownTimeout = TimeSpan.Zero
         };
 
@@ -612,7 +612,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
         var serviceContext = new TestServiceContext(LoggerFactory, metrics: new KestrelMetrics(testMeterFactory))
         {
             ShutdownTimeout = TimeSpan.Zero,
-            MemoryPoolFactory = new TestServiceContext.WrappingMemoryPoolFactory(() => System.Buffers.PinnedBlockMemoryPoolFactory.CreatePinnedBlockMemoryPool())
+            MemoryPoolFactory = new TestServiceContext.WrappingMemoryPoolFactory(() => TestMemoryPoolFactory.CreatePinnedBlockMemoryPool())
         };
 
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/KestrelMetricsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/KestrelMetricsTests.cs
@@ -273,7 +273,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
 
         var serviceContext = new TestServiceContext(LoggerFactory, metrics: new KestrelMetrics(testMeterFactory))
         {
-            //MemoryPoolFactory = PinnedBlockMemoryPoolFactory.CreatePinnedBlockMemoryPool,
+            MemoryPoolFactory = new TestServiceContext.WrappingMemoryPoolFactory(() => PinnedBlockMemoryPoolFactory.CreatePinnedBlockMemoryPool()),
             ShutdownTimeout = TimeSpan.Zero
         };
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/TestTransport/TestServer.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/TestTransport/TestServer.cs
@@ -70,7 +70,7 @@ internal class TestServer : IAsyncDisposable, IStartup
     {
         _app = app;
         Context = context;
-        _memoryPool = context.MemoryPoolFactory.CreatePool();
+        _memoryPool = context.MemoryPoolFactory.Create();
         _transportFactory = new InMemoryTransportFactory();
         HttpClientSlim = new InMemoryHttpClientSlim(this);
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/TestTransport/TestServer.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/TestTransport/TestServer.cs
@@ -70,7 +70,7 @@ internal class TestServer : IAsyncDisposable, IStartup
     {
         _app = app;
         Context = context;
-        _memoryPool = context.MemoryPoolFactory();
+        _memoryPool = context.MemoryPoolFactory.CreatePool();
         _transportFactory = new InMemoryTransportFactory();
         HttpClientSlim = new InMemoryHttpClientSlim(this);
 

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
@@ -8,6 +8,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Security;
 using System.Text;
+using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Hosting;

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Interop.FunctionalTests.csproj
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Interop.FunctionalTests.csproj
@@ -27,6 +27,7 @@
     <Compile Include="$(SharedSourceRoot)Metrics\TestMeterFactory.cs" LinkBase="shared" />
     <Compile Include="$(KestrelSharedSourceRoot)test\TransportTestHelpers\TlsAlpnSupportedAttribute.cs" Link="shared\TransportTestHelpers\TlsAlpnSupportedAttribute.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)test\ServerRetryHelper.cs" LinkBase="shared" />
+    <Compile Include="$(RepoRoot)src\Shared\Buffers.MemoryPool\*.cs" LinkBase="MemoryPool" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Servers/Kestrel/test/Sockets.FunctionalTests/TransportSelector.cs
+++ b/src/Servers/Kestrel/test/Sockets.FunctionalTests/TransportSelector.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Buffers;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 
@@ -10,18 +8,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests;
 
 public static class TransportSelector
 {
-    public static IHostBuilder GetHostBuilder(Func<MemoryPool<byte>> memoryPoolFactory = null,
-                                                    long? maxReadBufferSize = null)
+    public static IHostBuilder GetHostBuilder(long? maxReadBufferSize = null)
     {
         return new HostBuilder()
             .ConfigureWebHost(webHostBuilder =>
             {
-                webHostBuilder
-                    .UseSockets(options =>
-                    {
-                        options.MemoryPoolFactory = memoryPoolFactory ?? options.MemoryPoolFactory;
-                        options.MaxReadBufferSize = maxReadBufferSize;
-                    });
+                webHostBuilder.UseSockets(options =>
+                {
+                    options.MaxReadBufferSize = maxReadBufferSize;
+                });
             });
     }
 }

--- a/src/Shared/Buffers.MemoryPool/DefaultMemoryPoolFactory.cs
+++ b/src/Shared/Buffers.MemoryPool/DefaultMemoryPoolFactory.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Microsoft.AspNetCore.Connections;
+
+namespace System.Buffers;
+
+internal sealed class DefaultMemoryPoolFactory : IMemoryPoolFactory<byte>, IDisposable
+{
+    private readonly IMeterFactory _meterFactory;
+    private readonly ConcurrentDictionary<PinnedBlockMemoryPool, PinnedBlockMemoryPool> _pools = new();
+    private readonly PeriodicTimer _timer;
+
+    public DefaultMemoryPoolFactory(IMeterFactory? meterFactory = null)
+    {
+        _meterFactory = meterFactory ?? NoopMeterFactory.Instance;
+        _timer = new PeriodicTimer(TimeSpan.FromSeconds(10));
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                while (await _timer.WaitForNextTickAsync())
+                {
+                    foreach (var pool in _pools.Keys)
+                    {
+                        pool.PerformEviction();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex);
+            }
+        });
+    }
+
+    public MemoryPool<byte> Create()
+    {
+        var pool = new PinnedBlockMemoryPool(_meterFactory);
+        pool.DisposeCallback = (self) =>
+        {
+            _pools.TryRemove(self, out _);
+        };
+
+        _pools.TryAdd(pool, pool);
+
+        return pool;
+    }
+
+    public void Dispose()
+    {
+        _timer.Dispose();
+    }
+
+    private sealed class NoopMeterFactory : IMeterFactory
+    {
+        public static NoopMeterFactory Instance = new NoopMeterFactory();
+
+        public Meter Create(MeterOptions options) => new Meter(options);
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Shared/Buffers.MemoryPool/DefaultMemoryPoolFactory.cs
+++ b/src/Shared/Buffers.MemoryPool/DefaultMemoryPoolFactory.cs
@@ -1,12 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using Microsoft.AspNetCore.Connections;
 
-namespace System.Buffers;
+namespace Microsoft.AspNetCore;
 
 #nullable enable
 

--- a/src/Shared/Buffers.MemoryPool/DefaultMemoryPoolFactory.cs
+++ b/src/Shared/Buffers.MemoryPool/DefaultMemoryPoolFactory.cs
@@ -8,6 +8,8 @@ using Microsoft.AspNetCore.Connections;
 
 namespace System.Buffers;
 
+#nullable enable
+
 internal sealed class DefaultMemoryPoolFactory : IMemoryPoolFactory<byte>, IDisposable
 {
     private readonly IMeterFactory _meterFactory;
@@ -40,12 +42,13 @@ internal sealed class DefaultMemoryPoolFactory : IMemoryPoolFactory<byte>, IDisp
     public MemoryPool<byte> Create()
     {
         var pool = new PinnedBlockMemoryPool(_meterFactory);
+
+        _pools.TryAdd(pool, pool);
+
         pool.DisposeCallback = (self) =>
         {
             _pools.TryRemove(self, out _);
         };
-
-        _pools.TryAdd(pool, pool);
 
         return pool;
     }

--- a/src/Shared/Buffers.MemoryPool/DiagnosticMemoryPool.cs
+++ b/src/Shared/Buffers.MemoryPool/DiagnosticMemoryPool.cs
@@ -1,9 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Linq;
 
-namespace System.Buffers;
+namespace Microsoft.AspNetCore;
 
 /// <summary>
 /// Used to allocate and distribute re-usable blocks of memory.

--- a/src/Shared/Buffers.MemoryPool/DiagnosticPoolBlock.cs
+++ b/src/Shared/Buffers.MemoryPool/DiagnosticPoolBlock.cs
@@ -1,12 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 #nullable enable
 
-namespace System.Buffers;
+namespace Microsoft.AspNetCore;
 
 /// <summary>
 /// Block tracking object used by the byte buffer memory pool. A slab is a large allocation which is divided into smaller blocks. The

--- a/src/Shared/Buffers.MemoryPool/MemoryPoolBlock.cs
+++ b/src/Shared/Buffers.MemoryPool/MemoryPoolBlock.cs
@@ -1,9 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Runtime.InteropServices;
 
-namespace System.Buffers;
+namespace Microsoft.AspNetCore;
 
 /// <summary>
 /// Wraps an array allocated in the pinned object heap in a reusable block of managed memory

--- a/src/Shared/Buffers.MemoryPool/MemoryPoolFactory.cs
+++ b/src/Shared/Buffers.MemoryPool/MemoryPoolFactory.cs
@@ -1,21 +1,23 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.Metrics;
+
 namespace System.Buffers;
 
 internal static class PinnedBlockMemoryPoolFactory
 {
-    public static MemoryPool<byte> Create()
+    public static MemoryPool<byte> Create(IMeterFactory meterFactory)
     {
 #if DEBUG
-        return new DiagnosticMemoryPool(CreatePinnedBlockMemoryPool());
+        return new DiagnosticMemoryPool(CreatePinnedBlockMemoryPool(meterFactory));
 #else
-        return CreatePinnedBlockMemoryPool();
+        return CreatePinnedBlockMemoryPool(meterFactory);
 #endif
     }
 
-    public static MemoryPool<byte> CreatePinnedBlockMemoryPool()
+    public static MemoryPool<byte> CreatePinnedBlockMemoryPool(IMeterFactory meterFactory)
     {
-        return new PinnedBlockMemoryPool();
+        return new PinnedBlockMemoryPool(meterFactory);
     }
 }

--- a/src/Shared/Buffers.MemoryPool/MemoryPoolFactory.cs
+++ b/src/Shared/Buffers.MemoryPool/MemoryPoolFactory.cs
@@ -1,9 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Diagnostics.Metrics;
 
-namespace System.Buffers;
+namespace Microsoft.AspNetCore;
 
 #nullable enable
 

--- a/src/Shared/Buffers.MemoryPool/MemoryPoolFactory.cs
+++ b/src/Shared/Buffers.MemoryPool/MemoryPoolFactory.cs
@@ -5,10 +5,13 @@ using System.Diagnostics.Metrics;
 
 namespace System.Buffers;
 
+#nullable enable
+
 internal static class PinnedBlockMemoryPoolFactory
 {
-    public static MemoryPool<byte> Create(IMeterFactory meterFactory)
+    public static MemoryPool<byte> Create(IMeterFactory? meterFactory = null)
     {
+        meterFactory ??= NoopMeterFactory.Instance;
 #if DEBUG
         return new DiagnosticMemoryPool(CreatePinnedBlockMemoryPool(meterFactory));
 #else
@@ -16,8 +19,20 @@ internal static class PinnedBlockMemoryPoolFactory
 #endif
     }
 
-    public static MemoryPool<byte> CreatePinnedBlockMemoryPool(IMeterFactory meterFactory)
+    public static MemoryPool<byte> CreatePinnedBlockMemoryPool(IMeterFactory? meterFactory = null)
     {
+        meterFactory ??= NoopMeterFactory.Instance;
         return new PinnedBlockMemoryPool(meterFactory);
+    }
+
+    private sealed class NoopMeterFactory : IMeterFactory
+    {
+        public static NoopMeterFactory Instance = new NoopMeterFactory();
+
+        public Meter Create(MeterOptions options) => new Meter(options);
+
+        public void Dispose()
+        {
+        }
     }
 }

--- a/src/Shared/Buffers.MemoryPool/MemoryPoolFactory.cs
+++ b/src/Shared/Buffers.MemoryPool/MemoryPoolFactory.cs
@@ -7,7 +7,7 @@ namespace System.Buffers;
 
 #nullable enable
 
-internal static class PinnedBlockMemoryPoolFactory
+internal static class TestMemoryPoolFactory
 {
     public static MemoryPool<byte> Create(IMeterFactory? meterFactory = null)
     {

--- a/src/Shared/Buffers.MemoryPool/MemoryPoolFactory.cs
+++ b/src/Shared/Buffers.MemoryPool/MemoryPoolFactory.cs
@@ -12,7 +12,6 @@ internal static class TestMemoryPoolFactory
 {
     public static MemoryPool<byte> Create(IMeterFactory? meterFactory = null)
     {
-        meterFactory ??= NoopMeterFactory.Instance;
 #if DEBUG
         return new DiagnosticMemoryPool(CreatePinnedBlockMemoryPool(meterFactory));
 #else
@@ -22,18 +21,6 @@ internal static class TestMemoryPoolFactory
 
     public static MemoryPool<byte> CreatePinnedBlockMemoryPool(IMeterFactory? meterFactory = null)
     {
-        meterFactory ??= NoopMeterFactory.Instance;
         return new PinnedBlockMemoryPool(meterFactory);
-    }
-
-    private sealed class NoopMeterFactory : IMeterFactory
-    {
-        public static NoopMeterFactory Instance = new NoopMeterFactory();
-
-        public Meter Create(MeterOptions options) => new Meter(options);
-
-        public void Dispose()
-        {
-        }
     }
 }

--- a/src/Shared/Buffers.MemoryPool/MemoryPoolThrowHelper.cs
+++ b/src/Shared/Buffers.MemoryPool/MemoryPoolThrowHelper.cs
@@ -5,7 +5,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
 
-namespace System.Buffers;
+namespace Microsoft.AspNetCore;
 
 internal sealed class MemoryPoolThrowHelper
 {

--- a/src/Shared/Buffers.MemoryPool/PinnedBlockMemoryPool.cs
+++ b/src/Shared/Buffers.MemoryPool/PinnedBlockMemoryPool.cs
@@ -1,14 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Collections.Concurrent;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Metrics;
 
 #nullable enable
 
-namespace System.Buffers;
+namespace Microsoft.AspNetCore;
 
 /// <summary>
 /// Used to allocate and distribute re-usable blocks of memory.
@@ -159,6 +158,12 @@ internal sealed class PinnedBlockMemoryPool : MemoryPool<byte>, IThreadPoolWorkI
         PerformEviction();
     }
 
+    /// <summary>
+    /// Examines the current usage and activity of the memory pool and evicts a calculated number of unused memory blocks.
+    /// The eviction policy is adaptive: if the pool is underutilized or idle, more blocks are evicted;
+    /// if activity is high, fewer or no blocks are evicted.
+    /// Evicted blocks are removed from the pool and their memory is unrooted for garbage collection.
+    /// </summary>
     internal void PerformEviction()
     {
         var currentCount = (uint)_blocks.Count;

--- a/src/Shared/Buffers.MemoryPool/PinnedBlockMemoryPool.cs
+++ b/src/Shared/Buffers.MemoryPool/PinnedBlockMemoryPool.cs
@@ -245,10 +245,10 @@ internal sealed class PinnedBlockMemoryPool : MemoryPool<byte>, IThreadPoolWorkI
     static void ScalableCount(ref uint counter)
     {
         // Start using random for counting after 2^12 (4096)
-        const int threshold = 8;
+        //const int threshold = 12;
         uint count = counter;
         uint delta = 1;
-#if true
+#if false
         if (count > 0)
         {
             int logCount = 31 - (int)uint.LeadingZeroCount(count);

--- a/src/Shared/Buffers.MemoryPool/PinnedBlockMemoryPoolMetrics.cs
+++ b/src/Shared/Buffers.MemoryPool/PinnedBlockMemoryPoolMetrics.cs
@@ -1,0 +1,86 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.Metrics;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+#nullable enable
+
+namespace System.Buffers;
+
+internal sealed class PinnedBlockMemoryPoolMetrics
+{
+    // Note: Dot separated instead of dash.
+    public const string MeterName = "System.Buffers.PinnedBlockMemoryPool";
+
+    private readonly Meter _meter;
+    private readonly UpDownCounter<long> _currentMemory;
+    private readonly UpDownCounter<long> _totalAllocatedMemory;
+    private readonly UpDownCounter<long> _evictedBlocks;
+    private readonly UpDownCounter<long> _evictedMemory;
+    private readonly UpDownCounter<long> _evictionAttempts;
+    private readonly Counter<long> _usageRate;
+
+    public PinnedBlockMemoryPoolMetrics(IMeterFactory meterFactory)
+    {
+        _meter = meterFactory.Create(MeterName);
+
+        _currentMemory = _meter.CreateUpDownCounter<long>(
+            "pinnedblockmemorypool.current_memory",
+            unit: "{bytes}",
+            description: "Number of bytes that are currently pooled by the pinned block memory pool.");
+
+        _totalAllocatedMemory = _meter.CreateUpDownCounter<long>(
+           "pinnedblockmemorypool.total_allocated",
+            unit: "{bytes}",
+            description: "Total number of allocations made by the pinned block memory pool.");
+
+        _evictedBlocks = _meter.CreateUpDownCounter<long>(
+           "pinnedblockmemorypool.evicted_blocks",
+            unit: "{blocks}",
+            description: "Total number of pooled blocks that have been evicted.");
+
+        _evictedMemory = _meter.CreateUpDownCounter<long>(
+           "pinnedblockmemorypool.evicted_memory",
+            unit: "{bytes}",
+            description: "Total number of bytes that have been evicted.");
+
+        _evictionAttempts = _meter.CreateUpDownCounter<long>(
+           "pinnedblockmemorypool.eviction_attempts",
+            unit: "{eviction}",
+            description: "Total number of eviction attempts.");
+
+        _usageRate = _meter.CreateCounter<long>(
+            "pinnedblockmemorypool.usage_rate",
+            unit: "bytes",
+            description: "Rate of bytes rented from the pool."
+            );
+    }
+
+    public void UpdateCurrentMemory(int bytes)
+    {
+        _currentMemory.Add(bytes);
+    }
+
+    public void IncrementTotalMemory(int bytes)
+    {
+        _totalAllocatedMemory.Add(bytes);
+    }
+
+    public void EvictBlock(int bytes)
+    {
+        _evictedBlocks.Add(1);
+        _evictedMemory.Add(bytes);
+    }
+
+    public void StartEviction()
+    {
+        _evictionAttempts.Add(1);
+    }
+
+    public void Rent(int bytes)
+    {
+        _usageRate.Add(bytes);
+    }
+}

--- a/src/Shared/Buffers.MemoryPool/PinnedBlockMemoryPoolMetrics.cs
+++ b/src/Shared/Buffers.MemoryPool/PinnedBlockMemoryPoolMetrics.cs
@@ -16,10 +16,8 @@ internal sealed class PinnedBlockMemoryPoolMetrics
 
     private readonly Meter _meter;
     private readonly UpDownCounter<long> _currentMemory;
-    private readonly UpDownCounter<long> _totalAllocatedMemory;
-    private readonly UpDownCounter<long> _evictedBlocks;
-    private readonly UpDownCounter<long> _evictedMemory;
-    private readonly UpDownCounter<long> _evictionAttempts;
+    private readonly Counter<long> _totalAllocatedMemory;
+    private readonly Counter<long> _evictedMemory;
     private readonly Counter<long> _usageRate;
 
     public PinnedBlockMemoryPoolMetrics(IMeterFactory meterFactory)
@@ -31,25 +29,15 @@ internal sealed class PinnedBlockMemoryPoolMetrics
             unit: "{bytes}",
             description: "Number of bytes that are currently pooled by the pinned block memory pool.");
 
-        _totalAllocatedMemory = _meter.CreateUpDownCounter<long>(
+        _totalAllocatedMemory = _meter.CreateCounter<long>(
            "pinnedblockmemorypool.total_allocated",
             unit: "{bytes}",
             description: "Total number of allocations made by the pinned block memory pool.");
 
-        _evictedBlocks = _meter.CreateUpDownCounter<long>(
-           "pinnedblockmemorypool.evicted_blocks",
-            unit: "{blocks}",
-            description: "Total number of pooled blocks that have been evicted.");
-
-        _evictedMemory = _meter.CreateUpDownCounter<long>(
+        _evictedMemory = _meter.CreateCounter<long>(
            "pinnedblockmemorypool.evicted_memory",
             unit: "{bytes}",
             description: "Total number of bytes that have been evicted.");
-
-        _evictionAttempts = _meter.CreateUpDownCounter<long>(
-           "pinnedblockmemorypool.eviction_attempts",
-            unit: "{eviction}",
-            description: "Total number of eviction attempts.");
 
         _usageRate = _meter.CreateCounter<long>(
             "pinnedblockmemorypool.usage_rate",
@@ -70,13 +58,7 @@ internal sealed class PinnedBlockMemoryPoolMetrics
 
     public void EvictBlock(int bytes)
     {
-        _evictedBlocks.Add(1);
         _evictedMemory.Add(bytes);
-    }
-
-    public void StartEviction()
-    {
-        _evictionAttempts.Add(1);
     }
 
     public void Rent(int bytes)

--- a/src/Shared/Buffers.MemoryPool/PinnedBlockMemoryPoolMetrics.cs
+++ b/src/Shared/Buffers.MemoryPool/PinnedBlockMemoryPoolMetrics.cs
@@ -2,48 +2,44 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.Metrics;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
 
 #nullable enable
 
-namespace System.Buffers;
+namespace Microsoft.AspNetCore;
 
 internal sealed class PinnedBlockMemoryPoolMetrics
 {
-    // Note: Dot separated instead of dash.
-    public const string MeterName = "System.Buffers.PinnedBlockMemoryPool";
+    public const string MeterName = "Microsoft.AspNetCore.MemoryPool";
 
     private readonly Meter _meter;
     private readonly UpDownCounter<long> _currentMemory;
     private readonly Counter<long> _totalAllocatedMemory;
     private readonly Counter<long> _evictedMemory;
-    private readonly Counter<long> _usageRate;
+    private readonly Counter<long> _totalRented;
 
     public PinnedBlockMemoryPoolMetrics(IMeterFactory meterFactory)
     {
         _meter = meterFactory.Create(MeterName);
 
         _currentMemory = _meter.CreateUpDownCounter<long>(
-            "pinnedblockmemorypool.current_memory",
+            "aspnetcore.memorypool.current_memory",
             unit: "{bytes}",
-            description: "Number of bytes that are currently pooled by the pinned block memory pool.");
+            description: "Number of bytes that are currently pooled by the pool.");
 
         _totalAllocatedMemory = _meter.CreateCounter<long>(
-           "pinnedblockmemorypool.total_allocated",
+           "aspnetcore.memorypool.total_allocated",
             unit: "{bytes}",
-            description: "Total number of allocations made by the pinned block memory pool.");
+            description: "Total number of allocations made by the pool.");
 
         _evictedMemory = _meter.CreateCounter<long>(
-           "pinnedblockmemorypool.evicted_memory",
+           "aspnetcore.memorypool.evicted_memory",
             unit: "{bytes}",
             description: "Total number of bytes that have been evicted.");
 
-        _usageRate = _meter.CreateCounter<long>(
-            "pinnedblockmemorypool.usage_rate",
+        _totalRented = _meter.CreateCounter<long>(
+            "aspnetcore.memorypool.total_rented",
             unit: "{bytes}",
-            description: "Rate of bytes rented from the pool."
-            );
+            description: "Total number of rented bytes from the pool.");
     }
 
     public void UpdateCurrentMemory(int bytes)
@@ -63,6 +59,6 @@ internal sealed class PinnedBlockMemoryPoolMetrics
 
     public void Rent(int bytes)
     {
-        _usageRate.Add(bytes);
+        _totalRented.Add(bytes);
     }
 }

--- a/src/Shared/Buffers.MemoryPool/PinnedBlockMemoryPoolMetrics.cs
+++ b/src/Shared/Buffers.MemoryPool/PinnedBlockMemoryPoolMetrics.cs
@@ -41,7 +41,7 @@ internal sealed class PinnedBlockMemoryPoolMetrics
 
         _usageRate = _meter.CreateCounter<long>(
             "pinnedblockmemorypool.usage_rate",
-            unit: "bytes",
+            unit: "{bytes}",
             description: "Rate of bytes rented from the pool."
             );
     }

--- a/src/Shared/Http2cat/Http2CatIServiceCollectionExtensions.cs
+++ b/src/Shared/Http2cat/Http2CatIServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ internal static class Http2CatIServiceCollectionExtensions
 {
     public static IServiceCollection UseHttp2Cat(this IServiceCollection services, Action<Http2CatOptions> configureOptions)
     {
+        services.AddMetrics();
         services.AddSingleton<IConnectionFactory, SocketConnectionFactory>();
         services.AddHostedService<Http2CatHostedService>();
         services.Configure(configureOptions);


### PR DESCRIPTION
Adding the ability to release (to the GC) memory from the `PinnedBlockMemoryPool`. It does this by counting the rent and return calls and using heuristics to decide if it should free up memory or not based on pool usage.

Additionally implements the newly approved `IMemoryPoolFactory<T>` interface and plumbs it through Kestrel, IIS, and HttpSys with the default implementation for `IMemoryPoolFactory<byte>` being the `PinnedBlockMemoryPool`.

Kestrel makes use of its heartbeat loop to clean up the memory pools, whereas IIS and HttpSys don't have the equivalent so they use a `PeriodicTimer` approach.

Adds metrics to the pool. Issue for those is at https://github.com/dotnet/aspnetcore/issues/61594.

Closes https://github.com/dotnet/aspnetcore/issues/61003
Closes https://github.com/dotnet/aspnetcore/issues/27394
Closes https://github.com/dotnet/aspnetcore/issues/55490

Did a few perf runs to see the impact of `Interlocked.Increment` on the `Rent` and `Return` paths.
Did longer 60 second runs to make sure the memory pools had plenty of opportunity to run clean up logic and see the impact of incrementing counters.

* A few runs of Plaintext Platform for 60 seconds had no noticeable impact (this is our 24m RPS scenario so it should be hitting the pool a lot)
* A few runs of MvcJsonOutput60k for 60 seconds had no noticeable impact (wanted a benchmark that wrote data to the response)
* A few runs of Plaintext Platform with 2 IOQueues (default is # cores/2) to make more requests use the same pool, this one might have a tiny impact on RPS, but there seemed to be a bit of noise, was getting 5.6m and 5.7m with 2 queues and 5.8m and 6m without PR, but it seemed noisy.

TLDR; didn't notice a perf impact with this PR and so removed the ScalableApproximateCounting code for now. Can always add it back if we find problems.