### PR TITLE
[release/2.3] Mark EFCore as Shipped

### DIFF
--- a/build/submodules.props
+++ b/build/submodules.props
@@ -36,6 +36,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Repository Include="EntityFrameworkCore" />
+    <ShippedRepository Include="EntityFrameworkCore" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This will prevent us from unnecessarily producing the already-published 2.3.0 EFCore packages, saving some build time.