### PR TITLE
made changes to fix xml comment not rendering properly

### DIFF
--- a/src/OpenApi/gen/XmlCommentGenerator.cs
+++ b/src/OpenApi/gen/XmlCommentGenerator.cs
@@ -49,7 +49,7 @@ public sealed partial class XmlCommentGenerator : IIncrementalGenerator
             var groupedAddOpenApiInvocations = output.Right;
             var (generatedCommentsFromXmlFile, generatedCommentsFromCompilation) = output.Left;
             var compiledXmlFileComments = !generatedCommentsFromXmlFile.IsDefaultOrEmpty
-                ? string.Join("\n", generatedCommentsFromXmlFile)
+                ? string.Join("\r\n", generatedCommentsFromXmlFile)
                 : string.Empty;
             Emit(context, compiledXmlFileComments, generatedCommentsFromCompilation, groupedAddOpenApiInvocations);
         });


### PR DESCRIPTION
## Description
This Change Fixes #62970. Use `\r\n` instead of `\n` when joining XML comments for consistent formatting in generated OpenAPI descriptions. This helps ensure descriptions render correctly in Swagger UI.
