### PR TITLE
Allow same type names in different namespaces in validator generator

### DIFF
--- a/src/Http/Http.Extensions/test/ValidationsGenerator/ValidationsGenerator.MultipleNamespaces.cs
+++ b/src/Http/Http.Extensions/test/ValidationsGenerator/ValidationsGenerator.MultipleNamespaces.cs
@@ -1,0 +1,126 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Http.ValidationsGenerator.Tests;
+
+public partial class ValidationsGeneratorTests : ValidationsGeneratorTestBase
+{
+    [Fact]
+    public async Task CanValidateMultipleNamespaces()
+    {
+        // Arrange
+        var source = """
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Validation;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+var builder = WebApplication.CreateBuilder();
+
+builder.Services.AddValidation();
+
+var app = builder.Build();
+
+app.MapPost("/namespace-one", (NamespaceOne.Type obj) => Results.Ok("Passed"));
+app.MapPost("/namespace-two", (NamespaceTwo.Type obj) => Results.Ok("Passed"));
+
+app.Run();
+
+namespace NamespaceOne {
+    public class Type
+    {
+        [StringLength(10)]
+        public string StringWithLength { get; set; } = string.Empty;
+    }
+}
+
+namespace NamespaceTwo {
+    public class Type
+    {
+        [StringLength(20)]
+        public string StringWithLength { get; set; } = string.Empty;
+    }
+}
+""";
+        await Verify(source, out var compilation);
+        await VerifyEndpoint(compilation, "/namespace-one", async (endpoint, serviceProvider) =>
+        {
+            await InvalidStringWithLengthProducesError(endpoint);
+            await ValidInputProducesNoWarnings(endpoint);
+
+            async Task InvalidStringWithLengthProducesError(Endpoint endpoint)
+            {
+                var payload = """
+                {
+                    "StringWithLength": "abcdefghijk"
+                }
+                """;
+                var context = CreateHttpContextWithPayload(payload, serviceProvider);
+
+                await endpoint.RequestDelegate(context);
+
+                var problemDetails = await AssertBadRequest(context);
+                Assert.Collection(problemDetails.Errors, kvp =>
+                {
+                    Assert.Equal("StringWithLength", kvp.Key);
+                    Assert.Equal("The field StringWithLength must be a string with a maximum length of 10.", kvp.Value.Single());
+                });
+            }
+
+            async Task ValidInputProducesNoWarnings(Endpoint endpoint)
+            {
+                var payload = """
+                {
+                    "StringWithLength": "abc"
+                }
+                """;
+                var context = CreateHttpContextWithPayload(payload, serviceProvider);
+                await endpoint.RequestDelegate(context);
+
+                Assert.Equal(200, context.Response.StatusCode);
+            }
+        });
+        await VerifyEndpoint(compilation, "/namespace-two", async (endpoint, serviceProvider) =>
+        {
+            await InvalidStringWithLengthProducesError(endpoint);
+            await ValidInputProducesNoWarnings(endpoint);
+
+            async Task InvalidStringWithLengthProducesError(Endpoint endpoint)
+            {
+                var payload = """
+                {
+                    "StringWithLength": "abcdefghijklmnopqrstu"
+                }
+                """;
+                var context = CreateHttpContextWithPayload(payload, serviceProvider);
+
+                await endpoint.RequestDelegate(context);
+
+                var problemDetails = await AssertBadRequest(context);
+                Assert.Collection(problemDetails.Errors, kvp =>
+                {
+                    Assert.Equal("StringWithLength", kvp.Key);
+                    Assert.Equal("The field StringWithLength must be a string with a maximum length of 20.", kvp.Value.Single());
+                });
+            }
+
+            async Task ValidInputProducesNoWarnings(Endpoint endpoint)
+            {
+                var payload = """
+                {
+                    "StringWithLength": "abcdefghijk"
+                }
+                """;
+                var context = CreateHttpContextWithPayload(payload, serviceProvider);
+                await endpoint.RequestDelegate(context);
+
+                Assert.Equal(200, context.Response.StatusCode);
+            }
+        });
+    }
+}

