### PR TITLE
Update to Microsoft.OpenApi 2.0.0-preview.18

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -325,8 +325,8 @@
     <XunitExtensibilityExecutionVersion>$(XunitVersion)</XunitExtensibilityExecutionVersion>
     <XUnitRunnerVisualStudioVersion>2.8.2</XUnitRunnerVisualStudioVersion>
     <MicrosoftDataSqlClientVersion>5.2.2</MicrosoftDataSqlClientVersion>
-    <MicrosoftOpenApiVersion>2.0.0-preview.17</MicrosoftOpenApiVersion>
-    <MicrosoftOpenApiYamlReaderVersion>2.0.0-preview.17</MicrosoftOpenApiYamlReaderVersion>
+    <MicrosoftOpenApiVersion>2.0.0-preview.18</MicrosoftOpenApiVersion>
+    <MicrosoftOpenApiYamlReaderVersion>2.0.0-preview.18</MicrosoftOpenApiYamlReaderVersion>
     <!-- dotnet tool versions (see also auto-updated DotnetEfVersion property). -->
     <DotnetDumpVersion>6.0.322601</DotnetDumpVersion>
     <DotnetServeVersion>1.10.93</DotnetServeVersion>

--- a/src/OpenApi/gen/XmlCommentGenerator.Emitter.cs
+++ b/src/OpenApi/gen/XmlCommentGenerator.Emitter.cs
@@ -61,7 +61,6 @@ namespace Microsoft.AspNetCore.OpenApi.Generated
     using Microsoft.OpenApi.Models;
     using Microsoft.OpenApi.Models.Interfaces;
     using Microsoft.OpenApi.Models.References;
-    using Microsoft.OpenApi.Any;
 
     {{GeneratedCodeAttribute}}
     file record XmlComment(

--- a/src/OpenApi/perf/Microbenchmarks/TransformersBenchmark.cs
+++ b/src/OpenApi/perf/Microbenchmarks/TransformersBenchmark.cs
@@ -5,7 +5,7 @@ using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.AspNetCore.OpenApi.Microbenchmarks;
@@ -105,11 +105,11 @@ public class TransformersBenchmark : OpenApiDocumentServiceTestBase
                 schema.Extensions ??= [];
                 if (context.JsonTypeInfo.Type == typeof(Todo) && context.ParameterDescription != null)
                 {
-                    schema.Extensions["x-my-extension"] = new OpenApiAny(context.ParameterDescription.Name);
+                    schema.Extensions["x-my-extension"] = new JsonNodeExtension(context.ParameterDescription.Name);
                 }
                 else
                 {
-                    schema.Extensions["x-my-extension"] = new OpenApiAny("response");
+                    schema.Extensions["x-my-extension"] = new JsonNodeExtension("response");
                 }
                 return Task.CompletedTask;
             });
@@ -179,11 +179,11 @@ public class TransformersBenchmark : OpenApiDocumentServiceTestBase
             schema.Extensions ??= [];
             if (context.JsonTypeInfo.Type == typeof(Todo) && context.ParameterDescription != null)
             {
-                schema.Extensions["x-my-extension"] = new OpenApiAny(context.ParameterDescription.Name);
+                schema.Extensions["x-my-extension"] = new JsonNodeExtension(context.ParameterDescription.Name);
             }
             else
             {
-                schema.Extensions["x-my-extension"] = new OpenApiAny("response");
+                schema.Extensions["x-my-extension"] = new JsonNodeExtension("response");
             }
             return Task.CompletedTask;
         }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.SourceGenerators.Tests/snapshots/AddOpenApiTests.CanInterceptAddOpenApi#OpenApiXmlCommentSupport.generated.verified.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.SourceGenerators.Tests/snapshots/AddOpenApiTests.CanInterceptAddOpenApi#OpenApiXmlCommentSupport.generated.verified.cs
