### PR TITLE
[release/2.3] Set service info for Microbuild plugin

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -109,6 +109,8 @@ extends:
               signType: $(_SignType)
               zipSources: false
               feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+              ConnectedServiceName: 'MicroBuild Signing Task (DevDiv)'
+              ConnectedPMEServiceName: 248d384a-b39b-46e3-8ad5-c2c210d5e7ca
           - task: DownloadPipelineArtifact@2
             displayName: Download artifacts
             inputs:
@@ -214,6 +216,8 @@ extends:
               signType: $(_SignType)
               zipSources: false
               feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+              ConnectedServiceName: 'MicroBuild Signing Task (DevDiv)'
+              ConnectedPMEServiceName: 248d384a-b39b-46e3-8ad5-c2c210d5e7ca
           - task: DownloadPipelineArtifact@0
             displayName: Download artifacts
             inputs:


### PR DESCRIPTION
2.3 doesn't use Arcade, so we have to do this manually