### PR TITLE
Fix for Unobserved `NavigationException` in Blazor SSR

### DIFF
--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Prerendering.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Prerendering.cs
@@ -235,22 +235,9 @@ internal partial class EndpointHtmlRenderer
                     // the child components to finish executing SetParametersAsync
                     await pendingWork;
                 }
-                catch (Exception ex)
+                catch (NavigationException navigationException)
                 {
-                    // We need to handle NavigationException specially to ensure it gets properly
-                    // processed through HandleNavigationException rather than being rethrown
-                    if (ex is NavigationException navigationEx)
-                    {
-                        if (_httpContext is not null)
-                        {
-                            await HandleNavigationException(_httpContext, navigationEx);
-                        }
-                        return;
-                    }
-                    else
-                    {
-                        throw;
-                    }
+                    await HandleNavigationException(_httpContext, navigationException);
                 }
             }
         }

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Prerendering.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Prerendering.cs
@@ -229,9 +229,29 @@ internal partial class EndpointHtmlRenderer
                 // Clear all pending work.
                 _nonStreamingPendingTasks.Clear();
 
-                // new work might be added before we check again as a result of waiting for all
-                // the child components to finish executing SetParametersAsync
-                await pendingWork;
+                try
+                {
+                    // new work might be added before we check again as a result of waiting for all
+                    // the child components to finish executing SetParametersAsync
+                    await pendingWork;
+                }
+                catch (Exception ex)
+                {
+                    // We need to handle NavigationException specially to ensure it gets properly
+                    // processed through HandleNavigationException rather than being rethrown
+                    if (ex is NavigationException navigationEx)
+                    {
+                        if (_httpContext is not null)
+                        {
+                            await HandleNavigationException(_httpContext, navigationEx);
+                        }
+                        return;
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
             }
         }
     }

--- a/src/Components/test/E2ETest/ServerRenderingTests/RedirectionTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/RedirectionTest.cs
@@ -221,6 +221,16 @@ public class RedirectionTest : ServerTestBase<BasicTestAppServerSiteFixture<Razo
         Assert.EndsWith("/subdir/redirect", Browser.Url);
     }
 
