### PR TITLE
Fix. Creating a Blazor project with a space in its name breaks the styling

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/.template.config/template.json
@@ -468,7 +468,6 @@
     },
     "copyrightYear": {
       "type": "generated",
-
       "generator": "now",
       "replaces": "copyrightYear",
       "parameters": {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/.template.config/template.json
@@ -323,6 +323,19 @@
       },
       "replaces": "44300"
     },
+    "StyleBundleName":{
+      "type": "generated",
+      "generator": "regex",
+      "replaces": "StyleBundleName",
+      "parameters": {
+      "source": "name",
+      "steps": [
+        {
+          "regex": " ",
+          "replacement": "_"
+        }]
+      }
+    },
     "InteractivityPlatform": {
       "type": "parameter",
       "datatype": "choice",
@@ -455,6 +468,7 @@
     },
     "copyrightYear": {
       "type": "generated",
+
       "generator": "now",
       "replaces": "copyrightYear",
       "parameters": {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/App.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/App.razor
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="@Assets["lib/bootstrap/dist/css/bootstrap.min.css"]" />
     ##endif*@
     <link rel="stylesheet" href="@Assets["app.css"]" />
-    <link rel="stylesheet" href="@Assets["BlazorWebCSharp.1.styles.css"]" />
+    <link rel="stylesheet" href="@Assets["StyleBundleName.styles.css"]" />
     <ImportMap />
     @*#if (SampleContent)
     <link rel="icon" type="image/png" href="favicon.png" />


### PR DESCRIPTION
# Fix. Creating a Blazor project with a space in its name breaks the styling

## Description

* Added a new `StyleBundleName` generator to the `src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/.template.config/template.json` file. This generator uses a regex-based transformation to replace spaces in the project name with underscores for it to be aligned with the sanitized assembly name.
* Updated the `src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/App.razor` file to use the dynamically generated `StyleBundleName` for the stylesheet reference, replacing the previously incorrectly bound value.

Fixes #52196 
