### PR TITLE
Avoid ODE in SignalR TestServer tests

### DIFF
--- a/src/SignalR/clients/csharp/Client/test/UnitTests/TestServerTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/TestServerTests.cs
@@ -63,7 +63,7 @@ public class TestServerTests : VerifiableLoggedTest
                 });
             connectionBuilder.Services.AddLogging();
             connectionBuilder.Services.AddSingleton(LoggerFactory);
-            var connection = connectionBuilder.Build();
+            await using var connection = connectionBuilder.Build();
 
             var originalMessage = "message";
             connection.On<string>("Echo", (receivedMessage) =>
@@ -118,7 +118,7 @@ public class TestServerTests : VerifiableLoggedTest
                 });
             connectionBuilder.Services.AddLogging();
             connectionBuilder.Services.AddSingleton(LoggerFactory);
-            var connection = connectionBuilder.Build();
+            await using var connection = connectionBuilder.Build();
 
             var originalMessage = "message";
             connection.On<string>("Echo", (receivedMessage) =>


### PR DESCRIPTION
Moving to `HostBuilder` and thus `TestServer` in the DI container, instead of explicitly creating it, has caused an ODE to appear in this test because we weren't closing the connection but were closing the host.

Should be fixed by closing the connection before closing the host.