### PR TITLE
Split helix into subsets

### DIFF
--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -570,11 +570,11 @@ stages:
           publishOnError: true
           includeForks: true
 
-    # Helix x64
+    # Helix x64 subset 1
     - template: jobs/default-build.yml
       parameters:
-        jobName: Helix_x64
-        jobDisplayName: 'Tests: Helix x64'
+        jobName: Helix_x64_Subset_1
+        jobDisplayName: 'Tests: Helix x64 Subset 1'
         agentOs: Windows
         timeoutInMinutes: 240
         steps:
@@ -587,14 +587,43 @@ stages:
         - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildRepoTasks -noBuildNative -noBuild -test
                   -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true
                   /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
-                  /p:VsTestUseMSBuildOutput=false /p:RunTemplateTests=false
+                  /p:VsTestUseMSBuildOutput=false /p:RunTemplateTests=false /p:HelixSubset=1
           displayName: Run build.cmd helix target
           env:
             HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
             SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
 
         artifacts:
-        - name: Helix_Logs_Attempt_$(System.JobAttempt)
+        - name: Helix_Subset_1_Logs_Attempt_$(System.JobAttempt)
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+
+    # Helix x64 subset 2
+    - template: jobs/default-build.yml
+      parameters:
+        jobName: Helix_x64_Subset_2
+        jobDisplayName: 'Tests: Helix x64 Subset 2'
+        agentOs: Windows
+        timeoutInMinutes: 240
+        steps:
+        # Build the shared framework
+        - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -nobl -all -pack -arch x64
+                  /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
+                  /p:VsTestUseMSBuildOutput=false
+          displayName: Build shared fx
+        # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
+        - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildRepoTasks -noBuildNative -noBuild -test
+                  -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true
+                  /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
+                  /p:VsTestUseMSBuildOutput=false /p:RunTemplateTests=false /p:HelixSubset=2
+          displayName: Run build.cmd helix target
+          env:
+            HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
+
+        artifacts:
+        - name: Helix_Subset_2_Logs_Attempt_$(System.JobAttempt)
           path: artifacts/log/
           publishOnError: true
           includeForks: true

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -624,8 +624,8 @@ extends:
         # Helix x64
         - template: .azure/pipelines/jobs/default-build.yml@self
           parameters:
-            jobName: Helix_x64
-            jobDisplayName: 'Tests: Helix x64'
+            jobName: Helix_x64_Subset_1
+            jobDisplayName: 'Tests: Helix x64 Subset 1'
             agentOs: Windows
             timeoutInMinutes: 240
             steps:
@@ -637,7 +637,7 @@ extends:
               displayName: Build shared fx
             # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
             - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildRepoTasks -noBuildNative -noBuild -test
-                      -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true
+                      -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:HelixSubset=1
                       /p:CrossgenOutput=false /p:RunTemplateTests=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
               displayName: Run build.cmd helix target
               env:
@@ -645,7 +645,36 @@ extends:
                 SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
 
             artifacts:
-            - name: Helix_Logs_Attempt_$(System.JobAttempt)
+            - name: Helix_Logs_Subset_1_Attempt_$(System.JobAttempt)
+              path: artifacts/log/
+              publishOnError: true
+              includeForks: true
+
+        # Helix x64
+        - template: .azure/pipelines/jobs/default-build.yml@self
+          parameters:
+            jobName: Helix_x64_Subset_2
+            jobDisplayName: 'Tests: Helix x64 Subset 2'
+            agentOs: Windows
+            timeoutInMinutes: 240
+            steps:
+            # Build the shared framework
+            - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -nobl -all -pack -arch x64
+                      /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
+              env:
+                MSBUILDUSESERVER: "1"
+              displayName: Build shared fx
+            # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
+            - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildRepoTasks -noBuildNative -noBuild -test
+                      -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:HelixSubset=2
+                      /p:CrossgenOutput=false /p:RunTemplateTests=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
+              displayName: Run build.cmd helix target
+              env:
+                HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
+                SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
+
+            artifacts:
+            - name: Helix_Logs_Subset_2_Attempt_$(System.JobAttempt)
               path: artifacts/log/
               publishOnError: true
               includeForks: true
@@ -747,7 +776,8 @@ extends:
                   - Windows_Test
                   - MacOS_Test
                   - Linux_Test
-                  - Helix_x64
+                  - Helix_x64_Subset_1
+                  - Helix_x64_Subset_2
               - ${{ if eq(variables.enableSourceIndex, 'true') }}:
                 - SourceIndexStage1
               - Source_Build_Managed

