### PR TITLE
[Blazor] `OwningComponentBase` Dispose method in .NET 10 gets back the original behavior

### DIFF
--- a/src/Components/Components/src/OwningComponentBase.cs
+++ b/src/Components/Components/src/OwningComponentBase.cs
@@ -72,17 +72,9 @@ public abstract class OwningComponentBase : ComponentBase, IDisposable, IAsyncDi
     /// <inheritdoc />
     async ValueTask IAsyncDisposable.DisposeAsync()
     {
-        if (!IsDisposed)
-        {
-            try
-            {
-                await DisposeAsyncCore().ConfigureAwait(false);
-            }
-            finally
-            {
-                Dispose(disposing: true);
-            }
-        }
+        await DisposeAsyncCore().ConfigureAwait(false);
+
+        Dispose(disposing: true);
         GC.SuppressFinalize(this);
     }
 

--- a/src/Components/Components/src/OwningComponentBase.cs
+++ b/src/Components/Components/src/OwningComponentBase.cs
@@ -86,7 +86,7 @@ public abstract class OwningComponentBase : ComponentBase, IDisposable, IAsyncDi
     /// <returns>A task that represents the asynchronous dispose operation.</returns>
     protected virtual async ValueTask DisposeAsyncCore()
     {
-        if (_scope.HasValue)
+        if (!IsDisposed && _scope.HasValue)
         {
             await _scope.Value.DisposeAsync().ConfigureAwait(false);
             _scope = null;

--- a/src/Components/Components/src/OwningComponentBase.cs
+++ b/src/Components/Components/src/OwningComponentBase.cs
@@ -74,8 +74,14 @@ public abstract class OwningComponentBase : ComponentBase, IDisposable, IAsyncDi
     {
         if (!IsDisposed)
         {
-            await DisposeAsyncCore().ConfigureAwait(false);
-            Dispose(disposing: true);
+            try
+            {
+                await DisposeAsyncCore().ConfigureAwait(false);
+            }
+            finally
+            {
+                Dispose(disposing: true);
+            }
         }
         GC.SuppressFinalize(this);
     }

--- a/src/Components/Components/src/OwningComponentBase.cs
+++ b/src/Components/Components/src/OwningComponentBase.cs
@@ -44,7 +44,7 @@ public abstract class OwningComponentBase : ComponentBase, IDisposable, IAsyncDi
         }
     }
 
-    /// <inhertidoc />
+    /// <inheritdoc />
     void IDisposable.Dispose()
     {
         Dispose(disposing: true);
@@ -69,12 +69,15 @@ public abstract class OwningComponentBase : ComponentBase, IDisposable, IAsyncDi
         }
     }
 
-    /// <inhertidoc />
+    /// <inheritdoc />
     async ValueTask IAsyncDisposable.DisposeAsync()
     {
-        await DisposeAsyncCore().ConfigureAwait(false);
-
-        Dispose(disposing: false);
+        if (!IsDisposed)
+        {
+            await DisposeAsyncCore().ConfigureAwait(false);
+            
+            Dispose(disposing: true);
+        }
         GC.SuppressFinalize(this);
     }
 
@@ -84,13 +87,11 @@ public abstract class OwningComponentBase : ComponentBase, IDisposable, IAsyncDi
     /// <returns>A task that represents the asynchronous dispose operation.</returns>
     protected virtual async ValueTask DisposeAsyncCore()
     {
-        if (!IsDisposed && _scope.HasValue)
+        if (_scope.HasValue)
         {
             await _scope.Value.DisposeAsync().ConfigureAwait(false);
             _scope = null;
         }
-
-        IsDisposed = true;
     }
 }
 

--- a/src/Components/Components/src/OwningComponentBase.cs
+++ b/src/Components/Components/src/OwningComponentBase.cs
@@ -75,7 +75,6 @@ public abstract class OwningComponentBase : ComponentBase, IDisposable, IAsyncDi
         if (!IsDisposed)
         {
             await DisposeAsyncCore().ConfigureAwait(false);
-            
             Dispose(disposing: true);
         }
         GC.SuppressFinalize(this);

--- a/src/Components/Components/test/OwningComponentBaseTest.cs
+++ b/src/Components/Components/test/OwningComponentBaseTest.cs
@@ -150,26 +150,6 @@ public class OwningComponentBaseTest
         Assert.Equal(1, counter.DisposedCount);
     }
 
-    [Fact]
-    public async Task DisposeAsyncCore_Override_WithException_StillCallsDispose()
-    {
-        var services = new ServiceCollection();
-        services.AddSingleton<Counter>();
-        services.AddTransient<MyService>();
-        var serviceProvider = services.BuildServiceProvider();
-
-        var renderer = new TestRenderer(serviceProvider);
-        var component = (ComponentWithThrowingDisposeAsyncCore)renderer.InstantiateComponent<ComponentWithThrowingDisposeAsyncCore>();
-
-        _ = component.MyService;
-        
-        await Assert.ThrowsAsync<InvalidOperationException>(async () => 
-            await ((IAsyncDisposable)component).DisposeAsync());
-        
-        Assert.True(component.DisposingParameter);
-        Assert.True(component.IsDisposedPublic);
-    }
-
     private class ComponentWithDispose : OwningComponentBase<MyService>
     {
         public MyService MyService => Service;
@@ -180,25 +160,6 @@ public class OwningComponentBaseTest
         {
             DisposingParameter = disposing;
             DisposeCallCount++;
-            base.Dispose(disposing);
-        }
-    }
-
-    private class ComponentWithThrowingDisposeAsyncCore : OwningComponentBase<MyService>
-    {
-        public MyService MyService => Service;
-        public bool? DisposingParameter { get; private set; }
-        public bool IsDisposedPublic => IsDisposed;
-
-        protected override async ValueTask DisposeAsyncCore()
-        {
-            await base.DisposeAsyncCore();
-            throw new InvalidOperationException("Something went wrong in async disposal");
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            DisposingParameter = disposing;
             base.Dispose(disposing);
         }
     }

