### PR TITLE
Run template tests on Components/MVC changes

### DIFF
--- a/.azure/pipelines/template-tests-pr.yml
+++ b/.azure/pipelines/template-tests-pr.yml
@@ -17,6 +17,8 @@ pr:
   paths:
     include:
     - src/ProjectTemplates/*
+    - src/Components/*
+    - src/Mvc/*
 
 variables:
 - name: _UseHelixOpenQueues

--- a/.azure/pipelines/template-tests-pr.yml
+++ b/.azure/pipelines/template-tests-pr.yml
@@ -47,6 +47,8 @@ jobs:
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
               /p:VsTestUseMSBuildOutput=false /p:OnlyTestProjectTemplates=true
       displayName: Run build.cmd helix target
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
     artifacts:
     - name: Helix_logs
       path: artifacts/log/


### PR DESCRIPTION
These are the areas most likely to cause template test failures