### PR TITLE
Fix Wasm.Performance benchmark invalid Locale

### DIFF
--- a/src/Components/benchmarkapps/Wasm.Performance/Driver/Program.cs
+++ b/src/Components/benchmarkapps/Wasm.Performance/Driver/Program.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Text;
@@ -21,10 +20,6 @@ public class Program
 
     public static async Task<int> Main(string[] args)
     {
-        // Set culture to en-US to avoid invalid @posix suffix. Fixes https://github.com/dotnet/aspnetcore/issues/64450
-        CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
-        CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
-
         // This cancellation token manages the timeout for the stress run.
         // By default the driver executes and reports a single Benchmark run. For stress runs,
         // we'll pass in the duration to execute the runs in seconds. This will cause this driver

--- a/src/Components/benchmarkapps/Wasm.Performance/Driver/Program.cs
+++ b/src/Components/benchmarkapps/Wasm.Performance/Driver/Program.cs
@@ -84,7 +84,10 @@ public class Program
         var timeForEachRun = TimeSpan.FromMinutes(3);
 
         var launchUrl = $"{testAppUrl}?resultsUrl={UrlEncoder.Default.Encode(receiverUrl)}#automated";
-        var page = await browser.NewPageAsync();
+        var page = await browser.NewPageAsync(new()
+        {
+            Locale = "en-US",
+        });
         await page.GotoAsync(launchUrl);
         page.Console += WriteBrowserConsoleMessage;
 

--- a/src/Components/benchmarkapps/Wasm.Performance/Driver/Program.cs
+++ b/src/Components/benchmarkapps/Wasm.Performance/Driver/Program.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Text;
@@ -20,6 +21,10 @@ public class Program
 
     public static async Task<int> Main(string[] args)
     {
+        // Set culture to en-US to avoid invalid @posix suffix. Fixes https://github.com/dotnet/aspnetcore/issues/64450
+        CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
+        CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
+
         // This cancellation token manages the timeout for the stress run.
         // By default the driver executes and reports a single Benchmark run. For stress runs,
         // we'll pass in the duration to execute the runs in seconds. This will cause this driver


### PR DESCRIPTION
# Fix BlazorWasm test invalid Locale

Update Wasm.Performance benchmark to explicitly set Locale to en-US.

## Description

Update Wasm.Performance benchmark to explicitly set Locale to en-US when browsing to the benchmark page to fix an invalid culture identifier (`en-us@posix`) error being hit in the ASP.NET Performance lab. 

Fixes #64450

The local test still gives the following error but it seems to be after all of the testing, when the container shutsdown:
`[Browser Log]: Failed to load resource: net::ERR_CONNECTION_RESET`

<details>

<summary>Full local test log:</summary>

```
sudo docker start 9696c5109 && sudo docker logs 9696c5109 -f
9696c5109
Application started.
warn: Microsoft.AspNetCore.Hosting.Diagnostics[15]
      Overriding HTTP_PORTS '8080' and HTTPS_PORTS ''. Binding to values defined by URLS instead 'http://127.0.0.1:0'.
warn: Microsoft.AspNetCore.Hosting.Diagnostics[15]
      Overriding HTTP_PORTS '8080' and HTTPS_PORTS ''. Binding to values defined by URLS instead 'http://127.0.0.1:0'.
Test app listening at http://127.0.0.1:44167.
[Browser Log]: Download size:  2663776
[Browser Log]: Completed benchmark Time to first UI
[Browser Log]: Completed benchmark Render 10 items
[Browser Log]: Completed benchmark Render 100 items
[Browser Log]: Completed benchmark Render 1000 items
[Browser Log]: Completed benchmark Serialize 1kb
[Browser Log]: Completed benchmark Serialize 340kb
[Browser Log]: Completed benchmark Serialize 340kb (Source Generated)
[Browser Log]: Completed benchmark Deserialize 1kb
[Browser Log]: Completed benchmark Deserialize 340kb
[Browser Log]: Completed benchmark Deserialize 340kb (Source Generated)
[Browser Log]: Completed benchmark Serialize 340kb (JavaScript)
[Browser Log]: Completed benchmark Deserialize 340kb (JavaScript)
[Browser Log]: Completed benchmark Render small nested component
[Browser Log]: Completed benchmark Render large nested component
[Browser Log]: Completed benchmark Render component with edit
[Browser Log]: Completed benchmark PlainTable: From blank
[Browser Log]: Completed benchmark PlainTable: Switch pages
[Browser Log]: Completed benchmark ComplexTable: From blank
[Browser Log]: Completed benchmark ComplexTable: Switch pages
[Browser Log]: Completed benchmark FastGrid: From blank
[Browser Log]: Completed benchmark FastGrid: Switch pages
#StartJobStatistics
{"Metadata":[{"Source":"BlazorWasm","Name":"blazorwasm/download-size","ShortDescription":"Download size (KB)","LongDescription":"Download size (KB)","Format":"n2"},{"Source":"BlazorWasm","Name":"blazorwasm/commit","ShortDescription":"Commit Hash","LongDescription":null,"Format":null},{"Source":"BlazorWasm","Name":"blazorwasm/time-to-first-ui","ShortDescription":"Time to first UI","LongDescription":"Time to render first UI (ms)","Format":"n2"},{"Source":"BlazorWasm","Name":"blazorwasm/render-10-items","ShortDescription":"Render 10 items","LongDescription":"Time to render 10 item list (ms)","Format":"n2"},{"Source":"BlazorWasm","Name":"blazorwasm/render-100-items","ShortDescription":"Render 100 items","LongDescription":"Time to render 100 item list (ms)","Format":"n2"},{"Source":"BlazorWasm","Name":"blazorwasm/render-1000-items","ShortDescription":"Render 1000 items","LongDescription":"Time to render 1000 item list (ms)","Format":"n2"},{"Source":"BlazorWasm","Name":"blazorwasm/jsonserialize-1kb","ShortDescription":"Serialize 1kb","LongDescription":"Serialize JSON 1kb - Time in ms","Format":"n2"},{"Source":"BlazorWasm","Name":"blazorwasm/jsonserialize-340kb","ShortDescription":"Serialize 340kb","LongDescription":"Serialize JSON 340kb - Time in ms","Format":"n2"},{"Source":"BlazorWasm","Name":"blazorwasm/jsonserialize-sourcegen-340kb","ShortDescription":"Serialize 340kb (Source Generated)","LongDescription":"Serialize JSON (SourceGen) 340kb - Time in ms","Format":"n2"},{"Source":"BlazorWasm","Name":"blazorwasm/jsondeserialize-1kb","ShortDescription":"Deserialize 1kb","LongDescription":"Deserialize JSON 1kb - Time in ms","Format":"n2"},{"Source":"BlazorWasm","Name":"blazorwasm/jsondeserialize-340kb","ShortDescription":"Deserialize 340kb","LongDescription":"Deserialize JSON 340kb - Time in ms","Format":"n2"},{"Source":"BlazorWasm","Name":"blazorwasm/jsondeserialize-sourcegen-340kb","ShortDescription":"Deserialize 340kb (Source Generated)","LongDescription":"Deserialize JSON (SourceGen) 340kb - Time in ms","Format":"n2"},{"Source":"BlazorWasm","Name":"blazorwasm/jsonserialize-javascript-340kb","ShortDescription":"Serialize 340kb (JavaScript)","LongDescription":"Serialize JSON 340kb using JavaScript - Time in ms","Format":"n2"},{"Source":"BlazorWasm","Name":"blazorwasm/jsondeserialize-javascript-340kb","ShortDescription":"Deserialize 340kb (JavaScript)","LongDescription":"Deserialize JSON 340kb using JavaScript - Time in ms","Format":"n2"},{"Source":"BlazorWasm","Name":"blazorwasm/orgchart-1-4-org","ShortDescription":"Render small nested component","LongDescription":"Time to render a complex component with small nesting (ms)","Format":"n2"},{"Source":"BlazorWasm","Name":"blazorwasm/orgchart-3-3-org","ShortDescription":"Render large nested component","LongDescription":"Time to render a complex component with large nesting (ms)","Format":"n2"},{"Source":"BlazorWasm","Name":"blazorwasm/edit-orgchart-3-2","ShortDescription":"Render component with edit","LongDescription":"Time to peform updates in a nested component (ms)","Format":"n2"},{"Source":"BlazorWasm","Name":"blazorwasm/render-plaintable-from-blank","ShortDescription":"PlainTable: From blank","LongDescription":"Time to render plain table from blank (ms)","Format":"n2"},{"Source":"BlazorWasm","Name":"blazorwasm/render-plaintable-switch-pages","ShortDescription":"PlainTable: Switch pages","LongDescription":"Time to render plain table change of page (ms)","Format":"n2"},{"Source":"BlazorWasm","Name":"blazorwasm/render-complextable-from-blank","ShortDescription":"ComplexTable: From blank","LongDescription":"Time to render complex table from blank (ms)","Format":"n2"},{"Source":"BlazorWasm","Name":"blazorwasm/render-complextable-switch-pages","ShortDescription":"ComplexTable: Switch pages","LongDescription":"Time to render complex table change of page (ms)","Format":"n2"},{"Source":"BlazorWasm","Name":"blazorwasm/render-fastgrid-from-blank","ShortDescription":"FastGrid: From blank","LongDescription":"Time to render fast grid from blank (ms)","Format":"n2"},{"Source":"BlazorWasm","Name":"blazorwasm/render-fastgrid-switch-pages","ShortDescription":"FastGrid: Switch pages","LongDescription":"Time to render fast grid change of page (ms)","Format":"n2"}],"Measurements":[{"Timestamp":"2025-12-16T19:35:01.8343392Z","Name":"blazorwasm/download-size","Value":2601.3438},{"Timestamp":"2025-12-16T19:35:01.8343937Z","Name":"blazorwasm/commit","Value":"54da4e6cfbc42d23b2896c73c5b195a9a8e8904b"},{"Timestamp":"2025-12-16T19:35:01.8348145Z","Name":"blazorwasm/time-to-first-ui","Value":427.09999999403954},{"Timestamp":"2025-12-16T19:35:01.834831Z","Name":"blazorwasm/render-10-items","Value":1.6426229508074581},{"Timestamp":"2025-12-16T19:35:01.8348318Z","Name":"blazorwasm/render-100-items","Value":6.044776119402985},{"Timestamp":"2025-12-16T19:35:01.8348322Z","Name":"blazorwasm/render-1000-items","Value":49.877777778440056},{"Timestamp":"2025-12-16T19:35:01.8348324Z","Name":"blazorwasm/jsonserialize-1kb","Value":0.7538606402957058},{"Timestamp":"2025-12-16T19:35:01.8348325Z","Name":"blazorwasm/jsonserialize-340kb","Value":13.968965517035846},{"Timestamp":"2025-12-16T19:35:01.8348328Z","Name":"blazorwasm/jsonserialize-sourcegen-340kb","Value":14.489285713859967},{"Timestamp":"2025-12-16T19:35:01.8348329Z","Name":"blazorwasm/jsondeserialize-1kb","Value":0.7604562737642586},{"Timestamp":"2025-12-16T19:35:01.834833Z","Name":"blazorwasm/jsondeserialize-340kb","Value":26.33750000037253},{"Timestamp":"2025-12-16T19:35:01.8348331Z","Name":"blazorwasm/jsondeserialize-sourcegen-340kb","Value":27.366666666666667},{"Timestamp":"2025-12-16T19:35:01.8348332Z","Name":"blazorwasm/jsonserialize-javascript-340kb","Value":0.4347826086956522},{"Timestamp":"2025-12-16T19:35:01.8348333Z","Name":"blazorwasm/jsondeserialize-javascript-340kb","Value":0.6616528925816875},{"Timestamp":"2025-12-16T19:35:01.8348334Z","Name":"blazorwasm/orgchart-1-4-org","Value":10.092499999701976},{"Timestamp":"2025-12-16T19:35:01.8348334Z","Name":"blazorwasm/orgchart-3-3-org","Value":59.58571428486279},{"Timestamp":"2025-12-16T19:35:01.8348336Z","Name":"blazorwasm/edit-orgchart-3-2","Value":21.663157894423136},{"Timestamp":"2025-12-16T19:35:01.8348338Z","Name":"blazorwasm/render-plaintable-from-blank","Value":100.04999999701977},{"Timestamp":"2025-12-16T19:35:01.8348339Z","Name":"blazorwasm/render-plaintable-switch-pages","Value":51.48750000074506},{"Timestamp":"2025-12-16T19:35:01.8348341Z","Name":"blazorwasm/render-complextable-from-blank","Value":195.66666666666669},{"Timestamp":"2025-12-16T19:35:01.8348342Z","Name":"blazorwasm/render-complextable-switch-pages","Value":173.59999999900657},{"Timestamp":"2025-12-16T19:35:01.8348343Z","Name":"blazorwasm/render-fastgrid-from-blank","Value":23.20555555489328},{"Timestamp":"2025-12-16T19:35:01.8348344Z","Name":"blazorwasm/render-fastgrid-switch-pages","Value":19.923809524093354}]}
#EndJobStatistics


Download size: 2601kb.
| Name | Description | Duration | NumExecutions |
--------------------------
| blazorwasm/time-to-first-ui | Time to first UI | 427.09999999403954 | 12 |
| blazorwasm/render-10-items | Render 10 items | 1.6426229508074581 | 3099 |
| blazorwasm/render-100-items | Render 100 items | 6.044776119402985 | 948 |
| blazorwasm/render-1000-items | Render 1000 items | 49.877777778440056 | 103 |
| blazorwasm/jsonserialize-1kb | Serialize 1kb | 0.7538606402957058 | 6865 |
| blazorwasm/jsonserialize-340kb | Serialize 340kb | 13.968965517035846 | 391 |
| blazorwasm/jsonserialize-sourcegen-340kb | Serialize 340kb (Source Generated) | 14.489285713859967 | 377 |
| blazorwasm/jsondeserialize-1kb | Deserialize 1kb | 0.7604562737642586 | 7378 |
| blazorwasm/jsondeserialize-340kb | Deserialize 340kb | 26.33750000037253 | 235 |
| blazorwasm/jsondeserialize-sourcegen-340kb | Deserialize 340kb (Source Generated) | 27.366666666666667 | 224 |
| blazorwasm/jsonserialize-javascript-340kb | Serialize 340kb (JavaScript) | 0.4347826086956522 | 13747 |
| blazorwasm/jsondeserialize-javascript-340kb | Deserialize 340kb (JavaScript) | 0.6616528925816875 | 8902 |
| blazorwasm/orgchart-1-4-org | Render small nested component | 10.092499999701976 | 483 |
| blazorwasm/orgchart-3-3-org | Render large nested component | 59.58571428486279 | 87 |
| blazorwasm/edit-orgchart-3-2 | Render component with edit | 21.663157894423136 | 214 |
| blazorwasm/render-plaintable-from-blank | PlainTable: From blank | 100.04999999701977 | 50 |
| blazorwasm/render-plaintable-switch-pages | PlainTable: Switch pages | 51.48750000074506 | 112 |
| blazorwasm/render-complextable-from-blank | ComplexTable: From blank | 195.66666666666669 | 30 |
| blazorwasm/render-complextable-switch-pages | ComplexTable: Switch pages | 173.59999999900657 | 33 |
| blazorwasm/render-fastgrid-from-blank | FastGrid: From blank | 23.20555555489328 | 238 |
| blazorwasm/render-fastgrid-switch-pages | FastGrid: Switch pages | 19.923809524093354 | 275 |
Done executing benchmark
[Browser Log]: Failed to load resource: net::ERR_CONNECTION_RESET
```

</details>