### PR TITLE
Update media type for JSON Patch

### DIFF
--- a/src/Features/JsonPatch.SystemTextJson/src/Microsoft.AspNetCore.JsonPatch.SystemTextJson.csproj
+++ b/src/Features/JsonPatch.SystemTextJson/src/Microsoft.AspNetCore.JsonPatch.SystemTextJson.csproj
@@ -17,6 +17,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Reference Include="Microsoft.AspNetCore.Http.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.AspNetCore.JsonPatch.SystemTextJson.Tests" />
   </ItemGroup>
 </Project>

--- a/src/Features/JsonPatch/build.cmd
+++ b/src/Features/JsonPatch/build.cmd
@@ -1,3 +1,3 @@
 @ECHO OFF
-SET RepoRoot=%~dp0..\..
+SET RepoRoot=%~dp0..\..\..
 %RepoRoot%\eng\build.cmd -projects %~dp0**\*.*proj %*

--- a/src/Features/JsonPatch/src/Microsoft.AspNetCore.JsonPatch.csproj
+++ b/src/Features/JsonPatch/src/Microsoft.AspNetCore.JsonPatch.csproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
     <Reference Include="Newtonsoft.Json" />
+    <Reference Include="Microsoft.AspNetCore.Http.Abstractions" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenApi/sample/Endpoints/MapSchemasEndpoints.cs
+++ b/src/OpenApi/sample/Endpoints/MapSchemasEndpoints.cs
@@ -4,6 +4,7 @@
 using System.Collections.Immutable;
 using System.ComponentModel;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.JsonPatch.SystemTextJson;
 
 public static class SchemasEndpointsExtensions
 {
@@ -36,6 +37,7 @@ public static class SchemasEndpointsExtensions
         schemas.MapPost("/location", (LocationContainer location) => { });
         schemas.MapPost("/parent", (ParentObject parent) => Results.Ok(parent));
         schemas.MapPost("/child", (ChildObject child) => Results.Ok(child));
+        schemas.MapPatch("/json-patch", (JsonPatchDocument<ParentObject> patchDoc) => Results.NoContent());
 
         return endpointRouteBuilder;
     }

--- a/src/OpenApi/sample/Sample.csproj
+++ b/src/OpenApi/sample/Sample.csproj
@@ -16,12 +16,13 @@
     <Reference Include="Microsoft.AspNetCore" />
     <Reference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <Reference Include="Microsoft.AspNetCore.Hosting" />
-    <Reference Include="Microsoft.AspNetCore.OpenApi" />
     <Reference Include="Microsoft.AspNetCore.Http" />
     <Reference Include="Microsoft.AspNetCore.Http.Results" />
+    <Reference Include="Microsoft.AspNetCore.JsonPatch.SystemTextJson" />
+    <Reference Include="Microsoft.AspNetCore.Mvc" />
+    <Reference Include="Microsoft.AspNetCore.OpenApi" />
     <Reference Include="Microsoft.AspNetCore.StaticFiles" />
     <Reference Include="Microsoft.Extensions.FileProviders.Embedded" />
-    <Reference Include="Microsoft.AspNetCore.Mvc" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
@@ -507,6 +507,28 @@
           }
         }
       }
+    },
+    "/schemas-by-ref/json-patch": {
+      "patch": {
+        "tags": [
+          "Sample"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonPatchDocumentOfParentObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -599,6 +621,7 @@
           }
         }
       },
+      "JsonPatchDocumentOfParentObject": { },
       "LocationContainer": {
         "required": [
           "location"

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
@@ -507,6 +507,28 @@
           }
         }
       }
+    },
+    "/schemas-by-ref/json-patch": {
+      "patch": {
+        "tags": [
+          "Sample"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonPatchDocumentOfParentObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -599,6 +621,7 @@
           }
         }
       },
+      "JsonPatchDocumentOfParentObject": { },
       "LocationContainer": {
         "required": [
           "location"


### PR DESCRIPTION
# Update media type for JSON Patch

Use `Content-Type: application/json-patch+json` for JSON patch.

## Description

- Use `Content-Type: application/json-patch+json` for JSON patch.
- Fix some code analyzer suggestions.
- Fix broken `build.cmd` for JsonPatch.

Adapted from #62057.

Fixes #61956.
