### PR TITLE
Add Changelog for SignalR typescript client

### DIFF
--- a/eng/scripts/CodeCheck.ps1
+++ b/eng/scripts/CodeCheck.ps1
@@ -215,8 +215,8 @@ try {
         }
 
         # Check for relevant changes to SignalR typescript files
-        $tsChanges = $changedFilesFromTarget | Where-Object { $_ -like "src/SignalR/clients/ts/*" -and $_ -ne "src/SignalR/clients/ts/changelog.md" }
-        $changelogChanged = $changedFilesFromTarget -contains "src/SignalR/clients/ts/changelog.md"
+        $tsChanges = $changedFilesFromTarget | Where-Object { $_ -like "src/SignalR/clients/ts/*" -and $_ -ne "src/SignalR/clients/ts/CHANGELOG.md" }
+        $changelogChanged = $changedFilesFromTarget -contains "src/SignalR/clients/ts/CHANGELOG.md"
         $signalrChangelogOverrideMarker = "[no changelog]"
 
         # Only enforce changelog rule if there are relevant TS changes
@@ -225,8 +225,8 @@ try {
             $hasOverride = git log origin/$targetBranch..HEAD --pretty=%B | Select-String -Pattern $signalrChangelogOverrideMarker -Quiet
 
             if (-not $hasOverride) {
-                LogError "Changes were made to 'src/SignalR/clients/ts/', but no update to 'changelog.md' was found."
-                LogError "Either update 'src/SignalR/clients/ts/changelog.md' or include '$signalrChangelogOverrideMarker' in your commit message."
+                LogError "Changes were made to 'src/SignalR/clients/ts/', but no update to 'CHANGELOG.md' was found."
+                LogError "Either update 'src/SignalR/clients/ts/CHANGELOG.md' or include '$signalrChangelogOverrideMarker' in your commit message."
                 exit 1
             } else {
                 Write-Host "SignalR Changelog update skipped due to override marker in commit message."

--- a/eng/scripts/CodeCheck.ps1
+++ b/eng/scripts/CodeCheck.ps1
@@ -213,6 +213,25 @@ try {
                 LogError $file
             }
         }
+
+        # Check for relevant changes to SignalR typescript files
+        $tsChanges = $changedFilesFromTarget | Where-Object { $_ -like "src/SignalR/clients/ts/*" -and $_ -ne "src/SignalR/clients/ts/changelog.md" }
+        $changelogChanged = $changedFilesFromTarget -contains "src/SignalR/clients/ts/changelog.md"
+        $signalrChangelogOverrideMarker = "[no changelog]"
+
+        # Only enforce changelog rule if there are relevant TS changes
+        if ($tsChanges.Count -gt 0 -and -not $changelogChanged) {
+            # Check if the override marker exists in recent commit messages
+            $hasOverride = git log origin/$targetBranch..HEAD --pretty=%B | Select-String -Pattern $signalrChangelogOverrideMarker -Quiet
+
+            if (-not $hasOverride) {
+                LogError "Changes were made to 'src/SignalR/clients/ts/', but no update to 'changelog.md' was found."
+                LogError "Either update 'src/SignalR/clients/ts/changelog.md' or include '$signalrChangelogOverrideMarker' in your commit message."
+                exit 1
+            } else {
+                Write-Host "SignalR Changelog update skipped due to override marker in commit message."
+            }
+        }
     }
 }
 finally {

--- a/src/SignalR/clients/ts/CHANGELOG.md
+++ b/src/SignalR/clients/ts/CHANGELOG.md
@@ -1,0 +1,56 @@
+Change log contains changes for both @microsoft/signalr and @microsoft/signalr-protocol-msgpack.
+
+## v10.0.0-preview.1.25120.3
+- Replaced deprecated `substr` usage with `substring` [#58732](https://github.com/dotnet/aspnetcore/pull/58732)
+- Bumped `ws` dependency to fix component vulnerability [#57536](https://github.com/dotnet/aspnetcore/pull/57536)
+- Bumped `webpack` from 5.93.0 to 5.94.0 [#57592](https://github.com/dotnet/aspnetcore/pull/57592)
+
+## v9.0.0
+- Bumped `ws` dependency to address security vulnerability [#58458](https://github.com/dotnet/aspnetcore/pull/58458)
+
+## v9.0.0-rc.2.24474.3
+- Added `Partitioned` flag to cookie for SignalR browser testing [#57997](https://github.com/dotnet/aspnetcore/pull/57997)
+
+## v9.0.0-preview.7.24406.2
+- Reverted split Node dependency workaround due to issues [#56766](https://github.com/dotnet/aspnetcore/pull/56766)
+
+## v9.0.0-preview.1.24081.5
+- Updated Karma config [#53247](https://github.com/dotnet/aspnetcore/pull/53247)
+- Node.js and npm infrastructure improvements [#53154](https://github.com/dotnet/aspnetcore/pull/53154)
+- Improved error handling in SignalR client: rejected promises in invocation messages [#52523](https://github.com/dotnet/aspnetcore/pull/52523)
+- Reordered SignalR message parameters for better readability [#51559](https://github.com/dotnet/aspnetcore/pull/51559)
+
+## v8.0.12
+- Updated `serialize-javascript` dependency [#58466](https://github.com/dotnet/aspnetcore/pull/58466)
+
+## v8.0.10
+- Upgraded `ws` from 7 to 7.5.10 [#57411](https://github.com/dotnet/aspnetcore/pull/57411)
+
+## v8.0.7
+- Reverted incorrect handling of Node dependency splitting [#55229](https://github.com/dotnet/aspnetcore/pull/55229)
+- Fixed error handling for rejected promises in incoming Invocation messages [#55230](https://github.com/dotnet/aspnetcore/pull/55230)
+
+## v8.0.2
+- Updated Karma config [#53411](https://github.com/dotnet/aspnetcore/pull/53411)
+
+## v8.0.0-rc.2.23480.2
+- Introduced **Stateful Reconnect** support in SignalR [#49940](https://github.com/dotnet/aspnetcore/pull/49940)
+- Renamed internal `UseAck` to `UseStatefulReconnect` [#50407](https://github.com/dotnet/aspnetcore/pull/50407)
+- Incremented HubProtocol version for Stateful Reconnect [#50442](https://github.com/dotnet/aspnetcore/pull/50442)
+
+## v8.0.0-preview.7.23375.9
+- Removed `__non_webpack_require__` workaround, improved Node dependency handling [#48154](https://github.com/dotnet/aspnetcore/pull/48154)
+
+## v8.0.0-preview.6.23329.11
+- SignalR client now sends `CloseMessage` to server [#48577](https://github.com/dotnet/aspnetcore/pull/48577)
+
+## v8.0.0-preview.5.23302.2
+- Fixed cookie handling with Fetch API on Node 18+ [#48076](https://github.com/dotnet/aspnetcore/pull/48076)
+
+## v8.0.0-preview.4.23260.4
+- Upgraded Webpack for SignalR builds [#47403](https://github.com/dotnet/aspnetcore/pull/47403)
+
+## v8.0.0-preview.1.23112.2
+- Fixed `CompletionMessage` handling for `false`/`null` result values [#45169](https://github.com/dotnet/aspnetcore/pull/45169)
+- Enabled `ServerTimeout` and `KeepAliveInterval` options in `HubConnectionBuilder` [#46065](https://github.com/dotnet/aspnetcore/pull/46065)
+- Migrated links to `learn.microsoft.com` [#46206](https://github.com/dotnet/aspnetcore/pull/46206)

--- a/src/SignalR/clients/ts/CHANGELOG.md
+++ b/src/SignalR/clients/ts/CHANGELOG.md
@@ -1,5 +1,10 @@
 Change log contains changes for both @microsoft/signalr and @microsoft/signalr-protocol-msgpack.
 
+## v10.0.0-rc.1
+
+- Implemented fix for correctly reporting retries in the SignalR TS client. [#62812](https://github.com/dotnet/aspnetcore/pull/62812)
+- Send Keep-Alive Ping Immediately When Previous Ping Is Overdue [#63195](https://github.com/dotnet/aspnetcore/pull/63195)
+
 ## v10.0.0-preview.1.25120.3
 - Replaced deprecated `substr` usage with `substring` [#58732](https://github.com/dotnet/aspnetcore/pull/58732)
 - Bumped `ws` dependency to fix component vulnerability [#57536](https://github.com/dotnet/aspnetcore/pull/57536)

--- a/src/SignalR/clients/ts/README.md
+++ b/src/SignalR/clients/ts/README.md
@@ -1,0 +1,12 @@
+## ASP.NET Core SignalR Typescript
+
+Contains the client-side implementation of the SignalR protocol in TypeScript/JavaScript.
+
+* `signalr/`: Contains the core functionality for connecting and interacting with a SignalR server. Shipped as `@microsoft/signalr` on npm.
+* `signalr-protocol-msgpack/`: Contains an extension to the core library to use [msgpack](https://msgpack.org/) for it's core serialization logic instead of JSON. Shipped as `@microsoft/signalr-protocol-msgpack` on npm.
+
+## Changelog
+
+The changelog is located at [`CHANGELOG.md`](CHANGELOG.md). It is manually updated when changes are made to either of the npm packages we ship.
+
+The CI should fail if changes are made to the libraries without any CHANGELOG updates. If the change isn't relevant to the CHANGELOG, add `[no changelog]` to one of the commit messages in the PR.

--- a/src/SignalR/clients/ts/signalr-protocol-msgpack/README.md
+++ b/src/SignalR/clients/ts/signalr-protocol-msgpack/README.md
@@ -1,6 +1,6 @@
 MsgPack support for SignalR for ASP.NET Core
 
-[Changelog](https://github.com/dotnet/aspnetcore/tree/main/src/SignalR/clients/ts/changelog.md)
+[Changelog](https://github.com/dotnet/aspnetcore/tree/main/src/SignalR/clients/ts/CHANGELOG.md)
 
 ## Installation
 

--- a/src/SignalR/clients/ts/signalr-protocol-msgpack/README.md
+++ b/src/SignalR/clients/ts/signalr-protocol-msgpack/README.md
@@ -1,5 +1,7 @@
 MsgPack support for SignalR for ASP.NET Core
 
+[Changelog](https://github.com/dotnet/aspnetcore/tree/main/src/SignalR/clients/ts/changelog.md)
+
 ## Installation
 
 ```bash

--- a/src/SignalR/clients/ts/signalr/README.md
+++ b/src/SignalR/clients/ts/signalr/README.md
@@ -1,6 +1,6 @@
 JavaScript and TypeScript clients for SignalR for ASP.NET Core and Azure SignalR Service
 
-[Changelog](https://github.com/dotnet/aspnetcore/tree/main/src/SignalR/clients/ts/changelog.md)
+[Changelog](https://github.com/dotnet/aspnetcore/tree/main/src/SignalR/clients/ts/CHANGELOG.md)
 
 ## Installation
 

--- a/src/SignalR/clients/ts/signalr/README.md
+++ b/src/SignalR/clients/ts/signalr/README.md
@@ -1,5 +1,7 @@
 JavaScript and TypeScript clients for SignalR for ASP.NET Core and Azure SignalR Service
 
+[Changelog](https://github.com/dotnet/aspnetcore/tree/main/src/SignalR/clients/ts/changelog.md)
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
Add a changelog for recent releases
Link to changelog from both npm packages
Add codecheck for CI to fail if a change was made to the npm projects and the changelog wasn't updated

See https://github.com/dotnet/aspnetcore/issues/50772