### PR TITLE
[OpenApi] Ignore unknown HTTP methods

### DIFF
--- a/src/OpenApi/sample/Controllers/TestController.cs
+++ b/src/OpenApi/sample/Controllers/TestController.cs
@@ -44,7 +44,7 @@ public class TestController : ControllerBase
     public ActionResult<CurrentWeather> NoHttpMethod()
         => Ok(new CurrentWeather(-100));
 
-    [HttpQuery] // See https://github.com/dotnet/aspnetcore/issues/61089
+    [HttpQuery]
     [Route("/query")]
     public ActionResult<CurrentWeather> HttpQueryMethod()
         => Ok(new CurrentWeather(0));

--- a/src/OpenApi/sample/Controllers/TestController.cs
+++ b/src/OpenApi/sample/Controllers/TestController.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
 
 [ApiController]
 [Route("[controller]")]
@@ -38,6 +39,24 @@ public class TestController : ControllerBase
     {
         return TypedResults.Ok(new CurrentWeather(1.0f));
     }
+
+    [Route("/nohttpmethod")]
+    public ActionResult<CurrentWeather> NoHttpMethod()
+        => Ok(new CurrentWeather(-100));
+
+    [HttpQuery] // See https://github.com/dotnet/aspnetcore/issues/61089
+    [Route("/query")]
+    public ActionResult<CurrentWeather> HttpQueryMethod()
+        => Ok(new CurrentWeather(0));
+
+    [HttpFoo] // See https://github.com/dotnet/aspnetcore/issues/60914
+    [Route("/unsupported")]
+    public ActionResult<CurrentWeather> UnsupportedHttpMethod()
+        => Ok(new CurrentWeather(100));
+
+    public class HttpQuery() : HttpMethodAttribute(["QUERY"]);
+
+    public class HttpFoo() : HttpMethodAttribute(["FOO"]);
 
     public class RouteParamsContainer
     {

--- a/src/OpenApi/src/Extensions/ApiDescriptionExtensions.cs
+++ b/src/OpenApi/src/Extensions/ApiDescriptionExtensions.cs
@@ -16,8 +16,8 @@ internal static class ApiDescriptionExtensions
     /// Maps the HTTP method of the ApiDescription to the HttpMethod.
     /// </summary>
     /// <param name="apiDescription">The ApiDescription to resolve an HttpMethod from.</param>
-    /// <returns>The <see cref="HttpMethod"/> associated with the given <paramref name="apiDescription"/>.</returns>
-    public static HttpMethod GetHttpMethod(this ApiDescription apiDescription) =>
+    /// <returns>The <see cref="HttpMethod"/> associated with the given <paramref name="apiDescription"/>, if known.</returns>
+    public static HttpMethod? GetHttpMethod(this ApiDescription apiDescription) =>
         apiDescription.HttpMethod?.ToUpperInvariant() switch
         {
             "GET" => HttpMethod.Get,
@@ -28,7 +28,7 @@ internal static class ApiDescriptionExtensions
             "HEAD" => HttpMethod.Head,
             "OPTIONS" => HttpMethod.Options,
             "TRACE" => HttpMethod.Trace,
-            _ => throw new InvalidOperationException($"Unsupported HTTP method: {apiDescription.HttpMethod}"),
+            _ => null,
         };
 
     /// <summary>

--- a/src/OpenApi/src/Extensions/ApiDescriptionExtensions.cs
+++ b/src/OpenApi/src/Extensions/ApiDescriptionExtensions.cs
@@ -28,6 +28,7 @@ internal static class ApiDescriptionExtensions
             "HEAD" => HttpMethod.Head,
             "OPTIONS" => HttpMethod.Options,
             "TRACE" => HttpMethod.Trace,
+            "QUERY" => HttpMethod.Query,
             _ => null,
         };
 

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Extensions/ApiDescriptionExtensionsTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Extensions/ApiDescriptionExtensionsTests.cs
@@ -63,20 +63,4 @@ public class ApiDescriptionExtensionsTests
         // Assert
         Assert.Equal(expectedHttpMethod, result);
     }
-
-    [Theory]
-    [InlineData("UNKNOWN")]
-    [InlineData("unknown")]
-    public void GetHttpMethod_ThrowsForUnknownHttpMethod(string methodName)
-    {
-        // Arrange
-        var apiDescription = new ApiDescription
-        {
-            HttpMethod = methodName
-        };
-
-        // Act & Assert
-        var exception = Assert.Throws<InvalidOperationException>(() => apiDescription.GetHttpMethod());
-        Assert.Equal($"Unsupported HTTP method: {methodName}", exception.Message);
-    }
 }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=controllers.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=controllers.verified.txt
@@ -124,6 +124,35 @@
           }
         }
       }
+    },
+    "/query": {
+      "query": {
+        "tags": [
+          "Test"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CurrentWeather"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CurrentWeather"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CurrentWeather"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=controllers.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=controllers.verified.txt
@@ -124,6 +124,35 @@
           }
         }
       }
+    },
+    "/query": {
+      "query": {
+        "tags": [
+          "Test"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CurrentWeather"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CurrentWeather"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CurrentWeather"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentLocalizationTests.VerifyOpenApiDocumentIsInvariant.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentLocalizationTests.VerifyOpenApiDocumentIsInvariant.verified.txt
@@ -1233,6 +1233,35 @@
           }
         }
       }
+    },
+    "/query": {
+      "query": {
+        "tags": [
+          "Test"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CurrentWeather"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CurrentWeather"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CurrentWeather"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {


### PR DESCRIPTION
# Ignore unknown HTTP methods

- Ignore unknown HTTP methods from OpenAPI documents.
- Generate OpenAPI operations for HTTP QUERY.

## Description

Exclude unsupported HTTP methods from the OpenAPI document, rather than throwing an exception.

Fixes #60914.
