### PR TITLE
Resolve relative JSON schema references in root schema

### DIFF
--- a/src/OpenApi/sample/Endpoints/MapSchemasEndpoints.cs
+++ b/src/OpenApi/sample/Endpoints/MapSchemasEndpoints.cs
@@ -41,6 +41,11 @@ public static class SchemasEndpointsExtensions
         schemas.MapPatch("/json-patch-generic", (JsonPatchDocument<ParentObject> patchDoc) => Results.NoContent());
         schemas.MapGet("/custom-iresult", () => new CustomIResultImplementor { Content = "Hello world!" })
             .Produces<CustomIResultImplementor>(200);
+
+        // Tests for validating scenarios related to https://github.com/dotnet/aspnetcore/issues/61194
+        schemas.MapPost("/config-with-generic-lists", (Config config) => Results.Ok(config));
+        schemas.MapPost("/project-response", (ProjectResponse project) => Results.Ok(project));
+        schemas.MapPost("/subscription", (Subscription subscription) => Results.Ok(subscription));
         return endpointRouteBuilder;
     }
 
@@ -110,5 +115,62 @@ public static class SchemasEndpointsExtensions
     {
         public int Id { get; set; }
         public required ParentObject Parent { get; set; }
+    }
+
+    // Example types for GitHub issue 61194: Generic types referenced multiple times
+    public sealed class Config
+    {
+        public List<ConfigItem> Items1 { get; set; } = [];
+        public List<ConfigItem> Items2 { get; set; } = [];
+    }
+
+    public sealed class ConfigItem
+    {
+        public int? Id { get; set; }
+        public string? Lang { get; set; }
+        public Dictionary<string, object?>? Words { get; set; }
+        public List<string>? Break { get; set; }
+        public string? WillBeGood { get; set; }
+    }
+
+    // Example types for GitHub issue 63054: Reused types across different hierarchies
+    public sealed class ProjectResponse
+    {
+        public required ProjectAddressResponse Address { get; init; }
+        public required ProjectBuilderResponse Builder { get; init; }
+    }
+
+    public sealed class ProjectAddressResponse
+    {
+        public required CityResponse City { get; init; }
+    }
+
+    public sealed class ProjectBuilderResponse
+    {
+        public required CityResponse City { get; init; }
+    }
+
+    public sealed class CityResponse
+    {
+        public string Name { get; set; } = "";
+    }
+
+    // Example types for GitHub issue 63211: Nullable reference types
+    public sealed class Subscription
+    {
+        public required string Id { get; set; }
+        public required RefProfile PrimaryUser { get; set; }
+        public RefProfile? SecondaryUser { get; set; }
+    }
+
+    public sealed class RefProfile
+    {
+        public required RefUser User { get; init; }
+    }
+
+    public sealed class RefUser
+    {
+        public string Name { get; set; } = "";
+        public string Email { get; set; } = "";
     }
 }

--- a/src/OpenApi/src/Services/OpenApiConstants.cs
+++ b/src/OpenApi/src/Services/OpenApiConstants.cs
@@ -15,6 +15,8 @@ internal static class OpenApiConstants
     internal const string RefId = "x-ref-id";
     internal const string RefDescriptionAnnotation = "x-ref-description";
     internal const string RefExampleAnnotation = "x-ref-example";
+    internal const string RefKeyword = "$ref";
+    internal const string RefPrefix = "#";
     internal const string DefaultOpenApiResponseKey = "default";
     // Since there's a finite set of HTTP methods that can be included in a given
     // OpenApiPaths, we can pre-allocate an array of these methods and use a direct

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -558,7 +558,7 @@ internal sealed class OpenApiSchemaService(
             throw new InvalidOperationException($"Only fragment references (starting with '{OpenApiConstants.RefPrefix}') are supported. Found: {refPath}");
         }
 
