### PR TITLE
[Blazor] Add OnRowClick EventCallback to QuickGrid

### DIFF
--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Unshipped.txt
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.OnRowClick.get -> Microsoft.AspNetCore.Components.EventCallback<TGridItem>
+Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.OnRowClick.set -> void

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
@@ -69,30 +69,17 @@
         var combinedClass = OnRowClick.HasDelegate
             ? string.IsNullOrEmpty(rowClass) ? "row-clickable" : $"row-clickable {rowClass}"
             : rowClass;
+        var rowClick = OnRowClick.HasDelegate ? EventCallback.Factory.Create<MouseEventArgs>(this, () => OnRowClick.InvokeAsync(item)) : default;
 
-        if (OnRowClick.HasDelegate)
-        {
-            <tr @key="@(ItemKey(item))"
-                aria-rowindex="@rowIndex"
-                class="@combinedClass"
-                @onclick="@(() => OnRowClick.InvokeAsync(item))">
-                @foreach (var col in _columns)
-                {
-                    <td class="@ColumnClass(col)" @key="@col">@{ col.CellContent(__builder, item); }</td>
-                }
-            </tr>
-        }
-        else
-        {
-            <tr @key="@(ItemKey(item))"
-                aria-rowindex="@rowIndex"
-                class="@combinedClass">
-                @foreach (var col in _columns)
-                {
-                    <td class="@ColumnClass(col)" @key="@col">@{ col.CellContent(__builder, item); }</td>
-                }
-            </tr>
-        }
+        <tr @key="@(ItemKey(item))"
+            aria-rowindex="@rowIndex"
+            class="@combinedClass"
+            @onclick="@rowClick">
+            @foreach (var col in _columns)
+            {
+                <td class="@ColumnClass(col)" @key="@col">@{ col.CellContent(__builder, item); }</td>
+            }
+        </tr>
     }
 
     private void RenderPlaceholderRow(RenderTreeBuilder __builder, PlaceholderContext placeholderContext)

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
@@ -66,9 +66,16 @@
     private void RenderRow(RenderTreeBuilder __builder, int rowIndex, TGridItem item)
     {
         var rowClass = RowClass?.Invoke(item);
+        var combinedClass = OnRowClick.HasDelegate
+            ? string.IsNullOrEmpty(rowClass) ? "row-clickable" : $"row-clickable {rowClass}"
+            : rowClass;
+
         if (OnRowClick.HasDelegate)
         {
-            <tr @key="@(ItemKey(item))" aria-rowindex="@rowIndex" class="row-clickable @rowClass" @onclick="@(() => OnRowClick.InvokeAsync(item))">
+            <tr @key="@(ItemKey(item))"
+                aria-rowindex="@rowIndex"
+                class="@combinedClass"
+                @onclick="@(() => OnRowClick.InvokeAsync(item))">
                 @foreach (var col in _columns)
                 {
                     <td class="@ColumnClass(col)" @key="@col">@{ col.CellContent(__builder, item); }</td>
@@ -77,7 +84,9 @@
         }
         else
         {
-            <tr @key="@(ItemKey(item))" aria-rowindex="@rowIndex" class="@rowClass">
+            <tr @key="@(ItemKey(item))"
+                aria-rowindex="@rowIndex"
+                class="@combinedClass">
                 @foreach (var col in _columns)
                 {
                     <td class="@ColumnClass(col)" @key="@col">@{ col.CellContent(__builder, item); }</td>

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor
@@ -66,12 +66,24 @@
     private void RenderRow(RenderTreeBuilder __builder, int rowIndex, TGridItem item)
     {
         var rowClass = RowClass?.Invoke(item);
-        <tr @key="@(ItemKey(item))" aria-rowindex="@rowIndex" class="@rowClass">
-            @foreach (var col in _columns)
-            {
-                <td class="@ColumnClass(col)" @key="@col">@{ col.CellContent(__builder, item); }</td>
-            }
-        </tr>
+        if (OnRowClick.HasDelegate)
+        {
+            <tr @key="@(ItemKey(item))" aria-rowindex="@rowIndex" class="row-clickable @rowClass" @onclick="@(() => OnRowClick.InvokeAsync(item))">
+                @foreach (var col in _columns)
+                {
+                    <td class="@ColumnClass(col)" @key="@col">@{ col.CellContent(__builder, item); }</td>
+                }
+            </tr>
+        }
+        else
+        {
+            <tr @key="@(ItemKey(item))" aria-rowindex="@rowIndex" class="@rowClass">
+                @foreach (var col in _columns)
+                {
+                    <td class="@ColumnClass(col)" @key="@col">@{ col.CellContent(__builder, item); }</td>
+                }
+            </tr>
+        }
     }
 
     private void RenderPlaceholderRow(RenderTreeBuilder __builder, PlaceholderContext placeholderContext)

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
@@ -109,6 +109,11 @@ public partial class QuickGrid<TGridItem> : IAsyncDisposable
     /// </summary>
     [Parameter] public Func<TGridItem, string?>? RowClass { get; set; }
 
+    /// <summary>
+    /// Optional. A callback that is invoked when a row is clicked.
+    /// </summary>
+    [Parameter] public EventCallback<TGridItem> OnRowClick { get; set; }
+
     [Inject] private IServiceProvider Services { get; set; } = default!;
     [Inject] private IJSRuntime JS { get; set; } = default!;
 

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.css
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.css
@@ -116,3 +116,8 @@ html[dir=rtl] .col-justify-end .col-options {
     right: unset;
     left: 0;
 }
+
+/* Clickable rows when OnRowClick is set */
+tr.row-clickable {
+    cursor: pointer;
+}

--- a/src/Components/test/E2ETest/Tests/QuickGridTest.cs
+++ b/src/Components/test/E2ETest/Tests/QuickGridTest.cs
@@ -215,4 +215,43 @@ public class QuickGridTest : ServerTestBase<ToggleExecutionModeServerFixture<Pro
         app = Browser.MountTestComponent<QuickGridVirtualizeComponent>();
         Browser.Equal("1", () => app.FindElement(By.Id("items-provider-call-count")).Text);
     }
+
+    [Fact]
+    public void OnRowClickTriggersCallback()
+    {
+        var grid = app.FindElement(By.CssSelector("#grid > table"));
+
+        // Verify no row has been clicked yet
+        Browser.Exists(By.Id("no-click"));
+
+        // Click on the first row (Julie Smith)
+        var firstRow = grid.FindElement(By.CssSelector("tbody > tr:nth-child(1)"));
+        firstRow.Click();
+
+        // Verify the callback was triggered with correct data
+        Browser.Equal("PersonId: 11203", () => app.FindElement(By.Id("clicked-person-id")).Text);
+        Browser.Equal("Name: Julie Smith", () => app.FindElement(By.Id("clicked-person-name")).Text);
+        Browser.Equal("Click count: 1", () => app.FindElement(By.Id("click-count")).Text);
+
+        // Click on another row (Jose Hernandez - 3rd row)
+        var thirdRow = grid.FindElement(By.CssSelector("tbody > tr:nth-child(3)"));
+        thirdRow.Click();
+
+        // Verify the callback was triggered with the new row's data
+        Browser.Equal("PersonId: 11898", () => app.FindElement(By.Id("clicked-person-id")).Text);
+        Browser.Equal("Name: Jose Hernandez", () => app.FindElement(By.Id("clicked-person-name")).Text);
+        Browser.Equal("Click count: 2", () => app.FindElement(By.Id("click-count")).Text);
+    }
+
+    [Fact]
+    public void OnRowClickAppliesCursorPointerStyle()
+    {
+        var grid = app.FindElement(By.CssSelector("#grid > table"));
+
+        // Verify the row has cursor: pointer style via the row-clickable class
+        var cursorStyle = Browser.ExecuteJavaScript<string>(@"
+            const row = document.querySelector('#grid > table > tbody > tr:nth-child(1)');
+            return row ? getComputedStyle(row).cursor : null;");
+        Assert.Equal("pointer", cursorStyle);
+    }
 }

--- a/src/Components/test/E2ETest/Tests/QuickGridTest.cs
+++ b/src/Components/test/E2ETest/Tests/QuickGridTest.cs
@@ -136,11 +136,11 @@ public class QuickGridTest : ServerTestBase<ToggleExecutionModeServerFixture<Pro
             if (firstName == "Julie")
             {
                 isJulieRowFound = true;
-                Assert.Equal("highlight", row.GetDomAttribute("class"));
+                Assert.Equal("row-clickable highlight", row.GetDomAttribute("class"));
             }
             else
             {
-                Assert.Null(row.GetDomAttribute("class"));
+                Assert.Equal("row-clickable", row.GetDomAttribute("class"));
             }
         }
 

--- a/src/Components/test/testassets/BasicTestApp/QuickGridTest/SampleQuickGridComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/QuickGridTest/SampleQuickGridComponent.razor
@@ -3,7 +3,7 @@
 <h3>Sample QuickGrid Component</h3>
 
 <div id="grid">
-    <QuickGrid @ref="@quickGridRef" Items="@FilteredPeople" Pagination="@pagination" RowClass="HighlightJulie" custom-attrib="somevalue" class="custom-class-attrib">
+    <QuickGrid @ref="@quickGridRef" Items="@FilteredPeople" Pagination="@pagination" RowClass="HighlightJulie" OnRowClick="@((Person p) => HandleRowClick(p))" custom-attrib="somevalue" class="custom-class-attrib">
         <PropertyColumn Property="@(p => p.PersonId)" Sortable="true" />
         <PropertyColumn Property="@(p => p.FirstName)" Sortable="true">
             <ColumnOptions>
@@ -20,11 +20,32 @@
 </div>
 <Paginator State="@pagination" />
 
+<div id="clicked-row-info">
+    @if (clickedPerson is not null)
+    {
+        <p id="clicked-person-id">PersonId: @clickedPerson.PersonId</p>
+        <p id="clicked-person-name">Name: @clickedPerson.FirstName @clickedPerson.LastName</p>
+        <p id="click-count">Click count: @clickCount</p>
+    }
+    else
+    {
+        <p id="no-click">No row clicked yet</p>
+    }
+</div>
+
 @code {
     record Person(int PersonId, string FirstName, string LastName, DateOnly BirthDate);
     PaginationState pagination = new PaginationState { ItemsPerPage = 10 };
     string firstNameFilter;
     QuickGrid<Person> quickGridRef;
+    Person clickedPerson;
+    int clickCount;
+
+    void HandleRowClick(Person person)
+    {
+        clickedPerson = person;
+        clickCount++;
+    }
 
     int ComputeAge(DateOnly birthDate)
         => DateTime.Now.Year - birthDate.Year - (birthDate.DayOfYear < DateTime.Now.DayOfYear ? 0 : 1);


### PR DESCRIPTION
### Summary

This PR adds a new `OnRowClick` parameter to the `QuickGrid` component, allowing users to handle row click events. This addresses a common scenario where developers need to respond to user clicks on grid rows.

Fixes #44899

### Changes

- Added `OnRowClick` parameter of type `EventCallback<TGridItem>` to `QuickGrid`
- When the delegate is set:
  - Row elements receive a `row-clickable` CSS class
  - A `cursor: pointer` style is applied via scoped CSS
  - Clicking the row invokes the callback with the clicked item
- Added E2E tests to verify the callback is triggered and cursor style is applied

### Usage Example

```razor
<QuickGrid Items="@people" OnRowClick="HandleRowClick">
    <PropertyColumn Property="@(p => p.Name)" />
</QuickGrid>

@code {
    void HandleRowClick(Person person)
    {
        // Handle the row click
        Console.WriteLine($"Clicked: {person.Name}");
    }
}
```

### Files Changed

| File | Description |
|------|-------------|
| `QuickGrid.razor` | Added if/else in RenderRow to apply click handler and CSS class |
| `QuickGrid.razor.cs` | Added `OnRowClick` parameter with XML docs |
| `QuickGrid.razor.css` | Added `.row-clickable` CSS class with cursor:pointer |
| `PublicAPI.Unshipped.txt` | Documented new public API |
| `SampleQuickGridComponent.razor` | Updated test component with OnRowClick handler |
| `QuickGridTest.cs` | Added E2E tests for OnRowClick behavior |