### PR TITLE
Fix NavMenuHighlightsCurrentLocation in headless mode

### DIFF
--- a/src/Components/test/E2ETest/Tests/ComponentRenderingTestBase.cs
+++ b/src/Components/test/E2ETest/Tests/ComponentRenderingTestBase.cs
@@ -374,7 +374,7 @@ public abstract class ComponentRenderingTestBase : ServerTestBase<ToggleExecutio
     [Fact]
     public void CanUseFocusExtensionToFocusElement()
     {
-        Browser.Manage().Window.Size = new System.Drawing.Size(100, 300);
+        Browser.SetWindowSize(100, 300);
         var appElement = Browser.MountTestComponent<ElementFocusComponent>();
 
         // y scroll position before click
@@ -408,7 +408,7 @@ public abstract class ComponentRenderingTestBase : ServerTestBase<ToggleExecutio
     [Fact]
     public void CanUseFocusExtensionToFocusSvgElement()
     {
-        Browser.Manage().Window.Size = new System.Drawing.Size(100, 300);
+        Browser.SetWindowSize(100, 300);
         var appElement = Browser.MountTestComponent<SvgFocusComponent>();
 
         var buttonElement = appElement.FindElement(By.Id("focus-button"));
@@ -430,7 +430,7 @@ public abstract class ComponentRenderingTestBase : ServerTestBase<ToggleExecutio
     [Fact]
     public void CanUseFocusExtensionToFocusElementPreventScroll()
     {
-        Browser.Manage().Window.Size = new System.Drawing.Size(600, 600);
+        Browser.SetWindowSize(600, 600);
         var appElement = Browser.MountTestComponent<ElementFocusComponent>();
 
         var buttonElement = Browser.Exists(By.Id("focus-button-prevented"));

--- a/src/Components/test/E2ETest/Tests/StandaloneAppTest.cs
+++ b/src/Components/test/E2ETest/Tests/StandaloneAppTest.cs
@@ -10,7 +10,7 @@ using Xunit.Abstractions;
 namespace Microsoft.AspNetCore.Components.E2ETest.Tests;
 
 public class StandaloneAppTest
-    : ServerTestBase<BlazorWasmTestAppFixture<StandaloneApp.Program>>, IDisposable
+    : ServerTestBase<BlazorWasmTestAppFixture<StandaloneApp.Program>>
 {
     public StandaloneAppTest(
         BrowserFixture browserFixture,
@@ -22,6 +22,12 @@ public class StandaloneAppTest
 
     protected override void InitializeAsyncCore()
     {
+        // The sidebar is hidden if the screen is too narrow.
+        // Without setting the window size explicitly, visibility-sensitive properties (e.g. IWebElement.Text)
+        // and element finders (e.g. By.LinkText) can behave unexpectedly, causing assertions to fail.
+        // In particular, this happens in the headless mode (used when running without debugger).
+        Browser.SetWindowSize(1920, 1080);
+
         Navigate("/");
         WaitUntilLoaded();
     }
@@ -43,12 +49,6 @@ public class StandaloneAppTest
     {
         var activeNavLinksSelector = By.CssSelector(".sidebar a.active");
         var mainHeaderSelector = By.TagName("h1");
-
-        // The sidebar is hidden if the screen is too narrow.
-        // Without setting the window size explicitly, visibility-sensitive properties
-        // such as IWebElement.Text can return empty strings, causing assertions to fail.
-        // In particular, this happens in the headless mode (used when running without debugger).
-        Browser.SetWindowSize(1920, 1080);
 
         // Verify we start at home, with the home link highlighted
         Assert.Equal("Hello, world!", Browser.Exists(mainHeaderSelector).Text);
@@ -132,10 +132,12 @@ public class StandaloneAppTest
         Browser.NotEqual("Loading...", () => app.Text);
     }
 
-    public void Dispose()
+    public override Task DisposeAsync()
     {
         // Make the tests run faster by navigating back to the home page when we are done
         // If we don't, then the next test will reload the whole page before it starts
         Browser.Exists(By.LinkText("Home")).Click();
+
+        return base.DisposeAsync();
     }
 }

--- a/src/Components/test/E2ETest/Tests/StandaloneAppTest.cs
+++ b/src/Components/test/E2ETest/Tests/StandaloneAppTest.cs
@@ -44,6 +44,12 @@ public class StandaloneAppTest
         var activeNavLinksSelector = By.CssSelector(".sidebar a.active");
         var mainHeaderSelector = By.TagName("h1");
 
+        // The sidebar is hidden if the screen is too narrow.
+        // Without setting the window size explicitly, visibility-sensitive properties
+        // such as IWebElement.Text can return empty strings, causing assertions to fail.
+        // In particular, this happens in the headless mode (used when running without debugger).
+        Browser.SetWindowSize(1920, 1080);
+
         // Verify we start at home, with the home link highlighted
         Assert.Equal("Hello, world!", Browser.Exists(mainHeaderSelector).Text);
         Assert.Collection(Browser.FindElements(activeNavLinksSelector),

--- a/src/Shared/E2ETesting/BrowserTestBase.cs
+++ b/src/Shared/E2ETesting/BrowserTestBase.cs
@@ -16,6 +16,7 @@ public class BrowserTestBase : IClassFixture<BrowserFixture>, IAsyncLifetime
 
     private ExceptionDispatchInfo _exceptionDispatchInfo;
     private IWebDriver _browser;
+    private System.Drawing.Size? _originalWindowSize;
 
     public BrowserTestBase(BrowserFixture browserFixture, ITestOutputHelper output)
     {
@@ -49,8 +50,13 @@ public class BrowserTestBase : IClassFixture<BrowserFixture>, IAsyncLifetime
 
     public BrowserFixture BrowserFixture { get; }
 
-    public Task DisposeAsync()
+    public virtual Task DisposeAsync()
     {
+        if (_originalWindowSize.HasValue && _originalWindowSize != Browser.Manage().Window.Size)
+        {
+            Browser.SetWindowSize(_originalWindowSize.Value.Width, _originalWindowSize.Value.Height);
+        }
+
         return Task.CompletedTask;
     }
 
@@ -77,6 +83,11 @@ public class BrowserTestBase : IClassFixture<BrowserFixture>, IAsyncLifetime
             var (browser, logs) = BrowserFixture.GetOrCreateBrowser(Output, isolationContext);
             _asyncBrowser.Value = browser;
             _logs.Value = logs;
+
+            if (!_originalWindowSize.HasValue)
+            {
+                _originalWindowSize = browser.Manage().Window.Size;
+            }
 
             Browser = browser;
         }

--- a/src/Shared/E2ETesting/BrowserTestBase.cs
+++ b/src/Shared/E2ETesting/BrowserTestBase.cs
@@ -52,9 +52,17 @@ public class BrowserTestBase : IClassFixture<BrowserFixture>, IAsyncLifetime
 
     public virtual Task DisposeAsync()
     {
-        if (_originalWindowSize.HasValue && _originalWindowSize != Browser.Manage().Window.Size)
+        try
         {
-            Browser.SetWindowSize(_originalWindowSize.Value.Width, _originalWindowSize.Value.Height);
+            if (_originalWindowSize.HasValue && _originalWindowSize.Value != Browser.Manage().Window.Size)
+            {
+                Browser.SetWindowSize(_originalWindowSize.Value.Width, _originalWindowSize.Value.Height);
+            }
+        }
+        catch (WebDriverException)
+        {
+            // An exception is thrown if the browser has been closed in the test.
+            // In that case we don't need to reset the window size.
         }
 
         return Task.CompletedTask;

--- a/src/Shared/E2ETesting/WebDriverExtensions.cs
+++ b/src/Shared/E2ETesting/WebDriverExtensions.cs
@@ -51,4 +51,11 @@ public static class WebDriverExtensions
 
         return false;
     }
+
+    public static void SetWindowSize(this IWebDriver driver, int width, int height)
+    {
+        ArgumentNullException.ThrowIfNull(driver);
+
+        driver.Manage().Window.Size = new System.Drawing.Size(width, height);
+    }
 }


### PR DESCRIPTION
This test is failing in CI and when run locally without debugger. The reason is that in the headless mode the window width is too small and the sidebar UI is hidden. This causes visibility-sensitive properties such as `IWebElement.Text` to return empty strings for hidden elements from the sidebar, causing assertions to fail.

The PR solves the issue by explicitly setting the window size for this particular test. We can discuss if the preferred solution is to set the window size globally when creating the test browser in the headless mode. Alternatively, the test could be fixed by using a visibility-independent API such as `IWebElement.GetDomProperty("innerText")` for reading the relevant values. However, using a realistic window size seems more appropriate for an E2E test.

The PR also adds the `IWebDriver.SetWindowSize` extension method. A few existing cases where window size is manipulated were refactored to use this method in order to make such cases more discoverable.

Fixes #54497