### PR TITLE
Pages that are re-executed should allow interactivity

### DIFF
--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Prerendering.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Prerendering.cs
@@ -20,7 +20,7 @@ internal partial class EndpointHtmlRenderer
 
     protected override IComponent ResolveComponentForRenderMode([DynamicallyAccessedMembers(Component)] Type componentType, int? parentComponentId, IComponentActivator componentActivator, IComponentRenderMode renderMode)
     {
-        if (_isHandlingErrors || _isReExecuted)
+        if (_isHandlingErrors)
         {
             // Ignore the render mode boundary in error scenarios.
             return componentActivator.CreateInstance(componentType);

--- a/src/Components/test/E2ETest/ServerRenderingTests/InteractivityTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/InteractivityTest.cs
@@ -1502,13 +1502,26 @@ public class InteractivityTest : ServerTestBase<BasicTestAppServerSiteFixture<Ra
         Assert404ReExecuted();
     }
 
-    [Fact]
-    public void BrowserNavigationToNotExistingPathReExecutesTo404()
+    [Theory]
+    // prerendering (SSR) is tested in NoInteractivityTest
+    [InlineData("ServerNonPrerendered")]
+    [InlineData("WebAssemblyNonPrerendered")]
+    public void BrowserNavigationToNotExistingPathReExecutesTo404(string renderMode)
     {
         // non-existing path has to have re-execution middleware set up
         // so it has to have "reexecution" prefix. Otherwise middleware mapping
         // will not be activated, see configuration in Startup
-        Navigate($"{ServerPathBase}/reexecution/not-existing-page");
+        Navigate($"{ServerPathBase}/reexecution/not-existing-page?renderMode={renderMode}");
+        Assert404ReExecuted();
+    }
+
+    [Fact]
+    public void BrowserNavigationToNotExistingPathReExecutesTo404_Interactive()
+    {
+        // non-existing path has to have re-execution middleware set up
+        // so it has to have "interactive-reexecution" prefix. Otherwise middleware mapping
+        // will not be activated, see configuration in Startup
+        Navigate($"{ServerPathBase}/interactive-reexecution/not-existing-page");
         Assert404ReExecuted();
         AssertReExecutedPageIsInteractive();
     }

--- a/src/Components/test/E2ETest/ServerRenderingTests/InteractivityTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/InteractivityTest.cs
@@ -1502,17 +1502,22 @@ public class InteractivityTest : ServerTestBase<BasicTestAppServerSiteFixture<Ra
         Assert404ReExecuted();
     }
 
-    [Theory]
-    // prerendering (SSR) is tested in NoInteractivityTest
-    [InlineData("ServerNonPrerendered")]
-    [InlineData("WebAssemblyNonPrerendered")]
-    public void BrowserNavigationToNotExistingPathReExecutesTo404(string renderMode)
+    [Fact]
+    public void BrowserNavigationToNotExistingPathReExecutesTo404()
     {
         // non-existing path has to have re-execution middleware set up
         // so it has to have "reexecution" prefix. Otherwise middleware mapping
         // will not be activated, see configuration in Startup
-        Navigate($"{ServerPathBase}/reexecution/not-existing-page?renderMode={renderMode}");
+        Navigate($"{ServerPathBase}/reexecution/not-existing-page");
         Assert404ReExecuted();
+        AssertReExecutedPageIsInteractive();
+    }
+
+    private void AssertReExecutedPageIsInteractive()
+    {
+        Browser.Equal("Current count: 0", () => Browser.FindElement(By.CssSelector("[role='status']")).Text);
+        Browser.Click(By.Id("increment-button"));
+        Browser.Equal("Current count: 1", () => Browser.FindElement(By.CssSelector("[role='status']")).Text);
     }
 
     private void Assert404ReExecuted() =>

--- a/src/Components/test/testassets/Components.TestServer/RazorComponentEndpointsStartup.cs
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponentEndpointsStartup.cs
@@ -109,6 +109,13 @@ public class RazorComponentEndpointsStartup<TRootComponent>
                 reexecutionApp.UseAntiforgery();
                 ConfigureEndpoints(reexecutionApp, env);
             });
