### PR TITLE
Improve expiration handling for client-persisted circuit state

### DIFF
--- a/src/Components/Server/src/Circuits/CircuitHost.cs
+++ b/src/Components/Server/src/Circuits/CircuitHost.cs
@@ -33,7 +33,7 @@ internal partial class CircuitHost : IAsyncDisposable
     private bool _onConnectionDownFired;
     private bool _disposed;
     private long _startTime;
-    private PersistedCircuitState _persistedCircuitState;
+    private ResumedPersistedCircuitState _persistedCircuitState;
 
     // This event is fired when there's an unrecoverable exception coming from the circuit, and
     // it need so be torn down. The registry listens to this even so that the circuit can
@@ -927,7 +927,7 @@ internal partial class CircuitHost : IAsyncDisposable
         }
     }
 
-    internal void AttachPersistedState(PersistedCircuitState persistedCircuitState)
+    internal void AttachPersistedState(ResumedPersistedCircuitState persistedCircuitState)
     {
         if (_persistedCircuitState != null)
         {
@@ -937,7 +937,7 @@ internal partial class CircuitHost : IAsyncDisposable
         _persistedCircuitState = persistedCircuitState;
     }
 
-    internal PersistedCircuitState TakePersistedCircuitState()
+    internal ResumedPersistedCircuitState TakePersistedCircuitState()
     {
         var result = _persistedCircuitState;
         _persistedCircuitState = null;

--- a/src/Components/Server/src/Circuits/ResumedPersistedCircuitState.cs
+++ b/src/Components/Server/src/Circuits/ResumedPersistedCircuitState.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Microsoft.AspNetCore.Components.Server.Circuits;
+
+[DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]
+internal class ResumedPersistedCircuitState
+{
+    public required IReadOnlyDictionary<string, byte[]> ApplicationState { get; init; }
+
+    public required IReadOnlyDictionary<int, WebRootComponentDescriptor> RootComponentDescriptors { get; init; }
+
+    private string GetDebuggerDisplay()
+    {
+        return $"ApplicationStateCount={ApplicationState?.Count ?? 0}, RootComponentCount={RootComponentDescriptors?.Count ?? 0}";
+    }
+}

--- a/src/Components/Server/src/Circuits/ResumedPersistedCircuitState.cs
+++ b/src/Components/Server/src/Circuits/ResumedPersistedCircuitState.cs
@@ -6,14 +6,12 @@ using System.Diagnostics;
 namespace Microsoft.AspNetCore.Components.Server.Circuits;
 
 [DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]
-internal class ResumedPersistedCircuitState
+internal sealed class ResumedPersistedCircuitState
 {
     public required IReadOnlyDictionary<string, byte[]> ApplicationState { get; init; }
 
     public required IReadOnlyDictionary<int, WebRootComponentDescriptor> RootComponentDescriptors { get; init; }
 
-    private string GetDebuggerDisplay()
-    {
-        return $"ApplicationStateCount={ApplicationState?.Count ?? 0}, RootComponentCount={RootComponentDescriptors?.Count ?? 0}";
-    }
+    private string GetDebuggerDisplay() =>
+        $"ApplicationStateCount={ApplicationState?.Count ?? 0}, RootComponentCount={RootComponentDescriptors?.Count ?? 0}";
 }

--- a/src/Components/Server/src/ComponentHub.cs
+++ b/src/Components/Server/src/ComponentHub.cs
@@ -328,7 +328,7 @@ internal sealed partial class ComponentHub : Hub
             {
                 // The circuit state cannot be retrieved. It might have been deleted or expired.
                 // We do not send an error to the client as this is a valid scenario
-                // that will be handled by the client reconnection logic. 
+                // that will be handled by the client reconnection logic.
                 Log.InvalidInputData(_logger);
                 return null;
             }
@@ -358,7 +358,13 @@ internal sealed partial class ComponentHub : Hub
             return null;
         }
 
-        if (!CircuitPersistenceManager.TryDeserializeWebRootComponentDescriptors(_serverComponentSerializer, persistedCircuitState.RootComponents, out var rootComponentDescriptors))
+        // Deserialize the root component descriptors to check whether they are valid and not expired.
+        // If successful, the data will be attached to the CircuitHost instance and used later in UpdateRootComponents.
+        // If not, return null and not send an error to allow the client to handle the rejection.
+        if (!CircuitPersistenceManager.TryDeserializeWebRootComponentDescriptors(
+            _serverComponentSerializer,
+            persistedCircuitState.RootComponents,
+            out var rootComponentDescriptors))
         {
             Log.InvalidInputData(_logger);
             return null;

--- a/src/Components/Server/test/Circuits/CircuitPersistenceManagerTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitPersistenceManagerTest.cs
@@ -286,7 +286,7 @@ public class CircuitPersistenceManagerTest
     {
         var deserializer = SetupMockDeserializer();
 
-        var result = CircuitPersistenceManager.ToRootComponentOperationBatch(deserializer.Object, [.. "{}"u8], "ops");
+        var result = CircuitPersistenceManager.ToRootComponentOperationBatch(deserializer.Object, new Dictionary<int, WebRootComponentDescriptor>(), "ops");
         Assert.NotNull(result);
     }
 
@@ -302,16 +302,7 @@ public class CircuitPersistenceManagerTest
                     false))
             .Returns(false);
 
