### PR TITLE
OpenAPI: Apply descriptions from [Description] to the schema reference instead of the actual schema for properties

### DIFF
--- a/src/OpenApi/src/Schemas/OpenApiJsonSchema.Helpers.cs
+++ b/src/OpenApi/src/Schemas/OpenApiJsonSchema.Helpers.cs
@@ -350,11 +350,6 @@ internal sealed partial class OpenApiJsonSchema
                 schema.Metadata ??= new Dictionary<string, object>();
                 schema.Metadata[OpenApiConstants.RefDescriptionAnnotation] = reader.GetString() ?? string.Empty;
                 break;
-            case OpenApiConstants.RefExampleAnnotation:
-                reader.Read();
-                schema.Metadata ??= new Dictionary<string, object>();
-                schema.Metadata[OpenApiConstants.RefExampleAnnotation] = reader.GetString() ?? string.Empty;
-                break;
 
             default:
                 reader.Skip();

--- a/src/OpenApi/src/Schemas/OpenApiJsonSchema.Helpers.cs
+++ b/src/OpenApi/src/Schemas/OpenApiJsonSchema.Helpers.cs
@@ -345,6 +345,17 @@ internal sealed partial class OpenApiJsonSchema
                 schema.Metadata ??= new Dictionary<string, object>();
                 schema.Metadata[OpenApiConstants.RefId] = reader.GetString() ?? string.Empty;
                 break;
