### PR TITLE
[release/8.0] AppContext for HttpSys CBT hardening

### DIFF
--- a/src/Shared/HttpSys/NativeInterop/HttpApiTypes.cs
+++ b/src/Shared/HttpSys/NativeInterop/HttpApiTypes.cs
@@ -2,8 +2,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using Microsoft.AspNetCore.Http;
@@ -652,6 +650,22 @@ internal static unsafe class HttpApiTypes
     {
         internal HTTP_FLAGS Flags;
         internal IntPtr RequestQueueHandle;
+    }
+
+    internal enum HTTP_AUTHENTICATION_HARDENING_LEVELS
+    {
+        HttpAuthenticationHardeningLegacy = 0,
+        HttpAuthenticationHardeningMedium,
+        HttpAuthenticationHardeningStrict
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct HTTP_CHANNEL_BIND_INFO
+    {
+        internal HTTP_AUTHENTICATION_HARDENING_LEVELS Hardening;
+        internal uint Flags;
+        internal /*PHTTP_SERVICE_BINDING_BASE**/ IntPtr ServiceNames;
+        internal uint NumberOfServiceNames;
     }
 
     [StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
# AppContext for HttpSys CBT hardening

## Description

Request from a partner team to allow setting hardened security for their HTTP.Sys applications.

## Customer Impact

By default there is no impact, this change is opt-in. If the change is enabled then it sets hardened security for the endpoints exposed by the HTTP.Sys application.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Purely opt-in change. We've also verified the change with the partner team.

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A