+    [Fact]
+    public void NavigationException_InAsyncContext_DoesNotBecomeUnobservedTaskException()
+    {
+        // Navigate to the page that triggers the circular redirect.
+        Navigate($"{ServerPathBase}/redirect/circular");
+
+        // The component will stop redirecting after 3 attempts and render the exception count.
+        Browser.Equal("0", () => Browser.FindElement(By.Id("unobserved-exceptions-count")).Text);
+    }
+
     private void AssertElementRemoved(IWebElement element)
     {
         Browser.True(() =>

--- a/src/Components/test/E2ETest/ServerRenderingTests/RedirectionTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/RedirectionTest.cs
@@ -224,6 +224,8 @@ public class RedirectionTest : ServerTestBase<BasicTestAppServerSiteFixture<Razo
     [Fact]
     public void NavigationException_InAsyncContext_DoesNotBecomeUnobservedTaskException()
     {
+        AppContext.SetSwitch("Microsoft.AspNetCore.Components.Endpoints.NavigationManager.DisableThrowNavigationException", false);
+
         // Navigate to the page that triggers the circular redirect.
         Navigate($"{ServerPathBase}/redirect/circular");
 

--- a/src/Components/test/testassets/Components.TestServer/Program.cs
+++ b/src/Components/test/testassets/Components.TestServer/Program.cs
@@ -81,8 +81,16 @@ public class Program
 
     public static IHost BuildWebHost(string[] args) => BuildWebHost<Startup>(args);
 
-    public static IHost BuildWebHost<TStartup>(string[] args) where TStartup : class =>
-        Host.CreateDefaultBuilder(args)
+    public static IHost BuildWebHost<TStartup>(string[] args) where TStartup : class
+    {
+        var unobservedTaskExceptionObserver = new UnobservedTaskExceptionObserver();
+        TaskScheduler.UnobservedTaskException += unobservedTaskExceptionObserver.OnUnobservedTaskException;
+
+        return Host.CreateDefaultBuilder(args)
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton(unobservedTaskExceptionObserver);
+            })
             .ConfigureLogging((ctx, lb) =>
             {
                 TestSink sink = new TestSink();
@@ -98,6 +106,7 @@ public class Program
                 webHostBuilder.UseStaticWebAssets();
             })
             .Build();
+    }
 
     private static int GetNextChildAppPortNumber()
     {

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Redirections/CircularRedirection.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Redirections/CircularRedirection.razor
@@ -1,0 +1,53 @@
+﻿@page "/redirect/circular"
+@using System.Collections.Concurrent
+@inject NavigationManager Nav
+@inject UnobservedTaskExceptionObserver Observer
+
+<h1>Hello, world!</h1>
+
+@if (_shouldStopRedirecting)
+{
+    <p id="unobserved-exceptions-count">@_unobservedExceptions.Count</p>
+
+    @if (_unobservedExceptions.Any())
+    {
+        <h2>Unobserved Exceptions (for debugging):</h2>
+        <ul>
+            @foreach (var ex in _unobservedExceptions)
+            {
+                <li>@ex.ToString()</li>
+            }
+        </ul>
+    }
+}
+
+@code {
+    private bool _shouldStopRedirecting;
+    private IReadOnlyCollection<Exception> _unobservedExceptions = Array.Empty<Exception>();
+
+    protected override async Task OnInitializedAsync()
+    {
+		int visits = Observer.GetCircularRedirectCount();
+		if (visits == 0)
+		{
+			// make sure we start with clean logs
+			Observer.Clear();
+		}
+
+        // Force GC collection to trigger finalizers - this is what causes the issue
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+        await Task.Yield();
+
+        if (Observer.GetAndIncrementCircularRedirectCount() < 3)
+        {
+            Nav.NavigateTo("redirect/circular");
+        }
+        else
+        {
+            _shouldStopRedirecting = true;
+            _unobservedExceptions = Observer.GetExceptions();
+        }
+    }
+}

--- a/src/Components/test/testassets/Components.TestServer/UnobservedTaskExceptionObserver.cs
+++ b/src/Components/test/testassets/Components.TestServer/UnobservedTaskExceptionObserver.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace TestServer;
+
+public class UnobservedTaskExceptionObserver
+{
+    private readonly ConcurrentQueue<Exception> _exceptions = new();
+    private int _circularRedirectCount;
+
+    public void OnUnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
+    {
+        _exceptions.Enqueue(e.Exception);
+        e.SetObserved(); // Mark as observed to prevent the process from crashing during tests
+    }
+
+    public bool HasExceptions => !_exceptions.IsEmpty;
+
+    public IReadOnlyCollection<Exception> GetExceptions() => _exceptions.ToArray();
+
+    public void Clear()
+    {
+        _exceptions.Clear();
+        _circularRedirectCount = 0;
+    }
+
+    public int GetCircularRedirectCount()
+    {
+        return _circularRedirectCount;
+    }
+
+    public int GetAndIncrementCircularRedirectCount()
+    {
+        return Interlocked.Increment(ref _circularRedirectCount) - 1;
+    }
+}


### PR DESCRIPTION
# Prevent rethrowing `NavigationException` in finalizer thread

## Description

When a NavigationException is thrown from an async component lifecycle method during Blazor server-side rendering, it can become an unobserved task exception if not properly handled. This happens specifically in circular redirection scenarios, where the exception is thrown and then the task is garbage collected before being properly observed.

The issue manifests as an unhandled exception in the finalizer thread with a stack trace like:

```
Unhandled caught: System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread.
 ---> Microsoft.AspNetCore.Components.NavigationException: Exception of type 'Microsoft.AspNetCore.Components.NavigationException' was thrown.
   at Microsoft.AspNetCore.Components.Endpoints.HttpNavigationManager.NavigateToCore(String uri, NavigationOptions options)
   ...
   at Microsoft.AspNetCore.Components.Endpoints.EndpointHtmlRenderer.<WaitForNonStreamingPendingTasks>g__Execute|43_0()
   at Microsoft.AspNetCore.Components.Endpoints.EndpointHtmlRenderer.WaitForResultReady(Boolean waitForQuiescence, PrerenderedComponentHtmlContent result)
```

## Root Cause

The issue occurs in the `WaitForNonStreamingPendingTasks` method in `EndpointHtmlRenderer`, where we await a collection of tasks without properly handling NavigationExceptions that might be thrown from them. When the task is garbage collected before completing, the unobserved exception is rethrown from the finalizer thread.

## Fix

We've added proper exception handling in `WaitForNonStreamingPendingTasks` to specifically catch, observe `NavigationExceptions` and handle navigation when possible.

## Validation

We added `NavigationException_InAsyncContext_DoesNotBecomeUnobservedTaskException` test that verifies no unobserved exceptions occur when a component causes circular redirections, even with forced garbage collection. We set the AppContext switch to make sure navigation uses the exception-driven flow.

Fixes #62167