### PR TITLE
Add WebAssemblyHotReloadCapabilities to Microsoft.AspNetCore.Components.WebAssembly.props

### DIFF
--- a/src/Components/WebAssembly/WebAssembly/src/targets/Microsoft.AspNetCore.Components.WebAssembly.props
+++ b/src/Components/WebAssembly/WebAssembly/src/targets/Microsoft.AspNetCore.Components.WebAssembly.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <BlazorWebAssemblyJSPath>$(MSBuildThisFileDirectory)blazor.webassembly.js</BlazorWebAssemblyJSPath>
     <BlazorRoutingEnableRegexConstraint Condition="'$(BlazorRoutingEnableRegexConstraint)' == ''">false</BlazorRoutingEnableRegexConstraint>
+    <WebAssemblyHotReloadCapabilities>Baseline;AddMethodToExistingType;AddStaticFieldToExistingType;NewTypeDefinition;ChangeCustomAttributes;AddInstanceFieldToExistingType;GenericAddMethodToExistingType;GenericUpdateMethod;UpdateParameters;GenericAddFieldToExistingType</WebAssemblyHotReloadCapabilities>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
dotnet-watch expects capabilities to be specified by the project for projects targeting net10+