### PR TITLE
Add gRPC JSON transcoding option for case insensitive field names

### DIFF
--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/GrpcJsonSettings.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/GrpcJsonSettings.cs
@@ -39,7 +39,7 @@ public sealed class GrpcJsonSettings
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The Protobuf JSON specification requires JSON property names to match field names exactly, including case.
+    /// The Protobuf JSON specification requires JSON property names to match message field names exactly, including case.
     /// Enabling this option may reduce interoperability, as case-insensitive field matching might not be supported
     /// by other JSON transcoding implementations.
     /// </para>
@@ -47,5 +47,5 @@ public sealed class GrpcJsonSettings
     /// For more information, see <see href="https://protobuf.dev/programming-guides/json/"/>.
     /// </para>
     /// </remarks>
-    public bool FieldNamesCaseInsensitive { get; set; }
+    public bool PropertyNameCaseInsensitive { get; set; }
 }

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/GrpcJsonSettings.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/GrpcJsonSettings.cs
@@ -39,8 +39,8 @@ public sealed class GrpcJsonSettings
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The Protobuf JSON specification requires JSON property names to match field names exactly, including case. 
-    /// Enabling this option may reduce interoperability, as case-insensitive field matching might not be supported 
+    /// The Protobuf JSON specification requires JSON property names to match field names exactly, including case.
+    /// Enabling this option may reduce interoperability, as case-insensitive field matching might not be supported
     /// by other JSON transcoding implementations.
     /// </para>
     /// <para>

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/GrpcJsonSettings.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/GrpcJsonSettings.cs
@@ -11,25 +11,41 @@ public sealed class GrpcJsonSettings
     /// <summary>
     /// Gets or sets a value that indicates whether fields with default values are ignored during serialization.
     /// This setting only affects fields which don't support "presence", such as singular non-optional proto3 primitive fields.
-    /// Default value is false.
+    /// Default value is <see langword="false"/>.
     /// </summary>
     public bool IgnoreDefaultValues { get; set; }
 
     /// <summary>
     /// Gets or sets a value that indicates whether <see cref="Enum"/> values are written as integers instead of strings.
-    /// Default value is false.
+    /// Default value is <see langword="false"/>.
     /// </summary>
     public bool WriteEnumsAsIntegers { get; set; }
 
     /// <summary>
     /// Gets or sets a value that indicates whether <see cref="long"/> and <see cref="ulong"/> values are written as strings instead of numbers.
-    /// Default value is false.
+    /// Default value is <see langword="false"/>.
     /// </summary>
     public bool WriteInt64sAsStrings { get; set; }
 
     /// <summary>
     /// Gets or sets a value that indicates whether JSON should use pretty printing.
-    /// Default value is false.
+    /// Default value is <see langword="false"/>.
     /// </summary>
     public bool WriteIndented { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value that indicates whether field names are compared using case-insensitive matching during deserialization.
+    /// The default value is <see langword="false"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The Protobuf JSON specification requires JSON property names to match field names exactly, including case. 
+    /// Enabling this option may reduce interoperability, as case-insensitive field matching might not be supported 
+    /// by other JSON transcoding implementations.
+    /// </para>
+    /// <para>
+    /// For more information, see <see href="https://protobuf.dev/programming-guides/json/"/>.
+    /// </para>
+    /// </remarks>
+    public bool FieldNamesCaseInsensitive { get; set; }
 }

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/GrpcJsonSettings.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/GrpcJsonSettings.cs
@@ -34,13 +34,13 @@ public sealed class GrpcJsonSettings
     public bool WriteIndented { get; set; }
 
     /// <summary>
-    /// Gets or sets a value that indicates whether field names are compared using case-insensitive matching during deserialization.
+    /// Gets or sets a value that indicates whether property names are compared using case-insensitive matching during deserialization.
     /// The default value is <see langword="false"/>.
     /// </summary>
     /// <remarks>
     /// <para>
     /// The Protobuf JSON specification requires JSON property names to match message field names exactly, including case.
-    /// Enabling this option may reduce interoperability, as case-insensitive field matching might not be supported
+    /// Enabling this option may reduce interoperability, as case-insensitive property matching might not be supported
     /// by other JSON transcoding implementations.
     /// </para>
     /// <para>

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/JsonConverterHelper.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/JsonConverterHelper.cs
@@ -46,7 +46,8 @@ internal static class JsonConverterHelper
             WriteIndented = writeIndented,
             NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals,
             Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-            TypeInfoResolver = typeInfoResolver
