### PR TITLE
[SignalR] [Java] Fix NPE when closing hub connection during negotiation

### DIFF
--- a/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -445,7 +445,8 @@ public class HubConnection implements AutoCloseable {
         CompletableSubject subject = CompletableSubject.create();
         startTask.onErrorComplete().subscribe(() ->
         {
-            Completable stop = connectionState.transport.stop();
+            Transport transport = connectionState.transport;
+            Completable stop = (transport != null) ? transport.stop() : Completable.complete();
             stop.subscribe(() -> subject.onComplete(), e -> subject.onError(e));
         });
 

--- a/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/HubConnectionTest.java
@@ -2784,6 +2784,26 @@ class HubConnectionTest {
     }
 
     @Test
+    public void closeWithPendingNegotiate() {
+        TestHttpClient client = new TestHttpClient()
+                .on("POST", (req) -> Single.just(new HttpResponse(404, "", TestUtils.emptyByteBuffer)).delay(200, TimeUnit.MILLISECONDS));
+
+        HubConnection hubConnection = HubConnectionBuilder
+                .create("http://example.com")
+                .withHttpClient(client)
+                .build();
+
+        Completable start = hubConnection.start();
+        assertEquals(HubConnectionState.CONNECTING, hubConnection.getConnectionState());
+        hubConnection.stop().timeout(3, TimeUnit.SECONDS).blockingAwait();
+        assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
+
+        HttpRequestException exception = assertThrows(HttpRequestException.class, () -> start.blockingAwait(10, TimeUnit.SECONDS));
+        assertEquals("Unexpected status code returned from negotiate: 404 .", exception.getMessage());
+        assertEquals(404, exception.getStatusCode());
+    }
+
+    @Test
     public void negotiateThatRedirectsForeverFailsAfter100Tries() {
         TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate?negotiateVersion=1",
                 (req) -> Single.just(new HttpResponse(200, "", TestUtils.stringToByteBuffer("{\"url\":\"http://example.com\"}"))));


### PR DESCRIPTION
# Fix NPE when closing hub connection during negotiation

Fixes a `NullPointerException` thrown if `HubConnection.close()` or `HubConnection.stop()` is called on a HubConnection while the negotiate request is still ongoing, and eventually fails.

## The cause and the effect

The following must happen for the NPE to trigger:
- start is called
- negotiate request is still ongoing, state is `HubConnectionState.CONNECTING`
- stop is called
  - the early return if HubConnectionState is DISCONNECTED is skipped because state is still connecting
- negotiate finishes with an error, never populating `connectionState.transport`
- last part of stop now triggers, trying to call `connectionState.transport.stop()`, but `connectionState.transport` is null.

This NPE is really insidious, because it cannot be caught as usual. RxJava will directly call `Thread.uncaughtException()` (through `RxJavaPlugins.onError()`), and the `HubConnection.stop()` Completable will never complete.
Alternatively `HubConnection.close()` will block forever (it calls `stop().blockingAwait()` with no timeout).

## The fix

Simply checking if transport is null before trying to close it will avoid this from happening. The start task which errored is guaranteed to be finished at that point, so there should be no leaks of the transport either, it won't be set after the error was thrown.

I also added a test for this specific scenario, it was failing before this fix, and now works as expected.
It unfortunately relies on timing of concurrently running start and stop, I chose a 100ms time window, which should hopefully not be flaky, and is in line with some other tests which also wait for 100 ms, so the test should not run for an unnecessarily long time.

Fixes #52907
