### PR TITLE
Fixed race condition in the disposing of the QuickGrid

### DIFF
--- a/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
+++ b/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
@@ -89,6 +89,7 @@
     <InternalsVisibleTo Include="Microsoft.AspNetCore.Components.Tests" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.Components.Endpoints.Tests" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.Components.Web.Tests" />
+    <InternalsVisibleTo Include="Microsoft.AspNetCore.Components.QuickGrid.Tests" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.Components.ProtectedBrowserStorage.Tests" />
     <InternalsVisibleTo Include="Components.TestServer" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
@@ -152,6 +152,8 @@ public partial class QuickGrid<TGridItem> : IAsyncDisposable
     // If the PaginationState mutates, it raises this event. We use it to trigger a re-render.
     private readonly EventCallbackSubscriber<PaginationState> _currentPageItemsChanged;
 
+    private bool _disposeBool;
+
     /// <summary>
     /// Constructs an instance of <see cref="QuickGrid{TGridItem}"/>.
     /// </summary>
@@ -206,6 +208,11 @@ public partial class QuickGrid<TGridItem> : IAsyncDisposable
         if (firstRender)
         {
             _jsModule = await JS.InvokeAsync<IJSObjectReference>("import", "./_content/Microsoft.AspNetCore.Components.QuickGrid/QuickGrid.razor.js");
+            if (_disposeBool)
+            {
+                // If the component has been disposed while JS module was being loaded, we don't need to continue
+                return;
+            }
             _jsEventDisposable = await _jsModule.InvokeAsync<IJSObjectReference>("init", _tableReference);
         }
 
@@ -434,6 +441,7 @@ public partial class QuickGrid<TGridItem> : IAsyncDisposable
     /// <inheritdoc />
     public async ValueTask DisposeAsync()
     {
+        _disposeBool = true;
         _currentPageItemsChanged.Dispose();
 
         try

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/test/FailingQuickGrid.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/test/FailingQuickGrid.cs
@@ -35,11 +35,6 @@ internal class FailingQuickGrid<TGridItem> : QuickGrid<TGridItem>, IAsyncDisposa
     public new async ValueTask DisposeAsync()
     {
         DisposeAsyncWasCalled = true;
-        // Intentionally do nothing to prevent _disposeBool from being set to true
-        // This means the OnAfterRenderAsync method will not detect that the component is disposed
-        // and will proceed to call init() even after disposal, demonstrating the race condition
-
-        // DO NOT call base.DisposeAsync() - this is the key to simulating the race condition
         await Task.CompletedTask;
     }
 

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/test/FailingQuickGrid.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/test/FailingQuickGrid.cs
@@ -1,0 +1,109 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.QuickGrid;
+using Microsoft.JSInterop;
+using System.Reflection;
+
+namespace Microsoft.AspNetCore.Components.QuickGrid.Test;
+
+/// <summary>
+/// A QuickGrid implementation that simulates the behavior before the race condition fix.
+/// This class intentionally does NOT set _disposeBool during disposal to simulate the race condition.
+/// </summary>
+/// <typeparam name="TGridItem">The type of data represented by each row in the grid.</typeparam>
+internal class FailingQuickGrid<TGridItem> : QuickGrid<TGridItem>, IAsyncDisposable
+{
+    [Inject] private IJSRuntime JS { get; set; } = default!;
+
+    private readonly TaskCompletionSource _onAfterRenderCompleted = new();
+    private bool _completionSignaled;
+
+    public bool DisposeAsyncWasCalled { get; private set; }
+
+    /// <summary>
+    /// Task that completes when OnAfterRenderAsync has finished executing.
+    /// This allows tests to wait deterministically for the race condition to occur.
+    /// </summary>
+    public Task OnAfterRenderCompleted => _onAfterRenderCompleted.Task;
+
+    /// <summary>
+    /// Intentionally does NOT call base.DisposeAsync() to prevent _disposeBool from being set.
+    /// This simulates the behavior before the fix was implemented.
+    /// </summary>
+    public new async ValueTask DisposeAsync()
+    {
+        DisposeAsyncWasCalled = true;
+        // Intentionally do nothing to prevent _disposeBool from being set to true
+        // This means the OnAfterRenderAsync method will not detect that the component is disposed
+        // and will proceed to call init() even after disposal, demonstrating the race condition
+
+        // DO NOT call base.DisposeAsync() - this is the key to simulating the race condition
+        await Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Explicit interface implementation to ensure our disposal method is called.
+    /// </summary>
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        await DisposeAsync();
+    }
+
+    /// <summary>
+    /// Check if _disposeBool is false, proving we didn't call base.DisposeAsync().
+    /// This is used by tests to verify that our simulation is working correctly.
+    /// </summary>
+    public bool IsDisposeBoolFalse()
+    {
+        var field = typeof(QuickGrid<TGridItem>).GetField("_disposeBool", BindingFlags.NonPublic | BindingFlags.Instance);
+        return field?.GetValue(this) is false;
+    }
+
+    /// <summary>
+    /// Override OnAfterRenderAsync to simulate the race condition by NOT checking _disposeBool.
+    /// This exactly replicates the code path that existed before the race condition fix.
+    /// </summary>
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        try
+        {
+            if (firstRender)
+            {
+                // Get the IJSRuntime (same as base class)
+                if (JS != null)
+                {
+                    // Import the JS module (this will trigger our TestJsRuntime's import logic)
+                    var jsModule = await JS.InvokeAsync<IJSObjectReference>("import",
+                        "./_content/Microsoft.AspNetCore.Components.QuickGrid/QuickGrid.razor.js");
+
+                    // THE KEY DIFFERENCE: The original code did NOT check _disposeBool here
+                    // The fix added: if (_disposeBool) return;
+                    // By omitting this check, we demonstrate the race condition where init gets called on disposed components
+
+                    // Call init - this happens even if component was disposed during import
+                    // For our test, we don't need a real table reference, just need to trigger the JS call
+                    await jsModule.InvokeAsync<IJSObjectReference>("init", new object());
+
+                    // Signal completion only after the init call has completed, and only once
+                    if (!_completionSignaled)
+                    {
+                        _completionSignaled = true;
+                        _onAfterRenderCompleted.TrySetResult();
+                    }
+                    return;
+                }
+            }
+        }
+        finally
+        {
+            // Only signal completion if we haven't already done it and this is the first render
+            if (firstRender && !_completionSignaled)
+            {
+                _completionSignaled = true;
+                _onAfterRenderCompleted.TrySetResult();
+            }
+        }
+    }
+}

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/test/FailingQuickGrid.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/test/FailingQuickGrid.cs
@@ -18,7 +18,6 @@ internal class FailingQuickGrid<TGridItem> : QuickGrid<TGridItem>, IAsyncDisposa
     [Inject] private IJSRuntime JS { get; set; } = default!;
 
     private readonly TaskCompletionSource _onAfterRenderCompleted = new();