--- a/docs/AddingNewProjects.md
+++ b/docs/AddingNewProjects.md
@@ -28,13 +28,13 @@ Sample PR of final result: https://github.com/dotnet/aspnetcore/pull/41945
   - If VS has not already modified these files, open the `.slnf` you want to add the project to. Create a solution folder for your project if doesn't exist already. Then right click solution folder -> Add -> Existing Project... -> follow the wizard.
 1. Run the `eng/scripts/GenerateProjectList.ps1` file to regenerate a number of `eng/*.props` files e.g. ProjectReferences.props.
 
-**Note:** If you are adding a new project to the root `src` directory, you will also need to add a reference in both of the `DotNetProjects` lists of the `eng/Build.props` file. The first list (the one with condition `'$(BuildMainlyReferenceProviders)' != 'true'"`) has items in the format of:
+**Note:** If you are adding a new project to the root `src` directory, you will also need to add a reference in both the `ProjectsWithTestsSubsetN` and `DotNetProjects` lists of the `eng/Build.props` file. The `ProjectsWithTestsSubsetN` lists (the one with condition `'$(BuildMainlyReferenceProviders)' != 'true'"`) has items in the format of:
   ```XML
-   <DotNetProjects Include="
+   <ProjectsWithTestsSubsetN Include="
                           $(RepoRoot)src\[YOUR FOLDER]\**\*.csproj;
                           ...
   ```
