### PR TITLE
Update all built-in AuthenticationSchemeOptions to initialize Events

### DIFF
--- a/src/Security/Authentication/Certificate/src/CertificateAuthenticationOptions.cs
+++ b/src/Security/Authentication/Certificate/src/CertificateAuthenticationOptions.cs
@@ -11,6 +11,14 @@ namespace Microsoft.AspNetCore.Authentication.Certificate;
 public class CertificateAuthenticationOptions : AuthenticationSchemeOptions
 {
     /// <summary>
+    /// Initializes a new instance of <see cref="CertificateAuthenticationOptions"/>.
+    /// </summary>
+    public CertificateAuthenticationOptions()
+    {
+        Events = new CertificateAuthenticationEvents();
+    }
+
+    /// <summary>
     /// Value indicating the types of certificates accepted by the authentication middleware.
     /// </summary>
     /// <value>

--- a/src/Security/Authentication/JwtBearer/src/JwtBearerOptions.cs
+++ b/src/Security/Authentication/JwtBearer/src/JwtBearerOptions.cs
@@ -32,6 +32,7 @@ public class JwtBearerOptions : AuthenticationSchemeOptions
         SecurityTokenValidators = new List<ISecurityTokenValidator> { _defaultHandler };
 #pragma warning restore CS0618 // Type or member is obsolete
         TokenHandlers = new List<TokenHandler> { _defaultTokenHandler };
+        Events = new JwtBearerEvents();
     }
 
     /// <summary>

