### PR TITLE
Microsoft.Extensions.ApiDescription.Server: parameterize target frameworks for nuspec file.

### DIFF
--- a/src/Tools/Extensions.ApiDescription.Server/src/Microsoft.Extensions.ApiDescription.Server.csproj
+++ b/src/Tools/Extensions.ApiDescription.Server/src/Microsoft.Extensions.ApiDescription.Server.csproj
@@ -35,6 +35,8 @@
   <ItemGroup>
     <NuspecProperty Include="artifactsBinDir=$(ArtifactsBinDir)" />
     <NuspecProperty Include="configuration=$(Configuration)" />
+    <NuspecProperty Include="corefxTfm=$(DefaultNetCoreTargetFramework)" />
+    <NuspecProperty Include="netfxTfm=$(DefaultNetFxTargetFramework)" />
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />

--- a/src/Tools/Extensions.ApiDescription.Server/src/Microsoft.Extensions.ApiDescription.Server.nuspec
+++ b/src/Tools/Extensions.ApiDescription.Server/src/Microsoft.Extensions.ApiDescription.Server.nuspec
@@ -8,9 +8,9 @@
     $CommonFileElements$
     <file src="build\*" target="build" />
     <file src="buildMultiTargeting\*" target="buildMultiTargeting" />
-    <file src="$artifactsBinDir$\dotnet-getdocument\$configuration$\net10.0\publish\*.*" target="tools" />
-    <file src="$artifactsBinDir$\GetDocument.Insider\$configuration$\net462\*.*" target="tools\net462" />
-    <file src="$artifactsBinDir$\GetDocument.Insider\x86\$configuration$\net462\*.*" target="tools\net462-x86" />
-    <file src="$artifactsBinDir$\GetDocument.Insider\$configuration$\net10.0\publish\*.*" target="tools\net10.0" />
+    <file src="$artifactsBinDir$\dotnet-getdocument\$configuration$\$corefxTfm$\publish\*.*" target="tools" />
+    <file src="$artifactsBinDir$\GetDocument.Insider\$configuration$\$netfxTfm$\*.*" target="tools\$netfxTfm$" />
+    <file src="$artifactsBinDir$\GetDocument.Insider\x86\$configuration$\$netfxTfm$\*.*" target="tools\$netfxTfm$-x86" />
+    <file src="$artifactsBinDir$\GetDocument.Insider\$configuration$\$corefxTfm$\publish\*.*" target="tools\$corefxTfm$" />
   </files>
 </package>


### PR DESCRIPTION
Because we have some target framework specific issues when building this repo with Mono, we set `DefaultNetFxTargetFramework` to another .NET Framework tfm.

This makes the nuspec file use the correct tfm for those builds.