+            TypeInfoResolver = typeInfoResolver,
+            PropertyNameCaseInsensitive = context.Settings.FieldNamesCaseInsensitive,
         };
         options.Converters.Add(new NullValueConverter());
         options.Converters.Add(new ByteStringConverter());

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/JsonConverterHelper.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/JsonConverterHelper.cs
@@ -47,7 +47,7 @@ internal static class JsonConverterHelper
             NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals,
             Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
             TypeInfoResolver = typeInfoResolver,
-            PropertyNameCaseInsensitive = context.Settings.FieldNamesCaseInsensitive,
+            PropertyNameCaseInsensitive = context.Settings.PropertyNameCaseInsensitive,
         };
         options.Converters.Add(new NullValueConverter());
         options.Converters.Add(new ByteStringConverter());

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/MessageTypeInfoResolver.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/MessageTypeInfoResolver.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/PublicAPI.Unshipped.txt
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.AspNetCore.Grpc.JsonTranscoding.GrpcJsonSettings.FieldNamesCaseInsensitive.get -> bool
+Microsoft.AspNetCore.Grpc.JsonTranscoding.GrpcJsonSettings.FieldNamesCaseInsensitive.set -> void

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/PublicAPI.Unshipped.txt
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/PublicAPI.Unshipped.txt
@@ -1,3 +1,3 @@
 #nullable enable
-Microsoft.AspNetCore.Grpc.JsonTranscoding.GrpcJsonSettings.FieldNamesCaseInsensitive.get -> bool
-Microsoft.AspNetCore.Grpc.JsonTranscoding.GrpcJsonSettings.FieldNamesCaseInsensitive.set -> void
+Microsoft.AspNetCore.Grpc.JsonTranscoding.GrpcJsonSettings.PropertyNameCaseInsensitive.get -> bool
+Microsoft.AspNetCore.Grpc.JsonTranscoding.GrpcJsonSettings.PropertyNameCaseInsensitive.set -> void

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterReadTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterReadTests.cs
@@ -66,7 +66,7 @@ public class JsonConverterReadTests
   ""HIDING_FIELD_NAME"": ""A field name""
 }";
 
-        var m = AssertReadJson<HelloRequest>(json, serializeOld: false, settings: new GrpcJsonSettings { FieldNamesCaseInsensitive = true });
+        var m = AssertReadJson<HelloRequest>(json, serializeOld: false, settings: new GrpcJsonSettings { PropertyNameCaseInsensitive = true });
         Assert.Equal("A field name", m.HidingFieldName);
     }
 
@@ -77,7 +77,7 @@ public class JsonConverterReadTests
   ""FIELD_NAME"": ""A field name""
 }";
 
-        var m = AssertReadJson<HelloRequest>(json, serializeOld: false, settings: new GrpcJsonSettings { FieldNamesCaseInsensitive = true });
+        var m = AssertReadJson<HelloRequest>(json, serializeOld: false, settings: new GrpcJsonSettings { PropertyNameCaseInsensitive = true });
         Assert.Equal("", m.FieldName);
         Assert.Equal("A field name", m.HidingFieldName);
     }
@@ -89,7 +89,7 @@ public class JsonConverterReadTests
   ""JSON_CUSTOMIZED_NAME"": ""A field name""
 }";
 
-        var m = AssertReadJson<HelloRequest>(json, serializeOld: false, settings: new GrpcJsonSettings { FieldNamesCaseInsensitive = true });
+        var m = AssertReadJson<HelloRequest>(json, serializeOld: false, settings: new GrpcJsonSettings { PropertyNameCaseInsensitive = true });
         Assert.Equal("A field name", m.FieldName);
     }
 
@@ -486,7 +486,7 @@ public class JsonConverterReadTests
   }
 }";
 
-        AssertReadJson<HelloRequest>(json, serializeOld: false, settings: new GrpcJsonSettings { FieldNamesCaseInsensitive = true });
+        AssertReadJson<HelloRequest>(json, serializeOld: false, settings: new GrpcJsonSettings { PropertyNameCaseInsensitive = true });
     }
 
     [Fact]
@@ -547,7 +547,7 @@ public class JsonConverterReadTests
   ""ONEOFNAME1"": ""test""
 }";
 
