### PR TITLE
Empty "http.route" tags should be set to "/"

### DIFF
--- a/src/Hosting/Hosting/src/Internal/HostingMetrics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingMetrics.cs
@@ -66,7 +66,7 @@ internal sealed class HostingMetrics : IDisposable
 
             // Add information gathered during request.
             tags.Add("http.response.status_code", GetBoxedStatusCode(statusCode));
-            if (route != null)
+            if (!string.IsNullOrEmpty(route))
             {
                 tags.Add("http.route", route);
             }

--- a/src/Hosting/Hosting/src/Internal/HostingMetrics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingMetrics.cs
@@ -69,7 +69,8 @@ internal sealed class HostingMetrics : IDisposable
             tags.Add("http.response.status_code", GetBoxedStatusCode(statusCode));
             if (route != null)
             {
-                var httpRoute = (route == string.Empty) ? "/" : route;
+                // An empty route ("") is valid and equivalent to "/" hence it's normalized for metrics
+                var httpRoute = route == string.Empty ? "/" : route;
                 tags.Add("http.route", httpRoute);
             }
 

--- a/src/Hosting/Hosting/src/Internal/HostingMetrics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingMetrics.cs
@@ -5,7 +5,6 @@ using System.Collections.Frozen;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Metrics;
-
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Shared;
 

--- a/src/Hosting/Hosting/src/Internal/HostingMetrics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingMetrics.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Metrics;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Shared;
 
 namespace Microsoft.AspNetCore.Hosting;
 
@@ -69,9 +70,7 @@ internal sealed class HostingMetrics : IDisposable
             tags.Add("http.response.status_code", GetBoxedStatusCode(statusCode));
             if (route != null)
             {
-                // An empty route ("") is valid and equivalent to "/" hence it's normalized for metrics
-                var httpRoute = route == string.Empty ? "/" : route;
-                tags.Add("http.route", httpRoute);
+                tags.Add("http.route", RouteDiagnosticsHelpers.ResolveHttpRoute(route));
             }
 
             // Add before some built in tags so custom tags are prioritized when dealing with duplicates.

--- a/src/Hosting/Hosting/src/Internal/HostingMetrics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingMetrics.cs
@@ -67,12 +67,11 @@ internal sealed class HostingMetrics : IDisposable
 
             // Add information gathered during request.
             tags.Add("http.response.status_code", GetBoxedStatusCode(statusCode));
-            var httpRoute = route;
-            if (string.IsNullOrEmpty(httpRoute))
+            if (route != null)
             {
-                httpRoute = "/";
+                var httpRoute = (route == string.Empty) ? "/" : route;
+                tags.Add("http.route", httpRoute);
             }
-            tags.Add("http.route", httpRoute);
 
             // Add before some built in tags so custom tags are prioritized when dealing with duplicates.
             if (customTags != null)

--- a/src/Hosting/Hosting/src/Internal/HostingMetrics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingMetrics.cs
@@ -5,6 +5,7 @@ using System.Collections.Frozen;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Metrics;
+
 using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Hosting;
@@ -66,10 +67,12 @@ internal sealed class HostingMetrics : IDisposable
 
             // Add information gathered during request.
             tags.Add("http.response.status_code", GetBoxedStatusCode(statusCode));
-            if (!string.IsNullOrEmpty(route))
+            var httpRoute = route;
+            if (string.IsNullOrEmpty(httpRoute))
             {
-                tags.Add("http.route", route);
+                httpRoute = "/";
             }
+            tags.Add("http.route", httpRoute);
 
             // Add before some built in tags so custom tags are prioritized when dealing with duplicates.
             if (customTags != null)