--- a/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidateComplexTypes#ValidatableInfoResolver.g.verified.cs
+++ b/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidateComplexTypes#ValidatableInfoResolver.g.verified.cs
@@ -64,17 +64,101 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
             validatableInfo = null;
             if (type == typeof(global::SubType))
             {
-                validatableInfo = CreateSubType();
+                validatableInfo = new GeneratedValidatableTypeInfo(
+                    type: typeof(global::SubType),
+                    members: [
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::SubType),
+                            propertyType: typeof(string),
+                            name: "RequiredProperty",
+                            displayName: "RequiredProperty"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::SubType),
+                            propertyType: typeof(string),
+                            name: "StringWithLength",
+                            displayName: "StringWithLength"
+                        ),
+                    ]
+                );
                 return true;
             }
             if (type == typeof(global::SubTypeWithInheritance))
             {
-                validatableInfo = CreateSubTypeWithInheritance();
+                validatableInfo = new GeneratedValidatableTypeInfo(
+                    type: typeof(global::SubTypeWithInheritance),
+                    members: [
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::SubTypeWithInheritance),
+                            propertyType: typeof(string),
+                            name: "EmailString",
+                            displayName: "EmailString"
+                        ),
+                    ]
+                );
                 return true;
             }
             if (type == typeof(global::ComplexType))
             {
-                validatableInfo = CreateComplexType();
+                validatableInfo = new GeneratedValidatableTypeInfo(
+                    type: typeof(global::ComplexType),
+                    members: [
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexType),
+                            propertyType: typeof(int),
+                            name: "IntegerWithRange",
+                            displayName: "IntegerWithRange"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexType),
+                            propertyType: typeof(int),
+                            name: "IntegerWithRangeAndDisplayName",
+                            displayName: "Valid identifier"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexType),
+                            propertyType: typeof(global::SubType),
+                            name: "PropertyWithMemberAttributes",
+                            displayName: "PropertyWithMemberAttributes"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexType),
+                            propertyType: typeof(global::SubType),
+                            name: "PropertyWithoutMemberAttributes",
+                            displayName: "PropertyWithoutMemberAttributes"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexType),
+                            propertyType: typeof(global::SubTypeWithInheritance),
+                            name: "PropertyWithInheritance",
+                            displayName: "PropertyWithInheritance"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexType),
+                            propertyType: typeof(global::System.Collections.Generic.List<global::SubType>),
+                            name: "ListOfSubTypes",
+                            displayName: "ListOfSubTypes"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexType),
+                            propertyType: typeof(int),
+                            name: "IntegerWithDerivedValidationAttribute",
+                            displayName: "IntegerWithDerivedValidationAttribute"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexType),
+                            propertyType: typeof(int),
+                            name: "IntegerWithCustomValidation",
+                            displayName: "IntegerWithCustomValidation"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexType),
+                            propertyType: typeof(int),
+                            name: "PropertyWithMultipleAttributes",
+                            displayName: "PropertyWithMultipleAttributes"
+                        ),
+                    ]
+                );
                 return true;
             }
 
@@ -87,104 +171,6 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
             validatableInfo = null;
             return false;
         }
-
-        private ValidatableTypeInfo CreateSubType()
-        {
-            return new GeneratedValidatableTypeInfo(
-                type: typeof(global::SubType),
-                members: [
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::SubType),
-                        propertyType: typeof(string),
-                        name: "RequiredProperty",
-                        displayName: "RequiredProperty"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::SubType),
-                        propertyType: typeof(string),
-                        name: "StringWithLength",
-                        displayName: "StringWithLength"
-                    ),
-                ]
-            );
-        }
-        private ValidatableTypeInfo CreateSubTypeWithInheritance()
-        {
-            return new GeneratedValidatableTypeInfo(
-                type: typeof(global::SubTypeWithInheritance),
-                members: [
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::SubTypeWithInheritance),
-                        propertyType: typeof(string),
-                        name: "EmailString",
-                        displayName: "EmailString"
-                    ),
-                ]
-            );
-        }
-        private ValidatableTypeInfo CreateComplexType()
-        {
-            return new GeneratedValidatableTypeInfo(
-                type: typeof(global::ComplexType),
-                members: [
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ComplexType),
-                        propertyType: typeof(int),
-                        name: "IntegerWithRange",
-                        displayName: "IntegerWithRange"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ComplexType),
-                        propertyType: typeof(int),
-                        name: "IntegerWithRangeAndDisplayName",
-                        displayName: "Valid identifier"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ComplexType),
-                        propertyType: typeof(global::SubType),
-                        name: "PropertyWithMemberAttributes",
-                        displayName: "PropertyWithMemberAttributes"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ComplexType),
-                        propertyType: typeof(global::SubType),
-                        name: "PropertyWithoutMemberAttributes",
-                        displayName: "PropertyWithoutMemberAttributes"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ComplexType),
-                        propertyType: typeof(global::SubTypeWithInheritance),
-                        name: "PropertyWithInheritance",
-                        displayName: "PropertyWithInheritance"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ComplexType),
-                        propertyType: typeof(global::System.Collections.Generic.List<global::SubType>),
-                        name: "ListOfSubTypes",
-                        displayName: "ListOfSubTypes"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ComplexType),
-                        propertyType: typeof(int),
-                        name: "IntegerWithDerivedValidationAttribute",
-                        displayName: "IntegerWithDerivedValidationAttribute"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ComplexType),
-                        propertyType: typeof(int),
-                        name: "IntegerWithCustomValidation",
-                        displayName: "IntegerWithCustomValidation"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ComplexType),
-                        propertyType: typeof(int),
-                        name: "PropertyWithMultipleAttributes",
-                        displayName: "PropertyWithMultipleAttributes"
-                    ),
-                ]
-            );
-        }
-
     }
 
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.AspNetCore.Http.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]

