### PR TITLE
Fix hot reload for Blazor route changes

### DIFF
--- a/src/Components/Endpoints/src/Builder/RazorComponentEndpointDataSourceFactory.cs
+++ b/src/Components/Endpoints/src/Builder/RazorComponentEndpointDataSourceFactory.cs
@@ -17,9 +17,14 @@ internal class RazorComponentEndpointDataSourceFactory(
 {
     public RazorComponentEndpointDataSource<TRootComponent> CreateDataSource<[DynamicallyAccessedMembers(Component)] TRootComponent>(IEndpointRouteBuilder endpoints)
     {
-        var builder = ComponentApplicationBuilder.GetBuilder<TRootComponent>() ??
-            DefaultRazorComponentApplication<TRootComponent>.Instance.GetBuilder();
+        var dataSource = new RazorComponentEndpointDataSource<TRootComponent>(providers, endpoints, factory, hotReloadService);
 
-        return new RazorComponentEndpointDataSource<TRootComponent>(builder, providers, endpoints, factory, hotReloadService);
+        dataSource.ComponentApplicationBuilderActions.Add(builder =>
+        {
+            var assembly = typeof(TRootComponent).Assembly;
+            IRazorComponentApplication.GetBuilderForAssembly(builder, assembly);
+        });
+
+        return dataSource;
     }
 }

--- a/src/Components/Endpoints/src/Builder/RazorComponentsEndpointConventionBuilder.cs
+++ b/src/Components/Endpoints/src/Builder/RazorComponentsEndpointConventionBuilder.cs
@@ -18,27 +18,25 @@ public sealed class RazorComponentsEndpointConventionBuilder : IEndpointConventi
     private readonly RazorComponentDataSourceOptions _options;
     private readonly List<Action<EndpointBuilder>> _conventions;
     private readonly List<Action<EndpointBuilder>> _finallyConventions;
+    private readonly List<Action<ComponentApplicationBuilder>> _componentApplicationBuilderActions;
 
     internal RazorComponentsEndpointConventionBuilder(
         object @lock,
-        ComponentApplicationBuilder builder,
         IEndpointRouteBuilder endpointRouteBuilder,
         RazorComponentDataSourceOptions options,
         List<Action<EndpointBuilder>> conventions,
-        List<Action<EndpointBuilder>> finallyConventions)
+        List<Action<EndpointBuilder>> finallyConventions,
+        List<Action<ComponentApplicationBuilder>> componentApplicationBuilderActions)
     {
         _lock = @lock;
-        ApplicationBuilder = builder;
         EndpointRouteBuilder = endpointRouteBuilder;
         _options = options;
         _conventions = conventions;
         _finallyConventions = finallyConventions;
+        _componentApplicationBuilderActions = componentApplicationBuilderActions;
     }
 
-    /// <summary>
-    /// Gets the <see cref="ComponentApplicationBuilder"/> that is used to build the endpoints.
-    /// </summary>
-    internal ComponentApplicationBuilder ApplicationBuilder { get; }
+    internal List<Action<ComponentApplicationBuilder>> ComponentApplicationBuilderActions => _componentApplicationBuilderActions;
 
     internal string? ManifestPath { get => _options.ManifestPath; set => _options.ManifestPath = value; }
 

--- a/src/Components/Endpoints/src/Builder/RazorComponentsEndpointConventionBuilderExtensions.cs
+++ b/src/Components/Endpoints/src/Builder/RazorComponentsEndpointConventionBuilderExtensions.cs
@@ -30,7 +30,7 @@ public static class RazorComponentsEndpointConventionBuilderExtensions
 
         foreach (var assembly in assemblies)
         {
-            builder.ApplicationBuilder.AddAssembly(assembly);
+            builder.ComponentApplicationBuilderActions.Add(b => b.AddAssembly(assembly));
         }
         return builder;
     }

