### PR TITLE
Prevent JS sources minification in debug

### DIFF
--- a/src/Components/Shared.JS/rollup.config.mjs
+++ b/src/Components/Shared.JS/rollup.config.mjs
@@ -52,7 +52,7 @@ export default function createBaseConfig({ inputOutputMap, dir, updateConfig }) 
           'Platform.isNode': 'false',
           preventAssignment: true
         }),
-        terser({
+        environment !== 'development' && terser({
           compress: {
             passes: 3
           },


### PR DESCRIPTION
I believe `npm run build` should not minify js files that it's producing in `src\Components\Web.JS\dist\Debug` . That's why we're using debug mode. There's a lot of hassle with debugging the minified files now or having to look for the place in rollup to disable minification.

## Description

- do not minify for `dist\Debug`
- keep minifying for `dist\Release`

Before this change:
both `dist\Debug` and `dist\Release` had same, minified contents.

## Use case:
Replacing packages in user's repro app with the current packs from the repo.

This is just a proposal and should be discussed if there is some real reason why we chose to minify in debug.