### PR TITLE
Add FromFormOrJsonModelBinder for mixed multipart/form-data and JSON support

### DIFF
--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/FromFormOrJsonModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/FromFormOrJsonModelBinder.cs
@@ -1,0 +1,82 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+
+/// <summary>
+/// A generic ModelBinder that supports both 'application/json' and 'multipart/form-data' content types.
+/// For multipart requests, it expects a 'payload' field containing a JSON object.
+/// Optionally, the target model can implement <see cref="IFormFileReceiver"/> to receive uploaded files from the form.
+/// </summary>
+public class FromFormOrJsonModelBinder<T> : IModelBinder where T : class
+{
+    private static readonly JsonSerializerOptions _defaultJsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+    public async Task BindModelAsync(ModelBindingContext bindingContext)
+    {
+        var request = bindingContext.HttpContext.Request;
+        var modelName = bindingContext.ModelName;
+
+        if (string.IsNullOrEmpty(request.ContentType))
+        {
+            bindingContext.ModelState.AddModelError(modelName, "Missing Content-Type header.");
+            bindingContext.Result = ModelBindingResult.Failed();
+            return;
+        }
+
+        try
+        {
+            T? model = null;
+
+            if (request.ContentType.StartsWith("multipart/form-data", StringComparison.OrdinalIgnoreCase))
+            {
+                var form = await request.ReadFormAsync(bindingContext.HttpContext.RequestAborted);
+
+                if (form.TryGetValue("payload", out var payloadJson) && !StringValues.IsNullOrEmpty(payloadJson))
+                {
+                    model = JsonSerializer.Deserialize<T>(payloadJson.ToString(), _defaultJsonOptions);
+                }
+
+                if (model is IFormFileReceiver receiver)
+                {
+                    receiver.SetFiles(form.Files);
+                }
+            }
+            else if (request.ContentType.StartsWith("application/json", StringComparison.OrdinalIgnoreCase))
+            {
+                model = await JsonSerializer.DeserializeAsync<T>(
+                    request.Body,
+                    _defaultJsonOptions,
+                    bindingContext.HttpContext.RequestAborted
+                );
+            }
+            else
+            {
+                bindingContext.ModelState.AddModelError(modelName, $"Unsupported Content-Type '{request.ContentType}'.");
+                bindingContext.Result = ModelBindingResult.Failed();
+                return;
+            }
+
+            if (model is null)
+            {
+                bindingContext.ModelState.AddModelError(modelName, "Could not deserialize the request body.");
+                bindingContext.Result = ModelBindingResult.Failed();
+                return;
+            }
+
+            bindingContext.Result = ModelBindingResult.Success(model);
+        }
+        catch (JsonException ex)
+        {
+            bindingContext.ModelState.AddModelError(bindingContext.ModelName, "Invalid JSON payload.");
+            bindingContext.Result = ModelBindingResult.Failed();
+        }
+        catch (Exception ex)
+        {
+            bindingContext.ModelState.AddModelError(bindingContext.ModelName, "Unexpected error during model binding.");
+            bindingContext.Result = ModelBindingResult.Failed();
+        }
+    }
+}

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/FromFormOrJsonModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/FromFormOrJsonModelBinder.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
 
@@ -68,12 +69,12 @@ public class FromFormOrJsonModelBinder<T> : IModelBinder where T : class
 
             bindingContext.Result = ModelBindingResult.Success(model);
         }
