### PR TITLE
Revert "Skip RequestPathBase_WithDoubleSlashes_Split for now"

### DIFF
--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/RequestPathBaseTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/RequestPathBaseTests.cs
@@ -41,7 +41,6 @@ public class RequestPathBaseTests : FixtureLoggedTest
     [InlineData("/Sub%5CApp/PathAndPathBase/", @"/Sub\App/PathAndPathBase", "/")]
     [InlineData("/Sub/App/PathAndPathBase/Path", "/Sub/App/PathAndPathBase", "/Path")]
     [InlineData("/Sub/App/PathANDPathBase/PATH", "/Sub/App/PathANDPathBase", "/PATH")]
-    [SkipOnCI]
     public async Task RequestPathBase_Split(string url, string expectedPathBase, string expectedPath)
     {
         // The test app trims the test name off of the request path and puts it on the PathBase.
@@ -71,7 +70,6 @@ public class RequestPathBaseTests : FixtureLoggedTest
     // [InlineData(@"/Sub/call//../App/PathAndPathBase//path1//path2", @"", "/Sub/call/App/PathAndPathBase//path1//path2")]
     [InlineData(@"/Sub/call/.%2e/App/PathAndPathBase//path1//path2", @"/Sub/App/PathAndPathBase", "//path1//path2")]
     [InlineData(@"/Sub/call/.%2E/App/PathAndPathBase//path1//path2", @"/Sub/App/PathAndPathBase", "//path1//path2")]
-    [SkipOnCI]
     public async Task RequestPathBase_WithDoubleSlashes_Split(string url, string expectedPathBase, string expectedPath)
     {
         // The test app trims the test name off of the request path and puts it on the PathBase.


### PR DESCRIPTION
The rollout may already be done