### PR TITLE
Add reflection-based support for wrapping JS interop calls as C# delegates

### DIFF
--- a/src/Components/test/E2ETest/Tests/InteropTest.cs
+++ b/src/Components/test/E2ETest/Tests/InteropTest.cs
@@ -108,7 +108,8 @@ public class InteropTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
             ["invokeNewWithClassConstructorAsync.function"] = "6",
             ["invokeNewWithNonConstructorAsync"] = "Success",
             // Function reference tests
-            ["changeFunctionViaObjectReferenceAsync"] = "42"
+            ["changeFunctionViaObjectReferenceAsync"] = "42",
+            ["invokeDelegateFromAsAsyncFunction"] = "42"
         };
 
         var expectedSyncValues = new Dictionary<string, string>

--- a/src/Components/test/testassets/BasicTestApp/InteropComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/InteropComponent.razor
@@ -614,6 +614,9 @@
         var testClassRef = await JSRuntime.InvokeNewAsync("jsInteropTests.TestClass", "abraka");
         await testClassRef.SetValueAsync("getTextLength", funcRef);
         ReturnValues["changeFunctionViaObjectReferenceAsync"] = (await testClassRef.InvokeAsync<int>("getTextLength")).ToString();
+
+        var funcDelegate = funcRef.AsAsyncFunction<Func<Task<int>>>();
+        ReturnValues["invokeDelegateFromAsAsyncFunction"] = (await funcDelegate()).ToString();
     }
 
     private void FunctionReferenceTests()

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/JSFunctionReference.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/JSFunctionReference.cs
@@ -122,6 +122,8 @@ internal readonly struct JSFunctionReference
         var gd when gd == typeof(Func<,,,,>) => nameof(Invoke4),
         var gd when gd == typeof(Func<,,,,,>) => nameof(Invoke5),
         var gd when gd == typeof(Func<,,,,,,>) => nameof(Invoke6),
+        var gd when gd == typeof(Func<,,,,,,,>) => nameof(Invoke7),
+        var gd when gd == typeof(Func<,,,,,,,,>) => nameof(Invoke8),
         _ => throw CreateInvalidTypeParameterException(delegateType)
     };
 
@@ -134,6 +136,8 @@ internal readonly struct JSFunctionReference
         var gd when gd == typeof(Func<,,,,>) => nameof(InvokeTask4),
         var gd when gd == typeof(Func<,,,,,>) => nameof(InvokeTask5),
         var gd when gd == typeof(Func<,,,,,,>) => nameof(InvokeTask6),
+        var gd when gd == typeof(Func<,,,,,,,>) => nameof(InvokeTask7),
+        var gd when gd == typeof(Func<,,,,,,,,>) => nameof(InvokeTask8),
         _ => throw CreateInvalidTypeParameterException(delegateType)
     };
 
@@ -146,6 +150,8 @@ internal readonly struct JSFunctionReference
         var gd when gd == typeof(Func<,,,,>) => nameof(InvokeVoid4),
         var gd when gd == typeof(Func<,,,,,>) => nameof(InvokeVoid5),
         var gd when gd == typeof(Func<,,,,,,>) => nameof(InvokeVoid6),
+        var gd when gd == typeof(Func<,,,,,,,>) => nameof(InvokeVoid7),
+        var gd when gd == typeof(Func<,,,,,,,,>) => nameof(InvokeVoid8),
         _ => throw CreateInvalidTypeParameterException(delegateType)
     };
 
@@ -158,6 +164,8 @@ internal readonly struct JSFunctionReference
         var gd when gd == typeof(Func<,,,,>) => nameof(InvokeVoidTask4),
         var gd when gd == typeof(Func<,,,,,>) => nameof(InvokeVoidTask5),
         var gd when gd == typeof(Func<,,,,,,>) => nameof(InvokeVoidTask6),
+        var gd when gd == typeof(Func<,,,,,,,>) => nameof(InvokeVoidTask7),
+        var gd when gd == typeof(Func<,,,,,,,,>) => nameof(InvokeVoidTask8),
         _ => throw CreateInvalidTypeParameterException(delegateType)
     };
 
@@ -169,6 +177,8 @@ internal readonly struct JSFunctionReference
     public ValueTask<TResult> Invoke4<T1, T2, T3, T4, [DynamicallyAccessedMembers(JsonSerialized)] TResult>(T1 arg1, T2 arg2, T3 arg3, T4 arg4) => _jsObjectReference.InvokeAsync<TResult>(string.Empty, [arg1, arg2, arg3, arg4]);
     public ValueTask<TResult> Invoke5<T1, T2, T3, T4, T5, [DynamicallyAccessedMembers(JsonSerialized)] TResult>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) => _jsObjectReference.InvokeAsync<TResult>(string.Empty, [arg1, arg2, arg3, arg4, arg5]);
     public ValueTask<TResult> Invoke6<T1, T2, T3, T4, T5, T6, [DynamicallyAccessedMembers(JsonSerialized)] TResult>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) => _jsObjectReference.InvokeAsync<TResult>(string.Empty, [arg1, arg2, arg3, arg4, arg5, arg6]);
