### PR TITLE
Revert SDK update

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "10.0.100-preview.6.25272.112"
+    "version": "10.0.100-preview.4.25216.37"
   },
   "tools": {
-    "dotnet": "10.0.100-preview.6.25272.112",
+    "dotnet": "10.0.100-preview.4.25216.37",
     "runtimes": {
       "dotnet/x86": [
         "$(MicrosoftInternalRuntimeAspNetCoreTransportVersion)"

--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "10.0.100-preview.4.25216.37"
+    "version": "10.0.100-preview.5.25265.106"
   },
   "tools": {
-    "dotnet": "10.0.100-preview.4.25216.37",
+    "dotnet": "10.0.100-preview.5.25265.106",
     "runtimes": {
       "dotnet/x86": [
         "$(MicrosoftInternalRuntimeAspNetCoreTransportVersion)"


### PR DESCRIPTION
The last SDK update broke test discovery: https://github.com/dotnet/aspnetcore/issues/62223. We should hold off on taking any more updates until the underlying bug is fixed