### PR TITLE
Fix incoming connections during app shutdown causing delays

### DIFF
--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
@@ -195,6 +195,7 @@ internal sealed partial class HttpConnectionDispatcher
 
             if (connection.TransportType != HttpTransportType.WebSockets || connection.UseStatefulReconnect)
             {
+                // No point in canceling if there isn't an active application task yet, that means this is the initial request for the connection
                 if (connection.ApplicationTask is not null && !await connection.CancelPreviousPoll(context))
                 {
                     // Connection closed. It's already set the response status code.

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
@@ -172,9 +172,6 @@ internal sealed partial class HttpConnectionDispatcher
                 if (connection is not null)
                 {
                     Log.EstablishedConnection(_logger);
-
-                    // Allow the reads to be canceled
-                    connection.Cancellation ??= new CancellationTokenSource();
                 }
             }
             else
@@ -215,6 +212,9 @@ internal sealed partial class HttpConnectionDispatcher
                 case HttpTransportType.None:
                     break;
                 case HttpTransportType.WebSockets:
+                    // Allow the reads to be canceled
+                    connection.Cancellation ??= new CancellationTokenSource();
+
                     var isReconnect = connection.ApplicationTask is not null;
                     var ws = new WebSocketsServerTransport(options.WebSockets, connection.Application, connection, _loggerFactory);
                     if (!connection.TryActivatePersistentConnection(connectionDelegate, ws, currentRequestTcs.Task, context, _logger))

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -216,6 +216,8 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
             context.Response.Body = ms;
             context.Request.QueryString = new QueryString("");
             await dispatcher.ExecuteNegotiateAsync(context, new HttpConnectionDispatcherOptions());
+
+            Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
             var negotiateResponse = JsonConvert.DeserializeObject<JObject>(Encoding.UTF8.GetString(ms.ToArray()));
 
             var error = negotiateResponse.Value<string>("error");
@@ -2558,7 +2560,7 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
             var appLifetime = new TestApplicationLifetime();
             var manager = CreateConnectionManager(LoggerFactory, appLifetime);
             var options = new HttpConnectionDispatcherOptions() { AllowStatefulReconnects = true };
-            options.WebSockets.CloseTimeout = TimeSpan.FromMilliseconds(1);
+
             // pretend negotiate occurred
             var connection = manager.CreateConnection(options, negotiateVersion: 1, useStatefulReconnect: true);
             connection.TransportType = HttpTransportType.WebSockets;
@@ -2611,7 +2613,6 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
             var appLifetime = new TestApplicationLifetime();
             var manager = CreateConnectionManager(LoggerFactory, appLifetime);
             var options = new HttpConnectionDispatcherOptions() { AllowStatefulReconnects = true };
-            options.WebSockets.CloseTimeout = TimeSpan.FromMilliseconds(1);
             // pretend negotiate occurred
             var connection = manager.CreateConnection(options, negotiateVersion: 1, useStatefulReconnect: true);
             connection.TransportType = HttpTransportType.WebSockets;
@@ -4217,7 +4218,7 @@ public class ReconnectConnectionHandler : ConnectionHandler
     {
         _writer.Complete();
         _writer = writer;
-        _pause.SetResult(true);
+        _pause.TrySetResult(true);
         return Task.CompletedTask;
     }
 }

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionManagerTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionManagerTests.cs
@@ -425,6 +425,26 @@ public class HttpConnectionManagerTests : VerifiableLoggedTest
         }
     }
 
+    [Fact]
+    public async Task ApplicationLifetimeStoppingApplicationStopsNewIncomingConnections()
+    {
+        using (StartVerifiableLog())
+        {
+            var appLifetime = new TestApplicationLifetime();
+            var connectionManager = CreateConnectionManager(LoggerFactory, appLifetime);
+
+            appLifetime.Start();
+
+            appLifetime.StopApplication();
+
+            var connection = connectionManager.CreateConnection();
+
+            Assert.Equal(HttpConnectionStatus.Disposed, connection.Status);
+            var result = await connection.Application.Output.FlushAsync();
+            Assert.True(result.IsCompleted);
+        }
+    }
+
     private static HttpConnectionManager CreateConnectionManager(ILoggerFactory loggerFactory, IHostApplicationLifetime lifetime = null, HttpConnectionsMetrics metrics = null)
     {
         lifetime ??= new EmptyApplicationLifetime();

--- a/src/SignalR/common/Http.Connections/test/WebSocketsTests.cs
+++ b/src/SignalR/common/Http.Connections/test/WebSocketsTests.cs
@@ -111,7 +111,8 @@ public class WebSocketsTests : VerifiableLoggedTest
     private HttpConnectionContext CreateHttpConnectionContext(DuplexPipe.DuplexPipePair pair, string loggerName = null)
     {
         return new HttpConnectionContext("foo", connectionToken: null, LoggerFactory.CreateLogger(loggerName ?? nameof(HttpConnectionContext)),
-            metricsContext: default, pair.Transport, pair.Application, new(), useStatefulReconnect: false);
+            metricsContext: default, pair.Transport, pair.Application, new(),
+            useStatefulReconnect: false, new EmptyApplicationLifetime());
     }
 
     [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/58947

There is a race between when the `IHostApplicationLifetime.ApplicationStopping` token fires and when the `IServer.StopAsync` (which unbinds connection listeners) runs ([ref](https://github.com/dotnet/runtime/blob/3db77c1827331b9ffe4585c2dae158bfb0dcc779/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs#L256-L260)). SignalR was listening to `ApplicationStopping` and closing all currently active connections, however new incoming connections right after `ApplicationStopping` fires are still accepted by the `IServer` implementation and SignalR was processing them and letting them stay around until the `IServer` implementation ungracefully closed them (30 second default).

The first part of the was to register with `ApplicationStopping` for all connections so they will start closing as soon as the token fires, either inline if the token is already canceled, or later.

While testing to make sure this fix worked, I noticed that connections with stateful reconnect enabled weren't shutting down quickly, this was because when we first created the connection we immediately ran `CancelPreviousPoll` which would clear the cancellation token being used to stop the websocket read loop. The fix was to not run `CancelPreviousPoll` for the first connection and move where the `CancellationToken` is created to be after the previous connection is canceled.