### PR TITLE
Improve logging and error handling for IIS ASP.NET Core module shadow copy

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationinfo.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationinfo.cpp
@@ -84,6 +84,8 @@ APPLICATION_INFO::CreateApplication(IHttpContext& pHttpContext)
         return S_OK;
     }
 
+    std::wstring pExceptionMessage;
+
     try
     {
         const WebConfigConfigurationSource configurationSource(m_pServer.GetAdminManager(), pHttpApplication);
@@ -138,29 +140,43 @@ APPLICATION_INFO::CreateApplication(IHttpContext& pHttpContext)
         }
         return S_OK;
     }
-    catch (const ConfigurationLoadException &ex)
-    {
-        EventLog::Error(
-            ASPNETCORE_CONFIGURATION_LOAD_ERROR,
-            ASPNETCORE_CONFIGURATION_LOAD_ERROR_MSG,
-            ex.get_message().c_str());
-    }
     catch (...)
     {
         OBSERVE_CAUGHT_EXCEPTION();
+        pExceptionMessage = CaughtExceptionToString();
         EventLog::Error(
             ASPNETCORE_CONFIGURATION_LOAD_ERROR,
             ASPNETCORE_CONFIGURATION_LOAD_ERROR_MSG,
-            L"");
+            pExceptionMessage.c_str());
     }
 
+    ErrorContext errorContext;
+    errorContext.statusCode = 500i16;
+    errorContext.subStatusCode = 30i16;
+    errorContext.generalErrorType = "ASP.NET Core app failed to start - An exception was thrown during startup";
+    if (GetLastError() == ERROR_ACCESS_DENIED)
+    {
+        errorContext.errorReason = "Ensure the application pool process model has write permissions to the shadow copy directory";
+    }
+    // TODO: Depend on show detailed errors or nah?
+    errorContext.detailedErrorContent = to_multi_byte_string(pExceptionMessage, CP_UTF8);
+    auto page = ANCM_ERROR_PAGE;
+
+
+    auto responseContent = FILE_UTILITY::GetHtml(g_hServerModule,
+                                                 page,
+                                                 errorContext.statusCode,
+                                                 errorContext.subStatusCode,
+                                                 errorContext.generalErrorType,
+                                                 errorContext.errorReason,
+                                                 errorContext.detailedErrorContent);
     m_pApplication = make_application<ServerErrorApplication>(
         pHttpApplication,
         E_FAIL,
         false /* disableStartupPage */,
-        "" /* responseContent */,
-        500i16 /* statusCode */,
-        0i16 /* subStatusCode */,
+        responseContent /* responseContent */,
+        errorContext.statusCode /* statusCode */,
+        errorContext.subStatusCode/* subStatusCode */,
         "Internal Server Error");
 
     return S_OK;
@@ -193,7 +209,26 @@ APPLICATION_INFO::TryCreateApplication(IHttpContext& pHttpContext, const ShimOpt
         }
     }
 
-    auto shadowCopyPath = HandleShadowCopy(options, pHttpContext);
+    std::filesystem::path shadowCopyPath;
+
+    // Only support shadow copying for IIS.
+    if (options.QueryShadowCopyEnabled() && !m_pServer.IsCommandLineLaunch())
+    {
+        try
+        {
+            shadowCopyPath = HandleShadowCopy(options, pHttpContext, error);
+        }
+        catch (...)
+        {
+            OBSERVE_CAUGHT_EXCEPTION();
+            throw;
+        }
+
+        if (shadowCopyPath.empty())
+        {
+            return E_FAIL;
+        }
+    }
 
     RETURN_IF_FAILED(m_handlerResolver.GetApplicationFactory(*pHttpContext.GetApplication(), shadowCopyPath, m_pApplicationFactory, options, error));
     LOG_INFO(L"Creating handler application");
@@ -275,74 +310,107 @@ APPLICATION_INFO::ShutDownApplication(const bool fServerInitiated)
  * we will start a thread that deletes all other folders in that directory.
  */
 std::filesystem::path
