### PR TITLE
Fix OpenApiJsonSchema array parsing

### DIFF
--- a/src/OpenApi/src/Schemas/OpenApiJsonSchema.Helpers.cs
+++ b/src/OpenApi/src/Schemas/OpenApiJsonSchema.Helpers.cs
@@ -140,6 +140,7 @@ internal sealed partial class OpenApiJsonSchema
         {
             type = JsonSchemaType.Array;
             var array = new JsonArray();
+            // Read to process JsonTokenType.StartArray before advancing
             reader.Read();
             while (reader.TokenType != JsonTokenType.EndArray)
             {

--- a/src/OpenApi/src/Schemas/OpenApiJsonSchema.Helpers.cs
+++ b/src/OpenApi/src/Schemas/OpenApiJsonSchema.Helpers.cs
@@ -140,6 +140,7 @@ internal sealed partial class OpenApiJsonSchema
         {
             type = JsonSchemaType.Array;
             var array = new JsonArray();
+            reader.Read();
             while (reader.TokenType != JsonTokenType.EndArray)
             {
                 array.Add(ReadJsonNode(ref reader));


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/62023

We weren't reading before calling the recursive function which meant we'd never advance the `Utf8JsonReader` and always be in the state `reader.TokenType == JsonTokenType.StartArray`