### PR TITLE
Block test that is failing after switching to latest-chrome

### DIFF
--- a/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
@@ -1309,7 +1309,7 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
     }
 
     [Theory]
-    [InlineData(true)]
+    // [InlineData(true)] QuarantinedTest: https://github.com/dotnet/aspnetcore/issues/61880
     [InlineData(false)]
     public void CanUseFormWithMethodGet(bool suppressEnhancedNavigation)
     {

--- a/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
@@ -1309,7 +1309,7 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
     }
 
     [Theory]
-    // [InlineData(true)] QuarantinedTest: https://github.com/dotnet/aspnetcore/issues/61880
+    // [InlineData(true)] QuarantinedTest: https://github.com/dotnet/aspnetcore/issues/61882
     [InlineData(false)]
     public void CanUseFormWithMethodGet(bool suppressEnhancedNavigation)
     {


### PR DESCRIPTION
## Description

Block the non-enhanced navigation test. Currently we rely on "https://dl.google.com/chrome/install/latest/chrome_installer.exe" for Selenium tests on Windows. For a few weeks, we can see stable failures on `CanUseFormWithMethodGet` that uses non-JS navigation. When running with an older chrome, e.g. "http://dl.google.com/chrome/install/375.126/chrome_installer.exe" that was used on the CI 6 weeks ago, this test never fails.
The failure is connected with a change in how the browser handles navigation and can be unblocked once it's fixed on a new browser version.

Fixes #61880
