### PR TITLE
[Hot Reload] Do not attempt to apply empty deltas.

### DIFF
--- a/src/Components/WebAssembly/WebAssembly/src/HotReload/HotReloadAgent.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/HotReload/HotReloadAgent.cs
@@ -118,6 +118,13 @@ internal sealed class HotReloadAgent : IDisposable
     {
         foreach (var delta in deltas)
         {
+            if (delta.MetadataDelta.Length == 0)
+            {
+                // When the debugger is attached the delta is empty.
+                // The client only calls to trigger metadata update handlers.
+                continue;
+            }
+
             Reporter.Report($"Applying delta to module {delta.ModuleId}.", AgentMessageSeverity.Verbose);
 
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())


### PR DESCRIPTION
Do not call the runtime to apply empty deltas. The change applies the same [condition we use in 10.0](https://github.com/dotnet/sdk/blob/main/src/BuiltInTools/HotReloadAgent/HotReloadAgent.cs#L129-L134) to 9.0.

## Description

The 9.0 runtime does not ignore empty deltas -- the change to ignore them was only implemented in .NET 10: https://github.com/dotnet/runtime/pull/120333.

When debugging WASM app with the new WASM ICoreDebug-based debugger, the debugger applies deltas and the agent is sent empty deltas. The expectation is that the deltas are ignored and the only action that the agent performs is invoking metadata update handlers.

If the deltas are not skipped in this scenario the 9.0 runtime throws an exception:
"Applying deltas through the debugger and System.Reflection.Metadata.MetadataUpdater.ApplyUpdate simultaneously is not supported"

If we didn't call the agent at all the deltas would be correctly applied by the new WASM debugger but the metadata update handlers wouldn't be executed and thus the app wouldn't function properly (caches not invalidated, UI not refreshed).

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2571149

## Customer Impact

Hot Reload is broken for customers debugging WASM projects from Visual Studio 2026 using the new ICorDebug-based WASM debugger and projects targeting net9.0.

## Regression?

- [x] Yes
- [ ] No

Partial regression: Previous versions of VS did not fail to apply change entirely, but also did not invoke update handlers, which leaves the app in partially-updated state.
Fixing that in VS caused regression in net90 projects because they lack the condition added in this change.

## Risk

- [ ] High
- [ ] Medium
- [x] Low

The condition is trivial and well tested in net10.

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

----

## When servicing release/2.3

- [ ] Make necessary changes in eng/PatchCo

