### PR TITLE
Add QUERY to known HTTP methods in HostingMetrics

### DIFF
--- a/src/Hosting/Hosting/src/Internal/HostingTelemetryHelpers.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingTelemetryHelpers.cs
@@ -38,6 +38,7 @@ internal static class HostingTelemetryHelpers
         KeyValuePair.Create(HttpMethods.Patch, HttpMethods.Patch),
         KeyValuePair.Create(HttpMethods.Post, HttpMethods.Post),
         KeyValuePair.Create(HttpMethods.Put, HttpMethods.Put),
+        KeyValuePair.Create(HttpMethods.Query, HttpMethods.Query),
         KeyValuePair.Create(HttpMethods.Trace, HttpMethods.Trace)
     ], StringComparer.OrdinalIgnoreCase);
 

--- a/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
@@ -1552,10 +1552,12 @@ public class HostingApplicationDiagnosticsTests : LoggedTest
     [InlineData("OPTIONS", null, "OPTIONS")]
     [InlineData("TRACE", null, "TRACE")]
     [InlineData("CONNECT", null, "CONNECT")]
+    [InlineData("QUERY", null, "QUERY")]
     [InlineData("CUSTOM", null, "HTTP")]
     [InlineData("weird", null, "HTTP")]
     [InlineData("GET", "hello/{name}", "GET hello/{name}")]
     [InlineData("POST", "hello/{name}", "POST hello/{name}")]
+    [InlineData("QUERY", "hello/{name}", "QUERY hello/{name}")]
     [InlineData("CUSTOM", "hello/{name}", "HTTP hello/{name}")]
     public void ActivityListeners_DisplayName(string method, string route, string expectedDisplayName)
     {


### PR DESCRIPTION
As discussed in https://github.com/dotnet/aspnetcore/issues/61089#issuecomment-2910466202, this PR is for adding `QUERY` to the known HTTP methods for hosting metrics.

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.