### PR TITLE
Fix the bug with scrolling in Virtualize component with scaled elements

### DIFF
--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -113,16 +113,13 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
         // Check for scale property (can have separate X/Y values)
         if (computedStyle.scale && computedStyle.scale !== 'none' && computedStyle.scale !== '1') {
           const parts = computedStyle.scale.split(' ');
-          const scaleX = parseFloat(parts[0]);
-          const scaleY = parts.length > 1 ? parseFloat(parts[1]) : scaleX;
+          const scaleY = parts.length > 1 ? parseFloat(parts[1]) : parseFloat(parts[0]);
           scaleFactor *= scaleY; // Use vertical scale for vertical scrolling
         }
 
         // Check for transform property (matrix form)
         if (computedStyle.transform && computedStyle.transform !== 'none') {
-          // Parse the transform matrix using DOMMatrix to extract scaleY
           const matrix = new DOMMatrix(computedStyle.transform);
-          // For vertical scrolling, we only need the Y-axis scale factor (d/m22)
           scaleFactor *= matrix.d;
         }
         element = element.parentElement;

--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -121,13 +121,11 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
 
         // Check for transform property (matrix form)
         if (computedStyle.transform && computedStyle.transform !== 'none') {
-          const match = computedStyle.transform.match(/matrix\(([^,]+),\s*([^,]+),\s*([^,]+),\s*([^,]+)/);
+          // A 2D transform matrix has 6 values: matrix(scaleX, skewY, skewX, scaleY, translateX, translateY)
+          const match = computedStyle.transform.match(/matrix\([^,]+,\s*[^,]+,\s*[^,]+,\s*([^,]+)/);
           if (match) {
-            const scaleX = parseFloat(match[1]);
-            const scaleY = parseFloat(match[4]);
-            if (Math.abs(scaleX - 1.0) > 0.01 || Math.abs(scaleY - 1.0) > 0.01) {
-              scaleFactor *= scaleY; // Use vertical scale
-            }
+            const scaleY = parseFloat(match[1]);
+            scaleFactor *= scaleY;
           }
         }
         element = element.parentElement;

--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -94,8 +94,7 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
       // scrolling glitches.
       rangeBetweenSpacers.setStartAfter(spacerBefore);
       rangeBetweenSpacers.setEndBefore(spacerAfter);
-      const rangeRect = rangeBetweenSpacers.getBoundingClientRect();
-      const spacerSeparation = rangeRect.height;
+      const spacerSeparation = rangeBetweenSpacers.getBoundingClientRect().height;
       const containerSize = entry.rootBounds?.height;
 
       // Accumulate scale factors from all parent elements as they multiply together
@@ -107,7 +106,7 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
         const computedStyle = getComputedStyle(element);
 
         // Check for zoom property (applies uniform scaling)
-        if (computedStyle.zoom && computedStyle.zoom !== 'normal' && computedStyle.zoom !== '1') {
+        if (computedStyle.zoom && computedStyle.zoom !== '1') {
           scaleFactor *= parseFloat(computedStyle.zoom);
         }
 
@@ -121,12 +120,10 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
 
         // Check for transform property (matrix form)
         if (computedStyle.transform && computedStyle.transform !== 'none') {
-          // A 2D transform matrix has 6 values: matrix(scaleX, skewY, skewX, scaleY, translateX, translateY)
-          const match = computedStyle.transform.match(/matrix\([^,]+,\s*[^,]+,\s*[^,]+,\s*([^,]+)/);
-          if (match) {
-            const scaleY = parseFloat(match[1]);
-            scaleFactor *= scaleY;
-          }
+          // Parse the transform matrix using DOMMatrix to extract scaleY
+          const matrix = new DOMMatrix(computedStyle.transform);
+          // For vertical scrolling, we only need the Y-axis scale factor (d/m22)
+          scaleFactor *= matrix.d;
         }
         element = element.parentElement;
       }

--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -94,16 +94,60 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
       // scrolling glitches.
       rangeBetweenSpacers.setStartAfter(spacerBefore);
       rangeBetweenSpacers.setEndBefore(spacerAfter);
-      const spacerSeparation = rangeBetweenSpacers.getBoundingClientRect().height;
+      const rangeRect = rangeBetweenSpacers.getBoundingClientRect();
+      const spacerSeparation = rangeRect.height;
       const containerSize = entry.rootBounds?.height;
 
+      // Accumulate scale factors from all parent elements as they multiply together
+      let scaleFactor = 1.0;
+
+      // Check for CSS scale/zoom/transform properties on parent elements (including body and html)
+      let element = spacerBefore.parentElement;
+      while (element) {
+        const computedStyle = getComputedStyle(element);
+
+        // Check for zoom property (applies uniform scaling)
+        if (computedStyle.zoom && computedStyle.zoom !== 'normal' && computedStyle.zoom !== '1') {
+          scaleFactor *= parseFloat(computedStyle.zoom);
+        }
+
+        // Check for scale property (can have separate X/Y values)
+        if (computedStyle.scale && computedStyle.scale !== 'none' && computedStyle.scale !== '1') {
+          const parts = computedStyle.scale.split(' ');
+          const scaleX = parseFloat(parts[0]);
+          const scaleY = parts.length > 1 ? parseFloat(parts[1]) : scaleX;
+          scaleFactor *= scaleY; // Use vertical scale for vertical scrolling
+        }
+
+        // Check for transform property (matrix form)
+        if (computedStyle.transform && computedStyle.transform !== 'none') {
+          const match = computedStyle.transform.match(/matrix\(([^,]+),\s*([^,]+),\s*([^,]+),\s*([^,]+)/);
+          if (match) {
+            const scaleX = parseFloat(match[1]);
+            const scaleY = parseFloat(match[4]);
+            if (Math.abs(scaleX - 1.0) > 0.01 || Math.abs(scaleY - 1.0) > 0.01) {
+              scaleFactor *= scaleY; // Use vertical scale
+            }
+          }
+        }
+        element = element.parentElement;
+      }
+
+      // Divide by scale factor to convert from physical pixels to logical pixels.
+      const unscaledSpacerSeparation = spacerSeparation / scaleFactor;
+      const unscaledContainerSize = containerSize !== null && containerSize !== undefined ? containerSize / scaleFactor : null;
+
       if (entry.target === spacerBefore) {
-        dotNetHelper.invokeMethodAsync('OnSpacerBeforeVisible', entry.intersectionRect.top - entry.boundingClientRect.top, spacerSeparation, containerSize);
+        const spacerSize = entry.intersectionRect.top - entry.boundingClientRect.top;
+        const unscaledSpacerSize = spacerSize / scaleFactor;
+        dotNetHelper.invokeMethodAsync('OnSpacerBeforeVisible', unscaledSpacerSize, unscaledSpacerSeparation, unscaledContainerSize);
       } else if (entry.target === spacerAfter && spacerAfter.offsetHeight > 0) {
         // When we first start up, both the "before" and "after" spacers will be visible, but it's only relevant to raise a
         // single event to load the initial data. To avoid raising two events, skip the one for the "after" spacer if we know
         // it's meaningless to talk about any overlap into it.
-        dotNetHelper.invokeMethodAsync('OnSpacerAfterVisible', entry.boundingClientRect.bottom - entry.intersectionRect.bottom, spacerSeparation, containerSize);
+        const spacerSize = entry.boundingClientRect.bottom - entry.intersectionRect.bottom;
+        const unscaledSpacerSize = spacerSize / scaleFactor;
+        dotNetHelper.invokeMethodAsync('OnSpacerAfterVisible', unscaledSpacerSize, unscaledSpacerSeparation, unscaledContainerSize);
       }
     });
   }

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using System.Linq;
 using BasicTestApp;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
@@ -426,16 +427,79 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
             name => Assert.Equal("Person 3", name));
     }
 