--- a/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidateIValidatableObject#ValidatableInfoResolver.g.verified.cs
+++ b/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidateIValidatableObject#ValidatableInfoResolver.g.verified.cs
@@ -64,17 +64,52 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
             validatableInfo = null;
             if (type == typeof(global::SubType))
             {
-                validatableInfo = CreateSubType();
+                validatableInfo = new GeneratedValidatableTypeInfo(
+                    type: typeof(global::SubType),
+                    members: [
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::SubType),
+                            propertyType: typeof(string),
+                            name: "RequiredProperty",
+                            displayName: "RequiredProperty"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::SubType),
+                            propertyType: typeof(string),
+                            name: "StringWithLength",
+                            displayName: "StringWithLength"
+                        ),
+                    ]
+                );
                 return true;
             }
             if (type == typeof(global::ValidatableSubType))
             {
-                validatableInfo = CreateValidatableSubType();
+                validatableInfo = new GeneratedValidatableTypeInfo(
+                    type: typeof(global::ValidatableSubType),
+                    members: []
+                );
                 return true;
             }
             if (type == typeof(global::ComplexValidatableType))
             {
-                validatableInfo = CreateComplexValidatableType();
+                validatableInfo = new GeneratedValidatableTypeInfo(
+                    type: typeof(global::ComplexValidatableType),
+                    members: [
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexValidatableType),
+                            propertyType: typeof(string),
+                            name: "Value2",
+                            displayName: "Value2"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexValidatableType),
+                            propertyType: typeof(global::ValidatableSubType),
+                            name: "SubType",
+                            displayName: "SubType"
+                        ),
+                    ]
+                );
                 return true;
             }
 
@@ -87,55 +122,6 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
             validatableInfo = null;
             return false;
         }
-
-        private ValidatableTypeInfo CreateSubType()
-        {
-            return new GeneratedValidatableTypeInfo(
-                type: typeof(global::SubType),
-                members: [
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::SubType),
-                        propertyType: typeof(string),
-                        name: "RequiredProperty",
-                        displayName: "RequiredProperty"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::SubType),
-                        propertyType: typeof(string),
-                        name: "StringWithLength",
-                        displayName: "StringWithLength"
-                    ),
-                ]
-            );
-        }
-        private ValidatableTypeInfo CreateValidatableSubType()
-        {
-            return new GeneratedValidatableTypeInfo(
-                type: typeof(global::ValidatableSubType),
-                members: []
-            );
-        }
-        private ValidatableTypeInfo CreateComplexValidatableType()
-        {
-            return new GeneratedValidatableTypeInfo(
-                type: typeof(global::ComplexValidatableType),
-                members: [
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ComplexValidatableType),
-                        propertyType: typeof(string),
-                        name: "Value2",
-                        displayName: "Value2"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ComplexValidatableType),
-                        propertyType: typeof(global::ValidatableSubType),
-                        name: "SubType",
-                        displayName: "SubType"
-                    ),
-                ]
-            );
-        }
-
     }
 
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.AspNetCore.Http.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]

