### PR TITLE
Reduce unsafe usage in AdaptiveCapacityDictionary

### DIFF
--- a/src/Shared/Dictionary/AdaptiveCapacityDictionary.cs
+++ b/src/Shared/Dictionary/AdaptiveCapacityDictionary.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Shared;
 
 namespace Microsoft.AspNetCore.Internal;
@@ -545,8 +544,7 @@ internal sealed class AdaptiveCapacityDictionary<TKey, TValue> : IDictionary<TKe
             Debug.Assert(_arrayStorage is not null);
             Debug.Assert(_count <= _arrayStorage.Length);
 
-            ref var r = ref MemoryMarshal.GetArrayDataReference(_arrayStorage);
-            return MemoryMarshal.CreateSpan(ref r, _count);
+            return _arrayStorage.AsSpan(0, _count);
         }
     }
 
@@ -558,9 +556,10 @@ internal sealed class AdaptiveCapacityDictionary<TKey, TValue> : IDictionary<TKe
 
         if (_count > 0)
         {
-            for (var i = 0; i < ArrayStorageSpan.Length; ++i)
+            var arrayStorageSpanLocal = ArrayStorageSpan; // call Span.Slice once rather than within loop
+            for (var i = 0; i < arrayStorageSpanLocal.Length; ++i)
             {
-                if (_comparer.Equals(ArrayStorageSpan[i].Key, key))
+                if (_comparer.Equals(arrayStorageSpanLocal[i].Key, key))
                 {
                     return i;
                 }

--- a/src/Shared/Dictionary/AdaptiveCapacityDictionary.cs
+++ b/src/Shared/Dictionary/AdaptiveCapacityDictionary.cs
@@ -556,10 +556,10 @@ internal sealed class AdaptiveCapacityDictionary<TKey, TValue> : IDictionary<TKe
 
         if (_count > 0)
         {
-            var arrayStorageSpanLocal = ArrayStorageSpan; // call Span.Slice once rather than within loop
-            for (var i = 0; i < arrayStorageSpanLocal.Length; ++i)
+            var localSpan = ArrayStorageSpan; // incur slice + bounds check once upfront instead of within loop
+            for (var i = 0; i < localSpan.Length; ++i)
             {
-                if (_comparer.Equals(arrayStorageSpanLocal[i].Key, key))
+                if (_comparer.Equals(localSpan[i].Key, key))
                 {
                     return i;
                 }


### PR DESCRIPTION
Removes unnecessary calls to the unsafe `MemoryMarshal.GetArrayDataReference` and `MemoryMarshal.CreateSpan` methods. The only thing this was doing was saving a single bounds check per call to `FindIndex` or `TryFindItem`, and this single bounds check is dwarfed by the call to `IEqualityComparer<T>.Equals` within the loop.

I hoisted the span into a local within the `FindIndex` method to ensure the bounds check occurs only once ahead of the loop, not within the loop itself.