### PR TITLE
Support file-based apps in user-secrets

### DIFF
--- a/src/Tools/Shared/SecretsHelpers/MsBuildProjectFinder.cs
+++ b/src/Tools/Shared/SecretsHelpers/MsBuildProjectFinder.cs
@@ -46,7 +46,7 @@ internal sealed class MsBuildProjectFinder
 
         if (!File.Exists(projectPath))
         {
-            throw new FileNotFoundException(SecretsHelpersResources.FormatError_ProjectPath_NotFound(projectPath));
+            throw new FileNotFoundException(SecretsHelpersResources.FormatError_File_NotFound(projectPath));
         }
 
         return projectPath;

--- a/src/Tools/Shared/SecretsHelpers/ProjectIdResolver.cs
+++ b/src/Tools/Shared/SecretsHelpers/ProjectIdResolver.cs
@@ -59,9 +59,8 @@ internal sealed class ProjectIdResolver
                 UseShellExecute = false,
                 ArgumentList =
                     {
-                        "msbuild",
+                        "build",
                         projectFile,
-                        "/nologo",
                         "/t:_ExtractUserSecretsMetadata", // defined in SecretManager.targets
                         "/p:_UserSecretsMetadataFile=" + outputFile,
                         "/p:Configuration=" + configuration,
@@ -72,7 +71,7 @@ internal sealed class ProjectIdResolver
             };
 
 #if DEBUG
-            _reporter.Verbose($"Invoking '{psi.FileName} {psi.Arguments}'");
+            _reporter.Verbose($"Invoking '{psi.FileName} {string.Join(' ', psi.ArgumentList)}'");
 #endif
 
             using var process = new Process()

--- a/src/Tools/Shared/SecretsHelpers/ProjectIdResolver.cs
+++ b/src/Tools/Shared/SecretsHelpers/ProjectIdResolver.cs
@@ -61,6 +61,7 @@ internal sealed class ProjectIdResolver
                     {
                         "build",
                         projectFile,
+                        "--no-restore",
                         "/t:_ExtractUserSecretsMetadata", // defined in SecretManager.targets
                         "/p:_UserSecretsMetadataFile=" + outputFile,
                         "/p:Configuration=" + configuration,

--- a/src/Tools/Shared/SecretsHelpers/SecretsHelpersResources.resx
+++ b/src/Tools/Shared/SecretsHelpers/SecretsHelpersResources.resx
@@ -132,7 +132,7 @@
   <data name="Error_ProjectMissingId" xml:space="preserve">
     <value>Could not find the global property 'UserSecretsId' in MSBuild project '{project}'. Ensure this property is set in the project or use the '--id' command line option.</value>
   </data>
-  <data name="Error_ProjectPath_NotFound" xml:space="preserve">
+  <data name="Error_File_NotFound" xml:space="preserve">
     <value>The file '{0}' does not exist.</value>
   </data>
   <data name="Message_ProjectAlreadyInitialized" xml:space="preserve">

--- a/src/Tools/Shared/SecretsHelpers/SecretsHelpersResources.resx
+++ b/src/Tools/Shared/SecretsHelpers/SecretsHelpersResources.resx
@@ -124,7 +124,7 @@
     <value>Multiple MSBuild project files found in '{projectPath}'. Specify which to use with the --project option.</value>
   </data>
   <data name="Error_NoProjectsFound" xml:space="preserve">
-    <value>Could not find a MSBuild project file in '{projectPath}'. Specify which project to use with the --project option.</value>
+    <value>Could not find a MSBuild project file in '{projectPath}'. Specify which project to use with the --project option. Use --file option for file-based apps.</value>
   </data>
   <data name="Error_ProjectFailedToLoad" xml:space="preserve">
     <value>Could not load the MSBuild project '{project}'.</value>
@@ -133,7 +133,7 @@
     <value>Could not find the global property 'UserSecretsId' in MSBuild project '{project}'. Ensure this property is set in the project or use the '--id' command line option.</value>
   </data>
   <data name="Error_ProjectPath_NotFound" xml:space="preserve">
-    <value>The project file '{0}' does not exist.</value>
+    <value>The file '{0}' does not exist.</value>
   </data>
   <data name="Message_ProjectAlreadyInitialized" xml:space="preserve">
     <value>The MSBuild project '{project}' has already been initialized with a UserSecretsId.</value>

--- a/src/Tools/dotnet-user-secrets/src/CommandLineOptions.cs
+++ b/src/Tools/dotnet-user-secrets/src/CommandLineOptions.cs
@@ -16,6 +16,7 @@ public class CommandLineOptions
     public bool IsHelp { get; private set; }
     public bool IsVerbose { get; private set; }
     public string Project { get; private set; }
+    public string File { get; private set; }
 
     public static CommandLineOptions Parse(string[] args, IConsole console)
     {
@@ -36,6 +37,9 @@ public class CommandLineOptions
         var optionProject = app.Option("-p|--project <PROJECT>", "Path to project. Defaults to searching the current directory.",
             CommandOptionType.SingleValue, inherited: true);
 
+        var optionFile = app.Option("-f|--file <FILE>", "Path to file-based app.",
+            CommandOptionType.SingleValue, inherited: true);
+
         var optionConfig = app.Option("-c|--configuration <CONFIGURATION>", "The project configuration to use. Defaults to 'Debug'.",
             CommandOptionType.SingleValue, inherited: true);
 
@@ -50,7 +54,7 @@ public class CommandLineOptions
         app.Command("remove", c => RemoveCommand.Configure(c, options));
         app.Command("list", c => ListCommand.Configure(c, options));
         app.Command("clear", c => ClearCommand.Configure(c, options));
-        app.Command("init", c => InitCommandFactory.Configure(c, options));
+        app.Command("init", c => InitCommandFactory.Configure(c, options, optionFile));
 
         // Show help information if no subcommand/option was specified.
         app.OnExecute(() => app.ShowHelp());
@@ -66,6 +70,12 @@ public class CommandLineOptions
         options.IsHelp = app.IsShowingInformation;
         options.IsVerbose = optionVerbose.HasValue();
         options.Project = optionProject.Value();
+        options.File = optionFile.Value();
+
+        if (options.File != null && options.Project != null)
+        {
+            throw new CommandParsingException(app, Resources.Error_ProjectAndFileOptions);
+        }
 
         return options;
     }

--- a/src/Tools/dotnet-user-secrets/src/Internal/InitCommand.cs
+++ b/src/Tools/dotnet-user-secrets/src/Internal/InitCommand.cs
@@ -16,13 +16,18 @@ public class InitCommandFactory : ICommand
 {
     public CommandLineOptions Options { get; }
 
-    internal static void Configure(CommandLineApplication command, CommandLineOptions options)
+    internal static void Configure(CommandLineApplication command, CommandLineOptions options, CommandOption optionFile)
     {
         command.Description = "Set a user secrets ID to enable secret storage";
         command.HelpOption();
 
         command.OnExecute(() =>
         {
+            if (optionFile.HasValue())
+            {
+                throw new CommandParsingException(command, Resources.Error_InitNotSupportedForFileBasedApps);
+            }
+
             options.Command = new InitCommandFactory(options);
         });
     }

--- a/src/Tools/dotnet-user-secrets/src/Program.cs
+++ b/src/Tools/dotnet-user-secrets/src/Program.cs
@@ -106,6 +106,6 @@ public class Program
         }
 
         var resolver = new ProjectIdResolver(reporter, _workingDirectory);
-        return resolver.Resolve(options.Project, options.Configuration);
+        return resolver.Resolve(options.Project ?? options.File, options.Configuration);
     }
 }