+    public ValueTask<TResult> Invoke7<T1, T2, T3, T4, T5, T6, T7, [DynamicallyAccessedMembers(JsonSerialized)] TResult>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7) => _jsObjectReference.InvokeAsync<TResult>(string.Empty, [arg1, arg2, arg3, arg4, arg5, arg6, arg7]);
+    public ValueTask<TResult> Invoke8<T1, T2, T3, T4, T5, T6, T7, T8, [DynamicallyAccessedMembers(JsonSerialized)] TResult>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8) => _jsObjectReference.InvokeAsync<TResult>(string.Empty, [arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8]);
 
     // Variants returning ValueTask using InvokeVoidAsync
     public ValueTask InvokeVoid0() => _jsObjectReference.InvokeVoidAsync(string.Empty);
@@ -178,6 +188,8 @@ internal readonly struct JSFunctionReference
     public ValueTask InvokeVoid4<T1, T2, T3, T4>(T1 arg1, T2 arg2, T3 arg3, T4 arg4) => _jsObjectReference.InvokeVoidAsync(string.Empty, [arg1, arg2, arg3, arg4]);
     public ValueTask InvokeVoid5<T1, T2, T3, T4, T5>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) => _jsObjectReference.InvokeVoidAsync(string.Empty, [arg1, arg2, arg3, arg4, arg5]);
     public ValueTask InvokeVoid6<T1, T2, T3, T4, T5, T6>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) => _jsObjectReference.InvokeVoidAsync(string.Empty, [arg1, arg2, arg3, arg4, arg5, arg6]);
+    public ValueTask InvokeVoid7<T1, T2, T3, T4, T5, T6, T7>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7) => _jsObjectReference.InvokeVoidAsync(string.Empty, [arg1, arg2, arg3, arg4, arg5, arg6, arg7]);
+    public ValueTask InvokeVoid8<T1, T2, T3, T4, T5, T6, T7, T8>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8) => _jsObjectReference.InvokeVoidAsync(string.Empty, [arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8]);
 
     // Variants returning Task<T> using InvokeAsync
     public Task<TResult> InvokeTask0<[DynamicallyAccessedMembers(JsonSerialized)] TResult>() => _jsObjectReference.InvokeAsync<TResult>(string.Empty, []).AsTask();
@@ -187,6 +199,8 @@ internal readonly struct JSFunctionReference
     public Task<TResult> InvokeTask4<T1, T2, T3, T4, [DynamicallyAccessedMembers(JsonSerialized)] TResult>(T1 arg1, T2 arg2, T3 arg3, T4 arg4) => _jsObjectReference.InvokeAsync<TResult>(string.Empty, [arg1, arg2, arg3, arg4]).AsTask();
     public Task<TResult> InvokeTask5<T1, T2, T3, T4, T5, [DynamicallyAccessedMembers(JsonSerialized)] TResult>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) => _jsObjectReference.InvokeAsync<TResult>(string.Empty, [arg1, arg2, arg3, arg4, arg5]).AsTask();
     public Task<TResult> InvokeTask6<T1, T2, T3, T4, T5, T6, [DynamicallyAccessedMembers(JsonSerialized)] TResult>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) => _jsObjectReference.InvokeAsync<TResult>(string.Empty, [arg1, arg2, arg3, arg4, arg5, arg6]).AsTask();
+    public Task<TResult> InvokeTask7<T1, T2, T3, T4, T5, T6, T7, [DynamicallyAccessedMembers(JsonSerialized)] TResult>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7) => _jsObjectReference.InvokeAsync<TResult>(string.Empty, [arg1, arg2, arg3, arg4, arg5, arg6, arg7]).AsTask();
+    public Task<TResult> InvokeTask8<T1, T2, T3, T4, T5, T6, T7, T8, [DynamicallyAccessedMembers(JsonSerialized)] TResult>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8) => _jsObjectReference.InvokeAsync<TResult>(string.Empty, [arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8]).AsTask();
 
     // Variants returning Task using InvokeVoidAsync
     public Task InvokeVoidTask0() => _jsObjectReference.InvokeVoidAsync(string.Empty).AsTask();
@@ -196,4 +210,6 @@ internal readonly struct JSFunctionReference
     public Task InvokeVoidTask4<T1, T2, T3, T4>(T1 arg1, T2 arg2, T3 arg3, T4 arg4) => _jsObjectReference.InvokeVoidAsync(string.Empty, [arg1, arg2, arg3, arg4]).AsTask();
     public Task InvokeVoidTask5<T1, T2, T3, T4, T5>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) => _jsObjectReference.InvokeVoidAsync(string.Empty, [arg1, arg2, arg3, arg4, arg5]).AsTask();
     public Task InvokeVoidTask6<T1, T2, T3, T4, T5, T6>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) => _jsObjectReference.InvokeVoidAsync(string.Empty, [arg1, arg2, arg3, arg4, arg5, arg6]).AsTask();
