### PR TITLE
Avoid cookie login redirects for known API endpoints

### DIFF
--- a/src/Http/Http.Abstractions/src/Metadata/ApiEndpointMetadata.cs
+++ b/src/Http/Http.Abstractions/src/Metadata/ApiEndpointMetadata.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Http.Metadata;
+
+/// <summary>
+/// Metadata that indicates the endpoint is intended for API clients.
+/// When present, authentication handlers should prefer returning status codes over browser redirects.
+/// </summary>
+internal sealed class ApiEndpointMetadata : IApiEndpointMetadata
+{
+    /// <summary>
+    /// Singleton instance of <see cref="ApiEndpointMetadata"/>.
+    /// </summary>
+    public static readonly ApiEndpointMetadata Instance = new();
+
+    private ApiEndpointMetadata()
+    {
+    }
+}

--- a/src/Http/Http.Abstractions/src/Metadata/IApiEndpointMetadata.cs
+++ b/src/Http/Http.Abstractions/src/Metadata/IApiEndpointMetadata.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Http.Metadata;
+
+/// <summary>
+/// Metadata that indicates the endpoint is an API intended for programatic access rather than direct browser navigation.
+/// When present, authentication handlers should prefer returning status codes over browser redirects.
+/// </summary>
+public interface IApiEndpointMetadata
+{
+}

--- a/src/Http/Http.Abstractions/src/Metadata/IApiEndpointMetadata.cs
+++ b/src/Http/Http.Abstractions/src/Metadata/IApiEndpointMetadata.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.AspNetCore.Http.Metadata;
 
 /// <summary>
-/// Metadata that indicates the endpoint is an API intended for programatic access rather than direct browser navigation.
+/// Metadata that indicates the endpoint is an API intended for programmatic access rather than direct browser navigation.
 /// When present, authentication handlers should prefer returning status codes over browser redirects.
 /// </summary>
 public interface IApiEndpointMetadata

--- a/src/Http/Http.Abstractions/src/Microsoft.AspNetCore.Http.Abstractions.csproj
+++ b/src/Http/Http.Abstractions/src/Microsoft.AspNetCore.Http.Abstractions.csproj
@@ -35,7 +35,6 @@ Microsoft.AspNetCore.Http.HttpResponse</Description>
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="Microsoft.AspNetCore.Http.Abstractions.Microbenchmarks" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.Http.Extensions" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.Http.Results" />
   </ItemGroup>
@@ -61,5 +60,6 @@ Microsoft.AspNetCore.Http.HttpResponse</Description>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.AspNetCore.Http.Abstractions.Tests" />
+    <InternalsVisibleTo Include="Microsoft.AspNetCore.Http.Abstractions.Microbenchmarks" />
   </ItemGroup>
 </Project>

--- a/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+Microsoft.AspNetCore.Http.Metadata.IApiEndpointMetadata
 Microsoft.AspNetCore.Http.Metadata.IDisableValidationMetadata
 Microsoft.AspNetCore.Http.ProducesResponseTypeMetadata.Description.get -> string?
 Microsoft.AspNetCore.Http.ProducesResponseTypeMetadata.Description.set -> void

--- a/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator/RequestDelegateGenerator.cs
+++ b/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator/RequestDelegateGenerator.cs
@@ -248,7 +248,12 @@ public sealed class RequestDelegateGenerator : IIncrementalGenerator
 
                 if (hasFormBody)
                 {
-                    codeWriter.WriteLine(RequestDelegateGeneratorSources.AntiforgeryMetadataType);
+                    codeWriter.WriteLine(RequestDelegateGeneratorSources.AntiforgeryMetadataClass);
+                }
+
+                if (hasJsonBody || hasResponseMetadata)
+                {
+                    codeWriter.WriteLine(RequestDelegateGeneratorSources.ApiEndpointMetadataClass);
                 }
 
                 if (hasFormBody || hasJsonBody || hasResponseMetadata)