@@ -43,7 +43,6 @@ namespace Microsoft.AspNetCore.OpenApi.Generated
     using Microsoft.OpenApi.Models;
     using Microsoft.OpenApi.Models.Interfaces;
     using Microsoft.OpenApi.Models.References;
-    using Microsoft.OpenApi.Any;
 
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.AspNetCore.OpenApi.SourceGenerators, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
     file record XmlComment(

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.SourceGenerators.Tests/snapshots/AdditionalTextsTests.CanHandleXmlForSchemasInAdditionalTexts#OpenApiXmlCommentSupport.generated.verified.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.SourceGenerators.Tests/snapshots/AdditionalTextsTests.CanHandleXmlForSchemasInAdditionalTexts#OpenApiXmlCommentSupport.generated.verified.cs
@@ -43,7 +43,6 @@ namespace Microsoft.AspNetCore.OpenApi.Generated
     using Microsoft.OpenApi.Models;
     using Microsoft.OpenApi.Models.Interfaces;
     using Microsoft.OpenApi.Models.References;
-    using Microsoft.OpenApi.Any;
 
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.AspNetCore.OpenApi.SourceGenerators, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
     file record XmlComment(

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.SourceGenerators.Tests/snapshots/CompletenessTests.SupportsAllXmlTagsOnSchemas#OpenApiXmlCommentSupport.generated.verified.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.SourceGenerators.Tests/snapshots/CompletenessTests.SupportsAllXmlTagsOnSchemas#OpenApiXmlCommentSupport.generated.verified.cs
@@ -43,7 +43,6 @@ namespace Microsoft.AspNetCore.OpenApi.Generated
     using Microsoft.OpenApi.Models;
     using Microsoft.OpenApi.Models.Interfaces;
     using Microsoft.OpenApi.Models.References;
-    using Microsoft.OpenApi.Any;
 
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.AspNetCore.OpenApi.SourceGenerators, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
     file record XmlComment(

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.SourceGenerators.Tests/snapshots/OperationTests.SupportsXmlCommentsOnOperationsFromControllers#OpenApiXmlCommentSupport.generated.verified.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.SourceGenerators.Tests/snapshots/OperationTests.SupportsXmlCommentsOnOperationsFromControllers#OpenApiXmlCommentSupport.generated.verified.cs
@@ -43,7 +43,6 @@ namespace Microsoft.AspNetCore.OpenApi.Generated
     using Microsoft.OpenApi.Models;
     using Microsoft.OpenApi.Models.Interfaces;
     using Microsoft.OpenApi.Models.References;
-    using Microsoft.OpenApi.Any;
 
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.AspNetCore.OpenApi.SourceGenerators, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
     file record XmlComment(

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.SourceGenerators.Tests/snapshots/OperationTests.SupportsXmlCommentsOnOperationsFromMinimalApis#OpenApiXmlCommentSupport.generated.verified.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.SourceGenerators.Tests/snapshots/OperationTests.SupportsXmlCommentsOnOperationsFromMinimalApis#OpenApiXmlCommentSupport.generated.verified.cs
@@ -43,7 +43,6 @@ namespace Microsoft.AspNetCore.OpenApi.Generated
     using Microsoft.OpenApi.Models;
     using Microsoft.OpenApi.Models.Interfaces;
     using Microsoft.OpenApi.Models.References;
-    using Microsoft.OpenApi.Any;
 
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.AspNetCore.OpenApi.SourceGenerators, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
     file record XmlComment(

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.SourceGenerators.Tests/snapshots/SchemaTests.SupportsXmlCommentsOnSchemas#OpenApiXmlCommentSupport.generated.verified.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.SourceGenerators.Tests/snapshots/SchemaTests.SupportsXmlCommentsOnSchemas#OpenApiXmlCommentSupport.generated.verified.cs
@@ -43,7 +43,6 @@ namespace Microsoft.AspNetCore.OpenApi.Generated
     using Microsoft.OpenApi.Models;
     using Microsoft.OpenApi.Models.Interfaces;
     using Microsoft.OpenApi.Models.References;
-    using Microsoft.OpenApi.Any;
 
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.AspNetCore.OpenApi.SourceGenerators, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
     file record XmlComment(

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.PolymorphicSchemas.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.PolymorphicSchemas.cs
@@ -3,7 +3,7 @@
 
 using System.Net.Http;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Models.References;
 

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.RequestBodySchemas.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.RequestBodySchemas.cs
@@ -10,7 +10,7 @@ using System.Text.Json.Serialization.Metadata;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Models.References;
 

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.ResponseSchemas.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.ResponseSchemas.cs
@@ -7,7 +7,7 @@ using System.Text.Json.Nodes;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 
 public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/CustomSchemaTransformerTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/CustomSchemaTransformerTests.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Models.References;
 
@@ -159,7 +159,7 @@ public class CustomSchemaTransformerTests : OpenApiDocumentServiceTestBase
 
                 // Add a reference to the example in the shape schema
                 schema.Extensions ??= [];
-                schema.Extensions["x-example-component"] = new OpenApiAny("#/components/schemas/TriangleExample");
+                schema.Extensions["x-example-component"] = new JsonNodeExtension("#/components/schemas/TriangleExample");
                 schema.Description = "A shape with an example reference";
             }
         });

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/Implementations/OpenApiSchemaReferenceTransformerTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/Implementations/OpenApiSchemaReferenceTransformerTests.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Models.References;
 using Microsoft.OpenApi.Writers;
@@ -287,7 +287,7 @@ public class OpenApiSchemaReferenceTransformerTests : OpenApiDocumentServiceTest
             if (context.JsonTypeInfo.Type == typeof(Todo) && context.ParameterDescription is not null)
             {
                 schema.Extensions ??= [];
-                schema.Extensions["x-my-extension"] = new OpenApiAny(context.ParameterDescription.Name);
+                schema.Extensions["x-my-extension"] = new JsonNodeExtension(context.ParameterDescription.Name);
             }
             return Task.CompletedTask;
         });
@@ -301,7 +301,7 @@ public class OpenApiSchemaReferenceTransformerTests : OpenApiDocumentServiceTest
             var responseSchema = getOperation.Responses["200"].Content["application/json"].Schema;
             // Schemas are distinct because of applied transformer so no reference is used.
             Assert.NotEqual(((OpenApiSchemaReference)requestSchema).Reference.Id, ((OpenApiSchemaReference)responseSchema).Reference.Id);
-            Assert.Equal("todo", ((OpenApiAny)requestSchema.Extensions["x-my-extension"]).Node.GetValue<string>());
+            Assert.Equal("todo", ((JsonNodeExtension)requestSchema.Extensions["x-my-extension"]).Node.GetValue<string>());
             Assert.False(responseSchema.Extensions.TryGetValue("x-my-extension", out var _));
         });
     }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/SchemaTransformerTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/SchemaTransformerTests.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Models.References;
 
