### PR TITLE
Treat ValidationContext as required in validation resolver APIs

### DIFF
--- a/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
@@ -24,7 +24,7 @@ Microsoft.AspNetCore.Http.Validation.ValidateContext.CurrentDepth.set -> void
 Microsoft.AspNetCore.Http.Validation.ValidateContext.CurrentValidationPath.get -> string!
 Microsoft.AspNetCore.Http.Validation.ValidateContext.CurrentValidationPath.set -> void
 Microsoft.AspNetCore.Http.Validation.ValidateContext.ValidateContext() -> void
-Microsoft.AspNetCore.Http.Validation.ValidateContext.ValidationContext.get -> System.ComponentModel.DataAnnotations.ValidationContext?
+Microsoft.AspNetCore.Http.Validation.ValidateContext.ValidationContext.get -> System.ComponentModel.DataAnnotations.ValidationContext!
 Microsoft.AspNetCore.Http.Validation.ValidateContext.ValidationContext.set -> void
 Microsoft.AspNetCore.Http.Validation.ValidateContext.ValidationErrors.get -> System.Collections.Generic.Dictionary<string!, string![]!>?
 Microsoft.AspNetCore.Http.Validation.ValidateContext.ValidationErrors.set -> void

--- a/src/Http/Http.Abstractions/src/Validation/ValidatableParameterInfo.cs
+++ b/src/Http/Http.Abstractions/src/Validation/ValidatableParameterInfo.cs
@@ -65,11 +65,6 @@ public abstract class ValidatableParameterInfo : IValidatableInfo
             return;
         }
 
-        // ValidationContext requires a non-null value although the invocation pattern that we use
-        // calls `GetValidationResult` and passes the value there. `GetValidationResult` tolerates
-        // null values so we only need to set a non-null value to the ValidationContext here.
-        context.ValidationContext ??= new ValidationContext(value ?? new object(), displayName: DisplayName, serviceProvider: null, items: null);
-
         context.ValidationContext.DisplayName = DisplayName;
         context.ValidationContext.MemberName = Name;
 

--- a/src/Http/Http.Abstractions/src/Validation/ValidatablePropertyInfo.cs
+++ b/src/Http/Http.Abstractions/src/Validation/ValidatablePropertyInfo.cs
@@ -75,8 +75,6 @@ public abstract class ValidatablePropertyInfo : IValidatableInfo
             context.CurrentValidationPath = $"{originalPrefix}.{Name}";
         }
 
-        context.ValidationContext ??= new ValidationContext(value ?? new object(), displayName: DisplayName, serviceProvider: null, items: null);
-
         context.ValidationContext.DisplayName = DisplayName;
         context.ValidationContext.MemberName = Name;
 

