### PR TITLE
[blazor] shared instances of ActivitySource

### DIFF
--- a/src/Components/Components/src/ComponentsActivitySource.cs
+++ b/src/Components/Components/src/ComponentsActivitySource.cs
@@ -59,7 +59,7 @@ internal class ComponentsActivitySource
         StopComponentActivity(ComponentsActivityLinkStore.Route, activityHandle, ex);
     }
 
-    public ComponentsActivityHandle StartEventActivity(string? componentType, string? methodName, string? attributeName)
+    public static ComponentsActivityHandle StartEventActivity(string? componentType, string? methodName, string? attributeName)
     {
         var activity = ActivitySource.CreateActivity(OnEventName, ActivityKind.Internal, parentId: null, null, null);
 

--- a/src/Components/Components/src/ComponentsActivitySource.cs
+++ b/src/Components/Components/src/ComponentsActivitySource.cs
@@ -15,7 +15,7 @@ internal class ComponentsActivitySource
     internal const string OnRouteName = $"{Name}.RouteChange";
     internal const string OnEventName = $"{Name}.HandleEvent";
 
-    private ActivitySource ActivitySource { get; } = new ActivitySource(Name);
+    private static ActivitySource ActivitySource { get; } = new ActivitySource(Name);
     private ComponentsActivityLinkStore? _componentsActivityLinkStore;
 
     public void Init(ComponentsActivityLinkStore store)

--- a/src/Components/Components/src/RenderTree/Renderer.cs
+++ b/src/Components/Components/src/RenderTree/Renderer.cs
@@ -461,7 +461,7 @@ public abstract partial class Renderer : IDisposable, IAsyncDisposable
         {
             receiverName ??= (callback.Receiver?.GetType() ?? callback.Delegate.Target?.GetType())?.FullName;
             methodName ??= callback.Delegate.Method?.Name;
-            activityHandle = ComponentActivitySource.StartEventActivity(receiverName, methodName, attributeName);
+            activityHandle = ComponentsActivitySource.StartEventActivity(receiverName, methodName, attributeName);
         }
 
         var eventStartTimestamp = ComponentMetrics != null && ComponentMetrics.IsEventEnabled ? Stopwatch.GetTimestamp() : 0;

--- a/src/Components/Components/test/ComponentsActivitySourceTest.cs
+++ b/src/Components/Components/test/ComponentsActivitySourceTest.cs
@@ -86,7 +86,7 @@ public class ComponentsActivitySourceTest
         componentsActivitySource.StartRouteActivity("ParentComponent", "/parent");
 
         // Act
-        var activityHandle = componentsActivitySource.StartEventActivity(componentType, methodName, attributeName);
+        var activityHandle = ComponentsActivitySource.StartEventActivity(componentType, methodName, attributeName);
         var activity = activityHandle.Activity;
 
         // Assert
@@ -113,7 +113,7 @@ public class ComponentsActivitySourceTest
         var componentsActivitySource = new ComponentsActivitySource();
         var linkstore = new ComponentsActivityLinkStore(null);
         componentsActivitySource.Init(linkstore);
-        var activityHandle = componentsActivitySource.StartEventActivity("TestComponent", "OnClick", "onclick");
+        var activityHandle = ComponentsActivitySource.StartEventActivity("TestComponent", "OnClick", "onclick");
         var activity = activityHandle.Activity;
         var exception = new InvalidOperationException("Test exception");
 
@@ -133,7 +133,7 @@ public class ComponentsActivitySourceTest
         var componentsActivitySource = new ComponentsActivitySource();
         var linkstore = new ComponentsActivityLinkStore(null);
         componentsActivitySource.Init(linkstore);
-        var activityHandle = componentsActivitySource.StartEventActivity("TestComponent", "OnClick", "onclick");
+        var activityHandle = ComponentsActivitySource.StartEventActivity("TestComponent", "OnClick", "onclick");
         var activity = activityHandle.Activity;
         var task = Task.CompletedTask;
 
@@ -152,7 +152,7 @@ public class ComponentsActivitySourceTest
         var componentsActivitySource = new ComponentsActivitySource();
         var linkstore = new ComponentsActivityLinkStore(null);
         componentsActivitySource.Init(linkstore);
-        var activityHandle = componentsActivitySource.StartEventActivity("TestComponent", "OnClick", "onclick");
+        var activityHandle = ComponentsActivitySource.StartEventActivity("TestComponent", "OnClick", "onclick");
         var activity = activityHandle.Activity;
         var exception = new InvalidOperationException("Test exception");
         var task = Task.FromException(exception);
@@ -192,7 +192,7 @@ public class ComponentsActivitySourceTest
         componentsActivitySource.Init(linkstore);
 
         // Act
-        var activityHandle = componentsActivitySource.StartEventActivity(null, null, null);
+        var activityHandle = ComponentsActivitySource.StartEventActivity(null, null, null);
         var activity = activityHandle.Activity;
 
         // Assert

--- a/src/Components/Server/src/Circuits/CircuitActivitySource.cs
+++ b/src/Components/Server/src/Circuits/CircuitActivitySource.cs
@@ -11,7 +11,7 @@ internal class CircuitActivitySource
 
     private ComponentsActivityLinkStore? _activityLinkStore;
 
-    private ActivitySource ActivitySource { get; } = new ActivitySource(Name);
+    private static ActivitySource ActivitySource { get; } = new ActivitySource(Name);
 
     public void Init(ComponentsActivityLinkStore store)
     {


### PR DESCRIPTION
registering new `ActivitySource` instance for each scope is expensive.

crank before the fix

![image](https://github.com/user-attachments/assets/d96dd03b-995f-4395-a170-063db9ba5ded)


crank after the fix

![image](https://github.com/user-attachments/assets/518dcab0-8770-49d6-8177-5be7910df305)
