### PR TITLE
Update swashbuckle dependnecy

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -178,7 +178,7 @@
     <SerilogSinksFileVersion>4.0.0</SerilogSinksFileVersion>
     <StackExchangeRedisVersion>2.7.27</StackExchangeRedisVersion>
     <SystemReactiveLinqVersion>5.0.0</SystemReactiveLinqVersion>
-    <SwashbuckleAspNetCoreVersion>6.6.2</SwashbuckleAspNetCoreVersion>
+    <SwashbuckleAspNetCoreVersion>6.9.0</SwashbuckleAspNetCoreVersion>
     <VerifySourceGeneratorsVersion>2.2.0</VerifySourceGeneratorsVersion>
     <VerifyXunitVersion>19.14.0</VerifyXunitVersion>
     <XunitAbstractionsVersion>2.0.3</XunitAbstractionsVersion>


### PR DESCRIPTION
There is a CVE on 6.6.2