### PR TITLE
Add System.Security.Cryptography.Pkcs to targeting pack

### DIFF
--- a/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.sfxproj
+++ b/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.sfxproj
@@ -101,17 +101,6 @@
     <PackageOverridesFile Include="$(ReferencePackageOverridesPath)" />
   </ItemGroup>
 
-  <!--
-    COMPAT: Remove the System.Security.Cryptography.Pkcs reference from the project.
-    We don't package System.Security.Cryptography.Pkcs into the reference pack for ASP.NET Core.
-  -->
-  <Target Name="_RemovePkcsReference" AfterTargets="ResolveReferences">
-    <ItemGroup>
-      <ReferencePath Remove="@(ReferencePath)" Condition="'%(FileName)' == 'System.Security.Cryptography.Pkcs'" />
-      <IgnoredReference Include="System.Security.Cryptography.Pkcs" />
-    </ItemGroup>
-  </Target>
-
   <Target Name="_AddAnalyzersToRefPack" BeforeTargets="GetFilesToPackage">
     <ItemGroup>
       <!-- Include analyzers from dotnet/runtime. Start with the non-Roslyn-versioned ones -->

--- a/src/Framework/test/TestData.cs
+++ b/src/Framework/test/TestData.cs
@@ -309,6 +309,7 @@ public static class TestData
                 { "Microsoft.Net.Http.Headers" },
                 { "System.Diagnostics.EventLog" },
                 { "System.Formats.Cbor" },
+                { "System.Security.Cryptography.Pkcs" },
                 { "System.Security.Cryptography.Xml" },
                 { "System.Threading.RateLimiting" },
             };


### PR DESCRIPTION
Fix https://github.com/dotnet/aspnetcore/issues/64125. This library wasn't in the targeting pack historically due to some quirks of reference resolution, but AFAIK there's not a strong reason to maintain that behavior. Adding it to the transport pack will fix some issues w/ package pruning.