### PR TITLE
[Static Assets] Consume `original-resource` instead of the `Etag`

### DIFF
--- a/src/StaticAssets/test/StaticAssetsIntegrationTests.cs
+++ b/src/StaticAssets/test/StaticAssetsIntegrationTests.cs
@@ -519,13 +519,12 @@ public class StaticAssetsIntegrationTests
                     Route = resource.Path,
                     AssetPath = $"{resource.Path}.gz",
                     Selectors = [new StaticAssetSelector("Content-Encoding", "gzip", "1.0")],
-                    Properties = [],
+                    Properties = [new("original-resource", $"\"{GetEtag(resource.Content)}\"")],
                     ResponseHeaders = [
                         new ("Accept-Ranges", "bytes"),
                         new ("Content-Type", GetContentType(filePath)),
 
                         new ("Content-Length", length.ToString(CultureInfo.InvariantCulture)),
-                        new ("ETag", $"W/\"{GetEtag(resource.Content)}\""),
                         new ("ETag", $"\"{GetEtagForFile(compressedFilePath)}\""),
                         new ("Last-Modified", lastModified.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)),
 


### PR DESCRIPTION
Paired with https://github.com/dotnet/sdk/pull/50420

---
Fix ETag header not found error for compressed resources in Release builds

## Description

When running ASP.NET Core applications with compressed static web assets in Release configuration, the runtime throws an `InvalidOperationException` with message "ETag header not found".

We removed the additional ETag in production because some servers experience issues with it. For development, we switched to emit the ETag only in the Debug configuration.

The runtime however depended on the ETag being present for development scenarios and when we removed it, it started causing issues with `dotnet run -c Release`.

The fix removes the usage of weak ETags for .NET 10.0 and onwards, replacing it with an `original-resource` endpoint property. The SDK will continue to emit weak ETags for .NET 9.0 for backwards compatibility.

Fixes #63364
---