### PR TITLE
Exclude some files from PR checks

### DIFF
--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -19,6 +19,15 @@ pr:
   branches:
     include:
     - '*'
+  paths:
+    exclude:
+    - .devcontainer/*
+    - .github/*
+    - .vscode/*
+    - docs/*
+    - '**/*.md'
+    - LICENSE.TXT
+    - THIRD-PARTY-NOTICES.TXT
 
 parameters:
 # Choose whether to skip tests when running pipeline manually.


### PR DESCRIPTION
We can skip CI on text-only/non-code changes, now that "Build Analysis" is the only required check. Matches exclusions for quarantined-pr