### PR TITLE
Enhance workflow with .NET installation steps for MCP servers

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -16,9 +16,28 @@ jobs:
     steps:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.2.2
 
-        # Include PrepareForHelix to maximise what is downloaded here
+      # Include PrepareForHelix to maximise what is downloaded here
       - name: Build solution
         env:
           # prevent GitInfo errors
           CI: false
         run: ./restore.sh
+
+      # For MCP servers like nuget's
+      - name: Install .NET 10.x
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            10.x
+          dotnet-quality: preview
+
+      # for MCP servers
+      - name: Install .NET 8.x
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.x
+
+      # Diagnostics in the log
+      - name: dotnet --info
+        run: dotnet --info        

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -40,4 +40,4 @@ jobs:
 
       # Diagnostics in the log
       - name: dotnet --info
-        run: dotnet --info        
+        run: dotnet --info


### PR DESCRIPTION
In order to use the NuGet MCP server, it apparently requires .NET 8. Installing .NET 10 as well for completeness. This only adds a few seconds and matches aspire
https://github.com/dotnet/aspire/blob/main/.github/workflows/copilot-setup-steps.yml