### PR TITLE
Copilot agent runs dotnet commands with correct dotnet.

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,3 +32,11 @@
 ## Running tests
 
 * To build and run tests in the repo, use the `build.sh` script that is located in each subdirectory within the `src` folder. For example, to run the build with tests in the `src/Http` directory, run `./src/Http/build.sh -test`.
+
+## .NET Environment
+
+* Before running any `dotnet` commands in this repository, always activate the locally installed .NET environment first by running the appropriate activation script from the repository root:
+  * On Windows: `. ./activate.ps1` (from repository root)
+  * On Linux/Mac: `source activate.sh` (from repository root)
+* If not in the repository root, navigate there first or use the full path to the activation script.
+* This ensures that the correct version of .NET SDK is used for the repository.


### PR DESCRIPTION
In agent mode in VSC copilot was always trying to run dotnet commands with global dotnet, not the one from the repo:
```
The command could not be loaded, possibly because:
  * You intended to execute a .NET application:
      The application 'test' does not exist.
  * You intended to execute a .NET SDK command:
      A compatible .NET SDK was not found.

Requested SDK version: 10.0.100-preview.7.25322.101
global.json file: C:\Users\Desktop\aspnetcore-fork4\global.json

Installed SDKs:
9.0.300 [C:\Program Files\dotnet\sdk]
9.0.302 [C:\Program Files\dotnet\sdk]

Install the [10.0.100-preview.7.25322.101] .NET SDK or update [C:\Users\Desktop\aspnetcore-fork4\global.json] to match an installed SDK.

Learn about SDK resolution:
https://aka.ms/dotnet/sdk-not-found
```

After updating the instruction it does not happen anymore.