--- a/src/Hosting/Hosting/src/Microsoft.AspNetCore.Hosting.csproj
+++ b/src/Hosting/Hosting/src/Microsoft.AspNetCore.Hosting.csproj
@@ -19,6 +19,7 @@
     <Compile Include="$(SharedSourceRoot)Metrics\MetricsExtensions.cs" />
     <Compile Include="$(SharedSourceRoot)Metrics\MetricsConstants.cs" />
     <Compile Include="$(SharedSourceRoot)Diagnostics\ActivityCreator.cs" />
+    <Compile Include="$(SharedSourceRoot)Diagnostics\RouteDiagnosticsHelpers.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
@@ -352,6 +352,71 @@ public class HostingApplicationDiagnosticsTests : LoggedTest
             });
     }
 
+    private sealed class EmptyRouteDiagnosticsMetadata : IRouteDiagnosticsMetadata
+    {
+        public string Route { get; } = "";
+    }
+
+    [Fact]
+    public void Metrics_Route_RouteTagMissingWhenEmpty()
+    {
+        // Arrange
+        var hostingEventSource = new HostingEventSource(Guid.NewGuid().ToString());
+
+        var testMeterFactory = new TestMeterFactory();
+        using var activeRequestsCollector = new MetricCollector<long>(testMeterFactory, HostingMetrics.MeterName, "http.server.active_requests");
+        using var requestDurationCollector = new MetricCollector<double>(testMeterFactory, HostingMetrics.MeterName, "http.server.request.duration");
+
+        // Act
+        var hostingApplication = CreateApplication(out var features, eventSource: hostingEventSource, meterFactory: testMeterFactory, configure: c =>
+        {
+            c.Request.Protocol = "1.1";
+            c.Request.Scheme = "http";
+            c.Request.Method = "POST";
+            c.Request.Host = new HostString("localhost");
+            c.Request.Path = "";
+            c.Request.ContentType = "text/plain";
+            c.Request.ContentLength = 1024;
+        });
+        var context = hostingApplication.CreateContext(features);
+
+        Assert.Collection(activeRequestsCollector.GetMeasurementSnapshot(),
+            m =>
+            {
+                Assert.Equal(1, m.Value);
+                Assert.Equal("http", m.Tags["url.scheme"]);
+                Assert.Equal("POST", m.Tags["http.request.method"]);
+            });
+
+        context.HttpContext.SetEndpoint(new Endpoint(
+            c => Task.CompletedTask,
+            new EndpointMetadataCollection(new EmptyRouteDiagnosticsMetadata()),
+            "Test empty endpoint"));
+
+        hostingApplication.DisposeContext(context, null);
+
+        // Assert
+        Assert.Collection(activeRequestsCollector.GetMeasurementSnapshot(),
+            m =>
+            {
+                Assert.Equal(1, m.Value);
+                Assert.Equal("http", m.Tags["url.scheme"]);
+                Assert.Equal("POST", m.Tags["http.request.method"]);
+            },
+            m =>
+            {
+                Assert.Equal(-1, m.Value);
+                Assert.Equal("http", m.Tags["url.scheme"]);
+                Assert.Equal("POST", m.Tags["http.request.method"]);
+            });
+        Assert.Collection(requestDurationCollector.GetMeasurementSnapshot(),
+            m =>
+            {
+                Assert.True(m.Value > 0);
+                Assert.False(m.Tags.ContainsKey("http.route"));
+            });
+    }
+
     [Fact]
     public void Metrics_DisableHttpMetricsWithMetadata_NoMetrics()
     {

--- a/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Diagnostics.Tracing;
 using System.Reflection;
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
@@ -15,6 +16,7 @@ using Microsoft.Extensions.Diagnostics.Metrics;
 using Microsoft.Extensions.Diagnostics.Metrics.Testing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
+
 using Moq;
 
 namespace Microsoft.AspNetCore.Hosting.Tests;
@@ -358,7 +360,7 @@ public class HostingApplicationDiagnosticsTests : LoggedTest
     }
 
     [Fact]
