### PR TITLE
[release/2.3] Forwarded Headers Middleware: Ignore XForwardedHeaders from Unknown Proxy

### DIFF
--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -22,4 +22,9 @@ Later on, this will be checked using this condition:
     <PackagesInPatch>
     </PackagesInPatch>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(VersionPrefix)' == '2.3.3' ">
+    <PackagesInPatch>
+      Microsoft.AspNetCore.HttpOverrides;
+    </PackagesInPatch>
+  </PropertyGroup>
 </Project>

--- a/src/Middleware/HttpOverrides/src/ForwardedHeadersMiddleware.cs
+++ b/src/Middleware/HttpOverrides/src/ForwardedHeadersMiddleware.cs
@@ -227,16 +227,17 @@ namespace Microsoft.AspNetCore.HttpOverrides
             for ( ; entriesConsumed < sets.Length; entriesConsumed++)
             {
                 var set = sets[entriesConsumed];
+
+                // For the first instance, allow remoteIp to be null for servers that don't support it natively.
+                if (currentValues.RemoteIpAndPort != null && checkKnownIps && !CheckKnownAddress(currentValues.RemoteIpAndPort.Address))
+                {
+                    // Stop at the first unknown remote IP, but still apply changes processed so far.
+                    _logger.LogDebug(1, $"Unknown proxy: {currentValues.RemoteIpAndPort}");
+                    break;
+                }
+
                 if (checkFor)
                 {
-                    // For the first instance, allow remoteIp to be null for servers that don't support it natively.
-                    if (currentValues.RemoteIpAndPort != null && checkKnownIps && !CheckKnownAddress(currentValues.RemoteIpAndPort.Address))
-                    {
-                        // Stop at the first unknown remote IP, but still apply changes processed so far.
-                        _logger.LogDebug(1, $"Unknown proxy: {currentValues.RemoteIpAndPort}");
-                        break;
-                    }
-
                     IPEndPoint parsedEndPoint;
                     if (IPEndPointParser.TryParse(set.IpAndPortText, out parsedEndPoint))
                     {


### PR DESCRIPTION
Backport of #61530 to release/2.3

# Forwarded Headers Middleware: Ignore XForwardedHeaders from Unknown Proxy

## Description

If the `ForwardedHeadersMiddleware` middleware is used without using `XForwardedFor` then the `KnownNetworks` and `KnownProxies` checks are skipped.

Fixes #61449

## Customer Impact

Expectations for `KnownNetworks` and `KnownProxies` settings are not always met. If you aren't careful with configuring your app (careful meaning aware of this issue), you can end up allowing traffic you didn't intend to allow.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Runs a check that was already there but runs it in more cases.

## Verification

- [ ] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
----

## When servicing release/2.1

- [x] Make necessary changes in eng/PatchConfig.props
