### PR TITLE
Added usage of TimeProvider instead of DateTimeOffset

### DIFF
--- a/src/Identity/test/Identity.Test/UserManagerTest.cs
+++ b/src/Identity/test/Identity.Test/UserManagerTest.cs
@@ -1240,6 +1240,39 @@ public class UserManagerTest
     }
 
     [Fact]
+    public async Task IsLockedOutAsyncUsesTimeProvider()
+    {
+        var isLockoutEnabled = true;
+        var user = new PocoUser();
+        var currentDate = DateTimeOffset.UtcNow;
+        var lockoutEndDate = (DateTimeOffset?)currentDate.AddMinutes(-1);
+        var timeProviderDate = currentDate.AddMinutes(-2);
+        var timeProvider = new Mock<TimeProvider>();
+        timeProvider.Setup(provider => provider.GetUtcNow())
+            .Returns(timeProviderDate);
+
+        var userLockoutStore = new Mock<IUserLockoutStore<PocoUser>>();
+        userLockoutStore.Setup(store =>
+            store.GetLockoutEnabledAsync(user, It.IsAny<CancellationToken>()))
+            .Returns(() => Task.FromResult(isLockoutEnabled));
+
+        userLockoutStore.Setup(store =>
+            store.GetLockoutEndDateAsync(user, It.IsAny<CancellationToken>()))
+            .Returns(() => Task.FromResult(lockoutEndDate));
+
+        var services = new ServiceCollection()
+            .AddSingleton(timeProvider.Object)
+            .AddSingleton<IUserStore<PocoUser>>(userLockoutStore.Object)
+            .AddLogging();
+
+        services.AddIdentity<PocoUser, PocoRole>();
+
+        var manager = services.BuildServiceProvider().GetService<UserManager<PocoUser>>();
+
+        Assert.True(await manager.IsLockedOutAsync(user));
+    }
+
+    [Fact]
     public async Task LockoutStoreMethodsFailWhenStoreNotImplemented()
     {
         var manager = MockHelpers.TestUserManager(new NoopUserStore());


### PR DESCRIPTION
# Added usage of TimeProvider instead of DateTimeOffset
## Description

Added usage of TimeProvider for NET 8 and higher versions. 
Other versions using DateTimeOffset

Fixes #62796
