### PR TITLE
Try register LazyAssemblyLoader to DI in AddInteractiveWebAssemblyCom…

### DIFF
--- a/src/Components/WebAssembly/Server/src/WebAssemblyRazorComponentsBuilderExtensions.cs
+++ b/src/Components/WebAssembly/Server/src/WebAssemblyRazorComponentsBuilderExtensions.cs
@@ -32,7 +32,7 @@ public static class WebAssemblyRazorComponentsBuilderExtensions
 
         if (lazyAssemblyLoaderType != null)
         {
-            builder.Services.AddScoped(lazyAssemblyLoaderType);
+            builder.Services.TryAddScoped(lazyAssemblyLoaderType);
         }
 
         return builder;

--- a/src/Components/WebAssembly/Server/src/WebAssemblyRazorComponentsBuilderExtensions.cs
+++ b/src/Components/WebAssembly/Server/src/WebAssemblyRazorComponentsBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
@@ -15,6 +16,9 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// </summary>
 public static class WebAssemblyRazorComponentsBuilderExtensions
 {
+    private const string LazyAssemblyLoaderAssemblyName = "Microsoft.AspNetCore.Components.WebAssembly";
+    private const string LazyAssemblyLoaderTypeName = "Microsoft.AspNetCore.Components.WebAssembly.Services.LazyAssemblyLoader";
+
     /// <summary>
     /// Adds services to support rendering interactive WebAssembly components.
     /// </summary>
@@ -27,7 +31,7 @@ public static class WebAssemblyRazorComponentsBuilderExtensions
         builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<RenderModeEndpointProvider, WebAssemblyEndpointProvider>());
 
         // Try register LazyAssemblyLoader to prevent crashes during prerendering.
-        // TODO: Remove this once LazyAssemblyLoader is deprecated.
+        // TODO: Remove this once LazyAssemblyLoader is no longer used.
         var lazyAssemblyLoaderType = GetLazyAssemblyLoaderType();
 
         if (lazyAssemblyLoaderType != null)
@@ -57,12 +61,13 @@ public static class WebAssemblyRazorComponentsBuilderExtensions
         return builder;
     }
 
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, LazyAssemblyLoaderTypeName, LazyAssemblyLoaderAssemblyName)]
     private static Type? GetLazyAssemblyLoaderType()
     {
         try
         {
-            var assembly = Assembly.Load("Microsoft.AspNetCore.Components.WebAssembly");
-            return assembly.GetType("Microsoft.AspNetCore.Components.WebAssembly.Services.LazyAssemblyLoader", throwOnError: false);
+            var assembly = Assembly.Load(LazyAssemblyLoaderAssemblyName);
+            return assembly.GetType(LazyAssemblyLoaderTypeName, throwOnError: false);
         }
         catch
         {

--- a/src/ProjectTemplates/test/Templates.Blazor.Tests/BlazorWebTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Blazor.Tests/BlazorWebTemplateTest.cs
@@ -29,7 +29,13 @@ public class BlazorWebTemplateTest(ProjectFactoryFixture projectFactory) : Blazo
 
         if (HasClientProject())
         {
-            // TODO: Remove this when LazyAssemblyLoader is no longer being used.
+            // In order to prevent an exception casued by missing LazyAssemblyLoader during pre-rendering,
+            // we are registering it into DI in AddInteractiveWebAssemblyComponents.
+            // To avoid adding new references between assemblies we try to resolve the type during run-time using reflection.
+            // This assert is here to check that the assembly containing LazyAssemblyLoader is actually present in a standard app
+            // created from the Blazor Web template.
+            // See https://github.com/dotnet/aspnetcore/issues/51966.
+            // TODO: Remove this when LazyAssemblyLoader is no longer being used, or the dependency graph changes so reflection is no longer needed.
             AssertServerProjectCanUseLazyAssemblyLoader(GetTargetProject(project));
         }
 


### PR DESCRIPTION
## Changes

- Adds DI registration for `LazyAssemblyLoader` in `AddInteractiveWebAssemblyComponents`.
- The type is loaded via reflection and only registered if it can be found.

## Description

We want to register `LazyAssemblyLoader` in `AddInteractiveWebAssemblyComponents` in order to prevent the confusing situation where a component that injects `LazyAssemblyLoader` works in the WebAssembly client but crashes during prerendering. (Note that it works when the wasm client takes over because `WebAssemblyHostBuilder.CreateDefault` registers `LazyAssemblyLoader`.)

However, this could not be done as is without adding a problematic reference between projects. To avoid this, the implementation uses reflection to try to load the `Microsoft.AspNetCore.Components.WebAssembly` assembly and get the type. If the assembly or the type cannot be found, no error is thrown.