### PR TITLE
Don't build Arm64 Windows installers in CI

### DIFF
--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -76,8 +76,6 @@ variables:
   value: /bl:artifacts/log/Release/Build.CodeSign.binlog
 - name: WindowsInstallersLogArgs
   value: /bl:artifacts/log/Release/Build.Installers.binlog
-- name: WindowsArm64InstallersLogArgs
-  value: /bl:artifacts/log/Release/Build.Installers.Arm64.binlog
 - name: _SignType
   value: ''
 - name: _InternalRuntimeDownloadArgs
@@ -205,29 +203,14 @@ stages:
                 -sign
                 -buildInstallers
                 -noBuildNative
-                /p:DotNetSignType=$(_SignType)
-                $(_BuildArgs)
-                $(_InternalRuntimeDownloadArgs)
-                $(WindowsInstallersLogArgs)
-        displayName: Build Installers
-
-      # Windows installers bundle and sharedfx msi for arm64
-      - script: ./eng/build.cmd
-                -ci
-                -prepareMachine
-                -noBuildRepoTasks
-                -arch arm64
-                -sign
-                -buildInstallers
-                -noBuildNative
                 -publish
                 /p:DotNetSignType=$(_SignType)
                 /p:AssetManifestFileName=aspnetcore-win.xml
                 $(_BuildArgs)
                 $(_PublishArgs)
                 $(_InternalRuntimeDownloadArgs)
-                $(WindowsArm64InstallersLogArgs)
-        displayName: Build ARM64 Installers
+                $(WindowsInstallersLogArgs)
+        displayName: Build Installers
 
       artifacts:
       - name: Windows_Logs_Attempt_$(System.JobAttempt)

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -78,8 +78,6 @@ variables:
   value: /bl:artifacts/log/Release/Build.CodeSign.binlog
 - name: WindowsInstallersLogArgs
   value: /bl:artifacts/log/Release/Build.Installers.binlog
-- name: WindowsArm64InstallersLogArgs
-  value: /bl:artifacts/log/Release/Build.Installers.Arm64.binlog
 - name: _InternalRuntimeDownloadArgs
   value: -RuntimeSourceFeed https://ci.dot.net/internal
          -RuntimeSourceFeedKey $(dotnetbuilds-internal-container-read-token-base64)
@@ -255,33 +253,16 @@ extends:
                     -sign
                     -buildInstallers
                     -noBuildNative
-                    /p:DotNetSignType=$(_SignType)
-                    $(_BuildArgs)
-                    $(_InternalRuntimeDownloadArgs)
-                    $(WindowsInstallersLogArgs)
-            env:
-              MSBUILDUSESERVER: "1"
-            displayName: Build Installers
-
-          # Windows installers bundle and sharedfx msi for arm64
-          - script: ./eng/build.cmd
-                    -ci
-                    -prepareMachine
-                    -noBuildRepoTasks
-                    -arch arm64
-                    -sign
-                    -buildInstallers
-                    -noBuildNative
                     -publish
                     /p:DotNetSignType=$(_SignType)
                     /p:AssetManifestFileName=aspnetcore-win.xml
                     $(_BuildArgs)
                     $(_PublishArgs)
                     $(_InternalRuntimeDownloadArgs)
-                    $(WindowsArm64InstallersLogArgs)
+                    $(WindowsInstallersLogArgs)
             env:
               MSBUILDUSESERVER: "1"
-            displayName: Build ARM64 Installers
+            displayName: Build Installers
 
           artifacts:
           - name: Windows_Logs_Attempt_$(System.JobAttempt)


### PR DESCRIPTION
The Arm64 SharedFx/Targeting Pack Windows installers get built during the regular repo build now, so we don't need a separate build step just for them anymore. That step was doing exactly the same work as the regular Windows Installer step.