### PR TITLE
[MVC.Testing] Fix NullReferenceException

### DIFF
--- a/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
+++ b/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
@@ -103,7 +103,7 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
             StartServer();
             if (_useKestrel)
             {
-                return _webHost!.Services;
+                return _webHost?.Services ?? _host!.Services;
             }
 
             return _host?.Services ?? _server!.Host.Services;
@@ -263,8 +263,8 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
         {
             var deferredHostBuilder = new DeferredHostBuilder();
             deferredHostBuilder.UseEnvironment(Environments.Development);
-            // There's no helper for UseApplicationName, but we need to 
-            // set the application name to the target entry point 
+            // There's no helper for UseApplicationName, but we need to
+            // set the application name to the target entry point
             // assembly name.
             deferredHostBuilder.ConfigureHostConfiguration(config =>
             {

--- a/src/Mvc/test/Mvc.FunctionalTests/KestrelBasedWebApplicationFactoryForMinimal.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/KestrelBasedWebApplicationFactoryForMinimal.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace Microsoft.AspNetCore.Mvc.FunctionalTests;
+
+public class KestrelBasedWebApplicationFactoryForMinimal : WebApplicationFactory<SimpleWebSiteWithWebApplicationBuilder.Program>
+{
+    public KestrelBasedWebApplicationFactoryForMinimal() : base()
+    {
+        // Use dynamically assigned port to avoid test conflicts in CI.
+        this.UseKestrel(0);
+    }
+}

--- a/src/Mvc/test/Mvc.FunctionalTests/RealServerUsingMinimalBackedIntegrationTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RealServerUsingMinimalBackedIntegrationTests.cs
@@ -9,11 +9,11 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests;
 
-public class RealServerBackedIntegrationTests : IClassFixture<KestrelBasedWebApplicationFactory>
+public class RealServerUsingMinimalBackedIntegrationTests : IClassFixture<KestrelBasedWebApplicationFactoryForMinimal>
 {
-    public KestrelBasedWebApplicationFactory Factory { get; }
+    public KestrelBasedWebApplicationFactoryForMinimal Factory { get; }
 
-    public RealServerBackedIntegrationTests(KestrelBasedWebApplicationFactory factory)
+    public RealServerUsingMinimalBackedIntegrationTests(KestrelBasedWebApplicationFactoryForMinimal factory)
     {
         Factory = factory;
     }
@@ -22,7 +22,7 @@ public class RealServerBackedIntegrationTests : IClassFixture<KestrelBasedWebApp
     public async Task RetrievesDataFromRealServer()
     {
         // Arrange
-        var expectedMediaType = MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
+        var expectedMediaType = MediaTypeHeaderValue.Parse("text/plain; charset=utf-8");
 
         // Act
         var client = Factory.CreateClient();
@@ -33,10 +33,7 @@ public class RealServerBackedIntegrationTests : IClassFixture<KestrelBasedWebApp
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal(expectedMediaType, response.Content.Headers.ContentType);
 
-        Assert.Contains("first", responseContent);
-        Assert.Contains("second", responseContent);
-        Assert.Contains("wall", responseContent);
-        Assert.Contains("floor", responseContent);
+        Assert.Contains("Hello World", responseContent);
     }
 
     [Fact]

--- a/src/Mvc/test/Mvc.FunctionalTests/RealServerWithDynamicPortIntegrationTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RealServerWithDynamicPortIntegrationTests.cs
@@ -3,7 +3,6 @@
 
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using Microsoft.AspNetCore.Mvc.Testing;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests;


### PR DESCRIPTION
# Fix NullReferenceException from WebApplicationFactory.Services

Fix `NullReferenceException` from `WebApplicationFactory.Services`.

## Description

Fix `NullReferenceException` accessing `Services` in a web application using top-level programs and add tests.

Fixes #62224
