### PR TITLE
Improve renderer unit test

### DIFF
--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
@@ -183,7 +183,7 @@ internal partial class EndpointHtmlRenderer : StaticHtmlRenderer, IComponentPrer
         base.AddPendingTask(componentState, task);
     }
 
-    private void SignalRendererToFinishRendering()
+    internal void SignalRendererToFinishRendering()
     {
         // sets a deferred stop on the renderer, which will have an effect after the current batch is completed
         _rendererIsStopped = true;

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
@@ -183,6 +183,7 @@ internal partial class EndpointHtmlRenderer : StaticHtmlRenderer, IComponentPrer
         base.AddPendingTask(componentState, task);
     }
 
+    // For testing purposes only
     internal void SignalRendererToFinishRendering()
     {
         // sets a deferred stop on the renderer, which will have an effect after the current batch is completed

--- a/src/Components/Endpoints/test/EndpointHtmlRendererTest.cs
+++ b/src/Components/Endpoints/test/EndpointHtmlRendererTest.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Components.Forms.Mapping;
 using Microsoft.AspNetCore.Components.Infrastructure;
 using Microsoft.AspNetCore.Components.Reflection;
 using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.RenderTree;
 using Microsoft.AspNetCore.Components.Test.Helpers;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.DataProtection;
@@ -47,18 +48,21 @@ public class EndpointHtmlRendererTest
     }
 
     [Fact]
-    public async Task DoesNotRenderChildAfterRendererStopped()
+    public async Task DoesNotRenderAfterRendererStopped()
     {
-        renderer.SignalRendererToFinishRendering();
-
         var httpContext = GetHttpContext();
         var writer = new StringWriter();
 
-        var result = await renderer.PrerenderComponentAsync(httpContext, typeof(SimpleComponent), null, ParameterView.Empty);
-        await renderer.Dispatcher.InvokeAsync(() => result.WriteTo(writer, HtmlEncoder.Default));
-        var content = writer.ToString();
+        var component = new StoppingRendererComponent();
+        var id = renderer.AssignRootComponentId(component);
+        await renderer.Dispatcher.InvokeAsync(() => renderer.RenderRootComponentAsync(id, ParameterView.Empty));
+        int initialRenderCount = renderer.RenderCount;
 
-        Assert.DoesNotContain("Hello from SimpleComponent", content);
+        renderer.SignalRendererToFinishRendering();
+
+        component.TaskCompletionSource.SetResult(false);
+        await renderer.Dispatcher.InvokeAsync(() => renderer.RenderRootComponentAsync(id, ParameterView.Empty));
+        Assert.Equal(initialRenderCount, renderer.RenderCount);
     }
 
     [Fact]
@@ -1772,18 +1776,19 @@ public class EndpointHtmlRendererTest
     private class TestEndpointHtmlRenderer : EndpointHtmlRenderer
     {
         private bool _rendererIsStopped = false;
+        private int _lastComponentId;
+        private int _renderCount;
+        private RenderBatch _lastBatch;
+
         public TestEndpointHtmlRenderer(IServiceProvider serviceProvider, ILoggerFactory loggerFactory) : base(serviceProvider, loggerFactory)
         {
         }
 
         internal int TestAssignRootComponentId(IComponent component)
         {
-            return base.AssignRootComponentId(component);
-        }
-        public void SignalRendererToFinishRendering()
-        {
-            // sets a deferred stop on the renderer, which will have an effect after the current batch is completed
-            _rendererIsStopped = true;
+            var id = base.AssignRootComponentId(component);
+            _lastComponentId = id;
+            return id;
         }
 
         protected override void ProcessPendingRender()
@@ -1793,6 +1798,19 @@ public class EndpointHtmlRendererTest
                 return;
             }
             base.ProcessPendingRender();
+
+            _renderCount++;
+            _lastBatch = GetCurrentRenderBatch();
+        }
+
+        public int RenderCount => _renderCount;
+
+        public RenderBatch GetCurrentRenderBatch() => _lastBatch;
+
+        public new void SignalRendererToFinishRendering()
+        {
+            _rendererIsStopped = true;
+            base.SignalRendererToFinishRendering();
         }
     }
 

--- a/src/Components/Endpoints/test/TestComponents/StoppingRendererComponent.razor
+++ b/src/Components/Endpoints/test/TestComponents/StoppingRendererComponent.razor
@@ -1,0 +1,17 @@
+﻿<h1>Hello from StoppingRendererComponent</h1>
+<p>State is @_state</p>
+
+@code {
+    private bool _state = true;
+
+    // expose a TCS so the test can control when OnInitializedAsync completes
+    public TaskCompletionSource<bool> TaskCompletionSource = new TaskCompletionSource<bool>();
+
+    protected override async Task OnInitializedAsync()
+    {
+        // wait until the test signals
+        var result = await TaskCompletionSource.Task;
+        _state = result;
+        StateHasChanged();
+    }
+}

--- a/src/Components/Server/src/Circuits/RemoteNavigationManager.cs
+++ b/src/Components/Server/src/Circuits/RemoteNavigationManager.cs
@@ -19,7 +19,7 @@ internal sealed partial class RemoteNavigationManager : NavigationManager, IHost
     private bool? _navigationLockStateBeforeJsRuntimeAttached;
     private const string _enableThrowNavigationException = "Microsoft.AspNetCore.Components.Endpoints.NavigationManager.EnableThrowNavigationException";
 
-    [FeatureSwitchDefinition("Microsoft.AspNetCore.Components.Endpoints.NavigationManager.EnableThrowNavigationException")]
+    [FeatureSwitchDefinition(_enableThrowNavigationException)]
     private static bool _throwNavigationException =>
         AppContext.TryGetSwitch(_enableThrowNavigationException, out var switchValue) && switchValue;
     private Func<string, Task>? _onNavigateTo;


### PR DESCRIPTION
This PR applies feedback from https://github.com/dotnet/aspnetcore/pull/61633. We wanted to merge the original PR asap, without re-running the CI.

## Description

- `DoesNotRenderChildAfterRendererStopped` -> it was testing if illegal render was possible after we stopped the renderer, the feedback suggested a flow of: render 1st time -> stop renderer - render 2nd time and check if render batches number grew.
- `TestEndpointHtmlRenderer` had its own mechanism of stopping the renderer, not connected to base's class stopping. Making the `EndpointHtmlRenderer` stopping method internal, allows the test to call it. Because we want `TestEndpointHtmlRenderer` to keep track of the number of batches rendered, we keep the stopping method on `TestEndpointHtmlRenderer` as well.
- Attributes can use parameters passed by constants. `FeatureSwitchDefinition` should reuse once defined string.