--- a/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidateMultipleNamespaces#ValidatableInfoResolver.g.verified.cs
+++ b/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidateMultipleNamespaces#ValidatableInfoResolver.g.verified.cs
@@ -62,19 +62,13 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
         public bool TryGetValidatableTypeInfo(global::System.Type type, [global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out global::Microsoft.AspNetCore.Http.Validation.IValidatableInfo? validatableInfo)
         {
             validatableInfo = null;
-            if (type == typeof(global::SubType))
+            if (type == typeof(global::NamespaceOne.Type))
             {
                 validatableInfo = new GeneratedValidatableTypeInfo(
-                    type: typeof(global::SubType),
+                    type: typeof(global::NamespaceOne.Type),
                     members: [
                         new GeneratedValidatablePropertyInfo(
-                            containingType: typeof(global::SubType),
-                            propertyType: typeof(string),
-                            name: "RequiredProperty",
-                            displayName: "RequiredProperty"
-                        ),
-                        new GeneratedValidatablePropertyInfo(
-                            containingType: typeof(global::SubType),
+                            containingType: typeof(global::NamespaceOne.Type),
                             propertyType: typeof(string),
                             name: "StringWithLength",
                             displayName: "StringWithLength"
@@ -83,106 +77,16 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
                 );
                 return true;
             }
-            if (type == typeof(global::SubTypeWithInheritance))
+            if (type == typeof(global::NamespaceTwo.Type))
             {
                 validatableInfo = new GeneratedValidatableTypeInfo(
-                    type: typeof(global::SubTypeWithInheritance),
+                    type: typeof(global::NamespaceTwo.Type),
                     members: [
                         new GeneratedValidatablePropertyInfo(
-                            containingType: typeof(global::SubTypeWithInheritance),
-                            propertyType: typeof(string),
-                            name: "EmailString",
-                            displayName: "EmailString"
-                        ),
-                    ]
-                );
-                return true;
-            }
-            if (type == typeof(global::SubTypeWithoutConstructor))
-            {
-                validatableInfo = new GeneratedValidatableTypeInfo(
-                    type: typeof(global::SubTypeWithoutConstructor),
-                    members: [
-                        new GeneratedValidatablePropertyInfo(
-                            containingType: typeof(global::SubTypeWithoutConstructor),
-                            propertyType: typeof(string),
-                            name: "RequiredProperty",
-                            displayName: "RequiredProperty"
-                        ),
-                        new GeneratedValidatablePropertyInfo(
-                            containingType: typeof(global::SubTypeWithoutConstructor),
+                            containingType: typeof(global::NamespaceTwo.Type),
                             propertyType: typeof(string),
                             name: "StringWithLength",
                             displayName: "StringWithLength"
-                        ),
-                    ]
-                );
-                return true;
-            }
-            if (type == typeof(global::ValidatableRecord))
-            {
-                validatableInfo = new GeneratedValidatableTypeInfo(
-                    type: typeof(global::ValidatableRecord),
-                    members: [
-                        new GeneratedValidatablePropertyInfo(
-                            containingType: typeof(global::ValidatableRecord),
-                            propertyType: typeof(int),
-                            name: "IntegerWithRange",
-                            displayName: "IntegerWithRange"
-                        ),
-                        new GeneratedValidatablePropertyInfo(
-                            containingType: typeof(global::ValidatableRecord),
-                            propertyType: typeof(int),
-                            name: "IntegerWithRangeAndDisplayName",
-                            displayName: "Valid identifier"
-                        ),
-                        new GeneratedValidatablePropertyInfo(
-                            containingType: typeof(global::ValidatableRecord),
-                            propertyType: typeof(global::SubType),
-                            name: "PropertyWithMemberAttributes",
-                            displayName: "PropertyWithMemberAttributes"
-                        ),
-                        new GeneratedValidatablePropertyInfo(
-                            containingType: typeof(global::ValidatableRecord),
-                            propertyType: typeof(global::SubType),
-                            name: "PropertyWithoutMemberAttributes",
-                            displayName: "PropertyWithoutMemberAttributes"
-                        ),
-                        new GeneratedValidatablePropertyInfo(
-                            containingType: typeof(global::ValidatableRecord),
-                            propertyType: typeof(global::SubTypeWithInheritance),
-                            name: "PropertyWithInheritance",
-                            displayName: "PropertyWithInheritance"
-                        ),
-                        new GeneratedValidatablePropertyInfo(
-                            containingType: typeof(global::ValidatableRecord),
-                            propertyType: typeof(global::SubTypeWithoutConstructor),
-                            name: "PropertyOfSubtypeWithoutConstructor",
-                            displayName: "PropertyOfSubtypeWithoutConstructor"
-                        ),
-                        new GeneratedValidatablePropertyInfo(
-                            containingType: typeof(global::ValidatableRecord),
-                            propertyType: typeof(global::System.Collections.Generic.List<global::SubType>),
-                            name: "ListOfSubTypes",
-                            displayName: "ListOfSubTypes"
-                        ),
-                        new GeneratedValidatablePropertyInfo(
-                            containingType: typeof(global::ValidatableRecord),
-                            propertyType: typeof(int),
-                            name: "IntegerWithDerivedValidationAttribute",
-                            displayName: "IntegerWithDerivedValidationAttribute"
-                        ),
-                        new GeneratedValidatablePropertyInfo(
-                            containingType: typeof(global::ValidatableRecord),
-                            propertyType: typeof(int),
-                            name: "IntegerWithCustomValidation",
-                            displayName: "IntegerWithCustomValidation"
-                        ),
-                        new GeneratedValidatablePropertyInfo(
-                            containingType: typeof(global::ValidatableRecord),
-                            propertyType: typeof(int),
-                            name: "PropertyWithMultipleAttributes",
-                            displayName: "PropertyWithMultipleAttributes"
                         ),
                     ]
                 );

--- a/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidateParameters#ValidatableInfoResolver.g.verified.cs
+++ b/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidateParameters#ValidatableInfoResolver.g.verified.cs
@@ -64,12 +64,50 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
             validatableInfo = null;
             if (type == typeof(global::TestService))
             {
-                validatableInfo = CreateTestService();
+                validatableInfo = new GeneratedValidatableTypeInfo(
+                    type: typeof(global::TestService),
+                    members: [
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::TestService),
+                            propertyType: typeof(int),
+                            name: "Value",
+                            displayName: "Value"
+                        ),
+                    ]
+                );
                 return true;
             }
             if (type == typeof(global::System.Collections.Generic.Dictionary<string, global::TestService>))
             {
-                validatableInfo = CreateDictionary_2();
+                validatableInfo = new GeneratedValidatableTypeInfo(
+                    type: typeof(global::System.Collections.Generic.Dictionary<string, global::TestService>),
+                    members: [
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::System.Collections.Generic.Dictionary<string, global::TestService>),
+                            propertyType: typeof(global::System.Collections.Generic.ICollection<global::TestService>),
+                            name: "System.Collections.Generic.IDictionary<TKey,TValue>.Values",
+                            displayName: "System.Collections.Generic.IDictionary<TKey,TValue>.Values"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::System.Collections.Generic.Dictionary<string, global::TestService>),
+                            propertyType: typeof(global::System.Collections.Generic.IEnumerable<global::TestService>),
+                            name: "System.Collections.Generic.IReadOnlyDictionary<TKey,TValue>.Values",
+                            displayName: "System.Collections.Generic.IReadOnlyDictionary<TKey,TValue>.Values"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::System.Collections.Generic.Dictionary<string, global::TestService>),
+                            propertyType: typeof(global::TestService),
+                            name: "this[]",
+                            displayName: "this[]"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::System.Collections.Generic.Dictionary<string, global::TestService>),
+                            propertyType: typeof(global::System.Collections.ICollection),
+                            name: "System.Collections.IDictionary.Values",
+                            displayName: "System.Collections.IDictionary.Values"
+                        ),
+                    ]
+                );
                 return true;
             }
 
