### PR TITLE
Disable PREfast in Identitymodel pipeline

### DIFF
--- a/.azure/pipelines/identitymodel-helix-matrix.yml
+++ b/.azure/pipelines/identitymodel-helix-matrix.yml
@@ -37,6 +37,8 @@ extends:
         compiled:
           enabled: false
           justificationForDisabling: 'This is a test-only pipeline. The same product code is already scanned in the main pipeline (aspnetcore-ci)'
+    featureFlags:
+      autoEnablePREfastWithNewRuleset: false
 
     stages:
     - stage: build


### PR DESCRIPTION
The new ruleset has been causing the pipeline to fail: https://dev.azure.com/dnceng/internal/_build/results?buildId=2738566&view=results