### PR TITLE
[OpenAPI] Get parameter description with [FromQuery]

### DIFF
--- a/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
@@ -309,6 +309,11 @@ internal static class JsonNodeSchemaExtensions
             var attributes = validations.OfType<ValidationAttribute>();
             schema.ApplyValidationAttributes(attributes);
         }
+        if (parameterDescription.ModelMetadata is Mvc.ModelBinding.Metadata.DefaultModelMetadata { Attributes.PropertyAttributes.Count: > 0 } metadata &&
+            metadata.Attributes.PropertyAttributes.OfType<DefaultValueAttribute>().LastOrDefault() is { } metadataDefaultValueAttribute)
+        {
+            schema.ApplyDefaultValue(metadataDefaultValueAttribute.Value, jsonTypeInfo);
+        }
         if (parameterDescription.ParameterDescriptor is IParameterInfoParameterDescriptor { ParameterInfo: { } parameterInfo })
         {
             if (parameterInfo.HasDefaultValue)

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentServiceTestsBase.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentServiceTestsBase.cs
@@ -229,7 +229,7 @@ public abstract class OpenApiDocumentServiceTestBase
 
         action.AttributeRouteInfo = new()
         {
-            Template = action.MethodInfo.GetCustomAttribute<RouteAttribute>()?.Template,
+            Template = action.MethodInfo.GetCustomAttribute<RouteAttribute>()?.Template ?? string.Empty,
             Name = action.MethodInfo.GetCustomAttribute<RouteAttribute>()?.Name,
             Order = action.MethodInfo.GetCustomAttribute<RouteAttribute>()?.Order ?? 0,
         };


### PR DESCRIPTION
# Get parameter description with [FromQuery]

Get an OpenAPI description when attribute is on an object's property.

## Description

Get the description from the associated object's property when `[FromQuery]` is applied to a property of an object used as a `[FromQuery]` parameter.

Fixes #61297