-    [Fact]
-    public void CanScrollWhenAppliedScale()
+    [Theory]
+    [InlineData("1")]
+    [InlineData("2")]
+    [InlineData("0.5")]
+    public void CanScrollWhenAppliedScale(string scaleY)
     {
         Browser.MountTestComponent<VirtualizationScale>();
         var container = Browser.Exists(By.Id("virtualize"));
 
-        var people = GetPeopleNames(container);
-        Assert.True(GetPeopleNames(container).Length > 0);
-        ScrollTopToEnd(Browser, container);
-        Assert.True(GetPeopleNames(container).Length > 0);
+        Browser.True(() =>
+        {
+            try
+            {
+                return Browser.FindElement(By.Id("virtualize"))
+                    .FindElements(By.CssSelector("tbody tr.person")).Count > 0;
+            }
+            catch (StaleElementReferenceException)
+            {
+                return false;
+            }
+        });
+
+        Browser.FindElement(By.Id("scale-y-input")).Clear();
+        Browser.FindElement(By.Id("scale-y-input")).SendKeys(scaleY);
+        Browser.FindElement(By.Id("btn")).Click();
+
+        // Scroll slowly (10px increments) and check if the first visible item changes unexpectedly.
+        // If the item index goes backward (e.g., from "5" to "4") instead of
+        // staying the same or advancing, that indicates flashing.
+        const string detectFlashingScript = @"
+        var done = arguments[0];
+        (async () => {
+            const SCROLL_INCREMENT = 10;
+            let previousTopItemIndex = null;
+            const container = document.querySelector('#virtualize');
+            if (!container) {
+                done(false);
+                return;
+            }
+
+            const getTopVisibleItemIndex = () => {
+                const firstRow = container.querySelector('tbody tr.person span');
+                if (!firstRow) return null;
+                return parseInt(firstRow.textContent, 10);
+            };
+
+            while (true) {
+                const previousScrollTop = container.scrollTop;
+                container.scrollTop += SCROLL_INCREMENT;
+                await new Promise(resolve => requestAnimationFrame(resolve));
+                const currentScrollTop = container.scrollTop;
+                if (currentScrollTop === previousScrollTop) {
+                    done(true);
+                    return;
+                }
+                const currentTopItemIndex = getTopVisibleItemIndex();
+                if (currentTopItemIndex === null) {
+                    done(false);
+                    return;
+                }
+                if (previousTopItemIndex !== null) {
+                    if (currentTopItemIndex < previousTopItemIndex) {
+                        done(false);
+                        return;
+                    }
+                }
+                previousTopItemIndex = currentTopItemIndex;
+            }
+        })();";
+
+        var jsExecutor = (IJavaScriptExecutor)Browser;
+        var noFlashingDetected = (bool)jsExecutor.ExecuteAsyncScript(detectFlashingScript);
+        Assert.True(noFlashingDetected);
     }
 
     [Theory]

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -426,6 +426,18 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
             name => Assert.Equal("Person 3", name));
     }
 