--- a/src/Components/Components/test/OwningComponentBaseTest.cs
+++ b/src/Components/Components/test/OwningComponentBaseTest.cs
@@ -115,6 +115,7 @@ public class OwningComponentBaseTest
     public async Task DisposeAsync_CallsDispose_WithDisposingTrue()
     {
         var services = new ServiceCollection();
+        services.AddSingleton<Counter>();
         services.AddTransient<MyService>();
         var serviceProvider = services.BuildServiceProvider();
 

--- a/src/Components/Components/test/OwningComponentBaseTest.cs
+++ b/src/Components/Components/test/OwningComponentBaseTest.cs
@@ -163,6 +163,7 @@ public class OwningComponentBaseTest
 
         _ = component.MyService;
         
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => 
             await ((IAsyncDisposable)component).DisposeAsync());
         
         Assert.True(component.DisposingParameter);
@@ -232,27 +233,6 @@ public class OwningComponentBaseTest
         Assert.Equal(1, component.ManagedResourcesCleanedUpCount);
     }
 
-    [Fact]
-    public void ComplexComponent_WithDisposingFalse_SkipsManagedResourceCleanup()
-    {
-        var services = new ServiceCollection();
-        services.AddSingleton<Counter>();
-        services.AddTransient<MyService>();
-        var serviceProvider = services.BuildServiceProvider();
-
-        var renderer = new TestRenderer(serviceProvider);
-        var component = (ComplexComponent)renderer.InstantiateComponent<ComplexComponent>();
-
-        _ = component.MyService;
-
-        component.TestDisposeWithFalse();
-
-        Assert.False(component.TimerDisposed);
-        Assert.False(component.CancellationTokenSourceDisposed);
-        Assert.False(component.EventUnsubscribed);
-        Assert.Equal(0, component.ManagedResourcesCleanedUpCount);
-    }
-
     private class ComplexComponent : OwningComponentBase<MyService>
     {
         private readonly System.Threading.Timer _timer;
@@ -271,8 +251,6 @@ public class OwningComponentBaseTest
             _cts = new CancellationTokenSource();
             _eventSubscribed = true;
         }
-
-        public void TestDisposeWithFalse() => Dispose(disposing: false);
 
         protected override void Dispose(bool disposing)
         {

--- a/src/Components/Components/test/OwningComponentBaseTest.cs
+++ b/src/Components/Components/test/OwningComponentBaseTest.cs
@@ -111,6 +111,33 @@ public class OwningComponentBaseTest
         void IDisposable.Dispose() => Counter.DisposedCount++;
     }
 
+    [Fact]
+    public async Task DisposeAsync_CallsDispose_WithDisposingTrue()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient<MyService>();
+        var serviceProvider = services.BuildServiceProvider();
+
+        var renderer = new TestRenderer(serviceProvider);
+        var component = (ComponentWithDispose)renderer.InstantiateComponent<ComponentWithDispose>();
+
+        _ = component.MyService;
+        await ((IAsyncDisposable)component).DisposeAsync();
+        Assert.True(component.DisposingParameter);
+    }
+
+    private class ComponentWithDispose : OwningComponentBase<MyService>
+    {
+        public MyService MyService => Service;
+        public bool? DisposingParameter { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            DisposingParameter = disposing;
+            base.Dispose(disposing);
+        }
+    }
+
     private class MyOwningComponent : OwningComponentBase<MyService>
     {
         public MyService MyService => Service;


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/64669.

In .NET 9, when a Blazor component was disposed, it called `IDisposable.Dispose()` which invoked `Dispose(bool disposing)` with `disposing=true`. In .NET 10, after PR #62583 added `IAsyncDisposable` support, the Blazor framework started calling `IAsyncDisposable.DisposeAsync()` instead. Following the standard .NET dispose pattern, `DisposeAsync()` called `Dispose(false)` to avoid double-disposal of managed resources. This broke user code that overrode `Dispose(bool disposing)` and expected `disposing=true` when the component was being cleaned up, causing any logic inside `if (disposing) { ... }` blocks to no longer execute. The fix ensures `Dispose(true)` is called from `DisposeAsync()` to maintain backward compatibility while still properly handling async disposal of the service scope.

# Changes
- Call `Dispose(true)` from `DisposeAsync()` to ensure user overrides of `Dispose(bool disposing)` receive [disposing=true], maintaining backward compatibility with .NET 9 behavior.
- Removed `IsDisposed = true` from `DisposeAsyncCore()]` - the responsibility of setting this flag is in the `Dispose(bool disposing)` method to avoid duplication and ensure consistency whether disposal happens via sync or async path.

# Tests

- **`DisposeAsync_CallsDispose_WithDisposingTrue`** - Verifies that `DisposeAsync()` passes `disposing=true` to user overrides of `Dispose(bool disposing)`, which is the core fix for issue.
- **`DisposeAsync_ThenDispose_IsIdempotent`** - Ensures that calling both `DisposeAsync()` and `Dispose()` doesn't cause double-disposal of resources, proving the implementation is safe for multiple disposal calls.
- **`ComplexComponent_DisposesResourcesOnlyWhenDisposingIsTrue`** - Demonstrates that with the fix (`disposing=true`), components with non-trivial disposal logic (timers, cancellation tokens, events) properly clean up managed resources.