### PR TITLE
[release/10.0] [backport fix] Fix Validation source generator deployment for non-Web SDKs

### DIFF
--- a/src/Shared/RoslynUtils/WellKnownTypes.cs
+++ b/src/Shared/RoslynUtils/WellKnownTypes.cs
@@ -19,7 +19,6 @@ internal class WellKnownTypes
 
     private readonly INamedTypeSymbol?[] _lazyWellKnownTypes;
     private readonly Compilation _compilation;
-    private readonly INamedTypeSymbol _missingTypeSymbol;
 
     static WellKnownTypes()
     {
@@ -52,7 +51,6 @@ internal class WellKnownTypes
     {
         _lazyWellKnownTypes = new INamedTypeSymbol?[WellKnownTypeData.WellKnownTypeNames.Length];
         _compilation = compilation;
-        _missingTypeSymbol = compilation.GetTypeByMetadataName(typeof(MissingType).FullName!)!;
     }
 
     public INamedTypeSymbol Get(SpecialType type)
@@ -60,7 +58,28 @@ internal class WellKnownTypes
         return _compilation.GetSpecialType(type);
     }
 
+    /// <summary>
+    /// Returns the type symbol for the specified well-known type, or throws if the type cannot be found.
+    /// </summary>
     public INamedTypeSymbol Get(WellKnownTypeData.WellKnownType type)
+    {
+        return Get(type, throwOnNotFound: true);
+    }
+
+    /// <summary>
+    /// Returns the type symbol for the specified well-known type, or a special marker type symbol if the type cannot be found.
+    /// </summary>
+    /// <remarks>
+    /// We use a special marker type for cases where some types can be legitimately missing.
+    /// E.g. The Microsoft.Extensions.Validation source generator checks against some types
+    /// from the shared framework which are missing in Blazor WebAssembly SDK projects.
+    /// </remarks>
+    public INamedTypeSymbol GetOptional(WellKnownTypeData.WellKnownType type)
+    {
+        return Get(type, throwOnNotFound: false);
+    }
+
+    private INamedTypeSymbol Get(WellKnownTypeData.WellKnownType type, bool throwOnNotFound)
     {
         var index = (int)type;
         var symbol = _lazyWellKnownTypes[index];
@@ -71,12 +90,22 @@ internal class WellKnownTypes
 
         // Symbol hasn't been added to the cache yet.
         // Resolve symbol from name, cache, and return.
-        return GetAndCache(index);
+        return GetAndCache(index, throwOnNotFound);
     }
 
