### PR TITLE
Remove _InternalRuntimeDownloadArgs from template tests job

### DIFF
--- a/.azure/pipelines/template-tests-pr.yml
+++ b/.azure/pipelines/template-tests-pr.yml
@@ -35,13 +35,12 @@ jobs:
     steps:
     # Build the shared framework
     - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -nobl -all -pack -arch x64
-              /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
-              /p:VsTestUseMSBuildOutput=false
+              /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log /p:VsTestUseMSBuildOutput=false
       displayName: Build shared fx
     # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
     - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildRepoTasks -noBuildNative -noBuild -test
               -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true
-              /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
+              /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
               /p:VsTestUseMSBuildOutput=false /p:OnlyTestProjectTemplates=true
       displayName: Run build.cmd helix target
     artifacts:


### PR DESCRIPTION
This arg isn't needed (nor is it set) for this public job