### PR TITLE
Deduplicate group messages across connections

### DIFF
--- a/src/SignalR/server/StackExchangeRedis/src/Internal/RedisSubscriptionManager.cs
+++ b/src/SignalR/server/StackExchangeRedis/src/Internal/RedisSubscriptionManager.cs
@@ -63,4 +63,14 @@ internal sealed class RedisSubscriptionManager
             _lock.Release();
         }
     }
+
+    public HubConnectionStore? GetStore(string id)
+    {
+        if (_subscriptions.TryGetValue(id, out var store))
+        {
+            return store;
+        }
+
+        return null;
+    }
 }


### PR DESCRIPTION
# Deduplicate SignalR group messages across connections

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

This change modifies `DefaultHubLifetimeManager` and `RedisHubLifetimeManager` to deduplicate SignalR group messages across connections. Previously, when a connection A is part of N-groups, and a SignalR message is sent to those N-groups, connection A will receive those messages N times. This changes instead checks which connections need to be addressed for a list of groups, and uniques them.

Fixes #61809
