### PR TITLE
Revert "[Blazor] Use DynamicDependency to preserve KeyValuePair for WebAssembly trimming"

### DIFF
--- a/src/Components/WebAssembly/WebAssembly/src/Services/DefaultWebAssemblyJSRuntime.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Services/DefaultWebAssemblyJSRuntime.cs
@@ -31,7 +31,6 @@ internal sealed partial class DefaultWebAssemblyJSRuntime : WebAssemblyJSRuntime
     [DynamicDependency(nameof(BeginInvokeDotNet))]
     [DynamicDependency(nameof(ReceiveByteArrayFromJS))]
     [DynamicDependency(nameof(UpdateRootComponentsCore))]
-    [DynamicDependency(JsonSerialized, typeof(KeyValuePair<,>))]
     private DefaultWebAssemblyJSRuntime()
     {
         ElementReferenceContext = new WebElementReferenceContext(this);


### PR DESCRIPTION
Reverts dotnet/aspnetcore#63099

Working around trimming issues with dynamicdependency is not reliable. Our documented way to fix trimming issues is by turning on warnings and solving the trim warnings. 