### PR TITLE
Fix. Quickgrid PropertyColumn Align property doesn't work with Align.Right

### DIFF
--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.css
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.css
@@ -80,6 +80,23 @@ td.col-justify-end {
     text-align: right;
 }
 
+.col-justify-start .col-options {
+    left: 0;
+    right: unset;
+}
+
+td.col-justify-start {
+    text-align: left;
+}
+
+td.col-justify-right {
+    text-align: right;
+}
+
+td.col-justify-left {
+    text-align: left;
+}
+
 /* Unfortunately we can't use the :dir pseudoselector due to lack of browser support. Instead we have to rely on
     the developer setting <html dir="rtl"> to detect if we're in RTL mode. */
 html[dir=rtl] td.col-justify-end {
@@ -89,6 +106,10 @@ html[dir=rtl] td.col-justify-end {
 html[dir=rtl] .col-options {
     left: unset;
     right: 0;
+}
+
+html[dir=rtl] td.col-justify-start {
+    text-align: right;
 }
 
 html[dir=rtl] .col-justify-end .col-options {

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.css
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.css
@@ -51,11 +51,6 @@ th ::deep .col-options-button {
     z-index: 1;
 }
 
-.col-justify-end .col-options {
-    left: unset;
-    right: 0;
-}
-
 .col-width-draghandle {
     position: absolute;
     top: 0;
@@ -76,8 +71,30 @@ td.col-justify-center {
     text-align: center;
 }
 
+.col-justify-end .col-options {
+    left: unset;
+    right: 0;
+}
+
 td.col-justify-end {
     text-align: right;
+}
+
+.col-justify-start .col-options {
+    left: 0;
+    right: unset;
+}
+
+td.col-justify-start {
+    text-align: left;
+}
+
+td.col-justify-right {
+    text-align: right;
+}
+
+td.col-justify-left {
+    text-align: left;
 }
 
 /* Unfortunately we can't use the :dir pseudoselector due to lack of browser support. Instead we have to rely on
@@ -89,6 +106,10 @@ html[dir=rtl] td.col-justify-end {
 html[dir=rtl] .col-options {
     left: unset;
     right: 0;
+}
+
+html[dir=rtl] td.col-justify-start {
+    text-align: right;
 }
 
 html[dir=rtl] .col-justify-end .col-options {

--- a/src/Components/test/E2ETest/Tests/QuickGridTest.cs
+++ b/src/Components/test/E2ETest/Tests/QuickGridTest.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.E2ETesting;
 using OpenQA.Selenium;
+using OpenQA.Selenium.Support.Extensions;
 using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Components.E2ETests.Tests;
@@ -149,6 +150,23 @@ public class QuickGridTest : ServerTestBase<ToggleExecutionModeServerFixture<Pro
         }
     }
 
+    [Fact]
+    public void RowStyleApplied()
+    {
+        var grid = app.FindElement(By.CssSelector("#grid > table"));
+        var birthDateColumn = grid.FindElement(By.CssSelector("thead > tr > th:nth-child(4)"));
+        var ageColumn = grid.FindElement(By.CssSelector("thead > tr > th:nth-child(5)"));
+
+        Assert.Contains("col-justify-center", birthDateColumn.GetAttribute("class"));
+        Assert.Contains("col-justify-right", ageColumn.GetAttribute("class"));
+        Assert.Equal("center", Browser.ExecuteJavaScript<string>(@"
+        const p = document.querySelector('tbody > tr:first-child > td:nth-child(4)');
+        return p ? getComputedStyle(p).textAlign : null;"));
+        Assert.Equal("right", Browser.ExecuteJavaScript<string>(@"
+        const p = document.querySelector('tbody > tr:first-child > td:nth-child(5)');
+        return p ? getComputedStyle(p).textAlign : null;"));
+    }
+    
     [Fact]
     public void CanOpenColumnOptions()
     {

--- a/src/Components/test/testassets/BasicTestApp/QuickGridTest/SampleQuickGridComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/QuickGridTest/SampleQuickGridComponent.razor
@@ -14,8 +14,8 @@
             </ColumnOptions>
         </PropertyColumn>
         <PropertyColumn Property="@(p => p.LastName)" Sortable="true" />
-        <PropertyColumn Property="@(p => p.BirthDate)" Format="yyyy-MM-dd" Sortable="true" />
-        <PropertyColumn Title="Age in years" Property="@(p => ComputeAge(p.BirthDate))" Sortable="true"/>
+        <PropertyColumn Property="@(p => p.BirthDate)" Format="yyyy-MM-dd" Sortable="true" Align="Align.Center" />
+        <PropertyColumn Title="Age in years" Property="@(p => ComputeAge(p.BirthDate))" Sortable="true" Align="Align.Right"/>
     </QuickGrid>
 </div>
 <Paginator State="@pagination" />


### PR DESCRIPTION
# Fix. Quickgrid PropertyColumn Align property doesn't work with Align.Right

## Description

This pull request refactors and fixes the column alignment and justification styles in the `QuickGrid.razor.css` file.

### Changes:
* Added new styles for `.col-justify-start .col-options` and `td.col-justify-start` to support left-aligned column options and text.
* Introduced `td.col-justify-right` and `td.col-justify-left` styles for explicit right and left text alignment.

### Reasoning for change:
In https://github.com/dotnet/aspnetcore/blob/8bb2b2067815996d9a8224ee38aa80a79f797827/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs#L424
Blazor assigns css classes based on the Align parameter that user has set. However, in the
https://github.com/dotnet/aspnetcore/blob/8bb2b2067815996d9a8224ee38aa80a79f797827/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.css#L75
there were no implementation for 3 out of existing 5 parameter options. This PR fixes implements missing options.

Fixes #50029 
