### PR TITLE
Identity metrics clean up

### DIFF
--- a/src/Identity/Core/src/SignInManagerMetrics.cs
+++ b/src/Identity/Core/src/SignInManagerMetrics.cs
@@ -182,7 +182,7 @@ internal sealed class SignInManagerMetrics : IDisposable
             SignInType.TwoFactor => "two_factor",
             SignInType.External => "external",
             SignInType.Passkey => "passkey",
-            _ => "_UNKNOWN"
+            _ => "_OTHER"
         };
     }
 

--- a/src/Identity/Core/src/SignInManagerMetrics.cs
+++ b/src/Identity/Core/src/SignInManagerMetrics.cs
@@ -14,8 +14,8 @@ internal sealed class SignInManagerMetrics : IDisposable
     public const string RememberTwoFactorCounterName = "aspnetcore.identity.sign_in.remember_two_factor";
     public const string ForgetTwoFactorCounterName = "aspnetcore.identity.sign_in.forget_two_factor";
     public const string CheckPasswordCounterName = "aspnetcore.identity.sign_in.check_password";
-    public const string SignInUserPrincipalCounterName = "aspnetcore.identity.sign_in.sign_in_principal";
-    public const string SignOutUserPrincipalCounterName = "aspnetcore.identity.sign_in.sign_out_principal";
+    public const string SignInUserPrincipalCounterName = "aspnetcore.identity.sign_in.sign_in";
+    public const string SignOutUserPrincipalCounterName = "aspnetcore.identity.sign_in.sign_out";
 
     private readonly Meter _meter;
     private readonly Counter<long> _authenticateCounter;
@@ -29,12 +29,12 @@ internal sealed class SignInManagerMetrics : IDisposable
     {
         _meter = meterFactory.Create(MeterName);
 
-        _authenticateCounter = _meter.CreateCounter<long>(AuthenticateCounterName, "count", "The number of authenticate attempts. The authenticate counter is incremented by sign in methods such as PasswordSignInAsync and TwoFactorSignInAsync.");
-        _rememberTwoFactorClientCounter = _meter.CreateCounter<long>(RememberTwoFactorCounterName, "count", "The number of two factor clients remembered.");
-        _forgetTwoFactorCounter = _meter.CreateCounter<long>(ForgetTwoFactorCounterName, "count", "The number of two factor clients forgotten.");
-        _checkPasswordCounter = _meter.CreateCounter<long>(CheckPasswordCounterName, "count", "The number of check password attempts. Checks that the account is in a state that can log in and that the password is valid using the UserManager.CheckPasswordAsync method.");
-        _signInUserPrincipalCounter = _meter.CreateCounter<long>(SignInUserPrincipalCounterName, "count", "The number of calls to sign in user principals.");
-        _signOutUserPrincipalCounter = _meter.CreateCounter<long>(SignOutUserPrincipalCounterName, "count", "The number of calls to sign out user principals.");
+        _authenticateCounter = _meter.CreateCounter<long>(AuthenticateCounterName, "{count}", "The number of authenticate attempts. The authenticate counter is incremented by sign in methods such as PasswordSignInAsync and TwoFactorSignInAsync.");
+        _rememberTwoFactorClientCounter = _meter.CreateCounter<long>(RememberTwoFactorCounterName, "{count}", "The number of two factor clients remembered.");
+        _forgetTwoFactorCounter = _meter.CreateCounter<long>(ForgetTwoFactorCounterName, "{count}", "The number of two factor clients forgotten.");
+        _checkPasswordCounter = _meter.CreateCounter<long>(CheckPasswordCounterName, "{check}", "The number of check password attempts. Checks that the account is in a state that can log in and that the password is valid using the UserManager.CheckPasswordAsync method.");
+        _signInUserPrincipalCounter = _meter.CreateCounter<long>(SignInUserPrincipalCounterName, "{sign_in}", "The number of calls to sign in user principals.");
+        _signOutUserPrincipalCounter = _meter.CreateCounter<long>(SignOutUserPrincipalCounterName, "{sign_out}", "The number of calls to sign out user principals.");
     }
 
     internal void CheckPasswordSignIn(string userType, SignInResult? result, Exception? exception = null)