+            case OpenApiConstants.RefDescriptionAnnotation:
+                reader.Read();
+                schema.Metadata ??= new Dictionary<string, object>();
+                schema.Metadata[OpenApiConstants.RefDescriptionAnnotation] = reader.GetString() ?? string.Empty;
+                break;
+            case OpenApiConstants.RefExampleAnnotation:
+                reader.Read();
+                schema.Metadata ??= new Dictionary<string, object>();
+                schema.Metadata[OpenApiConstants.RefExampleAnnotation] = reader.GetString() ?? string.Empty;
+                break;
+
             default:
                 reader.Skip();
                 break;

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -107,25 +107,26 @@ internal sealed class OpenApiSchemaService(
             }
             if (context.PropertyInfo is { AttributeProvider: { } attributeProvider })
             {
+                var propertyAttributes = attributeProvider.GetCustomAttributes(inherit: false);
                 var isInlinedSchema = schema[OpenApiConstants.SchemaId] is null;
                 if (isInlinedSchema)
                 {
-                    if (attributeProvider.GetCustomAttributes(inherit: false).OfType<ValidationAttribute>() is { } validationAttributes)
+                    if (propertyAttributes.OfType<ValidationAttribute>() is { } validationAttributes)
                     {
                         schema.ApplyValidationAttributes(validationAttributes);
                     }
-                    if (attributeProvider.GetCustomAttributes(inherit: false).OfType<DefaultValueAttribute>().LastOrDefault() is { } defaultValueAttribute)
+                    if (propertyAttributes.OfType<DefaultValueAttribute>().LastOrDefault() is { } defaultValueAttribute)
                     {
                         schema.ApplyDefaultValue(defaultValueAttribute.Value, context.TypeInfo);
                     }
-                    if (attributeProvider.GetCustomAttributes(inherit: false).OfType<DescriptionAttribute>().LastOrDefault() is { } descriptionAttribute)
+                    if (propertyAttributes.OfType<DescriptionAttribute>().LastOrDefault() is { } descriptionAttribute)
                     {
                         schema[OpenApiSchemaKeywords.DescriptionKeyword] = descriptionAttribute.Description;
                     }
                 }
                 else
                 {
-                    if (attributeProvider.GetCustomAttributes(inherit: false).OfType<DescriptionAttribute>().LastOrDefault() is { } descriptionAttribute)
+                    if (propertyAttributes.OfType<DescriptionAttribute>().LastOrDefault() is { } descriptionAttribute)
                     {
                         schema[OpenApiConstants.RefDescriptionAnnotation] = descriptionAttribute.Description;
                     }

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -108,17 +108,17 @@ internal sealed class OpenApiSchemaService(
             if (context.PropertyInfo is { AttributeProvider: { } attributeProvider })
             {
                 var propertyAttributes = attributeProvider.GetCustomAttributes(inherit: false);
+                if (propertyAttributes.OfType<ValidationAttribute>() is { } validationAttributes)
+                {
+                    schema.ApplyValidationAttributes(validationAttributes);
+                }
+                if (propertyAttributes.OfType<DefaultValueAttribute>().LastOrDefault() is { } defaultValueAttribute)
+                {
+                    schema.ApplyDefaultValue(defaultValueAttribute.Value, context.TypeInfo);
+                }
                 var isInlinedSchema = schema[OpenApiConstants.SchemaId] is null;
                 if (isInlinedSchema)
                 {
-                    if (propertyAttributes.OfType<ValidationAttribute>() is { } validationAttributes)
-                    {
-                        schema.ApplyValidationAttributes(validationAttributes);
-                    }
-                    if (propertyAttributes.OfType<DefaultValueAttribute>().LastOrDefault() is { } defaultValueAttribute)
-                    {
-                        schema.ApplyDefaultValue(defaultValueAttribute.Value, context.TypeInfo);
-                    }
                     if (propertyAttributes.OfType<DescriptionAttribute>().LastOrDefault() is { } descriptionAttribute)
                     {
                         schema[OpenApiSchemaKeywords.DescriptionKeyword] = descriptionAttribute.Description;

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -101,31 +101,31 @@ internal sealed class OpenApiSchemaService(
             {
                 schema.ApplyNullabilityContextInfo(jsonPropertyInfo);
             }
-            if (context.TypeInfo.Type.GetCustomAttributes(inherit: false).OfType<DescriptionAttribute>().LastOrDefault() is DescriptionAttribute typeDescriptionAttribute)
+            if (context.TypeInfo.Type.GetCustomAttributes(inherit: false).OfType<DescriptionAttribute>().LastOrDefault() is { } typeDescriptionAttribute)
             {
                 schema[OpenApiSchemaKeywords.DescriptionKeyword] = typeDescriptionAttribute.Description;
             }
             if (context.PropertyInfo is { AttributeProvider: { } attributeProvider })
             {
-                var isInlinedSchema = schema["x-schema-id"] is null;
+                var isInlinedSchema = schema[OpenApiConstants.SchemaId] is null;
                 if (isInlinedSchema)
                 {
                     if (attributeProvider.GetCustomAttributes(inherit: false).OfType<ValidationAttribute>() is { } validationAttributes)
                     {
                         schema.ApplyValidationAttributes(validationAttributes);
                     }
-                    if (attributeProvider.GetCustomAttributes(inherit: false).OfType<DefaultValueAttribute>().LastOrDefault() is DefaultValueAttribute defaultValueAttribute)
+                    if (attributeProvider.GetCustomAttributes(inherit: false).OfType<DefaultValueAttribute>().LastOrDefault() is { } defaultValueAttribute)
                     {
                         schema.ApplyDefaultValue(defaultValueAttribute.Value, context.TypeInfo);
                     }
-                    if (attributeProvider.GetCustomAttributes(inherit: false).OfType<DescriptionAttribute>().LastOrDefault() is DescriptionAttribute descriptionAttribute)
+                    if (attributeProvider.GetCustomAttributes(inherit: false).OfType<DescriptionAttribute>().LastOrDefault() is { } descriptionAttribute)
                     {
                         schema[OpenApiSchemaKeywords.DescriptionKeyword] = descriptionAttribute.Description;
                     }
                 }
                 else
                 {
-                    if (attributeProvider.GetCustomAttributes(inherit: false).OfType<DescriptionAttribute>().LastOrDefault() is DescriptionAttribute descriptionAttribute)
+                    if (attributeProvider.GetCustomAttributes(inherit: false).OfType<DescriptionAttribute>().LastOrDefault() is { } descriptionAttribute)
                     {
                         schema[OpenApiConstants.RefDescriptionAnnotation] = descriptionAttribute.Description;
                     }

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -101,6 +101,10 @@ internal sealed class OpenApiSchemaService(
             {
                 schema.ApplyNullabilityContextInfo(jsonPropertyInfo);
             }
+            if (context.TypeInfo.Type.GetCustomAttributes(inherit: false).OfType<DescriptionAttribute>().LastOrDefault() is DescriptionAttribute typeDescriptionAttribute)
+            {
+                schema[OpenApiSchemaKeywords.DescriptionKeyword] = typeDescriptionAttribute.Description;
+            }
             if (context.PropertyInfo is { AttributeProvider: { } attributeProvider })
             {
                 var isInlinedSchema = schema["x-schema-id"] is null;
@@ -128,7 +132,7 @@ internal sealed class OpenApiSchemaService(
                 }
             }
 
-                return schema;
+            return schema;
         }
     };
 

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.Annotations.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.Annotations.cs
@@ -50,9 +50,8 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
                     Assert.Null(reference.Reference.Description);
                 });
 
-            var childSchema = document.Components.Schemas["DescribedChildDto"];
-            // TODO: Handle descriptions on classes
-            // Assert.Equal("Class: DescribedChildDto", "DescribedChildDto");
+            var referencedSchema = document.Components.Schemas["DescribedChildDto"];
+            Assert.Equal("Class: DescribedChildDto", referencedSchema.Description);
         });
 
     }
@@ -118,8 +117,7 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
                 {
                     Assert.Equal("inlinedNoDescription", property.Key);
                     var inlinedSchema = Assert.IsType<OpenApiSchema>(property.Value);
-                    // TODO: Handle descriptions on classes
-                    // Assert.Equal("Class: DescribedInlinedDto", inlinedSchema.Description);
+                    Assert.Equal("Class: DescribedInlinedDto", inlinedSchema.Description);
                 });
         });
     }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.Annotations.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.Annotations.cs
