### PR TITLE
Make sure .pdb for AspnetcoreCA gets published to symbol server

### DIFF
--- a/src/Installers/Windows/AspNetCoreModule-Setup/CustomAction/aspnetcoreCA.vcxproj
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/CustomAction/aspnetcoreCA.vcxproj
@@ -99,7 +99,7 @@
       <_BuiltPdbPath Include="$([System.IO.Path]::ChangeExtension($(TargetPath), '.pdb'))" />
     </ItemGroup>
 
-    <Copy SourceFiles="@(_BuiltPdbPath)" DestinationFolder="$(SymbolsOutputPath)$(TargetName)\$(TargetName).pdb" />
-    <Copy SourceFiles="@(_BuiltPdbPath)" DestinationFolder="$(SymbolsOutputPath)$(TargetName)\IISCustomActionDll.pdb" />
+    <Copy SourceFiles="@(_BuiltPdbPath)" DestinationFiles="$(SymbolsOutputPath)$(TargetName)\$(TargetName).pdb" />
+    <Copy SourceFiles="@(_BuiltPdbPath)" DestinationFiles="$(SymbolsOutputPath)$(TargetName)\IISCustomActionDll.pdb" />
   </Target>
 </Project>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/CustomAction/aspnetcoreCA.vcxproj
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/CustomAction/aspnetcoreCA.vcxproj
@@ -100,6 +100,6 @@
     </ItemGroup>
 
     <Copy SourceFiles="@(_BuiltPdbPath)" DestinationFiles="$(SymbolsOutputPath)$(TargetName)\$(TargetName).pdb" />
-    <Copy SourceFiles="@(_BuiltPdbPath)" DestinationFiles="$(SymbolsOutputPath)$(TargetName)\IISCustomActionDll.pdb" />
+    <Copy SourceFiles="@(_BuiltPdbPath)" DestinationFiles="$(SymbolsOutputPath)IISCustomActionDll\IISCustomActionDll.pdb" />
   </Target>
 </Project>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/CustomAction/aspnetcoreCA.vcxproj
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/CustomAction/aspnetcoreCA.vcxproj
@@ -93,4 +93,13 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+
+  <Target Name="_CopySymbolsToPublishDir" AfterTargets="Build" >
+    <ItemGroup>
+      <_BuiltPdbPath Include="$([System.IO.Path]::ChangeExtension($(TargetPath), '.pdb'))" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(_BuiltPdbPath)" DestinationFolder="$(SymbolsOutputPath)$(TargetName)\$(TargetName).pdb" />
+    <Copy SourceFiles="@(_BuiltPdbPath)" DestinationFolder="$(SymbolsOutputPath)$(TargetName)\IISCustomActionDll.pdb" />
+  </Target>
 </Project>


### PR DESCRIPTION
Should fix some APIScan bugs. Anything in the symbol output dir gets indexed by Arcade: https://github.com/dotnet/aspnetcore/blob/178dda5af78a5d9894635086b55b8148732032c2/eng/Publishing.props#L20. Should backport this 10.0 for rc2.

CC @danmoseley 