### PR TITLE
Update `Microsoft.Build` versions to 17.8.43

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -48,10 +48,10 @@
     <UsagePattern IdentityGlob="System.Formats.Asn1/6.0.0" />
 
     <!-- Used only for RepoTasks -->
-    <UsagePattern IdentityGlob="Microsoft.Build.Framework/17.8.29" />
-    <UsagePattern IdentityGlob="Microsoft.Build.Tasks.Core/17.8.29" />
-    <UsagePattern IdentityGlob="Microsoft.Build.Utilities.Core/17.8.29" />
-    <UsagePattern IdentityGlob="Microsoft.NET.StringTools/17.8.29" />
+    <UsagePattern IdentityGlob="Microsoft.Build.Framework/17.8.43" />
+    <UsagePattern IdentityGlob="Microsoft.Build.Tasks.Core/17.8.43" />
+    <UsagePattern IdentityGlob="Microsoft.Build.Utilities.Core/17.8.43" />
+    <UsagePattern IdentityGlob="Microsoft.NET.StringTools/17.8.43" />
     <UsagePattern IdentityGlob="Microsoft.VisualStudio.Setup.Configuration.Interop/3.2.2146" />
   </IgnorePatterns>
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -227,11 +227,11 @@
     <MicrosoftCodeAnalysisRazorVersion>6.0.0</MicrosoftCodeAnalysisRazorVersion>
     <!-- Partner teams -->
     <MicrosoftBCLHashCodeVersion>1.1.1</MicrosoftBCLHashCodeVersion>
-    <MicrosoftBuildVersion>17.8.29</MicrosoftBuildVersion>
+    <MicrosoftBuildVersion>17.8.43</MicrosoftBuildVersion>
     <MicrosoftAzureSignalRVersion>1.2.0</MicrosoftAzureSignalRVersion>
-    <MicrosoftBuildFrameworkVersion>17.8.29</MicrosoftBuildFrameworkVersion>
-    <MicrosoftBuildTasksCoreVersion>17.8.29</MicrosoftBuildTasksCoreVersion>
-    <MicrosoftBuildUtilitiesCoreVersion>17.8.29</MicrosoftBuildUtilitiesCoreVersion>
+    <MicrosoftBuildFrameworkVersion>17.8.43</MicrosoftBuildFrameworkVersion>
+    <MicrosoftBuildTasksCoreVersion>17.8.43</MicrosoftBuildTasksCoreVersion>
+    <MicrosoftBuildUtilitiesCoreVersion>17.8.43</MicrosoftBuildUtilitiesCoreVersion>
     <MicrosoftBuildLocatorVersion>1.2.6</MicrosoftBuildLocatorVersion>
     <!--
       Temporarily override the Microsoft.NET.Test.Sdk version Arcade defaults to. That's incompatible w/ test


### PR DESCRIPTION
Addresses CG-related build failures