### PR TITLE
[OpenApi] Generate schema for JSON Patch endpoints

### DIFF
--- a/src/OpenApi/sample/Endpoints/MapSchemasEndpoints.cs
+++ b/src/OpenApi/sample/Endpoints/MapSchemasEndpoints.cs
@@ -37,7 +37,8 @@ public static class SchemasEndpointsExtensions
         schemas.MapPost("/location", (LocationContainer location) => { });
         schemas.MapPost("/parent", (ParentObject parent) => Results.Ok(parent));
         schemas.MapPost("/child", (ChildObject child) => Results.Ok(child));
-        schemas.MapPatch("/json-patch", (JsonPatchDocument<ParentObject> patchDoc) => Results.NoContent());
+        schemas.MapPatch("/json-patch", (JsonPatchDocument patchDoc) => Results.NoContent());
+        schemas.MapPatch("/json-patch-generic", (JsonPatchDocument<ParentObject> patchDoc) => Results.NoContent());
 
         return endpointRouteBuilder;
     }

--- a/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.JsonPatch.SystemTextJson;
 
 namespace Microsoft.AspNetCore.OpenApi;
 
@@ -32,6 +33,7 @@ internal static class JsonTypeInfoExtensions
         [typeof(string)] = "string",
         [typeof(IFormFile)] = "IFormFile",
         [typeof(IFormFileCollection)] = "IFormFileCollection",
+        [typeof(JsonPatchDocument)] = "JsonPatchDocument",
         [typeof(PipeReader)] = "PipeReader",
         [typeof(Stream)] = "Stream"
     };
@@ -64,6 +66,13 @@ internal static class JsonTypeInfoExtensions
         if (_simpleTypeToName.TryGetValue(type, out var simpleName))
         {
             return simpleName;
+        }
+
+        // Use the same JSON Patch schema for all generic JsonPatchDocument<T> types
+        // as otherwise we'll generate a schema per type argument which are otherwise identical.
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(JsonPatchDocument<>))
+        {
+            return _simpleTypeToName[typeof(JsonPatchDocument)];
         }
 
         // Although arrays are enumerable types they are not encoded correctly

--- a/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.JsonPatch.SystemTextJson;
 
 namespace Microsoft.AspNetCore.OpenApi;
 
@@ -33,7 +32,6 @@ internal static class JsonTypeInfoExtensions
         [typeof(string)] = "string",
         [typeof(IFormFile)] = "IFormFile",
         [typeof(IFormFileCollection)] = "IFormFileCollection",
-        [typeof(JsonPatchDocument)] = "JsonPatchDocument",
         [typeof(PipeReader)] = "PipeReader",
         [typeof(Stream)] = "Stream"
     };
@@ -68,11 +66,12 @@ internal static class JsonTypeInfoExtensions
             return simpleName;
         }
 
-        // Use the same JSON Patch schema for all generic JsonPatchDocument<T> types
-        // as otherwise we'll generate a schema per type argument which are otherwise identical.
-        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(JsonPatchDocument<>))
+        // Use the same JSON Patch schema for all JSON Patch document types (JsonPatchDocument,
+        // JsonPatchDocument<T>, derived types, etc.) as otherwise we'll generate a schema
+        // per unique type which are otherwise identical to each other.
+        if (type.IsJsonPatchDocument())
         {
-            return _simpleTypeToName[typeof(JsonPatchDocument)];
+            return "JsonPatchDocument";
         }
 
         // Although arrays are enumerable types they are not encoded correctly

--- a/src/OpenApi/src/Extensions/TypeExtensions.cs
+++ b/src/OpenApi/src/Extensions/TypeExtensions.cs
@@ -19,7 +19,8 @@ internal static class TypeExtensions
         while (modelType != null && modelType != typeof(object))
         {
             if (modelType.Namespace == JsonPatchDocumentNamespace &&
-                (modelType.Name == JsonPatchDocumentName || modelType.Name.StartsWith(JsonPatchDocumentNameOfT, StringComparison.Ordinal)))
+                (modelType.Name == JsonPatchDocumentName ||
+                 (modelType.IsGenericType && modelType.GenericTypeArguments.Length == 1 && modelType.Name == JsonPatchDocumentNameOfT)))
             {
                 return true;
             }

--- a/src/OpenApi/src/Extensions/TypeExtensions.cs
+++ b/src/OpenApi/src/Extensions/TypeExtensions.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.JsonPatch.SystemTextJson;
+
+namespace Microsoft.AspNetCore.OpenApi;
+
+internal static class TypeExtensions
+{
+    public static bool IsJsonPatchDocument(this Type type)
+    {
+        if (type.IsAssignableTo(typeof(JsonPatchDocument)))
+        {
+            return true;
+        }
+
+        var modelType = type;
+
+        while (modelType != null && modelType != typeof(object))
+        {
+            if (modelType.IsGenericType && modelType.GetGenericTypeDefinition() == typeof(JsonPatchDocument<>))
+            {
+                return true;
+            }
+
+            modelType = modelType.BaseType;
+        }
+
+        return false;
+    }
+}

