### PR TITLE
Exempt parameters resolved from DI from validation

### DIFF
--- a/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.ValidationsGenerator/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.ValidationsGenerator/Extensions/ITypeSymbolExtensions.cs
@@ -124,4 +124,18 @@ internal static class ITypeSymbolExtensions
 
         return null;
     }
+
+    /// <summary>
+    /// Checks if the parameter is marked with [FromService] or [FromKeyedService] attributes.
+    /// </summary>
+    /// <param name="parameter">The parameter to check.</param>
+    /// <param name="fromServiceMetadataSymbol">The symbol representing the [FromService] attribute.</param>
+    /// <param name="fromKeyedServiceAttributeSymbol">The symbol representing the [FromKeyedService] attribute.</param>
+    internal static bool IsServiceParameter(this IParameterSymbol parameter, INamedTypeSymbol fromServiceMetadataSymbol, INamedTypeSymbol fromKeyedServiceAttributeSymbol)
+    {
+        return parameter.GetAttributes().Any(attr =>
+            attr.AttributeClass is not null &&
+            (attr.AttributeClass.ImplementsInterface(fromServiceMetadataSymbol) ||
+             SymbolEqualityComparer.Default.Equals(attr.AttributeClass, fromKeyedServiceAttributeSymbol)));
+    }
 }

--- a/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.ValidationsGenerator/Parsers/ValidationsGenerator.TypesParser.cs
+++ b/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.ValidationsGenerator/Parsers/ValidationsGenerator.TypesParser.cs
@@ -39,6 +39,7 @@ public sealed partial class ValidationsGenerator : IIncrementalGenerator
             if (parameter.GetAttributes().Any(attr => attr.AttributeClass is not null && attr.AttributeClass.ImplementsInterface(fromServiceMetadataSymbol)))
             {
                 continue;
+            }
 
             _ = TryExtractValidatableType(parameter.Type, wellKnownTypes, ref validatableTypes, ref visitedTypes);
         }

--- a/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.ValidationsGenerator/Parsers/ValidationsGenerator.TypesParser.cs
+++ b/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.ValidationsGenerator/Parsers/ValidationsGenerator.TypesParser.cs
@@ -25,10 +25,20 @@ public sealed partial class ValidationsGenerator : IIncrementalGenerator
         var parameters = operation.TryGetRouteHandlerMethod(operation.SemanticModel, out var method)
             ? method.Parameters
             : [];
+
+        var fromServiceMetadataSymbol = wellKnownTypes.Get(
+            WellKnownTypeData.WellKnownType.Microsoft_AspNetCore_Http_Metadata_IFromServiceMetadata);
+
         var validatableTypes = new HashSet<ValidatableType>(ValidatableTypeComparer.Instance);
         List<ITypeSymbol> visitedTypes = [];
+
         foreach (var parameter in parameters)
         {
+            if (parameter.GetAttributes().Any(attr => attr.AttributeClass is not null && attr.AttributeClass.ImplementsInterface(fromServiceMetadataSymbol)))
+            {
+                continue;
+            }
+
             _ = TryExtractValidatableType(parameter.Type, wellKnownTypes, ref validatableTypes, ref visitedTypes);
         }
         return [.. validatableTypes];

--- a/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.ValidationsGenerator/Parsers/ValidationsGenerator.TypesParser.cs
+++ b/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.ValidationsGenerator/Parsers/ValidationsGenerator.TypesParser.cs
@@ -28,15 +28,16 @@ public sealed partial class ValidationsGenerator : IIncrementalGenerator
 
         var fromServiceMetadataSymbol = wellKnownTypes.Get(
             WellKnownTypeData.WellKnownType.Microsoft_AspNetCore_Http_Metadata_IFromServiceMetadata);
