### PR TITLE
Make Blazor WASM respect current UI culture

### DIFF
--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCultureProvider.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCultureProvider.cs
@@ -81,7 +81,7 @@ internal partial class WebAssemblyCultureProvider
         // starting from the current culture and walking up the graph of parents.
         // At the end of the the walk, we'll have a list of culture names that look like
         // [ "fr-FR", "fr" ]
-        while ((cultureInfo != null && cultureInfo != CultureInfo.InvariantCulture) || (uiCultureInfo != null && uiCultureInfo != CultureInfo.InvariantCulture))
+        while (cultureInfo != null || uiCultureInfo != null)
         {
             if (cultureInfo != null && cultureInfo != CultureInfo.InvariantCulture)
             {
@@ -93,8 +93,8 @@ internal partial class WebAssemblyCultureProvider
                 culturesToLoad.Add(uiCultureInfo.Name);
             }
 
-            cultureInfo = (cultureInfo?.Parent == cultureInfo) ? null : cultureInfo?.Parent;
-            uiCultureInfo = (uiCultureInfo?.Parent == uiCultureInfo) ? null : uiCultureInfo?.Parent;
+            cultureInfo = (cultureInfo?.Parent == cultureInfo || cultureInfo == CultureInfo.InvariantCulture) ? null : cultureInfo?.Parent;
+            uiCultureInfo = (uiCultureInfo?.Parent == uiCultureInfo || uiCultureInfo == CultureInfo.InvariantCulture) ? null : uiCultureInfo?.Parent;
         }
 
         return culturesToLoad.ToArray();

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCultureProvider.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCultureProvider.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Linq;
 using System.Runtime.InteropServices.JavaScript;
 
 namespace Microsoft.AspNetCore.Components.WebAssembly.Hosting;
@@ -74,7 +75,7 @@ internal partial class WebAssemblyCultureProvider
 
     internal static string[] GetCultures(CultureInfo? cultureInfo, CultureInfo? uiCultureInfo = null)
     {
-        var culturesToLoad = new List<string>();
+        var culturesToLoad = new HashSet<string>();
 
         // Once WASM is ready, we have to use .NET's assembly loading to load additional assemblies.
         // First calculate all possible cultures that the application might want to load. We do this by
@@ -97,7 +98,7 @@ internal partial class WebAssemblyCultureProvider
             uiCultureInfo = (uiCultureInfo?.Parent == uiCultureInfo || uiCultureInfo == CultureInfo.InvariantCulture) ? null : uiCultureInfo?.Parent;
         }
 
-        return culturesToLoad.ToArray();
+        return culturesToLoad.ToList().ToArray();
     }
 
     private partial class WebAssemblyCultureProviderInterop

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCultureProvider.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCultureProvider.cs
@@ -88,7 +88,7 @@ internal partial class WebAssemblyCultureProvider
                 culturesToLoad.Add(cultureInfo.Name);
             }
 
-            if (uiCultureInfo?.Name != cultureInfo?.Name && uiCultureInfo != null && uiCultureInfo != CultureInfo.InvariantCulture)
+            if (uiCultureInfo != null && uiCultureInfo.Name != cultureInfo?.Name && uiCultureInfo != CultureInfo.InvariantCulture)
             {
                 culturesToLoad.Add(uiCultureInfo.Name);
             }

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCultureProvider.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCultureProvider.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Linq;
 using System.Runtime.InteropServices.JavaScript;
 
 namespace Microsoft.AspNetCore.Components.WebAssembly.Hosting;
@@ -62,7 +63,7 @@ internal partial class WebAssemblyCultureProvider
             throw new PlatformNotSupportedException("This method is only supported in the browser.");
         }
 
-        var culturesToLoad = GetCultures(CultureInfo.CurrentCulture);
+        var culturesToLoad = GetCultures(CultureInfo.CurrentCulture).Union(GetCultures(CultureInfo.CurrentUICulture)).ToArray();
 
         if (culturesToLoad.Length == 0)
         {

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCultureProvider.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCultureProvider.cs
@@ -76,11 +76,6 @@ internal partial class WebAssemblyCultureProvider
     {
         var culturesToLoad = new List<string>();
 
-        if (uiCultureInfo == null)
-        {
-            uiCultureInfo = cultureInfo;
-        }
-
         // Once WASM is ready, we have to use .NET's assembly loading to load additional assemblies.
         // First calculate all possible cultures that the application might want to load. We do this by
         // starting from the current culture and walking up the graph of parents.
@@ -98,8 +93,8 @@ internal partial class WebAssemblyCultureProvider
                 culturesToLoad.Add(uiCultureInfo.Name);
             }
 
-            cultureInfo = cultureInfo?.Parent;
-            uiCultureInfo = uiCultureInfo?.Parent;
+            cultureInfo = (cultureInfo?.Parent == cultureInfo) ? null : cultureInfo?.Parent;
+            uiCultureInfo = (uiCultureInfo?.Parent == uiCultureInfo) ? null : uiCultureInfo?.Parent;
         }
 
         return culturesToLoad.ToArray();

