### PR TITLE
Fix path filter for template test PR job

### DIFF
--- a/.azure/pipelines/template-tests-pr.yml
+++ b/.azure/pipelines/template-tests-pr.yml
@@ -16,7 +16,7 @@ pr:
     - release/*
   paths:
     include:
-    - src/ProjectTemplates/**/*
+    - src/ProjectTemplates/*
 
 variables:
 - name: _UseHelixOpenQueues


### PR DESCRIPTION
Docs claim it should be `**/*`, but apparently they're wrong. Runtime does it w/ one wildcard. I also tested this out here: https://github.com/dotnet/aspnetcore/pull/62484