### PR TITLE
[release/10.0-preview7] Workaround Linker bug for arm64

### DIFF
--- a/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/all.cmd
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/all.cmd
@@ -1,2 +1,3 @@
 call %1 -host_arch=x64 -arch=arm64 -no_logo
 call build.cmd %2 %3 %4
+exit /b 0

--- a/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/build.cmd
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/build.cmd
@@ -8,7 +8,7 @@ cl /nologo /c /arm64EC /Fo%objDir%\aspnetcorev2_x64.obj empty.cpp
 link /lib /nologo /machine:arm64 /def:aspnetcorev2_arm64.def /out:%objDir%\aspnetcorev2_arm64.lib
 link /lib /nologo /machine:x64 /def:aspnetcorev2_x64.def /out:%objDir%\aspnetcorev2_x64.lib
 
-link /dll /nologo /noentry /machine:arm64x /defArm64Native:aspnetcorev2_arm64.def /def:aspnetcorev2_x64.def %objDir%\aspnetcorev2_arm64.obj %objDir%\aspnetcorev2_x64.obj %objDir%\..\AspNetCoreModuleShim\x64\%configuration%\aspnetcoremodule.res /out:%binDir%\aspnetcorev2.dll %objDir%\aspnetcorev2_arm64.lib %objDir%\aspnetcorev2_x64.lib
+link /dll /nologo /noentry /machine:arm64x /defArm64Native:aspnetcorev2_arm64.def /def:aspnetcorev2_x64.def %objDir%\aspnetcorev2_arm64.obj %objDir%\aspnetcorev2_x64.obj %objDir%\..\AspNetCoreModuleShim\x64\%configuration%\aspnetcoremodule.res /out:%binDir%\aspnetcorev2.dll %objDir%\aspnetcorev2_arm64.lib %objDir%\aspnetcorev2_x64.lib /FORCE:UNRESOLVED
 
 cl /nologo /nologo /c /Fo%objDir%\aspnetcorev2_outofprocess_arm64.obj empty.cpp
 cl /nologo /nologo /c /arm64EC /Fo%objDir%\aspnetcorev2_outofprocess_x64.obj empty.cpp
@@ -16,4 +16,4 @@ cl /nologo /nologo /c /arm64EC /Fo%objDir%\aspnetcorev2_outofprocess_x64.obj emp
 link /lib /nologo /machine:arm64 /def:aspnetcorev2_outofprocess_arm64.def /out:%objDir%\aspnetcorev2_outofprocess_arm64.lib
 link /lib /nologo /machine:x64 /def:aspnetcorev2_outofprocess_x64.def /out:%objDir%\aspnetcorev2_outofprocess_x64.lib
 
-link /dll /nologo /noentry /machine:arm64x /defArm64Native:aspnetcorev2_outofprocess_arm64.def /def:aspnetcorev2_outofprocess_x64.def %objDir%\aspnetcorev2_outofprocess_arm64.obj %objDir%\aspnetcorev2_outofprocess_x64.obj %objDir%\..\OutOfProcessRequestHandler\x64\%configuration%\outofprocessrequesthandler.res /out:%binDir%\aspnetcorev2_outofprocess.dll %objDir%\aspnetcorev2_outofprocess_arm64.lib %objDir%\aspnetcorev2_outofprocess_x64.lib
+link /dll /nologo /noentry /machine:arm64x /defArm64Native:aspnetcorev2_outofprocess_arm64.def /def:aspnetcorev2_outofprocess_x64.def %objDir%\aspnetcorev2_outofprocess_arm64.obj %objDir%\aspnetcorev2_outofprocess_x64.obj %objDir%\..\OutOfProcessRequestHandler\x64\%configuration%\outofprocessrequesthandler.res /out:%binDir%\aspnetcorev2_outofprocess.dll %objDir%\aspnetcorev2_outofprocess_arm64.lib %objDir%\aspnetcorev2_outofprocess_x64.lib /FORCE:UNRESOLVED

--- a/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/build.proj
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/build.proj
@@ -16,6 +16,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="Build" DependsOnTargets="SetBuildDefaultEnvironmentVariables">
     <MakeDir Directories="$(ObjDir);$(BinDir)" />
-    <Exec Command="all.cmd $(Prompt) $(ObjDir) $(BinDir) $(Configuration)" />
+     <!-- Ignore link.exe ARM64X pure forwarder bug -->
+    <Exec Command="all.cmd $(Prompt) $(ObjDir) $(BinDir) $(Configuration)" ContinueOnError="true" IgnoreStandardErrorWarningFormat="true" />
   </Target>
 </Project>


### PR DESCRIPTION
P7 backport of https://github.com/dotnet/aspnetcore/pull/62585 - unblocks the build. https://learn.microsoft.com/en-us/windows/arm/arm64x-build#building-an-arm64x-pure-forwarder-dll doesn't work out of the box currently