### PR TITLE
Clarify Sandbox endpoint separation: Path vs Webhook

### DIFF
--- a/src/Grpc/JsonTranscoding/test/testassets/Sandbox/Sandbox.csproj
+++ b/src/Grpc/JsonTranscoding/test/testassets/Sandbox/Sandbox.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework> 
   </PropertyGroup>
 
   <ItemGroup>
@@ -8,7 +8,10 @@
     <Protobuf Include="transcoding.proto" GrpcServices="Server" />
 
     <Reference Include="Grpc.AspNetCore" />
-    <Reference Include="Microsoft.AspNetCore.Grpc.JsonTranscoding" />
-    <Reference Include="Microsoft.AspNetCore.Grpc.Swagger" />
+    <Reference Include="Microsoft.AspNetCore.Grpc.JsonTranscoding">      
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Grpc.Swagger" >
+    </Reference>     
   </ItemGroup>
 </Project>
+ 

--- a/src/Grpc/JsonTranscoding/test/testassets/Sandbox/Services/Metadata/PathItemTypeAttribute.cs
+++ b/src/Grpc/JsonTranscoding/test/testassets/Sandbox/Services/Metadata/PathItemTypeAttribute.cs
@@ -1,0 +1,15 @@
+namespace Sandbox.Services.Metadata
+{
+    public enum PathItemType
+    {
+        Standard,
+        Webhook
+    }
+
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Delegate)]
+    public class PathItemTypeAttribute : Attribute
+    {
+        public PathItemType Type { get; }
+        public PathItemTypeAttribute(PathItemType type) => Type = type;
+    }
+}

