### PR TITLE
Enable `E2ETest.ServerExecutionTests.CircuitTests`

### DIFF
--- a/src/Components/test/E2ETest/Tests/CircuitTests.cs
+++ b/src/Components/test/E2ETest/Tests/CircuitTests.cs
@@ -43,15 +43,7 @@ public class CircuitTests : ServerTestBase<BasicTestAppServerSiteFixture<ServerS
         var targetButton = Browser.Exists(By.Id(id));
         targetButton.Click();
 
-        // Triggering an error will show the exception UI
-        Browser.Exists(By.CssSelector("#blazor-error-ui[style='display: block;']"));
-
-        // Dismiss the error UI by clicking the dismiss button
-        var dismissButton = Browser.Exists(By.CssSelector("#blazor-error-ui .dismiss"));
-        dismissButton.Click();
-
-        // Wait for error UI to be hidden
-        Browser.Exists(By.CssSelector("#blazor-error-ui[style='display: none;']"));
+        DismissBlazorErrorUI();
 
         // Clicking the button again will trigger a server disconnect
         targetButton.Click();
@@ -72,14 +64,8 @@ public class CircuitTests : ServerTestBase<BasicTestAppServerSiteFixture<ServerS
         targetButton.Click();
         // Clicking it again hides the component and invokes the rethrow which triggers the exception
         targetButton.Click();
-        Browser.Exists(By.CssSelector("#blazor-error-ui[style='display: block;']"));
 
-        // Dismiss the error UI by clicking the dismiss button
-        var dismissButton = Browser.Exists(By.CssSelector("#blazor-error-ui .dismiss"));
-        dismissButton.Click();
-
-        // Wait for error UI to be hidden
-        Browser.Exists(By.CssSelector("#blazor-error-ui[style='display: none;']"));
+        DismissBlazorErrorUI();
 
         // Clicking it again causes the circuit to disconnect
         targetButton.Click();
@@ -106,5 +92,18 @@ public class CircuitTests : ServerTestBase<BasicTestAppServerSiteFixture<ServerS
         {
             Assert.Contains(log, entry => entry.Message.Contains(message));
         }
+    }
+
+    void DismissBlazorErrorUI()
+    {
+        // Triggering an error will show the exception UI
+        Browser.Exists(By.CssSelector("#blazor-error-ui[style='display: block;']"));
+
+        // Dismiss the error UI by clicking the dismiss button
+        var dismissButton = Browser.Exists(By.CssSelector("#blazor-error-ui .dismiss"));
+        dismissButton.Click();
+
+        // Wait for error UI to be hidden
+        Browser.Exists(By.CssSelector("#blazor-error-ui[style='display: none;']"));
     }
 }

--- a/src/Components/test/E2ETest/Tests/CircuitTests.cs
+++ b/src/Components/test/E2ETest/Tests/CircuitTests.cs
@@ -35,7 +35,6 @@ public class CircuitTests : ServerTestBase<BasicTestAppServerSiteFixture<ServerS
     [InlineData("render-throw")]
     [InlineData("afterrender-sync-throw")]
     [InlineData("afterrender-async-throw")]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/57588")]
     public void ComponentLifecycleMethodThrowsExceptionTerminatesTheCircuit(string id)
     {
         Browser.MountTestComponent<ReliabilityComponent>();
@@ -47,6 +46,13 @@ public class CircuitTests : ServerTestBase<BasicTestAppServerSiteFixture<ServerS
         // Triggering an error will show the exception UI
         Browser.Exists(By.CssSelector("#blazor-error-ui[style='display: block;']"));
 
+        // Dismiss the error UI by clicking the dismiss button
+        var dismissButton = Browser.Exists(By.CssSelector("#blazor-error-ui .dismiss"));
+        dismissButton.Click();
+
+        // Wait for error UI to be hidden
+        Browser.Exists(By.CssSelector("#blazor-error-ui[style='display: none;']"));
+
         // Clicking the button again will trigger a server disconnect
         targetButton.Click();
 
@@ -54,7 +60,6 @@ public class CircuitTests : ServerTestBase<BasicTestAppServerSiteFixture<ServerS
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/57588")]
     public void ComponentDisposeMethodThrowsExceptionTerminatesTheCircuit()
     {
         Browser.MountTestComponent<ReliabilityComponent>();
@@ -68,6 +73,13 @@ public class CircuitTests : ServerTestBase<BasicTestAppServerSiteFixture<ServerS
         // Clicking it again hides the component and invokes the rethrow which triggers the exception
         targetButton.Click();
         Browser.Exists(By.CssSelector("#blazor-error-ui[style='display: block;']"));
+
+        // Dismiss the error UI by clicking the dismiss button
+        var dismissButton = Browser.Exists(By.CssSelector("#blazor-error-ui .dismiss"));
+        dismissButton.Click();
+
+        // Wait for error UI to be hidden
+        Browser.Exists(By.CssSelector("#blazor-error-ui[style='display: none;']"));
 
         // Clicking it again causes the circuit to disconnect
         targetButton.Click();


### PR DESCRIPTION
The test checks if we correctly terminate the circuit after an exception was thrown. The check if the circuit was terminated involves clicking a button that got hidden by error window with the throw exception.

There was an attempt to fix it by moving the window position, so that the button becomes visible. Why don't we close the window to make sure button visibility is not a problem?

Fixes #57551