--- a/src/OpenApi/src/Extensions/TypeExtensions.cs
+++ b/src/OpenApi/src/Extensions/TypeExtensions.cs
@@ -1,24 +1,25 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.AspNetCore.JsonPatch.SystemTextJson;
-
 namespace Microsoft.AspNetCore.OpenApi;
 
 internal static class TypeExtensions
 {
+    private const string JsonPatchDocumentNamespace = "Microsoft.AspNetCore.JsonPatch.SystemTextJson";
+    private const string JsonPatchDocumentName = "JsonPatchDocument";
+    private const string JsonPatchDocumentNameOfT = "JsonPatchDocument`1";
+
     public static bool IsJsonPatchDocument(this Type type)
     {
-        if (type.IsAssignableTo(typeof(JsonPatchDocument)))
-        {
-            return true;
-        }
-
+        // We cannot depend on the actual runtime type as
+        // Microsoft.AspNetCore.JsonPatch.SystemTextJson is not
+        // AoT compatible so cannot be referenced by Microsoft.AspNetCore.OpenApi.
         var modelType = type;
 
         while (modelType != null && modelType != typeof(object))
         {
-            if (modelType.IsGenericType && modelType.GetGenericTypeDefinition() == typeof(JsonPatchDocument<>))
+            if (modelType.Namespace == JsonPatchDocumentNamespace &&
+                (modelType.Name == JsonPatchDocumentName || modelType.Name.StartsWith(JsonPatchDocumentNameOfT, StringComparison.Ordinal)))
             {
                 return true;
             }

--- a/src/OpenApi/src/Microsoft.AspNetCore.OpenApi.csproj
+++ b/src/OpenApi/src/Microsoft.AspNetCore.OpenApi.csproj
@@ -17,7 +17,6 @@
     <Reference Include="Microsoft.AspNetCore" />
     <Reference Include="Microsoft.AspNetCore.Http.Abstractions" />
     <Reference Include="Microsoft.AspNetCore.Http.Results" />
-    <Reference Include="Microsoft.AspNetCore.JsonPatch.SystemTextJson" />
     <Reference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" />
     <Reference Include="Microsoft.AspNetCore.Mvc.Core" />
     <Reference Include="Microsoft.AspNetCore.Routing" />

--- a/src/OpenApi/src/Microsoft.AspNetCore.OpenApi.csproj
+++ b/src/OpenApi/src/Microsoft.AspNetCore.OpenApi.csproj
@@ -14,13 +14,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.OpenApi" />
+    <Reference Include="Microsoft.AspNetCore" />
     <Reference Include="Microsoft.AspNetCore.Http.Abstractions" />
     <Reference Include="Microsoft.AspNetCore.Http.Results" />
-    <Reference Include="Microsoft.AspNetCore.Routing" />
-    <Reference Include="Microsoft.AspNetCore.Mvc.Core" />
+    <Reference Include="Microsoft.AspNetCore.JsonPatch.SystemTextJson" />
     <Reference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" />
-    <Reference Include="Microsoft.AspNetCore" />
+    <Reference Include="Microsoft.AspNetCore.Mvc.Core" />
+    <Reference Include="Microsoft.AspNetCore.Routing" />
+    <Reference Include="Microsoft.OpenApi" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenApi/src/Schemas/OpenApiJsonSchema.Helpers.cs
+++ b/src/OpenApi/src/Schemas/OpenApiJsonSchema.Helpers.cs
@@ -298,8 +298,14 @@ internal sealed partial class OpenApiJsonSchema
             case OpenApiSchemaKeywords.AnyOfKeyword:
                 reader.Read();
                 schema.Type = JsonSchemaType.Object;
-                var schemas = ReadList<OpenApiJsonSchema>(ref reader);
-                schema.AnyOf = schemas?.Select(s => s.Schema as IOpenApiSchema).ToList();
+                var anyOfSchemas = ReadList<OpenApiJsonSchema>(ref reader);
+                schema.AnyOf = anyOfSchemas?.Select(s => s.Schema as IOpenApiSchema).ToList();
+                break;
+            case OpenApiSchemaKeywords.OneOfKeyword:
+                reader.Read();
+                schema.Type = JsonSchemaType.Object;
+                var oneOfSchemas = ReadList<OpenApiJsonSchema>(ref reader);
+                schema.OneOf = oneOfSchemas?.Select(s => s.Schema as IOpenApiSchema).ToList();
                 break;
             case OpenApiSchemaKeywords.DiscriminatorKeyword:
                 reader.Read();

--- a/src/OpenApi/src/Schemas/OpenApiSchemaKeywords.cs
+++ b/src/OpenApi/src/Schemas/OpenApiSchemaKeywords.cs
@@ -10,6 +10,7 @@ internal class OpenApiSchemaKeywords
     public const string AdditionalPropertiesKeyword = "additionalProperties";
     public const string RequiredKeyword = "required";
     public const string AnyOfKeyword = "anyOf";
+    public const string OneOfKeyword = "oneOf";
     public const string EnumKeyword = "enum";
     public const string DefaultKeyword = "default";
     public const string DescriptionKeyword = "description";

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.JsonPatch.SystemTextJson;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
@@ -719,6 +720,12 @@ internal sealed class OpenApiDocumentService(
                 // Assume "application/octet-stream" as the default media type
                 // for stream-based parameter types.
                 supportedRequestFormats = [new ApiRequestFormat { MediaType = "application/octet-stream" }];
+            }
+            else if (bodyParameter.Type == typeof(JsonPatchDocument) || (bodyParameter.Type.IsGenericType && bodyParameter.Type.GetGenericTypeDefinition() == typeof(JsonPatchDocument<>)))
+            {
+                // Assume "application/json-patch+json" as the default media type
+                // for JSON Patch documents.
+                supportedRequestFormats = [new ApiRequestFormat { MediaType = "application/json-patch+json" }];
             }
             else
             {

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -17,7 +17,6 @@ using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Http.Metadata;
-using Microsoft.AspNetCore.JsonPatch.SystemTextJson;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
@@ -721,7 +720,7 @@ internal sealed class OpenApiDocumentService(
                 // for stream-based parameter types.
                 supportedRequestFormats = [new ApiRequestFormat { MediaType = "application/octet-stream" }];
             }
-            else if (bodyParameter.Type == typeof(JsonPatchDocument) || (bodyParameter.Type.IsGenericType && bodyParameter.Type.GetGenericTypeDefinition() == typeof(JsonPatchDocument<>)))
+            else if (bodyParameter.Type.IsJsonPatchDocument())
             {
                 // Assume "application/json-patch+json" as the default media type
                 // for JSON Patch documents.

--- a/src/OpenApi/src/Services/OpenApiGenerator.cs
+++ b/src/OpenApi/src/Services/OpenApiGenerator.cs
@@ -451,7 +451,7 @@ internal sealed class OpenApiGenerator
         else if (parameter.ParameterType == typeof(IFormFile) ||
                  parameter.ParameterType == typeof(IFormFileCollection) ||
                  parameter.ParameterType == typeof(JsonPatchDocument) ||
-                 parameter.ParameterType == typeof(JsonPatchDocument<>))
+                 (parameter.ParameterType.IsGenericType && parameter.ParameterType.GetGenericTypeDefinition() == typeof(JsonPatchDocument<>)))
         {
             return (true, null, null);
         }

--- a/src/OpenApi/src/Services/OpenApiGenerator.cs
+++ b/src/OpenApi/src/Services/OpenApiGenerator.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Metadata;
-using Microsoft.AspNetCore.JsonPatch.SystemTextJson;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Formatters;
@@ -450,8 +449,7 @@ internal sealed class OpenApiGenerator
         }
         else if (parameter.ParameterType == typeof(IFormFile) ||
                  parameter.ParameterType == typeof(IFormFileCollection) ||
-                 parameter.ParameterType == typeof(JsonPatchDocument) ||
-                 (parameter.ParameterType.IsGenericType && parameter.ParameterType.GetGenericTypeDefinition() == typeof(JsonPatchDocument<>)))
+                 parameter.ParameterType.IsJsonPatchDocument())
         {
             return (true, null, null);
         }

--- a/src/OpenApi/src/Services/OpenApiGenerator.cs
+++ b/src/OpenApi/src/Services/OpenApiGenerator.cs
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.JsonPatch.SystemTextJson;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Formatters;
@@ -447,7 +448,10 @@ internal sealed class OpenApiGenerator
                 return (false, ParameterLocation.Query, null);
             }
         }