@@ -156,15 +156,15 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
         options.AddSchemaTransformer((schema, context, cancellationToken) =>
         {
             schema.Extensions ??= [];
-            schema.Extensions["x-my-extension"] = new OpenApiAny("1");
+            schema.Extensions["x-my-extension"] = new JsonNodeExtension("1");
             schema.Format = "1";
             return Task.CompletedTask;
         });
         options.AddSchemaTransformer((schema, context, cancellationToken) =>
         {
             schema.Extensions ??= [];
-            Assert.Equal("1", ((OpenApiAny)schema.Extensions["x-my-extension"]).Node.GetValue<string>());
-            schema.Extensions["x-my-extension"] = new OpenApiAny("2");
+            Assert.Equal("1", ((JsonNodeExtension)schema.Extensions["x-my-extension"]).Node.GetValue<string>());
+            schema.Extensions["x-my-extension"] = new JsonNodeExtension("2");
             return Task.CompletedTask;
         });
 
@@ -172,7 +172,7 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
         {
             var operation = Assert.Single(document.Paths.Values).Operations.Values.Single();
             var schema = operation.RequestBody.Content["application/json"].Schema;
-            Assert.Equal("2", ((OpenApiAny)schema.Extensions["x-my-extension"]).Node.GetValue<string>());
+            Assert.Equal("2", ((JsonNodeExtension)schema.Extensions["x-my-extension"]).Node.GetValue<string>());
         });
     }
 
