### PR TITLE
QuickGrid: Adds Multi Column Sorting

### DIFF
--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/Columns/SortColumn.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/Columns/SortColumn.cs
@@ -1,0 +1,18 @@
+﻿namespace Microsoft.AspNetCore.Components.QuickGrid;
+
+/// <summary>
+/// Provides information about the column that has sorting applied.
+/// </summary>
+/// <typeparam name="TGridItem">The type of data represented by each row in the grid.</typeparam>
+public class SortColumn<TGridItem>
+{
+    /// <summary>
+    /// The column that has sorting applied.
+    /// </summary>
+    public ColumnBase<TGridItem>? Column { get; init; }
+
+    /// <summary>
+    /// Whether or not the sort is ascending.
+    /// </summary>
+    public bool Ascending { get; internal set; }
+}

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/Columns/SortColumn.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/Columns/SortColumn.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.AspNetCore.Components.QuickGrid;
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.QuickGrid;
 
 /// <summary>
 /// Provides information about the column that has sorting applied.

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/GridItemsProviderRequest.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/GridItemsProviderRequest.cs
@@ -37,7 +37,13 @@ public readonly struct GridItemsProviderRequest<TGridItem>
     /// or <see cref="GetSortByProperties"/>, since they also account for <see cref="SortByColumn" /> and <see cref="SortByAscending" /> automatically.
     /// </summary>
     [Obsolete("Use " + nameof(SortColumns) + " instead.")]
-    public ColumnBase<TGridItem>? SortByColumn { get; init; }
+    public ColumnBase<TGridItem>? SortByColumn
+    {
+        get => _sortByColumn;
+        init => _sortByColumn = value;
+    }
+
+    private readonly ColumnBase<TGridItem>? _sortByColumn;
 
     /// <summary>
     /// Specifies the current sort direction.
@@ -46,7 +52,13 @@ public readonly struct GridItemsProviderRequest<TGridItem>
     /// or <see cref="GetSortByProperties"/>, since they also account for <see cref="SortByColumn" /> and <see cref="SortByAscending" /> automatically.
     /// </summary>
     [Obsolete("Use " + nameof(SortColumns) + " instead.")]
-    public bool SortByAscending { get; init; }
+    public bool SortByAscending
+    {
+        get => _sortByAscending;
+        init => _sortByAscending = value;
+    }
+
+    private readonly bool _sortByAscending;
 
     /// <summary>
     /// A token that indicates if the request should be cancelled.
@@ -60,12 +72,11 @@ public readonly struct GridItemsProviderRequest<TGridItem>
         Count = count;
         SortColumns = sortColumns;
 
-        var sortColumn = sortColumns.FirstOrDefault();
-
-        if (sortColumn != null)
+        if (sortColumns.Any())
         {
-            SortByColumn = sortColumn.Column;
-            SortByAscending = sortColumn.Ascending;
+            var sortColumn = sortColumns[0];
+            _sortByColumn = sortColumn.Column;
+            _sortByAscending = sortColumn.Ascending;
         }
 
         CancellationToken = cancellationToken;

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/GridItemsProviderRequest.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/GridItemsProviderRequest.cs
@@ -54,7 +54,11 @@ public readonly struct GridItemsProviderRequest<TGridItem>
         for (var i = 0; i < SortColumns.Count; i++)
         {
             var sortColumn = SortColumns[i];
-            source = sortColumn.Column.SortBy.Apply(source, sortColumn.Ascending, i == 0);
+
+            if (sortColumn.Column?.SortBy != null)
+            {
+                source = sortColumn.Column.SortBy.Apply(source, sortColumn.Ascending, i == 0);
+            }
         }
 
         return source;
