### PR TITLE
[release/2.3] Update branding to 2.3.4

### DIFF
--- a/eng/Baseline.Designer.props
+++ b/eng/Baseline.Designer.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-    <AspNetCoreBaselineVersion>2.3.2</AspNetCoreBaselineVersion>
+    <AspNetCoreBaselineVersion>2.3.3</AspNetCoreBaselineVersion>
   </PropertyGroup>
   <!-- Package: dotnet-dev-certs-->
   <PropertyGroup Condition=" '$(PackageId)' == 'dotnet-dev-certs' ">
@@ -464,7 +464,7 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.HttpOverrides-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.HttpOverrides' ">
-    <BaselinePackageVersion>2.3.0</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.3</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.HttpOverrides' AND '$(TargetFramework)' == 'netstandard2.0' ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.0, )" />

--- a/eng/Baseline.xml
+++ b/eng/Baseline.xml
@@ -4,7 +4,7 @@ This file contains a list of all the packages and their versions which were rele
 build of ASP.NET Core 2.1.x. Update this list when preparing for a new patch.
 
 -->
-<Baseline Version="2.3.2">
+<Baseline Version="2.3.3">
   <Package Id="dotnet-dev-certs" Version="2.1.1" />
   <Package Id="dotnet-sql-cache" Version="2.1.1" />
   <Package Id="dotnet-user-secrets" Version="2.1.1" />
@@ -57,7 +57,7 @@ build of ASP.NET Core 2.1.x. Update this list when preparing for a new patch.
   <Package Id="Microsoft.AspNetCore.Http.Extensions" Version="2.3.0" />
   <Package Id="Microsoft.AspNetCore.Http.Features" Version="2.3.0" />
   <Package Id="Microsoft.AspNetCore.Http" Version="2.3.0" />
-  <Package Id="Microsoft.AspNetCore.HttpOverrides" Version="2.3.0" />
+  <Package Id="Microsoft.AspNetCore.HttpOverrides" Version="2.3.3" />
   <Package Id="Microsoft.AspNetCore.HttpsPolicy" Version="2.3.0" />
   <Package Id="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.3.0" />
   <Package Id="Microsoft.AspNetCore.Identity.Specification.Tests" Version="2.3.0" />

--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -32,4 +32,8 @@ Later on, this will be checked using this condition:
       Microsoft.AspNetCore.HttpOverrides;
     </PackagesInPatch>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(VersionPrefix)' == '2.3.4' ">
+    <PackagesInPatch>
+    </PackagesInPatch>
+  </PropertyGroup>
 </Project>

--- a/version.props
+++ b/version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AspNetCoreMajorVersion>2</AspNetCoreMajorVersion>
     <AspNetCoreMinorVersion>3</AspNetCoreMinorVersion>
-    <AspNetCorePatchVersion>3</AspNetCorePatchVersion>
+    <AspNetCorePatchVersion>4</AspNetCorePatchVersion>
     <ValidateBaseline>true</ValidateBaseline>
 
     <PreReleaseLabel>servicing</PreReleaseLabel>


### PR DESCRIPTION
This pull request updates the baseline and patch versioning for ASP.NET Core to ensure consistency across the project. The key changes involve updating version numbers in multiple configuration files and adding a new property group for version `2.3.4`.

### Version Updates:

* [`eng/Baseline.Designer.props`](diffhunk://#diff-4d871589215547801f33bd38b80acdafc64a81820998305889f2b78f5feef064L5-R5): Updated `AspNetCoreBaselineVersion` from `2.3.2` to `2.3.3` and `BaselinePackageVersion` for `Microsoft.AspNetCore.HttpOverrides` from `2.3.0` to `2.3.3`. [[1]](diffhunk://#diff-4d871589215547801f33bd38b80acdafc64a81820998305889f2b78f5feef064L5-R5) [[2]](diffhunk://#diff-4d871589215547801f33bd38b80acdafc64a81820998305889f2b78f5feef064L467-R467)
* [`eng/Baseline.xml`](diffhunk://#diff-f9561e127e2a447b5c99b768de51e0eff8e910dcf1930a01169ccbc8b3a05909L7-R7): Updated the baseline version from `2.3.2` to `2.3.3` and the package version for `Microsoft.AspNetCore.HttpOverrides` from `2.3.0` to `2.3.3`. [[1]](diffhunk://#diff-f9561e127e2a447b5c99b768de51e0eff8e910dcf1930a01169ccbc8b3a05909L7-R7) [[2]](diffhunk://#diff-f9561e127e2a447b5c99b768de51e0eff8e910dcf1930a01169ccbc8b3a05909L60-R60)
* [`version.props`](diffhunk://#diff-e4bed5b736f205989dd4fdb6d78acfe9126577983d325d378ce91794d74e63c8L5-R5): Incremented the `AspNetCorePatchVersion` from `3` to `4`.

### New Patch Configuration:

* [`eng/PatchConfig.props`](diffhunk://#diff-34bcfd4dda2dd22cd2c28dfa3618f880996db857ac27ea509f78c83ec707c424R35-R38): Added a new property group for version `2.3.4` with an empty `PackagesInPatch` element.