### PR TITLE
Follow-up on IsLocalhost TLD local dev

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/AddressBinder.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/AddressBinder.cs
@@ -152,10 +152,11 @@ internal sealed class AddressBinder
             }
 
             // Check for use of .localhost TLD (Top Level Domain)
-            if (host.Length > 10 && host.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase))
+            const string localhostTld = ".localhost";
+            if (host.Length > localhostTld.Length && host.EndsWith(localhostTld, StringComparison.OrdinalIgnoreCase))
             {
                 // Take all but the .localhost TLD as the prefix
-                prefix = host[..^10]; // 10 is the length of ".localhost"
+                prefix = host[..^localhostTld.Length];
                 return true;
             }
 

--- a/src/Servers/Kestrel/Core/src/Internal/AddressBinder.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/AddressBinder.cs
@@ -142,18 +142,17 @@ internal sealed class AddressBinder
 
         return options;
 
-        bool IsLocalhost(string host, out string? prefix)
+        static bool IsLocalhost(string host, out string? prefix)
         {
             // Check for "localhost"
-            if (string.Equals(parsedAddress.Host, "localhost", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase))
             {
                 prefix = null;
                 return true;
             }
 
             // Check for use of .localhost TLD (Top Level Domain)
-            if (host.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase)
-                && !string.Equals(parsedAddress.Host, ".localhost", StringComparison.OrdinalIgnoreCase))
+            if (host.Length > 10 && host.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase))
             {
                 // Take all but the .localhost TLD as the prefix
                 prefix = host[..^10]; // 10 is the length of ".localhost"


### PR DESCRIPTION
# IsLocalhost TLD optimization

IsLocalhost avoids capturing closure. Follow up on comment https://github.com/dotnet/aspnetcore/pull/62593#discussion_r2215834037

## Description

Changed `IsLocalhost` from an instance method to a static method. Updated the parameter to use `host` directly instead of `parsedAddress.Host`. Modified the check for the `.localhost` TLD to ensure the host length is greater than 10, optimizing the condition to avoid unnecessary checks for shorter hostnames.

It also avoids an additional string comparison, slightly improving the performance (both optimized and non-optimized (`[MethodImpl(MethodImplOptions.NoOptimization)]` cases), given this code is likely to run a lot with Debug builds.

Fixes #62592 
