### PR TITLE
[release/10.0] Implement KnownNetworks dual list

### DIFF
--- a/src/DefaultBuilder/src/ForwardedHeadersOptionsSetup.cs
+++ b/src/DefaultBuilder/src/ForwardedHeadersOptionsSetup.cs
@@ -27,9 +27,6 @@ internal sealed class ForwardedHeadersOptionsSetup : IConfigureOptions<Forwarded
         options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
         // Only loopback proxies are allowed by default. Clear that restriction because forwarders are
         // being enabled by explicit configuration.
-#pragma warning disable ASPDEPR005 // KnownNetworks is obsolete
-        options.KnownNetworks.Clear();
-#pragma warning restore ASPDEPR005 // KnownNetworks is obsolete
         options.KnownIPNetworks.Clear();
         options.KnownProxies.Clear();
     }

--- a/src/Middleware/HttpOverrides/src/DualIPNetworkList.cs
+++ b/src/Middleware/HttpOverrides/src/DualIPNetworkList.cs
@@ -1,0 +1,140 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPDEPR005 // Type or member is obsolete
+
+using AspNetIPNetwork = Microsoft.AspNetCore.HttpOverrides.IPNetwork;
+using IPAddress = System.Net.IPAddress;
+using IPNetwork = System.Net.IPNetwork;
+
+namespace Microsoft.AspNetCore.Builder;
+
+/// <summary>
+/// Internal list implementation that keeps <see cref="System.Net.IPNetwork"/> and the obsolete
+/// <see cref="Microsoft.AspNetCore.HttpOverrides.IPNetwork"/> collections in sync. Modifications
+/// through either interface are reflected in the other.
+/// </summary>
+internal sealed class DualIPNetworkList : IList<IPNetwork>, IList<AspNetIPNetwork>
+{
+    // Two independent underlying lists so each side behaves exactly like a List<T> with respect to
+    // enumeration versioning, capacity growth, etc. They are kept strictly in sync by all mutating operations.
+    private readonly List<IPNetwork> _system = new();
+    private readonly List<AspNetIPNetwork> _aspnet = new();
+
+    public DualIPNetworkList()
+    {
+        // Default entry (loopback) added to both representations.
+        var loopback = new IPNetwork(IPAddress.Loopback, 8);
+        _system.Add(loopback);
+        _aspnet.Add(new AspNetIPNetwork(loopback.BaseAddress, loopback.PrefixLength));
+    }
+
+    int ICollection<IPNetwork>.Count => _system.Count;
+    int ICollection<AspNetIPNetwork>.Count => _aspnet.Count;
+
+    bool ICollection<IPNetwork>.IsReadOnly => false;
+    bool ICollection<AspNetIPNetwork>.IsReadOnly => false;
+
+    IPNetwork IList<IPNetwork>.this[int index]
+    {
+        get => _system[index];
+        set
+        {
+            _system[index] = value;
+            _aspnet[index] = new AspNetIPNetwork(value.BaseAddress, value.PrefixLength);
+        }
+    }
+
+    AspNetIPNetwork IList<AspNetIPNetwork>.this[int index]
+    {
+        get => _aspnet[index];
+        set
+        {
+            _aspnet[index] = value;
+            _system[index] = new IPNetwork(value.Prefix, value.PrefixLength);
+        }
+    }
+
+    void ICollection<IPNetwork>.Add(IPNetwork item)
+    {
+        _system.Add(item);
+        _aspnet.Add(new AspNetIPNetwork(item.BaseAddress, item.PrefixLength));
+    }
+
+    void ICollection<AspNetIPNetwork>.Add(AspNetIPNetwork item)
+    {
+        _aspnet.Add(item);
+        _system.Add(new IPNetwork(item.Prefix, item.PrefixLength));
+    }
+
+    public void Clear()
+    {
+        _system.Clear();
+        _aspnet.Clear();
+    }
+
+    void ICollection<IPNetwork>.Clear() => Clear();
+    void ICollection<AspNetIPNetwork>.Clear() => Clear();
+
+    bool ICollection<IPNetwork>.Contains(IPNetwork item) => _system.Contains(item);
+    bool ICollection<AspNetIPNetwork>.Contains(AspNetIPNetwork item) => _aspnet.Contains(item);
+
+    public void CopyTo(IPNetwork[] array, int arrayIndex) => _system.CopyTo(array, arrayIndex);
+    public void CopyTo(AspNetIPNetwork[] array, int arrayIndex) => _aspnet.CopyTo(array, arrayIndex);
+
+    void ICollection<IPNetwork>.CopyTo(IPNetwork[] array, int arrayIndex) => CopyTo(array, arrayIndex);
+    void ICollection<AspNetIPNetwork>.CopyTo(AspNetIPNetwork[] array, int arrayIndex) => CopyTo(array, arrayIndex);
+
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => _system.GetEnumerator();
+
+    IEnumerator<IPNetwork> IEnumerable<IPNetwork>.GetEnumerator() => _system.GetEnumerator();
+    IEnumerator<AspNetIPNetwork> IEnumerable<AspNetIPNetwork>.GetEnumerator() => _aspnet.GetEnumerator();
+
+    int IList<IPNetwork>.IndexOf(IPNetwork item) => _system.IndexOf(item);
+    int IList<AspNetIPNetwork>.IndexOf(AspNetIPNetwork item) => _aspnet.IndexOf(item);
+
+    void IList<IPNetwork>.Insert(int index, IPNetwork item)
+    {
+        _system.Insert(index, item);
+        _aspnet.Insert(index, new AspNetIPNetwork(item.BaseAddress, item.PrefixLength));
+    }
+
+    void IList<AspNetIPNetwork>.Insert(int index, AspNetIPNetwork item)
+    {
+        _aspnet.Insert(index, item);
+        _system.Insert(index, new IPNetwork(item.Prefix, item.PrefixLength));
+    }
+
+    bool ICollection<IPNetwork>.Remove(IPNetwork item)
+    {
+        var idx = _system.IndexOf(item);
+        if (idx >= 0)
+        {
+            RemoveAt(idx);
+            return true;
+        }
+        return false;
+    }
+
+    bool ICollection<AspNetIPNetwork>.Remove(AspNetIPNetwork item)
+    {
+        var idx = _aspnet.IndexOf(item);
+        if (idx >= 0)
+        {
+            RemoveAt(idx);
+            return true;
+        }
+        return false;
+    }
+
+    public void RemoveAt(int index)
+    {
+        _system.RemoveAt(index);
+        _aspnet.RemoveAt(index);
+    }
+
+    void IList<IPNetwork>.RemoveAt(int index) => RemoveAt(index);
+    void IList<AspNetIPNetwork>.RemoveAt(int index) => RemoveAt(index);
+}
+
+#pragma warning restore ASPDEPR005 // Type or member is obsolete

