### PR TITLE
Add AppContext switch in patch release to opt-out of breaking behavior change in ForwardedHeaders middleware

### DIFF
--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -37,4 +37,9 @@ Later on, this will be checked using this condition:
       Microsoft.Net.Http.Headers;
     </PackagesInPatch>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(VersionPrefix)' == '2.3.5' ">
+    <PackagesInPatch>
+      Microsoft.AspNetCore.HttpOverrides;
+    </PackagesInPatch>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
# Add AppContext switch in patch release to opt-out of breaking behavior change in ForwardedHeaders middleware.

## Description

We previously fixed a bug where `KnownProxies` and `KnownNetworks` weren't being applied in common cases. We didn't realize at the time this would break many customers apps.

The workaround is to configure `KnownProxies` and `KnownNetworks`, which is intended, and our docs do state that users should configure these. But due to the bug we recently fixed, users didn't need to configure those options for the app to work.

We're adding an app context switch to opt-out of the breaking change and go back to the previous behavior. This gives users the option to update their app code at a more convenient time, e.g. when 10.0 releases.

## Customer Impact

Customers have noticed that updating to the latest patch breaks scenarios like Https redirection and auth flows due to the X-Forwarded-Proto header not being applied anymore. 

## Regression?

- [x] Yes
- [ ] No

2.3.4, 8.0.17, 9.0.6
Change was made on purpose to harden security, but didn't realize it would cause a regression.

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Just adding an app context switch. Test coverage added for the switch as well.

## Verification

- [ ] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

----

## When servicing release/2.1

- [x] Make necessary changes in eng/PatchConfig.props