+    [Fact]
+    public void CanScrollWhenAppliedScale()
+    {
+        Browser.MountTestComponent<VirtualizationScale>();
+        var container = Browser.Exists(By.Id("virtualize"));
+
+        var people = GetPeopleNames(container);
+        Assert.True(GetPeopleNames(container).Length > 0);
+        ScrollTopToEnd(Browser, container);
+        Assert.True(GetPeopleNames(container).Length > 0);
+    }
+
     [Theory]
     [InlineData("simple-scroll-horizontal")]
     [InlineData("complex-scroll-horizontal")]

--- a/src/Components/test/testassets/BasicTestApp/Index.razor
+++ b/src/Components/test/testassets/BasicTestApp/Index.razor
@@ -123,6 +123,7 @@
         <option value="BasicTestApp.VirtualizationMaxItemCount">Virtualization MaxItemCount</option>
         <option value="BasicTestApp.VirtualizationMaxItemCount_AppContext">Virtualization MaxItemCount (via AppContext)</option>
         <option value="BasicTestApp.VirtualizationTable">Virtualization HTML table</option>
+        <option value="BasicTestApp.VirtualizationScale">Virtualization with scale</option>
         <option value="BasicTestApp.VirtualizationLargeOverscan">Virtualization large overscan</option>
         <option value="BasicTestApp.HotReload.RenderOnHotReload">Render on hot reload</option>
         <option value="BasicTestApp.SectionsTest.ParentComponentWithTwoChildren">Sections test</option>

--- a/src/Components/test/testassets/BasicTestApp/QuickGridTest/QuickGridVirtualizeComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/QuickGridTest/QuickGridVirtualizeComponent.razor
@@ -29,7 +29,7 @@
             Interlocked.Increment(ref ItemsProviderCallCount);
             StateHasChanged();
             return GridItemsProviderResult.From(
-                items: Enumerable.Range(1, 100).Select(i => new Person { Id = i, Name = $"Person {i}" }).ToList(),
+                items: Enumerable.Range(request.StartIndex, request.Count ?? 10).Select(i => new Person { Id = i, Name = $"Person {i}" }).ToList(),
                 totalItemCount: 100);
         };
     }

--- a/src/Components/test/testassets/BasicTestApp/VirtualizationScale.razor
+++ b/src/Components/test/testassets/BasicTestApp/VirtualizationScale.razor
@@ -1,0 +1,33 @@
+﻿<div id="virtualize" style="height: 200px; overflow: auto">
+    <Virtualize ItemsProvider="@itemsProvider">
+        <tr class="person"><span>@context.Name</span></tr>
+    </Virtualize>
+</div>
+
+@code {
+    internal class Person
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private ItemsProviderDelegate<Person> itemsProvider = default!;
+
+    protected override void OnInitialized()
+    {
+        itemsProvider = async request =>
+        {
+            await Task.CompletedTask;
+            return new ItemsProviderResult<Person>(
+                items: Enumerable.Range(request.StartIndex, request.Count).Select(i => new Person { Id = i, Name = $"Person {i}" }).ToList(),
+                totalItemCount: 100);
+        };
+    }
+}
+
+<style>
+    body {
+        scale: 2 0.5;
+        transform-origin: top left;
+    }
+</style>

