### PR TITLE
Fix:Modifications made by SchemaTransformer to Parameters do not take effect immediately

### DIFF
--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -444,6 +444,8 @@ internal sealed class OpenApiDocumentService(
                 continue;
             }
 
+            // Execute 'schemaTransformers' ahead of time to apply modifications made by 'schemaTransformers' to the parameter.
+            var schema = await _componentService.GetOrCreateSchemaAsync(document, GetTargetType(description, parameter), scopedServiceProvider, schemaTransformers, parameter, cancellationToken: cancellationToken);
             var openApiParameter = new OpenApiParameter
             {
                 Name = parameter.Name,
@@ -455,7 +457,7 @@ internal sealed class OpenApiDocumentService(
                     _ => ParameterLocation.Query
                 },
                 Required = IsRequired(parameter),
-                Schema = await _componentService.GetOrCreateSchemaAsync(document, GetTargetType(description, parameter), scopedServiceProvider, schemaTransformers, parameter, cancellationToken: cancellationToken),
+                Schema = schema,
                 Description = GetParameterDescriptionFromAttribute(parameter)
             };
 

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/SchemaTransformerTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/SchemaTransformerTests.cs
@@ -942,6 +942,29 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
         Assert.Equal([1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3], transformerOrder);
     }
 
+    [Fact]
+    public async Task SchemaTransformer_TransformsParameterNameToUppercase()
+    {
+        var builder = CreateBuilder();
+
+        builder.MapGet("/todo", (Todo todo) => { });
+
+        var options = new OpenApiOptions();
+        options.AddSchemaTransformer((schema, context, cancellationToken) =>
+        {
+            context.ParameterDescription.Name = context.ParameterDescription.Name.ToUpper();
+            return Task.CompletedTask;
+        });
+
+        await VerifyOpenApiDocument(builder, options, document =>
+        {
+            var path = Assert.Single(document.Paths.Values);
+            var getOperation = path.Operations[HttpMethod.Get];
+            var parameterName = getOperation.Parameters[0].Name;
+            Assert.Equal("TODO", parameterName);
+        });
+    }
+
     private class PolymorphicContainer
     {
         public string Name { get; }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/SchemaTransformerTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/SchemaTransformerTests.cs
@@ -947,12 +947,12 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
     {
         var builder = CreateBuilder();
 
-        builder.MapGet("/todo", (Todo todo) => { });
+        builder.MapGet("/todo", (int todo) => { });
 
         var options = new OpenApiOptions();
         options.AddSchemaTransformer((schema, context, cancellationToken) =>
         {
-            context.ParameterDescription.Name = context.ParameterDescription.Name.ToUpper(System.Globalization.CultureInfo.CurrentCulture);
+            context.ParameterDescription.Name = context.ParameterDescription.Name.ToUpper(CultureInfo.CurrentCulture);
             return Task.CompletedTask;
         });
 

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/SchemaTransformerTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/SchemaTransformerTests.cs
@@ -952,7 +952,7 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
         var options = new OpenApiOptions();
         options.AddSchemaTransformer((schema, context, cancellationToken) =>
         {
-            context.ParameterDescription.Name = context.ParameterDescription.Name.ToUpper();
+            context.ParameterDescription.Name = context.ParameterDescription.Name.ToUpper(System.Globalization.CultureInfo.CurrentCulture);
             return Task.CompletedTask;
         });
 


### PR DESCRIPTION
## Problem

Modifications made by "SchemaTransformer" to Parameter will not take effect immediately, because "SchemaTransformer" is run when "OpenApiParameter" is constructed, rather than running "SchemaTransformer" first.
<img width="1663" height="384" alt="image" src="https://github.com/user-attachments/assets/bde8bb43-d21e-4459-b873-9e3d26e1e78e" />


## Solution

Execute "SchemaTransformer" in advance to take effect of parameter changes
<img width="1738" height="376" alt="image" src="https://github.com/user-attachments/assets/9138aadd-3f8c-42cd-b46e-d3ae52182d8c" />


Fixes #62893
