### PR TITLE
[release/8.0] Revert "Update dependencies from https://github.com/dotnet/arcade build 20251112.3 (#64349)"

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -376,26 +376,26 @@
       <Uri>https://github.com/dotnet/winforms</Uri>
       <Sha>abda8e3bfa78319363526b5a5f86863ec979940e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.25562.3">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.25515.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>e8483fe03c7d3257c68f6013441da5d72eeb8392</Sha>
+      <Sha>6544413e02741855b701468aa8afc6cf8ca62c72</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="8.0.0-beta.25562.3">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="8.0.0-beta.25515.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>e8483fe03c7d3257c68f6013441da5d72eeb8392</Sha>
+      <Sha>6544413e02741855b701468aa8afc6cf8ca62c72</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Templating" Version="8.0.0-beta.25562.3">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Templating" Version="8.0.0-beta.25515.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>e8483fe03c7d3257c68f6013441da5d72eeb8392</Sha>
+      <Sha>6544413e02741855b701468aa8afc6cf8ca62c72</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="8.0.0-beta.25562.3">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="8.0.0-beta.25515.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>e8483fe03c7d3257c68f6013441da5d72eeb8392</Sha>
+      <Sha>6544413e02741855b701468aa8afc6cf8ca62c72</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="8.0.0-beta.25562.3">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="8.0.0-beta.25515.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>e8483fe03c7d3257c68f6013441da5d72eeb8392</Sha>
+      <Sha>6544413e02741855b701468aa8afc6cf8ca62c72</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Diagnostics.Testing" Version="9.0.0-preview.9.24518.1">
       <Uri>https://github.com/dotnet/extensions</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -162,9 +162,9 @@
     <NuGetVersioningVersion>6.2.4</NuGetVersioningVersion>
     <NuGetFrameworksVersion>6.2.4</NuGetFrameworksVersion>
     <!-- Packages from dotnet/arcade -->
-    <MicrosoftDotNetBuildTasksInstallersVersion>8.0.0-beta.25562.3</MicrosoftDotNetBuildTasksInstallersVersion>
-    <MicrosoftDotNetBuildTasksTemplatingVersion>8.0.0-beta.25562.3</MicrosoftDotNetBuildTasksTemplatingVersion>
-    <MicrosoftDotNetRemoteExecutorVersion>8.0.0-beta.25562.3</MicrosoftDotNetRemoteExecutorVersion>
+    <MicrosoftDotNetBuildTasksInstallersVersion>8.0.0-beta.25515.1</MicrosoftDotNetBuildTasksInstallersVersion>
+    <MicrosoftDotNetBuildTasksTemplatingVersion>8.0.0-beta.25515.1</MicrosoftDotNetBuildTasksTemplatingVersion>
+    <MicrosoftDotNetRemoteExecutorVersion>8.0.0-beta.25515.1</MicrosoftDotNetRemoteExecutorVersion>
     <!-- Packages from dotnet/source-build-externals -->
     <MicrosoftSourceBuildIntermediatesourcebuildexternalsVersion>8.0.0-alpha.1.25202.2</MicrosoftSourceBuildIntermediatesourcebuildexternalsVersion>
     <!-- Packages from dotnet/source-build-reference-packages -->

--- a/eng/common/templates-official/job/publish-build-assets.yml
+++ b/eng/common/templates-official/job/publish-build-assets.yml
@@ -152,11 +152,6 @@ jobs:
           BARBuildId: ${{ parameters.BARBuildId }}
           PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
 
-      # Darc is targeting 8.0, so make sure it's installed
-      - task: UseDotNet@2
-        inputs:
-          version: 8.0.x
-
       - task: AzureCLI@2
         displayName: Publish Using Darc
         inputs:

--- a/eng/common/templates-official/post-build/post-build.yml
+++ b/eng/common/templates-official/post-build/post-build.yml
@@ -271,11 +271,6 @@ stages:
 
         - task: NuGetAuthenticate@1
 
-        # Darc is targeting 8.0, so make sure it's installed
-        - task: UseDotNet@2
-          inputs:
-            version: 8.0.x
-
         - task: AzureCLI@2
           displayName: Publish Using Darc
           inputs:

--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -148,11 +148,6 @@ jobs:
           BARBuildId: ${{ parameters.BARBuildId }}
           PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
 
-      # Darc is targeting 8.0, so make sure it's installed
-      - task: UseDotNet@2
-        inputs:
-          version: 8.0.x
-
       - task: AzureCLI@2
         displayName: Publish Using Darc
         inputs:

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -267,11 +267,6 @@ stages:
 
         - task: NuGetAuthenticate@1
 
-        # Darc is targeting 8.0, so make sure it's installed
-        - task: UseDotNet@2
-          inputs:
-            version: 8.0.x
-
         - task: AzureCLI@2
           displayName: Publish Using Darc
           inputs:

--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "8.0.121"
+    "version": "8.0.122"
   },
   "tools": {
-    "dotnet": "8.0.121",
+    "dotnet": "8.0.122",
     "runtimes": {
       "dotnet/x86": [
         "$(MicrosoftNETCoreBrowserDebugHostTransportVersion)"

--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "8.0.122"
+    "version": "8.0.121"
   },
   "tools": {
-    "dotnet": "8.0.122",
+    "dotnet": "8.0.121",
     "runtimes": {
       "dotnet/x86": [
         "$(MicrosoftNETCoreBrowserDebugHostTransportVersion)"
@@ -25,8 +25,8 @@
   },
   "msbuild-sdks": {
     "Yarn.MSBuild": "1.22.19",
-    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.25562.3",
-    "Microsoft.DotNet.Helix.Sdk": "8.0.0-beta.25562.3"
+    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.25515.1",
+    "Microsoft.DotNet.Helix.Sdk": "8.0.0-beta.25515.1"
   },
   "native-tools": {
     "jdk": "latest"


### PR DESCRIPTION
Revert "Update dependencies from https://github.com/dotnet/arcade build 20251112.3 (#64349)"

This reverts commit 7e9dd50821e43e0949355c47bb44c41538850e9c.
