### PR TITLE
Fix: This handles the issue where a URL parameter like `?age=null` ca…

### DIFF
--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/SimpleTypeModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/SimpleTypeModelBinder.cs
@@ -74,6 +74,13 @@ public class SimpleTypeModelBinder : IModelBinder
                 // Other than the StringConverter, converters Trim() the value then throw if the result is empty.
                 model = null;
             }
+            else if (bindingContext.ModelMetadata.IsNullableValueType && value == "null")
+            {
+                // Fix: This handles the issue where a URL parameter like `?age=null` cannot be bound to an `int?` type.
+                // This fix ensures that when the frontend sends a URL parameter with `null` value (e.g., `new URLSearchParams({ age: null }).toString()`),
+                // it correctly binds to a nullable integer (`int?`) instead of causing a binding error.
+                model = null;
+            }
             else
             {
                 model = _typeConverter.ConvertFrom(


### PR DESCRIPTION
…nnot be bound to an `int?` type

Fix: This handles the issue where a URL parameter like `?age=null` cannot be bound to an `int?` type. This fix ensures that when the frontend sends a URL parameter with `null` value (e.g., `new URLSearchParams({ age: null }).toString()`),
 it correctly binds to a nullable integer (`int?`) instead of causing a binding error.

# {PR title}

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

{Detail}

Fixes #{bug number} (in this specific format)
