### PR TITLE
Unescape relative path before file lookup to fix space-in-filename issue

### DIFF
--- a/src/Components/WebView/WebView/src/StaticContentProvider.cs
+++ b/src/Components/WebView/WebView/src/StaticContentProvider.cs
@@ -27,6 +27,8 @@ internal sealed class StaticContentProvider
         {
             var relativePath = _appBaseUri.MakeRelativeUri(fileUri).ToString();
 
+            relativePath = Uri.UnescapeDataString(relativePath);
+
             // Content in the file provider takes first priority
             // Next we may fall back on supplying the host page to support deep linking
             // If there's no match, fall back on serving embedded framework content


### PR DESCRIPTION
### Summary

When serving files, if the requested path contains spaces or other special characters, the lookup fails because `Uri.MakeRelativeUri` returns a URL-encoded path (e.g. spaces become `%20`). The file provider expects a plain file path, not a URL-encoded one.

This PR adds a call to `Uri.UnescapeDataString` after `MakeRelativeUri`, ensuring the relative path is correctly unescaped before being used to retrieve files.
