### PR TITLE
Update Visual Studio and xcopy-msbuild in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -18,7 +18,7 @@
       ]
     },
     "vs": {
-      "version": "17.13",
+      "version": "17.14",
       "components": [
         "Microsoft.VisualStudio.Component.VC.ATL",
         "Microsoft.VisualStudio.Component.VC.ATL.ARM64",
@@ -26,7 +26,7 @@
         "Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
       ]
     },
-    "xcopy-msbuild": "17.13.0"
+    "xcopy-msbuild": "17.14.16"
   },
   "native-tools": {
     "jdk": "latest"


### PR DESCRIPTION
# Update Visual Studio and xcopy-msbuild in global.json

Updated `vs` to the latest available version and `xcopy-msbuild` to the latest available version on dotnet-eng within `global.json` 
