### PR TITLE
[Blazor] Emit antiforgery only when streaming, a form has been placed on the page or there are interactive render modes configured

### DIFF
--- a/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
+++ b/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Diagnostics;
+using System.Net.Http;
 using System.Text;
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Antiforgery;
@@ -142,7 +143,7 @@ internal partial class RazorComponentEndpointInvoker : IRazorComponentEndpointIn
 
             context.Response.Headers.ContentEncoding = "identity";
         }
-        else
+        else if (endpoint.Metadata.GetMetadata<ConfiguredRenderModesMetadata>()?.ConfiguredRenderModes.Length == 0)
         {
             // Disable token generation on EndpointAntiforgeryStateProvider if we are not streaming.
             var provider = (EndpointAntiforgeryStateProvider)context.RequestServices.GetRequiredService<AntiforgeryStateProvider>();

--- a/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
+++ b/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
@@ -76,14 +76,6 @@ internal partial class RazorComponentEndpointInvoker : IRazorComponentEndpointIn
             return;
         }
 
-        context.Response.OnStarting(() =>
-        {
-            // Generate the antiforgery tokens before we start streaming the response, as it needs
-            // to set the cookie header.
-            antiforgery!.GetAndStoreTokens(context);
-            return Task.CompletedTask;
-        });
-
         if (httpActivityContext != default)
         {
             _activityLinkStore.SetActivityContext(ComponentsActivityLinkStore.Http, httpActivityContext, null);
@@ -154,6 +146,8 @@ internal partial class RazorComponentEndpointInvoker : IRazorComponentEndpointIn
 
         if (!quiesceTask.IsCompletedSuccessfully)
         {
+            // We need to ensure that the antiforgery tokens are generated and stored in the response
+            antiforgery!.GetAndStoreTokens(context);
             await _renderer.SendStreamingUpdatesAsync(context, quiesceTask, bufferWriter);
         }
         else

--- a/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
+++ b/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
@@ -3,7 +3,6 @@
 
 using System.Buffers;
 using System.Diagnostics;
-using System.Net.Http;
 using System.Text;
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Antiforgery;


### PR DESCRIPTION
Fixes #54232