### PR TITLE
provide xml doc on `IFormFile.FileName` for user attention

### DIFF
--- a/src/Http/Http.Features/src/IFormFile.cs
+++ b/src/Http/Http.Features/src/IFormFile.cs
@@ -36,6 +36,16 @@ public interface IFormFile
     /// <summary>
     /// Gets the file name from the Content-Disposition header.
     /// </summary>
+    /// <remarks>
+    /// Do not use the <see cref="FileName"/> property of <see cref="IFormFile"/> other than for display and logging.
+    /// When displaying or logging, HTML encode the file name.  A cyberattacker can provide a malicious filename, including full paths or relative paths.
+    /// <para>
+    /// You can use the following code to remove the path from the file name:
+    /// </para>
+    /// <code>
+    /// string untrustedFileName = Path.GetFileName(pathName);
+    /// </code>
+    /// </remarks>
     string FileName { get; }
 
     /// <summary>

--- a/src/Http/Http.Features/src/IFormFile.cs
+++ b/src/Http/Http.Features/src/IFormFile.cs
@@ -43,7 +43,7 @@ public interface IFormFile
     /// You can use the following code to remove the path from the file name:
     /// </para>
     /// <code>
-    /// string untrustedFileName = Path.GetFileName(pathName);
+    /// string untrustedFileName = Path.GetFileName(formFile.FileName);
     /// </code>
     /// </remarks>
     string FileName { get; }

--- a/src/Http/Http.Features/src/IFormFile.cs
+++ b/src/Http/Http.Features/src/IFormFile.cs
@@ -38,7 +38,7 @@ public interface IFormFile
     /// </summary>
     /// <remarks>
     /// Do not use the <see cref="FileName"/> property of <see cref="IFormFile"/> other than for display and logging.
-    /// When displaying or logging, HTML encode the file name.  A cyberattacker can provide a malicious filename, including full paths or relative paths.
+    /// When displaying or logging, HTML encode the file name. A cyberattacker can provide a malicious filename, including full paths or relative paths.
     /// <para>
     /// You can use the following code to remove the path from the file name:
     /// </para>


### PR DESCRIPTION
Describes that `FileName` should not be used directly as [per doc](https://learn.microsoft.com/en-us/aspnet/core/mvc/models/file-uploads?view=aspnetcore-10.0#upload-small-files-with-buffered-model-binding-to-physical-storage). Raises user attention when using `Filename` directly
