### PR TITLE
Fix Microsoft.Extensions.Caching.Hybrid repo origin and CoherentParentDependency

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -51,10 +51,6 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>df4663b92c2f2d25b66e44524478d9016c812949</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Caching.Hybrid" Version="10.0.0-alpha.2.24462.2">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>f485d74550db5bd91617accc1bb548ae6013756b</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0-preview.7.25351.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>df4663b92c2f2d25b66e44524478d9016c812949</Sha>
@@ -400,13 +396,17 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>df4663b92c2f2d25b66e44524478d9016c812949</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Diagnostics.Testing" Version="9.6.0-preview.1.25271.2">
+    <Dependency Name="Microsoft.Extensions.Caching.Hybrid" Version="9.8.0-preview.1.25358.1">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>6f29ab505709370fc9b72bf4bb7e004a7662f69f</Sha>
+      <Sha>23c62b80989f7baf55dc394829895b636f960fdc</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.TimeProvider.Testing" Version="9.6.0-preview.1.25271.2">
+    <Dependency Name="Microsoft.Extensions.Diagnostics.Testing" Version="9.8.0-preview.1.25358.1">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>6f29ab505709370fc9b72bf4bb7e004a7662f69f</Sha>
+      <Sha>23c62b80989f7baf55dc394829895b636f960fdc</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.TimeProvider.Testing" Version="9.8.0-preview.1.25358.1">
+      <Uri>https://github.com/dotnet/extensions</Uri>
+      <Sha>23c62b80989f7baf55dc394829895b636f960fdc</Sha>
     </Dependency>
     <Dependency Name="NuGet.Frameworks" Version="6.2.4">
       <Uri>https://github.com/nuget/nuget.client</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -420,25 +420,25 @@
       <Uri>https://github.com/nuget/nuget.client</Uri>
       <Sha>8fef55f5a55a3b4f2c96cd1a9b5ddc51d4b927f8</Sha>
     </Dependency>
-    <Dependency Name="optimization.windows_nt-x64.MIBC.Runtime" Version="1.0.0-prerelease.25217.3" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="optimization.windows_nt-x64.MIBC.Runtime" Version="1.0.0-prerelease.25324.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-optimization</Uri>
-      <Sha>bff9b4a349cfa7e3d83264d8953613d98a7b04eb</Sha>
+      <Sha>86968b14b5c2ba5104d205665c76c22544c067f6</Sha>
     </Dependency>
-    <Dependency Name="optimization.windows_nt-x86.MIBC.Runtime" Version="1.0.0-prerelease.25217.3" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="optimization.windows_nt-x86.MIBC.Runtime" Version="1.0.0-prerelease.25324.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-optimization</Uri>
-      <Sha>bff9b4a349cfa7e3d83264d8953613d98a7b04eb</Sha>
+      <Sha>86968b14b5c2ba5104d205665c76c22544c067f6</Sha>
     </Dependency>
-    <Dependency Name="optimization.linux-x64.MIBC.Runtime" Version="1.0.0-prerelease.25217.3" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="optimization.linux-x64.MIBC.Runtime" Version="1.0.0-prerelease.25324.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-optimization</Uri>
-      <Sha>bff9b4a349cfa7e3d83264d8953613d98a7b04eb</Sha>
+      <Sha>86968b14b5c2ba5104d205665c76c22544c067f6</Sha>
     </Dependency>
-    <Dependency Name="optimization.windows_nt-arm64.MIBC.Runtime" Version="1.0.0-prerelease.25217.3" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="optimization.windows_nt-arm64.MIBC.Runtime" Version="1.0.0-prerelease.25324.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-optimization</Uri>
-      <Sha>bff9b4a349cfa7e3d83264d8953613d98a7b04eb</Sha>
+      <Sha>86968b14b5c2ba5104d205665c76c22544c067f6</Sha>
     </Dependency>
-    <Dependency Name="optimization.linux-arm64.MIBC.Runtime" Version="1.0.0-prerelease.25217.3" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="optimization.linux-arm64.MIBC.Runtime" Version="1.0.0-prerelease.25324.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-optimization</Uri>
-      <Sha>bff9b4a349cfa7e3d83264d8953613d98a7b04eb</Sha>
+      <Sha>86968b14b5c2ba5104d205665c76c22544c067f6</Sha>
     </Dependency>
     <!-- Dependencies required for source build to lift to the previously-source-built version. -->
     <Dependency Name="Microsoft.Build" Version="17.12.36">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -182,11 +182,11 @@
     <!-- Packages from dotnet/xdt -->
     <MicrosoftWebXdtVersion>10.0.0-preview.25351.105</MicrosoftWebXdtVersion>
     <!-- dotnet-optimization dependencies -->
