### PR TITLE
Get native .pdb into Shared Framework symbol package

### DIFF
--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.Composite.sfxproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.Composite.sfxproj
@@ -31,6 +31,11 @@
     <AllowedReferenceRelatedFileExtensions>.pdb</AllowedReferenceRelatedFileExtensions>
 
     <PartialCompositeAssemblyListPath>PartialCompositeAssemblyListPath.txt</PartialCompositeAssemblyListPath>
+
+    <GetSharedFrameworkFilesForReadyToRunDependsOn>
+      $(GetSharedFrameworkFilesForReadyToRunDependsOn);
+      _ResolveCopyLocalNativeReference;
+    </GetSharedFrameworkFilesForReadyToRunDependsOn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -84,6 +89,11 @@
         Include="$(ArtifactsBinDir)InProcessRequestHandler\$(NativePlatform)\$(Configuration)\aspnetcorev2_inprocess.dll" />
   </ItemGroup>
 
+  <Target Name="_ResolveCopyLocalNativeReference">
+    <ItemGroup>
+      <ReferenceCopyLocalPaths Include="@(NativeRuntimeAsset)" />
+    </ItemGroup>
+  </Target>
 
   <Target Name="_WarnAboutUnbuiltNativeDependencies"
           BeforeTargets="Build"

--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.Composite.sfxproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.Composite.sfxproj
@@ -31,11 +31,6 @@
     <AllowedReferenceRelatedFileExtensions>.pdb</AllowedReferenceRelatedFileExtensions>
 
     <PartialCompositeAssemblyListPath>PartialCompositeAssemblyListPath.txt</PartialCompositeAssemblyListPath>
-
-    <GetSharedFrameworkFilesForReadyToRunDependsOn>
-      $(GetSharedFrameworkFilesForReadyToRunDependsOn);
-      _ResolveCopyLocalNativeReference;
-    </GetSharedFrameworkFilesForReadyToRunDependsOn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -87,13 +82,9 @@
 
     <NativeRuntimeAsset Condition=" '$(UseIisNativeAssets)' == 'true' AND !$(BuildNative) "
         Include="$(ArtifactsBinDir)InProcessRequestHandler\$(NativePlatform)\$(Configuration)\aspnetcorev2_inprocess.dll" />
+    <NativeRuntimeAsset Condition=" '$(UseIisNativeAssets)' == 'true' AND !$(BuildNative) "
+        Include="$(ArtifactsBinDir)InProcessRequestHandler\$(NativePlatform)\$(Configuration)\aspnetcorev2_inprocess.pdb" />
   </ItemGroup>
-
-  <Target Name="_ResolveCopyLocalNativeReference">
-    <ItemGroup>
-      <ReferenceCopyLocalPaths Include="@(NativeRuntimeAsset)" />
-    </ItemGroup>
-  </Target>
 
   <Target Name="_WarnAboutUnbuiltNativeDependencies"
           BeforeTargets="Build"

--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.sfxproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.sfxproj
@@ -40,6 +40,11 @@
 
     <!-- TODO: Try to remove this disable property -->
     <DisablePackageReferenceRestrictions>true</DisablePackageReferenceRestrictions>
+
+    <GetSharedFrameworkFilesForReadyToRunDependsOn>
+      $(GetSharedFrameworkFilesForReadyToRunDependsOn);
+      _ResolveCopyLocalNativeReference;
+    </GetSharedFrameworkFilesForReadyToRunDependsOn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(BuildInstallers)' == 'true' or '$(TargetOsName)' == 'win'">
@@ -81,6 +86,11 @@
         Include="$(ArtifactsBinDir)InProcessRequestHandler\$(NativePlatform)\$(Configuration)\aspnetcorev2_inprocess.dll" />
   </ItemGroup>
 
+  <Target Name="_ResolveCopyLocalNativeReference">
+    <ItemGroup>
+      <ReferenceCopyLocalPaths Include="@(NativeRuntimeAsset)" />
+    </ItemGroup>
+  </Target>
 
   <Target Name="_WarnAboutUnbuiltNativeDependencies"
           BeforeTargets="Build"

--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.sfxproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.sfxproj
@@ -40,11 +40,6 @@
 
     <!-- TODO: Try to remove this disable property -->
     <DisablePackageReferenceRestrictions>true</DisablePackageReferenceRestrictions>
-
-    <GetSharedFrameworkFilesForReadyToRunDependsOn>
-      $(GetSharedFrameworkFilesForReadyToRunDependsOn);
-      _ResolveCopyLocalNativeReference;
-    </GetSharedFrameworkFilesForReadyToRunDependsOn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(BuildInstallers)' == 'true' or '$(TargetOsName)' == 'win'">
@@ -84,13 +79,9 @@
 
     <NativeRuntimeAsset Condition=" '$(UseIisNativeAssets)' == 'true' AND !$(BuildNative) "
         Include="$(ArtifactsBinDir)InProcessRequestHandler\$(NativePlatform)\$(Configuration)\aspnetcorev2_inprocess.dll" />
+    <NativeRuntimeAsset Condition=" '$(UseIisNativeAssets)' == 'true' AND !$(BuildNative) "
+        Include="$(ArtifactsBinDir)InProcessRequestHandler\$(NativePlatform)\$(Configuration)\aspnetcorev2_inprocess.pdb" />
   </ItemGroup>
-
-  <Target Name="_ResolveCopyLocalNativeReference">
-    <ItemGroup>
-      <ReferenceCopyLocalPaths Include="@(NativeRuntimeAsset)" />
-    </ItemGroup>
-  </Target>
 
   <Target Name="_WarnAboutUnbuiltNativeDependencies"
           BeforeTargets="Build"


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/62123. Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2718027&view=results

Matches instructions from arcade docs