### PR TITLE
[OpenApi] Test schema reference validity

### DIFF
--- a/src/OpenApi/sample/Controllers/TestController.cs
+++ b/src/OpenApi/sample/Controllers/TestController.cs
@@ -60,10 +60,10 @@ public class TestController : ControllerBase
 
     public class RouteParamsContainer
     {
-        [FromRoute]
+        [FromRoute(Name = "id")]
         public int Id { get; set; }
 
-        [FromRoute]
+        [FromRoute(Name = "name")]
         [MinLength(5)]
         [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = "MinLengthAttribute works without reflection on string properties.")]
         public string? Name { get; set; }

--- a/src/OpenApi/src/Extensions/ApiDescriptionExtensions.cs
+++ b/src/OpenApi/src/Extensions/ApiDescriptionExtensions.cs
@@ -28,7 +28,7 @@ internal static class ApiDescriptionExtensions
             "HEAD" => HttpMethod.Head,
             "OPTIONS" => HttpMethod.Options,
             "TRACE" => HttpMethod.Trace,
-            "QUERY" => HttpMethod.Query,
+            "QUERY" => null, // OpenAPI as of 3.1 does not yet support HTTP QUERY
             _ => null,
         };
 

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/OpenApiDocumentIntegrationTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/OpenApiDocumentIntegrationTests.cs
@@ -129,8 +129,20 @@ public sealed class OpenApiDocumentIntegrationTests(SampleAppFixture fixture) : 
 
         private void ValidateSchemaReference(OpenApiSchemaReference reference)
         {
-            if (reference.RecursiveTarget is not null)
+            try
             {
+                if (reference.RecursiveTarget is not null)
+                {
+                    return;
+                }
+            }
+            catch (InvalidOperationException ex)
+            {
+                // Thrown if a circular reference is detected
+                context.Enter($"{PathString[2..]}/{OpenApiSchemaKeywords.RefKeyword}");
+                context.CreateError(ruleName, ex.Message);
+                context.Exit();
+
                 return;
             }
 

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/OpenApiDocumentIntegrationTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/OpenApiDocumentIntegrationTests.cs
@@ -1,9 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Nodes;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Reader;
 
 [UsesVerify]
 public sealed class OpenApiDocumentIntegrationTests(SampleAppFixture fixture) : IClassFixture<SampleAppFixture>
@@ -64,6 +66,152 @@ public sealed class OpenApiDocumentIntegrationTests(SampleAppFixture fixture) : 
 
         var errors = actual.Document.Validate(ruleSet);
         Assert.Empty(errors);
+    }
+
+    [Theory] // See https://github.com/dotnet/aspnetcore/issues/63090
+    [MemberData(nameof(OpenApiDocuments))]
+    public async Task OpenApiDocumentReferencesAreValid(string documentName, OpenApiSpecVersion version)
+    {
+        var json = await GetOpenApiDocument(documentName, version);
+
+        var result = OpenApiDocument.Parse(json, format: "json");
+
+        var document = result.Document;
+        var documentNode = JsonNode.Parse(json);
+
+        var actual = new List<string>();
+
+        // TODO What other parts of the document should also be validated for references to be comprehensive?
+        // Likely also needs to be recursive to validate all references in schemas, parameters, etc.
+        if (document.Components is { Schemas.Count: > 0 } components)
+        {
+            foreach (var schema in components.Schemas)
+            {
+                if (schema.Value.Properties is { Count: > 0 } properties)
+                {
+                    foreach (var property in properties)
+                    {
+                        if (property.Value is not OpenApiSchemaReference reference)
+                        {
+                            continue;
+                        }
+
+                        var id = reference.Reference.ReferenceV3;
+
+                        if (!IsValidSchemaReference(id, documentNode))
+                        {
+                            actual.Add($"Reference '{id}' on property '{property.Key}' of schema '{schema.Key}' is invalid.");
+                        }
+                    }
+                }
+
+                if (schema.Value.AllOf is { Count: > 0 } allOf)
+                {
+                    foreach (var child in allOf)
+                    {
+                        if (child is not OpenApiSchemaReference reference)
+                        {
+                            continue;
+                        }
+
+                        var id = reference.Reference.ReferenceV3;
+
+                        if (!IsValidSchemaReference(id, documentNode))
+                        {
+                            actual.Add($"Reference '{id}' for AllOf of schema '{schema.Key}' is invalid.");
+                        }
+                    }
+                }
+
+                if (schema.Value.AnyOf is { Count: > 0 } anyOf)
+                {
+                    foreach (var child in anyOf)
+                    {
+                        if (child is not OpenApiSchemaReference reference)
+                        {
+                            continue;
+                        }
+
+                        var id = reference.Reference.ReferenceV3;
+
+                        if (!IsValidSchemaReference(id, documentNode))
+                        {
+                            actual.Add($"Reference '{id}' for AnyOf of schema '{schema.Key}' is invalid.");
+                        }
+                    }
+                }
+
+                if (schema.Value.OneOf is { Count: > 0 } oneOf)
+                {
+                    foreach (var child in oneOf)
+                    {
+                        if (child is not OpenApiSchemaReference reference)
+                        {
+                            continue;
+                        }
+
+                        var id = reference.Reference.ReferenceV3;
+
+                        if (!IsValidSchemaReference(id, documentNode))
+                        {
+                            actual.Add($"Reference '{id}' for OneOf of schema '{schema.Key}' is invalid.");
+                        }
+                    }
+                }
+
+                if (schema.Value.Discriminator is { Mapping.Count: > 0 } discriminator)
+                {
+                    foreach (var child in discriminator.Mapping)
+                    {
+                        if (child.Value is not OpenApiSchemaReference reference)
+                        {
+                            continue;
+                        }
+
+                        var id = reference.Reference.ReferenceV3;
+
+                        if (!IsValidSchemaReference(id, documentNode))
+                        {
+                            actual.Add($"Reference '{id}' for Discriminator '{child.Key}' of schema '{schema.Key}' is invalid.");
+                        }
+                    }
+                }
+            }
+        }
+
+        foreach (var path in document.Paths)
+        {
+            foreach (var operation in path.Value.Operations)
+            {
+                if (operation.Value.Parameters is not { Count: > 0 } parameters)
+                {
+                    continue;
+                }
+
+                foreach (var parameter in parameters)
+                {
+                    if (parameter.Schema is not OpenApiSchemaReference reference)
+                    {
+                        continue;
+                    }
+
+                    var id = reference.Reference.ReferenceV3;
+
+                    if (!IsValidSchemaReference(id, documentNode))
+                    {
+                        actual.Add($"Reference '{id}' on parameter '{parameter.Name}' of path '{path.Key}' of operation '{operation.Key}' is invalid.");
+                    }
+                }
+            }
+        }
+
+        Assert.Empty(actual);
+
+        static bool IsValidSchemaReference(string id, JsonNode baseNode)
+        {
+            var pointer = new JsonPointer(id.Replace("#/", "/"));
+            return pointer.Find(baseNode) is not null;
+        }
     }
 
     private async Task<string> GetOpenApiDocument(string documentName, OpenApiSpecVersion version)

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=controllers.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=controllers.verified.txt
@@ -12,7 +12,7 @@
         ],
         "parameters": [
           {
-            "name": "Id",
+            "name": "id",
             "in": "path",
             "required": true,
             "schema": {
@@ -21,7 +21,7 @@
             }
           },
           {
-            "name": "Name",
+            "name": "name",
             "in": "path",
             "required": true,
             "schema": {
@@ -116,35 +116,6 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CurrentWeather"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/query": {
-      "query": {
-        "tags": [
-          "Test"
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/CurrentWeather"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CurrentWeather"
-                }
-              },
-              "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CurrentWeather"
                 }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=controllers.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=controllers.verified.txt
@@ -12,7 +12,7 @@
         ],
         "parameters": [
           {
-            "name": "Id",
+            "name": "id",
             "in": "path",
             "required": true,
             "schema": {
@@ -21,7 +21,7 @@
             }
           },
           {
-            "name": "Name",
+            "name": "name",
             "in": "path",
             "required": true,
             "schema": {
@@ -116,35 +116,6 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CurrentWeather"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/query": {
-      "query": {
-        "tags": [
-          "Test"
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/CurrentWeather"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CurrentWeather"
-                }
-              },
-              "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CurrentWeather"
                 }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentLocalizationTests.VerifyOpenApiDocumentIsInvariant.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentLocalizationTests.VerifyOpenApiDocumentIsInvariant.verified.txt
@@ -1165,7 +1165,7 @@
         ],
         "parameters": [
           {
-            "name": "Id",
+            "name": "id",
             "in": "path",
             "required": true,
             "schema": {
@@ -1174,7 +1174,7 @@
             }
           },
           {
-            "name": "Name",
+            "name": "name",
             "in": "path",
             "required": true,
             "schema": {
@@ -1269,35 +1269,6 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CurrentWeather"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/query": {
-      "query": {
-        "tags": [
-          "Test"
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/CurrentWeather"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CurrentWeather"
-                }
-              },
-              "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CurrentWeather"
                 }


### PR DESCRIPTION
# Test schema reference validity

Add integration test for invalid OpenAPI schema references.

## Description

Add a draft of a way to test whether OpenAPI schema references are invalid which builds on top of #63092.

The test fails as it reveals the two issues described in #63090.

~~Will separately open a feature request for Microsoft.OpenApi to have this built-in to the validation rulesets.~~ https://github.com/microsoft/OpenAPI.NET/issues/2453 and https://github.com/microsoft/OpenAPI.NET/pull/2459
