### PR TITLE
[OpenAPI] Refactor MapOpenApi

### DIFF
--- a/src/OpenApi/src/Extensions/OpenApiEndpointRouteBuilderExtensions.cs
+++ b/src/OpenApi/src/Extensions/OpenApiEndpointRouteBuilderExtensions.cs
@@ -54,21 +54,27 @@ public static class OpenApiEndpointRouteBuilderExtensions
                     var document = await documentService.GetOpenApiDocumentAsync(context.RequestServices, context.Request, context.RequestAborted);
                     var documentOptions = options.Get(lowercasedDocumentName);
 
-                    using var writer = new Utf8BufferTextWriter();
-                    writer.SetWriter(context.Response.BodyWriter);
+                    using var textWriter = new Utf8BufferTextWriter();
+                    textWriter.SetWriter(context.Response.BodyWriter);
+
+                    string contentType;
+                    OpenApiWriterBase openApiWriter;
 
                     if (UseYaml(pattern))
                     {
-                        context.Response.ContentType = "text/plain+yaml;charset=utf-8";
-                        await context.Response.StartAsync();
-                        await document.SerializeAsync(new OpenApiYamlWriter(writer), documentOptions.OpenApiVersion, context.RequestAborted);
+                        contentType = "text/plain+yaml;charset=utf-8";
+                        openApiWriter = new OpenApiYamlWriter(textWriter);
                     }
                     else
                     {
-                        context.Response.ContentType = "application/json;charset=utf-8";
-                        await context.Response.StartAsync();
-                        await document.SerializeAsync(new OpenApiJsonWriter(writer), documentOptions.OpenApiVersion, context.RequestAborted);
+                        contentType = "application/json;charset=utf-8";
+                        openApiWriter = new OpenApiJsonWriter(textWriter);
                     }
+
+                    context.Response.ContentType = contentType;
+
+                    await context.Response.StartAsync();
+                    await document.SerializeAsync(openApiWriter, documentOptions.OpenApiVersion, context.RequestAborted);
                     await context.Response.BodyWriter.FlushAsync(context.RequestAborted);
                 }
             }).ExcludeFromDescription();


### PR DESCRIPTION
# Refactor MapOpenApi

Refactor the `MapOpenApi()` method.

## Description

Refactor the `MapOpenApi()` method to avoid two almost identical code blocks by assigning the differing values into variables and then using.

Subjective change, so feel free to close if you preferred it as it was.