-        var result = CircuitPersistenceManager.ToRootComponentOperationBatch(deserializer.Object, [.. "{}"u8], "ops");
-        Assert.Null(result);
-    }
-
-    [Fact]
-    public void ToRootComponentOperationBatch_Fails_IfDeserializingPersistedRootComponents_Fails()
-    {
-        var deserializer = SetupMockDeserializer();
-
-        var result = CircuitPersistenceManager.ToRootComponentOperationBatch(deserializer.Object, [.. "invalid-json"u8], "ops");
+        var result = CircuitPersistenceManager.ToRootComponentOperationBatch(deserializer.Object, new Dictionary<int, WebRootComponentDescriptor>(), "ops");
         Assert.Null(result);
     }
 
@@ -324,12 +315,12 @@ public class CircuitPersistenceManagerTest
                 BatchId = 1,
                 Operations = [new RootComponentOperation { Type = RootComponentOperationType.Add, SsrComponentId = 1 }]
             });
-        var result = CircuitPersistenceManager.ToRootComponentOperationBatch(deserializer.Object, [.. "{}"u8], "ops");
+        var result = CircuitPersistenceManager.ToRootComponentOperationBatch(deserializer.Object, new Dictionary<int, WebRootComponentDescriptor>(), "ops");
         Assert.Null(result);
     }
 
     [Fact]
-    public void Fails_IfMarkerForOperationNotFound()
+    public void Fails_IfDescriptorForOperationNotFound()
     {
         var deserializer = SetupMockDeserializer(
             new RootComponentOperationBatch
@@ -337,25 +328,16 @@ public class CircuitPersistenceManagerTest
                 BatchId = 1,
                 Operations = [new RootComponentOperation { Type = RootComponentOperationType.Add, SsrComponentId = 1 }]
             });
-        var result = CircuitPersistenceManager.ToRootComponentOperationBatch(deserializer.Object, [.. """{ "2": {} }"""u8], "ops");
+        var rootComponentDescriptors = new Dictionary<int, WebRootComponentDescriptor>
+        {
+            [2] = new WebRootComponentDescriptor(typeof(RootComponent), new WebRootComponentParameters())
+        };
+        var result = CircuitPersistenceManager.ToRootComponentOperationBatch(deserializer.Object, rootComponentDescriptors, "ops");
         Assert.Null(result);
     }
 
     [Fact]
-    public void Fails_IfUnableToDeserialize_PersistedComponentStateMarker()
-    {
-        var deserializer = SetupMockDeserializer(
-            new RootComponentOperationBatch
-            {
-                BatchId = 1,
-                Operations = [new RootComponentOperation { Type = RootComponentOperationType.Add, SsrComponentId = 1 }]
-            }, fail: false, deserializeMarker: false);
-        var result = CircuitPersistenceManager.ToRootComponentOperationBatch(deserializer.Object, [.. """{ "1": {} }"""u8], "ops");
-        Assert.Null(result);
-    }
-
-    [Fact]
-    public void Fails_WorksWhen_RootComponentsAndOperations_MatchAndCanBeDeserialized()
+    public void WorksWhen_RootComponentsAndOperations_MatchAndCanBeDeserialized()
     {
         var deserializer = SetupMockDeserializer(
             new RootComponentOperationBatch
@@ -363,7 +345,11 @@ public class CircuitPersistenceManagerTest
                 BatchId = 1,
                 Operations = [new RootComponentOperation { Type = RootComponentOperationType.Add, SsrComponentId = 1 }]
             }, fail: false, deserializeMarker: true);
-        var result = CircuitPersistenceManager.ToRootComponentOperationBatch(deserializer.Object, [.. """{ "1": {} }"""u8], "ops");
+        var rootComponentDescriptors = new Dictionary<int, WebRootComponentDescriptor>
+        {
+            [1] = new WebRootComponentDescriptor(typeof(RootComponent), new WebRootComponentParameters())
+        };
+        var result = CircuitPersistenceManager.ToRootComponentOperationBatch(deserializer.Object, rootComponentDescriptors, "ops");
         Assert.NotNull(result);
     }
 