+            app.Map("/interactive-reexecution", reexecutionApp =>
+            {
+                reexecutionApp.UseStatusCodePagesWithReExecute("/not-found-reexecute-interactive", createScopeForStatusCodePages: true);
+                reexecutionApp.UseRouting();
+                reexecutionApp.UseAntiforgery();
+                ConfigureEndpoints(reexecutionApp, env);
+            });
 
             ConfigureSubdirPipeline(app, env);
         });

--- a/src/Components/test/testassets/TestContentPackage/NotFound/ReExecutedComponent.razor
+++ b/src/Components/test/testassets/TestContentPackage/NotFound/ReExecutedComponent.razor
@@ -1,0 +1,4 @@
+<PageTitle>Re-executed page</PageTitle>
+
+<h3 id="test-info">Welcome On Page Re-executed After Not Found Event</h3>
+<p>This page is shown when UseStatusCodePagesWithReExecute is set and another page sets 404</p>

--- a/src/Components/test/testassets/TestContentPackage/NotFound/ReexecutedPage.razor
+++ b/src/Components/test/testassets/TestContentPackage/NotFound/ReexecutedPage.razor
@@ -1,6 +1,20 @@
 ﻿@page "/not-found-reexecute"
+@rendermode RenderMode.InteractiveServer
 
 <PageTitle>Re-executed page</PageTitle>
 
 <h3 id="test-info">Welcome On Page Re-executed After Not Found Event</h3>
 <p>This page is shown when UseStatusCodePagesWithReExecute is set and another page sets 404</p>
+
+<p role="status">Current count: @currentCount</p>
+
+<button id="increment-button" class="btn btn-primary" @onclick="IncrementCount">Click me</button>
+
+@code {
+    private int currentCount = 0;
+
+    private void IncrementCount()
+    {
+        currentCount++;
+    }
+}

--- a/src/Components/test/testassets/TestContentPackage/NotFound/ReexecutedPage.razor
+++ b/src/Components/test/testassets/TestContentPackage/NotFound/ReexecutedPage.razor
@@ -1,20 +1,3 @@
 ﻿@page "/not-found-reexecute"
-@rendermode RenderMode.InteractiveServer
 
-<PageTitle>Re-executed page</PageTitle>
-
-<h3 id="test-info">Welcome On Page Re-executed After Not Found Event</h3>
-<p>This page is shown when UseStatusCodePagesWithReExecute is set and another page sets 404</p>
-
-<p role="status">Current count: @currentCount</p>
-
-<button id="increment-button" class="btn btn-primary" @onclick="IncrementCount">Click me</button>
-
-@code {
-    private int currentCount = 0;
-
-    private void IncrementCount()
-    {
-        currentCount++;
-    }
-}
+<ReExecutedComponent />

--- a/src/Components/test/testassets/TestContentPackage/NotFound/ReexecutedPageInteractive.razor
+++ b/src/Components/test/testassets/TestContentPackage/NotFound/ReexecutedPageInteractive.razor
@@ -1,0 +1,17 @@
+﻿@page "/not-found-reexecute-interactive"
+@rendermode RenderMode.InteractiveServer
+
+<ReExecutedComponent />
+
+<p role="status">Current count: @currentCount</p>
+
+<button id="increment-button" class="btn btn-primary" @onclick="IncrementCount">Click me</button>
+
+@code {
+    private int currentCount = 0;
+
+    private void IncrementCount()
+    {
+        currentCount++;
+    }
+}


### PR DESCRIPTION
# Do not skip Render Mode boundary for re-executions

Re-executed page components should have configurable render mode because typically re-executed page is used in the same places as page rendered by `NavigationManager.NotFound()`. By allowing interactivity in the latter but not supporting it in the former case, we introduce inconsistency.

## Description

- In case of error handling and re-execution, we used to always apply SSR. It does not make sense from the consistency reasons mentioned above. Re-execution case gets removed from the "always SSR" processing. Its render mode resolution will follow the same logic as any other component's.
- The test for checking interactivity on re-executed pages was added.

Fixes #63963
