### PR TITLE
[release/9.0] [OpenAPI] Use invariant culture for TextWriter

### DIFF
--- a/src/OpenApi/sample/Controllers/TestController.cs
+++ b/src/OpenApi/sample/Controllers/TestController.cs
@@ -24,6 +24,15 @@ public class TestController : ControllerBase
         return Ok(todo);
     }
 
+    [HttpGet]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(CurrentWeather), 200)]
+    [Route("/getcultureinvariant")]
+    public IActionResult GetCurrentWeather()
+    {
+        return Ok(new CurrentWeather(1.0f));
+    }
+
     public class RouteParamsContainer
     {
         [FromRoute]
@@ -36,4 +45,6 @@ public class TestController : ControllerBase
     }
 
     public record MvcTodo(string Title, string Description, bool IsCompleted);
+
+    public record CurrentWeather([Range(-100.5f, 100.5f)] float Temperature = 0.1f);
 }

--- a/src/OpenApi/sample/Program.cs
+++ b/src/OpenApi/sample/Program.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Immutable;
 using System.ComponentModel;
+using System.Globalization;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.OpenApi.Models;
@@ -35,6 +36,32 @@ builder.Services.AddOpenApi("forms");
 builder.Services.AddOpenApi("schemas-by-ref");
 
 var app = builder.Build();
+
+// Run requests with a culture that uses commas to format decimals to
+// verify the invariant culture is used to generate the OpenAPI document.
+app.Use((next) =>
+{
+    return async context =>
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        var originalUICulture = CultureInfo.CurrentUICulture;
+
+        var newCulture = new CultureInfo("fr-FR");
+
+        try
+        {
+            CultureInfo.CurrentCulture = newCulture;
+            CultureInfo.CurrentUICulture = newCulture;
+
+            await next(context);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+            CultureInfo.CurrentUICulture = originalUICulture;
+        }
+    };
+});
 
 app.MapOpenApi();
 if (app.Environment.IsDevelopment())

--- a/src/OpenApi/src/Extensions/OpenApiEndpointRouteBuilderExtensions.cs
+++ b/src/OpenApi/src/Extensions/OpenApiEndpointRouteBuilderExtensions.cs
@@ -46,7 +46,8 @@ public static class OpenApiEndpointRouteBuilderExtensions
                     var document = await documentService.GetOpenApiDocumentAsync(context.RequestServices, context.Request, context.RequestAborted);
                     var documentOptions = options.Get(documentName);
                     using var output = MemoryBufferWriter.Get();
-                    using var writer = Utf8BufferTextWriter.Get(output);
+                    using var writer = new Utf8BufferTextWriter(System.Globalization.CultureInfo.InvariantCulture);
+                    writer.SetWriter(output);
                     try
                     {
                         document.Serialize(new OpenApiJsonWriter(writer), documentOptions.OpenApiVersion);

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/OpenApiDocumentIntegrationTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/OpenApiDocumentIntegrationTests.cs
@@ -1,12 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
 using Microsoft.AspNetCore.InternalTesting;
-using Microsoft.AspNetCore.OpenApi;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Writers;
 
 [UsesVerify]
 public sealed class OpenApiDocumentIntegrationTests(SampleAppFixture fixture) : IClassFixture<SampleAppFixture>
@@ -20,21 +15,12 @@ public sealed class OpenApiDocumentIntegrationTests(SampleAppFixture fixture) : 
     [InlineData("schemas-by-ref")]
     public async Task VerifyOpenApiDocument(string documentName)
     {
-        var documentService = fixture.Services.GetRequiredKeyedService<OpenApiDocumentService>(documentName);
-        var scopedServiceProvider = fixture.Services.CreateScope();
-        var document = await documentService.GetOpenApiDocumentAsync(scopedServiceProvider.ServiceProvider);
-        await Verifier.Verify(GetOpenApiJson(document))
+        using var client = fixture.CreateClient();
+        var json = await client.GetStringAsync($"/openapi/{documentName}.json");
+        await Verify(json)
             .UseDirectory(SkipOnHelixAttribute.OnHelix()
                 ? Path.Combine(Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT"), "Integration", "snapshots")
                 : "snapshots")
             .UseParameters(documentName);
-    }
-
-    private static string GetOpenApiJson(OpenApiDocument document)
-    {
-        using var textWriter = new StringWriter(CultureInfo.InvariantCulture);
-        var jsonWriter = new OpenApiJsonWriter(textWriter);
-        document.SerializeAsV3(jsonWriter);
-        return textWriter.ToString();
     }
 }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=controllers.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=controllers.verified.txt
@@ -4,6 +4,11 @@
     "title": "Sample | controllers",
     "version": "1.0.0"
   },