--- a/src/Components/Server/test/Circuits/CircuitPersistenceManagerTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitPersistenceManagerTest.cs
@@ -307,7 +307,7 @@ public class CircuitPersistenceManagerTest
     }
 
     [Fact]
-    public void Fails_IfDifferentNumberOfRootComponentsAndOperations()
+    public void ToRootComponentOperationBatch_Fails_IfDifferentNumberOfRootComponentsAndOperations()
     {
         var deserializer = SetupMockDeserializer(
             new RootComponentOperationBatch
@@ -320,7 +320,7 @@ public class CircuitPersistenceManagerTest
     }
 
     [Fact]
-    public void Fails_IfDescriptorForOperationNotFound()
+    public void ToRootComponentOperationBatch_Fails_IfDescriptorForOperationNotFound()
     {
         var deserializer = SetupMockDeserializer(
             new RootComponentOperationBatch
@@ -337,7 +337,7 @@ public class CircuitPersistenceManagerTest
     }
 
     [Fact]
-    public void WorksWhen_RootComponentsAndOperations_MatchAndCanBeDeserialized()
+    public void ToRootComponentOperationBatch_WorksWhen_RootComponentsAndOperations_MatchAndCanBeDeserialized()
     {
         var deserializer = SetupMockDeserializer(
             new RootComponentOperationBatch

--- a/src/Components/Server/test/Circuits/CircuitRegistryTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitRegistryTest.cs
@@ -348,7 +348,12 @@ public class CircuitRegistryTest
 
         var circuitHost = TestCircuitHost.Create(circuitIdFactory.CreateCircuitId(), serviceProvider.CreateAsyncScope());
         registry.Register(circuitHost);
-        circuitHost.AttachPersistedState(new PersistedCircuitState());
+        var state = new ResumedPersistedCircuitState
+        {
+            ApplicationState = new Dictionary<string, byte[]>(),
+            RootComponentDescriptors = new Dictionary<int, WebRootComponentDescriptor>(),
+        };
+        circuitHost.AttachPersistedState(state);
         var client = Mock.Of<ISingleClientProxy>();
         var newId = "new-connection";
 

--- a/src/Components/Server/test/Circuits/ComponentHubTest.cs
+++ b/src/Components/Server/test/Circuits/ComponentHubTest.cs
@@ -262,7 +262,7 @@ public class ComponentHubTest
         providerMock.Setup(m => m.RestoreCircuitAsync(It.IsAny<CircuitId>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new PersistedCircuitState
             {
-                RootComponents = [],
+                RootComponents = [.. """{}"""u8],
                 ApplicationState = ReadOnlyDictionary<string, byte[]>.Empty,
             });
 

--- a/src/Components/test/testassets/Components.TestServer/RazorComponentEndpointsStartup.cs
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponentEndpointsStartup.cs
@@ -59,6 +59,14 @@ public class RazorComponentEndpointsStartup<TRootComponent>
                     options.PersistedCircuitInMemoryMaxRetained = 0;
                     options.DetailedErrors = true;
                 }
+                var retentionPeriod = Configuration.GetValue<int?>("PersistedCircuitRetentionPeriod");
+                if (retentionPeriod.HasValue)
+                {
+                    // This sets both in-memory and distributed persisted circuit retention periods to the specified value in milliseconds.
+                    // This setting can be used to test expiration of persisted circuit state, including client-held state in case of graceful pause.
+                    options.PersistedCircuitInMemoryRetentionPeriod = TimeSpan.FromMilliseconds(retentionPeriod.Value);
+                    options.PersistedCircuitDistributedRetentionPeriod = TimeSpan.FromMilliseconds(retentionPeriod.Value);
+                }
                 options.RootComponents.RegisterForJavaScript<TestContentPackage.PersistentComponents.ComponentWithPersistentState>("dynamic-js-root-counter");
             })
             .AddAuthenticationStateSerialization(options =>


### PR DESCRIPTION
When client tries to resume the circuit after the client-held serialized state expires, the operation fails without proper handling. (See comment for details.)

## Description

- Moves de-serialization of root component descriptors from `UpdateRootComponents` earlier to `ResumeCircuit` to allow checking whether the data is valid and not expired. The operation now explicitly fails if the data is not valid (meaning it could not be used later anyway).
- Fixes bug in calculation of the expiration date for the client-persisted state.
- Adds new E2E test that covers the scenario with expired client-persisted state.
- Updates existing tests to account for the refactoring of `ResumeCircuit` and `UpdateRootComponents`.

Fixes #64607