### PR TITLE
[9.0] Make duplicate deb/rpm packages so we can sign them with the new PMC key

### DIFF
--- a/src/Installers/Debian/Directory.Build.targets
+++ b/src/Installers/Debian/Directory.Build.targets
@@ -60,5 +60,6 @@
     </PropertyGroup>
 
     <Copy SourceFiles="$(IntermediateOutputPath)out/$(BuildScriptOutputFileName)" DestinationFiles="$(TargetPath)" />
+    <Copy SourceFiles="$(IntermediateOutputPath)out/$(BuildScriptOutputFileName)" DestinationFiles="$(OutputPath)$(NewKeyTargetFileName)" />
   </Target>
 </Project>

--- a/src/Installers/Debian/Runtime/Debian.Runtime.debproj
+++ b/src/Installers/Debian/Runtime/Debian.Runtime.debproj
@@ -34,6 +34,7 @@
 
   <PropertyGroup>
     <TargetFileName>$(RuntimeInstallerBaseName)-$(SharedFxVersion)-x64.deb</TargetFileName>
+    <NewKeyTargetFileName>$(RuntimeInstallerBaseName)-$(SharedFxVersion)-newkey-x64.deb</NewKeyTargetFileName>
     <TargetPath>$(TargetDir)$(TargetFileName)</TargetPath>
     <!-- DebPackageVersion does not match the ASP.NET Core runtime verison. -->
     <DebPackageVersion>$(VersionPrefix)</DebPackageVersion>

--- a/src/Installers/Debian/TargetingPack/Debian.TargetingPack.debproj
+++ b/src/Installers/Debian/TargetingPack/Debian.TargetingPack.debproj
@@ -38,6 +38,7 @@
 
   <PropertyGroup>
     <TargetFileName>$(TargetingPackInstallerBaseName)-$(TargetingPackVersion)-$(TargetArchitecture).deb</TargetFileName>
+    <NewKeyTargetFileName>$(TargetingPackInstallerBaseName)-$(TargetingPackVersion)-newkey-$(TargetArchitecture).deb</NewKeyTargetFileName>
     <TargetPath>$(TargetDir)$(TargetFileName)</TargetPath>
 
     <DebPackageVersion>$(TargetingPackVersionPrefix)</DebPackageVersion>

--- a/src/Installers/Rpm/Directory.Build.props
+++ b/src/Installers/Rpm/Directory.Build.props
@@ -11,6 +11,7 @@
 
     <CblMariner1VersionSuffix>-cm.1</CblMariner1VersionSuffix>
     <CblMariner2VersionSuffix>-cm.2</CblMariner2VersionSuffix>
+    <NewKeyVersionSuffix>-newkey</NewKeyVersionSuffix>
 
     <!-- All installers are shipping assets. -->
     <IsShipping>true</IsShipping>

--- a/src/Installers/Rpm/Directory.Build.targets
+++ b/src/Installers/Rpm/Directory.Build.targets
@@ -40,6 +40,7 @@
     <PropertyGroup>
       <CblMariner1TargetPath>$(InstallersOutputPath)$(CblMarinerBaseName)$(CblMariner1VersionSuffix)$(CblMarinerExtension)</CblMariner1TargetPath>
       <CblMariner2TargetPath>$(InstallersOutputPath)$(CblMarinerBaseName)$(CblMariner2VersionSuffix)$(CblMarinerExtension)</CblMariner2TargetPath>
+      <NewKeyTargetPath>$(InstallersOutputPath)$(NewKeyBaseName)$(NewKeyVersionSuffix)$(NewKeyExtension)</NewKeyTargetPath>
     </PropertyGroup>
 
     <!-- Create layout: Create changelog -->
@@ -103,5 +104,13 @@
           UseHardlinksIfPossible="False" />
 
     <Message Text="$(TargetPath) -> $(CblMariner2TargetPath)" Importance="high" />
+
+    <Copy SourceFiles="$(TargetPath)"
+          DestinationFiles="$(NewKeyTargetPath)"
+          OverwriteReadOnlyFiles="True"
+          SkipUnchangedFiles="False"
+          UseHardlinksIfPossible="False" />
+
+    <Message Text="$(TargetPath) -> $(NewKeyTargetPath)" Importance="high" />
   </Target>
 </Project>

--- a/src/Installers/Rpm/Runtime/Rpm.Runtime.rpmproj
+++ b/src/Installers/Rpm/Runtime/Rpm.Runtime.rpmproj
@@ -16,5 +16,7 @@
     <TargetPath>$(InstallersOutputPath)$(TargetFileName)</TargetPath>
     <CblMarinerBaseName>$(RuntimeInstallerBaseName)-$(SharedFxVersion)</CblMarinerBaseName>
     <CblMarinerExtension>-$(RpmArch).rpm</CblMarinerExtension>
+    <NewKeyBaseName>$(RuntimeInstallerBaseName)-$(SharedFxVersion)</NewKeyBaseName>
+    <NewKeyExtension>-$(RpmArch).rpm</NewKeyExtension>
   </PropertyGroup>
 </Project>

--- a/src/Installers/Rpm/TargetingPack/Rpm.TargetingPack.rpmproj
+++ b/src/Installers/Rpm/TargetingPack/Rpm.TargetingPack.rpmproj
@@ -33,6 +33,8 @@
     <TargetPath>$(InstallersOutputPath)$(TargetFileName)</TargetPath>
     <CblMarinerBaseName>$(TargetingPackInstallerBaseName)-$(TargetingPackVersion)</CblMarinerBaseName>
     <CblMarinerExtension>-$(RpmArch).rpm</CblMarinerExtension>
+    <NewKeyBaseName>$(TargetingPackInstallerBaseName)-$(TargetingPackVersion)</NewKeyBaseName>
+    <NewKeyExtension>-$(RpmArch).rpm</NewKeyExtension>
 
     <PackageVersion>$(TargetingPackVersionPrefix)</PackageVersion>
 


### PR DESCRIPTION
Contributes to https://github.com/dotnet/arcade/issues/16047

# Make duplicate deb/rpm packages so we can sign them with the new PMC key

## Description

PMC has added a new signing key for packages published to repositories for new Linux distributions they will add support for, such as Debian 13 and SLES vNext. Packages pushed to these feeds must be signed with the new key. Existing feeds will maintain the same keys. The .NET signing infrastructure requires us to have separate copies of the package files to have them signed with different keys. This PR introduces separate copies of the DEB and RPM installers to be signed with the new signing keys.

Contributes to https://github.com/dotnet/arcade/issues/16047

## Customer Impact

Without this change, we can't ship `.deb` installers for Debian 13. With this change, we can.

## Regression?

- [ ] Yes
- [X] No


## Risk

- [ ] High
- [ ] Medium
- [X] Low

[Justify the selection above]

## Verification

- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [X] Yes
- [ ] No
- [ ] N/A
