### PR TITLE
Fix multiple requests for ItemsProvider when changing the TotalItemCount

### DIFF
--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
@@ -335,7 +335,6 @@ public partial class QuickGrid<TGridItem> : IAsyncDisposable
         else
         {
             // If we're not using Virtualize, we build and execute a request against the items provider directly
-            _lastRefreshedPaginationStateHash = Pagination?.GetHashCode();
             var startIndex = Pagination is null ? 0 : (Pagination.CurrentPageIndex * Pagination.ItemsPerPage);
             var request = new GridItemsProviderRequest<TGridItem>(
                 startIndex, Pagination?.ItemsPerPage, _sortByColumn, _sortByAscending, thisLoadCts.Token);
@@ -347,6 +346,7 @@ public partial class QuickGrid<TGridItem> : IAsyncDisposable
                 Pagination?.SetTotalItemCountAsync(result.TotalItemCount);
                 _pendingDataLoadCancellationTokenSource = null;
             }
+            _lastRefreshedPaginationStateHash = Pagination?.GetHashCode();
         }
     }
 

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
@@ -344,9 +344,9 @@ public partial class QuickGrid<TGridItem> : IAsyncDisposable
                 _currentNonVirtualizedViewItems = result.Items;
                 _ariaBodyRowCount = _currentNonVirtualizedViewItems.Count;
                 Pagination?.SetTotalItemCountAsync(result.TotalItemCount);
+                _lastRefreshedPaginationStateHash = Pagination?.GetHashCode();
                 _pendingDataLoadCancellationTokenSource = null;
             }
-            _lastRefreshedPaginationStateHash = Pagination?.GetHashCode();
         }
     }
 

--- a/src/Components/test/E2ETest/Tests/QuickGridTest.cs
+++ b/src/Components/test/E2ETest/Tests/QuickGridTest.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.E2ETesting;
 using OpenQA.Selenium;
+using OpenQA.Selenium.Interactions;
 using OpenQA.Selenium.Support.Extensions;
 using Xunit.Abstractions;
 
@@ -214,5 +215,35 @@ public class QuickGridTest : ServerTestBase<ToggleExecutionModeServerFixture<Pro
     {
         app = Browser.MountTestComponent<QuickGridVirtualizeComponent>();
         Browser.Equal("1", () => app.FindElement(By.Id("items-provider-call-count")).Text);
+    }
+
+    [Fact]
+    public void FilterUsingSetCurrentPageDoesNotCauseExtraRefresh()
+    {
+        app = Browser.MountTestComponent<QuickGridFilterComponent>();
+
+        Browser.Equal("1", () => app.FindElement(By.Id("items-provider-calls")).Text);
+
+        var filterInput = app.FindElement(By.Id("filter-input"));
+        filterInput.Clear();
+        filterInput.SendKeys("Item 1");
+        app.FindElement(By.Id("apply-filter-reset-pagination-btn")).Click();
+
+        Browser.Equal("2", () => app.FindElement(By.Id("items-provider-calls")).Text);
+    }
+
+    [Fact]
+    public void FilterUsingRefreshDataDoesNotCauseExtraRefresh()
+    {
+        app = Browser.MountTestComponent<QuickGridFilterComponent>();
+
+        Browser.Equal("1", () => app.FindElement(By.Id("items-provider-calls")).Text);
+
+        var filterInput = app.FindElement(By.Id("filter-input"));
+        filterInput.Clear();
+        filterInput.SendKeys("Item 1");
+        app.FindElement(By.Id("apply-filter-refresh-data-btn")).Click();
+
+        Browser.Equal("2", () => app.FindElement(By.Id("items-provider-calls")).Text);
     }
 }

--- a/src/Components/test/E2ETest/Tests/QuickGridTest.cs
+++ b/src/Components/test/E2ETest/Tests/QuickGridTest.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.E2ETesting;
 using OpenQA.Selenium;
-using OpenQA.Selenium.Interactions;
 using OpenQA.Selenium.Support.Extensions;
 using Xunit.Abstractions;
 

--- a/src/Components/test/testassets/BasicTestApp/Index.razor
+++ b/src/Components/test/testassets/BasicTestApp/Index.razor
@@ -96,7 +96,9 @@
         <option value="@GetTestServerProjectComponent("Components.TestServer.ProtectedBrowserStorageUsageComponent")">Protected browser storage usage</option>
         <option value="@GetTestServerProjectComponent("Components.TestServer.ProtectedBrowserStorageInjectionComponent")">Protected browser storage injection</option>
         <option value="BasicTestApp.QuickGridTest.SampleQuickGridComponent">QuickGrid Example</option>
+        <option value="BasicTestApp.QuickGridTest.QuickGridFilterComponent">QuickGrid with Filter Example</option>
         <option value="BasicTestApp.QuickGridTest.QuickGridVirtualizeComponent">QuickGrid with Virtualize Example</option>
+        <option value="BasicTestApp.QuickGridTest.QuickGridFilterComponent">QuickGrid Filter ItemsProvider Calls Test</option>
         <option value="BasicTestApp.RazorTemplates">Razor Templates</option>
         <option value="BasicTestApp.Reconnection.ReconnectionComponent">Reconnection server-side blazor</option>
         <option value="BasicTestApp.RedTextComponent">Red text</option>