-        else if (parameter.ParameterType == typeof(IFormFile) || parameter.ParameterType == typeof(IFormFileCollection))
+        else if (parameter.ParameterType == typeof(IFormFile) ||
+                 parameter.ParameterType == typeof(IFormFileCollection) ||
+                 parameter.ParameterType == typeof(JsonPatchDocument) ||
+                 parameter.ParameterType == typeof(JsonPatchDocument<>))
         {
             return (true, null, null);
         }

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -13,6 +13,7 @@ using System.Text.Json.Schema;
 using System.Text.Json.Serialization.Metadata;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Json;
+using Microsoft.AspNetCore.JsonPatch.SystemTextJson;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
@@ -82,6 +83,10 @@ internal sealed class OpenApiSchemaService(
                     }
                 };
             }
+            else if (type == typeof(JsonPatchDocument) || (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(JsonPatchDocument<>)))
+            {
+                schema = CreateSchemaForJsonPatch();
+            }
             // STJ uses `true` in place of an empty object to represent a schema that matches
             // anything (like the `object` type) or types with user-defined converters. We override
             // this default behavior here to match the format expected in OpenAPI v3.
@@ -116,6 +121,95 @@ internal sealed class OpenApiSchemaService(
             return schema;
         }
     };
+
+    private static JsonObject CreateSchemaForJsonPatch()
+    {
+        var addReplaceTest = new JsonObject()
+        {
+            [OpenApiSchemaKeywords.TypeKeyword] = "object",
+            [OpenApiSchemaKeywords.AdditionalPropertiesKeyword] = false,
+            [OpenApiSchemaKeywords.RequiredKeyword] = JsonArray(["op", "path", "value"]),
+            [OpenApiSchemaKeywords.PropertiesKeyword] = new JsonObject
+            {
+                ["op"] = new JsonObject()
+                {
+                    [OpenApiSchemaKeywords.TypeKeyword] = "string",
+                    [OpenApiSchemaKeywords.EnumKeyword] = JsonArray(["add", "replace", "test"]),
+                },
+                ["path"] = new JsonObject()
+                {
+                    [OpenApiSchemaKeywords.TypeKeyword] = "string"
+                },
+                ["value"] = new JsonObject()
+            }
+        };
+
+        var moveCopy = new JsonObject()
+        {
+            [OpenApiSchemaKeywords.TypeKeyword] = "object",
+            [OpenApiSchemaKeywords.AdditionalPropertiesKeyword] = false,
+            [OpenApiSchemaKeywords.RequiredKeyword] = JsonArray(["op", "path", "from"]),
+            [OpenApiSchemaKeywords.PropertiesKeyword] = new JsonObject
+            {
+                ["op"] = new JsonObject()
+                {
+                    [OpenApiSchemaKeywords.TypeKeyword] = "string",
+                    [OpenApiSchemaKeywords.EnumKeyword] = JsonArray(["move", "copy"]),
+                },
+                ["path"] = new JsonObject()
+                {
+                    [OpenApiSchemaKeywords.TypeKeyword] = "string"
+                },
+                ["from"] = new JsonObject()
+                {
+                    [OpenApiSchemaKeywords.TypeKeyword] = "string"
+                },
+            }
+        };
+
+        var remove = new JsonObject()
+        {
+            [OpenApiSchemaKeywords.TypeKeyword] = "object",
+            [OpenApiSchemaKeywords.AdditionalPropertiesKeyword] = false,
+            [OpenApiSchemaKeywords.PropertiesKeyword] = new JsonObject
+            {
+                ["op"] = new JsonObject()
+                {
+                    [OpenApiSchemaKeywords.TypeKeyword] = "string",
+                    [OpenApiSchemaKeywords.EnumKeyword] = JsonArray(["remove"])
+                },
+                ["path"] = new JsonObject()
+                {
+                    [OpenApiSchemaKeywords.TypeKeyword] = "string"
+                },
+            }
+        };
+
+        return new JsonObject
+        {
+            [OpenApiConstants.SchemaId] = "JsonPatchDocument",
+            [OpenApiSchemaKeywords.TypeKeyword] = "array",
+            [OpenApiSchemaKeywords.ItemsKeyword] = new JsonObject
+            {
+                [OpenApiSchemaKeywords.OneOfKeyword] = JsonArray([addReplaceTest, moveCopy, remove])
+            },
+        };
+
+        // Using JsonArray inline causes the compile to pick the generic Add<T>() overload
+        // which then generates native AoT warnings without adding a cost. To Avoid that use
+        // this helper method that uses JsonNode to pick the native AoT compatible overload instead.
+        static JsonArray JsonArray(ReadOnlySpan<JsonNode> values)
+        {
+            var array = new JsonArray();
+
+            foreach (var value in values)
+            {
+                array.Add(value);
+            }
+
+            return array;
+        }
+    }
 
     internal async Task<OpenApiSchema> GetOrCreateUnresolvedSchemaAsync(OpenApiDocument? document, Type type, IServiceProvider scopedServiceProvider, IOpenApiSchemaTransformer[] schemaTransformers, ApiParameterDescription? parameterDescription = null, CancellationToken cancellationToken = default)
     {
@@ -320,9 +414,10 @@ internal sealed class OpenApiSchemaService(
             }
         }
 
