### PR TITLE
Unquarantine `RadioButtonGetsResetAfterSubmittingEnhancedForm`

### DIFF
--- a/src/Components/test/E2ETest/ServerRenderingTests/EnhancedNavigationTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/EnhancedNavigationTest.cs
@@ -520,7 +520,6 @@ public class EnhancedNavigationTest : ServerTestBase<BasicTestAppServerSiteFixtu
     [Theory]
     [InlineData("server")]
     [InlineData("wasm")]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/61143")]
     public void NavigationManagerUriGetsUpdatedOnEnhancedNavigation_BothServerAndWebAssembly(string runtimeThatInvokedNavigation)
     {
         Navigate($"{ServerPathBase}/nav");

--- a/src/Components/test/E2ETest/ServerRenderingTests/EnhancedNavigationTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/EnhancedNavigationTest.cs
@@ -520,6 +520,7 @@ public class EnhancedNavigationTest : ServerTestBase<BasicTestAppServerSiteFixtu
     [Theory]
     [InlineData("server")]
     [InlineData("wasm")]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/61143")]
     public void NavigationManagerUriGetsUpdatedOnEnhancedNavigation_BothServerAndWebAssembly(string runtimeThatInvokedNavigation)
     {
         Navigate($"{ServerPathBase}/nav");

--- a/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
@@ -1344,19 +1344,19 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
     {
         GoTo("forms/form-with-checkbox-and-radio-button");
 
-        Assert.False(Browser.Exists(By.Id("checkbox")).Selected);
-        Assert.False(Browser.Exists(By.Id("radio-button")).Selected);
+        WaitAssert.False(Browser, () => Browser.Exists(By.Id("checkbox")).Selected);
+        WaitAssert.False(Browser, () => Browser.Exists(By.Id("radio-button")).Selected);
 
         Browser.Exists(By.Id("checkbox")).Click();
         Browser.Exists(By.Id("radio-button")).Click();
 
-        Assert.True(Browser.Exists(By.Id("checkbox")).Selected);
-        Assert.True(Browser.Exists(By.Id("radio-button")).Selected);
+        WaitAssert.True(Browser, () => Browser.Exists(By.Id("checkbox")).Selected);
+        WaitAssert.True(Browser, () => Browser.Exists(By.Id("radio-button")).Selected);
 
         Browser.Exists(By.Id("submit-button")).Click();
 
-        Assert.False(Browser.Exists(By.Id("checkbox")).Selected);
-        Assert.False(Browser.Exists(By.Id("radio-button")).Selected);
+        WaitAssert.False(Browser, () => Browser.Exists(By.Id("checkbox")).Selected);
+        WaitAssert.False(Browser, () => Browser.Exists(By.Id("radio-button")).Selected);
     }
 
     [Fact]

--- a/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
@@ -1340,7 +1340,6 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/61144")]
     public void RadioButtonGetsResetAfterSubmittingEnhancedForm()
     {
         GoTo("forms/form-with-checkbox-and-radio-button");


### PR DESCRIPTION
Investigating failures from https://github.com/dotnet/aspnetcore/pull/63534, I found out that these issues that fail on net8 have 100% pass rate on net9. They can be enabled.

Issues that they refer to are resolved for main. On main we added `WaitAssert` in the place that was reported originally as failing. We can backport that change as well.