### PR TITLE
Dispose the certificate chain elements with the chain

### DIFF
--- a/src/Security/Authentication/Certificate/src/CertificateAuthenticationHandler.cs
+++ b/src/Security/Authentication/Certificate/src/CertificateAuthenticationHandler.cs
@@ -157,7 +157,7 @@ internal sealed class CertificateAuthenticationHandler : AuthenticationHandler<C
         finally
         {
             // Disposing the chain does not dispose the elements we potentially built.
-            // Annoyingly do the full walk manually to dispose.
+            // Do the full walk manually to dispose.
             for (int chainElementIndex = 0; chainElementIndex < chain.ChainElements.Count; ++chainElementIndex)
             {
                 chain.ChainElements[chainElementIndex].Certificate.Dispose();

--- a/src/Security/Authentication/Certificate/src/CertificateAuthenticationHandler.cs
+++ b/src/Security/Authentication/Certificate/src/CertificateAuthenticationHandler.cs
@@ -158,9 +158,9 @@ internal sealed class CertificateAuthenticationHandler : AuthenticationHandler<C
         {
             // Disposing the chain does not dispose the elements we potentially built.
             // Do the full walk manually to dispose.
-            for (int chainElementIndex = 0; chainElementIndex < chain.ChainElements.Count; ++chainElementIndex)
+            for (var i = 0; i < chain.ChainElements.Count; i++)
             {
-                chain.ChainElements[chainElementIndex].Certificate.Dispose();
+                chain.ChainElements[i].Certificate.Dispose();
             }
 
             chain.Dispose();

--- a/src/Shared/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/UnixCertificateManager.cs
@@ -108,7 +108,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
                 var certPath = Path.Combine(sslCertDir, certificateNickname + ".pem");
                 if (File.Exists(certPath))
                 {
-                    var candidate = X509CertificateLoader.LoadCertificateFromFile(certPath);
+                    using var candidate = X509CertificateLoader.LoadCertificateFromFile(certPath);
                     if (AreCertificatesEqual(certificate, candidate))
                     {
                         foundCert = true;

--- a/src/Shared/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/UnixCertificateManager.cs
@@ -62,18 +62,31 @@ internal sealed partial class UnixCertificateManager : CertificateManager
         // Building the chain will check whether dotnet trusts the cert.  We could, instead,
         // enumerate the Root store and/or look for the file in the OpenSSL directory, but
         // this tests the real-world behavior.
-        using var chain = new X509Chain();
-        // This is just a heuristic for whether or not we should prompt the user to re-run with `--trust`
-        // so we don't need to check revocation (which doesn't really make sense for dev certs anyway)
-        chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-        if (chain.Build(certificate))
+        var chain = new X509Chain();
+        try
         {
-            sawTrustSuccess = true;
-        }
-        else
+            // This is just a heuristic for whether or not we should prompt the user to re-run with `--trust`
+            // so we don't need to check revocation (which doesn't really make sense for dev certs anyway)
+            chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+            if (chain.Build(certificate))
+            {
+                sawTrustSuccess = true;
+            }
+            else
+            {
+                sawTrustFailure = true;
+                Log.UnixNotTrustedByDotnet();
+            }
+        finally
         {
-            sawTrustFailure = true;
-            Log.UnixNotTrustedByDotnet();
+            // Disposing the chain does not dispose the elements we potentially built.
+            // Annoyingly do the full walk manually to dispose.
+            for (int chainElementIndex = 0; chainElementIndex < chain.ChainElements.Count; ++chainElementIndex)
+            {
+                chain.ChainElements[chainElementIndex].Certificate.Dispose();
+            }
+
+            chain.Dispose();
         }
 
         // Will become the name of the file on disk and the nickname in the NSS DBs

--- a/src/Shared/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/UnixCertificateManager.cs
@@ -77,6 +77,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
                 sawTrustFailure = true;
                 Log.UnixNotTrustedByDotnet();
             }
+        }
         finally
         {
             // Disposing the chain does not dispose the elements we potentially built.

--- a/src/Shared/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/UnixCertificateManager.cs
@@ -81,7 +81,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
         finally
         {
             // Disposing the chain does not dispose the elements we potentially built.
-            // Annoyingly do the full walk manually to dispose.
+            // Do the full walk manually to dispose.
             for (int chainElementIndex = 0; chainElementIndex < chain.ChainElements.Count; ++chainElementIndex)
             {
                 chain.ChainElements[chainElementIndex].Certificate.Dispose();

--- a/src/Shared/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/UnixCertificateManager.cs
@@ -82,9 +82,9 @@ internal sealed partial class UnixCertificateManager : CertificateManager
         {
             // Disposing the chain does not dispose the elements we potentially built.
             // Do the full walk manually to dispose.
-            for (int chainElementIndex = 0; chainElementIndex < chain.ChainElements.Count; ++chainElementIndex)
+            for (var i = 0; i < chain.ChainElements.Count; i++)
             {
-                chain.ChainElements[chainElementIndex].Certificate.Dispose();
+                chain.ChainElements[i].Certificate.Dispose();
             }
 
             chain.Dispose();


### PR DESCRIPTION
# Dispose the certificate chain elements within the chain

This pr is going to fix a series of native memory leaks we have seen due to leaking certificates on the chain at Roblox. (fingers crossed)

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

{Detail}

Fixes #{bug number} (in this specific format)
