### PR TITLE
Avoid running many Linux job variants on PR

### DIFF
--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -322,164 +322,169 @@ stages:
         inputName: Linux_x64
 
   # Build Linux ARM
-  - template: jobs/default-build.yml
-    parameters:
-      jobName: Linux_arm_build
-      jobDisplayName: "Build: Linux ARM"
-      agentOs: Linux
-      buildArgs:
-        --arch arm
-        --pack
-        --all
-        --no-build-java
-        --publish
-        -p:OnlyPackPlatformSpecificPackages=true
-        -p:AssetManifestFileName=aspnetcore-Linux_arm.xml
-        $(_BuildArgs)
-        $(_PublishArgs)
-        $(_InternalRuntimeDownloadArgs)
-      artifacts:
-      - name: Linux_arm_Logs_Attempt_$(System.JobAttempt)
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: Linux_arm_Packages
-        path: artifacts/packages/
-
-  - ${{ if ne(variables.PostBuildSign, 'true') }}:
-    - template: jobs/codesign-xplat.yml
+  - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+    - template: jobs/default-build.yml
       parameters:
-        inputName: Linux_arm
+        jobName: Linux_arm_build
+        jobDisplayName: "Build: Linux ARM"
+        agentOs: Linux
+        buildArgs:
+          --arch arm
+          --pack
+          --all
+          --no-build-java
+          --publish
+          -p:OnlyPackPlatformSpecificPackages=true
+          -p:AssetManifestFileName=aspnetcore-Linux_arm.xml
+          $(_BuildArgs)
+          $(_PublishArgs)
+          $(_InternalRuntimeDownloadArgs)
+        artifacts:
+        - name: Linux_arm_Logs_Attempt_$(System.JobAttempt)
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Linux_arm_Packages
+          path: artifacts/packages/
+
+    - ${{ if ne(variables.PostBuildSign, 'true') }}:
+      - template: jobs/codesign-xplat.yml
+        parameters:
+          inputName: Linux_arm
 
   # Build Linux ARM64
-  - template: jobs/default-build.yml
-    parameters:
-      jobName: Linux_arm64_build
-      jobDisplayName: "Build: Linux ARM64"
-      agentOs: Linux
-      steps:
-      - script: ./eng/build.sh
-            --ci
-            --arch arm64
-            --pack
-            --build-installers
-            --all
-            --no-build-java
-            -p:OnlyPackPlatformSpecificPackages=true
-            $(_BuildArgs)
-            $(_InternalRuntimeDownloadArgs)
-        displayName: Run build.sh
-      artifacts:
-      - name: Linux_arm64_Logs_Attempt_$(System.JobAttempt)
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: Linux_arm64_Packages
-        path: artifacts/packages/
-
-  - ${{ if ne(variables.PostBuildSign, 'true') }}:
-    - template: jobs/codesign-xplat.yml
+  - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+    - template: jobs/default-build.yml
       parameters:
-        inputName: Linux_arm64
+        jobName: Linux_arm64_build
+        jobDisplayName: "Build: Linux ARM64"
+        agentOs: Linux
+        steps:
+        - script: ./eng/build.sh
+              --ci
+              --arch arm64
+              --pack
+              --build-installers
+              --all
+              --no-build-java
+              -p:OnlyPackPlatformSpecificPackages=true
+              $(_BuildArgs)
+              $(_InternalRuntimeDownloadArgs)
+          displayName: Run build.sh
+        artifacts:
+        - name: Linux_arm64_Logs_Attempt_$(System.JobAttempt)
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Linux_arm64_Packages
+          path: artifacts/packages/
+
+    - ${{ if ne(variables.PostBuildSign, 'true') }}:
+      - template: jobs/codesign-xplat.yml
+        parameters:
+          inputName: Linux_arm64
 
   # Build Linux Musl x64
-  - template: jobs/default-build.yml
-    parameters:
-      jobName: Linux_musl_x64_build
-      jobDisplayName: "Build: Linux Musl x64"
-      agentOs: Linux
-      container: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-build-amd64
-      buildArgs:
-        --arch x64
-        --os-name linux-musl
-        --pack
-        --all
-        --no-build-java
-        --publish
-        -p:OnlyPackPlatformSpecificPackages=true
-        -p:AssetManifestFileName=aspnetcore-Linux_musl_x64.xml
-        $(_BuildArgs)
-        $(_PublishArgs)
-        $(_InternalRuntimeDownloadArgs)
-      disableComponentGovernance: true
-      artifacts:
-      - name: Linux_musl_x64_Logs_Attempt_$(System.JobAttempt)
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: Linux_musl_x64_Packages
-        path: artifacts/packages/
-
-  - ${{ if ne(variables.PostBuildSign, 'true') }}:
-    - template: jobs/codesign-xplat.yml
+  - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+    - template: jobs/default-build.yml
       parameters:
