### PR TITLE
Decrease the execution time of the longest E2E tests

### DIFF
--- a/src/Components/test/testassets/BasicTestApp/VirtualizationLargeOverscan.razor
+++ b/src/Components/test/testassets/BasicTestApp/VirtualizationLargeOverscan.razor
@@ -2,11 +2,11 @@
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 
 <div id="virtualize-large-overscan" style="height: 600px; overflow-y: auto; outline: 1px solid #999; background:#f8f8f8;">
-    <Virtualize Items="_items" ItemSize="30" MaxItemCount="100" OverscanCount="200">
-        <div class="large-overscan-item" @key="context" style="height:30px; line-height:30px; border-bottom:1px solid #ddd;">Item @context</div>
+    <Virtualize Items="_items" ItemSize="20" MaxItemCount="100" OverscanCount="200">
+        <div class="large-overscan-item" @key="context" style="height:20px; line-height:20px; border-bottom:1px solid #ddd;">Item @context</div>
     </Virtualize>
 </div>
 
 @code {
-    private IList<int> _items = Enumerable.Range(0, 5000).ToList();
+    private IList<int> _items = Enumerable.Range(0, 500).ToList();
 }


### PR DESCRIPTION
Fixes #64075

- Two E2E virtualization tests take much more time than other top long-running tests.

**Root cause:**
The test component used 5000 items × 30px = 150,000px of scroll height, requiring ~250 `PageDown` iterations to scroll through.

**Justification:**
There is no justification for 5k items, the same check, reflecting the conditions from the original issue https://github.com/dotnet/aspnetcore/issues/63651 can be done with 500 elements.

**Fix:**
Reduced to 500 items × 20px = 10,000px (~17 iterations) while preserving the test's purpose: validating that `OverscanCount > MaxItemCount` triggers elevation of effective max.

**Safety measures:**
We could go down even more. The fixing PR mentioned that the core of the problem was with `OverscanCount > MaxItemCount`. We could use e.g. 100 items with `OverscanCount`=40 and `MaxItemCount` = 20 that would reduce the test time ~8x. But only if @javiercn does not have any arguments against that breaking the goal of the test.

**What's preserved:**
- `OverscanCount="200"` and `MaxItemCount="100"` (original relationship)
- `ItemSize="20"` (matches the Aspire issue that triggered the original fix)
- Assertion `>= 200` items rendered initially
- Full scroll-through validation of contiguity