### PR TITLE
[OpenAPI] Validate OpenAPI documents

### DIFF
--- a/src/OpenApi/sample/Controllers/TestController.cs
+++ b/src/OpenApi/sample/Controllers/TestController.cs
@@ -60,10 +60,10 @@ public class TestController : ControllerBase
 
     public class RouteParamsContainer
     {
-        [FromRoute]
+        [FromRoute(Name = "id")]
         public int Id { get; set; }
 
-        [FromRoute]
+        [FromRoute(Name = "name")]
         [MinLength(5)]
         [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = "MinLengthAttribute works without reflection on string properties.")]
         public string? Name { get; set; }

--- a/src/OpenApi/src/Extensions/ApiDescriptionExtensions.cs
+++ b/src/OpenApi/src/Extensions/ApiDescriptionExtensions.cs
@@ -20,6 +20,7 @@ internal static class ApiDescriptionExtensions
     public static HttpMethod? GetHttpMethod(this ApiDescription apiDescription) =>
         apiDescription.HttpMethod?.ToUpperInvariant() switch
         {
+            // Only add methods documented in the OpenAPI spec: https://spec.openapis.org/oas/v3.1.1.html#path-item-object
             "GET" => HttpMethod.Get,
             "POST" => HttpMethod.Post,
             "PUT" => HttpMethod.Put,
@@ -28,7 +29,6 @@ internal static class ApiDescriptionExtensions
             "HEAD" => HttpMethod.Head,
             "OPTIONS" => HttpMethod.Options,
             "TRACE" => HttpMethod.Trace,
-            "QUERY" => null, // OpenAPI as of 3.1 does not yet support HTTP QUERY
             _ => null,
         };
 

--- a/src/OpenApi/src/Extensions/ApiDescriptionExtensions.cs
+++ b/src/OpenApi/src/Extensions/ApiDescriptionExtensions.cs
@@ -28,7 +28,7 @@ internal static class ApiDescriptionExtensions
             "HEAD" => HttpMethod.Head,
             "OPTIONS" => HttpMethod.Options,
             "TRACE" => HttpMethod.Trace,
-            "QUERY" => HttpMethod.Query,
+            "QUERY" => null, // OpenAPI as of 3.1 does not yet support HTTP QUERY
             _ => null,
         };
 

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/OpenApiDocumentIntegrationTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/OpenApiDocumentIntegrationTests.cs
@@ -1,9 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Nodes;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Reader;
 
 [UsesVerify]
 public sealed class OpenApiDocumentIntegrationTests(SampleAppFixture fixture) : IClassFixture<SampleAppFixture>
@@ -66,11 +68,122 @@ public sealed class OpenApiDocumentIntegrationTests(SampleAppFixture fixture) : 
         Assert.Empty(errors);
     }
 
+    // The test below can be removed when https://github.com/microsoft/OpenAPI.NET/issues/2453 is implemented
+
+    [Theory] // See https://github.com/dotnet/aspnetcore/issues/63090
+    [MemberData(nameof(OpenApiDocuments))]
+    public async Task OpenApiDocumentReferencesAreValid(string documentName, OpenApiSpecVersion version)
+    {
+        var json = await GetOpenApiDocument(documentName, version);
+
+        var result = OpenApiDocument.Parse(json, format: "json");
+
+        var document = result.Document;
+        var documentNode = JsonNode.Parse(json);
+
+        var ruleName = "OpenApiDocumentReferencesAreValid";
+        var rule = new ValidationRule<OpenApiDocument>(ruleName, (context, item) =>
+        {
+            var visitor = new OpenApiSchemaReferenceVisitor(ruleName, context, documentNode);
+
+            var walker = new OpenApiWalker(visitor);
+            walker.Walk(item);
+        });
+
+        var ruleSet = new ValidationRuleSet();
+        ruleSet.Add(typeof(OpenApiDocument), rule);
+
+        var errors = document.Validate(ruleSet);
+
+        Assert.Empty(errors);
+    }
+
     private async Task<string> GetOpenApiDocument(string documentName, OpenApiSpecVersion version)
     {
         var documentService = fixture.Services.GetRequiredKeyedService<OpenApiDocumentService>(documentName);
         var scopedServiceProvider = fixture.Services.CreateScope();
         var document = await documentService.GetOpenApiDocumentAsync(scopedServiceProvider.ServiceProvider);
         return await document.SerializeAsJsonAsync(version);
+    }
+
+    private sealed class OpenApiSchemaReferenceVisitor(
+        string ruleName,
+        IValidationContext context,
+        JsonNode document) : OpenApiVisitorBase
+    {
+        public override void Visit(IOpenApiReferenceHolder referenceHolder)
+        {
+            if (referenceHolder is OpenApiSchemaReference { Reference.IsLocal: true } reference)
+            {
+                ValidateSchemaReference(reference);
+            }
+        }
+
+        public override void Visit(IOpenApiSchema schema)
+        {
+            if (schema is OpenApiSchemaReference { Reference.IsLocal: true } reference)
+            {
+                ValidateSchemaReference(reference);
+            }
+        }
+
+        private void ValidateSchemaReference(OpenApiSchemaReference reference)
+        {
+            try
+            {
+                if (reference.RecursiveTarget is not null)
+                {
+                    return;
+                }
+            }
+            catch (InvalidOperationException ex)
+            {
+                // Thrown if a circular reference is detected
+                context.Enter($"{PathString[2..]}/{OpenApiSchemaKeywords.RefKeyword}");
+                context.CreateError(ruleName, ex.Message);
+                context.Exit();
+
+                return;
+            }
+
+            var id = reference.Reference.ReferenceV3;
+
+            if (id is { Length: > 0 } && !IsValidSchemaReference(id, document))
+            {
+                var isValid = false;
+
+                // Sometimes ReferenceV3 is not a valid JSON pointer, but the $ref
+                // associated with it still points to a valid location in the document.
+                // In these cases, we need to find it manually to verify that fact before
+                // generating a warning that the schema reference is indeed invalid.
+                var parent = Find(PathString, document);
+                var @ref = parent[OpenApiSchemaKeywords.RefKeyword];
+                var path = PathString[2..]; // Trim off the leading "#/" as the context is already at the root
+
+                if (@ref is not null && @ref.GetValueKind() is System.Text.Json.JsonValueKind.String &&
+                    @ref.GetValue<string>() is { Length: > 0 } refId)
+                {
+                    id = refId;
+                    path += $"/{OpenApiSchemaKeywords.RefKeyword}";
+                    isValid = IsValidSchemaReference(id, document);
+                }
+
+                if (!isValid)
+                {
+                    context.Enter(path);
+                    context.CreateWarning(ruleName, $"The schema reference '{id}' does not point to an existing schema.");
+                    context.Exit();
+                }
+            }
+
+            static bool IsValidSchemaReference(string id, JsonNode baseNode)
+                => Find(id, baseNode) is not null;
+
+            static JsonNode Find(string id, JsonNode baseNode)
+            {
+                var pointer = new JsonPointer(id.Replace("#/", "/"));
+                return pointer.Find(baseNode);
+            }
+        }
     }
 }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/OpenApiDocumentIntegrationTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/OpenApiDocumentIntegrationTests.cs
