### PR TITLE
Fix handling for Name property on DisplayAttribute

### DIFF
--- a/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.ValidationsGenerator/Extensions/ISymbolExtensions.cs
+++ b/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.ValidationsGenerator/Extensions/ISymbolExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 
@@ -14,17 +15,19 @@ internal static class ISymbolExtensions
             .FirstOrDefault(attribute =>
                 attribute.AttributeClass is { } attributeClass &&
                 SymbolEqualityComparer.Default.Equals(attributeClass, displayAttribute));
+
         if (displayNameAttribute is not null)
         {
-            if (displayNameAttribute.ConstructorArguments.Length > 0)
+            if (!displayNameAttribute.NamedArguments.IsDefaultOrEmpty)
             {
-                return displayNameAttribute.ConstructorArguments[0].Value?.ToString() ?? property.Name;
+                foreach (var namedArgument in displayNameAttribute.NamedArguments)
+                {
+                    if (string.Equals(namedArgument.Key, "Name", StringComparison.Ordinal))
+                    {
+                        return namedArgument.Value.Value?.ToString() ?? property.Name;
+                    }
+                }
             }
-            else if (displayNameAttribute.NamedArguments.Length > 0)
-            {
-                return displayNameAttribute.NamedArguments[0].Value.Value?.ToString() ?? property.Name;
-            }
-            return property.Name;
         }
 
         return property.Name;

--- a/src/Http/Http.Extensions/test/ValidationsGenerator/ValidationsGenerator.IValidatableObject.cs
+++ b/src/Http/Http.Extensions/test/ValidationsGenerator/ValidationsGenerator.IValidatableObject.cs
@@ -54,6 +54,8 @@ public class ComplexValidatableType: IValidatableObject
 public class SubType
 {
     [Required]
+    // This gets ignored since it has an unsupported constructor name
+    [Display(ShortName = "SubType")]
     public string RequiredProperty { get; set; } = "some-value";
 
     [StringLength(10)]


### PR DESCRIPTION
Contributes towards https://github.com/dotnet/aspnetcore/issues/61589.

There's more work to do to get the implementation to process localization-based resource types (we need to access the attribute at runtime and call the `GetName` attribute at runtime) but approach this incrementally to make progress.