### PR TITLE
Disable automated inter-branch merges for 10.0

### DIFF
--- a/github-merge-flow.jsonc
+++ b/github-merge-flow.jsonc
@@ -1,20 +1,5 @@
 // IMPORTANT: This file is read by the merge flow from main branch only. 
 {
     "merge-flow-configurations": {
-        // Automate opening PRs to merge release/10.0 to main
-        "release/10.0":{
-            "MergeToBranch": "main",
-            "ExtraSwitches": "-QuietComments"
-        },
-        // Automate opening PRs to merge release/10.0-rc1 to release/10.0
-        "release/10.0-rc1":{
-            "MergeToBranch": "release/10.0",
-            "ExtraSwitches": "-QuietComments"
-        },
-        // Automate opening PRs to merge release/10.0-rc2 to release/10.0
-        "release/10.0-rc2":{
-            "MergeToBranch": "release/10.0",
-            "ExtraSwitches": "-QuietComments"
-        }
     }
 }


### PR DESCRIPTION
Reverts dotnet/aspnetcore#63277. Now that RC2 is locked down, `release/10.0` should be treated like any other servicing branches, which means no more auto-merges. PRs should first be opened against `main`, then backported.