@@ -68,8 +68,6 @@ public sealed class OpenApiDocumentIntegrationTests(SampleAppFixture fixture) : 
         Assert.Empty(errors);
     }
 
-    // The test below can be removed when https://github.com/microsoft/OpenAPI.NET/issues/2453 is implemented
-
     [Theory] // See https://github.com/dotnet/aspnetcore/issues/63090
     [MemberData(nameof(OpenApiDocuments))]
     public async Task OpenApiDocumentReferencesAreValid(string documentName, OpenApiSpecVersion version)
@@ -103,6 +101,7 @@ public sealed class OpenApiDocumentIntegrationTests(SampleAppFixture fixture) : 
         var documentService = fixture.Services.GetRequiredKeyedService<OpenApiDocumentService>(documentName);
         var scopedServiceProvider = fixture.Services.CreateScope();
         var document = await documentService.GetOpenApiDocumentAsync(scopedServiceProvider.ServiceProvider);
+
         return await document.SerializeAsJsonAsync(version);
     }
 

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=controllers.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=controllers.verified.txt
@@ -12,7 +12,7 @@
         ],
         "parameters": [
           {
-            "name": "Id",
+            "name": "id",
             "in": "path",
             "required": true,
             "schema": {
@@ -21,7 +21,7 @@
             }
           },
           {
-            "name": "Name",
+            "name": "name",
             "in": "path",
             "required": true,
             "schema": {
@@ -116,35 +116,6 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CurrentWeather"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/query": {
-      "query": {
-        "tags": [
-          "Test"
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/CurrentWeather"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CurrentWeather"
-                }
-              },
-              "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CurrentWeather"
                 }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=controllers.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=controllers.verified.txt
@@ -12,7 +12,7 @@
         ],
         "parameters": [
           {
-            "name": "Id",
+            "name": "id",
             "in": "path",
             "required": true,
             "schema": {
@@ -21,7 +21,7 @@
             }
           },
           {
-            "name": "Name",
+            "name": "name",
             "in": "path",
             "required": true,
             "schema": {
@@ -116,35 +116,6 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CurrentWeather"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/query": {
-      "query": {
-        "tags": [
-          "Test"
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/CurrentWeather"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CurrentWeather"
-                }
-              },
-              "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CurrentWeather"
                 }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentLocalizationTests.VerifyOpenApiDocumentIsInvariant.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentLocalizationTests.VerifyOpenApiDocumentIsInvariant.verified.txt
@@ -1250,7 +1250,7 @@
         ],
         "parameters": [
           {
-            "name": "Id",
+            "name": "id",
             "in": "path",
             "required": true,
             "schema": {
@@ -1259,7 +1259,7 @@
             }
           },
           {
-            "name": "Name",
+            "name": "name",
             "in": "path",
             "required": true,
             "schema": {
@@ -1354,35 +1354,6 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CurrentWeather"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/query": {
-      "query": {
-        "tags": [
-          "Test"
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/CurrentWeather"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CurrentWeather"
-                }
-              },
-              "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CurrentWeather"
                 }


### PR DESCRIPTION
# Validate OpenAPI documents

Validate OpenAPI documents generated in tests for validity.

## Description

To see if I could flush out the errors for #63090 with Microsoft.OpenApi's built-in validation (it doesn't find them) I spotted a few other validation errors that are. This fixes them and adds some tests that validate the generated documents using the default ruleset.

- Validate OpenAPI documents with Microsoft.OpenApi.
- Exclude `HTTP QUERY` endpoints as they are not valid in OpenAPI 3.1 (added by #63034).
- Fix incorrect parameter casing validation warnings.

Relates to #63090.
