### PR TITLE
Swap out Win11 for Win-VS2022 in CI

### DIFF
--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -6,8 +6,8 @@ pr:
     - main
   paths:
     include:
-    - src/Servers/IIS/*
-    - src/Servers/HttpSys/*
+    - src/Servers/IIS/**/*
+    - src/Servers/HttpSys/**/*
 schedules:
 # Cron timezone is UTC.
 - cron: "0 */12 * * *"

--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -1,6 +1,13 @@
 # We only want to run full helix matrix on main
-pr: none
 trigger: none
+pr:
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - src/Servers/IIS/*
+    - src/Servers/HttpSys/*
 schedules:
 # Cron timezone is UTC.
 - cron: "0 */12 * * *"

--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -1,6 +1,13 @@
 # We only want to run full helix matrix on main
-pr: none
 trigger: none
+pr:
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - src/Servers/IIS/**/*
+    - src/Servers/HttpSys/**/*
 schedules:
 # Cron timezone is UTC.
 - cron: "0 */12 * * *"

--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -1,13 +1,6 @@
 # We only want to run full helix matrix on main
+pr: none
 trigger: none
-pr:
-  branches:
-    include:
-    - main
-  paths:
-    include:
-    - src/Servers/IIS/**/*
-    - src/Servers/HttpSys/**/*
 schedules:
 # Cron timezone is UTC.
 - cron: "0 */12 * * *"

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -30,7 +30,7 @@
       <ItemGroup>
         <HelixAvailableTargetQueue Include="Ubuntu.2004.Amd64.Open" Platform="Linux" />
         <HelixAvailableTargetQueue Include="OSX.15.Amd64.Open" Platform="OSX" />
-        <HelixAvailableTargetQueue Include="Windows.11.Amd64.Client.Open" Platform="Windows" />
+        <HelixAvailableTargetQueue Include="Windows.Amd64.VS2022.Pre.Open" Platform="Windows" />
       </ItemGroup>
     </When>
     <Otherwise>
@@ -52,7 +52,7 @@
 
         <!-- Windows -->
         <HelixAvailableTargetQueue Include="Windows.Amd64.Server2022.Open" Platform="Windows" />
-        <HelixAvailableTargetQueue Include="Windows.Amd64.VS2022.Pre.Open" Platform="Windows" />
+        <HelixAvailableTargetQueue Include="Windows.11.Amd64.Client.Open" Platform="Windows" />
 
         <!-- IIS Express isn't supported on arm64 and most of the IsWindowsOnlyTests depend on its setup scripts. -->
         <HelixAvailableTargetQueue Include="windows.11.arm64.open" Platform="Windows"