+    public Task InvokeVoidTask7<T1, T2, T3, T4, T5, T6, T7>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7) => _jsObjectReference.InvokeVoidAsync(string.Empty, [arg1, arg2, arg3, arg4, arg5, arg6, arg7]).AsTask();
+    public Task InvokeVoidTask8<T1, T2, T3, T4, T5, T6, T7, T8>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8) => _jsObjectReference.InvokeVoidAsync(string.Empty, [arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8]).AsTask();
 }

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/JSFunctionReference.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/JSFunctionReference.cs
@@ -1,0 +1,197 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using static Microsoft.AspNetCore.Internal.LinkerFlags;
+
+namespace Microsoft.JSInterop.Infrastructure;
+
+/// <summary>
+/// TODO(OR): Document this.
+/// </summary>
+internal readonly struct JSFunctionReference
+{
+    private static readonly ConcurrentDictionary<Type, MethodInfo> _methodInfoCache = new();
+
+    private readonly IJSObjectReference _jsObjectReference;
+
+    /// <summary>
+    /// Caches previously constructed MethodInfo instances for various delegate types.
+    /// </summary>
+    public static ConcurrentDictionary<Type, MethodInfo> MethodInfoCache => _methodInfoCache;
+
+    public JSFunctionReference(IJSObjectReference jsObjectReference)
+    {
+        _jsObjectReference = jsObjectReference;
+    }
+
+    /// <summary>
+    /// TODO(OR): Document this.
+    /// </summary>
+    public static T CreateInvocationDelegate<T>(IJSObjectReference jsObjectReference) where T : Delegate
+    {
+        Type delegateType = typeof(T);
+
+        if (MethodInfoCache.TryGetValue(delegateType, out var wrapperMethod))
+        {
+            var wrapper = new JSFunctionReference(jsObjectReference);
+            return (T)Delegate.CreateDelegate(delegateType, wrapper, wrapperMethod);
+        }
+
+        if (!delegateType.IsGenericType)
+        {
+            throw new ArgumentException("The delegate type must be a Func.");
+        }
+
+        var returnTypeCandidate = delegateType.GenericTypeArguments[^1];
+
+        if (returnTypeCandidate == typeof(ValueTask))
+        {
+            var methodName = GetVoidMethodName(delegateType.GetGenericTypeDefinition());
+            return CreateVoidDelegate<T>(delegateType, jsObjectReference, methodName);
+        }
+        else if (returnTypeCandidate == typeof(Task))
+        {
+            var methodName = GetVoidTaskMethodName(delegateType.GetGenericTypeDefinition());
+            return CreateVoidDelegate<T>(delegateType, jsObjectReference, methodName);
+        }
+        else
+        {
+            var returnTypeGenericTypeDefinition = returnTypeCandidate.GetGenericTypeDefinition();
+
+            if (returnTypeGenericTypeDefinition == typeof(ValueTask<>))
+            {
+                var methodName = GetMethodName(delegateType.GetGenericTypeDefinition());
+                var innerReturnType = returnTypeCandidate.GenericTypeArguments[0];
+                return CreateDelegate<T>(delegateType, innerReturnType, jsObjectReference, methodName);
+            }
+
+            else if (returnTypeGenericTypeDefinition == typeof(Task<>))
+            {
+                var methodName = GetTaskMethodName(delegateType.GetGenericTypeDefinition());
+                var innerReturnType = returnTypeCandidate.GenericTypeArguments[0];
+                return CreateDelegate<T>(delegateType, innerReturnType, jsObjectReference, methodName);
+            }
+            else
+            {
+                throw new ArgumentException("The delegate return type must be Task<TResult> or ValueTask<TResult>.");
+            }
+        }
+    }
+
+    private static T CreateDelegate<T>(Type delegateType, Type returnType, IJSObjectReference jsObjectReference, string methodName) where T : Delegate
+    {
+        var wrapper = new JSFunctionReference(jsObjectReference);
+        var wrapperMethod = typeof(JSFunctionReference).GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance)!;
+        Type[] genericArguments = [.. delegateType.GenericTypeArguments[..^1], returnType];
+
+#pragma warning disable IL2060 // Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+        var concreteWrapperMethod = wrapperMethod.MakeGenericMethod(genericArguments);
+#pragma warning restore IL2060 // Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+
+        MethodInfoCache.TryAdd(delegateType, concreteWrapperMethod);
+
+        return (T)Delegate.CreateDelegate(delegateType, wrapper, concreteWrapperMethod);
+    }
+
+    private static T CreateVoidDelegate<T>(Type delegateType, IJSObjectReference jsObjectReference, string methodName) where T : Delegate
+    {
+        var wrapper = new JSFunctionReference(jsObjectReference);
+        var wrapperMethod = typeof(JSFunctionReference).GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance)!;
+        Type[] genericArguments = delegateType.GenericTypeArguments[..^1];
+
+#pragma warning disable IL2060 // Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+        var concreteWrapperMethod = wrapperMethod.MakeGenericMethod(genericArguments);
+#pragma warning restore IL2060 // Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+
+        MethodInfoCache.TryAdd(delegateType, concreteWrapperMethod);
+
+        return (T)Delegate.CreateDelegate(delegateType, wrapper, concreteWrapperMethod);
+    }
+
+    private static string GetMethodName(Type genericDelegateTypeDefiniton) => genericDelegateTypeDefiniton switch
+    {
+        var gd when gd == typeof(Func<>) => nameof(Invoke0),
+        var gd when gd == typeof(Func<,>) => nameof(Invoke1),
+        var gd when gd == typeof(Func<,,>) => nameof(Invoke2),
+        var gd when gd == typeof(Func<,,,>) => nameof(Invoke3),
+        var gd when gd == typeof(Func<,,,,>) => nameof(Invoke4),
+        var gd when gd == typeof(Func<,,,,,>) => nameof(Invoke5),
+        var gd when gd == typeof(Func<,,,,,,>) => nameof(Invoke6),
+        _ => throw new NotSupportedException($"The type {genericDelegateTypeDefiniton} is not supported.")
+    };
+
+    private static string GetTaskMethodName(Type genericDelegateTypeDefiniton) => genericDelegateTypeDefiniton switch
+    {
+        var gd when gd == typeof(Func<>) => nameof(InvokeTask0),
+        var gd when gd == typeof(Func<,>) => nameof(InvokeTask1),
+        var gd when gd == typeof(Func<,,>) => nameof(InvokeTask2),
+        var gd when gd == typeof(Func<,,,>) => nameof(InvokeTask3),
+        var gd when gd == typeof(Func<,,,,>) => nameof(InvokeTask4),
+        var gd when gd == typeof(Func<,,,,,>) => nameof(InvokeTask5),
+        var gd when gd == typeof(Func<,,,,,,>) => nameof(InvokeTask6),
+        _ => throw new NotSupportedException($"The type {genericDelegateTypeDefiniton} is not supported.")
+    };
+
+    private static string GetVoidMethodName(Type genericDelegateTypeDefiniton) => genericDelegateTypeDefiniton switch
+    {
+        var gd when gd == typeof(Func<>) => nameof(InvokeVoid0),
+        var gd when gd == typeof(Func<,>) => nameof(InvokeVoid1),
+        var gd when gd == typeof(Func<,,>) => nameof(InvokeVoid2),
+        var gd when gd == typeof(Func<,,,>) => nameof(InvokeVoid3),
+        var gd when gd == typeof(Func<,,,,>) => nameof(InvokeVoid4),
+        var gd when gd == typeof(Func<,,,,,>) => nameof(InvokeVoid5),
+        var gd when gd == typeof(Func<,,,,,,>) => nameof(InvokeVoid6),
+        _ => throw new NotSupportedException($"The type {genericDelegateTypeDefiniton} is not supported.")
+    };
+
+    private static string GetVoidTaskMethodName(Type genericDelegateTypeDefiniton) => genericDelegateTypeDefiniton switch
+    {
+        var gd when gd == typeof(Func<>) => nameof(InvokeVoidTask0),
+        var gd when gd == typeof(Func<,>) => nameof(InvokeVoidTask1),
+        var gd when gd == typeof(Func<,,>) => nameof(InvokeVoidTask2),
+        var gd when gd == typeof(Func<,,,>) => nameof(InvokeVoidTask3),
+        var gd when gd == typeof(Func<,,,,>) => nameof(InvokeVoidTask4),
+        var gd when gd == typeof(Func<,,,,,>) => nameof(InvokeVoidTask5),
+        var gd when gd == typeof(Func<,,,,,,>) => nameof(InvokeVoidTask6),
+        _ => throw new NotSupportedException($"The type {genericDelegateTypeDefiniton} is not supported.")
+    };
+
+    // Variants returning ValueTask<T> using InvokeAsync
+    public ValueTask<TResult> Invoke0<[DynamicallyAccessedMembers(JsonSerialized)] TResult>() => _jsObjectReference.InvokeAsync<TResult>(string.Empty, []);
+    public ValueTask<TResult> Invoke1<T1, [DynamicallyAccessedMembers(JsonSerialized)] TResult>(T1 arg1) => _jsObjectReference.InvokeAsync<TResult>(string.Empty, [arg1]);
+    public ValueTask<TResult> Invoke2<T1, T2, [DynamicallyAccessedMembers(JsonSerialized)] TResult>(T1 arg1, T2 arg2) => _jsObjectReference.InvokeAsync<TResult>(string.Empty, [arg1, arg2]);
+    public ValueTask<TResult> Invoke3<T1, T2, T3, [DynamicallyAccessedMembers(JsonSerialized)] TResult>(T1 arg1, T2 arg2, T3 arg3) => _jsObjectReference.InvokeAsync<TResult>(string.Empty, [arg1, arg2, arg3]);
+    public ValueTask<TResult> Invoke4<T1, T2, T3, T4, [DynamicallyAccessedMembers(JsonSerialized)] TResult>(T1 arg1, T2 arg2, T3 arg3, T4 arg4) => _jsObjectReference.InvokeAsync<TResult>(string.Empty, [arg1, arg2, arg3, arg4]);
+    public ValueTask<TResult> Invoke5<T1, T2, T3, T4, T5, [DynamicallyAccessedMembers(JsonSerialized)] TResult>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) => _jsObjectReference.InvokeAsync<TResult>(string.Empty, [arg1, arg2, arg3, arg4, arg5]);
+    public ValueTask<TResult> Invoke6<T1, T2, T3, T4, T5, T6, [DynamicallyAccessedMembers(JsonSerialized)] TResult>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) => _jsObjectReference.InvokeAsync<TResult>(string.Empty, [arg1, arg2, arg3, arg4, arg5, arg6]);
+
+    // Variants returning ValueTask using InvokeVoidAsync
+    public ValueTask InvokeVoid0() => _jsObjectReference.InvokeVoidAsync(string.Empty);
+    public ValueTask InvokeVoid1<T1>(T1 arg1) => _jsObjectReference.InvokeVoidAsync(string.Empty, [arg1]);
+    public ValueTask InvokeVoid2<T1, T2>(T1 arg1, T2 arg2) => _jsObjectReference.InvokeVoidAsync(string.Empty, [arg1, arg2]);
+    public ValueTask InvokeVoid3<T1, T2, T3>(T1 arg1, T2 arg2, T3 arg3) => _jsObjectReference.InvokeVoidAsync(string.Empty, [arg1, arg2, arg3]);
+    public ValueTask InvokeVoid4<T1, T2, T3, T4>(T1 arg1, T2 arg2, T3 arg3, T4 arg4) => _jsObjectReference.InvokeVoidAsync(string.Empty, [arg1, arg2, arg3, arg4]);
+    public ValueTask InvokeVoid5<T1, T2, T3, T4, T5>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) => _jsObjectReference.InvokeVoidAsync(string.Empty, [arg1, arg2, arg3, arg4, arg5]);
+    public ValueTask InvokeVoid6<T1, T2, T3, T4, T5, T6>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) => _jsObjectReference.InvokeVoidAsync(string.Empty, [arg1, arg2, arg3, arg4, arg5, arg6]);
+
+    // Variants returning Task<T> using InvokeAsync
+    public Task<TResult> InvokeTask0<[DynamicallyAccessedMembers(JsonSerialized)] TResult>() => _jsObjectReference.InvokeAsync<TResult>(string.Empty, []).AsTask();
+    public Task<TResult> InvokeTask1<T1, [DynamicallyAccessedMembers(JsonSerialized)] TResult>(T1 arg1) => _jsObjectReference.InvokeAsync<TResult>(string.Empty, [arg1]).AsTask();
+    public Task<TResult> InvokeTask2<T1, T2, [DynamicallyAccessedMembers(JsonSerialized)] TResult>(T1 arg1, T2 arg2) => _jsObjectReference.InvokeAsync<TResult>(string.Empty, [arg1, arg2]).AsTask();
+    public Task<TResult> InvokeTask3<T1, T2, T3, [DynamicallyAccessedMembers(JsonSerialized)] TResult>(T1 arg1, T2 arg2, T3 arg3) => _jsObjectReference.InvokeAsync<TResult>(string.Empty, [arg1, arg2, arg3]).AsTask();
+    public Task<TResult> InvokeTask4<T1, T2, T3, T4, [DynamicallyAccessedMembers(JsonSerialized)] TResult>(T1 arg1, T2 arg2, T3 arg3, T4 arg4) => _jsObjectReference.InvokeAsync<TResult>(string.Empty, [arg1, arg2, arg3, arg4]).AsTask();
+    public Task<TResult> InvokeTask5<T1, T2, T3, T4, T5, [DynamicallyAccessedMembers(JsonSerialized)] TResult>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) => _jsObjectReference.InvokeAsync<TResult>(string.Empty, [arg1, arg2, arg3, arg4, arg5]).AsTask();
+    public Task<TResult> InvokeTask6<T1, T2, T3, T4, T5, T6, [DynamicallyAccessedMembers(JsonSerialized)] TResult>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) => _jsObjectReference.InvokeAsync<TResult>(string.Empty, [arg1, arg2, arg3, arg4, arg5, arg6]).AsTask();
+
+    // Variants returning Task using InvokeVoidAsync
+    public Task InvokeVoidTask0() => _jsObjectReference.InvokeVoidAsync(string.Empty).AsTask();
+    public Task InvokeVoidTask1<T1>(T1 arg1) => _jsObjectReference.InvokeVoidAsync(string.Empty, [arg1]).AsTask();
+    public Task InvokeVoidTask2<T1, T2>(T1 arg1, T2 arg2) => _jsObjectReference.InvokeVoidAsync(string.Empty, [arg1, arg2]).AsTask();
+    public Task InvokeVoidTask3<T1, T2, T3>(T1 arg1, T2 arg2, T3 arg3) => _jsObjectReference.InvokeVoidAsync(string.Empty, [arg1, arg2, arg3]).AsTask();
+    public Task InvokeVoidTask4<T1, T2, T3, T4>(T1 arg1, T2 arg2, T3 arg3, T4 arg4) => _jsObjectReference.InvokeVoidAsync(string.Empty, [arg1, arg2, arg3, arg4]).AsTask();
+    public Task InvokeVoidTask5<T1, T2, T3, T4, T5>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) => _jsObjectReference.InvokeVoidAsync(string.Empty, [arg1, arg2, arg3, arg4, arg5]).AsTask();
+    public Task InvokeVoidTask6<T1, T2, T3, T4, T5, T6>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) => _jsObjectReference.InvokeVoidAsync(string.Empty, [arg1, arg2, arg3, arg4, arg5, arg6]).AsTask();
+}

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/JSFunctionReference.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/JSFunctionReference.cs
@@ -9,7 +9,7 @@ using static Microsoft.AspNetCore.Internal.LinkerFlags;
 namespace Microsoft.JSInterop.Infrastructure;
 
 /// <summary>