-APPLICATION_INFO::HandleShadowCopy(const ShimOptions& options, IHttpContext& pHttpContext)
+APPLICATION_INFO::HandleShadowCopy(const ShimOptions& options, IHttpContext& pHttpContext, ErrorContext& error)
 {
-    std::filesystem::path shadowCopyPath;
+    std::filesystem::path shadowCopyPath = options.QueryShadowCopyDirectory();
+    std::wstring physicalPath = pHttpContext.GetApplication()->GetApplicationPhysicalPath();
 
-    // Only support shadow copying for IIS.
-    if (options.QueryShadowCopyEnabled() && !m_pServer.IsCommandLineLaunch())
+    // Make shadow copy path absolute.
+    if (!shadowCopyPath.is_absolute())
     {
-        shadowCopyPath = options.QueryShadowCopyDirectory();
-        std::wstring physicalPath = pHttpContext.GetApplication()->GetApplicationPhysicalPath();
+        shadowCopyPath = std::filesystem::absolute(std::filesystem::path(physicalPath) / shadowCopyPath);
+    }
 
-        // Make shadow copy path absolute.
-        if (!shadowCopyPath.is_absolute())
+    // The shadow copy directory itself isn't copied to directly.
+    // Instead subdirectories with numerically increasing names are created.
+    // This is because on shutdown, the app itself will still have all dlls loaded,
+    // meaning we can't copy to the same subdirectory. Therefore, on shutdown,
+    // we create a directory that is one larger than the previous largest directory number.
+    auto directoryName = 0;
+    std::string directoryNameStr = "0";
+    auto shadowCopyBaseDirectory = std::filesystem::directory_entry(shadowCopyPath);
+    if (!shadowCopyBaseDirectory.exists())
+    {
+        LOG_INFOF(L"Attempting to Create Directory");
+
+        auto ret = CreateDirectory(shadowCopyBaseDirectory.path().wstring().c_str(), nullptr);
+        if (!ret)
         {
-            shadowCopyPath = std::filesystem::absolute(std::filesystem::path(physicalPath) / shadowCopyPath);
-        }
-
-        // The shadow copy directory itself isn't copied to directly.
-        // Instead subdirectories with numerically increasing names are created.
-        // This is because on shutdown, the app itself will still have all dlls loaded,
-        // meaning we can't copy to the same subdirectory. Therefore, on shutdown,
-        // we create a directory that is one larger than the previous largest directory number.
-        auto directoryName = 0;
-        std::string directoryNameStr = "0";
-        auto shadowCopyBaseDirectory = std::filesystem::directory_entry(shadowCopyPath);
-        if (!shadowCopyBaseDirectory.exists())
-        {
-            CreateDirectory(shadowCopyBaseDirectory.path().wstring().c_str(), nullptr);
-        }
-
-        for (auto& entry : std::filesystem::directory_iterator(shadowCopyPath))
-        {
-            if (entry.is_directory())
-            {
-                try
-                {
-                    auto tempDirName = entry.path().filename().string();
-                    int intFileName = std::stoi(tempDirName);
-                    if (intFileName > directoryName)
-                    {
-                        directoryName = intFileName;
-                        directoryNameStr = tempDirName;
-                    }
-                }
-                catch (...)
-                {
-                    OBSERVE_CAUGHT_EXCEPTION();
-                    // Ignore any folders that can't be converted to an int.
-                }
-            }
-        }
-
-        int copiedFileCount = 0;
-
-        shadowCopyPath = shadowCopyPath / directoryNameStr;
-        LOG_INFOF(L"Copying to shadow copy directory %ls.", shadowCopyPath.c_str());
-
-        // Avoid using canonical for shadowCopyBaseDirectory
-        // It could expand to a network drive, or an expanded link folder path
-        // We already made it an absolute path relative to the physicalPath above
-        HRESULT hr = Environment::CopyToDirectory(physicalPath, shadowCopyPath, options.QueryCleanShadowCopyDirectory(), shadowCopyBaseDirectory.path(), copiedFileCount);
-
-        LOG_INFOF(L"Finished copying %d files to shadow copy directory %ls.", copiedFileCount, shadowCopyBaseDirectory.path().c_str());
-
-        if (hr != S_OK)
-        {
-            return std::wstring();
+            LOG_ERRORF(L"Failed to create shadow copy base directory %ls. Error: %d",
+                        shadowCopyBaseDirectory.path().c_str(),
+                        GetLastError());
         }
     }
 
+    for (auto& entry : std::filesystem::directory_iterator(shadowCopyPath))
+    {
+        if (entry.is_directory())
+        {
+            try
+            {
+                auto tempDirName = entry.path().filename().string();
+                int intFileName = std::stoi(tempDirName);
+                if (intFileName > directoryName)
+                {
+                    directoryName = intFileName;
+                    directoryNameStr = tempDirName;
+                }
+            }
+            catch (...)
+            {
+                OBSERVE_CAUGHT_EXCEPTION();
+                // Ignore any folders that can't be converted to an int.
+            }
+        }
+    }
+
+    int copiedFileCount = 0;
+
+    shadowCopyPath = shadowCopyPath / directoryNameStr;
+    LOG_INFOF(L"Copying from %ls to shadow copy directory %ls.", physicalPath.c_str(), shadowCopyPath.c_str());
+
+    // Avoid using canonical for shadowCopyBaseDirectory
+    // It could expand to a network drive, or an expanded link folder path
+    // We already made it an absolute path relative to the physicalPath above
+    try {
+        // CopyToDirectory throws exception on failure, therefore don't need to check return value
+        Environment::CopyToDirectory(physicalPath, shadowCopyPath, options.QueryCleanShadowCopyDirectory(), shadowCopyBaseDirectory.path(), copiedFileCount);
+    }
+    catch (const std::system_error& ex)
+    {
+        auto exWideString = to_wide_string(ex.what(), CP_ACP);
+
+        std::wstring logMessage = format(L"Failed to copy files from %s to shadow copy directory %s. Error: %s",
+                                         physicalPath.c_str(),
+                                         shadowCopyPath.c_str(),
+                                         exWideString.c_str());
+
+        LOG_ERRORF(L"%ls", logMessage.c_str());
+        EventLog::Error(ASPNETCORE_CONFIGURATION_LOAD_ERROR,
+                        ASPNETCORE_CONFIGURATION_LOAD_ERROR_MSG,
+                        logMessage.c_str());
+
+        // TODO: Better substatus code
+        error.statusCode = 500i16;
+        error.subStatusCode = 30i16;
+
+        std::string errorMessage = "Failed to copy to shadow copy directory";
+        auto exceptionCode = ex.code().value();
+        if (exceptionCode == ERROR_ACCESS_DENIED || exceptionCode == ERROR_PATH_NOT_FOUND)
+        {
+            errorMessage = "No permissions to shadow copy directory";
+        }
+
+        error.generalErrorType = format("ASP.NET Core app failed to start - %s", errorMessage.c_str());
+        error.errorReason = format("Ensure the application pool process model has write permissions to the shadow copy directory %ls",
+                                   shadowCopyPath.c_str());
+        if (options.QueryShowDetailedErrors())
+        {
+            error.detailedErrorContent = ex.what();
+        }
+        return std::wstring();
+    }
+
+    LOG_INFOF(L"Finished copying %d files to shadow copy directory %ls.", copiedFileCount, shadowCopyBaseDirectory.path().c_str());
     return shadowCopyPath;
 }

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationinfo.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationinfo.h
@@ -80,7 +80,7 @@ private:
     TryCreateApplication(IHttpContext& pHttpContext, const ShimOptions& options, ErrorContext& error);
 
     std::filesystem::path
