### PR TITLE
Quarantine VerifyOpenApiDocumentIsInvariant

### DIFF
--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/OpenApiDocumentLocalizationTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/OpenApiDocumentLocalizationTests.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.InternalTesting;
 public sealed class OpenApiDocumentLocalizationTests(LocalizedSampleAppFixture fixture) : IClassFixture<LocalizedSampleAppFixture>
 {
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/63079")]
     public async Task VerifyOpenApiDocumentIsInvariant()
     {
         using var client = fixture.CreateClient();


### PR DESCRIPTION
Test is failing often.