### PR TITLE
Unquarantine RevalidatingServerAuthenticationStateProviderTest.SuppliesCancellationTokenThatSignalsWhenRevalidationLoopIsBeingDiscarded

### DIFF
--- a/src/Components/Server/test/Circuits/RevalidatingServerAuthenticationStateProviderTest.cs
+++ b/src/Components/Server/test/Circuits/RevalidatingServerAuthenticationStateProviderTest.cs
@@ -142,7 +142,6 @@ public class RevalidatingServerAuthenticationStateProviderTest
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/60472")]
     public async Task SuppliesCancellationTokenThatSignalsWhenRevalidationLoopIsBeingDiscarded()
     {
         // Arrange


### PR DESCRIPTION
This test has not failed in the last 30 days (https://dev.azure.com/dnceng-public/public/_test/analytics?definitionId=84&contextType=build).

When running all tests from the test class locally in a loop, 300/300 runs succeeded.

Fixes #60472 