### PR TITLE
[OpenApi] Use GetCustomAttributes<T>

### DIFF
--- a/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
@@ -320,7 +320,7 @@ internal static class JsonNodeSchemaExtensions
                 schema.ApplyDefaultValue(defaultValueAttribute.Value, jsonTypeInfo);
             }
 
-            if (parameterInfo.GetCustomAttributes().OfType<ValidationAttribute>() is { } validationAttributes)
+            if (parameterInfo.GetCustomAttributes<ValidationAttribute>() is { } validationAttributes)
             {
                 schema.ApplyValidationAttributes(validationAttributes);
             }


### PR DESCRIPTION
# Use GetCustomAttributes<T>

Use `GetCustomAttributes<T>()`.

## Description

Use `GetCustomAttributes<T>()` instead of `GetCustomAttributes().OfType<T>()` to avoid need to use LINQ.