@@ -82,54 +120,6 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
             validatableInfo = null;
             return false;
         }
-
-        private ValidatableTypeInfo CreateTestService()
-        {
-            return new GeneratedValidatableTypeInfo(
-                type: typeof(global::TestService),
-                members: [
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::TestService),
-                        propertyType: typeof(int),
-                        name: "Value",
-                        displayName: "Value"
-                    ),
-                ]
-            );
-        }
-        private ValidatableTypeInfo CreateDictionary_2()
-        {
-            return new GeneratedValidatableTypeInfo(
-                type: typeof(global::System.Collections.Generic.Dictionary<string, global::TestService>),
-                members: [
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::System.Collections.Generic.Dictionary<string, global::TestService>),
-                        propertyType: typeof(global::System.Collections.Generic.ICollection<global::TestService>),
-                        name: "System.Collections.Generic.IDictionary<TKey,TValue>.Values",
-                        displayName: "System.Collections.Generic.IDictionary<TKey,TValue>.Values"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::System.Collections.Generic.Dictionary<string, global::TestService>),
-                        propertyType: typeof(global::System.Collections.Generic.IEnumerable<global::TestService>),
-                        name: "System.Collections.Generic.IReadOnlyDictionary<TKey,TValue>.Values",
-                        displayName: "System.Collections.Generic.IReadOnlyDictionary<TKey,TValue>.Values"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::System.Collections.Generic.Dictionary<string, global::TestService>),
-                        propertyType: typeof(global::TestService),
-                        name: "this[]",
-                        displayName: "this[]"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::System.Collections.Generic.Dictionary<string, global::TestService>),
-                        propertyType: typeof(global::System.Collections.ICollection),
-                        name: "System.Collections.IDictionary.Values",
-                        displayName: "System.Collections.IDictionary.Values"
-                    ),
-                ]
-            );
-        }
-
     }
 
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.AspNetCore.Http.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]

--- a/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidatePolymorphicTypes#ValidatableInfoResolver.g.verified.cs
+++ b/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidatePolymorphicTypes#ValidatableInfoResolver.g.verified.cs
@@ -64,27 +64,82 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
             validatableInfo = null;
             if (type == typeof(global::DerivedType))
             {
-                validatableInfo = CreateDerivedType();
+                validatableInfo = new GeneratedValidatableTypeInfo(
+                    type: typeof(global::DerivedType),
+                    members: [
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::DerivedType),
+                            propertyType: typeof(string),
+                            name: "Value3",
+                            displayName: "Value3"
+                        ),
+                    ]
+                );
                 return true;
             }
             if (type == typeof(global::BaseType))
             {
-                validatableInfo = CreateBaseType();
+                validatableInfo = new GeneratedValidatableTypeInfo(
+                    type: typeof(global::BaseType),
+                    members: [
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::BaseType),
+                            propertyType: typeof(int),
+                            name: "Value1",
+                            displayName: "Value 1"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::BaseType),
+                            propertyType: typeof(string),
+                            name: "Value2",
+                            displayName: "Value2"
+                        ),
+                    ]
+                );
                 return true;
             }
             if (type == typeof(global::DerivedValidatableType))
             {
-                validatableInfo = CreateDerivedValidatableType();
+                validatableInfo = new GeneratedValidatableTypeInfo(
+                    type: typeof(global::DerivedValidatableType),
+                    members: [
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::DerivedValidatableType),
+                            propertyType: typeof(string),
+                            name: "Value3",
+                            displayName: "Value3"
+                        ),
+                    ]
+                );
                 return true;
             }
             if (type == typeof(global::BaseValidatableType))
             {
-                validatableInfo = CreateBaseValidatableType();
+                validatableInfo = new GeneratedValidatableTypeInfo(
+                    type: typeof(global::BaseValidatableType),
+                    members: []
+                );
                 return true;
             }
             if (type == typeof(global::ContainerType))
             {
-                validatableInfo = CreateContainerType();
+                validatableInfo = new GeneratedValidatableTypeInfo(
+                    type: typeof(global::ContainerType),
+                    members: [
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ContainerType),
+                            propertyType: typeof(global::BaseType),
+                            name: "BaseType",
+                            displayName: "BaseType"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ContainerType),
+                            propertyType: typeof(global::BaseValidatableType),
+                            name: "BaseValidatableType",
+                            displayName: "BaseValidatableType"
+                        ),
+                    ]
+                );
                 return true;
             }
 
@@ -97,83 +152,6 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
             validatableInfo = null;
             return false;
         }