-    private bool _completionSignaled;
 
     public bool DisposeAsyncWasCalled { get; private set; }
 
@@ -71,25 +70,14 @@ internal class FailingQuickGrid<TGridItem> : QuickGrid<TGridItem>, IAsyncDisposa
                     // Import the JS module (this will trigger our TestJsRuntime's import logic)
                     var jsModule = await JS.InvokeAsync<IJSObjectReference>("import",
                         "./_content/Microsoft.AspNetCore.Components.QuickGrid/QuickGrid.razor.js");
-
                     await jsModule.InvokeAsync<IJSObjectReference>("init", new object());
-
-                    // Signal completion only after the init call has completed, and only once
-                    if (!_completionSignaled)
-                    {
-                        _completionSignaled = true;
-                        _onAfterRenderCompleted.TrySetResult();
-                    }
-                    return;
                 }
             }
         }
         finally
         {
-            // Only signal completion if we haven't already done it and this is the first render
-            if (firstRender && !_completionSignaled)
+            if (firstRender)
             {
-                _completionSignaled = true;
                 _onAfterRenderCompleted.TrySetResult();
             }
         }

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/test/GridRaceConditionTest.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/test/GridRaceConditionTest.cs
@@ -76,7 +76,7 @@ public class GridRaceConditionTest
         // and demonstrate the race condition by calling init after disposal
         moduleLoadCompletion.SetResult();
 