@@ -68,7 +72,7 @@ public readonly struct GridItemsProviderRequest<TGridItem>
     {
         foreach (var sortColumn in SortColumns)
         {
-            yield return sortColumn.Column.SortBy?.ToPropertyList(sortColumn.Ascending) ?? [];
+            yield return sortColumn.Column?.SortBy?.ToPropertyList(sortColumn.Ascending) ?? [];
         }
     }
 }

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Shipped.txt
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Shipped.txt
@@ -120,6 +120,11 @@ Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.Theme.get -> stri
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.Theme.set -> void
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.Virtualize.get -> bool
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.Virtualize.set -> void
+Microsoft.AspNetCore.Components.QuickGrid.SortColumn<TGridItem>
+Microsoft.AspNetCore.Components.QuickGrid.SortColumn<TGridItem>.Ascending.get -> bool
+Microsoft.AspNetCore.Components.QuickGrid.SortColumn<TGridItem>.Column.get -> Microsoft.AspNetCore.Components.QuickGrid.ColumnBase<TGridItem>?
+Microsoft.AspNetCore.Components.QuickGrid.SortColumn<TGridItem>.Column.init -> void
+Microsoft.AspNetCore.Components.QuickGrid.SortColumn<TGridItem>.SortColumn() -> void
 Microsoft.AspNetCore.Components.QuickGrid.SortDirection
 Microsoft.AspNetCore.Components.QuickGrid.SortDirection.Ascending = 1 -> Microsoft.AspNetCore.Components.QuickGrid.SortDirection
 Microsoft.AspNetCore.Components.QuickGrid.SortDirection.Auto = 0 -> Microsoft.AspNetCore.Components.QuickGrid.SortDirection

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Shipped.txt
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Shipped.txt
@@ -41,12 +41,7 @@ Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.Ca
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.CancellationToken.init -> void
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.Count.get -> int?
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.Count.init -> void
-Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.GetSortByProperties() -> System.Collections.Generic.IReadOnlyCollection<Microsoft.AspNetCore.Components.QuickGrid.SortedProperty>!
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.GridItemsProviderRequest() -> void
-Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.SortByAscending.get -> bool
-Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.SortByAscending.init -> void
-Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.SortByColumn.get -> Microsoft.AspNetCore.Components.QuickGrid.ColumnBase<TGridItem>?
-Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.SortByColumn.init -> void
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.StartIndex.get -> int
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.StartIndex.init -> void
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderResult

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Shipped.txt
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Shipped.txt
@@ -95,6 +95,7 @@ Microsoft.AspNetCore.Components.QuickGrid.PropertyColumn<TGridItem, TProp>.Prope
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.AdditionalAttributes.get -> System.Collections.Generic.IReadOnlyDictionary<string!, object!>?
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.AdditionalAttributes.set -> void
+Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.AddUpdateSortByColumnAsync(Microsoft.AspNetCore.Components.QuickGrid.ColumnBase<TGridItem>! column, Microsoft.AspNetCore.Components.QuickGrid.SortDirection direction = Microsoft.AspNetCore.Components.QuickGrid.SortDirection.Auto) -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.ChildContent.get -> Microsoft.AspNetCore.Components.RenderFragment?
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.ChildContent.set -> void
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.Class.get -> string?

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Shipped.txt
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Shipped.txt
@@ -116,6 +116,7 @@ Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.QuickGrid() -> vo
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.RefreshDataAsync() -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.ShowColumnOptionsAsync(Microsoft.AspNetCore.Components.QuickGrid.ColumnBase<TGridItem>! column) -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.SortByColumnAsync(Microsoft.AspNetCore.Components.QuickGrid.ColumnBase<TGridItem>! column, Microsoft.AspNetCore.Components.QuickGrid.SortDirection direction = Microsoft.AspNetCore.Components.QuickGrid.SortDirection.Auto) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.SortColumns.get -> System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Components.QuickGrid.SortColumn<TGridItem>!>!
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.Theme.get -> string?
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.Theme.set -> void
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.Virtualize.get -> bool

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Shipped.txt
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Shipped.txt
@@ -41,10 +41,12 @@ Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.Ca
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.CancellationToken.init -> void
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.Count.get -> int?
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.Count.init -> void
-Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.GetSortByProperties() -> System.Collections.Generic.IEnumerable<System.Collections.Generic.IReadOnlyCollection<Microsoft.AspNetCore.Components.QuickGrid.SortedProperty>!>!
+Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.GetSortByProperties() -> System.Collections.Generic.IReadOnlyCollection<Microsoft.AspNetCore.Components.QuickGrid.SortedProperty>!
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.GridItemsProviderRequest() -> void
-Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.SortColumns.get -> System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Components.QuickGrid.SortColumn<TGridItem>!>!
-Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.SortColumns.init -> void
+Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.SortByAscending.get -> bool
+Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.SortByAscending.init -> void
+Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.SortByColumn.get -> Microsoft.AspNetCore.Components.QuickGrid.ColumnBase<TGridItem>?
+Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.SortByColumn.init -> void
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.StartIndex.get -> int
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.StartIndex.init -> void
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderResult
@@ -95,7 +97,6 @@ Microsoft.AspNetCore.Components.QuickGrid.PropertyColumn<TGridItem, TProp>.Prope
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.AdditionalAttributes.get -> System.Collections.Generic.IReadOnlyDictionary<string!, object!>?
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.AdditionalAttributes.set -> void
-Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.AddUpdateSortByColumnAsync(Microsoft.AspNetCore.Components.QuickGrid.ColumnBase<TGridItem>! column, Microsoft.AspNetCore.Components.QuickGrid.SortDirection direction = Microsoft.AspNetCore.Components.QuickGrid.SortDirection.Auto) -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.ChildContent.get -> Microsoft.AspNetCore.Components.RenderFragment?
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.ChildContent.set -> void
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.Class.get -> string?
@@ -117,16 +118,10 @@ Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.QuickGrid() -> vo
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.RefreshDataAsync() -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.ShowColumnOptionsAsync(Microsoft.AspNetCore.Components.QuickGrid.ColumnBase<TGridItem>! column) -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.SortByColumnAsync(Microsoft.AspNetCore.Components.QuickGrid.ColumnBase<TGridItem>! column, Microsoft.AspNetCore.Components.QuickGrid.SortDirection direction = Microsoft.AspNetCore.Components.QuickGrid.SortDirection.Auto) -> System.Threading.Tasks.Task!
-Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.SortColumns.get -> System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Components.QuickGrid.SortColumn<TGridItem>!>!
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.Theme.get -> string?
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.Theme.set -> void
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.Virtualize.get -> bool
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.Virtualize.set -> void
-Microsoft.AspNetCore.Components.QuickGrid.SortColumn<TGridItem>
-Microsoft.AspNetCore.Components.QuickGrid.SortColumn<TGridItem>.Ascending.get -> bool
-Microsoft.AspNetCore.Components.QuickGrid.SortColumn<TGridItem>.Column.get -> Microsoft.AspNetCore.Components.QuickGrid.ColumnBase<TGridItem>?
-Microsoft.AspNetCore.Components.QuickGrid.SortColumn<TGridItem>.Column.init -> void
-Microsoft.AspNetCore.Components.QuickGrid.SortColumn<TGridItem>.SortColumn() -> void
 Microsoft.AspNetCore.Components.QuickGrid.SortDirection
 Microsoft.AspNetCore.Components.QuickGrid.SortDirection.Ascending = 1 -> Microsoft.AspNetCore.Components.QuickGrid.SortDirection
 Microsoft.AspNetCore.Components.QuickGrid.SortDirection.Auto = 0 -> Microsoft.AspNetCore.Components.QuickGrid.SortDirection

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Shipped.txt
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Shipped.txt
@@ -41,12 +41,10 @@ Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.Ca
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.CancellationToken.init -> void
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.Count.get -> int?
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.Count.init -> void
-Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.GetSortByProperties() -> System.Collections.Generic.IReadOnlyCollection<Microsoft.AspNetCore.Components.QuickGrid.SortedProperty>!
+Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.GetSortByProperties() -> System.Collections.Generic.IEnumerable<System.Collections.Generic.IReadOnlyCollection<Microsoft.AspNetCore.Components.QuickGrid.SortedProperty>!>!
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.GridItemsProviderRequest() -> void
-Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.SortByAscending.get -> bool
-Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.SortByAscending.init -> void
-Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.SortByColumn.get -> Microsoft.AspNetCore.Components.QuickGrid.ColumnBase<TGridItem>?
-Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.SortByColumn.init -> void
+Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.SortColumns.get -> System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Components.QuickGrid.SortColumn<TGridItem>!>!
+Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.SortColumns.init -> void
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.StartIndex.get -> int
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.StartIndex.init -> void
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderResult

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Shipped.txt
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Shipped.txt
@@ -41,7 +41,12 @@ Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.Ca
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.CancellationToken.init -> void
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.Count.get -> int?
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.Count.init -> void
+Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.GetSortByProperties() -> System.Collections.Generic.IReadOnlyCollection<Microsoft.AspNetCore.Components.QuickGrid.SortedProperty>!
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.GridItemsProviderRequest() -> void
+Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.SortByAscending.get -> bool
+Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.SortByAscending.init -> void
+Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.SortByColumn.get -> Microsoft.AspNetCore.Components.QuickGrid.ColumnBase<TGridItem>?
+Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.SortByColumn.init -> void
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.StartIndex.get -> int
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.StartIndex.init -> void
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderResult

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Unshipped.txt
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
 #nullable enable
-Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.GetSortByProperties() -> System.Collections.Generic.IEnumerable<System.Collections.Generic.IReadOnlyCollection<Microsoft.AspNetCore.Components.QuickGrid.SortedProperty>!>!
+Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.GetSortColumnProperties() -> System.Collections.Generic.IEnumerable<System.Collections.Generic.IReadOnlyCollection<Microsoft.AspNetCore.Components.QuickGrid.SortedProperty>!>!
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.SortColumns.get -> System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Components.QuickGrid.SortColumn<TGridItem>!>!
 Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.SortColumns.init -> void
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.AddUpdateSortByColumnAsync(Microsoft.AspNetCore.Components.QuickGrid.ColumnBase<TGridItem>! column, Microsoft.AspNetCore.Components.QuickGrid.SortDirection direction = Microsoft.AspNetCore.Components.QuickGrid.SortDirection.Auto) -> System.Threading.Tasks.Task!

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Unshipped.txt
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Unshipped.txt
@@ -1,4 +1,14 @@
 #nullable enable
+Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.GetSortByProperties() -> System.Collections.Generic.IEnumerable<System.Collections.Generic.IReadOnlyCollection<Microsoft.AspNetCore.Components.QuickGrid.SortedProperty>!>!
+Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.SortColumns.get -> System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Components.QuickGrid.SortColumn<TGridItem>!>!
+Microsoft.AspNetCore.Components.QuickGrid.GridItemsProviderRequest<TGridItem>.SortColumns.init -> void
+Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.AddUpdateSortByColumnAsync(Microsoft.AspNetCore.Components.QuickGrid.ColumnBase<TGridItem>! column, Microsoft.AspNetCore.Components.QuickGrid.SortDirection direction = Microsoft.AspNetCore.Components.QuickGrid.SortDirection.Auto) -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.HideColumnOptionsAsync() -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.RowClass.get -> System.Func<TGridItem, string?>?
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.RowClass.set -> void
+Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.SortColumns.get -> System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Components.QuickGrid.SortColumn<TGridItem>!>!
+Microsoft.AspNetCore.Components.QuickGrid.SortColumn<TGridItem>
+Microsoft.AspNetCore.Components.QuickGrid.SortColumn<TGridItem>.Ascending.get -> bool
+Microsoft.AspNetCore.Components.QuickGrid.SortColumn<TGridItem>.Column.get -> Microsoft.AspNetCore.Components.QuickGrid.ColumnBase<TGridItem>?
+Microsoft.AspNetCore.Components.QuickGrid.SortColumn<TGridItem>.Column.init -> void
+Microsoft.AspNetCore.Components.QuickGrid.SortColumn<TGridItem>.SortColumn() -> void

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
@@ -261,6 +261,14 @@ public partial class QuickGrid<TGridItem> : IAsyncDisposable
         return AddUpdateSortByColumnAsync(column, direction);
     }
 
