### PR TITLE
Revert "Baseline tests should check for all possible extensions of not expected files"

### DIFF
--- a/src/ProjectTemplates/test/Templates.Tests/BaselineTest.cs
+++ b/src/ProjectTemplates/test/Templates.Tests/BaselineTest.cs
@@ -88,7 +88,15 @@ public class BaselineTest : LoggedTest
         foreach (var file in filesInFolder)
         {
             var relativePath = file.Replace(Project.TemplateOutputDir, "").Replace("\\", "/").Trim('/');
-            if (IsIgnoredPath(relativePath))
+            if (relativePath.EndsWith(".csproj", StringComparison.Ordinal) ||
+                relativePath.EndsWith(".fsproj", StringComparison.Ordinal) ||
+                relativePath.EndsWith(".props", StringComparison.Ordinal) ||
+                relativePath.EndsWith(".sln", StringComparison.Ordinal) ||
+                relativePath.EndsWith(".targets", StringComparison.Ordinal) ||
+                relativePath.StartsWith("bin/", StringComparison.Ordinal) ||
+                relativePath.StartsWith("obj/", StringComparison.Ordinal) ||
+                relativePath.Contains("/bin/", StringComparison.Ordinal) ||
+                relativePath.Contains("/obj/", StringComparison.Ordinal))
             {
                 continue;
             }
@@ -109,12 +117,6 @@ public class BaselineTest : LoggedTest
             }
         }
     }
-
-    private static bool IsIgnoredPath(string relativePath) =>
-        relativePath.StartsWith("bin/", StringComparison.Ordinal) ||
-        relativePath.StartsWith("obj/", StringComparison.Ordinal) ||
-        relativePath.Contains("/bin/", StringComparison.Ordinal) ||
-        relativePath.Contains("/obj/", StringComparison.Ordinal);
 
     private void AssertFileExists(string basePath, string path, bool shouldExist)
     {


### PR DESCRIPTION
Reverts dotnet/aspnetcore#62752. Otherwise we're hitting e.g.
```
 Templates.Test.BaselineTest.Template_Produces_The_Right_Set_Of_FilesAsync(arguments: "new webapiaot", expectedFiles: ["appsettings.Development.json", "appsettings.json", "Program.cs", "{ProjectName}.http", "Properties/launchSettings.json"]) [FAIL]
2025-07-18T10:12:56.2136848Z [xUnit.net 00:00:45.03]       Assert.Contains() Failure: Item not found in collection
2025-07-18T10:12:56.2144101Z [xUnit.net 00:00:45.03]       Collection: ["appsettings.Development.json", "appsettings.json", "Program.cs", "AspNet.bbodgsnrnn0m.http", "Properties/launchSettings.json"]
2025-07-18T10:12:56.2149708Z [xUnit.net 00:00:45.03]       Not found:  "AspNet.bbodgsnrnn0m.csproj"
2025-07-18T10:12:56.2158846Z [xUnit.net 00:00:45.03]       Stack Trace:
2025-07-18T10:12:56.2171727Z [xUnit.net 00:00:45.04]         /_/src/ProjectTemplates/test/Templates.Tests/BaselineTest.cs(95,0): at Templates.Test.BaselineTest.Template_Produces_The_Right_Set_Of_FilesAsync(String arguments, String[] expectedFiles)
2025-07-18T10:12:56.2178046Z [xUnit.net 00:00:45.04]         --- End of stack trace from previous location ---
```
https://helixr1107v0xdeko0k025g8.blob.core.windows.net/dotnet-aspnetcore-refs-pull-62414-merge-def57de839324dcc92/Templates.Tests--net10.0/1/console.5b6b9c66.log?helixlogtype=result&skoid=8eda00af-b5ec-4be9-b69b-0919a2338892&sktid=72f988bf-86f1-41af-91ab-2d7cd011db47&skt=2025-07-18T11%3A28%3A28Z&ske=2025-07-18T12%3A28%3A28Z&sks=b&skv=2024-11-04&sv=2024-11-04&se=2025-07-18T12%3A28%3A28Z&sr=b&sp=rl&sig=mpa5aE54QrIgppgfUzhQoIc3HACd0PBd7pXVZCTQLYA%3D

We can re-do it with updated baseline ~~once the `yml` gets edited to be triggered on template tests changes later.~~ `.yml` does not need updates, the job was blocked from [other reasons](https://github.com/dotnet/aspnetcore/pull/62806#pullrequestreview-3033694588).
For now, the goal is to unblock CI.