### PR TITLE
Fix runtime architecture detection logic in ANCM

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/Environment.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/Environment.cpp
@@ -133,6 +133,23 @@ std::wstring Environment::GetDllDirectoryValue()
     return expandedStr;
 }
 
+ProcessorArchitecture Environment::GetCurrentProcessArchitecture()
+{
+    // Use compile-time detection - we know which architectures we support
+    // and this is the most reliable and efficient approach. IsWow64Process2
+    // doesn't show the correct architecture when running under x64 emulation
+    // on ARM64.
+#if defined(_M_ARM64)
+    return ProcessorArchitecture::ARM64;
+#elif defined(_M_AMD64)
+    return ProcessorArchitecture::AMD64;
+#elif defined(_M_IX86)
+    return ProcessorArchitecture::x86;
+#else
+    static_assert(false, "Unknown target architecture");
+#endif
+}
+
 bool Environment::IsRunning64BitProcess()
 {
     // Check the bitness of the currently running process

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/Environment.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/Environment.h
@@ -5,6 +5,7 @@
 
 #include <string>
 #include <optional>
+#include "ProcessorArchitecture.h"
 
 class Environment
 {
@@ -22,6 +23,8 @@ public:
     std::wstring GetDllDirectoryValue();
     static
     bool IsRunning64BitProcess();
+    static
+    ProcessorArchitecture GetCurrentProcessArchitecture();
     static
     HRESULT CopyToDirectory(const std::wstring& source, const std::filesystem::path& destination, bool cleanDest, const std::filesystem::path& directoryToIgnore, int& copiedFileCount);
     static

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxrResolver.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxrResolver.h
@@ -8,8 +8,8 @@
 #include <filesystem>
 #include <optional>
 #include <string>
-
 #include "ErrorContext.h"
+#include "ProcessorArchitecture.h"
 
 #define READ_BUFFER_SIZE 4096
 
@@ -74,7 +74,7 @@ private:
         const std::filesystem::path & requestedPath
     );
 
-    static BOOL IsX64(const WCHAR* dotnetPath);
+    static ProcessorArchitecture GetFileProcessorArchitecture(const WCHAR* binaryPath);
 
     struct LocalFreeDeleter
     {

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/ProcessorArchitecture.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/ProcessorArchitecture.h
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+#pragma once
+
+enum class ProcessorArchitecture
+{
+    Unknown,
+    x86,
+    AMD64,
+    ARM64
+};
+
+inline const wchar_t* ProcessorArchitectureToString(ProcessorArchitecture arch)
+{
+    switch (arch)
+    {
+        case ProcessorArchitecture::x86:
+            return L"x86";
+        case ProcessorArchitecture::AMD64:
+            return L"AMD64";
+        case ProcessorArchitecture::ARM64:
+            return L"ARM64";
+        case ProcessorArchitecture::Unknown:
+        default:
+            return L"Unknown";
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/63650

A recent change (https://github.com/dotnet/aspnetcore/pull/61894) inadvertently regressed a scenario that was working by accident.

That change switched us away from using `GetBinaryTypeW` to determine the architecture of a binary, because that method actually loads the binary into the process and we wanted to avoid that. However, what was missed there is that in some cases (e.g. x64 process running on arm64) the function fails entirely (since it can't even load the binary), which used to lead us to skip that binary when doing our probing and instead rely on fallback methods.

After https://github.com/dotnet/aspnetcore/pull/61894, we started to correctly determine that both x64 and arm64 binaries are 64-bit, but since we weren't distinguishing between the two, we could end up attempting to load the wrong one.

This fixes that by actually determining the specific architecture and ensuring a match. There's some nearby code that needs to be rethought as well, but I'm trying to keep this change minimal so we can minimize risk late in .NET 10.