### PR TITLE
Delete redundant caches for EmptyHttpResult

### DIFF
--- a/src/Http/Http.Results/src/Results.cs
+++ b/src/Http/Http.Results/src/Results.cs
@@ -1025,7 +1025,7 @@ public static partial class Results
     /// <summary>
     /// Produces an empty result response, that when executed will do nothing.
     /// </summary>
-    public static IResult Empty { get; } = TypedResults.Empty;
+    public static IResult Empty => EmptyHttpResult.Instance;
 
     /// <summary>
     /// Provides a container for external libraries to extend

--- a/src/Http/Http.Results/src/TypedResults.cs
+++ b/src/Http/Http.Results/src/TypedResults.cs
@@ -1115,7 +1115,7 @@ public static class TypedResults
     /// <summary>
     /// Produces an empty result response, that when executed will do nothing.
     /// </summary>
-    public static EmptyHttpResult Empty { get; } = EmptyHttpResult.Instance;
+    public static EmptyHttpResult Empty => EmptyHttpResult.Instance;
 
     /// <summary>
     /// Provides a container for external libraries to extend


### PR DESCRIPTION
Delete redundant caches for EmptyHttpResult. This has secondary effect of allowing ResultExtensions to be trimmed when it is not used since it is not going to share the static constructor with EmptyHttpResult.