### PR TITLE
Baseline tests should check for all possible extensions of not expected files

### DIFF
--- a/src/ProjectTemplates/test/Templates.Tests/BaselineTest.cs
+++ b/src/ProjectTemplates/test/Templates.Tests/BaselineTest.cs
@@ -88,12 +88,7 @@ public class BaselineTest : LoggedTest
         foreach (var file in filesInFolder)
         {
             var relativePath = file.Replace(Project.TemplateOutputDir, "").Replace("\\", "/").Trim('/');
-            if (relativePath.EndsWith(".csproj", StringComparison.Ordinal) ||
-                relativePath.EndsWith(".fsproj", StringComparison.Ordinal) ||
-                relativePath.EndsWith(".props", StringComparison.Ordinal) ||
-                relativePath.EndsWith(".sln", StringComparison.Ordinal) ||
-                relativePath.EndsWith(".targets", StringComparison.Ordinal) ||
-                relativePath.StartsWith("bin/", StringComparison.Ordinal) ||
+            if (relativePath.StartsWith("bin/", StringComparison.Ordinal) ||
                 relativePath.StartsWith("obj/", StringComparison.Ordinal) ||
                 relativePath.Contains("/bin/", StringComparison.Ordinal) ||
                 relativePath.Contains("/obj/", StringComparison.Ordinal))

--- a/src/ProjectTemplates/test/Templates.Tests/BaselineTest.cs
+++ b/src/ProjectTemplates/test/Templates.Tests/BaselineTest.cs
@@ -88,10 +88,7 @@ public class BaselineTest : LoggedTest
         foreach (var file in filesInFolder)
         {
             var relativePath = file.Replace(Project.TemplateOutputDir, "").Replace("\\", "/").Trim('/');
-            if (relativePath.StartsWith("bin/", StringComparison.Ordinal) ||
-                relativePath.StartsWith("obj/", StringComparison.Ordinal) ||
-                relativePath.Contains("/bin/", StringComparison.Ordinal) ||
-                relativePath.Contains("/obj/", StringComparison.Ordinal))
+            if (IsIgnoredPath(relativePath))
             {
                 continue;
             }
@@ -112,6 +109,12 @@ public class BaselineTest : LoggedTest
             }
         }
     }
+
+    private static bool IsIgnoredPath(string relativePath) =>
+        relativePath.StartsWith("bin/", StringComparison.Ordinal) ||
+        relativePath.StartsWith("obj/", StringComparison.Ordinal) ||
+        relativePath.Contains("/bin/", StringComparison.Ordinal) ||
+        relativePath.Contains("/obj/", StringComparison.Ordinal);
 
     private void AssertFileExists(string basePath, string path, bool shouldExist)
     {


### PR DESCRIPTION
After https://github.com/dotnet/aspnetcore/pull/62593 renamed some template files, we could see additional files in templates structure. It could be visible only locally, in case the repository run template tests before and after the PR got in.

This revealed one issue with baseline tests: they would not fail, even if repository was creating a template with incorrect application structure, with three `.csproj` files instead of only one.

In the particular case of such rename, this behavior would not have been caught by the developer applying the change - for them, the additional dirs would not exist. This change does not aim at improving cleaning the repo from old assets. It is trying to fix possible other cases when we would have additional contents of extensions that we don't currently check for. Maybe there's a good reason we're not doing that. Currently, I don't see it, so I am posting this update.

## Description

- Tests: Baseline tests should check for all the types of "not expected" contents, regardless of extension. Skipping `bin` and `obj` dirs should stay.

~~Fixes #62746~~
