### PR TITLE
Fix PaginationState UI not refreshing on filtered count reduction (#58487)

### DIFF
--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/test/PaginationStateTest.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/test/PaginationStateTest.cs
@@ -1,0 +1,147 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Components.QuickGrid.Tests;
+
+public class PaginationTests
+{
+    [Fact]
+    public async Task PaginationState_RaisesTotalItemCountChanged_AfterPageResetWithSameTotalCount()
+    {
+        // Verifies that TotalItemCountChanged fires when the page is reset due to reduced item count,
+        // even when the second call to SetTotalItemCountAsync has the same total as the first call.
+
+        // Arrange
+        var pagination = new PaginationState { ItemsPerPage = 10 };
+        var totalItemCountChangedCallCount = 0;
+        int? lastTotalItemCount = null;
+
+        pagination.TotalItemCountChanged += (sender, count) =>
+        {
+            totalItemCountChangedCallCount++;
+            lastTotalItemCount = count;
+        };
+
+        // Simulate initial state: user is on page 5 (index 4) with 50 items total
+        await pagination.SetCurrentPageIndexAsync(4);
+        await pagination.SetTotalItemCountAsync(50);
+
+        Assert.Equal(4, pagination.CurrentPageIndex);
+        Assert.Equal(50, pagination.TotalItemCount);
+        Assert.Equal(1, totalItemCountChangedCallCount);
+        Assert.Equal(50, lastTotalItemCount);
+
+        totalItemCountChangedCallCount = 0;
+
+        // Act - Simulate query returning fewer items, triggering page reset and subsequent re-query
+        // The first call sets the internal flag (fix logic)
+        await pagination.SetTotalItemCountAsync(20);
+        // The second call (simulating re-render) consumes the flag and raises the event
+        await pagination.SetTotalItemCountAsync(20);
+
+        // Assert
+        Assert.True(totalItemCountChangedCallCount > 0,
+            $"TotalItemCountChanged should have fired after pagination state stabilized, but it fired {totalItemCountChangedCallCount} times. " +
+            "This means paginators won't re-render to show the updated page count.");
+        Assert.Equal(20, lastTotalItemCount);
+        Assert.Equal(1, pagination.CurrentPageIndex);
+    }
+
+    [Fact]
+    public async Task PaginationState_ResetsToLastPage_WhenCurrentPageExceedsLastPage()
+    {
+        // Arrange
+        var pagination = new PaginationState { ItemsPerPage = 10 };
+        await pagination.SetCurrentPageIndexAsync(4);
+        await pagination.SetTotalItemCountAsync(50);
+
+        Assert.Equal(4, pagination.CurrentPageIndex);
+        Assert.Equal(50, pagination.TotalItemCount);
+
+        // Act
+        await pagination.SetTotalItemCountAsync(20);
+
+        // Assert
+        Assert.Equal(1, pagination.CurrentPageIndex);
+        Assert.Equal(20, pagination.TotalItemCount);
+    }
+
+    [Fact]
+    public async Task PaginationState_CalculatesLastPageIndexCorrectly()
+    {
+        // Arrange
+        var pagination = new PaginationState { ItemsPerPage = 10 };
+
+        // Act & Assert
+        await pagination.SetTotalItemCountAsync(1);
+        Assert.Equal(0, pagination.LastPageIndex);
+
+        await pagination.SetTotalItemCountAsync(10);
+        Assert.Equal(0, pagination.LastPageIndex);
+
+        await pagination.SetTotalItemCountAsync(11);
+        Assert.Equal(1, pagination.LastPageIndex);
+
+        await pagination.SetTotalItemCountAsync(20);
+        Assert.Equal(1, pagination.LastPageIndex);
+
+        await pagination.SetTotalItemCountAsync(21);
+        Assert.Equal(2, pagination.LastPageIndex);
+    }
+
+    [Fact]
+    public async Task PaginationState_RaisesTotalItemCountChanged_WhenTotalCountChanges()
+    {
+        // Arrange
+        var pagination = new PaginationState { ItemsPerPage = 10 };
+        var eventCallCount = 0;
+        int? lastEventValue = null;
+
+        pagination.TotalItemCountChanged += (sender, count) =>
+        {
+            eventCallCount++;
+            lastEventValue = count;
+        };
+
+        // Act & Assert
+        await pagination.SetTotalItemCountAsync(50);
+        Assert.Equal(1, eventCallCount);
+        Assert.Equal(50, lastEventValue);
+
+        await pagination.SetTotalItemCountAsync(30);
+        Assert.Equal(2, eventCallCount);
+        Assert.Equal(30, lastEventValue);
+
+        await pagination.SetTotalItemCountAsync(30);
+        Assert.Equal(2, eventCallCount);
+        Assert.Equal(30, lastEventValue);
+    }
+
+    [Fact]
+    public async Task PaginationState_DoesNotResetPage_WhenCurrentPageIsStillValid()
+    {
+        // Arrange
+        var pagination = new PaginationState { ItemsPerPage = 10 };
+        var totalItemCountChangedCallCount = 0;
+
+        pagination.TotalItemCountChanged += (sender, count) =>
+        {
+            totalItemCountChangedCallCount++;
+        };
+
+        await pagination.SetCurrentPageIndexAsync(2);
+        await pagination.SetTotalItemCountAsync(50);
+
+        totalItemCountChangedCallCount = 0;
+
+        // Act
+        await pagination.SetTotalItemCountAsync(40);
+
+        // Assert
+        Assert.Equal(2, pagination.CurrentPageIndex);
+        Assert.Equal(1, totalItemCountChangedCallCount);
+    }
+}

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/test/PaginationStateTest.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/test/PaginationStateTest.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Components.QuickGrid.Tests;
 
-public class PaginationTests
+public class PaginationStateTest
 {
     [Fact]
     public async Task PaginationState_RaisesTotalItemCountChanged_AfterPageResetWithSameTotalCount()


### PR DESCRIPTION
## Description
Fixes #58487

Addresses a race condition in `PaginationState` where `TotalItemCountChanged` was not raised when the item count reduction triggered a page index reset.

### Bug Logic
1.  User is on Page 10 of 10 (100 items).
2.  Filter reduces items to 5.
3.  `SetTotalItemCountAsync(5)` detects invalid page -> calls `SetCurrentPageIndexAsync(0)`.
4.  `SetCurrentPageIndexAsync` triggers a data refresh, calling `SetTotalItemCountAsync(5)` again.
5.  The second call sees `TotalItemCount` is already 5, so it exits early without raising the event.
6.  Result: UI stays on "Page 10" (phantom state).

### Fix
Added a `_hasPendingTotalItemCountChangedEvent` flag.
*   When a page reset is required, we set the flag.
*   The subsequent recursive call checks this flag and raises the event even if the count hasn't changed.

### Acknowledgements
Special thanks to @htmlsplash for identifying the root cause and proposing the solution in the issue discussion.

## Verification
Added PaginationTests suite with regression test for the bug where TotalItemCountChanged fails to fire after page reset when the subsequent re-query returns the same total count. Additional tests cover page reset behavior, LastPageIndex calculation, event firing, and page preservation scenarios.