### PR TITLE
Include a warning about host spoofing in xml

### DIFF
--- a/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
@@ -1,9 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.AspNetCore.Http.Metadata;
-using Microsoft.AspNetCore.Routing;
-using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Routing;

--- a/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Builder;
 

--- a/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
@@ -5,6 +5,9 @@ using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.WebUtilities;
 
 namespace Microsoft.AspNetCore.Builder;
 

--- a/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
@@ -22,6 +22,20 @@ public static class RoutingEndpointConventionBuilderExtensions
     /// An empty collection means any host will be accepted.
     /// </param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
+    /// <remarks>
+    /// APIs that depend on the <see href="https://developer.mozilla.org/docs/Web/HTTP/Headers/Host">Host header</see>, including
+    /// <see cref="HttpRequest.Host"/> and <see cref="RequireHost"/>, are vulnerable to client spoofing.
+    ///
+    /// To safeguard against host and port spoofing:
+    /// <list type="bullet">
+    /// <item><description>
+    /// Verify the server name used during the TLS handshake using <see href="https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.connections.features.itlshandshakefeature.hostname">ITlsHandshakeFeature.HostName</see>.
+    /// </description></item>
+    /// <item><description>
+    /// Verify the local port where the connection was accepted using <see cref="HttpContext.Connection"/> (specifically <see cref="ConnectionInfo.LocalPort"/>).
+    /// </description></item>
+    /// </list>
+    /// </remarks>
     public static TBuilder RequireHost<TBuilder>(this TBuilder builder, params string[] hosts) where TBuilder : IEndpointConventionBuilder
     {
         ArgumentNullException.ThrowIfNull(builder);


### PR DESCRIPTION
# Include a warning about host spoofing in xml

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Summary of the changes

Adds remarks for warning about host spoofing
Changes taken from previously unmerged PR https://github.com/dotnet/aspnetcore/pull/54971

## Description

Update API remarks for RoutingEndpointConventionBuilderExtensions.RequireHost to warn about host spoofing

This is how it looks like in VS code after changes. Idk why crefs are not rendered properly in VS code. 

<img width="1114" height="231" alt="image" src="https://github.com/user-attachments/assets/de2a5439-f17e-4e92-981a-babbb0bb625d" />


Fixes #48818