--- a/src/Security/Authentication/Negotiate/src/NegotiateOptions.cs
+++ b/src/Security/Authentication/Negotiate/src/NegotiateOptions.cs
@@ -9,6 +9,14 @@ namespace Microsoft.AspNetCore.Authentication.Negotiate;
 public class NegotiateOptions : AuthenticationSchemeOptions
 {
     /// <summary>
+    /// Initializes a new instance of <see cref="NegotiateOptions"/>.
+    /// </summary>
+    public NegotiateOptions()
+    {
+        Events = new NegotiateEvents();
+    }
+
+    /// <summary>
     /// The object provided by the application to process events raised by the negotiate authentication handler.
     /// The application may use the existing NegotiateEvents instance and assign delegates only to the events it
     /// wants to process. The application may also replace it with its own derived instance.

--- a/src/Security/Authentication/Negotiate/test/Negotiate.Test/NegotiateHandlerTests.cs
+++ b/src/Security/Authentication/Negotiate/test/Negotiate.Test/NegotiateHandlerTests.cs
@@ -21,6 +21,13 @@ namespace Microsoft.AspNetCore.Authentication.Negotiate;
 public class NegotiateHandlerTests
 {
     [Fact]
+    public void EventsPropertyIsInitializedOnConstruction()
+    {
+        var options = new NegotiateOptions();
+        Assert.NotNull(options.Events);
+    }
+
+    [Fact]
     public async Task Anonymous_MissingConnectionFeatures_ThrowsNotSupported()
     {
         using var host = await CreateHostAsync();

--- a/src/Security/Authentication/test/BearerTokenTests.cs
+++ b/src/Security/Authentication/test/BearerTokenTests.cs
@@ -23,4 +23,11 @@ public class BearerTokenTests : SharedAuthenticationTests<BearerTokenOptions>
     {
         services.AddBearerToken(configure);
     }
+
+    [Fact]
+    public void EventsPropertyIsInitializedOnConstruction()
+    {
+        var options = new BearerTokenOptions();
+        Assert.NotNull(options.Events);
+    }
 }

--- a/src/Security/Authentication/test/CertificateTests.cs
+++ b/src/Security/Authentication/test/CertificateTests.cs
@@ -22,6 +22,12 @@ namespace Microsoft.AspNetCore.Authentication.Certificate.Test;
 
 public class ClientCertificateAuthenticationTests
 {
+    [Fact]
+    public void EventsPropertyIsInitializedOnConstruction()
+    {
+        var options = new CertificateAuthenticationOptions();
+        Assert.NotNull(options.Events);
+    }
 
     [Fact]
     public async Task VerifySchemeDefaults()

--- a/src/Security/Authentication/test/CookieTests.cs
+++ b/src/Security/Authentication/test/CookieTests.cs
@@ -33,6 +33,13 @@ public class CookieTests : SharedAuthenticationTests<CookieAuthenticationOptions
     }
 
     [Fact]
+    public void EventsPropertyIsInitializedOnConstruction()
+    {
+        var options = new CookieAuthenticationOptions();
+        Assert.NotNull(options.Events);
+    }
+
+    [Fact]
     public async Task NormalRequestPassesThrough()
     {
         using var host = await CreateHost(s => { });

--- a/src/Security/Authentication/test/FacebookTests.cs
+++ b/src/Security/Authentication/test/FacebookTests.cs
@@ -43,6 +43,13 @@ public class FacebookTests : RemoteAuthenticationTests<FacebookOptions>
     }
 
     [Fact]
+    public void EventsPropertyIsInitializedOnConstruction()
+    {
+        var options = new FacebookOptions();
+        Assert.NotNull(options.Events);
+    }
+
+    [Fact]
     public async Task ThrowsIfAppIdMissing()
     {
         using var host = await CreateHost(

--- a/src/Security/Authentication/test/GoogleTests.cs
+++ b/src/Security/Authentication/test/GoogleTests.cs
@@ -43,6 +43,13 @@ public class GoogleTests : RemoteAuthenticationTests<GoogleOptions>
     }
 
     [Fact]
+    public void EventsPropertyIsInitializedOnConstruction()
+    {
+        var options = new GoogleOptions();
+        Assert.NotNull(options.Events);
+    }
+
+    [Fact]
     public async Task ChallengeWillTriggerRedirection()
     {
         using var host = await CreateHost(o =>

--- a/src/Security/Authentication/test/JwtBearerTests.cs
+++ b/src/Security/Authentication/test/JwtBearerTests.cs
@@ -33,15 +33,14 @@ public class JwtBearerTests : SharedAuthenticationTests<JwtBearerOptions>
 
     protected override void RegisterAuth(AuthenticationBuilder services, Action<JwtBearerOptions> configure)
     {
-        services.AddJwtBearer(o =>
-        {
-            ConfigureDefaults(o);
-            configure.Invoke(o);
-        });
+        services.AddJwtBearer(configure);
     }
 
-    private void ConfigureDefaults(JwtBearerOptions o)
+    [Fact]
+    public void EventsPropertyIsInitializedOnConstruction()
     {
+        var options = new JwtBearerOptions();
+        Assert.NotNull(options.Events);
     }
 
     [Fact]

--- a/src/Security/Authentication/test/MicrosoftAccountTests.cs
+++ b/src/Security/Authentication/test/MicrosoftAccountTests.cs
@@ -44,6 +44,13 @@ public class MicrosoftAccountTests : RemoteAuthenticationTests<MicrosoftAccountO
     }
 
     [Fact]
+    public void EventsPropertyIsInitializedOnConstruction()
+    {
+        var options = new MicrosoftAccountOptions();
+        Assert.NotNull(options.Events);
+    }
+
+    [Fact]
     public async Task ChallengeWillTriggerApplyRedirectEvent()
     {
         using var host = await CreateHost(o =>

--- a/src/Security/Authentication/test/OAuthTests.cs
+++ b/src/Security/Authentication/test/OAuthTests.cs
@@ -32,6 +32,13 @@ public class OAuthTests : RemoteAuthenticationTests<OAuthOptions>
     }
 
     [Fact]
+    public void EventsPropertyIsInitializedOnConstruction()
+    {
+        var options = new OAuthOptions();
+        Assert.NotNull(options.Events);
+    }
+
+    [Fact]
     public async Task ThrowsIfClientIdMissing()
     {
         using var host = await CreateHost(

--- a/src/Security/Authentication/test/OpenIdConnect/OpenIdConnectTests.cs
+++ b/src/Security/Authentication/test/OpenIdConnect/OpenIdConnectTests.cs
@@ -25,6 +25,13 @@ public class OpenIdConnectTests
     static readonly string nonceDelimiter = ".";
     const string DefaultHost = @"https://example.com";
 
+    [Fact]
+    public void EventsPropertyIsInitializedOnConstruction()
+    {
+        var options = new OpenIdConnectOptions();
+        Assert.NotNull(options.Events);
+    }
+
     /// <summary>
     /// Tests RedirectForSignOutContext replaces the OpenIdConnectMesssage correctly.
     /// </summary>

--- a/src/Security/Authentication/test/TwitterTests.cs
+++ b/src/Security/Authentication/test/TwitterTests.cs
@@ -42,6 +42,13 @@ public class TwitterTests : RemoteAuthenticationTests<TwitterOptions>
     }
 
     [Fact]
+    public void EventsPropertyIsInitializedOnConstruction()
+    {
+        var options = new TwitterOptions();
+        Assert.NotNull(options.Events);
+    }
+
+    [Fact]
     public async Task ChallengeWillTriggerApplyRedirectEvent()
     {
         using var host = await CreateHost(o =>

--- a/src/Security/Authentication/test/WsFederation/WsFederationTest.cs
+++ b/src/Security/Authentication/test/WsFederation/WsFederationTest.cs
@@ -24,6 +24,13 @@ namespace Microsoft.AspNetCore.Authentication.WsFederation;
 public class WsFederationTest
 {
     [Fact]
+    public void EventsPropertyIsInitializedOnConstruction()
+    {
+        var options = new WsFederationOptions();
+        Assert.NotNull(options.Events);
+    }
+
+    [Fact]
     public async Task VerifySchemeDefaults()
     {
         var services = new ServiceCollection();


### PR DESCRIPTION
I'm not exactly sure why `Events` isn't always initialized to a non-null value especially given that the property is annotated as being non-nullable. It is initialized in a bunch of other `AuthenticationSchemeOptions` like `CookieAuthenticationOptions`, `OpenIdConnectOptions`, `BearerTokenOptions`, etc. Changing it now for existing options type could theoretically break people who already used something like `options.Events ??= new ....` although I imagine most code would either omit the `??` part or only initialize to the default Events type.

Maybe the idea during the initial design of these types was that more people would derive from the Events type and set the Events property to their custom type during the initial design, but I don't think I've ever seen that outside of our tests.

Fixes #43313