-        var path = refPath.TrimStart('#').TrimStart('/');
+        var path = refPath.TrimStart('#', '/');
         if (string.IsNullOrEmpty(path))
         {
             return rootSchema;
@@ -578,13 +578,13 @@ internal sealed class OpenApiSchemaService(
                 }
                 else
                 {
-                    var partialPath = string.Join("/", segments.Take(i + 1));
+                    var partialPath = string.Join('/', segments.Take(i + 1));
                     throw new InvalidOperationException($"Failed to resolve reference '{refPath}': path segment '{segment}' not found at '#{partialPath}'");
                 }
             }
             else
             {
-                var partialPath = string.Join("/", segments.Take(i));
+                var partialPath = string.Join('/', segments.Take(i));
                 throw new InvalidOperationException($"Failed to resolve reference '{refPath}': cannot navigate beyond '#{partialPath}' - expected object but found {current?.GetType().Name ?? "null"}");
             }
         }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
@@ -611,7 +611,10 @@
             "$ref": "#/components/schemas/Category"
           },
           "tags": {
-            "$ref": "#/components/schemas/Category/properties/parent/properties/tags"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Tag"
+            }
           }
         }
       },
@@ -645,7 +648,10 @@
           "seq2": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ContainerType/properties/seq1/items"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         }
@@ -665,7 +671,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "$ref": "#/components/schemas/Root/properties/item1/properties/name"
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "value": {
             "type": "integer",

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
@@ -570,6 +570,72 @@
           }
         }
       }
+    },
+    "/schemas-by-ref/config-with-generic-lists": {
+      "post": {
+        "tags": [
+          "Sample"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Config"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/schemas-by-ref/project-response": {
+      "post": {
+        "tags": [
+          "Sample"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectResponse"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/schemas-by-ref/subscription": {
+      "post": {
+        "tags": [
+          "Sample"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Subscription"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -630,6 +696,60 @@
           },
           "parent": {
             "$ref": "#/components/schemas/ParentObject"
+          }
+        }
+      },
+      "CityResponse": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "Config": {
+        "type": "object",
+        "properties": {
+          "items1": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConfigItem"
+            }
+          },
+          "items2": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConfigItem"
+            }
+          }
+        }
+      },
+      "ConfigItem": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "lang": {
+            "type": "string",
+            "nullable": true
+          },
+          "words": {
+            "type": "object",
+            "nullable": true
+          },
+          "break": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "willBeGood": {
+            "type": "string",
+            "nullable": true
           }
         }
       },
@@ -856,6 +976,66 @@
           }
         }
       },
+      "ProjectAddressResponse": {
+        "required": [
+          "city"
+        ],
+        "type": "object",
+        "properties": {
+          "city": {
+            "$ref": "#/components/schemas/CityResponse"
+          }
+        }
+      },
+      "ProjectBuilderResponse": {
+        "required": [
+          "city"
+        ],
+        "type": "object",
+        "properties": {
+          "city": {
+            "$ref": "#/components/schemas/CityResponse"
+          }
+        }
+      },
+      "ProjectResponse": {
+        "required": [
+          "address",
+          "builder"
+        ],
+        "type": "object",
+        "properties": {
+          "address": {
+            "$ref": "#/components/schemas/ProjectAddressResponse"
+          },
+          "builder": {
+            "$ref": "#/components/schemas/ProjectBuilderResponse"
+          }
+        }
+      },
+      "RefProfile": {
+        "required": [
+          "user"
+        ],
+        "type": "object",
+        "properties": {
+          "user": {
+            "$ref": "#/components/schemas/RefUser"
+          }
+        },
+        "nullable": true
+      },
+      "RefUser": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          }
+        }
+      },
       "Root": {
         "type": "object",
         "properties": {
@@ -927,6 +1107,24 @@
           "sides": {
             "type": "integer",
             "format": "int32"
+          }
+        }
+      },
+      "Subscription": {
+        "required": [
+          "id",
+          "primaryUser"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "primaryUser": {
+            "$ref": "#/components/schemas/RefProfile"
+          },
+          "secondaryUser": {
+            "$ref": "#/components/schemas/RefProfile"
           }
         }
       },

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
@@ -611,7 +611,10 @@
             "$ref": "#/components/schemas/Category"
           },
           "tags": {
-            "$ref": "#/components/schemas/Category/properties/parent/properties/tags"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Tag"
+            }
           }
         }
       },
@@ -645,7 +648,10 @@
           "seq2": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ContainerType/properties/seq1/items"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         }
