### PR TITLE
Auth metrics updates

### DIFF
--- a/src/Http/Authentication.Core/src/AuthenticationMetrics.cs
+++ b/src/Http/Authentication.Core/src/AuthenticationMetrics.cs
@@ -31,22 +31,22 @@ internal sealed class AuthenticationMetrics
 
         _challengeCount = _meter.CreateCounter<long>(
             "aspnetcore.authentication.challenges",
-            unit: "{request}",
+            unit: "{challenge}",
             description: "The total number of times a scheme is challenged.");
 
         _forbidCount = _meter.CreateCounter<long>(
             "aspnetcore.authentication.forbids",
-            unit: "{request}",
+            unit: "{forbid}",
             description: "The total number of times an authenticated user attempts to access a resource they are not permitted to access.");
 
         _signInCount = _meter.CreateCounter<long>(
             "aspnetcore.authentication.sign_ins",
-            unit: "{request}",
+            unit: "{sign_in}",
             description: "The total number of times a principal is signed in with a scheme.");
 
         _signOutCount = _meter.CreateCounter<long>(
             "aspnetcore.authentication.sign_outs",
-            unit: "{request}",
+            unit: "{sign_out}",
             description: "The total number of times a principal is signed out with a scheme.");
     }
 

--- a/src/Security/Authorization/Core/src/AuthorizationMetrics.cs
+++ b/src/Security/Authorization/Core/src/AuthorizationMetrics.cs
@@ -18,31 +18,31 @@ internal sealed class AuthorizationMetrics
     public const string MeterName = "Microsoft.AspNetCore.Authorization";
 
     private readonly Meter _meter;
-    private readonly Counter<long> _authorizedRequestCount;
+    private readonly Counter<long> _authorizedCount;
 
     public AuthorizationMetrics(IMeterFactory meterFactory)
     {
         _meter = meterFactory.Create(MeterName);
 
-        _authorizedRequestCount = _meter.CreateCounter<long>(
+        _authorizedCount = _meter.CreateCounter<long>(
             "aspnetcore.authorization.attempts",
-            unit: "{request}",
-            description: "The total number of requests for which authorization was attempted.");
+            unit: "{attempt}",
+            description: "The total number of authorization attempts.");
     }
 
-    public void AuthorizedRequestCompleted(ClaimsPrincipal user, string? policyName, AuthorizationResult? result, Exception? exception)
+    public void AuthorizeAttemptCompleted(ClaimsPrincipal user, string? policyName, AuthorizationResult? result, Exception? exception)
     {
-        if (_authorizedRequestCount.Enabled)
+        if (_authorizedCount.Enabled)
         {
-            AuthorizedRequestCompletedCore(user, policyName, result, exception);
+            AuthorizeAttemptCore(user, policyName, result, exception);
         }
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private void AuthorizedRequestCompletedCore(ClaimsPrincipal user, string? policyName, AuthorizationResult? result, Exception? exception)
+    private void AuthorizeAttemptCore(ClaimsPrincipal user, string? policyName, AuthorizationResult? result, Exception? exception)
     {
         var tags = new TagList([
-            new("user.is_authenticated", user.Identity?.IsAuthenticated ?? false)
+            new("aspnetcore.user.is_authenticated", user.Identity?.IsAuthenticated ?? false)
         ]);
 
         if (policyName is not null)
@@ -61,6 +61,6 @@ internal sealed class AuthorizationMetrics
             tags.Add("error.type", exception.GetType().FullName);
         }
 
-        _authorizedRequestCount.Add(1, tags);
+        _authorizedCount.Add(1, tags);
     }
 }

--- a/src/Security/Authorization/Core/src/DefaultAuthorizationServiceImpl.cs
+++ b/src/Security/Authorization/Core/src/DefaultAuthorizationServiceImpl.cs
@@ -30,11 +30,11 @@ internal sealed class DefaultAuthorizationServiceImpl(
         }
         catch (Exception ex)
         {
-            metrics.AuthorizedRequestCompleted(user, policyName: null, result: null, ex);
+            metrics.AuthorizeAttemptCompleted(user, policyName: null, result: null, ex);
             throw;
         }
 
-        metrics.AuthorizedRequestCompleted(user, policyName: null, result, exception: null);
+        metrics.AuthorizeAttemptCompleted(user, policyName: null, result, exception: null);
         return result;
     }
 
@@ -52,11 +52,11 @@ internal sealed class DefaultAuthorizationServiceImpl(
         }
         catch (Exception ex)
         {
-            metrics.AuthorizedRequestCompleted(user, policyName, result: null, ex);
+            metrics.AuthorizeAttemptCompleted(user, policyName, result: null, ex);
             throw;
         }
 
