### PR TITLE
Fix test discovery failure in IIS.FunctionalTests when running on non-Windows platforms.

### DIFF
--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Infrastructure/SkipIfNotAdminAttribute.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Infrastructure/SkipIfNotAdminAttribute.cs
@@ -14,6 +14,11 @@ public sealed class SkipIfNotAdminAttribute : Attribute, ITestCondition
     {
         get
         {
+            if (!OperatingSystem.IsWindows())
+            {
+                return false;
+            }
+
             var identity = WindowsIdentity.GetCurrent();
             var principal = new WindowsPrincipal(identity);
             return principal.IsInRole(WindowsBuiltInRole.Administrator) || SkipInVSTSAttribute.RunningInVSTS;


### PR DESCRIPTION
### Summary
Fix test discovery failure in IIS.FunctionalTests when running on non-Windows platforms.

### Issue
CI has observed test failures on Linux in multiple IIS test suites:
- **IIS.FunctionalTests** (2 failures)
- **IISExpress.FunctionalTests** (2 failures)

Both fail during test discovery with `PlatformNotSupportedException` because `SkipIfNotAdminAttribute` calls `WindowsIdentity.GetCurrent()` without checking the platform first.

### Fix
Add platform check in `SkipIfNotAdminAttribute.IsMet` before calling Windows-specific APIs.


cc: @giritrivedi