### PR TITLE
Quarantine EmbeddingServerAppInsideIframe_WithCompressionEnabled_Fails 

### DIFF
--- a/src/Components/test/E2ETest/ServerExecutionTests/WebSocketCompressionTests.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/WebSocketCompressionTests.cs
@@ -184,7 +184,7 @@ public partial class NoneAncestorWebSocketCompressionTests : BlockedWebSocketCom
 
 public partial class NoneAncestorWebSocketAppliesPolicyOnCallbackCompressionTests : BlockedWebSocketCompressionTests
 {
-    public NoneAncestorWebSocketAppliesPolicyOnCallback`CompressionTests(
+    public NoneAncestorWebSocketAppliesPolicyOnCallbackCompressionTests(
         BrowserFixture browserFixture,
         BasicTestAppServerSiteFixture<RazorComponentEndpointsStartup<App>> serverFixture,
         ITestOutputHelper output)

--- a/src/Components/test/E2ETest/ServerExecutionTests/WebSocketCompressionTests.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/WebSocketCompressionTests.cs
@@ -7,6 +7,7 @@ using Components.TestServer.RazorComponents;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.E2ETesting;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using OpenQA.Selenium;
 using TestServer;
@@ -96,6 +97,7 @@ public abstract partial class BlockedWebSocketCompressionTests(
     : ServerTestBase<BasicTestAppServerSiteFixture<RazorComponentEndpointsStartup<App>>>(browserFixture, serverFixture, output)
 {
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/64305")]
     public void EmbeddingServerAppInsideIframe_WithCompressionEnabled_Fails()
     {
         Navigate("/subdir/iframe");
@@ -182,7 +184,7 @@ public partial class NoneAncestorWebSocketCompressionTests : BlockedWebSocketCom
 
 public partial class NoneAncestorWebSocketAppliesPolicyOnCallbackCompressionTests : BlockedWebSocketCompressionTests
 {
-    public NoneAncestorWebSocketAppliesPolicyOnCallbackCompressionTests(
+    public NoneAncestorWebSocketAppliesPolicyOnCallback`CompressionTests(
         BrowserFixture browserFixture,
         BasicTestAppServerSiteFixture<RazorComponentEndpointsStartup<App>> serverFixture,
         ITestOutputHelper output)


### PR DESCRIPTION
This PR quarantines EmbeddingServerAppInsideIframe_WithCompressionEnabled_Fails tests.

Issue: https://github.com/dotnet/aspnetcore/issues/64305