--- a/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator/RequestDelegateGeneratorSources.cs
+++ b/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator/RequestDelegateGeneratorSources.cs
@@ -479,19 +479,39 @@ internal static class RequestDelegateGeneratorSources
     }
 """;
 
-    public static string AntiforgeryMetadataType = """
-file sealed class AntiforgeryMetadata : IAntiforgeryMetadata
-{
-    public static readonly IAntiforgeryMetadata ValidationRequired = new AntiforgeryMetadata(true);
-
-    public AntiforgeryMetadata(bool requiresValidation)
+    public static string AntiforgeryMetadataClass = """
+    file sealed class AntiforgeryMetadata : IAntiforgeryMetadata
     {
-        RequiresValidation = requiresValidation;
-    }
+        public static readonly IAntiforgeryMetadata ValidationRequired = new AntiforgeryMetadata(true);
 
-    public bool RequiresValidation { get; }
-}
+        public AntiforgeryMetadata(bool requiresValidation)
+        {
+            RequiresValidation = requiresValidation;
+        }
+
+        public bool RequiresValidation { get; }
+    }
 """;
+
+    public static string ApiEndpointMetadataClass = """
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
+""";
+
     public static string GetGeneratedRouteBuilderExtensionsSource(string endpoints, string helperMethods, string helperTypes, ImmutableHashSet<string> verbs) => $$"""
 {{SourceHeader}}
 

--- a/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator/StaticRouteHandlerModel/StaticRouteHandlerModel.Emitter.cs
+++ b/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator/StaticRouteHandlerModel/StaticRouteHandlerModel.Emitter.cs
@@ -205,7 +205,7 @@ internal static class StaticRouteHandlerModelEmitter
             return;
         }
 
-        if (!endpoint.Response.IsAwaitable && (response.HasNoResponse || response.IsIResult))
+        if (response.HasNoResponse || response.IsIResult)
         {
             return;
         }
@@ -215,13 +215,10 @@ internal static class StaticRouteHandlerModelEmitter
         {
             codeWriter.WriteLine($"options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof(string), contentTypes: GeneratedMetadataConstants.PlaintextContentType));");
         }
-        else if (response.IsAwaitable && response.ResponseType == null)
-        {
-            codeWriter.WriteLine($"options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof(void), contentTypes: GeneratedMetadataConstants.PlaintextContentType));");
-        }
         else if (response.ResponseType is { } responseType)
         {
             codeWriter.WriteLine($$"""options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof({{responseType.ToDisplayString(EmitterConstants.DisplayFormatWithoutNullability)}}), contentTypes: GeneratedMetadataConstants.JsonContentType));""");
+            codeWriter.WriteLine("ApiEndpointMetadata.AddApiEndpointMetadataIfMissing(options.EndpointBuilder);");
         }
     }
 
@@ -339,13 +336,15 @@ internal static class StaticRouteHandlerModelEmitter
             codeWriter.WriteLine("if (!serviceProviderIsService.IsService(type))");
             codeWriter.StartBlock();
             codeWriter.WriteLine("options.EndpointBuilder.Metadata.Add(new AcceptsMetadata(type: type, isOptional: isOptional, contentTypes: GeneratedMetadataConstants.JsonContentType));");
+            codeWriter.WriteLine("options.EndpointBuilder.Metadata.Add(ApiEndpointMetadata.Instance);");
             codeWriter.WriteLine("break;");
             codeWriter.EndBlock();
             codeWriter.EndBlock();
         }
         else
         {
-            codeWriter.WriteLine($"options.EndpointBuilder.Metadata.Add(new AcceptsMetadata(contentTypes: GeneratedMetadataConstants.JsonContentType));");
+            codeWriter.WriteLine("options.EndpointBuilder.Metadata.Add(new AcceptsMetadata(contentTypes: GeneratedMetadataConstants.JsonContentType));");
+            codeWriter.WriteLine("options.EndpointBuilder.Metadata.Add(ApiEndpointMetadata.Instance);");
         }
     }
 

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -401,7 +401,14 @@ public static partial class RequestDelegateFactory
                 InferAntiforgeryMetadata(factoryContext);
             }
 
-            PopulateBuiltInResponseTypeMetadata(methodInfo.ReturnType, factoryContext.EndpointBuilder);
+            // If this endpoint expects a JSON request body, we assume its an API endpoint not intended for browser navigation.
+            // When present, authentication handlers should prefer returning status codes over browser redirects.
+            if (factoryContext.JsonRequestBodyParameter is not null)
+            {
+                factoryContext.EndpointBuilder.Metadata.Add(ApiEndpointMetadata.Instance);
+            }
+
+            PopulateBuiltInResponseTypeMetadata(methodInfo.ReturnType, factoryContext);
 
             // Add metadata provided by the delegate return type and parameter types next, this will be more specific than inferred metadata from above
             EndpointMetadataPopulator.PopulateMetadata(methodInfo, factoryContext.EndpointBuilder, factoryContext.Parameters);
@@ -1023,37 +1030,40 @@ public static partial class RequestDelegateFactory
         return Expression.Block(localVariables, checkParamAndCallMethod);
     }
 
-    private static void PopulateBuiltInResponseTypeMetadata(Type returnType, EndpointBuilder builder)
+    private static void PopulateBuiltInResponseTypeMetadata(Type returnType, RequestDelegateFactoryContext factoryContext)
     {
         if (returnType.IsByRefLike)
         {
             throw GetUnsupportedReturnTypeException(returnType);
         }
 
-        var isAwaitable = false;
         if (CoercedAwaitableInfo.IsTypeAwaitable(returnType, out var coercedAwaitableInfo))
         {
             returnType = coercedAwaitableInfo.AwaitableInfo.ResultType;
-            isAwaitable = true;
         }
 
         // Skip void returns and IResults. IResults might implement IEndpointMetadataProvider but otherwise we don't know what it might do.
-        if (!isAwaitable && (returnType == typeof(void) || typeof(IResult).IsAssignableFrom(returnType)))
+        if (returnType == typeof(void) || typeof(IResult).IsAssignableFrom(returnType))
         {
             return;
         }
+
+        var builder = factoryContext.EndpointBuilder;
 
         if (returnType == typeof(string))
         {
             builder.Metadata.Add(ProducesResponseTypeMetadata.CreateUnvalidated(type: typeof(string), statusCode: 200, PlaintextContentType));
         }
-        else if (returnType == typeof(void))
-        {
-            builder.Metadata.Add(ProducesResponseTypeMetadata.CreateUnvalidated(returnType, statusCode: 200, PlaintextContentType));
-        }
         else
         {
             builder.Metadata.Add(ProducesResponseTypeMetadata.CreateUnvalidated(returnType, statusCode: 200, DefaultAcceptsAndProducesContentType));
+
+            if (factoryContext.JsonRequestBodyParameter is null)
+            {
+                // Since this endpoint responds with JSON, we assume its an API endpoint not intended for browser navigation,
+                // but we don't want to bother adding this metadata twice if we've already inferred it based on the expected JSON request body.
+                builder.Metadata.Add(ApiEndpointMetadata.Instance);
+            }
         }
     }
 

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/HandlesEndpointsWithAndWithoutDiagnostics.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/HandlesEndpointsWithAndWithoutDiagnostics.generated.txt
@@ -225,6 +225,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_BindAsync_NullableReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_BindAsync_NullableReturn.generated.txt
@@ -363,6 +363,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_BindAsync_Snapshot.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_BindAsync_Snapshot.generated.txt
@@ -2225,6 +2225,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitBodyParam_ComplexReturn_Snapshot.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitBodyParam_ComplexReturn_Snapshot.generated.txt
@@ -412,6 +412,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitHeader_ComplexTypeArrayParam.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitHeader_ComplexTypeArrayParam.generated.txt
@@ -72,6 +72,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 var parameters = methodInfo.GetParameters();
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("p", parameters[0], hasTryParse: true, hasBindAsync: false, isOptional: false));
                 options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof(global::System.Int32), contentTypes: GeneratedMetadataConstants.JsonContentType));
+                ApiEndpointMetadata.AddApiEndpointMetadataIfMissing(options.EndpointBuilder);
                 return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
             };
             RequestDelegateFactoryFunc createRequestDelegate = (del, options, inferredMetadataResult) =>
@@ -259,6 +260,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitHeader_NullableStringArrayParam.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitHeader_NullableStringArrayParam.generated.txt
@@ -72,6 +72,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 var parameters = methodInfo.GetParameters();
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("p", parameters[0], hasTryParse: false, hasBindAsync: false, isOptional: false));
                 options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof(global::System.Int32), contentTypes: GeneratedMetadataConstants.JsonContentType));
+                ApiEndpointMetadata.AddApiEndpointMetadataIfMissing(options.EndpointBuilder);
                 return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
             };
             RequestDelegateFactoryFunc createRequestDelegate = (del, options, inferredMetadataResult) =>
@@ -231,6 +232,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitHeader_StringArrayParam.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitHeader_StringArrayParam.generated.txt
@@ -72,6 +72,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 var parameters = methodInfo.GetParameters();
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("p", parameters[0], hasTryParse: false, hasBindAsync: false, isOptional: false));
                 options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof(global::System.Int32), contentTypes: GeneratedMetadataConstants.JsonContentType));
+                ApiEndpointMetadata.AddApiEndpointMetadataIfMissing(options.EndpointBuilder);
                 return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
             };
             RequestDelegateFactoryFunc createRequestDelegate = (del, options, inferredMetadataResult) =>
@@ -231,6 +232,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitQuery_ComplexTypeArrayParam.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitQuery_ComplexTypeArrayParam.generated.txt
@@ -72,6 +72,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 var parameters = methodInfo.GetParameters();
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("p", parameters[0], hasTryParse: true, hasBindAsync: false, isOptional: false));
                 options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof(global::System.Int32), contentTypes: GeneratedMetadataConstants.JsonContentType));
+                ApiEndpointMetadata.AddApiEndpointMetadataIfMissing(options.EndpointBuilder);
                 return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
             };
             RequestDelegateFactoryFunc createRequestDelegate = (del, options, inferredMetadataResult) =>
@@ -259,6 +260,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitQuery_IntArrayParam_Optional.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitQuery_IntArrayParam_Optional.generated.txt
@@ -72,6 +72,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 var parameters = methodInfo.GetParameters();
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("p", parameters[0], hasTryParse: true, hasBindAsync: false, isOptional: true));
                 options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof(global::System.Int32[]), contentTypes: GeneratedMetadataConstants.JsonContentType));
+                ApiEndpointMetadata.AddApiEndpointMetadataIfMissing(options.EndpointBuilder);
                 return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
             };
             RequestDelegateFactoryFunc createRequestDelegate = (del, options, inferredMetadataResult) =>
@@ -259,6 +260,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitQuery_IntArrayParam_Optional_QueryNotPresent.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitQuery_IntArrayParam_Optional_QueryNotPresent.generated.txt
@@ -72,6 +72,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 var parameters = methodInfo.GetParameters();
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("p", parameters[0], hasTryParse: true, hasBindAsync: false, isOptional: true));
                 options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof(global::System.Int32[]), contentTypes: GeneratedMetadataConstants.JsonContentType));
+                ApiEndpointMetadata.AddApiEndpointMetadataIfMissing(options.EndpointBuilder);
                 return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
             };
             RequestDelegateFactoryFunc createRequestDelegate = (del, options, inferredMetadataResult) =>
@@ -259,6 +260,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitQuery_NullableIntArrayParam_Optional.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitQuery_NullableIntArrayParam_Optional.generated.txt
@@ -72,6 +72,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 var parameters = methodInfo.GetParameters();
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("p", parameters[0], hasTryParse: true, hasBindAsync: false, isOptional: true));
                 options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof(global::System.Int32?[]), contentTypes: GeneratedMetadataConstants.JsonContentType));
+                ApiEndpointMetadata.AddApiEndpointMetadataIfMissing(options.EndpointBuilder);
                 return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
             };
             RequestDelegateFactoryFunc createRequestDelegate = (del, options, inferredMetadataResult) =>
@@ -259,6 +260,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitQuery_NullableIntArrayParam_Optional_QueryNotPresent.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitQuery_NullableIntArrayParam_Optional_QueryNotPresent.generated.txt
@@ -72,6 +72,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 var parameters = methodInfo.GetParameters();
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("p", parameters[0], hasTryParse: true, hasBindAsync: false, isOptional: true));
                 options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof(global::System.Int32?[]), contentTypes: GeneratedMetadataConstants.JsonContentType));
+                ApiEndpointMetadata.AddApiEndpointMetadataIfMissing(options.EndpointBuilder);
                 return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
             };
             RequestDelegateFactoryFunc createRequestDelegate = (del, options, inferredMetadataResult) =>
@@ -259,6 +260,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitQuery_NullableStringArrayParam.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitQuery_NullableStringArrayParam.generated.txt
@@ -72,6 +72,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 var parameters = methodInfo.GetParameters();
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("p", parameters[0], hasTryParse: false, hasBindAsync: false, isOptional: false));
                 options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof(global::System.Int32), contentTypes: GeneratedMetadataConstants.JsonContentType));
+                ApiEndpointMetadata.AddApiEndpointMetadataIfMissing(options.EndpointBuilder);
                 return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
             };
             RequestDelegateFactoryFunc createRequestDelegate = (del, options, inferredMetadataResult) =>
@@ -230,6 +231,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitQuery_StringArrayParam.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitQuery_StringArrayParam.generated.txt
@@ -72,6 +72,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 var parameters = methodInfo.GetParameters();
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("p", parameters[0], hasTryParse: false, hasBindAsync: false, isOptional: false));
                 options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof(global::System.Int32), contentTypes: GeneratedMetadataConstants.JsonContentType));
+                ApiEndpointMetadata.AddApiEndpointMetadataIfMissing(options.EndpointBuilder);
                 return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
             };
             RequestDelegateFactoryFunc createRequestDelegate = (del, options, inferredMetadataResult) =>
@@ -230,6 +231,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitQuery_StringArrayParam_Optional.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitQuery_StringArrayParam_Optional.generated.txt
@@ -72,6 +72,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 var parameters = methodInfo.GetParameters();
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("p", parameters[0], hasTryParse: false, hasBindAsync: false, isOptional: true));
                 options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof(global::System.String[]), contentTypes: GeneratedMetadataConstants.JsonContentType));
+                ApiEndpointMetadata.AddApiEndpointMetadataIfMissing(options.EndpointBuilder);
                 return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
             };
             RequestDelegateFactoryFunc createRequestDelegate = (del, options, inferredMetadataResult) =>
@@ -230,6 +231,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitQuery_StringArrayParam_Optional_QueryNotPresent.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitQuery_StringArrayParam_Optional_QueryNotPresent.generated.txt
@@ -72,6 +72,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 var parameters = methodInfo.GetParameters();
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("p", parameters[0], hasTryParse: false, hasBindAsync: false, isOptional: true));
                 options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof(global::System.String[]), contentTypes: GeneratedMetadataConstants.JsonContentType));
+                ApiEndpointMetadata.AddApiEndpointMetadataIfMissing(options.EndpointBuilder);
                 return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
             };
             RequestDelegateFactoryFunc createRequestDelegate = (del, options, inferredMetadataResult) =>
@@ -230,6 +231,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitServiceParam_SimpleReturn_Snapshot.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitServiceParam_SimpleReturn_Snapshot.generated.txt
@@ -439,6 +439,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitSource_SimpleReturn_Snapshot.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitSource_SimpleReturn_Snapshot.generated.txt
@@ -606,6 +606,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ImplicitQuery_ComplexTypeArrayParam.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ImplicitQuery_ComplexTypeArrayParam.generated.txt
@@ -72,6 +72,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 var parameters = methodInfo.GetParameters();
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("p", parameters[0], hasTryParse: true, hasBindAsync: false, isOptional: false));
                 options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof(global::System.Int32), contentTypes: GeneratedMetadataConstants.JsonContentType));
+                ApiEndpointMetadata.AddApiEndpointMetadataIfMissing(options.EndpointBuilder);
                 return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
             };
             RequestDelegateFactoryFunc createRequestDelegate = (del, options, inferredMetadataResult) =>
@@ -266,6 +267,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ImplicitQuery_IntArrayParam_Optional.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ImplicitQuery_IntArrayParam_Optional.generated.txt
@@ -72,6 +72,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 var parameters = methodInfo.GetParameters();
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("p", parameters[0], hasTryParse: true, hasBindAsync: false, isOptional: true));
                 options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof(global::System.Int32[]), contentTypes: GeneratedMetadataConstants.JsonContentType));
+                ApiEndpointMetadata.AddApiEndpointMetadataIfMissing(options.EndpointBuilder);
                 return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
             };
             RequestDelegateFactoryFunc createRequestDelegate = (del, options, inferredMetadataResult) =>
@@ -266,6 +267,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ImplicitQuery_IntArrayParam_Optional_QueryNotPresent.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ImplicitQuery_IntArrayParam_Optional_QueryNotPresent.generated.txt
@@ -72,6 +72,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 var parameters = methodInfo.GetParameters();
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("p", parameters[0], hasTryParse: true, hasBindAsync: false, isOptional: true));
                 options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof(global::System.Int32[]), contentTypes: GeneratedMetadataConstants.JsonContentType));
+                ApiEndpointMetadata.AddApiEndpointMetadataIfMissing(options.EndpointBuilder);
                 return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
             };
             RequestDelegateFactoryFunc createRequestDelegate = (del, options, inferredMetadataResult) =>
@@ -266,6 +267,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ImplicitQuery_NullableIntArrayParam_Optional.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ImplicitQuery_NullableIntArrayParam_Optional.generated.txt
@@ -72,6 +72,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 var parameters = methodInfo.GetParameters();
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("p", parameters[0], hasTryParse: true, hasBindAsync: false, isOptional: true));
                 options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof(global::System.Int32?[]), contentTypes: GeneratedMetadataConstants.JsonContentType));
+                ApiEndpointMetadata.AddApiEndpointMetadataIfMissing(options.EndpointBuilder);
                 return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
             };
             RequestDelegateFactoryFunc createRequestDelegate = (del, options, inferredMetadataResult) =>
@@ -266,6 +267,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ImplicitQuery_NullableIntArrayParam_Optional_QueryNotPresent.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ImplicitQuery_NullableIntArrayParam_Optional_QueryNotPresent.generated.txt
@@ -72,6 +72,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 var parameters = methodInfo.GetParameters();
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("p", parameters[0], hasTryParse: true, hasBindAsync: false, isOptional: true));
                 options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof(global::System.Int32?[]), contentTypes: GeneratedMetadataConstants.JsonContentType));
+                ApiEndpointMetadata.AddApiEndpointMetadataIfMissing(options.EndpointBuilder);
                 return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
             };
             RequestDelegateFactoryFunc createRequestDelegate = (del, options, inferredMetadataResult) =>
@@ -266,6 +267,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ImplicitQuery_NullableStringArrayParam.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ImplicitQuery_NullableStringArrayParam.generated.txt
@@ -81,12 +81,14 @@ namespace Microsoft.AspNetCore.Http.Generated
                     if (!serviceProviderIsService.IsService(type))
                     {
                         options.EndpointBuilder.Metadata.Add(new AcceptsMetadata(type: type, isOptional: isOptional, contentTypes: GeneratedMetadataConstants.JsonContentType));
+                        options.EndpointBuilder.Metadata.Add(ApiEndpointMetadata.Instance);
                         break;
                     }
                 }
                 var parameters = methodInfo.GetParameters();
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("p", parameters[0], hasTryParse: false, hasBindAsync: false, isOptional: false));
                 options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof(global::System.Int32), contentTypes: GeneratedMetadataConstants.JsonContentType));
+                ApiEndpointMetadata.AddApiEndpointMetadataIfMissing(options.EndpointBuilder);
                 return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
             };
             RequestDelegateFactoryFunc createRequestDelegate = (del, options, inferredMetadataResult) =>
@@ -327,6 +329,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ImplicitQuery_NullableStringArrayParam_EmptyQueryValues.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ImplicitQuery_NullableStringArrayParam_EmptyQueryValues.generated.txt
@@ -81,12 +81,14 @@ namespace Microsoft.AspNetCore.Http.Generated
                     if (!serviceProviderIsService.IsService(type))
                     {
                         options.EndpointBuilder.Metadata.Add(new AcceptsMetadata(type: type, isOptional: isOptional, contentTypes: GeneratedMetadataConstants.JsonContentType));
+                        options.EndpointBuilder.Metadata.Add(ApiEndpointMetadata.Instance);
                         break;
                     }
                 }
                 var parameters = methodInfo.GetParameters();
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("p", parameters[0], hasTryParse: false, hasBindAsync: false, isOptional: false));
                 options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof(global::System.Int32), contentTypes: GeneratedMetadataConstants.JsonContentType));
+                ApiEndpointMetadata.AddApiEndpointMetadataIfMissing(options.EndpointBuilder);
                 return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
             };
             RequestDelegateFactoryFunc createRequestDelegate = (del, options, inferredMetadataResult) =>
@@ -327,6 +329,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ImplicitQuery_NullableStringArrayParam_QueryNotPresent.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ImplicitQuery_NullableStringArrayParam_QueryNotPresent.generated.txt
@@ -81,12 +81,14 @@ namespace Microsoft.AspNetCore.Http.Generated
                     if (!serviceProviderIsService.IsService(type))
                     {
                         options.EndpointBuilder.Metadata.Add(new AcceptsMetadata(type: type, isOptional: isOptional, contentTypes: GeneratedMetadataConstants.JsonContentType));
+                        options.EndpointBuilder.Metadata.Add(ApiEndpointMetadata.Instance);
                         break;
                     }
                 }
                 var parameters = methodInfo.GetParameters();
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("p", parameters[0], hasTryParse: false, hasBindAsync: false, isOptional: false));
                 options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof(global::System.Int32), contentTypes: GeneratedMetadataConstants.JsonContentType));
+                ApiEndpointMetadata.AddApiEndpointMetadataIfMissing(options.EndpointBuilder);
                 return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
             };
             RequestDelegateFactoryFunc createRequestDelegate = (del, options, inferredMetadataResult) =>
@@ -327,6 +329,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ImplicitQuery_StringArrayParam.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ImplicitQuery_StringArrayParam.generated.txt
@@ -81,12 +81,14 @@ namespace Microsoft.AspNetCore.Http.Generated
                     if (!serviceProviderIsService.IsService(type))
                     {
                         options.EndpointBuilder.Metadata.Add(new AcceptsMetadata(type: type, isOptional: isOptional, contentTypes: GeneratedMetadataConstants.JsonContentType));
+                        options.EndpointBuilder.Metadata.Add(ApiEndpointMetadata.Instance);
                         break;
                     }
                 }
                 var parameters = methodInfo.GetParameters();
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("p", parameters[0], hasTryParse: false, hasBindAsync: false, isOptional: false));
                 options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof(global::System.Int32), contentTypes: GeneratedMetadataConstants.JsonContentType));
+                ApiEndpointMetadata.AddApiEndpointMetadataIfMissing(options.EndpointBuilder);
                 return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
             };
             RequestDelegateFactoryFunc createRequestDelegate = (del, options, inferredMetadataResult) =>
@@ -327,6 +329,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ImplicitQuery_StringArrayParam_Optional.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ImplicitQuery_StringArrayParam_Optional.generated.txt
@@ -81,12 +81,14 @@ namespace Microsoft.AspNetCore.Http.Generated
                     if (!serviceProviderIsService.IsService(type))
                     {
                         options.EndpointBuilder.Metadata.Add(new AcceptsMetadata(type: type, isOptional: isOptional, contentTypes: GeneratedMetadataConstants.JsonContentType));
+                        options.EndpointBuilder.Metadata.Add(ApiEndpointMetadata.Instance);
                         break;
                     }
                 }
                 var parameters = methodInfo.GetParameters();
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("p", parameters[0], hasTryParse: false, hasBindAsync: false, isOptional: true));
                 options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof(global::System.String[]), contentTypes: GeneratedMetadataConstants.JsonContentType));
+                ApiEndpointMetadata.AddApiEndpointMetadataIfMissing(options.EndpointBuilder);
                 return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
             };
             RequestDelegateFactoryFunc createRequestDelegate = (del, options, inferredMetadataResult) =>
@@ -327,6 +329,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ImplicitQuery_StringArrayParam_Optional_QueryNotPresent.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ImplicitQuery_StringArrayParam_Optional_QueryNotPresent.generated.txt
@@ -81,12 +81,14 @@ namespace Microsoft.AspNetCore.Http.Generated
                     if (!serviceProviderIsService.IsService(type))
                     {
                         options.EndpointBuilder.Metadata.Add(new AcceptsMetadata(type: type, isOptional: isOptional, contentTypes: GeneratedMetadataConstants.JsonContentType));
+                        options.EndpointBuilder.Metadata.Add(ApiEndpointMetadata.Instance);
                         break;
                     }
                 }
                 var parameters = methodInfo.GetParameters();
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("p", parameters[0], hasTryParse: false, hasBindAsync: false, isOptional: true));
                 options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof(global::System.String[]), contentTypes: GeneratedMetadataConstants.JsonContentType));
+                ApiEndpointMetadata.AddApiEndpointMetadataIfMissing(options.EndpointBuilder);
                 return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
             };
             RequestDelegateFactoryFunc createRequestDelegate = (del, options, inferredMetadataResult) =>
@@ -327,6 +329,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_JsonBodyOrService_HandlesBothJsonAndService.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_JsonBodyOrService_HandlesBothJsonAndService.generated.txt
@@ -82,6 +82,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     if (!serviceProviderIsService.IsService(type))
                     {
                         options.EndpointBuilder.Metadata.Add(new AcceptsMetadata(type: type, isOptional: isOptional, contentTypes: GeneratedMetadataConstants.JsonContentType));
+                        options.EndpointBuilder.Metadata.Add(ApiEndpointMetadata.Instance);
                         break;
                     }
                 }
@@ -345,6 +346,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_MultipleSpecialTypeParam_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_MultipleSpecialTypeParam_StringReturn.generated.txt
@@ -234,6 +234,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_MultipleStringParam_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_MultipleStringParam_StringReturn.generated.txt
@@ -267,6 +267,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_NoParam_StringReturn_WithFilter.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_NoParam_StringReturn_WithFilter.generated.txt
@@ -225,6 +225,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ReturnsString_Has_Metadata.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ReturnsString_Has_Metadata.generated.txt
@@ -225,6 +225,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ReturnsTodo_Has_Metadata.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ReturnsTodo_Has_Metadata.generated.txt
@@ -70,6 +70,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 Debug.Assert(options.EndpointBuilder != null, "EndpointBuilder not found.");
                 options.EndpointBuilder.Metadata.Add(new System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.AspNetCore.Http.RequestDelegateGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42"));
                 options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof(global::Microsoft.AspNetCore.Http.Generators.Tests.Todo), contentTypes: GeneratedMetadataConstants.JsonContentType));
+                ApiEndpointMetadata.AddApiEndpointMetadataIfMissing(options.EndpointBuilder);
                 return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
             };
             RequestDelegateFactoryFunc createRequestDelegate = (del, options, inferredMetadataResult) =>
@@ -218,6 +219,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleComplexTypeParam_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleComplexTypeParam_StringReturn.generated.txt
@@ -266,6 +266,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleEnumParam_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleEnumParam_StringReturn.generated.txt
@@ -266,6 +266,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleNullableStringParam_WithEmptyQueryStringValueProvided_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleNullableStringParam_WithEmptyQueryStringValueProvided_StringReturn.generated.txt
@@ -238,6 +238,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_TakesCustomMetadataEmitter_Has_Metadata.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_TakesCustomMetadataEmitter_Has_Metadata.generated.txt
@@ -81,6 +81,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     if (!serviceProviderIsService.IsService(type))
                     {
                         options.EndpointBuilder.Metadata.Add(new AcceptsMetadata(type: type, isOptional: isOptional, contentTypes: GeneratedMetadataConstants.JsonContentType));
+                        options.EndpointBuilder.Metadata.Add(ApiEndpointMetadata.Instance);
                         break;
                     }
                 }
@@ -333,6 +334,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapMethods_Get_WithArrayQueryString_AndBody_ShouldUseQueryString.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapMethods_Get_WithArrayQueryString_AndBody_ShouldUseQueryString.generated.txt
@@ -81,6 +81,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     if (!serviceProviderIsService.IsService(type))
                     {
                         options.EndpointBuilder.Metadata.Add(new AcceptsMetadata(type: type, isOptional: isOptional, contentTypes: GeneratedMetadataConstants.JsonContentType));
+                        options.EndpointBuilder.Metadata.Add(ApiEndpointMetadata.Instance);
                         break;
                     }
                 }
@@ -334,6 +335,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapMethods_PostAndGet_WithArrayQueryString_AndBody_ShouldUseQueryString.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapMethods_PostAndGet_WithArrayQueryString_AndBody_ShouldUseQueryString.generated.txt
@@ -81,6 +81,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     if (!serviceProviderIsService.IsService(type))
                     {
                         options.EndpointBuilder.Metadata.Add(new AcceptsMetadata(type: type, isOptional: isOptional, contentTypes: GeneratedMetadataConstants.JsonContentType));
+                        options.EndpointBuilder.Metadata.Add(ApiEndpointMetadata.Instance);
                         break;
                     }
                 }
@@ -334,6 +335,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapMethods_PostAndPut_WithArrayQueryString_AndBody_ShouldUseBody.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapMethods_PostAndPut_WithArrayQueryString_AndBody_ShouldUseBody.generated.txt
@@ -81,6 +81,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     if (!serviceProviderIsService.IsService(type))
                     {
                         options.EndpointBuilder.Metadata.Add(new AcceptsMetadata(type: type, isOptional: isOptional, contentTypes: GeneratedMetadataConstants.JsonContentType));
+                        options.EndpointBuilder.Metadata.Add(ApiEndpointMetadata.Instance);
                         break;
                     }
                 }
@@ -334,6 +335,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapMethods_Post_WithArrayQueryString_AndBody_ShouldUseBody.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapMethods_Post_WithArrayQueryString_AndBody_ShouldUseBody.generated.txt
@@ -81,6 +81,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     if (!serviceProviderIsService.IsService(type))
                     {
                         options.EndpointBuilder.Metadata.Add(new AcceptsMetadata(type: type, isOptional: isOptional, contentTypes: GeneratedMetadataConstants.JsonContentType));
+                        options.EndpointBuilder.Metadata.Add(ApiEndpointMetadata.Instance);
                         break;
                     }
                 }
@@ -334,6 +335,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapPost_WithArrayQueryString_AndBody_ShouldUseBody.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapPost_WithArrayQueryString_AndBody_ShouldUseBody.generated.txt
@@ -81,6 +81,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     if (!serviceProviderIsService.IsService(type))
                     {
                         options.EndpointBuilder.Metadata.Add(new AcceptsMetadata(type: type, isOptional: isOptional, contentTypes: GeneratedMetadataConstants.JsonContentType));
+                        options.EndpointBuilder.Metadata.Add(ApiEndpointMetadata.Instance);
                         break;
                     }
                 }
@@ -334,6 +335,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapPost_WithArrayQueryString_ShouldFail.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapPost_WithArrayQueryString_ShouldFail.generated.txt
@@ -81,12 +81,14 @@ namespace Microsoft.AspNetCore.Http.Generated
                     if (!serviceProviderIsService.IsService(type))
                     {
                         options.EndpointBuilder.Metadata.Add(new AcceptsMetadata(type: type, isOptional: isOptional, contentTypes: GeneratedMetadataConstants.JsonContentType));
+                        options.EndpointBuilder.Metadata.Add(ApiEndpointMetadata.Instance);
                         break;
                     }
                 }
                 var parameters = methodInfo.GetParameters();
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("p", parameters[0], hasTryParse: false, hasBindAsync: false, isOptional: false));
                 options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof(global::System.Int32), contentTypes: GeneratedMetadataConstants.JsonContentType));
+                ApiEndpointMetadata.AddApiEndpointMetadataIfMissing(options.EndpointBuilder);
                 return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
             };
             RequestDelegateFactoryFunc createRequestDelegate = (del, options, inferredMetadataResult) =>
@@ -327,6 +329,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/Multiple_MapAction_NoParam_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/Multiple_MapAction_NoParam_StringReturn.generated.txt
@@ -414,6 +414,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/Multiple_MapAction_WithParams_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/Multiple_MapAction_WithParams_StringReturn.generated.txt
@@ -428,6 +428,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/RequestDelegateValidateGeneratedFormCode.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/RequestDelegateValidateGeneratedFormCode.generated.txt
@@ -373,17 +373,17 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
-file sealed class AntiforgeryMetadata : IAntiforgeryMetadata
-{
-    public static readonly IAntiforgeryMetadata ValidationRequired = new AntiforgeryMetadata(true);
-
-    public AntiforgeryMetadata(bool requiresValidation)
+    file sealed class AntiforgeryMetadata : IAntiforgeryMetadata
     {
-        RequiresValidation = requiresValidation;
-    }
+        public static readonly IAntiforgeryMetadata ValidationRequired = new AntiforgeryMetadata(true);
 
-    public bool RequiresValidation { get; }
-}
+        public AntiforgeryMetadata(bool requiresValidation)
+        {
+            RequiresValidation = requiresValidation;
+        }
+
+        public bool RequiresValidation { get; }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/SupportsDifferentInterceptorsFromSameLocation.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/SupportsDifferentInterceptorsFromSameLocation.generated.txt
@@ -388,6 +388,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/SupportsSameInterceptorsFromDifferentFiles.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/SupportsSameInterceptorsFromDifferentFiles.generated.txt
@@ -257,6 +257,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/VerifyAsParametersBaseline.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/VerifyAsParametersBaseline.generated.txt
@@ -446,6 +446,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 Debug.Assert(options.EndpointBuilder != null, "EndpointBuilder not found.");
                 options.EndpointBuilder.Metadata.Add(new System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.AspNetCore.Http.RequestDelegateGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42"));
                 options.EndpointBuilder.Metadata.Add(new AcceptsMetadata(contentTypes: GeneratedMetadataConstants.JsonContentType));
+                options.EndpointBuilder.Metadata.Add(ApiEndpointMetadata.Instance);
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("HttpContext", new PropertyAsParameterInfo(false, typeof(Microsoft.AspNetCore.Http.Generators.Tests.ParametersListWithImplicitFromBody)!.GetProperty("HttpContext")!, typeof(Microsoft.AspNetCore.Http.Generators.Tests.ParametersListWithImplicitFromBody).GetConstructor(new[] { typeof(Microsoft.AspNetCore.Http.HttpContext), typeof(Microsoft.AspNetCore.Http.Generators.Tests.TodoStruct) })?.GetParameters()[0]), hasTryParse: false, hasBindAsync: false, isOptional: false));
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("Todo", new PropertyAsParameterInfo(false, typeof(Microsoft.AspNetCore.Http.Generators.Tests.ParametersListWithImplicitFromBody)!.GetProperty("Todo")!, typeof(Microsoft.AspNetCore.Http.Generators.Tests.ParametersListWithImplicitFromBody).GetConstructor(new[] { typeof(Microsoft.AspNetCore.Http.HttpContext), typeof(Microsoft.AspNetCore.Http.Generators.Tests.TodoStruct) })?.GetParameters()[1]), hasTryParse: false, hasBindAsync: false, isOptional: false));
                 options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof(string), contentTypes: GeneratedMetadataConstants.PlaintextContentType));
@@ -567,6 +568,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 Debug.Assert(options.EndpointBuilder != null, "EndpointBuilder not found.");
                 options.EndpointBuilder.Metadata.Add(new System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.AspNetCore.Http.RequestDelegateGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42"));
                 options.EndpointBuilder.Metadata.Add(new AcceptsMetadata(contentTypes: GeneratedMetadataConstants.JsonContentType));
+                options.EndpointBuilder.Metadata.Add(ApiEndpointMetadata.Instance);
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("HttpContext", new PropertyAsParameterInfo(false, typeof(Microsoft.AspNetCore.Http.Generators.Tests.ParametersListWithMetadataType)!.GetProperty("HttpContext")!, typeof(Microsoft.AspNetCore.Http.Generators.Tests.ParametersListWithMetadataType).GetConstructor(new[] { typeof(Microsoft.AspNetCore.Http.HttpContext), typeof(Microsoft.AspNetCore.Http.Generators.Tests.AddsCustomParameterMetadataAsProperty) })?.GetParameters()[0]), hasTryParse: false, hasBindAsync: false, isOptional: false));
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("Value", new PropertyAsParameterInfo(false, typeof(Microsoft.AspNetCore.Http.Generators.Tests.ParametersListWithMetadataType)!.GetProperty("Value")!, typeof(Microsoft.AspNetCore.Http.Generators.Tests.ParametersListWithMetadataType).GetConstructor(new[] { typeof(Microsoft.AspNetCore.Http.HttpContext), typeof(Microsoft.AspNetCore.Http.Generators.Tests.AddsCustomParameterMetadataAsProperty) })?.GetParameters()[1]), hasTryParse: false, hasBindAsync: false, isOptional: false));
                 var parameterInfos = methodInfo.GetParameters();
@@ -683,6 +685,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 Debug.Assert(options.EndpointBuilder != null, "EndpointBuilder not found.");
                 options.EndpointBuilder.Metadata.Add(new System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.AspNetCore.Http.RequestDelegateGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42"));
                 options.EndpointBuilder.Metadata.Add(new AcceptsMetadata(contentTypes: GeneratedMetadataConstants.JsonContentType));
+                options.EndpointBuilder.Metadata.Add(ApiEndpointMetadata.Instance);
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("Todo", new PropertyAsParameterInfo(false, typeof(Microsoft.AspNetCore.Http.Generators.Tests.ParameterRecordStructWithJsonBodyOrService)!.GetProperty("Todo")!), hasTryParse: false, hasBindAsync: false, isOptional: false));
                 options.EndpointBuilder.Metadata.Add(new ParameterBindingMetadata("Service", new PropertyAsParameterInfo(false, typeof(Microsoft.AspNetCore.Http.Generators.Tests.ParameterRecordStructWithJsonBodyOrService)!.GetProperty("Service")!), hasTryParse: false, hasBindAsync: false, isOptional: false));
                 options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, type: typeof(string), contentTypes: GeneratedMetadataConstants.PlaintextContentType));
@@ -966,6 +969,22 @@ namespace Microsoft.AspNetCore.Http.Generated
 
     }
 
+    file sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static readonly ApiEndpointMetadata Instance = new();
+
+        private ApiEndpointMetadata()
+        {
+        }
+
+        public static void AddApiEndpointMetadataIfMissing(EndpointBuilder builder)
+        {
+            if (!builder.Metadata.Any(m => m is IApiEndpointMetadata))
+            {
+                builder.Metadata.Add(Instance);
+            }
+        }
+    }
     %GENERATEDCODEATTRIBUTE%
     file static class GeneratedMetadataConstants
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.Metadata.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.Metadata.cs
@@ -83,17 +83,14 @@ app.MapGet("/", Task<string> () => Task.FromResult("Hello, world!"));
     }
 
     [Fact]
-    public async Task MapAction_ReturnsTask_ProducesInferredMetadata()
+    public async Task MapAction_ReturnsTask_ProducesNoInferredProducesResponseTypeMetadata()
     {
         var (_, compilation) = await RunGeneratorAsync("""
 app.MapGet("/", Task () => Task.CompletedTask);
 """);
         var endpoint = GetEndpointFromCompilation(compilation);
 
-        var metadata = endpoint.Metadata.OfType<IProducesResponseTypeMetadata>().Single();
-        Assert.Equal(200, metadata.StatusCode);
-        Assert.Equal("text/plain", metadata.ContentTypes.Single());
-        Assert.Equal(typeof(void), metadata.Type);
+        Assert.Empty(endpoint.Metadata.OfType<IProducesResponseTypeMetadata>());
     }
 
     [Fact]
@@ -111,17 +108,14 @@ app.MapGet("/", ValueTask<string> () => ValueTask.FromResult("Hello, world!"));
     }
 
     [Fact]
-    public async Task MapAction_ReturnsValueTask_ProducesInferredMetadata()
+    public async Task MapAction_ReturnsValueTask_ProducesNoInferredProducesResponseTypeMetadata()
     {
         var (_, compilation) = await RunGeneratorAsync("""
 app.MapGet("/", ValueTask () => ValueTask.CompletedTask);
 """);
         var endpoint = GetEndpointFromCompilation(compilation);
 
-        var metadata = endpoint.Metadata.OfType<IProducesResponseTypeMetadata>().Single();
-        Assert.Equal(200, metadata.StatusCode);
-        Assert.Equal("text/plain", metadata.ContentTypes.Single());
-        Assert.Equal(typeof(void), metadata.Type);
+        Assert.Empty(endpoint.Metadata.OfType<IProducesResponseTypeMetadata>());
     }
 
     [Fact]
@@ -530,6 +524,8 @@ app.MapPost("/test/pattern", [Attribute1, Attribute2] (AddsCustomParameterMetada
         Assert.Collection(filteredMetadata,
             // Inferred AcceptsMetadata from RDF for complex type
             m => Assert.True(m is IAcceptsMetadata am && am.RequestType == typeof(AddsCustomParameterMetadata)),
+            // Inferred IApiEndpointMetadata from RDF for complex request and response type
+            m => Assert.True(m is IApiEndpointMetadata),
             // Parameter binding metadata inferred by RDF
             m => Assert.True(m is IParameterBindingMetadata { Name: "param1" }),
             // Inferred ProducesResopnseTypeMetadata from RDF for complex type

--- a/src/Http/Http.Results/src/Accepted.cs
+++ b/src/Http/Http.Results/src/Accepted.cs
@@ -82,5 +82,6 @@ public sealed class Accepted : IResult, IEndpointMetadataProvider, IStatusCodeHt
         ArgumentNullException.ThrowIfNull(builder);
 
         builder.Metadata.Add(new ProducesResponseTypeMetadata(StatusCodes.Status202Accepted, typeof(void)));
+        builder.Metadata.Add(ApiEndpointMetadata.Instance);
     }
 }

--- a/src/Http/Http.Results/src/AcceptedAtRoute.cs
+++ b/src/Http/Http.Results/src/AcceptedAtRoute.cs
@@ -109,5 +109,6 @@ public sealed class AcceptedAtRoute : IResult, IEndpointMetadataProvider, IStatu
         ArgumentNullException.ThrowIfNull(builder);
 
         builder.Metadata.Add(new ProducesResponseTypeMetadata(StatusCodes.Status202Accepted, typeof(void)));
+        builder.Metadata.Add(ApiEndpointMetadata.Instance);
     }
 }

--- a/src/Http/Http.Results/src/AcceptedAtRouteOfT.cs
+++ b/src/Http/Http.Results/src/AcceptedAtRouteOfT.cs
@@ -123,5 +123,6 @@ public sealed class AcceptedAtRoute<TValue> : IResult, IEndpointMetadataProvider
         ArgumentNullException.ThrowIfNull(builder);
 
         builder.Metadata.Add(ProducesResponseTypeMetadata.CreateUnvalidated(typeof(TValue), StatusCodes.Status202Accepted, ContentTypeConstants.ApplicationJsonContentTypes));
+        builder.Metadata.Add(ApiEndpointMetadata.Instance);
     }
 }

--- a/src/Http/Http.Results/src/AcceptedOfT.cs
+++ b/src/Http/Http.Results/src/AcceptedOfT.cs
@@ -101,5 +101,6 @@ public sealed class Accepted<TValue> : IResult, IEndpointMetadataProvider, IStat
         ArgumentNullException.ThrowIfNull(builder);
 
         builder.Metadata.Add(ProducesResponseTypeMetadata.CreateUnvalidated(typeof(TValue), StatusCodes.Status202Accepted, ContentTypeConstants.ApplicationJsonContentTypes));
+        builder.Metadata.Add(ApiEndpointMetadata.Instance);
     }
 }

--- a/src/Http/Http.Results/src/BadRequest.cs
+++ b/src/Http/Http.Results/src/BadRequest.cs
@@ -52,5 +52,6 @@ public sealed class BadRequest : IResult, IEndpointMetadataProvider, IStatusCode
         ArgumentNullException.ThrowIfNull(builder);
 
         builder.Metadata.Add(new ProducesResponseTypeMetadata(StatusCodes.Status400BadRequest, typeof(void)));
+        builder.Metadata.Add(ApiEndpointMetadata.Instance);
     }
 }

--- a/src/Http/Http.Results/src/BadRequestOfT.cs
+++ b/src/Http/Http.Results/src/BadRequestOfT.cs
@@ -66,5 +66,6 @@ public sealed class BadRequest<TValue> : IResult, IEndpointMetadataProvider, ISt
         ArgumentNullException.ThrowIfNull(builder);
 
         builder.Metadata.Add(ProducesResponseTypeMetadata.CreateUnvalidated(typeof(TValue), StatusCodes.Status400BadRequest, ContentTypeConstants.ApplicationJsonContentTypes));
+        builder.Metadata.Add(ApiEndpointMetadata.Instance);
     }
 }

--- a/src/Http/Http.Results/src/Conflict.cs
+++ b/src/Http/Http.Results/src/Conflict.cs
@@ -52,5 +52,6 @@ public sealed class Conflict : IResult, IEndpointMetadataProvider, IStatusCodeHt
         ArgumentNullException.ThrowIfNull(builder);
 
         builder.Metadata.Add(new ProducesResponseTypeMetadata(StatusCodes.Status409Conflict, typeof(void)));
+        builder.Metadata.Add(ApiEndpointMetadata.Instance);
     }
 }

--- a/src/Http/Http.Results/src/ConflictOfT.cs
+++ b/src/Http/Http.Results/src/ConflictOfT.cs
@@ -66,5 +66,6 @@ public sealed class Conflict<TValue> : IResult, IEndpointMetadataProvider, IStat
         ArgumentNullException.ThrowIfNull(builder);
 
         builder.Metadata.Add(ProducesResponseTypeMetadata.CreateUnvalidated(typeof(TValue), StatusCodes.Status409Conflict, ContentTypeConstants.ApplicationJsonContentTypes));
+        builder.Metadata.Add(ApiEndpointMetadata.Instance);
     }
 }

--- a/src/Http/Http.Results/src/Created.cs
+++ b/src/Http/Http.Results/src/Created.cs
@@ -82,5 +82,6 @@ public sealed class Created : IResult, IEndpointMetadataProvider, IStatusCodeHtt
         ArgumentNullException.ThrowIfNull(builder);
 
         builder.Metadata.Add(new ProducesResponseTypeMetadata(StatusCodes.Status201Created, typeof(void)));
+        builder.Metadata.Add(ApiEndpointMetadata.Instance);
     }
 }

--- a/src/Http/Http.Results/src/CreatedAtRoute.cs
+++ b/src/Http/Http.Results/src/CreatedAtRoute.cs
@@ -109,5 +109,6 @@ public sealed class CreatedAtRoute : IResult, IEndpointMetadataProvider, IStatus
         ArgumentNullException.ThrowIfNull(builder);
 
         builder.Metadata.Add(new ProducesResponseTypeMetadata(StatusCodes.Status201Created, typeof(void)));
+        builder.Metadata.Add(ApiEndpointMetadata.Instance);
     }
 }

--- a/src/Http/Http.Results/src/CreatedAtRouteOfT.cs
+++ b/src/Http/Http.Results/src/CreatedAtRouteOfT.cs
@@ -126,5 +126,6 @@ public sealed class CreatedAtRoute<TValue> : IResult, IEndpointMetadataProvider,
         ArgumentNullException.ThrowIfNull(builder);
 
         builder.Metadata.Add(ProducesResponseTypeMetadata.CreateUnvalidated(typeof(TValue), StatusCodes.Status201Created, ContentTypeConstants.ApplicationJsonContentTypes));
+        builder.Metadata.Add(ApiEndpointMetadata.Instance);
     }
 }

--- a/src/Http/Http.Results/src/CreatedOfT.cs
+++ b/src/Http/Http.Results/src/CreatedOfT.cs
@@ -100,5 +100,6 @@ public sealed class Created<TValue> : IResult, IEndpointMetadataProvider, IStatu
         ArgumentNullException.ThrowIfNull(builder);
 
         builder.Metadata.Add(ProducesResponseTypeMetadata.CreateUnvalidated(typeof(TValue), StatusCodes.Status201Created, ContentTypeConstants.ApplicationJsonContentTypes));
+        builder.Metadata.Add(ApiEndpointMetadata.Instance);
     }
 }

--- a/src/Http/Http.Results/src/InternalServerErrorOfT.cs
+++ b/src/Http/Http.Results/src/InternalServerErrorOfT.cs
@@ -66,5 +66,6 @@ public sealed class InternalServerError<TValue> : IResult, IEndpointMetadataProv
         ArgumentNullException.ThrowIfNull(builder);
 
         builder.Metadata.Add(ProducesResponseTypeMetadata.CreateUnvalidated(typeof(TValue), StatusCodes.Status500InternalServerError, ContentTypeConstants.ApplicationJsonContentTypes));
+        builder.Metadata.Add(ApiEndpointMetadata.Instance);
     }
 }

--- a/src/Http/Http.Results/src/JsonHttpResultOfT.cs
+++ b/src/Http/Http.Results/src/JsonHttpResultOfT.cs
@@ -2,8 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -13,7 +16,7 @@ namespace Microsoft.AspNetCore.Http.HttpResults;
 /// <summary>
 /// An action result which formats the given object as JSON.
 /// </summary>
-public sealed partial class JsonHttpResult<TValue> : IResult, IStatusCodeHttpResult, IValueHttpResult, IValueHttpResult<TValue>, IContentTypeHttpResult
+public sealed partial class JsonHttpResult<TValue> : IResult, IEndpointMetadataProvider, IStatusCodeHttpResult, IValueHttpResult, IValueHttpResult<TValue>, IContentTypeHttpResult
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="Json"/> class with the values.
@@ -117,7 +120,7 @@ public sealed partial class JsonHttpResult<TValue> : IResult, IStatusCodeHttpRes
                     typedJsonTypeInfo,
                     contentType: ContentType);
             }
-            
+
             return httpContext.Response.WriteAsJsonAsync(
                 Value,
                 JsonTypeInfo,
@@ -130,5 +133,10 @@ public sealed partial class JsonHttpResult<TValue> : IResult, IStatusCodeHttpRes
             Value,
             ContentType,
             JsonSerializerOptions);
+    }
+
+    static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder)
+    {
+        builder.Metadata.Add(ApiEndpointMetadata.Instance);
     }
 }

--- a/src/Http/Http.Results/src/NoContent.cs
+++ b/src/Http/Http.Results/src/NoContent.cs
@@ -52,5 +52,6 @@ public class NoContent : IResult, IEndpointMetadataProvider, IStatusCodeHttpResu
         ArgumentNullException.ThrowIfNull(builder);
 
         builder.Metadata.Add(new ProducesResponseTypeMetadata(StatusCodes.Status204NoContent, typeof(void)));
+        builder.Metadata.Add(ApiEndpointMetadata.Instance);
     }
 }

--- a/src/Http/Http.Results/src/NotFoundOfT.cs
+++ b/src/Http/Http.Results/src/NotFoundOfT.cs
@@ -65,5 +65,6 @@ public sealed class NotFound<TValue> : IResult, IEndpointMetadataProvider, IStat
         ArgumentNullException.ThrowIfNull(builder);
 
         builder.Metadata.Add(ProducesResponseTypeMetadata.CreateUnvalidated(typeof(TValue), StatusCodes.Status404NotFound, ContentTypeConstants.ApplicationJsonContentTypes));
+        builder.Metadata.Add(ApiEndpointMetadata.Instance);
     }
 }

--- a/src/Http/Http.Results/src/Ok.cs
+++ b/src/Http/Http.Results/src/Ok.cs
@@ -51,5 +51,6 @@ public sealed class Ok : IResult, IEndpointMetadataProvider, IStatusCodeHttpResu
         ArgumentNullException.ThrowIfNull(builder);
 
         builder.Metadata.Add(new ProducesResponseTypeMetadata(StatusCodes.Status200OK, typeof(void)));
+        builder.Metadata.Add(ApiEndpointMetadata.Instance);
     }
 }

--- a/src/Http/Http.Results/src/OkOfT.cs
+++ b/src/Http/Http.Results/src/OkOfT.cs
@@ -65,5 +65,6 @@ public sealed class Ok<TValue> : IResult, IEndpointMetadataProvider, IStatusCode
         ArgumentNullException.ThrowIfNull(builder);
 
         builder.Metadata.Add(ProducesResponseTypeMetadata.CreateUnvalidated(typeof(TValue), StatusCodes.Status200OK, ContentTypeConstants.ApplicationJsonContentTypes));
+        builder.Metadata.Add(ApiEndpointMetadata.Instance);
     }
 }

--- a/src/Http/Http.Results/src/ProblemHttpResult.cs
+++ b/src/Http/Http.Results/src/ProblemHttpResult.cs
@@ -4,6 +4,9 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using System.Reflection;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http.Metadata;
 
 namespace Microsoft.AspNetCore.Http.HttpResults;
 
@@ -11,7 +14,7 @@ namespace Microsoft.AspNetCore.Http.HttpResults;
 /// An <see cref="IResult"/> that on execution will write Problem Details
 /// HTTP API responses based on <see href="https://tools.ietf.org/html/rfc7807"/>
 /// </summary>
-public sealed class ProblemHttpResult : IResult, IStatusCodeHttpResult, IContentTypeHttpResult, IValueHttpResult, IValueHttpResult<ProblemDetails>
+public sealed class ProblemHttpResult : IResult, IEndpointMetadataProvider, IStatusCodeHttpResult, IContentTypeHttpResult, IValueHttpResult, IValueHttpResult<ProblemDetails>
 {
     /// <summary>
     /// Creates a new <see cref="ProblemHttpResult"/> instance with
@@ -68,5 +71,14 @@ public sealed class ProblemHttpResult : IResult, IStatusCodeHttpResult, IContent
                 value: ProblemDetails,
                 ContentType);
         }
+    }
+
+    /// <inheritdoc/>
+    static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(method);
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Metadata.Add(ApiEndpointMetadata.Instance);
     }
 }

--- a/src/Http/Http.Results/src/ServerSentEventsResult.cs
+++ b/src/Http/Http.Results/src/ServerSentEventsResult.cs
@@ -105,5 +105,6 @@ public sealed class ServerSentEventsResult<T> : IResult, IEndpointMetadataProvid
         ArgumentNullException.ThrowIfNull(builder);
 
         builder.Metadata.Add(new ProducesResponseTypeMetadata(StatusCodes.Status200OK, typeof(SseItem<T>), contentTypes: ["text/event-stream"]));
+        builder.Metadata.Add(ApiEndpointMetadata.Instance);
     }
 }

--- a/src/Http/Http.Results/src/UnprocessableEntity.cs
+++ b/src/Http/Http.Results/src/UnprocessableEntity.cs
@@ -52,5 +52,6 @@ public sealed class UnprocessableEntity : IResult, IEndpointMetadataProvider, IS
         ArgumentNullException.ThrowIfNull(builder);
 
         builder.Metadata.Add(new ProducesResponseTypeMetadata(StatusCodes.Status422UnprocessableEntity, typeof(void)));
+        builder.Metadata.Add(ApiEndpointMetadata.Instance);
     }
 }

--- a/src/Http/Http.Results/src/UnprocessableEntityOfT.cs
+++ b/src/Http/Http.Results/src/UnprocessableEntityOfT.cs
@@ -66,5 +66,6 @@ public sealed class UnprocessableEntity<TValue> : IResult, IEndpointMetadataProv
         ArgumentNullException.ThrowIfNull(builder);
 
         builder.Metadata.Add(ProducesResponseTypeMetadata.CreateUnvalidated(typeof(TValue), StatusCodes.Status422UnprocessableEntity, ContentTypeConstants.ApplicationJsonContentTypes));
+        builder.Metadata.Add(ApiEndpointMetadata.Instance);
     }
 }

--- a/src/Http/Http.Results/src/ValidationProblem.cs
+++ b/src/Http/Http.Results/src/ValidationProblem.cs
@@ -77,5 +77,6 @@ public sealed class ValidationProblem : IResult, IEndpointMetadataProvider, ISta
         ArgumentNullException.ThrowIfNull(builder);
 
         builder.Metadata.Add(ProducesResponseTypeMetadata.CreateUnvalidated(typeof(HttpValidationProblemDetails), StatusCodes.Status400BadRequest, ContentTypeConstants.ProblemDetailsContentTypes));
+        builder.Metadata.Add(ApiEndpointMetadata.Instance);
     }
 }

--- a/src/Http/Http.Results/test/AcceptedAtRouteOfTResultTests.cs
+++ b/src/Http/Http.Results/test/AcceptedAtRouteOfTResultTests.cs
@@ -134,6 +134,8 @@ public class AcceptedAtRouteOfTResultTests
         Assert.Equal(StatusCodes.Status202Accepted, producesResponseTypeMetadata.StatusCode);
         Assert.Equal(typeof(Todo), producesResponseTypeMetadata.Type);
         Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/json");
+
+        Assert.Contains(builder.Metadata, m => m is IApiEndpointMetadata);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/AcceptedAtRouteResultTests.cs
+++ b/src/Http/Http.Results/test/AcceptedAtRouteResultTests.cs
@@ -87,6 +87,8 @@ public class AcceptedAtRouteResultTests
         var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
         Assert.Equal(StatusCodes.Status202Accepted, producesResponseTypeMetadata.StatusCode);
         Assert.Equal(typeof(void), producesResponseTypeMetadata.Type);
+
+        Assert.Contains(builder.Metadata, m => m is IApiEndpointMetadata);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/AcceptedOfTResultTests.cs
+++ b/src/Http/Http.Results/test/AcceptedOfTResultTests.cs
@@ -75,6 +75,8 @@ public class AcceptedOfTResultTests
         Assert.Equal(StatusCodes.Status202Accepted, producesResponseTypeMetadata.StatusCode);
         Assert.Equal(typeof(Todo), producesResponseTypeMetadata.Type);
         Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/json");
+
+        Assert.Contains(builder.Metadata, m => m is IApiEndpointMetadata);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/AcceptedResultTests.cs
+++ b/src/Http/Http.Results/test/AcceptedResultTests.cs
@@ -44,6 +44,8 @@ public class AcceptedResultTests
         var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
         Assert.Equal(StatusCodes.Status202Accepted, producesResponseTypeMetadata.StatusCode);
         Assert.Equal(typeof(void), producesResponseTypeMetadata.Type);
+
+        Assert.Contains(builder.Metadata, m => m is IApiEndpointMetadata);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/BadRequestOfTResultTests.cs
+++ b/src/Http/Http.Results/test/BadRequestOfTResultTests.cs
@@ -118,6 +118,8 @@ public class BadRequestOfTResultTests
         Assert.Equal(StatusCodes.Status400BadRequest, producesResponseTypeMetadata.StatusCode);
         Assert.Equal(typeof(Todo), producesResponseTypeMetadata.Type);
         Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/json");
+
+        Assert.Contains(builder.Metadata, m => m is IApiEndpointMetadata);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/BadRequestResultTests.cs
+++ b/src/Http/Http.Results/test/BadRequestResultTests.cs
@@ -57,6 +57,8 @@ public class BadRequestResultTests
         var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
         Assert.Equal(StatusCodes.Status400BadRequest, producesResponseTypeMetadata.StatusCode);
         Assert.Equal(typeof(void), producesResponseTypeMetadata.Type);
+
+        Assert.Contains(builder.Metadata, m => m is IApiEndpointMetadata);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/ConflictOfTResultTests.cs
+++ b/src/Http/Http.Results/test/ConflictOfTResultTests.cs
@@ -96,6 +96,8 @@ public class ConflictOfTResultTests
         Assert.Equal(StatusCodes.Status409Conflict, producesResponseTypeMetadata.StatusCode);
         Assert.Equal(typeof(Todo), producesResponseTypeMetadata.Type);
         Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/json");
+
+        Assert.Contains(builder.Metadata, m => m is IApiEndpointMetadata);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/ConflictResultTests.cs
+++ b/src/Http/Http.Results/test/ConflictResultTests.cs
@@ -58,6 +58,8 @@ public class ConflictResultTests
         var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
         Assert.Equal(StatusCodes.Status409Conflict, producesResponseTypeMetadata.StatusCode);
         Assert.Equal(typeof(void), producesResponseTypeMetadata.Type);
+
+        Assert.Contains(builder.Metadata, m => m is IApiEndpointMetadata);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/CreatedAtRouteOfTResultTests.cs
+++ b/src/Http/Http.Results/test/CreatedAtRouteOfTResultTests.cs
@@ -104,6 +104,8 @@ public partial class CreatedAtRouteOfTResultTests
         Assert.Equal(StatusCodes.Status201Created, producesResponseTypeMetadata.StatusCode);
         Assert.Equal(typeof(Todo), producesResponseTypeMetadata.Type);
         Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/json");
+
+        Assert.Contains(builder.Metadata, m => m is IApiEndpointMetadata);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/CreatedAtRouteResultTests.cs
+++ b/src/Http/Http.Results/test/CreatedAtRouteResultTests.cs
@@ -85,6 +85,8 @@ public partial class CreatedAtRouteResultTests
         var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
         Assert.Equal(StatusCodes.Status201Created, producesResponseTypeMetadata.StatusCode);
         Assert.Equal(typeof(void), producesResponseTypeMetadata.Type);
+
+        Assert.Contains(builder.Metadata, m => m is IApiEndpointMetadata);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/CreatedOfTResultTests.cs
+++ b/src/Http/Http.Results/test/CreatedOfTResultTests.cs
@@ -110,6 +110,8 @@ public class CreatedOfTResultTests
         Assert.Equal(StatusCodes.Status201Created, producesResponseTypeMetadata.StatusCode);
         Assert.Equal(typeof(Todo), producesResponseTypeMetadata.Type);
         Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/json");
+
+        Assert.Contains(builder.Metadata, m => m is IApiEndpointMetadata);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/CreatedResultTests.cs
+++ b/src/Http/Http.Results/test/CreatedResultTests.cs
@@ -75,6 +75,8 @@ public class CreatedResultTests
         var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
         Assert.Equal(StatusCodes.Status201Created, producesResponseTypeMetadata.StatusCode);
         Assert.Equal(typeof(void), producesResponseTypeMetadata.Type);
+
+        Assert.Contains(builder.Metadata, m => m is IApiEndpointMetadata);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/InternalServerErrorOfTResultTests.cs
+++ b/src/Http/Http.Results/test/InternalServerErrorOfTResultTests.cs
@@ -118,6 +118,8 @@ public class InternalServerErrorOfTResultTests
         Assert.Equal(StatusCodes.Status500InternalServerError, producesResponseTypeMetadata.StatusCode);
         Assert.Equal(typeof(Todo), producesResponseTypeMetadata.Type);
         Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/json");
+
+        Assert.Contains(builder.Metadata, m => m is IApiEndpointMetadata);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/JsonResultTests.cs
+++ b/src/Http/Http.Results/test/JsonResultTests.cs
@@ -1,11 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using System.Text.Unicode;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Json;
+using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -309,6 +314,24 @@ public class JsonResultTests
         Assert.IsType<string>(result.Value);
         Assert.Equal(value, result.Value);
     }
+
+    [Fact]
+    public void PopulateMetadata_AddsNonBrowserEndpointMetadata()
+    {
+        // Arrange
+        JsonHttpResult<Todo> MyApi() { throw new NotImplementedException(); }
+        var metadata = new List<object>();
+        var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
+
+        // Act
+        PopulateMetadata<JsonHttpResult<Todo>>(((Delegate)MyApi).GetMethodInfo(), builder);
+
+        // Assert
+        Assert.Contains(builder.Metadata, m => m is IApiEndpointMetadata);
+    }
+
+    private static void PopulateMetadata<TResult>(MethodInfo method, EndpointBuilder builder)
+        where TResult : IEndpointMetadataProvider => TResult.PopulateMetadata(method, builder);
 
     private static IServiceProvider CreateServices()
     {

--- a/src/Http/Http.Results/test/NoContentResultTests.cs
+++ b/src/Http/Http.Results/test/NoContentResultTests.cs
@@ -54,6 +54,9 @@ public class NoContentResultTests
         var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
         Assert.Equal(StatusCodes.Status204NoContent, producesResponseTypeMetadata.StatusCode);
         Assert.Equal(typeof(void), producesResponseTypeMetadata.Type);
+
+        // Assert ApiEndpointMetadata is added
+        Assert.Contains(builder.Metadata, m => m is IApiEndpointMetadata);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/NotFoundOfTResultTests.cs
+++ b/src/Http/Http.Results/test/NotFoundOfTResultTests.cs
@@ -78,6 +78,8 @@ public class NotFoundOfTResultTests
         Assert.Equal(StatusCodes.Status404NotFound, producesResponseTypeMetadata.StatusCode);
         Assert.Equal(typeof(Todo), producesResponseTypeMetadata.Type);
         Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/json");
+
+        Assert.Contains(builder.Metadata, m => m is IApiEndpointMetadata);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/OkOfTResultTests.cs
+++ b/src/Http/Http.Results/test/OkOfTResultTests.cs
@@ -95,6 +95,8 @@ public class OkOfTResultTests
         Assert.Equal(StatusCodes.Status200OK, producesResponseTypeMetadata.StatusCode);
         Assert.Equal(typeof(Todo), producesResponseTypeMetadata.Type);
         Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/json");
+
+        Assert.Contains(builder.Metadata, m => m is IApiEndpointMetadata);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/OkResultTests.cs
+++ b/src/Http/Http.Results/test/OkResultTests.cs
@@ -56,6 +56,8 @@ public class OkResultTests
         var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
         Assert.Equal(StatusCodes.Status200OK, producesResponseTypeMetadata.StatusCode);
         Assert.Equal(typeof(void), producesResponseTypeMetadata.Type);
+
+        Assert.Contains(builder.Metadata, m => m is IApiEndpointMetadata);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/UnprocessableEntityOfTResultTests.cs
+++ b/src/Http/Http.Results/test/UnprocessableEntityOfTResultTests.cs
@@ -95,6 +95,8 @@ public class UnprocessableEntityOfTResultTests
         Assert.Equal(StatusCodes.Status422UnprocessableEntity, producesResponseTypeMetadata.StatusCode);
         Assert.Equal(typeof(Todo), producesResponseTypeMetadata.Type);
         Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/json");
+
+        Assert.Contains(builder.Metadata, m => m is IApiEndpointMetadata);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/UnprocessableEntityResultTests.cs
+++ b/src/Http/Http.Results/test/UnprocessableEntityResultTests.cs
@@ -57,6 +57,8 @@ public class UnprocessableEntityResultTests
         var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
         Assert.Equal(StatusCodes.Status422UnprocessableEntity, producesResponseTypeMetadata.StatusCode);
         Assert.Equal(typeof(void), producesResponseTypeMetadata.Type);
+
+        Assert.Contains(builder.Metadata, m => m is IApiEndpointMetadata);
     }
 
     [Fact]

--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -332,10 +332,9 @@ internal sealed class EndpointMetadataApiDescriptionProvider : IApiDescriptionPr
         var defaultErrorType = errorMetadata?.Type ?? typeof(void);
         var contentTypes = new MediaTypeCollection();
 
-        // If the return type is an IResult or an awaitable IResult, then we should treat it as a void return type
-        // since we can't infer anything without additional metadata.
-        if (typeof(IResult).IsAssignableFrom(responseType) ||
-            producesResponseMetadata.Any(metadata => typeof(IResult).IsAssignableFrom(metadata.Type)))
+        // If the return type is an IResult or wrapped in a Task or ValueTask, then we should treat it as a void return type
+        // since we can't infer anything without additional metadata or requiring unreferenced code.
+        if (IsTaskOrValueTask(responseType) || typeof(IResult).IsAssignableFrom(responseType))
         {
             responseType = typeof(void);
         }
@@ -426,6 +425,23 @@ internal sealed class EndpointMetadataApiDescriptionProvider : IApiDescriptionPr
             // For more information, check the related bug: https://github.com/dotnet/aspnetcore/issues/60518
             return apiResponseType == metadataType ||
                 metadataType?.IsAssignableFrom(apiResponseType) == true;
+        }
+
+        static bool IsTaskOrValueTask(Type returnType)
+        {
+            // If this method did not need to be trim-safe, we would use CoercedAwaitableInfo.IsTypeAwaitable, but we cannot.
+            if (returnType.IsAssignableFrom(typeof(Task)) || returnType.IsAssignableFrom(typeof(ValueTask)))
+            {
+                return true;
+            }
+
+            if (returnType.FullName is null)
+            {
+                return false;
+            }
+
+            return returnType.FullName.StartsWith("System.Threading.Tasks.Task`1[", StringComparison.Ordinal) ||
+                returnType.FullName.StartsWith("System.Threading.Tasks.ValueTask`1[", StringComparison.Ordinal);
         }
     }
 

--- a/src/Mvc/Mvc.Core/src/ApiControllerAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/ApiControllerAttribute.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 
 namespace Microsoft.AspNetCore.Mvc;
@@ -17,6 +18,6 @@ namespace Microsoft.AspNetCore.Mvc;
 /// </para>
 /// </summary>
 [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
-public class ApiControllerAttribute : ControllerAttribute, IApiBehaviorMetadata
+public class ApiControllerAttribute : ControllerAttribute, IApiBehaviorMetadata, IApiEndpointMetadata
 {
 }

--- a/src/Mvc/Mvc.Core/test/ApplicationModels/DefaultApplicationModelProviderTest.cs
+++ b/src/Mvc/Mvc.Core/test/ApplicationModels/DefaultApplicationModelProviderTest.cs
@@ -3,6 +3,7 @@
 
 using System.Reflection;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Mvc.ActionConstraints;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
@@ -1277,8 +1278,9 @@ public class DefaultApplicationModelProviderTest
 
         // Assert
         Assert.NotNull(selector.EndpointMetadata);
-        Assert.Single(selector.EndpointMetadata);
-        Assert.IsType<ProducesResponseTypeMetadata>(selector.EndpointMetadata.Single()); 
+        Assert.Equal(2, selector.EndpointMetadata.Count);
+        Assert.Single(selector.EndpointMetadata.OfType<ProducesResponseTypeMetadata>());
+        Assert.Single(selector.EndpointMetadata.OfType<IApiEndpointMetadata>());
         Assert.Equal(200, ((ProducesResponseTypeMetadata)selector.EndpointMetadata[0]).StatusCode);
     }
 

--- a/src/SignalR/common/Http.Connections/src/ConnectionEndpointRouteBuilderExtensions.cs
+++ b/src/SignalR/common/Http.Connections/src/ConnectionEndpointRouteBuilderExtensions.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.Http.Connections.Internal;
+using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Http.Timeouts;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -125,6 +126,9 @@ public static class ConnectionEndpointRouteBuilderExtensions
             {
                 e.Metadata.Add(data);
             }
+
+            // Add INonBrowserEndpointMetadata to indicate this is a non-browser endpoint (SignalR)
+            e.Metadata.Add(ApiEndpointMetadata.Instance);
         });
 
         return new ConnectionEndpointRouteBuilder(compositeConventionBuilder);
@@ -154,5 +158,10 @@ public static class ConnectionEndpointRouteBuilderExtensions
                 endpointConventionBuilder.Finally(finalConvention);
             }
         }
+    }
+
+    private sealed class ApiEndpointMetadata : IApiEndpointMetadata
+    {
+        public static ApiEndpointMetadata Instance { get; } = new();
     }
 }

--- a/src/SignalR/common/Http.Connections/src/ConnectionEndpointRouteBuilderExtensions.cs
+++ b/src/SignalR/common/Http.Connections/src/ConnectionEndpointRouteBuilderExtensions.cs
@@ -127,7 +127,7 @@ public static class ConnectionEndpointRouteBuilderExtensions
                 e.Metadata.Add(data);
             }
 
-            // Add INonBrowserEndpointMetadata to indicate this is a non-browser endpoint (SignalR)
+            // Add IApiEndpointMetadata to indicate this is a non-browser endpoint (SignalR)
             e.Metadata.Add(ApiEndpointMetadata.Instance);
         });
 


### PR DESCRIPTION
This adds IApiEndpointMetadata as new public API. It doesn't add any attributes or extension methods, but we do add it automatically for endpoints where RDF/RDG read a JSON request body or write a JSON response body. ApiController endpoints, SignalR endpoints and endpoints with TypedResults return-types that we know to be API-oriented also get this metadata automatically.

API Proposal: #62883

Fixes #9039