-while the second (the one with condition `'$(BuildMainlyReferenceProviders)' == 'true'"`) has them in the format of (note the second `src`):
+. You should add your project to whichever `ProjectsWithTestsSubsetN` list is shorter (`ProjectsWithTestsSubset1` or `ProjectsWithTestsSubset2`). The `DotNetProjects` list (the one with condition `'$(BuildMainlyReferenceProviders)' == 'true'"`) has them in the format of (note the second `src`):
   ```XML
   <DotNetProjects Include="
                         $(RepoRoot)src\[YOUR FOLDER]\**\src\*.csproj;

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -280,8 +280,8 @@
                           $(RepoRoot)**\obj\**\*;"
                         Condition=" '$(BuildMainlyReferenceProviders)' != 'true' " />
 
-        <DotNetProjects Condition=" '$(HelixSubset)' == '' OR '$(HelixSubset)' == '1'"Include="@(ProjectsWithTestsSubset1)" />
-        <DotNetProjects Condition=" '$(HelixSubset)' == '' OR '$(HelixSubset)' == '2'"Include="@(ProjectsWithTestsSubset2)" />
+        <DotNetProjects Condition=" '$(HelixSubset)' == '' OR '$(HelixSubset)' == '1'" Include="@(ProjectsWithTestsSubset1)" />
+        <DotNetProjects Condition=" '$(HelixSubset)' == '' OR '$(HelixSubset)' == '2'" Include="@(ProjectsWithTestsSubset2)" />
 
         <ProjectToBuild Condition=" '$(BuildManaged)' == 'true'" Include="@(DotNetProjects)" Exclude="@(ProjectToExclude)" BuildStep="managed" />
         <ProjectToExclude Condition=" '$(BuildManaged)' != 'true'" Include="@(DotNetProjects)" />

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -150,56 +150,22 @@
           Use caution to avoid deep recursion. If the globbing pattern picks up something which exceeds MAX_PATH,
           the entire pattern will silently fail to evaluate correctly.
         -->
+
+        <!-- Strictly non-test projects - test projects are added in subsets below -->
+        <!-- 
+            When adding new projects to this file, add them to either ProjectsWithTestsSubset1 or 
+            ProjectsWithTestsSubset2 - whichever has fewer entries
+        -->
         <DotNetProjects Include="
+                          $(RepoRoot)src\Assets\**\*.*proj;
                           $(RepoRoot)src\Framework\App.Ref\src\Microsoft.AspNetCore.App.Ref.sfxproj;
                           $(RepoRoot)src\Framework\App.Ref.Internal\src\Microsoft.AspNetCore.App.Ref.Internal.csproj;
                           $(RepoRoot)src\Framework\App.Runtime\src\aspnetcore-runtime.proj;
                           $(RepoRoot)src\Framework\App.Runtime\src\aspnetcore-runtime-composite.proj;
                           $(RepoRoot)src\Framework\App.Runtime\src\aspnetcore-base-runtime.proj;
                           $(RepoRoot)src\Framework\App.Runtime\bundle\aspnetcore-runtime-bundle.bundleproj;
-                          $(RepoRoot)src\Framework\AspNetCoreAnalyzers\test\Microsoft.AspNetCore.App.Analyzers.Test.csproj;
-                          $(RepoRoot)src\Framework\test\Microsoft.AspNetCore.App.UnitTests.csproj;
-                          $(RepoRoot)src\Assets\**\*.*proj;
-                          $(RepoRoot)src\Caching\**\*.*proj;
-                          $(RepoRoot)src\DefaultBuilder\**\*.*proj;
-                          $(RepoRoot)src\Features\**\*.*proj;
-                          $(RepoRoot)src\DataProtection\**\*.*proj;
-                          $(RepoRoot)src\Antiforgery\**\*.*proj;
-                          $(RepoRoot)src\Hosting\**\*.*proj;
-                          $(RepoRoot)src\Http\**\*.*proj;
-                          $(RepoRoot)src\HttpClientFactory\**\*.*proj;
-                          $(RepoRoot)src\Html.Abstractions\**\*.*proj;
-                          $(RepoRoot)src\Identity\**\*.*proj;
-                          $(RepoRoot)src\Servers\**\*.csproj;
-                          $(RepoRoot)src\Security\**\*.*proj;
-                          $(RepoRoot)src\SiteExtensions\Microsoft.Web.Xdt.Extensions\**\*.csproj;
-                          $(RepoRoot)src\SiteExtensions\LoggingAggregate\test\**\*.csproj;
-                          $(RepoRoot)src\Shared\**\*.*proj;
-                          $(RepoRoot)src\Tools\**\*.*proj;
-                          $(RepoRoot)src\Logging.AzureAppServices\**\src\*.csproj;
-                          $(RepoRoot)src\Middleware\**\*.csproj;
-                          $(RepoRoot)src\Razor\**\*.*proj;
-                          $(RepoRoot)src\Mvc\**\*.*proj;
-                          $(RepoRoot)src\Azure\**\*.*proj;
-                          $(RepoRoot)src\SignalR\**\*.csproj;
-                          $(RepoRoot)src\StaticAssets\**\*.csproj;
-                          $(RepoRoot)src\Components\**\*.csproj;
-                          $(RepoRoot)src\Analyzers\**\*.csproj;
-                          $(RepoRoot)src\FileProviders\**\*.csproj;
-                          $(RepoRoot)src\Configuration.KeyPerFile\**\*.csproj;
-                          $(RepoRoot)src\Localization\**\*.csproj;
-                          $(RepoRoot)src\ObjectPool\**\*.csproj;
-                          $(RepoRoot)src\JSInterop\**\*.csproj;
-                          $(RepoRoot)src\WebEncoders\**\*.csproj;
-                          $(RepoRoot)src\HealthChecks\**\*.csproj;
-                          $(RepoRoot)src\Testing\**\*.csproj;
-                          $(RepoRoot)src\Grpc\**\*.csproj;
-                          $(RepoRoot)src\ProjectTemplates\**\*.csproj;
-                          $(RepoRoot)src\Extensions\**\*.csproj;
-                          $(RepoRoot)src\BuildAfterTargetingPack\*.csproj;
-                          $(RepoRoot)src\OpenApi\**\*.csproj;
-                          $(RepoRoot)src\Validation\**\*.csproj;
                           $(RepoRoot)eng\tools\HelixTestRunner\HelixTestRunner.csproj;
+                          $(RepoRoot)src\BuildAfterTargetingPack\*.csproj;
                           "
                         Exclude="
                           @(ProjectToBuild);
@@ -252,6 +218,70 @@
                           $(RepoRoot)**\bin\**\*;
                           $(RepoRoot)**\obj\**\*;"
                         Condition=" '$(BuildMainlyReferenceProviders)' == 'true' " />
+
+
+        <ProjectsWithTestsSubset1 Include="
+                          $(RepoRoot)src\Framework\AspNetCoreAnalyzers\test\Microsoft.AspNetCore.App.Analyzers.Test.csproj;
+                          $(RepoRoot)src\Framework\test\Microsoft.AspNetCore.App.UnitTests.csproj;
+                          $(RepoRoot)src\Caching\**\*.*proj;
+                          $(RepoRoot)src\DefaultBuilder\**\*.*proj;
+                          $(RepoRoot)src\Features\**\*.*proj;
+                          $(RepoRoot)src\DataProtection\**\*.*proj;
+                          $(RepoRoot)src\Antiforgery\**\*.*proj;
+                          $(RepoRoot)src\Hosting\**\*.*proj;
+                          $(RepoRoot)src\Http\**\*.*proj;
+                          $(RepoRoot)src\HttpClientFactory\**\*.*proj;
+                          $(RepoRoot)src\Html.Abstractions\**\*.*proj;
+                          $(RepoRoot)src\Identity\**\*.*proj;
+                          $(RepoRoot)src\Servers\**\*.csproj;
+                          $(RepoRoot)src\Security\**\*.*proj;
+                          $(RepoRoot)src\SiteExtensions\Microsoft.Web.Xdt.Extensions\**\*.csproj;
+                          $(RepoRoot)src\SiteExtensions\LoggingAggregate\test\**\*.csproj;
+                          $(RepoRoot)src\Shared\**\*.*proj;
+                          $(RepoRoot)src\Tools\**\*.*proj;
+                          $(RepoRoot)src\Logging.AzureAppServices\**\src\*.csproj;
+                          $(RepoRoot)src\Middleware\**\*.csproj;
+                          "
+                        Exclude="
+                          @(ProjectToBuild);
+                          @(ProjectToExclude);
+                          $(RepoRoot)**\node_modules\**\*;
+                          $(RepoRoot)**\bin\**\*;
+                          $(RepoRoot)**\obj\**\*;"
+                        Condition=" '$(BuildMainlyReferenceProviders)' != 'true' " />
+
+        <ProjectsWithTestsSubset2 Include="
+                          $(RepoRoot)src\Razor\**\*.*proj;
+                          $(RepoRoot)src\Mvc\**\*.*proj;
+                          $(RepoRoot)src\Azure\**\*.*proj;
+                          $(RepoRoot)src\SignalR\**\*.csproj;
+                          $(RepoRoot)src\StaticAssets\**\*.csproj;
+                          $(RepoRoot)src\Components\**\*.csproj;
+                          $(RepoRoot)src\Analyzers\**\*.csproj;
+                          $(RepoRoot)src\FileProviders\**\*.csproj;
+                          $(RepoRoot)src\Configuration.KeyPerFile\**\*.csproj;
+                          $(RepoRoot)src\Localization\**\*.csproj;
+                          $(RepoRoot)src\ObjectPool\**\*.csproj;
+                          $(RepoRoot)src\JSInterop\**\*.csproj;
+                          $(RepoRoot)src\WebEncoders\**\*.csproj;
+                          $(RepoRoot)src\HealthChecks\**\*.csproj;
+                          $(RepoRoot)src\Testing\**\*.csproj;
+                          $(RepoRoot)src\Grpc\**\*.csproj;
+                          $(RepoRoot)src\ProjectTemplates\**\*.csproj;
+                          $(RepoRoot)src\Extensions\**\*.csproj;
+                          $(RepoRoot)src\OpenApi\**\*.csproj;
+                          $(RepoRoot)src\Validation\**\*.csproj;
+                          "
+                        Exclude="
+                          @(ProjectToBuild);
+                          @(ProjectToExclude);
+                          $(RepoRoot)**\node_modules\**\*;
+                          $(RepoRoot)**\bin\**\*;
+                          $(RepoRoot)**\obj\**\*;"
+                        Condition=" '$(BuildMainlyReferenceProviders)' != 'true' " />
+
+        <DotNetProjects Condition=" '$(HelixSubset)' == '' OR '$(HelixSubset)' == '1'"Include="@(ProjectsWithTestsSubset1)" />
+        <DotNetProjects Condition=" '$(HelixSubset)' == '' OR '$(HelixSubset)' == '2'"Include="@(ProjectsWithTestsSubset2)" />
 
         <ProjectToBuild Condition=" '$(BuildManaged)' == 'true'" Include="@(DotNetProjects)" Exclude="@(ProjectToExclude)" BuildStep="managed" />
         <ProjectToExclude Condition=" '$(BuildManaged)' != 'true'" Include="@(DotNetProjects)" />

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -151,11 +151,12 @@
           the entire pattern will silently fail to evaluate correctly.
         -->
 
-        <!-- Strictly non-test projects - test projects are added in subsets below -->
         <!-- 
-            When adding new projects to this file, add them to either ProjectsWithTestsSubset1 or 
-            ProjectsWithTestsSubset2 - whichever has fewer entries
+          When adding new projects to this file, add them to either ProjectsWithTestsSubset1 or 
+          ProjectsWithTestsSubset2 - whichever has fewer entries.
         -->
+
+        <!-- Strictly projects with no associated tests - projects with tests are added in subsets below. -->
         <DotNetProjects Include="
                           $(RepoRoot)src\Assets\**\*.*proj;
                           $(RepoRoot)src\Framework\App.Ref\src\Microsoft.AspNetCore.App.Ref.sfxproj;


### PR DESCRIPTION
Split our helix tests into 2 separate jobs (subset 1 and subset 2). Doing so cuts about 15 minutes off of total PR CI execution time.