### PR TITLE
Fix empty render of the ErrorBoundary

### DIFF
--- a/src/Components/Components/src/ComponentBase.cs
+++ b/src/Components/Components/src/ComponentBase.cs
@@ -43,15 +43,6 @@ public abstract class ComponentBase : IComponent, IHandleEvent, IHandleAfterRend
     }
 
     /// <summary>
-    ///  Gets or sets a value that indicates whether there is a pending queued render.
-    /// </summary>
-    internal bool HasPendingQueuedRender
-    {
-        get => _hasPendingQueuedRender;
-        set => _hasPendingQueuedRender = value;
-    }
-
-    /// <summary>
     /// Gets the <see cref="Components.RendererInfo"/> the component is running on.
     /// </summary>
     protected RendererInfo RendererInfo => _renderHandle.RendererInfo;
@@ -133,7 +124,11 @@ public abstract class ComponentBase : IComponent, IHandleEvent, IHandleAfterRend
     {
         if (_hasPendingQueuedRender)
         {
-            return;
+            if (!_renderHandle.RemoveAllowNextRender())
+            {
+                return;
+            }
+            _hasPendingQueuedRender = false;
         }
 
         if (_hasNeverRendered || ShouldRender() || _renderHandle.IsRenderingOnMetadataUpdate)

--- a/src/Components/Components/src/ComponentBase.cs
+++ b/src/Components/Components/src/ComponentBase.cs
@@ -43,6 +43,15 @@ public abstract class ComponentBase : IComponent, IHandleEvent, IHandleAfterRend
     }
 
     /// <summary>
+    ///  Gets or sets a value that indicates whether there is a pending queued render.
+    /// </summary>
+    internal bool HasPendingQueuedRender
+    {
+        get => _hasPendingQueuedRender;
+        set => _hasPendingQueuedRender = value;
+    }
+
+    /// <summary>
     /// Gets the <see cref="Components.RendererInfo"/> the component is running on.
     /// </summary>
     protected RendererInfo RendererInfo => _renderHandle.RendererInfo;

--- a/src/Components/Components/src/RenderHandle.cs
+++ b/src/Components/Components/src/RenderHandle.cs
@@ -24,6 +24,15 @@ public readonly struct RenderHandle
     internal ComponentsMetrics? ComponentMetrics => _renderer?.ComponentMetrics;
     internal ComponentsActivitySource? ComponentActivitySource => _renderer?.ComponentActivitySource;
 
+    internal bool RemoveAllowNextRender()
+    {
+        if (_renderer == null)
+        {
+            ThrowNotInitialized();
+        }
+        return _renderer.RemoveAllowNextRender(_componentId);
+    }
+
     /// <summary>
     /// Gets the <see cref="Components.Dispatcher" /> associated with the component.
     /// </summary>

--- a/src/Components/Components/src/RenderTree/Renderer.cs
+++ b/src/Components/Components/src/RenderTree/Renderer.cs
@@ -1176,6 +1176,13 @@ public abstract partial class Renderer : IDisposable, IAsyncDisposable
                 // making it render an empty fragment. Ensures that failed components don't continue to
                 // operate, which would be a whole new kind of edge case to support forever.
                 AddToRenderQueue(candidate.ComponentId, builder => { });
+                if (candidate.Component is ComponentBase componentBase)
+                {
+                    // If the ErrorBoundary already handled one error and caught another, there can be a bug, where
+                    // HasPendingQueuedRender is still true from the previous error handling render. Clear it to avoid
+                    // rendering empty fragment and skipping the ErrorContent.
+                    componentBase.HasPendingQueuedRender = false;
+                }
 
                 try
                 {

--- a/src/Components/test/E2ETest/Tests/ErrorBoundaryTest.cs
+++ b/src/Components/test/E2ETest/Tests/ErrorBoundaryTest.cs
@@ -115,6 +115,16 @@ public class ErrorBoundaryTest : ServerTestBase<ToggleExecutionModeServerFixture
     }
 
     [Fact]
