### PR TITLE
Fix memory pool metrics unit to follow standard

### DIFF
--- a/src/Servers/Kestrel/Core/test/PinnedBlockMemoryPoolTests.cs
+++ b/src/Servers/Kestrel/Core/test/PinnedBlockMemoryPoolTests.cs
@@ -231,7 +231,7 @@ public class PinnedBlockMemoryPoolTests : MemoryPoolTests
     public void CurrentMemoryMetricTracksPooledMemory()
     {
         var testMeterFactory = new TestMeterFactory();
-        using var currentMemoryMetric = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.MemoryPool", "aspnetcore.memorypool.current_memory");
+        using var currentMemoryMetric = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.MemoryPool", "aspnetcore.memory_pool.current_memory");
 
         var pool = new PinnedBlockMemoryPool(testMeterFactory);
 
@@ -267,7 +267,7 @@ public class PinnedBlockMemoryPoolTests : MemoryPoolTests
     public void TotalAllocatedMetricTracksAllocatedMemory()
     {
         var testMeterFactory = new TestMeterFactory();
-        using var totalMemoryMetric = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.MemoryPool", "aspnetcore.memorypool.total_allocated");
+        using var totalMemoryMetric = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.MemoryPool", "aspnetcore.memory_pool.total_allocated");
 
         var pool = new PinnedBlockMemoryPool(testMeterFactory);
 
@@ -290,7 +290,7 @@ public class PinnedBlockMemoryPoolTests : MemoryPoolTests
     public void TotalRentedMetricTracksRentOperations()
     {
         var testMeterFactory = new TestMeterFactory();
-        using var rentMetric = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.MemoryPool", "aspnetcore.memorypool.total_rented");
+        using var rentMetric = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.MemoryPool", "aspnetcore.memory_pool.total_rented");
 
         var pool = new PinnedBlockMemoryPool(testMeterFactory);
 
@@ -315,7 +315,7 @@ public class PinnedBlockMemoryPoolTests : MemoryPoolTests
     public void EvictedMemoryMetricTracksEvictedMemory()
     {
         var testMeterFactory = new TestMeterFactory();
-        using var evictMetric = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.MemoryPool", "aspnetcore.memorypool.evicted_memory");
+        using var evictMetric = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.MemoryPool", "aspnetcore.memory_pool.evicted_memory");
 
         var pool = new PinnedBlockMemoryPool(testMeterFactory);
 
@@ -352,7 +352,7 @@ public class PinnedBlockMemoryPoolTests : MemoryPoolTests
     public void MetricsAreAggregatedAcrossPoolsWithSameMeterFactory()
     {
         var testMeterFactory = new TestMeterFactory();
-        using var rentMetric = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.MemoryPool", "aspnetcore.memorypool.total_rented");
+        using var rentMetric = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.MemoryPool", "aspnetcore.memory_pool.total_rented");
 
         var pool1 = new PinnedBlockMemoryPool(testMeterFactory);
         var pool2 = new PinnedBlockMemoryPool(testMeterFactory);

--- a/src/Shared/Buffers.MemoryPool/PinnedBlockMemoryPoolMetrics.cs
+++ b/src/Shared/Buffers.MemoryPool/PinnedBlockMemoryPoolMetrics.cs
@@ -23,22 +23,22 @@ internal sealed class PinnedBlockMemoryPoolMetrics
 
         _currentMemory = _meter.CreateUpDownCounter<long>(
             "aspnetcore.memorypool.current_memory",
-            unit: "{bytes}",
+            unit: "By",
             description: "Number of bytes that are currently pooled by the pool.");
 
         _totalAllocatedMemory = _meter.CreateCounter<long>(
            "aspnetcore.memorypool.total_allocated",
-            unit: "{bytes}",
+            unit: "By",
             description: "Total number of allocations made by the pool.");
 
         _evictedMemory = _meter.CreateCounter<long>(
            "aspnetcore.memorypool.evicted_memory",
-            unit: "{bytes}",
+            unit: "By",
             description: "Total number of bytes that have been evicted.");
 
         _totalRented = _meter.CreateCounter<long>(
             "aspnetcore.memorypool.total_rented",
-            unit: "{bytes}",
+            unit: "By",
             description: "Total number of rented bytes from the pool.");
     }
 

--- a/src/Shared/Buffers.MemoryPool/PinnedBlockMemoryPoolMetrics.cs
+++ b/src/Shared/Buffers.MemoryPool/PinnedBlockMemoryPoolMetrics.cs
@@ -22,22 +22,22 @@ internal sealed class PinnedBlockMemoryPoolMetrics
         _meter = meterFactory.Create(MeterName);
 
         _currentMemory = _meter.CreateUpDownCounter<long>(
-            "aspnetcore.memorypool.current_memory",
+            "aspnetcore.memory_pool.current_memory",
             unit: "By",
             description: "Number of bytes that are currently pooled by the pool.");
 
         _totalAllocatedMemory = _meter.CreateCounter<long>(
-           "aspnetcore.memorypool.total_allocated",
+           "aspnetcore.memory_pool.total_allocated",
             unit: "By",
             description: "Total number of allocations made by the pool.");
 
         _evictedMemory = _meter.CreateCounter<long>(
-           "aspnetcore.memorypool.evicted_memory",
+           "aspnetcore.memory_pool.evicted_memory",
             unit: "By",
             description: "Total number of bytes that have been evicted.");
 
         _totalRented = _meter.CreateCounter<long>(
-            "aspnetcore.memorypool.total_rented",
+            "aspnetcore.memory_pool.total_rented",
             unit: "By",
             description: "Total number of rented bytes from the pool.");
     }


### PR DESCRIPTION
The Unified Code for Units of Measure (UCUM) standard for bytes is `By` and should be the unit here.

Edit: Also renamed counters