### PR TITLE
Update global.json to allow hosts to transparently use repo-local global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,11 @@
 {
   "sdk": {
-    "version": "10.0.100-preview.6.25315.102"
+    "version": "10.0.100-preview.6.25315.102",
+    "paths": [
+      ".dotnet",
+      "$host$"
+    ],
+    "errorMessage": "The .NET SDK is not installed or is not configured correctly. Please run ./build to install the correct SDK version locally."
   },
   "tools": {
     "dotnet": "10.0.100-preview.6.25315.102",


### PR DESCRIPTION
# Use global.json paths feature to make IDE usage easier

This was added in preview 3 to make working with dotnet repos in IDEs easier/more consistent: https://learn.microsoft.com/en-us/dotnet/core/tools/global-json#paths