### PR TITLE
Fix post actions for Razor Class Library template

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/template.json
@@ -100,7 +100,7 @@
       "continueOnError": true
     },
     {
-      "id": "openInEditor",
+      "id": "openPageInEditor",
       "condition": "(SupportPagesAndViews && HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
       "description": "Opens Areas/MyFeature/Pages/Page1.cshtml in the editor",
       "manualInstructions": [],
@@ -111,7 +111,7 @@
       "continueOnError": true
     },
     {
-      "id": "openInEditor",
+      "id": "openComponentInEditor",
       "condition": "(!SupportPagesAndViews && HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
       "description": "Opens Component1.razor in the editor",
       "manualInstructions": [],

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/template.json
@@ -77,8 +77,12 @@
       "path": "Company.RazorClassLibrary1.csproj"
     },
     {
-      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "condition": "(SupportPagesAndViews && HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
       "path": "Areas/MyFeature/Pages/Page1.cshtml"
+    },
+    {
+      "condition": "(!SupportPagesAndViews && HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "Component1.razor"
     }
   ],
   "defaultName": "RazorClassLibrary",
@@ -97,8 +101,19 @@
     },
     {
       "id": "openInEditor",
-      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "condition": "(SupportPagesAndViews && HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
       "description": "Opens Areas/MyFeature/Pages/Page1.cshtml in the editor",
+      "manualInstructions": [],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "args": {
+        "files": "1"
+      },
+      "continueOnError": true
+    },
+    {
+      "id": "openInEditor",
+      "condition": "(!SupportPagesAndViews && HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens Component1.razor in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
       "args": {


### PR DESCRIPTION
The Razor Class Library template has an option, `SupportsPagesAndViews` that causes it to produce one of two sets of files. If true, then `Areas/MyFeature/Pages/Page1.cshtml` is created. If false, then `Component1.razor` is created.

The issue with the previous template is that the set of primary outputs and the corresponding `openInEditor` post-actions were not taking this option into account, and were always trying to open the `Page1.cshtml` file, even if it didn't exist on disk.

This led to the bug described in https://github.com/microsoft/vscode-dotnettools/issues/2489

C# Dev Kit has been patched to not show warnings when a template specifies that non-existent files should be opened.

With the change here, users creating this template will now see the correct file opened. This applies both to VS and CDK.