@@ -665,7 +671,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "$ref": "#/components/schemas/Root/properties/item1/properties/name"
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "value": {
             "type": "integer",

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=schemas-by-ref.verified.txt
@@ -570,6 +570,72 @@
           }
         }
       }
+    },
+    "/schemas-by-ref/config-with-generic-lists": {
+      "post": {
+        "tags": [
+          "Sample"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Config"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/schemas-by-ref/project-response": {
+      "post": {
+        "tags": [
+          "Sample"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectResponse"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/schemas-by-ref/subscription": {
+      "post": {
+        "tags": [
+          "Sample"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Subscription"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -630,6 +696,70 @@
           },
           "parent": {
             "$ref": "#/components/schemas/ParentObject"
+          }
+        }
+      },
+      "CityResponse": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "Config": {
+        "type": "object",
+        "properties": {
+          "items1": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConfigItem"
+            }
+          },
+          "items2": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConfigItem"
+            }
+          }
+        }
+      },
+      "ConfigItem": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": [
+              "null",
+              "integer"
+            ],
+            "format": "int32"
+          },
+          "lang": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "words": {
+            "type": [
+              "null",
+              "object"
+            ]
+          },
+          "break": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "willBeGood": {
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
@@ -856,6 +986,68 @@
           }
         }
       },
+      "ProjectAddressResponse": {
+        "required": [
+          "city"
+        ],
+        "type": "object",
+        "properties": {
+          "city": {
+            "$ref": "#/components/schemas/CityResponse"
+          }
+        }
+      },
+      "ProjectBuilderResponse": {
+        "required": [
+          "city"
+        ],
+        "type": "object",
+        "properties": {
+          "city": {
+            "$ref": "#/components/schemas/CityResponse"
+          }
+        }
+      },
+      "ProjectResponse": {
+        "required": [
+          "address",
+          "builder"
+        ],
+        "type": "object",
+        "properties": {
+          "address": {
+            "$ref": "#/components/schemas/ProjectAddressResponse"
+          },
+          "builder": {
+            "$ref": "#/components/schemas/ProjectBuilderResponse"
+          }
+        }
+      },
+      "RefProfile": {
+        "required": [
+          "user"
+        ],
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "user": {
+            "$ref": "#/components/schemas/RefUser"
+          }
+        }
+      },
+      "RefUser": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          }
+        }
+      },
       "Root": {
         "type": "object",
         "properties": {
@@ -927,6 +1119,24 @@
           "sides": {
             "type": "integer",
             "format": "int32"
+          }
+        }
+      },
+      "Subscription": {
+        "required": [
+          "id",
+          "primaryUser"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "primaryUser": {
+            "$ref": "#/components/schemas/RefProfile"
+          },
+          "secondaryUser": {
+            "$ref": "#/components/schemas/RefProfile"
           }
         }
       },

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentLocalizationTests.VerifyOpenApiDocumentIsInvariant.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentLocalizationTests.VerifyOpenApiDocumentIsInvariant.verified.txt
@@ -1096,6 +1096,72 @@
         }
       }
     },
