### PR TITLE
Blazor identity template should load shared key and qr url on authenticator enabled

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/EnableAuthenticator.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/EnableAuthenticator.razor
@@ -88,6 +88,8 @@ else
             RedirectManager.RedirectToInvalidUser(UserManager, HttpContext);
             return;
         }
+
+        await LoadSharedKeyAndQrCodeUriAsync(user);
     }
 
     private async Task OnValidSubmitAsync()


### PR DESCRIPTION
Reported in https://github.com/dotnet/aspnetcore/issues/62171#issuecomment-2935538460.

The bug was introduced in https://github.com/dotnet/aspnetcore/pull/61633, when refactoring and mitigating results of `NavigationException` removal.

## Description

`await LoadSharedKeyAndQrCodeUriAsync(user);`

was originally in the `EnableAuthenticator.razor` file, it got removed by mistake when adding `if (user is null)` checks. This PR reverts the removal.

Credits to @sciocoder who detected the mistake.