### PR TITLE
Avoid race that can cause Kestrel's RequestAborted to not fire

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -415,8 +415,9 @@ internal abstract partial class HttpProtocol : IHttpResponseControl
             if (!_connectionAborted && _abortedCts is not null)
             {
                 // _connectionAborted is terminal and only set inside the _abortLock, so if it isn't set here,
-                // it has not been canceled yet.
-                Trace.Assert(_abortedCts.TryReset());
+                // _abortedCts has not been canceled yet.
+                var resetSuccess = _abortedCts.TryReset();
+                Debug.Assert(resetSuccess);
             }
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -129,7 +129,6 @@ internal abstract partial class Http2Stream : HttpProtocol, IThreadPoolWorkItem,
     protected override void OnReset()
     {
         _keepAlive = true;
-        _connectionAborted = false;
         _userTrailers = null;
 
         // Reset Http2 Features

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -610,8 +610,8 @@ internal sealed class Http3Connection : IHttp3StreamLifetimeHandler, IRequestPro
         }
         else
         {
-            reusableStream.InitializeWithExistingContext(streamContext.Transport);
             stream = reusableStream;
+            reusableStream.InitializeWithExistingContext(streamContext.Transport);
         }
 
         _streamLifetimeHandler.OnStreamCreated(stream);

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -606,7 +606,7 @@ internal sealed class Http3Connection : IHttp3StreamLifetimeHandler, IRequestPro
             s is not Http3Stream<TContext> { CanReuse: true } reusableStream)
         {
             stream = new Http3Stream<TContext>(application, CreateHttpStreamContext(streamContext));
-            persistentStateFeature.State.Add(StreamPersistentStateKey, stream);
+            persistentStateFeature.State[StreamPersistentStateKey] = stream;
         }
         else
         {

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -66,6 +66,8 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
     private bool IsAbortedRead => (_completionState & StreamCompletionFlags.AbortedRead) == StreamCompletionFlags.AbortedRead;
     public bool IsCompleted => (_completionState & StreamCompletionFlags.Completed) == StreamCompletionFlags.Completed;
 
+    public bool CanReuse => !_connectionAborted && HasResponseCompleted;
+
     public bool ReceivedEmptyRequestBody
     {
         get
@@ -957,7 +959,6 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
     protected override void OnReset()
     {
         _keepAlive = true;
-        _connectionAborted = false;
         _userTrailers = null;
         _isWebTransportSessionAccepted = false;
         _isMethodConnect = false;


### PR DESCRIPTION
Before this change, Kestrel had a narrow race where it could fail to trigger the RequestAborted token despite the underlying connection closing. Because CancellationTokenSource.TryReset() is not thread-safe, concurrent calls to Cancel() made by CancelRequestAbortedTokenCallback() on a background thread can end up being ignored.

https://github.com/dotnet/runtime/blob/2dbdff1a7aebd64b4b265d99b173cd77f088c36e/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs#L477-L479

I observed exactly this when debugging a hanging test from [Send MCP-Protocol-Version header in Streamable HTTP client transport · modelcontextprotocol/csharp-sdk@735be0f](https://github.com/modelcontextprotocol/csharp-sdk/actions/runs/15717633269/attempts/1) by looking at the memory dump from [testresults-windows-latest-Release](https://github.com/modelcontextprotocol/csharp-sdk/actions/runs/15717633269/artifacts/3349122960). There you can see that there's a SSE request hanging because RequestAborted never firing despite ConnectionContext.ConnectionClosed firing and Http1Connection._connectionAborted being set.

I think this is definitely the right change for HTTP/1.1, and I copied the CanReuse logic from HTTP/2 for HTTP/3 so it hopefully shouldn't cause issues there, but please double check this @JamesNK. If the new logic does cause issues, it likely means the previous logic was even more broken for HTTP/3, because that would mean _connectionAborted could be Reset() to false while CancelRequestAbortedTokenCallback() from a call to HttpContext.Abort() from a previous request was still scheduled on the thread pool.

To fix this, I made _connectionAborted a terminal state and never reset _abortedCts to null. I think the only alternatives would be to somehow synchronize with the CancelRequestAbortedTokenCallback() and delay resetting until that completes or to not pool altogether.