### PR TITLE
Fix passkey login error experience

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Login.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Login.razor
@@ -101,7 +101,7 @@
     {
         if (!string.IsNullOrEmpty(Input.Passkey?.Error))
         {
-            errorMessage = $"Error: Could not log in using the provided passkey: {Input.Passkey.Error}";
+            errorMessage = $"Error: {Input.Passkey.Error}";
             return;
         }
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/Passkeys.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/Passkeys.razor
@@ -90,7 +90,7 @@ else
 
         if (!string.IsNullOrEmpty(Input.Error))
         {
-            RedirectManager.RedirectToCurrentPageWithStatus($"Error: Could not add a passkey: {Input.Error}", HttpContext);
+            RedirectManager.RedirectToCurrentPageWithStatus($"Error: {Input.Error}", HttpContext);
             return;
         }
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/Passkeys.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/Passkeys.razor
@@ -110,7 +110,7 @@ else
         var attestationResult = await SignInManager.PerformPasskeyAttestationAsync(Input.CredentialJson, options);
         if (!attestationResult.Succeeded)
         {
-            RedirectManager.RedirectToCurrentPageWithStatus($"Error: Could not add the passkey: {attestationResult.Failure.Message}.", HttpContext);
+            RedirectManager.RedirectToCurrentPageWithStatus($"Error: Could not add the passkey: {attestationResult.Failure.Message}", HttpContext);
             return;
         }
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Shared/PasskeySubmit.razor.js
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Shared/PasskeySubmit.razor.js
@@ -45,7 +45,7 @@ customElements.define('passkey-submit', class extends HTMLElement {
         this.internals.form.addEventListener('submit', (event) => {
             if (event.submitter?.name === '__passkeySubmit') {
                 event.preventDefault();
-                this.obtainCredentialAndSubmit();
+                this.obtainAndSubmitCredential();
             }
         });
 
@@ -56,31 +56,37 @@ customElements.define('passkey-submit', class extends HTMLElement {
         this.abortController?.abort();
     }
 
-    async obtainCredentialAndSubmit(useConditionalMediation = false) {
+    async obtainCredential(useConditionalMediation, signal) {
+        if (this.attrs.operation === 'Create') {
+            return await createCredential(signal);
+        } else if (this.attrs.operation === 'Request') {
+            const email = new FormData(this.internals.form).get(this.attrs.emailName);
+            const mediation = useConditionalMediation ? 'conditional' : undefined;
+            return await requestCredential(email, mediation, signal);
+        } else {
+            throw new Error(`Unknown passkey operation '${this.attrs.operation}'.`);
+        }
+    }
+
+    async obtainAndSubmitCredential(useConditionalMediation = false) {
         this.abortController?.abort();
         this.abortController = new AbortController();
         const signal = this.abortController.signal;
         const formData = new FormData();
         try {
-            let credential;
-            if (this.attrs.operation === 'Create') {
-                credential = await createCredential(signal);
-            } else if (this.attrs.operation === 'Request') {
-                const email = new FormData(this.internals.form).get(this.attrs.emailName);
-                const mediation = useConditionalMediation ? 'conditional' : undefined;
-                credential = await requestCredential(email, mediation, signal);
-            } else {
-                throw new Error(`Unknown passkey operation '${operation}'.`);
-            }
+            const credential = await this.obtainCredential(useConditionalMediation, signal);
             const credentialJson = JSON.stringify(credential);
             formData.append(`${this.attrs.name}.CredentialJson`, credentialJson);
         } catch (error) {
-            if (error.name === 'AbortError') {
-                // Canceled by user action, do not submit the form
+            console.error(error);
+            if (useConditionalMediation || error.name === 'AbortError') {
+                // We do not relay the error to the user if:
+                // 1. We are attempting conditional mediation, meaning the user did not initiate the operation.
+                // 2. The user explicitly canceled the operation and aborting the operation is expected.
                 return;
             }
-            formData.append(`${this.attrs.name}.Error`, error.message);
-            console.error(error);
+            const errorMessage = error.name === 'NotAllowedError' ? 'Unable to authenticate.' : error.message;
+            formData.append(`${this.attrs.name}.Error`, errorMessage);
         }
         this.internals.setFormValue(formData);
         this.internals.form.submit();
@@ -88,7 +94,7 @@ customElements.define('passkey-submit', class extends HTMLElement {
 
     async tryAutofillPasskey() {
         if (this.attrs.operation === 'Request' && await PublicKeyCredential.isConditionalMediationAvailable()) {
-            await this.obtainCredentialAndSubmit(/* useConditionalMediation */ true);
+            await this.obtainAndSubmitCredential(/* useConditionalMediation */ true);
         }
     }
 });

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Shared/PasskeySubmit.razor.js
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Shared/PasskeySubmit.razor.js
@@ -95,7 +95,9 @@ customElements.define('passkey-submit', class extends HTMLElement {
                 // 2. The user explicitly canceled the operation.
                 return;
             }
-            const errorMessage = error.name === 'NotAllowedError' ? 'Unable to authenticate.' : error.message;
+            const errorMessage = error.name === 'NotAllowedError'
+                ? 'No passkey was provided by the authenticator.'
+                : error.message;
             formData.append(`${this.attrs.name}.Error`, errorMessage);
         }
         this.internals.setFormValue(formData);

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Shared/PasskeySubmit.razor.js
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Shared/PasskeySubmit.razor.js
@@ -1,4 +1,10 @@
-﻿async function fetchWithErrorHandling(url, options = {}) {
+﻿const browserSupportsPasskeys =
+    typeof navigator.credentials !== 'undefined' &&
+    typeof window.PublicKeyCredential !== 'undefined' &&
+    typeof window.PublicKeyCredential.parseCreationOptionsFromJSON === 'function' &&
+    typeof window.PublicKeyCredential.parseRequestOptionsFromJSON === 'function';
+
+async function fetchWithErrorHandling(url, options = {}) {
     const response = await fetch(url, {
         credentials: 'include',
         ...options
@@ -57,6 +63,10 @@ customElements.define('passkey-submit', class extends HTMLElement {
     }
 
     async obtainCredential(useConditionalMediation, signal) {
+        if (!browserSupportsPasskeys) {
+            throw new Error('Some passkey features are missing. Please update your browser.');
+        }
+
         if (this.attrs.operation === 'Create') {
             return await createCredential(signal);
         } else if (this.attrs.operation === 'Request') {
@@ -93,7 +103,7 @@ customElements.define('passkey-submit', class extends HTMLElement {
     }
 
     async tryAutofillPasskey() {
-        if (this.attrs.operation === 'Request' && await PublicKeyCredential.isConditionalMediationAvailable()) {
+        if (browserSupportsPasskeys && this.attrs.operation === 'Request' && await PublicKeyCredential.isConditionalMediationAvailable?.()) {
             await this.obtainAndSubmitCredential(/* useConditionalMediation */ true);
         }
     }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Shared/PasskeySubmit.razor.js
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Shared/PasskeySubmit.razor.js
@@ -92,7 +92,7 @@ customElements.define('passkey-submit', class extends HTMLElement {
             if (useConditionalMediation || error.name === 'AbortError') {
                 // We do not relay the error to the user if:
                 // 1. We are attempting conditional mediation, meaning the user did not initiate the operation.
-                // 2. The user explicitly canceled the operation and aborting the operation is expected.
+                // 2. The user explicitly canceled the operation.
                 return;
             }
             const errorMessage = error.name === 'NotAllowedError' ? 'Unable to authenticate.' : error.message;


### PR DESCRIPTION
# Fix passkey login error experience

Improves passkey login error messages and fixes an issue where passkey autofill failure can result in the page refreshing indefinitely.

## Description

If the browser is missing certain passkey APIs, passkey autofill (conditional mediation) can fail. This causes the page to refresh to display the error, but the refresh itself causes passkey autofill to be attempted again. As a result, the page continues to refresh indefinitely.

In addition, displayed error messages are technical and not user-friendly. If an error does occur during passkey login, the user should have a clear understanding of the problem, and the technical details should be logged to the browser console rather than displayed in the UI.

This PR makes the following changes:
1. A more friendly error message is displayed if passkey login fails due to the authenticator failing to authenticate the user.
    _Before:_
    <img width="359" alt="authenticator_failure_before" src="https://github.com/user-attachments/assets/f3e4d768-7767-471b-b8c6-d9359b3da0b1" />
    _After:_
    <img width="360" alt="authenticator_failure_after" src="https://github.com/user-attachments/assets/fb69e170-ab2d-40c6-887f-b4dd7ff75c3d" />
2. If the browser is missing passkey features, the error message clearly states this.
    _Before:_
    <img width="356" alt="missing_features_before" src="https://github.com/user-attachments/assets/ef8fdf7a-a431-42f5-bee9-56f6b665a57a" />
    _After:_
    <img width="370" alt="missing_features_after" src="https://github.com/user-attachments/assets/da3b7ee3-517b-402c-a7c0-9917ba75b4a6" />
3. If any type of passkey failure occurs during passkey autofill, don't relay the error to the user. This both provides a better UX because the user likely isn't expecting to see an error for an action they didn't initiate, and it also fixes the indefinite refresh bug.

Fixes https://github.com/dotnet/aspnetcore-manualtests/issues/3693
