### PR TITLE
Replace unload event with pagehide for sending disconnect beacon from Blazor client

### DIFF
--- a/src/Components/Web.JS/src/Boot.Server.Common.ts
+++ b/src/Components/Web.JS/src/Boot.Server.Common.ts
@@ -121,7 +121,7 @@ async function startServerCore(components: RootComponentManager<ServerComponentD
 
   Blazor.disconnect = cleanup;
 
-  window.addEventListener('unload', cleanup, { capture: false, once: true });
+  window.addEventListener('pagehide', cleanup, { capture: false, once: true });
 
   logger.log(LogLevel.Information, 'Blazor server-side application started.');
 


### PR DESCRIPTION
Replaces the `unload` event with `pagehide` for sending disconnect beacon from the Blazor client to the server.

The two should fire in (practically) the same situations but `pagehide` is not deprecated and does not cause warnings for the users.

More fundamental improvements for the circuit cleanup scenarios will be done in later PRs.

Fixes https://github.com/dotnet/aspnetcore/issues/54793
