### PR TITLE
Support all subscribers to `OnNotFound` event

### DIFF
--- a/src/Components/Components/src/Routing/Router.cs
+++ b/src/Components/Components/src/Routing/Router.cs
@@ -409,21 +409,24 @@ public partial class Router : IComponent, IHandleAfterRender, IDisposable
         }
     }
 
-    private void RenderComponentByRoute(RenderTreeBuilder builder, string route)
+    internal void RenderComponentByRoute(RenderTreeBuilder builder, string route)
     {
         var componentType = FindComponentTypeByRoute(route);
 
-        if (componentType != null)
+        if (componentType is null)
         {
-            builder.OpenComponent<RouteView>(0);
-            builder.AddAttribute(1, nameof(RouteView.RouteData),
-                new RouteData(componentType, new Dictionary<string, object>()));
-            builder.CloseComponent();
+            throw new InvalidOperationException($"No component found for route '{route}'. " +
+                $"Ensure the route matches a component with a [Route] attribute.");
         }
+
+        builder.OpenComponent<RouteView>(0);
+        builder.AddAttribute(1, nameof(RouteView.RouteData),
+            new RouteData(componentType, new Dictionary<string, object>()));
+        builder.CloseComponent();
     }
 
     [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
-    private Type? FindComponentTypeByRoute(string route)
+    internal Type? FindComponentTypeByRoute(string route)
     {
         RefreshRouteTable();
         var normalizedRoute = route.StartsWith('/') ? route : $"/{route}";

--- a/src/Components/Components/src/Routing/Router.cs
+++ b/src/Components/Components/src/Routing/Router.cs
@@ -490,8 +490,8 @@ public partial class Router : IComponent, IHandleAfterRender, IDisposable
         [LoggerMessage(3, LogLevel.Debug, "Navigating to non-component URI '{ExternalUri}' in response to path '{Path}' with base URI '{BaseUri}'", EventName = "NavigatingToExternalUri")]
         internal static partial void NavigatingToExternalUri(ILogger logger, string externalUri, string path, string baseUri);
 
-        [LoggerMessage(4, LogLevel.Debug, $"Displaying {nameof(NotFound)} on request", EventName = "DisplayingNotFoundOnRequest")]
-        internal static partial void DisplayingNotFound(ILogger logger, string displayedPath);
+        [LoggerMessage(4, LogLevel.Debug, $"Displaying contents of {{displayedContentPath}} on request", EventName = "DisplayingNotFoundOnRequest")]
+        internal static partial void DisplayingNotFound(ILogger logger, string displayedContentPath);
 #pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/Components/Components/src/Routing/Router.cs
+++ b/src/Components/Components/src/Routing/Router.cs
@@ -394,17 +394,18 @@ public partial class Router : IComponent, IHandleAfterRender, IDisposable
         bool renderContentIsProvided = NotFoundPage != null || args.Path != null;
         if (_renderHandle.IsInitialized && renderContentIsProvided)
         {
-            Log.DisplayingNotFound(_logger);
-            if (NotFoundPage == null && !string.IsNullOrEmpty(args.Path))
+            if (!string.IsNullOrEmpty(args.Path))
             {
                 // The path can be set by a subscriber not defined in blazor framework.
                 _renderHandle.Render(builder => RenderComponentByRoute(builder, args.Path));
-                return;
             }
-
-            // Having the path set signals to the endpoint renderer that router handled rendering.
-            args.Path = _notFoundPageRoute;
-            RenderNotFound();
+            else
+            {
+                // Having the path set signals to the endpoint renderer that router handled rendering.
+                args.Path = _notFoundPageRoute;
+                RenderNotFound();
+            }
+            Log.DisplayingNotFound(_logger, args.Path);
         }
     }
 
@@ -490,7 +491,7 @@ public partial class Router : IComponent, IHandleAfterRender, IDisposable
         internal static partial void NavigatingToExternalUri(ILogger logger, string externalUri, string path, string baseUri);
 
         [LoggerMessage(4, LogLevel.Debug, $"Displaying {nameof(NotFound)} on request", EventName = "DisplayingNotFoundOnRequest")]
-        internal static partial void DisplayingNotFound(ILogger logger);
+        internal static partial void DisplayingNotFound(ILogger logger, string displayedPath);
 #pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/App.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/App.razor
@@ -1,4 +1,5 @@
-﻿@using Components.TestServer.RazorComponents.Pages.Forms
+﻿@implements IDisposable
+@using Components.TestServer.RazorComponents.Pages.Forms
 @using Components.WasmMinimal.Pages.NotFound
 @using TestContentPackage.NotFound
 @using Components.TestServer.RazorComponents
@@ -12,7 +13,39 @@
     [SupplyParameterFromQuery(Name = "useCustomRouter")]
     public string? UseCustomRouter { get; set; }
 
+    [Parameter]
+    [SupplyParameterFromQuery(Name = "appSetsEventArgsPath")]
+    public bool AppSetsEventArgsPath { get; set; }
+
     private Type? NotFoundPageType { get; set; }
+    private NavigationManager _navigationManager = default!;
+
+    [Inject]
+    private NavigationManager NavigationManager
+    {
+        get => _navigationManager;
+        set
+        {
+            _navigationManager = value;
+        }
+    }
+
+    private void OnNotFoundEvent(object sender, NotFoundEventArgs e)
+    {
+        var type = typeof(CustomNotFoundPage);
+        var routeAttributes = type.GetCustomAttributes(typeof(RouteAttribute), inherit: true);
+        if (routeAttributes.Length == 0)
+        {
+            throw new InvalidOperationException($"The type {type.FullName} " +
+                $"does not have a {typeof(RouteAttribute).FullName} applied to it.");
+        }
+
+        var routeAttribute = (RouteAttribute)routeAttributes[0];
+        if (routeAttribute.Template != null)
+        {
+            e.Path = routeAttribute.Template;
+        }
+    }
 
     protected override void OnParametersSet()
     {
@@ -23,6 +56,18 @@
         else
         {
             NotFoundPageType = null;
+        }
+        if (AppSetsEventArgsPath && _navigationManager is not null)
+        {
+            _navigationManager.OnNotFound += OnNotFoundEvent;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (AppSetsEventArgsPath)
+        {
+            _navigationManager.OnNotFound -= OnNotFoundEvent;
         }
     }
 }


### PR DESCRIPTION
# External subscribers can set `NotFoundEventArgs.Path`

Connected with risks listed in https://github.com/dotnet/aspnetcore/issues/62412. In this PR, the listed scenarios are treated as supported, excluding case "we have no router and the request has not started" where we are not able to render the path set by external subscriber and only re-execution could render the not found contents.

This PR focuses on fixing scenario "we have blazor's router and the request has not started, we allow the Router to render only if it has `NotFoundPage` parameter passed". It also adds tests for all the scenarios mentioned in the linked issue.

## Description

- Previously `Router` ignored all event calls if `NotFoundPage` was not populated. That included a case of external subscriber that set `NotFoundEventArgs.Path`.
- We're changing the condition to treat populated `args.Path` as a request to render the contents in this path. In that case, `Router` is able to find a component type by route and render it.
- [Docs] The update adds flexibility: application can either set `Router.NotFoundPage` or `NotFoundEventArgs.Path`. If both are defined, we should respect `NotFoundEventArgs.Path` because it's easier to overwrite it. It can be used, e.g. like this:
```
NavigationManager.OnNotFound += (sender, args) =>
{
    // Show different not-found pages based on the attempted URL
    if (NavigationManager.BaseUri.StartsWith("/admin/"))
        args.Path = "/admin-not-found";
    else if (NavigationManager.BaseUri.StartsWith("/api/"))
        args.Path = "/api-not-found";
    else if (NavigationManager.BaseUri.StartsWith("/user/"))
        args.Path = "/user-not-found";
    // Otherwise, let the default `NotFoundPage` handle it
};
```
- [Docs] For the scenario to work, external subscriber has to subscribe to `NavigationManager.OnNotFound` before `Router` does it. In case of custom router, it's enough to do it in its `OnParametersSet/Async`, in case of default `Router`, it's best to do it in `App.razor`.