### PR TITLE
Re-enable `FormWithParentBindingContextTest.CanUseFormWithMethodGet`

### DIFF
--- a/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithNoBackForwardCacheTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithNoBackForwardCacheTest.cs
@@ -27,7 +27,7 @@ public class FormWithNoBackForwardCacheTest : ServerTestBase<BasicTestAppServerS
 
     public override Task InitializeAsync()
     {
-        return InitializeAsync(BrowserFixture.BackForwardCacheContext);
+        return InitializeAsync(BrowserFixture.StreamingBackForwardCacheContext);
     }
 
     private void SuppressEnhancedNavigation(bool shouldSuppress)

--- a/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithNoBackForwardCacheTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithNoBackForwardCacheTest.cs
@@ -1,0 +1,89 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.ObjectModel;
+using System.Net.Http;
+using System.Text;
+using Components.TestServer.RazorComponents;
+using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
+using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
+using Microsoft.AspNetCore.E2ETesting;
+using Microsoft.AspNetCore.InternalTesting;
+using OpenQA.Selenium;
+using TestServer;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Components.E2ETests.ServerRenderingTests.FormHandlingTests;
+
+public class FormWithNoBackForwardCacheTest : ServerTestBase<BasicTestAppServerSiteFixture<RazorComponentEndpointsStartup<App>>>
+{
+    public FormWithNoBackForwardCacheTest(
+        BrowserFixture browserFixture,
+        BasicTestAppServerSiteFixture<RazorComponentEndpointsStartup<App>> serverFixture,
+        ITestOutputHelper output)
+        : base(browserFixture, serverFixture, output)
+    {
+    }
+
+    public override Task InitializeAsync()
+    {
+        return InitializeAsync(BrowserFixture.BackForwardCacheContext);
+    }
+
+    private void SuppressEnhancedNavigation(bool shouldSuppress)
+        => EnhancedNavigationTestUtil.SuppressEnhancedNavigation(this, shouldSuppress);
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CanUseFormWithMethodGet(bool suppressEnhancedNavigation)
+    {
+        SuppressEnhancedNavigation(suppressEnhancedNavigation);
+        Navigate($"{ServerPathBase}/forms/method-get");
+        Browser.Equal("Form with method=get", () => Browser.FindElement(By.TagName("h2")).Text);
+
+        // Validate initial state
+        var stringInput = Browser.FindElement(By.Id("mystring"));
+        var boolInput = Browser.FindElement(By.Id("mybool"));
+        Browser.Equal("Initial value", () => stringInput.GetDomProperty("value"));
+        Browser.Equal("False", () => boolInput.GetDomProperty("checked"));
+
+        // Edit and submit the form; check it worked
+        stringInput.Clear();
+        stringInput.SendKeys("Edited value");
+        boolInput.Click();
+        Browser.FindElement(By.Id("submit-get-form")).Click();
+        AssertUiState("Edited value", true);
+        Browser.Contains($"MyString=Edited+value", () => Browser.Url);
+        Browser.Contains($"MyBool=True", () => Browser.Url);
+
+        // Check 'back' correctly gets us to the previous state
+        Browser.Navigate().Back();
+        AssertUiState("Initial value", false);
+        Browser.False(() => Browser.Url.Contains("MyString"));
+        Browser.False(() => Browser.Url.Contains("MyBool"));
+
+        // Check 'forward' correctly recreates the edited state
+        Browser.Navigate().Forward();
+        AssertUiState("Edited value", true);
+        Browser.Contains($"MyString=Edited+value", () => Browser.Url);
+        Browser.Contains($"MyBool=True", () => Browser.Url);
+
+        void AssertUiState(string expectedStringValue, bool expectedBoolValue)
+        {
+            Browser.Equal(expectedStringValue, () => Browser.FindElement(By.Id("mystring-value")).Text);
+            Browser.Equal(expectedBoolValue.ToString(), () => Browser.FindElement(By.Id("mybool-value")).Text);
+
+            // If we're not suppressing, we'll keep referencing the same elements to show they were preserved
+            if (suppressEnhancedNavigation)
+            {
+                stringInput = Browser.FindElement(By.Id("mystring"));
+                boolInput = Browser.FindElement(By.Id("mybool"));
+            }
+
+            Browser.Equal(expectedStringValue, () => stringInput.GetDomProperty("value"));
+            Browser.Equal(expectedBoolValue.ToString(), () => boolInput.GetDomProperty("checked"));
+        }
+    }
+}
+