@@ -190,7 +190,7 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
             if (context.JsonTypeInfo.Type == typeof(Todo))
             {
                 schema.Extensions ??= [];
-                schema.Extensions["x-my-extension"] = new OpenApiAny("1");
+                schema.Extensions["x-my-extension"] = new JsonNodeExtension("1");
             }
             return Task.CompletedTask;
         });
@@ -200,10 +200,10 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
             var path = Assert.Single(document.Paths.Values);
             var postOperation = path.Operations[HttpMethod.Post];
             var requestSchema = postOperation.RequestBody.Content["application/json"].Schema;
-            Assert.Equal("1", ((OpenApiAny)requestSchema.Extensions["x-my-extension"]).Node.GetValue<string>());
+            Assert.Equal("1", ((JsonNodeExtension)requestSchema.Extensions["x-my-extension"]).Node.GetValue<string>());
             var getOperation = path.Operations[HttpMethod.Get];
             var responseSchema = getOperation.Responses["200"].Content["application/json"].Schema;
-            Assert.Equal("1", ((OpenApiAny)responseSchema.Extensions["x-my-extension"]).Node.GetValue<string>());
+            Assert.Equal("1", ((JsonNodeExtension)responseSchema.Extensions["x-my-extension"]).Node.GetValue<string>());
         });
     }
 
@@ -220,7 +220,7 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
         {
             if (context.JsonTypeInfo.Type == typeof(Todo) && context.ParameterDescription is not null)
             {
-                schema.Extensions["x-my-extension"] = new OpenApiAny(context.ParameterDescription.Name);
+                schema.Extensions["x-my-extension"] = new JsonNodeExtension(context.ParameterDescription.Name);
             }
             return Task.CompletedTask;
         });
@@ -230,7 +230,7 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
             var path = Assert.Single(document.Paths.Values);
             var postOperation = path.Operations[HttpMethod.Post];
             var requestSchema = postOperation.RequestBody.Content["application/json"].Schema;
-            Assert.Equal("todo", ((OpenApiAny)requestSchema.Extensions["x-my-extension"]).Node.GetValue<string>());
+            Assert.Equal("todo", ((JsonNodeExtension)requestSchema.Extensions["x-my-extension"]).Node.GetValue<string>());
             var getOperation = path.Operations[HttpMethod.Get];
             var responseSchema = getOperation.Responses["200"].Content["application/json"].Schema;
             Assert.False(responseSchema.Extensions.TryGetValue("x-my-extension", out var _));
@@ -253,10 +253,10 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
             var path = Assert.Single(document.Paths.Values);
             var postOperation = path.Operations[HttpMethod.Post];
             var requestSchema = postOperation.RequestBody.Content["application/json"].Schema;
-            Assert.Equal("1", ((OpenApiAny)requestSchema.Extensions["x-my-extension"]).Node.GetValue<string>());
+            Assert.Equal("1", ((JsonNodeExtension)requestSchema.Extensions["x-my-extension"]).Node.GetValue<string>());
             var getOperation = path.Operations[HttpMethod.Get];
             var responseSchema = getOperation.Responses["200"].Content["application/json"].Schema;
-            Assert.Equal("1", ((OpenApiAny)responseSchema.Extensions["x-my-extension"]).Node.GetValue<string>());
+            Assert.Equal("1", ((JsonNodeExtension)responseSchema.Extensions["x-my-extension"]).Node.GetValue<string>());
         });
     }
 
