### PR TITLE
Fix typo in IEndpointSelectorPolicy documentation

### DIFF
--- a/src/Http/Routing/src/Matching/IEndpointSelectorPolicy.cs
+++ b/src/Http/Routing/src/Matching/IEndpointSelectorPolicy.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Http;
 namespace Microsoft.AspNetCore.Routing.Matching;
 
 /// <summary>
-/// A <see cref="MatcherPolicy"/> interface that can implemented to filter endpoints
+/// A <see cref="MatcherPolicy"/> interface that can be implemented to filter endpoints
 /// in a <see cref="CandidateSet"/>. Implementations of <see cref="IEndpointSelectorPolicy"/> must
 /// inherit from <see cref="MatcherPolicy"/> and should be registered in
 /// the dependency injection container as singleton services of type <see cref="MatcherPolicy"/>.


### PR DESCRIPTION
# Fix typo in IEndpointSelectorPolicy documentation

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [+] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [+] You've included unit or integration tests for your change, where applicable.
- [+] You've included inline docs for your change, where applicable.
- [-] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

This is just a fix of of the typo in xmldoc.
