### PR TITLE
Align the summary with `ToBaseRelativePath` actual job

### DIFF
--- a/src/Components/Components/src/NavigationManager.cs
+++ b/src/Components/Components/src/NavigationManager.cs
@@ -246,7 +246,7 @@ public abstract class NavigationManager
 
     /// <summary>
     /// Converts a relative URI into an absolute one (by resolving it
-    /// relative to the current absolute URI).
+    /// relative to the base URI).
     /// </summary>
     /// <param name="relativeUri">The relative URI.</param>
     /// <returns>The absolute URI.</returns>


### PR DESCRIPTION
In relation to https://github.com/dotnet/aspnetcore/issues/23615#issuecomment-3178176273.

The doc summary is misleading and contributes to AI hallucinations.

"current absolute URI" is `NavigationManager._uri`
and the method uses `_baseUri`, so "relative to the base URI" is more correct.