--- a/src/Tools/dotnet-user-secrets/src/Resources.resx
+++ b/src/Tools/dotnet-user-secrets/src/Resources.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -134,13 +134,13 @@ Use the '--help' flag to see info.</value>
     <value>No secrets configured for this application.</value>
   </data>
   <data name="Error_NoProjectsFound" xml:space="preserve">
-    <value>Could not find a MSBuild project file in '{projectPath}'. Specify which project to use with the --project option.</value>
+    <value>Could not find a MSBuild project file in '{projectPath}'. Specify which project to use with the --project option. Use --file option for file-based apps.</value>
   </data>
   <data name="Error_ProjectMissingId" xml:space="preserve">
     <value>Could not find the global property 'UserSecretsId' in MSBuild project '{project}'. Ensure this property is set in the project or use the '--id' command line option.</value>
   </data>
   <data name="Error_ProjectPath_NotFound" xml:space="preserve">
-    <value>The project file '{path}' does not exist.</value>
+    <value>The file '{path}' does not exist.</value>
   </data>
   <data name="Error_ProjectFailedToLoad" xml:space="preserve">
     <value>Could not load the MSBuild project '{project}'.</value>
@@ -168,5 +168,11 @@ Use the '--help' flag to see info.</value>
   </data>
   <data name="Message_SetUserSecretsIdForProject" xml:space="preserve">
     <value>Set UserSecretsId to '{userSecretsId}' for MSBuild project '{project}'.</value>
+  </data>
+  <data name="Error_ProjectAndFileOptions" xml:space="preserve">
+    <value>Cannot use both --file and --project options together.</value>
+  </data>
+  <data name="Error_InitNotSupportedForFileBasedApps" xml:space="preserve">
+    <value>Init command is currently not supported for file-based apps. Please add '#:property UserSecretsId=...' manually.</value>
   </data>
 </root>

--- a/src/Tools/dotnet-user-secrets/src/Resources.resx
+++ b/src/Tools/dotnet-user-secrets/src/Resources.resx
@@ -133,14 +133,8 @@ Use the '--help' flag to see info.</value>
   <data name="Error_No_Secrets_Found" xml:space="preserve">
     <value>No secrets configured for this application.</value>
   </data>
