### PR TITLE
Fix exit code handling in runtests.cmd

### DIFF
--- a/eng/helix/content/runtests.cmd
+++ b/eng/helix/content/runtests.cmd
@@ -21,12 +21,9 @@ set "PATH=%HELIX_WORKITEM_ROOT%;%PATH%;%HELIX_WORKITEM_ROOT%\node\bin"
 echo Set path to: "%PATH%"
 echo.
 
-set exit_code=0
-
 echo "Running tests: dotnet %HELIX_CORRELATION_PAYLOAD%/HelixTestRunner/HelixTestRunner.dll --target %$target% --runtime %$aspRuntimeVersion% --queue %$queue% --arch %$arch% --quarantined %$quarantined% --helixTimeout %$helixTimeout% --playwright %$installPlaywright%"
 dotnet %HELIX_CORRELATION_PAYLOAD%/HelixTestRunner/HelixTestRunner.dll --target %$target% --runtime %$aspRuntimeVersion% --queue %$queue% --arch %$arch% --quarantined %$quarantined% --helixTimeout %$helixTimeout% --playwright %$installPlaywright%
-if not errorlevel 0 (
-    set exit_code=%errorlevel%
-)
+set exit_code=%errorlevel%
+
 echo "Finished running tests: exit_code=%exit_code%"
 EXIT /b %exit_code%


### PR DESCRIPTION
We were inadvertently setting exit code = 0 even if a test failed.

This is because the way the `errorlevel` _command_ works is that it checks whether the last command exit code was **greater than or equal** to the argument.

So checking `errorlevel 0` in the if reports true even when we have exit code 1 and then we negate that and don't enter the if block.

We don't actually need this if check at all since we just want to print the value so we can just capture the `%errorlevel%` _variable_.
