### PR TITLE
Label all maestro PRs w/ area-infrastructure

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -239,8 +239,6 @@ configuration:
         - titleContains:
             pattern: Source code updates
             isRegex: False
-      - targetsBranch:
-          branch: main
       then:
       - addLabel:
           label: area-infrastructure


### PR DESCRIPTION
This pull request includes a small change to the `.github/policies/resourceManagement.yml` file. The change removes the `targetsBranch` condition that specified the `main` branch as a target for applying the policy to apply the `area-infrastructure` label to dependency update PRs.