### PR TITLE
[Blazor] Remove HotReload agent packages from dependencies of Components.WebAssembly

### DIFF
--- a/src/Components/WebAssembly/WebAssembly/src/Microsoft.AspNetCore.Components.WebAssembly.csproj
+++ b/src/Components/WebAssembly/WebAssembly/src/Microsoft.AspNetCore.Components.WebAssembly.csproj
@@ -21,8 +21,8 @@
     <Reference Include="Microsoft.Extensions.Configuration.Binder" />
     <Reference Include="Microsoft.Extensions.Logging" />
     <Reference Include="Microsoft.JSInterop.WebAssembly" />
-    <Reference Include="Microsoft.DotNet.HotReload.Agent" />
-    <Reference Include="Microsoft.DotNet.HotReload.Agent.Data" />
+    <Reference Include="Microsoft.DotNet.HotReload.Agent" PrivateAssets="all" />
+    <Reference Include="Microsoft.DotNet.HotReload.Agent.Data" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Regression from https://github.com/dotnet/aspnetcore/pull/61821.

Before this PR
![image](https://github.com/user-attachments/assets/a785981d-c97b-40c2-b3e8-98ac22c4974b)

After this PR
![image](https://github.com/user-attachments/assets/373b7f35-162d-43a2-a7a7-cfdf2f6ffae1)
