### PR TITLE
Changed initial culture detection

### DIFF
--- a/src/Components/Web.JS/src/GlobalExports.ts
+++ b/src/Components/Web.JS/src/GlobalExports.ts
@@ -74,6 +74,7 @@ export interface IBlazor {
     renderBatch?: (browserRendererId: number, batchAddress: Pointer) => void;
     getConfig?: (fileName: string) => Uint8Array | undefined;
     getApplicationEnvironment?: () => string;
+    getApplicationCulture?: () => string;
     dotNetCriticalError?: any;
     loadLazyAssembly?: any;
     loadSatelliteAssemblies?: any;

--- a/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
@@ -154,6 +154,7 @@ function prepareRuntimeConfig(options: Partial<WebAssemblyStartOptions>, onConfi
     }
 
     Blazor._internal.getApplicationEnvironment = () => loadedConfig.applicationEnvironment!;
+    Blazor._internal.getApplicationCulture = () => loadedConfig.applicationCulture!;  
 
     onConfigLoadedCallback?.(loadedConfig);
 

--- a/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
@@ -154,7 +154,7 @@ function prepareRuntimeConfig(options: Partial<WebAssemblyStartOptions>, onConfi
     }
 
     Blazor._internal.getApplicationEnvironment = () => loadedConfig.applicationEnvironment!;
-    Blazor._internal.getApplicationCulture = () => loadedConfig.applicationCulture!;  
+    Blazor._internal.getApplicationCulture = () => loadedConfig.applicationCulture!;
 
     onConfigLoadedCallback?.(loadedConfig);
 

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCultureProvider.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCultureProvider.cs
@@ -17,23 +17,19 @@ internal partial class WebAssemblyCultureProvider
     internal const string ReadSatelliteAssemblies = "window.Blazor._internal.readSatelliteAssemblies";
 
     // For unit testing.
-    internal WebAssemblyCultureProvider(CultureInfo initialCulture, CultureInfo initialUICulture)
+    internal WebAssemblyCultureProvider(CultureInfo initialCulture)
     {
         InitialCulture = initialCulture;
-        InitialUICulture = initialUICulture;
     }
 
     public static WebAssemblyCultureProvider? Instance { get; private set; }
 
     public CultureInfo InitialCulture { get; }
 
-    public CultureInfo InitialUICulture { get; }
-
     internal static void Initialize()
     {
         Instance = new WebAssemblyCultureProvider(
-            initialCulture: CultureInfo.GetCultureInfo(WebAssemblyCultureProviderInterop.GetApplicationCulture() ?? CultureInfo.InvariantCulture.Name),
-            initialUICulture: CultureInfo.CurrentUICulture);
+            initialCulture: CultureInfo.GetCultureInfo(WebAssemblyCultureProviderInterop.GetApplicationCulture() ?? CultureInfo.InvariantCulture.Name));
     }
 
     public void ThrowIfCultureChangeIsUnsupported()

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCultureProvider.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCultureProvider.cs
@@ -32,7 +32,7 @@ internal partial class WebAssemblyCultureProvider
     internal static void Initialize()
     {
         Instance = new WebAssemblyCultureProvider(
-            initialCulture: CultureInfo.CurrentCulture,
+            initialCulture: CultureInfo.GetCultureInfo(WebAssemblyCultureProviderInterop.GetApplicationCulture() ?? CultureInfo.InvariantCulture.Name),
             initialUICulture: CultureInfo.CurrentUICulture);
     }
 
@@ -48,8 +48,7 @@ internal partial class WebAssemblyCultureProvider
         // The current method is invoked as part of WebAssemblyHost.RunAsync i.e. after user code in Program.MainAsync has run
         // thus allows us to detect if the culture was changed by user code.
         if (Environment.GetEnvironmentVariable("__BLAZOR_SHARDED_ICU") == "1" &&
-            ((!CultureInfo.CurrentCulture.Name.Equals(InitialCulture.Name, StringComparison.Ordinal) ||
-              !CultureInfo.CurrentUICulture.Name.Equals(InitialUICulture.Name, StringComparison.Ordinal))))
+            (!CultureInfo.CurrentCulture.Name.Equals(InitialCulture.Name, StringComparison.Ordinal)))
         {
             throw new InvalidOperationException("Blazor detected a change in the application's culture that is not supported with the current project configuration. " +
                 "To change culture dynamically during startup, set <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData> in the application's project file.");
@@ -118,5 +117,8 @@ internal partial class WebAssemblyCultureProvider
     {
         [JSImport("INTERNAL.loadSatelliteAssemblies")]
         public static partial Task LoadSatelliteAssemblies(string[] culturesToLoad);
+
+        [JSImport("Blazor._internal.getApplicationCulture", "blazor-internal")]
+        public static partial string GetApplicationCulture();
     }
 }