-    private INamedTypeSymbol GetAndCache(int index)
+    private INamedTypeSymbol GetAndCache(int index, bool throwOnNotFound)
     {
-        var result = GetTypeByMetadataNameInTargetAssembly(WellKnownTypeData.WellKnownTypeNames[index]) ?? _missingTypeSymbol;
+        var result = GetTypeByMetadataNameInTargetAssembly(WellKnownTypeData.WellKnownTypeNames[index]);
+
+        if (result == null && throwOnNotFound)
+        {
+            throw new InvalidOperationException($"Failed to resolve well-known type '{WellKnownTypeData.WellKnownTypeNames[index]}'.");
+        }
+        else
+        {
+            result ??= _compilation.GetTypeByMetadataName(typeof(MissingType).FullName!)!;
+        }
+
         Interlocked.CompareExchange(ref _lazyWellKnownTypes[index], result, null);
 
         // GetTypeByMetadataName should always return the same instance for a name.

--- a/src/Validation/gen/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Validation/gen/Extensions/ITypeSymbolExtensions.cs
@@ -95,13 +95,13 @@ internal static class ITypeSymbolExtensions
     // types themselves so we short-circuit on them.
     internal static bool IsExemptType(this ITypeSymbol type, WellKnownTypes wellKnownTypes)
     {
-        return SymbolEqualityComparer.Default.Equals(type, wellKnownTypes.Get(WellKnownTypeData.WellKnownType.Microsoft_AspNetCore_Http_HttpContext))
-               || SymbolEqualityComparer.Default.Equals(type, wellKnownTypes.Get(WellKnownTypeData.WellKnownType.Microsoft_AspNetCore_Http_HttpRequest))
-               || SymbolEqualityComparer.Default.Equals(type, wellKnownTypes.Get(WellKnownTypeData.WellKnownType.Microsoft_AspNetCore_Http_HttpResponse))
+        return SymbolEqualityComparer.Default.Equals(type, wellKnownTypes.GetOptional(WellKnownTypeData.WellKnownType.Microsoft_AspNetCore_Http_HttpContext))
+               || SymbolEqualityComparer.Default.Equals(type, wellKnownTypes.GetOptional(WellKnownTypeData.WellKnownType.Microsoft_AspNetCore_Http_HttpRequest))
+               || SymbolEqualityComparer.Default.Equals(type, wellKnownTypes.GetOptional(WellKnownTypeData.WellKnownType.Microsoft_AspNetCore_Http_HttpResponse))
                || SymbolEqualityComparer.Default.Equals(type, wellKnownTypes.Get(WellKnownTypeData.WellKnownType.System_Threading_CancellationToken))
-               || SymbolEqualityComparer.Default.Equals(type, wellKnownTypes.Get(WellKnownTypeData.WellKnownType.Microsoft_AspNetCore_Http_IFormCollection))
-               || SymbolEqualityComparer.Default.Equals(type, wellKnownTypes.Get(WellKnownTypeData.WellKnownType.Microsoft_AspNetCore_Http_IFormFileCollection))
-               || SymbolEqualityComparer.Default.Equals(type, wellKnownTypes.Get(WellKnownTypeData.WellKnownType.Microsoft_AspNetCore_Http_IFormFile))
+               || SymbolEqualityComparer.Default.Equals(type, wellKnownTypes.GetOptional(WellKnownTypeData.WellKnownType.Microsoft_AspNetCore_Http_IFormCollection))
+               || SymbolEqualityComparer.Default.Equals(type, wellKnownTypes.GetOptional(WellKnownTypeData.WellKnownType.Microsoft_AspNetCore_Http_IFormFileCollection))
+               || SymbolEqualityComparer.Default.Equals(type, wellKnownTypes.GetOptional(WellKnownTypeData.WellKnownType.Microsoft_AspNetCore_Http_IFormFile))
                || SymbolEqualityComparer.Default.Equals(type, wellKnownTypes.Get(WellKnownTypeData.WellKnownType.System_IO_Stream))
                || SymbolEqualityComparer.Default.Equals(type, wellKnownTypes.Get(WellKnownTypeData.WellKnownType.System_IO_Pipelines_PipeReader));
     }

--- a/src/Validation/gen/Parsers/ValidationsGenerator.TypesParser.cs
+++ b/src/Validation/gen/Parsers/ValidationsGenerator.TypesParser.cs
@@ -27,9 +27,9 @@ public sealed partial class ValidationsGenerator : IIncrementalGenerator
             ? method.Parameters
             : [];
 
-        var fromServiceMetadataSymbol = wellKnownTypes.Get(
+        var fromServiceMetadataSymbol = wellKnownTypes.GetOptional(
             WellKnownTypeData.WellKnownType.Microsoft_AspNetCore_Http_Metadata_IFromServiceMetadata);
-        var fromKeyedServiceAttributeSymbol = wellKnownTypes.Get(
+        var fromKeyedServiceAttributeSymbol = wellKnownTypes.GetOptional(
             WellKnownTypeData.WellKnownType.Microsoft_Extensions_DependencyInjection_FromKeyedServicesAttribute);
         var skipValidationAttributeSymbol = wellKnownTypes.Get(
             WellKnownTypeData.WellKnownType.Microsoft_Extensions_Validation_SkipValidationAttribute);
@@ -127,9 +127,9 @@ public sealed partial class ValidationsGenerator : IIncrementalGenerator
         var members = new List<ValidatableProperty>();
         var resolvedRecordProperty = new List<IPropertySymbol>();
 
-        var fromServiceMetadataSymbol = wellKnownTypes.Get(
+        var fromServiceMetadataSymbol = wellKnownTypes.GetOptional(
             WellKnownTypeData.WellKnownType.Microsoft_AspNetCore_Http_Metadata_IFromServiceMetadata);
-        var fromKeyedServiceAttributeSymbol = wellKnownTypes.Get(
+        var fromKeyedServiceAttributeSymbol = wellKnownTypes.GetOptional(
             WellKnownTypeData.WellKnownType.Microsoft_Extensions_DependencyInjection_FromKeyedServicesAttribute);
         var jsonIgnoreAttributeSymbol = wellKnownTypes.Get(
             WellKnownTypeData.WellKnownType.System_Text_Json_Serialization_JsonIgnoreAttribute);


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspnetcore/pull/63687 to release/10.0

# [backport fix] Fix Validation source generator deployment for non-Web SDKs

This PR fixes incomplete backport https://github.com/dotnet/aspnetcore/pull/63715.

## Description

I forgot to update that PR with an additional commit that I pushed into the original approved bugfix PR (https://github.com/dotnet/aspnetcore/pull/63687/commits) after code review.

The missing commit lessens the impact of the merged change on other ASP.NET Core analyzers (other than the Validation source generator). In particular, the commit re-enables throwing behavior of certain checks that were put in place to spot packaging problems.

## Customer Impact

There is no direct customer impact but the partial change decreases our ability to spot packaging issues early.

## Regression?

- [x] Yes
- [ ] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

This fix decreases risk of packaging errors going unnoticed.

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [x] Yes
- [ ] No
- [ ] N/A

----

## When servicing release/2.3

- [ ] Make necessary changes in eng/PatchConfig.props
