### PR TITLE
Unblock `NavigationLock_OverlappingNavigationsCancelExistingNavigations_HistoryNavigation`

### DIFF
--- a/src/Components/test/E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/E2ETest/Tests/RoutingTest.cs
@@ -970,7 +970,6 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/61080")]
     public void NavigationLock_OverlappingNavigationsCancelExistingNavigations_HistoryNavigation()
     {
         SetUrlViaPushState("/");
@@ -994,6 +993,7 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
         Browser.Navigate().Back();
 
         // The navigation lock has initiated its "location changing" handler and is displaying navigation controls
+        Browser.Equal(expectedStartingAbsoluteUri, () => app.FindElement(By.Id("test-info")).Text);
         Browser.Exists(By.CssSelector("#navigation-lock-0 > div.blocking-controls"));
 
         // The location was reverted to what it was before the navigation started


### PR DESCRIPTION
The test was quarantined but I cannot reproduce the failure. The issue log indicates that the failure occurred on checking css element selector that was not present. It looks like a timing issue that could have happened if the page was not fully loaded at the time of the check. We can avoid it by adding another check that waits for the page to be loaded.

## Description

- Unblock the test.
- Make sure we finished navigating back before checking the css selectors.

Fixes #61080
