### PR TITLE
Fix shared code policy triggering on PRs with zero file changes

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -1,11 +1,11 @@
 # Policybot docs live at https://eng.ms/docs/more/github-inside-microsoft/policies/resource-management
-id: 
+id:
 name: GitOps.PullRequestIssueManagement
 description: GitOps.PullRequestIssueManagement primitive
-owner: 
+owner:
 resource: repository
 disabled: false
-where: 
+where:
 configuration:
   resourceManagementConfiguration:
     scheduledSearches:
@@ -347,10 +347,9 @@ configuration:
       - payloadType: Pull_Request
       - isAction:
           action: Opened
-      - or:
-        - includesModifiedFiles:
-            files:
-            - src/Shared/Runtime
+      - includesModifiedFiles:
+          files:
+          - src/Shared/Runtime
       then:
       - addReply:
           reply: Greetings human! You've submitted a PR that modifies code that is shared with https://github.com/dotnet/runtime . Please make sure you synchronize this code with the changes in that repo!
@@ -759,8 +758,8 @@ configuration:
       - enableAutoMerge:
           mergeMethod: "squash"
       description: '[Infrastructure PRs] Add area-infrastructure label to dependabot update Pull Requests & enable auto-merge'
-onFailure: 
-onSuccess: 
+onFailure:
+onSuccess:
 
 
 

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -352,7 +352,7 @@ configuration:
           - src/Shared/Runtime
       then:
       - addReply:
-          reply: Greetings human! You've submitted a PR that modifies code that is shared with https://github.com/dotnet/runtime . Please make sure you synchronize this code with the changes in that repo!
+          reply: Greetings! You've submitted a PR that modifies code that is shared with https://github.com/dotnet/runtime . Please make sure you synchronize this code with the changes in that repo!
       - addLabel:
           label: 'Attention: Shared Code Modified'
       description: '[Shared Code PRs] Flag PRs that affect shared code src/Shared/Runtime'


### PR DESCRIPTION
The shared code policy in resourceManagement.yml was incorrectly triggering on pull requests that had zero file changes (most noticeable in Copilot PRs which are initially empty).

I'm not 100% sure but I think this is caused by an unnecessary `or:` wrapper around a single `includesModifiedFiles` condition. Let's see if this fixes it.