-
-        private ValidatableTypeInfo CreateDerivedType()
-        {
-            return new GeneratedValidatableTypeInfo(
-                type: typeof(global::DerivedType),
-                members: [
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::DerivedType),
-                        propertyType: typeof(string),
-                        name: "Value3",
-                        displayName: "Value3"
-                    ),
-                ]
-            );
-        }
-        private ValidatableTypeInfo CreateBaseType()
-        {
-            return new GeneratedValidatableTypeInfo(
-                type: typeof(global::BaseType),
-                members: [
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::BaseType),
-                        propertyType: typeof(int),
-                        name: "Value1",
-                        displayName: "Value 1"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::BaseType),
-                        propertyType: typeof(string),
-                        name: "Value2",
-                        displayName: "Value2"
-                    ),
-                ]
-            );
-        }
-        private ValidatableTypeInfo CreateDerivedValidatableType()
-        {
-            return new GeneratedValidatableTypeInfo(
-                type: typeof(global::DerivedValidatableType),
-                members: [
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::DerivedValidatableType),
-                        propertyType: typeof(string),
-                        name: "Value3",
-                        displayName: "Value3"
-                    ),
-                ]
-            );
-        }
-        private ValidatableTypeInfo CreateBaseValidatableType()
-        {
-            return new GeneratedValidatableTypeInfo(
-                type: typeof(global::BaseValidatableType),
-                members: []
-            );
-        }
-        private ValidatableTypeInfo CreateContainerType()
-        {
-            return new GeneratedValidatableTypeInfo(
-                type: typeof(global::ContainerType),
-                members: [
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ContainerType),
-                        propertyType: typeof(global::BaseType),
-                        name: "BaseType",
-                        displayName: "BaseType"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ContainerType),
-                        propertyType: typeof(global::BaseValidatableType),
-                        name: "BaseValidatableType",
-                        displayName: "BaseValidatableType"
-                    ),
-                ]
-            );
-        }
-
     }
 
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.AspNetCore.Http.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]

--- a/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidateRecursiveTypes#ValidatableInfoResolver.g.verified.cs
+++ b/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidateRecursiveTypes#ValidatableInfoResolver.g.verified.cs
@@ -64,7 +64,23 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
             validatableInfo = null;
             if (type == typeof(global::RecursiveType))
             {
-                validatableInfo = CreateRecursiveType();
+                validatableInfo = new GeneratedValidatableTypeInfo(
+                    type: typeof(global::RecursiveType),
+                    members: [
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::RecursiveType),
+                            propertyType: typeof(int),
+                            name: "Value",
+                            displayName: "Value"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::RecursiveType),
+                            propertyType: typeof(global::RecursiveType),
+                            name: "Next",
+                            displayName: "Next"
+                        ),
+                    ]
+                );
                 return true;
             }
 
@@ -77,28 +93,6 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
             validatableInfo = null;
             return false;
         }
-
-        private ValidatableTypeInfo CreateRecursiveType()
-        {
-            return new GeneratedValidatableTypeInfo(
-                type: typeof(global::RecursiveType),
-                members: [
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::RecursiveType),
-                        propertyType: typeof(int),
-                        name: "Value",
-                        displayName: "Value"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::RecursiveType),
-                        propertyType: typeof(global::RecursiveType),
-                        name: "Next",
-                        displayName: "Next"
-                    ),
-                ]
-            );
-        }
-
     }
 
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.AspNetCore.Http.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]

--- a/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidateTypeWithParsableProperties#ValidatableInfoResolver.g.verified.cs
+++ b/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidateTypeWithParsableProperties#ValidatableInfoResolver.g.verified.cs
@@ -64,7 +64,65 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
             validatableInfo = null;
             if (type == typeof(global::ComplexTypeWithParsableProperties))
             {
-                validatableInfo = CreateComplexTypeWithParsableProperties();
+                validatableInfo = new GeneratedValidatableTypeInfo(
+                    type: typeof(global::ComplexTypeWithParsableProperties),
+                    members: [
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexTypeWithParsableProperties),
+                            propertyType: typeof(global::System.Guid?),
+                            name: "GuidWithRegularExpression",
+                            displayName: "GuidWithRegularExpression"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexTypeWithParsableProperties),
+                            propertyType: typeof(global::System.TimeOnly?),
+                            name: "TimeOnlyWithRequiredValue",
+                            displayName: "TimeOnlyWithRequiredValue"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexTypeWithParsableProperties),
+                            propertyType: typeof(string),
+                            name: "Url",
+                            displayName: "Url"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexTypeWithParsableProperties),
+                            propertyType: typeof(global::System.DateOnly?),
+                            name: "DateOnlyWithRange",
+                            displayName: "DateOnlyWithRange"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexTypeWithParsableProperties),
+                            propertyType: typeof(global::System.DateTime?),
+                            name: "DateTimeWithRange",
+                            displayName: "DateTimeWithRange"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexTypeWithParsableProperties),
+                            propertyType: typeof(decimal?),
+                            name: "DecimalWithRange",
+                            displayName: "DecimalWithRange"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexTypeWithParsableProperties),
+                            propertyType: typeof(global::System.TimeSpan?),
+                            name: "TimeSpanWithHourRange",
+                            displayName: "TimeSpanWithHourRange"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexTypeWithParsableProperties),
+                            propertyType: typeof(bool),
+                            name: "BooleanWithRange",
+                            displayName: "BooleanWithRange"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexTypeWithParsableProperties),
+                            propertyType: typeof(global::System.Version),
+                            name: "VersionWithRegex",
+                            displayName: "VersionWithRegex"
+                        ),
+                    ]
+                );
                 return true;
             }
 
