### PR TITLE
chore: browser-testing workflow issues improvements

### DIFF
--- a/.github/workflows/browsertesting-issue-body.md
+++ b/.github/workflows/browsertesting-issue-body.md
@@ -21,4 +21,4 @@ Please, open the PR against `main` branch and include changes to the files liste
 
 Also:
 - mention @dotnet/aspnet-build in the opened Pull Request - this will be a responsible engineer for changes validation.
-- add the `build-ops`label to the opened Pull Request
+- add the `build-ops` label to the opened Pull Request

--- a/.github/workflows/browsertesting-issue-body.md
+++ b/.github/workflows/browsertesting-issue-body.md
@@ -18,4 +18,7 @@ To update the Selenium and Playwright versions, these files need to be updated:
 ## Actions
 
 Please, open the PR against `main` branch and include changes to the files listed above.
-Also mention @dotnet/aspnet-build in the opened Pull Request - this will be a responsible engineer for changes validation.
+
+Also:
+- mention @dotnet/aspnet-build in the opened Pull Request - this will be a responsible engineer for changes validation.
+- add the `build-ops`label to the opened Pull Request


### PR DESCRIPTION
We need to have `build-ops` label to be on the PR for selenium\playwright dependencies updates. Example of PR: https://github.com/dotnet/aspnetcore/pull/62877