-        inputName: Linux_musl_x64
+        jobName: Linux_musl_x64_build
+        jobDisplayName: "Build: Linux Musl x64"
+        agentOs: Linux
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-build-amd64
+        buildArgs:
+          --arch x64
+          --os-name linux-musl
+          --pack
+          --all
+          --no-build-java
+          --publish
+          -p:OnlyPackPlatformSpecificPackages=true
+          -p:AssetManifestFileName=aspnetcore-Linux_musl_x64.xml
+          $(_BuildArgs)
+          $(_PublishArgs)
+          $(_InternalRuntimeDownloadArgs)
+        disableComponentGovernance: true
+        artifacts:
+        - name: Linux_musl_x64_Logs_Attempt_$(System.JobAttempt)
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Linux_musl_x64_Packages
+          path: artifacts/packages/
+
+    - ${{ if ne(variables.PostBuildSign, 'true') }}:
+      - template: jobs/codesign-xplat.yml
+        parameters:
+          inputName: Linux_musl_x64
 
   # Build Linux Musl ARM
-  - template: jobs/default-build.yml
-    parameters:
-      jobName: Linux_musl_arm_build
-      jobDisplayName: "Build: Linux Musl ARM"
-      agentOs: Linux
-      useHostedUbuntu: false
-      container: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-build-amd64
-      buildArgs:
-        --arch arm
-        --os-name linux-musl
-        --pack
-        --all
-        --no-build-java
-        --publish
-        -p:OnlyPackPlatformSpecificPackages=true
-        -p:AssetManifestFileName=aspnetcore-Linux_musl_arm.xml
-        $(_BuildArgs)
-        $(_PublishArgs)
-        $(_InternalRuntimeDownloadArgs)
-      artifacts:
-      - name: Linux_musl_arm_Logs_Attempt_$(System.JobAttempt)
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: Linux_musl_arm_Packages
-        path: artifacts/packages/
-
-  - ${{ if ne(variables.PostBuildSign, 'true') }}:
-    - template: jobs/codesign-xplat.yml
+  - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+    - template: jobs/default-build.yml
       parameters:
-        inputName: Linux_musl_arm
+        jobName: Linux_musl_arm_build
+        jobDisplayName: "Build: Linux Musl ARM"
+        agentOs: Linux
+        useHostedUbuntu: false
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-build-amd64
+        buildArgs:
+          --arch arm
+          --os-name linux-musl
+          --pack
+          --all
+          --no-build-java
+          --publish
+          -p:OnlyPackPlatformSpecificPackages=true
+          -p:AssetManifestFileName=aspnetcore-Linux_musl_arm.xml
+          $(_BuildArgs)
+          $(_PublishArgs)
+          $(_InternalRuntimeDownloadArgs)
+        artifacts:
+        - name: Linux_musl_arm_Logs_Attempt_$(System.JobAttempt)
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Linux_musl_arm_Packages
+          path: artifacts/packages/
+
+    - ${{ if ne(variables.PostBuildSign, 'true') }}:
+      - template: jobs/codesign-xplat.yml
+        parameters:
+          inputName: Linux_musl_arm
 
   # Build Linux Musl ARM64
-  - template: jobs/default-build.yml
-    parameters:
-      jobName: Linux_musl_arm64_build
-      jobDisplayName: "Build: Linux Musl ARM64"
-      agentOs: Linux
-      useHostedUbuntu: false
-      container: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-build-amd64
-      buildArgs:
-        --arch arm64
-        --os-name linux-musl
-        --pack
-        --all
-        --no-build-java
-        --publish
-        -p:OnlyPackPlatformSpecificPackages=true
-        -p:AssetManifestFileName=aspnetcore-Linux_musl_arm64.xml
-        $(_BuildArgs)
-        $(_PublishArgs)
-        $(_InternalRuntimeDownloadArgs)
-      artifacts:
-      - name: Linux_musl_arm64_Logs_Attempt_$(System.JobAttempt)
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: Linux_musl_arm64_Packages
-        path: artifacts/packages/
-
-  - ${{ if ne(variables.PostBuildSign, 'true') }}:
-    - template: jobs/codesign-xplat.yml
+  - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+    - template: jobs/default-build.yml
       parameters:
