### PR TITLE
Re-execution middleware works with POST

### DIFF
--- a/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
+++ b/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
@@ -175,11 +175,10 @@ internal partial class RazorComponentEndpointInvoker : IRazorComponentEndpointIn
     private async Task<RequestValidationState> ValidateRequestAsync(HttpContext context, IAntiforgery? antiforgery)
     {
         var processPost = HttpMethods.IsPost(context.Request.Method) &&
-            // Disable POST functionality during exception handling and reexecution.
+            // Disable POST functionality during exception handling.
             // The exception handler middleware will not update the request method, and we don't
             // want to run the form handling logic against the error page.
-            context.Features.Get<IExceptionHandlerFeature>() == null &&
-            context.Features.Get<IStatusCodePagesFeature>() == null;
+            context.Features.Get<IExceptionHandlerFeature>() == null;
 
         if (processPost)
         {

--- a/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
@@ -49,6 +49,20 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
         DispatchToFormCore(dispatchToForm);
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CanDispatchToTheDefaultFormWithReExecutionMiddleware(bool suppressEnhancedNavigation)
+    {
+        var dispatchToForm = new DispatchToForm(this)
+        {
+            Url = "reexecution/forms/default-form",
+            FormCssSelector = "form",
+            SuppressEnhancedNavigation = suppressEnhancedNavigation,
+        };
+        DispatchToFormCore(dispatchToForm);
+    }
+
     [Fact]
     public void PlainFormIsNotEnhancedByDefault()
     {
@@ -894,6 +908,21 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
+    public void FormNoAntiforgeryReturnBadRequestWithReExecutionMiddleware(bool suppressEnhancedNavigation)
+    {
+        var dispatchToForm = new DispatchToForm(this)
+        {
+            Url = "reexecution/forms/no-antiforgery",
+            FormCssSelector = "form",
+            ShouldCauseBadRequest = true,
+            SuppressEnhancedNavigation = suppressEnhancedNavigation,
+        };
+        DispatchToFormCore(dispatchToForm);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
     public void FormNoAntiforgeryReturnBadRequest(bool suppressEnhancedNavigation)
     {
         var dispatchToForm = new DispatchToForm(this)
@@ -966,6 +995,21 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
         var dispatchToForm = new DispatchToForm(this)
         {
             Url = "forms/no-handler",
+            FormCssSelector = "form",
+            ShouldCauseBadRequest = true,
+            SuppressEnhancedNavigation = suppressEnhancedNavigation,
+        };
+        DispatchToFormCore(dispatchToForm);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void FormNoHandlerReturnBadRequestWithReExecutionMiddleware(bool suppressEnhancedNavigation)
+    {
+        var dispatchToForm = new DispatchToForm(this)
+        {
+            Url = "reexecution/forms/no-handler",
             FormCssSelector = "form",
             ShouldCauseBadRequest = true,
             SuppressEnhancedNavigation = suppressEnhancedNavigation,

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/DefaultForm.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/DefaultForm.razor
@@ -1,4 +1,5 @@
 ﻿@page "/forms/default-form"
+@page "/reexecution/forms/default-form"
 @using Microsoft.AspNetCore.Components.Forms
 
 <h2>Default form</h2>

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/FormNoAntiforgery.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/FormNoAntiforgery.razor
@@ -1,4 +1,5 @@
 ﻿@page "/forms/no-antiforgery"
+@page "/reexecution/forms/no-antiforgery"
 @using Microsoft.AspNetCore.Components.Forms
 
 <h2>Default form</h2>

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/FormNoHandler.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/FormNoHandler.razor
@@ -1,4 +1,5 @@
 ﻿@page "/forms/no-handler"
+@page "/reexecution/forms/no-handler"
 @using Microsoft.AspNetCore.Components.Forms
 
 <h2>Form with no handler</h2>


### PR DESCRIPTION
## Description

In https://github.com/dotnet/aspnetcore/pull/60970 a check for `IStatusCodePagesFeature` was added to define if the request should be treated as POST or not. It does not make sense to change the way we're handling POST only because re-execution middleware is set. 

Fixes #62260 
The template was tested with this change and the issue does not occur.