### PR TITLE
[Blazor] Clear RootTypeCache cache on HotReload

### DIFF
--- a/src/Components/Server/src/Microsoft.AspNetCore.Components.Server.csproj
+++ b/src/Components/Server/src/Microsoft.AspNetCore.Components.Server.csproj
@@ -39,6 +39,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(ComponentsSharedSourceRoot)src\HotReloadManager.cs" LinkBase="HotReload" />
     <Compile Include="$(ComponentsSharedSourceRoot)src\CacheHeaderSettings.cs" Link="Shared\CacheHeaderSettings.cs" />
     <Compile Include="$(ComponentsSharedSourceRoot)src\ArrayBuilder.cs" LinkBase="Circuits" />
     <Compile Include="$(ComponentsSharedSourceRoot)src\RenderBatchWriter.cs" LinkBase="Circuits" />

--- a/src/Components/Shared/src/RootTypeCache.cs
+++ b/src/Components/Shared/src/RootTypeCache.cs
@@ -26,7 +26,9 @@ internal sealed class RootTypeCache
         {
             HotReloadManager.Default.OnDeltaApplied += ClearCache;
         }
-    }
+    };
+
+    private static void ClearCache() => _typeToKeyLookUp.Clear();
 #endif
 
     public Type? GetRootType(string assembly, string type)

--- a/src/Components/Shared/src/RootTypeCache.cs
+++ b/src/Components/Shared/src/RootTypeCache.cs
@@ -1,12 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.Components.HotReload;
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-#if COMPONENTS
-using Microsoft.AspNetCore.Components.HotReload;
-#endif
 
 #if COMPONENTS
 namespace Microsoft.AspNetCore.Components.Infrastructure;
@@ -15,21 +13,27 @@ namespace Microsoft.AspNetCore.Components;
 #endif
 
 // A cache for root component types
-internal sealed class RootTypeCache
+internal sealed class RootTypeCache : IDisposable
 {
     private readonly ConcurrentDictionary<Key, Type?> _typeToKeyLookUp = new();
 
-#if COMPONENTS
-    static RootTypeCache()
+    public RootTypeCache()
     {
         if (HotReloadManager.Default.MetadataUpdateSupported)
         {
             HotReloadManager.Default.OnDeltaApplied += ClearCache;
         }
-    };
+    }
 
-    private static void ClearCache() => _typeToKeyLookUp.Clear();
-#endif
+    internal void ClearCache() => _typeToKeyLookUp.Clear();
+
+    public void Dispose()
+    {
+        if (HotReloadManager.Default.MetadataUpdateSupported)
+        {
+            HotReloadManager.Default.OnDeltaApplied -= ClearCache;
+        }
+    }
 
     public Type? GetRootType(string assembly, string type)
     {

--- a/src/Components/Shared/src/RootTypeCache.cs
+++ b/src/Components/Shared/src/RootTypeCache.cs
@@ -4,6 +4,9 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+#if COMPONENTS
+using Microsoft.AspNetCore.Components.HotReload;
+#endif
 
 #if COMPONENTS
 namespace Microsoft.AspNetCore.Components.Infrastructure;
@@ -15,6 +18,16 @@ namespace Microsoft.AspNetCore.Components;
 internal sealed class RootTypeCache
 {
     private readonly ConcurrentDictionary<Key, Type?> _typeToKeyLookUp = new();
+
+#if COMPONENTS
+    static RootTypeCache()
+    {
+        if (HotReloadManager.Default.MetadataUpdateSupported)
+        {
+            HotReloadManager.Default.OnDeltaApplied += ClearCache;
+        }
+    }
+#endif
 
     public Type? GetRootType(string assembly, string type)
     {

--- a/src/Components/WebAssembly/WebAssembly/src/Microsoft.AspNetCore.Components.WebAssembly.csproj
+++ b/src/Components/WebAssembly/WebAssembly/src/Microsoft.AspNetCore.Components.WebAssembly.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(ComponentsSharedSourceRoot)src\HotReloadManager.cs" LinkBase="HotReload" />
     <Compile Include="$(ComponentsSharedSourceRoot)src\BrowserNavigationManagerInterop.cs" />
     <Compile Include="$(ComponentsSharedSourceRoot)src\PullFromJSDataStream.cs" />
     <Compile Include="$(ComponentsSharedSourceRoot)src\TransmitDataStreamToJS.cs" />


### PR DESCRIPTION
- Clear `RootTypeCache` on HotReload.
- The `HotReloadManager.cs` is now included in Components.Server & Components.WebAssembly as well.
- The `RootTypeCache` implements `IDisposable` although at the moment all usages are "singleton".

Fixes https://github.com/dotnet/aspnetcore/issues/63286