### PR TITLE
Restore Gradle dependencies to in-repo cache in CI

### DIFF
--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -47,6 +47,8 @@ parameters:
 variables:
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: true
+- name: GRADLE_USER_HOME
+  value: $(Build.SourcesDirectory)/.gradle
 - name: _TeamName
   value:  AspNetCore
 - name: _PublishUsingPipelines

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -31,6 +31,8 @@ parameters:
 variables:
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: true
+- name: GRADLE_USER_HOME
+  value: $(Build.SourcesDirectory)/.gradle
 - name: _TeamName
   value:  AspNetCore
 - name: _PublishUsingPipelines

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -112,7 +112,7 @@ jobs:
             demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
         ${{ if eq(parameters.agentOs, 'Windows') }}:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals windows.vs2022preview.amd64.open
+          demands: ImageOverride -equals windows.vs2022.amd64.open
       ${{ if ne(parameters.container, '') }}:
         container: ${{ parameters.container }}
       ${{ if ne(parameters.disableComponentGovernance, '') }}:
@@ -328,7 +328,7 @@ jobs:
         ${{ if eq(parameters.agentOs, 'Windows') }}:
           name: $(DncEngInternalBuildPool)
           # Visual Studio Enterprise - contains some stuff, like SQL Server and IIS Express, that we use for testing
-          image: windows.vs2022preview.amd64
+          image: windows.vs2022.amd64
           os: windows
       ${{ if ne(parameters.container, '') }}:
         container: ${{ parameters.container }}

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -112,7 +112,7 @@ jobs:
             demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
         ${{ if eq(parameters.agentOs, 'Windows') }}:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals windows.vs2022.amd64.open
+          demands: ImageOverride -equals windows.vs2022preview.amd64.open
       ${{ if ne(parameters.container, '') }}:
         container: ${{ parameters.container }}
       ${{ if ne(parameters.disableComponentGovernance, '') }}:
@@ -328,7 +328,7 @@ jobs:
         ${{ if eq(parameters.agentOs, 'Windows') }}:
           name: $(DncEngInternalBuildPool)
           # Visual Studio Enterprise - contains some stuff, like SQL Server and IIS Express, that we use for testing
-          image: windows.vs2022.amd64
+          image: windows.vs2022preview.amd64
           os: windows
       ${{ if ne(parameters.container, '') }}:
         container: ${{ parameters.container }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ artifacts/
 bin/
 obj/
 .dotnet/
+.gradle/
 .nuget/
 .packages/
 .tools/


### PR DESCRIPTION
Today these dependencies get restored to a cache outside the repo, so they don't get scanned by Component Governance.