### PR TITLE
Fix logic for .msi version in Hosting Bundle

### DIFF
--- a/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
+++ b/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
@@ -102,8 +102,9 @@
     <BundleNameShort>Microsoft .NET $(PackageBrandingVersion)</BundleNameShort>
     <SharedFxPackageVersion>$(PackageVersion)</SharedFxPackageVersion>
     <SharedFxMsiVersion>$(PackageVersion)</SharedFxMsiVersion>
-    <SharedFxMsiVersion
-        Condition="! $(PackageVersion.Contains('$(_PreReleaseLabel)'))">$(PackageVersion)-$(_PreReleaseLabel)$(_BuildNumberLabels)</SharedFxMsiVersion>
+    <NonStableVersion>$(PackageVersion)</NonStableVersion>
+    <NonStableVersion
+        Condition="! $(NonStableVersion.Contains('$(_BuildNumberLabels)'))">$(PackageVersion)-$(_PreReleaseLabel)$(_BuildNumberLabels)</NonStableVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -122,7 +123,7 @@
 
   <!-- CrossArchitectureInstallerBasePath is a global property, so use a new property instead of modifying it -->
   <PropertyGroup Condition="'$(AddVersionToCrossArchitectureInstallerBasePath)' == 'true'">
-    <CrossArchitectureInstallerBasePathNormalized>$([MSBuild]::NormalizeDirectory('$(CrossArchitectureInstallerBasePath)', 'aspnetcore', 'Runtime', '$(SharedFxMsiVersion)'))</CrossArchitectureInstallerBasePathNormalized>
+    <CrossArchitectureInstallerBasePathNormalized>$([MSBuild]::NormalizeDirectory('$(CrossArchitectureInstallerBasePath)', 'aspnetcore', 'Runtime', '$(NonStableVersion)'))</CrossArchitectureInstallerBasePathNormalized>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(AddVersionToCrossArchitectureInstallerBasePath)' != 'true'">


### PR DESCRIPTION
The aspnetcore-runtime .msi will have a stable version in servicing, but we always need to calculate the non-stable version for when we restore assets in VMR build pass 2. Fixes https://github.com/dotnet/aspnetcore/issues/61951