@@ -1,0 +1,145 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+using System.Net.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.AspNetCore.Routing;
+
+public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
+{
+    [Fact]
+    public async Task SchemaDescriptions_HandlesSchemaReferences()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPost("/", (DescribedReferencesDto dto) => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths["/"].Operations[HttpMethod.Post];
+            var requestBody = operation.RequestBody;
+
+            Assert.NotNull(requestBody);
+            var content = Assert.Single(requestBody.Content);
+            Assert.Equal("application/json", content.Key);
+            Assert.NotNull(content.Value.Schema);
+            var schema = content.Value.Schema;
+            Assert.Equal(JsonSchemaType.Object, schema.Type);
+            Assert.Collection(schema.Properties,
+                property =>
+                {
+                    Assert.Equal("child1", property.Key);
+                    var reference = Assert.IsType<OpenApiSchemaReference>(property.Value);
+                    Assert.Equal("Property: DescribedReferencesDto.Child1", reference.Reference.Description);
+                },
+                property =>
+                {
+                    Assert.Equal("child2", property.Key);
+                    var reference = Assert.IsType<OpenApiSchemaReference>(property.Value);
+                    Assert.Equal("Property: DescribedReferencesDto.Child2", reference.Reference.Description);
+                },
+                property =>
+                {
+                    Assert.Equal("childNoDescription", property.Key);
+                    var reference = Assert.IsType<OpenApiSchemaReference>(property.Value);
+                    Assert.Null(reference.Reference.Description);
+                });
+
+            var childSchema = document.Components.Schemas["DescribedChildDto"];
+            // TODO: Handle descriptions on classes
+            // Assert.Equal("Class: DescribedChildDto", "DescribedChildDto");
+        });
+
+    }
+
+    [Description("Class: DescribedReferencesDto")]
+    public class DescribedReferencesDto
+    {
+        [Description("Property: DescribedReferencesDto.Child1")]
+        public DescribedChildDto Child1 { get; set; }
+
+        [Description("Property: DescribedReferencesDto.Child2")]
+        public DescribedChildDto Child2 { get; set; }
+
+        public DescribedChildDto ChildNoDescription { get; set; }
+    }
+
+    [Description("Class: DescribedChildDto")]
+    public class DescribedChildDto
+    {
+        [Description("Property: DescribedChildDto.ChildValue")]
+        public string ChildValue { get; set; }
+    }
+
+    [Fact]
+    public async Task SchemaDescriptions_HandlesInlinedSchemas()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        var options = new OpenApiOptions();
+        var originalCreateSchemaReferenceId = options.CreateSchemaReferenceId;
+        options.CreateSchemaReferenceId = (x) => x.Type == typeof(DescribedInlinedDto) ? null : originalCreateSchemaReferenceId(x);
+
+        // Act
+        builder.MapPost("/", (DescribedInlinedSchemasDto dto) => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, options, document =>
+        {
+            var operation = document.Paths["/"].Operations[HttpMethod.Post];
+            var requestBody = operation.RequestBody;
+
+            Assert.NotNull(requestBody);
+            var content = Assert.Single(requestBody.Content);
+            Assert.Equal("application/json", content.Key);
+            Assert.NotNull(content.Value.Schema);
+            var schema = content.Value.Schema;
+            Assert.Equal(JsonSchemaType.Object, schema.Type);
+            Assert.Collection(schema.Properties,
+                property =>
+                {
+                    Assert.Equal("inlined1", property.Key);
+                    var inlinedSchema = Assert.IsType<OpenApiSchema>(property.Value);
+                    Assert.Equal("Property: DescribedInlinedSchemasDto.Inlined1", inlinedSchema.Description);
+                },
+                property =>
+                {
+                    Assert.Equal("inlined2", property.Key);
+                    var inlinedSchema = Assert.IsType<OpenApiSchema>(property.Value);
+                    Assert.Equal("Property: DescribedInlinedSchemasDto.Inlined2", inlinedSchema.Description);
+                },
+                property =>
+                {
+                    Assert.Equal("inlinedNoDescription", property.Key);
+                    var inlinedSchema = Assert.IsType<OpenApiSchema>(property.Value);
+                    // TODO: Handle descriptions on classes
+                    // Assert.Equal("Class: DescribedInlinedDto", inlinedSchema.Description);
+                });
+        });
+    }
+
+    [Description("Class: DescribedInlinedSchemasDto")]
+    public class DescribedInlinedSchemasDto
+    {
+        [Description("Property: DescribedInlinedSchemasDto.Inlined1")]
+        public DescribedInlinedDto Inlined1 { get; set; }
+
+        [Description("Property: DescribedInlinedSchemasDto.Inlined2")]
+        public DescribedInlinedDto Inlined2 { get; set; }
+
+        public DescribedInlinedDto InlinedNoDescription { get; set; }
+    }
+
+    [Description("Class: DescribedInlinedDto")]
+    public class DescribedInlinedDto
+    {
+        [Description("Property: DescribedInlinedDto.ChildValue")]
+        public string ChildValue { get; set; }
+    }
+}


### PR DESCRIPTION
# OpenAPI: Apply descriptions from [Description] to the schema reference instead of the actual schema for properties

Update the json schema exporter for openapi to apply x-reference metadata for references.

## Description

When a property of a class is a complex type and becomes a reference, the description was wrongfully applied to the actual schema instead of the reference.

Related previous PR #62213
Fixes #63175 
