### PR TITLE
Quarantine failing Passkey tests in UserStoreTest

### DIFF
--- a/src/Identity/Specification.Tests/src/IdentitySpecificationTestBase.cs
+++ b/src/Identity/Specification.Tests/src/IdentitySpecificationTestBase.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Security.Claims;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;

--- a/src/Identity/Specification.Tests/src/IdentitySpecificationTestBase.cs
+++ b/src/Identity/Specification.Tests/src/IdentitySpecificationTestBase.cs
@@ -610,6 +610,7 @@ public abstract class IdentitySpecificationTestBase<TUser, TRole, TKey> : UserMa
     /// Test.
     /// </summary>
     /// <returns>Task</returns>
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/64055")]
     [Fact]
     public async Task CanAddAndRetrievePasskey()
     {
@@ -649,6 +650,7 @@ public abstract class IdentitySpecificationTestBase<TUser, TRole, TKey> : UserMa
     /// Test.
     /// </summary>
     /// <returns>Task</returns>
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/64055")]
     [Fact]
     public async Task CanRemovePasskey()
     {
@@ -687,6 +689,7 @@ public abstract class IdentitySpecificationTestBase<TUser, TRole, TKey> : UserMa
     /// Test.
     /// </summary>
     /// <returns>Task</returns>
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/64055")]
     [Fact]
     public async Task CanAddMultiplePasskeys()
     {
@@ -743,6 +746,7 @@ public abstract class IdentitySpecificationTestBase<TUser, TRole, TKey> : UserMa
     /// Test.
     /// </summary>
     /// <returns>Task</returns>
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/64055")]
     [Fact]
     public async Task UpdatingPasskeyChangesOnlyMutableFields()
     {


### PR DESCRIPTION
They are blocking PRs from merging and have a rich failure history.


## Description

Related issue: https://github.com/dotnet/aspnetcore/issues/64055.
