### PR TITLE
Fix Create Property Model Name for Complex Objects

### DIFF
--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ComplexObjectModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ComplexObjectModelBinder.cs
@@ -364,7 +364,7 @@ public sealed partial class ComplexObjectModelBinder : IModelBinder
             }
 
             var fieldName = property.BinderModelName ?? property.PropertyName!;
-            var modelName = ModelNames.CreatePropertyModelName(bindingContext.ModelName, fieldName);
+            var modelName = ModelNames.CreatePropertyModelNameOptimized(bindingContext.ModelName, fieldName);
             var result = await BindPropertyAsync(bindingContext, property, propertyBinder, fieldName, modelName);
 
             if (result.IsModelSet)

--- a/src/Mvc/Mvc.Core/src/ModelBinding/ModelNames.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/ModelNames.cs
@@ -61,4 +61,44 @@ public static class ModelNames
 
         return prefix + "." + propertyName;
     }
+
+    /// <summary>
+    /// Create a model property name using a prefix and a property name,
+    /// with a small optimization to avoid redundancy.
+    ///
+    /// For example, if both <paramref name="prefix"/> and <paramref name="propertyName"/> are "parameter"
+    /// (ignoring case), the result will be just "parameter" instead of "parameter.Parameter".
+    /// </summary>
+    /// <param name="prefix">The prefix to use.</param>
+    /// <param name="propertyName">The property name.</param>
+    /// <returns>The property model name.</returns>
+    public static string CreatePropertyModelNameOptimized(string? prefix, string? propertyName)
+    {
+        if (string.IsNullOrEmpty(prefix))
+        {
+            return propertyName ?? string.Empty;
+        }
+
+        if (string.IsNullOrEmpty(propertyName))
+        {
+            return prefix ?? string.Empty;
+        }
+
+        if (propertyName.StartsWith('['))
+        {
+            // The propertyName might represent an indexer access, in which case combining
+            // with a 'dot' would be invalid. This case occurs only when called from ValidationVisitor.
+            return prefix + propertyName;
+        }
+
+        if (string.Equals(prefix, propertyName, StringComparison.OrdinalIgnoreCase))
+        {
+            // if we are dealing with with something like:
+            // prefix = parameter and propertyName = parameter
+            // it should fallback to the property name.
+            return propertyName;
+        }
+
+        return prefix + "." + propertyName;
+    }
 }

--- a/src/Mvc/Mvc.Core/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.Core/src/PublicAPI.Unshipped.txt
@@ -6,3 +6,4 @@ Microsoft.AspNetCore.Mvc.ProducesDefaultResponseTypeAttribute.Description.get ->
 Microsoft.AspNetCore.Mvc.ProducesDefaultResponseTypeAttribute.Description.set -> void
 Microsoft.AspNetCore.Mvc.ProducesResponseTypeAttribute.Description.get -> string?
 Microsoft.AspNetCore.Mvc.ProducesResponseTypeAttribute.Description.set -> void
+static Microsoft.AspNetCore.Mvc.ModelBinding.ModelNames.CreatePropertyModelNameOptimized(string? prefix, string? propertyName) -> string!


### PR DESCRIPTION
# Fix Create Property Model Name for Complex Objects

## Description
Added an option to optimize model names where the model name is the same
as one of its properties when binding the model name. This should only
be used when this is the desired behavior. Tests have been added to
assert this behavior when passing parameters whose model name is the
same as the property to be bound.

Now the optimization option allows to treat the modelName and the propertyName with only one if
both are equal.

I [opened a PR trying to solve](https://github.com/dotnet/aspnetcore/pull/58068) this almost 1 year ago, but I didn't have enough knowledge and ended up abandoning ship. Halfway through, I also deleted my fork of the old repository, so I didn't update the old PR, but I decided to finish this work in another one after having learned a little more. I'm sorry about that and I apologize to everyone who was counting on this.

Fixes #57637