### PR TITLE
Only run template tests when templates change

### DIFF
--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -585,7 +585,7 @@ stages:
         - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildRepoTasks -noBuildNative -noBuild -test
                   -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true
                   /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
-                  /p:VsTestUseMSBuildOutput=false /p:OnlyTestProjectTemplates=true
+                  /p:VsTestUseMSBuildOutput=false /p:RunTemplateTests=false
           displayName: Run build.cmd helix target
           env:
             HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues

--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -582,10 +582,10 @@ stages:
                   /p:VsTestUseMSBuildOutput=false
           displayName: Build shared fx
         # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
-        - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -nobl -all -noBuildRepoTasks -noBuildNative -noBuild -test
+        - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildRepoTasks -noBuildNative -noBuild -test
                   -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true
                   /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
-                  /p:VsTestUseMSBuildOutput=false
+                  /p:VsTestUseMSBuildOutput=false /p:OnlyTestProjectTemplates=true
           displayName: Run build.cmd helix target
           env:
             HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -634,9 +634,9 @@ extends:
                 MSBUILDUSESERVER: "1"
               displayName: Build shared fx
             # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
-            - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -nobl -all -noBuildRepoTasks -noBuildNative -noBuild -test
+            - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildRepoTasks -noBuildNative -noBuild -test
                       -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true
-                      /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
+                      /p:CrossgenOutput=false /p:RunTemplateTests=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
               displayName: Run build.cmd helix target
               env:
                 HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues

--- a/.azure/pipelines/template-tests-pr.yml
+++ b/.azure/pipelines/template-tests-pr.yml
@@ -1,0 +1,50 @@
+# Configure which branches trigger builds
+# We want to run template tests on release/8.0 and later as well as on certain PRs
+trigger:
+  batch: true
+  branches:
+    include:
+    - main
+    - release/*
+
+# Run PR validation on branches that include Helix tests
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - main
+    - release/*
+  paths:
+    include:
+    - src/ProjectTemplates/**/*
+
+variables:
+- name: _UseHelixOpenQueues
+  value: ${{ ne(variables['System.TeamProject'], 'internal') }}
+- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+  - group: DotNet-HelixApi-Access
+- template: /eng/common/templates/variables/pool-providers.yml
+
+jobs:
+- template: jobs/default-build.yml
+  parameters:
+    jobName: Helix_templates_x64
+    jobDisplayName: 'Tests: Helix template tests x64'
+    agentOs: Windows
+    timeoutInMinutes: 120
+    steps:
+    # Build the shared framework
+    - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -nobl -all -pack -arch x64
+              /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
+              /p:VsTestUseMSBuildOutput=false
+      displayName: Build shared fx
+    # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
+    - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildRepoTasks -noBuildNative -noBuild -test
+              -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true
+              /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
+              /p:VsTestUseMSBuildOutput=false /p:OnlyTestProjectTemplates=true
+      displayName: Run build.cmd helix target
+    artifacts:
+    - name: Helix_logs
+      path: artifacts/log/
+      publishOnError: true

--- a/.azure/pipelines/template-tests-pr.yml
+++ b/.azure/pipelines/template-tests-pr.yml
@@ -31,7 +31,7 @@ jobs:
     jobName: Helix_templates_x64
     jobDisplayName: 'Tests: Helix template tests x64'
     agentOs: Windows
-    timeoutInMinutes: 120
+    timeoutInMinutes: 180
     steps:
     # Build the shared framework
     - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -nobl -all -pack -arch x64

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -9,7 +9,7 @@
     the format is correct) and undo any temporary changes. When complete, only BuildAfterTargetingPack.csproj and
     other @(RequiresDelayedBuild) projects should mention projects listed in RequiresDelayedBuildProjects.props.
   -->
-  <Import Project="RequiresDelayedBuildProjects.props" />
+  <Import Project="RequiresDelayedBuildProjects.props" Condition="'$(OnlyTestProjectTemplates)' != 'true'" />
 
   <!-- These projects are always excluded, even when -projects is specified on command line. -->
   <ItemGroup>

--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -6,6 +6,7 @@
       This must be reset in order for Build.props to evaluate a list of projects to be tested on Helix.
     -->
     <ProjectToBuild Condition="'$(ProjectToBuild)' == '$(MSBuildProjectFullPath)'"/>
+    <ProjectToBuild Condition="'$(OnlyTestProjectTemplates)' == 'true'">$(RepoRoot)src\ProjectTemplates\**\*.csproj</ProjectToBuild>
 
     <!--
       Do not load NuGet.targets since this project doesn't reference anything from NuGet. Reduces `msbuild`

--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -6,7 +6,7 @@
       This must be reset in order for Build.props to evaluate a list of projects to be tested on Helix.
     -->
     <ProjectToBuild Condition="'$(ProjectToBuild)' == '$(MSBuildProjectFullPath)'"/>
-    <ProjectToBuild Condition="'$(OnlyTestProjectTemplates)' == 'true'">$(RepoRoot)src\ProjectTemplates\**\*.csproj</ProjectToBuild>
+    <ProjectToBuild Condition="'$(OnlyTestProjectTemplates)' == 'true'">$(RepoRoot)src\ProjectTemplates\test\**\*.csproj</ProjectToBuild>
 
     <!--
       Do not load NuGet.targets since this project doesn't reference anything from NuGet. Reduces `msbuild`


### PR DESCRIPTION
Should significantly cut down on the time it takes to run Helix jobs (@BrennanConroy reports almost an hour of time save). Also adds a new job that will only run when the ProjectTemplates folder is touched, which runs _just_ the template tests in Helix.

Note - some template tests run only in the local jobs. Those will still run in all PRs (but those ones are very quick)