### PR TITLE
Log when an enhanced navigation fails

### DIFF
--- a/src/Components/Web.JS/src/Services/NavigationEnhancement.ts
+++ b/src/Components/Web.JS/src/Services/NavigationEnhancement.ts
@@ -455,6 +455,7 @@ function enhancedNavigationIsEnabledForForm(form: HTMLFormElement): boolean {
 function retryEnhancedNavAsFullPageLoad(internalDestinationHref: string) {
   // The ? trick here is the same workaround as described in #10839, and without it, the user
   // would not be able to use the back button afterwards.
+  console.warn(`Enhanced navigation failed for destination ${internalDestinationHref}. Falling back to full page load.`);
   history.replaceState(null, '', internalDestinationHref + '?');
   location.replace(internalDestinationHref);
 }

--- a/src/Components/test/E2ETest/ServerRenderingTests/EnhancedNavigationTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/EnhancedNavigationTest.cs
@@ -73,6 +73,10 @@ public class EnhancedNavigationTest : ServerTestBase<BasicTestAppServerSiteFixtu
         Navigate($"{ServerPathBase}/nav");
         Browser.Exists(By.TagName("nav")).FindElement(By.LinkText("Non-HTML page")).Click();
         Browser.Equal("Hello, this is plain text", () => Browser.Exists(By.TagName("html")).Text);
+
+        //Check if the fall back because of the non-html response sends a warning
+        var logs = Browser.GetBrowserLogs(LogLevel.Warning);
+        Assert.Contains(logs, log => log.Message.Contains("Enhanced navigation failed for destination") && log.Message.Contains("Falling back to full page load.") && !log.Message.Contains("Error"));
     }
 
     [Fact]
@@ -324,10 +328,6 @@ public class EnhancedNavigationTest : ServerTestBase<BasicTestAppServerSiteFixtu
         Browser.Exists(By.Id("refresh-with-refresh")).Click();
         Browser.True(() => IsElementStale(initialRenderIdElement));
 
-        //Check if the warning about the fail were logged.
-        var logs = Browser.GetBrowserLogs(LogLevel.Warning);
-        Assert.Contains(logs, log => log.Message.Contains("Enhanced navigation failed for destination") && !log.Message.Contains("Error"));
-
         var finalRenderIdElement = Browser.Exists(By.Id("render-id"));
         var finalRenderId = -1;
         Browser.True(() => int.TryParse(finalRenderIdElement.Text, out finalRenderId));
@@ -469,6 +469,11 @@ public class EnhancedNavigationTest : ServerTestBase<BasicTestAppServerSiteFixtu
         Browser.Exists(By.TagName("nav")).FindElement(By.LinkText("Non-Blazor HTML page")).Click();
         Browser.Equal("This is a non-Blazor endpoint", () => Browser.Exists(By.TagName("h1")).Text);
         Assert.Equal("undefined", Browser.ExecuteJavaScript<string>("return typeof Blazor")); // Blazor JS is NOT loaded
+
+        //Check if the fall back because of the non-blazor endpoint navigation sends a warning
+        var logs = Browser.GetBrowserLogs(LogLevel.Warning);
+        Assert.Contains(logs, log => log.Message.Contains("Enhanced navigation failed for destination") && log.Message.Contains("Falling back to full page load.") && !log.Message.Contains("Error"));
+
     }
 
     [Theory]

--- a/src/Components/test/E2ETest/ServerRenderingTests/EnhancedNavigationTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/EnhancedNavigationTest.cs
@@ -324,6 +324,10 @@ public class EnhancedNavigationTest : ServerTestBase<BasicTestAppServerSiteFixtu
         Browser.Exists(By.Id("refresh-with-refresh")).Click();
         Browser.True(() => IsElementStale(initialRenderIdElement));
 
+        //Check if the warning about the fail were logged.
+        var logs = Browser.GetBrowserLogs(LogLevel.Warning);
+        Assert.Contains(logs, log => log.Message.Contains("Enhanced navigation failed for destination") && !log.Message.Contains("Error"));
+
         var finalRenderIdElement = Browser.Exists(By.Id("render-id"));
         var finalRenderId = -1;
         Browser.True(() => int.TryParse(finalRenderIdElement.Text, out finalRenderId));


### PR DESCRIPTION
# Log when an enhanced navigation fails

## Description

This pull request enhances the `retryEnhancedNavAsFullPageLoad` and adds warning when enhanced navigation falls back to the full page rendering. The main changes is adding warning and additions to the tests that ensure that warning are being sent.

### Changes:
- Added `console.warn()` to the [NavigationEnhancement.ts](src/Components/Web.JS/src/Services/NavigationEnhancement.ts)
- Added testing for the thrown warnings in the [EnhancedNavigationTest.cs](src/Components/test/E2ETest/ServerRenderingTests/EnhancedNavigationTest.cs)

Fixes #51229
