### PR TITLE
Skip IResult in metadata if it implements IEndpointMetadataProvider

### DIFF
--- a/src/Mvc/Mvc.ApiExplorer/src/ApiResponseTypeProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/ApiResponseTypeProvider.cs
@@ -231,9 +231,10 @@ internal sealed class ApiResponseTypeProvider
 
         foreach (var metadata in responseMetadata)
         {
-            // `IResult` metadata inserted for awaitable types should
-            // not be considered for response metadata.
-            if (typeof(IResult).IsAssignableFrom(metadata.Type))
+            // Skip IResult types that implement IEndpointMetadataProvider (built-in framework types like TypedResults)
+            // since they handle their own metadata population. Custom IResult implementations that don't implement
+            // IEndpointMetadataProvider should be included in response metadata for API documentation.
+            if (typeof(IResult).IsAssignableFrom(metadata.Type) && typeof(IEndpointMetadataProvider).IsAssignableFrom(metadata.Type))
             {
                 continue;
             }

--- a/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
@@ -629,6 +629,32 @@ public class EndpointMetadataApiDescriptionProviderTest
     }
 
     [Fact]
+    public void ResponseProducesMetadataWithIResultImplementor()
+    {
+        var apiDescription = GetApiDescription(
+            [ProducesResponseType(typeof(CustomIResultImplementor), StatusCodes.Status200OK)] () => new CustomIResultImplementor { Content = "Hello, World!" });
+
+        var okResponseType = Assert.Single(apiDescription.SupportedResponseTypes);
+
+        Assert.Equal(200, okResponseType.StatusCode);
+        Assert.Equal(typeof(CustomIResultImplementor), okResponseType.Type);
+        Assert.Equal(typeof(CustomIResultImplementor), okResponseType.ModelMetadata?.ModelType);
+
+        var okResponseFormat = Assert.Single(okResponseType.ApiResponseFormats);
+        Assert.Equal("application/json", okResponseFormat.MediaType);
+    }
+
+    public class CustomIResultImplementor : IResult
+    {
+        public required string Content { get; set; }
+
+        public Task ExecuteAsync(HttpContext httpContext)
+        {
+            return httpContext.Response.WriteAsJsonAsync(this);
+        }
+    }
+
+    [Fact]
     public void AddsFromRouteParameterAsPath()
     {
         static void AssertPathParameter(ApiDescription apiDescription)

--- a/src/OpenApi/sample/Endpoints/MapSchemasEndpoints.cs
+++ b/src/OpenApi/sample/Endpoints/MapSchemasEndpoints.cs
@@ -39,8 +39,18 @@ public static class SchemasEndpointsExtensions
         schemas.MapPost("/child", (ChildObject child) => Results.Ok(child));
         schemas.MapPatch("/json-patch", (JsonPatchDocument patchDoc) => Results.NoContent());
         schemas.MapPatch("/json-patch-generic", (JsonPatchDocument<ParentObject> patchDoc) => Results.NoContent());
-
+        schemas.MapGet("/custom-iresult", () => new CustomIResultImplementor { Content = "Hello world!" })
+            .Produces<CustomIResultImplementor>(200);
         return endpointRouteBuilder;
+    }
+
+    public class CustomIResultImplementor : IResult
+    {
+        public required string Content { get; set; }
+        public Task ExecuteAsync(HttpContext httpContext)
+        {
+            return Task.CompletedTask;
+        }
     }
 
     public sealed class Category

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
@@ -551,6 +551,25 @@
           }
         }
       }
+    },
+    "/schemas-by-ref/custom-iresult": {
+      "get": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomIResultImplementor"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -628,6 +647,17 @@
             "items": {
               "$ref": "#/components/schemas/ContainerType/properties/seq1/items"
             }
+          }
+        }
+      },
+      "CustomIResultImplementor": {
+        "required": [
+          "content"
+        ],
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string"
           }
         }
       },

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
@@ -551,6 +551,25 @@
           }
         }
       }
+    },
+    "/schemas-by-ref/custom-iresult": {
+      "get": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomIResultImplementor"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -628,6 +647,17 @@
             "items": {
               "$ref": "#/components/schemas/ContainerType/properties/seq1/items"
             }
+          }
+        }
+      },
+      "CustomIResultImplementor": {
+        "required": [
+          "content"
+        ],
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string"
           }
         }
       },

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentLocalizationTests.VerifyOpenApiDocumentIsInvariant.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentLocalizationTests.VerifyOpenApiDocumentIsInvariant.verified.txt
@@ -1077,6 +1077,25 @@
         }
       }
     },
+    "/schemas-by-ref/custom-iresult": {
+      "get": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomIResultImplementor"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/responses/200-add-xml": {
       "get": {
         "tags": [
@@ -1407,6 +1426,17 @@
             "type": "number",
             "format": "float",
             "default": 0.1
+          }
+        }
+      },
+      "CustomIResultImplementor": {
+        "required": [
+          "content"
+        ],
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string"
           }
         }
       },


### PR DESCRIPTION
Closes https://github.com/dotnet/aspnetcore/issues/57801, specifically https://github.com/dotnet/aspnetcore/issues/57801#issuecomment-2439578287.

Current implementation assumes that any `IResult` type in metadata is one that implements `IEndpointMetadataProvider` to populate its value type, but that's not the case for all types that implement `IResult`.

Note, there is a case that doesn't work with this current check:

```csharp
class MyResult : IResult, IEndpointMetadataProvider
{
  public string Content { get; set; }
  public PopulateMetadata()
  {
     builder.Metadata.Add(new ProducesResponseTypeMetadata(typeof(MyResult));
  }
}
```

But I'm inclined that scenarios like the above should be modeled like:

```csharp
class MyResult<T> : IResult, IEndpointMetadataProvider
{
  public T Value { get; }
  public PopulateMetadata()
  {
     builder.Metadata.Add(new ProducesResponseTypeMetadata(typeof(T));
  }
}
```