### PR TITLE
[Blazor] Disable preloading for enhanced navigation

### DIFF
--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Streaming.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Streaming.cs
@@ -324,7 +324,7 @@ internal partial class EndpointHtmlRenderer
         }
     }
 
-    private static bool IsProgressivelyEnhancedNavigation(HttpRequest request)
+    internal static bool IsProgressivelyEnhancedNavigation(HttpRequest request)
     {
         // For enhanced nav, the Blazor JS code controls the "accept" header precisely, so we can be very specific about the format
         var accept = request.Headers.Accept;

--- a/src/Components/Endpoints/src/Rendering/SSRRenderModeBoundary.cs
+++ b/src/Components/Endpoints/src/Rendering/SSRRenderModeBoundary.cs
@@ -124,6 +124,11 @@ internal class SSRRenderModeBoundary : IComponent
 
     private void PreloadWebAssemblyAssets()
     {
+        if (EndpointHtmlRenderer.IsProgressivelyEnhancedNavigation(_httpContext.Request))
+        {
+            return;
+        }
+
         var preloads = _httpContext.GetEndpoint()?.Metadata.GetMetadata<ResourcePreloadCollection>();
         if (preloads != null && preloads.TryGetAssets("webassembly", out var preloadAssets))
         {

--- a/src/Components/Web.JS/src/Rendering/DomMerging/AttributeSync.ts
+++ b/src/Components/Web.JS/src/Rendering/DomMerging/AttributeSync.ts
@@ -43,7 +43,7 @@ export function synchronizeAttributes(destination: Element, source: Element) {
   }
 }
 
-export function attributeSetsAreIdentical(destAttrs: NamedNodeMap, sourceAttrs: NamedNodeMap): boolean {
+function attributeSetsAreIdentical(destAttrs: NamedNodeMap, sourceAttrs: NamedNodeMap): boolean {
   const destAttrsLength = destAttrs.length;
   if (destAttrsLength !== sourceAttrs.length) {
     return false;

--- a/src/Components/Web.JS/src/Rendering/DomMerging/AttributeSync.ts
+++ b/src/Components/Web.JS/src/Rendering/DomMerging/AttributeSync.ts
@@ -43,7 +43,7 @@ export function synchronizeAttributes(destination: Element, source: Element) {
   }
 }
 
-function attributeSetsAreIdentical(destAttrs: NamedNodeMap, sourceAttrs: NamedNodeMap): boolean {
+export function attributeSetsAreIdentical(destAttrs: NamedNodeMap, sourceAttrs: NamedNodeMap): boolean {
   const destAttrsLength = destAttrs.length;
   if (destAttrsLength !== sourceAttrs.length) {
     return false;


### PR DESCRIPTION
Enhanced navigation presents several challenges for preloading
- DOM merging: Preloading elements may be different between pages which may result in different order, resulting in removing and adding elements, resulting in browser triggering more preload requests than necessary.
- WebAssembly runtime state: When navigating between pages, WebAssembly is not restarting, only for the first page we need a preloading element.

This PR disables generating preloading elements from `ResourcePreloader` when the HTTP request is for enhanced navigation.
It alsore removes previous attempt to solve the DOM merging problem from https://github.com/dotnet/aspnetcore/pull/63239