### PR TITLE
Add pipeline that's always green, for doc-only PRs

### DIFF
--- a/.azure/pipelines/report-green.yml
+++ b/.azure/pipelines/report-green.yml
@@ -1,3 +1,7 @@
+# This CI job only runs on PRs where all other jobs are skipped.
+# This allows Build Analysis to report green. Without this, no jobs would run,
+# causing Build Analysis to hang indefinitely (or until someone commented "ba-g {justification}" on the PR).
+
 # Only run this on PRs
 trigger: none
 # Run for all branches, only on paths that no-op other jobs
@@ -26,8 +30,7 @@ jobs:
     - job: Report_Green
       enableSBOM: false
       pool:
-        name: $(DncEngPublicBuildPool)
-        demands: ImageOverride -equals 1es-windows-2022
+        vmImage: ubuntu-22.04
       steps:
       - powershell: |
           exit 0

--- a/.azure/pipelines/report-green.yml
+++ b/.azure/pipelines/report-green.yml
@@ -1,0 +1,34 @@
+# Only run this on PRs
+trigger: none
+# Run for all branches, only on paths that no-op other jobs
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - '*'
+  paths:
+    include:
+    - .devcontainer/*
+    - .github/*
+    - .vscode/*
+    - docs/*
+    - '**/*.md'
+    - LICENSE.TXT
+    - THIRD-PARTY-NOTICES.TXT
+
+# ABG - Always Be Green
+jobs:
+- template: /eng/common/templates/jobs/jobs.yml
+  parameters:
+    enableTelemetry: true
+    helixRepo: dotnet/aspnetcore
+    jobs:
+    - job: Report_Green
+      enableSBOM: false
+      pool:
+        name: $(DncEngPublicBuildPool)
+        demands: ImageOverride -equals 1es-windows-2022
+      steps:
+      - powershell: |
+          exit 0
+        displayName: Exit 0


### PR DESCRIPTION
Today, when you open a PR against any of the following paths, no CI job will run. Therefore, Build Analysis hangs indefinitely, because it's waiting for any pipeline to finish - this means devs can't merge such PRs without being an admin, or knowing the magic incantation to unblock Build Analysis (`ba-g {justification}`). 

If we add a new "always green" pipeline that only runs on such PRs, we can work around the issue until https://github.com/dotnet/dnceng/issues/5442 is resolved. Note that a github action wouldn't work here, as Build Analysis only looks for AzDO pipelines.

```
    - .devcontainer/*
    - .github/*
    - .vscode/*
    - docs/*
    - '**/*.md'
    - LICENSE.TXT
    - THIRD-PARTY-NOTICES.TXT
 ```