### PR TITLE
Fix fetch request in data-enhance-nav="false" for same-page anchors

### DIFF
--- a/src/Components/Web.JS/src/Services/NavigationEnhancement.ts
+++ b/src/Components/Web.JS/src/Services/NavigationEnhancement.ts
@@ -120,7 +120,8 @@ function onPopState(state: PopStateEvent) {
     return;
   }
 
-  if (isSameUrlWithDifferentHash(currentContentUrl, location.href)) {
+  if (state.state == null && isSameUrlWithDifferentHash(currentContentUrl, location.href)) {
+    currentContentUrl = location.href;
     return;
   }
 

--- a/src/Components/Web.JS/src/Services/NavigationEnhancement.ts
+++ b/src/Components/Web.JS/src/Services/NavigationEnhancement.ts
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { synchronizeDomContent } from '../Rendering/DomMerging/DomSync';
-import { attachProgrammaticEnhancedNavigationHandler, handleClickForNavigationInterception, hasInteractiveRouter, isForSamePath, isSamePageWithHash, notifyEnhancedNavigationListeners, performScrollToElementOnTheSamePage, isHashOnlyChange } from './NavigationUtils';
+import { attachProgrammaticEnhancedNavigationHandler, handleClickForNavigationInterception, hasInteractiveRouter, isForSamePath, notifyEnhancedNavigationListeners, performScrollToElementOnTheSamePage, isSameUrlWithDifferentHash } from './NavigationUtils';
 import { resetScrollAfterNextBatch, resetScrollIfNeeded } from '../Rendering/Renderer';
 
 /*
@@ -99,7 +99,7 @@ function onDocumentClick(event: MouseEvent) {
   handleClickForNavigationInterception(event, absoluteInternalHref => {
     const originalLocation = location.href;
 
-    const shouldScrollToHash = isSamePageWithHash(absoluteInternalHref);
+    const shouldScrollToHash = isSameUrlWithDifferentHash(originalLocation, absoluteInternalHref);
     history.pushState(null, /* ignored title */ '', absoluteInternalHref);
 
     if (shouldScrollToHash) {
@@ -120,7 +120,7 @@ function onPopState(state: PopStateEvent) {
     return;
   }
 
-  if (isHashOnlyChange(currentContentUrl, location.href)) {
+  if (isSameUrlWithDifferentHash(currentContentUrl, location.href)) {
     return;
   }
 

--- a/src/Components/Web.JS/src/Services/NavigationEnhancement.ts
+++ b/src/Components/Web.JS/src/Services/NavigationEnhancement.ts
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { synchronizeDomContent } from '../Rendering/DomMerging/DomSync';
-import { attachProgrammaticEnhancedNavigationHandler, handleClickForNavigationInterception, hasInteractiveRouter, isForSamePath, notifyEnhancedNavigationListeners, performScrollToElementOnTheSamePage, isSameUrlWithDifferentHash } from './NavigationUtils';
+import { attachProgrammaticEnhancedNavigationHandler, handleClickForNavigationInterception, hasInteractiveRouter, isForSamePath, notifyEnhancedNavigationListeners, performScrollToElementOnTheSamePage, isSamePageWithHash } from './NavigationUtils';
 import { resetScrollAfterNextBatch, resetScrollIfNeeded } from '../Rendering/Renderer';
 
 /*
@@ -99,7 +99,7 @@ function onDocumentClick(event: MouseEvent) {
   handleClickForNavigationInterception(event, absoluteInternalHref => {
     const originalLocation = location.href;
 
-    const shouldScrollToHash = isSameUrlWithDifferentHash(originalLocation, absoluteInternalHref);
+    const shouldScrollToHash = isSamePageWithHash(originalLocation, absoluteInternalHref);
     history.pushState(null, /* ignored title */ '', absoluteInternalHref);
 
     if (shouldScrollToHash) {
@@ -120,7 +120,7 @@ function onPopState(state: PopStateEvent) {
     return;
   }
 
-  if (state.state == null && isSameUrlWithDifferentHash(currentContentUrl, location.href)) {
+  if (state.state == null && isSamePageWithHash(currentContentUrl, location.href)) {
     currentContentUrl = location.href;
     return;
   }

--- a/src/Components/Web.JS/src/Services/NavigationEnhancement.ts
+++ b/src/Components/Web.JS/src/Services/NavigationEnhancement.ts
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { synchronizeDomContent } from '../Rendering/DomMerging/DomSync';
-import { attachProgrammaticEnhancedNavigationHandler, handleClickForNavigationInterception, hasInteractiveRouter, isForSamePath, isSamePageWithHash, notifyEnhancedNavigationListeners, performScrollToElementOnTheSamePage } from './NavigationUtils';
+import { attachProgrammaticEnhancedNavigationHandler, handleClickForNavigationInterception, hasInteractiveRouter, isForSamePath, isSamePageWithHash, notifyEnhancedNavigationListeners, performScrollToElementOnTheSamePage, isHashOnlyChange } from './NavigationUtils';
 import { resetScrollAfterNextBatch, resetScrollIfNeeded } from '../Rendering/Renderer';
 
 /*
@@ -117,6 +117,10 @@ function onDocumentClick(event: MouseEvent) {
 
 function onPopState(state: PopStateEvent) {
   if (hasInteractiveRouter()) {
+    return;
+  }
+
+  if (isHashOnlyChange(currentContentUrl, location.href)){
     return;
   }
 

--- a/src/Components/Web.JS/src/Services/NavigationEnhancement.ts
+++ b/src/Components/Web.JS/src/Services/NavigationEnhancement.ts
@@ -120,7 +120,7 @@ function onPopState(state: PopStateEvent) {
     return;
   }
 
-  if (isHashOnlyChange(currentContentUrl, location.href)){
+  if (isHashOnlyChange(currentContentUrl, location.href)) {
     return;
   }
 

--- a/src/Components/Web.JS/src/Services/NavigationManager.ts
+++ b/src/Components/Web.JS/src/Services/NavigationManager.ts
@@ -4,7 +4,7 @@
 import '@microsoft/dotnet-js-interop';
 import { resetScrollAfterNextBatch } from '../Rendering/Renderer';
 import { EventDelegator } from '../Rendering/Events/EventDelegator';
-import { attachEnhancedNavigationListener, getInteractiveRouterRendererId, handleClickForNavigationInterception, hasInteractiveRouter, hasProgrammaticEnhancedNavigationHandler, isForSamePath, isSameUrlWithDifferentHash, isWithinBaseUriSpace, performProgrammaticEnhancedNavigation, performScrollToElementOnTheSamePage, scrollToElement, setHasInteractiveRouter, toAbsoluteUri } from './NavigationUtils';
+import { attachEnhancedNavigationListener, getInteractiveRouterRendererId, handleClickForNavigationInterception, hasInteractiveRouter, hasProgrammaticEnhancedNavigationHandler, isForSamePath, isSamePageWithHash, isWithinBaseUriSpace, performProgrammaticEnhancedNavigation, performScrollToElementOnTheSamePage, scrollToElement, setHasInteractiveRouter, toAbsoluteUri } from './NavigationUtils';
 import { WebRendererId } from '../Rendering/WebRendererId';
 import { isRendererAttached } from '../Rendering/WebRendererInteropMethods';
 
@@ -150,7 +150,7 @@ function performExternalNavigation(uri: string, replace: boolean) {
 async function performInternalNavigation(absoluteInternalHref: string, interceptedLink: boolean, replace: boolean, state: string | undefined = undefined, skipLocationChangingCallback = false) {
   ignorePendingNavigation();
 
-  if (isSameUrlWithDifferentHash(location.href, absoluteInternalHref)) {
+  if (isSamePageWithHash(location.href, absoluteInternalHref)) {
     saveToBrowserHistory(absoluteInternalHref, replace, state);
     performScrollToElementOnTheSamePage(absoluteInternalHref);
     return;

--- a/src/Components/Web.JS/src/Services/NavigationManager.ts
+++ b/src/Components/Web.JS/src/Services/NavigationManager.ts
@@ -4,7 +4,7 @@
 import '@microsoft/dotnet-js-interop';
 import { resetScrollAfterNextBatch } from '../Rendering/Renderer';
 import { EventDelegator } from '../Rendering/Events/EventDelegator';
-import { attachEnhancedNavigationListener, getInteractiveRouterRendererId, handleClickForNavigationInterception, hasInteractiveRouter, hasProgrammaticEnhancedNavigationHandler, isForSamePath, isSamePageWithHash, isWithinBaseUriSpace, performProgrammaticEnhancedNavigation, performScrollToElementOnTheSamePage, scrollToElement, setHasInteractiveRouter, toAbsoluteUri } from './NavigationUtils';
+import { attachEnhancedNavigationListener, getInteractiveRouterRendererId, handleClickForNavigationInterception, hasInteractiveRouter, hasProgrammaticEnhancedNavigationHandler, isForSamePath, isSameUrlWithDifferentHash, isWithinBaseUriSpace, performProgrammaticEnhancedNavigation, performScrollToElementOnTheSamePage, scrollToElement, setHasInteractiveRouter, toAbsoluteUri } from './NavigationUtils';
 import { WebRendererId } from '../Rendering/WebRendererId';
 import { isRendererAttached } from '../Rendering/WebRendererInteropMethods';
 
@@ -150,7 +150,7 @@ function performExternalNavigation(uri: string, replace: boolean) {
 async function performInternalNavigation(absoluteInternalHref: string, interceptedLink: boolean, replace: boolean, state: string | undefined = undefined, skipLocationChangingCallback = false) {
   ignorePendingNavigation();
 
-  if (isSamePageWithHash(absoluteInternalHref)) {
+  if (isSameUrlWithDifferentHash(location.href, absoluteInternalHref)) {
     saveToBrowserHistory(absoluteInternalHref, replace, state);
     performScrollToElementOnTheSamePage(absoluteInternalHref);
     return;

--- a/src/Components/Web.JS/src/Services/NavigationUtils.ts
+++ b/src/Components/Web.JS/src/Services/NavigationUtils.ts
@@ -52,6 +52,17 @@ export function isSamePageWithHash(absoluteHref: string): boolean {
   return url.hash !== '' && location.origin === url.origin && location.pathname === url.pathname && location.search === url.search;
 }
 
+export function isHashOnlyChange(oldUrl: string, newUrl: string): boolean {
+  try {
+    const a = new URL(oldUrl);
+    const b = new URL(newUrl);
+    return a.origin === b.origin && a.pathname === b.pathname
+      && a.search === b.search && a.hash !== b.hash;
+  } catch {
+    return false;
+  }
+}
+
 export function isForSamePath(url1: string, url2: string) {
   // We are going to use the scheme, host, port and path to determine if the two URLs are compatible.
   // We do not account for the query string as we want to allow for the query string to change.

--- a/src/Components/Web.JS/src/Services/NavigationUtils.ts
+++ b/src/Components/Web.JS/src/Services/NavigationUtils.ts
@@ -47,15 +47,11 @@ export function isWithinBaseUriSpace(href: string) {
   && (nextChar === '' || nextChar === '/' || nextChar === '?' || nextChar === '#');
 }
 
-export function isSameUrlWithDifferentHash(oldUrl: string, newUrl: string): boolean {
-  try {
-    const a = new URL(oldUrl);
-    const b = new URL(newUrl);
-    return a.origin === b.origin && a.pathname === b.pathname
-      && a.search === b.search && b.hash !== '';
-  } catch {
-    return false;
-  }
+export function isSamePageWithHash(oldUrl: string, newUrl: string): boolean {
+  const a = new URL(oldUrl);
+  const b = new URL(newUrl);
+  return a.origin === b.origin && a.pathname === b.pathname
+    && a.search === b.search && b.hash !== '';
 }
 
 export function isForSamePath(url1: string, url2: string) {

--- a/src/Components/Web.JS/src/Services/NavigationUtils.ts
+++ b/src/Components/Web.JS/src/Services/NavigationUtils.ts
@@ -47,17 +47,12 @@ export function isWithinBaseUriSpace(href: string) {
   && (nextChar === '' || nextChar === '/' || nextChar === '?' || nextChar === '#');
 }
 
-export function isSamePageWithHash(absoluteHref: string): boolean {
-  const url = new URL(absoluteHref);
-  return url.hash !== '' && location.origin === url.origin && location.pathname === url.pathname && location.search === url.search;
-}
-
-export function isHashOnlyChange(oldUrl: string, newUrl: string): boolean {
+export function isSameUrlWithDifferentHash(oldUrl: string, newUrl: string): boolean {
   try {
     const a = new URL(oldUrl);
     const b = new URL(newUrl);
     return a.origin === b.origin && a.pathname === b.pathname
-      && a.search === b.search && a.hash !== b.hash;
+      && a.search === b.search && b.hash !== '';
   } catch {
     return false;
   }

--- a/src/Components/test/E2ETest/ServerRenderingTests/EnhancedNavigationTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/EnhancedNavigationTest.cs
@@ -197,31 +197,37 @@ public class EnhancedNavigationTest : ServerTestBase<BasicTestAppServerSiteFixtu
     }
 
     [Fact]
-    public void NonEnhancedNavCanScrollToHashWithoutFetchingPage()
+    public void NonEnhancedNavCanScrollToHashWithoutFetchingPageAnchor()
     {
         Navigate($"{ServerPathBase}/nav/scroll-to-hash");
-        Browser.Equal("Scroll to hash", () => Browser.Exists(By.TagName("h1")).Text);
+        var originalTextElem = Browser.Exists(By.CssSelector("#anchor #text"));
+        Browser.Equal("Text", () => originalTextElem.Text);
 
-        var javascript = (IJavaScriptExecutor)Browser;
-        javascript.ExecuteScript(@"
-            window.testFetchCalls = [];
-            const originalFetch = window.fetch;
-            window.fetch = function(...args) {
-                window.testFetchCalls.push(args[0]);
-                return originalFetch.apply(this, args);
-                };");
-
-        Browser.Exists(By.Id("scroll-anchor-enhance-nav-false")).Click();
+        Browser.Exists(By.CssSelector("#anchor #scroll-anchor")).Click();
         Browser.True(() => Browser.GetScrollY() > 500);
         Browser.True(() => Browser
-            .Exists(By.Id("uri-on-page-load-enhance-nav-false"))
+            .Exists(By.CssSelector("#anchor #uri-on-page-load"))
             .GetDomAttribute("data-value")
             .EndsWith("scroll-to-hash", StringComparison.Ordinal));
 
-        var fetchCalls = javascript.ExecuteScript("return window.testFetchCalls;") as IEnumerable<object>;
-        var relevantCalls = fetchCalls?.Where(call => call.ToString().Contains("scroll-to-hash")) ?? Enumerable.Empty<object>();
+        Browser.Equal("Text", () => originalTextElem.Text);
+    }
 
-        Assert.Empty(relevantCalls);
+    [Fact]
+    public void NonEnhancedNavCanScrollToHashWithoutFetchingPageNavLink()
+    {
+        Navigate($"{ServerPathBase}/nav/scroll-to-hash");
+        var originalTextElem = Browser.Exists(By.CssSelector("#navlink #text"));
+        Browser.Equal("Text", () => originalTextElem.Text);
+
+        Browser.Exists(By.CssSelector("#navlink #scroll-anchor")).Click();
+        Browser.True(() => Browser.GetScrollY() > 500);
+        Browser.True(() => Browser
+            .Exists(By.CssSelector("#navlink #uri-on-page-load"))
+            .GetDomAttribute("data-value")
+            .EndsWith("scroll-to-hash", StringComparison.Ordinal));
+
+        Browser.Equal("Text", () => originalTextElem.Text);
     }
 
     [Theory]

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/EnhancedNav/PageForScrollingToHash.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/EnhancedNav/PageForScrollingToHash.razor
@@ -13,6 +13,11 @@
     <div id="uri-on-page-load" style="display: none" data-value="@uriOnPageLoad"></div>
 </p>
 
+<p data-enhance-nav="false">
+    <a id="scroll-anchor-enhance-nav-false" href="nav/scroll-to-hash#some-content">Scroll via anchor</a>
+    <div id="uri-on-page-load-enhance-nav-false" style="display: none" data-value="@uriOnPageLoad"></div>
+</p>
+
 <div style="height: 2000px; border: 2px dashed red;">spacer</div>
 
 @if (showContent)

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/EnhancedNav/PageForScrollingToHash.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/EnhancedNav/PageForScrollingToHash.razor
@@ -1,6 +1,7 @@
 ﻿@page "/nav/scroll-to-hash"
 @attribute [StreamRendering]
 @inject NavigationManager NavigationManager
+@using Microsoft.AspNetCore.Components.Forms
 
 <PageTitle>Page for scrolling to hash</PageTitle>
 
@@ -13,10 +14,17 @@
     <div id="uri-on-page-load" style="display: none" data-value="@uriOnPageLoad"></div>
 </p>
 
-<p data-enhance-nav="false">
-    <a id="scroll-anchor-enhance-nav-false" href="nav/scroll-to-hash#some-content">Scroll via anchor</a>
-    <div id="uri-on-page-load-enhance-nav-false" style="display: none" data-value="@uriOnPageLoad"></div>
-</p>
+<div data-enhance-nav="false" id="anchor">
+    <a id="scroll-anchor" href="nav/scroll-to-hash#some-content">Scroll via anchor</a>
+    <div id="uri-on-page-load" style="display: none" data-value="@uriOnPageLoad"></div>
+    <p id="text">Text</p>
+</div>
+
+<div data-enhance-nav="false" id="navlink">
+    <NavLink id="scroll-anchor" href="nav/scroll-to-hash#some-content">Scroll via NavLink</NavLink>
+    <div id="uri-on-page-load" style="display: none" data-value="@uriOnPageLoad"></div>
+    <p id="text">Text</p>
+</div>
 
 <div style="height: 2000px; border: 2px dashed red;">spacer</div>
 


### PR DESCRIPTION
# Fix fetch request in data-enhance-nav="false" for same-page anchors

## Description

This pull request enhances the navigation logic to better handle hash-only changes in URLs, ensuring that navigation to anchors within the same page does not trigger a full page reload or unnecessary fetch requests. It introduces a utility function to detect hash-only changes and updates the navigation handler to leverage this, improving performance and user experience. Additional end-to-end tests and markup updates verify and demonstrate the new behavior.

### Changes:
* Added the `isHashOnlyChange` utility function in `NavigationUtils.ts` to detect when a navigation event only changes the hash fragment, avoiding unnecessary page loads.
* Updated the `onPopState` handler in `NavigationEnhancement.ts` to use `isHashOnlyChange`, preventing enhanced navigation logic from running when only the hash changes.
* Added a new end-to-end test in `EnhancedNavigationTest.cs` to verify that non-enhanced navigation to a hash does not trigger a page fetch, ensuring the scroll behavior works as expected without unnecessary network activity.

Fixes #63396
