### PR TITLE
Use shallow clones for CI jobs

### DIFF
--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -98,6 +98,8 @@ stages:
       jobName: Code_check
       jobDisplayName: Code check
       agentOs: Windows
+      # Need full history for git log comparison in CodeCheck.ps1
+      fetchDepth: 0
       steps:
       - powershell: ./eng/scripts/CodeCheck.ps1 -ci $(_InternalRuntimeDownloadArgs)
         displayName: Run eng/scripts/CodeCheck.ps1

--- a/.azure/pipelines/ci-unofficial.yml
+++ b/.azure/pipelines/ci-unofficial.yml
@@ -111,6 +111,8 @@ extends:
             jobName: Code_check
             jobDisplayName: Code check
             agentOs: Windows
+            # Need full history for git log comparison in CodeCheck.ps1
+            fetchDepth: 0
             beforeBuild:
             - script: git submodule update --init
               displayName: Update submodules

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -138,6 +138,8 @@ extends:
             jobName: Code_check
             jobDisplayName: Code check
             agentOs: Windows
+            # Need full history for git log comparison in CodeCheck.ps1
+            fetchDepth: 0
             steps:
             - powershell: ./eng/scripts/CodeCheck.ps1 -ci $(_InternalRuntimeDownloadArgs)
               displayName: Run eng/scripts/CodeCheck.ps1

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -71,6 +71,9 @@ parameters:
   timeoutInMinutes: 180
   testRunTitle: $(AgentOsName)-$(BuildConfiguration)
   useHostedUbuntu: true
+  # Checkout optimization parameters
+  fetchDepth: 1
+  fetchTags: false
 
   # We need longer than the default amount of 5 minutes to upload our logs/artifacts. (We currently take around 5 mins in the best case).
   # This makes sure we have time to upload everything in the case of a build timeout - really important for investigating a build
@@ -159,6 +162,9 @@ jobs:
             - name: ${{ pair.key }}
               value: ${{ pair.value }}
       steps:
+      - checkout: self
+        fetchDepth: ${{ parameters.fetchDepth }}
+        fetchTags: ${{ parameters.fetchTags }}
       - ${{ if ne(parameters.agentOs, 'Windows') }}:
         - script: df -h
           displayName: Disk size
@@ -385,6 +391,9 @@ jobs:
             - name: ${{ pair.key }}
               value: ${{ pair.value }}
       steps:
+      - checkout: self
+        fetchDepth: ${{ parameters.fetchDepth }}
+        fetchTags: ${{ parameters.fetchTags }}
       - ${{ if ne(parameters.agentOs, 'Windows') }}:
         - script: df -h
           displayName: Disk size


### PR DESCRIPTION
This PR optimizes the git checkout step across all CI jobs by using shallow clones (`fetchDepth: 1`) and disabling tag fetching (`fetchTags: false`).

The current default checkout fetches all branches, tags, and full history on all ~17 jobs we run. This takes a while (on some jobs well over a minute).

Since the jobs run in parallel we won't actually reduce wall clock time per PR by 17 minutes but this should help make our infrastructure more efficient.