-        catch (JsonException ex)
+        catch (JsonException)
         {
             bindingContext.ModelState.AddModelError(bindingContext.ModelName, "Invalid JSON payload.");
             bindingContext.Result = ModelBindingResult.Failed();
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             bindingContext.ModelState.AddModelError(bindingContext.ModelName, "Unexpected error during model binding.");
             bindingContext.Result = ModelBindingResult.Failed();

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/FromFormOrJsonModelBinderProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/FromFormOrJsonModelBinderProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using System.Linq;
 
 namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
 {
@@ -15,7 +16,10 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 throw new ArgumentNullException(nameof(context));
             }
 
-            var binderAttribute = context.Metadata.BinderMetadata as FromFormOrJsonAttribute;
+            var parameter = context.Metadata.ParameterInfo;
+            var binderAttribute = parameter?.GetCustomAttributes(typeof(FromFormOrJsonAttribute), true)
+                                        .FirstOrDefault() as FromFormOrJsonAttribute;
+
             if (binderAttribute != null)
             {
                 var binderType = typeof(FromFormOrJsonModelBinder<>).MakeGenericType(context.Metadata.ModelType);

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/FromFormOrJsonModelBinderProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/FromFormOrJsonModelBinderProvider.cs
@@ -1,0 +1,28 @@
+using System;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
+{
+    /// <summary>
+    /// Provides a model binder for parameters annotated with FromFormOrJsonAttribute.
+    /// </summary>
+    public class FromFormOrJsonModelBinderProvider : IModelBinderProvider
+    {
+        public IModelBinder? GetBinder(ModelBinderProviderContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var binderAttribute = context.Metadata.BinderMetadata as FromFormOrJsonAttribute;
+            if (binderAttribute != null)
+            {
+                var binderType = typeof(FromFormOrJsonModelBinder<>).MakeGenericType(context.Metadata.ModelType);
+                return (IModelBinder?)Activator.CreateInstance(binderType);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Mvc/Mvc.Core/src/ModelBinding/FromFormOrJsonAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/FromFormOrJsonAttribute.cs
@@ -6,7 +6,7 @@ namespace Microsoft.AspNetCore.Mvc;
 /// Indicates that a parameter should be bound using the FromFormOrJsonModelBinder.
 /// </summary>
 [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = true)]
-public class FromFormOrJsonAttribute : ModelBinderAttribute
+public sealed class FromFormOrJsonAttribute : Attribute, IBindingSourceMetadata
 {
-    public FromFormOrJsonAttribute() : base(typeof(FromFormOrJsonModelBinder<>)) { }
+    public BindingSource BindingSource => BindingSource.Custom;
 }

--- a/src/Mvc/Mvc.Core/src/ModelBinding/FromFormOrJsonAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/FromFormOrJsonAttribute.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace Microsoft.AspNetCore.Mvc;
+
+/// <summary>
+/// Indicates that a parameter should be bound using the FromFormOrJsonModelBinder.
+/// </summary>
+[AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = true)]
+public class FromFormOrJsonAttribute : ModelBinderAttribute
+{
+    public FromFormOrJsonAttribute() : base(typeof(FromFormOrJsonModelBinder<>)) { }
+}

--- a/src/Mvc/Mvc.Core/src/ModelBinding/IFormFileReceiver.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/IFormFileReceiver.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding;
+
+/// <summary>
+/// Optional interface for models that wish to receive uploaded files from multipart/form-data requests.
+/// </summary>
+public interface IFormFileReceiver
+{
+    void SetFiles(IFormFileCollection files);
+}

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Binders/FromFormOrJsonModelBinderTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Binders/FromFormOrJsonModelBinderTest.cs
@@ -3,11 +3,11 @@ using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.ModelBinding.Tests;

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Binders/FromFormOrJsonModelBinderTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Binders/FromFormOrJsonModelBinderTest.cs
@@ -1,0 +1,87 @@
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Internal;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Tests;
+
+public class FromFormOrJsonModelBinderTest
+{
+    private static DefaultHttpContext CreateHttpContextWithJson<T>(T payload)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.ContentType = "application/json";
+
+        var json = JsonSerializer.Serialize(payload);
+        var bytes = Encoding.UTF8.GetBytes(json);
+        context.Request.Body = new MemoryStream(bytes);
+
+        return context;
+    }
+
+    private static DefaultHttpContext CreateHttpContextWithForm<T>(T payload)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.ContentType = "multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW";
+        var form = new FormCollection(new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
+        {
+            { "payload", JsonSerializer.Serialize(payload) }
+        });
+
+        context.Request.Form = form;
+        return context;
+    }
+
+    public class SampleDto
+    {
+        public string Name { get; set; }
+    }
+
+    [Fact]
+    public async Task BindsFromJsonPayload()
+    {
+        // Arrange
+        var dto = new SampleDto { Name = "Json Test" };
+        var httpContext = CreateHttpContextWithJson(dto);
+        var bindingContext = GetBindingContext<SampleDto>(httpContext);
+
+        var binder = new FromFormOrJsonModelBinder<SampleDto>();
+
+        // Act
+        await binder.BindModelAsync(bindingContext);
+
+        // Assert
+        Assert.True(bindingContext.Result.IsModelSet);
+        var result = Assert.IsType<SampleDto>(bindingContext.Result.Model);
+        Assert.Equal("Json Test", result.Name);
+    }
+
+    private static DefaultModelBindingContext GetBindingContext<T>(HttpContext httpContext)
+    {
+        var metadataProvider = new EmptyModelMetadataProvider();
+        var modelMetadata = metadataProvider.GetMetadataForType(typeof(T));
+        return new DefaultModelBindingContext
+        {
+            ModelMetadata = modelMetadata,
+            ModelName = "model",
+            ModelState = new ModelStateDictionary(),
+            ValueProvider = new SimpleValueProvider(),
+            ActionContext = new ActionContext
+            {
+                HttpContext = httpContext,
+                RouteData = new Microsoft.AspNetCore.Routing.RouteData(),
+                ActionDescriptor = new Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor()
+            },
+            FieldName = "model",
+            BindingSource = BindingSource.Custom,
+            HttpContext = httpContext,
+        };
+    }
+}


### PR DESCRIPTION
Fixes #61856

This PR introduces a generic model binder (`FromFormOrJsonModelBinder<T>`) that enables binding from both `application/json` and `multipart/form-data` request types into a single model.

Key additions:
- `FromFormOrJsonModelBinder<T>` – the core binder
- `FromFormOrJsonAttribute` – attribute to annotate parameters
- `FromFormOrJsonModelBinderProvider` – resolves the correct generic type
- `IFormFileReceiver` – optional interface for models to receive files
- Unit test for JSON payload support

This is useful for modern APIs that need to support clients submitting structured data along with file uploads.

Let me know if you'd like to see additional test coverage or refinements.
