### PR TITLE
chore: remove obsolete comment from OpenApiDocumentProvider

### DIFF
--- a/src/OpenApi/src/Services/OpenApiDocumentProvider.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentProvider.cs
@@ -47,9 +47,6 @@ internal sealed class OpenApiDocumentProvider(IServiceProvider serviceProvider) 
         // See OpenApiServiceCollectionExtensions.cs for more info.
         var lowercasedDocumentName = documentName.ToLowerInvariant();
 
-        // Microsoft.OpenAPI does not provide async APIs for writing the JSON
-        // document to a file. See https://github.com/microsoft/OpenAPI.NET/issues/421 for
-        // more info.
         var targetDocumentService = serviceProvider.GetRequiredKeyedService<OpenApiDocumentService>(lowercasedDocumentName);
         using var scopedService = serviceProvider.CreateScope();
         var document = await targetDocumentService.GetOpenApiDocumentAsync(scopedService.ServiceProvider);


### PR DESCRIPTION
# Remove obsolete comment from OpenApiDocumentProvider

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

This PR removes an obsolete comment from the source code since we have been using async APIs since version 2.0.0 of the `Microsoft.OpenAPI` package.
