### PR TITLE
OpenAPI: Remove workspace component registration

### DIFF
--- a/src/OpenApi/src/Extensions/OpenApiDocumentExtensions.cs
+++ b/src/OpenApi/src/Extensions/OpenApiDocumentExtensions.cs
@@ -20,10 +20,7 @@ internal static class OpenApiDocumentExtensions
         document.Components ??= new();
         document.Components.Schemas ??= new Dictionary<string, IOpenApiSchema>();
         document.Components.Schemas[schemaId] = schema;
-        document.Workspace ??= new();
-        var location = document.BaseUri + "/components/schemas/" + schemaId;
-        document.Workspace.RegisterComponentForDocument(document, schema, location);
-
+        
         object? description = null;
         object? example = null;
         if (schema is OpenApiSchema actualSchema)


### PR DESCRIPTION
# OpenAPI: Remove workspace component registration

It can be removed because it's not required and not the correct location to be able to resolved, causing duplicate schema registrations in the workspace.

Fixes #63598 