@@ -77,70 +135,6 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
             validatableInfo = null;
             return false;
         }
-
-        private ValidatableTypeInfo CreateComplexTypeWithParsableProperties()
-        {
-            return new GeneratedValidatableTypeInfo(
-                type: typeof(global::ComplexTypeWithParsableProperties),
-                members: [
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ComplexTypeWithParsableProperties),
-                        propertyType: typeof(global::System.Guid?),
-                        name: "GuidWithRegularExpression",
-                        displayName: "GuidWithRegularExpression"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ComplexTypeWithParsableProperties),
-                        propertyType: typeof(global::System.TimeOnly?),
-                        name: "TimeOnlyWithRequiredValue",
-                        displayName: "TimeOnlyWithRequiredValue"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ComplexTypeWithParsableProperties),
-                        propertyType: typeof(string),
-                        name: "Url",
-                        displayName: "Url"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ComplexTypeWithParsableProperties),
-                        propertyType: typeof(global::System.DateOnly?),
-                        name: "DateOnlyWithRange",
-                        displayName: "DateOnlyWithRange"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ComplexTypeWithParsableProperties),
-                        propertyType: typeof(global::System.DateTime?),
-                        name: "DateTimeWithRange",
-                        displayName: "DateTimeWithRange"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ComplexTypeWithParsableProperties),
-                        propertyType: typeof(decimal?),
-                        name: "DecimalWithRange",
-                        displayName: "DecimalWithRange"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ComplexTypeWithParsableProperties),
-                        propertyType: typeof(global::System.TimeSpan?),
-                        name: "TimeSpanWithHourRange",
-                        displayName: "TimeSpanWithHourRange"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ComplexTypeWithParsableProperties),
-                        propertyType: typeof(bool),
-                        name: "BooleanWithRange",
-                        displayName: "BooleanWithRange"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ComplexTypeWithParsableProperties),
-                        propertyType: typeof(global::System.Version),
-                        name: "VersionWithRegex",
-                        displayName: "VersionWithRegex"
-                    ),
-                ]
-            );
-        }
-
     }
 
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.AspNetCore.Http.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]

--- a/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidateTypesWithAttribute#ValidatableInfoResolver.g.verified.cs
+++ b/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.CanValidateTypesWithAttribute#ValidatableInfoResolver.g.verified.cs
@@ -64,17 +64,95 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
             validatableInfo = null;
             if (type == typeof(global::SubType))
             {
-                validatableInfo = CreateSubType();
+                validatableInfo = new GeneratedValidatableTypeInfo(
+                    type: typeof(global::SubType),
+                    members: [
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::SubType),
+                            propertyType: typeof(string),
+                            name: "RequiredProperty",
+                            displayName: "RequiredProperty"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::SubType),
+                            propertyType: typeof(string),
+                            name: "StringWithLength",
+                            displayName: "StringWithLength"
+                        ),
+                    ]
+                );
                 return true;
             }
             if (type == typeof(global::SubTypeWithInheritance))
             {
-                validatableInfo = CreateSubTypeWithInheritance();
+                validatableInfo = new GeneratedValidatableTypeInfo(
+                    type: typeof(global::SubTypeWithInheritance),
+                    members: [
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::SubTypeWithInheritance),
+                            propertyType: typeof(string),
+                            name: "EmailString",
+                            displayName: "EmailString"
+                        ),
+                    ]
+                );
                 return true;
             }
             if (type == typeof(global::ComplexType))
             {
-                validatableInfo = CreateComplexType();
+                validatableInfo = new GeneratedValidatableTypeInfo(
+                    type: typeof(global::ComplexType),
+                    members: [
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexType),
+                            propertyType: typeof(int),
+                            name: "IntegerWithRange",
+                            displayName: "IntegerWithRange"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexType),
+                            propertyType: typeof(int),
+                            name: "IntegerWithRangeAndDisplayName",
+                            displayName: "Valid identifier"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexType),
+                            propertyType: typeof(global::SubType),
+                            name: "PropertyWithMemberAttributes",
+                            displayName: "PropertyWithMemberAttributes"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexType),
+                            propertyType: typeof(global::SubType),
+                            name: "PropertyWithoutMemberAttributes",
+                            displayName: "PropertyWithoutMemberAttributes"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexType),
+                            propertyType: typeof(global::SubTypeWithInheritance),
+                            name: "PropertyWithInheritance",
+                            displayName: "PropertyWithInheritance"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexType),
+                            propertyType: typeof(global::System.Collections.Generic.List<global::SubType>),
+                            name: "ListOfSubTypes",
+                            displayName: "ListOfSubTypes"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexType),
+                            propertyType: typeof(int),
+                            name: "IntegerWithCustomValidationAttribute",
+                            displayName: "IntegerWithCustomValidationAttribute"
+                        ),
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexType),
+                            propertyType: typeof(int),
+                            name: "PropertyWithMultipleAttributes",
+                            displayName: "PropertyWithMultipleAttributes"
+                        ),
+                    ]
+                );
                 return true;
             }
 
