### PR TITLE
Fixes in PrefixResolver

### DIFF
--- a/src/Components/Endpoints/src/FormMapping/PrefixResolver.cs
+++ b/src/Components/Endpoints/src/FormMapping/PrefixResolver.cs
@@ -68,9 +68,7 @@ internal readonly struct PrefixResolver : IDisposable
                 else if (separatorX == -1)
                 {
                     // x has no more segments, y has remaining segments
-                    var segmentX = x.Value.Span[currentXPos..];
-                    var segmentY = y.Value.Span[currentYPos..][..separatorY];
-                    compare = MemoryExtensions.CompareTo(segmentX, segmentY, StringComparison.Ordinal);
+                    compare = MemoryExtensions.CompareTo(x.Value.Span[currentXPos..], y.Value.Span[currentYPos..][..separatorY], StringComparison.Ordinal);
                     if (compare == 0 && !checkPrefix)
                     {
                         return -1;
@@ -80,9 +78,7 @@ internal readonly struct PrefixResolver : IDisposable
                 else if (separatorY == -1)
                 {
                     // y has no more segments, x has remaining segments
-                    var segmentX = x.Value.Span[currentXPos..][..separatorX];
-                    var segmentY = y.Value.Span[currentYPos..];
-                    compare = MemoryExtensions.CompareTo(segmentX, segmentY, StringComparison.Ordinal);
+                    compare = MemoryExtensions.CompareTo(x.Value.Span[currentXPos..][..separatorX], y.Value.Span[currentYPos..], StringComparison.Ordinal);
                     if (compare == 0 && !checkPrefix)
                     {
                         return 1;
@@ -90,8 +86,6 @@ internal readonly struct PrefixResolver : IDisposable
                     return compare;
                 }
 
-                var segmentX = x.Value.Span[currentXPos..][..separatorX];
-                var segmentY = y.Value.Span[currentYPos..][..separatorY];
                 compare = MemoryExtensions.CompareTo(x.Value.Span[currentXPos..][..separatorX], y.Value.Span[currentYPos..][..separatorY], StringComparison.Ordinal);
                 if (compare != 0)
                 {

--- a/src/Components/Endpoints/src/FormMapping/PrefixResolver.cs
+++ b/src/Components/Endpoints/src/FormMapping/PrefixResolver.cs
@@ -50,7 +50,10 @@ internal readonly struct PrefixResolver : IDisposable
         // When comparing values, y is the element we are trying to find.
         public int Compare(FormKey x, FormKey y)
         {
-            int separatorX = 0, separatorY = 0, currentXPos = 0, currentYPos = 0;
+            var separatorX = 0;
+            var separatorY = 0;
+            var currentXPos = 0;
+            var currentYPos = 0;
             while (separatorX != -1 && separatorY != -1)
             {
                 separatorX = x.Value.Span[currentXPos..].IndexOfAny('.', '[');
@@ -65,7 +68,9 @@ internal readonly struct PrefixResolver : IDisposable
                 else if (separatorX == -1)
                 {
                     // x has no more segments, y has remaining segments
-                    compare = MemoryExtensions.CompareTo(x.Value.Span[currentXPos..], y.Value.Span[currentYPos..][..separatorY], StringComparison.Ordinal);
+                    var segmentX = x.Value.Span[currentXPos..];
+                    var segmentY = y.Value.Span[currentYPos..][..separatorY];
+                    compare = MemoryExtensions.CompareTo(segmentX, segmentY, StringComparison.Ordinal);
                     if (compare == 0 && !checkPrefix)
                     {
                         return -1;
@@ -75,7 +80,9 @@ internal readonly struct PrefixResolver : IDisposable
                 else if (separatorY == -1)
                 {
                     // y has no more segments, x has remaining segments
-                    compare = MemoryExtensions.CompareTo(x.Value.Span[currentXPos..][..separatorX], y.Value.Span[currentYPos..], StringComparison.Ordinal);
+                    var segmentX = x.Value.Span[currentXPos..][..separatorX];
+                    var segmentY = y.Value.Span[currentYPos..];
+                    compare = MemoryExtensions.CompareTo(segmentX, segmentY, StringComparison.Ordinal);
                     if (compare == 0 && !checkPrefix)
                     {
                         return 1;
@@ -83,6 +90,8 @@ internal readonly struct PrefixResolver : IDisposable
                     return compare;
                 }
 
+                var segmentX = x.Value.Span[currentXPos..][..separatorX];
+                var segmentY = y.Value.Span[currentYPos..][..separatorY];
                 compare = MemoryExtensions.CompareTo(x.Value.Span[currentXPos..][..separatorX], y.Value.Span[currentYPos..][..separatorY], StringComparison.Ordinal);
                 if (compare != 0)
                 {

--- a/src/Components/Endpoints/src/FormMapping/PrefixResolver.cs
+++ b/src/Components/Endpoints/src/FormMapping/PrefixResolver.cs
@@ -50,47 +50,43 @@ internal readonly struct PrefixResolver : IDisposable
         // When comparing values, y is the element we are trying to find.
         public int Compare(FormKey x, FormKey y)
         {
-            var separatorX = 0;
-            var separatorY = 0;
-            var currentXPos = 0;
-            var currentYPos = 0;
+            int separatorX = 0, separatorY = 0, currentXPos = 0, currentYPos = 0;
             while (separatorX != -1 && separatorY != -1)
             {
                 separatorX = x.Value.Span[currentXPos..].IndexOfAny('.', '[');
                 separatorY = y.Value.Span[currentYPos..].IndexOfAny('.', '[');
+                int compare;
 
                 if (separatorX == -1 && separatorY == -1)
                 {
-                    // no more segments, compare the remaining substrings
+                    // Both x and y have no more segments, compare the remaining segments
                     return MemoryExtensions.CompareTo(x.Value.Span[currentXPos..], y.Value.Span[currentYPos..], StringComparison.Ordinal);
                 }
                 else if (separatorX == -1)
                 {
-                    // x has no more segments, but y does, so x is less than y
-                    return -1;
+                    // x has no more segments, y has remaining segments
+                    compare = MemoryExtensions.CompareTo(x.Value.Span[currentXPos..], y.Value.Span[currentYPos..][..separatorY], StringComparison.Ordinal);
+                    if (compare == 0 && !checkPrefix)
+                    {
+                        return -1;
+                    }
+                    return compare;
                 }
                 else if (separatorY == -1)
                 {
-                    if (!checkPrefix)
+                    // y has no more segments, x has remaining segments
+                    compare = MemoryExtensions.CompareTo(x.Value.Span[currentXPos..][..separatorX], y.Value.Span[currentYPos..], StringComparison.Ordinal);
+                    if (compare == 0 && !checkPrefix)
                     {
-                        // We are just sorting, so x is greater than y because it has more segments.
                         return 1;
                     }
-
-                    var match = MemoryExtensions.CompareTo(
-                        x.Value.Span[currentXPos..][..separatorX],
-                        y.Value.Span[currentYPos..], StringComparison.Ordinal);
-
-                    return match;
+                    return compare;
                 }
 
-                // both have segments, compare the segments
-                var segmentX = x.Value.Span[currentXPos..][..separatorX];
-                var segmentY = y.Value.Span[currentYPos..][..separatorY];
-                var compareResult = MemoryExtensions.CompareTo(segmentX, segmentY, StringComparison.Ordinal);
-                if (compareResult != 0)
+                compare = MemoryExtensions.CompareTo(x.Value.Span[currentXPos..][..separatorX], y.Value.Span[currentYPos..][..separatorY], StringComparison.Ordinal);
+                if (compare != 0)
                 {
-                    return compareResult;
+                    return compare;
                 }
 
                 currentXPos += separatorX + 1;

--- a/src/Components/Endpoints/test/Binding/PrefixResolverTests.cs
+++ b/src/Components/Endpoints/test/Binding/PrefixResolverTests.cs
@@ -80,6 +80,40 @@ public class PrefixResolverTests
     }
 
     [Theory]
+    [InlineData("Model")]
+    [InlineData("Model.Model")]
+    [InlineData("Model[0].Model")]
+    public void ContainsPrefix_HasEntries(string prefix)
+    {
+        // Arrange - Simulating the exact scenario from debugging
+        var keys = new string[] { "__RequestVerificationToken", "_handler", "Model.Name", "Model.Model.Name", "Model[0].Model.Name", "Model[0].Name" };
+        var container = new PrefixResolver(GetKeys(keys), keys.Length);
+
+        // Act
+        var result = container.HasPrefix(prefix.AsMemory());
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Theory]
+    [InlineData("Model")]
+    [InlineData("Model.Model")]
+    [InlineData("Model[0].Model")]
+    public void ContainsPrefix_DoesNotHaveEntries(string prefix)
+    {
+        // Arrange - Simulating the exact scenario from debugging
+        var keys = new string[] { "__RequestVerificationToken", "_handler" };
+        var container = new PrefixResolver(GetKeys(keys), keys.Length);
+
+        // Act
+        var result = container.HasPrefix(prefix.AsMemory());
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Theory]
     [InlineData("a")]
     [InlineData("b")]
     [InlineData("b.xy")]

--- a/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
@@ -1423,6 +1423,16 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
     }
 
     [Fact]
+    public void EditFormRecursiveBinding()
+    {
+        GoTo("forms/recursive-edit-form");
+        Browser.Equal("", () => Browser.Exists(By.Id("result-form")).Text);
+        Browser.Exists(By.Id("text-input")).SendKeys("John");
+        Browser.Exists(By.Id("submit-button")).Click();
+        Browser.Equal("John", () => Browser.Exists(By.Id("result-form")).Text);
+    }
+
+    [Fact]
     public void RadioButtonGetsResetAfterSubmittingEnhancedForm()
     {
         GoTo("forms/form-with-checkbox-and-radio-button");

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/RecursiveEditFormBinding.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/RecursiveEditFormBinding.razor
@@ -1,0 +1,42 @@
+﻿@page "/forms/recursive-edit-form"
+@using Microsoft.AspNetCore.Components.Forms
+
+<PageTitle>Home</PageTitle>
+
+<EditForm EditContext="FormContext" OnSubmit="Submit" FormName="RequestForm">
+        <InputText id="text-input" @bind-Value="Model!.Name" />
+        <button type="submit" id="submit-button">Submit</button>
+</EditForm>
+
+<p id="result-form">@ModelName</p>
+
+@code {
+    string ModelName;
+
+    [SupplyParameterFromForm(FormName = "RequestForm")]
+    private MyModel? Model { get; set; }
+
+    private EditContext FormContext = null!;
+
+    public class MyModel
+    {
+        public string? Name { get; set; }
+
+        public MyModel? Parent { get; set; }
+    }
+
+    protected override void OnInitialized()
+    {
+        if (Model == null)
+        {
+            Model = new();
+        }
+
+        FormContext = new EditContext(Model);
+    }
+
+    private void Submit()
+    {
+        ModelName = Model?.Name ?? string.Empty;
+    }
+}


### PR DESCRIPTION
# Fixes in PrefixResolver

## Description

This pull request improves the form binding logic and its test coverage, particularly around recursive model binding scenarios and prefix resolution. The main changes include enhancements to the `FormKeyComparer` for more reliable segment comparison, new and expanded unit tests for prefix handling, and the addition of a new E2E test and supporting Razor page for recursive form binding.

### Changes:

* Changed the `FormKeyComparer` logic in `PrefixResolver.cs` to improve segment comparison accuracy, especially when handling cases where one key has more segments than the other. This makes prefix resolution more robust and correct.
* Added new unit tests in `PrefixResolverTests.cs` to verify correct behavior of prefix detection with and without matching entries, ensuring the resolver works for both positive and negative scenarios.
* Introduced a new E2E test in `FormWithParentBindingContextTest.cs` that verifies recursive form binding works as expected, including input and form submission behavior.

Fixes #61341
