### PR TITLE
fix: correct permissions for `browsertesting-open-issue` workflow

### DIFF
--- a/.github/workflows/browsertesting-open-issue.yml
+++ b/.github/workflows/browsertesting-open-issue.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   create-issue:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
continuation for https://github.com/dotnet/aspnetcore/pull/62845, it appears that we need to set permissions on the job so that GH_TOKEN has enough rights to open the issue. see failed workflow run: https://github.com/dotnet/aspnetcore/actions/runs/16465776673/job/46542680254 and error:

> Run gh issue create \
  gh issue create \
    --title "Request Browser-Testing Dependencies Update" \
    --body-file ".github/workflows/browsertesting-issue-body.md" \
    --assignee "@copilot"
  shell: /usr/bin/bash -e {0}
  env:
    GH_TOKEN: ***
    GH_REPO: dotnet/aspnetcore
  **GraphQL: Resource not accessible by integration (createIssue)**