### PR TITLE
Remove SiteExtensions from AspNetCore.slnx

### DIFF
--- a/AspNetCore.slnx
+++ b/AspNetCore.slnx
@@ -1146,10 +1146,6 @@
   <Folder Name="/src/SiteExtensions/">
     <Project Path="src/SiteExtensions/LoggingBranch/LB.csproj" />
   </Folder>
-  <Folder Name="/src/SiteExtensions/LoggingAggregate/">
-    <Project Path="src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj" />
-    <Project Path="src/SiteExtensions/LoggingAggregate/test/Microsoft.AspNetCore.AzureAppServices.SiteExtension.Tests/Microsoft.AspNetCore.AzureAppServices.SiteExtension.Tests.csproj" />
-  </Folder>
   <Folder Name="/src/SiteExtensions/Microsoft.Web.Xdt.Extensions/">
     <Project Path="src/SiteExtensions/Microsoft.Web.Xdt.Extensions/src/Microsoft.Web.Xdt.Extensions.csproj" />
     <Project Path="src/SiteExtensions/Microsoft.Web.Xdt.Extensions/tests/Microsoft.Web.Xdt.Extensions.Tests.csproj" />

--- a/AspNetCore.slnx
+++ b/AspNetCore.slnx
@@ -1143,15 +1143,9 @@
     <Project Path="src/SignalR/server/StackExchangeRedis/src/Microsoft.AspNetCore.SignalR.StackExchangeRedis.csproj" />
     <Project Path="src/SignalR/server/StackExchangeRedis/test/Microsoft.AspNetCore.SignalR.StackExchangeRedis.Tests.csproj" />
   </Folder>
-  <Folder Name="/src/SiteExtensions/">
-    <Project Path="src/SiteExtensions/LoggingBranch/LB.csproj" />
-  </Folder>
   <Folder Name="/src/SiteExtensions/Microsoft.Web.Xdt.Extensions/">
     <Project Path="src/SiteExtensions/Microsoft.Web.Xdt.Extensions/src/Microsoft.Web.Xdt.Extensions.csproj" />
     <Project Path="src/SiteExtensions/Microsoft.Web.Xdt.Extensions/tests/Microsoft.Web.Xdt.Extensions.Tests.csproj" />
-  </Folder>
-  <Folder Name="/src/SiteExtensions/Sdk/">
-    <Project Path="src/SiteExtensions/Sdk/HostingStartup/HostingStartup.csproj" />
   </Folder>
   <Folder Name="/src/Testing/">
     <Project Path="src/Analyzers/Microsoft.AspNetCore.Analyzer.Testing/src/Microsoft.AspNetCore.Analyzer.Testing.csproj" />


### PR DESCRIPTION
This project requires an entire packed build of the repo and makes restores cumbersome when loading the AspNetCore.slnx file.