### PR TITLE
Update branding to preview7

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -380,18 +380,18 @@ configuration:
           branch: main
       then:
       - addMilestone:
-          milestone: 10.0-preview6
+          milestone: 10.0-preview7
       description: '[Milestone Assignments] Assign Milestone to PRs merged to the `main` branch'
     - if:
       - payloadType: Pull_Request
       - isAction:
           action: Closed
       - targetsBranch:
-          branch: release/10.0-preview5
+          branch: release/10.0-preview6
       then:
       - removeMilestone
       - addMilestone:
-          milestone: 10.0-preview5
+          milestone: 10.0-preview6
       description: '[Milestone Assignments] Assign Milestone to PRs merged to release/10.0-preview1 branch'
     - if:
       - payloadType: Issues

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,7 +9,7 @@
     <AspNetCoreMajorVersion>10</AspNetCoreMajorVersion>
     <AspNetCoreMinorVersion>0</AspNetCoreMinorVersion>
     <AspNetCorePatchVersion>0</AspNetCorePatchVersion>
-    <PreReleaseVersionIteration>6</PreReleaseVersionIteration>
+    <PreReleaseVersionIteration>7</PreReleaseVersionIteration>
     <ValidateBaseline>true</ValidateBaseline>
     <IdentityModelVersion Condition="'$(IsIdentityModelTestJob)' != 'true'">8.0.1</IdentityModelVersion>
     <IdentityModelVersion Condition="'$(IsIdentityModelTestJob)' == 'true'">*-*</IdentityModelVersion>


### PR DESCRIPTION
This pull request updates milestone and version settings to reflect the transition from `10.0-preview6` to `10.0-preview7`. The changes ensure consistency across resource management policies and version configurations.

Version updates:

* [`.github/policies/resourceManagement.yml`](diffhunk://#diff-fc796b019795da5d3269d452fcdb1827ca9c8789a41f2e2dc1551f70b8f36878L383-R394): Updated milestone assignments and target branches in resource management policies to reflect the new version `10.0-preview7`.
* [`eng/Versions.props`](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L12-R12): Incremented the `PreReleaseVersionIteration` from `6` to `7` to align with the updated versioning scheme.