--- a/src/Middleware/HttpOverrides/src/ForwardedHeadersMiddleware.cs
+++ b/src/Middleware/HttpOverrides/src/ForwardedHeadersMiddleware.cs
@@ -213,11 +213,7 @@ public class ForwardedHeadersMiddleware
             // Host and Scheme initial values are never inspected, no need to set them here.
         };
 
-        var checkKnownIps = _options.KnownIPNetworks.Count > 0
-#pragma warning disable ASPDEPR005 // KnownNetworks is obsolete
-            || _options.KnownNetworks.Count > 0
-#pragma warning restore ASPDEPR005 // KnownNetworks is obsolete
-            || _options.KnownProxies.Count > 0;
+        var checkKnownIps = _options.KnownIPNetworks.Count > 0 || _options.KnownProxies.Count > 0;
         bool applyChanges = false;
         int entriesConsumed = 0;
 
@@ -410,15 +406,6 @@ public class ForwardedHeadersMiddleware
                 return true;
             }
         }
-#pragma warning disable ASPDEPR005 // KnownNetworks is obsolete
-        foreach (var network in _options.KnownNetworks)
-        {
-            if (network.Contains(address))
-            {
-                return true;
-            }
-        }
-#pragma warning restore ASPDEPR005 // KnownNetworks is obsolete
         return false;
     }
 

