### PR TITLE
Fix OpenAPI Culture formatting for RangeAttribute and Unit Tests

### DIFF
--- a/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
@@ -97,8 +97,8 @@ internal static class JsonNodeSchemaExtensions
                     ? CultureInfo.InvariantCulture
                     : CultureInfo.CurrentCulture;
 
-                var minString = rangeAttribute.Minimum.ToString();
-                var maxString = rangeAttribute.Maximum.ToString();
+                var minString = string.Format(targetCulture, "{0}", rangeAttribute.Minimum);
+                var maxString = string.Format(targetCulture, "{0}", rangeAttribute.Maximum);
 
                 if (decimal.TryParse(minString, NumberStyles.Any, targetCulture, out var minDecimal))
                 {

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.SourceGenerators.Tests/SchemaTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.SourceGenerators.Tests/SchemaTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Http;

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.SourceGenerators.Tests/SnapshotTestHelper.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.SourceGenerators.Tests/SnapshotTestHelper.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Globalization;
 using System.Reflection;
 using System.Runtime.Loader;
 using System.Text;
@@ -16,6 +17,7 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Writers;
 
 namespace Microsoft.AspNetCore.OpenApi.SourceGenerators.Tests;
 
@@ -197,8 +199,7 @@ public static partial class SnapshotTestHelper
 
             var service = services.GetService(serviceType) ?? throw new InvalidOperationException("Could not resolve IDocumentProvider service.");
             using var stream = new MemoryStream();
-            var encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
-            using var writer = new StreamWriter(stream, encoding, bufferSize: 1024, leaveOpen: true);
+            using var writer = new FormattingStreamWriter(stream, CultureInfo.InvariantCulture) { AutoFlush = true };
             var targetMethod = serviceType.GetMethod("GenerateAsync", [typeof(string), typeof(TextWriter)]) ?? throw new InvalidOperationException("Could not resolve GenerateAsync method.");
             targetMethod.Invoke(service, ["v1", writer]);
             stream.Position = 0;


### PR DESCRIPTION
# Fix OpenAPI Culture formatting for RangeAttribute and Unit Tests

This is to fix unit tests and formatting issues when having a culture with `,` as decimal seperator.

## Description

This is to fix unit tests and formatting issues when having a culture with `,` as decimal seperator. It fixes the range attribute by formatting it using the target locale. And the xml comment tests by using the FormattingStreamWriter as mentioned in:
https://github.com/microsoft/OpenAPI.NET/issues/657#issuecomment-1088761305.

Partially Fixes progress for #61965
