### PR TITLE
Re-enable template local validation scripts on CI

### DIFF
--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -619,8 +619,6 @@ stages:
         agentOs: Windows
         isAzDOTestingJob: true
         timeoutInMinutes: 240
-        # Temporarily disabled due to https://github.com/dotnet/aspnetcore/issues/63140
-        condition: 'false'
         steps:
         - script: git submodule update --init
           displayName: Update submodules


### PR DESCRIPTION
- Enables back the `Locally` scripts running on CI. The sdk version got bumped since the PR that disabled it.

Proof that it was running: [log](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1138270&view=logs&j=d9092465-e29c-5735-3051-a3146222728b&t=fe9475a8-32a4-5dd3-2fbb-dc2c1db4af95).

<img width="732" height="146" alt="image" src="https://github.com/user-attachments/assets/5f779522-484a-41dc-a7de-08af93e1205e" />


Fixes #63140
