### PR TITLE
 Send Keep-Alive Ping Immediately When Previous Ping Is Overdue

### DIFF
--- a/src/SignalR/clients/ts/signalr/src/HubConnection.ts
+++ b/src/SignalR/clients/ts/signalr/src/HubConnection.ts
@@ -1153,7 +1153,7 @@ export class HubConnection {
         return { type: MessageType.Close };
     }
 
-    private _trySendPingMessage(): Promise<void> {
+    private async _trySendPingMessage(): Promise<void> {
         try {
             await this._sendMessage(this._cachedPingMessage);
         } catch {

--- a/src/SignalR/clients/ts/signalr/src/HubConnection.ts
+++ b/src/SignalR/clients/ts/signalr/src/HubConnection.ts
@@ -726,7 +726,12 @@ export class HubConnection {
             {
                 let nextPing = this._nextKeepAlive - new Date().getTime();
                 if (nextPing < 0) {
-                    nextPing = 0;
+                    if (this._connectionState === HubConnectionState.Connected) {
+                        this._sendMessage(this._cachedPingMessage).catch((e) => {
+                            this._logger.log(LogLevel.Warning, "Error sending keep-alive message"  + e);
+                        });
+                        return;
+                    }
                 }
 
                 // The timer needs to be set from a networking callback to avoid Chrome timer throttling from causing timers to run once a minute

--- a/src/SignalR/clients/ts/signalr/src/HubConnection.ts
+++ b/src/SignalR/clients/ts/signalr/src/HubConnection.ts
@@ -725,6 +725,7 @@ export class HubConnection {
             let nextPing = this._nextKeepAlive - new Date().getTime();
             if (nextPing < 0) {
                 if (this._connectionState === HubConnectionState.Connected) {
+                    // eslint-disable-next-line @typescript-eslint/no-floating-promises
                     this._trySendPingMessage();
                 }
                 return;
@@ -740,7 +741,7 @@ export class HubConnection {
                 // The timer needs to be set from a networking callback to avoid Chrome timer throttling from causing timers to run once a minute
                 this._pingServerHandle = setTimeout(async () => {
                     if (this._connectionState === HubConnectionState.Connected) {
-                        this._trySendPingMessage();
+                        await this._trySendPingMessage();
                     }
                 }, nextPing);
             }
@@ -1152,9 +1153,9 @@ export class HubConnection {
         return { type: MessageType.Close };
     }
 
-    private _trySendPingMessage(): void {
+    private _trySendPingMessage(): Promise<void> {
         try {
-            this._sendMessage(this._cachedPingMessage);
+            await this._sendMessage(this._cachedPingMessage);
         } catch {
             // We don't care about the error. It should be seen elsewhere in the client.
             // The connection is probably in a bad or closed state now, cleanup the timer so it stops triggering


### PR DESCRIPTION
#  Send Keep-Alive Ping Immediately When Previous Ping Is Overdue

Trigger Client-to-Server Keep-Alive ping immediately if nextPing is overdue. The behavior should remain in parity as sending it immediately vs adding it to setTimeout with 0 delay are the same.

## Description
We've observed that some browser clients occasionally enter a hidden (but not frozen) state, during which JavaScript timers are paused. As a result, the Client-to-Server Keep-Alive ping fails to fire, causing the server to reach the ClientTimeoutInterval and disconnect the client.
The client then attempts to reconnect, but because the browser remains in a hidden state, setTimeout continues to be paused, preventing the ping from firing again. This leads to repeated disconnections and reconnections until the browser either becomes frozen or returns to an active state. This behavior results in unnecessary reconnect traffic on the server.

Note: The frozen state works as expected, where Server will disconnect Client once the ClientTimeoutInterval has been exceeded. And the Client will not reconnect until the browser is unfrozen.

This issue doesn't occur consistently across all hidden browser states. We suspect it may be influenced by the following,
- Browser type
- Power-saving mode
- Desktop vs. laptop environments

We've patched our SignalR client (v8.0.7) to immediately fire the Keep-Alive ping if nextPing is in the past, rather than relying on setTimeout, which may be paused. This change helped resolve the repeated reconnections for such sessions.
{Detail}