-        AssertReadJson<HelloRequest>(json, serializeOld: false, settings: new GrpcJsonSettings { FieldNamesCaseInsensitive = true });
+        AssertReadJson<HelloRequest>(json, serializeOld: false, settings: new GrpcJsonSettings { PropertyNameCaseInsensitive = true });
     }
 
     [Fact]
@@ -569,7 +569,7 @@ public class JsonConverterReadTests
   ""ONEOFNAME2"": ""test""
 }";
 
-        AssertReadJsonError<HelloRequest>(json, ex => Assert.Equal("Multiple values specified for oneof oneof_test", ex.Message.TrimEnd('.')), deserializeOld: false, settings: new GrpcJsonSettings { FieldNamesCaseInsensitive = true });
+        AssertReadJsonError<HelloRequest>(json, ex => Assert.Equal("Multiple values specified for oneof oneof_test", ex.Message.TrimEnd('.')), deserializeOld: false, settings: new GrpcJsonSettings { PropertyNameCaseInsensitive = true });
     }
 
     [Fact]
@@ -634,7 +634,7 @@ public class JsonConverterReadTests
   ""BYTESVALUE"": ""SGVsbG8gd29ybGQ=""
 }";
 
-        var result = AssertReadJson<HelloRequest.Types.Wrappers>(json, serializeOld: false, settings: new GrpcJsonSettings { FieldNamesCaseInsensitive = true });
+        var result = AssertReadJson<HelloRequest.Types.Wrappers>(json, serializeOld: false, settings: new GrpcJsonSettings { PropertyNameCaseInsensitive = true });
         Assert.Equal("A string", result.StringValue);
     }
 
@@ -728,7 +728,7 @@ public class JsonConverterReadTests
     {
         var json = @"{""B"":10,""A"":20,""D"":30}";
 
-        var m = AssertReadJson<Issue047349Message>(json, serializeOld: false, settings: new GrpcJsonSettings { FieldNamesCaseInsensitive = true });
+        var m = AssertReadJson<Issue047349Message>(json, serializeOld: false, settings: new GrpcJsonSettings { PropertyNameCaseInsensitive = true });
 
         Assert.Equal(10, m.A);
         Assert.Equal(20, m.B);
@@ -752,7 +752,7 @@ public class JsonConverterReadTests
     {
         var json = @"{""B"":10,""A"":20,""C"":30}";
 
-        var m = AssertReadJson<Issue047349Message>(json, serializeOld: false, settings: new GrpcJsonSettings { FieldNamesCaseInsensitive = true });
+        var m = AssertReadJson<Issue047349Message>(json, serializeOld: false, settings: new GrpcJsonSettings { PropertyNameCaseInsensitive = true });
 
         Assert.Equal(10, m.A);
         Assert.Equal(20, m.B);
@@ -775,7 +775,7 @@ public class JsonConverterReadTests
     {
         var json = @"{""a"":10,""A"":20}";
 
-        AssertReadJsonError<FieldNameCaseMessage>(json, ex => Assert.Equal("The JSON property name for 'Transcoding.FieldNameCaseMessage.A' collides with another property.", ex.Message), deserializeOld: false, settings: new GrpcJsonSettings { FieldNamesCaseInsensitive = true });
+        AssertReadJsonError<FieldNameCaseMessage>(json, ex => Assert.Equal("The JSON property name for 'Transcoding.FieldNameCaseMessage.A' collides with another property.", ex.Message), deserializeOld: false, settings: new GrpcJsonSettings { PropertyNameCaseInsensitive = true });
     }
 
     private TValue AssertReadJson<TValue>(string value, GrpcJsonSettings? settings = null, DescriptorRegistry? descriptorRegistry = null, bool serializeOld = true) where TValue : IMessage, new()

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterReadTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterReadTests.cs
@@ -60,6 +60,40 @@ public class JsonConverterReadTests
     }
 
     [Fact]
+    public void NonJsonName_CaseInsensitive()
+    {
+        var json = @"{
+  ""HIDING_FIELD_NAME"": ""A field name""
+}";
+
+        var m = AssertReadJson<HelloRequest>(json, serializeOld: false, settings: new GrpcJsonSettings { FieldNamesCaseInsensitive = true });
+        Assert.Equal("A field name", m.HidingFieldName);
+    }
+
+    [Fact]
+    public void HidingJsonName_CaseInsensitive()
+    {
+        var json = @"{
+  ""FIELD_NAME"": ""A field name""
+}";
+
+        var m = AssertReadJson<HelloRequest>(json, serializeOld: false, settings: new GrpcJsonSettings { FieldNamesCaseInsensitive = true });
+        Assert.Equal("", m.FieldName);
+        Assert.Equal("A field name", m.HidingFieldName);
+    }
+
+    [Fact]
+    public void JsonCustomizedName_CaseInsensitive()
+    {
+        var json = @"{
+  ""JSON_CUSTOMIZED_NAME"": ""A field name""
+}";
+
+        var m = AssertReadJson<HelloRequest>(json, serializeOld: false, settings: new GrpcJsonSettings { FieldNamesCaseInsensitive = true });
+        Assert.Equal("A field name", m.FieldName);
+    }
+
+    [Fact]
     public void ReadObjectProperties()
     {
         var json = @"{
@@ -439,6 +473,23 @@ public class JsonConverterReadTests
     }
 
     [Fact]