-        inputName: Linux_musl_arm64
+        jobName: Linux_musl_arm64_build
+        jobDisplayName: "Build: Linux Musl ARM64"
+        agentOs: Linux
+        useHostedUbuntu: false
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-build-amd64
+        buildArgs:
+          --arch arm64
+          --os-name linux-musl
+          --pack
+          --all
+          --no-build-java
+          --publish
+          -p:OnlyPackPlatformSpecificPackages=true
+          -p:AssetManifestFileName=aspnetcore-Linux_musl_arm64.xml
+          $(_BuildArgs)
+          $(_PublishArgs)
+          $(_InternalRuntimeDownloadArgs)
+        artifacts:
+        - name: Linux_musl_arm64_Logs_Attempt_$(System.JobAttempt)
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Linux_musl_arm64_Packages
+          path: artifacts/packages/
+
+    - ${{ if ne(variables.PostBuildSign, 'true') }}:
+      - template: jobs/codesign-xplat.yml
+        parameters:
+          inputName: Linux_musl_arm64
 
   - ${{ if ne(parameters.skipTests, 'true') }}:
     # Test jobs

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -355,164 +355,169 @@ extends:
             inputName: Linux_x64
 
       # Build Linux ARM
-      - template: .azure/pipelines/jobs/default-build.yml@self
-        parameters:
-          jobName: Linux_arm_build
-          jobDisplayName: "Build: Linux ARM"
-          agentOs: Linux
-          buildArgs:
-            --arch arm
-            --pack
-            --all
-            --no-build-java
-            $(_ArcadePublishNonWindowsArg)
-            -p:OnlyPackPlatformSpecificPackages=true
-            -p:AssetManifestFileName=aspnetcore-Linux_arm.xml
-            $(_BuildArgs)
-            $(_PublishArgs)
-            $(_InternalRuntimeDownloadArgs)
-          artifacts:
-          - name: Linux_arm_Logs_Attempt_$(System.JobAttempt)
-            path: artifacts/log/
-            publishOnError: true
-            includeForks: true
-          - name: Linux_arm_Packages
-            path: artifacts/packages/
-
-      - ${{ if ne(variables.PostBuildSign, 'true') }}:
-        - template: .azure/pipelines/jobs/codesign-xplat.yml@self
+      - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+        - template: .azure/pipelines/jobs/default-build.yml@self
           parameters:
-            inputName: Linux_arm
+            jobName: Linux_arm_build
+            jobDisplayName: "Build: Linux ARM"
+            agentOs: Linux
+            buildArgs:
+              --arch arm
+              --pack
+              --all
+              --no-build-java
+              $(_ArcadePublishNonWindowsArg)
+              -p:OnlyPackPlatformSpecificPackages=true
+              -p:AssetManifestFileName=aspnetcore-Linux_arm.xml
+              $(_BuildArgs)
+              $(_PublishArgs)
+              $(_InternalRuntimeDownloadArgs)
+            artifacts:
+            - name: Linux_arm_Logs_Attempt_$(System.JobAttempt)
+              path: artifacts/log/
+              publishOnError: true
+              includeForks: true
+            - name: Linux_arm_Packages
+              path: artifacts/packages/
+
+        - ${{ if ne(variables.PostBuildSign, 'true') }}:
+          - template: .azure/pipelines/jobs/codesign-xplat.yml@self
+            parameters:
+              inputName: Linux_arm
 
       # Build Linux ARM64
-      - template: .azure/pipelines/jobs/default-build.yml@self
-        parameters:
-          jobName: Linux_arm64_build
-          jobDisplayName: "Build: Linux ARM64"
-          agentOs: Linux
-          buildArgs:
-            --arch arm64
-            --pack
-            --all
-            --build-installers
-            --no-build-java
-            $(_ArcadePublishNonWindowsArg)
-            -p:OnlyPackPlatformSpecificPackages=true
-            -p:AssetManifestFileName=aspnetcore-Linux_arm64.xml
-            $(_BuildArgs)
-            $(_PublishArgs)
-            $(_InternalRuntimeDownloadArgs)
-          artifacts:
-          - name: Linux_arm64_Logs_Attempt_$(System.JobAttempt)
-            path: artifacts/log/
-            publishOnError: true
-            includeForks: true
-          - name: Linux_arm64_Packages
-            path: artifacts/packages/
-
-      - ${{ if ne(variables.PostBuildSign, 'true') }}:
-        - template: .azure/pipelines/jobs/codesign-xplat.yml@self
+      - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+        - template: .azure/pipelines/jobs/default-build.yml@self
           parameters:
