### PR TITLE
Make IdentityErrorDescriber extendable.

### DIFF
--- a/src/Identity/Extensions.Core/src/IdentityErrorDescriber.cs
+++ b/src/Identity/Extensions.Core/src/IdentityErrorDescriber.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Identity;
 /// <remarks>
 /// These errors are returned to controllers and are generally used as display messages to end users.
 /// </remarks>
-public class IdentityErrorDescriber
+public partial class IdentityErrorDescriber
 {
     /// <summary>
     /// Returns the default <see cref="IdentityError"/>.


### PR DESCRIPTION
# Make IdentityErrorDescriber a partial class

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable. <!-- In this case, making a class partial doesn't typically require new tests unless new functionality was added in a separate part. -->
- [ ] You've included inline docs for your change, where applicable. <!-- No new public APIs or significant behavior changes introduced by making it partial. -->
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue. <!-- Assuming an issue exists for this change or the rationale will be discussed in the PR. -->

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

Makes IdentityErrorDescriber a partial class

## Description

This change updates the `IdentityErrorDescriber` class to be a partial class. This allows for extensions to be defined in separate files, improving organization and maintainability for scenarios where custom error descriptions are added.