### PR TITLE
Skip unfixable NavigationLock tests

### DIFF
--- a/src/Components/test/E2ETest/ServerExecutionTests/NavigationLockPrerenderingTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/NavigationLockPrerenderingTest.cs
@@ -26,7 +26,23 @@ public class NavigationLockPrerenderingTest : ServerTestBase<BasicTestAppServerS
 
     [Fact]
     [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/57153")]
-    public void NavigationIsLockedAfterPrerendering()
+    public void ExternalNavigationIsLockedAfterPrerendering()
+    {
+        Navigate("/locked-navigation");
+
+        // Assert that the component rendered successfully
+        Browser.Equal("Prevented navigations: 0", () => Browser.FindElement(By.Id("num-prevented-navigations")).Text);
+
+        BeginInteractivity();
+
+        // Assert that external navigations are blocked
+        Browser.Navigate().GoToUrl("about:blank");
+        Browser.SwitchTo().Alert().Dismiss();
+        Browser.Equal("Prevented navigations: 0", () => Browser.FindElement(By.Id("num-prevented-navigations")).Text);
+    }
+
+    [Fact]
+    public void InternalNavigationIsLockedAfterPrerendering()
     {
         Navigate("/locked-navigation");
 
@@ -37,11 +53,6 @@ public class NavigationLockPrerenderingTest : ServerTestBase<BasicTestAppServerS
 
         // Assert that internal navigations are blocked
         Browser.Click(By.Id("internal-navigation-link"));
-        Browser.Equal("Prevented navigations: 1", () => Browser.FindElement(By.Id("num-prevented-navigations")).Text);
-
-        // Assert that external navigations are blocked
-        Browser.Navigate().GoToUrl("about:blank");
-        Browser.SwitchTo().Alert().Dismiss();
         Browser.Equal("Prevented navigations: 1", () => Browser.FindElement(By.Id("num-prevented-navigations")).Text);
     }
 

--- a/src/Components/test/E2ETest/ServerExecutionTests/NavigationLockPrerenderingTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/NavigationLockPrerenderingTest.cs
@@ -24,8 +24,7 @@ public class NavigationLockPrerenderingTest : ServerTestBase<BasicTestAppServerS
     public override Task InitializeAsync()
         => InitializeAsync(BrowserFixture.RoutingTestContext);
 
-    // See https://github.com/dotnet/aspnetcore/issues/57153
-    [Fact(Skip = "BeforeUnload alert does not work with Selenium/ChromeDriver after update")]
+    [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/57153")]
     public void ExternalNavigationIsLockedAfterPrerendering()
     {
         Navigate("/locked-navigation");

--- a/src/Components/test/E2ETest/ServerExecutionTests/NavigationLockPrerenderingTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/NavigationLockPrerenderingTest.cs
@@ -24,8 +24,8 @@ public class NavigationLockPrerenderingTest : ServerTestBase<BasicTestAppServerS
     public override Task InitializeAsync()
         => InitializeAsync(BrowserFixture.RoutingTestContext);
 
-    [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/57153")]
+    // See https://github.com/dotnet/aspnetcore/issues/57153
+    [Fact(Skip = "BeforeUnload alert does not work with Selenium/ChromeDriver after update")]
     public void ExternalNavigationIsLockedAfterPrerendering()
     {
         Navigate("/locked-navigation");

--- a/src/Components/test/E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/E2ETest/Tests/RoutingTest.cs
@@ -1155,8 +1155,7 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
         Browser.Equal("1", () => app.FindElement(By.Id("location-changed-count"))?.Text);
     }
 
-    // See https://github.com/dotnet/aspnetcore/issues/57153
-    [Fact(Skip = "BeforeUnload alert does not work with Selenium/ChromeDriver after update")]
+    [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/57153")]
     public void NavigationLock_CanBlockExternalNavigation()
     {
         SetUrlViaPushState("/");

--- a/src/Components/test/E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/E2ETest/Tests/RoutingTest.cs
@@ -1155,8 +1155,8 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
         Browser.Equal("1", () => app.FindElement(By.Id("location-changed-count"))?.Text);
     }
 
-    [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/57153")]
+    // See https://github.com/dotnet/aspnetcore/issues/57153
+    [Fact(Skip = "BeforeUnload alert does not work with Selenium/ChromeDriver after update")]
     public void NavigationLock_CanBlockExternalNavigation()
     {
         SetUrlViaPushState("/");


### PR DESCRIPTION
- Skips tests that involve use of the `NavigationLock` component to prevent external navigation. This feature cannot be tested properly after a Selenium/ChromeDriver update which caused the navigation confirmation alert to not be displayed.
- Splits a `NavigationLock` test into two methods to cover internal and external navigation separately. Only the latter needs to be skipped.

We agreed to use this as a temporary solution for #57153 