### PR TITLE
Don't bind to IPv6 when the OS doesn't support it

### DIFF
--- a/src/Servers/Kestrel/Core/src/AnyIPListenOptions.cs
+++ b/src/Servers/Kestrel/Core/src/AnyIPListenOptions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core;
 internal sealed class AnyIPListenOptions : ListenOptions
 {
     internal AnyIPListenOptions(int port)
-        : base(new IPEndPoint(IPAddress.IPv6Any, port))
+        : base(new IPEndPoint(Socket.OSSupportsIPv6 ? IPAddress.IPv6Any : IPAddress.Any, port))
     {
     }
 

--- a/src/Servers/Kestrel/Core/src/AnyIPListenOptions.cs
+++ b/src/Servers/Kestrel/Core/src/AnyIPListenOptions.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Net;
+using System.Net.Sockets;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 using Microsoft.Extensions.Logging;
 

--- a/src/Servers/Kestrel/Core/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests.csproj
+++ b/src/Servers/Kestrel/Core/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests.csproj
@@ -30,5 +30,6 @@
     <Reference Include="Microsoft.Extensions.Logging" />
     <Reference Include="Microsoft.Extensions.Diagnostics.Testing" />
     <Reference Include="Microsoft.Extensions.TimeProvider.Testing" />
+    <Reference Include="Microsoft.DotNet.RemoteExecutor" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/122435
