### PR TITLE
Fix SuppliesCancellationTokenThatSignalsWhenRevalidationLoopIsBeingDiscarded flake

### DIFF
--- a/src/Components/Server/test/Circuits/RevalidatingServerAuthenticationStateProviderTest.cs
+++ b/src/Components/Server/test/Circuits/RevalidatingServerAuthenticationStateProviderTest.cs
@@ -142,7 +142,6 @@ public class RevalidatingServerAuthenticationStateProviderTest
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/60472")]
     public async Task SuppliesCancellationTokenThatSignalsWhenRevalidationLoopIsBeingDiscarded()
     {
         // Arrange
@@ -174,9 +173,11 @@ public class RevalidatingServerAuthenticationStateProviderTest
         Assert.Equal("different user", (await provider.GetAuthenticationStateAsync()).User.Identity.Name);
 
         // Subsequent revalidation can complete successfully
+        // We are checking all new logs because the revalidation loop iteration
+        // may happen multiple times (this made the test flaky in the past)
         await provider.NextValidateAuthenticationStateAsyncCall;
-        Assert.Collection(provider.RevalidationCallLog.Skip(1),
-             call => Assert.Equal("different user", call.AuthenticationState.User.Identity.Name));
+        Assert.All(provider.RevalidationCallLog.Skip(1),
+            call => Assert.Equal("different user", call.AuthenticationState.User.Identity.Name));
     }
 
     [Fact]


### PR DESCRIPTION
Fixes and unquarantines `Microsoft.AspNetCore.Components.RevalidatingServerAuthenticationStateProviderTest.SuppliesCancellationTokenThatSignalsWhenRevalidationLoopIsBeingDiscarded`.

The test was flaky because the loop in `RevalidatingServerAuthenticationStateProvider.RevalidationLoop` can do multiple iterations between the relevant lines of the test. This means that `ValidateAuthenticationStateAsync` is (successfully) fired multiple times and logs more than one (identical) logs. If I understand the context correctly, this is a legitimate outcome and the assertion should not check for strict log collection equivalnce, only that the remaining logs in the collection are as expected.

When runnning the test locally with the revalidation interval set to 3ms instead of 50ms, I got ~1/400 failed runs. With the change, no runs failed after 3000+ executions.

Alternatively, the `TestRevalidatingServerAuthenticationStateProvider` class could be rewritten to allow stricter dependable assertions. However, this solution seems cost-efficient.

Fixes #60472