### PR TITLE
Improve nullable annotation on CancelInvocationMessage.InvocationId

### DIFF
--- a/src/SignalR/common/SignalR.Common/src/Protocol/CancelInvocationMessage.cs
+++ b/src/SignalR/common/SignalR.Common/src/Protocol/CancelInvocationMessage.cs
@@ -17,4 +17,7 @@ public class CancelInvocationMessage : HubInvocationMessage
     public CancelInvocationMessage(string invocationId) : base(invocationId)
     {
     }
+
+    /// <inheritdoc cref="HubInvocationMessage.InvocationId" />
+    public new string InvocationId => base.InvocationId!;
 }

--- a/src/SignalR/common/SignalR.Common/src/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/SignalR/common/SignalR.Common/src/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Microsoft.AspNetCore.SignalR.Protocol.CancelInvocationMessage.InvocationId.get -> string!

--- a/src/SignalR/common/SignalR.Common/src/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/SignalR/common/SignalR.Common/src/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Microsoft.AspNetCore.SignalR.Protocol.CancelInvocationMessage.InvocationId.get -> string!

--- a/src/SignalR/common/SignalR.Common/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/SignalR/common/SignalR.Common/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Microsoft.AspNetCore.SignalR.Protocol.CancelInvocationMessage.InvocationId.get -> string!


### PR DESCRIPTION
This declares a `new` property for `string InvocationId { get; }` so that the compiler sees it as non-nullable, consistent with the constructor declared on the same type.