### PR TITLE
Enhance validation error handling in ValidationEndpointFilterFactory using IProblemDetailsService

### DIFF
--- a/src/Http/Http.Extensions/test/ValidationFilterEndpointFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/ValidationFilterEndpointFactoryTests.cs
@@ -1,0 +1,121 @@
+#pragma warning disable ASP0029 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel.DataAnnotations;
+using System.Net.Mime;
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Http.Extensions.Tests;
+
+public class ValidationFilterEndpointFactoryTests
+{
+    [Fact]
+    public async Task GetHttpValidationProblemDetailsWhenProblemDetailsServiceNotRegistered()
+    {
+        var services = new ServiceCollection();
+        services.AddValidation();
+        var serviceProvider = services.BuildServiceProvider();
+
+        var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(serviceProvider));
+
+        // Act - Create one endpoint with validation
+        builder.MapGet("test-enabled", ([Range(5, 10)] int param) => "Validation enabled here.");
+
+        // Build the endpoints
+        var dataSource = Assert.Single(builder.DataSources);
+        var endpoints = dataSource.Endpoints;
+
+        // Get filter factories from endpoint
+        var endpoint = endpoints[0];
+
+        var context = new DefaultHttpContext
+        {
+            RequestServices = serviceProvider
+        };
+
+        context.Request.Method = "GET";
+        context.Request.QueryString = new QueryString("?param=15");
+        using var ms = new MemoryStream();
+        context.Response.Body = ms;
+
+        await endpoint.RequestDelegate(context);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, context.Response.StatusCode);
+        Assert.StartsWith(MediaTypeNames.Application.Json, context.Response.ContentType, StringComparison.OrdinalIgnoreCase);
+
+        ms.Seek(0, SeekOrigin.Begin);
+        var problemDetails = await JsonSerializer.DeserializeAsync<ProblemDetails>(ms, JsonSerializerOptions.Web);
+
+        Assert.Equal("One or more validation errors occurred.", problemDetails.Title);
+
+        // Check that ProblemDetails contains the errors object with 1 validation error
+        Assert.True(problemDetails.Extensions.TryGetValue("errors", out var errorsObj));
+        var errors = Assert.IsType<JsonElement>(errorsObj);
+        Assert.True(errors.EnumerateObject().Count() == 1);
+    }
+
+    [Fact]
+    public async Task UseProblemDetailsServiceWhenAddedInServiceCollection()
+    {
+        var services = new ServiceCollection();
+        services.AddValidation();
+        services.AddProblemDetails();
+        var serviceProvider = services.BuildServiceProvider();
+
+        var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(serviceProvider));
+
+        // Act - Create one endpoint with validation
+        builder.MapGet("test-enabled", ([Range(5, 10)] int param) => "Validation enabled here.");
+
+        // Build the endpoints
+        var dataSource = Assert.Single(builder.DataSources);
+        var endpoints = dataSource.Endpoints;
+
+        // Get filter factories from endpoint
+        var endpoint = endpoints[0];
+
+        var context = new DefaultHttpContext
+        {
+            RequestServices = serviceProvider
+        };
+
+        context.Request.Method = "GET";
+        context.Request.QueryString = new QueryString("?param=15");
+        using var ms = new MemoryStream();
+        context.Response.Body = ms;
+
+        await endpoint.RequestDelegate(context);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, context.Response.StatusCode);
+        Assert.StartsWith(MediaTypeNames.Application.ProblemJson, context.Response.ContentType, StringComparison.OrdinalIgnoreCase);
+
+        ms.Seek(0, SeekOrigin.Begin);
+        var problemDetails = await JsonSerializer.DeserializeAsync<ProblemDetails>(ms, JsonSerializerOptions.Web);
+
+        Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.5.1", problemDetails.Type);
+        Assert.Equal("One or more validation errors occurred.", problemDetails.Title);
+        Assert.Equal(StatusCodes.Status400BadRequest, problemDetails.Status);
+
+        // Check that ProblemDetails contains the errors object with 1 validation error
+        Assert.True(problemDetails.Extensions.TryGetValue("errors", out var errorsObj));
+        var errors = Assert.IsType<JsonElement>(errorsObj);
+        Assert.True(errors.EnumerateObject().Count() == 1);
+    }
+
+    private class DefaultEndpointRouteBuilder(IApplicationBuilder applicationBuilder) : IEndpointRouteBuilder
+    {
+        private IApplicationBuilder ApplicationBuilder { get; } = applicationBuilder ?? throw new ArgumentNullException(nameof(applicationBuilder));
+        public IApplicationBuilder CreateApplicationBuilder() => ApplicationBuilder.New();
+        public ICollection<EndpointDataSource> DataSources { get; } = [];
+        public IServiceProvider ServiceProvider => ApplicationBuilder.ApplicationServices;
+    }
+}

