### PR TITLE
[HeaderDictionary] Reassign the underlying enumerator after calling reset

### DIFF
--- a/src/Http/Http/src/FormCollection.cs
+++ b/src/Http/Http/src/FormCollection.cs
@@ -225,12 +225,15 @@ public class FormCollection : IFormCollection
                 return Current;
             }
         }
-
+        
         void IEnumerator.Reset()
         {
             if (_notEmpty)
             {
-                ((IEnumerator)_dictionaryEnumerator).Reset();
+                // The cast causes the enumerator to be copied by value so we must cast it back to the original type after resetting.
+                var enumerator = (IEnumerator)_dictionaryEnumerator;
+                enumerator.Reset();
+                _dictionaryEnumerator = (Dictionary<string, StringValues>.Enumerator)enumerator;
             }
         }
     }

--- a/src/Http/Http/src/HeaderDictionary.cs
+++ b/src/Http/Http/src/HeaderDictionary.cs
@@ -451,7 +451,10 @@ public class HeaderDictionary : IHeaderDictionary
         {
             if (_notEmpty)
             {
-                ((IEnumerator)_dictionaryEnumerator).Reset();
+                // The cast causes the enumerator to be copied by value so we must cast it back to the original type after resetting.
+                var enumerator = (IEnumerator)_dictionaryEnumerator;
+                enumerator.Reset();
+                _dictionaryEnumerator = (Dictionary<string, StringValues>.Enumerator)enumerator;
             }
         }
     }

--- a/src/Http/Http/src/Internal/RequestCookieCollection.cs
+++ b/src/Http/Http/src/Internal/RequestCookieCollection.cs
@@ -218,11 +218,14 @@ internal sealed class RequestCookieCollection : IRequestCookieCollection
         {
         }
 
-        public void Reset()
+        void IEnumerator.Reset()
         {
             if (_notEmpty)
             {
-                ((IEnumerator)_dictionaryEnumerator).Reset();
+                // The cast causes the enumerator to be copied by value so we must cast it back to the original type after resetting.
+                var enumerator = (IEnumerator)_dictionaryEnumerator;
+                enumerator.Reset();
+                _dictionaryEnumerator = (AdaptiveCapacityDictionary<string, string>.Enumerator)enumerator;
             }
         }
     }

--- a/src/Http/Http/src/QueryCollection.cs
+++ b/src/Http/Http/src/QueryCollection.cs
@@ -246,7 +246,10 @@ public class QueryCollection : IQueryCollection
         {
             if (_notEmpty)
             {
-                ((IEnumerator)_dictionaryEnumerator).Reset();
+                // The cast causes the enumerator to be copied by value so we must cast it back to the original type after resetting.
+                var enumerator = (IEnumerator)_dictionaryEnumerator;
+                enumerator.Reset();
+                _dictionaryEnumerator = (Dictionary<string, StringValues>.Enumerator)enumerator;
             }
         }
     }

--- a/src/Http/Http/src/QueryCollectionInternal.cs
+++ b/src/Http/Http/src/QueryCollectionInternal.cs
@@ -124,7 +124,10 @@ internal sealed class QueryCollectionInternal : IQueryCollection
         {
             if (_notEmpty)
             {
-                ((IEnumerator)_dictionaryEnumerator).Reset();
+                // The cast causes the enumerator to be copied by value so we must cast it back to the original type after resetting.
+                var enumerator = (IEnumerator)_dictionaryEnumerator;
+                enumerator.Reset();
+                _dictionaryEnumerator = (AdaptiveCapacityDictionary<string, StringValues>.Enumerator)enumerator;
             }
         }
     }

--- a/src/Http/Http/test/HeaderDictionaryTests.cs
+++ b/src/Http/Http/test/HeaderDictionaryTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
+using Microsoft.AspNetCore.InternalTesting.Tracing;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Http;
@@ -131,5 +133,39 @@ public class HeaderDictionaryTests
 
         IDictionary<string, StringValues> asIDictionary = emptyHeaders;
         Assert.Throws<KeyNotFoundException>(() => asIDictionary["Header1"]);
+    }
+
+    [Fact]
+    public void EnumeratorResetsCorrectly()
+    {
+        var headers = new HeaderDictionary(
+            new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "Header1", "Value1" },
+                { "Header2", "Value2" },
+                { "Header3", "Value3" }
+            });
+
+        var enumerator = headers.GetEnumerator();
+        var initial = enumerator.Current;
+
+        Assert.True(enumerator.MoveNext());
+
+        var first = enumerator.Current;
+        var last = enumerator.Current;
+
+        while (enumerator.MoveNext())
+        {
+            last = enumerator.Current;
+        }
+
+        Assert.NotEqual(first, initial);
+        Assert.NotEqual(first, last);
+
+        ((IEnumerator)enumerator).Reset();
+
+        Assert.Equal(enumerator.Current, initial);
+        Assert.True(enumerator.MoveNext());
+        Assert.Equal(enumerator.Current, first);
     }
 }

