### PR TITLE
Update branding to 2.3.3

### DIFF
--- a/eng/Baseline.Designer.props
+++ b/eng/Baseline.Designer.props
@@ -1155,7 +1155,7 @@
   </ItemGroup>
   <!-- Package: Microsoft.Extensions.Identity.Stores-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Identity.Stores' ">
-    <BaselinePackageVersion>2.3.0</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.2</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Identity.Stores' AND '$(TargetFramework)' == 'netstandard2.0' ">
     <BaselinePackageReference Include="Microsoft.Extensions.Identity.Core" Version="[2.3.0, )" />

--- a/eng/Baseline.Designer.props
+++ b/eng/Baseline.Designer.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-    <AspNetCoreBaselineVersion>2.3.1</AspNetCoreBaselineVersion>
+    <AspNetCoreBaselineVersion>2.3.2</AspNetCoreBaselineVersion>
   </PropertyGroup>
   <!-- Package: dotnet-dev-certs-->
   <PropertyGroup Condition=" '$(PackageId)' == 'dotnet-dev-certs' ">

--- a/eng/Baseline.xml
+++ b/eng/Baseline.xml
@@ -123,7 +123,7 @@ build of ASP.NET Core 2.1.x. Update this list when preparing for a new patch.
   <Package Id="Microsoft.AspNetCore" Version="2.3.0" />
   <Package Id="Microsoft.CodeAnalysis.Razor" Version="2.3.0" />
   <Package Id="Microsoft.Extensions.Identity.Core" Version="2.3.0" />
-  <Package Id="Microsoft.Extensions.Identity.Stores" Version="2.3.0" />
+  <Package Id="Microsoft.Extensions.Identity.Stores" Version="2.3.2" />
   <Package Id="Microsoft.Net.Http.Headers" Version="2.3.0" />
   <Package Id="Microsoft.Net.Sdk.Razor" Version="2.3.0" />
   <Package Id="Microsoft.Owin.Security.Interop" Version="2.3.0" />

--- a/eng/Baseline.xml
+++ b/eng/Baseline.xml
@@ -4,7 +4,7 @@ This file contains a list of all the packages and their versions which were rele
 build of ASP.NET Core 2.1.x. Update this list when preparing for a new patch.
 
 -->
-<Baseline Version="2.3.1">
+<Baseline Version="2.3.2">
   <Package Id="dotnet-dev-certs" Version="2.1.1" />
   <Package Id="dotnet-sql-cache" Version="2.1.1" />
   <Package Id="dotnet-user-secrets" Version="2.1.1" />

--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -23,4 +23,8 @@ Later on, this will be checked using this condition:
       Microsoft.Extensions.Identity.Stores;
     </PackagesInPatch>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(VersionPrefix)' == '2.3.3' ">
+    <PackagesInPatch>
+    </PackagesInPatch>
+  </PropertyGroup>
 </Project>

--- a/version.props
+++ b/version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AspNetCoreMajorVersion>2</AspNetCoreMajorVersion>
     <AspNetCoreMinorVersion>3</AspNetCoreMinorVersion>
-    <AspNetCorePatchVersion>2</AspNetCorePatchVersion>
+    <AspNetCorePatchVersion>3</AspNetCorePatchVersion>
     <ValidateBaseline>true</ValidateBaseline>
 
     <PreReleaseLabel>servicing</PreReleaseLabel>


### PR DESCRIPTION
This pull request updates the versioning and configuration for the `Microsoft.Extensions.Identity.Stores` package and related ASP.NET Core components. The most important changes include updating the baseline package version, modifying the patch configuration, and incrementing the patch version in the version properties.

### Version Updates:

* [`eng/Baseline.Designer.props`](diffhunk://#diff-4d871589215547801f33bd38b80acdafc64a81820998305889f2b78f5feef064L1158-R1158): Updated the `BaselinePackageVersion` for `Microsoft.Extensions.Identity.Stores` from `2.3.0` to `2.3.2`.
* [`eng/Baseline.xml`](diffhunk://#diff-f9561e127e2a447b5c99b768de51e0eff8e910dcf1930a01169ccbc8b3a05909L126-R126): Updated the package version for `Microsoft.Extensions.Identity.Stores` from `2.3.0` to `2.3.2` in the baseline configuration.

### Patch Configuration:

* [`eng/PatchConfig.props`](diffhunk://#diff-34bcfd4dda2dd22cd2c28dfa3618f880996db857ac27ea509f78c83ec707c424R26-R29): Added a new conditional `PropertyGroup` for `VersionPrefix` `2.3.3`, preparing for potential future patches.

### Version Properties:

* [`version.props`](diffhunk://#diff-e4bed5b736f205989dd4fdb6d78acfe9126577983d325d378ce91794d74e63c8L5-R5): Incremented the `AspNetCorePatchVersion` from `2` to `3`, reflecting the new patch level for ASP.NET Core.