-/// TODO(OR): Document this.
+/// Helper for constructing a Func delegate that wraps interop call to a JavaScript function referenced via <see cref="IJSObjectReference"/>.
 /// </summary>
 internal readonly struct JSFunctionReference
 {
@@ -25,9 +25,6 @@ internal readonly struct JSFunctionReference
         _jsObjectReference = jsObjectReference;
     }
 
-    /// <summary>
-    /// TODO(OR): Document this.
-    /// </summary>
     public static T CreateInvocationDelegate<T>(IJSObjectReference jsObjectReference) where T : Delegate
     {
         Type delegateType = typeof(T);

--- a/src/JSInterop/Microsoft.JSInterop/src/JSObjectReferenceExtensions.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSObjectReferenceExtensions.cs
@@ -1,9 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using Microsoft.JSInterop.Infrastructure;
 using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
@@ -171,12 +169,13 @@ public static class JSObjectReferenceExtensions
     }
 
     /// <summary>
-    /// TODO(OR): Document this.
+    /// Converts a JavaScript function reference into a .NET delegate of the specified type.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="jsObjectReference"></param>
-    /// <returns></returns>
-    /// <exception cref="ArgumentException"></exception>
+    /// <typeparam name="T">The type of the delegate to create. Must be a Func with the result type <see cref="Task"/>, <see cref="Task{R}"/>, <see cref="ValueTask"/>, or <see cref="ValueTask{R}"/>.</typeparam>
+    /// <param name="jsObjectReference">The JavaScript object reference that represents the function to be invoked.</param>
+    /// <returns>A Func delegate of type <typeparamref name="T"/> that can be used to invoke the JavaScript function.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="jsObjectReference"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when <typeparamref name="T"/> is not a valid Func type.</exception>
     public static T AsAsyncFunction<T>(this IJSObjectReference jsObjectReference) where T : Delegate
     {
         ArgumentNullException.ThrowIfNull(jsObjectReference);

--- a/src/JSInterop/Microsoft.JSInterop/src/JSObjectReferenceExtensions.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSObjectReferenceExtensions.cs
@@ -177,7 +177,7 @@ public static class JSObjectReferenceExtensions
     /// <param name="jsObjectReference"></param>
     /// <returns></returns>
     /// <exception cref="ArgumentException"></exception>
-    public static T AsFunction<T>(this IJSObjectReference jsObjectReference) where T : Delegate
+    public static T AsAsyncFunction<T>(this IJSObjectReference jsObjectReference) where T : Delegate
     {
         ArgumentNullException.ThrowIfNull(jsObjectReference);
 

--- a/src/JSInterop/Microsoft.JSInterop/src/JSObjectReferenceExtensions.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSObjectReferenceExtensions.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using Microsoft.JSInterop.Infrastructure;
 using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
@@ -166,5 +168,19 @@ public static class JSObjectReferenceExtensions
         var cancellationToken = cancellationTokenSource?.Token ?? CancellationToken.None;
 
         return jsObjectReference.InvokeNewAsync(identifier, cancellationToken, args);
+    }
+
+    /// <summary>
+    /// TODO(OR): Document this.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="jsObjectReference"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentException"></exception>
+    public static T AsFunction<T>(this IJSObjectReference jsObjectReference) where T : Delegate
+    {
+        ArgumentNullException.ThrowIfNull(jsObjectReference);
+
+        return JSFunctionReference.CreateInvocationDelegate<T>(jsObjectReference);
     }
 }

