### PR TITLE
Omit key services with derived attribute from OpenAPI definitions

### DIFF
--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -274,7 +274,7 @@ internal sealed class EndpointMetadataApiDescriptionProvider : IApiDescriptionPr
         {
             return (BindingSource.FormFile, fromFormAttribute.Name ?? parameter.Name ?? string.Empty, false, parameterType);
         }
-        else if (parameter.ParameterInfo.CustomAttributes.Any(a => typeof(IFromServiceMetadata).IsAssignableFrom(a.AttributeType) || typeof(FromKeyedServicesAttribute) == a.AttributeType) ||
+        else if (parameter.ParameterInfo.CustomAttributes.Any(a => a.AttributeType.IsAssignableTo(typeof(IFromServiceMetadata)) || a.AttributeType.IsAssignableTo(typeof(FromKeyedServicesAttribute))) ||
                  parameterType == typeof(HttpContext) ||
                  parameterType == typeof(HttpRequest) ||
                  parameterType == typeof(HttpResponse) ||

--- a/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
@@ -796,6 +796,7 @@ public class EndpointMetadataApiDescriptionProviderTest
         Assert.Empty(GetApiDescription((IInferredServiceInterface foo) => { }).ParameterDescriptions);
         Assert.Empty(GetApiDescription(([FromServices] InferredServiceClass foo) => { }).ParameterDescriptions);
         Assert.Empty(GetApiDescription(([FromKeyedServices("foo")] InferredServiceClass foo) => { }).ParameterDescriptions);
+        Assert.Empty(GetApiDescription(([CustomFromKeyedServices("foo")] InferredServiceClass foo) => { }).ParameterDescriptions);
         Assert.Empty(GetApiDescription((HttpContext context) => { }).ParameterDescriptions);
         Assert.Empty(GetApiDescription((HttpRequest request) => { }).ParameterDescriptions);
         Assert.Empty(GetApiDescription((HttpResponse response) => { }).ParameterDescriptions);
@@ -1811,6 +1812,10 @@ public class EndpointMetadataApiDescriptionProviderTest
     }
 
     private class InferredServiceClass : IInferredServiceInterface
+    {
+    }
+
+    private class CustomFromKeyedServicesAttribute(string key) : FromKeyedServicesAttribute("Custom" + key)
     {
     }
 

--- a/src/OpenApi/src/Services/OpenApiGenerator.cs
+++ b/src/OpenApi/src/Services/OpenApiGenerator.cs
@@ -424,7 +424,7 @@ internal sealed class OpenApiGenerator
         {
             return (true, null, null);
         }
-        else if (parameter.CustomAttributes.Any(a => typeof(IFromServiceMetadata).IsAssignableFrom(a.AttributeType) || typeof(FromKeyedServicesAttribute) == a.AttributeType) ||
+        else if (parameter.CustomAttributes.Any(a => a.AttributeType.IsAssignableTo(typeof(IFromServiceMetadata)) || a.AttributeType.IsAssignableTo(typeof(FromKeyedServicesAttribute))) ||
                 parameter.ParameterType == typeof(HttpContext) ||
                 parameter.ParameterType == typeof(HttpRequest) ||
                 parameter.ParameterType == typeof(HttpResponse) ||

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiGeneratorTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiGeneratorTests.cs
@@ -414,6 +414,7 @@ public class OpenApiOperationGeneratorTests
         Assert.Empty(GetOpenApiOperation((IInferredServiceInterface foo) => { }).Parameters);
         Assert.Empty(GetOpenApiOperation(([FromServices] int foo) => { }).Parameters);
         Assert.Empty(GetOpenApiOperation(([FromKeyedServices("foo")] int foo) => { }).Parameters);
+        Assert.Empty(GetOpenApiOperation(([CustomFromKeyedServices("foo")] int foo) => { }).Parameters);
         Assert.Empty(GetOpenApiOperation((HttpContext context) => { }).Parameters);
         Assert.Empty(GetOpenApiOperation((HttpRequest request) => { }).Parameters);
         Assert.Empty(GetOpenApiOperation((HttpResponse response) => { }).Parameters);
@@ -1083,6 +1084,10 @@ public class OpenApiOperationGeneratorTests
     }
 
     private interface IInferredServiceInterface
+    {
+    }
+
+    private class CustomFromKeyedServicesAttribute(string key) : FromKeyedServicesAttribute("Custom" + key)
     {
     }
 


### PR DESCRIPTION
# Omit key services with derived attribute from OpenAPI definitions

Instead of checking the attribute type is exactly `FromKeyedServicesAttribute`, it now checks if it's assignable to it, so that it also covers derived attributes.

Note, I find the relatively newer `IsAssignableTo` easier to follow than `IsAssignableFrom` so opted for that, and in a slightly opinionated way I changed the existing code on that line to use that too, for some local consistency. I hope that's ok.

Fixes #58739