-  <data name="Error_NoProjectsFound" xml:space="preserve">
-    <value>Could not find a MSBuild project file in '{projectPath}'. Specify which project to use with the --project option. Use --file option for file-based apps.</value>
-  </data>
   <data name="Error_ProjectMissingId" xml:space="preserve">
     <value>Could not find the global property 'UserSecretsId' in MSBuild project '{project}'. Ensure this property is set in the project or use the '--id' command line option.</value>
-  </data>
-  <data name="Error_ProjectPath_NotFound" xml:space="preserve">
-    <value>The file '{path}' does not exist.</value>
   </data>
   <data name="Error_ProjectFailedToLoad" xml:space="preserve">
     <value>Could not load the MSBuild project '{project}'.</value>

--- a/src/Tools/dotnet-user-secrets/test/SecretManagerTests.cs
+++ b/src/Tools/dotnet-user-secrets/test/SecretManagerTests.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.IO;
 using System.Text;
 using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.AspNetCore.Tools;
 using Microsoft.Extensions.Configuration.UserSecrets;
 using Microsoft.Extensions.Configuration.UserSecrets.Tests;
 using Microsoft.Extensions.Tools.Internal;
@@ -64,7 +65,7 @@ public class SecretManagerTests : IClassFixture<UserSecretsTestFixture>
         var secretManager = CreateProgram();
 
         secretManager.RunInternal("list", "--project", projectPath);
-        Assert.Contains(Resources.FormatError_ProjectPath_NotFound(projectPath), _console.GetOutput());
+        Assert.Contains(SecretsHelpersResources.FormatError_ProjectPath_NotFound(projectPath), _console.GetOutput());
     }
 
     [Fact]

--- a/src/Tools/dotnet-user-secrets/test/UserSecretsTestFixture.cs
+++ b/src/Tools/dotnet-user-secrets/test/UserSecretsTestFixture.cs
@@ -52,6 +52,12 @@ public class UserSecretsTestFixture : IDisposable
         return CreateProject(userSecretsId);
     }
 
+    public string GetTempFileBasedApp(out string userSecretsId)
+    {
+        userSecretsId = Guid.NewGuid().ToString();
+        return CreateFileBasedApp(userSecretsId);
+    }
+
     public string CreateProject(string userSecretsId)
     {
         var projectPath = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "usersecretstest", Guid.NewGuid().ToString()));
@@ -63,20 +69,38 @@ public class UserSecretsTestFixture : IDisposable
             Path.Combine(projectPath.FullName, "TestProject.csproj"),
             string.Format(CultureInfo.InvariantCulture, ProjectTemplate, prop));
 
-        var id = userSecretsId;
+        AddToDisposables(userSecretsId, projectPath);
+
+        return projectPath.FullName;
+    }
+
+    public string CreateFileBasedApp(string userSecretsId)
+    {
+        var directory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "usersecretstest", Guid.NewGuid().ToString()));
+
+        File.WriteAllText(Path.Join(directory.FullName, "app.cs"), $"""
+            #:property UserSecretsId={userSecretsId}
+            Console.WriteLine();
+            """);
+
+        AddToDisposables(userSecretsId, directory);
+
+        return directory.FullName;
+    }
+
+    private void AddToDisposables(string userSecretsId, DirectoryInfo dir)
+    {
         _disposables.Push(() =>
         {
             try
             {
                 // may throw if id is bad
-                var secretsDir = Path.GetDirectoryName(PathHelper.GetSecretsPathFromSecretsId(id));
+                var secretsDir = Path.GetDirectoryName(PathHelper.GetSecretsPathFromSecretsId(userSecretsId));
                 TryDelete(secretsDir);
             }
             catch { }
         });
-        _disposables.Push(() => TryDelete(projectPath.FullName));
-
-        return projectPath.FullName;
+        _disposables.Push(() => TryDelete(dir.FullName));
     }
 
     private static void TryDelete(string directory)


### PR DESCRIPTION
# Support file-based apps in user-secrets

Makes the `dotnet user-secrets` tool work for file-based apps (via a new `--file` argument) analogously to how it works for project-based apps today.

## Description

Supports `dotnet user-secrets` commands for file-based apps except `dotnet user-secrets init` (currently you have to set `#:property UserSecretsId=...` manually but we plan to add support for implicit `UserSecretsId`s in file-based apps but the technical side of that is still being discussed).

Resolves https://github.com/dotnet/aspnetcore/issues/63440.

## Customer Impact

Driven by Aspire needs.

## Regression?

- [ ] Yes
- [x] No - this is a new feature

## Risk

- [ ] High
- [ ] Medium
- [x] Low - this is a new feature which shouldn't affect any existing features

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