+    /// <summary>
+    /// Adds or updates sorting of the specified <paramref name="column"/>.
+    /// If the column is not already being tracked it will be appended, otherwise it's direction is updated with it's position unchanged.
+    /// </summary>
+    /// <param name="column">The column that defines the new sort order.</param>
+    /// <param name="direction">The direction of sorting.  If the value is <see cref="SortDirection.Auto"/>, then it will toggle the direction on each call.</param>
+    /// <returns>A <see cref="Task"/> representing the completion of the operation.</returns>
+    /// <exception cref="NotSupportedException"></exception>
     public Task AddUpdateSortByColumnAsync(ColumnBase<TGridItem> column, SortDirection direction = SortDirection.Auto)
     {
         var sortBy = _sortByColumns.FirstOrDefault(sbc => sbc.Column == column);

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
@@ -242,7 +242,7 @@ public partial class QuickGrid<TGridItem> : IAsyncDisposable
         _collectingColumns = false;
     }
 
-    private List<SortColumn<TGridItem>> _sortByColumns = [];
+    private readonly List<SortColumn<TGridItem>> _sortByColumns = [];
 
     /// <summary>
     /// The list of columns that have sorting applied.

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
@@ -242,6 +242,13 @@ public partial class QuickGrid<TGridItem> : IAsyncDisposable
         _collectingColumns = false;
     }
 
