### PR TITLE
Passkeys - JSON.stringify() fallback for various password managers

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Shared/PasskeySubmit.razor.js
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Shared/PasskeySubmit.razor.js
@@ -164,7 +164,7 @@ customElements.define('passkey-submit', class extends HTMLElement {
         // Uint8Array to base64
         if (o instanceof Uint8Array) {
             var str = "";
-            var len = o.byteLength;
+            const len = o.byteLength;
 
             for (var i = 0; i < len; i++) {
                 str += String.fromCharCode(o[i]);

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Shared/PasskeySubmit.razor.js
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Shared/PasskeySubmit.razor.js
@@ -166,7 +166,7 @@ customElements.define('passkey-submit', class extends HTMLElement {
             var str = "";
             const len = o.byteLength;
 
-            for (var i = 0; i < len; i++) {
+            for (let i = 0; i < len; i++) {
                 str += String.fromCharCode(o[i]);
             }
             o = window.btoa(str);

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Shared/PasskeySubmit.razor.js
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Shared/PasskeySubmit.razor.js
@@ -98,7 +98,8 @@ customElements.define('passkey-submit', class extends HTMLElement {
             try {
                 credentialJson = JSON.stringify(credential);
             } catch (error) {
-                if (error.message !== 'Illegal invocation') {
+                // Check for 'TypeError' instead of relying on the exact error message.
+                if (error.name !== 'TypeError') {
                     throw error;
                 }
                 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Shared/PasskeySubmit.razor.js
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Shared/PasskeySubmit.razor.js
@@ -152,32 +152,30 @@ customElements.define('passkey-submit', class extends HTMLElement {
             return undefined;
         }
         
-        // Array or ArrayBuffer to Uint8Array
+        // Normalize Array to Uint8Array
         if (Array.isArray(o)) {
             o = Uint8Array.from(o);
         }
-
+        
+        // Normalize ArrayBuffer to Uint8Array
         if (o instanceof ArrayBuffer) {
             o = new Uint8Array(o);
         }
 
-        // Uint8Array to base64
+        // Convert Uint8Array to base64
         if (o instanceof Uint8Array) {
-            var str = "";
-            const len = o.byteLength;
-
-            for (let i = 0; i < len; i++) {
+            let str = '';
+            for (let i = 0; i < o.byteLength; i++) {
                 str += String.fromCharCode(o[i]);
             }
             o = window.btoa(str);
         }
 
-        if (typeof o !== "string") {
-            throw new Error("could not coerce to string");
+        if (typeof o !== 'string') {
+            throw new Error("Could not convert to base64 string");
         }
 
-        // base64 to base64url
-        // NOTE: "=" at the end of challenge is optional, strip it off here
+        // Convert base64 to base64url
         o = o.replace(/\+/g, "-").replace(/\//g, "_").replace(/=*$/g, "");
 
         return o;


### PR DESCRIPTION
# Passkeys - JSON.stringify() fallback for various password managers

Some password managers do not implement `PublicKeyCredential.prototype.toJSON` correctly, which is required for `JSON.stringify()` to work when serializing a passkey credential - e.g. https://www.1password.community/discussions/1password/typeerror-illegal-invocation-in-chrome-browser/47399

This PR adds a fallback to work with various password managers.

- Issue: https://github.com/dotnet/aspnetcore/issues/62916
- Note the helper function to convert to base64 is from @abergs helper functions at https://github.com/passwordless-lib/fido2-net-lib/blob/master/Demo/wwwroot/js/helpers.js (MIT License, suggestions on how to communicate this in the PR are welcome)