### PR TITLE
Load handler DLL with load dir on the path

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/HandlerResolver.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/HandlerResolver.cpp
@@ -110,7 +110,7 @@ HandlerResolver::LoadRequestHandlerAssembly(const IHttpApplication &pApplication
 
         LOG_INFOF(L"Loading request handler:  '%ls'", handlerDllPath.c_str());
 
-        hRequestHandlerDll = LoadLibrary(handlerDllPath.c_str());
+        hRequestHandlerDll = LoadLibraryEx(handlerDllPath.c_str(), nullptr, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR);
         RETURN_LAST_ERROR_IF_NULL(hRequestHandlerDll);
 
         if (preventUnload)


### PR DESCRIPTION
Fix #63772

See that issue for context.

This change updates the handler DLL load call from `LoadLibrary` to `LoadLibraryEx` with the flags
`LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR`

The handler DLL exports `CreateApplication` as a forwarded export to an architecture-specific DLL. The plain `LoadLibrary` does not search the handler’s directory when resolving that forwarder. As a result, the loader fails to locate the arch-specific DLL and the scenario breaks (the user gets a 500 error).