### PR TITLE
QuickGrid: Adds EmptyContentTemplate

### DIFF
--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/EmptyContentTemplate.razor
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/EmptyContentTemplate.razor
@@ -1,0 +1,6 @@
+﻿@namespace Microsoft.AspNetCore.Components.QuickGrid
+@typeparam TGridItem
+
+@{
+    InternalGridContext.Grid.SetEmptyContent(this);
+}

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/EmptyContentTemplate.razor.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/EmptyContentTemplate.razor.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.AspNetCore.Components.QuickGrid.Infrastructure;
+
+namespace Microsoft.AspNetCore.Components.QuickGrid;
+
+public partial class EmptyContentTemplate<TGridItem>
+{
+    [CascadingParameter] internal InternalGridContext<TGridItem> InternalGridContext { get; set; } = default!;
+
+    [Parameter] public RenderFragment ChildContent { get; set; }
+}

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/EmptyContentTemplate.razor.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/EmptyContentTemplate.razor.cs
@@ -5,9 +5,16 @@ using Microsoft.AspNetCore.Components.QuickGrid.Infrastructure;
 
 namespace Microsoft.AspNetCore.Components.QuickGrid;
 
+/// <summary>
+/// A component that is displayed when the <see cref="QuickGrid{TGridItem}"/> has no data available.
+/// </summary>
+/// <typeparam name="TGridItem">The type of data represented by each row in the grid.</typeparam>
 public partial class EmptyContentTemplate<TGridItem>
 {
     [CascadingParameter] internal InternalGridContext<TGridItem> InternalGridContext { get; set; } = default!;
 
-    [Parameter] public RenderFragment ChildContent { get; set; }
+    /// <summary>
+    /// Defines the content to be rendered by <see cref="QuickGrid{TGridItem}"/> when no data is available.
+    /// </summary>
+    [Parameter] public RenderFragment? ChildContent { get; set; }
 }

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/EmptyContentTemplate.razor.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/EmptyContentTemplate.razor.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Components.QuickGrid.Infrastructure;
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.QuickGrid.Infrastructure;
 
 namespace Microsoft.AspNetCore.Components.QuickGrid;
 

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Shipped.txt
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Shipped.txt
@@ -34,6 +34,10 @@ Microsoft.AspNetCore.Components.QuickGrid.ColumnBase<TGridItem>.Sortable.get -> 
 Microsoft.AspNetCore.Components.QuickGrid.ColumnBase<TGridItem>.Sortable.set -> void
 Microsoft.AspNetCore.Components.QuickGrid.ColumnBase<TGridItem>.Title.get -> string?
 Microsoft.AspNetCore.Components.QuickGrid.ColumnBase<TGridItem>.Title.set -> void
+Microsoft.AspNetCore.Components.QuickGrid.EmptyContentTemplate<TGridItem>
+Microsoft.AspNetCore.Components.QuickGrid.EmptyContentTemplate<TGridItem>.ChildContent.get -> Microsoft.AspNetCore.Components.RenderFragment?
+Microsoft.AspNetCore.Components.QuickGrid.EmptyContentTemplate<TGridItem>.ChildContent.set -> void
+Microsoft.AspNetCore.Components.QuickGrid.EmptyContentTemplate<TGridItem>.EmptyContentTemplate() -> void
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProvider<TGridItem>
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.ApplySorting(System.Linq.IQueryable<TGridItem>! source) -> System.Linq.IQueryable<TGridItem>!

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Shipped.txt
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Shipped.txt
@@ -34,10 +34,6 @@ Microsoft.AspNetCore.Components.QuickGrid.ColumnBase<TGridItem>.Sortable.get -> 
 Microsoft.AspNetCore.Components.QuickGrid.ColumnBase<TGridItem>.Sortable.set -> void
 Microsoft.AspNetCore.Components.QuickGrid.ColumnBase<TGridItem>.Title.get -> string?
 Microsoft.AspNetCore.Components.QuickGrid.ColumnBase<TGridItem>.Title.set -> void