+    public void CanHandleMultipleExceptionsForOnce()
+    {
+        var container = Browser.Exists(By.Id("throw-multiple-errors-foreach-test"));
+        container.FindElement(By.ClassName("throw-multiple-errors-foreach")).Click();
+        Browser.Collection(() => container.FindElements(By.ClassName("error-message")),
+            elem => Assert.Equal("There was an error.", elem.Text));
+        AssertGlobalErrorState(false);
+    }
+
+    [Fact]
     public void CanHandleErrorsAfterDisposingComponent()
     {
         var container = Browser.Exists(By.Id("error-after-disposal-test"));

--- a/src/Components/test/testassets/BasicTestApp/ErrorBoundaryTest/ErrorBoundaryCases.razor
+++ b/src/Components/test/testassets/BasicTestApp/ErrorBoundaryTest/ErrorBoundaryCases.razor
@@ -53,6 +53,26 @@
 </div>
 
 <hr />
+<h2>Error boundary can handle multiple errors thrown</h2>
+<div id="throw-multiple-errors-foreach-test">
+    <ErrorBoundary>
+        <ChildContent>
+            @if (throwMultipleErrorsForeach)
+            {
+                @foreach (var item in Enumerable.Range(1, 3))
+                {
+                    <ForeachErrorsChild />
+                }
+            }
+        </ChildContent>
+        <ErrorContent>
+            <p class="error-message">There was an error.</p>
+        </ErrorContent>
+    </ErrorBoundary>
+    <button class="throw-multiple-errors-foreach" @onclick="@(() => throwMultipleErrorsForeach = true)">Throw multiple errors from child</button>
+</div>
+
+<hr />
 <h2>Exception inline in error boundary markup</h2>
 <p>This shows that, if an ErrorBoundary itself fails while rendering its own ChildContent, then it can catch its own exception. But if the error comes from the error content, this triggers the "infinite error loop" detection logic and becomes fatal.</p>
 <div id="inline-error-test">
@@ -139,6 +159,8 @@
     private bool disposalTestBeginDelayedError;
     private bool multipleChildrenBeginDelayedError;
     private bool twoErrorsInChild;
+
+    private bool throwMultipleErrorsForeach;
 
     void EventHandlerErrorSync()
         => throw new InvalidTimeZoneException("Synchronous error from event handler");

--- a/src/Components/test/testassets/BasicTestApp/ErrorBoundaryTest/ForeachErrorsChild.razor
+++ b/src/Components/test/testassets/BasicTestApp/ErrorBoundaryTest/ForeachErrorsChild.razor
@@ -1,0 +1,8 @@
+<h2>Subcomponent</h2>
+
+@code {
+  protected override void OnInitialized()
+  {
+    throw new Exception("Error from foreach child");
+  }
+}


### PR DESCRIPTION
# Fix empty render of the ErrorBoundary

## Description

This PR fixes a bug where ErrorBoundary renders empty content instead of ErrorContent when multiple child components throw errors in quick succession (e.g., errors thrown inside a foreach loop like in the test example).

### How it works normally (single error):
The Renderer queues an empty render to clear the subtree, then calls `HandleException`, which queues the ErrorContent render. This works correctly.

### The bug (multiple errors):
When a second error is thrown:
1. Renderer queues another empty render - this sets `_hasPendingQueuedRender = true`
2. Renderer calls `HandleException` to queue the ErrorContent render
3. `StateHasChanged()` returns early because `_hasPendingQueuedRender` is still `true` from step 1
4. The ErrorContent render is never queued

The queue ends up with: `[empty, ErrorContent, empty]` instead of `[empty, ErrorContent, empty, ErrorContent]`. After the first ErrorContent renders, only the empty render remains in the queue, clearing the error UI.

### Solution:
We already use path `ComponentBase` -> `RenderHandle` -> `Renderer`. By adding new `_componentsAllowNextRender` hash set we now can queue components that need to render with ignoring `_hasPendingQueuedRender` flag.

Fixes #56950