@@ -276,10 +276,10 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
             var path = Assert.Single(document.Paths.Values);
             var postOperation = path.Operations[HttpMethod.Post];
             var requestSchema = postOperation.RequestBody.Content["application/json"].Schema;
-            Assert.Equal("1", ((OpenApiAny)requestSchema.Extensions["x-my-extension"]).Node.GetValue<string>());
+            Assert.Equal("1", ((JsonNodeExtension)requestSchema.Extensions["x-my-extension"]).Node.GetValue<string>());
             var getOperation = path.Operations[HttpMethod.Get];
             var responseSchema = getOperation.Responses["200"].Content["application/json"].Schema;
-            Assert.Equal("1", ((OpenApiAny)responseSchema.Extensions["x-my-extension"]).Node.GetValue<string>());
+            Assert.Equal("1", ((JsonNodeExtension)responseSchema.Extensions["x-my-extension"]).Node.GetValue<string>());
         });
     }
 
@@ -303,21 +303,21 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
             var path = Assert.Single(document.Paths.Values);
             var postOperation = path.Operations[HttpMethod.Post];
             var requestSchema = postOperation.RequestBody.Content["application/json"].Schema;
-            value = ((OpenApiAny)requestSchema.Extensions["x-my-extension"]).Node.GetValue<string>();
+            value = ((JsonNodeExtension)requestSchema.Extensions["x-my-extension"]).Node.GetValue<string>();
             Assert.Equal(Dependency.InstantiationCount.ToString(CultureInfo.InvariantCulture), value);
             var getOperation = path.Operations[HttpMethod.Get];
             var responseSchema = getOperation.Responses["200"].Content["application/json"].Schema;
-            Assert.Equal(value, ((OpenApiAny)responseSchema.Extensions["x-my-extension"]).Node.GetValue<string>());
+            Assert.Equal(value, ((JsonNodeExtension)responseSchema.Extensions["x-my-extension"]).Node.GetValue<string>());
         });
         await VerifyOpenApiDocument(builder, options, document =>
         {
             var path = Assert.Single(document.Paths.Values);
             var postOperation = path.Operations[HttpMethod.Post];
             var requestSchema = postOperation.RequestBody.Content["application/json"].Schema;
-            Assert.Equal(value, ((OpenApiAny)requestSchema.Extensions["x-my-extension"]).Node.GetValue<string>());
+            Assert.Equal(value, ((JsonNodeExtension)requestSchema.Extensions["x-my-extension"]).Node.GetValue<string>());
             var getOperation = path.Operations[HttpMethod.Get];
             var responseSchema = getOperation.Responses["200"].Content["application/json"].Schema;
-            Assert.Equal(value, ((OpenApiAny)responseSchema.Extensions["x-my-extension"]).Node.GetValue<string>());
+            Assert.Equal(value, ((JsonNodeExtension)responseSchema.Extensions["x-my-extension"]).Node.GetValue<string>());
         });
     }
 
@@ -500,7 +500,7 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
             if (context.JsonTypeInfo.Type == typeof(Triangle))
             {
                 schema.Extensions ??= [];
-                schema.Extensions["x-my-extension"] = new OpenApiAny("this-is-a-triangle");
+                schema.Extensions["x-my-extension"] = new JsonNodeExtension("this-is-a-triangle");
             }
             return Task.CompletedTask;
         });
@@ -518,7 +518,7 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
             path = document.Paths["/triangle"];
             postOperation = path.Operations[HttpMethod.Post];
             requestSchema = postOperation.RequestBody.Content["application/json"].Schema;
-            Assert.Equal("this-is-a-triangle", ((OpenApiAny)requestSchema.Extensions["x-my-extension"]).Node.GetValue<string>());
+            Assert.Equal("this-is-a-triangle", ((JsonNodeExtension)requestSchema.Extensions["x-my-extension"]).Node.GetValue<string>());
         });
     }
 