--- a/src/Servers/HttpSys/test/FunctionalTests/Http2Tests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Http2Tests.cs
@@ -21,7 +21,6 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests;
 
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class Http2Tests : LoggedTest
 {
     private const string VersionForReset = "10.0.19529";

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/AspNetCorePortTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/AspNetCorePortTests.cs
@@ -29,7 +29,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 #endif
 
 [Collection(PublishedSitesCollection.Name)]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class AspNetCorePortTests : IISFunctionalTestBase
 {
     // Port range allowed by ANCM config

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/BasicAuthTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/BasicAuthTests.cs
@@ -28,7 +28,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 #endif
 
 [Collection(PublishedSitesCollection.Name)]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class BasicAuthTests : IISFunctionalTestBase
 {
     public BasicAuthTests(PublishedSitesFixture fixture) : base(fixture)

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/CompressionTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/CompressionTests.cs
@@ -26,7 +26,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 #endif
 
 [Collection(IISCompressionSiteCollection.Name)]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class CompressionTests : FixtureLoggedTest
 {
     private readonly IISCompressionSiteFixture _fixture;

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/FrebTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/FrebTests.cs
@@ -31,7 +31,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 #endif
 
 [Collection(PublishedSitesCollection.Name)]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class FrebTests : IISFunctionalTestBase
 {
     public FrebTests(PublishedSitesFixture fixture) : base(fixture)

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/GlobalVersionTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/GlobalVersionTests.cs
@@ -29,7 +29,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 #endif
 
 [Collection(PublishedSitesCollection.Name)]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class GlobalVersionTests : IISFunctionalTestBase
 {
     public GlobalVersionTests(PublishedSitesFixture fixture) : base(fixture)

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Http2Tests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Http2Tests.cs
@@ -38,7 +38,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 /// with newer functionality.
 /// </summary>
 [Collection(IISHttpsTestSiteCollection.Name)]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class Http2Tests
 {
     public Http2Tests(IISTestSiteFixture fixture)

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/HttpsTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/HttpsTests.cs
@@ -31,7 +31,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 
 [Collection(PublishedSitesCollection.Name)]
 [SkipIfNotAdmin]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class ClientCertificateTests : IISFunctionalTestBase
 {
     private readonly ClientCertificateFixture _certFixture;

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Latin1Tests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Latin1Tests.cs
@@ -27,7 +27,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 #endif
 
 [Collection(PublishedSitesCollection.Name)]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class Latin1Tests : IISFunctionalTestBase
 {
     public Latin1Tests(PublishedSitesFixture fixture) : base(fixture)

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/LoggingTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/LoggingTests.cs
@@ -29,7 +29,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 #endif
 
 [Collection(PublishedSitesCollection.Name)]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class LoggingTests : IISFunctionalTestBase
 {
     public LoggingTests(PublishedSitesFixture fixture) : base(fixture)

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/MaxRequestBodySizeTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/MaxRequestBodySizeTests.cs
@@ -26,7 +26,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 #endif
 
 [Collection(PublishedSitesCollection.Name)]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class MaxRequestBodySizeTests : IISFunctionalTestBase
 {
     public MaxRequestBodySizeTests(PublishedSitesFixture fixture) : base(fixture)

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/MultiApplicationTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/MultiApplicationTests.cs
@@ -28,7 +28,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 #endif
 
 [Collection(PublishedSitesCollection.Name)]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class MultiApplicationTests : IISFunctionalTestBase
 {
     private PublishedApplication _publishedApplication;

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/RequestPathBaseTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/RequestPathBaseTests.cs
@@ -21,7 +21,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 #endif
 
 [Collection(IISSubAppSiteCollection.Name)]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;" + "Windows.Amd64.VS2022.Pre;")]
 public class RequestPathBaseTests : FixtureLoggedTest
 {
     private readonly IISSubAppSiteFixture _fixture;

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/RequestPathBaseTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/RequestPathBaseTests.cs
@@ -31,7 +31,6 @@ public class RequestPathBaseTests : FixtureLoggedTest
     }
 
     [ConditionalTheory]
-    [SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;" + "Windows.Amd64.VS2022.Pre;")]
     [RequiresNewHandler]
     [InlineData("/Sub/App/PathAndPathBase", "/Sub/App/PathAndPathBase", "")]
     [InlineData("/SUb/APp/PathAndPAthBase", "/SUb/APp/PathAndPAthBase", "")]
@@ -52,7 +51,6 @@ public class RequestPathBaseTests : FixtureLoggedTest
     }
 
     [ConditionalTheory]
-    [SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;" + "Windows.Amd64.VS2022.Pre;")]
     [RequiresNewHandler]
     [InlineData("//Sub/App/PathAndPathBase", "//Sub/App/PathAndPathBase", "")]
     [InlineData(@"/\Sub/App/PathAndPathBase/", @"/\Sub/App/PathAndPathBase", "/")]

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/RequestResponseTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/RequestResponseTests.cs
@@ -30,7 +30,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 #endif
 
 [Collection(IISTestSiteCollectionInProc.Name)]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class RequestResponseTests
 {
     private readonly IISTestSiteFixture _fixture;

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/WebSocketInProcessTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/WebSocketInProcessTests.cs
@@ -23,10 +23,9 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 [Collection(IISTestSiteCollectionInProc.Name)]
 [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win8, SkipReason = "No WebSocket supported on Win7")]
 #if IISEXPRESS_FUNCTIONALS
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open")]
 #else
 // These queues do not have websockets enabled currently for full IIS
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;Windows.Amd64.Server2022.Open")]
+[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.Server2022.Open")]
 #endif
 public class WebSocketsInProcessTests : WebSocketsTests
 {

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/WebSocketOutOfProcessTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/WebSocketOutOfProcessTests.cs
@@ -23,10 +23,9 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 [Collection(IISTestSiteCollectionOutOfProc.Name)]
 [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win8, SkipReason = "No WebSocket supported on Win7")]
 #if IISEXPRESS_FUNCTIONALS
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open")]
 #else
 // These queues do not have websockets enabled currently for full IIS
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;Windows.Amd64.Server2022.Open")]
+[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.Server2022.Open")]
 #endif
 public class WebSocketsOutOfProcessTests : WebSocketsTests
 {

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/WindowsAuthTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/WindowsAuthTests.cs
@@ -28,7 +28,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 #endif
 
 [Collection(PublishedSitesCollection.Name)]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class WindowsAuthTests : IISFunctionalTestBase
 {
     public WindowsAuthTests(PublishedSitesFixture fixture) : base(fixture)

--- a/src/Servers/IIS/IIS/test/Common.LongTests/ShutdownTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.LongTests/ShutdownTests.cs
@@ -27,7 +27,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 
 // Contains all tests related to shutdown, including app_offline, abort, and app recycle
 [Collection(PublishedSitesCollection.Name)]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class ShutdownTests : IISFunctionalTestBase
 {
     public ShutdownTests(PublishedSitesFixture fixture) : base(fixture)

--- a/src/Servers/IIS/IIS/test/Common.LongTests/ShutdownTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.LongTests/ShutdownTests.cs
@@ -389,7 +389,6 @@ public class ShutdownTests : IISFunctionalTestBase
     }
 
     [ConditionalFact]
-    [SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
     [MaximumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10_20H2, SkipReason = "Shutdown hangs https://github.com/dotnet/aspnetcore/issues/25107")]
     public async Task AppOfflineAddedAndRemovedStress_InProcess()
     {
@@ -559,7 +558,6 @@ public class ShutdownTests : IISFunctionalTestBase
     }
 
     [ConditionalFact]
-    [SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
     public async Task ConfigurationTouchedStress_InProcess()
     {
         await ConfigurationTouchedStress(HostingModel.InProcess);

--- a/src/Servers/IIS/IIS/test/Common.LongTests/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.LongTests/StartupTests.cs
@@ -31,7 +31,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 
 // Contains all tests related to Startup, requiring starting ANCM/IIS every time.
 [Collection(PublishedSitesCollection.Name)]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;" + "Windows.Amd64.VS2022.Pre;")]
 public class StartupTests : IISFunctionalTestBase
 {
     public StartupTests(PublishedSitesFixture fixture) : base(fixture)

--- a/src/Servers/IIS/IIS/test/Common.LongTests/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.LongTests/StartupTests.cs
@@ -1297,7 +1297,6 @@ public class StartupTests : IISFunctionalTestBase
     [ConditionalFact]
     [RequiresNewHandler]
     [RequiresNewShim]
-    [SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;" + "Windows.Amd64.VS2022.Pre;")]
     public async Task ServerAddressesIncludesBaseAddress()
     {
         var appName = "\u041C\u043E\u0451\u041F\u0440\u0438\u043B\u043E\u0436\u0435\u043D\u0438\u0435";

--- a/src/Servers/IIS/IIS/test/Common.LongTests/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.LongTests/StartupTests.cs
@@ -1297,6 +1297,7 @@ public class StartupTests : IISFunctionalTestBase
     [ConditionalFact]
     [RequiresNewHandler]
     [RequiresNewShim]
+    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/62787", Queues = "Windows.Amd64.VS2022.Pre.Open;" + "Windows.Amd64.VS2022.Pre;")]
     public async Task ServerAddressesIncludesBaseAddress()
     {
         var appName = "\u041C\u043E\u0451\u041F\u0440\u0438\u043B\u043E\u0436\u0435\u043D\u0438\u0435";

--- a/src/Servers/IIS/IIS/test/IIS.FunctionalTests/Http2TrailersResetTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.FunctionalTests/Http2TrailersResetTests.cs
@@ -26,7 +26,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 /// on IIS Express even on the new Windows versions because IIS Express has its own outdated copy of IIS.
 /// </summary>
 [Collection(IISHttpsTestSiteCollection.Name)]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class Http2TrailerResetTests : FunctionalTestsBase
 {
     private const string WindowsVersionForTrailers = "10.0.20238";

--- a/src/Servers/IIS/IIS/test/IIS.FunctionalTests/Http3Tests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.FunctionalTests/Http3Tests.cs
@@ -27,7 +27,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 [MsQuicSupported]
 [HttpSysHttp3Supported]
 [Collection(IISHttpsTestSiteCollection.Name)]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class Http3Tests : FunctionalTestsBase
 {
     public Http3Tests(IISTestSiteFixture fixture)

--- a/src/Servers/IIS/IIS/test/IIS.NewHandler.FunctionalTests/NewHandlerTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.NewHandler.FunctionalTests/NewHandlerTests.cs
@@ -12,7 +12,6 @@ using Xunit.Sdk;
 namespace Microsoft.AspNetCore.Server.IIS.NewHandler.FunctionalTests;
 
 [Collection(PublishedSitesCollection.Name)]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class NewHandlerTests : IISFunctionalTestBase
 {
     public NewHandlerTests(PublishedSitesFixture fixture) : base(fixture)

--- a/src/Servers/IIS/IIS/test/IIS.NewShim.FunctionalTests/NewShimTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.NewShim.FunctionalTests/NewShimTests.cs
@@ -10,7 +10,6 @@ using Xunit.Sdk;
 namespace Microsoft.AspNetCore.Server.IIS.NewShim.FunctionalTests;
 
 [Collection(PublishedSitesCollection.Name)]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class NewShimTests : IISFunctionalTestBase
 {
     public NewShimTests(PublishedSitesFixture fixture) : base(fixture)

--- a/src/Servers/IIS/IIS/test/IIS.ShadowCopy.Tests/ShadowCopyTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.ShadowCopy.Tests/ShadowCopyTests.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Server.IIS.FunctionalTests.Utilities;
 namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 
 [Collection(PublishedSitesCollection.Name)]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class ShadowCopyTests : IISFunctionalTestBase
 {
     public ShadowCopyTests(PublishedSitesFixture fixture) : base(fixture)

--- a/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/ApplicationInitializationTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/ApplicationInitializationTests.cs
@@ -29,7 +29,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 #endif
 
 [Collection(PublishedSitesCollection.Name)]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class ApplicationInitializationTests : IISFunctionalTestBase
 {
     public ApplicationInitializationTests(PublishedSitesFixture fixture) : base(fixture)

--- a/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/StdOutRedirectionTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/StdOutRedirectionTests.cs
@@ -25,7 +25,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 #endif
 
 [Collection(PublishedSitesCollection.Name)]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class StdOutRedirectionTests : IISFunctionalTestBase
 {
     public StdOutRedirectionTests(PublishedSitesFixture fixture) : base(fixture)

--- a/src/Servers/IIS/IIS/test/IIS.Tests/ClientDisconnectTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/ClientDisconnectTests.cs
@@ -15,7 +15,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 
 [SkipIfHostableWebCoreNotAvailable]
 [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win8, SkipReason = "https://github.com/aspnet/IISIntegration/issues/866")]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class ClientDisconnectTests : StrictTestServerTests
 {
     [ConditionalFact]

--- a/src/Servers/IIS/IIS/test/IIS.Tests/ConnectionIdFeatureTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/ConnectionIdFeatureTests.cs
@@ -10,7 +10,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 
 [SkipIfHostableWebCoreNotAvailable]
 [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win8, SkipReason = "https://github.com/aspnet/IISIntegration/issues/866")]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class ConnectionIdFeatureTests : StrictTestServerTests
 {
     [ConditionalFact]

--- a/src/Servers/IIS/IIS/test/IIS.Tests/HttpBodyControlFeatureTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/HttpBodyControlFeatureTests.cs
@@ -11,7 +11,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 
 [SkipIfHostableWebCoreNotAvailable]
 [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win8, SkipReason = "https://github.com/aspnet/IISIntegration/issues/866")]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class HttpBodyControlFeatureTests : StrictTestServerTests
 {
     [ConditionalFact]

--- a/src/Servers/IIS/IIS/test/IIS.Tests/MaxRequestBodySizeTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/MaxRequestBodySizeTests.cs
@@ -18,7 +18,6 @@ namespace IIS.Tests;
 
 [SkipIfHostableWebCoreNotAvailable]
 [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win8, SkipReason = "https://github.com/aspnet/IISIntegration/issues/866")]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class MaxRequestBodySizeTests : LoggedTest
 {
     [ConditionalFact]

--- a/src/Servers/IIS/IIS/test/IIS.Tests/ResponseAbortTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/ResponseAbortTests.cs
@@ -13,7 +13,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 
 [SkipIfHostableWebCoreNotAvailable]
 [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win8, SkipReason = "https://github.com/aspnet/IISIntegration/issues/866")]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class ResponseAbortTests : StrictTestServerTests
 {
     [ConditionalFact]

--- a/src/Servers/IIS/IIS/test/IIS.Tests/ResponseBodySizeTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/ResponseBodySizeTests.cs
@@ -8,7 +8,6 @@ namespace IIS.Tests;
 
 [SkipIfHostableWebCoreNotAvailable]
 [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win8, SkipReason = "https://github.com/aspnet/IISIntegration/issues/866")]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class ResponseBodySizeTests : LoggedTest
 {
     [ConditionalFact]

--- a/src/Servers/IIS/IIS/test/IIS.Tests/TestServerTest.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/TestServerTest.cs
@@ -11,7 +11,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 
 [SkipIfHostableWebCoreNotAvailable]
 [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win8, SkipReason = "https://github.com/aspnet/IISIntegration/issues/866")]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class TestServerTest : StrictTestServerTests
 {
     [ConditionalFact]

--- a/src/Servers/IIS/IIS/test/IIS.Tests/TlsHandshakeFeatureTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/TlsHandshakeFeatureTests.cs
@@ -10,7 +10,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 
 [SkipIfHostableWebCoreNotAvailable]
 [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win8, SkipReason = "https://github.com/aspnet/IISIntegration/issues/866")]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class TlsHandshakeFeatureTests : StrictTestServerTests
 {
     [ConditionalFact]

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/AppOfflineIISExpressTests.cs
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/AppOfflineIISExpressTests.cs
@@ -11,7 +11,6 @@ using Xunit;
 namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests;
 
 [Collection(PublishedSitesCollection.Name)]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class AppOfflineIISExpressTests : IISFunctionalTestBase
 {
     public AppOfflineIISExpressTests(PublishedSitesFixture fixture) : base(fixture)

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/IISExpressShutdownTests.cs
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/IISExpressShutdownTests.cs
@@ -45,7 +45,6 @@ public class IISExpressShutdownTests : IISFunctionalTestBase
     }
 
     [ConditionalFact]
-    [SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
     public async Task ServerShutsDownWhenMainExitsStress()
     {
         var parameters = Fixture.GetBaseDeploymentParameters();

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/OutOfProcess/MultipleAppTests.cs
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/OutOfProcess/MultipleAppTests.cs
@@ -15,7 +15,6 @@ using Xunit;
 namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests;
 
 [Collection(PublishedSitesCollection.Name)]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class MultipleAppTests : IISFunctionalTestBase
 {
     public MultipleAppTests(PublishedSitesFixture fixture) : base(fixture)

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/OutOfProcess/NtlmAuthentationTest.cs
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/OutOfProcess/NtlmAuthentationTest.cs
@@ -15,7 +15,6 @@ using Xunit.Abstractions;
 namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests;
 
 [Collection(PublishedSitesCollection.Name)]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class NtlmAuthenticationTests : IISFunctionalTestBase
 {
     // Test only runs on IISExpress today as our CI machines do not have

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/UpgradeFeatureDetectionTests.cs
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/UpgradeFeatureDetectionTests.cs
@@ -14,7 +14,6 @@ using Xunit;
 namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests;
 
 [Collection(PublishedSitesCollection.Name)]
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class UpgradeFeatureDetectionTests : IISFunctionalTestBase
 {
     private readonly string _isWebsocketsSupported = Environment.OSVersion.Version >= new Version(6, 2) ? "Enabled" : "Disabled";

--- a/src/Servers/IIS/IISIntegration/test/Tests/IISExtensionTests.cs
+++ b/src/Servers/IIS/IISIntegration/test/Tests/IISExtensionTests.cs
@@ -12,7 +12,6 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Server.IISIntegration;
 
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class IISExtensionTests
 {
     [Fact]

--- a/src/Servers/IIS/IISIntegration/test/Tests/IISMiddlewareTests.cs
+++ b/src/Servers/IIS/IISIntegration/test/Tests/IISMiddlewareTests.cs
@@ -18,7 +18,6 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Server.IISIntegration;
 
-[SkipOnHelix("Unsupported queue", Queues = "Windows.Amd64.VS2022.Pre.Open;")]
 public class IISMiddlewareTests
 {
     [Fact]


### PR DESCRIPTION
There have been zero test failures out of 1.5 million tests ran on the Win-VS2022 queue over the past month, while the Win11 queue has been very flaky (92 test failures out of 3.2 million over the same period). We originally moved the VS2022 queue over to the helix matrix due to flakiness caused by https://github.com/dotnet/dnceng/issues/3844, but that hasn't repro'd in aspnetcore at all over the past 30 days.

As an example, our flakiest test over the past 30 days has been `Microsoft.AspNetCore.Components.Test.ComponentBaseTest.RendersAfterParametersSetAndInitAsyncTasksAreCompleted`, which failed 5 times in 108 runs on the Win11 queue, but passed in all 59 of its runs on the VS2022 queue.