### PR TITLE
[Proposal] Performance/usability improvements for analyzer tests

### DIFF
--- a/src/Framework/AspNetCoreAnalyzers/test/Extensions/CSharpAnalyzerTestExtensions.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/Extensions/CSharpAnalyzerTestExtensions.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Analyzers.Verifiers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Microsoft.AspNetCore.Analyzers;
+
+public static class CSharpAnalyzerTestExtensions
+{
+    extension<TAnalyzer, TVerifier>(CSharpAnalyzerTest<TAnalyzer, TVerifier>)
+        where TAnalyzer : DiagnosticAnalyzer, new()
+        where TVerifier : IVerifier, new()
+    {
+        public static CSharpAnalyzerTest<TAnalyzer, TVerifier> Create([StringSyntax("C#-test")] string source, params ReadOnlySpan<DiagnosticResult> expectedDiagnostics)
+        {
+            var test = new CSharpAnalyzerTest<TAnalyzer, TVerifier>
+            {
+                TestCode = source.ReplaceLineEndings(),
+                // We need to set the output type to an exe to properly
+                // support top-level programs in the tests. Otherwise,
+                // the test infra will assume we are trying to build a library.
+                TestState = { OutputKind = OutputKind.ConsoleApplication },
+                ReferenceAssemblies = CSharpAnalyzerVerifier<TAnalyzer>.GetReferenceAssemblies(),
+            };
+
+            test.ExpectedDiagnostics.AddRange(expectedDiagnostics);
+            return test;
+        }
+    }
+
+    public static CSharpAnalyzerTest<TAnalyzer, TVerifier> WithSource<TAnalyzer, TVerifier>(this CSharpAnalyzerTest<TAnalyzer, TVerifier> test, [StringSyntax("C#-test")] string source)
+        where TAnalyzer : DiagnosticAnalyzer, new()
+        where TVerifier : IVerifier, new()
+    {
+        test.TestState.Sources.Add(source);
+        return test;
+    }
+}


### PR DESCRIPTION
I would like to propose some improvements for code analyzer tests.
I also proposed this in Roslyn SDK repo: [#1226](https://github.com/dotnet/roslyn-sdk/pull/1226)

Currently `CSharpAnalyzerVerifier<TAnalyzer>.VerifyAnalyzerAsync` method is used to run a code analyzer test:

```cs
public async Task Test()
{
    var source = "...";
    var expectedDiagnostics = new[] { ... };
    await VerifyCS.VerifyAnalyzerAsync(source, expectedDiagnostics); // VerifyCS is a type alias
}
```

**Proposal**

I believe that a factory method that creates a `CSharpAnalyzerTest<TAnalyzer, TVerifier>` could improve both usability and performance of tests. While this type comes from a package and cannot be modified, but it's possible to add such a method with the new extension members feature in C# 14:

```cs
public static class CSharpAnalyzerTestExtensions
{
    extension<TAnalyzer, TVerifier>(CSharpAnalyzerTest<TAnalyzer, TVerifier>) where ...
    {
        public static CSharpAnalyzerTest<TAnalyzer, TVerifier> Create([StringSyntax("C#-test")] string source, params ReadOnlySpan<DiagnosticResult> expectedDiagnostics);
    }

    public static CSharpAnalyzerTest<TAnalyzer, TVerifier> WithSource<TAnalyzer, TVerifier>(this CSharpAnalyzerTest<TAnalyzer, TVerifier> test, [StringSyntax("C#-test")] string source);
}
```

Using such a helper method could have some benefits:

- It improves performance of tests because diagnostics are passed as `params ReadOnlySpan<DiagnosticResult>` that avoids array allocation. This is not possible with the async `VerifyAnalyzerAsync` method.

- This allows to use additional helper methods that can be used to customize the test, to provide additional sources or test configuration if needed. For example, if each test needs some common code, test source code can be split into multiple 'files' and additional source can be provided using `WithSource` extension:

  ```cs
  private const string Program = """
      public class Program
      {
          public static void Main() { }
      }
      """;

  public async Task Test()
  {
      var source = "...";
      var test = CSTest.Create(source, CreateDiagnostic()).WithSource(Program); // CSTest is type alias
      await test.RunAsync();
  }
  ```

  This avoids code duplication as otherwise common code has to be included in each test. This can also keep the test source code clean so that it contains only the code necessary for a particular test without additional 'noise'.

- Using `[StringSyntax("C#-test")]` attribute will ensure that test C# code gets syntax highlighting in Visual Studio for tests creating `CSharpAnalyzerTest` instance explicitly so that it can be customized (please see #63642).

- This will avoid the need to create 'local' helper methods in analyzer test classes that need to customize a test in some way.

**Examples**

I included some tests using this approach in #63657