### PR TITLE
Enable automated inter-branch merges for 10.0

### DIFF
--- a/github-merge-flow.jsonc
+++ b/github-merge-flow.jsonc
@@ -1,5 +1,20 @@
 // IMPORTANT: This file is read by the merge flow from main branch only. 
 {
     "merge-flow-configurations": {
+        // Automate opening PRs to merge release/10.0 to main
+        "release/10.0":{
+            "MergeToBranch": "main",
+            "ExtraSwitches": "-QuietComments"
+        },
+        // Automate opening PRs to merge release/10.0-rc1 to release/10.0
+        "release/10.0-rc1":{
+            "MergeToBranch": "release/10.0",
+            "ExtraSwitches": "-QuietComments"
+        },
+        // Automate opening PRs to merge release/10.0-rc2 to release/10.0
+        "release/10.0-rc2":{
+            "MergeToBranch": "release/10.0",
+            "ExtraSwitches": "-QuietComments"
+        }
     }
 }


### PR DESCRIPTION
Once we snap for RC1, the RC1/RC2 branches should auto-merge to release/10.0, which should auto-merge to main. Will revert this once RC2 locks down.