-Microsoft.AspNetCore.Components.QuickGrid.EmptyContentTemplate<TGridItem>
-Microsoft.AspNetCore.Components.QuickGrid.EmptyContentTemplate<TGridItem>.ChildContent.get -> Microsoft.AspNetCore.Components.RenderFragment?
-Microsoft.AspNetCore.Components.QuickGrid.EmptyContentTemplate<TGridItem>.ChildContent.set -> void
-Microsoft.AspNetCore.Components.QuickGrid.EmptyContentTemplate<TGridItem>.EmptyContentTemplate() -> void
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProvider<TGridItem>
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.ApplySorting(System.Linq.IQueryable<TGridItem>! source) -> System.Linq.IQueryable<TGridItem>!
@@ -106,8 +102,6 @@ Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.ChildContent.set 
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.Class.get -> string?
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.Class.set -> void
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.DisposeAsync() -> System.Threading.Tasks.ValueTask
-Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.EmptyContent.get -> Microsoft.AspNetCore.Components.RenderFragment?
-Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.EmptyContent.set -> void
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.ItemKey.get -> System.Func<TGridItem, object!>!
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.ItemKey.set -> void
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.Items.get -> System.Linq.IQueryable<TGridItem>?

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Shipped.txt
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Shipped.txt
@@ -106,6 +106,8 @@ Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.ChildContent.set 
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.Class.get -> string?
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.Class.set -> void
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.EmptyContent.get -> Microsoft.AspNetCore.Components.RenderFragment?
+Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.EmptyContent.set -> void
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.ItemKey.get -> System.Func<TGridItem, object!>!
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.ItemKey.set -> void
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.Items.get -> System.Linq.IQueryable<TGridItem>?

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Unshipped.txt
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Unshipped.txt
@@ -1,4 +1,10 @@
 #nullable enable
+Microsoft.AspNetCore.Components.QuickGrid.EmptyContentTemplate<TGridItem>
+Microsoft.AspNetCore.Components.QuickGrid.EmptyContentTemplate<TGridItem>.ChildContent.get -> Microsoft.AspNetCore.Components.RenderFragment?
+Microsoft.AspNetCore.Components.QuickGrid.EmptyContentTemplate<TGridItem>.ChildContent.set -> void
+Microsoft.AspNetCore.Components.QuickGrid.EmptyContentTemplate<TGridItem>.EmptyContentTemplate() -> void
+Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.EmptyContent.get -> Microsoft.AspNetCore.Components.RenderFragment?
+Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.EmptyContent.set -> void
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.HideColumnOptionsAsync() -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.RowClass.get -> System.Func<TGridItem, string?>?
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.RowClass.set -> void

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Unshipped.txt
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+~override Microsoft.AspNetCore.Components.QuickGrid.EmptyContentTemplate<TGridItem>.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) -> void
 Microsoft.AspNetCore.Components.QuickGrid.EmptyContentTemplate<TGridItem>
 Microsoft.AspNetCore.Components.QuickGrid.EmptyContentTemplate<TGridItem>.ChildContent.get -> Microsoft.AspNetCore.Components.RenderFragment?
 Microsoft.AspNetCore.Components.QuickGrid.EmptyContentTemplate<TGridItem>.ChildContent.set -> void

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
@@ -98,11 +98,11 @@
             @foreach (var col in _columns)
             {
                 <td class="grid-cell-placeholder @ColumnClass(col)" @key="@col">@{ col.RenderPlaceholderContent(__builder, placeholderContext); }</td>
-        }
-    </tr>
-        }
+            }
+        </tr>
+    }
 
-        private void RenderColumnHeaders(RenderTreeBuilder __builder)
+    private void RenderColumnHeaders(RenderTreeBuilder __builder)
     {
         foreach (var col in _columns)
         {

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
@@ -88,32 +88,32 @@
             @foreach (var col in _columns)
             {
                 <td class="@ColumnClass(col)" @key="@col">@{ col.CellContent(__builder, item); }</td>
+            }
+        </tr>
+    }
+
+    private void RenderPlaceholderRow(RenderTreeBuilder __builder, PlaceholderContext placeholderContext)
+    {
+        <tr aria-rowindex="@(placeholderContext.Index + 1)">
+            @foreach (var col in _columns)
+            {
+                <td class="grid-cell-placeholder @ColumnClass(col)" @key="@col">@{ col.RenderPlaceholderContent(__builder, placeholderContext); }</td>
         }
     </tr>
-}
+        }
 
