### PR TITLE
Exclude .js files from signing

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -30,6 +30,8 @@
     <FileSignInfo Include="ancm.mof" CertificateName="None" />
     <!-- Exclude the apphost because this is expected to be code-signed by customers after the SDK modifies it. -->
     <FileSignInfo Include="apphost.exe" CertificateName="None" />
+    <!-- We don't need to code sign .js files because they are not used in Windows Script Host. -->
+    <FileExtensionSignInfo Update=".js" CertificateName="None" />
 
     <!--
       These files should already be signed by the .NET Core team. They have to be listed again here because we recreate a redistributable which includes the Microsoft.NETCore.App runtime.


### PR DESCRIPTION
Related to https://github.com/dotnet/sdk/pull/48653

Default .js signing was removed from Arcade, so there's now an error when signing aspnetcore artifacts in the VMR:
```
D:\a_work\1\vmr\artifacts\source-built-sdks\Microsoft.DotNet.Arcade.Sdk\tools\Sign.proj(76,5): error : Skipping file 'D:\a_work\1\vmr\src\aspnetcore\artifacts\tmp\Release\ContainerSigning\940_framework/blazor.web.js' because .js files are no longer signed by default. To disable this warning, please explicitly define the FileExtensionSignInfo for the .js extension or set the MSBuild property 'NoSignJS' to 'true'.
```

This PR fixes that failure.