-        if (schema.Items is not null)
+        // If the schema is an array but uses AnyOf or OneOf then ElementType is null
+        if (schema.Items is not null && jsonTypeInfo.ElementType is not null)
         {
-            var elementTypeInfo = _jsonSerializerOptions.GetTypeInfo(jsonTypeInfo.ElementType!);
+            var elementTypeInfo = _jsonSerializerOptions.GetTypeInfo(jsonTypeInfo.ElementType);
             await InnerApplySchemaTransformersAsync(schema.Items, elementTypeInfo, null, context, transformer, cancellationToken);
         }
 

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -170,6 +170,7 @@ internal sealed class OpenApiSchemaService(
         {
             [OpenApiSchemaKeywords.TypeKeyword] = "object",
             [OpenApiSchemaKeywords.AdditionalPropertiesKeyword] = false,
+            [OpenApiSchemaKeywords.RequiredKeyword] = JsonArray(["op", "path"]),
             [OpenApiSchemaKeywords.PropertiesKeyword] = new JsonObject
             {
                 ["op"] = new JsonObject()

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -13,7 +13,6 @@ using System.Text.Json.Schema;
 using System.Text.Json.Serialization.Metadata;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Json;
-using Microsoft.AspNetCore.JsonPatch.SystemTextJson;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
@@ -83,7 +82,7 @@ internal sealed class OpenApiSchemaService(
                     }
                 };
             }
-            else if (type == typeof(JsonPatchDocument) || (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(JsonPatchDocument<>)))
+            else if (type.IsJsonPatchDocument())
             {
                 schema = CreateSchemaForJsonPatch();
             }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Extensions/JsonTypeInfoExtensionsTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Extensions/JsonTypeInfoExtensionsTests.cs
@@ -5,6 +5,7 @@ using System.IO.Pipelines;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.JsonPatch.SystemTextJson;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OpenApi;
 
@@ -58,6 +59,8 @@ public class JsonTypeInfoExtensionsTests
         [(new { Id = 1, Name = "Todo" }).GetType(), "AnonymousTypeOfintAndstring"],
         [typeof(IFormFile), "IFormFile"],
         [typeof(IFormFileCollection), "IFormFileCollection"],
+        [typeof(JsonPatchDocument), "JsonPatchDocument"],
+        [typeof(JsonPatchDocument<Todo>), "JsonPatchDocument"],
         [typeof(Stream), "Stream"],
         [typeof(PipeReader), "PipeReader"],
         [typeof(Results<Ok<TodoWithDueDate>, Ok<Todo>>), "ResultsOfOkOfTodoWithDueDateAndOkOfTodo"],

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
@@ -517,6 +517,28 @@
           "content": {
             "application/json-patch+json": {
               "schema": {
+                "$ref": "#/components/schemas/JsonPatchDocument"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/schemas-by-ref/json-patch-generic": {
+      "patch": {
+        "tags": [
+          "Sample"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
                 "$ref": "#/components/schemas/JsonPatchDocumentOfParentObject"
               }
             }
@@ -621,6 +643,7 @@
           }
         }
       },
+      "JsonPatchDocument": { },
       "JsonPatchDocumentOfParentObject": { },
       "LocationContainer": {
         "required": [

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
@@ -539,7 +539,7 @@
           "content": {
             "application/json-patch+json": {
               "schema": {
-                "$ref": "#/components/schemas/JsonPatchDocumentOfParentObject"
+                "$ref": "#/components/schemas/JsonPatchDocument"
               }
             }
           },
@@ -643,8 +643,76 @@
           }
         }
       },
