### PR TITLE
#62774 Fix JWT Bearer unit tests failing if local timezone is UTC+N

### DIFF
--- a/src/Security/Authentication/test/JwtBearerTests.cs
+++ b/src/Security/Authentication/test/JwtBearerTests.cs
@@ -972,7 +972,7 @@ public class JwtBearerTests : SharedAuthenticationTests<JwtBearerOptions>
             issuer: "issuer.contoso.com",
             audience: "audience.contoso.com",
             claims: claims,
-            expires: DateTime.MaxValue,
+            expires: new DateTime(DateTime.MaxValue.Ticks, DateTimeKind.Utc),
             signingCredentials: creds);
 
         var tokenText = new JwtSecurityTokenHandler().WriteToken(token);
@@ -1000,8 +1000,7 @@ public class JwtBearerTests : SharedAuthenticationTests<JwtBearerOptions>
         var expiresElement = dom.RootElement.GetProperty("expires");
         Assert.Equal(JsonValueKind.String, expiresElement.ValueKind);
 
-        var elementValue = DateTime.Parse(expiresElement.GetString(), CultureInfo.InvariantCulture);
-        var elementValueUtc = elementValue.ToUniversalTime();
+        var elementValueUtc = DateTime.Parse(expiresElement.GetString(), CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
         // roundtrip DateTime.MaxValue through parsing because it is lossy and we
         // need equivalent values to compare against.
         var max = DateTime.Parse(DateTime.MaxValue.ToString(CultureInfo.InvariantCulture), CultureInfo.InvariantCulture);

--- a/src/Security/Authentication/test/JwtBearerTests_Handler.cs
+++ b/src/Security/Authentication/test/JwtBearerTests_Handler.cs
@@ -917,7 +917,7 @@ public class JwtBearerTests_Handler : SharedAuthenticationTests<JwtBearerOptions
            issuer: "issuer.contoso.com",
            audience: "audience.contoso.com",
            claims: claims,
-           expires: DateTime.MaxValue,
+           expires: new DateTime(DateTime.MaxValue.Ticks, DateTimeKind.Utc),
            signingCredentials: creds);
 
         var tokenText = new JwtSecurityTokenHandler().WriteToken(token);
@@ -944,8 +944,7 @@ public class JwtBearerTests_Handler : SharedAuthenticationTests<JwtBearerOptions
         var expiresElement = dom.RootElement.GetProperty("expires");
         Assert.Equal(JsonValueKind.String, expiresElement.ValueKind);
 
-        var elementValue = DateTime.Parse(expiresElement.GetString(), CultureInfo.InvariantCulture);
-        var elementValueUtc = elementValue.ToUniversalTime();
+        var elementValueUtc = DateTime.Parse(expiresElement.GetString(), CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
         // roundtrip DateTime.MaxValue through parsing because it is lossy and we
         // need equivalent values to compare against.
         var max = DateTime.Parse(DateTime.MaxValue.ToString(CultureInfo.InvariantCulture), CultureInfo.InvariantCulture);


### PR DESCRIPTION
Tests were failing if local timezone is to the east of UTC, due to `DateTime.MaxValue` is locale-specific. Add explicit `DateTimeKind` UTC and immediate conversion to UTC when parsing, since this time is unrepresentable in local timezone

Fixes #62774
