### PR TITLE
Fix sanitization of type names in validations generator

### DIFF
--- a/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.ValidationsGenerator/Emitters/ValidationsGenerator.Emitter.cs
+++ b/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.ValidationsGenerator/Emitters/ValidationsGenerator.Emitter.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.Text;
 using System.Text;
 using Microsoft.CodeAnalysis.CSharp;
 using System.IO;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.AspNetCore.Http.ValidationsGenerator;
 
@@ -14,6 +15,7 @@ public sealed partial class ValidationsGenerator : IIncrementalGenerator
 {
     public static string GeneratedCodeConstructor => $@"global::System.CodeDom.Compiler.GeneratedCodeAttribute(""{typeof(ValidationsGenerator).Assembly.FullName}"", ""{typeof(ValidationsGenerator).Assembly.GetName().Version}"")";
     public static string GeneratedCodeAttribute => $"[{GeneratedCodeConstructor}]";
+    private static readonly Regex InvalidNameCharsRegex = new("[^0-9A-Za-z_]", RegexOptions.Compiled);
 
     internal static void Emit(SourceProductionContext context, (InterceptableLocation? AddValidation, ImmutableArray<ValidatableType> ValidatableTypes) emitInputs)
     {
@@ -238,12 +240,7 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
 
     private static string SanitizeTypeName(string typeName)
     {
-        // Replace invalid characters with underscores and remove generic notation
-        return typeName
-            .Replace(".", "_")
-            .Replace("<", "_")
-            .Replace(">", "_")
-            .Replace(",", "_")
-            .Replace(" ", "_");
+        // Replace invalid characters with underscores
+        return InvalidNameCharsRegex.Replace(typeName, "_");
     }
 }

--- a/src/Http/Http.Extensions/test/ValidationsGenerator/ValidationsGenerator.Parameters.cs
+++ b/src/Http/Http.Extensions/test/ValidationsGenerator/ValidationsGenerator.Parameters.cs
@@ -28,7 +28,7 @@ builder.Services.AddKeyedSingleton<TestService>("serviceKey");
 
 var app = builder.Build();
 
-app.MapGet("/params", (
+app.MapPost("/params", (
     // Skipped from validation because it is resolved as a service by IServiceProviderIsService
     TestService testService,
     // Skipped from validation because it is marked as a [FromKeyedService] parameter
@@ -39,7 +39,8 @@ app.MapGet("/params", (
     [CustomValidation(ErrorMessage = "Value must be an even number")] int value4 = 4,
     [CustomValidation, Range(10, 100)] int value5 = 10,
     // Skipped from validation because it is marked as a [FromService] parameter
-    [FromServices] [Range(10, 100)] int? value6 = 4) => "OK");
+    [FromServices] [Range(10, 100)] int? value6 = 4,
+    Dictionary<string, TestService>? testDict = null) => "OK");
 
 app.Run();
 

--- a/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidateParameters#ValidatableInfoResolver.g.verified.cs
+++ b/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidateParameters#ValidatableInfoResolver.g.verified.cs
@@ -67,6 +67,11 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
                 validatableInfo = CreateTestService();
                 return true;
             }
+            if (type == typeof(global::System.Collections.Generic.Dictionary<string, global::TestService>))
+            {
+                validatableInfo = CreateDictionary_2();
+                return true;
+            }
 
             return false;
         }
@@ -88,6 +93,38 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
                         propertyType: typeof(int),
                         name: "Value",
                         displayName: "Value"
+                    ),
+                ]
+            );
+        }
+        private ValidatableTypeInfo CreateDictionary_2()
+        {
+            return new GeneratedValidatableTypeInfo(
+                type: typeof(global::System.Collections.Generic.Dictionary<string, global::TestService>),
+                members: [
+                    new GeneratedValidatablePropertyInfo(
+                        containingType: typeof(global::System.Collections.Generic.Dictionary<string, global::TestService>),
+                        propertyType: typeof(global::System.Collections.Generic.ICollection<global::TestService>),
+                        name: "System.Collections.Generic.IDictionary<TKey,TValue>.Values",
+                        displayName: "System.Collections.Generic.IDictionary<TKey,TValue>.Values"
+                    ),
+                    new GeneratedValidatablePropertyInfo(
+                        containingType: typeof(global::System.Collections.Generic.Dictionary<string, global::TestService>),
+                        propertyType: typeof(global::System.Collections.Generic.IEnumerable<global::TestService>),
+                        name: "System.Collections.Generic.IReadOnlyDictionary<TKey,TValue>.Values",
+                        displayName: "System.Collections.Generic.IReadOnlyDictionary<TKey,TValue>.Values"
+                    ),
+                    new GeneratedValidatablePropertyInfo(
+                        containingType: typeof(global::System.Collections.Generic.Dictionary<string, global::TestService>),
+                        propertyType: typeof(global::TestService),
+                        name: "this[]",
+                        displayName: "this[]"
+                    ),
+                    new GeneratedValidatablePropertyInfo(
+                        containingType: typeof(global::System.Collections.Generic.Dictionary<string, global::TestService>),
+                        propertyType: typeof(global::System.Collections.ICollection),
+                        name: "System.Collections.IDictionary.Values",
+                        displayName: "System.Collections.IDictionary.Values"
                     ),
                 ]
             );


### PR DESCRIPTION
This pull request introduces several updates to the `ValidationsGenerator` in the `Microsoft.AspNetCore.Http` project, focusing on improving type name sanitization.

* Replaced the custom logic for sanitizing type names in `SanitizeTypeName` with a compiled `Regex` (`InvalidNameCharsRegex`) for improved clarity and maintainability. (`src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.ValidationsGenerator/Emitters/ValidationsGenerator.Emitter.cs`, [[1]](diffhunk://#diff-28419fb8200eab6ea23e621dbbc1a777683b653a4fc41bec1df521365f0540f0R10-R18) [[2]](diffhunk://#diff-28419fb8200eab6ea23e621dbbc1a777683b653a4fc41bec1df521365f0540f0L241-R244)

Fixes https://github.com/dotnet/aspnetcore/issues/61388.

Note: I realize that as a follow-up to this change we need to make updates to the implementation to support validating dictionary values. Since that's a bit more involved I'll pull it out into a separate PR.