--- a/src/Http/Http.Extensions/test/ValidationFilterEndpointFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/ValidationFilterEndpointFactoryTests.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Http.Extensions.Tests;
 
-public class ValidationFilterEndpointFactoryTests
+public class ValidationEndpointFilterFactoryTests
 {
     [Fact]
     public async Task GetHttpValidationProblemDetailsWhenProblemDetailsServiceNotRegistered()

--- a/src/Http/Routing/src/ValidationEndpointFilterFactory.cs
+++ b/src/Http/Routing/src/ValidationEndpointFilterFactory.cs
@@ -103,13 +103,13 @@ internal static class ValidationEndpointFilterFactory
                     {
                         // We need to prevent further execution, because the actual
                         // ProblemDetails response has already been written by ProblemDetailsService.
-                        return await ValueTask.FromResult(EmptyHttpResult.Instance);
+                        return EmptyHttpResult.Instance;
                     }
                 }
 
                 // Fallback to the default implementation.
                 context.HttpContext.Response.ContentType = MediaTypeNames.Application.ProblemJson;
-                return await ValueTask.FromResult(problemDetails);
+                return problemDetails;
             }
 
             return await next(context);

--- a/src/Http/Routing/src/ValidationEndpointFilterFactory.cs
+++ b/src/Http/Routing/src/ValidationEndpointFilterFactory.cs
@@ -5,7 +5,9 @@
 
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Net.Mime;
 using System.Reflection;
+using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -87,8 +89,27 @@ internal static class ValidationEndpointFilterFactory
             if (validateContext is { ValidationErrors.Count: > 0 })
             {
                 context.HttpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
-                context.HttpContext.Response.ContentType = "application/problem+json";
-                return await ValueTask.FromResult(new HttpValidationProblemDetails(validateContext.ValidationErrors));
+
+                var problemDetails = new HttpValidationProblemDetails(validateContext.ValidationErrors);
+
+                var problemDetailsService = context.HttpContext.RequestServices.GetService<IProblemDetailsService>();
+                if (problemDetailsService is not null)
+                {
+                    if (await problemDetailsService.TryWriteAsync(new()
+                    {
+                        HttpContext = context.HttpContext,
+                        ProblemDetails = problemDetails
+                    }))
+                    {
+                        // We need to prevent further execution, because the actual
+                        // ProblemDetails response has already been written by ProblemDetailsService.
+                        return await ValueTask.FromResult(EmptyHttpResult.Instance);
+                    }
+                }
+
+                // Fallback to the default implementation.
+                context.HttpContext.Response.ContentType = MediaTypeNames.Application.ProblemJson;
+                return await ValueTask.FromResult(problemDetails);
             }
 
             return await next(context);


### PR DESCRIPTION
# Modify validation error handling to utilize IProblemDetailsService for response writing

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

This PR updates the `ValidationEndpointFilterFactory` to improve how HTTP validation errors are handled, specifically by integrating with the `IProblemDetailsService` for enhanced response customization. The changes include adjustments to the response logic and dependency usage.

## Description

* **Integration with `IProblemDetailsService`**: Added logic to check for and utilize `IProblemDetailsService` to write custom problem details responses if available. This allows for more flexible and centralized error handling.
* **Fallback to default implementation**: Ensured a fallback mechanism to return `HttpValidationProblemDetails` if `IProblemDetailsService` is not present.

Fixes #61219