### PR TITLE
Fix test EmbeddingServerAppInsideIframe_WithCompressionEnabled_Fails 

### DIFF
--- a/src/Components/test/E2ETest/ServerExecutionTests/WebSocketCompressionTests.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/WebSocketCompressionTests.cs
@@ -108,7 +108,7 @@ public abstract partial class BlockedWebSocketCompressionTests(
         Assert.True(
             ParseErrorMessageRegexOld.IsMatch(logs[0].Message) ||
             ParseErrorMessageRegexNew.IsMatch(logs[0].Message),
-            $"Expected log message to match one of the CSP error patterns. Actual: {logs[0].Message}");
+            $"Expected log message to match one of the CSP error patterns: {ParseErrorMessageRegexOld} or {ParseErrorMessageRegexNew}. Actual: {logs[0].Message}");
     }
 
     [GeneratedRegex(@"security - Refused to frame 'http://\d+\.\d+\.\d+\.\d+:\d+/' because an ancestor violates the following Content Security Policy directive: ""frame-ancestors 'none'"".")]

--- a/src/Components/test/E2ETest/ServerExecutionTests/WebSocketCompressionTests.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/WebSocketCompressionTests.cs
@@ -97,7 +97,6 @@ public abstract partial class BlockedWebSocketCompressionTests(
     : ServerTestBase<BasicTestAppServerSiteFixture<RazorComponentEndpointsStartup<App>>>(browserFixture, serverFixture, output)
 {
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/64305")]
     public void EmbeddingServerAppInsideIframe_WithCompressionEnabled_Fails()
     {
         Navigate("/subdir/iframe");
@@ -106,11 +105,17 @@ public abstract partial class BlockedWebSocketCompressionTests(
 
         Assert.True(logs.Count > 0);
 
-        Assert.Matches(ParseErrorMessageRegex, logs[0].Message);
+        Assert.True(
+            ParseErrorMessageRegexOld.IsMatch(logs[0].Message) ||
+            ParseErrorMessageRegexNew.IsMatch(logs[0].Message),
+            $"Expected log message to match one of the CSP error patterns. Actual: {logs[0].Message}");
     }
 
     [GeneratedRegex(@"security - Refused to frame 'http://\d+\.\d+\.\d+\.\d+:\d+/' because an ancestor violates the following Content Security Policy directive: ""frame-ancestors 'none'"".")]
-    private static partial Regex ParseErrorMessageRegex { get; }
+    private static partial Regex ParseErrorMessageRegexOld { get; }
+
+    [GeneratedRegex(@"security - Framing 'http://\d+\.\d+\.\d+\.\d+:\d+/' violates the following Content Security Policy directive: ""frame-ancestors 'none'"".")]
+    private static partial Regex ParseErrorMessageRegexNew { get; }
 }
 
 public partial class DefaultConfigurationWebSocketCompressionTests : AllowedWebSocketCompressionTests


### PR DESCRIPTION
# Fix test EmbeddingServerAppInsideIframe_WithCompressionEnabled_Fails 

## Description

This pull request changes the error message check in the test due to changes in the [Chromium](https://github.com/chromium/chromium/commit/5ddd160917b57001a9a9eb1bcfce0153469894e3). This makes test not fail anymore. 

# Changes:
* Added new error message control to the test.
* Removed the `[QuarantinedTest]` attribute from the test.

Fixes #64305 
