### PR TITLE
Fix UploadPathSegment for productVersion.txt

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -62,7 +62,7 @@
                       Encoding="ASCII" />
 
     <ItemGroup>
-      <Artifact Include="@(ProductVersionFile)" Kind="Blob" UploadPathSegment="Runtime" />
+      <Artifact Include="@(ProductVersionFile)" Kind="Blob" UploadPathSegment="Runtime/" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
It's supposed to end with slash.

This fixes https://github.com/dotnet/release/issues/1321
