### PR TITLE
Revert log level severity for unknown proxy in ForwardedHeadersMiddleware

### DIFF
--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -49,6 +49,7 @@ Later on, this will be checked using this condition:
   </PropertyGroup>
   <PropertyGroup Condition=" '$(VersionPrefix)' == '2.3.7' ">
     <PackagesInPatch>
+      Microsoft.AspNetCore.HttpOverrides;
     </PackagesInPatch>
   </PropertyGroup>
 </Project>

--- a/src/Middleware/HttpOverrides/src/ForwardedHeadersMiddleware.cs
+++ b/src/Middleware/HttpOverrides/src/ForwardedHeadersMiddleware.cs
@@ -249,7 +249,7 @@ namespace Microsoft.AspNetCore.HttpOverrides
                     if (currentValues.RemoteIpAndPort != null && checkKnownIps && !CheckKnownAddress(currentValues.RemoteIpAndPort.Address))
                     {
                         // Stop at the first unknown remote IP, but still apply changes processed so far.
-                        _logger.LogWarning(1, $"Unknown proxy: {currentValues.RemoteIpAndPort}");
+                        _logger.LogDebug(1, $"Unknown proxy: {currentValues.RemoteIpAndPort}");
                         break;
                     }
                 }


### PR DESCRIPTION
# Revert logging severity in ForwardedHeaders middleware

## Description

As part of strengthening our security posture in the ForwardedHeaders middleware we increased the severity of a log from `Debug` to `Warning` hoping to give consumers a more obvious signal that unexpected requests were hitting their application.

Unfortunately, that change doesn't have the intended effect as it's not uncommon to receive valid requests that have unknown IP addresses in the forwarded headers. e.g. In a proxy scenario where the proxy isn't hosted in a well-defined IP range, or a request goes through many proxy layers and the application is only aware of the last layer, etc.


## Customer Impact

Customers are receiving lots of Warning logs, which may trigger telemetry checks, unexpectedly increase log storage size, etc.

## Regression?

- [x] Yes
- [ ] No

Change was intended as a signal that unexpected requests were being received, which isn't really accurate in real apps.

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Just changing a log level to what it was before.

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

----

## When servicing release/2.1

- [x] Make necessary changes in eng/PatchConfig.props