--- a/src/Http/Http.Abstractions/src/Validation/ValidatablePropertyInfo.cs
+++ b/src/Http/Http.Abstractions/src/Validation/ValidatablePropertyInfo.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel.DataAnnotations;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.AspNetCore.Http.Validation;
@@ -61,8 +60,6 @@ public abstract class ValidatablePropertyInfo : IValidatableInfo
     /// <inheritdoc />
     public virtual async Task ValidateAsync(object? value, ValidateContext context, CancellationToken cancellationToken)
     {
-        Debug.Assert(context.ValidationContext is not null);
-
         var property = DeclaringType.GetProperty(Name) ?? throw new InvalidOperationException($"Property '{Name}' not found on type '{DeclaringType.Name}'.");
         var propertyValue = property.GetValue(value);
         var validationAttributes = GetValidationAttributes();
@@ -77,6 +74,8 @@ public abstract class ValidatablePropertyInfo : IValidatableInfo
         {
             context.CurrentValidationPath = $"{originalPrefix}.{Name}";
         }
+
+        context.ValidationContext ??= new ValidationContext(value ?? new object(), displayName: DisplayName, serviceProvider: null, items: null);
 
         context.ValidationContext.DisplayName = DisplayName;
         context.ValidationContext.MemberName = Name;

--- a/src/Http/Http.Abstractions/src/Validation/ValidatableTypeInfo.cs
+++ b/src/Http/Http.Abstractions/src/Validation/ValidatableTypeInfo.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel.DataAnnotations;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
@@ -45,11 +44,14 @@ public abstract class ValidatableTypeInfo : IValidatableInfo
     /// <inheritdoc />
     public virtual async Task ValidateAsync(object? value, ValidateContext context, CancellationToken cancellationToken)
     {
-        Debug.Assert(context.ValidationContext is not null);
         if (value == null)
         {
             return;
         }
+
+        // Although classes can be annotated with [DisplayName], we only process display names when producing
+        // errors for properties so we can pass the `Type.Name` as the display name for the type here.
+        context.ValidationContext ??= new ValidationContext(value, displayName: Type.Name, serviceProvider: null, items: null);
 
         // Check if we've exceeded the maximum depth
         if (context.CurrentDepth >= context.ValidationOptions.MaxDepth)

--- a/src/Http/Http.Abstractions/src/Validation/ValidatableTypeInfo.cs
+++ b/src/Http/Http.Abstractions/src/Validation/ValidatableTypeInfo.cs
@@ -49,10 +49,6 @@ public abstract class ValidatableTypeInfo : IValidatableInfo
             return;
         }
 
-        // Although classes can be annotated with [DisplayName], we only process display names when producing
-        // errors for properties so we can pass the `Type.Name` as the display name for the type here.
-        context.ValidationContext ??= new ValidationContext(value, displayName: Type.Name, serviceProvider: null, items: null);
-
         // Check if we've exceeded the maximum depth
         if (context.CurrentDepth >= context.ValidationOptions.MaxDepth)
         {

--- a/src/Http/Http.Abstractions/src/Validation/ValidateContext.cs
+++ b/src/Http/Http.Abstractions/src/Validation/ValidateContext.cs
@@ -16,7 +16,24 @@ public sealed class ValidateContext
     /// Gets or sets the validation context used for validating objects that implement <see cref="IValidatableObject"/> or have <see cref="ValidationAttribute"/>.
     /// This context provides access to service provider and other validation metadata.
     /// </summary>
-    public ValidationContext? ValidationContext { get; set; }
+    /// <remarks>
+    /// This property should be set by the consumer of the <see cref="IValidatableInfo"/>
+    /// interface to provide the necessary context for validation. The object should be initialized
+    /// with the current object being validated, the display name, and the service provider to support
+    /// the complete set of validation scenarios.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var validationContext = new ValidationContext(objectToValidate, serviceProvider, items);
+    /// var validationOptions = serviceProvider.GetService&lt;IOptions&lt;ValidationOptions&gt;&gt;()?.Value;
+    /// var validateContext = new ValidateContext
+    /// {
+    ///     ValidationContext = validationContext,
+    ///     ValidationOptions = validationOptions
+    /// };
+    /// </code>
+    /// </example>
+    public required ValidationContext ValidationContext { get; set; }
 
     /// <summary>
     /// Gets or sets the prefix used to identify the current object being validated in a complex object graph.

--- a/src/Http/Http.Abstractions/test/Validation/ValidatableParameterInfoTests.cs
+++ b/src/Http/Http.Abstractions/test/Validation/ValidatableParameterInfoTests.cs
@@ -287,60 +287,6 @@ public class ValidatableParameterInfoTests
         Assert.Equal("Test exception", error.Value.First());
     }
 
-    [Fact]
-    public async Task Validate_WithoutValidationContext_RequiredParameter_AddsErrorAndInitializesValidationContext()
-    {
-        // Arrange
-        var paramInfo = CreateTestParameterInfo(
-            parameterType: typeof(string),
-            name: "testParam",
-            displayName: "Test Parameter",
-            validationAttributes: [new RequiredAttribute()]);
-
-        // Create a ValidateContext without a pre-populated ValidationContext
-        var context = new ValidateContext
-        {
-            ValidationOptions = new TestValidationOptions(new Dictionary<Type, ValidatableTypeInfo>())
-        };
-
-        // Sanity check
-        Assert.Null(context.ValidationContext);
-
-        // Act
-        await paramInfo.ValidateAsync(null, context, default);
-
-        // Assert – a ValidationContext should have been created and the error recorded
-        Assert.NotNull(context.ValidationContext);
-        var errors = context.ValidationErrors;
-        Assert.NotNull(errors);
-        var error = Assert.Single(errors);
-        Assert.Equal("testParam", error.Key);
-        Assert.Equal("The Test Parameter field is required.", error.Value.Single());
-    }
-
-    [Fact]
-    public async Task Validate_WithoutValidationContext_ValidValue_NoErrors()
-    {
-        // Arrange
-        var paramInfo = CreateTestParameterInfo(
-            parameterType: typeof(int),
-            name: "testParam",
-            displayName: "Test Parameter",
-            validationAttributes: [new RangeAttribute(10, 100)]);
-
-        var context = new ValidateContext
-        {
-            ValidationOptions = new TestValidationOptions(new Dictionary<Type, ValidatableTypeInfo>())
-        };
-
-        // Act
-        await paramInfo.ValidateAsync(50, context, default);
-
-        // Assert – ValidationContext initialized, but no errors added
-        Assert.NotNull(context.ValidationContext);
-        Assert.Null(context.ValidationErrors);
-    }
-
     private TestValidatableParameterInfo CreateTestParameterInfo(
         Type parameterType,
         string name,

--- a/src/Http/Http.Abstractions/test/Validation/ValidatableParameterInfoTests.cs
+++ b/src/Http/Http.Abstractions/test/Validation/ValidatableParameterInfoTests.cs
@@ -287,6 +287,60 @@ public class ValidatableParameterInfoTests
         Assert.Equal("Test exception", error.Value.First());
     }
 
+    [Fact]
+    public async Task Validate_WithoutValidationContext_RequiredParameter_AddsErrorAndInitializesValidationContext()
+    {
+        // Arrange
+        var paramInfo = CreateTestParameterInfo(
+            parameterType: typeof(string),
+            name: "testParam",
+            displayName: "Test Parameter",
+            validationAttributes: [new RequiredAttribute()]);
+
+        // Create a ValidateContext without a pre-populated ValidationContext
+        var context = new ValidateContext
+        {
+            ValidationOptions = new TestValidationOptions(new Dictionary<Type, ValidatableTypeInfo>())
+        };
+
+        // Sanity check
+        Assert.Null(context.ValidationContext);
+
+        // Act
+        await paramInfo.ValidateAsync(null, context, default);
+
+        // Assert – a ValidationContext should have been created and the error recorded
+        Assert.NotNull(context.ValidationContext);
+        var errors = context.ValidationErrors;
+        Assert.NotNull(errors);
+        var error = Assert.Single(errors);
+        Assert.Equal("testParam", error.Key);
+        Assert.Equal("The Test Parameter field is required.", error.Value.Single());
+    }
+
+    [Fact]
+    public async Task Validate_WithoutValidationContext_ValidValue_NoErrors()
+    {
+        // Arrange
+        var paramInfo = CreateTestParameterInfo(
+            parameterType: typeof(int),
+            name: "testParam",
+            displayName: "Test Parameter",
+            validationAttributes: [new RangeAttribute(10, 100)]);
+
+        var context = new ValidateContext
+        {
+            ValidationOptions = new TestValidationOptions(new Dictionary<Type, ValidatableTypeInfo>())
+        };
+
+        // Act
+        await paramInfo.ValidateAsync(50, context, default);
+
+        // Assert – ValidationContext initialized, but no errors added
+        Assert.NotNull(context.ValidationContext);
+        Assert.Null(context.ValidationErrors);
+    }
+
     private TestValidatableParameterInfo CreateTestParameterInfo(
         Type parameterType,
         string name,


### PR DESCRIPTION
This pull request improves the validation logic in the `Microsoft.AspNetCore.Http.Validation` namespace by ensuring that a `ValidationContext` is a required property.

Fixes https://github.com/dotnet/aspnetcore/issues/61738

This pull request introduces several updates to the validation framework in `Microsoft.AspNetCore.Http`, focusing on improving type safety, simplifying validation logic, and enhancing test coverage. The key changes include making the `ValidationContext` property in `ValidateContext` required, removing redundant `Debug.Assert` statements, and updating tests to align with the new `ValidateContext` initialization pattern.

### Validation Framework Updates:

* **`ValidationContext` Property Update**:
  - The `ValidationContext` property in `ValidateContext` is now marked as `required`, ensuring it is always initialized. Additional documentation and examples have been added to clarify its usage. (`[[1]](diffhunk://#diff-b16fffb7593a94827187c81633f618740d0315cafe67c1ad148e74ee73d48369L19-R36)`, `[[2]](diffhunk://#diff-c25699c95b8367fb6f1c1c20b4566b5f15479fae809d04f1aee4faef7e36c883L27-R27)`)
  - The `ValidationContext` initialization in tests has been updated to use object initializers, improving readability and consistency. (`[[1]](diffhunk://#diff-f089fa164925b2123ac8f2eb82a21c16006c355262f84596e6cbf32a0ab25a43L44-R53)`, `[[2]](diffhunk://#diff-f089fa164925b2123ac8f2eb82a21c16006c355262f84596e6cbf32a0ab25a43L99-R111)`, `[[3]](diffhunk://#diff-f089fa164925b2123ac8f2eb82a21c16006c355262f84596e6cbf32a0ab25a43R143-L159)`, and others)

* **Simplification of Validation Logic**:
  - Removed `Debug.Assert` statements that checked for the presence of `ValidationContext`, as this is now enforced by the `required` modifier. (`[[1]](diffhunk://#diff-688f42bea373bd51787ca8ee43ca3a6456beba2ccf638189bc4d64a549627401L63-L64)`, `[[2]](diffhunk://#diff-c3a66d105b9c639c52f0ac3f111af08016219a354b470f31322b068cfadab37cL64-L65)`, `[[3]](diffhunk://#diff-4747a7dd84b487cb53a7e83e9402dac63077283371409e02b324106251c36d5bL48)`)
  - Adjusted the `Create` method in `ValidationEndpointFilterFactory` to initialize `ValidateContext` lazily, reducing unnecessary object creation. (`[[1]](diffhunk://#diff-5d39135cbdf8958ffced3a56b7d0b970c302cb2c24d32b8672b1c9c9c004c187L46-R46)`, `[[2]](diffhunk://#diff-5d39135cbdf8958ffced3a56b7d0b970c302cb2c24d32b8672b1c9c9c004c187L60-R81)`)

### Test Enhancements:

* Updated test cases in `ValidatableTypeInfoTests` to reflect the new `ValidateContext` initialization pattern, ensuring consistency and improved maintainability. (`[[1]](diffhunk://#diff-f089fa164925b2123ac8f2eb82a21c16006c355262f84596e6cbf32a0ab25a43L308-L313)`, `[[2]](diffhunk://#diff-f089fa164925b2123ac8f2eb82a21c16006c355262f84596e6cbf32a0ab25a43R346-L362)`, `[[3]](diffhunk://#diff-f089fa164925b2123ac8f2eb82a21c16006c355262f84596e6cbf32a0ab25a43R381-L398)`, and others)