+    public void MapMessages_CaseInsensitive()
+    {
+        var json = @"{
+  ""mapMessage"": {
+    ""name1"": {
+      ""SUBFIELD"": ""value1""
+    },
+    ""name2"": {
+      ""SUBFIELD"": ""value2""
+    }
+  }
+}";
+
+        AssertReadJson<HelloRequest>(json, serializeOld: false, settings: new GrpcJsonSettings { FieldNamesCaseInsensitive = true });
+    }
+
+    [Fact]
     public void MapKeyBool()
     {
         var json = @"{
@@ -449,6 +500,19 @@ public class JsonConverterReadTests
 }";
 
         AssertReadJson<HelloRequest>(json);
+    }
+
+    [Fact]
+    public void MapKeyBool_CaseInsensitive()
+    {
+        var json = @"{
+  ""mapKeybool"": {
+    ""TRUE"": ""value1"",
+    ""FALSE"": ""value2""
+  }
+}";
+
+        AssertReadJson<HelloRequest>(json, serializeOld: false);
     }
 
     [Fact]
@@ -475,6 +539,16 @@ public class JsonConverterReadTests
     }
 
     [Fact]
+    public void OneOf_CaseInsensitive_Success()
+    {
+        var json = @"{
+  ""ONEOFNAME1"": ""test""
+}";
+
+        AssertReadJson<HelloRequest>(json, serializeOld: false, settings: new GrpcJsonSettings { FieldNamesCaseInsensitive = true });
+    }
+
+    [Fact]
     public void OneOf_Failure()
     {
         var json = @"{
@@ -483,6 +557,17 @@ public class JsonConverterReadTests
 }";
 
         AssertReadJsonError<HelloRequest>(json, ex => Assert.Equal("Multiple values specified for oneof oneof_test", ex.Message.TrimEnd('.')));
+    }
+
+    [Fact]
+    public void OneOf_CaseInsensitive_Failure()
+    {
+        var json = @"{
+  ""ONEOFNAME1"": ""test"",
+  ""ONEOFNAME2"": ""test""
+}";
+
+        AssertReadJsonError<HelloRequest>(json, ex => Assert.Equal("Multiple values specified for oneof oneof_test", ex.Message.TrimEnd('.')), deserializeOld: false, settings: new GrpcJsonSettings { FieldNamesCaseInsensitive = true });
     }
 
     [Fact]
@@ -528,7 +613,27 @@ public class JsonConverterReadTests
   ""bytesValue"": ""SGVsbG8gd29ybGQ=""
 }";
 
-        AssertReadJson<HelloRequest.Types.Wrappers>(json);
+        var result = AssertReadJson<HelloRequest.Types.Wrappers>(json);
+        Assert.Equal("A string", result.StringValue);
+    }
+
+    [Fact]
+    public void NullableWrappers_CaseInsensitive()
+    {
+        var json = @"{
+  ""STRINGVALUE"": ""A string"",
+  ""INT32VALUE"": 1,
+  ""INT64VALUE"": ""2"",
+  ""FLOATVALUE"": 1.2,
+  ""DOUBLEVALUE"": 1.1,
+  ""BOOLVALUE"": true,
+  ""UINT32VALUE"": 3,
+  ""UINT64VALUE"": ""4"",
+  ""BYTESVALUE"": ""SGVsbG8gd29ybGQ=""
+}";
+
+        var result = AssertReadJson<HelloRequest.Types.Wrappers>(json, serializeOld: false, settings: new GrpcJsonSettings { FieldNamesCaseInsensitive = true });
+        Assert.Equal("A string", result.StringValue);
     }
 
     [Fact]