--- a/src/Components/WebAssembly/WebAssembly/src/Services/IInternalJSImportMethods.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Services/IInternalJSImportMethods.cs
@@ -8,6 +8,8 @@ internal interface IInternalJSImportMethods
     string GetPersistedState();
 
     string GetApplicationEnvironment();
+    
+    string GetApplicationCulture();
 
     void AttachRootComponentToElement(string domElementSelector, int componentId, int rendererId);
 

--- a/src/Components/WebAssembly/WebAssembly/src/Services/InternalJSImportMethods.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Services/InternalJSImportMethods.cs
@@ -27,6 +27,9 @@ internal partial class InternalJSImportMethods : IInternalJSImportMethods
     public string GetApplicationEnvironment()
         => GetApplicationEnvironmentCore();
 
+    public string GetApplicationCulture()
+        => GetApplicationCultureCore();
+
     public void AttachRootComponentToElement(string domElementSelector, int componentId, int rendererId)
         => AttachRootComponentToElementCore(domElementSelector, componentId, rendererId);
 
@@ -71,6 +74,9 @@ internal partial class InternalJSImportMethods : IInternalJSImportMethods
 
     [JSImport("Blazor._internal.getApplicationEnvironment", "blazor-internal")]
     private static partial string GetApplicationEnvironmentCore();
+
+    [JSImport("Blazor._internal.getApplicationCulture", "blazor-internal")]
+    private static partial string GetApplicationCultureCore();
 
     [JSImport("Blazor._internal.attachRootComponentToElement", "blazor-internal")]
     private static partial void AttachRootComponentToElementCore(string domElementSelector, int componentId, int rendererId);

--- a/src/Components/WebAssembly/WebAssembly/test/Hosting/WebAssemblyCultureProviderTest.cs
+++ b/src/Components/WebAssembly/WebAssembly/test/Hosting/WebAssemblyCultureProviderTest.cs
@@ -47,7 +47,7 @@ public class WebAssemblyCultureProviderTest
         try
         {
             // WebAssembly is initialized with en-US
-            var cultureProvider = new WebAssemblyCultureProvider(new CultureInfo("en-US"), new CultureInfo("en-US"));
+            var cultureProvider = new WebAssemblyCultureProvider(new CultureInfo("en-US"));
 
             // Culture is changed to fr-FR as part of the app
             using var cultureReplacer = new CultureReplacer("fr-FR");

--- a/src/Components/WebAssembly/WebAssembly/test/Hosting/WebAssemblyHostTest.cs
+++ b/src/Components/WebAssembly/WebAssembly/test/Hosting/WebAssemblyHostTest.cs
@@ -97,7 +97,7 @@ public class WebAssemblyHostTest
     private class TestSatelliteResourcesLoader : WebAssemblyCultureProvider
     {
         internal TestSatelliteResourcesLoader()
-            : base(CultureInfo.CurrentCulture, CultureInfo.CurrentUICulture)
+            : base(CultureInfo.CurrentCulture)
         {
         }
 

--- a/src/Components/WebAssembly/WebAssembly/test/TestInternalJSImportMethods.cs
+++ b/src/Components/WebAssembly/WebAssembly/test/TestInternalJSImportMethods.cs
@@ -16,6 +16,9 @@ internal sealed class TestInternalJSImportMethods : IInternalJSImportMethods
 
     public string GetApplicationEnvironment()
         => _environment;
+    
+    public string GetApplicationCulture()
+        => "en-US";
 
     public string GetPersistedState()
         => null;


### PR DESCRIPTION
# Changed initial culture detection

## Description:

This pull request introduces support for retrieving and managing the application's culture information throughout the Blazor WebAssembly stack. The main changes include adding a new method for accessing the application culture from both JavaScript and .NET, updating initialization logic to use this value, and ensuring the culture can be accessed and tested consistently.

## Logic behind change:

The previously introduced method of checking the initial culture of the application was flawed. In the meaning, it held the culture that was set after before `WebAssemblyHostBuilder.CreateDefault(args)` run as initial. It was not correct. We should assume that culture that runtime detected as default. The additional change in runtime (https://github.com/dotnet/runtime/pull/119269) was made to make this fix possible. 

We as well checked the differences between initial UI culture and the current UI culture, which is not correct, because browser and JS do not divide between UI culture and culture. Therefore some unprompted errors could've been thrown. 

### Changes:
* Added a new method `getApplicationCulture` and implemented it in the runtime configuration setup, allowing JavaScript to expose the application's culture to .NET. 
* Updated initialization logic in `WebAssemblyCultureProvider` to use the culture provided by JavaScript, falling back to invariant culture if unavailable. 
* Extended the `IInternalJSImportMethods` interface and its implementation to include the new `GetApplicationCulture` method, enabling .NET code to retrieve the culture via interop. 
* Modified culture change detection logic to only check for changes in `CurrentCulture` and not `CurrentUICulture`, refining the conditions under which an exception is thrown for unsupported culture changes.

Fixes #37258
 