### PR TITLE
[Blazor][HotReload] Capture the execution context before calling RenderRootComponentsOnHotReload

### DIFF
--- a/src/Components/Components/src/RenderTree/Renderer.cs
+++ b/src/Components/Components/src/RenderTree/Renderer.cs
@@ -6,7 +6,6 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Threading;
 using Microsoft.AspNetCore.Components.HotReload;
 using Microsoft.AspNetCore.Components.Infrastructure;
 using Microsoft.AspNetCore.Components.Reflection;
@@ -1383,9 +1382,9 @@ public abstract partial class Renderer : IDisposable, IAsyncDisposable
     {
         public void RerenderOnHotReload()
         {
-            if (_executionContext is null)
+            if (executionContext is null)
             {
-                _renderer.RenderRootComponentsOnHotReload();
+                renderer.RenderRootComponentsOnHotReload();
             }
             else
             {

--- a/src/Components/Components/test/RendererTest.cs
+++ b/src/Components/Components/test/RendererTest.cs
@@ -5033,7 +5033,8 @@ public class RendererTest
     {
         await using var renderer = new TestRenderer();
 
-        renderer.HotReloadManager = HotReloadManager.Default;
+        var hotReloadManager = new HotReloadManager { MetadataUpdateSupported = true };
+        renderer.HotReloadManager = hotReloadManager;
         HotReloadManager.Default.MetadataUpdateSupported = true;
 
         var component = new AsyncLocalCaptureComponent();
@@ -5053,7 +5054,7 @@ public class RendererTest
         {
             // Simulate environment where the ambient value is not present on the hot reload thread.
             ServiceAccessor.TestAsyncLocal.Value = null;
-            HotReloadManager.UpdateApplication([]);
+            hotReloadManager.TriggerOnDeltaApplied();
         });
         thread.Start();
         thread.Join();

--- a/src/Components/Shared/src/HotReloadManager.cs
+++ b/src/Components/Shared/src/HotReloadManager.cs
@@ -25,4 +25,7 @@ internal sealed class HotReloadManager
     /// MetadataUpdateHandler event. This is invoked by the hot reload host via reflection.
     /// </summary>
     public static void UpdateApplication(Type[]? _) => Default.OnDeltaApplied?.Invoke();
+
+    // For testing purposes only
+    internal void TriggerOnDeltaApplied() => OnDeltaApplied?.Invoke();
 }


### PR DESCRIPTION
Ensure ExecutionContext flows to hot reload re-renders

## Description

- capture the current `ExecutionContext` when subscribing to `HotReloadManager.OnDeltaApplied`
- invoke `RenderRootComponentsOnHotReload` via a helper that restores the captured context, preserving AsyncLocal values
- add a regression test that simulates hot reload and confirms AsyncLocal data survives the re-render

Fixes #45741

## Customer Impact

AsyncLocal-backed data (e.g., culture, logging scopes, circuit state) was being lost after hot reload, leading to incorrect behavior on subsequent renders.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Changes are scoped to the hot reload subscription path, reuse existing render logic, and are exercised by automated tests.

## Verification

- [ ] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A