+    private List<SortColumn<TGridItem>> _sortByColumns = [];
+
+    /// <summary>
+    /// The list of columns that have sorting applied.
+    /// </summary>
+    public IReadOnlyList<SortColumn<TGridItem>> SortColumns => _sortByColumns;
+
     /// <summary>
     /// Sets the grid's current sort column to the specified <paramref name="column"/>.
     /// </summary>
@@ -250,15 +257,27 @@ public partial class QuickGrid<TGridItem> : IAsyncDisposable
     /// <returns>A <see cref="Task"/> representing the completion of the operation.</returns>
     public Task SortByColumnAsync(ColumnBase<TGridItem> column, SortDirection direction = SortDirection.Auto)
     {
-        _sortByAscending = direction switch
+        _sortByColumns.RemoveAll(sbc => sbc.Column != column);
+        return AddUpdateSortByColumnAsync(column, direction);
+    }
+
+    public Task AddUpdateSortByColumnAsync(ColumnBase<TGridItem> column, SortDirection direction = SortDirection.Auto)
+    {
+        var sortBy = _sortByColumns.FirstOrDefault(sbc => sbc.Column == column);
+
+        if (sortBy == null)
+        {
+            sortBy = new() { Column = column };
+            _sortByColumns.Add(sortBy);
+        }
+
+        sortBy.Ascending = direction switch
         {
             SortDirection.Ascending => true,
             SortDirection.Descending => false,
-            SortDirection.Auto => _sortByColumn != column || !_sortByAscending,
-            _ => throw new NotSupportedException($"Unknown sort direction {direction}"),
+            SortDirection.Auto => !sortBy.Ascending,
+            _ => throw new NotSupportedException($"Unknown sort direction {direction}")
         };
-
-        _sortByColumn = column;
 
         StateHasChanged(); // We want to see the updated sort order in the header, even before the data query is completed
         return RefreshDataAsync();
@@ -320,7 +339,7 @@ public partial class QuickGrid<TGridItem> : IAsyncDisposable
             _lastRefreshedPaginationStateHash = Pagination?.GetHashCode();
             var startIndex = Pagination is null ? 0 : (Pagination.CurrentPageIndex * Pagination.ItemsPerPage);
             var request = new GridItemsProviderRequest<TGridItem>(
-                startIndex, Pagination?.ItemsPerPage, _sortByColumn, _sortByAscending, thisLoadCts.Token);
+                startIndex, Pagination?.ItemsPerPage, SortColumns, thisLoadCts.Token);
             var result = await ResolveItemsRequestAsync(request);
             if (!thisLoadCts.IsCancellationRequested)
             {
@@ -356,7 +375,7 @@ public partial class QuickGrid<TGridItem> : IAsyncDisposable
         }
 
         var providerRequest = new GridItemsProviderRequest<TGridItem>(
-            startIndex, count, _sortByColumn, _sortByAscending, request.CancellationToken);
+            startIndex, count, SortColumns, request.CancellationToken);
         var providerResult = await ResolveItemsRequestAsync(providerRequest);
 
         if (!request.CancellationToken.IsCancellationRequested)


### PR DESCRIPTION
# QuickGrid: Adds Multi Column Sorting

## Description

This pull request adds multi column sorting capabilities to QuickGrid.  AddUpdateSortByColumnAsync can be called by columns to append or change the sort direction of an existing sorted column.  For EF implementations multi column sorting is handled automatically.  The existing SortByColumnAsync method clears all other columns and simply flips the direction of the column that was clicked.  This enables users to, for example, specify ctrl+click appends the column and a normal click clears other columns and allows for things like ColumnOptions to be used so the default single column sorting functionality is maintained, but the underlying capability is now included in the box to support multiple column sorting.

Additionally, this PR exposes the SortColumns so individual columns can easily apply this logic and benefit from additional functionality like making it trivial to swap an icon out based on it's current sort state independent of the aria tags on the tr itself since that's much more difficult to get at in those cases.

Fixes #62494 
