### PR TITLE
[release/8.0] Use wait assert in flaky tests

### DIFF
--- a/src/Components/test/E2ETest/ServerRenderingTests/EnhancedNavigationTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/EnhancedNavigationTest.cs
@@ -526,13 +526,21 @@ public class EnhancedNavigationTest : ServerTestBase<BasicTestAppServerSiteFixtu
 
         Browser.Exists(By.TagName("nav")).FindElement(By.LinkText("LocationChanged/LocationChanging event (server-and-wasm)")).Click();
         Browser.Equal("Page with location changed components", () => Browser.Exists(By.TagName("h1")).Text);
-        Assert.EndsWith("/nav/location-changed/server-and-wasm", Browser.Exists(By.Id("nav-uri-server")).Text);
-        Assert.EndsWith("/nav/location-changed/server-and-wasm", Browser.Exists(By.Id("nav-uri-wasm")).Text);
+        Browser.True(() => Browser.Exists(By.Id("nav-uri-server")).Text.EndsWith(
+            "/nav/location-changed/server-and-wasm",
+            StringComparison.Ordinal));
+        Browser.True(() => Browser.Exists(By.Id("nav-uri-wasm")).Text.EndsWith(
+            "/nav/location-changed/server-and-wasm",
+            StringComparison.Ordinal));
 
         Browser.Exists(By.Id($"update-query-string-{runtimeThatInvokedNavigation}")).Click();
 
-        Assert.EndsWith($"/nav/location-changed/server-and-wasm?query=1", Browser.Exists(By.Id($"nav-uri-server")).Text);
-        Assert.EndsWith($"/nav/location-changed/server-and-wasm?query=1", Browser.Exists(By.Id($"nav-uri-wasm")).Text);
+        Browser.True(() => Browser.Exists(By.Id("nav-uri-server")).Text.EndsWith(
+            "/nav/location-changed/server-and-wasm?query=1",
+            StringComparison.Ordinal));
+        Browser.True(() => Browser.Exists(By.Id("nav-uri-wasm")).Text.EndsWith(
+            "/nav/location-changed/server-and-wasm?query=1",
+            StringComparison.Ordinal));
     }
 
     [Theory]

--- a/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
@@ -1344,19 +1344,19 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
     {
         GoTo("forms/form-with-checkbox-and-radio-button");
 
-        Assert.False(Browser.Exists(By.Id("checkbox")).Selected);
-        Assert.False(Browser.Exists(By.Id("radio-button")).Selected);
+        WaitAssert.False(Browser, () => Browser.Exists(By.Id("checkbox")).Selected);
+        WaitAssert.False(Browser, () => Browser.Exists(By.Id("radio-button")).Selected);
 
         Browser.Exists(By.Id("checkbox")).Click();
         Browser.Exists(By.Id("radio-button")).Click();
 
-        Assert.True(Browser.Exists(By.Id("checkbox")).Selected);
-        Assert.True(Browser.Exists(By.Id("radio-button")).Selected);
+        WaitAssert.True(Browser, () => Browser.Exists(By.Id("checkbox")).Selected);
+        WaitAssert.True(Browser, () => Browser.Exists(By.Id("radio-button")).Selected);
 
         Browser.Exists(By.Id("submit-button")).Click();
 
-        Assert.False(Browser.Exists(By.Id("checkbox")).Selected);
-        Assert.False(Browser.Exists(By.Id("radio-button")).Selected);
+        WaitAssert.False(Browser, () => Browser.Exists(By.Id("checkbox")).Selected);
+        WaitAssert.False(Browser, () => Browser.Exists(By.Id("radio-button")).Selected);
     }
 
     [Fact]

--- a/src/SignalR/server/StackExchangeRedis/test/RedisEndToEnd.cs
+++ b/src/SignalR/server/StackExchangeRedis/test/RedisEndToEnd.cs
@@ -184,6 +184,7 @@ public class RedisEndToEndTests : VerifiableLoggedTest
     [ConditionalTheory]
     [SkipIfDockerNotPresent]
     [MemberData(nameof(TransportTypesAndProtocolTypes))]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/63582")]
     public async Task CanSendAndReceiveUserMessagesUserNameWithPatternIsTreatedAsLiteral(HttpTransportType transportType, string protocolName)
     {
         using (StartVerifiableLog())


### PR DESCRIPTION
- Backport of https://github.com/dotnet/aspnetcore/pull/63556

It was done to main branch as well. The pass rate without this PR is 20%. This PR checks if just backporting the assert fix is enough or was there a bigger framework fix between ne9 and ne8. After 6 runs the failure was not reproduced. If it's not fully fixed then at least it significantly improved the pass rate.

- Fixes https://github.com/dotnet/aspnetcore/issues/61143. 

It used to have 0% pass rate before this PR. With the fix, it did not fail yet.

- Quarantine test that fails on every run and is not related to the changes in this PR: https://github.com/dotnet/aspnetcore/issues/63582.
