### PR TITLE
#62732 Fix password validation in PasswordHasher`1: add bound check for salt size before array allocation

### DIFF
--- a/src/Identity/Extensions.Core/src/PasswordHasher.cs
+++ b/src/Identity/Extensions.Core/src/PasswordHasher.cs
@@ -260,12 +260,11 @@ public class PasswordHasher<TUser> : IPasswordHasher<TUser> where TUser : class
             int saltLength = (int)ReadNetworkByteOrder(hashedPassword, 9);
 
             // Read the salt: must be >= 128 bits
-            if (saltLength < 128 / 8 || saltLength + 13 > hashedPassword.Length)
+            if (saltLength < 128 / 8)
             {
                 return false;
             }
-            byte[] salt = new byte[saltLength];
-            Buffer.BlockCopy(hashedPassword, 13, salt, 0, salt.Length);
+            byte[] salt = hashedPassword.AsSpan(13, saltLength).ToArray();
 
             // Read the subkey (the rest of the payload): must be >= 128 bits
             int subkeyLength = hashedPassword.Length - 13 - salt.Length;

--- a/src/Identity/Extensions.Core/src/PasswordHasher.cs
+++ b/src/Identity/Extensions.Core/src/PasswordHasher.cs
@@ -260,7 +260,7 @@ public class PasswordHasher<TUser> : IPasswordHasher<TUser> where TUser : class
             int saltLength = (int)ReadNetworkByteOrder(hashedPassword, 9);
 
             // Read the salt: must be >= 128 bits
-            if (saltLength < 128 / 8)
+            if (saltLength < 128 / 8 || saltLength + 13 > hashedPassword.Length)
             {
                 return false;
             }

--- a/src/Identity/test/Identity.Test/PasswordHasherTest.cs
+++ b/src/Identity/test/Identity.Test/PasswordHasherTest.cs
@@ -113,6 +113,7 @@ public class PasswordHasherTest
     [InlineData("AQAAAAIAAAAyAAAAEOMwvh3+FZxqkdMBz2ekgGhwQ4A=")] // too short
     [InlineData("AQAAAAIAAAAyAAAAEOMwvh3+FZxqkdMBz2ekgGhwQ4B6pZWND6zgESBuWiHwAAAAAAAAAAAA")] // extra data at end
     [InlineData("AQAAAAIAAYagAP///wABAgMEBQYHCAkKCwwNDg/Q8A0WMKbtHQJQ2DHCdoEeeFBrgNlldq6vH4qX/CGqGQ==")] // salt length greater than data length
+    [InlineData("AQAAAAEAACcQf////4r8+J3NDEnMWKlHbhJQ6N5oooZ7hUi3cr/qAjd7Lc1Sv6GhorP7Ly0AzCv9PAmKww==")] // salt length is Int32.MaxValue
     [InlineData("AQAAAAIAAYagAAAACAABAgMEBQYH4qLSh7iNSI12qySxAkyR0XgpXpvNiwqhBJFNLbJKKFw=")] // salt length (8 bytes) less than minimum allowed
     public void VerifyHashedPassword_FailureCases(string hashedPassword)
     {

--- a/src/Identity/test/Identity.Test/PasswordHasherTest.cs
+++ b/src/Identity/test/Identity.Test/PasswordHasherTest.cs
@@ -112,6 +112,8 @@ public class PasswordHasherTest
     [InlineData("AQAAAAAAAAD6AAAAEAhftMyfTJyAAAAAAAAAAAAAAAAAAAih5WsjXaR3PA9M")] // incorrect password
     [InlineData("AQAAAAIAAAAyAAAAEOMwvh3+FZxqkdMBz2ekgGhwQ4A=")] // too short
     [InlineData("AQAAAAIAAAAyAAAAEOMwvh3+FZxqkdMBz2ekgGhwQ4B6pZWND6zgESBuWiHwAAAAAAAAAAAA")] // extra data at end
+    [InlineData("AQAAAAIAAYagAP///wABAgMEBQYHCAkKCwwNDg/Q8A0WMKbtHQJQ2DHCdoEeeFBrgNlldq6vH4qX/CGqGQ==")] // salt length greater than data length
+    [InlineData("AQAAAAIAAYagAAAACAABAgMEBQYH4qLSh7iNSI12qySxAkyR0XgpXpvNiwqhBJFNLbJKKFw=")] // salt length (8 bytes) less than minimum allowed
     public void VerifyHashedPassword_FailureCases(string hashedPassword)
     {
         // Arrange


### PR DESCRIPTION
# Add bound check for salt size before array allocation

## Description

To prevent memory allocation of arbitrary-sized array, in case when password hash is corrupted or intentionally modified.

Bytes 9-13 of password hash (`AspNetUsers.PasswordHash`) contain a 32-bit number. It is read during password verification, and array of that size is immediately allocated.

Fixes #62732