@@ -571,11 +571,11 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
             schema.Extensions ??= [];
             if (context.JsonTypeInfo.Type == typeof(Triangle))
             {
-                schema.Extensions["x-my-extension"] = new OpenApiAny("this-is-a-triangle");
+                schema.Extensions["x-my-extension"] = new JsonNodeExtension("this-is-a-triangle");
             }
             if (context.JsonTypeInfo.Type == typeof(Square))
             {
-                schema.Extensions["x-my-extension"] = new OpenApiAny("this-is-a-square");
+                schema.Extensions["x-my-extension"] = new JsonNodeExtension("this-is-a-square");
             }
             return Task.CompletedTask;
         });
@@ -590,13 +590,13 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
             var triangleSubschema = Assert.Single(itemSchema.AnyOf.Where(s => ((OpenApiSchemaReference)s).Reference.Id == "ShapeTriangle"));
             // Assert that the x-my-extension type is set to this-is-a-triangle
             Assert.True(triangleSubschema.Extensions.TryGetValue("x-my-extension", out var triangleExtension));
-            Assert.Equal("this-is-a-triangle", ((OpenApiAny)triangleExtension).Node.GetValue<string>());
+            Assert.Equal("this-is-a-triangle", ((JsonNodeExtension)triangleExtension).Node.GetValue<string>());
 
             // Assert that the `Square` type within the polymorphic type list has been updated
             var squareSubschema = Assert.Single(itemSchema.AnyOf.Where(s => ((OpenApiSchemaReference)s).Reference.Id == "ShapeSquare"));
             // Assert that the x-my-extension type is set to this-is-a-square
             Assert.True(squareSubschema.Extensions.TryGetValue("x-my-extension", out var squareExtension));
-            Assert.Equal("this-is-a-square", ((OpenApiAny)squareExtension).Node.GetValue<string>());
+            Assert.Equal("this-is-a-square", ((JsonNodeExtension)squareExtension).Node.GetValue<string>());
         });
     }
 
@@ -613,11 +613,11 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
             schema.Extensions ??= [];
             if (context.JsonTypeInfo.Type == typeof(Triangle))
             {
-                schema.Extensions["x-my-extension"] = new OpenApiAny("this-is-a-triangle");
+                schema.Extensions["x-my-extension"] = new JsonNodeExtension("this-is-a-triangle");
             }
             if (context.JsonTypeInfo.Type == typeof(Square))
             {
-                schema.Extensions["x-my-extension"] = new OpenApiAny("this-is-a-square");
+                schema.Extensions["x-my-extension"] = new JsonNodeExtension("this-is-a-square");
             }
             return Task.CompletedTask;
         });
@@ -632,13 +632,13 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
             var triangleSubschema = Assert.Single(someShapeSchema.AnyOf.Where(s => ((OpenApiSchemaReference)s).Reference.Id == "ShapeTriangle"));
             // Assert that the x-my-extension type is set to this-is-a-triangle
             Assert.True(triangleSubschema.Extensions.TryGetValue("x-my-extension", out var triangleExtension));
-            Assert.Equal("this-is-a-triangle", ((OpenApiAny)triangleExtension).Node.GetValue<string>());
+            Assert.Equal("this-is-a-triangle", ((JsonNodeExtension)triangleExtension).Node.GetValue<string>());
 
             // Assert that the `Square` type within the polymorphic type list has been updated
             var squareSubschema = Assert.Single(someShapeSchema.AnyOf.Where(s => ((OpenApiSchemaReference)s).Reference.Id == "ShapeSquare"));
             // Assert that the x-my-extension type is set to this-is-a-square
             Assert.True(squareSubschema.Extensions.TryGetValue("x-my-extension", out var squareExtension));
-            Assert.Equal("this-is-a-square", ((OpenApiAny)squareExtension).Node.GetValue<string>());
+            Assert.Equal("this-is-a-square", ((JsonNodeExtension)squareExtension).Node.GetValue<string>());
         });
     }
 
