### PR TITLE
Add skip paths for components-e2e

### DIFF
--- a/.azure/pipelines/components-e2e-tests.yml
+++ b/.azure/pipelines/components-e2e-tests.yml
@@ -17,6 +17,15 @@ pr:
   branches:
     include:
     - '*'
+  paths:
+    exclude:
+    - .devcontainer/*
+    - .github/*
+    - .vscode/*
+    - docs/*
+    - '**/*.md'
+    - LICENSE.TXT
+    - THIRD-PARTY-NOTICES.TXT
 
 variables:
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE


### PR DESCRIPTION
Matches what's in `ci-public` and `quarantined-test`

This pull request updates the `.azure/pipelines/components-e2e-tests.yml` file to exclude specific paths from triggering the pipeline. 

Pipeline configuration updates:

* Added a `paths.exclude` section to prevent changes in the following paths from triggering the pipeline:
  - `.devcontainer/*`
  - `.github/*`
  - `.vscode/*`
  - `docs/*`
  - `**/*.md`
  - `LICENSE.TXT`
  - `THIRD-PARTY-NOTICES.TXT`