@@ -87,98 +165,6 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
             validatableInfo = null;
             return false;
         }
-
-        private ValidatableTypeInfo CreateSubType()
-        {
-            return new GeneratedValidatableTypeInfo(
-                type: typeof(global::SubType),
-                members: [
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::SubType),
-                        propertyType: typeof(string),
-                        name: "RequiredProperty",
-                        displayName: "RequiredProperty"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::SubType),
-                        propertyType: typeof(string),
-                        name: "StringWithLength",
-                        displayName: "StringWithLength"
-                    ),
-                ]
-            );
-        }
-        private ValidatableTypeInfo CreateSubTypeWithInheritance()
-        {
-            return new GeneratedValidatableTypeInfo(
-                type: typeof(global::SubTypeWithInheritance),
-                members: [
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::SubTypeWithInheritance),
-                        propertyType: typeof(string),
-                        name: "EmailString",
-                        displayName: "EmailString"
-                    ),
-                ]
-            );
-        }
-        private ValidatableTypeInfo CreateComplexType()
-        {
-            return new GeneratedValidatableTypeInfo(
-                type: typeof(global::ComplexType),
-                members: [
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ComplexType),
-                        propertyType: typeof(int),
-                        name: "IntegerWithRange",
-                        displayName: "IntegerWithRange"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ComplexType),
-                        propertyType: typeof(int),
-                        name: "IntegerWithRangeAndDisplayName",
-                        displayName: "Valid identifier"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ComplexType),
-                        propertyType: typeof(global::SubType),
-                        name: "PropertyWithMemberAttributes",
-                        displayName: "PropertyWithMemberAttributes"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ComplexType),
-                        propertyType: typeof(global::SubType),
-                        name: "PropertyWithoutMemberAttributes",
-                        displayName: "PropertyWithoutMemberAttributes"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ComplexType),
-                        propertyType: typeof(global::SubTypeWithInheritance),
-                        name: "PropertyWithInheritance",
-                        displayName: "PropertyWithInheritance"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ComplexType),
-                        propertyType: typeof(global::System.Collections.Generic.List<global::SubType>),
-                        name: "ListOfSubTypes",
-                        displayName: "ListOfSubTypes"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ComplexType),
-                        propertyType: typeof(int),
-                        name: "IntegerWithCustomValidationAttribute",
-                        displayName: "IntegerWithCustomValidationAttribute"
-                    ),
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ComplexType),
-                        propertyType: typeof(int),
-                        name: "PropertyWithMultipleAttributes",
-                        displayName: "PropertyWithMultipleAttributes"
-                    ),
-                ]
-            );
-        }
-
     }
 
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.AspNetCore.Http.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]

--- a/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.DoesNotEmitForExemptTypes#ValidatableInfoResolver.g.verified.cs
+++ b/src/Http/Http.Extensions/test/ValidationsGenerator/snapshots/ValidationsGeneratorTests.DoesNotEmitForExemptTypes#ValidatableInfoResolver.g.verified.cs
@@ -64,7 +64,17 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
             validatableInfo = null;
             if (type == typeof(global::ComplexType))
             {
-                validatableInfo = CreateComplexType();
+                validatableInfo = new GeneratedValidatableTypeInfo(
+                    type: typeof(global::ComplexType),
+                    members: [
+                        new GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexType),
+                            propertyType: typeof(int),
+                            name: "IntegerWithRange",
+                            displayName: "IntegerWithRange"
+                        ),
+                    ]
+                );
                 return true;
             }
 
@@ -77,22 +87,6 @@ namespace Microsoft.AspNetCore.Http.Validation.Generated
             validatableInfo = null;
             return false;
         }
-
-        private ValidatableTypeInfo CreateComplexType()
-        {
-            return new GeneratedValidatableTypeInfo(
-                type: typeof(global::ComplexType),
-                members: [
-                    new GeneratedValidatablePropertyInfo(
-                        containingType: typeof(global::ComplexType),
-                        propertyType: typeof(int),
-                        name: "IntegerWithRange",
-                        displayName: "IntegerWithRange"
-                    ),
-                ]
-            );
-        }
-
     }
 
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.AspNetCore.Http.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]


### PR DESCRIPTION
# Allow same type names in different namespaces in validator generator

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

This PR inlines the validatable type information to prevent name collisions when e.g. a same name type is used in different namespaces.

## Description

- Remove the `CreateMethods` generation
- Replace `CreateMethods with adding the type information directly in `TryGetValidatableTypeInfo`. We could also generate unique names by including the namespace, but this won't work for system types (e.g. collections or dictionaries)
- Update snapshots
- Create a new unit test that uses two namespaces with the same type, but with a different validation


Fixes #61971