-            inputName: Linux_arm64
+            jobName: Linux_arm64_build
+            jobDisplayName: "Build: Linux ARM64"
+            agentOs: Linux
+            buildArgs:
+              --arch arm64
+              --pack
+              --all
+              --build-installers
+              --no-build-java
+              $(_ArcadePublishNonWindowsArg)
+              -p:OnlyPackPlatformSpecificPackages=true
+              -p:AssetManifestFileName=aspnetcore-Linux_arm64.xml
+              $(_BuildArgs)
+              $(_PublishArgs)
+              $(_InternalRuntimeDownloadArgs)
+            artifacts:
+            - name: Linux_arm64_Logs_Attempt_$(System.JobAttempt)
+              path: artifacts/log/
+              publishOnError: true
+              includeForks: true
+            - name: Linux_arm64_Packages
+              path: artifacts/packages/
+
+        - ${{ if ne(variables.PostBuildSign, 'true') }}:
+          - template: .azure/pipelines/jobs/codesign-xplat.yml@self
+            parameters:
+              inputName: Linux_arm64
 
       # Build Linux Musl x64
-      - template: .azure/pipelines/jobs/default-build.yml@self
-        parameters:
-          jobName: Linux_musl_x64_build
-          jobDisplayName: "Build: Linux Musl x64"
-          agentOs: Linux
-          container: azureLinux30Net10BuildAmd64
-          buildArgs:
-            --arch x64
-            --os-name linux-musl
-            --pack
-            --all
-            --no-build-java
-            $(_ArcadePublishNonWindowsArg)
-            -p:OnlyPackPlatformSpecificPackages=true
-            -p:AssetManifestFileName=aspnetcore-Linux_musl_x64.xml
-            $(_BuildArgs)
-            $(_PublishArgs)
-            $(_InternalRuntimeDownloadArgs)
-          disableComponentGovernance: true
-          artifacts:
-          - name: Linux_musl_x64_Logs_Attempt_$(System.JobAttempt)
-            path: artifacts/log/
-            publishOnError: true
-            includeForks: true
-          - name: Linux_musl_x64_Packages
-            path: artifacts/packages/
-
-      - ${{ if ne(variables.PostBuildSign, 'true') }}:
-        - template: .azure/pipelines/jobs/codesign-xplat.yml@self
+      - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+        - template: .azure/pipelines/jobs/default-build.yml@self
           parameters:
-            inputName: Linux_musl_x64
+            jobName: Linux_musl_x64_build
+            jobDisplayName: "Build: Linux Musl x64"
+            agentOs: Linux
+            container: azureLinux30Net10BuildAmd64
+            buildArgs:
+              --arch x64
+              --os-name linux-musl
+              --pack
+              --all
+              --no-build-java
+              $(_ArcadePublishNonWindowsArg)
+              -p:OnlyPackPlatformSpecificPackages=true
+              -p:AssetManifestFileName=aspnetcore-Linux_musl_x64.xml
+              $(_BuildArgs)
+              $(_PublishArgs)
+              $(_InternalRuntimeDownloadArgs)
+            disableComponentGovernance: true
+            artifacts:
+            - name: Linux_musl_x64_Logs_Attempt_$(System.JobAttempt)
+              path: artifacts/log/
+              publishOnError: true
+              includeForks: true
+            - name: Linux_musl_x64_Packages
+              path: artifacts/packages/
+
+        - ${{ if ne(variables.PostBuildSign, 'true') }}:
+          - template: .azure/pipelines/jobs/codesign-xplat.yml@self
+            parameters:
+              inputName: Linux_musl_x64
 
       # Build Linux Musl ARM
-      - template: .azure/pipelines/jobs/default-build.yml@self
-        parameters:
-          jobName: Linux_musl_arm_build
-          jobDisplayName: "Build: Linux Musl ARM"
-          agentOs: Linux
-          useHostedUbuntu: false
-          container: azureLinux30Net10BuildAmd64
-          buildArgs:
-            --arch arm
-            --os-name linux-musl
-            --pack
-            --all
-            --no-build-java
-            $(_ArcadePublishNonWindowsArg)
-            -p:OnlyPackPlatformSpecificPackages=true
-            -p:AssetManifestFileName=aspnetcore-Linux_musl_arm.xml
-            $(_BuildArgs)
-            $(_PublishArgs)
-            $(_InternalRuntimeDownloadArgs)
-          artifacts:
-          - name: Linux_musl_arm_Logs_Attempt_$(System.JobAttempt)
-            path: artifacts/log/
-            publishOnError: true
-            includeForks: true
-          - name: Linux_musl_arm_Packages
-            path: artifacts/packages/
-
-      - ${{ if ne(variables.PostBuildSign, 'true') }}:
-        - template: .azure/pipelines/jobs/codesign-xplat.yml@self
+      - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+        - template: .azure/pipelines/jobs/default-build.yml@self
           parameters:
