### PR TITLE
remove redundant tag in IAsyncResultFilter and IResultFilter interfaces

### DIFF
--- a/src/Mvc/Mvc.Abstractions/src/Filters/IAsyncResultFilter.cs
+++ b/src/Mvc/Mvc.Abstractions/src/Filters/IAsyncResultFilter.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Mvc.Filters;
 /// <para>
 /// <see cref="IResultFilter"/> and <see cref="IAsyncResultFilter"/> instances are not executed in cases where
 /// an authorization filter or resource filter short-circuits the request to prevent execution of the action.
-/// <see cref="IResultFilter"/>. <see cref="IResultFilter"/> and <see cref="IAsyncResultFilter"/> implementations
+/// <see cref="IResultFilter"/> and <see cref="IAsyncResultFilter"/> implementations
 /// are also not executed in cases where an exception filter handles an exception by producing an action result.
 /// </para>
 /// <para>

--- a/src/Mvc/Mvc.Abstractions/src/Filters/IResultFilter.cs
+++ b/src/Mvc/Mvc.Abstractions/src/Filters/IResultFilter.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Mvc.Filters;
 /// <para>
 /// <see cref="IResultFilter"/> and <see cref="IAsyncResultFilter"/> instances are not executed in cases where
 /// an authorization filter or resource filter short-circuits the request to prevent execution of the action.
-/// <see cref="IResultFilter"/>. <see cref="IResultFilter"/> and <see cref="IAsyncResultFilter"/> implementations
+/// <see cref="IResultFilter"/> and <see cref="IAsyncResultFilter"/> implementations
 /// are also not executed in cases where an exception filter handles an exception by producing an action result.
 /// </para>
 /// <para>


### PR DESCRIPTION
# Remove redundant tag in IAsyncResultFilter and IResultFilter interfaces

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

Remove the redundant tag `<see cref="IResultFilter"/>.` of both IAsyncResultFilter and IResultFilter interfaces.

Fixes #62995
