### PR TITLE
[Blazor] Always treat "preloads" as new elements when doing enhanced navigation

### DIFF
--- a/src/Components/Web.JS/src/Rendering/DomMerging/DomSync.ts
+++ b/src/Components/Web.JS/src/Rendering/DomMerging/DomSync.ts
@@ -308,6 +308,11 @@ function domNodeComparer(a: Node, b: Node): UpdateCost {
         return UpdateCost.Infinite;
       }
 
+      // Always treat "preloads" as new elements.
+      if ((b as Element).tagName === 'LINK' && (b as Element).attributes.getNamedItem('rel')?.value === 'preload') {
+        return UpdateCost.Infinite;
+      }
+
       return UpdateCost.None;
     case Node.DOCUMENT_TYPE_NODE:
       // It's invalid to insert or delete doctype, and we have no use case for doing that. So just skip such

--- a/src/Components/Web.JS/src/Rendering/DomMerging/DomSync.ts
+++ b/src/Components/Web.JS/src/Rendering/DomMerging/DomSync.ts
@@ -309,7 +309,7 @@ function domNodeComparer(a: Node, b: Node): UpdateCost {
       }
 
       // Always treat "preloads" as new elements.
-      if ((b as Element).tagName === 'LINK' && (b as Element).attributes.getNamedItem('rel')?.value === 'preload') {
+      if (isPreloadElement(a as Element) || isPreloadElement(b as Element)) {
         return UpdateCost.Infinite;
       }
 
@@ -322,6 +322,10 @@ function domNodeComparer(a: Node, b: Node): UpdateCost {
       // For anything else we know nothing, so the risk-averse choice is to say we can't retain or update the old value
       return UpdateCost.Infinite;
   }
+}
+
+function isPreloadElement(el: Element): bool {
+  return el.tagName === 'LINK' && el.attributes.getNamedItem('rel')?.value === 'preload';
 }
 
 function upgradeComponentCommentsToLogicalRootComments(root: Node): ComponentDescriptor[] {

--- a/src/Components/Web.JS/src/Rendering/DomMerging/DomSync.ts
+++ b/src/Components/Web.JS/src/Rendering/DomMerging/DomSync.ts
@@ -324,7 +324,7 @@ function domNodeComparer(a: Node, b: Node): UpdateCost {
   }
 }
 
-function isPreloadElement(el: Element): bool {
+function isPreloadElement(el: Element): boolean {
   return el.tagName === 'LINK' && el.attributes.getNamedItem('rel')?.value === 'preload';
 }
 


### PR DESCRIPTION
Once `rel="preload"` appears on element, browser eagerly starts to download the file. If we modify existing element, it may happen, based on the order of attributes, that we trigger preloading incorrect asset.