### PR TITLE
Fix path traversal when generating output file name in GetDocumentInsider

### DIFF
--- a/src/Tools/GetDocumentInsider/tests/GetDocumentTests.cs
+++ b/src/Tools/GetDocumentInsider/tests/GetDocumentTests.cs
@@ -237,4 +237,21 @@ public class GetDocumentTests(ITestOutputHelper output)
         Assert.True(File.Exists(Path.Combine(outputPath.FullName, "Sample.json")));
         Assert.True(File.Exists(Path.Combine(outputPath.FullName, "Sample_internal.json")));
     }
+
+    [Theory]
+    [InlineData("a/../b", "Sample_a_._b.json")]
+    [InlineData(@"a\..\b", "Sample_a_._b.json")]
+    [InlineData("..", "Sample_..json")]
+    public void GetDocumentPath_SanitizesDocumentName(string documentName, string expectedFileName)
+    {
+        // We validate the path generation logic directly to avoid coupling this test to sample app document names.
+        var method = typeof(GetDocumentCommandWorker).GetMethod("GetDocumentPath", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        var outputDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var resultPath = (string)method.Invoke(null, [documentName, "Sample", outputDir]);
+
+        Assert.Equal(expectedFileName, Path.GetFileName(resultPath));
+        Assert.Equal(outputDir, Path.GetDirectoryName(resultPath));
+    }
 }


### PR DESCRIPTION
## Summary
Fixes an issue where GetDocumentInsider used the raw `documentName` value when
constructing the output file path, allowing directory separators or traversal
sequences to influence the generated path.

## Details
Although a sanitized version of `documentName` was computed, it was not used when
building the final output file name.

This change ensures the sanitized value is always used and treats directory
separators consistently across platforms.

## Tests
Adds a regression test to ensure values such as `a/../b` or `a\..\b` cannot affect
the output path.

## Notes
This issue was previously reported to MSRC (VULN-168240) and classified as a
non-serviciable security case.

Fixes #64758