-            inputName: Linux_musl_arm
+            jobName: Linux_musl_arm_build
+            jobDisplayName: "Build: Linux Musl ARM"
+            agentOs: Linux
+            useHostedUbuntu: false
+            container: azureLinux30Net10BuildAmd64
+            buildArgs:
+              --arch arm
+              --os-name linux-musl
+              --pack
+              --all
+              --no-build-java
+              $(_ArcadePublishNonWindowsArg)
+              -p:OnlyPackPlatformSpecificPackages=true
+              -p:AssetManifestFileName=aspnetcore-Linux_musl_arm.xml
+              $(_BuildArgs)
+              $(_PublishArgs)
+              $(_InternalRuntimeDownloadArgs)
+            artifacts:
+            - name: Linux_musl_arm_Logs_Attempt_$(System.JobAttempt)
+              path: artifacts/log/
+              publishOnError: true
+              includeForks: true
+            - name: Linux_musl_arm_Packages
+              path: artifacts/packages/
+
+        - ${{ if ne(variables.PostBuildSign, 'true') }}:
+          - template: .azure/pipelines/jobs/codesign-xplat.yml@self
+            parameters:
+              inputName: Linux_musl_arm
 
       # Build Linux Musl ARM64
-      - template: .azure/pipelines/jobs/default-build.yml@self
-        parameters:
-          jobName: Linux_musl_arm64_build
-          jobDisplayName: "Build: Linux Musl ARM64"
-          agentOs: Linux
-          useHostedUbuntu: false
-          container: azureLinux30Net10BuildAmd64
-          buildArgs:
-            --arch arm64
-            --os-name linux-musl
-            --pack
-            --all
-            --no-build-java
-            $(_ArcadePublishNonWindowsArg)
-            -p:OnlyPackPlatformSpecificPackages=true
-            -p:AssetManifestFileName=aspnetcore-Linux_musl_arm64.xml
-            $(_BuildArgs)
-            $(_PublishArgs)
-            $(_InternalRuntimeDownloadArgs)
-          artifacts:
-          - name: Linux_musl_arm64_Logs_Attempt_$(System.JobAttempt)
-            path: artifacts/log/
-            publishOnError: true
-            includeForks: true
-          - name: Linux_musl_arm64_Packages
-            path: artifacts/packages/
-
-      - ${{ if ne(variables.PostBuildSign, 'true') }}:
-        - template: .azure/pipelines/jobs/codesign-xplat.yml@self
+      - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+        - template: .azure/pipelines/jobs/default-build.yml@self
           parameters:
-            inputName: Linux_musl_arm64
+            jobName: Linux_musl_arm64_build
+            jobDisplayName: "Build: Linux Musl ARM64"
+            agentOs: Linux
+            useHostedUbuntu: false
+            container: azureLinux30Net10BuildAmd64
+            buildArgs:
+              --arch arm64
+              --os-name linux-musl
+              --pack
+              --all
+              --no-build-java
+              $(_ArcadePublishNonWindowsArg)
+              -p:OnlyPackPlatformSpecificPackages=true
+              -p:AssetManifestFileName=aspnetcore-Linux_musl_arm64.xml
+              $(_BuildArgs)
+              $(_PublishArgs)
+              $(_InternalRuntimeDownloadArgs)
+            artifacts:
+            - name: Linux_musl_arm64_Logs_Attempt_$(System.JobAttempt)
+              path: artifacts/log/
+              publishOnError: true
+              includeForks: true
+            - name: Linux_musl_arm64_Packages
+              path: artifacts/packages/
+
+        - ${{ if ne(variables.PostBuildSign, 'true') }}:
+          - template: .azure/pipelines/jobs/codesign-xplat.yml@self
+            parameters:
+              inputName: Linux_musl_arm64
 
       - template: .azure/pipelines/jobs/default-build.yml@self
         parameters:


### PR DESCRIPTION
Skip a bunch of the Linux variants for PR jobs. There's almost nothing we can do in this repo to break these so we're mostly just spending the extra ~hour of machine time per PR run for no value.

Note that I left `Linux x64` alone but moved the others to not be triggered on PR jobs.

<img width="260" height="196" alt="image" src="https://github.com/user-attachments/assets/f8fe8e91-d574-4012-9239-44b1ab21c062" />
