### PR TITLE
Fix: Check FrameType before accessing ComponentId in tests

### DIFF
--- a/src/Components/Components/test/RendererTest.cs
+++ b/src/Components/Components/test/RendererTest.cs
@@ -2243,7 +2243,7 @@ public class RendererTest
             .Where(frame => frame.FrameType == RenderTreeFrameType.Component)
             .Select(frame => frame.ComponentId)
             .ToList();
-        var childComponent3 = batch.ReferenceFrames.Where(f => f.ComponentId == 3)
+        var childComponent3 = batch.ReferenceFrames.Where(f => f.FrameType == RenderTreeFrameType.Component && f.ComponentId == 3)
             .Single().Component;
         Assert.Equal(new[] { 1, 2 }, childComponentIds);
         Assert.IsType<FakeComponent>(childComponent3);
@@ -3050,7 +3050,7 @@ public class RendererTest
         component.TriggerRender();
         var childComponentId = renderer.Batches.Single()
             .ReferenceFrames
-            .Where(f => f.ComponentId != 0)
+            .Where(f => f.FrameType == RenderTreeFrameType.Component && f.ComponentId != 0)
             .Single()
             .ComponentId;
         var origEventHandlerId = renderer.Batches.Single()


### PR DESCRIPTION
## Summary

Fixes test failures on big-endian architectures (s390x) by checking `FrameType` before accessing `ComponentId` in `RendererTest`.

## Tests Fixed
- `QueuedRenderIsSkippedIfComponentWasAlreadyDisposedInSameBatch`

## Problem

Test was failing on s390x with `System.InvalidOperationException: Sequence contains more than one element`.


## Root Cause

### Field Overlap in RenderTreeFrame

`RenderTreeFrame` uses explicit struct layout with overlapping fields:

```csharp
[StructLayout(LayoutKind.Explicit, Pack = 4)]
public struct RenderTreeFrame
{
    [FieldOffset(8)]  internal ulong AttributeEventHandlerIdField;  // 8 bytes: offset 8-15
    [FieldOffset(12)] internal int ComponentIdField;                // 4 bytes: offset 12-15
    // These fields OVERLAP at offset 12-15!
}
```

### API Contract

The API documentation at [RenderTreeFrame.cs:161-165](https://github.com/dotnet/aspnetcore/blob/main/src/Components/Components/src/RenderTree/RenderTreeFrame.cs#L161-L165) clearly states:

```csharp
/// <summary>
/// If the <see cref="FrameType"/> property equals <see cref="RenderTreeFrameType.Component"/>,
/// gets the child component instance identifier.
/// </summary>
public int ComponentId => ComponentIdField;
```

The test accessed `ComponentId` without first checking `FrameType == Component`, violating this documented precondition.

### Why It Failed on s390x (Big-Endian)

Due to the field overlap at offset 12-15, endianness affects what value is read:

| Architecture | Endianness | AttributeEventHandlerId=1 | Memory Layout | ComponentId reads as |
|--------------|------------|---------------------------|---------------|---------------------|
| x64, ppc64le | Little | 1 | `01 00 00 00 00 00 00 00` | 0 (upper bytes) |
| s390x | Big | 1 | `00 00 00 00 00 00 00 01` | 1 (lower bytes) |

**On little-endian:** Reading `ComponentId` from an Attribute frame returns **0** (bug hidden)  
**On big-endian:** Reading `ComponentId` from an Attribute frame returns **the AttributeEventHandlerId value** (bug exposed)


### Change 2: Fix same pattern preventively

**File:** `src/Components/Components/test/RendererTest.cs`

```diff
- var childComponent3 = batch.ReferenceFrames.Where(f => f.ComponentId == 3)
+ var childComponent3 = batch.ReferenceFrames.Where(f => f.FrameType == RenderTreeFrameType.Component && f.ComponentId == 3)
      .Single().Component;
```

**Test:** `RenderBatchIncludesListOfDisposedComponents`  
**Status:** Not currently failing, but uses the same incorrect pattern

cc: @giritrivedi