-      "JsonPatchDocument": { },
-      "JsonPatchDocumentOfParentObject": { },
+      "JsonPatchDocument": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "oneOf": [
+            {
+              "required": [
+                "op",
+                "path",
+                "value"
+              ],
+              "type": "object",
+              "properties": {
+                "op": {
+                  "enum": [
+                    "add",
+                    "replace",
+                    "test"
+                  ],
+                  "type": "string"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "value": { }
+              },
+              "additionalProperties": false
+            },
+            {
+              "required": [
+                "op",
+                "path",
+                "from"
+              ],
+              "type": "object",
+              "properties": {
+                "op": {
+                  "enum": [
+                    "move",
+                    "copy"
+                  ],
+                  "type": "string"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "from": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "op": {
+                  "enum": [
+                    "remove"
+                  ],
+                  "type": "string"
+                },
+                "path": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
       "LocationContainer": {
         "required": [
           "location"

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
@@ -696,6 +696,10 @@
               "additionalProperties": false
             },
             {
+              "required": [
+                "op",
+                "path"
+              ],
               "type": "object",
               "properties": {
                 "op": {

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
@@ -517,6 +517,28 @@
           "content": {
             "application/json-patch+json": {
               "schema": {
+                "$ref": "#/components/schemas/JsonPatchDocument"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/schemas-by-ref/json-patch-generic": {
+      "patch": {
+        "tags": [
+          "Sample"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
                 "$ref": "#/components/schemas/JsonPatchDocumentOfParentObject"
               }
             }
@@ -621,6 +643,7 @@
           }
         }
       },
+      "JsonPatchDocument": { },
       "JsonPatchDocumentOfParentObject": { },
       "LocationContainer": {
         "required": [

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
@@ -539,7 +539,7 @@
           "content": {
             "application/json-patch+json": {
               "schema": {
-                "$ref": "#/components/schemas/JsonPatchDocumentOfParentObject"
+                "$ref": "#/components/schemas/JsonPatchDocument"
               }
             }
           },
@@ -643,8 +643,76 @@
           }
         }
       },
-      "JsonPatchDocument": { },
-      "JsonPatchDocumentOfParentObject": { },
+      "JsonPatchDocument": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "oneOf": [
+            {
+              "required": [
+                "op",
+                "path",
+                "value"
+              ],
+              "type": "object",
+              "properties": {
+                "op": {
+                  "enum": [
+                    "add",
+                    "replace",
+                    "test"
+                  ],
+                  "type": "string"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "value": { }
+              },
+              "additionalProperties": false
+            },
+            {
+              "required": [
+                "op",
+                "path",
+                "from"
+              ],
+              "type": "object",
+              "properties": {
+                "op": {
+                  "enum": [
+                    "move",
+                    "copy"
+                  ],
+                  "type": "string"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "from": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "op": {
+                  "enum": [
+                    "remove"
+                  ],
+                  "type": "string"
+                },
+                "path": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
       "LocationContainer": {
         "required": [
           "location"

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
@@ -696,6 +696,10 @@
               "additionalProperties": false
             },
             {
+              "required": [
+                "op",
+                "path"
+              ],
               "type": "object",
               "properties": {
                 "op": {

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentLocalizationTests.VerifyOpenApiDocumentIsInvariant.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentLocalizationTests.VerifyOpenApiDocumentIsInvariant.verified.txt
@@ -1485,6 +1485,10 @@
               "additionalProperties": false
             },
             {
+              "required": [
+                "op",
+                "path"
+              ],
               "type": "object",
               "properties": {
                 "op": {

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentLocalizationTests.VerifyOpenApiDocumentIsInvariant.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentLocalizationTests.VerifyOpenApiDocumentIsInvariant.verified.txt
@@ -1064,7 +1064,7 @@
           "content": {
             "application/json-patch+json": {
               "schema": {
-                "$ref": "#/components/schemas/JsonPatchDocumentOfParentObject"
+                "$ref": "#/components/schemas/JsonPatchDocument"
               }
             }
           },
@@ -1432,8 +1432,76 @@
           }
         }
       },
-      "JsonPatchDocument": { },
-      "JsonPatchDocumentOfParentObject": { },
+      "JsonPatchDocument": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "oneOf": [
+            {
+              "required": [
+                "op",
+                "path",
+                "value"
+              ],
+              "type": "object",
+              "properties": {
+                "op": {
+                  "enum": [
+                    "add",
+                    "replace",
+                    "test"
+                  ],
+                  "type": "string"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "value": { }
+              },
+              "additionalProperties": false
+            },
+            {
+              "required": [
+                "op",
+                "path",
+                "from"
+              ],
+              "type": "object",
+              "properties": {
+                "op": {
+                  "enum": [
+                    "move",
+                    "copy"
+                  ],
+                  "type": "string"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "from": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "op": {
+                  "enum": [
+                    "remove"
+                  ],
+                  "type": "string"
+                },
+                "path": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
       "LocationContainer": {
         "required": [
           "location"

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentLocalizationTests.VerifyOpenApiDocumentIsInvariant.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentLocalizationTests.VerifyOpenApiDocumentIsInvariant.verified.txt
@@ -1042,6 +1042,28 @@
           "content": {
             "application/json-patch+json": {
               "schema": {
+                "$ref": "#/components/schemas/JsonPatchDocument"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/schemas-by-ref/json-patch-generic": {
+      "patch": {
+        "tags": [
+          "Sample"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
                 "$ref": "#/components/schemas/JsonPatchDocumentOfParentObject"
               }
             }
@@ -1410,6 +1432,7 @@
           }
         }
       },
+      "JsonPatchDocument": { },
       "JsonPatchDocumentOfParentObject": { },
       "LocationContainer": {
         "required": [

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.RequestBody.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.RequestBody.cs
@@ -3,9 +3,11 @@
 
 using System.IO.Pipelines;
 using System.Net.Http;
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.AspNetCore.JsonPatch.SystemTextJson;
 using Microsoft.AspNetCore.Mvc;
 
 public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBase
@@ -1131,4 +1133,250 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
     private void ActionWithStream(Stream stream) { }
     [Route("/pipereader")]
     private void ActionWithPipeReader(PipeReader pipeReader) { }
+
+    [Fact]
+    public async Task GetRequestBody_HandlesJsonPatchBody()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPatch("/", (JsonPatchDocument patch) => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var paths = Assert.Single(document.Paths.Values);
+            var operation = paths.Operations[HttpMethod.Patch];
+            Assert.NotNull(operation.RequestBody);
+            Assert.False(operation.RequestBody.Required);
+            Assert.NotNull(operation.RequestBody.Content);
+            var content = Assert.Single(operation.RequestBody.Content);
+            Assert.Equal("application/json-patch+json", content.Key);
+        });
+    }
+
+#nullable enable
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task GetRequestBody_HandlesJsonPatchBodyOptionality(bool isOptional)
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        if (isOptional)
+        {
+            builder.MapPatch("/", (JsonPatchDocument? patch) => { });
+        }
+        else
+        {
+            builder.MapPatch("/", (JsonPatchDocument patch) => { });
+        }
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var paths = Assert.Single(document.Paths.Values);
+            var operation = paths.Operations![HttpMethod.Patch];
+            Assert.NotNull(operation.RequestBody);
+            Assert.Equal(!isOptional, operation.RequestBody.Required);
+        });
+
+    }
+#nullable restore
+
+    [Fact]
+    public async Task GetRequestBody_HandlesJsonPatchBodyWithAttribute()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPatch("/", ([FromBody] JsonPatchDocument patch) => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var paths = Assert.Single(document.Paths.Values);
+            var operation = paths.Operations[HttpMethod.Patch];
+            Assert.NotNull(operation.RequestBody);
+            Assert.False(operation.RequestBody.Required);
+            Assert.NotNull(operation.RequestBody.Content);
+            var content = Assert.Single(operation.RequestBody.Content);
+            Assert.Equal("application/json-patch+json", content.Key);
+        });
+    }
+
+    [Fact]
+    public async Task GetRequestBody_HandlesJsonPatchBodyWithAcceptsMetadata()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPatch("/", (JsonPatchDocument name) => { }).Accepts(typeof(JsonPatchDocument), "application/vnd.github.patch+json");
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var paths = Assert.Single(document.Paths.Values);
+            var operation = paths.Operations[HttpMethod.Patch];
+            Assert.NotNull(operation.RequestBody);
+            Assert.NotNull(operation.RequestBody.Content);
+            var content = Assert.Single(operation.RequestBody.Content);
+            Assert.Equal("application/vnd.github.patch+json", content.Key);
+        });
+    }
+
+    [Fact]
+    public async Task GetRequestBody_HandlesJsonPatchBodyWithConsumesAttribute()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPatch("/", [Consumes(typeof(JsonPatchDocument), "application/vnd.github.patch+json")] (JsonPatchDocument patch) => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var paths = Assert.Single(document.Paths.Values);
+            var operation = paths.Operations[HttpMethod.Patch];
+            Assert.NotNull(operation.RequestBody);
+            Assert.NotNull(operation.RequestBody.Content);
+            var content = Assert.Single(operation.RequestBody.Content);
+            Assert.Equal("application/vnd.github.patch+json", content.Key);
+        });
+    }
+
+    [Fact]
+    public async Task GetRequestBody_HandlesGenericJsonPatchBody()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPatch("/", (JsonPatchDocument<JsonPatchModel> patch) => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var paths = Assert.Single(document.Paths.Values);
+            var operation = paths.Operations[HttpMethod.Patch];
+            Assert.NotNull(operation.RequestBody);
+            Assert.False(operation.RequestBody.Required);
+            Assert.NotNull(operation.RequestBody.Content);
+            var content = Assert.Single(operation.RequestBody.Content);
+            Assert.Equal("application/json-patch+json", content.Key);
+        });
+    }
+
+#nullable enable
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task GetRequestBody_HandlesGenericJsonPatchBodyOptionality(bool isOptional)
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        if (isOptional)
+        {
+            builder.MapPatch("/", (JsonPatchDocument<JsonPatchModel>? patch) => { });
+        }
+        else
+        {
+            builder.MapPatch("/", (JsonPatchDocument<JsonPatchModel> patch) => { });
+        }
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var paths = Assert.Single(document.Paths.Values);
+            var operation = paths.Operations![HttpMethod.Patch];
+            Assert.NotNull(operation.RequestBody);
+            Assert.Equal(!isOptional, operation.RequestBody.Required);
+        });
+
+    }
+#nullable restore
+
+    [Fact]
+    public async Task GetRequestBody_HandlesGenericJsonPatchBodyWithAttribute()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPatch("/", ([FromBody] JsonPatchDocument<JsonPatchModel> patch) => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var paths = Assert.Single(document.Paths.Values);
+            var operation = paths.Operations[HttpMethod.Patch];
+            Assert.NotNull(operation.RequestBody);
+            Assert.False(operation.RequestBody.Required);
+            Assert.NotNull(operation.RequestBody.Content);
+            var content = Assert.Single(operation.RequestBody.Content);
+            Assert.Equal("application/json-patch+json", content.Key);
+        });
+    }
+
+    [Fact]
+    public async Task GetRequestBody_HandlesGenericJsonPatchBodyWithAcceptsMetadata()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPatch("/", (JsonPatchDocument<JsonPatchModel> name) => { })
+               .Accepts(typeof(JsonPatchDocument<JsonPatchModel>), "application/vnd.github.patch+json");
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var paths = Assert.Single(document.Paths.Values);
+            var operation = paths.Operations[HttpMethod.Patch];
+            Assert.NotNull(operation.RequestBody);
+            Assert.NotNull(operation.RequestBody.Content);
+            var content = Assert.Single(operation.RequestBody.Content);
+            Assert.Equal("application/vnd.github.patch+json", content.Key);
+        });
+    }
+
+    [Fact]
+    public async Task GetRequestBody_HandlesGenericJsonPatchBodyWithConsumesAttribute()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPatch("/", [Consumes(typeof(JsonPatchDocument<JsonPatchModel>), "application/vnd.github.patch+json")] (JsonPatchDocument<JsonPatchModel> patch) => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var paths = Assert.Single(document.Paths.Values);
+            var operation = paths.Operations[HttpMethod.Patch];
+            Assert.NotNull(operation.RequestBody);
+            Assert.NotNull(operation.RequestBody.Content);
+            var content = Assert.Single(operation.RequestBody.Content);
+            Assert.Equal("application/vnd.github.patch+json", content.Key);
+        });
+    }
+
+#nullable enable
+    private sealed class JsonPatchModel
+    {
+        [JsonPropertyName("first")]
+        public string? First { get; set; }
+
+        [JsonPropertyName("second")]
+        public string? Second { get; set; }
+    }
+#nullable restore
 }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.RequestBody.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.RequestBody.cs