--- a/src/Identity/Core/src/SignInManagerMetrics.cs
+++ b/src/Identity/Core/src/SignInManagerMetrics.cs
@@ -49,7 +49,7 @@ internal sealed class SignInManagerMetrics : IDisposable
             { "aspnetcore.identity.user_type", userType },
         };
         AddSignInResult(ref tags, result);
-        AddExceptionTags(ref tags, exception);
+        AddErrorTag(ref tags, exception);
 
         _checkPasswordCounter.Add(1, tags);
     }
@@ -69,7 +69,7 @@ internal sealed class SignInManagerMetrics : IDisposable
         };
         AddIsPersistent(ref tags, isPersistent);
         AddSignInResult(ref tags, result);
-        AddExceptionTags(ref tags, exception);
+        AddErrorTag(ref tags, exception);
 
         _authenticateCounter.Add(1, tags);
     }
@@ -87,7 +87,7 @@ internal sealed class SignInManagerMetrics : IDisposable
             { "aspnetcore.identity.authentication_scheme", authenticationScheme },
         };
         AddIsPersistent(ref tags, isPersistent);
-        AddExceptionTags(ref tags, exception);
+        AddErrorTag(ref tags, exception);
 
         _signInUserPrincipalCounter.Add(1, tags);
     }
@@ -104,7 +104,7 @@ internal sealed class SignInManagerMetrics : IDisposable
             { "aspnetcore.identity.user_type", userType },
             { "aspnetcore.identity.authentication_scheme", authenticationScheme },
         };
-        AddExceptionTags(ref tags, exception);
+        AddErrorTag(ref tags, exception);
 
         _signOutUserPrincipalCounter.Add(1, tags);
     }
@@ -121,7 +121,7 @@ internal sealed class SignInManagerMetrics : IDisposable
             { "aspnetcore.identity.user_type", userType },
             { "aspnetcore.identity.authentication_scheme", authenticationScheme }
         };
-        AddExceptionTags(ref tags, exception);
+        AddErrorTag(ref tags, exception);
 
         _rememberTwoFactorClientCounter.Add(1, tags);
     }
@@ -138,7 +138,7 @@ internal sealed class SignInManagerMetrics : IDisposable
             { "aspnetcore.identity.user_type", userType },
             { "aspnetcore.identity.authentication_scheme", authenticationScheme }
         };
-        AddExceptionTags(ref tags, exception);
+        AddErrorTag(ref tags, exception);
 
         _forgetTwoFactorCounter.Add(1, tags);
     }
@@ -164,7 +164,7 @@ internal sealed class SignInManagerMetrics : IDisposable
         }
     }
 
-    private static void AddExceptionTags(ref TagList tags, Exception? exception)
+    private static void AddErrorTag(ref TagList tags, Exception? exception)
     {
         if (exception != null)
         {

--- a/src/Identity/Extensions.Core/src/UserManagerMetrics.cs
+++ b/src/Identity/Extensions.Core/src/UserManagerMetrics.cs
@@ -32,9 +32,9 @@ internal sealed class UserManagerMetrics : IDisposable
     public UserManagerMetrics(IMeterFactory meterFactory)
     {
         _meter = meterFactory.Create(MeterName);
-        _createCounter = _meter.CreateCounter<long>(CreateCounterName, "{create}", "The number of users created.");
-        _updateCounter = _meter.CreateCounter<long>(UpdateCounterName, "{update}", "The number of user updates.");
-        _deleteCounter = _meter.CreateCounter<long>(DeleteCounterName, "{delete}", "The number of users deleted.");
+        _createCounter = _meter.CreateCounter<long>(CreateCounterName, "{user}", "The number of users created.");
+        _updateCounter = _meter.CreateCounter<long>(UpdateCounterName, "{user}", "The number of users updated.");
+        _deleteCounter = _meter.CreateCounter<long>(DeleteCounterName, "{user}", "The number of users deleted.");
         _checkPasswordCounter = _meter.CreateCounter<long>(CheckPasswordCounterName, "{check}", "The number of check password attempts. Only checks whether the password is valid and not whether the user account is in a state that can log in.");
         _verifyTokenCounter = _meter.CreateCounter<long>(VerifyTokenCounterName, "{count}", "The number of token verification attempts.");
         _generateTokenCounter = _meter.CreateCounter<long>(GenerateTokenCounterName, "{count}", "The number of token generation attempts.");
@@ -52,7 +52,7 @@ internal sealed class UserManagerMetrics : IDisposable
             { "aspnetcore.identity.user_type", userType }
         };
         AddIdentityResultTags(ref tags, result);
-        AddExceptionTags(ref tags, exception, result: result);
+        AddErrorTag(ref tags, exception, result: result);
 
         _createCounter.Add(1, tags);
     }
@@ -70,7 +70,7 @@ internal sealed class UserManagerMetrics : IDisposable
             { "aspnetcore.identity.user.update_type", GetUpdateType(updateType) },
         };
         AddIdentityResultTags(ref tags, result);
