### PR TITLE
Remove the trailing '/' from logged localhost message

### DIFF
--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostService.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostService.cs
@@ -171,7 +171,7 @@ internal sealed partial class GenericWebHostService : IHostedService
                     if (address.Contains(".localhost", StringComparison.OrdinalIgnoreCase) && Uri.TryCreate(address, UriKind.Absolute, out var uri) && uri.Host.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase))
                     {
                         // Log the localhost address without the sub-domain prefix too
-                        Log.ListeningOnAddress(LifetimeLogger, new UriBuilder(uri) { Host = "localhost" }.ToString());
+                        Log.ListeningOnAddress(LifetimeLogger, new UriBuilder(uri) { Host = "localhost" }.ToString().TrimEnd('/'));
                     }
                 }
             }

--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostService.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostService.cs
@@ -171,7 +171,7 @@ internal sealed partial class GenericWebHostService : IHostedService
                     if (address.Contains(".localhost", StringComparison.OrdinalIgnoreCase) && Uri.TryCreate(address, UriKind.Absolute, out var uri) && uri.Host.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase))
                     {
                         // Log the localhost address without the sub-domain prefix too
-                        Log.ListeningOnAddress(LifetimeLogger, new UriBuilder(uri) { Host = "localhost" }.Uri.GetLeftPart(UriPartial.Authority));
+                        Log.ListeningOnAddress(LifetimeLogger, new UriBuilder(uri) { Host = "localhost" }.ToString().TrimEnd('/'));
                     }
                 }
             }

--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostService.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostService.cs
@@ -171,7 +171,7 @@ internal sealed partial class GenericWebHostService : IHostedService
                     if (address.Contains(".localhost", StringComparison.OrdinalIgnoreCase) && Uri.TryCreate(address, UriKind.Absolute, out var uri) && uri.Host.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase))
                     {
                         // Log the localhost address without the sub-domain prefix too
-                        Log.ListeningOnAddress(LifetimeLogger, new UriBuilder(uri) { Host = "localhost" }.ToString().TrimEnd('/'));
+                        Log.ListeningOnAddress(LifetimeLogger, new UriBuilder(uri) { Host = "localhost" }.Uri.GetLeftPart(UriPartial.Authority));
                     }
                 }
             }


### PR DESCRIPTION
Noticed that when using a URL like `myapp.dev.localhost` with the new templates, Kestrel logs both the `myapp.dev.localhost` and `localhost` addresses, but for the `localhost` address it includes the trailing slash (due to us using Uri.ToString()). This fixes it so that the slash isn't logged, aligning it with the format of the .localhost address.