+    "/schemas-by-ref/config-with-generic-lists": {
+      "post": {
+        "tags": [
+          "Sample"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Config"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/schemas-by-ref/project-response": {
+      "post": {
+        "tags": [
+          "Sample"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectResponse"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/schemas-by-ref/subscription": {
+      "post": {
+        "tags": [
+          "Sample"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Subscription"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/responses/200-add-xml": {
       "get": {
         "tags": [
@@ -1400,6 +1466,70 @@
           }
         }
       },
+      "CityResponse": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "Config": {
+        "type": "object",
+        "properties": {
+          "items1": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConfigItem"
+            }
+          },
+          "items2": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConfigItem"
+            }
+          }
+        }
+      },
+      "ConfigItem": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": [
+              "null",
+              "integer"
+            ],
+            "format": "int32"
+          },
+          "lang": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "words": {
+            "type": [
+              "null",
+              "object"
+            ]
+          },
+          "break": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "willBeGood": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
       "ContainerType": {
         "type": "object",
         "properties": {
@@ -1680,6 +1810,28 @@
         },
         "description": "The project that contains Todo items."
       },
+      "ProjectAddressResponse": {
+        "required": [
+          "city"
+        ],
+        "type": "object",
+        "properties": {
+          "city": {
+            "$ref": "#/components/schemas/CityResponse"
+          }
+        }
+      },
+      "ProjectBuilderResponse": {
+        "required": [
+          "city"
+        ],
+        "type": "object",
+        "properties": {
+          "city": {
+            "$ref": "#/components/schemas/CityResponse"
+          }
+        }
+      },
       "ProjectRecord": {
         "required": [
           "name",
@@ -1697,6 +1849,46 @@
           }
         },
         "description": "The project that contains Todo items."
+      },
+      "ProjectResponse": {
+        "required": [
+          "address",
+          "builder"
+        ],
+        "type": "object",
+        "properties": {
+          "address": {
+            "$ref": "#/components/schemas/ProjectAddressResponse"
+          },
+          "builder": {
+            "$ref": "#/components/schemas/ProjectBuilderResponse"
+          }
+        }
+      },
+      "RefProfile": {
+        "required": [
+          "user"
+        ],
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "user": {
+            "$ref": "#/components/schemas/RefUser"
+          }
+        }
+      },
+      "RefUser": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          }
+        }
       },
       "Root": {
         "type": "object",
@@ -1769,6 +1961,24 @@
           "sides": {
             "type": "integer",
             "format": "int32"
+          }
+        }
+      },
+      "Subscription": {
+        "required": [
+          "id",
+          "primaryUser"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "primaryUser": {
+            "$ref": "#/components/schemas/RefProfile"
+          },
+          "secondaryUser": {
+            "$ref": "#/components/schemas/RefProfile"
           }
         }
       },

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentLocalizationTests.VerifyOpenApiDocumentIsInvariant.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentLocalizationTests.VerifyOpenApiDocumentIsInvariant.verified.txt
@@ -1378,7 +1378,10 @@
             "$ref": "#/components/schemas/Category"
           },
           "tags": {
-            "$ref": "#/components/schemas/Category/properties/parent/properties/tags"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Tag"
+            }
           }
         }
       },
@@ -1412,7 +1415,10 @@
           "seq2": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ContainerType/properties/seq1/items"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         }
