### PR TITLE
Fixed devtools url used for debug with chrome and edge

### DIFF
--- a/src/Components/WebAssembly/Server/src/TargetPickerUi.cs
+++ b/src/Components/WebAssembly/Server/src/TargetPickerUi.cs
@@ -389,7 +389,7 @@ firefox --start-debugger-server 6000 -new-tab about:debugging");
                 return devtoolsFrontendUrl;
             }
 
-            UriHelper.FromAbsolute(url, out _, out _, out _, out var query, out _);
+            UriHelper.FromAbsolute(devtoolsFrontendUrl, out _, out _, out _, out var query, out _);
             return $"{DefaultBrowserDevToolsPagePath}{query}";
         }
     }

--- a/src/Components/WebAssembly/Server/src/TargetPickerUi.cs
+++ b/src/Components/WebAssembly/Server/src/TargetPickerUi.cs
@@ -383,7 +383,7 @@ firefox --start-debugger-server 6000 -new-tab about:debugging");
 
             const string DefaultBrowserDevToolsPagePath = "devtools/inspector.html";
 
-            if (devtoolsFrontendUrl.StartsWith(DefaultBrowserDevToolsPagePath))
+            if (devtoolsFrontendUrl.AsSpan().TrimStart('/').StartsWith(DefaultBrowserDevToolsPagePath))
             {
                 return devtoolsFrontendUrl;
             }

--- a/src/Components/WebAssembly/Server/src/TargetPickerUi.cs
+++ b/src/Components/WebAssembly/Server/src/TargetPickerUi.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
 using System.Dynamic;
 
 namespace Microsoft.AspNetCore.Components.WebAssembly.Server;
@@ -388,8 +389,8 @@ firefox --start-debugger-server 6000 -new-tab about:debugging");
                 return devtoolsFrontendUrl;
             }
 
-            string queryString = devtoolsFrontendUrl[devtoolsFrontendUrl.IndexOf('?')..];
-            return $"{DefaultBrowserDevToolsPagePath}?{queryString}";
+            UriHelper.FromAbsolute(url, out _, out _, out _, out var query, out _);
+            return $"{DefaultBrowserDevToolsPagePath}{query}";
         }
     }
 


### PR DESCRIPTION
This PR ensure the correct creation of the devtools url with proxy to use for debug with chrome and edge browser which recently changed how urls are returned from "localhost:9222/json".

Browser tested:
Edge 	Version 136.0.3240.50
Chrome 	Version 136.0.7103.49

Fixes #61559 
