### PR TITLE
[release/10.0-preview5] NoWarn SIGN004

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -133,6 +133,9 @@
 
     <!-- // Temporary diagnostic code from https://github.com/dotnet/extensions/pull/4130 for metrics APIs used in test. -->
     <NoWarn>$(NoWarn);TBD</NoWarn>
+
+    <!-- In Preview5 only, NoWarn this signing error about mismatched 1st/3rd party .dll/signatures. SignTool mistakenly sees R2R images as 3rd-party -->
+    <NoWarn>$(NoWarn);SIGN004</NoWarn>
   </PropertyGroup>
 
   <!-- Source code settings -->


### PR DESCRIPTION
SignTool mistakenly sees R2R images as 3rd-party, because they don't have a copyright string. Therefore we get an error about signing 3rd party libraries w/ 1st party signatures. NoWarn this for now in p5 - we're working on a better fix in Arcade for the long term.