### PR TITLE
Add Endpoint property to HttpContext and DefaultHttpContext

### DIFF
--- a/src/Http/Http.Abstractions/src/HttpContext.cs
+++ b/src/Http/Http.Abstractions/src/HttpContext.cs
@@ -73,6 +73,15 @@ public abstract class HttpContext
     public abstract ISession Session { get; set; }
 
     /// <summary>
+    /// Gets or sets the <see cref="Endpoint"/> for the current request.
+    /// </summary>
+    /// <remarks>
+    /// The endpoint for a request is typically set by routing middleware. A request might not have
+    /// an endpoint if routing middleware hasn't run yet, or the request didn't match a route.
+    /// </remarks>
+    public abstract Endpoint? Endpoint { get; set; }
+
+    /// <summary>
     /// Aborts the connection underlying this request.
     /// </summary>
     public abstract void Abort();
@@ -90,7 +99,7 @@ public abstract class HttpContext
         public HttpContextFeatureDebugView Features => new HttpContextFeatureDebugView(_context.Features);
         public HttpRequest Request => _context.Request;
         public HttpResponse Response => _context.Response;
-        public Endpoint? Endpoint => _context.GetEndpoint();
+        public Endpoint? Endpoint => _context.Endpoint;
         public ConnectionInfo Connection => _context.Connection;
         public WebSocketManager WebSockets => _context.WebSockets;
         public ClaimsPrincipal User => _context.User;

--- a/src/Http/Http.Abstractions/src/HttpContext.cs
+++ b/src/Http/Http.Abstractions/src/HttpContext.cs
@@ -79,7 +79,11 @@ public abstract class HttpContext
     /// The endpoint for a request is typically set by routing middleware. A request might not have
     /// an endpoint if routing middleware hasn't run yet, or the request didn't match a route.
     /// </remarks>
-    public abstract Endpoint? Endpoint { get; set; }
+    public virtual Endpoint? Endpoint
+    {
+        get => this.GetEndpoint();
+        set => this.SetEndpoint(value);
+    }
 
     /// <summary>
     /// Aborts the connection underlying this request.

--- a/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
@@ -1,6 +1,6 @@
 #nullable enable
-abstract Microsoft.AspNetCore.Http.HttpContext.Endpoint.get -> Microsoft.AspNetCore.Http.Endpoint?
-abstract Microsoft.AspNetCore.Http.HttpContext.Endpoint.set -> void
+virtual Microsoft.AspNetCore.Http.HttpContext.Endpoint.get -> Microsoft.AspNetCore.Http.Endpoint?
+virtual Microsoft.AspNetCore.Http.HttpContext.Endpoint.set -> void
 Microsoft.AspNetCore.Antiforgery.CsrfProtectionResult
 Microsoft.AspNetCore.Antiforgery.CsrfProtectionResult.IsAllowed.get -> bool
 static Microsoft.AspNetCore.Antiforgery.CsrfProtectionResult.Allowed() -> Microsoft.AspNetCore.Antiforgery.CsrfProtectionResult!

--- a/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+abstract Microsoft.AspNetCore.Http.HttpContext.Endpoint.get -> Microsoft.AspNetCore.Http.Endpoint?
+abstract Microsoft.AspNetCore.Http.HttpContext.Endpoint.set -> void
 Microsoft.AspNetCore.Antiforgery.CsrfProtectionResult
 Microsoft.AspNetCore.Antiforgery.CsrfProtectionResult.IsAllowed.get -> bool
 static Microsoft.AspNetCore.Antiforgery.CsrfProtectionResult.Allowed() -> Microsoft.AspNetCore.Antiforgery.CsrfProtectionResult!

--- a/src/Http/Http.Abstractions/test/EndpointHttpContextExtensionsTests.cs
+++ b/src/Http/Http.Abstractions/test/EndpointHttpContextExtensionsTests.cs
@@ -142,6 +142,72 @@ public class EndpointHttpContextExtensionsTests
         Assert.Equal(initialEndpoint, endpoint);
     }
 
+    [Fact]
+    public void EndpointProperty_Get_ReturnsNullByDefault()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+
+        // Act
+        var endpoint = context.Endpoint;
+
+        // Assert
+        Assert.Null(endpoint);
+    }
+
+    [Fact]
+    public void EndpointProperty_SetAndGet_Roundtrip()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        var testEndpoint = new Endpoint(c => Task.CompletedTask, EndpointMetadataCollection.Empty, "Test endpoint");
+
+        // Act
+        context.Endpoint = testEndpoint;
+        var retrievedEndpoint = context.Endpoint;
+
+        // Assert
+        Assert.Equal(testEndpoint, retrievedEndpoint);
+    }
+
+    [Fact]
+    public void EndpointProperty_SetNull_ClearsEndpoint()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        var testEndpoint = new Endpoint(c => Task.CompletedTask, EndpointMetadataCollection.Empty, "Test endpoint");
+        context.Endpoint = testEndpoint;
+
+        // Act
+        context.Endpoint = null;
+
+        // Assert
+        Assert.Null(context.Endpoint);
+    }
+
+    [Fact]
+    public void EndpointProperty_ConsistentWithExtensionMethods()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        var testEndpoint = new Endpoint(c => Task.CompletedTask, EndpointMetadataCollection.Empty, "Test endpoint");
+
+        // Act - Set via property
+        context.Endpoint = testEndpoint;
+
+        // Assert - Both property and extension method return the same value
+        Assert.Equal(testEndpoint, context.Endpoint);
+        Assert.Equal(testEndpoint, context.GetEndpoint());
+
+        // Act - Set via extension method
+        var newEndpoint = new Endpoint(c => Task.CompletedTask, EndpointMetadataCollection.Empty, "New endpoint");
+        context.SetEndpoint(newEndpoint);
+
+        // Assert - Both property and extension method return the new value
+        Assert.Equal(newEndpoint, context.Endpoint);
+        Assert.Equal(newEndpoint, context.GetEndpoint());
+    }
+
     private class EndpointFeature : IEndpointFeature
     {
         public Endpoint? Endpoint { get; set; }

--- a/src/Http/Http/src/DefaultHttpContext.cs
+++ b/src/Http/Http/src/DefaultHttpContext.cs
@@ -213,6 +213,13 @@ public sealed class DefaultHttpContext : HttpContext
         }
     }
 
+    /// <inheritdoc/>
+    public override Endpoint? Endpoint
+    {
+        get { return this.GetEndpoint(); }
+        set { this.SetEndpoint(value); }
+    }
+
     // This property exists because of backwards compatibility.
     // We send an anonymous object with an HttpContext property
     // via DiagnosticListener in various events throughout the pipeline. Instead

--- a/src/Http/Http/src/DefaultHttpContext.cs
+++ b/src/Http/Http/src/DefaultHttpContext.cs
@@ -213,13 +213,6 @@ public sealed class DefaultHttpContext : HttpContext
         }
     }
 
-    /// <inheritdoc/>
-    public override Endpoint? Endpoint
-    {
-        get { return this.GetEndpoint(); }
-        set { this.SetEndpoint(value); }
-    }
-
     // This property exists because of backwards compatibility.
     // We send an anonymous object with an HttpContext property
     // via DiagnosticListener in various events throughout the pipeline. Instead


### PR DESCRIPTION
Fixes #50522

This PR introduces a new `HttpContext.Endpoint` property, providing direct access to the selected `Endpoint` associated with the current request.