### PR TITLE
Rename according to feedback.

### DIFF
--- a/src/Components/WebAssembly/testassets/StandaloneApp/Pages/Index.razor
+++ b/src/Components/WebAssembly/testassets/StandaloneApp/Pages/Index.razor
@@ -1,5 +1,5 @@
 ﻿@page "/"
 
-<h1 id="session-storage-anchor">Hello, world!</h1>
+<h1 id="session-storage-marker">Hello, world!</h1>
 
 Welcome to your new app.

--- a/src/Components/test/E2ETest/ServerRenderingTests/EnhancedNavigationTestUtil.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/EnhancedNavigationTestUtil.cs
@@ -89,7 +89,7 @@ public static class EnhancedNavigationTestUtil
     {
         // Navigate to the test origin to ensure the browser is on the correct state to access sessionStorage
         fixture.Navigate($"{fixture.ServerPathBase}/");
-        fixture.Browser.Exists(By.Id("session-storage-anchor"));
+        fixture.Browser.Exists(By.Id("session-storage-marker"));
     }
 
     public static long GetScrollY(this IWebDriver browser)

--- a/src/Components/test/testassets/BasicTestApp/Index.razor
+++ b/src/Components/test/testassets/BasicTestApp/Index.razor
@@ -2,7 +2,7 @@
 @using System.Web
 @inject NavigationManager NavigationManager
 
-<p id="session-storage-anchor"></p>
+<p id="session-storage-marker"></p>
 <div id="test-selector">
     Select test:
     <select id="test-selector-select" @bind=SelectedComponentTypeName>

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Index.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Index.razor
@@ -2,6 +2,6 @@
 
 <PageTitle>Home</PageTitle>
 
-<h1 id="session-storage-anchor">Hello</h1>
+<h1 id="session-storage-marker">Hello</h1>
 
 <p>This is a Razor Component endpoint.</p>


### PR DESCRIPTION
## Description

- Rename `anchor` to `marker`.
- This PR does not remove the exception flow from the enhanced nav supression utilities, as suggested in https://github.com/dotnet/aspnetcore/pull/63132#discussion_r2319135751. All the operations on browser/driver when the session is closed result in an "invalid session id" exception. At the same time, there is no property that would not trigger an exception and that we can check to define if the browser is still running. Even if we try an approach of finding the process with the browser to check its `HasExited` property, we are not able to find it without executing code on the webdriver - that will also throw the exception in question.

Follow up for #63132