-    HandleShadowCopy(const ShimOptions& options, IHttpContext& pHttpContext);
+    HandleShadowCopy(const ShimOptions& options, IHttpContext& pHttpContext, ErrorContext& error);
 
     IHttpServer            &m_pServer;
     HandlerResolver        &m_handlerResolver;

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/Environment.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/Environment.cpp
@@ -168,7 +168,23 @@ void Environment::CopyToDirectoryInner(const std::filesystem::path& source, cons
     auto destinationDirEntry = std::filesystem::directory_entry(destination);
     if (!destinationDirEntry.exists())
     {
-        CreateDirectory(destination.wstring().c_str(), nullptr);
+        auto ret = CreateDirectory(destination.wstring().c_str(), nullptr);
+        if (!ret)
+        {
+            // TODO: macro this or not?
+            std::string msg = format("Failed to create destination directory: %s (source: %s)",
+                                      destination.string().c_str(),
+                                      source.string().c_str());
+            auto ex = std::system_error(GetLastError(), std::system_category(), msg);
+            try {
+                throw ex;
+            }
+            catch (...)
+            {
+                OBSERVE_CAUGHT_EXCEPTION();
+                throw;
+            }
+        }
     }
 
     for (auto& path : std::filesystem::directory_iterator(source))
@@ -187,13 +203,29 @@ void Environment::CopyToDirectoryInner(const std::filesystem::path& source, cons
                     continue;
                 }
             }
-
+            auto sourcePathString = path.path().wstring();
+            auto destinationPathString = destinationPath.wstring();
+            auto ret = CopyFile(sourcePathString.c_str(), destinationPathString.c_str(), FALSE);
+            if (!ret)
+            {
+                std::string msg = format("Failed to copy file %s to %s",
+                                         sourcePathString.c_str(),
+                                         destinationPathString.c_str());
+                auto ex = std::system_error(GetLastError(), std::system_category(), msg);
+                try {
+                    throw ex;
+                }
+                catch (...)
+                {
+                    OBSERVE_CAUGHT_EXCEPTION();
+                    throw;
+                }
+            }
             copiedFileCount++;
