### PR TITLE
Fix templatestrings in RazorClassLibrary template

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.cs.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.cs.json
@@ -9,5 +9,6 @@
   "symbols/SupportPagesAndViews/description": "Určuje, jestli se má podporovat přidávání dalších stránek a zobrazení Razor do této knihovny.",
   "postActions/restore/description": "Obnoví balíčky NuGet vyžadované tímto projektem.",
   "postActions/restore/manualInstructions/default/text": "Spustit dotnet restore",
-  "postActions/openInEditor/description": "Otevře soubor areas/MyFeature/Pages/Page1.cshtml v editoru."
+  "postActions/openPageInEditor/description": "Otevře soubor areas/MyFeature/Pages/Page1.cshtml v editoru.",
+  "postActions/openComponentInEditor/description": "Opens Component1.razor in the editor"
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.de.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.de.json
@@ -9,5 +9,6 @@
   "symbols/SupportPagesAndViews/description": "Gibt an, ob das Hinzufügen herkömmlicher Razor Pages und Ansichten zu dieser Bibliothek unterstützt werden soll.",
   "postActions/restore/description": "„NuGet-Pakete“ wiederherstellen, die für dieses Projekt erforderlich sind.",
   "postActions/restore/manualInstructions/default/text": "„dotnet restore“ ausführen",
-  "postActions/openInEditor/description": "Öffnet Areas/MyFeature/Pages/Page1.cshtml im Editor"
+  "postActions/openPageInEditor/description": "Öffnet Areas/MyFeature/Pages/Page1.cshtml im Editor",
+  "postActions/openComponentInEditor/description": "Opens Component1.razor in the editor"
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.en.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.en.json
@@ -9,5 +9,6 @@
   "symbols/SupportPagesAndViews/description": "Whether to support adding traditional Razor pages and Views to this library.",
   "postActions/restore/description": "Restore NuGet packages required by this project.",
   "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
-  "postActions/openInEditor/description": "Opens Areas/MyFeature/Pages/Page1.cshtml in the editor"
+  "postActions/openPageInEditor/description": "Opens Areas/MyFeature/Pages/Page1.cshtml in the editor",
+  "postActions/openComponentInEditor/description": "Opens Component1.razor in the editor"
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.es.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.es.json
@@ -9,5 +9,6 @@
   "symbols/SupportPagesAndViews/description": "Indica si se admite la adición de vistas y Razor Pages tradicionales a esta biblioteca.",
   "postActions/restore/description": "Restaure los paquetes NuGet necesarios para este proyecto.",
   "postActions/restore/manualInstructions/default/text": "Ejecutar \"dotnet restore\"",
-  "postActions/openInEditor/description": "Abre Areas/MyFeature/Pages/Page1.cshtml en el editor"
+  "postActions/openPageInEditor/description": "Abre Areas/MyFeature/Pages/Page1.cshtml en el editor",
+  "postActions/openComponentInEditor/description": "Opens Component1.razor in the editor"
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.fr.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.fr.json
@@ -9,5 +9,6 @@
   "symbols/SupportPagesAndViews/description": "Indique si l’ajout de pages et de vues Razor classiques à cette bibliothèque.",
   "postActions/restore/description": "Restaurez les packages NuGet requis par ce projet.",
   "postActions/restore/manualInstructions/default/text": "Exécuter « dotnet restore »",
-  "postActions/openInEditor/description": "Ouvre Areas/MyFeature/Pages/Page1.cshtml dans l’éditeur"
+  "postActions/openPageInEditor/description": "Ouvre Areas/MyFeature/Pages/Page1.cshtml dans l’éditeur",
+  "postActions/openComponentInEditor/description": "Opens Component1.razor in the editor"
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.it.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.it.json
@@ -9,5 +9,6 @@
   "symbols/SupportPagesAndViews/description": "Indica se supportare l'aggiunta di pagine e visualizzazioni Razor tradizionali a questa libreria.",
   "postActions/restore/description": "Ripristina i pacchetti NuGet richiesti da questo progetto.",
   "postActions/restore/manualInstructions/default/text": "Esegui 'dotnet restore'",
-  "postActions/openInEditor/description": "Apre Areas/MyFeature/Pages/Page1.cshtml nell'editor"
+  "postActions/openPageInEditor/description": "Apre Areas/MyFeature/Pages/Page1.cshtml nell'editor",
+  "postActions/openComponentInEditor/description": "Opens Component1.razor in the editor"
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.ja.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.ja.json
@@ -9,5 +9,6 @@
   "symbols/SupportPagesAndViews/description": "このライブラリに対して、従来の Razor ページとビューの追加をサポートするかどうか。",
   "postActions/restore/description": "このプロジェクトに必要な NuGet パッケージを復元します。",
   "postActions/restore/manualInstructions/default/text": "'dotnet restore' を実行する",
-  "postActions/openInEditor/description": "エディターで Areas/MyFeature/Pages/Page1.cshtml を開きます"
+  "postActions/openPageInEditor/description": "エディターで Areas/MyFeature/Pages/Page1.cshtml を開きます",
+  "postActions/openComponentInEditor/description": "Opens Component1.razor in the editor"
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.ko.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.ko.json
@@ -9,5 +9,6 @@
   "symbols/SupportPagesAndViews/description": "이 라이브러리에 기존 Razor 페이지 및 보기 추가를 지원할지 여부입니다.",
   "postActions/restore/description": "이 프로젝트에 필요한 NuGet 패키지를 복원합니다.",
   "postActions/restore/manualInstructions/default/text": "'dotnet restore' 실행",