-        // Wait for OnAfterRenderAsync to complete - deterministic timing instead of arbitrary delay
+        // Wait until after OnAfterRenderAsync has completed, to make sure jsmodule import started and the reported issue is reproduced
         var failingGrid = testComponent.FailingQuickGrid;
         await failingGrid.OnAfterRenderCompleted;
 

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/test/GridRaceConditionTest.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/test/GridRaceConditionTest.cs
@@ -1,0 +1,144 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.RenderTree;
+using Microsoft.AspNetCore.Components.QuickGrid;
+using Microsoft.AspNetCore.Components.Test.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
+
+namespace Microsoft.AspNetCore.Components.QuickGrid.Test;
+
+public class GridRaceConditionTest
+{
+    private TestRenderer _renderer = new();
+    private TaskCompletionSource _tcs = new();
+
+    public GridRaceConditionTest()
+    {
+        var testJsRuntime = new TestJsRuntime(_tcs);
+        var serviceProvider = new ServiceCollection()
+            .AddSingleton<IJSRuntime>(testJsRuntime)
+            .BuildServiceProvider();
+        _renderer = new(serviceProvider);
+    }
+
+    [Fact]
+    public async Task CanCorrectlyDisposeAsync()
+    {
+        var testComponent = new TestComponent();
+
+        var componentId = _renderer.AssignRootComponentId(testComponent);
+        _renderer.RenderRootComponent(componentId);
+        await Task.Delay(10);
+        _renderer.RenderRootComponent(componentId);
+        _tcs.SetResult();
+    }
+}
+
+internal class TestComponent : ComponentBase
+{
+    private bool _firstRender = true;
+    private PaginationState _pagination = new() { ItemsPerPage = 2 };
+
+    internal class Person
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public int Age { get; set; }
+    }
+
+    private IQueryable<Person> _people = new List<Person>
+    {
+        new Person { Id = 1, Name = "John Doe", Age = 30 },
+        new Person { Id = 2, Name = "Jane Smith", Age = 25 },
+        new Person { Id = 3, Name = "Alice Johnson", Age = 22 }
+    }.AsQueryable();
+
+    protected override void BuildRenderTree(RenderTreeBuilder builder)
+    {
+        if (_firstRender)
+        {
+            //Render the QuickGrid
+            builder.OpenComponent<QuickGrid<Person>>(0);
+            builder.AddAttribute(1, "Items", _people);
+            builder.AddAttribute(2, "Pagination", _pagination);
+            builder.AddAttribute(3, nameof(QuickGrid<Person>.ChildContent),
+                (RenderFragment)(builder => BuildColumnsRenderFragment(builder)));
+            builder.CloseComponent();
+
+            builder.OpenComponent<Paginator>(4);
+            builder.AddAttribute(5, "State", _pagination);
+            builder.CloseComponent();
+            _firstRender = false;
+        }
+    }
+
+    protected void BuildColumnsRenderFragment(RenderTreeBuilder builder)
+    {
+        //Render the PropertyColumn for Id
+        builder.OpenComponent<PropertyColumn<Person, int>>(0);
+        builder.AddAttribute(1, nameof(PropertyColumn<Person, int>.Property),
+            (System.Linq.Expressions.Expression<Func<Person, int>>)(p => p.Id));
+        builder.AddAttribute(2, nameof(PropertyColumn<Person, int>.Sortable), true);
+        builder.CloseComponent();
+
+        //Render the PropertyColumn for Name
+        builder.OpenComponent<PropertyColumn<Person, string>>(3);
+        builder.AddAttribute(4, nameof(PropertyColumn<Person, string>.Property),
+            (System.Linq.Expressions.Expression<Func<Person, string>>)(p => p.Name));
+        builder.AddAttribute(5, nameof(PropertyColumn<Person, string>.Sortable), true);
+        builder.CloseComponent();
+
+        //Render the PropertyColumn for Age
+        builder.OpenComponent<PropertyColumn<Person, int>>(6);
+        builder.AddAttribute(7, nameof(PropertyColumn<Person, int>.Property),
+            (System.Linq.Expressions.Expression<Func<Person, int>>)(p => p.Age));
+        builder.AddAttribute(8, nameof(PropertyColumn<Person, int>.Sortable), true);
+        builder.CloseComponent();
+    }
+
+    public void TriggerRender()
+    {
+        InvokeAsync(StateHasChanged);
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await Task.Delay(1);
+            StateHasChanged();
+        }
+        await base.OnAfterRenderAsync(firstRender);
+    }
+}
+
+internal class TestJsRuntime(TaskCompletionSource tcs) : IJSRuntime
+{
+    private readonly TaskCompletionSource _tcs = tcs;
+
+    public async ValueTask<TValue> InvokeAsync<TValue>(string identifier, object[] args = null)
+    {
+        if (identifier == "import" && args != null && args.Length > 0 && args[0] is string modulePath)
+        {
+            if (modulePath == "./_content/Microsoft.AspNetCore.Components.QuickGrid/QuickGrid.razor.js")
+            {
+                await _tcs.Task;
+                return default!;
+            }
+        }
+        throw new Exception("JS import was not correctly processed while disposing of the component.");
+    }
+
+    public ValueTask<IJSObjectReference> InvokeAsync(string identifier, params object[] args)
+    {
+        throw new NotImplementedException();
+    }
+
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object[] args)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/test/Microsoft.AspNetCore.Components.QuickGrid.Tests.csproj
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/test/Microsoft.AspNetCore.Components.QuickGrid.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
@@ -8,8 +8,10 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Components.QuickGrid" />
   </ItemGroup>