--- a/src/Grpc/JsonTranscoding/test/testassets/Sandbox/Services/PatientEndpointService.cs
+++ b/src/Grpc/JsonTranscoding/test/testassets/Sandbox/Services/PatientEndpointService.cs
@@ -1,0 +1,181 @@
+using static Server.Startup;
+
+namespace Sandbox.Services
+{
+    public static class PatientEndpointService
+    {
+        public static void MapPatientEndpoints(this IEndpointRouteBuilder app)
+        {
+
+            var patients = new List<Patient>
+                            {
+                                new Patient(1, "John Doe", "New York", 30),
+                                new Patient(2, "Jane Smith", "Los Angeles", 25),
+                                new Patient(3, "Sam Brown", "Chicago", 40)
+                            };
+            //Standard API endpoint
+
+            app.MapGet("/patients", () => patients)
+                .WithMetadata(new PathItemTypeAttribute(PathItemType.Standard));
+
+            app.MapGet("/patients/{id}", (int id) =>
+            {
+                var patient = patients.FirstOrDefault(p => p.id == id);
+                return patient is not null ? Results.Ok(patient) : Results.NotFound();
+            }).WithMetadata(new PathItemTypeAttribute(PathItemType.Standard));
+
+            app.MapPost("/patients", (Patient patient) =>
+            {
+                patients.Add(patient);
+                return Results.Created($"/patients/{patient.id}", patient);
+            })
+              .WithMetadata(new PathItemTypeAttribute(PathItemType.Standard));
+
+            //Webhook endpoint
+
+            app.MapPost("/webhook/patientcreated", (Patient patient) =>
+            {
+                // Process the webhook payload
+                Console.WriteLine($"Webhook received for patient: {patient.Name}");
+                return Results.Ok();
+            }).WithMetadata(new PathItemTypeAttribute(PathItemType.Webhook));
+
+            app.MapGet("/appDocument.json", (IEnumerable<EndpointDataSource> source) =>
+            {
+                var json = CustomOpenApiDocumentGenerator.Generate(source);
+                return Results.Text(json, "application/json");
+            });
+
+        }
+
+        public record Patient(int id, string Name, string Location, int age);
+
+        public enum PathItemType
+        {
+            Standard,
+            Webhook
+        }
+
+        [AttributeUsage(AttributeTargets.Method | AttributeTargets.Delegate)]
+        public class PathItemTypeAttribute : Attribute
+        {
+            public PathItemType Type { get; }
+            public PathItemTypeAttribute(PathItemType type) => Type = type;
+        }
+    }
+
+      static class CustomOpenApiDocumentGenerator
+    {
+        public static string Generate(IEnumerable<EndpointDataSource> endpointSources)
+        {
+            // 1. Build the OpenApiDocument
+            var document = new OpenApiDocument
+            {
+                Info = new OpenApiInfo
+                {
+                    Title = "MinimalAPI | v1",
+                    Version = "1.0.0"
+                },
+                Paths = new OpenApiPaths()
+            };
+
+            // 2. Collect endpoints into groups (Standard/Webhook) and populate Paths + Extensions
+            var documentGroups = new Dictionary<PathItemType, OpenApiPaths>
+            {
+                [PathItemType.Standard] = new OpenApiPaths(),
+                [PathItemType.Webhook] = new OpenApiPaths()
+            };
+
+            foreach (var source in endpointSources)
+            {
+                foreach (var endpoint in source.Endpoints)
+                {
+                    var routePattern = (endpoint as RouteEndpoint)?.RoutePattern?.RawText;
+                    if (string.IsNullOrWhiteSpace(routePattern)) continue;
+                    if (routePattern.Equals("/appDocument.json", StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    var method = endpoint.Metadata.OfType<HttpMethodMetadata>()
+                                 .FirstOrDefault()?.HttpMethods.FirstOrDefault()?.ToUpper() ?? "GET";
+
+                    var type = endpoint.Metadata.OfType<PathItemTypeAttribute>().FirstOrDefault()?.Type
+                               ?? PathItemType.Standard;
+
+                    var paths = documentGroups[type];
+
+                    if (!paths.TryGetValue(routePattern, out var pathItem))
+                    {
+                        pathItem = new OpenApiPathItem();
+                        paths[routePattern] = pathItem;
+                    }
+
+                    var opType = OperationTypeFromString(method);
+
+                    if (!pathItem.Operations.ContainsKey(opType))
+                    {
+                        pathItem.Operations[opType] = new OpenApiOperation
+                        {
+                            Summary = endpoint.DisplayName,
+                            Responses = new OpenApiResponses
+                            {
+                                ["200"] = new OpenApiResponse { Description = "OK" }
+                            }
+                        };
+                    }
+                }
+            }
+
+            // Merge Standard paths into document.Paths
+            foreach (var kv in documentGroups[PathItemType.Standard])
+                document.Paths[kv.Key] = kv.Value;
+
+            // Add Webhooks as an extension
+            if (documentGroups[PathItemType.Webhook].Any())
+            {
+                var webhookObj = new OpenApiObject();
+                foreach (var kv in documentGroups[PathItemType.Webhook])
+                {
+                    var pathObj = new OpenApiObject();
+                    foreach (var op in kv.Value.Operations)
+                    {
+                        var opObj = new OpenApiObject
+                        {
+                            ["summary"] = new OpenApiString(op.Value.Summary ?? ""),
+                            ["responses"] = new OpenApiObject
+                            {
+                                ["200"] = new OpenApiObject
+                                {
+                                    ["description"] = new OpenApiString("OK")
+                                }
+                            }
+                        };
+                        pathObj[op.Key.ToString().ToLower()] = opObj;
+                    }
+                    webhookObj[kv.Key] = pathObj;
+                }
+                document.Extensions["webhooks"] = webhookObj;
+            }
+
+            // 3. Serialize OpenApiDocument to JSON string
+            using var stream = new MemoryStream();
+            using var writer = new StreamWriter(stream);
+            var openApiWriter = new OpenApiJsonWriter(writer);
+            document.SerializeAsV3(openApiWriter);
+            writer.Flush();
+            stream.Position = 0;
+
+            using var reader = new StreamReader(stream);
+            return reader.ReadToEnd();
+        }
+
+        private static OperationType OperationTypeFromString(string method) => method.ToUpper() switch
+        {
+            "GET" => OperationType.Get,
+            "POST" => OperationType.Post,
+            "PUT" => OperationType.Put,
+            "PATCH" => OperationType.Patch,
+            "DELETE" => OperationType.Delete,
+            _ => OperationType.Get
+        };
+    }
+}

--- a/src/Grpc/JsonTranscoding/test/testassets/Sandbox/Services/PatientEndpointService.cs
+++ b/src/Grpc/JsonTranscoding/test/testassets/Sandbox/Services/PatientEndpointService.cs
@@ -1,4 +1,8 @@
 using static Server.Startup;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Writers;
+using Sandbox.Services.Metadata;
 
 namespace Sandbox.Services
 {
@@ -28,8 +32,7 @@ namespace Sandbox.Services
             {
                 patients.Add(patient);
                 return Results.Created($"/patients/{patient.id}", patient);
-            })
-              .WithMetadata(new PathItemTypeAttribute(PathItemType.Standard));
+            }).WithMetadata(new PathItemTypeAttribute(PathItemType.Standard));
 
             //Webhook endpoint
 