-        AddExceptionTags(ref tags, exception, result: result);
+        AddErrorTag(ref tags, exception, result: result);
 
         _updateCounter.Add(1, tags);
     }
@@ -87,7 +87,7 @@ internal sealed class UserManagerMetrics : IDisposable
             { "aspnetcore.identity.user_type", userType }
         };
         AddIdentityResultTags(ref tags, result);
-        AddExceptionTags(ref tags, exception, result: result);
+        AddErrorTag(ref tags, exception, result: result);
 
         _deleteCounter.Add(1, tags);
     }
@@ -107,7 +107,7 @@ internal sealed class UserManagerMetrics : IDisposable
         {
             tags.Add("aspnetcore.identity.password_check_result", GetPasswordResult(result, passwordMissing: null, userMissing));
         }
-        AddExceptionTags(ref tags, exception);
+        AddErrorTag(ref tags, exception);
 
         _checkPasswordCounter.Add(1, tags);
     }
@@ -128,7 +128,7 @@ internal sealed class UserManagerMetrics : IDisposable
         {
             tags.Add("aspnetcore.identity.token_verified", result == true ? "success" : "failure");
         }
-        AddExceptionTags(ref tags, exception);
+        AddErrorTag(ref tags, exception);
 
         _verifyTokenCounter.Add(1, tags);
     }
@@ -145,7 +145,7 @@ internal sealed class UserManagerMetrics : IDisposable
             { "aspnetcore.identity.user_type", userType },
             { "aspnetcore.identity.token_purpose", GetTokenPurpose(purpose) },
         };
-        AddExceptionTags(ref tags, exception);
+        AddErrorTag(ref tags, exception);
 
         _generateTokenCounter.Add(1, tags);
     }
@@ -187,7 +187,7 @@ internal sealed class UserManagerMetrics : IDisposable
         }
     }
 
-    private static void AddExceptionTags(ref TagList tags, Exception? exception, IdentityResult? result = null)
+    private static void AddErrorTag(ref TagList tags, Exception? exception, IdentityResult? result = null)
     {
         var value = exception?.GetType().FullName ?? result?.Errors.FirstOrDefault()?.Code;
         if (value != null)

--- a/src/Identity/Extensions.Core/src/UserManagerMetrics.cs
+++ b/src/Identity/Extensions.Core/src/UserManagerMetrics.cs
@@ -169,7 +169,7 @@ internal sealed class UserManagerMetrics : IDisposable
             "EmailConfirmation" => "email_confirmation",
             "ChangeEmail" => "change_email",
             "TwoFactor" => "two_factor",
-            _ => "_UNKNOWN"
+            _ => "_OTHER"
         };
     }
 
@@ -204,7 +204,7 @@ internal sealed class UserManagerMetrics : IDisposable
             (PasswordVerificationResult.Failed, false, false) => "failure",
             (null, true, false) => "password_missing",
             (null, false, true) => "user_missing",
-            _ => "_UNKNOWN"
+            _ => "_OTHER"
         };
     }
 
@@ -244,7 +244,7 @@ internal sealed class UserManagerMetrics : IDisposable
             UserUpdateType.RedeemTwoFactorRecoveryCode => "redeem_two_factor_recovery_code",
             UserUpdateType.SetPasskey => "set_passkey",
             UserUpdateType.RemovePasskey => "remove_passkey",
