### PR TITLE
Add AppContext switch in patch release to opt-out of breaking behavior change in ForwardedHeaders middleware.

### DIFF
--- a/src/Middleware/HttpOverrides/src/ForwardedHeadersMiddleware.cs
+++ b/src/Middleware/HttpOverrides/src/ForwardedHeadersMiddleware.cs
@@ -21,6 +21,7 @@ public class ForwardedHeadersMiddleware
     private readonly ForwardedHeadersOptions _options;
     private readonly RequestDelegate _next;
     private readonly ILogger _logger;
+    private readonly bool _ignoreUnknownProxiesWithoutFor;
     private bool _allowAllHosts;
     private IList<StringSegment>? _allowedHosts;
 
@@ -62,6 +63,18 @@ public class ForwardedHeadersMiddleware
         _options = options.Value;
         _logger = loggerFactory.CreateLogger<ForwardedHeadersMiddleware>();
         _next = next;
+
+        if (AppContext.TryGetSwitch("Microsoft.AspNetCore.HttpOverrides.IgnoreUnknownProxiesWithoutFor", out var enabled)
+            && enabled)
+        {
+            _ignoreUnknownProxiesWithoutFor = true;
+        }
+
+        if (Environment.GetEnvironmentVariable("MICROSOFT_ASPNETCORE_HTTPOVERRIDES_IGNORE_UNKNOWN_PROXIES_WITHOUT_FOR") is string env
+            && (env.Equals("true", StringComparison.OrdinalIgnoreCase) || env.Equals("1")))
+        {
+            _ignoreUnknownProxiesWithoutFor = true;
+        }
 
         PreProcessHosts();
     }
@@ -220,15 +233,20 @@ public class ForwardedHeadersMiddleware
         for (; entriesConsumed < sets.Length; entriesConsumed++)
         {
             var set = sets[entriesConsumed];
-            // For the first instance, allow remoteIp to be null for servers that don't support it natively.
-            if (currentValues.RemoteIpAndPort != null && checkKnownIps && !CheckKnownAddress(currentValues.RemoteIpAndPort.Address))
+            // Opt-out of breaking change behavior where we now always check KnownProxies and KnownNetworks
+            // It used to be guarded by the ForwardedHeaders.XForwardedFor flag, but now we always check it.
+            if (!_ignoreUnknownProxiesWithoutFor || checkFor)
             {
-                // Stop at the first unknown remote IP, but still apply changes processed so far.
-                if (_logger.IsEnabled(LogLevel.Debug))
+                // For the first instance, allow remoteIp to be null for servers that don't support it natively.
+                if (currentValues.RemoteIpAndPort != null && checkKnownIps && !CheckKnownAddress(currentValues.RemoteIpAndPort.Address))
                 {
-                    _logger.LogDebug(1, "Unknown proxy: {RemoteIpAndPort}", currentValues.RemoteIpAndPort);
+                    // Stop at the first unknown remote IP, but still apply changes processed so far.
+                    if (_logger.IsEnabled(LogLevel.Warning))
+                    {
+                        _logger.LogWarning(1, "Unknown proxy: {RemoteIpAndPort}", currentValues.RemoteIpAndPort);
+                    }
+                    break;
                 }
-                break;
             }
 
             if (checkFor)

--- a/src/Middleware/HttpOverrides/test/ForwardedHeadersMiddlewareTest.cs
+++ b/src/Middleware/HttpOverrides/test/ForwardedHeadersMiddlewareTest.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -1033,6 +1034,67 @@ public class ForwardedHeadersMiddlewareTests
                 Assert.Equal("/pathbase", context.Request.PathBase);
             }
         }
+    }
+
+    [Theory]
+    [InlineData(ForwardedHeaders.XForwardedFor)]
+    [InlineData(ForwardedHeaders.XForwardedHost)]
+    [InlineData(ForwardedHeaders.XForwardedProto)]
+    [InlineData(ForwardedHeaders.XForwardedPrefix)]
+    public void AppContextDoesNotValidateUnknownProxyWithoutForwardedFor(ForwardedHeaders forwardedHeaders)
+    {
+        RemoteExecutor.Invoke(static async (forwardedHeadersName) =>
+        {
+            Assert.True(Enum.TryParse<ForwardedHeaders>(forwardedHeadersName, out var forwardedHeaders));
+            AppContext.SetSwitch("Microsoft.AspNetCore.HttpOverrides.IgnoreUnknownProxiesWithoutFor", true);
+            using var host = new HostBuilder()
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder
+                .UseTestServer()
+                .Configure(app =>
+                {
+                    var options = new ForwardedHeadersOptions
+                    {
+                        ForwardedHeaders = forwardedHeaders
+                    };
+                    app.UseForwardedHeaders(options);
+                });
+            }).Build();
+
+            await host.StartAsync();
+
+            var server = host.GetTestServer();
+
+            var context = await server.SendAsync(c =>
+            {
+                c.Request.Headers["X-Forwarded-For"] = "11.111.111.11";
+                c.Request.Headers["X-Forwarded-Host"] = "testhost";
+                c.Request.Headers["X-Forwarded-Proto"] = "Protocol";
+                c.Request.Headers["X-Forwarded-Prefix"] = "/pathbase";
+                c.Connection.RemoteIpAddress = IPAddress.Parse("10.0.0.1");
+                c.Connection.RemotePort = 99;
+            });
+
+            if (forwardedHeaders.HasFlag(ForwardedHeaders.XForwardedFor))
+            {
+                // X-Forwarded-For ignored since 10.0.0.1 isn't in KnownProxies
+                Assert.Equal("10.0.0.1", context.Connection.RemoteIpAddress.ToString());
+            }
+            if (forwardedHeaders.HasFlag(ForwardedHeaders.XForwardedHost))
+            {
+                Assert.Equal("testhost", context.Request.Host.ToString());
+            }
+            if (forwardedHeaders.HasFlag(ForwardedHeaders.XForwardedProto))
+            {
+                Assert.Equal("Protocol", context.Request.Scheme);
+            }
+            if (forwardedHeaders.HasFlag(ForwardedHeaders.XForwardedPrefix))
+            {
+                Assert.Equal("/pathbase", context.Request.PathBase);
+            }
+            return RemoteExecutor.SuccessExitCode;
+        }, forwardedHeaders.ToString()).Dispose();
     }
 
     [Fact]


### PR DESCRIPTION
# Add AppContext switch in patch release to opt-out of breaking behavior change in ForwardedHeaders middleware.

## Description

We previously fixed a bug where `KnownProxies` and `KnownNetworks` weren't being applied in common cases. We didn't realize at the time this would break many customers apps.

The workaround is to configure `KnownProxies` and `KnownNetworks`, which is intended, and our docs do state that users should configure these. But due to the bug we recently fixed, users didn't need to configure those options for the app to work.

We're adding an app context switch to opt-out of the breaking change and go back to the previous behavior. This gives users the option to update their app code at a more convenient time, e.g. when 10.0 releases.

## Customer Impact

Customers have noticed that updating to the latest patch breaks scenarios like Https redirection and auth flows due to the X-Forwarded-Proto header not being applied anymore. 

## Regression?

- [x] Yes
- [ ] No

2.3.4, 8.0.17, 9.0.6
Change was made on purpose to harden security, but didn't realize it would cause a regression.

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Just adding an app context switch. Test coverage added for the switch as well.

## Verification

- [ ] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A