### PR TITLE
Pass container image correctly for source-build job in official build

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -691,7 +691,7 @@ extends:
           enableInternalSources: true
           platform:
             name: 'Managed'
-            container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream-10-amd64'
+            container: azureLinux30Net10BuildAmd64
             buildScript: './eng/build.sh'
             buildArguments: '--source-build $(_InternalRuntimeDownloadArgs)'
             jobProperties:


### PR DESCRIPTION
1ES PT expects an object with the container image, not just the name. Use the same  azureLinux30Net10BuildAmd64 container as we do in other jobs since we only build managed code.
