### PR TITLE
[Blazor] Rename LinkPreload to ResourcePreloader

### DIFF
--- a/src/Components/Endpoints/src/Assets/ResourcePreloader.cs
+++ b/src/Components/Endpoints/src/Assets/ResourcePreloader.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Components.Rendering;
 namespace Microsoft.AspNetCore.Components;
 
 /// <summary>
-/// Represents link elements for preloading assets.
+/// Represents a component that renders preload link elements for resources.
 /// </summary>
 public sealed class ResourcePreloader : IComponent
 {

--- a/src/Components/Endpoints/src/Assets/ResourcePreloader.cs
+++ b/src/Components/Endpoints/src/Assets/ResourcePreloader.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Components;
 /// <summary>
 /// Represents link elements for preloading assets.
 /// </summary>
-public sealed class LinkPreload : IComponent
+public sealed class ResourcePreloader : IComponent
 {
     private RenderHandle renderHandle;
     private List<PreloadAsset>? assets;

--- a/src/Components/Endpoints/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Endpoints/src/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
 #nullable enable
-Microsoft.AspNetCore.Components.LinkPreload
-Microsoft.AspNetCore.Components.LinkPreload.LinkPreload() -> void
+Microsoft.AspNetCore.Components.ResourcePreloader
+Microsoft.AspNetCore.Components.ResourcePreloader.ResourcePreloader() -> void
 Microsoft.Extensions.DependencyInjection.RazorComponentsRazorComponentBuilderExtensions
 static Microsoft.Extensions.DependencyInjection.RazorComponentsRazorComponentBuilderExtensions.RegisterPersistentService<TPersistentService>(this Microsoft.Extensions.DependencyInjection.IRazorComponentsBuilder! builder, Microsoft.AspNetCore.Components.IComponentRenderMode! renderMode) -> Microsoft.Extensions.DependencyInjection.IRazorComponentsBuilder!

--- a/src/Components/Endpoints/test/TestComponents/WebAssemblyPreloadWrapper.razor
+++ b/src/Components/Endpoints/test/TestComponents/WebAssemblyPreloadWrapper.razor
@@ -1,4 +1,4 @@
 ﻿@using Microsoft.AspNetCore.Components.Web
-<LinkPreload />
+<ResourcePreloader />
 
 <WebAssemblyPreloadComponent @rendermode="@(new InteractiveWebAssemblyRenderMode(prerender: true))" />

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/App.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/App.razor
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <base href="/" />
-    <LinkPreload />
+    <ResourcePreloader />
     @*#if (SampleContent)
     <link rel="stylesheet" href="@Assets["lib/bootstrap/dist/css/bootstrap.min.css"]" />
     ##endif*@


### PR DESCRIPTION
Rename the component rendering preloading links based on API review.

```diff
- <LinkPreload  />
+ <ResourcePreloader />
```

Fixes https://github.com/dotnet/aspnetcore/issues/62374

cc @guardrex 