### PR TITLE
Add submodule checkout to copilot-setup-steps.yml

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -15,6 +15,8 @@ jobs:
     # If you do not check out your code, Copilot will do this for you.
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4.2.2
+        with:
+          submodules: 'true'
 
       # Include PrepareForHelix to maximise what is downloaded here
       - name: Build solution


### PR DESCRIPTION
Copilot fails to build certain projects without the MessagePack submodule checked out