### PR TITLE
Update `ResourceCollectionProvider` to take advantage of Declarative persistent component state

### DIFF
--- a/src/Components/Components/src/PersistentState/PersistentServicesRegistry.cs
+++ b/src/Components/Components/src/PersistentState/PersistentServicesRegistry.cs
@@ -206,25 +206,18 @@ internal sealed class PersistentServicesRegistry
 
         public (string, Type)[] KeyTypePairs => _cachedKeysForService;
 
-        // Mapping for internal classes bundled in different assemblies during prerendering and WASM rendering.
-        private static readonly Dictionary<string, string> _canonicalMap = new(StringComparer.OrdinalIgnoreCase)
-        {
-            { "Microsoft.AspNetCore.Components.Endpoints", "Microsoft.AspNetCore.Components" },
-            { "Microsoft.AspNetCore.Components.WebAssembly", "Microsoft.AspNetCore.Components" }
-        };
-
         private static string ComputeKey(Type keyType, string propertyName)
         {
             // This happens once per type and property combo, so allocations are ok.
             var assemblyName = keyType.Assembly.FullName;
-            var assemblySimpleName = keyType.Assembly.GetName().Name ?? "";
-            if (_canonicalMap.TryGetValue(assemblySimpleName, out var canonicalAssembly))
-            {
-                assemblyName = canonicalAssembly;
-            }
-
             var typeName = keyType.FullName;
-            var inputString = string.Join(".", assemblyName, typeName, propertyName);
+
+            // Internal classes can be bundled in different assemblies during prerendering and WASM rendering.
+            bool isTypeInternal = (!keyType.IsPublic && !keyType.IsNested) || keyType.IsNestedAssembly;
+            var inputString = isTypeInternal
+                ? string.Join(".", typeName, propertyName)
+                : string.Join(".", assemblyName, typeName, propertyName);
+
             var input = Encoding.UTF8.GetBytes(inputString);
             var hash = SHA256.HashData(input);
             return Convert.ToBase64String(hash);

--- a/src/Components/Endpoints/src/DependencyInjection/RazorComponentsServiceCollectionExtensions.cs
+++ b/src/Components/Endpoints/src/DependencyInjection/RazorComponentsServiceCollectionExtensions.cs
@@ -75,6 +75,7 @@ public static class RazorComponentsServiceCollectionExtensions
         services.TryAddScoped<WebAssemblySettingsEmitter>();
 
         services.TryAddScoped<ResourceCollectionProvider>();
+        RegisterPersistentComponentStateServiceCollectionExtensions.AddPersistentServiceRegistration<ResourceCollectionProvider>(services, RenderMode.InteractiveWebAssembly);
 
         // Form handling
         services.AddSupplyValueFromFormProvider();

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
@@ -149,7 +149,7 @@ internal partial class EndpointHtmlRenderer : StaticHtmlRenderer, IComponentPrer
         var resourceCollectionProvider = resourceCollectionUrl != null ? httpContext.RequestServices.GetService<ResourceCollectionProvider>() : null;
         if (resourceCollectionUrl != null && resourceCollectionProvider != null)
         {
-            resourceCollectionProvider.SetResourceCollectionUrl(resourceCollectionUrl.Url);
+            resourceCollectionProvider.ResourceCollectionUrl = resourceCollectionUrl.Url;
             resourceCollectionProvider.SetResourceCollection(resourceCollection ?? ResourceAssetCollection.Empty);
         }
     }

--- a/src/Components/Endpoints/test/RazorComponentsServiceCollectionExtensionsTest.cs
+++ b/src/Components/Endpoints/test/RazorComponentsServiceCollectionExtensionsTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.Forms.Mapping;
 using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.AspNetCore.Hosting;
@@ -92,7 +93,12 @@ public class RazorComponentsServiceCollectionExtensionsTest
                 {
                     typeof(SupplyParameterFromFormValueProvider),
                     typeof(SupplyParameterFromQueryValueProvider),
-                }
+                },
+                [typeof(IPersistentServiceRegistration)] = new[]
+                {
+                    typeof(ResourceCollectionProvider),
+                    typeof(AntiforgeryStateProvider),
+                },
             };
         }
     }

--- a/src/Components/Shared/src/ResourceCollectionProvider.cs
+++ b/src/Components/Shared/src/ResourceCollectionProvider.cs
@@ -11,22 +11,22 @@ using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
 internal class ResourceCollectionProvider
 {
-    private const string ResourceCollectionUrlKey = "__ResourceCollectionUrl";
     private string? _url;
-    private ResourceAssetCollection? _resourceCollection;
-    private readonly PersistentComponentState _state;
-    private readonly IJSRuntime _jsRuntime;
 
-    [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "Strings are not trimmed")]
-    public ResourceCollectionProvider(PersistentComponentState state, IJSRuntime jsRuntime)
+    [SupplyParameterFromPersistentComponentState]
+    public string? ResourceCollectionUrl
     {
-        _state = state;
+        get => _url;
+        set => _url = value;
+    }
+    private ResourceAssetCollection? _resourceCollection;
+    private readonly IJSRuntime _jsRuntime;
+    public ResourceCollectionProvider(IJSRuntime jsRuntime)
+    {
         _jsRuntime = jsRuntime;
-        _ = _state.TryTakeFromJson(ResourceCollectionUrlKey, out _url);
     }
 
     [MemberNotNull(nameof(_url))]
