### PR TITLE
InvalidOperationException when decompressed data exceeds request body size limit

### DIFF
--- a/src/Middleware/RequestDecompression/src/RequestDecompressionMiddleware.cs
+++ b/src/Middleware/RequestDecompression/src/RequestDecompressionMiddleware.cs
@@ -63,7 +63,7 @@ internal sealed partial class RequestDecompressionMiddleware
                     ?? context.Features.Get<IHttpMaxRequestBodySizeFeature>()?.MaxRequestBodySize;
 
             context.Request.Body = new SizeLimitedStream(decompressionStream, sizeLimit, (long totalBytesRead, long sizeLimit) => throw new BadHttpRequestException(
-                    $"The request's Content-Length {totalBytesRead} is larger than the request body size limit {sizeLimit}.",
+                    $"The decompressed request body is larger than the request body size limit {sizeLimit}.",
                     StatusCodes.Status413PayloadTooLarge));
             await _next(context);
         }

--- a/src/Middleware/RequestDecompression/src/RequestDecompressionMiddleware.cs
+++ b/src/Middleware/RequestDecompression/src/RequestDecompressionMiddleware.cs
@@ -62,7 +62,7 @@ internal sealed partial class RequestDecompressionMiddleware
                 context.GetEndpoint()?.Metadata?.GetMetadata<IRequestSizeLimitMetadata>()?.MaxRequestBodySize
                     ?? context.Features.Get<IHttpMaxRequestBodySizeFeature>()?.MaxRequestBodySize;
 
-            context.Request.Body = new SizeLimitedStream(decompressionStream, sizeLimit, (long totalBytesRead, long sizeLimit) => throw new BadHttpRequestException(
+            context.Request.Body = new SizeLimitedStream(decompressionStream, sizeLimit, static (long sizeLimit) => throw new BadHttpRequestException(
                     $"The decompressed request body is larger than the request body size limit {sizeLimit}.",
                     StatusCodes.Status413PayloadTooLarge));
             await _next(context);

--- a/src/Middleware/RequestDecompression/src/RequestDecompressionMiddleware.cs
+++ b/src/Middleware/RequestDecompression/src/RequestDecompressionMiddleware.cs
@@ -62,7 +62,9 @@ internal sealed partial class RequestDecompressionMiddleware
                 context.GetEndpoint()?.Metadata?.GetMetadata<IRequestSizeLimitMetadata>()?.MaxRequestBodySize
                     ?? context.Features.Get<IHttpMaxRequestBodySizeFeature>()?.MaxRequestBodySize;
 
-            context.Request.Body = new SizeLimitedStream(decompressionStream, sizeLimit);
+            context.Request.Body = new SizeLimitedStream(decompressionStream, sizeLimit, (long totalBytesRead, long sizeLimit) => throw new BadHttpRequestException(
+                    $"The request's Content-Length {totalBytesRead} is larger than the request body size limit {sizeLimit}.",
+                    StatusCodes.Status413PayloadTooLarge));
             await _next(context);
         }
         finally

--- a/src/Middleware/RequestDecompression/test/RequestDecompressionMiddlewareTests.cs
+++ b/src/Middleware/RequestDecompression/test/RequestDecompressionMiddlewareTests.cs
@@ -499,8 +499,8 @@ public class RequestDecompressionMiddlewareTests
         if (exceedsLimit)
         {
             Assert.NotNull(exception);
-            Assert.IsAssignableFrom<InvalidOperationException>(exception);
-            Assert.Equal("The maximum number of bytes have been read.", exception.Message);
+            Assert.IsAssignableFrom<BadHttpRequestException>(exception);
+            Assert.Equal(StatusCodes.Status413PayloadTooLarge, ((BadHttpRequestException)exception).StatusCode);
         }
         else
         {
@@ -583,8 +583,8 @@ public class RequestDecompressionMiddlewareTests
         if (exceedsLimit)
         {
             Assert.NotNull(exception);
-            Assert.IsAssignableFrom<InvalidOperationException>(exception);
-            Assert.Equal("The maximum number of bytes have been read.", exception.Message);
+            Assert.IsAssignableFrom<BadHttpRequestException>(exception);
+            Assert.Equal(StatusCodes.Status413PayloadTooLarge, ((BadHttpRequestException)exception).StatusCode);
         }
         else
         {

--- a/src/Shared/SizeLimitedStream.cs
+++ b/src/Shared/SizeLimitedStream.cs
@@ -5,15 +5,16 @@ internal sealed class SizeLimitedStream : Stream
 {
     private readonly Stream _innerStream;
     private readonly long? _sizeLimit;
-
+    private readonly Action<long, long>? _handleSizeLimit;
     private long _totalBytesRead;
 
-    public SizeLimitedStream(Stream innerStream, long? sizeLimit)
+    public SizeLimitedStream(Stream innerStream, long? sizeLimit, Action<long, long>? handleSizeLimit = null)
     {
         ArgumentNullException.ThrowIfNull(innerStream);
 
         _innerStream = innerStream;
         _sizeLimit = sizeLimit;
+        _handleSizeLimit = handleSizeLimit;
     }
 
     public override bool CanRead => _innerStream.CanRead;
@@ -48,7 +49,14 @@ internal sealed class SizeLimitedStream : Stream
         _totalBytesRead += bytesRead;
         if (_totalBytesRead > _sizeLimit)
         {
-            throw new InvalidOperationException("The maximum number of bytes have been read.");
+            if (_handleSizeLimit != null)
+            {
+                _handleSizeLimit(_totalBytesRead, _sizeLimit.Value);
+            }
+            else
+            {
+                throw new InvalidOperationException("The maximum number of bytes have been read.");
+            }
         }
 
         return bytesRead;
@@ -81,7 +89,14 @@ internal sealed class SizeLimitedStream : Stream
         _totalBytesRead += bytesRead;
         if (_totalBytesRead > _sizeLimit)
         {
-            throw new InvalidOperationException("The maximum number of bytes have been read.");
+            if (_handleSizeLimit != null)
+            {
+                _handleSizeLimit(_totalBytesRead, _sizeLimit.Value);
+            }
+            else
+            {
+                throw new InvalidOperationException("The maximum number of bytes have been read.");
+            }
         }
 
         return bytesRead;

--- a/src/Shared/SizeLimitedStream.cs
+++ b/src/Shared/SizeLimitedStream.cs
@@ -1,14 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 internal sealed class SizeLimitedStream : Stream
 {
     private readonly Stream _innerStream;
     private readonly long? _sizeLimit;
-    private readonly Action<long, long>? _handleSizeLimit;
+    private readonly Action<long>? _handleSizeLimit;
     private long _totalBytesRead;
 
-    public SizeLimitedStream(Stream innerStream, long? sizeLimit, Action<long, long>? handleSizeLimit = null)
+    public SizeLimitedStream(Stream innerStream, long? sizeLimit, Action<long>? handleSizeLimit = null)
     {
         ArgumentNullException.ThrowIfNull(innerStream);
 
@@ -51,7 +53,7 @@ internal sealed class SizeLimitedStream : Stream
         {
             if (_handleSizeLimit != null)
             {
-                _handleSizeLimit(_totalBytesRead, _sizeLimit.Value);
+                _handleSizeLimit(_sizeLimit.Value);
             }
             else
             {
@@ -91,7 +93,7 @@ internal sealed class SizeLimitedStream : Stream
         {
             if (_handleSizeLimit != null)
             {
-                _handleSizeLimit(_totalBytesRead, _sizeLimit.Value);
+                _handleSizeLimit(_sizeLimit.Value);
             }
             else
             {


### PR DESCRIPTION
fix #61723 