@@ -655,11 +655,11 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
             schema.Extensions ??= [];
             if (context.JsonTypeInfo.Type == typeof(Triangle))
             {
-                schema.Extensions["x-my-extension"] = new OpenApiAny("this-is-a-triangle");
+                schema.Extensions["x-my-extension"] = new JsonNodeExtension("this-is-a-triangle");
             }
             if (context.JsonTypeInfo.Type == typeof(Square))
             {
-                schema.Extensions["x-my-extension"] = new OpenApiAny("this-is-a-square");
+                schema.Extensions["x-my-extension"] = new JsonNodeExtension("this-is-a-square");
             }
             return Task.CompletedTask;
         });
@@ -674,13 +674,13 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
             var triangleSubschema = Assert.Single(someShapeSchema.AnyOf.Where(s => ((OpenApiSchemaReference)s).Reference.Id == "ShapeTriangle"));
             // Assert that the x-my-extension type is set to this-is-a-triangle
             Assert.True(triangleSubschema.Extensions.TryGetValue("x-my-extension", out var triangleExtension));
-            Assert.Equal("this-is-a-triangle", ((OpenApiAny)triangleExtension).Node.GetValue<string>());
+            Assert.Equal("this-is-a-triangle", ((JsonNodeExtension)triangleExtension).Node.GetValue<string>());
 
             // Assert that the `Square` type within the polymorphic type list has been updated
             var squareSubschema = Assert.Single(someShapeSchema.AnyOf.Where(s => ((OpenApiSchemaReference)s).Reference.Id == "ShapeSquare"));
             // Assert that the x-my-extension type is set to this-is-a-square
             Assert.True(squareSubschema.Extensions.TryGetValue("x-my-extension", out var squareExtension));
-            Assert.Equal("this-is-a-square", ((OpenApiAny)squareExtension).Node.GetValue<string>());
+            Assert.Equal("this-is-a-square", ((JsonNodeExtension)squareExtension).Node.GetValue<string>());
         });
     }
 
@@ -742,7 +742,7 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
         UseNotSchemaTransformer(options, (schema, context, cancellationToken) =>
         {
             schema.Extensions ??= [];
-            schema.Extensions["modified-by-not-schema-transformer"] = new OpenApiAny(true);
+            schema.Extensions["modified-by-not-schema-transformer"] = new JsonNodeExtension(true);
             return Task.CompletedTask;
         });
 
@@ -752,13 +752,13 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
             var path = document.Paths["/todo"];
             var getOperation = path.Operations[HttpMethod.Get];
             var responseSchema = getOperation.Responses["200"].Content["application/json"].Schema;
-            Assert.True(((OpenApiAny)responseSchema.Not.Extensions["modified-by-not-schema-transformer"]).Node.GetValue<bool>());
+            Assert.True(((JsonNodeExtension)responseSchema.Not.Extensions["modified-by-not-schema-transformer"]).Node.GetValue<bool>());
 
             var shapePath = document.Paths["/shape"];
             var shapeOperation = shapePath.Operations[HttpMethod.Post];
             var shapeRequestSchema = shapeOperation.RequestBody.Content["application/json"].Schema;
             var triangleSchema = Assert.Single(shapeRequestSchema.AnyOf.Where(s => ((OpenApiSchemaReference)s).Reference.Id == "ShapeTriangle"));
-            Assert.True(((OpenApiAny)triangleSchema.Not.Extensions["modified-by-not-schema-transformer"]).Node.GetValue<bool>());
+            Assert.True(((JsonNodeExtension)triangleSchema.Not.Extensions["modified-by-not-schema-transformer"]).Node.GetValue<bool>());
         });
 
         static void UseNotSchemaTransformer(OpenApiOptions options, Func<OpenApiSchema, OpenApiSchemaTransformerContext, CancellationToken, Task> func)
@@ -958,7 +958,7 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
             if (context.JsonTypeInfo.Type == typeof(Todo))
             {
                 schema.Extensions ??= [];
-                schema.Extensions["x-my-extension"] = new OpenApiAny("1");
+                schema.Extensions["x-my-extension"] = new JsonNodeExtension("1");
             }
             return Task.CompletedTask;
         }