-private void RenderPlaceholderRow(RenderTreeBuilder __builder, PlaceholderContext placeholderContext)
-{
-    <tr aria-rowindex="@(placeholderContext.Index + 1)">
-        @foreach (var col in _columns)
-        {
-            <td class="grid-cell-placeholder @ColumnClass(col)" @key="@col">@{ col.RenderPlaceholderContent(__builder, placeholderContext); }</td>
-    }
-</tr>
-    }
-
-    private void RenderColumnHeaders(RenderTreeBuilder __builder)
-{
-    foreach (var col in _columns)
+        private void RenderColumnHeaders(RenderTreeBuilder __builder)
     {
-        <th class="@ColumnHeaderClass(col)" aria-sort="@AriaSortValue(col)" @key="@col" scope="col">
-            <div class="col-header-content">@col.HeaderContent</div>
+        foreach (var col in _columns)
+        {
+            <th class="@ColumnHeaderClass(col)" aria-sort="@AriaSortValue(col)" @key="@col" scope="col">
+                <div class="col-header-content">@col.HeaderContent</div>
 
-            @if (col == _displayOptionsForColumn)
-            {
-                <div class="col-options">@col.ColumnOptions</div>
-            }
-        </th>
+                @if (col == _displayOptionsForColumn)
+                {
+                    <div class="col-options">@col.ColumnOptions</div>
+                }
+            </th>
+        }
     }
-}
 }

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
@@ -20,12 +20,13 @@
                 @if (Virtualize)
                 {
                     <Virtualize @ref="@_virtualizeComponent"
-                        TItem="(int RowIndex, TGridItem Data)"
-                        ItemSize="@ItemSize"
-                        OverscanCount="@OverscanCount"
-                        ItemsProvider="@ProvideVirtualizedItems"
-                        ItemContent="@(item => builder => RenderRow(builder, item.RowIndex, item.Data))"
-                        Placeholder="@(placeholderContext => builder => RenderPlaceholderRow(builder, placeholderContext))" />
+                                TItem="(int RowIndex, TGridItem Data)"
+                                ItemSize="@ItemSize"
+                                OverscanCount="@OverscanCount"
+                                ItemsProvider="@ProvideVirtualizedItems"
+                                ItemContent="@(item => builder => RenderRow(builder, item.RowIndex, item.Data))"
+                                EmptyContent="@EmptyContent"
+                                Placeholder="@(placeholderContext => builder => RenderPlaceholderRow(builder, placeholderContext))" />
                 }
                 else
                 {
@@ -41,9 +42,17 @@
     {
         var initialRowIndex = 2; // aria-rowindex is 1-based, plus the first row is the header
         var rowIndex = initialRowIndex;
-        foreach (var item in _currentNonVirtualizedViewItems)
+
+        if (EmptyContent != null && _currentNonVirtualizedViewItems.Count == 0)
         {
-            RenderRow(__builder, rowIndex++, item);
+            RenderEmptyRow(__builder, rowIndex++);
+        }
+        else
+        {
+            foreach (var item in _currentNonVirtualizedViewItems)
+            {
+                RenderRow(__builder, rowIndex++, item);
+            }
         }
 
         // When pagination is enabled, by default ensure we render the exact number of expected rows per page,
@@ -63,6 +72,15 @@
         }
     }
 