@@ -1153,6 +1153,8 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
             Assert.NotNull(operation.RequestBody.Content);
             var content = Assert.Single(operation.RequestBody.Content);
             Assert.Equal("application/json-patch+json", content.Key);
+            var schema = Assert.IsType<OpenApiSchemaReference>(content.Value.Schema);
+            Assert.Equal("JsonPatchDocument", schema.Reference.Id);
         });
     }
 
@@ -1206,6 +1208,8 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
             Assert.NotNull(operation.RequestBody.Content);
             var content = Assert.Single(operation.RequestBody.Content);
             Assert.Equal("application/json-patch+json", content.Key);
+            var schema = Assert.IsType<OpenApiSchemaReference>(content.Value.Schema);
+            Assert.Equal("JsonPatchDocument", schema.Reference.Id);
         });
     }
 
@@ -1227,6 +1231,8 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
             Assert.NotNull(operation.RequestBody.Content);
             var content = Assert.Single(operation.RequestBody.Content);
             Assert.Equal("application/vnd.github.patch+json", content.Key);
+            var schema = Assert.IsType<OpenApiSchemaReference>(content.Value.Schema);
+            Assert.Equal("JsonPatchDocument", schema.Reference.Id);
         });
     }
 
@@ -1248,6 +1254,8 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
             Assert.NotNull(operation.RequestBody.Content);
             var content = Assert.Single(operation.RequestBody.Content);
             Assert.Equal("application/vnd.github.patch+json", content.Key);
