### PR TITLE
Prevent `ObjectDisposedException` from becoming unobserved during circuit cleanup

### DIFF
--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Redirections/CircularRedirection.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Redirections/CircularRedirection.razor
@@ -13,9 +13,22 @@
     {
         <h2>Unobserved Exceptions (for debugging):</h2>
         <ul>
-            @foreach (var ex in _unobservedExceptions)
+            @foreach (var exceptionDetail in _unobservedExceptions)
             {
-                <li>@ex.ToString()</li>
+                <li>
+                    <strong>Observed at:</strong> @exceptionDetail.ObservedAt.ToString("yyyy-MM-dd HH:mm:ss.fff") UTC<br/>
+                    <strong>Thread ID:</strong> @exceptionDetail.ObservedThreadId<br/>
+                    <strong>From Finalizer Thread:</strong> @exceptionDetail.IsFromFinalizerThread<br/>
+                    <strong>Exception:</strong> @exceptionDetail.Exception.ToString()<br/>
+                    <details>
+                        <summary>Detailed Exception Information</summary>
+                        <pre>@exceptionDetail.DetailedExceptionInfo</pre>
+                    </details>
+                    <details>
+                        <summary>Call Stack When Observed</summary>
+                        <pre>@exceptionDetail.ObservedCallStack</pre>
+                    </details>
+                </li>
             }
         </ul>
     }
@@ -23,16 +36,16 @@
 
 @code {
     private bool _shouldStopRedirecting;
-    private IReadOnlyCollection<Exception> _unobservedExceptions = Array.Empty<Exception>();
+    private IReadOnlyCollection<UnobservedExceptionDetails> _unobservedExceptions = Array.Empty<UnobservedExceptionDetails>();
 
     protected override async Task OnInitializedAsync()
     {
-		int visits = Observer.GetCircularRedirectCount();
-		if (visits == 0)
-		{
-			// make sure we start with clean logs
-			Observer.Clear();
-		}
+        int visits = Observer.GetCircularRedirectCount();
+        if (visits == 0)
+        {
+            // make sure we start with clean logs
+            Observer.Clear();
+        }
 
         // Force GC collection to trigger finalizers - this is what causes the issue
         GC.Collect();
@@ -47,7 +60,7 @@
         else
         {
             _shouldStopRedirecting = true;
-            _unobservedExceptions = Observer.GetExceptions();
+            _unobservedExceptions = Observer.GetExceptionDetails();
         }
     }
 }

--- a/src/Components/test/testassets/Components.TestServer/UnobservedTaskExceptionObserver.cs
+++ b/src/Components/test/testassets/Components.TestServer/UnobservedTaskExceptionObserver.cs
@@ -2,24 +2,134 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
 using System.Threading;
+using System.Linq;
 
 namespace TestServer;
 