--- a/src/Components/Endpoints/test/Builder/RazorComponentsEndpointConventionBuilderExtensionsTest.cs
+++ b/src/Components/Endpoints/test/Builder/RazorComponentsEndpointConventionBuilderExtensionsTest.cs
@@ -245,7 +245,7 @@ public class RazorComponentsEndpointConventionBuilderExtensionsTest
     private RazorComponentsEndpointConventionBuilder CreateRazorComponentsAppBuilder(IEndpointRouteBuilder endpointBuilder)
     {
         var builder = endpointBuilder.MapRazorComponents<App>();
-        builder.ApplicationBuilder.AddLibrary(new AssemblyComponentLibraryDescriptor(
+        builder.ComponentApplicationBuilderActions.Add(b => b.AddLibrary(new AssemblyComponentLibraryDescriptor(
             "App",
             [new PageComponentBuilder {
                 PageType = typeof(App),
@@ -253,7 +253,7 @@ public class RazorComponentsEndpointConventionBuilderExtensionsTest
                 AssemblyName = "App",
             }],
             []
-        ));
+        )));
         return builder;
     }
 

--- a/src/Components/Endpoints/test/HotReloadServiceTests.cs
+++ b/src/Components/Endpoints/test/HotReloadServiceTests.cs
@@ -23,9 +23,8 @@ public class HotReloadServiceTests
     public void UpdatesEndpointsWhenHotReloadChangeTokenTriggered()
     {
         // Arrange
-        var builder = CreateBuilder(typeof(ServerComponent));
         var services = CreateServices(typeof(MockEndpointProvider));
-        var endpointDataSource = CreateDataSource<App>(builder, services);
+        var endpointDataSource = CreateDataSource<App>(services, ConfigureServerComponentBuilder);
         var invoked = false;
 
         // Act
@@ -41,9 +40,8 @@ public class HotReloadServiceTests
     public void AddNewEndpointWhenDataSourceChanges()
     {
         // Arrange
-        var builder = CreateBuilder(typeof(ServerComponent));
         var services = CreateServices(typeof(MockEndpointProvider));
-        var endpointDataSource = CreateDataSource<App>(builder, services);
+        var endpointDataSource = CreateDataSource<App>(services, ConfigureServerComponentBuilder);
 
         // Assert - 1
         var endpoint = Assert.IsType<RouteEndpoint>(
@@ -52,15 +50,17 @@ public class HotReloadServiceTests
         Assert.Equal("/server", endpoint.RoutePattern.RawText);
 
         // Act - 2
-        endpointDataSource.Builder.Pages.AddFromLibraryInfo("TestAssembly2", new[]
-        {
-            new PageComponentBuilder
+        endpointDataSource.ComponentApplicationBuilderActions.Add(
+            b => b.Pages.AddFromLibraryInfo("TestAssembly2", new[]
             {
-                AssemblyName = "TestAssembly2",
-                PageType = typeof(StaticComponent),
-                RouteTemplates = new List<string> { "/app/test" }
-            }
-        });
+                new PageComponentBuilder
+                {
+                    AssemblyName = "TestAssembly2",
+                    PageType = typeof(StaticComponent),
+                    RouteTemplates = new List<string> { "/app/test" }
+                }
+            }));
+
         HotReloadService.UpdateApplication(null);
 
         // Assert - 2
@@ -76,9 +76,8 @@ public class HotReloadServiceTests
     public void RemovesEndpointWhenDataSourceChanges()
     {
         // Arrange
-        var builder = CreateBuilder(typeof(ServerComponent));
         var services = CreateServices(typeof(MockEndpointProvider));
-        var endpointDataSource = CreateDataSource<App>(builder, services);
+        var endpointDataSource = CreateDataSource<App>(services, ConfigureServerComponentBuilder);
 
         // Assert - 1
         var endpoint = Assert.IsType<RouteEndpoint>(Assert.Single(endpointDataSource.Endpoints,
@@ -87,7 +86,7 @@ public class HotReloadServiceTests
         Assert.Equal("/server", endpoint.RoutePattern.RawText);
 
         // Act - 2
-        endpointDataSource.Builder.RemoveLibrary("TestAssembly");
+        endpointDataSource.ComponentApplicationBuilderActions.Add(b => b.RemoveLibrary("TestAssembly"));
         endpointDataSource.Options.ConfiguredRenderModes.Clear();
         HotReloadService.UpdateApplication(null);
 
@@ -100,9 +99,8 @@ public class HotReloadServiceTests
     public void ModifiesEndpointWhenDataSourceChanges()
     {
         // Arrange
-        var builder = CreateBuilder(typeof(ServerComponent));
         var services = CreateServices(typeof(MockEndpointProvider));
-        var endpointDataSource = CreateDataSource<App>(builder, services);
+        var endpointDataSource = CreateDataSource<App>(services, ConfigureServerComponentBuilder);
 
         // Assert - 1
         var endpoint = Assert.IsType<RouteEndpoint>(Assert.Single(endpointDataSource.Endpoints, e => e.Metadata.GetMetadata<RootComponentMetadata>() != null));
@@ -124,9 +122,8 @@ public class HotReloadServiceTests
     public void NotifiesCompositeEndpointDataSource()
     {
         // Arrange
-        var builder = CreateBuilder(typeof(ServerComponent));
         var services = CreateServices(typeof(MockEndpointProvider));
-        var endpointDataSource = CreateDataSource<App>(builder, services);
+        var endpointDataSource = CreateDataSource<App>(services, ConfigureServerComponentBuilder);
         var compositeEndpointDataSource = new CompositeEndpointDataSource(
             new[] { endpointDataSource });
 
@@ -137,7 +134,7 @@ public class HotReloadServiceTests
         Assert.Equal("/server", compositeEndpoint.RoutePattern.RawText);
 
         // Act - 2
-        endpointDataSource.Builder.Pages.RemoveFromAssembly("TestAssembly");
+        endpointDataSource.ComponentApplicationBuilderActions.Add(b => b.Pages.RemoveFromAssembly("TestAssembly"));
         endpointDataSource.Options.ConfiguredRenderModes.Clear();
         HotReloadService.UpdateApplication(null);
 
@@ -148,37 +145,14 @@ public class HotReloadServiceTests
         Assert.Empty(compositePageEndpoints);
     }
 
-    private sealed class WrappedChangeTokenDisposable : IDisposable
-    {
-        public bool IsDisposed { get; private set; }
-        private readonly IDisposable _innerDisposable;
-
-        public WrappedChangeTokenDisposable(IDisposable innerDisposable)
-        { 
-            _innerDisposable = innerDisposable;
-        }
-
-        public void Dispose()
-        { 
-             IsDisposed = true;
-             _innerDisposable.Dispose();
-        }
-    }
-
     [Fact]
     public void ConfirmChangeTokenDisposedHotReload()
     {
         // Arrange
-        var builder = CreateBuilder(typeof(ServerComponent));
         var services = CreateServices(typeof(MockEndpointProvider));
-        var endpointDataSource = CreateDataSource<App>(builder, services);
-
-        WrappedChangeTokenDisposable wrappedChangeTokenDisposable = null;
-
-        endpointDataSource.SetDisposableChangeTokenAction = (IDisposable disposableChangeToken) => {
-            wrappedChangeTokenDisposable = new WrappedChangeTokenDisposable(disposableChangeToken); 
-            return wrappedChangeTokenDisposable;
-        };
+        var endpointDataSource = CreateDataSource<App>(services, ConfigureServerComponentBuilder, null);
+        var changeTokenSource = endpointDataSource.ChangeTokenSource;
+        var changeToken = endpointDataSource.GetChangeToken();
 
         var endpoint = Assert.IsType<RouteEndpoint>(Assert.Single(endpointDataSource.Endpoints, e => e.Metadata.GetMetadata<RootComponentMetadata>() != null));
         Assert.Equal("/server", endpoint.RoutePattern.RawText);
@@ -187,18 +161,21 @@ public class HotReloadServiceTests
         // Make a modification and then perform a hot reload.
         endpointDataSource.Conventions.Add(builder =>
             builder.Metadata.Add(new TestMetadata()));
+
         HotReloadService.UpdateApplication(null);
         HotReloadService.ClearCache(null);
 
         // Confirm the change token is disposed after ClearCache
-        Assert.True(wrappedChangeTokenDisposable.IsDisposed);
+        Assert.True(changeToken.HasChanged);
+        Assert.Throws<ObjectDisposedException>(() => changeTokenSource.Token);
     }
 
     private class TestMetadata { }
 
-    private ComponentApplicationBuilder CreateBuilder(params Type[] types)
+    private class TestAssembly : Assembly;
+
+    private static void ConfigureBuilder(ComponentApplicationBuilder builder, params Type[] types)
     {
-        var builder = new ComponentApplicationBuilder();
         builder.AddLibrary(new AssemblyComponentLibraryDescriptor(
             "TestAssembly",
             Array.Empty<PageComponentBuilder>(),
@@ -208,8 +185,11 @@ public class HotReloadServiceTests
                 ComponentType = t,
                 RenderMode = t.GetCustomAttribute<RenderModeAttribute>()
             }).ToArray()));
+    }
 
-        return builder;
+    private static void ConfigureServerComponentBuilder(ComponentApplicationBuilder builder)
+    {
+        ConfigureBuilder(builder, typeof(StaticComponent));
     }
 
     private IServiceProvider CreateServices(params Type[] types)
@@ -227,16 +207,21 @@ public class HotReloadServiceTests
     }
 
     private static RazorComponentEndpointDataSource<TComponent> CreateDataSource<TComponent>(
-        ComponentApplicationBuilder builder,
         IServiceProvider services,
-        IComponentRenderMode[] renderModes = null)
+        Action<ComponentApplicationBuilder> configureBuilder = null,
+        IComponentRenderMode[] renderModes = null,
+        HotReloadService hotReloadService = null)
     {
         var result = new RazorComponentEndpointDataSource<TComponent>(
-            builder,
             new[] { new MockEndpointProvider() },
             new TestEndpointRouteBuilder(services),
             new RazorComponentEndpointFactory(),
-            new HotReloadService() { MetadataUpdateSupported = true });
+            hotReloadService ?? new HotReloadService() { MetadataUpdateSupported = true });
+
+        if (configureBuilder is not null)
+        {
+            result.ComponentApplicationBuilderActions.Add(configureBuilder);
+        }
 
         if (renderModes != null)
         {

--- a/src/Components/Endpoints/test/HotReloadServiceTests.cs
+++ b/src/Components/Endpoints/test/HotReloadServiceTests.cs
@@ -189,7 +189,7 @@ public class HotReloadServiceTests
 
     private static void ConfigureServerComponentBuilder(ComponentApplicationBuilder builder)
     {
-        ConfigureBuilder(builder, typeof(StaticComponent));
+        ConfigureBuilder(builder, typeof(ServerComponent));
     }
 
     private IServiceProvider CreateServices(params Type[] types)

--- a/src/Components/Endpoints/test/RazorComponentEndpointDataSourceTest.cs
+++ b/src/Components/Endpoints/test/RazorComponentEndpointDataSourceTest.cs
@@ -24,6 +24,11 @@ public class RazorComponentEndpointDataSourceTest
     public void RegistersEndpoints()
     {
         var endpointDataSource = CreateDataSource<App>();
+        endpointDataSource.ComponentApplicationBuilderActions.Add(builder =>
+        {
+            var assembly = typeof(App).Assembly;
+            IRazorComponentApplication.GetBuilderForAssembly(builder, assembly);
+        });
 
         var endpoints = endpointDataSource.Endpoints;
 
@@ -33,10 +38,15 @@ public class RazorComponentEndpointDataSourceTest
     [Fact]
     public void NoDiscoveredModesDefaultsToStatic()
     {
-
-        var builder = CreateBuilder();
         var services = CreateServices(typeof(ServerEndpointProvider));
-        var endpointDataSource = CreateDataSource<App>(builder, services);
+        var endpointDataSource = CreateDataSource<App>(services);
+
+        endpointDataSource.ComponentApplicationBuilderActions.Add(builder =>
+        {
+            builder.AddLibrary(new AssemblyComponentLibraryDescriptor(
+                "TestAssembly",
+                Array.Empty<PageComponentBuilder>(), Array.Empty<ComponentBuilder>()));
+        });
 
         var endpoints = endpointDataSource.Endpoints;
 
@@ -199,22 +209,6 @@ public class RazorComponentEndpointDataSourceTest
             },
         };
 
-    private ComponentApplicationBuilder CreateBuilder(params Type[] types)
-    {
-        var builder = new ComponentApplicationBuilder();
-        builder.AddLibrary(new AssemblyComponentLibraryDescriptor(
-            "TestAssembly",
-            Array.Empty<PageComponentBuilder>(),
-            types.Select(t => new ComponentBuilder
-            {
-                AssemblyName = "TestAssembly",
-                ComponentType = t,
-                RenderMode = t.GetCustomAttribute<RenderModeAttribute>()
-            }).ToArray()));
-
-        return builder;
-    }
-
     private IServiceProvider CreateServices(params Type[] types)
     {
         var services = new ServiceCollection();
@@ -230,12 +224,10 @@ public class RazorComponentEndpointDataSourceTest
     }
 
     private RazorComponentEndpointDataSource<TComponent> CreateDataSource<TComponent>(
-        ComponentApplicationBuilder builder = null,
         IServiceProvider services = null,
         IComponentRenderMode[] renderModes = null)
     {
         var result = new RazorComponentEndpointDataSource<TComponent>(
-            builder ?? DefaultRazorComponentApplication<TComponent>.Instance.GetBuilder(),
             services?.GetService<IEnumerable<RenderModeEndpointProvider>>() ?? Enumerable.Empty<RenderModeEndpointProvider>(),
             new TestEndpointRouteBuilder(services ?? CreateServices()),
             new RazorComponentEndpointFactory(),


### PR DESCRIPTION
Fixes two bugs that prevented hot reload from applying changes in Blazor routes.

### Premature change token disposal

A bug introduced in https://github.com/dotnet/aspnetcore/pull/53750 caused the change token used by `RazorComponentEndpointDataSource` to be disposed before the callback registered on the token is invoked. This means that `UpdateEndpoints` is not being called at all during hot reload.

This PR does not remove the token disposal so that the memory leak is not re-introduced. Instead, the PR moves the disposal of the current token to `UpdateEndpoints` itself. This is valid because the role of the change token is precisely to trigger the update and the token is replaced at the end of `UpdateEndpoints` with a new one (as before).

### Stale route data

The first bug was previously hiding a further problem in how we cache route data used by the main ASP.NET Core routing. This data was computed once during application start up and then reused in every `UpdateEndpoints` invocation. This means that we did not re-scan the assemblies for added, modified, or removed routes.

The PR changes the implementation of `RazorComponentEndpointDataSource` and related types so that we do not store a pre-built instance of `ComponentApplicationBuilder`. Instead we store a list of configuration actions that were invoked for the current `RazorComponentEndpointDataSource`. When the route data needs to be updated, these actions are replayed on a new `ComponentApplicationBuilder` instance, thus ensuring an up-to-date state. Note that this follows the same pattern as we already use for endpoint conventions.

### Result

After the change, hot reload works as expected in the following scenarios:

- A route is changed or added for an existing page.
- A route is added for a new page.

Hot reload still does not work when deleting a page with route.


Fixes #52582