--- a/src/JSInterop/Microsoft.JSInterop/src/PublicAPI.Unshipped.txt
+++ b/src/JSInterop/Microsoft.JSInterop/src/PublicAPI.Unshipped.txt
@@ -56,6 +56,7 @@ Microsoft.JSInterop.JSRuntime.InvokeNewAsync(string! identifier, object?[]? args
 Microsoft.JSInterop.JSRuntime.InvokeNewAsync(string! identifier, System.Threading.CancellationToken cancellationToken, object?[]? args) -> System.Threading.Tasks.ValueTask<Microsoft.JSInterop.IJSObjectReference!>
 Microsoft.JSInterop.JSRuntime.SetValueAsync<TValue>(string! identifier, TValue value) -> System.Threading.Tasks.ValueTask
 Microsoft.JSInterop.JSRuntime.SetValueAsync<TValue>(string! identifier, TValue value, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
+static Microsoft.JSInterop.JSObjectReferenceExtensions.AsFunction<T>(this Microsoft.JSInterop.IJSObjectReference! jsObjectReference) -> T!
 static Microsoft.JSInterop.JSObjectReferenceExtensions.InvokeNewAsync(this Microsoft.JSInterop.IJSObjectReference! jsObjectReference, string! identifier, params object?[]? args) -> System.Threading.Tasks.ValueTask<Microsoft.JSInterop.IJSObjectReference!>
 static Microsoft.JSInterop.JSObjectReferenceExtensions.InvokeNewAsync(this Microsoft.JSInterop.IJSObjectReference! jsObjectReference, string! identifier, System.Threading.CancellationToken cancellationToken, object?[]? args) -> System.Threading.Tasks.ValueTask<Microsoft.JSInterop.IJSObjectReference!>
 static Microsoft.JSInterop.JSObjectReferenceExtensions.InvokeNewAsync(this Microsoft.JSInterop.IJSObjectReference! jsObjectReference, string! identifier, System.TimeSpan timeout, object?[]? args) -> System.Threading.Tasks.ValueTask<Microsoft.JSInterop.IJSObjectReference!>

--- a/src/JSInterop/Microsoft.JSInterop/src/PublicAPI.Unshipped.txt
+++ b/src/JSInterop/Microsoft.JSInterop/src/PublicAPI.Unshipped.txt
@@ -56,7 +56,7 @@ Microsoft.JSInterop.JSRuntime.InvokeNewAsync(string! identifier, object?[]? args
 Microsoft.JSInterop.JSRuntime.InvokeNewAsync(string! identifier, System.Threading.CancellationToken cancellationToken, object?[]? args) -> System.Threading.Tasks.ValueTask<Microsoft.JSInterop.IJSObjectReference!>
 Microsoft.JSInterop.JSRuntime.SetValueAsync<TValue>(string! identifier, TValue value) -> System.Threading.Tasks.ValueTask
 Microsoft.JSInterop.JSRuntime.SetValueAsync<TValue>(string! identifier, TValue value, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
-static Microsoft.JSInterop.JSObjectReferenceExtensions.AsFunction<T>(this Microsoft.JSInterop.IJSObjectReference! jsObjectReference) -> T!
+static Microsoft.JSInterop.JSObjectReferenceExtensions.AsAsyncFunction<T>(this Microsoft.JSInterop.IJSObjectReference! jsObjectReference) -> T!
 static Microsoft.JSInterop.JSObjectReferenceExtensions.InvokeNewAsync(this Microsoft.JSInterop.IJSObjectReference! jsObjectReference, string! identifier, params object?[]? args) -> System.Threading.Tasks.ValueTask<Microsoft.JSInterop.IJSObjectReference!>
 static Microsoft.JSInterop.JSObjectReferenceExtensions.InvokeNewAsync(this Microsoft.JSInterop.IJSObjectReference! jsObjectReference, string! identifier, System.Threading.CancellationToken cancellationToken, object?[]? args) -> System.Threading.Tasks.ValueTask<Microsoft.JSInterop.IJSObjectReference!>
 static Microsoft.JSInterop.JSObjectReferenceExtensions.InvokeNewAsync(this Microsoft.JSInterop.IJSObjectReference! jsObjectReference, string! identifier, System.TimeSpan timeout, object?[]? args) -> System.Threading.Tasks.ValueTask<Microsoft.JSInterop.IJSObjectReference!>

--- a/src/JSInterop/Microsoft.JSInterop/test/JSObjectReferenceExtensionsTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/JSObjectReferenceExtensionsTest.cs
@@ -1,0 +1,192 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection.PortableExecutable;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.JSInterop.Implementation;
+using Microsoft.JSInterop.Infrastructure;
+
+namespace Microsoft.JSInterop.Tests;
+
+public class JSObjectReferenceExtensionsTest
+{
+    [Fact]
+    public void AsAsyncFunction_WithVoidValueTaskFunc_ReturnsFunc()
+    {
+        var jsRuntime = new TestJSRuntime();
+        var jsObjectReference = new JSObjectReference(jsRuntime, 1);
+
+        // Act
+        var func = jsObjectReference.AsAsyncFunction<Func<int, ValueTask>>();
+
+        // Assert
+        Assert.NotNull(func);
+        Assert.IsType<Func<int, ValueTask>>(func);
+    }
+
+    [Fact]
+    public void AsAsyncFunction_WithVoidTaskFunc_ReturnsFunc()
+    {
+        var jsRuntime = new TestJSRuntime();
+        var jsObjectReference = new JSObjectReference(jsRuntime, 1);
+
+        // Act
+        var func = jsObjectReference.AsAsyncFunction<Func<int, Task>>();
+
+        // Assert
+        Assert.NotNull(func);
+        Assert.IsType<Func<int, Task>>(func);
+    }
+
+    [Fact]
+    public void AsAsyncFunction_WithValueTaskFunc_ReturnsFunc()
+    {
+        var jsRuntime = new TestJSRuntime();
+        var jsObjectReference = new JSObjectReference(jsRuntime, 1);
+
+        // Act
+        var func = jsObjectReference.AsAsyncFunction<Func<int, ValueTask<int>>>();
+
+        // Assert
+        Assert.NotNull(func);
+        Assert.IsType<Func<int, ValueTask<int>>>(func);
+    }
+
+    [Fact]
+    public void AsAsyncFunction_WithTaskFunc_ReturnsFunc()
+    {
+        var jsRuntime = new TestJSRuntime();
+        var jsObjectReference = new JSObjectReference(jsRuntime, 1);
+
+        // Act
+        var func = jsObjectReference.AsAsyncFunction<Func<int, Task<int>>>();
+
+        // Assert
+        Assert.NotNull(func);
+        Assert.IsType<Func<int, Task<int>>>(func);
+    }
+
+    [Fact]
+    public void AsAsyncFunction_WithValueTaskFunc_ReturnsFunc_ThatInvokesInterop()
+    {
+        // Arrange
+        var jsRuntime = new TestJSRuntime();
+        var jsObjectReference = new JSObjectReference(jsRuntime, 1);
+
+        var bytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(42));
+        var reader = new Utf8JsonReader(bytes);
+
+        // Act
+        var func = jsObjectReference.AsAsyncFunction<Func<int, ValueTask<int>>>();
+        ValueTask<int> task = func(1);
+
+        jsRuntime.EndInvokeJS(
+            jsRuntime.InvokeCalls[0].AsyncHandle,
+            /* succeeded: */ true,
+            ref reader);
+
+        // Assert
+        Assert.True(task.IsCompleted);
+#pragma warning disable xUnit1031 // Do not use blocking task operations in test method
+        Assert.Equal(42, task.Result);
+#pragma warning restore xUnit1031 // Do not use blocking task operations in test method
+    }
+
+    [Fact]
+    public void AsAsyncFunction_WithTaskFunc_ReturnsFunc_ThatInvokesInterop()
+    {
+        // Arrange
+        var jsRuntime = new TestJSRuntime();
+        var jsObjectReference = new JSObjectReference(jsRuntime, 1);
+
+        var bytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(42));
+        var reader = new Utf8JsonReader(bytes);
+
+        // Act
+        var func = jsObjectReference.AsAsyncFunction<Func<int, Task<int>>>();
+        Task<int> task = func(1);
+
+        jsRuntime.EndInvokeJS(
+            jsRuntime.InvokeCalls[0].AsyncHandle,
+            /* succeeded: */ true,
+            ref reader);
+
+        // Assert
+        Assert.True(task.IsCompleted);
+#pragma warning disable xUnit1031 // Do not use blocking task operations in test method
+        Assert.Equal(42, task.Result);
+#pragma warning restore xUnit1031 // Do not use blocking task operations in test method
+    }
+
+    [Fact]
+    public void AsAsyncFunction_WithEventHandlerDelegate_Throws()
+    {
+        var jsRuntime = new TestJSRuntime();
+        var jsObjectReference = new JSObjectReference(jsRuntime, 1);
+
+        // Act/Assert
+        Assert.Throws<InvalidOperationException>(jsObjectReference.AsAsyncFunction<EventHandler>);
+    }
+
+    [Fact]
+    public void AsAsyncFunction_WithActionDelegate_Throws()
+    {
+        var jsRuntime = new TestJSRuntime();
+        var jsObjectReference = new JSObjectReference(jsRuntime, 1);
+
+        // Act/Assert
+        Assert.Throws<InvalidOperationException>(jsObjectReference.AsAsyncFunction<Action<int>>);
+    }
+
+    [Fact]
+    public void AsAsyncFunction_WithFuncWithInvalidReturnType_Throws()
+    {
+        var jsRuntime = new TestJSRuntime();
+        var jsObjectReference = new JSObjectReference(jsRuntime, 1);
+
+        // Act/Assert
+        Assert.Throws<InvalidOperationException>(jsObjectReference.AsAsyncFunction<Func<int>>);
+    }
+
+    [Fact]
+    public void AsAsyncFunction_WithFuncWithTooManyParams_Throws()
+    {
+        var jsRuntime = new TestJSRuntime();
+        var jsObjectReference = new JSObjectReference(jsRuntime, 1);
+
+        // Act/Assert
+        Assert.Throws<InvalidOperationException>(jsObjectReference.AsAsyncFunction<Func<int, int, int, int, int, int, int, int, int>>);
+    }
+
+    class TestJSRuntime : JSInProcessRuntime
+    {
+        public List<JSInvocationInfo> InvokeCalls { get; set; } = [];
+
+        public string? NextResultJson { get; set; }
+
+        protected override string? InvokeJS(string identifier, string? argsJson, JSCallResultType resultType, long targetInstanceId)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override string? InvokeJS(in JSInvocationInfo invocationInfo)
+        {
+            InvokeCalls.Add(invocationInfo);
+            return NextResultJson;
+        }
+
+        protected override void BeginInvokeJS(long taskId, string identifier, [StringSyntax("Json")] string? argsJson, JSCallResultType resultType, long targetInstanceId)
+            => throw new NotImplementedException("This test only covers sync calls");
+
+        protected override void BeginInvokeJS(in JSInvocationInfo invocationInfo)
+        {
+            InvokeCalls.Add(invocationInfo);
+        }
+
+        protected internal override void EndInvokeDotNet(DotNetInvocationInfo invocationInfo, in DotNetInvocationResult invocationResult)
+            => throw new NotImplementedException("This test only covers sync calls");
+    }
+}

--- a/src/JSInterop/Microsoft.JSInterop/test/JSObjectReferenceExtensionsTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/JSObjectReferenceExtensionsTest.cs
@@ -158,7 +158,7 @@ public class JSObjectReferenceExtensionsTest
         var jsObjectReference = new JSObjectReference(jsRuntime, 1);
 
         // Act/Assert
-        Assert.Throws<InvalidOperationException>(jsObjectReference.AsAsyncFunction<Func<int, int, int, int, int, int, int, int, int>>);
+        Assert.Throws<InvalidOperationException>(jsObjectReference.AsAsyncFunction<Func<int, int, int, int, int, int, int, int, int, Task>>);
     }
 
     class TestJSRuntime : JSInProcessRuntime


### PR DESCRIPTION
This is a work-in-progress implementation of `AsAsyncFunction` extension method for `IJSObjectReference`. The method creates an asynchronous `Func<...>` delegate that serves as a C#-native typed wrapper that invokes the referenced JS function via interop.

Sync variant and the full PR description can be added after we finalize implementation design.

This is the reflection-based alternative to https://github.com/dotnet/aspnetcore/pull/61721.