-    [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "Strings are not trimmed")]
     internal void SetResourceCollectionUrl(string url)
     {
         if (_url != null)
@@ -34,13 +34,6 @@ internal class ResourceCollectionProvider
             throw new InvalidOperationException("The resource collection URL has already been set.");
         }
         _url = url;
-        PersistingComponentStateSubscription registration = default;
-        registration = _state.RegisterOnPersisting(() =>
-        {
-            _state.PersistAsJson(ResourceCollectionUrlKey, _url);
-            registration.Dispose();
-            return Task.CompletedTask;
-        }, RenderMode.InteractiveWebAssembly);
     }
 
     internal async Task<ResourceAssetCollection> GetResourceCollection()

--- a/src/Components/Shared/src/ResourceCollectionProvider.cs
+++ b/src/Components/Shared/src/ResourceCollectionProvider.cs
@@ -17,23 +17,21 @@ internal class ResourceCollectionProvider
     public string? ResourceCollectionUrl
     {
         get => _url;
-        set => _url = value;
+        set
+        {
+            if (_url != null)
+            {
+                throw new InvalidOperationException("The resource collection URL has already been set.");
+            }
+            _url = value;
+        }
     }
+
     private ResourceAssetCollection? _resourceCollection;
     private readonly IJSRuntime _jsRuntime;
     public ResourceCollectionProvider(IJSRuntime jsRuntime)
     {
         _jsRuntime = jsRuntime;
-    }
-
-    [MemberNotNull(nameof(_url))]
-    internal void SetResourceCollectionUrl(string url)
-    {
-        if (_url != null)
-        {
-            throw new InvalidOperationException("The resource collection URL has already been set.");
-        }
-        _url = url;
     }
 
     internal async Task<ResourceAssetCollection> GetResourceCollection()
@@ -58,6 +56,8 @@ internal class ResourceCollectionProvider
 
         var module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", _url);
         var result = await module.InvokeAsync<ResourceAsset[]>("get");
-        return result == null ? ResourceAssetCollection.Empty : new ResourceAssetCollection(result);
+        var collection = result == null ? ResourceAssetCollection.Empty : new ResourceAssetCollection(result);
+        var asset = collection["BasicTestApp.styles.css"];
+        return collection;
     }
 }

--- a/src/Components/Shared/src/ResourceCollectionProvider.cs
+++ b/src/Components/Shared/src/ResourceCollectionProvider.cs
@@ -56,8 +56,6 @@ internal class ResourceCollectionProvider
 
         var module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", _url);
         var result = await module.InvokeAsync<ResourceAsset[]>("get");
-        var collection = result == null ? ResourceAssetCollection.Empty : new ResourceAssetCollection(result);
-        var asset = collection["BasicTestApp.styles.css"];
-        return collection;
+        return result == null ? ResourceAssetCollection.Empty : new ResourceAssetCollection(result);
     }
 }

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHostBuilder.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHostBuilder.cs
@@ -308,6 +308,7 @@ public sealed class WebAssemblyHostBuilder
         Services.AddSupplyValueFromPersistentComponentStateProvider();
         Services.AddSingleton<IErrorBoundaryLogger, WebAssemblyErrorBoundaryLogger>();
         Services.AddSingleton<ResourceCollectionProvider>();
+        RegisterPersistentComponentStateServiceCollectionExtensions.AddPersistentServiceRegistration<ResourceCollectionProvider>(Services, RenderMode.InteractiveWebAssembly);
         Services.AddLogging(builder =>
         {
             builder.AddProvider(new WebAssemblyConsoleLoggerProvider(DefaultWebAssemblyJSRuntime.Instance));


### PR DESCRIPTION
Follow-up for https://github.com/dotnet/aspnetcore/pull/60634.

## Framework changes
`ResourceCollectionUrl` saving and restoring responsibility is moved to `PersistentServicesRegistry`.

I order to support  `[SupplyParameterFromPersistentComponentState]` attribute, the field holding resources url had to be transformed from private field to a public property (`ResourceCollectionUrl`). Now it exposes a setter that replaced `SetResourceCollectionUrl` method used internally on initialization.

Key computation for some internal assemblies that are referenced by both: server and client blazor code was not deterministic. We produced the key hashing a string that contained assembly name. Assembly name changes between prerendering and WASM rendering in case of internal shared assemblies. As a workaround, we decided to detect types with `internal` modifier and skip assembly name in the key computation.

## Test changes
`AddRazorComponentsTwice_DoesNotDuplicateServices` test was checking if double call of `AddRazorComponents` does not duplicate the services that were supposed to be instantiated once. Before this PR `IPersistentServiceRegistration` was registered only once, so it was listed as 'single-registration' service. In this PR we added a new registration of `IPersistentServiceRegistration` in the same `AddRazorComponents`. We had to change test's expectations and  list `IPersistentServiceRegistration` as a 'multi-registration' service.
