### PR TITLE
Remove retrials of fixed tests

### DIFF
--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -10,8 +10,6 @@
     {"testName": {"contains": "CanLaunchPhotinoWebViewAndClickButton"}},
     {"testName": {"contains": "CheckInvalidHostingModelParameter"}},
     {"testName": {"contains": "CheckNewShimIsUsed"}}, // Issue: https://github.com/dotnet/aspnetcore/issues/57538
-    {"testName": {"contains": "ComponentLifecycleMethodThrowsExceptionTerminatesTheCircuit"}}, // Issue: https://github.com/dotnet/aspnetcore/issues/57551
-    {"testName": {"contains": "ComponentDisposeMethodThrowsExceptionTerminatesTheCircuit"}}, // Issue: https://github.com/dotnet/aspnetcore/issues/57551
     {"testName": {"contains": "PhoneFactorFailsAfterSecurityStampChangeTest"}}, // Issue: https://github.com/dotnet/aspnetcore/issues/58231
     {"testName": {"contains": "AbortSendsFinalGOAWAY"}}, // Issue: https://github.com/dotnet/aspnetcore/issues/59358
     {"testName": {"contains": "Http2_RequestWithDataAndContentLength_Success"}}, // Issue: https://github.com/dotnet/aspnetcore/issues/63266


### PR DESCRIPTION
Updated according to https://github.com/dotnet/aspnetcore-internal/issues/4769#issuecomment-3642606696.

For these 2 removals we know what fixed it.
`CertificateChangedOnDisk` might be lucky to pass for the last 90 days. Leaving on the list. 
`CheckInvalidHostingModelParameter` - due to its dependence on deployment, HTTP, event logging I am not 100% sure if we should remove it. It's up to discussion or can be done later when another 90 days of all-green period will be confirmed.

Fixed by https://github.com/dotnet/aspnetcore/pull/63143.