### PR TITLE
Add empty string check for recovery code

### DIFF
--- a/src/Identity/EntityFrameworkCore/test/EF.Test/UserStoreTest.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/UserStoreTest.cs
@@ -144,6 +144,9 @@ public class UserStoreTest : IdentitySpecificationTestBase<IdentityUser, Identit
         await Assert.ThrowsAsync<ArgumentNullException>("user", async () => await store.GetTwoFactorEnabledAsync(null));
         await Assert.ThrowsAsync<ArgumentNullException>("user",
             async () => await store.SetTwoFactorEnabledAsync(null, true));
+        await Assert.ThrowsAsync<ArgumentNullException>("user", async () => await store.RedeemCodeAsync(user: null, code: "fake", default));
+        await Assert.ThrowsAsync<ArgumentNullException>("code", async () => await store.RedeemCodeAsync(new IdentityUser("fake"), code: null, default));
+        await Assert.ThrowsAsync<ArgumentException>("code", async () => await store.RedeemCodeAsync(new IdentityUser("fake"), code: "", default));
         await Assert.ThrowsAsync<ArgumentNullException>("user", async () => await store.GetAccessFailedCountAsync(null));
         await Assert.ThrowsAsync<ArgumentNullException>("user", async () => await store.GetLockoutEnabledAsync(null));
         await Assert.ThrowsAsync<ArgumentNullException>("user", async () => await store.SetLockoutEnabledAsync(null, false));

--- a/src/Identity/Extensions.Stores/src/UserStoreBase.cs
+++ b/src/Identity/Extensions.Stores/src/UserStoreBase.cs
@@ -969,7 +969,7 @@ public abstract class UserStoreBase<TUser, [DynamicallyAccessedMembers(Dynamical
         ThrowIfDisposed();
 
         ArgumentNullThrowHelper.ThrowIfNull(user);
-        ArgumentNullThrowHelper.ThrowIfNull(code);
+        ArgumentNullThrowHelper.ThrowIfNullOrEmpty(code);
 
         var mergedCodes = await GetTokenAsync(user, InternalLoginProvider, RecoveryCodeTokenName, cancellationToken).ConfigureAwait(false) ?? "";
         var splitCodes = mergedCodes.Split(';');

--- a/src/Shared/ThrowHelpers/ArgumentNullThrowHelper.cs
+++ b/src/Shared/ThrowHelpers/ArgumentNullThrowHelper.cs
@@ -30,6 +30,29 @@ internal static partial class ArgumentNullThrowHelper
 #endif
     }
 
+    /// <summary>Throws an <see cref="ArgumentException"/> if <paramref name="argument"/> is null or empty.</summary>
+    /// <param name="argument">The <see cref="string"/> argument to validate as non-null and non-empty.</param>
+    /// <param name="paramName">The name of the parameter with which <paramref name="argument"/> corresponds.</param>
+    public static void ThrowIfNullOrEmpty(
+#if INTERNAL_NULLABLE_ATTRIBUTES || NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
+        [NotNull]
+#endif
+        string? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+    {
+#if !NET7_0_OR_GREATER || NETSTANDARD || NETFRAMEWORK
+        if (argument is null)
+        {
+            Throw(paramName);
+        }
+        else if (argument.Length == 0)
+        {
+            throw new ArgumentException("Must not be null or empty", paramName);
+        }
+#else
+        ArgumentException.ThrowIfNullOrEmpty(argument, paramName);
+#endif
+    }
+
 #if !NET7_0_OR_GREATER || NETSTANDARD || NETFRAMEWORK
 #if INTERNAL_NULLABLE_ATTRIBUTES || NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
     [DoesNotReturn]


### PR DESCRIPTION
If an empty string gets passed as the recovery code to `UserStoreBase.RedeemCodeAsync(TUser user, string code, CancellationToken ct)`, the method returns `true`, incorrectly indicating a valid recovery code. This PR resolves the issue by validating that the `code` argument is not an empty string.