### PR TITLE
docs: Update OpenApiVersion description

### DIFF
--- a/src/OpenApi/src/Services/OpenApiOptions.cs
+++ b/src/OpenApi/src/Services/OpenApiOptions.cs
@@ -33,7 +33,7 @@ public sealed class OpenApiOptions
     }
 
     /// <summary>
-    /// The version of the OpenAPI specification to use. Defaults to <see cref="OpenApiSpecVersion.OpenApi3_0"/>.
+    /// The version of the OpenAPI specification to use. Defaults to <see cref="OpenApiSpecVersion.OpenApi3_1"/>.
     /// </summary>
     public OpenApiSpecVersion OpenApiVersion { get; set; } = OpenApiSpecVersion.OpenApi3_1;
 


### PR DESCRIPTION
Update OpenApiVersion description

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

**Summary**

While developing, I noticed that the summary for the `OpenApiVersion` property incorrectly referenced `OpenApi3_0` as the default. This PR updates the comment to correctly reference `OpenApi3_1`.