-        metrics.AuthorizedRequestCompleted(user, policyName, result, exception: null);
+        metrics.AuthorizeAttemptCompleted(user, policyName, result, exception: null);
         return result;
     }
 }

--- a/src/Security/Authorization/test/AuthorizationMetricsTest.cs
+++ b/src/Security/Authorization/test/AuthorizationMetricsTest.cs
@@ -32,7 +32,7 @@ public class AuthorizationMetricsTest
         Assert.Equal(1, measurement.Value);
         Assert.Equal("Basic", (string)measurement.Tags["aspnetcore.authorization.policy"]);
         Assert.Equal("success", (string)measurement.Tags["aspnetcore.authorization.result"]);
-        Assert.True((bool)measurement.Tags["user.is_authenticated"]);
+        Assert.True((bool)measurement.Tags["aspnetcore.user.is_authenticated"]);
     }
 
     [Fact]
@@ -57,7 +57,7 @@ public class AuthorizationMetricsTest
         Assert.Equal(1, measurement.Value);
         Assert.Equal("Basic", (string)measurement.Tags["aspnetcore.authorization.policy"]);
         Assert.Equal("failure", (string)measurement.Tags["aspnetcore.authorization.result"]);
-        Assert.False((bool)measurement.Tags["user.is_authenticated"]);
+        Assert.False((bool)measurement.Tags["aspnetcore.user.is_authenticated"]);
     }
 
     [Fact]
@@ -82,7 +82,7 @@ public class AuthorizationMetricsTest
         Assert.Equal(1, measurement.Value);
         Assert.Equal("UnknownPolicy", (string)measurement.Tags["aspnetcore.authorization.policy"]);
         Assert.Equal("System.InvalidOperationException", (string)measurement.Tags["error.type"]);
-        Assert.False((bool)measurement.Tags["user.is_authenticated"]);
+        Assert.False((bool)measurement.Tags["aspnetcore.user.is_authenticated"]);
         Assert.False(measurement.Tags.ContainsKey("aspnetcore.authorization.result"));
     }
 
@@ -110,7 +110,7 @@ public class AuthorizationMetricsTest
         var measurement = Assert.Single(authorizedRequestsCollector.GetMeasurementSnapshot());
         Assert.Equal(1, measurement.Value);
         Assert.Equal("success", (string)measurement.Tags["aspnetcore.authorization.result"]);
-        Assert.False((bool)measurement.Tags["user.is_authenticated"]);
+        Assert.False((bool)measurement.Tags["aspnetcore.user.is_authenticated"]);
         Assert.False(measurement.Tags.ContainsKey("aspnetcore.authorization.policy"));
     }
 
@@ -135,7 +135,7 @@ public class AuthorizationMetricsTest
         var measurement = Assert.Single(authorizedRequestsCollector.GetMeasurementSnapshot());
         Assert.Equal(1, measurement.Value);
         Assert.Equal("failure", (string)measurement.Tags["aspnetcore.authorization.result"]);
-        Assert.False((bool)measurement.Tags["user.is_authenticated"]);
+        Assert.False((bool)measurement.Tags["aspnetcore.user.is_authenticated"]);
         Assert.False(measurement.Tags.ContainsKey("aspnetcore.authorization.policy"));
     }
 
@@ -164,7 +164,7 @@ public class AuthorizationMetricsTest
         var measurement = Assert.Single(authorizedRequestsCollector.GetMeasurementSnapshot());
         Assert.Equal(1, measurement.Value);
         Assert.Equal("System.InvalidOperationException", (string)measurement.Tags["error.type"]);
-        Assert.False((bool)measurement.Tags["user.is_authenticated"]);
+        Assert.False((bool)measurement.Tags["aspnetcore.user.is_authenticated"]);
         Assert.False(measurement.Tags.ContainsKey("aspnetcore.authorization.policy"));
         Assert.False(measurement.Tags.ContainsKey("aspnetcore.authorization.result"));
     }


### PR DESCRIPTION
- Change `user.is_authenticated` to `aspnetcore.user.is_authenticated`. Feedback at https://github.com/open-telemetry/semantic-conventions/pull/2531#discussion_r2217564812 is there isn't a standard on attributes for `user.*` so we shouldn't use it. It could be `aspnetcore.user.is_authenticated` or `aspnetcore.identity.is_authenticated`
- Change metric units to not all be `{request}`.
  - Authorization API isn't tied to HTTP requests so it doesn't make sense there.
  - While the authentication API does take `HttpContext` as an argument, so involves requests, I think there are better units.
