### PR TITLE
Add an InputHidden component for Blazor

### DIFF
--- a/src/Components/Web/src/Forms/InputHidden.cs
+++ b/src/Components/Web/src/Forms/InputHidden.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Microsoft.AspNetCore.Components.Forms;
+
+/// <summary>
+/// An hidden input component for storing <see cref="string"/> values.
+/// </summary>
+public class InputHidden : InputBase<string?>
+{
+    /// <summary>
+    /// Gets or sets the associated <see cref="ElementReference"/>.
+    /// <para>
+    /// May be <see langword="null"/> if accessed before the component is rendered.
+    /// </para>
+    /// </summary>
+    [DisallowNull] public ElementReference? Element { get; protected set; }
+
+    /// <inheritdoc />
+    protected override void BuildRenderTree(RenderTreeBuilder builder)
+    {
+        builder.OpenElement(0, "input");
+        builder.AddAttribute(1, "type", "hidden");
+        builder.AddMultipleAttributes(2, AdditionalAttributes);
+        builder.AddAttributeIfNotNullOrEmpty(3, "name", NameAttributeValue);
+        builder.AddAttributeIfNotNullOrEmpty(4, "class", CssClass);
+        builder.AddAttribute(5, "value", CurrentValueAsString);
+        builder.AddAttribute(6, "onchange", EventCallback.Factory.CreateBinder<string?>(this, __value => CurrentValueAsString = __value, CurrentValueAsString));
+        builder.SetUpdatesAttributeName("value");
+        builder.AddElementReferenceCapture(7, __inputReference => Element = __inputReference);
+        builder.CloseElement();
+    }
+
+    /// <inheritdoc />
+    protected override bool TryParseValueFromString(string? value, out string? result, [NotNullWhen(false)] out string? validationErrorMessage)
+    {
+        result = value;
+        validationErrorMessage = null;
+        return true;
+    }
+}

--- a/src/Components/Web/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Web/src/PublicAPI.Unshipped.txt
@@ -2,6 +2,7 @@
 Microsoft.AspNetCore.Components.Forms.InputHidden
 Microsoft.AspNetCore.Components.Forms.InputHidden.Element.get -> Microsoft.AspNetCore.Components.ElementReference?
 Microsoft.AspNetCore.Components.Forms.InputHidden.Element.set -> void
+Microsoft.AspNetCore.Components.Forms.InputHidden.InputHidden() -> void
 Microsoft.AspNetCore.Components.Web.Internal.IInternalWebJSInProcessRuntime.InvokeJS(in Microsoft.JSInterop.Infrastructure.JSInvocationInfo invocationInfo) -> string!
 override Microsoft.AspNetCore.Components.Forms.InputHidden.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void
 override Microsoft.AspNetCore.Components.Forms.InputHidden.TryParseValueFromString(string? value, out string? result, out string? validationErrorMessage) -> bool

--- a/src/Components/Web/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Web/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,8 @@
 #nullable enable
+Microsoft.AspNetCore.Components.Forms.InputHidden
+Microsoft.AspNetCore.Components.Forms.InputHidden.Element.get -> Microsoft.AspNetCore.Components.ElementReference?
+Microsoft.AspNetCore.Components.Forms.InputHidden.Element.set -> void
 Microsoft.AspNetCore.Components.Web.Internal.IInternalWebJSInProcessRuntime.InvokeJS(in Microsoft.JSInterop.Infrastructure.JSInvocationInfo invocationInfo) -> string!
+override Microsoft.AspNetCore.Components.Forms.InputHidden.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void
+override Microsoft.AspNetCore.Components.Forms.InputHidden.TryParseValueFromString(string? value, out string? result, out string? validationErrorMessage) -> bool
 virtual Microsoft.AspNetCore.Components.Routing.NavLink.ShouldMatch(string! uriAbsolute) -> bool

--- a/src/Components/Web/test/Forms/InputHiddenTest.cs
+++ b/src/Components/Web/test/Forms/InputHiddenTest.cs
@@ -16,8 +16,8 @@ public class InputHiddenTest
             ValueExpression = () => model.StringProperty,
         };
 
-    // Act
-    var inputHiddenComponent = await InputRenderer.RenderAndGetComponent(rootComponent);
+        // Act
+        var inputHiddenComponent = await InputRenderer.RenderAndGetComponent(rootComponent);
 
         // Assert
         Assert.NotNull(inputHiddenComponent.Element);

