### PR TITLE
Changes in embedded dirs should also trigger templates testing

### DIFF
--- a/.azure/pipelines/template-tests-pr.yml
+++ b/.azure/pipelines/template-tests-pr.yml
@@ -16,9 +16,9 @@ pr:
     - release/*
   paths:
     include:
-    - src/ProjectTemplates/*
-    - src/Components/*
-    - src/Mvc/*
+    - src/ProjectTemplates/**
+    - src/Components/**
+    - src/Mvc/**
 
 variables:
 - name: _UseHelixOpenQueues

--- a/src/ProjectTemplates/test/Templates.Tests/BaselineTest.cs
+++ b/src/ProjectTemplates/test/Templates.Tests/BaselineTest.cs
@@ -88,15 +88,7 @@ public class BaselineTest : LoggedTest
         foreach (var file in filesInFolder)
         {
             var relativePath = file.Replace(Project.TemplateOutputDir, "").Replace("\\", "/").Trim('/');
-            if (relativePath.EndsWith(".csproj", StringComparison.Ordinal) ||
-                relativePath.EndsWith(".fsproj", StringComparison.Ordinal) ||
-                relativePath.EndsWith(".props", StringComparison.Ordinal) ||
-                relativePath.EndsWith(".sln", StringComparison.Ordinal) ||
-                relativePath.EndsWith(".targets", StringComparison.Ordinal) ||
-                relativePath.StartsWith("bin/", StringComparison.Ordinal) ||
-                relativePath.StartsWith("obj/", StringComparison.Ordinal) ||
-                relativePath.Contains("/bin/", StringComparison.Ordinal) ||
-                relativePath.Contains("/obj/", StringComparison.Ordinal))
+            if (IsIgnoredPath(relativePath))
             {
                 continue;
             }
@@ -117,6 +109,12 @@ public class BaselineTest : LoggedTest
             }
         }
     }
+
+    private static bool IsIgnoredPath(string relativePath) =>
+        relativePath.StartsWith("bin/", StringComparison.Ordinal) ||
+        relativePath.StartsWith("obj/", StringComparison.Ordinal) ||
+        relativePath.Contains("/bin/", StringComparison.Ordinal) ||
+        relativePath.Contains("/obj/", StringComparison.Ordinal);
 
     private void AssertFileExists(string basePath, string path, bool shouldExist)
     {

--- a/src/ProjectTemplates/test/Templates.Tests/BaselineTest.cs
+++ b/src/ProjectTemplates/test/Templates.Tests/BaselineTest.cs
@@ -88,7 +88,15 @@ public class BaselineTest : LoggedTest
         foreach (var file in filesInFolder)
         {
             var relativePath = file.Replace(Project.TemplateOutputDir, "").Replace("\\", "/").Trim('/');
-            if (IsIgnoredPath(relativePath))
+            if (relativePath.EndsWith(".csproj", StringComparison.Ordinal) ||
+                relativePath.EndsWith(".fsproj", StringComparison.Ordinal) ||
+                relativePath.EndsWith(".props", StringComparison.Ordinal) ||
+                relativePath.EndsWith(".sln", StringComparison.Ordinal) ||
+                relativePath.EndsWith(".targets", StringComparison.Ordinal) ||
+                relativePath.StartsWith("bin/", StringComparison.Ordinal) ||
+                relativePath.StartsWith("obj/", StringComparison.Ordinal) ||
+                relativePath.Contains("/bin/", StringComparison.Ordinal) ||
+                relativePath.Contains("/obj/", StringComparison.Ordinal))
             {
                 continue;
             }
@@ -109,12 +117,6 @@ public class BaselineTest : LoggedTest
             }
         }
     }
-
-    private static bool IsIgnoredPath(string relativePath) =>
-        relativePath.StartsWith("bin/", StringComparison.Ordinal) ||
-        relativePath.StartsWith("obj/", StringComparison.Ordinal) ||
-        relativePath.Contains("/bin/", StringComparison.Ordinal) ||
-        relativePath.Contains("/obj/", StringComparison.Ordinal);
 
     private void AssertFileExists(string basePath, string path, bool shouldExist)
     {


### PR DESCRIPTION
Follow up for https://github.com/dotnet/aspnetcore/pull/62752#issuecomment-3089213318.

## Description

PR https://github.com/dotnet/aspnetcore/pull/6275 did not trigger the template test, even though its change was under path listed in trigger mechanisms:
https://github.com/dotnet/aspnetcore/blob/366296cf792ef5c6b5b5341e02fc1e7f38840fe6/.azure/pipelines/template-tests-pr.yml#L19

Investigating further, we need double wildcard there if we want changes to files embedded deeper in the structure to also trigger the job:
https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/file-matching-patterns?view=azure-devops

