### PR TITLE
[release/2.3] Update branding to 2.3.5

### DIFF
--- a/eng/Baseline.Designer.props
+++ b/eng/Baseline.Designer.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-    <AspNetCoreBaselineVersion>2.3.3</AspNetCoreBaselineVersion>
+    <AspNetCoreBaselineVersion>2.3.4</AspNetCoreBaselineVersion>
   </PropertyGroup>
   <!-- Package: dotnet-dev-certs-->
   <PropertyGroup Condition=" '$(PackageId)' == 'dotnet-dev-certs' ">
@@ -1164,7 +1164,7 @@
   </ItemGroup>
   <!-- Package: Microsoft.Net.Http.Headers-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.Net.Http.Headers' ">
-    <BaselinePackageVersion>2.3.0</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.4</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Net.Http.Headers' AND '$(TargetFramework)' == 'netstandard2.0' ">
     <BaselinePackageReference Include="Microsoft.Extensions.Primitives" Version="[8.0.0, )" />

--- a/eng/Baseline.xml
+++ b/eng/Baseline.xml
@@ -4,7 +4,7 @@ This file contains a list of all the packages and their versions which were rele
 build of ASP.NET Core 2.1.x. Update this list when preparing for a new patch.
 
 -->
-<Baseline Version="2.3.3">
+<Baseline Version="2.3.4">
   <Package Id="dotnet-dev-certs" Version="2.1.1" />
   <Package Id="dotnet-sql-cache" Version="2.1.1" />
   <Package Id="dotnet-user-secrets" Version="2.1.1" />
@@ -124,7 +124,7 @@ build of ASP.NET Core 2.1.x. Update this list when preparing for a new patch.
   <Package Id="Microsoft.CodeAnalysis.Razor" Version="2.3.0" />
   <Package Id="Microsoft.Extensions.Identity.Core" Version="2.3.0" />
   <Package Id="Microsoft.Extensions.Identity.Stores" Version="2.3.2" />
-  <Package Id="Microsoft.Net.Http.Headers" Version="2.3.0" />
+  <Package Id="Microsoft.Net.Http.Headers" Version="2.3.4" />
   <Package Id="Microsoft.Net.Sdk.Razor" Version="2.3.0" />
   <Package Id="Microsoft.Owin.Security.Interop" Version="2.3.0" />
 </Baseline>

--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -37,4 +37,8 @@ Later on, this will be checked using this condition:
       Microsoft.Net.Http.Headers;
     </PackagesInPatch>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(VersionPrefix)' == '2.3.5' ">
+    <PackagesInPatch>
+    </PackagesInPatch>
+  </PropertyGroup>
 </Project>

--- a/version.props
+++ b/version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AspNetCoreMajorVersion>2</AspNetCoreMajorVersion>
     <AspNetCoreMinorVersion>3</AspNetCoreMinorVersion>
-    <AspNetCorePatchVersion>4</AspNetCorePatchVersion>
+    <AspNetCorePatchVersion>5</AspNetCorePatchVersion>
     <ValidateBaseline>true</ValidateBaseline>
 
     <PreReleaseLabel>servicing</PreReleaseLabel>


### PR DESCRIPTION
This pull request updates baseline versions and package configurations across several files to prepare for the next patch release of ASP.NET Core. The changes ensure consistency in versioning and introduce configuration for a new patch version.

### Baseline version updates:
* [`eng/Baseline.Designer.props`](diffhunk://#diff-4d871589215547801f33bd38b80acdafc64a81820998305889f2b78f5feef064L5-R5): Updated `AspNetCoreBaselineVersion` from `2.3.3` to `2.3.4` and `BaselinePackageVersion` for `Microsoft.Net.Http.Headers` from `2.3.0` to `2.3.4`. [[1]](diffhunk://#diff-4d871589215547801f33bd38b80acdafc64a81820998305889f2b78f5feef064L5-R5) [[2]](diffhunk://#diff-4d871589215547801f33bd38b80acdafc64a81820998305889f2b78f5feef064L1167-R1167)
* [`eng/Baseline.xml`](diffhunk://#diff-f9561e127e2a447b5c99b768de51e0eff8e910dcf1930a01169ccbc8b3a05909L7-R7): Updated baseline version from `2.3.3` to `2.3.4` and updated the package version for `Microsoft.Net.Http.Headers` from `2.3.0` to `2.3.4`. [[1]](diffhunk://#diff-f9561e127e2a447b5c99b768de51e0eff8e910dcf1930a01169ccbc8b3a05909L7-R7) [[2]](diffhunk://#diff-f9561e127e2a447b5c99b768de51e0eff8e910dcf1930a01169ccbc8b3a05909L127-R127)

### Configuration for new patch version:
* [`eng/PatchConfig.props`](diffhunk://#diff-34bcfd4dda2dd22cd2c28dfa3618f880996db857ac27ea509f78c83ec707c424R40-R43): Added a new property group for `VersionPrefix` `2.3.5`, preparing for the next patch release.
* [`version.props`](diffhunk://#diff-e4bed5b736f205989dd4fdb6d78acfe9126577983d325d378ce91794d74e63c8L5-R5): Updated `AspNetCorePatchVersion` from `4` to `5` to reflect the new patch version.