### PR TITLE
[release/10.0] Fix ANCM Install path for WOW64

### DIFF
--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/aspnetcoremodulev2.wxs
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/aspnetcoremodulev2.wxs
@@ -260,7 +260,7 @@
                 </RegistryKey>
             </Component>
 
-            <StandardDirectory Id="ProgramFiles6432Folder">
+            <StandardDirectory Id="ProgramFilesFolder">
                  <Directory Id="IISModuleDirectory32" Name="IIS">
                     <Directory Id="INSTALLLOCATION32" ShortName="ANCM" Name="Asp.Net Core Module">
                         <Directory Id="VersionDir32" Name="$(ProductVersionString)" SourceName="WowOnly">


### PR DESCRIPTION
ANCM's WOW64 support module should always install to the x86 program files folder. Before this change, we were installing it based on Installer architecture, which could be x64.