### PR TITLE
Add auto-merges for SDK updates

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -653,6 +653,8 @@ configuration:
           label: 'Type: Dependency Update :arrow_up_small:'
       - approvePullRequest:
           comment: Auto-approving SDK update.
+      - enableAutoMerge:
+          mergeMethod: "squash"
       description: '[Infrastructure PRs] Add area-infrastructure label to SDK update Pull Requests'
 onFailure: 
 onSuccess: 


### PR DESCRIPTION
This pull request introduces a configuration update to the `.github/policies/resourceManagement.yml` file to enhance automation for dependency update pull requests.

Automation improvements:

* [`.github/policies/resourceManagement.yml`](diffhunk://#diff-fc796b019795da5d3269d452fcdb1827ca9c8789a41f2e2dc1551f70b8f36878R656-R657): Added an `enableAutoMerge` step with the `squash` merge method for dependency update pull requests, streamlining the merging process.