+  "servers": [
+    {
+      "url": "http://localhost/"
+    }
+  ],
   "paths": {
     "/getbyidandname/{id}/{name}": {
       "get": {
@@ -88,9 +93,41 @@
           }
         }
       }
+    },
+    "/getcultureinvariant": {
+      "get": {
+        "tags": [
+          "Test"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CurrentWeather"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
-  "components": { },
+  "components": {
+    "schemas": {
+      "CurrentWeather": {
+        "type": "object",
+        "properties": {
+          "temperature": {
+            "type": "number",
+            "format": "float",
+            "default": 0.1
+          }
+        }
+      }
+    }
+  },
   "tags": [
     {
       "name": "Test"

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=forms.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=forms.verified.txt
@@ -4,6 +4,11 @@
     "title": "Sample | forms",
     "version": "1.0.0"
   },
+  "servers": [
+    {
+      "url": "http://localhost/"
+    }
+  ],
   "paths": {
     "/forms/form-file": {
       "post": {

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=responses.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=responses.verified.txt
@@ -4,6 +4,11 @@
     "title": "Sample | responses",
     "version": "1.0.0"
   },
+  "servers": [
+    {
+      "url": "http://localhost/"
+    }
+  ],
   "paths": {
     "/responses/200-add-xml": {
       "get": {

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
@@ -4,6 +4,11 @@
     "title": "Sample | schemas-by-ref",
     "version": "1.0.0"
   },
+  "servers": [
+    {
+      "url": "http://localhost/"
+    }
+  ],
   "paths": {
     "/schemas-by-ref/typed-results": {
       "get": {

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v1.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v1.verified.txt
@@ -4,6 +4,11 @@
     "title": "Sample | v1",
     "version": "1.0.0"
   },
+  "servers": [
+    {
+      "url": "http://localhost/"
+    }
+  ],
   "paths": {
     "/v1/array-of-guids": {
       "get": {

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v2.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=v2.verified.txt
@@ -11,6 +11,11 @@
     },
     "version": "1.0.0"
   },
+  "servers": [
+    {
+      "url": "http://localhost/"
+    }
+  ],
   "paths": {
     "/v2/users": {
       "get": {

--- a/src/SignalR/common/Shared/Utf8BufferTextWriter.cs
+++ b/src/SignalR/common/Shared/Utf8BufferTextWriter.cs
@@ -35,6 +35,12 @@ internal sealed class Utf8BufferTextWriter : TextWriter
         _encoder = _utf8NoBom.GetEncoder();
     }
 
+    public Utf8BufferTextWriter(IFormatProvider formatProvider)
+        : base(formatProvider)
+    {
+        _encoder = _utf8NoBom.GetEncoder();
+    }
+
     public static Utf8BufferTextWriter Get(IBufferWriter<byte> bufferWriter)
     {
         var writer = _cachedInstance;


### PR DESCRIPTION
Use culture-invariant TextWriter implementation for OpenAPI.

Port of #62193 for .NET 9.

## Description  
To avoid any accidental changes to SignalR's use of `Utf8BufferTextWriter` I've removed the use of the writer pooling for OpenAPI and instead a new instance is created every time.

Fixes #60628

## Customer Impact  
Developers run into this issue when hosting under non-en cultures, but no workarounds are available.

## Regression?
- [ ] Yes  
- [x] No (Bug has existed throughout 9.0 previews; not a regression from an earlier serviced release.)

## Risk  
- [ ] High  
- [ ] Medium  
- [x] Low

Change is isolated to the OpenAPI serialization path and uses an existing overload; no impact on runtime behavior or other subsystems.

## Verification  
- [x] Manual 
- [x] Automated

## Packaging changes reviewed?  
- [ ] Yes  
- [ ] No  
- [x] N/A  