+        var fromKeyedServiceAttributeSymbol = wellKnownTypes.Get(
+            WellKnownTypeData.WellKnownType.Microsoft_Extensions_DependencyInjection_FromKeyedServicesAttribute);
 
         var validatableTypes = new HashSet<ValidatableType>(ValidatableTypeComparer.Instance);
         List<ITypeSymbol> visitedTypes = [];
 
         foreach (var parameter in parameters)
         {
-            // Skip attributes that implement the IFromServiceMetadata interface.
-            // These attributes are used for dependency injection (DI) purposes and do not require validation.
-            if (parameter.GetAttributes().Any(attr => attr.AttributeClass is not null && attr.AttributeClass.ImplementsInterface(fromServiceMetadataSymbol)))
+            // Skip parameters that are injected as services
+            if (parameter.IsServiceParameter(fromServiceMetadataSymbol, fromKeyedServiceAttributeSymbol))
             {
                 continue;
             }

--- a/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.ValidationsGenerator/Parsers/ValidationsGenerator.TypesParser.cs
+++ b/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.ValidationsGenerator/Parsers/ValidationsGenerator.TypesParser.cs
@@ -34,10 +34,11 @@ public sealed partial class ValidationsGenerator : IIncrementalGenerator
 
         foreach (var parameter in parameters)
         {
+            // Skip attributes that implement the IFromServiceMetadata interface.
+            // These attributes are used for dependency injection (DI) purposes and do not require validation.
             if (parameter.GetAttributes().Any(attr => attr.AttributeClass is not null && attr.AttributeClass.ImplementsInterface(fromServiceMetadataSymbol)))
             {
                 continue;
-            }
 
             _ = TryExtractValidatableType(parameter.Type, wellKnownTypes, ref validatableTypes, ref visitedTypes);
         }

--- a/src/Http/Http.Extensions/test/ValidationsGenerator/ValidationsGenerator.IValidatableObject.cs
+++ b/src/Http/Http.Extensions/test/ValidationsGenerator/ValidationsGenerator.IValidatableObject.cs
@@ -21,6 +21,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 var builder = WebApplication.CreateBuilder();
 builder.Services.AddSingleton<IRangeService, RangeService>();
+builder.Services.AddKeyedSingleton<TestService>("serviceKey");
 builder.Services.AddValidation();
 
 var app = builder.Build();
@@ -29,7 +30,8 @@ app.MapPost("/validatable-object", (
     ComplexValidatableType model,
     // Demonstrates that parameters that are annotated with [FromService] are not processed
     // by the source generator and not emitted as ValidatableTypes in the generated code.
-    [FromServices] IRangeService rangeService) => Results.Ok(rangeService.GetMinimum()));
+    [FromServices] IRangeService rangeService,
+    [FromKeyedServices("serviceKey")] TestService testService) => Results.Ok(rangeService.GetMinimum()));
 
 app.Run();
 
