### PR TITLE
Add passkey count and name length limits

### DIFF
--- a/src/Identity/Core/src/IdentityPasskeyOptions.cs
+++ b/src/Identity/Core/src/IdentityPasskeyOptions.cs
@@ -69,15 +69,16 @@ public class IdentityPasskeyOptions
     /// </para>
     /// <para>
     /// Possible values are "required", "preferred", and "discouraged".
+    /// If set to <see langword="null"/>, the effective value is "preferred".
     /// </para>
     /// <para>
-    /// If left <see langword="null"/>, the browser defaults to "preferred".
+    /// The default value is "required".
     /// </para>
     /// <para>
     /// See <see href="https://www.w3.org/TR/webauthn-3/#enumdef-userverificationrequirement"/>.
     /// </para>
     /// </remarks>
-    public string? UserVerificationRequirement { get; set; }
+    public string? UserVerificationRequirement { get; set; } = "required";
 
     /// <summary>
     /// Gets or sets the extent to which the server desires to create a client-side discoverable credential.

--- a/src/Identity/Core/src/IdentityPasskeyOptions.cs
+++ b/src/Identity/Core/src/IdentityPasskeyOptions.cs
@@ -87,16 +87,17 @@ public class IdentityPasskeyOptions
     /// This option only applies when creating a new passkey, and is not enforced on the server.
     /// </para>
     /// <para>
-    /// Possible values are "discouraged", "preferred", or "required".
+    /// Possible values are "discouraged", "preferred", "required", or <see langword="null"/>.
+    /// If set to <see langword="null"/>, the effective value is "discouraged".
     /// </para>
     /// <para>
-    /// If left <see langword="null"/>, the browser defaults to "preferred".
+    /// The default value is "preferred".
     /// </para>
     /// <para>
     /// See <see href="https://www.w3.org/TR/webauthn-3/#enumdef-residentkeyrequirement"/>.
     /// </para>
     /// </remarks>
-    public string? ResidentKeyRequirement { get; set; }
+    public string? ResidentKeyRequirement { get; set; } = "preferred";
 
     /// <summary>
     /// Gets or sets the attestation conveyance preference.

--- a/src/Identity/Extensions.Stores/src/IdentityPasskeyData.cs
+++ b/src/Identity/Extensions.Stores/src/IdentityPasskeyData.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Identity;
 

--- a/src/Identity/test/Identity.Test/IdentityPasskeyOptionsTest.cs
+++ b/src/Identity/test/Identity.Test/IdentityPasskeyOptionsTest.cs
@@ -12,9 +12,9 @@ public class IdentityPasskeyOptionsTest
 
         Assert.Equal(TimeSpan.FromMinutes(5), options.AuthenticatorTimeout);
         Assert.Equal(32, options.ChallengeSize);
+        Assert.Equal("preferred", options.ResidentKeyRequirement);
+        Assert.Equal("required", options.UserVerificationRequirement);
         Assert.Null(options.ServerDomain);
-        Assert.Null(options.UserVerificationRequirement);
-        Assert.Null(options.ResidentKeyRequirement);
         Assert.Null(options.AttestationConveyancePreference);
         Assert.Null(options.AuthenticatorAttachment);
         Assert.Null(options.IsAllowedAlgorithm);

