### PR TITLE
Fix Blazor Wasm.Performance benchmarks build

### DIFF
--- a/src/Components/benchmarkapps/Wasm.Performance/dockerfile
+++ b/src/Components/benchmarkapps/Wasm.Performance/dockerfile
@@ -25,7 +25,7 @@ RUN git init \
 
 RUN ./restore.sh
 RUN npm run build
-RUN .dotnet/dotnet publish -c Release -r linux-x64 --sc true -o /app ./src/Components/benchmarkapps/Wasm.Performance/Driver/Wasm.Performance.Driver.csproj
+RUN .dotnet/dotnet publish -c Release -r linux-x64 --sc true -o /app ./src/Components/benchmarkapps/Wasm.Performance/Driver/Wasm.Performance.Driver.csproj -p:BlazorFingerprintBlazorJs=false
 RUN chmod +x /app/Wasm.Performance.Driver
 
 WORKDIR /app


### PR DESCRIPTION
It currently runs into a known issue with fingerprinting that is fixed in 10.0 RTM. Disabling fingerprinting for now as a workaround.