@@ -88,6 +90,12 @@ public class RangeService : IRangeService
 {
     public int GetMinimum() => 10;
     public int GetMaximum() => 100;
+}
+
+public class TestService
+{
+    [Range(10, 100)]
+    public int Value { get; set; } = 4;
 }
 """;
 

--- a/src/Http/Http.Extensions/test/ValidationsGenerator/ValidationsGenerator.IValidatableObject.cs
+++ b/src/Http/Http.Extensions/test/ValidationsGenerator/ValidationsGenerator.IValidatableObject.cs
@@ -15,6 +15,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Validation;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -24,7 +25,11 @@ builder.Services.AddValidation();
 
 var app = builder.Build();
 
-app.MapPost("/validatable-object", (ComplexValidatableType model) => Results.Ok());
+app.MapPost("/validatable-object", (
+    ComplexValidatableType model,
+    // Demonstrates that parameters that are annotated with [FromService] are not processed
+    // by the source generator and not emitted as ValidatableTypes in the generated code.
+    [FromServices] IRangeService rangeService) => Results.Ok(rangeService.GetMinimum()));
 
 app.Run();
 

--- a/src/Http/Http.Extensions/test/ValidationsGenerator/ValidationsGenerator.Parameters.cs
+++ b/src/Http/Http.Extensions/test/ValidationsGenerator/ValidationsGenerator.Parameters.cs
@@ -24,12 +24,15 @@ var builder = WebApplication.CreateBuilder();
 
 builder.Services.AddValidation();
 builder.Services.AddSingleton<TestService>();
+builder.Services.AddKeyedSingleton<TestService>("serviceKey");
 
 var app = builder.Build();
 
 app.MapGet("/params", (
     // Skipped from validation because it is resolved as a service by IServiceProviderIsService
     TestService testService,
+    // Skipped from validation because it is marked as a [FromKeyedService] parameter
+    [FromKeyedServices("serviceKey")] TestService testService2,
     [Range(10, 100)] int value1,
     [Range(10, 100), Display(Name = "Valid identifier")] int value2,
     [Required] string value3 = "some-value",

--- a/src/Http/Http.Extensions/test/ValidationsGenerator/ValidationsGenerator.Parameters.cs
+++ b/src/Http/Http.Extensions/test/ValidationsGenerator/ValidationsGenerator.Parameters.cs
@@ -16,27 +16,39 @@ using System.Linq;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Validation;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 
 var builder = WebApplication.CreateBuilder();
 
 builder.Services.AddValidation();
+builder.Services.AddSingleton<TestService>();
 
 var app = builder.Build();
 
 app.MapGet("/params", (
+    // Skipped from validation because it is resolved as a service by IServiceProviderIsService
+    TestService testService,
     [Range(10, 100)] int value1,
     [Range(10, 100), Display(Name = "Valid identifier")] int value2,
     [Required] string value3 = "some-value",
     [CustomValidation(ErrorMessage = "Value must be an even number")] int value4 = 4,
-    [CustomValidation, Range(10, 100)] int value5 = 10) => "OK");
+    [CustomValidation, Range(10, 100)] int value5 = 10,
+    // Skipped from validation because it is marked as a [FromService] parameter
+    [FromServices] [Range(10, 100)] int? value6 = 4) => "OK");
 
 app.Run();
 
 public class CustomValidationAttribute : ValidationAttribute
 {
     public override bool IsValid(object? value) => value is int number && number % 2 == 0;
+}
+
+public class TestService
+{
+    [Range(10, 100)]
+    public int Value { get; set; } = 4;
 }
 """;
         await Verify(source, out var compilation);

--- a/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidateParameters#ValidatableInfoResolver.g.verified.cs
+++ b/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidateParameters#ValidatableInfoResolver.g.verified.cs
@@ -60,6 +60,11 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
         public bool TryGetValidatableTypeInfo(global::System.Type type, [global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out global::Microsoft.AspNetCore.Http.Validation.IValidatableInfo? validatableInfo)
         {
             validatableInfo = null;
+            if (type == typeof(global::TestService))
+            {
+                validatableInfo = CreateTestService();
+                return true;
+            }
 
             return false;
         }
@@ -71,6 +76,20 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
             return false;
         }
 
+        private ValidatableTypeInfo CreateTestService()
+        {
+            return new GeneratedValidatableTypeInfo(
+                type: typeof(global::TestService),
+                members: [
+                    new GeneratedValidatablePropertyInfo(
+                        containingType: typeof(global::TestService),
+                        propertyType: typeof(int),
+                        name: "Value",
+                        displayName: "Value"
+                    ),
+                ]
+            );
+        }
 
     }
 


### PR DESCRIPTION
This pull request introduces changes to improve the handling of service-resolved parameters in ASP.NET Core's validation system. The updates ensure that parameters marked with `[FromServices]` or resolved from the dependency injection (DI) container are excluded from validation.

Fixes https://github.com/dotnet/aspnetcore/issues/61392
Fixes https://github.com/dotnet/aspnetcore/issues/61770