### PR TITLE
Fix metadata typos

### DIFF
--- a/src/Http/Routing/src/HostAttribute.cs
+++ b/src/Http/Routing/src/HostAttribute.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Shared;
 namespace Microsoft.AspNetCore.Routing;
 
 /// <summary>
-/// Attribute for providing host metdata that is used during routing.
+/// Attribute for providing host metadata that is used during routing.
 /// </summary>
 [DebuggerDisplay("{ToString(),nq}")]
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]

--- a/src/Http/Routing/test/UnitTests/Builder/RequestDelegateEndpointRouteBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/RequestDelegateEndpointRouteBuilderExtensionsTest.cs
@@ -402,7 +402,7 @@ public class RequestDelegateEndpointRouteBuilderExtensionsTest
         var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(EmptyServiceProvider.Instance));
 
         // Act
-        var endpointBuilder = builder.MapMethods("/", new[] { "METHOD" }, HandleHttpMetdata);
+        var endpointBuilder = builder.MapMethods("/", new[] { "METHOD" }, HandleHttpMetadata);
         endpointBuilder.WithMetadata(new HttpMethodMetadata(new[] { "BUILDER" }));
 
         // Assert
@@ -526,7 +526,7 @@ public class RequestDelegateEndpointRouteBuilderExtensionsTest
     private static Task Handle(HttpContext context) => Task.CompletedTask;
 
     [HttpMethod("ATTRIBUTE")]
-    private static Task HandleHttpMetdata(HttpContext context) => Task.CompletedTask;
+    private static Task HandleHttpMetadata(HttpContext context) => Task.CompletedTask;
 
     private class HttpMethodAttribute : Attribute, IHttpMethodMetadata
     {

--- a/src/Middleware/CORS/src/Infrastructure/IDisableCorsAttribute.cs
+++ b/src/Middleware/CORS/src/Infrastructure/IDisableCorsAttribute.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.AspNetCore.Cors.Infrastructure;
 
 /// <summary>
-/// An interface which can be used to identify a type which provides metdata to disable cors for a resource.
+/// An interface which can be used to identify a type which provides metadata to disable cors for a resource.
 /// </summary>
 public interface IDisableCorsAttribute : ICorsMetadata
 {

--- a/src/Shared/StackTrace/StackFrame/StackTraceHelper.cs
+++ b/src/Shared/StackTrace/StackFrame/StackTraceHelper.cs
@@ -46,7 +46,7 @@ internal sealed class StackTraceHelper
             var method = frame.GetMethod();
 
             // MethodInfo should always be available for methods in the stack, but double check for null here.
-            // Apps with trimming enabled may remove some metdata. Better to be safe than sorry.
+            // Apps with trimming enabled may remove some metadata. Better to be safe than sorry.
             if (method == null)
             {
                 continue;


### PR DESCRIPTION
# Fix metadata typos

Fix typos of "metadata".

## Description

Fix typos of _"metadata"_ as _"metdata"_ in the codebase.

Spotted when reading some `///` comments in VS.
