### PR TITLE
Create copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+- To build and run tests in the repo, use the `build.sh` script that is located in each subdirectory within the `src` folder.
+- Always generate code that conforms with the guidelines provided in the .editorconfig file in the root of this repo.
+- Always generate XML docs for public APIs that are introduced in each change.


### PR DESCRIPTION
This is meant to help us get better quality out of the Copilot agent, specifically by telling it how it should build and test changes in the repo.