--- a/src/Components/Web/test/Forms/InputHiddenTest.cs
+++ b/src/Components/Web/test/Forms/InputHiddenTest.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.Forms;
+
+public class InputHiddenTest
+{
+    [Fact]
+    public async Task InputElementIsAssignedSuccessfully()
+    {
+        // Arrange
+        var model = new TestModel();
+        var rootComponent = new TestInputHostComponent<string, InputHidden>
+        {
+            EditContext = new EditContext(model),
+            ValueExpression = () => model.StringProperty,
+        };
+
+    // Act
+    var inputHiddenComponent = await InputRenderer.RenderAndGetComponent(rootComponent);
+
+        // Assert
+        Assert.NotNull(inputHiddenComponent.Element);
+    }
+
+    private class TestModel
+    {
+        public string StringProperty { get; set; }
+    }
+}

--- a/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
@@ -116,10 +116,9 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
             SuppressEnhancedNavigation = suppressEnhancedNavigation,
         };
         DispatchToFormCore(dispatchToForm);
-        var textHidden = Browser.Exists(By.Id("hidden")).GetDomProperty("value");
-        Assert.Equal("stranger", textHidden);
-        var textPass = Browser.Exists(By.Id("pass")).Text;
-        Assert.Equal("Hello stranger!", textPass);
+
+        Browser.Equal("stranger", () => Browser.Exists(By.Id("hidden")).GetDomProperty("value"));
+        Browser.Equal("Hello stranger!", () => Browser.Exists(By.Id("pass")).Text);
     }
 
     [Theory]

--- a/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
@@ -107,6 +107,24 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
+    public void InputHiddenCanStoreData(bool suppressEnhancedNavigation)
+    {
+        var dispatchToForm = new DispatchToForm(this)
+        {
+            Url = "forms/default-form-input-hidden",
+            FormCssSelector = "form",
+            SuppressEnhancedNavigation = suppressEnhancedNavigation,
+        };
+        DispatchToFormCore(dispatchToForm);
+        var textHidden = Browser.Exists(By.Id("hidden")).GetDomProperty("value");
+        Assert.Equal("stranger", textHidden);
+        var textPass = Browser.Exists(By.Id("pass")).Text;
+        Assert.Equal("Hello stranger!", textPass);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
     public void DataAnnotationsWorkForForms(bool suppressEnhancedNavigation)
     {
         var dispatchToForm = new DispatchToForm(this)

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/DefaultFormInputHidden.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/DefaultFormInputHidden.razor
@@ -1,0 +1,21 @@
+﻿@page "/forms/default-form-input-hidden"
+@page "/reexecution/forms/default-form-input-hidden"
+@using Microsoft.AspNetCore.Components.Forms
+
+<h2>Default form Input Hidden</h2>
+
+<EditForm Enhance Model="Parameter" method="POST" OnValidSubmit="() => _submitted = true" FormName="someform">
+    <InputHidden id="hidden" @bind-Value="Parameter" />
+    <input id="send" type="submit" value="Send" />
+</EditForm>
+
+@if (_submitted)
+{
+    <p id="pass">Hello @Parameter!</p>
+}
+
+@code {
+    bool _submitted = false;
+
+    [SupplyParameterFromForm] public string Parameter { get; set; } = "stranger";
+}


### PR DESCRIPTION
# Add an InputHidden component for Blazor
## Description

Implemented and added a new component `InputHidden`, which allows developers to handle hidden input fields in forms. It includes the implementation of the component, updates to the public API, unit tests, end-to-end tests.

### Changes:
- Added the `InputHidden` class in `src/Components/Web/src/Forms/InputHidden.cs`, which extends `InputBase<string?>` to provide a hidden input field for storing `string` values.
- Updated `src/Components/Web/src/PublicAPI.Unshipped.txt` to include the new `InputHidden` component and its associated methods and properties.
- Added `InputHiddenTest` unit test in `src/Components/Web/test/Forms/InputHiddenTest.cs` .
- Added `InputHiddenCanStoreData` test in `FormWithParentBindingContextTest.cs` to validate that the `InputHidden` component can store and bind data.

Fixes #55720