-  "postActions/openInEditor/description": "편집기에서 Areas/MyFeature/Pages/Page1.cshtml을 엽니다."
+  "postActions/openPageInEditor/description": "편집기에서 Areas/MyFeature/Pages/Page1.cshtml을 엽니다.",
+  "postActions/openComponentInEditor/description": "Opens Component1.razor in the editor"
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.pl.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.pl.json
@@ -9,5 +9,6 @@
   "symbols/SupportPagesAndViews/description": "Określa, czy obsługiwać dodawanie tradycyjnych stron Razor i wyświetleń do tej biblioteki.",
   "postActions/restore/description": "Przywróć pakiety NuGet wymagane przez ten projekt.",
   "postActions/restore/manualInstructions/default/text": "Uruchom polecenie \"dotnet restore\"",
-  "postActions/openInEditor/description": "Otwiera plik Areas/MyFeature/Pages/Page1.cshtml w edytorze"
+  "postActions/openPageInEditor/description": "Otwiera plik Areas/MyFeature/Pages/Page1.cshtml w edytorze",
+  "postActions/openComponentInEditor/description": "Opens Component1.razor in the editor"
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.pt-BR.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.pt-BR.json
@@ -9,5 +9,6 @@
   "symbols/SupportPagesAndViews/description": "Se é necessário dar suporte à adição de páginas e exibições tradicionais do Razor a esta biblioteca.",
   "postActions/restore/description": "Restaure os pacotes NuGet exigidos por este projeto.",
   "postActions/restore/manualInstructions/default/text": "Executar 'dotnet restore'",
-  "postActions/openInEditor/description": "Abre Areas/MyFeature/Pages/Page1.cshtml no editor"
+  "postActions/openPageInEditor/description": "Abre Areas/MyFeature/Pages/Page1.cshtml no editor",
+  "postActions/openComponentInEditor/description": "Opens Component1.razor in the editor"
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.ru.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.ru.json
@@ -9,5 +9,6 @@
   "symbols/SupportPagesAndViews/description": "Следует ли поддерживать добавление традиционных страниц и представлений Razor в эту библиотеку.",
   "postActions/restore/description": "Восстановление пакетов NuGet, необходимых для этого проекта.",
   "postActions/restore/manualInstructions/default/text": "Выполнить команду \"dotnet restore\"",
-  "postActions/openInEditor/description": "Открывает Areas/MyFeature/Pages/Page1.cshtml в редакторе"
+  "postActions/openPageInEditor/description": "Открывает Areas/MyFeature/Pages/Page1.cshtml в редакторе",
+  "postActions/openComponentInEditor/description": "Opens Component1.razor in the editor"
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.tr.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.tr.json
@@ -9,5 +9,6 @@
   "symbols/SupportPagesAndViews/description": "Bu kitaplığa geleneksel Razor sayfaları ve görünümleri eklemenin desteklenip desteklenmeyeceği.",
   "postActions/restore/description": "Bu projenin gerektirdiği NuGet paketlerini geri yükleyin.",
   "postActions/restore/manualInstructions/default/text": "'dotnet restore' çalıştır",
-  "postActions/openInEditor/description": "Düzenleyicide Areas/MyFeature/Pages/Page1.cshtml dosyasını açar"
+  "postActions/openPageInEditor/description": "Düzenleyicide Areas/MyFeature/Pages/Page1.cshtml dosyasını açar",
+  "postActions/openComponentInEditor/description": "Opens Component1.razor in the editor"
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.zh-Hans.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.zh-Hans.json
@@ -9,5 +9,6 @@
   "symbols/SupportPagesAndViews/description": "是否支持将传统的 Razor Pages 和视图添加到此库。",
   "postActions/restore/description": "还原此项目所需的 NuGet 包。",
   "postActions/restore/manualInstructions/default/text": "运行 \"dotnet restore\"",
-  "postActions/openInEditor/description": "在编辑器中打开 Areas/MyFeature/Pages/Page1.cshtml"
+  "postActions/openPageInEditor/description": "在编辑器中打开 Areas/MyFeature/Pages/Page1.cshtml",
+  "postActions/openComponentInEditor/description": "Opens Component1.razor in the editor"
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.zh-Hant.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.zh-Hant.json
@@ -9,5 +9,6 @@
   "symbols/SupportPagesAndViews/description": "是否支援將傳統 Razor 頁面及檢視新增至此程式庫。",
   "postActions/restore/description": "還原此專案所需的 NuGet 套件。",
   "postActions/restore/manualInstructions/default/text": "執行 'dotnet restore'",
-  "postActions/openInEditor/description": "在編輯器中開啟 Areas/MyFeature/Pages/Page1.cshtml"
+  "postActions/openPageInEditor/description": "在編輯器中開啟 Areas/MyFeature/Pages/Page1.cshtml",
+  "postActions/openComponentInEditor/description": "Opens Component1.razor in the editor"
 }


### PR DESCRIPTION
When building locally these files get modified with the new keys. Looks like this was caused by https://github.com/dotnet/aspnetcore/pull/64532
