### PR TITLE
Restore Gradle dependencies to in-repo cache in CI

### DIFF
--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -47,6 +47,8 @@ parameters:
 variables:
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: true
+- name: GRADLE_USER_HOME
+  value: $(Build.SourcesDirectory)/.gradle
 - name: _TeamName
   value:  AspNetCore
 - name: _PublishUsingPipelines

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -31,6 +31,8 @@ parameters:
 variables:
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: true
+- name: GRADLE_USER_HOME
+  value: $(Build.SourcesDirectory)/.gradle
 - name: _TeamName
   value:  AspNetCore
 - name: _PublishUsingPipelines

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ artifacts/
 bin/
 obj/
 .dotnet/
+.gradle/
 .nuget/
 .packages/
 .tools/


### PR DESCRIPTION
We started seeing failures in the installer build after https://github.com/dotnet/aspnetcore/pull/62275 was merged - it's not clear to me how they could be related, but trying out a revert anyways