### PR TITLE
QuickGrid: Adds option to disable rendering of filler rows

### DIFF
--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/Pagination/PaginationState.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/Pagination/PaginationState.cs
@@ -11,6 +11,11 @@ namespace Microsoft.AspNetCore.Components.QuickGrid;
 public class PaginationState
 {
     /// <summary>
+    /// Whether or not to render empty rows to fill the view.  
+    /// </summary>
+    public bool RenderFillerRows = true;
+
+    /// <summary>
     /// Gets or sets the number of items on each page.
     /// </summary>
     public int ItemsPerPage { get; set; } = 10;

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/Pagination/PaginationState.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/Pagination/PaginationState.cs
@@ -13,7 +13,7 @@ public class PaginationState
     /// <summary>
     /// Whether or not to render empty rows to fill the view.  
     /// </summary>
-    public bool RenderFillerRows = true;
+    public bool RenderFillerRows { get; set; } = true;
 
     /// <summary>
     /// Gets or sets the number of items on each page.

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Shipped.txt
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Shipped.txt
@@ -78,6 +78,8 @@ Microsoft.AspNetCore.Components.QuickGrid.PaginationState.ItemsPerPage.get -> in
 Microsoft.AspNetCore.Components.QuickGrid.PaginationState.ItemsPerPage.set -> void
 Microsoft.AspNetCore.Components.QuickGrid.PaginationState.LastPageIndex.get -> int?
 Microsoft.AspNetCore.Components.QuickGrid.PaginationState.PaginationState() -> void
+Microsoft.AspNetCore.Components.QuickGrid.PaginationState.RenderFillerRows.get -> bool
+Microsoft.AspNetCore.Components.QuickGrid.PaginationState.RenderFillerRows.set -> void
 Microsoft.AspNetCore.Components.QuickGrid.PaginationState.SetCurrentPageIndexAsync(int pageIndex) -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Components.QuickGrid.PaginationState.TotalItemCount.get -> int?
 Microsoft.AspNetCore.Components.QuickGrid.PaginationState.TotalItemCountChanged -> System.EventHandler<int?>?

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Shipped.txt
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Shipped.txt
@@ -78,8 +78,6 @@ Microsoft.AspNetCore.Components.QuickGrid.PaginationState.ItemsPerPage.get -> in
 Microsoft.AspNetCore.Components.QuickGrid.PaginationState.ItemsPerPage.set -> void
 Microsoft.AspNetCore.Components.QuickGrid.PaginationState.LastPageIndex.get -> int?
 Microsoft.AspNetCore.Components.QuickGrid.PaginationState.PaginationState() -> void
-Microsoft.AspNetCore.Components.QuickGrid.PaginationState.RenderFillerRows.get -> bool
-Microsoft.AspNetCore.Components.QuickGrid.PaginationState.RenderFillerRows.set -> void
 Microsoft.AspNetCore.Components.QuickGrid.PaginationState.SetCurrentPageIndexAsync(int pageIndex) -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Components.QuickGrid.PaginationState.TotalItemCount.get -> int?
 Microsoft.AspNetCore.Components.QuickGrid.PaginationState.TotalItemCountChanged -> System.EventHandler<int?>?

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Unshipped.txt
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+Microsoft.AspNetCore.Components.QuickGrid.PaginationState.RenderFillerRows.get -> bool
+Microsoft.AspNetCore.Components.QuickGrid.PaginationState.RenderFillerRows.set -> void
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.HideColumnOptionsAsync() -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.RowClass.get -> System.Func<TGridItem, string?>?
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.RowClass.set -> void

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
@@ -48,7 +48,6 @@
 
         // When pagination is enabled, by default ensure we render the exact number of expected rows per page,
         // even if there aren't enough data items. This avoids the layout jumping on the last page.
-        // Consider making this optional.
         if (Pagination is not null && Pagination.RenderFillerRows)
         {
             while (rowIndex++ < initialRowIndex + Pagination.ItemsPerPage)

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
@@ -49,7 +49,7 @@
         // When pagination is enabled, by default ensure we render the exact number of expected rows per page,
         // even if there aren't enough data items. This avoids the layout jumping on the last page.
         // Consider making this optional.
-        if (Pagination is not null)
+        if (Pagination is not null && Pagination.RenderFillerRows)
         {
             while (rowIndex++ < initialRowIndex + Pagination.ItemsPerPage)
             {


### PR DESCRIPTION
# QuickGrid: Adds option to disable rendering of filler rows

## Description

This pull request add an option to PaginationState to disable rendering of filler rows.  It keeps the default functionality of rendering the filler rows.  I understand that one way to deal with this is to style it with CSS, but in some cases that's impractical, overly complex, and desirable.  This provides users the ability to choose how they want it to behave without being forced to use CSS which prevents them from changing from one method to another on a per instance basis.  The existing code noted that it should be considered to make it optional as well.


NOTE: I submitted this previously but I needed to move it to a feature branch and continue working it down to ensure all the checks are passing.

@Nick-Stanton I'm tagging you since it looks like you were the original author that added the comment that it should be considered to make this functionality optional.

Fixes #57199 #59096
