### PR TITLE
[Mvc] Avoid exception in route analyzer

### DIFF
--- a/src/Shared/Roslyn/MvcFacts.cs
+++ b/src/Shared/Roslyn/MvcFacts.cs
@@ -70,7 +70,8 @@ internal static class MvcFacts
         }
 
         // Overridden methods from Object class, e.g. Equals(Object), GetHashCode(), etc., are not valid.
-        if (GetDeclaringType(method).SpecialType == SpecialType.System_Object)
+        var declaringType = GetDeclaringType(method);
+        if (declaringType == null || declaringType.SpecialType == SpecialType.System_Object)
         {
             return false;
         }
@@ -98,13 +99,13 @@ internal static class MvcFacts
         return method.DeclaredAccessibility == Accessibility.Public;
     }
 
-    private static INamedTypeSymbol GetDeclaringType(IMethodSymbol method)
+    private static INamedTypeSymbol? GetDeclaringType(IMethodSymbol method)
     {
         while (method.IsOverride)
         {
             if (method.OverriddenMethod == null)
             {
-                throw new InvalidOperationException($"{nameof(method.OverriddenMethod)} cannot be null.");
+                return null;
             }
 
             method = method.OverriddenMethod;


### PR DESCRIPTION
# Avoid exception in route analyzer

Avoid throwing if `IMethodSymbol.OverriddenMethod` is `null`.

## Description

Avoid throwing if `IMethodSymbol.OverriddenMethod` is `null` if `IMethodSymbol.IsOverride` is `true`.

I would have written a test, but there's no repo in the issue and I have no idea what would make this eventuality occur.

Fixes #59736