+            var schema = Assert.IsType<OpenApiSchemaReference>(content.Value.Schema);
+            Assert.Equal("JsonPatchDocument", schema.Reference.Id);
         });
     }
 
@@ -1270,6 +1278,8 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
             Assert.NotNull(operation.RequestBody.Content);
             var content = Assert.Single(operation.RequestBody.Content);
             Assert.Equal("application/json-patch+json", content.Key);
+            var schema = Assert.IsType<OpenApiSchemaReference>(content.Value.Schema);
+            Assert.Equal("JsonPatchDocument", schema.Reference.Id);
         });
     }
 
@@ -1323,6 +1333,8 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
             Assert.NotNull(operation.RequestBody.Content);
             var content = Assert.Single(operation.RequestBody.Content);
             Assert.Equal("application/json-patch+json", content.Key);
+            var schema = Assert.IsType<OpenApiSchemaReference>(content.Value.Schema);
+            Assert.Equal("JsonPatchDocument", schema.Reference.Id);
         });
     }
 
@@ -1345,6 +1357,8 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
             Assert.NotNull(operation.RequestBody.Content);
             var content = Assert.Single(operation.RequestBody.Content);
             Assert.Equal("application/vnd.github.patch+json", content.Key);
+            var schema = Assert.IsType<OpenApiSchemaReference>(content.Value.Schema);
+            Assert.Equal("JsonPatchDocument", schema.Reference.Id);
         });
     }
 
