### PR TITLE
Quarantine ProcessBufferedRenderBatches_WritesRenders

### DIFF
--- a/src/Components/Server/test/Circuits/RemoteRendererTest.cs
+++ b/src/Components/Server/test/Circuits/RemoteRendererTest.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.Server;
 using Microsoft.AspNetCore.Components.Server.Circuits;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -126,6 +127,7 @@ public class RemoteRendererTest
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/61807")]
     public async Task ProcessBufferedRenderBatches_WritesRenders()
     {
         // Arrange
@@ -767,6 +769,17 @@ public class RemoteRendererTest
         public void TriggerRender()
         {
             var task = _renderHandle.Dispatcher.InvokeAsync(() => _renderHandle.Render(_renderFragment));
+
+            // TODO: Remove the following block once ProcessBufferedRenderBatches_WritesRenders is fixed.
+            if (!task.IsCompletedSuccessfully)
+            {
+                // Log the task state for debugging purposes.
+                var status = task.Status;
+                var innerException = task.Exception?.InnerException;
+                var message = $"Render task should succeed synchronously.\nStatus: '{status}'\nInner exception: '{innerException}'";
+                Assert.True(task.IsCompletedSuccessfully, message);
+            }
+
             Assert.True(task.IsCompletedSuccessfully);
         }
     }

--- a/src/Components/Server/test/Circuits/RemoteRendererTest.cs
+++ b/src/Components/Server/test/Circuits/RemoteRendererTest.cs
@@ -770,17 +770,12 @@ public class RemoteRendererTest
         {
             var task = _renderHandle.Dispatcher.InvokeAsync(() => _renderHandle.Render(_renderFragment));
 
-            // TODO: Remove the following block once ProcessBufferedRenderBatches_WritesRenders is fixed.
-            if (!task.IsCompletedSuccessfully)
-            {
-                // Log the task state for debugging purposes.
-                var status = task.Status;
-                var innerException = task.Exception?.InnerException;
-                var message = $"Render task should succeed synchronously.\nStatus: '{status}'\nInner exception: '{innerException}'";
-                Assert.True(task.IsCompletedSuccessfully, message);
-            }
+            // Log the task state for debugging purposes.
+            var status = task.Status;
+            var innerException = task.Exception?.InnerException;
+            var message = $"Render task should succeed synchronously.\nStatus: '{status}'\nInner exception: '{innerException}'";
 
-            Assert.True(task.IsCompletedSuccessfully);
+            Assert.True(task.IsCompletedSuccessfully, message);
         }
     }
 


### PR DESCRIPTION
The `RemoteRendererTest.ProcessBufferedRenderBatches_WritesRenders` test occasionaly fails because one of the rendering tasks does not complete as expected. That means that the task either failed with an unhandled exception, or has not completed synchronously.

The PR quarantines the test and adds temporary logging of the task state to help us eventually get more insight into the underlying issue.