### PR TITLE
Fix race condition in EventTest.PreventDefault_DoNotApplyByDefault

### DIFF
--- a/src/Components/test/E2ETest/Infrastructure/WebDriverExtensions/WebDriverExtensions.cs
+++ b/src/Components/test/E2ETest/Infrastructure/WebDriverExtensions/WebDriverExtensions.cs
@@ -43,6 +43,16 @@ internal static class WebDriverExtensions
         });
     }
 
+    public static void WaitForUrlToContain(this IWebDriver browser, string expectedUrlSubstring, int timeoutInSeconds = 5)
+    {
+        var wait = new DefaultWait<IWebDriver>(browser)
+        {
+            Timeout = TimeSpan.FromSeconds(timeoutInSeconds),
+            PollingInterval = TimeSpan.FromMilliseconds(100)
+        };
+        wait.Until(driver => driver.Url.Contains(expectedUrlSubstring, StringComparison.Ordinal));
+    }
+
     public static long GetElementPositionWithRetry(this IWebDriver browser, string elementId, int retryCount = 3, int delayBetweenRetriesMs = 100)
     {
         var jsExecutor = (IJavaScriptExecutor)browser;

--- a/src/Components/test/E2ETest/Infrastructure/WebDriverExtensions/WebDriverExtensions.cs
+++ b/src/Components/test/E2ETest/Infrastructure/WebDriverExtensions/WebDriverExtensions.cs
@@ -43,16 +43,6 @@ internal static class WebDriverExtensions
         });
     }
 
-    public static void WaitForUrlToContain(this IWebDriver browser, string expectedUrlSubstring, int timeoutInSeconds = 5)
-    {
-        var wait = new DefaultWait<IWebDriver>(browser)
-        {
-            Timeout = TimeSpan.FromSeconds(timeoutInSeconds),
-            PollingInterval = TimeSpan.FromMilliseconds(100)
-        };
-        wait.Until(driver => driver.Url.Contains(expectedUrlSubstring, StringComparison.Ordinal));
-    }
-
     public static long GetElementPositionWithRetry(this IWebDriver browser, string elementId, int retryCount = 3, int delayBetweenRetriesMs = 100)
     {
         var jsExecutor = (IJavaScriptExecutor)browser;

--- a/src/Components/test/E2ETest/Tests/EventTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventTest.cs
@@ -284,8 +284,7 @@ public class EventTest : ServerTestBase<ToggleExecutionModeServerFixture<Program
         appElement.FindElement(By.Id("form-2-button")).Click();
 
         // The URL should change because the submit event is not prevented
-        var wait = new WebDriverWait(Browser, TimeSpan.FromSeconds(3));
-        wait.Until(driver => driver.Url.Contains("about:blank"));
+        Browser.WaitForUrlToContain("about:blank");
     }
 
     [Fact]

--- a/src/Components/test/E2ETest/Tests/EventTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventTest.cs
@@ -284,7 +284,7 @@ public class EventTest : ServerTestBase<ToggleExecutionModeServerFixture<Program
         appElement.FindElement(By.Id("form-2-button")).Click();
 
         // The URL should change because the submit event is not prevented
-        Browser.WaitForUrlToContain("about:blank");
+        Browser.Contains("about:blank", () => Browser.Url);
     }
 
     [Fact]

--- a/src/Components/test/E2ETest/Tests/EventTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventTest.cs
@@ -278,12 +278,14 @@ public class EventTest : ServerTestBase<ToggleExecutionModeServerFixture<Program
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/62533")]
-    public void PreventDefault_DotNotApplyByDefault()
+    public void PreventDefault_DoNotApplyByDefault()
     {
         var appElement = Browser.MountTestComponent<EventPreventDefaultComponent>();
         appElement.FindElement(By.Id("form-2-button")).Click();
-        Assert.Contains("about:blank", Browser.Url);
+
+        // The URL should change because the submit event is not prevented
+        var wait = new WebDriverWait(Browser, TimeSpan.FromSeconds(3));
+        wait.Until(driver => driver.Url.Contains("about:blank"));
     }
 
     [Fact]


### PR DESCRIPTION
The quarantined test was flaky due to a race condition. The assert failed when the test driver did not manage to change the URL in time.

I used a script to execute the test in a loop (on an M2 Mac):

- Before the change the test failed in 44/300 runs.
- After the change the test failed in 0/300 runs.

Fixes #62533