@@ -609,8 +714,19 @@ public class JsonConverterReadTests
     {
         var json = @"{""b"":10,""a"":20,""d"":30}";
 
-        // TODO: Current Google.Protobuf version doesn't have fix. Update when available. 3.23.0 or later?
-        var m = AssertReadJson<Issue047349Message>(json, serializeOld: false);
+        var m = AssertReadJson<Issue047349Message>(json);
+
+        Assert.Equal(10, m.A);
+        Assert.Equal(20, m.B);
+        Assert.Equal(30, m.C);
+    }
+
+    [Fact]
+    public void JsonNamePriority_CaseInsensitive_JsonName()
+    {
+        var json = @"{""B"":10,""A"":20,""D"":30}";
+
+        var m = AssertReadJson<Issue047349Message>(json, serializeOld: false, settings: new GrpcJsonSettings { FieldNamesCaseInsensitive = true });
 
         Assert.Equal(10, m.A);
         Assert.Equal(20, m.B);
@@ -622,12 +738,42 @@ public class JsonConverterReadTests
     {
         var json = @"{""b"":10,""a"":20,""c"":30}";
 
-        // TODO: Current Google.Protobuf version doesn't have fix. Update when available. 3.23.0 or later?
-        var m = AssertReadJson<Issue047349Message>(json, serializeOld: false);
+        var m = AssertReadJson<Issue047349Message>(json);
 
         Assert.Equal(10, m.A);
         Assert.Equal(20, m.B);
         Assert.Equal(30, m.C);
+    }
+
+    [Fact]
+    public void JsonNamePriority_CaseInsensitive_FieldNameFallback()
+    {
+        var json = @"{""B"":10,""A"":20,""C"":30}";
+
+        var m = AssertReadJson<Issue047349Message>(json, serializeOld: false, settings: new GrpcJsonSettings { FieldNamesCaseInsensitive = true });
+
+        Assert.Equal(10, m.A);
+        Assert.Equal(20, m.B);
+        Assert.Equal(30, m.C);
+    }
+
+    [Fact]
+    public void FieldNameCase_Success()
+    {
+        var json = @"{""a"":10,""A"":20}";
+
+        var m = AssertReadJson<FieldNameCaseMessage>(json);
+
+        Assert.Equal(10, m.A);
+        Assert.Equal(20, m.B);
+    }
+
+    [Fact]
+    public void FieldNameCase_CaseInsensitive_Failure()
+    {
+        var json = @"{""a"":10,""A"":20}";
+
+        AssertReadJsonError<FieldNameCaseMessage>(json, ex => Assert.Equal("The JSON property name for 'Transcoding.FieldNameCaseMessage.A' collides with another property.", ex.Message), deserializeOld: false, settings: new GrpcJsonSettings { FieldNamesCaseInsensitive = true });
     }
 
     private TValue AssertReadJson<TValue>(string value, GrpcJsonSettings? settings = null, DescriptorRegistry? descriptorRegistry = null, bool serializeOld = true) where TValue : IMessage, new()

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterReadTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterReadTests.cs
@@ -512,6 +512,8 @@ public class JsonConverterReadTests
   }
 }";
 
+        // Note: JSON property names here are keys in a dictionary, not fields. So FieldNamesCaseInsensitive doesn't apply.
+        // The new serializer supports converting true/false to boolean keys while ignoring case.
         AssertReadJson<HelloRequest>(json, serializeOld: false);
     }
 

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Proto/transcoding.proto
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Proto/transcoding.proto
@@ -235,3 +235,8 @@ message HelloReply {
 message NullValueContainer {
   google.protobuf.NullValue null_value = 1;
 }
+
+message FieldNameCaseMessage {
+  int32 a = 1;
+  int32 b = 2  [json_name="A"];
+}


### PR DESCRIPTION
## Description

Add a `FieldNamesCaseInsensitive` setting to gRPC JSON transcoding.

Fixes https://github.com/dotnet/aspnetcore/issues/50401
