### PR TITLE
[release/9.0] Don't use netcoreapp2.1 in dotnet-get-document

### DIFF
--- a/src/Tools/Extensions.ApiDescription.Server/src/Microsoft.Extensions.ApiDescription.Server.csproj
+++ b/src/Tools/Extensions.ApiDescription.Server/src/Microsoft.Extensions.ApiDescription.Server.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <!-- Included primarily to ensure dotnet-getdocument and GetDocument.Insider can be referenced. -->
-    <TargetFrameworks>netcoreapp2.1;$(DefaultNetCoreTargetFramework);$(DefaultNetFxTargetFramework)</TargetFrameworks>
+    <TargetFrameworks>(DefaultNetCoreTargetFramework);$(DefaultNetFxTargetFramework)</TargetFrameworks>
 
     <Description>MSBuild tasks and targets for build-time Swagger and OpenApi document generation</Description>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>

--- a/src/Tools/Extensions.ApiDescription.Server/src/Microsoft.Extensions.ApiDescription.Server.csproj
+++ b/src/Tools/Extensions.ApiDescription.Server/src/Microsoft.Extensions.ApiDescription.Server.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <!-- Included primarily to ensure dotnet-getdocument and GetDocument.Insider can be referenced. -->
-    <TargetFrameworks>(DefaultNetCoreTargetFramework);$(DefaultNetFxTargetFramework)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework);$(DefaultNetFxTargetFramework)</TargetFrameworks>
 
     <Description>MSBuild tasks and targets for build-time Swagger and OpenApi document generation</Description>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>

--- a/src/Tools/Extensions.ApiDescription.Server/src/Microsoft.Extensions.ApiDescription.Server.nuspec
+++ b/src/Tools/Extensions.ApiDescription.Server/src/Microsoft.Extensions.ApiDescription.Server.nuspec
@@ -8,10 +8,8 @@
     $CommonFileElements$
     <file src="build\*" target="build" />
     <file src="buildMultiTargeting\*" target="buildMultiTargeting" />
-    <file src="$artifactsBinDir$\dotnet-getdocument\$configuration$\netcoreapp2.1\publish\*.*" target="tools" />
     <file src="$artifactsBinDir$\GetDocument.Insider\$configuration$\net462\*.*" target="tools\net462" />
     <file src="$artifactsBinDir$\GetDocument.Insider\x86\$configuration$\net462\*.*" target="tools\net462-x86" />
-    <file src="$artifactsBinDir$\GetDocument.Insider\$configuration$\netcoreapp2.1\publish\*.*" target="tools\netcoreapp2.1" />
     <file src="$artifactsBinDir$\GetDocument.Insider\$configuration$\net9.0\publish\*.*" target="tools\net9.0" />
   </files>
 </package>

--- a/src/Tools/GetDocumentInsider/src/GetDocument.Insider.csproj
+++ b/src/Tools/GetDocumentInsider/src/GetDocument.Insider.csproj
@@ -5,7 +5,7 @@
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
     <RootNamespace>Microsoft.Extensions.ApiDescription.Tool</RootNamespace>
-    <TargetFrameworks>netcoreapp2.1;$(DefaultNetCoreTargetFramework);$(DefaultNetFxTargetFramework)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework);$(DefaultNetFxTargetFramework)</TargetFrameworks>
     <IsShippingPackage>false</IsShippingPackage>
     <NoWarn>$(NoWarn);nullable</NoWarn>
   </PropertyGroup>
@@ -17,12 +17,6 @@
   <ItemGroup Condition="'$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)'">
     <Reference Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" />
     <Reference Include="Microsoft.Extensions.Hosting.Abstractions" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.6.0">
-      <AllowExplicitReference>true</AllowExplicitReference>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1'">

--- a/src/Tools/dotnet-getdocument/src/Commands/InvokeCommand.cs
+++ b/src/Tools/dotnet-getdocument/src/Commands/InvokeCommand.cs
@@ -79,13 +79,9 @@ internal sealed class InvokeCommand : HelpCommandBase
                             projectName,
                             targetFramework.Version));
                     }
-                    else if (targetFramework.Version >= new Version(7, 0))
-                    {
-                        toolsDirectory = Path.Combine(thisPath, $"net{targetFramework.Version}");
-                    }
                     else
                     {
-                        toolsDirectory = Path.Combine(thisPath, "netcoreapp2.1");
+                        toolsDirectory = Path.Combine(thisPath, $"net{targetFramework.Version}");
                     }
 
                     executable = DotNetMuxer.MuxerPathOrDefault();

--- a/src/Tools/dotnet-getdocument/src/dotnet-getdocument.csproj
+++ b/src/Tools/dotnet-getdocument/src/dotnet-getdocument.csproj
@@ -5,7 +5,7 @@
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
     <RootNamespace>Microsoft.Extensions.ApiDescription.Tool</RootNamespace>
-    <TargetFrameworks>netcoreapp2.1;$(DefaultNetCoreTargetFramework)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
     <UseAppHost>false</UseAppHost>
     <IsShippingPackage>false</IsShippingPackage>
   </PropertyGroup>


### PR DESCRIPTION
netcoreapp2.1 is no longer supported