+/// <summary>
+/// Represents detailed information about an unobserved task exception, including the original call stack.
+/// </summary>
+public class UnobservedExceptionDetails
+{
+    /// <summary>
+    /// The original exception that was unobserved.
+    /// </summary>
+    public Exception Exception { get; init; }
+
+    /// <summary>
+    /// The timestamp when the exception was observed.
+    /// </summary>
+    public DateTime ObservedAt { get; init; }
+
+    /// <summary>
+    /// The current call stack when the exception was observed (may show finalizer thread).
+    /// </summary>
+    public string ObservedCallStack { get; init; }
+
+    /// <summary>
+    /// Detailed breakdown of inner exceptions and their stack traces.
+    /// </summary>
+    public string DetailedExceptionInfo { get; init; }
+
+    /// <summary>
+    /// The managed thread ID where the exception was observed.
+    /// </summary>
+    public int ObservedThreadId { get; init; }
+
+    /// <summary>
+    /// Whether this exception was observed on the finalizer thread.
+    /// </summary>
+    public bool IsFromFinalizerThread { get; init; }
+
+    public UnobservedExceptionDetails(Exception exception)
+    {
+        Exception = exception;
+        ObservedAt = DateTime.UtcNow;
+        ObservedCallStack = Environment.StackTrace;
+        DetailedExceptionInfo = BuildDetailedExceptionInfo(exception);
+        ObservedThreadId = Environment.CurrentManagedThreadId;
+        IsFromFinalizerThread = Thread.CurrentThread.IsThreadPoolThread && Thread.CurrentThread.IsBackground;
+    }
+
+    private static string BuildDetailedExceptionInfo(Exception exception)
+    {
+        var sb = new StringBuilder();
+        var currentException = exception;
+        var depth = 0;
+
+        while (currentException is not null)
+        {
+            var indent = new string(' ', depth * 2);
+            sb.AppendLine(CultureInfo.InvariantCulture, $"{indent}Exception Type: {currentException.GetType().FullName}");
+            sb.AppendLine(CultureInfo.InvariantCulture, $"{indent}Message: {currentException.Message}");
+
+            if (currentException.Data.Count > 0)
+            {
+                sb.AppendLine(CultureInfo.InvariantCulture, $"{indent}Data:");
+                foreach (var key in currentException.Data.Keys)
+                {
+                    sb.AppendLine(CultureInfo.InvariantCulture, $"{indent}  {key}: {currentException.Data[key]}");
+                }
+            }
+
+            if (!string.IsNullOrEmpty(currentException.StackTrace))
+            {
+                sb.AppendLine(CultureInfo.InvariantCulture, $"{indent}Stack Trace:");
+                sb.AppendLine(currentException.StackTrace);
+            }
+
+            // Handle AggregateException specially to extract all inner exceptions
+            if (currentException is AggregateException aggregateException)
+            {
+                sb.AppendLine(CultureInfo.InvariantCulture, $"{indent}Aggregate Exception contains {aggregateException.InnerExceptions.Count} inner exceptions:");
+                for (int i = 0; i < aggregateException.InnerExceptions.Count; i++)
+                {
+                    sb.AppendLine(CultureInfo.InvariantCulture, $"{indent}  Inner Exception {i + 1}:");
+                    sb.AppendLine(BuildDetailedExceptionInfo(aggregateException.InnerExceptions[i]));
+                }
+                break; // Don't process InnerException for AggregateException as we've handled all inner exceptions
+            }
+
+            currentException = currentException.InnerException;
+            depth++;
+
+            if (currentException is not null)
+            {
+                sb.AppendLine(CultureInfo.InvariantCulture, $"{indent}--- Inner Exception ---");
+            }
+        }
+
+        return sb.ToString();
+    }
+}
+
 public class UnobservedTaskExceptionObserver
 {
-    private readonly ConcurrentQueue<Exception> _exceptions = new();
+    private readonly ConcurrentQueue<UnobservedExceptionDetails> _exceptions = new();
     private int _circularRedirectCount;
 
     public void OnUnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
     {
-        _exceptions.Enqueue(e.Exception);
+        var details = new UnobservedExceptionDetails(e.Exception);
+        _exceptions.Enqueue(details);
         e.SetObserved(); // Mark as observed to prevent the process from crashing during tests
     }
 
     public bool HasExceptions => !_exceptions.IsEmpty;
 
-    public IReadOnlyCollection<Exception> GetExceptions() => _exceptions.ToArray();
+    /// <summary>
+    /// Gets the detailed exception information including original call stacks.
+    /// </summary>
+    public IReadOnlyCollection<UnobservedExceptionDetails> GetExceptionDetails() => _exceptions.ToArray();
+
+    /// <summary>
+    /// Gets the raw exceptions for backward compatibility.
+    /// </summary>
+    public IReadOnlyCollection<Exception> GetExceptions() => _exceptions.ToArray().Select(d => d.Exception).ToList();
 
     public void Clear()
     {


### PR DESCRIPTION
Issue similar to https://github.com/dotnet/aspnetcore/pull/62554.

[log](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1090989&view=logs&j=fe94c0c9-bb8c-5d6f-3b51-887173cc2f5c&t=b4bd3469-f776-5941-b623-568498d38bde&s=96ac2280-8cb4-5df5-99de-dd2da759617d)
```
[xUnit.net 00:20:37.86]     Microsoft.AspNetCore.Components.E2ETests.ServerRenderingTests.RedirectionTest.NavigationException_InAsyncContext_DoesNotBecomeUnobservedTaskException [FAIL]
  Failed Microsoft.AspNetCore.Components.E2ETests.ServerRenderingTests.RedirectionTest.NavigationException_InAsyncContext_DoesNotBecomeUnobservedTaskException [36 s]
  Error Message:
   OpenQA.Selenium.BrowserAssertFailedException : Xunit.Sdk.EqualException: Assert.Equal() Failure: Values differ
Expected: 0
Actual:   4

<h1>Hello, world!</h1><p id="unobserved-exceptions-count">4</p><h2>Unobserved Exceptions (for debugging):</h2>
        <ul><li>System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (Cannot access a disposed object.
Object name: 'IServiceProvider'.)
 ---&gt; System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'IServiceProvider'.
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.ThrowHelper.ThrowObjectDisposedException()
   at Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService[T](IServiceProvider provider)
   at Microsoft.AspNetCore.Components.Server.Circuits.CircuitPersistenceManager.PauseCircuitAsync(CircuitHost circuit, Boolean saveStateToClient, CancellationToken cancellation) in /home/vsts/work/1/s/src/Components/Server/src/Circuits/CircuitPersistenceManager.cs:line 25
   at Microsoft.AspNetCore.Components.Server.Circuits.CircuitRegistry.PauseAndDisposeCircuitHost(CircuitHost circuitHost, Boolean saveStateToClient) in /home/vsts/work/1/s/src/Components/Server/src/Circuits/CircuitRegistry.cs:line 312
   --- End of inner exception stack trace ---</li><li>System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (Cannot access a disposed object.
Object name: 'IServiceProvider'.)
 ---&gt; System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'IServiceProvider'.
```

## Description

`PeristanceManager.PauseCircuitAsync` tries to resolve the `ComponentStatePersistenceManager` service from an already disposed service provider during circuit cleanup (triggered by garbage collection), causing an `ObjectDisposedException` to be thrown. 
https://github.com/dotnet/aspnetcore/blob/ea282bf14ecf044e62492c375a8a08e86d00de87/src/Components/Server/src/Circuits/CircuitPersistenceManager.cs#L25

Theoretically we are subscribed to `circuitHost.UnhandledException` but it did not get triggered in this situation. The fix is to observe the exception. I chose `CircuitRegistry` for it because it has `CircuitHost_UnhandledException` method to handle that gracefully.

This failure was obsered once on CI, see the log above. Running that test locally on repeat did not reveal any hits after 1k runs.