-    <optimizationwindows_ntx64MIBCRuntimeVersion>1.0.0-prerelease.25217.3</optimizationwindows_ntx64MIBCRuntimeVersion>
-    <optimizationwindows_ntx86MIBCRuntimeVersion>1.0.0-prerelease.25217.3</optimizationwindows_ntx86MIBCRuntimeVersion>
-    <optimizationwindows_ntarm64MIBCRuntimeVersion>1.0.0-prerelease.25217.3</optimizationwindows_ntarm64MIBCRuntimeVersion>
-    <optimizationlinuxx64MIBCRuntimeVersion>1.0.0-prerelease.25217.3</optimizationlinuxx64MIBCRuntimeVersion>
-    <optimizationlinuxarm64MIBCRuntimeVersion>1.0.0-prerelease.25217.3</optimizationlinuxarm64MIBCRuntimeVersion>
+    <optimizationwindows_ntx64MIBCRuntimeVersion>1.0.0-prerelease.25324.1</optimizationwindows_ntx64MIBCRuntimeVersion>
+    <optimizationwindows_ntx86MIBCRuntimeVersion>1.0.0-prerelease.25324.1</optimizationwindows_ntx86MIBCRuntimeVersion>
+    <optimizationwindows_ntarm64MIBCRuntimeVersion>1.0.0-prerelease.25324.1</optimizationwindows_ntarm64MIBCRuntimeVersion>
+    <optimizationlinuxx64MIBCRuntimeVersion>1.0.0-prerelease.25324.1</optimizationlinuxx64MIBCRuntimeVersion>
+    <optimizationlinuxarm64MIBCRuntimeVersion>1.0.0-prerelease.25324.1</optimizationlinuxarm64MIBCRuntimeVersion>
   </PropertyGroup>
   <!--
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -74,7 +74,6 @@
     <MicrosoftNETCoreBrowserDebugHostTransportVersion>10.0.0-preview.7.25351.105</MicrosoftNETCoreBrowserDebugHostTransportVersion>
     <MicrosoftExtensionsCachingAbstractionsVersion>10.0.0-preview.7.25351.105</MicrosoftExtensionsCachingAbstractionsVersion>
     <MicrosoftExtensionsCachingMemoryVersion>10.0.0-preview.7.25351.105</MicrosoftExtensionsCachingMemoryVersion>
-    <MicrosoftExtensionsCachingHybridVersion>10.0.0-alpha.2.24462.2</MicrosoftExtensionsCachingHybridVersion>
     <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.0-preview.7.25351.105</MicrosoftExtensionsConfigurationAbstractionsVersion>
     <MicrosoftExtensionsConfigurationBinderVersion>10.0.0-preview.7.25351.105</MicrosoftExtensionsConfigurationBinderVersion>
     <MicrosoftExtensionsConfigurationCommandLineVersion>10.0.0-preview.7.25351.105</MicrosoftExtensionsConfigurationCommandLineVersion>
@@ -144,8 +143,9 @@
     <SystemNumericsTensorsVersion>10.0.0-preview.7.25351.105</SystemNumericsTensorsVersion>
     <SystemRuntimeCachingVersion>10.0.0-preview.7.25351.105</SystemRuntimeCachingVersion>
     <!-- Packages from dotnet/extensions -->
-    <MicrosoftExtensionsDiagnosticsTestingVersion>9.6.0-preview.1.25271.2</MicrosoftExtensionsDiagnosticsTestingVersion>
-    <MicrosoftExtensionsTimeProviderTestingVersion>9.6.0-preview.1.25271.2</MicrosoftExtensionsTimeProviderTestingVersion>
+    <MicrosoftExtensionsCachingHybridVersion>9.8.0-preview.1.25358.1</MicrosoftExtensionsCachingHybridVersion>
+    <MicrosoftExtensionsDiagnosticsTestingVersion>9.8.0-preview.1.25358.1</MicrosoftExtensionsDiagnosticsTestingVersion>
+    <MicrosoftExtensionsTimeProviderTestingVersion>9.8.0-preview.1.25358.1</MicrosoftExtensionsTimeProviderTestingVersion>
     <!-- Packages from dotnet/efcore -->
     <dotnetefVersion>10.0.0-preview.7.25351.105</dotnetefVersion>
     <MicrosoftEntityFrameworkCoreInMemoryVersion>10.0.0-preview.7.25351.105</MicrosoftEntityFrameworkCoreInMemoryVersion>


### PR DESCRIPTION
The Microsoft.Extensions.Caching.Hybrid package is built in dotnet/extensions. It's also a toolset dependency (we can only use it in tests) so move it to the appropriate section.

We also noticed that the darc updates were broken due to the CoherentParentDependency on the optimization packages, which no longer works since there's no aspnetcore->runtime dependency anymore with the VMR.
