### PR TITLE
Fix unofficial build

### DIFF
--- a/.azure/pipelines/ci-unofficial.yml
+++ b/.azure/pipelines/ci-unofficial.yml
@@ -203,6 +203,7 @@ extends:
                     -noBuildNative
                     $(_BuildArgs)
                     $(_InternalRuntimeDownloadArgs)
+                    /p:_DevBuild=true
             env:
               MSBUILDUSESERVER: "1"
             displayName: Build SiteExtension

--- a/src/SiteExtensions/Directory.Build.props
+++ b/src/SiteExtensions/Directory.Build.props
@@ -8,6 +8,7 @@
     <BaseIntermediateOutputPath Condition="'$(DotNetBuildPass)' == '2'">$([MSBuild]::NormalizeDirectory('$(BaseIntermediateOutputPath)', '$(TargetArchitecture)'))</BaseIntermediateOutputPath>
     <IntermediateOutputPath Condition="'$(PlatformName)' == 'AnyCPU' AND '$(DotNetBuildPass)' == '2'">$([MSBuild]::NormalizeDirectory('$(BaseIntermediateOutputPath)', '$(Configuration)'))</IntermediateOutputPath>
     <IntermediateOutputPath Condition="'$(PlatformName)' != 'AnyCPU' AND '$(DotNetBuildPass)' == '2'">$([MSBuild]::NormalizeDirectory('$(BaseIntermediateOutputPath)', '$(PlatformName)', '$(Configuration)'))</IntermediateOutputPath>
+    <NoWarn Condition="'$(_DevBuild)' == 'true'">$(NoWarn);NU3027</NoWarn>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
SiteExtensions build consumes packages that it expects to be real-signed. The unofficial pipeline does test-signing instead, so we should ignore that error there.

Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2785826&view=results