--- a/src/Middleware/HttpOverrides/src/ForwardedHeadersOptions.cs
+++ b/src/Middleware/HttpOverrides/src/ForwardedHeadersOptions.cs
@@ -13,6 +13,10 @@ namespace Microsoft.AspNetCore.Builder;
 /// </summary>
 public class ForwardedHeadersOptions
 {
+    // Backing dual list that keeps the obsolete and new types in sync.
+    // Once the obsolete IList<IPNetwork> property is removed this can be changed to a simple List<IPNetwork>.
+    private readonly DualIPNetworkList _knownNetworks = new();
+
     /// <summary>
     /// Gets or sets the header used to retrieve the originating client IP. Defaults to the value specified by
     /// <see cref="ForwardedHeadersDefaults.XForwardedForHeaderName"/>.
@@ -87,12 +91,12 @@ public class ForwardedHeadersOptions
     /// Obsolete, please use <see cref="KnownIPNetworks"/> instead
     /// </summary>
     [Obsolete("Please use KnownIPNetworks instead. For more information, visit https://aka.ms/aspnet/deprecate/005.", DiagnosticId = "ASPDEPR005")]
-    public IList<AspNetIPNetwork> KnownNetworks { get; } = new List<AspNetIPNetwork>() { new(IPAddress.Loopback, 8) };
+    public IList<AspNetIPNetwork> KnownNetworks => _knownNetworks;
 
     /// <summary>
     /// Address ranges of known proxies to accept forwarded headers from.
     /// </summary>
-    public IList<IPNetwork> KnownIPNetworks { get; } = new List<IPNetwork>() { new(IPAddress.Loopback, 8) };
+    public IList<IPNetwork> KnownIPNetworks => _knownNetworks;
 
     /// <summary>
     /// The allowed values from x-forwarded-host. If the list is empty then all hosts are allowed.

--- a/src/Middleware/HttpOverrides/test/DualIPNetworkListTests.cs
+++ b/src/Middleware/HttpOverrides/test/DualIPNetworkListTests.cs
@@ -1,0 +1,248 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Xunit;
+using AspNetIPNetwork = Microsoft.AspNetCore.HttpOverrides.IPNetwork;
+
+namespace Microsoft.AspNetCore.HttpOverrides;
+
+public class DualIPNetworkListTests
+{
+    [Fact]
+    public void DefaultContainsLoopback()
+    {
+        var options = new ForwardedHeadersOptions();
+        Assert.Single(options.KnownIPNetworks);
+        Assert.Equal("127.0.0.0", options.KnownIPNetworks[0].BaseAddress.ToString());
+        Assert.Equal(8, options.KnownIPNetworks[0].PrefixLength);
+#pragma warning disable ASPDEPR005
+        Assert.Single(options.KnownNetworks);
+        Assert.Equal("127.0.0.0", options.KnownNetworks[0].Prefix.ToString());
+        Assert.Equal(8, options.KnownNetworks[0].PrefixLength);
+#pragma warning restore ASPDEPR005
+    }
+
+    [Fact]
+    public void AddThroughSystemCollectionVisibleViaObsolete()
+    {
+        var options = new ForwardedHeadersOptions();
+        options.KnownIPNetworks.Add(System.Net.IPNetwork.Parse("10.0.0.0/8"));
+#pragma warning disable ASPDEPR005
+        var obsoleteList = options.KnownNetworks;
+        Assert.Equal(2, obsoleteList.Count);
+        Assert.Equal(IPAddress.Parse("10.0.0.0"), obsoleteList[1].Prefix);
+        Assert.Equal(8, obsoleteList[1].PrefixLength);
+#pragma warning restore ASPDEPR005
+    }
+
+    [Fact]
+    public void AddThroughObsoleteCollectionVisibleViaSystem()
+    {
+#pragma warning disable ASPDEPR005
+        var options = new ForwardedHeadersOptions();
+        options.KnownNetworks.Add(new AspNetIPNetwork(IPAddress.Parse("192.168.0.0"), 16));
+        Assert.Equal(2, options.KnownIPNetworks.Count);
+        Assert.Equal("192.168.0.0/16", options.KnownIPNetworks[1].ToString());
+#pragma warning restore ASPDEPR005
+    }
+
+    [Fact]
+    public void ReplaceViaSystemIndexerUpdatesObsolete()
+    {
+        var options = new ForwardedHeadersOptions();
+        options.KnownIPNetworks[0] = System.Net.IPNetwork.Parse("172.16.0.0/12");
+#pragma warning disable ASPDEPR005
+        Assert.Equal(IPAddress.Parse("172.16.0.0"), options.KnownNetworks[0].Prefix);
+        Assert.Equal(12, options.KnownNetworks[0].PrefixLength);
+#pragma warning restore ASPDEPR005
+    }
+
+    [Fact]
+    public void ReplaceViaObsoleteIndexerUpdatesSystem()
+    {
+#pragma warning disable ASPDEPR005
+        var options = new ForwardedHeadersOptions();
+        options.KnownNetworks[0] = new AspNetIPNetwork(IPAddress.Parse("172.16.0.0"), 12);
+        Assert.Equal("172.16.0.0/12", options.KnownIPNetworks[0].ToString());
+#pragma warning restore ASPDEPR005
+    }
+
+    [Fact]
+    public void ClearClearsBoth()
+    {
+        var options = new ForwardedHeadersOptions();
+        options.KnownIPNetworks.Clear();
+#pragma warning disable ASPDEPR005
+        Assert.Empty(options.KnownNetworks);
+#pragma warning restore ASPDEPR005
+        Assert.Empty(options.KnownIPNetworks);
+    }
+
+    [Fact]
+    public void RemoveThroughEitherCollectionRemovesFromBoth()
+    {
+        var options = new ForwardedHeadersOptions();
+        options.KnownIPNetworks.Add(System.Net.IPNetwork.Parse("10.0.0.0/8"));
+        var first = options.KnownIPNetworks[0];
+        var removed = options.KnownIPNetworks.Remove(first);
+        Assert.True(removed);
+#pragma warning disable ASPDEPR005
+        var obsoleteList = options.KnownNetworks;
+        Assert.DoesNotContain(obsoleteList, n => n.Prefix.Equals(IPAddress.Loopback));
+#pragma warning restore ASPDEPR005
+        Assert.Single(options.KnownIPNetworks); // only the 10.0.0.0/8 entry should remain
+    }
+
+    // New tests to cover each IList<T> member for both interfaces
+
+    [Fact]
+    public void ContainsWorksForBothLists()
+    {
+        var options = new ForwardedHeadersOptions();
+        var loopback = options.KnownIPNetworks[0];
+        Assert.Contains(loopback, options.KnownIPNetworks);
+#pragma warning disable ASPDEPR005
+        Assert.Contains(options.KnownNetworks, n => n.Prefix.Equals(loopback.BaseAddress) && n.PrefixLength == loopback.PrefixLength);
+#pragma warning restore ASPDEPR005
+    }
+
+    [Fact]
+    public void CopyToSystem()
+    {
+        var options = new ForwardedHeadersOptions();
+        options.KnownIPNetworks.Add(System.Net.IPNetwork.Parse("10.0.0.0/8"));
+        var arr = new System.Net.IPNetwork[5];
+        options.KnownIPNetworks.CopyTo(arr, 1);
+        Assert.Equal("127.0.0.0/8", arr[1].ToString());
+        Assert.Equal("10.0.0.0/8", arr[2].ToString());
+    }
+
+    [Fact]
+    public void CopyToObsolete()
+    {
+#pragma warning disable ASPDEPR005
+        var options = new ForwardedHeadersOptions();
+        options.KnownNetworks.Add(new AspNetIPNetwork(IPAddress.Parse("10.0.0.0"), 8));
+        var arr = new AspNetIPNetwork[5];
+        options.KnownNetworks.CopyTo(arr, 2);
+        Assert.Null(arr[0]);
+        Assert.Equal(IPAddress.Parse("127.0.0.0"), arr[2].Prefix);
+        Assert.Equal(8, arr[2].PrefixLength);
+        Assert.Equal(IPAddress.Parse("10.0.0.0"), arr[3].Prefix);
+        Assert.Equal(8, arr[3].PrefixLength);
+#pragma warning restore ASPDEPR005
+    }
+
+    [Fact]
+    public void IndexOfSystem()
+    {
+        var options = new ForwardedHeadersOptions();
+        options.KnownIPNetworks.Add(System.Net.IPNetwork.Parse("10.0.0.0/8"));
+        Assert.Equal(1, options.KnownIPNetworks.IndexOf(System.Net.IPNetwork.Parse("10.0.0.0/8")));
+    }
+
+    [Fact]
+    public void IndexOfObsolete()
+    {
+        // AspNetIPNetwork doesn't implement Equals, so IndexOf uses reference equality.
+        // This keeps the obsolete behavior intact.
+
+#pragma warning disable ASPDEPR005
+        var options = new ForwardedHeadersOptions();
+        var item = new AspNetIPNetwork(IPAddress.Parse("10.0.0.0"), 8);
+        options.KnownNetworks.Add(item);
+        Assert.Equal(-1, options.KnownNetworks.IndexOf(new AspNetIPNetwork(IPAddress.Parse("10.0.0.0"), 8)));
+        Assert.Equal(1, options.KnownNetworks.IndexOf(item));
+#pragma warning restore ASPDEPR005
+    }
+
+    [Fact]
+    public void InsertSystem()
+    {
+        var options = new ForwardedHeadersOptions();
+        options.KnownIPNetworks.Insert(0, System.Net.IPNetwork.Parse("10.0.0.0/8"));
+        Assert.Equal("10.0.0.0/8", options.KnownIPNetworks[0].ToString());
+#pragma warning disable ASPDEPR005
+        Assert.Equal(IPAddress.Parse("10.0.0.0"), options.KnownNetworks[0].Prefix);
+#pragma warning restore ASPDEPR005
+    }
+
+    [Fact]
+    public void InsertObsolete()
+    {
+#pragma warning disable ASPDEPR005
+        var options = new ForwardedHeadersOptions();
+        options.KnownNetworks.Insert(0, new AspNetIPNetwork(IPAddress.Parse("10.0.0.0"), 8));
+        Assert.Equal("10.0.0.0/8", options.KnownIPNetworks[0].ToString());
+#pragma warning restore ASPDEPR005
+    }
+
+    [Fact]
+    public void RemoveAtSystem()
+    {
+        var options = new ForwardedHeadersOptions();
+        options.KnownIPNetworks.Add(System.Net.IPNetwork.Parse("10.0.0.0/8"));
+        options.KnownIPNetworks.RemoveAt(0); // remove loopback
+#pragma warning disable ASPDEPR005
+        Assert.DoesNotContain(options.KnownNetworks, n => n.Prefix.Equals(IPAddress.Loopback));
+#pragma warning restore ASPDEPR005
+        Assert.Single(options.KnownIPNetworks); // only 10.0.0.0/8
+    }
+
+    [Fact]
+    public void RemoveAtObsolete()
+    {
+#pragma warning disable ASPDEPR005
+        var options = new ForwardedHeadersOptions();
+        options.KnownNetworks.Add(new AspNetIPNetwork(IPAddress.Parse("10.0.0.0"), 8));
+        options.KnownNetworks.RemoveAt(0); // remove loopback
+        Assert.DoesNotContain(options.KnownIPNetworks, n => n.BaseAddress.Equals(IPAddress.Loopback));
+        Assert.Single(options.KnownIPNetworks); // only 10.0.0.0/8
+#pragma warning restore ASPDEPR005
+    }
+
+    [Fact]
+    public void EnumerateSystem()
+    {
+        var options = new ForwardedHeadersOptions();
+        options.KnownIPNetworks.Add(System.Net.IPNetwork.Parse("10.0.0.0/8"));
+        var list = options.KnownIPNetworks.ToList();
+        Assert.Equal(2, list.Count);
+        Assert.Contains(list, n => n.BaseAddress.Equals(IPAddress.Parse("10.0.0.0")));
+    }
+
+    [Fact]
+    public void EnumerateObsolete()
+    {
+#pragma warning disable ASPDEPR005
+        var options = new ForwardedHeadersOptions();
+        options.KnownNetworks.Add(new AspNetIPNetwork(IPAddress.Parse("10.0.0.0"), 8));
+        var list = options.KnownNetworks.ToList();
+        Assert.Equal(2, list.Count);
+        Assert.Contains(list, n => n.Prefix.Equals(IPAddress.Parse("10.0.0.0")));
+#pragma warning restore ASPDEPR005
+    }
+
+    [Fact]
+    public void IsReadOnlyFalse()
+    {
+        var options = new ForwardedHeadersOptions();
+        Assert.False(options.KnownIPNetworks.IsReadOnly);
+#pragma warning disable ASPDEPR005
+        Assert.False(options.KnownNetworks.IsReadOnly);
+#pragma warning restore ASPDEPR005
+    }
+
+    [Fact]
+    public void CountSyncAfterMixedOperations()
+    {
+        var options = new ForwardedHeadersOptions();
+        options.KnownIPNetworks.Add(System.Net.IPNetwork.Parse("10.0.0.0/8"));
+#pragma warning disable ASPDEPR005
+        options.KnownNetworks.Add(new AspNetIPNetwork(IPAddress.Parse("192.168.0.0"), 16));
+        Assert.Equal(options.KnownIPNetworks.Count, options.KnownNetworks.Count);
+#pragma warning restore ASPDEPR005
+    }
+}


### PR DESCRIPTION
## Description

[This PR](https://github.com/dotnet/aspnetcore/pull/62490) is introducing a new property and obsoleting another. They both represent the same concept and are both used in the codebase. However users will only be able to update the new one, and clearing it won't affect the previous one which is still used throughout the code.

This PR adds tests to ensure that the expected behavior is not broken when using a single property. The previous tests were manipulating both, which users can't do. They successfully raise failing tests.
It's then adding a new collection that will back the two properties, such that altering either property will have the same effect (share collection).

Fixes #63627

## Customer Impact

Http Overrides features is broken, failing customers app during auth.

## Regression?

- [x] Yes
- [ ] No

In 10.0-rc1

## Risk

- [ ] High
- [x] Medium
- [ ] Low

The other option is to revert the obsoletion of the previous property described [in this announcement](https://github.com/aspnet/Announcements/issues/523)

## Verification

- [ ] Manual (required)
- [x] Automated