-            _ => "_UNKNOWN"
+            _ => "_OTHER"
         };
     }
 

--- a/src/Identity/Extensions.Core/src/UserManagerMetrics.cs
+++ b/src/Identity/Extensions.Core/src/UserManagerMetrics.cs
@@ -152,7 +152,7 @@ internal sealed class UserManagerMetrics : IDisposable
 
     private static string GetTokenPurpose(string purpose)
     {
-        // Purpose could be any value and can't be used as a tag value. However, there are known purposes
+        // Purpose could be any value and can't be used directly as a tag value. However, there are known purposes
         // on UserManager that we can detect and use as a tag value. Some could have a ':' in them followed by user data.
         // We need to trim them to content before ':' and then match to known values.
         ReadOnlySpan<char> trimmedPurpose = purpose;
@@ -161,7 +161,8 @@ internal sealed class UserManagerMetrics : IDisposable
         {
             trimmedPurpose = purpose.AsSpan(0, colonIndex);
         }
-        
+
+        // These are known purposes that are specified in ASP.NET Core Identity.
         return trimmedPurpose switch
         {
             "ResetPassword" => "reset_password",

--- a/src/Identity/test/Identity.Test/UserManagerTest.cs
+++ b/src/Identity/test/Identity.Test/UserManagerTest.cs
@@ -952,13 +952,13 @@ public class UserManagerTest
         Assert.Collection(generateToken.GetMeasurementSnapshot(),
             m => MetricsHelpers.AssertContainsTags(m.Tags,
             [
-                KeyValuePair.Create<string, object>("aspnetcore.identity.token_purpose", "_UNKNOWN"),
+                KeyValuePair.Create<string, object>("aspnetcore.identity.token_purpose", "_OTHER"),
                 KeyValuePair.Create<string, object>("error.type", "System.NotSupportedException"),
             ]));
         Assert.Collection(verifyToken.GetMeasurementSnapshot(),
             m => MetricsHelpers.AssertContainsTags(m.Tags,
             [
-                KeyValuePair.Create<string, object>("aspnetcore.identity.token_purpose", "_UNKNOWN"),
+                KeyValuePair.Create<string, object>("aspnetcore.identity.token_purpose", "_OTHER"),
                 KeyValuePair.Create<string, object>("error.type", "System.NotSupportedException"),
             ]));
     }

--- a/src/Identity/test/Identity.Test/UserManagerTest.cs
+++ b/src/Identity/test/Identity.Test/UserManagerTest.cs
@@ -174,7 +174,7 @@ public class UserManagerTest
             [
                 KeyValuePair.Create<string, object>("aspnetcore.identity.user_type", "Microsoft.AspNetCore.Identity.Test.PocoUser"),
                 KeyValuePair.Create<string, object>("aspnetcore.identity.result", "failure"),
-                KeyValuePair.Create<string, object>("aspnetcore.identity.result_error_code", "ConcurrencyFailure")
+                KeyValuePair.Create<string, object>("aspnetcore.identity.error_code", "ConcurrencyFailure")
             ]));
     }
 
@@ -664,7 +664,7 @@ public class UserManagerTest
         Assert.Collection(checkPassword.GetMeasurementSnapshot(),
             m => MetricsHelpers.AssertContainsTags(m.Tags,
             [
-                KeyValuePair.Create<string, object>("aspnetcore.identity.user.password_result", "success_rehash_needed")
+                KeyValuePair.Create<string, object>("aspnetcore.identity.password_check_result", "success_rehash_needed")
             ]));
     }
 
@@ -871,7 +871,7 @@ public class UserManagerTest
         Assert.Collection(checkPassword.GetMeasurementSnapshot(),
             m => MetricsHelpers.AssertContainsTags(m.Tags,
             [
-                KeyValuePair.Create<string, object>("aspnetcore.identity.user.password_result", "user_missing")
+                KeyValuePair.Create<string, object>("aspnetcore.identity.password_check_result", "user_missing")
             ]));
     }
 


### PR DESCRIPTION
- Replace _UNKNOWN with _OTHER in identity metrics. `_OTHER` is the correct value to use when give a value outside of the known set.
- Apply https://github.com/open-telemetry/semantic-conventions/pull/2508 feedback