### PR TITLE
Surface ApiDescription.Server logs in Terminal Logger

### DIFF
--- a/src/Tools/Extensions.ApiDescription.Server/src/build/Microsoft.Extensions.ApiDescription.Server.targets
+++ b/src/Tools/Extensions.ApiDescription.Server/src/build/Microsoft.Extensions.ApiDescription.Server.targets
@@ -64,7 +64,7 @@
 
     <Message Importance="high" Text="%0AGenerateOpenApiDocuments:" />
     <Message Importance="high" Text="  $(_DotNetGetDocumentCommand)" />
-    <Exec Command="$(_DotNetGetDocumentCommand)" LogStandardErrorAsError="true" />
+    <Exec Command="$(_DotNetGetDocumentCommand)" LogStandardErrorAsError="true" StandardOutputImportance="High" />
   </Target>
 
   <!-- Unless this is an inner build or default timing is disabled, tie document retrieval into the build. -->


### PR DESCRIPTION
Fixes #62273. Elevates StandardOutputImportance to High for the Exec task in Microsoft.Extensions.ApiDescription.Server.targets to ensure logs are visible in the default .NET 8 Terminal Logger.