### PR TITLE
[release/9.0] (http2): Lower WINDOWS_UPDATE received on (half)closed stream to stream abortion

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -1156,8 +1156,12 @@ internal sealed partial class Http2Connection : IHttp2StreamLifetimeHandler, IHt
         {
             if (stream.RstStreamReceived)
             {
-                // Hard abort, do not allow any more frames on this stream.
-                throw CreateReceivedFrameStreamAbortedException(stream);
+                // WINDOW_UPDATE received after we have already processed an inbound RST_STREAM for this stream.
+                // RFC 7540 (Sections 5.1, 6.9) / RFC 9113 do not explicitly define semantics for WINDOW_UPDATE on a
+                // stream in the "closed" state due to a reset by client. We surface it as a stream error (STREAM_CLOSED)
+                // rather than aborting the entire connection to keep behavior deterministic and consistent with other servers.
+                // https://github.com/dotnet/aspnetcore/issues/63726
+                throw new Http2StreamErrorException(_incomingFrame.StreamId, CoreStrings.Http2StreamAborted, Http2ErrorCode.STREAM_CLOSED);
             }
 
             if (!stream.TryUpdateOutputWindow(_incomingFrame.WindowUpdateSizeIncrement))

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -3588,6 +3588,7 @@ public class Http2ConnectionTests : Http2TestBase
     public async Task RST_STREAM_IncompleteRequest_AdditionalWindowUpdateFrame_ConnectionAborted()
     {
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
         var headers = new[]
         {
             new KeyValuePair<string, string>(InternalHeaderNames.Method, "POST"),
@@ -3595,6 +3596,7 @@ public class Http2ConnectionTests : Http2TestBase
             new KeyValuePair<string, string>(InternalHeaderNames.Scheme, "http"),
         };
         await InitializeConnectionAsync(context => tcs.Task);
+
         await StartStreamAsync(1, headers, endStream: false);
         await SendDataAsync(1, new byte[1], endStream: false);
         await SendRstStreamAsync(1);


### PR DESCRIPTION
Backport of #63873 to release/9.0

# (http2): Lower WINDOWS_UPDATE received on (half)closed stream to stream abortion

Change affects the server HTTP/2 behavior in the case client sends the RST_STREAM frame (moving stream to half-closed or closed state) and then sends another packet - WINDOW_UPDATE. Server behavior varies in this case (RFC HTTP/2 does not describe this case extremely clear) - for example HTTP.SYS does interpet this as a stream-level error (ignore of WINDOW_UPDATE packet); but Kestrel is more strict and sends the GO_AWAY packet closing not only the stream, but also the whole connection.

Such restrictive behavior of Kestrel impacts the client, which observes cancellations and has to re-establish the connection frequently. 

Fixes #63726

## Customer Impact

1P Customer which processes intensive traffic of another 1P customer with a Golang-based client observes high volume of cancellations. This not only impacts the performance where a new connection has to be established, but also means all streams existing on the connection were lost, resulting in bunch of customers seeing high latency.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Small change in behavior making Kestrel less restrictive. Also is being tested by the 1P team.

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

----

## When servicing release/2.3

- [ ] Make necessary changes in eng/PatchConfig.props
