### PR TITLE
[OpenAPI] Only enable XML source gen for C#

### DIFF
--- a/src/OpenApi/gen/XmlCommentGenerator.cs
+++ b/src/OpenApi/gen/XmlCommentGenerator.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.AspNetCore.OpenApi.SourceGenerators;
 
-[Generator]
+[Generator(LanguageNames.CSharp)]
 public sealed partial class XmlCommentGenerator : IIncrementalGenerator
 {
     public void Initialize(IncrementalGeneratorInitializationContext context)


### PR DESCRIPTION
# Only enable XML source generator for C#

Only enable the OpenAPI XML source generator for C#.

## Description

Only enable the OpenAPI XML source generator for C# as it is not tested for any other language.

See https://github.com/dotnet/aspnetcore/pull/61069#discussion_r2101309741.
