### PR TITLE
follow-up: kestrel tls listener callback

### DIFF
--- a/src/Servers/Kestrel/Core/test/TlsListenerTests.cs
+++ b/src/Servers/Kestrel/Core/test/TlsListenerTests.cs
@@ -122,7 +122,7 @@ public class TlsListenerTests
         await writer.WriteAsync(new byte[2] { 0x03, 0x01 });
         cts.Cancel();
 
-        await Assert.ThrowsAsync<OperationCanceledException>(async () => await listenerTask);
+        await VerifyThrowsAnyAsync(() => listenerTask, typeof(OperationCanceledException), typeof(TaskCanceledException));
         Assert.False(tlsClientHelloCallbackInvoked);
     }
 

--- a/src/Servers/Kestrel/Core/test/TlsListenerTests.cs
+++ b/src/Servers/Kestrel/Core/test/TlsListenerTests.cs
@@ -158,8 +158,8 @@ public class TlsListenerTests
         Assert.Equal(5, readResult.Buffer.Length);
 
         // ensuring that we have read limited number of times
-        Assert.True(reader.ReadAsyncCounter is >= 2 && reader.ReadAsyncCounter is <= 4,
-            $"Expected ReadAsync() to happen about 2-4 times. Actually happened {reader.ReadAsyncCounter} times.");
+        Assert.True(reader.ReadAsyncCounter is >= 2 && reader.ReadAsyncCounter is <= 5,
+            $"Expected ReadAsync() to happen about 2-5 times. Actually happened {reader.ReadAsyncCounter} times.");
     }
 
     private async Task RunTlsClientHelloCallbackTest_WithMultipleSegments(

--- a/src/Servers/Kestrel/Core/test/TlsListenerTests.cs
+++ b/src/Servers/Kestrel/Core/test/TlsListenerTests.cs
@@ -70,9 +70,7 @@ public class TlsListenerTests
         var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(3));
 
         await writer.WriteAsync(new byte[1] { 0x16 });
-        await VerifyThrowsAnyAsync(
-            async () => await listener.OnTlsClientHelloAsync(transportConnection, cts.Token),
-            typeof(OperationCanceledException), typeof(TaskCanceledException));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => listener.OnTlsClientHelloAsync(transportConnection, cts.Token));
         Assert.False(tlsClientHelloCallbackInvoked);
     }
 
@@ -95,9 +93,7 @@ public class TlsListenerTests
         cts.Cancel();
 
         await writer.WriteAsync(new byte[1] { 0x16 });
-        await VerifyThrowsAnyAsync(
-            async () => await listener.OnTlsClientHelloAsync(transportConnection, cts.Token),
-            typeof(OperationCanceledException), typeof(TaskCanceledException));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => listener.OnTlsClientHelloAsync(transportConnection, cts.Token));
         Assert.False(tlsClientHelloCallbackInvoked);
     }
 
@@ -122,7 +118,7 @@ public class TlsListenerTests
         await writer.WriteAsync(new byte[2] { 0x03, 0x01 });
         cts.Cancel();
 
-        await VerifyThrowsAnyAsync(() => listenerTask, typeof(OperationCanceledException), typeof(TaskCanceledException));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => listenerTask);
         Assert.False(tlsClientHelloCallbackInvoked);
     }
 
@@ -623,28 +619,4 @@ public class TlsListenerTests
         _invalidTlsClientHelloHeader, _invalid3BytesMessage, _invalid9BytesMessage,
         _invalidUnknownProtocolVersion1, _invalidUnknownProtocolVersion2, _invalidIncorrectHandshakeMessageType
     };
-
-    static async Task VerifyThrowsAnyAsync(Func<Task> code, params Type[] exceptionTypes)
-    {
-        if (exceptionTypes == null || exceptionTypes.Length == 0)
-        {
-            throw new ArgumentException("At least one exception type must be provided.", nameof(exceptionTypes));
-        }
-
-        try
-        {
-            await code();
-        }
-        catch (Exception ex)
-        {
-            if (exceptionTypes.Any(type => type.IsInstanceOfType(ex)))
-            {
-                return;
-            }
-
-            throw ThrowsException.ForIncorrectExceptionType(exceptionTypes.First(), ex);
-        }
-
-        throw ThrowsException.ForNoException(exceptionTypes.First());
-    }
 }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/TlsListenerTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/TlsListenerTests.cs
@@ -95,14 +95,11 @@ public class TlsListenerTests : TestApplicationErrorLoggerLoggedTest
         {
             using (var connection = server.CreateConnection())
             {
-                using (var sslStream = new SslStream(connection.Stream, false, (sender, cert, chain, errors) => true, null))
-                {
-                    await connection.TransportConnection.Input.WriteAsync(new byte[] { 0x16 });
-                    var readResult = await connection.TransportConnection.Output.ReadAsync();
+                await connection.TransportConnection.Input.WriteAsync(new byte[] { 0x16 });
+                var readResult = await connection.TransportConnection.Output.ReadAsync();
 
-                    // HttpsConnectionMiddleware catches the exception, so we can only check the effects of the timeout here
-                    Assert.True(readResult.IsCompleted);
-                }
+                // HttpsConnectionMiddleware catches the exception, so we can only check the effects of the timeout here
+                Assert.True(readResult.IsCompleted);
             }
         }
 


### PR DESCRIPTION
Adds a test [discussed here](https://github.com/dotnet/aspnetcore/pull/62177#discussion_r2124904179) and fixes the check limits in other test which is failing in [helix](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1060741&view=ms.vss-test-web.build-test-results-tab&runId=28617956&paneView=debug&resultId=124743).

Fixes #62172
