### PR TITLE
Add MIME Type for .msg

### DIFF
--- a/src/Components/WebView/WebView/src/FileExtensionContentTypeProvider.cs
+++ b/src/Components/WebView/WebView/src/FileExtensionContentTypeProvider.cs
@@ -199,6 +199,7 @@ internal sealed class FileExtensionContentTypeProvider : IContentTypeProvider
                 { ".mpp", "application/vnd.ms-project" },
                 { ".mpv2", "video/mpeg" },
                 { ".ms", "application/x-troff-ms" },
+                { ".msg", "application/vnd.ms-outlook" },
                 { ".msi", "application/octet-stream" },
                 { ".mso", "application/octet-stream" },
                 { ".mvb", "application/x-msmediaview" },

--- a/src/Middleware/StaticFiles/src/FileExtensionContentTypeProvider.cs
+++ b/src/Middleware/StaticFiles/src/FileExtensionContentTypeProvider.cs
@@ -193,6 +193,7 @@ public class FileExtensionContentTypeProvider : IContentTypeProvider
                 { ".mpp", "application/vnd.ms-project" },
                 { ".mpv2", "video/mpeg" },
                 { ".ms", "application/x-troff-ms" },
+                { ".msg", "application/vnd.ms-outlook" },
                 { ".msi", "application/octet-stream" },
                 { ".mso", "application/octet-stream" },
                 { ".mvb", "application/x-msmediaview" },


### PR DESCRIPTION
# Add MIME Type for .msg

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.


Add msg extension to list of files used by static file middleware.

## Description

Adds support for the .msg file extension (used for Outlook email files) to the FileExtensionContentTypeProvider in the Microsoft.AspNetCore.StaticFiles package. The MIME type application/vnd.ms-outlook is now returned when .msg files are encountered.

This improves developer experience by eliminating the need to manually add this mapping in every project that handles .msg files.

Fixes #63019