### PR TITLE
Add AllowedUsernameCharacters to InvalidUserName error

### DIFF
--- a/src/Identity/Extensions.Core/src/IdentityErrorDescriber.cs
+++ b/src/Identity/Extensions.Core/src/IdentityErrorDescriber.cs
@@ -95,13 +95,14 @@ public class IdentityErrorDescriber
     /// Returns an <see cref="IdentityError"/> indicating the specified user <paramref name="userName"/> is invalid.
     /// </summary>
     /// <param name="userName">The user name that is invalid.</param>
+    /// <param name="allowedUsernameCharacters">The characters that are allowed in the username.</param>
     /// <returns>An <see cref="IdentityError"/> indicating the specified user <paramref name="userName"/> is invalid.</returns>
-    public virtual IdentityError InvalidUserName(string? userName)
+    public virtual IdentityError InvalidUserName(string? userName, string? allowedUsernameCharacters)
     {
         return new IdentityError
         {
             Code = nameof(InvalidUserName),
-            Description = Resources.FormatInvalidUserName(userName)
+            Description = Resources.FormatInvalidUserName(userName, allowedUsernameCharacters)
         };
     }
 

--- a/src/Identity/Extensions.Core/src/PublicAPI.Shipped.txt
+++ b/src/Identity/Extensions.Core/src/PublicAPI.Shipped.txt
@@ -387,7 +387,7 @@ virtual Microsoft.AspNetCore.Identity.IdentityErrorDescriber.DuplicateUserName(s
 virtual Microsoft.AspNetCore.Identity.IdentityErrorDescriber.InvalidEmail(string? email) -> Microsoft.AspNetCore.Identity.IdentityError!
 virtual Microsoft.AspNetCore.Identity.IdentityErrorDescriber.InvalidRoleName(string? role) -> Microsoft.AspNetCore.Identity.IdentityError!
 virtual Microsoft.AspNetCore.Identity.IdentityErrorDescriber.InvalidToken() -> Microsoft.AspNetCore.Identity.IdentityError!
-virtual Microsoft.AspNetCore.Identity.IdentityErrorDescriber.InvalidUserName(string? userName) -> Microsoft.AspNetCore.Identity.IdentityError!
+virtual Microsoft.AspNetCore.Identity.IdentityErrorDescriber.InvalidUserName(string? userName, string? allowedUsernameCharacters) -> Microsoft.AspNetCore.Identity.IdentityError!
 virtual Microsoft.AspNetCore.Identity.IdentityErrorDescriber.LoginAlreadyAssociated() -> Microsoft.AspNetCore.Identity.IdentityError!
 virtual Microsoft.AspNetCore.Identity.IdentityErrorDescriber.PasswordMismatch() -> Microsoft.AspNetCore.Identity.IdentityError!
 virtual Microsoft.AspNetCore.Identity.IdentityErrorDescriber.PasswordRequiresDigit() -> Microsoft.AspNetCore.Identity.IdentityError!

--- a/src/Identity/Extensions.Core/src/Resources.resx
+++ b/src/Identity/Extensions.Core/src/Resources.resx
@@ -1,17 +1,17 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -162,8 +162,8 @@
     <comment>Error when a token is not recognized</comment>
   </data>
   <data name="InvalidUserName" xml:space="preserve">
-    <value>Username '{0}' is invalid, can only contain letters or digits.</value>
-    <comment>User names can only contain letters or digits</comment>
+    <value>Username '{0}' is invalid, can only contain the following characters '{1}'.</value>
+    <comment>User names can only contain characters defined in 'AllowedUsernameCharacters'. By default these are 'a-Z0-9._@+-'</comment>
   </data>
   <data name="LoginAlreadyAssociated" xml:space="preserve">
     <value>A user with this login already exists.</value>

--- a/src/Identity/Extensions.Core/src/UserValidator.cs
+++ b/src/Identity/Extensions.Core/src/UserValidator.cs
@@ -56,13 +56,13 @@ public class UserValidator<TUser> : IUserValidator<TUser> where TUser : class
         if (string.IsNullOrWhiteSpace(userName))
         {
             errors ??= new List<IdentityError>();
-            errors.Add(Describer.InvalidUserName(userName));
+            errors.Add(Describer.InvalidUserName(userName, manager.Options.User.AllowedUserNameCharacters));
         }
         else if (!string.IsNullOrEmpty(manager.Options.User.AllowedUserNameCharacters) &&
             userName.Any(c => !manager.Options.User.AllowedUserNameCharacters.Contains(c)))
         {
             errors ??= new List<IdentityError>();
-            errors.Add(Describer.InvalidUserName(userName));
+            errors.Add(Describer.InvalidUserName(userName, manager.Options.User.AllowedUserNameCharacters));
         }
         else
         {

--- a/src/Identity/Specification.Tests/src/UserManagerSpecificationTests.cs
+++ b/src/Identity/Specification.Tests/src/UserManagerSpecificationTests.cs
@@ -248,7 +248,7 @@ public abstract class UserManagerSpecificationTestBase<TUser, TKey>
 
         var newUser = CreateTestUser(username, useNamePrefixAsUserName: true);
         IdentityResultAssert.IsSuccess(await manager.CreateAsync(newUser));
-        var error = _errorDescriber.InvalidUserName("");
+        var error = _errorDescriber.InvalidUserName("", manager.Options.User.AllowedUserNameCharacters);
         IdentityResultAssert.IsFailure(await manager.SetUserNameAsync(newUser, ""), error);
         IdentityResultAssert.VerifyLogMessage(manager.Logger, $"User validation failed: {error.Code}.");
 

--- a/src/Identity/test/Identity.Test/UserValidatorTest.cs
+++ b/src/Identity/test/Identity.Test/UserValidatorTest.cs
@@ -32,7 +32,7 @@ public class UserValidatorTest
         var result = await validator.ValidateAsync(manager, user);
 
         // Assert
-        IdentityResultAssert.IsFailure(result, new IdentityErrorDescriber().InvalidUserName(input));
+        IdentityResultAssert.IsFailure(result, new IdentityErrorDescriber().InvalidUserName(input, manager.Options.User.AllowedUserNameCharacters));
     }
 
     [Theory]


### PR DESCRIPTION
# Add AllowedUsernameCharacters to InvalidUserName error


- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

Added the AllowedUsernameCharacters string to the InvalidUserName error message. This constitutes a change to the public API so would be best to double check everything is ok before merging. Maybe an overload for this method would be better for backwards compatibility? Just let me know! :)

Fixes #39375 
