### PR TITLE
Only ping build-ops for main

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -156,6 +156,8 @@ configuration:
       - isNotDraftPullRequest
       - isPullRequest
       - isOpen
+      - targetsBranch:
+
       - noActivitySince:
           days: 7
       - isNotLabeledWith:
@@ -200,6 +202,8 @@ configuration:
       filters:
       - isPullRequest
       - isOpen
+      - targetsBranch:
+          branch: main
       - hasLabel:
           label: 'Type: Dependency Update :arrow_up_small:'
       - noActivitySince:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -185,10 +185,8 @@ configuration:
       filters:
       - isPullRequest
       - isOpen
-      - targetsBranch:
-          branch: main
       - hasLabel:
-          label: 'Type: Dependency Update :arrow_up_small:'
+          label: 'build-ops'
       - noActivitySince:
           days: 1
       actions:
@@ -202,10 +200,8 @@ configuration:
       filters:
       - isPullRequest
       - isOpen
-      - targetsBranch:
-          branch: main
       - hasLabel:
-          label: 'Type: Dependency Update :arrow_up_small:'
+          label: 'build-ops'
       - noActivitySince:
           days: 3
       actions:
@@ -307,6 +303,8 @@ configuration:
           label: area-infrastructure
       - addLabel:
           label: 'Type: Merge Forward :fast_forward:'
+      - addLabel:
+          label: 'build-ops'
       - approvePullRequest:
           comment: Auto-approving branch merge.
       description: '[Infrastructure PRs] Add area-infrastructure label to auto-merge Pull Requests'
@@ -538,16 +536,16 @@ configuration:
       - isAction:
           action: Opened
       - targetsBranch:
-          branch: release/2.1
+          branch: release/2.3
       then:
       - addMilestone:
-          milestone: 2.1.x
+          milestone: 2.3.x
       - addReply:
           reply: >-
             Hi @${issueAuthor}. If this is not a tell-mode PR, please make sure to follow the instructions laid out in the [servicing process](https://aka.ms/aspnet/servicing) document.
 
             Otherwise, please add `tell-mode` label.
-      description: Add release/2.1 targeting PRs to the servicing project
+      description: Add release/2.3 targeting PRs to the servicing project
     - if:
       - payloadType: Pull_Request
       - labelAdded:
@@ -694,6 +692,8 @@ configuration:
           label: area-infrastructure
       - addLabel:
           label: 'Type: Dependency Update :arrow_up_small:'
+      - addLabel:
+          label: 'build-ops'
       - approvePullRequest:
           comment: Auto-approving SDK update.
       - enableAutoMerge:
@@ -713,6 +713,8 @@ configuration:
           label: area-infrastructure
       - addLabel:
           label: 'Type: Dependency Update :arrow_up_small:'
+      - addLabel:
+          label: 'build-ops'
       - approvePullRequest:
           comment: Auto-approving dependabot update.
       - enableAutoMerge:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -189,8 +189,6 @@ configuration:
           label: 'Type: Dependency Update :arrow_up_small:'
       - noActivitySince:
           days: 1
-      - targetsBranch:
-          branch: main
       actions:
       - addReply:
           reply: This dependency PR has had no activity for a full business day - @dotnet/aspnet-build please take a look if you are on build-ops.
@@ -206,8 +204,6 @@ configuration:
           label: 'Type: Dependency Update :arrow_up_small:'
       - noActivitySince:
           days: 3
-      - targetsBranch:
-          branch: main
       actions:
       - addReply:
           reply: This dependency PR has had no activity for a full business day - @dotnet/aspnet-build please take a look if you are on build-ops.

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -189,6 +189,8 @@ configuration:
           label: 'Type: Dependency Update :arrow_up_small:'
       - noActivitySince:
           days: 1
+      - targetsBranch:
+          branch: main
       actions:
       - addReply:
           reply: This dependency PR has had no activity for a full business day - @dotnet/aspnet-build please take a look if you are on build-ops.
@@ -204,6 +206,8 @@ configuration:
           label: 'Type: Dependency Update :arrow_up_small:'
       - noActivitySince:
           days: 3
+      - targetsBranch:
+          branch: main
       actions:
       - addReply:
           reply: This dependency PR has had no activity for a full business day - @dotnet/aspnet-build please take a look if you are on build-ops.

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -156,8 +156,6 @@ configuration:
       - isNotDraftPullRequest
       - isPullRequest
       - isOpen
-      - targetsBranch:
-
       - noActivitySince:
           days: 7
       - isNotLabeledWith:
@@ -187,6 +185,8 @@ configuration:
       filters:
       - isPullRequest
       - isOpen
+      - targetsBranch:
+          branch: main
       - hasLabel:
           label: 'Type: Dependency Update :arrow_up_small:'
       - noActivitySince:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -291,6 +291,26 @@ configuration:
       - isAction:
           action: Opened
       - isActivitySender:
+          user: dotnet-maestro[bot]
+          issueAuthor: False
+      - targetsBranch:
+          branch: main
+      - or:
+        - titleContains:
+            pattern: Update dependencies
+            isRegex: False
+        - titleContains:
+            pattern: Source code updates
+            isRegex: False
+      then:
+      - addLabel:
+          label: 'build-ops'
+      description: '[Infrastructure PRs] Add build-ops label to dependency update Pull Requests against main'
+    - if:
+      - payloadType: Pull_Request
+      - isAction:
+          action: Opened
+      - isActivitySender:
           user: dotnet-maestro-bot
           issueAuthor: False
       - titleContains:


### PR DESCRIPTION
Update new actions to only bug build-ops for PRs against main

This pull request updates the `.github/policies/resourceManagement.yml` file to refine the conditions for dependency update policies. The changes introduce a new `targetsBranch` condition to ensure the policies apply specifically to the `main` branch.

Dependency update policy refinements:

* [`.github/policies/resourceManagement.yml`](diffhunk://#diff-fc796b019795da5d3269d452fcdb1827ca9c8789a41f2e2dc1551f70b8f36878R192-R193): Added a `targetsBranch` condition to specify that the `branch` must be `main` for the policy triggered by `noActivitySince: days: 1`.
* [`.github/policies/resourceManagement.yml`](diffhunk://#diff-fc796b019795da5d3269d452fcdb1827ca9c8789a41f2e2dc1551f70b8f36878R209-R210): Added a `targetsBranch` condition to specify that the `branch` must be `main` for the policy triggered by `noActivitySince: days: 3`.