### PR TITLE
Fix HttpSys test failure on non-Windows platforms.

### DIFF
--- a/src/Servers/HttpSys/test/FunctionalTests/RequestTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/RequestTests.cs
@@ -361,7 +361,7 @@ public class RequestTests : LoggedTest
         }
     }
 
-    [Fact]
+    [ConditionalFact]
     public async Task Latin1UrlIsRejected()
     {
         string root;


### PR DESCRIPTION
### Summary
Fix HttpSys test failure on non-Windows platforms.

### Issue
CI observed failure in `Microsoft.AspNetCore.Server.HttpSys.FunctionalTests.RequestTests.Latin1UrlIsRejected` on Linux.

Test fails with `EntryPointNotFoundException: HttpInitialize` because HttpSys is Windows-only.

### Fix
Change `[Fact]` to `[ConditionalFact]` to align with other HttpSys tests that properly skip on non-Windows platforms.

cc: @giritrivedi