### PR TITLE
[release/9.0] Fix nginx install on mac, linux

### DIFF
--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -578,7 +578,7 @@ stages:
         isAzDOTestingJob: true
         buildArgs: --all --test --binaryLog /p:RunTemplateTests=false /p:SkipHelixReadyTests=true $(_InternalRuntimeDownloadArgs)
         beforeBuild:
-        - bash: "./eng/scripts/install-nginx-mac.sh"
+        - bash: "./eng/scripts/install-nginx.sh"
           displayName: Installing Nginx
         artifacts:
         - name: MacOS_Test_Logs_Attempt_$(System.JobAttempt)
@@ -599,7 +599,7 @@ stages:
         useHostedUbuntu: false
         buildArgs: --all --test --binaryLog /p:RunTemplateTests=false /p:SkipHelixReadyTests=true $(_InternalRuntimeDownloadArgs)
         beforeBuild:
-        - bash: "./eng/scripts/install-nginx-linux.sh"
+        - bash: "./eng/scripts/install-nginx.sh"
           displayName: Installing Nginx
         - bash: "echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p"
           displayName: Increase inotify limit

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -639,7 +639,7 @@ extends:
             isAzDOTestingJob: true
             buildArgs: --all --test --binaryLog /p:RunTemplateTests=false /p:SkipHelixReadyTests=true $(_InternalRuntimeDownloadArgs)
             beforeBuild:
-            - bash: "./eng/scripts/install-nginx-mac.sh"
+            - bash: "./eng/scripts/install-nginx.sh"
               displayName: Installing Nginx
             artifacts:
             - name: MacOS_Test_Logs_Attempt_$(System.JobAttempt)
@@ -660,7 +660,7 @@ extends:
             useHostedUbuntu: false
             buildArgs: --all --test --binaryLog /p:RunTemplateTests=false /p:SkipHelixReadyTests=true $(_InternalRuntimeDownloadArgs)
             beforeBuild:
-            - bash: "./eng/scripts/install-nginx-linux.sh"
+            - bash: "./eng/scripts/install-nginx.sh"
               displayName: Installing Nginx
             - bash: "echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p"
               displayName: Increase inotify limit

--- a/eng/scripts/install-nginx-mac.sh
+++ b/eng/scripts/install-nginx-mac.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-brew update
-brew list openssl || brew install openssl
-brew list nginx || brew install nginx

--- a/eng/scripts/install-nginx.sh
+++ b/eng/scripts/install-nginx.sh
@@ -6,7 +6,7 @@ scriptroot="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 reporoot="$(dirname "$(dirname "$scriptroot")")"
 nginxinstall="$reporoot/.tools/nginx"
 
-curl -sSL http://nginx.org/download/nginx-1.26.3.tar.gz --retry 5 | tar zxfv - -C /tmp && cd /tmp/nginx-1.26.3/
+curl -sSL http://nginx.org/download/nginx-1.29.1.tar.gz --retry 5 | tar zxfv - -C /tmp && cd /tmp/nginx-1.29.1/
 ./configure --prefix=$nginxinstall --with-http_ssl_module --without-http_rewrite_module
 make
 make install


### PR DESCRIPTION
Already fixed in main, 10, & 8. Centralize on 1 script for installing nginx on non-win, and pin to the latest working version.