### PR TITLE
Avoid having a separate global.json for template tests

### DIFF
--- a/src/ProjectTemplates/TestInfrastructure/PrepareForTest.targets
+++ b/src/ProjectTemplates/TestInfrastructure/PrepareForTest.targets
@@ -120,7 +120,7 @@
       <_FilesToCopy Include="$(LocalDotNetRoot)shared\**\*" DestinationRelativeFolder="shared\" />
       <_FilesToCopy Include="$(LocalDotNetRoot)sdk\**\*" DestinationRelativeFolder="sdk\" />
       <_FilesToCopy Include="$(SharedFrameworkLayoutRoot)\**\*" />
-      <_FilesToCopy Include="$(RepoRoot)\global.json" />
+      <_FilesToCopy Include="$(RepoRoot)\global.json" DestinationRelativeFolder="../" />
 
       <_DestinationFiles Include="@(_FilesToCopy->'$(TemplateTestDotNetRoot)%(DestinationRelativeFolder)%(RecursiveDir)%(Filename)%(Extension)')" />
     </ItemGroup>

--- a/src/ProjectTemplates/global.json
+++ b/src/ProjectTemplates/global.json
@@ -1,7 +1,0 @@
-{
-  "sdk": {
-    "version": "10.0.100-rc.1.25411.109",
-    "paths": [ "scripts/.dotnet", "$host$" ],
-    "errorMessage": "The .NET SDK could not be found, run ./restore.cmd or ./restore.sh first."
-  }
-}


### PR DESCRIPTION
Follow up for https://github.com/dotnet/aspnetcore/pull/62619.

We want to avoid having the dotnet version defined in multiple places. We can use the mechanism of copying the main `global.json` to templates location, just making sure the destination path is correct.