-    public void Metrics_Route_RouteTagMissingWhenEmpty()
+    public void Metrics_Route_RouteTagIsRootWhenEmpty()
     {
         // Arrange
         var hostingEventSource = new HostingEventSource(Guid.NewGuid().ToString());
@@ -413,7 +415,7 @@ public class HostingApplicationDiagnosticsTests : LoggedTest
             m =>
             {
                 Assert.True(m.Value > 0);
-                Assert.False(m.Tags.ContainsKey("http.route"));
+                Assert.Equal("/", m.Tags["http.route"]);
             });
     }
 

--- a/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Diagnostics.Tracing;
 using System.Reflection;
-
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
@@ -16,7 +15,6 @@ using Microsoft.Extensions.Diagnostics.Metrics;
 using Microsoft.Extensions.Diagnostics.Metrics.Testing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
-
 using Moq;
 
 namespace Microsoft.AspNetCore.Hosting.Tests;

--- a/src/Http/Routing/src/Microsoft.AspNetCore.Routing.csproj
+++ b/src/Http/Routing/src/Microsoft.AspNetCore.Routing.csproj
@@ -38,6 +38,7 @@
     <Compile Include="$(SharedSourceRoot)AntiforgeryMetadata.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)HttpExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)ContentTypeConstants.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Diagnostics\RouteDiagnosticsHelpers.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Http/Routing/src/RoutingMetrics.cs
+++ b/src/Http/Routing/src/RoutingMetrics.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.Metrics;
+using Microsoft.AspNetCore.Shared;
 
 namespace Microsoft.AspNetCore.Routing;
 
@@ -31,7 +32,7 @@ internal sealed class RoutingMetrics
     public void MatchSuccess(string route, bool isFallback)
     {
         _matchAttemptsCounter.Add(1,
-            new KeyValuePair<string, object?>("http.route", route),
+            new KeyValuePair<string, object?>("http.route", RouteDiagnosticsHelpers.ResolveHttpRoute(route)),
             new KeyValuePair<string, object?>("aspnetcore.routing.match_status", "success"),
             new KeyValuePair<string, object?>("aspnetcore.routing.is_fallback", isFallback ? BoxedTrue : BoxedFalse));
     }

--- a/src/Shared/Diagnostics/RouteDiagnosticsHelpers.cs
+++ b/src/Shared/Diagnostics/RouteDiagnosticsHelpers.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Shared;
+
+internal static class RouteDiagnosticsHelpers
+{
+    public static string ResolveHttpRoute(string route)
+    {
+        // A route that matches the root of the website could be an empty string. This is problematic.
+        // 1. It is potentially confusing, "What does empty string mean?"
+        // 2. Some telemetry tools have problems with empty string values, e.g. https://github.com/dotnet/aspnetcore/pull/62432
+        //
+        // The fix is to resolve empty string route to "/" in metrics.
+        return string.IsNullOrEmpty(route) ? "/" : route;
+    }
+}


### PR DESCRIPTION
# HostingMetrics: empty "http.route" tags shouldn't be present

When pushing metrics to third-party softwares such as prometheus. Having empty-valued labels will cause issues

## Description

`Microsoft.AspNetCore.Hosting` create a metric called `http.server.request.duration` documented here: <https://learn.microsoft.com/en-us/aspnet/core/log-mon/metrics/built-in>

One the available labels is `http.route` which is optional.

**Issue:**

`http.route` can be populated with various string such as:
- path/to/my/route/{id}
- index
- api/controller/route
- \<empty string\>
- ...

And it can also be missing.

However, based on the [OpenMetrics spec](https://github.com/prometheus/OpenMetrics/blob/main/specification/OpenMetrics.md#label) used by Prometheus, empty label values should be treated as if the label was not present.
That means when exporting data to prometheus, we currently create two different metrics (one for http_route= \<empty string\>, one for the missing http_route), which create a "duplicate sample for timestamp" error when importing data.

**Fix:**

To fix this issue, I changed the metric labelling so an empty route doesn't create the label, as if the variable was null.

Fixes #62431
