### PR TITLE
Only enable internal sources for internal/rel branches

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -47,6 +47,12 @@ variables:
     value: true
   - name: _ArcadePublishNonWindowsArg
     value: --publish
+- ${{ if startswith(variables['Build.SourceBranch'], 'refs/heads/internal/release/') }}:
+  - name: enableInternalSources
+    value: true
+- ${{ else }}:
+  - name: enableInternalSources
+    value: false
 - name: _UseHelixOpenQueues
   value: ${{ ne(variables['System.TeamProject'], 'internal') }}
 - ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
@@ -700,7 +706,7 @@ extends:
       # Source build
       - template: /eng/common/templates-official/job/source-build.yml@self
         parameters:
-          enableInternalSources: true
+          enableInternalSources: $(enableInternalSources)
           platform:
             name: 'Managed'
             container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream-10-amd64'


### PR DESCRIPTION
Source build is broken currently, because internal feeds are getting inserted into nuget.config, but aren't getting auth'd.