### PR TITLE
Allow `UserStore` to update passkey name

### DIFF
--- a/src/Identity/EntityFrameworkCore/src/IdentityUserPasskeyExtensions.cs
+++ b/src/Identity/EntityFrameworkCore/src/IdentityUserPasskeyExtensions.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+
+internal static class IdentityUserPasskeyExtensions
+{
+    extension<TKey>(IdentityUserPasskey<TKey> passkey)
+        where TKey : IEquatable<TKey>
+    {
+        public void UpdateFromUserPasskeyInfo(UserPasskeyInfo passkeyInfo)
+        {
+            passkey.Data.Name = passkeyInfo.Name;
+            passkey.Data.SignCount = passkeyInfo.SignCount;
+            passkey.Data.IsBackedUp = passkeyInfo.IsBackedUp;
+            passkey.Data.IsUserVerified = passkeyInfo.IsUserVerified;
+        }
+
+        public UserPasskeyInfo ToUserPasskeyInfo()
+            => new(
+                passkey.CredentialId,
+                passkey.Data.PublicKey,
+                passkey.Data.CreatedAt,
+                passkey.Data.SignCount,
+                passkey.Data.Transports,
+                passkey.Data.IsUserVerified,
+                passkey.Data.IsBackupEligible,
+                passkey.Data.IsBackedUp,
+                passkey.Data.AttestationObject,
+                passkey.Data.ClientDataJson)
+            {
+                Name = passkey.Data.Name
+            };
+    }
+}

--- a/src/Identity/EntityFrameworkCore/src/UserOnlyStore.cs
+++ b/src/Identity/EntityFrameworkCore/src/UserOnlyStore.cs
@@ -708,6 +708,7 @@ public class UserOnlyStore<TUser, TContext, TKey, TUserClaim, TUserLogin, TUserT
         cancellationToken.ThrowIfCancellationRequested();
         ThrowIfDisposed();
         ArgumentNullException.ThrowIfNull(user);
+        ArgumentNullException.ThrowIfNull(credentialId);
 
         var passkey = await FindUserPasskeyAsync(user.Id, credentialId, cancellationToken).ConfigureAwait(false);
         if (passkey != null)

--- a/src/Identity/EntityFrameworkCore/src/UserOnlyStore.cs
+++ b/src/Identity/EntityFrameworkCore/src/UserOnlyStore.cs
@@ -625,10 +625,7 @@ public class UserOnlyStore<TUser, TContext, TKey, TUserClaim, TUserLogin, TUserT
         var userPasskey = await FindUserPasskeyByIdAsync(passkey.CredentialId, cancellationToken).ConfigureAwait(false);
         if (userPasskey != null)
         {
-            userPasskey.Data.Name = passkey.Name;
-            userPasskey.Data.SignCount = passkey.SignCount;
-            userPasskey.Data.IsBackedUp = passkey.IsBackedUp;
-            userPasskey.Data.IsUserVerified = passkey.IsUserVerified;
+            userPasskey.UpdateFromUserPasskeyInfo(passkey);
             UserPasskeys.Update(userPasskey);
         }
         else
@@ -655,20 +652,7 @@ public class UserOnlyStore<TUser, TContext, TKey, TUserClaim, TUserLogin, TUserT
         var userId = user.Id;
         var passkeys = await UserPasskeys
             .Where(p => p.UserId.Equals(userId))
-            .Select(p => new UserPasskeyInfo(
-                p.CredentialId,
-                p.Data.PublicKey,
-                p.Data.CreatedAt,
-                p.Data.SignCount,
-                p.Data.Transports,
-                p.Data.IsUserVerified,
-                p.Data.IsBackupEligible,
-                p.Data.IsBackedUp,
-                p.Data.AttestationObject,
-                p.Data.ClientDataJson)
-            {
-                Name = p.Data.Name,
-            })
+            .Select(p => p.ToUserPasskeyInfo())
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
@@ -711,24 +695,7 @@ public class UserOnlyStore<TUser, TContext, TKey, TUserClaim, TUserLogin, TUserT
         ArgumentNullException.ThrowIfNull(credentialId);
 
         var passkey = await FindUserPasskeyAsync(user.Id, credentialId, cancellationToken).ConfigureAwait(false);
