### PR TITLE
Fix OpenAPI schema generation for FileContentResult to use binary format

### DIFF
--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -13,6 +13,7 @@ using System.Text.Json.Schema;
 using System.Text.Json.Serialization.Metadata;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Json;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
@@ -120,6 +121,28 @@ internal sealed class OpenApiSchemaService(
             return schema;
         }
     };
+
+    private static string GetBinarySchemaId(Type type)
+    {
+        if (type == typeof(IFormFile))
+        {
+            return "IFormFile";
+        }
+        else if (type == typeof(Stream))
+        {
+            return "Stream";
+        }
+        else if (type == typeof(PipeReader))
+        {
+            return "PipeReader";
+        }
+        else if (type == typeof(FileContentResult))
+        {
+            return "FileContentResult";
+        }
+
+        return type.Name;
+    }
 
     private static JsonObject CreateSchemaForJsonPatch()
     {

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -66,7 +66,7 @@ internal sealed class OpenApiSchemaService(
                 {
                     [OpenApiSchemaKeywords.TypeKeyword] = "string",
                     [OpenApiSchemaKeywords.FormatKeyword] = "binary",
-                    [OpenApiConstants.SchemaId] = type == typeof(FileContentResult) ? "FileContentResult" : "IFormFile"
+                    [OpenApiConstants.SchemaId] = GetBinarySchemaId(type)
                 };
             }
             else if (type == typeof(IFormFileCollection))

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -58,15 +58,15 @@ internal sealed class OpenApiSchemaService(
         TransformSchemaNode = (context, schema) =>
         {
             var type = context.TypeInfo.Type;
-            // Fix up schemas generated for IFormFile, IFormFileCollection, Stream, and PipeReader
+            // Fix up schemas generated for IFormFile, IFormFileCollection, Stream, PipeReader, and FileContentResult
             // that appear as properties within complex types.
-            if (type == typeof(IFormFile) || type == typeof(Stream) || type == typeof(PipeReader))
+            if (type == typeof(IFormFile) || type == typeof(Stream) || type == typeof(PipeReader) || type == typeof(FileContentResult))
             {
                 schema = new JsonObject
                 {
                     [OpenApiSchemaKeywords.TypeKeyword] = "string",
                     [OpenApiSchemaKeywords.FormatKeyword] = "binary",
-                    [OpenApiConstants.SchemaId] = "IFormFile"
+                    [OpenApiConstants.SchemaId] = type == typeof(FileContentResult) ? "FileContentResult" : "IFormFile"
                 };
             }
             else if (type == typeof(IFormFileCollection))


### PR DESCRIPTION
# Fix OpenAPI schema generation for FileContentResult to use binary format

Summary of the changes (Less than 80 chars)

## Description

This PR fixes #63172 by ensuring that `FileContentResult` is correctly represented as a binary file response in the generated OpenAPI schema instead of being treated as a JSON object reference.

## Changes

- Added `FileContentResult` to the list of types that should be represented as binary data in the OpenAPI schema
- Modified the `TransformSchemaNode` logic in `OpenApiSchemaService` to handle `FileContentResult` with the binary format

Fixes #63172 
