### PR TITLE
Preserve antiforgery token

### DIFF
--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHostBuilder.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHostBuilder.cs
@@ -319,6 +319,7 @@ public sealed class WebAssemblyHostBuilder
 
         return new WebAssemblyHost(this, services, scope, _persistedState);
     }
+
     [DynamicDependency(JsonSerialized, typeof(DefaultAntiforgeryStateProvider))]
     [DynamicDependency(JsonSerialized, typeof(AntiforgeryRequestToken))]
     internal void InitializeDefaultServices()

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHostBuilder.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHostBuilder.cs
@@ -319,7 +319,6 @@ public sealed class WebAssemblyHostBuilder
 
         return new WebAssemblyHost(this, services, scope, _persistedState);
     }
-    
     [DynamicDependency(JsonSerialized, typeof(DefaultAntiforgeryStateProvider))]
     [DynamicDependency(JsonSerialized, typeof(AntiforgeryRequestToken))]
     internal void InitializeDefaultServices()

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHostBuilder.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHostBuilder.cs
@@ -319,7 +319,9 @@ public sealed class WebAssemblyHostBuilder
 
         return new WebAssemblyHost(this, services, scope, _persistedState);
     }
-
+    
+    [DynamicDependency(JsonSerialized, typeof(DefaultAntiforgeryStateProvider))]
+    [DynamicDependency(JsonSerialized, typeof(AntiforgeryRequestToken))]
     internal void InitializeDefaultServices()
     {
         Services.AddSingleton<IJSRuntime>(DefaultWebAssemblyJSRuntime.Instance);


### PR DESCRIPTION
# Fix antiforgery token trimming in Blazor WebAssembly prerendering

Add DynamicDependency attributes to prevent IL trimming of antiforgery type.

## Description

When a Blazor WebAssembly app with Individual Identity authentication is published with `PublishTrimmed=true`, the antiforgery token persisted during SSR is not restored during the SSR-to-WASM handoff. This causes the `<AntiforgeryToken>` component to render nothing in interactive mode, breaking form submissions.

**Root cause:** The IL trimmer removes `DefaultAntiforgeryStateProvider.CurrentToken` property and `AntiforgeryRequestToken` constructor because they're only accessed via reflection by the persistent state system.

**Fix:** Add `[DynamicDependency(JsonSerialized, typeof(...))]` attributes on `WebAssemblyHostBuilder.InitializeDefaultServices()` to preserve:
- `DefaultAntiforgeryStateProvider` - ensures the `[PersistentState] CurrentToken` property is preserved
- `AntiforgeryRequestToken` - ensures the constructor and properties are preserved for JSON deserialization

## Known workarounds:

```
<linker>
	<!--  AntiforgeryRequestToken deserialization issues  -->
	<assembly fullname="Microsoft.AspNetCore.Components.Web">
		<type fullname="Microsoft.AspNetCore.Components.Forms.AntiforgeryRequestToken" preserve="all"/>
	</assembly>
	<assembly fullname="Microsoft.AspNetCore.Components.WebAssembly">
		<type fullname="Microsoft.AspNetCore.Components.Forms.DefaultAntiforgeryStateProvider" preserve="all"/>
	</assembly>
</linker>
```

Fixes #64693
