### PR TITLE
Fix: exit code is ignored.

### DIFF
--- a/.azure/pipelines/components-e2e-tests.yml
+++ b/.azure/pipelines/components-e2e-tests.yml
@@ -59,7 +59,7 @@ jobs:
     - script: .dotnet/dotnet build ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-restore
       displayName: Build
     - script: |
-        set -o pipefail
+        set -eo pipefail
 
         .dotnet/dotnet test ./src/Components/test/E2ETest \
           -c $(BuildConfiguration) \


### PR DESCRIPTION
Follow up for https://github.com/dotnet/aspnetcore/pull/62222 after @akoeplinger's feedback. The code of E2E tests was not propagated correctly to the CI job.