--- a/src/Identity/test/Identity.Test/Passkeys/PasskeyHandlerAssertionTest.cs
+++ b/src/Identity/test/Identity.Test/Passkeys/PasskeyHandlerAssertionTest.cs
@@ -980,7 +980,10 @@ public class PasskeyHandlerAssertionTest
     {
         private static readonly byte[] _defaultCredentialId = [1, 2, 3, 4, 5, 6, 7, 8];
 
-        public IdentityPasskeyOptions PasskeyOptions { get; } = new();
+        public IdentityPasskeyOptions PasskeyOptions { get; } = new()
+        {
+            UserVerificationRequirement = "preferred",
+        };
         public string Origin { get; set; } = "https://example.com";
         public PocoUser User { get; set; } = new()
         {

--- a/src/Identity/test/Identity.Test/Passkeys/PasskeyHandlerAttestationTest.cs
+++ b/src/Identity/test/Identity.Test/Passkeys/PasskeyHandlerAttestationTest.cs
@@ -978,7 +978,10 @@ public class PasskeyHandlerAttestationTest
         private static readonly byte[] _defaultAaguid = new byte[16];
         private static readonly byte[] _defaultAttestationStatement = [0xA0]; // Empty CBOR map
 
-        public IdentityPasskeyOptions PasskeyOptions { get; } = new();
+        public IdentityPasskeyOptions PasskeyOptions { get; } = new()
+        {
+            UserVerificationRequirement = "preferred",
+        };
         public string? UserId { get; set; } = "df0a3af4-bd65-440f-82bd-5b839e300dcd";
         public string? UserName { get; set; } = "johndoe";
         public string? UserDisplayName { get; set; } = "John Doe";

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/Passkeys.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/Passkeys.razor
@@ -48,10 +48,15 @@ else
 
 <form @formname="add-passkey" @onsubmit="AddPasskey" method="post">
     <AntiforgeryToken />
-    @if (currentPasskeys is not { Count: >= MaxPasskeyCount })
+    @if (currentPasskeys is { Count: >= MaxPasskeyCount })
+    {
+        <p class="text-danger">You have reached the maximum number of allowed passkeys. Please delete one before adding a new one.</p>
+    }
+    else
     {
         <PasskeySubmit Operation="PasskeyOperation.Create" Name="Input" class="btn btn-primary">Add a new passkey</PasskeySubmit>
     }
+
 </form>
 
 @code {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/Passkeys.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/Passkeys.razor
@@ -48,10 +48,15 @@ else
 
 <form @formname="add-passkey" @onsubmit="AddPasskey" method="post">
     <AntiforgeryToken />
-    <PasskeySubmit Operation="PasskeyOperation.Create" Name="Input" class="btn btn-primary">Add a new passkey</PasskeySubmit>
+    @if (currentPasskeys is not { Count: >= MaxPasskeyCount })
+    {
+        <PasskeySubmit Operation="PasskeyOperation.Create" Name="Input" class="btn btn-primary">Add a new passkey</PasskeySubmit>
+    }
 </form>
 
 @code {
+    private const int MaxPasskeyCount = 100;
+
     private ApplicationUser? user;
     private IList<UserPasskeyInfo>? currentPasskeys;
 
@@ -97,6 +102,12 @@ else
         if (string.IsNullOrEmpty(Input.CredentialJson))
         {
             RedirectManager.RedirectToCurrentPageWithStatus("Error: The browser did not provide a passkey.", HttpContext);
+            return;
+        }
+
+        if (currentPasskeys!.Count >= MaxPasskeyCount)
+        {
+            RedirectManager.RedirectToCurrentPageWithStatus($"Error: You have reached the maximum number of allowed passkeys.", HttpContext);
             return;
         }
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/RenamePasskey.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/RenamePasskey.razor
@@ -89,7 +89,7 @@
     private sealed class InputModel
     {
         [Required]
-        [MaxLength(200, ErrorMessage = "Passkey names must be no longer than 200 characters.")]
+        [StringLength(200, ErrorMessage = "Passkey names must be no longer than {1} characters.")]
         public string Name { get; set; } = "";
     }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/RenamePasskey.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/RenamePasskey.razor
@@ -89,6 +89,7 @@
     private sealed class InputModel
     {
         [Required]
+        [MaxLength(200, ErrorMessage = "Passkey names must be no longer than 200 characters.")]
         public string Name { get; set; } = "";
     }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Shared/PasskeySubmit.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Shared/PasskeySubmit.razor
@@ -35,6 +35,6 @@
 
     protected override void OnInitialized()
     {
-        tokens = Services.GetRequiredService<IAntiforgery>()?.GetTokens(HttpContext);
+        tokens = Services.GetService<IAntiforgery>()?.GetTokens(HttpContext);
     }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/appsettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/appsettings.json
@@ -4,7 +4,7 @@
 //#if (UseLocalDB)
 //    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnet-BlazorWebCSharp__1-53bc9b9d-9d6a-45d4-8429-2a2761773502;Trusted_Connection=True;MultipleActiveResultSets=true"
 //#else
-//    "DefaultConnection": "DataSource=Data\\app.db;Cache=Shared"
+//    "DefaultConnection": "DataSource=Data/app.db;Cache=Shared"
 //#endif
 //  },
 ////#endif

--- a/src/ProjectTemplates/test/Templates.Blazor.Tests/BlazorTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Blazor.Tests/BlazorTemplateTest.cs
@@ -233,6 +233,14 @@ public abstract class BlazorTemplateTest : BrowserTestBase
                 await page.ClickAsync("text=Add a new passkey");
 
                 await page.WaitForSelectorAsync("text=Enter a name for your passkey");
+
+                // First check that we can't register a passkey with a long name.
+                var longName = new string('a', count: 201);
+                await page.FillAsync("[name=\"Input.Name\"]", longName);
+                await page.ClickAsync("text=Continue");
+                await page.WaitForSelectorAsync("text=Passkey names must be no longer than 200 characters.");
+
+                // Now register a passkey with a valid name
                 await page.FillAsync("[name=\"Input.Name\"]", "My passkey");
                 await page.ClickAsync("text=Continue");
 


### PR DESCRIPTION
Changes in this PR:
* Updates the Blazor Web App project template to enforce limits on passkey name length and the number of passkeys that can be registered to an account
* Changes the default value of `ResidentKeyRequirement` to "preferred" so that security keys supporting resident keys register a client-side discoverable credential when possible
* Updates the sqlite connection string to use a `/` instead of `\\` to fix a bug when creating the project template on macOS.

Fixes https://github.com/dotnet/AspNetCore-ManualTests/issues/3709
Fixes https://github.com/dotnet/aspnetcore-manualtests/issues/3699
Fixes https://github.com/dotnet/aspnetcore/issues/60807