-
-
+  
+  <ItemGroup>
+    <Compile Include="$(ComponentsSharedSourceRoot)test\**\*.cs" LinkBase="Helpers" />
+  </ItemGroup>
 
   <ItemGroup>
     <Using Include="Xunit" />

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/test/NotFailingQuickGrid.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/test/NotFailingQuickGrid.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.JSInterop;
+
+namespace Microsoft.AspNetCore.Components.QuickGrid.Tests;
+/// <summary>
+/// A QuickGrid implementation that uses the same implementation of the basic QuickGrid with the additions of the OnAfterRenderCompleted task.
+/// </summary>
+/// /// <typeparam name="TGridItem">The type of data represented by each row in the grid.</typeparam>
+internal class NotFailingGrid<TGridItem> : QuickGrid<TGridItem>
+{
+    [Inject] private IJSRuntime JS { get; set; } = default!;
+
+    private readonly TaskCompletionSource _onAfterRenderCompleted = new();
+
+    private bool _completionSignaled;
+
+    /// <summary>
+    /// Task that completes when OnAfterRenderAsync has finished executing.
+    /// This allows tests to wait deterministically for the race condition to occur.
+    /// </summary>
+    public Task OnAfterRenderCompleted => _onAfterRenderCompleted.Task;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        try
+        {
+            if (firstRender)
+            {
+                await base.OnAfterRenderAsync(firstRender);
+                _onAfterRenderCompleted.TrySetResult();
+                _completionSignaled = true;
+                return;
+            }
+        }
+        finally
+        {
+            if (firstRender && _completionSignaled)
+            {
+                _onAfterRenderCompleted.TrySetResult();
+                _completionSignaled = true;
+            }
+        }
+    }
+}

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/test/NotFailingQuickGrid.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/test/NotFailingQuickGrid.cs
@@ -32,14 +32,18 @@ internal class NotFailingGrid<TGridItem> : QuickGrid<TGridItem>
             if (firstRender)
             {
                 await base.OnAfterRenderAsync(firstRender);
-                _onAfterRenderCompleted.TrySetResult();
-                _completionSignaled = true;
+                if (!_completionSignaled)
+                {
+                    _completionSignaled = true;
+                    _onAfterRenderCompleted.TrySetResult();
+                }
+                ;
                 return;
             }
         }
         finally
         {
-            if (firstRender && _completionSignaled)
+            if (firstRender && !_completionSignaled)
             {
                 _onAfterRenderCompleted.TrySetResult();
                 _completionSignaled = true;

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/test/NotFailingQuickGrid.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/test/NotFailingQuickGrid.cs
@@ -17,8 +17,6 @@ internal class NotFailingGrid<TGridItem> : QuickGrid<TGridItem>
 
     private readonly TaskCompletionSource _onAfterRenderCompleted = new();
 
-    private bool _completionSignaled;
-
     /// <summary>
     /// Task that completes when OnAfterRenderAsync has finished executing.
     /// This allows tests to wait deterministically for the race condition to occur.
@@ -32,21 +30,13 @@ internal class NotFailingGrid<TGridItem> : QuickGrid<TGridItem>
             if (firstRender)
             {
                 await base.OnAfterRenderAsync(firstRender);
-                if (!_completionSignaled)
-                {
-                    _completionSignaled = true;
-                    _onAfterRenderCompleted.TrySetResult();
-                }
-                ;
-                return;
             }
         }
         finally
         {
-            if (firstRender && !_completionSignaled)
+            if (firstRender)
             {
                 _onAfterRenderCompleted.TrySetResult();
-                _completionSignaled = true;
             }
         }
     }


### PR DESCRIPTION
# Fixed race condition in the disposing of the QuickGrid

## Description

This pull request introduces changes to improve the disposal logic of the `QuickGrid` component and adds new tests to ensure proper handling of race conditions during disposal. It also updates project files to include new test dependencies and internal visibility settings. Below is a summary of the most important changes:

### Changes: 
* Added a `_disposeBool` flag to the `QuickGrid` component to track its disposal state and prevent further operations if disposal is in progress.
* Updated the `DisposeAsync` method to set `_disposeBool` to `true` and ensure proper cleanup of resources. 
* Modified the `OnAfterRenderAsync` method to check the `_disposeBool` flag and exit early if the component is being disposed while the JavaScript module is loading. 
* Introduced a new test class, `GridRaceConditionTest`, to verify that the `QuickGrid` component can handle race conditions during disposal without errors. This includes simulating JavaScript interop behavior and rendering scenarios.
* Added `InternalsVisibleTo` for `Microsoft.AspNetCore.Components.QuickGrid.Tests` in the `Microsoft.AspNetCore.Components.csproj` file to allow internal access for testing purposes.
* Updated the `Microsoft.AspNetCore.Components.QuickGrid.Tests.csproj` file to include shared test helpers and dependencies for the new tests. 

Fixes #47173

