### PR TITLE
Make 'blazor-enhanced-nav' headers comparison case insensitive

### DIFF
--- a/src/Components/Web.JS/src/Services/NavigationEnhancement.ts
+++ b/src/Components/Web.JS/src/Services/NavigationEnhancement.ts
@@ -242,7 +242,7 @@ export async function performEnhancedPageLoad(internalDestinationHref: string, i
         }
       }
 
-      if (isSuccessResponse && response.headers.get('blazor-enhanced-nav') !== 'allow') {
+      if (isSuccessResponse && response.headers.get('blazor-enhanced-nav')?.toLowerCase() !== 'allow') {
         // This appears to be a non-Blazor-Endpoint success response. We don't want to use enhanced nav
         // because the content we receive is not designed to be patched into an existing frame,
         // and may be incompatible with the Blazor JS that's already here.


### PR DESCRIPTION
Limiting output cache duration causes the enhanced nav headers to be set as "Allow", not "allow", as it is without cache limitation. The issue cannot be reproduced in-tree, branch that attempted to add the tests: https://github.com/ilonatommy/aspnetcore/tree/cache-issue-tests.

The reason for changing headers casing is under investigation while the CI runs.

## Description

To be investigated.

Before this change:
<img width="2381" height="1105" alt="image" src="https://github.com/user-attachments/assets/739d32dd-befd-4c08-ba19-664a3b6a93cf" />

After this change:
<img width="2167" height="807" alt="image" src="https://github.com/user-attachments/assets/5cbe1714-39dc-4970-9454-e99850bcd8c2" />

Fixes #55534
