### PR TITLE
Refactor param binding failure handling in RequestDelegate

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -1012,6 +1012,9 @@ public static partial class RequestDelegateFactory
                 CompletedTaskExpr);
         }
 
+        // checkWasParamCheckFailure is a conditional expression: if WasParamCheckFailureExpr is true
+        // (i.e. any parameter binding or validation failed), it executes failureBranch (returns a 400);
+        // otherwise it invokes the handler method and writes its response.
         var checkWasParamCheckFailure = Expression.Condition(
             WasParamCheckFailureExpr,
             failureBranch,

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -376,7 +376,7 @@ public static partial class RequestDelegateFactory
         }
 
         var responseWritingMethodCall = factoryContext.ParamCheckExpressions.Count > 0 ?
-            CreateParamCheckingResponseWritingMethodCall(returnType, factoryContext) :
+            CreateParamCheckingResponseWritingMethodCall(returnType, factoryContext, filterPipeline is not null) :
             AddResponseWritingToMethodCall(factoryContext.MethodCall, returnType, factoryContext);
 
         if (factoryContext.UsingTempSourceString)
@@ -943,7 +943,7 @@ public static partial class RequestDelegateFactory
 
     // If we're calling TryParse or validating parameter optionality and
     // wasParamCheckFailure indicates it failed, set a 400 StatusCode instead of calling the method.
-    private static Expression CreateParamCheckingResponseWritingMethodCall(Type returnType, RequestDelegateFactoryContext factoryContext)
+    private static Expression CreateParamCheckingResponseWritingMethodCall(Type returnType, RequestDelegateFactoryContext factoryContext, bool filterPipelineBuilt)
     {
         // {
         //     string tempSourceString;
@@ -993,33 +993,40 @@ public static partial class RequestDelegateFactory
 
         localVariables[factoryContext.ExtraLocals.Count] = WasParamCheckFailureExpr;
 
-        // On parameter binding failure:
-        //  - If filters are present (pipeline built -> returnType ValueTask<object?>), run the filter pipeline so that
-        //    filters can observe/modify the 400 response. The handler itself will be skipped by the StatusCode >= 400
-        //    check embedded in the pipeline (see CreateFilterPipeline), allowing filters to customize the error.
-        //  - If no filters are present, just set 400 and short-circuit.
-        Expression failureBranch;
-        if (factoryContext.EndpointBuilder.FilterFactories.Count > 0 && returnType == typeof(ValueTask<object?>))
+        // If filters have been registered, we set the `wasParamCheckFailure` property
+        // but do not return from the invocation to allow the filters to run.
+        if (filterPipelineBuilt)
         {
-            failureBranch = Expression.Block(
-                Expression.Assign(StatusCodeExpr, Expression.Constant(400)),
-                AddResponseWritingToMethodCall(factoryContext.MethodCall!, returnType, factoryContext));
+            // if (wasParamCheckFailure)
+            // {
+            //   httpContext.Response.StatusCode = 400;
+            // }
+            // return RequestDelegateFactory.ExecuteObjectReturn(invocationPipeline.Invoke(context) as object);
+            var checkWasParamCheckFailureWithFilters = Expression.Block(
+                Expression.IfThen(
+                    WasParamCheckFailureExpr,
+                    Expression.Assign(StatusCodeExpr, Expression.Constant(400))),
+                AddResponseWritingToMethodCall(factoryContext.MethodCall!, returnType, factoryContext)
+            );
+
+            checkParamAndCallMethod[factoryContext.ParamCheckExpressions.Count] = checkWasParamCheckFailureWithFilters;
         }
         else
         {
-            failureBranch = Expression.Block(
-                Expression.Assign(StatusCodeExpr, Expression.Constant(400)),
-                CompletedTaskExpr);
+            // wasParamCheckFailure ? {
+            //  httpContext.Response.StatusCode = 400;
+            //  return Task.CompletedTask;
+            // } : {
+            //  return RequestDelegateFactory.ExecuteObjectReturn(invocationPipeline.Invoke(context) as object);
+            // }
+            var checkWasParamCheckFailure = Expression.Condition(
+                WasParamCheckFailureExpr,
+                Expression.Block(
+                    Expression.Assign(StatusCodeExpr, Expression.Constant(400)),
+                    CompletedTaskExpr),
+                AddResponseWritingToMethodCall(factoryContext.MethodCall!, returnType, factoryContext));
+            checkParamAndCallMethod[factoryContext.ParamCheckExpressions.Count] = checkWasParamCheckFailure;
         }
-
-        // checkWasParamCheckFailure is a conditional expression: if WasParamCheckFailureExpr is true
-        // (i.e. any parameter binding or validation failed), it executes failureBranch (returns a 400);
-        // otherwise it invokes the handler method and writes its response.
-        var checkWasParamCheckFailure = Expression.Condition(
-            WasParamCheckFailureExpr,
-            failureBranch,
-            AddResponseWritingToMethodCall(factoryContext.MethodCall!, returnType, factoryContext));
-        checkParamAndCallMethod[factoryContext.ParamCheckExpressions.Count] = checkWasParamCheckFailure;
 
         return Expression.Block(localVariables, checkParamAndCallMethod);
     }

--- a/src/Http/Routing/test/UnitTests/Builder/RouteHandlerEndpointRouteBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/RouteHandlerEndpointRouteBuilderExtensionsTest.cs
@@ -1102,6 +1102,39 @@ public class RouteHandlerEndpointRouteBuilderExtensionsTest : LoggedTest
     }
 
     [Fact]
+    public async Task ParameterBindingFailure_WithEndpointFilterFactory_HandlerReturningValueTaskOfObject_DoesNotExecuteHandler()
+    {
+        // Arrange - handler returns ValueTask<object?> which matches the filter pipeline return type
+        var services = new ServiceCollection().AddSingleton(LoggerFactory);
+        var serviceProvider = services.BuildServiceProvider();
+
+        var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(serviceProvider));
+        var handlerExecuted = false;
+
+        builder.MapGet("/test/{id}", ValueTask<object?> (HttpContext httpContext, Guid id) =>
+        {
+            handlerExecuted = true;
+            return new(id.ToString());
+        }).AddEndpointFilterFactory((_, next) => next);
+
+        var dataSource = GetBuilderEndpointDataSource(builder);
+        var endpoint = Assert.Single(dataSource.Endpoints);
+
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = serviceProvider
+        };
+        httpContext.Request.RouteValues["id"] = "invalid-guid";
+
+        // Act
+        await endpoint.RequestDelegate!(httpContext);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, httpContext.Response.StatusCode);
+        Assert.False(handlerExecuted, "Handler should not have been executed when parameter binding fails");
+    }
+
+    [Fact]
     public async Task ParameterBindingFailure_WithoutFilter_DoesNotExecuteHandler()
     {
         // Arrange


### PR DESCRIPTION
## Description

Refactor `RequestDelegateFactory` to handle parameter binding failures more flexibly:
- Execute filter pipelines on failure if filters are present and return type is `ValueTask<object?>`, allowing filters to observe/modify the 400 response.
- Short-circuit with a 400 response if no filters are present.
- Simplify logic using `Expression.Condition` and `Expression.Block`.

Add new test cases in `RouteHandlerEndpointRouteBuilderExtensionsTest.cs`:
- Validate behavior with/without filters and custom responses.
- Ensure handlers are not executed on binding failure.

Fixes #64341