@@ -49,19 +52,7 @@ namespace Sandbox.Services
         }
 
         public record Patient(int id, string Name, string Location, int age);
-
-        public enum PathItemType
-        {
-            Standard,
-            Webhook
-        }
-
-        [AttributeUsage(AttributeTargets.Method | AttributeTargets.Delegate)]
-        public class PathItemTypeAttribute : Attribute
-        {
-            public PathItemType Type { get; }
-            public PathItemTypeAttribute(PathItemType type) => Type = type;
-        }
+        
     }
 
       static class CustomOpenApiDocumentGenerator
@@ -101,7 +92,7 @@ namespace Sandbox.Services
                     var type = endpoint.Metadata.OfType<PathItemTypeAttribute>().FirstOrDefault()?.Type
                                ?? PathItemType.Standard;
 
-                    var paths = documentGroups[type];
+                    var paths = documentGroups[(PathItemType)type!];
 
                     if (!paths.TryGetValue(routePattern, out var pathItem))
                     {

--- a/src/Grpc/JsonTranscoding/test/testassets/Sandbox/Startup.cs
+++ b/src/Grpc/JsonTranscoding/test/testassets/Sandbox/Startup.cs
@@ -45,6 +45,22 @@ public class Startup
         {
             endpoints.MapGrpcService<JsonTranscodingGreeterService>();
             endpoints.MapGrpcService<GreeterService>();
+            endpoints.MapPatientEndpoints();
         });
     }
+
+    public enum PathItemType
+    {
+        Standard,
+        Webhook
+    }
+
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Delegate)]
+    public class PathItemTypeAttribute : Attribute
+    {
+        public PathItemType Type { get; }
+        public PathItemTypeAttribute(PathItemType type) => Type = type;
+    }
+
+  
 }


### PR DESCRIPTION
# {Clarify Sandbox endpoint separation: Path vs Webhook}
 

- [ X] I've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] I've included unit or integration tests for your change, where applicable.
       - This change is scoped to the Sandbox project and does not affect runtime behavior or require tests.
- [X ] I've included inline docs for your change, where applicable.
       - Endpoint separation is documented via `PathItemTypeAttribute` and modularized in `PatientEndpointService`.
       - A sample JSON output document  is attached to illustrate how standard path endpoints and webhook endpoints are distinguished in the OpenAPI schema.  
       > **Note**: When webhook endpoints are separated from standard paths using metadata like `PathItemType.Webhook` , they may not listed in tools like Postman that rely on conventional OpenAPI path discovery.
- [ X] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
     -This PR addresses #64039 by clarifying webhook or path routing in the sandbox.

 
Summary of the changes (Less than 80 chars)
Clarify endpoint separation using PathItemType metadata.
## Description

{Modularized patient-related endpoints into `PatientEndpoinService.cs` to clarify architectural separation between standard path routes and webhook routes using `PathItemTypeAttribute`. Attached a sample JSON output to illustrate how OpenAPI schema distinguishes these endpoints.  }

Fixes #{#64039} (in this specific format)
[appDocument.json](https://github.com/user-attachments/files/22963075/appDocument.json)