@@ -1366,6 +1380,8 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
             Assert.NotNull(operation.RequestBody.Content);
             var content = Assert.Single(operation.RequestBody.Content);
             Assert.Equal("application/vnd.github.patch+json", content.Key);
+            var schema = Assert.IsType<OpenApiSchemaReference>(content.Value.Schema);
+            Assert.Equal("JsonPatchDocument", schema.Reference.Id);
         });
     }
 
@@ -1379,4 +1395,56 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
         public string? Second { get; set; }
     }
 #nullable restore
+
+    [Fact]
+    public async Task GetRequestBody_HandlesCustomJsonPatchBody()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPatch("/", (CustomJsonPatchDocument patch) => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var paths = Assert.Single(document.Paths.Values);
+            var operation = paths.Operations[HttpMethod.Patch];
+            Assert.NotNull(operation.RequestBody);
+            Assert.False(operation.RequestBody.Required);
+            Assert.NotNull(operation.RequestBody.Content);
+            var content = Assert.Single(operation.RequestBody.Content);
+            Assert.Equal("application/json-patch+json", content.Key);
+            var schema = Assert.IsType<OpenApiSchemaReference>(content.Value.Schema);
+            Assert.Equal("JsonPatchDocument", schema.Reference.Id);
+        });
+    }
+
+    private class CustomJsonPatchDocument : JsonPatchDocument;
+
+    [Fact]
+    public async Task GetRequestBody_HandlesGenericCustomJsonPatchBody()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPatch("/", (CustomJsonPatchDocument<JsonPatchModel> patch) => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var paths = Assert.Single(document.Paths.Values);
+            var operation = paths.Operations[HttpMethod.Patch];
+            Assert.NotNull(operation.RequestBody);
+            Assert.False(operation.RequestBody.Required);
+            Assert.NotNull(operation.RequestBody.Content);
+            var content = Assert.Single(operation.RequestBody.Content);
+            Assert.Equal("application/json-patch+json", content.Key);
+            var schema = Assert.IsType<OpenApiSchemaReference>(content.Value.Schema);
+            Assert.Equal("JsonPatchDocument", schema.Reference.Id);
+        });
+    }
+
+    private class CustomJsonPatchDocument<T> : JsonPatchDocument<T> where T : class;
 }


### PR DESCRIPTION
# Generate schema for JSON Patch endpoints

Generate an OpenAPI schema for JSON Patch endpoints.

## Description

Follow-up for https://github.com/dotnet/aspnetcore/pull/62988#discussion_r2246474495.

I did a bit Googling and came up with a schema that's a synthesis of different examples I found. It could potentially be simplified to not use `OneOf`.

I couldn't see any obvious reason to generate a different schema for `JsonPatchDocument<T>` compared to `JsonPatchDocument` as the patch schema is the same for both as it isn't strongly-typed to the document being patched, so both use the same schema.

Tested locally by adding SwaggerUI to the Sample App and viewing the operation generated, then using the sample request as-is and submitting it and inspecting the in-memory document in the debugger to check that it was deserialized correctly and all seems to work as expected.

<img width="1443" height="1214" alt="image" src="https://github.com/user-attachments/assets/c18b7430-1628-4b7d-bc76-72a8f4954cbd" />
