### PR TITLE
SignalR: Throw exception when method does not exist.

### DIFF
--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -2419,7 +2419,7 @@ public partial class HubConnection : IAsyncDisposable
             if (!_hubConnection._handlers.TryGetValue(methodName, out var invocationHandlerList))
             {
                 Log.MissingHandler(_logger, methodName);
-                return Type.EmptyTypes;
+                throw new KeyNotFoundException($"Method with name '{methodName}' does not exist.");
             }
 
             // We use the parameter types of the first handler


### PR DESCRIPTION
SignalR: Throw exception when method does not exist.
 
Fixes #63084 
