### PR TITLE
Switch to assetless build for official builds

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -711,44 +711,14 @@ extends:
       - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
         - template: /eng/common/templates-official/job/publish-build-assets.yml@self
           parameters:
-            dependsOn:
-              - Windows_build
-              - ${{ if ne(variables.PostBuildSign, 'true') }}:
-                - CodeSign_Xplat_MacOS_arm64
-                - CodeSign_Xplat_MacOS_x64
-                - CodeSign_Xplat_Linux_x64
-                - CodeSign_Xplat_Linux_arm
-                - CodeSign_Xplat_Linux_arm64
-                - CodeSign_Xplat_Linux_musl_x64
-                - CodeSign_Xplat_Linux_musl_arm
-                - CodeSign_Xplat_Linux_musl_arm64
-              - ${{ if eq(variables.PostBuildSign, 'true') }}:
-                - MacOs_arm64_build
-                - MacOs_x64_build
-                - Linux_x64_build
-                - Linux_arm_build
-                - Linux_arm64_build
-                - Linux_musl_x64_build
-                - Linux_musl_arm_build
-                - Linux_musl_arm64_build
-              # In addition to the dependencies above that provide assets, ensure the build was successful overall.
-              - ${{ if in(variables['Build.Reason'], 'Manual') }}:
-                - Code_check
-                - ${{ if ne(parameters.skipTests, 'true') }}:
-                  - Windows_Test
-                  - MacOS_Test
-                  - Linux_Test
-                  - Helix_x64_Subset_1
-                  - Helix_x64_Subset_2
-              - ${{ if eq(variables.enableSourceIndex, 'true') }}:
-                - SourceIndexStage1
-              - Source_Build_Managed
+            dependsOn: []
             pool:
               name: $(DncEngInternalBuildPool)
               demands: ImageOverride -equals 1es-windows-2019
             publishUsingPipelines: ${{ variables._PublishUsingPipelines }}
             enablePublishBuildArtifacts: true # publish artifacts/log files
             publishAssetsImmediately: true # Don't use a separate stage for darc publishing.
+            isAssetlessBuild: true
 
     - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
       - template: /eng/common/templates-official/post-build/post-build.yml@self


### PR DESCRIPTION
Part of https://github.com/dotnet/dotnet/issues/711, fixes https://github.com/dotnet/aspnetcore/issues/64510. We don't ship via the official build anymore. Making our build assetless allows aspnetcore commits to flow to the VMR much quicker after merging.