### PR TITLE
Fix OpenApiJsonSchema array parsing (#62051)

### DIFF
--- a/src/OpenApi/src/Schemas/OpenApiJsonSchema.Helpers.cs
+++ b/src/OpenApi/src/Schemas/OpenApiJsonSchema.Helpers.cs
@@ -136,6 +136,8 @@ internal sealed partial class OpenApiJsonSchema
         {
             type = "array";
             var array = new OpenApiArray();
+            // Read to process JsonTokenType.StartArray before advancing
+            reader.Read();
             while (reader.TokenType != JsonTokenType.EndArray)
             {
                 array.Add(ReadOpenApiAny(ref reader));

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.ParameterSchemas.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.ParameterSchemas.cs
@@ -742,10 +742,10 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
         // Assert
         await VerifyOpenApiDocument(builder, document =>
         {
-            var operation = document.Paths["/api"].Operations[HttpMethod.Post];
+            var operation = document.Paths["/api"].Operations[OperationType.Post];
             var param = Assert.Single(operation.Parameters);
             Assert.NotNull(param.Schema);
-            Assert.IsType<JsonArray>(param.Schema.Default);
+            Assert.IsType<OpenApiArray>(param.Schema.Default);
             // Type is null, it's up to the user to configure this via a custom schema
             // transformer for types with a converter.
             Assert.Null(param.Schema.Type);
@@ -769,10 +769,10 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
         // Assert
         await VerifyOpenApiDocument(builder, document =>
         {
-            var operation = document.Paths["/api"].Operations[HttpMethod.Post];
+            var operation = document.Paths["/api"].Operations[OperationType.Post];
             var param = Assert.Single(operation.Parameters);
             Assert.NotNull(param.Schema);
-            Assert.IsType<JsonObject>(param.Schema.Default);
+            Assert.IsType<OpenApiObject>(param.Schema.Default);
             // Type is null, it's up to the user to configure this via a custom schema
             // transformer for types with a converter.
             Assert.Null(param.Schema.Type);

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.ParameterSchemas.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.ParameterSchemas.cs
@@ -722,4 +722,93 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             return true;
         }
     }
+
+    // Regression test for https://github.com/dotnet/aspnetcore/issues/62023
+    // Testing that the array parsing in our OpenApiJsonSchema works
+    [Fact]
+    public async Task CustomConverterThatOutputsArrayWithDefaultValue()
+    {
+        // Arrange
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.ConfigureHttpJsonOptions(options =>
+        {
+            options.SerializerOptions.Converters.Add(new EnumArrayTypeConverter());
+        });
+        var builder = CreateBuilder(serviceCollection);
+
+        // Act
+        builder.MapPost("/api", (EnumArrayType e = EnumArrayType.None) => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths["/api"].Operations[HttpMethod.Post];
+            var param = Assert.Single(operation.Parameters);
+            Assert.NotNull(param.Schema);
+            Assert.IsType<JsonArray>(param.Schema.Default);
+            // Type is null, it's up to the user to configure this via a custom schema
+            // transformer for types with a converter.
+            Assert.Null(param.Schema.Type);
+        });
+    }
+
+    [Fact]
+    public async Task CustomConverterThatOutputsObjectWithDefaultValue()
+    {
+        // Arrange
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.ConfigureHttpJsonOptions(options =>
+        {
+            options.SerializerOptions.Converters.Add(new EnumObjectTypeConverter());
+        });
+        var builder = CreateBuilder(serviceCollection);
+
+        // Act
+        builder.MapPost("/api", (EnumArrayType e = EnumArrayType.None) => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths["/api"].Operations[HttpMethod.Post];
+            var param = Assert.Single(operation.Parameters);
+            Assert.NotNull(param.Schema);
+            Assert.IsType<JsonObject>(param.Schema.Default);
+            // Type is null, it's up to the user to configure this via a custom schema
+            // transformer for types with a converter.
+            Assert.Null(param.Schema.Type);
+        });
+    }
+
+    public enum EnumArrayType
+    {
+        None = 1
+    }
+
+    public class EnumArrayTypeConverter : JsonConverter<EnumArrayType>
+    {
+        public override EnumArrayType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return new EnumArrayType();
+        }
+
+        public override void Write(Utf8JsonWriter writer, EnumArrayType value, JsonSerializerOptions options)
+        {
+            writer.WriteStartArray();
+            writer.WriteEndArray();
+        }
+    }
+
+    public class EnumObjectTypeConverter : JsonConverter<EnumArrayType>
+    {
+        public override EnumArrayType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return new EnumArrayType();
+        }
+
+        public override void Write(Utf8JsonWriter writer, EnumArrayType value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WriteEndObject();
+        }
+    }
 }


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspnetcore/pull/62051

# Fix OpenApiJsonSchema array parsing

## Description

When using the `MapOpenApi()` endpoint with a custom json converter that outputs an array with a default value, the app would crash with a stack overflow. The issue was that we never advanced the `Utf8JsonReader` when calling a recursive function. So we'd end up looking at the same json value over and over until stack overflowing.

Fixes #62023

## Customer Impact

App can crash when accessing the OpenApi endpoint.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Obvious bug once pointed out. Fixed missing test coverage.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A