### PR TITLE
Allow CI jobs to continueOnError

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -540,6 +540,7 @@ extends:
           jobDisplayName: "Test: Windows Server x64"
           agentOs: Windows
           isAzDOTestingJob: true
+          continueOnError: true
           # Just uploading artifacts/logs/ files can take 15 minutes. Doubling the cancel timeout for this job.
           cancelTimeoutInMinutes: 30
           buildArgs: -all -pack -test -binaryLog /p:SkipHelixReadyTests=true /p:SkipIISNewHandlerTests=true /p:SkipIISTests=true

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -62,6 +62,7 @@ parameters:
   isAzDOTestingJob: false
   enablePublishTestResults: ''
   enableSbom: true
+  continueOnError: false
   variables: []
 
   configuration: 'Release'
@@ -207,6 +208,7 @@ jobs:
           - script: $(BuildDirectory)\build.cmd -ci -prepareMachine -nativeToolsOnMachine -Configuration $(BuildConfiguration) $(BuildScriptArgs)
               /p:DotNetSignType=$(_SignType)
             displayName: Run build.cmd
+            continueOnError: ${{ parameters.continueOnError }}
             env:
               COMPlus_DbgEnableMiniDump: 1
               COMPlus_DbgMiniDumpName: "$(System.DefaultWorkingDirectory)/dotnet-%d.%t.core"
@@ -214,6 +216,7 @@ jobs:
         - ${{ if ne(parameters.agentOs, 'Windows') }}:
           - script: $(BuildDirectory)/build.sh --ci --configuration $(BuildConfiguration) $(BuildScriptArgs)
             displayName: Run build.sh
+            continueOnError: ${{ parameters.continueOnError }}
             env:
               COMPlus_DbgEnableMiniDump: 1
               COMPlus_DbgMiniDumpName: "$(System.DefaultWorkingDirectory)/dotnet-%d.%t.core"
@@ -443,6 +446,7 @@ jobs:
           - script: $(BuildDirectory)\build.cmd -ci -prepareMachine -nativeToolsOnMachine -Configuration $(BuildConfiguration) $(BuildScriptArgs)
               /p:DotNetSignType=$(_SignType)
             displayName: Run build.cmd
+            continueOnError: ${{ parameters.continueOnError }}
             env:
               COMPlus_DbgEnableMiniDump: 1
               COMPlus_DbgMiniDumpName: "$(System.DefaultWorkingDirectory)/dotnet-%d.%t.core"
@@ -450,6 +454,7 @@ jobs:
         - ${{ if ne(parameters.agentOs, 'Windows') }}:
           - script: $(BuildDirectory)/build.sh --ci --configuration $(BuildConfiguration) $(BuildScriptArgs)
             displayName: Run build.sh
+            continueOnError: ${{ parameters.continueOnError }}
             env:
               COMPlus_DbgEnableMiniDump: 1
               COMPlus_DbgMiniDumpName: "$(System.DefaultWorkingDirectory)/dotnet-%d.%t.core"


### PR DESCRIPTION
This pull request introduces changes to Azure Pipelines configuration files to add support for the `continueOnError` parameter in specific jobs. The changes ensure better control over job execution behavior when errors occur, allowing for conditional continuation based on the parameter.

### Changes to Azure Pipelines configuration:

* [`.azure/pipelines/ci.yml`](diffhunk://#diff-1098d6428d09da3af3f88de8a763b427287613c3d02a7876283747b4b6998240R543): Added `continueOnError: true` to the Windows Server x64 testing job to allow it to continue execution even if errors are encountered.

* `.azure/pipelines/jobs/default-build.yml`:
  - Added a `continueOnError` parameter with a default value of `false` to the job parameters, enabling customization of error-handling behavior.
  - Updated multiple build scripts (`build.cmd` and `build.sh`) to use the `continueOnError` parameter, ensuring that the behavior aligns with the specified parameter value. [[1]](diffhunk://#diff-d505db965eec34885645b784a8342b8e68b6275694e826a7ad1d7f2ad2a32783R211-R219) [[2]](diffhunk://#diff-d505db965eec34885645b784a8342b8e68b6275694e826a7ad1d7f2ad2a32783R449-R457)