--- a/src/Components/WebAssembly/WebAssembly/test/Hosting/WebAssemblyCultureProviderTest.cs
+++ b/src/Components/WebAssembly/WebAssembly/test/Hosting/WebAssemblyCultureProviderTest.cs
@@ -25,7 +25,8 @@ public class WebAssemblyCultureProviderTest
     }
 
     [Theory]
-    [InlineData("fr-FR", "tzm-Latn-DZ", new[] { "fr-FR", "tzm-Latn-DZ", "fr", "tzm-Latn", "tzm" })]
+    [InlineData("fr-FR", "tzm-Latn-DZ", new[] { "fr-FR", "fr", "tzm-Latn-DZ", "tzm-Latn", "tzm" })]
+    [InlineData("en-US", "en-GB", new[] { "en-US", "en", "en-GB" })]
     [InlineData("fr-FR", null, new[] { "fr-FR", "fr" })]
     [InlineData(null, null, new string[0])]
     public void GetCultures_ReturnCultureClosureWithUICulture(string cultureName, string uiCultureName, string[] expected)

--- a/src/Components/WebAssembly/WebAssembly/test/Hosting/WebAssemblyCultureProviderTest.cs
+++ b/src/Components/WebAssembly/WebAssembly/test/Hosting/WebAssemblyCultureProviderTest.cs
@@ -26,11 +26,13 @@ public class WebAssemblyCultureProviderTest
 
     [Theory]
     [InlineData("fr-FR", "tzm-Latn-DZ", new[] { "fr-FR", "tzm-Latn-DZ", "fr", "tzm-Latn", "tzm" })]
+    [InlineData("fr-FR", null, new[] { "fr-FR", "fr" })]
+    [InlineData(null, null, new string[0])]
     public void GetCultures_ReturnCultureClosureWithUICulture(string cultureName, string uiCultureName, string[] expected)
     {
         // Arrange
-        var culture = new CultureInfo(cultureName);
-        var uiCulture = new CultureInfo(uiCultureName);
+        var culture = cultureName != null ? new CultureInfo(cultureName) : null;
+        var uiCulture = uiCultureName != null ? new CultureInfo(uiCultureName) : null;
         // Act
         var actual = WebAssemblyCultureProvider.GetCultures(culture, uiCulture);
         // Assert

--- a/src/Components/WebAssembly/WebAssembly/test/Hosting/WebAssemblyCultureProviderTest.cs
+++ b/src/Components/WebAssembly/WebAssembly/test/Hosting/WebAssemblyCultureProviderTest.cs
@@ -24,6 +24,19 @@ public class WebAssemblyCultureProviderTest
         Assert.Equal(expected, actual);
     }
 