+    private void RenderEmptyRow(RenderTreeBuilder __builder, int rowIndex)
+    {
+        <tr aria-rowindex="@rowIndex">
+            <td colspan="@_columns.Count">
+                @EmptyContent
+            </td>
+        </tr>
+    }
+
     private void RenderRow(RenderTreeBuilder __builder, int rowIndex, TGridItem item)
     {
         var rowClass = RowClass?.Invoke(item);
@@ -70,32 +88,32 @@
             @foreach (var col in _columns)
             {
                 <td class="@ColumnClass(col)" @key="@col">@{ col.CellContent(__builder, item); }</td>
-            }
-        </tr>
-    }
+        }
+    </tr>
+}
 
-    private void RenderPlaceholderRow(RenderTreeBuilder __builder, PlaceholderContext placeholderContext)
-    {
-        <tr aria-rowindex="@(placeholderContext.Index + 1)">
-            @foreach (var col in _columns)
-            {
-                <td class="grid-cell-placeholder @ColumnClass(col)" @key="@col">@{ col.RenderPlaceholderContent(__builder, placeholderContext); }</td>
-            }
-        </tr>
+private void RenderPlaceholderRow(RenderTreeBuilder __builder, PlaceholderContext placeholderContext)
+{
+    <tr aria-rowindex="@(placeholderContext.Index + 1)">
+        @foreach (var col in _columns)
+        {
+            <td class="grid-cell-placeholder @ColumnClass(col)" @key="@col">@{ col.RenderPlaceholderContent(__builder, placeholderContext); }</td>
+    }
+</tr>
     }
 
     private void RenderColumnHeaders(RenderTreeBuilder __builder)
+{
+    foreach (var col in _columns)
     {
-        foreach (var col in _columns)
-        {
-            <th class="@ColumnHeaderClass(col)" aria-sort="@AriaSortValue(col)" @key="@col" scope="col">
-                <div class="col-header-content">@col.HeaderContent</div>
+        <th class="@ColumnHeaderClass(col)" aria-sort="@AriaSortValue(col)" @key="@col" scope="col">
+            <div class="col-header-content">@col.HeaderContent</div>
 
-                @if (col == _displayOptionsForColumn)
-                {
-                    <div class="col-options">@col.ColumnOptions</div>
-                }
-            </th>
-        }
+            @if (col == _displayOptionsForColumn)
+            {
+                <div class="col-options">@col.ColumnOptions</div>
+            }
+        </th>
     }
+}
 }

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
@@ -124,6 +124,13 @@ public partial class QuickGrid<TGridItem> : IAsyncDisposable
     // We cascade the InternalGridContext to descendants, which in turn call it to add themselves to _columns
     // This happens on every render so that the column list can be updated dynamically
     private readonly InternalGridContext<TGridItem> _internalGridContext;
+
+    /// <summary>
+    /// Gets or sets a <see cref="RenderFragment" /> that will be rendered when no data is available to display.
+    /// This allows derived components to specify a default if the user does not specify it.
+    /// </summary>
+    protected internal RenderFragment? EmptyContent { get; protected set; }
+
     private readonly List<ColumnBase<TGridItem>> _columns;
     private bool _collectingColumns; // Columns might re-render themselves arbitrarily. We only want to capture them at a defined time.
 
@@ -214,6 +221,11 @@ public partial class QuickGrid<TGridItem> : IAsyncDisposable
             _checkColumnOptionsPosition = false;
             _ = _jsModule?.InvokeVoidAsync("checkColumnOptionsPosition", _tableReference).AsTask();
         }
+    }
+
+    internal void SetEmptyContent(EmptyContentTemplate<TGridItem> emptyContentTemplate)
+    {
+        EmptyContent = emptyContentTemplate.ChildContent;
     }
 
     // Invoked by descendant columns at a special time during rendering


### PR DESCRIPTION
# QuickGrid: Adds EmptyContentTemplate

## Description

This PR adds an EmptyContentTemplate component to QuickGrid.  When specified by a user they can simply add markup for EmptyContentTemplate and it's child content will be applied to both Virtualize and Paginated views of their table.  It also exposes 
an internal RenderFragment for EmptyContent so that derivitives of QuickGrid can specify a default implementation easily and still allow users to override.  This is a similar model to how ColumnBase deals with the HeaderTemplate.

Fixes #50498 
