### PR TITLE
Add PublishInstallerBaseVersion back

### DIFF
--- a/eng/Common.props
+++ b/eng/Common.props
@@ -47,5 +47,6 @@
     <PublishAllBuildsAssetsInThisJob Condition="('$(OS)' == 'Windows_NT' and '$(DotNetBuildOrchestrator)' != 'true')
                                                 or ('$(DotNetBuildOrchestrator)' == 'true' and '$(EnableDefaultRidSpecificArtifacts)' != 'true'
                                                     and ('$(DotNetBuildPass)' == '' or '$(DotNetBuildPass)' == '1'))">true</PublishAllBuildsAssetsInThisJob>
+    <PublishInstallerBaseVersion Condition="'$(PublishInstallerBaseVersion)' == ''">$(PublishAllBuildsAssetsInThisJob)</PublishInstallerBaseVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
I accidentally removed this in https://github.com/dotnet/aspnetcore/pull/61271

This pull request introduces a small change to the `eng/Common.props` file. It adds a new property, `PublishInstallerBaseVersion`, which defaults to the value of `PublishAllBuildsAssetsInThisJob` if not explicitly set.