### PR TITLE
CreateServer with TestServerOptions in WebApplicationFactory

### DIFF
--- a/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
+++ b/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyModel;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Mvc.Testing;
 
@@ -588,7 +589,16 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
     /// </summary>
     /// <param name="serviceProvider">The <see cref="IServiceProvider"/> from the bootstrapped application.</param>
     /// <returns></returns>
-    protected virtual TestServer CreateServer(IServiceProvider serviceProvider) => new(serviceProvider);
+    protected virtual TestServer CreateServer(IServiceProvider serviceProvider)
+    {
+        var options = serviceProvider.GetService<IOptions<TestServerOptions>>();
+        if (options is not null)
+        {
+            return new(serviceProvider, options);
+        }
+
+        return new(serviceProvider);
+    }
 
     /// <summary>
     /// Creates the <see cref="IHost"/> with the bootstrapped application in <paramref name="builder"/>.

--- a/src/Mvc/test/Mvc.FunctionalTests/TestServerWithCustomConfigurationIntegrationTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/TestServerWithCustomConfigurationIntegrationTests.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+
+namespace Microsoft.AspNetCore.Mvc.FunctionalTests;
+
+public class CustomWebApplicationFactory : WebApplicationFactory<SimpleWebSite.Startup>
+{
+    public Action<TestServerOptions> ConfigureOptions { get; set; }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseTestServer(ConfigureOptions);
+    }
+}
+
+public class TestServerWithCustomConfigurationIntegrationTests : IClassFixture<CustomWebApplicationFactory>
+{
+    public CustomWebApplicationFactory Factory { get; }
+
+    public TestServerWithCustomConfigurationIntegrationTests(CustomWebApplicationFactory factory)
+    {
+        Factory = factory;
+    }
+
+    [Fact]
+    public async Task ServerConfigured()
+    {
+        // Arrange
+        var optionsConfiguredCounter = 0;
+        Factory.ConfigureOptions = options =>
+        {
+            options.AllowSynchronousIO = true;
+            options.PreserveExecutionContext = true;
+            optionsConfiguredCounter++;
+        };
+
+        // Act
+        Assert.Equal(0, optionsConfiguredCounter);
+        Factory.StartServer();
+
+        using var client = Factory.CreateClient();
+
+        using var response = await client.GetAsync("/");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(1, optionsConfiguredCounter);
+        Assert.True(Factory.Server.AllowSynchronousIO);
+        Assert.True(Factory.Server.PreserveExecutionContext);
+    }
+}


### PR DESCRIPTION
# CreateServer with TestServerOptions in WebApplicationFactory

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

Applies the configured `TestServerOptions` when creating a `TestServer` in a `WebApplicationFactory`.
It addresses a regression introduced in https://github.com/dotnet/aspnetcore/commit/c80f3e5f4bba33cd9be2f9b8d65900b1077e0dfc#diff-c70063a52c125c1f25ca65f24827d42e1385d34eac3b567d180b5eb9cd53e696R341

Fixes #64593