--- a/src/Components/test/testassets/BasicTestApp/VirtualizationScale.razor
+++ b/src/Components/test/testassets/BasicTestApp/VirtualizationScale.razor
@@ -1,13 +1,18 @@
 ﻿<div style="scale: @ScaleX @ScaleY; transform-origin: top left;">
     <div id="virtualize" style="height: 200px; overflow: auto">
-        <Virtualize ItemsProvider="@itemsProvider">
-            <tr class="person"><span>@context.Name</span></tr>
-        </Virtualize>
+        <table>
+            <tbody>
+                <Virtualize ItemsProvider="@itemsProvider">
+                    <tr class="person"><span>@context.Id</span></tr>
+            </Virtualize>
+            </tbody>
+        </table>
     </div>
 </div>
 
-<input type="number" @bind="ScaleX" />
-<input type="number" @bind="ScaleY" />
+<input type="number" @bind="ScaleX" id="scale-x-input" />
+<input type="number" @bind="ScaleY" id="scale-y-input" />
+<button id="btn">Click</button>
 
 @code {
     internal class Person
@@ -16,8 +21,8 @@
         public string Name { get; set; } = string.Empty;
     }
 
-    public double ScaleX { get; set; } = 1.0;
-    public double ScaleY { get; set; } = 1.0;
+    public double? ScaleX { get; set; } = 1.0;
+    public double? ScaleY { get; set; } = 1.0;
 
     private ItemsProviderDelegate<Person> itemsProvider = default!;
 

--- a/src/Components/test/testassets/BasicTestApp/VirtualizationScale.razor
+++ b/src/Components/test/testassets/BasicTestApp/VirtualizationScale.razor
@@ -1,8 +1,13 @@
-﻿<div id="virtualize" style="height: 200px; overflow: auto">
-    <Virtualize ItemsProvider="@itemsProvider">
-        <tr class="person"><span>@context.Name</span></tr>
-    </Virtualize>
+﻿<div style="scale: @ScaleX @ScaleY; transform-origin: top left;">
+    <div id="virtualize" style="height: 200px; overflow: auto">
+        <Virtualize ItemsProvider="@itemsProvider">
+            <tr class="person"><span>@context.Name</span></tr>
+        </Virtualize>
+    </div>
 </div>
+
+<input type="number" @bind="ScaleX" />
+<input type="number" @bind="ScaleY" />
 
 @code {
     internal class Person
@@ -10,6 +15,9 @@
         public int Id { get; set; }
         public string Name { get; set; } = string.Empty;
     }
+
+    public double ScaleX { get; set; } = 1.0;
+    public double ScaleY { get; set; } = 1.0;
 
     private ItemsProviderDelegate<Person> itemsProvider = default!;
 
@@ -24,10 +32,3 @@
         };
     }
 }
-
-<style>
-    body {
-        scale: 2 0.5;
-        transform-origin: top left;
-    }
-</style>


### PR DESCRIPTION
# Fix the bug with scrolling in Virtualize component with scaled elements

## Description

This pull request improves the `Virtualize` component’s handling of CSS scaling and transforms, ensuring correct virtualization behavior when parent elements use scale, zoom, or transform properties. It also adds new test to verify these changes.

The issue was caused by inconsistent scaling algorithm between JS and C#. JS operates on physical units, let's call it physical pixels - scaled pixel values. It used to send physical measurements to C#. C# operates on logical pixels, see e.g. `ItemSize` description
https://github.com/dotnet/aspnetcore/blob/a54e8dfed01df6a5e2772d5266297d6317a93226/src/Components/Web/src/Virtualization/Virtualize.cs#L91
and it assumed the values received from JS are not scaled. This PR standardizes the sizes to support logical-pixels-based communication between JS and C#.

## Alternatives:
- Convert all the calculations and logic of C# code to physical pixels. Component's input parameters can change on each render. If we wanted to convert them to physical values on each change (e.g storing the physical value as a private component member), it brings a similar performance overhead as the currently proposed fix. 
- Changing the meaning of the public parameters (from logical pixels to physical pixels) it would be a breaking change.
- Officially decide we do not support scaling of the DOM elements that contain virtualize component. The scale could be used for the virtualize element only. Thanks to this, we would avoid transversing the DOM tree bottom-up - the most costly operation in this change.

### Changes:

* Updated `Virtualize.ts` to detect and correctly handle CSS scale, zoom, and transform properties on parent elements, adjusting scroll calculations so virtualization works accurately under scaling scenarios.
* Added a new test `CanScrollWhenAppliedScale` to verify that virtualization works when CSS scale is applied.

Fixes #59354