@@ -1007,7 +1007,7 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
         {
             dependency.TestMethod();
             schema.Extensions ??= [];
-            schema.Extensions["x-my-extension"] = new OpenApiAny(Dependency.InstantiationCount.ToString(CultureInfo.InvariantCulture));
+            schema.Extensions["x-my-extension"] = new JsonNodeExtension(Dependency.InstantiationCount.ToString(CultureInfo.InvariantCulture));
             return Task.CompletedTask;
         }
     }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/TypeBasedTransformerLifetimeTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/TypeBasedTransformerLifetimeTests.cs
@@ -4,7 +4,7 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 
 public class TypeBasedTransformerLifetimeTests : OpenApiDocumentServiceTestBase
@@ -349,7 +349,7 @@ public class TypeBasedTransformerLifetimeTests : OpenApiDocumentServiceTestBase
             if (context.JsonTypeInfo.Type == typeof(Todo))
             {
                 schema.Extensions ??= [];
-                schema.Extensions["x-my-extension"] = new OpenApiAny("1");
+                schema.Extensions["x-my-extension"] = new JsonNodeExtension("1");
             }
             return Task.CompletedTask;
         }


### PR DESCRIPTION
This pull request updates the `Microsoft.OpenApi` and related libraries to version `2.0.0-preview.18` and replaces the usage of `OpenApiAny` with `JsonNodeExtension` across the codebase. It also removes unused `using Microsoft.OpenApi.Any` statements in several files. These changes improve compatibility with the updated library version and streamline the code.

### Dependency Updates:
* Updated `MicrosoftOpenApiVersion` and `MicrosoftOpenApiYamlReaderVersion` to `2.0.0-preview.18` in `eng/Versions.props`.

### Code Refactoring:
* Replaced `OpenApiAny` with `JsonNodeExtension` for schema extensions in multiple files, such as `TransformersBenchmark.cs`, `CustomSchemaTransformerTests.cs`, and `SchemaTransformerTests.cs`. This improves alignment with the updated library. [[1]](diffhunk://#diff-9fc86114a6c135b21594047b7df9782e874098915df63e3f61ef2f483a91b79cL108-R112) [[2]](diffhunk://#diff-9aaa2719ca39ad87fd66bf5f06ea08fc77908bfeeeed4604df3375007fa91a99L162-R162) [[3]](diffhunk://#diff-985b6ca92638375c7469fbaee5496e58fd9ac4ecb8dccf7160e35e25ce676ebbL159-R175)

### Cleanup:
* Removed unused `using Microsoft.OpenApi.Any` statements and replaced them with `using Microsoft.OpenApi.Extensions` where necessary in both source and test files. [[1]](diffhunk://#diff-ccf1c2147f9ea676bdeaf8a0b062fc74276a1a893e4d0a6ef1fb56c96238162fL64) [[2]](diffhunk://#diff-9aaa2719ca39ad87fd66bf5f06ea08fc77908bfeeeed4604df3375007fa91a99L12-R12) [[3]](diffhunk://#diff-985b6ca92638375c7469fbaee5496e58fd9ac4ecb8dccf7160e35e25ce676ebbL11-R11)

### Test Updates:
* Updated test assertions to use `JsonNodeExtension` instead of `OpenApiAny` to validate schema extensions in test files, such as `SchemaTransformerTests.cs` and `OpenApiSchemaReferenceTransformerTests.cs`. [[1]](diffhunk://#diff-985b6ca92638375c7469fbaee5496e58fd9ac4ecb8dccf7160e35e25ce676ebbL203-R206) [[2]](diffhunk://#diff-71159ec9ef30b35ef7f860c58a6dfe0fc0e35ad349da86efb8847f58b9dab2f4L304-R304)

These changes ensure compatibility with the latest library version and remove deprecated or unused code.