### PR TITLE
Clarify VPN requirement in Wasm.Performance README.md

### DIFF
--- a/src/Components/benchmarkapps/Wasm.Performance/README.md
+++ b/src/Components/benchmarkapps/Wasm.Performance/README.md
@@ -7,7 +7,7 @@ See https://github.com/aspnet/Benchmarks#benchmarks for usage guidance on using 
 
 The TestApp is a regular BlazorWASM project and can be run using `dotnet run`. The Driver is an app that uses Playwright to launch a browser and run the test app, reporting benchmark results in Crank's protocol format. You generally do not need to run the Driver locally, you can do so if needed via `dotnet run`.
 
-The benchmark app can also be run using [Crank](https://github.com/dotnet/crank?tab=readme-ov-file). To run the benchmark app in the Benchmark server, follow the Crank installation steps and then run:
+The benchmark app can also be run using [Crank](https://github.com/dotnet/crank?tab=readme-ov-file). To run the benchmark app in the Benchmark server, follow the Crank installation steps, connect to the VPN and then run:
 
 ```
 crank --config https://github.com/dotnet/aspnetcore/blob/main/src/Components/benchmarkapps/Wasm.Performance/benchmarks.compose.json?raw=true --config https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true --scenario blazorwasmbenchmark --profile aspnet-perf-lin


### PR DESCRIPTION
VPN is required for connecting to the benchmark server.

