### PR TITLE
Fix repository URL in Microsoft.JSInterop.JS

### DIFF
--- a/src/JSInterop/Microsoft.JSInterop.JS/src/package.json
+++ b/src/JSInterop/Microsoft.JSInterop.JS/src/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/dotnet/extensions.git"
+    "url": "git+https://github.com/dotnet/aspnetcore.git"
   },
   "author": "Microsoft",
   "license": "MIT",


### PR DESCRIPTION
We were still referencing the old dotnet/extensions location.