-            CopyFile(path.path().wstring().c_str(), destinationPath.wstring().c_str(), FALSE);
         }
         else if (path.is_directory())
         {
-            auto sourceInnerDirectory = path.path();
+            auto& sourceInnerDirectory = path.path();
 
             if (sourceInnerDirectory.wstring().rfind(directoryToIgnore, 0) != 0)
             {

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/exceptions.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/exceptions.h
@@ -9,6 +9,7 @@
 #include "debugutil.h"
 #include "StringHelpers.h"
 #include "InvalidOperationException.h"
+#include "ConfigurationLoadException.h"
 #include "ntassert.h"
 #include "NonCopyable.h"
 #include "EventTracing.h"
@@ -197,6 +198,11 @@ __declspec(noinline) inline HRESULT CaughtExceptionHResult(LOCATION_ARGUMENTS_ON
         ReportException(LOCATION_CALL exception);
         return exception.GetResult();
     }
+    catch (const ConfigurationLoadException& exception)
+    {
+        ReportException(LOCATION_CALL exception);
+        return HRESULT_FROM_WIN32(ERROR_UNHANDLED_EXCEPTION);
+    }
     catch (const InvalidOperationException& exception)
     {
         ReportException(LOCATION_CALL exception);
@@ -223,6 +229,10 @@ __declspec(noinline) inline std::wstring CaughtExceptionToString()
     catch (const InvalidOperationException& exception)
     {
         return exception.as_wstring();
+    }
+    catch (const ConfigurationLoadException& exception)
+    {
+        return exception.get_message();
     }
     catch (const std::system_error& exception)
     {

--- a/src/Servers/IIS/IIS/test/IIS.ShadowCopy.Tests/ShadowCopyTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.ShadowCopy.Tests/ShadowCopyTests.cs
@@ -1,29 +1,96 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+using System.Security.AccessControl;
+using System.Security.Principal;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests.Utilities;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 
 [Collection(PublishedSitesCollection.Name)]
-public class ShadowCopyTests : IISFunctionalTestBase
+public class ShadowCopyTests(PublishedSitesFixture fixture) : IISFunctionalTestBase(fixture)
 {
-    public ShadowCopyTests(PublishedSitesFixture fixture) : base(fixture)
+
+    public bool IsDirectoryEmpty(string path)
     {
+        return !Directory.EnumerateFileSystemEntries(path).Any();
+    }
+
+    [ConditionalFact]
+    public async Task ShadowCopy_FailsWithUsefulExceptionMessage_WhenNoPermissionsToShadowCopyDirectory()
+    {
+        // Arrange
+        using var shadowCopyDirectory = TempDirectory.CreateWithNoPermissions(Logger);
+        var deploymentParameters = Fixture.GetBaseDeploymentParameters();
+        deploymentParameters.HandlerSettings["enableShadowCopy"] = "true";
+        deploymentParameters.HandlerSettings["shadowCopyDirectory"] = shadowCopyDirectory.DirectoryPath;
+
+        var deploymentResult = await DeployAsync(deploymentParameters);
+
+        // Act
+        var response = await deploymentResult.HttpClient.GetAsync("Wow!");
+
+        // Assert
+        Assert.Equal(System.Net.HttpStatusCode.InternalServerError, response.StatusCode);
+        Assert.True(response.Content.Headers.ContentLength > 0);
+        Assert.Equal("text/html", response.Content.Headers.ContentType.MediaType);
+
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Access is denied", content, StringComparison.InvariantCultureIgnoreCase);
+        Assert.Contains(shadowCopyDirectory.DirectoryPath, content, StringComparison.InvariantCultureIgnoreCase);
+
+        shadowCopyDirectory.RestoreAllPermissions();
+        Assert.True(IsDirectoryEmpty(shadowCopyDirectory.DirectoryPath), "Expected shadow copy shadowCopyDirectory to be empty");
+    }
+
+    [ConditionalFact]
+    public async Task ShadowCopy_FailsWithUsefulExceptionMessage_WhenNoWritePermissionsToShadowCopyDirectory()
+    {
+        // Arrange
+        using var shadowCopyDirectory = TempDirectory.CreateWithNoWritePermissions(Logger);
+        var deploymentParameters = Fixture.GetBaseDeploymentParameters();
+        deploymentParameters.HandlerSettings["enableShadowCopy"] = "true";
+        deploymentParameters.HandlerSettings["shadowCopyDirectory"] = shadowCopyDirectory.DirectoryPath;
+
+        var deploymentResult = await DeployAsync(deploymentParameters);
+
+        // Act
+        var response = await deploymentResult.HttpClient.GetAsync("Wow!");
+
+        // Assert
+        Assert.Equal(System.Net.HttpStatusCode.InternalServerError, response.StatusCode);
+        Assert.True(response.Content.Headers.ContentLength > 0);
+        Assert.Equal("text/html", response.Content.Headers.ContentType.MediaType);
+
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.True(content.Contains("Failed to create destination directory: ", StringComparison.InvariantCultureIgnoreCase) ||
+                    content.Contains("Failed to copy file ", StringComparison.InvariantCultureIgnoreCase),
+                    "Expected exception message for failure to copy to shadow copy directory");
+        Assert.Contains(shadowCopyDirectory.DirectoryPath, content, StringComparison.InvariantCultureIgnoreCase);
+
+        shadowCopyDirectory.RestoreAllPermissions();
+        // If failed to copy then the shadowCopyDirectory should be empty
+        Assert.True(IsDirectoryEmpty(shadowCopyDirectory.DirectoryPath), "Expected shadow copy shadowCopyDirectory to be empty");
     }
 
     [ConditionalFact]
     public async Task ShadowCopyDoesNotLockFiles()
     {
-        using var directory = TempDirectory.Create();
+        // Arrange
+        using var shadowCopyDirectory = TempDirectory.Create();
         var deploymentParameters = Fixture.GetBaseDeploymentParameters();
         deploymentParameters.HandlerSettings["enableShadowCopy"] = "true";
-        deploymentParameters.HandlerSettings["shadowCopyDirectory"] = directory.DirectoryPath;
+        deploymentParameters.HandlerSettings["shadowCopyDirectory"] = shadowCopyDirectory.DirectoryPath;
 
         var deploymentResult = await DeployAsync(deploymentParameters);
+
+        // Act
         var response = await deploymentResult.HttpClient.GetAsync("Wow!");
 
+        // Assert
         Assert.True(response.IsSuccessStatusCode);
         var directoryInfo = new DirectoryInfo(deploymentResult.ContentRoot);
 
@@ -42,14 +109,18 @@ public class ShadowCopyTests : IISFunctionalTestBase
     [ConditionalFact]
     public async Task ShadowCopyRelativeInSameDirectoryWorks()
     {
-        var directoryName = Path.GetRandomFileName();
+        // Arrange
+        var shadowCopyDirectoryName = Path.GetRandomFileName();
         var deploymentParameters = Fixture.GetBaseDeploymentParameters();
         deploymentParameters.HandlerSettings["enableShadowCopy"] = "true";
-        deploymentParameters.HandlerSettings["shadowCopyDirectory"] = directoryName;
+        deploymentParameters.HandlerSettings["shadowCopyDirectory"] = shadowCopyDirectoryName;
 
         var deploymentResult = await DeployAsync(deploymentParameters);
+
+        // Act
         var response = await deploymentResult.HttpClient.GetAsync("Wow!");
 
+        // Assert
         Assert.True(response.IsSuccessStatusCode);
         var directoryInfo = new DirectoryInfo(deploymentResult.ContentRoot);
 
@@ -59,7 +130,7 @@ public class ShadowCopyTests : IISFunctionalTestBase
             fileInfo.Delete();
         }
 
-        var tempDirectoryPath = Path.Combine(deploymentResult.ContentRoot, directoryName);
+        var tempDirectoryPath = Path.Combine(deploymentResult.ContentRoot, shadowCopyDirectoryName);
         foreach (var dirInfo in directoryInfo.GetDirectories())
         {
             if (!tempDirectoryPath.Equals(dirInfo.FullName))
@@ -72,18 +143,22 @@ public class ShadowCopyTests : IISFunctionalTestBase
     [ConditionalFact]
     public async Task ShadowCopyRelativeOutsideDirectoryWorks()
     {
-        using var directory = TempDirectory.Create();
+        // Arrange
+        using var shadowCopyDirectory = TempDirectory.Create();
         var deploymentParameters = Fixture.GetBaseDeploymentParameters();
         deploymentParameters.HandlerSettings["enableShadowCopy"] = "true";
-        deploymentParameters.HandlerSettings["shadowCopyDirectory"] = $"..\\{directory.DirectoryInfo.Name}";
-        deploymentParameters.ApplicationPath = directory.DirectoryPath;
+        deploymentParameters.HandlerSettings["shadowCopyDirectory"] = $"..\\{shadowCopyDirectory.DirectoryInfo.Name}";
+        deploymentParameters.ApplicationPath = shadowCopyDirectory.DirectoryPath;
 
         var deploymentResult = await DeployAsync(deploymentParameters);
+
+        // Act
         var response = await deploymentResult.HttpClient.GetAsync("Wow!");
 
-        // Check if directory can be deleted.
+        // Check if content root shadowCopyDirectory can be deleted.
         // Can't delete the folder but can delete all content in it.
 
+        // Assert
         Assert.True(response.IsSuccessStatusCode);
         var directoryInfo = new DirectoryInfo(deploymentResult.ContentRoot);
 
@@ -105,17 +180,22 @@ public class ShadowCopyTests : IISFunctionalTestBase
     [ConditionalFact]
     public async Task ShadowCopySingleFileChangedWorks()
     {
-        using var directory = TempDirectory.Create();
+        // Arrange
+        using var shadowCopyDirectory = TempDirectory.Create();
         var deploymentParameters = Fixture.GetBaseDeploymentParameters();
         deploymentParameters.HandlerSettings["enableShadowCopy"] = "true";
-        deploymentParameters.HandlerSettings["shadowCopyDirectory"] = directory.DirectoryPath;
+        deploymentParameters.HandlerSettings["shadowCopyDirectory"] = shadowCopyDirectory.DirectoryPath;
 
         var deploymentResult = await DeployAsync(deploymentParameters);
 
-        DirectoryCopy(deploymentResult.ContentRoot, directory.DirectoryPath, copySubDirs: true);
+        DirectoryCopy(deploymentResult.ContentRoot, shadowCopyDirectory.DirectoryPath, copySubDirs: true);
 
+        // Act
         var response = await deploymentResult.HttpClient.GetAsync("Wow!");
+        // Assert
         Assert.True(response.IsSuccessStatusCode);
+
+        // Arrange
         // Rewrite file
         var dirInfo = new DirectoryInfo(deploymentResult.ContentRoot);
 
@@ -129,8 +209,9 @@ public class ShadowCopyTests : IISFunctionalTestBase
             }
         }
         var fileContents = File.ReadAllBytes(dllPath);
-        File.WriteAllBytes(dllPath, fileContents);
 
+        // Act & Assert
+        File.WriteAllBytes(dllPath, fileContents);
         await deploymentResult.AssertRecycledAsync();
 
         response = await deploymentResult.HttpClient.GetAsync("Wow!");
@@ -140,10 +221,11 @@ public class ShadowCopyTests : IISFunctionalTestBase
     [ConditionalFact]
     public async Task ShadowCopyDeleteFolderDuringShutdownWorks()
     {
-        using var directory = TempDirectory.Create();
+        // Arrange
+        using var shadowCopyDirectory = TempDirectory.Create();
         var deploymentParameters = Fixture.GetBaseDeploymentParameters();
         deploymentParameters.HandlerSettings["enableShadowCopy"] = "true";
-        deploymentParameters.HandlerSettings["shadowCopyDirectory"] = directory.DirectoryPath;
+        deploymentParameters.HandlerSettings["shadowCopyDirectory"] = shadowCopyDirectory.DirectoryPath;
 
         var deploymentResult = await DeployAsync(deploymentParameters);
         var deleteDirPath = Path.Combine(deploymentResult.ContentRoot, "wwwroot/deletethis");
@@ -156,12 +238,15 @@ public class ShadowCopyTests : IISFunctionalTestBase
         AddAppOffline(deploymentResult.ContentRoot);
         await AssertAppOffline(deploymentResult);
 
+        // Act
+
         // Delete folder + file after app is shut down
-        // Testing specific path on startup where we compare the app directory contents with the shadow copy directory
+        // Testing specific path on startup where we compare the app shadowCopyDirectory contents with the shadow copy shadowCopyDirectory
         Directory.Delete(deleteDirPath, recursive: true);
 
         RemoveAppOffline(deploymentResult.ContentRoot);
 
+        // Assert
         await deploymentResult.AssertRecycledAsync();
 
         response = await deploymentResult.HttpClient.GetAsync("Wow!");
@@ -171,23 +256,29 @@ public class ShadowCopyTests : IISFunctionalTestBase
     [ConditionalFact]
     public async Task ShadowCopyE2EWorksWithFolderPresent()
     {
-        using var directory = TempDirectory.Create();
+        // Arrange
+        using var shadowCopyDirectory = TempDirectory.Create();
         var deploymentParameters = Fixture.GetBaseDeploymentParameters();
         deploymentParameters.HandlerSettings["enableShadowCopy"] = "true";
-        deploymentParameters.HandlerSettings["shadowCopyDirectory"] = directory.DirectoryPath;
+        deploymentParameters.HandlerSettings["shadowCopyDirectory"] = shadowCopyDirectory.DirectoryPath;
         var deploymentResult = await DeployAsync(deploymentParameters);
 
-        DirectoryCopy(deploymentResult.ContentRoot, Path.Combine(directory.DirectoryPath, "0"), copySubDirs: true);
+        DirectoryCopy(deploymentResult.ContentRoot, Path.Combine(shadowCopyDirectory.DirectoryPath, "0"), copySubDirs: true);
 
+        // Act
         var response = await deploymentResult.HttpClient.GetAsync("Wow!");
+
+        // Assert
         Assert.True(response.IsSuccessStatusCode);
 
+        // Arrange
         using var secondTempDir = TempDirectory.Create();
 
         // copy back and forth to cause file change notifications.
         DirectoryCopy(deploymentResult.ContentRoot, secondTempDir.DirectoryPath, copySubDirs: true);
         DirectoryCopy(secondTempDir.DirectoryPath, deploymentResult.ContentRoot, copySubDirs: true);
 
+        // Act & Assert
         await deploymentResult.AssertRecycledAsync();
 
         response = await deploymentResult.HttpClient.GetAsync("Wow!");
@@ -197,6 +288,7 @@ public class ShadowCopyTests : IISFunctionalTestBase
     [ConditionalFact]
     public async Task ShadowCopyE2EWorksWithOldFoldersPresent()
     {
+        // Arrange
         using var directory = TempDirectory.Create();
         var deploymentParameters = Fixture.GetBaseDeploymentParameters();
         deploymentParameters.HandlerSettings["enableShadowCopy"] = "true";
@@ -206,17 +298,22 @@ public class ShadowCopyTests : IISFunctionalTestBase
         // Start with 1 to exercise the incremental logic
         DirectoryCopy(deploymentResult.ContentRoot, Path.Combine(directory.DirectoryPath, "1"), copySubDirs: true);
 
+        // Act
         var response = await deploymentResult.HttpClient.GetAsync("Wow!");
+
+        // Assert
         Assert.True(response.IsSuccessStatusCode);
 
+        // Arrange
         using var secondTempDir = TempDirectory.Create();
 
         // copy back and forth to cause file change notifications.
         DirectoryCopy(deploymentResult.ContentRoot, secondTempDir.DirectoryPath, copySubDirs: true);
         DirectoryCopy(secondTempDir.DirectoryPath, deploymentResult.ContentRoot, copySubDirs: true);
 
+        // Act & Assert
         response = await deploymentResult.HttpClient.GetAsync("Wow!");
-        Assert.False(Directory.Exists(Path.Combine(directory.DirectoryPath, "0")), "Expected 0 shadow copy directory to be skipped");
+        Assert.False(Directory.Exists(Path.Combine(directory.DirectoryPath, "0")), "Expected 0 shadow copy shadowCopyDirectory to be skipped");
 
         // Depending on timing, this could result in a shutdown failure, but sometimes it succeeds, handle both situations
         if (!response.IsSuccessStatusCode)
@@ -224,11 +321,12 @@ public class ShadowCopyTests : IISFunctionalTestBase
             Assert.True(response.ReasonPhrase == "Application Shutting Down" || response.ReasonPhrase == "Server has been shutdown");
         }
 
-        // This shutdown should trigger a copy to the next highest directory, which will be 2
+        // This shutdown should trigger a copy to the next highest shadowCopyDirectory, which will be 2
         await deploymentResult.AssertRecycledAsync();
 
-        Assert.True(Directory.Exists(Path.Combine(directory.DirectoryPath, "2")), "Expected 2 shadow copy directory");
+        Assert.True(Directory.Exists(Path.Combine(directory.DirectoryPath, "2")), "Expected 2 shadow copy shadowCopyDirectory");
 
+        // Act & Assert
         response = await deploymentResult.HttpClient.GetAsync("Wow!");
         Assert.True(response.IsSuccessStatusCode);
     }
@@ -237,28 +335,32 @@ public class ShadowCopyTests : IISFunctionalTestBase
     [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/58106")]
     public async Task ShadowCopyCleansUpOlderFolders()
     {
-        using var directory = TempDirectory.Create();
+        // Arrange
+        using var shadowCopyDirectory = TempDirectory.Create();
         var deploymentParameters = Fixture.GetBaseDeploymentParameters();
         deploymentParameters.HandlerSettings["enableShadowCopy"] = "true";
-        deploymentParameters.HandlerSettings["shadowCopyDirectory"] = directory.DirectoryPath;
+        deploymentParameters.HandlerSettings["shadowCopyDirectory"] = shadowCopyDirectory.DirectoryPath;
         var deploymentResult = await DeployAsync(deploymentParameters);
 
         // Start with a bunch of junk
-        DirectoryCopy(deploymentResult.ContentRoot, Path.Combine(directory.DirectoryPath, "1"), copySubDirs: true);
-        DirectoryCopy(deploymentResult.ContentRoot, Path.Combine(directory.DirectoryPath, "3"), copySubDirs: true);
-        DirectoryCopy(deploymentResult.ContentRoot, Path.Combine(directory.DirectoryPath, "10"), copySubDirs: true);
+        DirectoryCopy(deploymentResult.ContentRoot, Path.Combine(shadowCopyDirectory.DirectoryPath, "1"), copySubDirs: true);
+        DirectoryCopy(deploymentResult.ContentRoot, Path.Combine(shadowCopyDirectory.DirectoryPath, "3"), copySubDirs: true);
+        DirectoryCopy(deploymentResult.ContentRoot, Path.Combine(shadowCopyDirectory.DirectoryPath, "10"), copySubDirs: true);
 
+        // Act & Assert
         var response = await deploymentResult.HttpClient.GetAsync("Wow!");
         Assert.True(response.IsSuccessStatusCode);
 
+        // Arrange
         using var secondTempDir = TempDirectory.Create();
 
         // copy back and forth to cause file change notifications.
         DirectoryCopy(deploymentResult.ContentRoot, secondTempDir.DirectoryPath, copySubDirs: true);
         DirectoryCopy(secondTempDir.DirectoryPath, deploymentResult.ContentRoot, copySubDirs: true);
 
+        // Act & Assert
         response = await deploymentResult.HttpClient.GetAsync("Wow!");
-        Assert.False(Directory.Exists(Path.Combine(directory.DirectoryPath, "0")), "Expected 0 shadow copy directory to be skipped");
+        Assert.False(Directory.Exists(Path.Combine(shadowCopyDirectory.DirectoryPath, "0")), "Expected 0 shadow copy shadowCopyDirectory to be skipped");
 
         // Depending on timing, this could result in a shutdown failure, but sometimes it succeeds, handle both situations
         if (!response.IsSuccessStatusCode)
@@ -266,39 +368,45 @@ public class ShadowCopyTests : IISFunctionalTestBase
             Assert.True(response.ReasonPhrase == "Application Shutting Down" || response.ReasonPhrase == "Server has been shutdown");
         }
 
-        // This shutdown should trigger a copy to the next highest directory, which will be 11
+        // This shutdown should trigger a copy to the next highest shadowCopyDirectory, which will be 11
         await deploymentResult.AssertRecycledAsync();
 
-        Assert.True(Directory.Exists(Path.Combine(directory.DirectoryPath, "11")), "Expected 11 shadow copy directory");
+        Assert.True(Directory.Exists(Path.Combine(shadowCopyDirectory.DirectoryPath, "11")), "Expected 11 shadow copy shadowCopyDirectory");
 
+        // Act & Assert
         response = await deploymentResult.HttpClient.GetAsync("Wow!");
         Assert.True(response.IsSuccessStatusCode);
 
         // Verify old directories were cleaned up
-        Assert.False(Directory.Exists(Path.Combine(directory.DirectoryPath, "1")), "Expected 1 shadow copy directory to be deleted");
-        Assert.False(Directory.Exists(Path.Combine(directory.DirectoryPath, "3")), "Expected 3 shadow copy directory to be deleted");
+        Assert.False(Directory.Exists(Path.Combine(shadowCopyDirectory.DirectoryPath, "1")), "Expected 1 shadow copy shadowCopyDirectory to be deleted");
+        Assert.False(Directory.Exists(Path.Combine(shadowCopyDirectory.DirectoryPath, "3")), "Expected 3 shadow copy shadowCopyDirectory to be deleted");
     }
 
     [ConditionalFact]
     public async Task ShadowCopyIgnoresItsOwnDirectoryWithRelativePathSegmentWhenCopying()
     {
-        using var directory = TempDirectory.Create();
+        // Arrange
+        using var shadowCopyDirectory = TempDirectory.Create();
         var deploymentParameters = Fixture.GetBaseDeploymentParameters();
         deploymentParameters.HandlerSettings["enableShadowCopy"] = "true";
         deploymentParameters.HandlerSettings["shadowCopyDirectory"] = "./ShadowCopy/../ShadowCopy/";
         var deploymentResult = await DeployAsync(deploymentParameters);
 
-        DirectoryCopy(deploymentResult.ContentRoot, Path.Combine(directory.DirectoryPath, "0"), copySubDirs: true);
+        DirectoryCopy(deploymentResult.ContentRoot, Path.Combine(shadowCopyDirectory.DirectoryPath, "0"), copySubDirs: true);
 
+        // Act & Assert
         var response = await deploymentResult.HttpClient.GetAsync("Wow!");
         Assert.True(response.IsSuccessStatusCode);
 
+        // Arrange
         using var secondTempDir = TempDirectory.Create();
 
+        // Act
         // copy back and forth to cause file change notifications.
         DirectoryCopy(deploymentResult.ContentRoot, secondTempDir.DirectoryPath, copySubDirs: true);
         DirectoryCopy(secondTempDir.DirectoryPath, deploymentResult.ContentRoot, copySubDirs: true, ignoreDirectory: "ShadowCopy");
 
+        // Assert
         await deploymentResult.AssertRecycledAsync();
 
         Assert.True(Directory.Exists(Path.Combine(deploymentResult.ContentRoot, "ShadowCopy")));
@@ -312,15 +420,19 @@ public class ShadowCopyTests : IISFunctionalTestBase
     [ConditionalFact]
     public async Task ShadowCopyIgnoresItsOwnDirectoryWhenCopying()
     {
-        using var directory = TempDirectory.Create();
+        // Arrange
+        using var shadowCopyDirectory = TempDirectory.Create();
         var deploymentParameters = Fixture.GetBaseDeploymentParameters();
         deploymentParameters.HandlerSettings["enableShadowCopy"] = "true";
         deploymentParameters.HandlerSettings["shadowCopyDirectory"] = "./ShadowCopy";
         var deploymentResult = await DeployAsync(deploymentParameters);
 
-        DirectoryCopy(deploymentResult.ContentRoot, Path.Combine(directory.DirectoryPath, "0"), copySubDirs: true);
+        DirectoryCopy(deploymentResult.ContentRoot, Path.Combine(shadowCopyDirectory.DirectoryPath, "0"), copySubDirs: true);
 
+        // Act
         var response = await deploymentResult.HttpClient.GetAsync("Wow!");
+
+        // Assert
         Assert.True(response.IsSuccessStatusCode);
 
         using var secondTempDir = TempDirectory.Create();
@@ -339,8 +451,110 @@ public class ShadowCopyTests : IISFunctionalTestBase
         Assert.True(response.IsSuccessStatusCode);
     }
 
+    public static int RunCommand(string command, string arguments, ILogger logger, string logPrefix = null)
+    {
+        // TODO: Move somewhere else helper class
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = command,
+            Arguments = arguments,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true
+        };
+        using var process = new Process { StartInfo = startInfo };
+        process.StartAndCaptureOutAndErrToLogger(logPrefix ?? command, logger);
+        process.WaitForExit(TimeSpan.FromSeconds(5));
+        return process.ExitCode;
+    }
+
+    public static void RemoveAllPermissions(DirectoryInfo directoryInfo)
+    {
+        var directorySecurity = directoryInfo.GetAccessControl();
+
+        // Take ownership before removing permissions
+        var currentUser = WindowsIdentity.GetCurrent().User;
+        directorySecurity.SetOwner(currentUser);
+        directoryInfo.SetAccessControl(directorySecurity);
+
+        // Remove all existing permissions
+        var emptyPermissions = new DirectorySecurity();
+        emptyPermissions.SetOwner(currentUser);
+        emptyPermissions.SetAccessRuleProtection(true, false); // Disable inheritance, remove all ACEs
+        directoryInfo.SetAccessControl(emptyPermissions);
+    }
+
+    public static void RemoveWritePermissions(DirectoryInfo directoryInfo)
+    {
+        var directorySecurity = directoryInfo.GetAccessControl();
+        // Deny Write access for Everyone
+        var everyone = new SecurityIdentifier(WellKnownSidType.WorldSid, null);
+
+        var denyRule = new FileSystemAccessRule(
+            everyone,
+            FileSystemRights.Write | FileSystemRights.Delete,
+            InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
+            PropagationFlags.None,
+            AccessControlType.Deny);
+
+        directorySecurity.AddAccessRule(denyRule);
+        directoryInfo.SetAccessControl(directorySecurity);
+    }
+
+    public class TempDirectoryRestrictedPermissions : TempDirectory
+    {
+        private bool _hasPermissions;
+
+        protected ILogger Logger { get; init; }
+
+        public TempDirectoryRestrictedPermissions(DirectoryInfo directoryInfo, ILogger logger, bool canRead) : base(directoryInfo)
+        {
+            Logger = logger;
+            if (canRead)
+            {
+                RemoveWritePermissions(directoryInfo);
+            }
+            else
+            {
+                RemoveAllPermissions(directoryInfo);
+            }
+        }
+
+        public void RestoreAllPermissions()
+        {
+            if (_hasPermissions) return;
+
+            RestoreAllPermissionsInner();
+
+            _hasPermissions = true;
+        }
+
+        private void RestoreAllPermissionsInner()
+        {
+            var res = RunCommand("takeown", $"/F \"{DirectoryPath}\" /R /D Y", Logger, "Takeown1");
+            res += RunCommand("icacls", $"\"{DirectoryPath}\" /grant Administrators:F /T", Logger, "Takeown2");
+            res += RunCommand("icacls", $"\"{DirectoryPath}\" /inheritance:e /T", Logger, "Takeown3");
+            res += RunCommand("icacls", $"\"{DirectoryPath}\" /reset /T", Logger, "Takeown4");
+
+            if (res != 0)
+            {
+                Logger.LogError("Failed to restore permissions for shadowCopyDirectory {DirectoryPath}. Takeown result: {TakeownResult}", DirectoryPath, res);
+            }
+        }
+
+        public override void Dispose()
+        {
+            RestoreAllPermissions();
+            base.Dispose();
+        }
+    }
+
     public class TempDirectory : IDisposable
     {
+        public string DirectoryPath { get; }
+        public DirectoryInfo DirectoryInfo { get; }
+
         public static TempDirectory Create()
         {
             var directoryPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
@@ -348,17 +562,27 @@ public class ShadowCopyTests : IISFunctionalTestBase
             return new TempDirectory(directoryInfo);
         }
 
-        public TempDirectory(DirectoryInfo directoryInfo)
+        public static TempDirectoryRestrictedPermissions CreateWithNoPermissions(ILogger logger)
         {
-            DirectoryInfo = directoryInfo;
-
-            DirectoryPath = directoryInfo.FullName;
+            var directoryPath = Path.Combine(Path.GetTempPath(), $"ShadowCopy{Path.GetRandomFileName()}");
+            var directoryInfo = Directory.CreateDirectory(directoryPath);
+            return new TempDirectoryRestrictedPermissions(directoryInfo, logger, false);
         }
 
-        public string DirectoryPath { get; }
-        public DirectoryInfo DirectoryInfo { get; }
+        public static TempDirectoryRestrictedPermissions CreateWithNoWritePermissions(ILogger logger)
+        {
+            var directoryPath = Path.Combine(Path.GetTempPath(), $"ShadowCopy{Path.GetRandomFileName()}");
+            var directoryInfo = Directory.CreateDirectory(directoryPath);
+            return new TempDirectoryRestrictedPermissions(directoryInfo, logger, true);
+        }
 
-        public void Dispose()
+        public TempDirectory(DirectoryInfo directoryInfo)
+        {
+            DirectoryPath = directoryInfo.FullName;
+            DirectoryInfo = directoryInfo;
+        }
+
+        public virtual void Dispose()
         {
             DeleteDirectory(DirectoryPath);
         }
@@ -384,7 +608,7 @@ public class ShadowCopyTests : IISFunctionalTestBase
             }
             catch (Exception e)
             {
-                Console.WriteLine($@"Failed to delete directory {directoryPath}: {e.Message}");
+                Console.WriteLine($@"Failed to delete shadowCopyDirectory {directoryPath}: {e.Message}");
             }
         }
     }
@@ -392,22 +616,22 @@ public class ShadowCopyTests : IISFunctionalTestBase
     // copied from https://learn.microsoft.com/dotnet/standard/io/how-to-copy-directories
     private static void DirectoryCopy(string sourceDirName, string destDirName, bool copySubDirs, string ignoreDirectory = "")
     {
-        // Get the subdirectories for the specified directory.
+        // Get the subdirectories for the specified shadowCopyDirectory.
         DirectoryInfo dir = new DirectoryInfo(sourceDirName);
 
         if (!dir.Exists)
         {
             throw new DirectoryNotFoundException(
-                "Source directory does not exist or could not be found: "
+                "Source shadowCopyDirectory does not exist or could not be found: "
                 + sourceDirName);
         }
 
         DirectoryInfo[] dirs = dir.GetDirectories();
 
-        // If the destination directory doesn't exist, create it.
+        // If the destination shadowCopyDirectory doesn't exist, create it.
         Directory.CreateDirectory(destDirName);
 
-        // Get the files in the directory and copy them to the new location.
+        // Get the files in the shadowCopyDirectory and copy them to the new location.
         FileInfo[] files = dir.GetFiles();
         foreach (FileInfo file in files)
         {

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployer.cs
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployer.cs
@@ -86,10 +86,9 @@ public class IISDeployer : IISDeployerBase
             // For now, only support using published output
             DeploymentParameters.PublishApplicationBeforeDeployment = true;
             // Move ASPNETCORE_DETAILEDERRORS to web config env variables
-            if (IISDeploymentParameters.EnvironmentVariables.ContainsKey(DetailedErrorsEnvironmentVariable))
+            if (IISDeploymentParameters.EnvironmentVariables.TryGetValue(DetailedErrorsEnvironmentVariable, out var value))
             {
-                IISDeploymentParameters.WebConfigBasedEnvironmentVariables[DetailedErrorsEnvironmentVariable] =
-                    IISDeploymentParameters.EnvironmentVariables[DetailedErrorsEnvironmentVariable];
+                IISDeploymentParameters.WebConfigBasedEnvironmentVariables[DetailedErrorsEnvironmentVariable] = value;
 
                 IISDeploymentParameters.EnvironmentVariables.Remove(DetailedErrorsEnvironmentVariable);
             }


### PR DESCRIPTION
# Improve logging and error handling for IIS ASP.NET Core module shadow copy

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)
Improve shadow copy logging and error handling

## Description

Goal of this PR: if shadow copy fails due to lack of permissions to the shadow copy directory

1. The application will return a useful 500 error instead of an empty
2. Useful logs will be printed to debug log output
3. Useful information will be logged in event viewer

### Laundry list of changes
- In CreateApplication, log exception message for all types of exception and not just ConfigurationLoadException
- When exception is thrown in CreateApplication, return useful HTTP 500 with exception message instead of an empty one
- I moved the code that checks if shadow copy is enabled up from HandleShadowCopy to TryCreateApplication
- TryCreateApplication will now return failed HRESULT if shadow copy fails
- HandleShadowCopy now takes an ErrorContext that will provide error information when it fails
- Added error handling in Environment::CopyToDirectory for when it fails; it also now throws exception
- Added two tests in ShadowCopyTests that test shadow copy failure behaviour when there's no permissions to the shadow copy directory, and when there's no write permissions
- Tiny refactor in IISDeployer.cs to use TryGetValue
- Some refactoring in ShadowCopyTests of variable renaming and adding Arrange Act Assert comments for clarity (can undo this if it's not wanted)

Fixes #62148 

Bare in mind I am well aware this is not production ready. However, I am not a C++ enjoyer (yet), so I am opening this PR with a reasonable working solution to get it reviewed instead of trying to perfect it myself.

I have left some TODOs in here which are mostly questions for the people who are going to review it. Once they are addressed I will remove them.

The code displays a new 500 error about shadow copying: what's the protocol on sub error codes for these? Is reusing existing ones okay or should a new one be made? I presume existing documentation elsewhere would also need to be updated?
