### PR TITLE
2->8 core for copilot setup runner

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -6,7 +6,7 @@ on: workflow_dispatch
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   copilot-setup-steps:
-    runs-on: ubuntu-latest
+    runs-on: 8-core-ubuntu-latest
 
     permissions:
       contents: read


### PR DESCRIPTION
Only takes about a minute off as we don't do much in the setup right now, but it's a minute, and would be more if we do more work.

experiments were: https://github.com/dotnet/aspnetcore/actions/workflows/copilot-setup-steps.yml