### PR TITLE
QuickGrid: Adds option to disable rendering of filler rows

### DIFF
--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/Pagination/PaginationState.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/Pagination/PaginationState.cs
@@ -11,6 +11,11 @@ namespace Microsoft.AspNetCore.Components.QuickGrid;
 public class PaginationState
 {
     /// <summary>
+    /// Whether or not to render empty rows to fill the view.  
+    /// </summary>
+    public bool RenderFillerRows = true;
+
+    /// <summary>
     /// Gets or sets the number of items on each page.
     /// </summary>
     public int ItemsPerPage { get; set; } = 10;

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
@@ -48,7 +48,6 @@
 
         // When pagination is enabled, by default ensure we render the exact number of expected rows per page,
         // even if there aren't enough data items. This avoids the layout jumping on the last page.
-        // Consider making this optional.
         if (Pagination is not null && Pagination.RenderFillerRows)
         {
             while (rowIndex++ < initialRowIndex + Pagination.ItemsPerPage)

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
@@ -49,7 +49,7 @@
         // When pagination is enabled, by default ensure we render the exact number of expected rows per page,
         // even if there aren't enough data items. This avoids the layout jumping on the last page.
         // Consider making this optional.
-        if (Pagination is not null)
+        if (Pagination is not null && Pagination.RenderFillerRows)
         {
             while (rowIndex++ < initialRowIndex + Pagination.ItemsPerPage)
             {


### PR DESCRIPTION
# QuickGrid: Adds option to disable rendering of filler rows

## Description

This pull request add an option to PaginationState to disable rendering of filler rows.

Fixes #57199 #59096 
