### PR TITLE
Fix a grammatical error in the XML documentation for RequireAuthenticatedSignIn in AuthenticationOptions.cs

### DIFF
--- a/src/Http/Authentication.Abstractions/src/AuthenticationOptions.cs
+++ b/src/Http/Authentication.Abstractions/src/AuthenticationOptions.cs
@@ -91,7 +91,7 @@ public class AuthenticationOptions
     public string? DefaultForbidScheme { get; set; }
 
     /// <summary>
-    /// If true, SignIn should throw if attempted with a user is not authenticated.
+    /// If true, SignIn should throw if attempted with a user who is not authenticated.
     /// A user is considered authenticated if <see cref="ClaimsIdentity.IsAuthenticated"/> returns <see langword="true" /> for the <see cref="ClaimsPrincipal"/> associated with the HTTP request.
     /// </summary>
     public bool RequireAuthenticatedSignIn { get; set; } = true;


### PR DESCRIPTION
**Summary of the changes**
Fixes a grammatical error in the XML documentation for `RequireAuthenticatedSignIn`.

## Description

This change corrects a grammatical issue in a comment that previously read:

> "SignIn should throw if attempted with a user is not authenticated."

The updated version clarifies the sentence:

> "SignIn should throw if attempted with a user who is not authenticated."

No functional code changes were made—this is a documentation-only fix to improve clarity and correctness.

*No issue number is referenced, as this is a minor documentation correction.*