--- a/src/Http/Http/test/QueryCollectionTests.cs
+++ b/src/Http/Http/test/QueryCollectionTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Http.Tests;
@@ -19,11 +20,11 @@ public class QueryCollectionTests
         // Test the null-dictionary code path too.
         Assert.Same(Array.Empty<string>(), (string[])QueryCollection.Empty["query1"]);
     }
-    
+
     [Fact]
     public void EnumeratorResetsCorrectly()
     {
-        var cookies = new QueryCollection(
+        var query = new QueryCollection(
             new Dictionary<string, StringValues>
             {
                 { "Query1", "Value1" },
@@ -31,7 +32,7 @@ public class QueryCollectionTests
                 { "Query3", "Value3" }
             });
 
-        var enumerator = cookies.GetEnumerator();
+        var enumerator = query.GetEnumerator();
         var initial = enumerator.Current;
 
         Assert.True(enumerator.MoveNext());

--- a/src/Http/Http/test/QueryCollectionTests.cs
+++ b/src/Http/Http/test/QueryCollectionTests.cs
@@ -19,4 +19,38 @@ public class QueryCollectionTests
         // Test the null-dictionary code path too.
         Assert.Same(Array.Empty<string>(), (string[])QueryCollection.Empty["query1"]);
     }
+    
+    [Fact]
+    public void EnumeratorResetsCorrectly()
+    {
+        var cookies = new QueryCollection(
+            new Dictionary<string, StringValues>
+            {
+                { "Query1", "Value1" },
+                { "Query2", "Value2" },
+                { "Query3", "Value3" }
+            });
+
+        var enumerator = cookies.GetEnumerator();
+        var initial = enumerator.Current;
+
+        Assert.True(enumerator.MoveNext());
+
+        var first = enumerator.Current;
+        var last = enumerator.Current;
+
+        while (enumerator.MoveNext())
+        {
+            last = enumerator.Current;
+        }
+
+        Assert.NotEqual(first, initial);
+        Assert.NotEqual(first, last);
+
+        ((IEnumerator)enumerator).Reset();
+
+        Assert.Equal(enumerator.Current, initial);
+        Assert.True(enumerator.MoveNext());
+        Assert.Equal(enumerator.Current, first);
+    }
 }

--- a/src/Http/Http/test/RequestCookiesCollectionTests.cs
+++ b/src/Http/Http/test/RequestCookiesCollectionTests.cs
@@ -79,4 +79,38 @@ public class RequestCookiesCollectionTests
             }
         }
     }
+    
+    [Fact]
+    public void EnumeratorResetsCorrectly()
+    {
+        var cookies = new RequestCookieCollection(
+            new Dictionary<string, string>
+            {
+                { "Cookie1", "Value1" },
+                { "Cookie2", "Value2" },
+                { "Cookie3", "Value3" }
+            });
+
+        var enumerator = cookies.GetEnumerator();
+        var initial = enumerator.Current;
+
+        Assert.True(enumerator.MoveNext());
+
+        var first = enumerator.Current;
+        var last = enumerator.Current;
+
+        while (enumerator.MoveNext())
+        {
+            last = enumerator.Current;
+        }
+
+        Assert.NotEqual(first, initial);
+        Assert.NotEqual(first, last);
+
+        ((IEnumerator)enumerator).Reset();
+
+        Assert.Equal(enumerator.Current, initial);
+        Assert.True(enumerator.MoveNext());
+        Assert.Equal(enumerator.Current, first);
+    }
 }

--- a/src/Http/Http/test/RequestCookiesCollectionTests.cs
+++ b/src/Http/Http/test/RequestCookiesCollectionTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Http.Tests;
@@ -79,7 +80,7 @@ public class RequestCookiesCollectionTests
             }
         }
     }
-    
+
     [Fact]
     public void EnumeratorResetsCorrectly()
     {


### PR DESCRIPTION
# [HeaderDictionary] Reassign the underlying enumerator after calling reset

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Calling `Reset()` on `HeaderDictionary.Enumerator` does not result in the enumerator being reset.

The issue is caused by the cast shown [here](https://github.com/dotnet/aspnetcore/blob/9f2b0880ff3c09db4a8915d62788a7d1ba62df64/src/Http/Http/src/HeaderDictionary.cs#L454) which results in the underlying enumerator being copied by value.

Fixes #61699