-        if (passkey != null)
-        {
-            return new UserPasskeyInfo(
-                passkey.CredentialId,
-                passkey.Data.PublicKey,
-                passkey.Data.CreatedAt,
-                passkey.Data.SignCount,
-                passkey.Data.Transports,
-                passkey.Data.IsUserVerified,
-                passkey.Data.IsBackupEligible,
-                passkey.Data.IsBackedUp,
-                passkey.Data.AttestationObject,
-                passkey.Data.ClientDataJson)
-            {
-                Name = passkey.Data.Name,
-            };
-        }
-        return null;
+        return passkey?.ToUserPasskeyInfo();
     }
 
     /// <summary>

--- a/src/Identity/EntityFrameworkCore/src/UserStore.cs
+++ b/src/Identity/EntityFrameworkCore/src/UserStore.cs
@@ -770,6 +770,7 @@ public class UserStore<TUser, TRole, TContext, [DynamicallyAccessedMembers(Dynam
         var userPasskey = await FindUserPasskeyByIdAsync(passkey.CredentialId, cancellationToken).ConfigureAwait(false);
         if (userPasskey != null)
         {
+            userPasskey.Data.Name = passkey.Name;
             userPasskey.Data.SignCount = passkey.SignCount;
             userPasskey.Data.IsBackedUp = passkey.IsBackedUp;
             userPasskey.Data.IsUserVerified = passkey.IsUserVerified;
@@ -851,6 +852,7 @@ public class UserStore<TUser, TRole, TContext, [DynamicallyAccessedMembers(Dynam
     {
         cancellationToken.ThrowIfCancellationRequested();
         ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(user);
         ArgumentNullException.ThrowIfNull(credentialId);
 
         var passkey = await FindUserPasskeyAsync(user.Id, credentialId, cancellationToken).ConfigureAwait(false);

--- a/src/Identity/EntityFrameworkCore/src/UserStore.cs
+++ b/src/Identity/EntityFrameworkCore/src/UserStore.cs
@@ -770,10 +770,7 @@ public class UserStore<TUser, TRole, TContext, [DynamicallyAccessedMembers(Dynam
         var userPasskey = await FindUserPasskeyByIdAsync(passkey.CredentialId, cancellationToken).ConfigureAwait(false);
         if (userPasskey != null)
         {
-            userPasskey.Data.Name = passkey.Name;
-            userPasskey.Data.SignCount = passkey.SignCount;
-            userPasskey.Data.IsBackedUp = passkey.IsBackedUp;
-            userPasskey.Data.IsUserVerified = passkey.IsUserVerified;
+            userPasskey.UpdateFromUserPasskeyInfo(passkey);
             UserPasskeys.Update(userPasskey);
         }
         else
@@ -800,20 +797,7 @@ public class UserStore<TUser, TRole, TContext, [DynamicallyAccessedMembers(Dynam
         var userId = user.Id;
         var passkeys = await UserPasskeys
             .Where(p => p.UserId.Equals(userId))
-            .Select(p => new UserPasskeyInfo(
-                p.CredentialId,
-                p.Data.PublicKey,
-                p.Data.CreatedAt,
-                p.Data.SignCount,
-                p.Data.Transports,
-                p.Data.IsUserVerified,
-                p.Data.IsBackupEligible,
-                p.Data.IsBackedUp,
-                p.Data.AttestationObject,
-                p.Data.ClientDataJson)
-            {
-                Name = p.Data.Name
-            })
+            .Select(p => p.ToUserPasskeyInfo())
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
@@ -856,24 +840,7 @@ public class UserStore<TUser, TRole, TContext, [DynamicallyAccessedMembers(Dynam
         ArgumentNullException.ThrowIfNull(credentialId);
 
         var passkey = await FindUserPasskeyAsync(user.Id, credentialId, cancellationToken).ConfigureAwait(false);
-        if (passkey != null)
-        {
-            return new UserPasskeyInfo(
-                passkey.CredentialId,
-                passkey.Data.PublicKey,
-                passkey.Data.CreatedAt,
-                passkey.Data.SignCount,
-                passkey.Data.Transports,
-                passkey.Data.IsUserVerified,
-                passkey.Data.IsBackupEligible,
-                passkey.Data.IsBackedUp,
-                passkey.Data.AttestationObject,
-                passkey.Data.ClientDataJson)
-            {
-                Name = passkey.Data.Name
-            };
-        }
-        return null;
+        return passkey?.ToUserPasskeyInfo();
     }
 
     /// <summary>

--- a/src/Identity/EntityFrameworkCore/test/EF.InMemory.Test/InMemoryStoreWithGenericsTest.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.InMemory.Test/InMemoryStoreWithGenericsTest.cs
@@ -24,6 +24,10 @@ public class InMemoryEFUserStoreTestWithGenerics
 
         var services = new ServiceCollection();
         services.AddHttpContextAccessor();
+        services.Configure<IdentityOptions>(options =>
+        {
+            options.Stores.SchemaVersion = IdentitySchemaVersions.Version3;
+        });
         services.AddDbContext<InMemoryContextWithGenerics>(
             options => options
                 .UseSqlite(_fixture.Connection)

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/DbUtil.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/DbUtil.cs
@@ -30,6 +30,11 @@ public static class DbUtil
                 .UseSqlite(connection);
         });
 
+        services.Configure<IdentityOptions>(options =>
+        {
+            options.Stores.SchemaVersion = IdentitySchemaVersions.Version3;
+        });
+
         return services;
     }
 

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/SqlStoreTestBase.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/SqlStoreTestBase.cs
@@ -37,6 +37,7 @@ public abstract class SqlStoreTestBase<TUser, TRole, TKey> : IdentitySpecificati
             options.Password.RequireNonAlphanumeric = false;
             options.Password.RequireUppercase = false;
             options.User.AllowedUserNameCharacters = null;
+            options.Stores.SchemaVersion = IdentitySchemaVersions.Version3;
         })
         .AddRoles<TRole>()
         .AddDefaultTokenProviders()

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/UserStoreEncryptPersonalDataTest.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/UserStoreEncryptPersonalDataTest.cs
@@ -25,6 +25,7 @@ public class ProtectedUserStoreTest : SqlStoreTestBase<IdentityUser, IdentityRol
             options.Password.RequireNonAlphanumeric = false;
             options.Password.RequireUppercase = false;
             options.User.AllowedUserNameCharacters = null;
+            options.Stores.SchemaVersion = IdentitySchemaVersions.Version3;
         })
         .AddDefaultTokenProviders()
         .AddEntityFrameworkStores<TestDbContext>()

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/UserStoreTest.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/UserStoreTest.cs
@@ -40,7 +40,12 @@ public class UserStoreTest : IdentitySpecificationTestBase<IdentityUser, Identit
 
     private IdentityDbContext CreateContext()
     {
-        var db = DbUtil.Create<IdentityDbContext>(_fixture.Connection);
+        var services = new ServiceCollection();
+        services.Configure<IdentityOptions>(options =>
+        {
+            options.Stores.SchemaVersion = IdentitySchemaVersions.Version3;
+        });
+        var db = DbUtil.Create<IdentityDbContext>(_fixture.Connection, services);
         db.Database.EnsureCreated();
         return db;
     }
@@ -195,7 +200,6 @@ public class UserStoreTest : IdentitySpecificationTestBase<IdentityUser, Identit
         userB.Email = "dupe@dupe.com";
         IdentityResultAssert.IsSuccess(await manager.CreateAsync(userB, "password"));
         await Assert.ThrowsAsync<InvalidOperationException>(async () => await manager.FindByEmailAsync("dupe@dupe.com"));
-
     }
 
     [ConditionalFact]

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/UserStoreTest.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/UserStoreTest.cs
@@ -40,12 +40,7 @@ public class UserStoreTest : IdentitySpecificationTestBase<IdentityUser, Identit
 
     private IdentityDbContext CreateContext()
     {
-        var services = new ServiceCollection();
-        services.Configure<IdentityOptions>(options =>
-        {
-            options.Stores.SchemaVersion = IdentitySchemaVersions.Version3;
-        });
-        var db = DbUtil.Create<IdentityDbContext>(_fixture.Connection, services);
+        var db = DbUtil.Create<IdentityDbContext>(_fixture.Connection);
         db.Database.EnsureCreated();
         return db;
     }

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/UserStoreWithGenericsTest.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/UserStoreWithGenericsTest.cs
@@ -21,7 +21,12 @@ public class UserStoreWithGenericsTest : IdentitySpecificationTestBase<IdentityU
 
     private ContextWithGenerics CreateContext()
     {
-        var db = DbUtil.Create<ContextWithGenerics>(_fixture.Connection);
+        var services = new ServiceCollection();
+        services.Configure<IdentityOptions>(options =>
+        {
+            options.Stores.SchemaVersion = IdentitySchemaVersions.Version3;
+        });
+        var db = DbUtil.Create<ContextWithGenerics>(_fixture.Connection, services);
         db.Database.EnsureCreated();
         return db;
     }

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/UserStoreWithGenericsTest.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/UserStoreWithGenericsTest.cs
@@ -21,12 +21,7 @@ public class UserStoreWithGenericsTest : IdentitySpecificationTestBase<IdentityU
 
     private ContextWithGenerics CreateContext()
     {
-        var services = new ServiceCollection();
-        services.Configure<IdentityOptions>(options =>
-        {
-            options.Stores.SchemaVersion = IdentitySchemaVersions.Version3;
-        });
-        var db = DbUtil.Create<ContextWithGenerics>(_fixture.Connection, services);
+        var db = DbUtil.Create<ContextWithGenerics>(_fixture.Connection);
         db.Database.EnsureCreated();
         return db;
     }

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/Utilities/ScratchDatabaseFixture.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/Utilities/ScratchDatabaseFixture.cs
@@ -4,6 +4,7 @@
 using System.Data.Common;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test;
 
@@ -23,7 +24,14 @@ public class ScratchDatabaseFixture : IDisposable
     }
 
     private DbContext CreateEmptyContext()
-        => new DbContext(new DbContextOptionsBuilder().UseSqlite(_connection).Options);
+    {
+        var services = new ServiceCollection();
+        services.Configure<IdentityOptions>(options => options.Stores.SchemaVersion = IdentitySchemaVersions.Version3);
+        return new DbContext(new DbContextOptionsBuilder()
+            .UseSqlite(_connection)
+            .UseApplicationServiceProvider(services.BuildServiceProvider())
+            .Options);
+    }
 
     public DbConnection Connection => _connection;
 

--- a/src/Identity/Specification.Tests/src/UserManagerSpecificationTests.cs
+++ b/src/Identity/Specification.Tests/src/UserManagerSpecificationTests.cs
@@ -61,6 +61,7 @@ public abstract class UserManagerSpecificationTestBase<TUser, TKey>
             options.Password.RequireNonAlphanumeric = false;
             options.Password.RequireUppercase = false;
             options.User.AllowedUserNameCharacters = null;
+            options.Stores.SchemaVersion = IdentitySchemaVersions.Version3;
         }).AddDefaultTokenProviders();
         AddUserStore(services, context);
         services.AddLogging();


### PR DESCRIPTION
## Summary

Fixes an issue where `UserStore` doesn't apply updates to a passkey's name after its initial creation.

## Details

The issue was only present in `UserStore`, as `UserOnlyStore` was already implemented correctly. I've added extra tests to protected against similar implementation inconsistencies.

Fixes https://github.com/dotnet/aspnetcore/issues/63923