--- a/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
@@ -1369,59 +1369,6 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
         Assert.Equal("Total: 7", Browser.Exists(By.Id("form-collection")).Text);
     }
 
-    [Theory]
-    // [InlineData(true)] QuarantinedTest: https://github.com/dotnet/aspnetcore/issues/61882
-    [InlineData(false)]
-    public void CanUseFormWithMethodGet(bool suppressEnhancedNavigation)
-    {
-        SuppressEnhancedNavigation(suppressEnhancedNavigation);
-        GoTo("forms/method-get");
-        Browser.Equal("Form with method=get", () => Browser.FindElement(By.TagName("h2")).Text);
-
-        // Validate initial state
-        var stringInput = Browser.FindElement(By.Id("mystring"));
-        var boolInput = Browser.FindElement(By.Id("mybool"));
-        Browser.Equal("Initial value", () => stringInput.GetDomProperty("value"));
-        Browser.Equal("False", () => boolInput.GetDomProperty("checked"));
-
-        // Edit and submit the form; check it worked
-        stringInput.Clear();
-        stringInput.SendKeys("Edited value");
-        boolInput.Click();
-        Browser.FindElement(By.Id("submit-get-form")).Click();
-        AssertUiState("Edited value", true);
-        Browser.Contains($"MyString=Edited+value", () => Browser.Url);
-        Browser.Contains($"MyBool=True", () => Browser.Url);
-
-        // Check 'back' correctly gets us to the previous state
-        Browser.Navigate().Back();
-        AssertUiState("Initial value", false);
-        Browser.False(() => Browser.Url.Contains("MyString"));
-        Browser.False(() => Browser.Url.Contains("MyBool"));
-
-        // Check 'forward' correctly recreates the edited state
-        Browser.Navigate().Forward();
-        AssertUiState("Edited value", true);
-        Browser.Contains($"MyString=Edited+value", () => Browser.Url);
-        Browser.Contains($"MyBool=True", () => Browser.Url);
-
-        void AssertUiState(string expectedStringValue, bool expectedBoolValue)
-        {
-            Browser.Equal(expectedStringValue, () => Browser.FindElement(By.Id("mystring-value")).Text);
-            Browser.Equal(expectedBoolValue.ToString(), () => Browser.FindElement(By.Id("mybool-value")).Text);
-
-            // If we're not suppressing, we'll keep referencing the same elements to show they were preserved
-            if (suppressEnhancedNavigation)
-            {
-                stringInput = Browser.FindElement(By.Id("mystring"));
-                boolInput = Browser.FindElement(By.Id("mybool"));
-            }
-
-            Browser.Equal(expectedStringValue, () => stringInput.GetDomProperty("value"));
-            Browser.Equal(expectedBoolValue.ToString(), () => boolInput.GetDomProperty("checked"));
-        }
-    }
-
     [Fact]
     public void RadioButtonGetsResetAfterSubmittingEnhancedForm()
     {

--- a/src/Shared/E2ETesting/BrowserFixture.cs
+++ b/src/Shared/E2ETesting/BrowserFixture.cs
@@ -16,6 +16,8 @@ public class BrowserFixture : IAsyncLifetime
     public static string StreamingContext { get; } = "streaming";
     public static string RoutingTestContext { get; } = "routing";
 
+    public static string BackForwardCacheContext { get; } = "backforwardcache";
+
     private readonly ConcurrentDictionary<string, (IWebDriver browser, ILogs log)> _browsers = new();
 
     public BrowserFixture(IMessageSink diagnosticsMessageSink)
@@ -145,6 +147,14 @@ public class BrowserFixture : IAsyncLifetime
         if (context?.StartsWith(StreamingContext, StringComparison.Ordinal) == true)
         {
             // Tells Selenium not to wait until the page navigation has completed before continuing with the tests
+            opts.PageLoadStrategy = PageLoadStrategy.None;
+        }
+
+        if (context?.Contains(BackForwardCacheContext, StringComparison.Ordinal) == true)
+        {
+            // Tells Selenium to disable the back/forward cache, which is enabled by default in Chrome.
+            // This is needed for tests that rely on the browser's back/forward navigation.
+            opts.AddArgument("--disable-back-forward-cache");
             opts.PageLoadStrategy = PageLoadStrategy.None;
         }
 

--- a/src/Shared/E2ETesting/BrowserFixture.cs
+++ b/src/Shared/E2ETesting/BrowserFixture.cs
@@ -15,8 +15,7 @@ public class BrowserFixture : IAsyncLifetime
 {
     public static string StreamingContext { get; } = "streaming";
     public static string RoutingTestContext { get; } = "routing";
-
-    public static string BackForwardCacheContext { get; } = "backforwardcache";
+    public static string StreamingBackForwardCacheContext { get; } = "streaming.backforwardcache";
 
     private readonly ConcurrentDictionary<string, (IWebDriver browser, ILogs log)> _browsers = new();
 
@@ -144,18 +143,17 @@ public class BrowserFixture : IAsyncLifetime
             opts.UseWebSocketUrl = true;
         }
 
-        if (context?.StartsWith(StreamingContext, StringComparison.Ordinal) == true)
+        if (context?.StartsWith(StreamingContext, StringComparison.Ordinal) == true || context?.StartsWith(StreamingBackForwardCacheContext, StringComparison.Ordinal) == true)
         {
             // Tells Selenium not to wait until the page navigation has completed before continuing with the tests
             opts.PageLoadStrategy = PageLoadStrategy.None;
         }
 
-        if (context?.Contains(BackForwardCacheContext, StringComparison.Ordinal) == true)
+        if (context?.StartsWith(StreamingBackForwardCacheContext, StringComparison.Ordinal) == true)
         {
             // Tells Selenium to disable the back/forward cache, which is enabled by default in Chrome.
             // This is needed for tests that rely on the browser's back/forward navigation.
             opts.AddArgument("--disable-back-forward-cache");
-            opts.PageLoadStrategy = PageLoadStrategy.None;
         }
 
         // Force language to english for tests


### PR DESCRIPTION
# Re-enable `FormWithParentBindingContextTest.CanUseFormWithMethodGet`

## Description

This pull request re-enables `FormWithParentBindingContextTest.CanUseFormWithMethodGet` by refactoring the test coverage for form handling with browser back/forward navigation by moving the relevant test from `FormWithParentBindingContextTest` to a new dedicated test class, `FormWithNoBackForwardCacheTest`. Additionally, it introduces a new browser context and configuration to ensure correct browser behavior for these tests. 

### Changes
* The `CanUseFormWithMethodGet` test has been removed from `FormWithParentBindingContextTest` and added to a new file and class, `FormWithNoBackForwardCacheTest` with different browser context.
* Added a new browser context constant, `BackForwardCacheContext`, to `BrowserFixture` for tests needing control over Chrome's back/forward cache.

### Reasoning behind changes:
In the recent changes in Chrome the Back/forward cache is now enabled by default. Due to this `autocomplete="off"` is not working correctly in the test. The new created ServerFixtureContext that disables this default behaviour in Chrome.

Fixes #61882
