### PR TITLE
Skip Microsoft.AspNetCore.App.Runtime.Composite.r2r.dll in signing check

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -17,6 +17,12 @@
     <FileSignInfo Include="Mono.Cecil.Rocks.dll" CertificateName="3PartySHA2" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Composite r2r images show up as fully native images and trigger the 3rd party warning when signing on Mac/Linux
+         even though they don't have readable copyright info. Skip those files in the signing check. -->
+    <ItemsToSkip3rdPartyCheck Include="Microsoft.AspNetCore.App.Runtime.Composite.r2r.dll" />
+  </ItemGroup>
+
   <PropertyGroup>
     <BaseRedistNetCorePath>$(ArtifactsObjDir)RedistSharedFx.Layout\$(Configuration)\</BaseRedistNetCorePath>
     <RedistNetCorePath>$(BaseRedistNetCorePath)$(TargetRuntimeIdentifier)\</RedistNetCorePath>


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/61954

I included this change in a signed build on my branch and it fixed the issue.