@@ -1454,7 +1460,10 @@
         "type": "object",
         "properties": {
           "name": {
-            "$ref": "#/components/schemas/Root/properties/item1/properties/name"
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "value": {
             "type": "integer",

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/Implementations/OpenApiSchemaReferenceTransformerTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/Implementations/OpenApiSchemaReferenceTransformerTests.cs
@@ -740,8 +740,7 @@ public class OpenApiSchemaReferenceTransformerTests : OpenApiDocumentServiceTest
             Assert.Equal("Category", ((OpenApiSchemaReference)requestSchema).Reference.Id);
 
             // Assert that $ref is used for nested Tags
-            // Todo: See https://github.com/microsoft/OpenAPI.NET/issues/2062
-            // Assert.Equal("Tag", ((OpenApiSchemaReference)requestSchema.Properties["tags"].Items).Reference.Id);
+            Assert.Equal("Tag", ((OpenApiSchemaReference)requestSchema.Properties["tags"].Items).Reference.Id);
 
             // Assert that $ref is used for nested Parent
             Assert.Equal("Category", ((OpenApiSchemaReference)requestSchema.Properties["parent"]).Reference.Id);

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/Implementations/OpenApiSchemaReferenceTransformerTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/Implementations/OpenApiSchemaReferenceTransformerTests.cs
@@ -870,5 +870,196 @@ public class OpenApiSchemaReferenceTransformerTests : OpenApiDocumentServiceTest
         public int Id { get; set; }
         public required ParentObject Parent { get; set; }
     }
+
+    // Test for: https://github.com/dotnet/aspnetcore/issues/61194
+    [Fact]
+    public async Task ResolveGenericTypesInListProperties()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        builder.MapPost("/", (Config config) => { });
+
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths["/"]?.Operations?[HttpMethod.Post];
+            var requestSchema = operation?.RequestBody?.Content?["application/json"].Schema;
+
+            // Assert $ref used for top-level
+            Assert.NotNull(requestSchema);
+            Assert.Equal("Config", ((OpenApiSchemaReference)requestSchema).Reference.Id);
+
+            // Get effective schema for Config
+            Assert.Equal(2, requestSchema.Properties!.Count);
+
+            // Check Items1 and Items2 properties
+            var items1Schema = requestSchema.Properties!["items1"];
+            var items2Schema = requestSchema.Properties!["items2"];
+
+            // Assert both are array types
+            Assert.Equal(JsonSchemaType.Array, items1Schema.Type);
+            Assert.Equal(JsonSchemaType.Array, items2Schema.Type);
+
+            // Assert items reference the same ConfigItem schema
+            Assert.Equal("ConfigItem", ((OpenApiSchemaReference)items1Schema.Items!).Reference.Id);
+            Assert.Equal("ConfigItem", ((OpenApiSchemaReference)items2Schema.Items!).Reference.Id);
+
+            // Verify the ConfigItem schema has proper content, not empty
+            var itemSchema = items1Schema.Items!;
+            Assert.True(itemSchema.Properties?.Count > 0, "ConfigItem schema should not be empty");
+            Assert.Contains("id", itemSchema.Properties?.Keys ?? []);
+            Assert.Contains("lang", itemSchema.Properties?.Keys ?? []);
+            Assert.Contains("words", itemSchema.Properties?.Keys ?? []);
+            Assert.Contains("break", itemSchema.Properties?.Keys ?? []);
+            Assert.Contains("willBeGood", itemSchema.Properties?.Keys ?? []);
+
+            Assert.Equal(["Config", "ConfigItem"], document.Components!.Schemas!.Keys.OrderBy(x => x));
+        });
+    }
+
+    // Test for: https://github.com/dotnet/aspnetcore/issues/63054
+    [Fact]
+    public async Task ResolveReusedTypesAcrossDifferentHierarchies()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        builder.MapPost("/", (ProjectResponse project) => { });
+
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths?["/"].Operations?[HttpMethod.Post];
+            var requestSchema = operation?.RequestBody?.Content?["application/json"].Schema;
+
+            // Assert $ref used for top-level
+            Assert.NotNull(requestSchema);
+            Assert.Equal("ProjectResponse", ((OpenApiSchemaReference)requestSchema).Reference.Id);
+
+            // Check Address property
+            var addressSchema = requestSchema.Properties!["address"];
+            Assert.Equal("AddressResponse", ((OpenApiSchemaReference)addressSchema).Reference.Id);
+
+            // Check Builder property
+            var builderSchema = requestSchema.Properties!["builder"];
+            Assert.Equal("BuilderResponse", ((OpenApiSchemaReference)builderSchema).Reference.Id);
+
+            // Verify CityResponse is properly referenced in Address
+            var cityInAddressSchema = addressSchema.Properties!["city"];
+            Assert.Equal("CityResponse", ((OpenApiSchemaReference)cityInAddressSchema).Reference.Id);
+
+            // Verify CityResponse is properly referenced in Builder
+            var cityInBuilderSchema = builderSchema.Properties!["city"];
+            Assert.Equal("CityResponse", ((OpenApiSchemaReference)cityInBuilderSchema).Reference.Id);
+
+            // Verify the CityResponse schema has proper content, not empty
+            var citySchema = cityInAddressSchema;
+            Assert.True(citySchema.Properties?.Count > 0, "CityResponse schema should not be empty");
+            Assert.Contains("name", citySchema.Properties?.Keys ?? []);
+
+            Assert.Equal(["AddressResponse", "BuilderResponse", "CityResponse", "ProjectResponse"],
+                        document.Components!.Schemas!.Keys.OrderBy(x => x));
+        });
+    }
+
+    // Test for: https://github.com/dotnet/aspnetcore/issues/63211
+    [Fact]
+    public async Task ResolveNullableReferenceTypes()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        builder.MapPost("/", (Subscription subscription) => { });
+
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths?["/"].Operations?[HttpMethod.Post];
+            var requestSchema = operation?.RequestBody?.Content?["application/json"].Schema;
+
+            // Assert $ref used for top-level
+            Assert.NotNull(requestSchema);
+            Assert.Equal("Subscription", ((OpenApiSchemaReference)requestSchema).Reference.Id);
+
+            // Check primaryUser property (required RefProfile)
+            var primaryUserSchema = requestSchema.Properties!["primaryUser"];
+            Assert.Equal("RefProfile", ((OpenApiSchemaReference)primaryUserSchema).Reference.Id);
+
+            // Check secondaryUser property (nullable RefProfile)
+            var secondaryUserSchema = requestSchema.Properties!["secondaryUser"];
+            Assert.Equal("RefProfile", ((OpenApiSchemaReference)secondaryUserSchema).Reference.Id);
+
+            // Verify the RefProfile schema has a User property that references RefUser
+            var userPropertySchema = primaryUserSchema.Properties!["user"];
+            Assert.Equal("RefUser", ((OpenApiSchemaReference)userPropertySchema).Reference.Id);
+
+            // Verify the RefUser schema has proper content, not empty
+            var userSchemaContent = userPropertySchema;
+            Assert.True(userSchemaContent.Properties?.Count > 0, "RefUser schema should not be empty");
+            Assert.Contains("name", userSchemaContent.Properties?.Keys ?? []);
+            Assert.Contains("email", userSchemaContent.Properties?.Keys ?? []);
+
+            // Both properties should reference the same RefProfile schema
+            Assert.Equal(((OpenApiSchemaReference)primaryUserSchema).Reference.Id,
+                        ((OpenApiSchemaReference)secondaryUserSchema).Reference.Id);
+
+            Assert.Equal(["RefProfile", "RefUser", "Subscription"], document.Components!.Schemas!.Keys.OrderBy(x => x));
+        });
+    }
+
+    // Test models for issue 61194
+    private class Config
+    {
+        public List<ConfigItem> Items1 { get; set; } = [];
+        public List<ConfigItem> Items2 { get; set; } = [];
+    }
+
+    private class ConfigItem
+    {
+        public int? Id { get; set; }
+        public string? Lang { get; set; }
+        public Dictionary<string, object?>? Words { get; set; }
+        public List<string>? Break { get; set; }
+        public string? WillBeGood { get; set; }
+    }
+
+    // Test models for issue 63054
+    private class ProjectResponse
+    {
+        public AddressResponse Address { get; init; } = new();
+        public BuilderResponse Builder { get; init; } = new();
+    }
+
+    private class AddressResponse
+    {
+        public CityResponse City { get; init; } = new();
+    }
+
+    private class BuilderResponse
+    {
+        public CityResponse City { get; init; } = new();
+    }
+
+    private class CityResponse
+    {
+        public string Name { get; set; } = "";
+    }
+
+    // Test models for issue 63211
+    public sealed class Subscription
+    {
+        public required string Id { get; set; }
+        public required RefProfile PrimaryUser { get; set; }
+        public RefProfile? SecondaryUser { get; set; }
+    }
+
+    public sealed class RefProfile
+    {
+        public required RefUser User { get; init; }
+    }
+
+    public sealed class RefUser
+    {
+        public string Name { get; set; } = "";
+        public string Email { get; set; } = "";
+    }
 }
 #nullable restore


### PR DESCRIPTION
Closes https://github.com/dotnet/aspnetcore/issues/61194.

This PR fixes a host of issues with generic types or types that appear multiple times in the type hierarchy by fully resolving the relative references in schemas that are generated by JsonSchemaExporter to inlined schemas to avoid generating invalid refs.

 Before (Unresolved References)
```
  {
    "type": "object",
    "properties": {
      "parent": {
        "$ref": "#/properties/parent/properties/tags"
      },
      "items": {
        "type": "array",
        "items": {
          "$ref": "#/properties/items/items"
        }
      }
    }
  }
```

 After (Resolved References)

```
  {
    "type": "object",
    "properties": {
      "parent": {
        "type": "object",
        "properties": {
          "tags": {
            "type": "array",
            "items": {
              "type": "object",
              "properties": {
                "name": {
                  "type": "string"
                }
              }
            }
          }
        }
      },
      "items": {
        "type": "array",
        "items": {
          "type": "object",
          "properties": {
            "id": {
              "type": "integer",
              "nullable": true
            },
            "lang": {
              "type": "string",
              "nullable": true
            }
          }
        }
      }
    }
  }
```