### PR TITLE
Ensure case-insensitive dictionary for null input

### DIFF
--- a/src/Http/WebUtilities/src/QueryHelpers.cs
+++ b/src/Http/WebUtilities/src/QueryHelpers.cs
@@ -117,14 +117,18 @@ public static class QueryHelpers
     /// Parse a query string into its component key and value parts.
     /// </summary>
     /// <param name="queryString">The raw query string value, with or without the leading '?'.</param>
-    /// <returns>A collection of parsed keys and values.</returns>
+    /// <returns>
+    /// A collection of parsed keys and values. The returned <see cref="Dictionary{TKey, TValue}"/> always uses a
+    /// case-insensitive (<see cref="StringComparer.OrdinalIgnoreCase"/>) key comparer so keys can be accessed
+    /// in a case-insensitive manner regardless of whether the input contained any elements.
+    /// </returns>
     public static Dictionary<string, StringValues> ParseQuery(string? queryString)
     {
         var result = ParseNullableQuery(queryString);
 
         if (result == null)
         {
-            return new Dictionary<string, StringValues>();
+            return new Dictionary<string, StringValues>(0, StringComparer.OrdinalIgnoreCase);
         }
 
         return result;

--- a/src/Http/WebUtilities/test/QueryHelpersTests.cs
+++ b/src/Http/WebUtilities/test/QueryHelpersTests.cs
@@ -198,4 +198,12 @@ public class QueryHelperTests
         var result = QueryHelpers.AddQueryString(uri, queryStrings);
         Assert.Equal(expectedUri, result);
     }
+
+    [Fact]
+    public void ParseQueryNullInputReturnsCaseInsensitiveDictionary()
+    {
+        var collection = QueryHelpers.ParseQuery(null);
+        collection["AbC"] = "value";
+        Assert.True(collection.Remove("abc"));
+    }
 }


### PR DESCRIPTION
# Ensure case-insensitive dictionary for null input

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Ensure QueryHelpers.ParseQuery returns case-insensitive dictionary on null

Fixes #49988