+    [Theory]
+    [InlineData("fr-FR", "tzm-Latn-DZ", new[] { "fr-FR", "tzm-Latn-DZ", "fr", "tzm-Latn", "tzm" })]
+    public void GetCultures_ReturnCultureClosureWithUICulture(string cultureName, string uiCultureName, string[] expected)
+    {
+        // Arrange
+        var culture = new CultureInfo(cultureName);
+        var uiCulture = new CultureInfo(uiCultureName);
+        // Act
+        var actual = WebAssemblyCultureProvider.GetCultures(culture, uiCulture);
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
     [Fact]
     public void ThrowIfCultureChangeIsUnsupported_ThrowsIfCulturesAreDifferentAndICUShardingIsUsed()
     {

--- a/src/Components/WebAssembly/WebAssembly/test/Hosting/WebAssemblyCultureProviderTest.cs
+++ b/src/Components/WebAssembly/WebAssembly/test/Hosting/WebAssemblyCultureProviderTest.cs
@@ -28,7 +28,6 @@ public class WebAssemblyCultureProviderTest
     [InlineData("fr-FR", "tzm-Latn-DZ", new[] { "fr-FR", "fr", "tzm-Latn-DZ", "tzm-Latn", "tzm" })]
     [InlineData("en-US", "en-GB", new[] { "en-US", "en", "en-GB" })]
     [InlineData("fr-FR", null, new[] { "fr-FR", "fr" })]
-    [InlineData(null, null, new string[0])]
     public void GetCultures_ReturnCultureClosureWithUICulture(string cultureName, string uiCultureName, string[] expected)
     {
         // Arrange

--- a/src/Components/test/E2ETest/Tests/WebAssemblyLocalizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/WebAssemblyLocalizationTest.cs
@@ -35,4 +35,23 @@ public class WebAssemblyLocalizationTest : ServerTestBase<ToggleExecutionModeSer
         var messageDisplay = Browser.Exists(By.Id("message-display"));
         Assert.Equal(message, messageDisplay.Text);
     }
+
+    [Theory]
+    [InlineData("en-US", "fr-FR", "Bonjour!")]
+    [InlineData("fr-FR", "en-US", "Hello!")]
+    public void CanSetCultureAndDifferentiateBetweenCurrentAndUICulture(string culture, string cultureUI, string message)
+    {
+        Navigate($"{ServerPathBase}/?culture={culture}&cultureUI={cultureUI}");
+
+        Browser.MountTestComponent<LocalizedText>();
+
+        var cultureDisplay = Browser.Exists(By.Id("culture-name-display"));
+        Assert.Equal($"Culture is: {culture}", cultureDisplay.Text);
+
+        var cultureUIDisplay = Browser.Exists(By.Id("culture-ui-display"));
+        Assert.Equal($"CultureUI is: {cultureUI}", cultureUIDisplay.Text);
+
+        var messageDisplay = Browser.Exists(By.Id("message-display"));
+        Assert.Equal(message, messageDisplay.Text);
+    }
 }

--- a/src/Components/test/testassets/BasicTestApp/LocalizedText.razor
+++ b/src/Components/test/testassets/BasicTestApp/LocalizedText.razor
@@ -1,2 +1,3 @@
 ﻿<h3 id="culture-name-display">Culture is: @System.Globalization.CultureInfo.CurrentCulture.Name</h3>
+<h3 id="culture-ui-display">CultureUI is: @System.Globalization.CultureInfo.CurrentUICulture.Name</h3>
 <p id="message-display">@Resources.Message</p>

--- a/src/Components/test/testassets/BasicTestApp/Program.cs
+++ b/src/Components/test/testassets/BasicTestApp/Program.cs
@@ -63,6 +63,7 @@ public class Program
     {
         // In the absence of a specified value, we want the culture to be en-US so that the tests for bind can work consistently.
         var culture = new CultureInfo("en-US");
+        var cultureUI = new CultureInfo("en-US");
 
         Uri uri = null;
         try
@@ -77,12 +78,18 @@ public class Program
         if (uri != null && HttpUtility.ParseQueryString(uri.Query)["culture"] is string cultureName)
         {
             culture = new CultureInfo(cultureName);
+            cultureUI = culture; // Default to the same culture for UI if not specified
+        }
+
+        if (uri != null && HttpUtility.ParseQueryString(uri.Query)["cultureUI"] is string cultureUIName)
+        {
+            cultureUI = new CultureInfo(cultureUIName);
         }
 
         // CultureInfo.CurrentCulture is async-scoped and will not affect the culture in sibling scopes.
         // Use CultureInfo.DefaultThreadCurrentCulture instead to modify the application's default scope.
         CultureInfo.DefaultThreadCurrentCulture = culture;
-        CultureInfo.DefaultThreadCurrentUICulture = culture;
+        CultureInfo.DefaultThreadCurrentUICulture = cultureUI;
     }
 
     // Supports E2E tests in StartupErrorNotificationTest


### PR DESCRIPTION
# Make Blazor WASM respect current UI culture

## Description

This pull request introduces support for differentiating between `CultureInfo.CurrentCulture` and `CultureInfo.CurrentUICulture` in WebAssembly applications. 

### Changes
* Updated `GetCultures` method in `WebAssemblyCultureProvider` to accept both `CultureInfo.CurrentCulture` and `CultureInfo.CurrentUICulture`, enabling separate handling of culture and UI culture. Adjusted logic to compute culture closure for both values.
* Added a new unit test in `WebAssemblyCultureProviderTest` to verify that `GetCultures` correctly computes the culture closure when both culture and UI culture are provided. 
* Added an E2E test in `WebAssemblyLocalizationTest` to validate that the application can differentiate between `CurrentCulture` and `CurrentUICulture` and display localized resources accordingly. To make this test work the changes were done to `LocalizedText.razor` and `BasicTestApp/Program.cs`.

Fixes #56824