--- a/src/Components/test/testassets/BasicTestApp/Index.razor
+++ b/src/Components/test/testassets/BasicTestApp/Index.razor
@@ -96,7 +96,6 @@
         <option value="@GetTestServerProjectComponent("Components.TestServer.ProtectedBrowserStorageUsageComponent")">Protected browser storage usage</option>
         <option value="@GetTestServerProjectComponent("Components.TestServer.ProtectedBrowserStorageInjectionComponent")">Protected browser storage injection</option>
         <option value="BasicTestApp.QuickGridTest.SampleQuickGridComponent">QuickGrid Example</option>
-        <option value="BasicTestApp.QuickGridTest.QuickGridFilterComponent">QuickGrid with Filter Example</option>
         <option value="BasicTestApp.QuickGridTest.QuickGridVirtualizeComponent">QuickGrid with Virtualize Example</option>
         <option value="BasicTestApp.QuickGridTest.QuickGridFilterComponent">QuickGrid Filter ItemsProvider Calls Test</option>
         <option value="BasicTestApp.RazorTemplates">Razor Templates</option>

--- a/src/Components/test/testassets/BasicTestApp/QuickGridTest/QuickGridFilterComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/QuickGridTest/QuickGridFilterComponent.razor
@@ -1,0 +1,68 @@
+﻿@using Microsoft.AspNetCore.Components.QuickGrid
+
+<div>
+    <input id="filter-input" type="text" @bind="filter" />
+    <button id="apply-filter-reset-pagination-btn" @onclick="ApplyFilterResetPagination">Apply Filter</button>
+    <button id="apply-filter-refresh-data-btn" @onclick="ApplyFilterRefreshData">Apply Filter</button>
+</div>
+
+<div class="grid">
+    <QuickGrid ItemsProvider="itemsProvider" Pagination="@pagination" @ref="gridRef">
+        <PropertyColumn Property="@(c => c.Id)" />
+        <PropertyColumn Property="@(c => c.Name)" />
+    </QuickGrid>
+</div>
+<Paginator State="@pagination" />
+
+<p id="items-provider-calls">@itemsProviderCalls</p>
+
+@code {
+    PaginationState pagination = new PaginationState { ItemsPerPage = 5 };
+    int itemsProviderCalls = 0;
+    GridItemsProvider<Item> itemsProvider;
+    QuickGrid<Item> gridRef;
+    string filter = string.Empty;
+
+    private readonly List<Item> allItems = Enumerable.Range(1, 25)
+        .Select(i => new Item { Id = i, Name = $"Item {i}" })
+        .ToList();
+
+    protected override void OnInitialized()
+    {
+        itemsProvider = async request =>
+        {
+            await Task.CompletedTask;
+
+            itemsProviderCalls++;
+            StateHasChanged();
+
+            var filteredItems = string.IsNullOrEmpty(filter)
+                ? allItems
+                : allItems.Where(i => i.Name.Contains(filter, StringComparison.OrdinalIgnoreCase)).ToList();
+
+            var totalCount = filteredItems.Count;
+            var pagedItems = filteredItems
+                .Skip(request.StartIndex)
+                .Take(request.Count ?? 5)
+                .ToList();
+
+            return GridItemsProviderResult.From(pagedItems, totalCount);
+        };
+    }
+
+    protected async Task ApplyFilterResetPagination()
+    {
+        await pagination.SetCurrentPageIndexAsync(0);
+    }
+
+    protected async Task ApplyFilterRefreshData()
+    {
+        await gridRef.RefreshDataAsync();
+    }
+
+    class Item
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/src/Components/test/testassets/BasicTestApp/QuickGridTest/QuickGridFilterComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/QuickGridTest/QuickGridFilterComponent.razor
@@ -19,7 +19,7 @@
 @code {
     PaginationState pagination = new PaginationState { ItemsPerPage = 5 };
     int itemsProviderCalls = 0;
-    GridItemsProvider<Item> itemsProvider;
+    GridItemsProvider<Item> itemsProvider = default!;
     QuickGrid<Item> gridRef;
     string filter = string.Empty;
 
@@ -33,7 +33,7 @@
         {
             await Task.CompletedTask;
 
-            itemsProviderCalls++;
+            Interlocked.Increment(ref itemsProviderCalls);
             StateHasChanged();
 
             var filteredItems = string.IsNullOrEmpty(filter)


### PR DESCRIPTION
# Fix multiple requests for ItemsProvider when changing the TotalItemCount

## Description

This pull request improves the QuickGrid component by fixing how pagination state is tracked to prevent unnecessary data refreshes, and adds new end-to-end tests and a test component to verify correct ItemsProvider call behavior when filtering. The main focus is on ensuring that applying filters via pagination reset or explicit data refresh does not trigger extra data loads.

**Changes:**

* Moved the assignment of `_lastRefreshedPaginationStateHash` in `QuickGrid.razor.cs` to after the data load completes, ensuring the hash accurately reflects the refreshed state and preventing unnecessary refreshes. 
* Added new end-to-end tests in `QuickGridTest.cs` to verify that filtering with either pagination reset or explicit refresh only results in a single additional ItemsProvider call, preventing redundant refreshes.
* Introduced a new test component, `QuickGridFilterComponent.razor`, to support these tests by simulating filtering and tracking ItemsProvider calls.

Fixes #62605
