### PR TITLE
Stop using outdated 5.0 sdk image in wasm benchmarks

### DIFF
--- a/src/Components/benchmarkapps/Wasm.Performance/dockerfile
+++ b/src/Components/benchmarkapps/Wasm.Performance/dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:latest AS build
 
 ENV StressRunDuration=0
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
The 5.0 image can't reach Debian apt repos anymore.