### PR TITLE
Fix attribute order dependency in ModelAttributesTest

### DIFF
--- a/src/Mvc/Mvc.Core/test/ModelBinding/Metadata/ModelAttributesTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Metadata/ModelAttributesTest.cs
@@ -216,10 +216,8 @@ public class ModelAttributesTest
             attribute => Assert.IsType<RequiredAttribute>(attribute),
             attribute => Assert.IsType<RangeAttribute>(attribute));
         Assert.Null(attributes.PropertyAttributes);
-        Assert.Collection(
-            // Take(1) because the attribute or attributes after SerializableAttribute are framework-specific.
-            attributes.TypeAttributes.Take(1),
-            attribute => Assert.IsType<SerializableAttribute>(attribute));
+        // Check that SerializableAttribute exists in TypeAttributes (order-agnostic)
+        Assert.Contains(attributes.TypeAttributes, attr => attr is SerializableAttribute);
     }
 
     [Fact]


### PR DESCRIPTION
# This PR fixes a test failure on Mono runtime by removing dependency on attribute ordering in ModelAttributesTest.GetAttributesForParameter_SomeAttributes

## Description
The test was failing on Mono runtime because it assumed `SerializableAttribute` would be the first attribute returned by `GetCustomAttributes()`
```
Failed Microsoft.AspNetCore.Mvc.ModelBinding.ModelAttributesTest.GetAttributesForParameter_SomeAttributes
Error: Assert.IsType() Failure: Value is not the exact type
Expected: typeof(System.SerializableAttribute) 
Actual:   typeof(System.Runtime.CompilerServices.IsReadOnlyAttribute)
```
see detail [here](https://github.com/dotnet/runtime/pull/117864#issuecomment-3105730282)

As pointed out by @jkotas in [dotnet/runtime#117864](https://github.com/dotnet/runtime/pull/117864#issuecomment-3105797089):

> "The order of attributes is not significant. [...] If the test depends on attributes being returned in a specific order, it should be fixed to not do that."

The [C# Specification](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/attributes#223-attribute-specification) confirms that **attribute order is not guaranteed**


This change ensures the test verifies the presence of the expected attribute without depending on its position, making it compliant with the C# specification and compatible across all .NET runtimes.


cc: @jkotas 