### PR TITLE
Replace static parameters in route pattern for telemetry

### DIFF
--- a/src/Http/Routing/src/Patterns/RoutePatternDebugStringFormatter.cs
+++ b/src/Http/Routing/src/Patterns/RoutePatternDebugStringFormatter.cs
@@ -7,12 +7,13 @@ namespace Microsoft.AspNetCore.Routing.Patterns;
 
 internal static class RoutePatternDebugStringFormatter
 {
+    private const char Separator = '/';
     private const string SeparatorString = "/";
 
     public static string Format(RoutePattern pattern)
     {
         // If there are no required values that match parameters, use the simple approach
-        if (pattern.RawText is { } rawText && !HasMatchingRequiredValues(pattern))
+        if (pattern.RawText is { Length: > 0 } rawText && !HasMatchingRequiredValues(pattern))
         {
             return rawText;
         }
@@ -26,7 +27,21 @@ internal static class RoutePatternDebugStringFormatter
             segments[i] = segmentString;
         }
 
-        return string.Join(SeparatorString, segments);
+        var result = string.Join(Separator, segments);
+
+        // Preserve leading slash from raw text
+        if (pattern.RawText is { Length: > 0 } rt && rt[0] == Separator)
+        {
+            result = Separator + result;
+        }
+
+        // Return "/" for empty results
+        if (result.Length == 0)
+        {
+            return SeparatorString;
+        }
+
+        return result;
     }
 
     private static bool HasMatchingRequiredValues(RoutePattern pattern)

--- a/src/Http/Routing/src/Patterns/RoutePatternDebugStringFormatter.cs
+++ b/src/Http/Routing/src/Patterns/RoutePatternDebugStringFormatter.cs
@@ -1,0 +1,88 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.AspNetCore.Routing.Patterns;
+
+internal static class RoutePatternDebugStringFormatter
+{
+    private const string SeparatorString = "/";
+
+    public static string Format(RoutePattern pattern)
+    {
+        // If there are no required values that match parameters, use the simple approach
+        if (pattern.RawText is { } rawText && !HasMatchingRequiredValues(pattern))
+        {
+            return rawText;
+        }
+
+        // Build the string replacing parameters with their required values when available
+        var segments = new string[pattern.PathSegments.Count];
+        for (var i = 0; i < pattern.PathSegments.Count; i++)
+        {
+            var segment = pattern.PathSegments[i];
+            var segmentString = GetSegmentDebuggerToString(pattern, segment);
+            segments[i] = segmentString;
+        }
+
+        return string.Join(SeparatorString, segments);
+    }
+
+    private static bool HasMatchingRequiredValues(RoutePattern pattern)
+    {
+        if (pattern.RequiredValues.Count == 0)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < pattern.Parameters.Count; i++)
+        {
+            if (TryGetRequiredValue(pattern, pattern.Parameters[i].Name, out _))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string GetSegmentDebuggerToString(RoutePattern pattern, RoutePatternPathSegment segment)
+    {
+        // Simple segment with single parameter that has a required value - just return the required value
+        if (segment.IsSimple && segment.Parts[0] is RoutePatternParameterPart parameter)
+        {
+            if (TryGetRequiredValue(pattern, parameter.Name, out var requiredValue))
+            {
+                return requiredValue;
+            }
+        }
+
+        // For complex segments, build the string part by part
+        var parts = new string[segment.Parts.Count];
+        for (var i = 0; i < segment.Parts.Count; i++)
+        {
+            var part = segment.Parts[i];
+            parts[i] = part is RoutePatternParameterPart paramPart && TryGetRequiredValue(pattern, paramPart.Name, out var value)
+                ? value
+                : part.DebuggerToString();
+        }
+
+        return string.Join(string.Empty, parts);
+    }
+
+    private static bool TryGetRequiredValue(RoutePattern pattern, string parameterName, [NotNullWhen(true)] out string? value)
+    {
+        if (pattern.RequiredValues.TryGetValue(parameterName, out var requiredValue) &&
+            requiredValue is not null &&
+            !RoutePattern.IsRequiredValueAny(requiredValue) &&
+            requiredValue.ToString() is { Length: > 0 } v)
+        {
+            value = v;
+            return true;
+        }
+
+        value = null;
+        return false;
+    }
+}

--- a/src/Http/Routing/src/Patterns/RoutePatternParameterPart.cs
+++ b/src/Http/Routing/src/Patterns/RoutePatternParameterPart.cs
@@ -99,10 +99,23 @@ internal sealed class RoutePatternParameterPart : RoutePatternPart
         foreach (var constraint in ParameterPolicies)
         {
             builder.Append(':');
-            builder.Append(constraint.ParameterPolicy);
+            if (constraint.Content is not null)
+            {
+                builder.Append(constraint.Content);
+            }
+            else if (constraint.ParameterPolicy is Constraints.RegexRouteConstraint regexConstraint)
+            {
+                builder.Append("regex(");
+                builder.Append(regexConstraint.Constraint);
+                builder.Append(')');
+            }
+            else if (constraint.ParameterPolicy is not null)
+            {
+                builder.Append(constraint.ParameterPolicy);
+            }
         }
 
-        if (Default != null)
+        if (Default is not null)
         {
             builder.Append('=');
             builder.Append(Default);

--- a/src/Http/Routing/test/UnitTests/Patterns/RoutePatternDebugStringFormatterTest.cs
+++ b/src/Http/Routing/test/UnitTests/Patterns/RoutePatternDebugStringFormatterTest.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Routing.Constraints;
 
 namespace Microsoft.AspNetCore.Routing.Patterns;
 
-public class RoutePatternTest
+public class RoutePatternDebugStringFormatterTest
 {
     [Fact]
     public void DebuggerToString_WithNoRequiredValues_ReturnsRawText()

--- a/src/Http/Routing/test/UnitTests/Patterns/RoutePatternTest.cs
+++ b/src/Http/Routing/test/UnitTests/Patterns/RoutePatternTest.cs
@@ -262,6 +262,79 @@ public class RoutePatternTest
         Assert.NotNull(reparsed);
     }
 
+    [Fact]
+    public void DebuggerToString_WithLeadingSlash_PreservesLeadingSlash()
+    {
+        // Arrange
+        var pattern = RoutePatternFactory.Parse(
+            "/{controller}/{action}",
+            defaults: null,
+            parameterPolicies: null,
+            requiredValues: new { controller = "Home", action = "Index" });
+
+        // Act
+        var result = pattern.DebuggerToString();
+
+        // Assert
+        Assert.Equal("/Home/Index", result);
+    }
+
+    [Fact]
+    public void DebuggerToString_WithLeadingSlashAndPartialRequiredValues_PreservesLeadingSlash()
+    {
+        // Arrange
+        var pattern = RoutePatternFactory.Parse(
+            "/{controller}/{action}/{id?}",
+            defaults: null,
+            parameterPolicies: null,
+            requiredValues: new { controller = "Store" });
+
+        // Act
+        var result = pattern.DebuggerToString();
+
+        // Assert
+        Assert.Equal("/Store/{action}/{id?}", result);
+    }
+
+    [Fact]
+    public void DebuggerToString_WithLeadingSlashNoRequiredValues_PreservesRawText()
+    {
+        // Arrange
+        var pattern = RoutePatternFactory.Parse("/{controller}/{action}");
+
+        // Act
+        var result = pattern.DebuggerToString();
+
+        // Assert
+        Assert.Equal("/{controller}/{action}", result);
+    }
+
+    [Fact]
+    public void DebuggerToString_EmptyPattern_ReturnsSlash()
+    {
+        // Arrange
+        var pattern = RoutePatternFactory.Parse("");
+
+        // Act
+        var result = pattern.DebuggerToString();
+
+        // Assert
+        Assert.Equal("/", result);
+    }
+
+    [Fact]
+    public void DebuggerToString_SlashOnlyPattern_ReturnsSlash()
+    {
+        // Arrange
+        var pattern = RoutePatternFactory.Parse("/");
+
+        // Act
+        var result = pattern.DebuggerToString();
+
+        // Assert
+        Assert.Equal("/", result);
+    }
+
     private static RouteValueDictionary ParseRequiredValues(string requiredValuesText)
     {
         var requiredValues = new RouteValueDictionary();

--- a/src/Http/Routing/test/UnitTests/Patterns/RoutePatternTest.cs
+++ b/src/Http/Routing/test/UnitTests/Patterns/RoutePatternTest.cs
@@ -1,0 +1,277 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Routing.Constraints;
+
+namespace Microsoft.AspNetCore.Routing.Patterns;
+
+public class RoutePatternTest
+{
+    [Fact]
+    public void DebuggerToString_WithNoRequiredValues_ReturnsRawText()
+    {
+        // Arrange
+        var pattern = RoutePatternFactory.Parse("{controller=Home}/{action=Index}/{id?}");
+
+        // Act
+        var result = pattern.DebuggerToString();
+
+        // Assert
+        Assert.Equal("{controller=Home}/{action=Index}/{id?}", result);
+    }
+
+    [Fact]
+    public void DebuggerToString_WithRequiredValues_ReplacesMatchingParameters()
+    {
+        // Arrange
+        var pattern = RoutePatternFactory.Parse(
+            "{controller=Home}/{action=Index}/{id?}",
+            defaults: null,
+            parameterPolicies: null,
+            requiredValues: new { controller = "Store", action = "Index" });
+
+        // Act
+        var result = pattern.DebuggerToString();
+
+        // Assert
+        Assert.Equal("Store/Index/{id?}", result);
+    }
+
+    [Fact]
+    public void DebuggerToString_WithPartialRequiredValues_ReplacesOnlyMatchingParameters()
+    {
+        // Arrange
+        var pattern = RoutePatternFactory.Parse(
+            "{controller}/{action}/{id?}",
+            defaults: null,
+            parameterPolicies: null,
+            requiredValues: new { controller = "Products" });
+
+        // Act
+        var result = pattern.DebuggerToString();
+
+        // Assert
+        Assert.Equal("Products/{action}/{id?}", result);
+    }
+
+    [Fact]
+    public void DebuggerToString_WithRequiredValueAny_DoesNotReplaceParameter()
+    {
+        // Arrange
+        var pattern = RoutePatternFactory.Parse(
+            "{controller}/{action}/{id?}",
+            defaults: null,
+            parameterPolicies: null,
+            requiredValues: new RouteValueDictionary
+            {
+                { "controller", RoutePattern.RequiredValueAny },
+                { "action", "Index" }
+            });
+
+        // Act
+        var result = pattern.DebuggerToString();
+
+        // Assert
+        Assert.Equal("{controller}/Index/{id?}", result);
+    }
+
+    [Fact]
+    public void DebuggerToString_WithNullRequiredValue_DoesNotReplaceParameter()
+    {
+        // Arrange
+        var pattern = RoutePatternFactory.Parse(
+            "{controller}/{action}/{id?}",
+            defaults: null,
+            parameterPolicies: null,
+            requiredValues: new RouteValueDictionary
+            {
+                { "controller", null },
+                { "action", "Index" }
+            });
+
+        // Act
+        var result = pattern.DebuggerToString();
+
+        // Assert
+        Assert.Equal("{controller}/Index/{id?}", result);
+    }
+
+    [Fact]
+    public void DebuggerToString_WithEmptyStringRequiredValue_DoesNotReplaceParameter()
+    {
+        // Arrange
+        var pattern = RoutePatternFactory.Parse(
+            "{controller}/{action}/{id?}",
+            defaults: null,
+            parameterPolicies: null,
+            requiredValues: new RouteValueDictionary
+            {
+                { "controller", "" },
+                { "action", "Index" }
+            });
+
+        // Act
+        var result = pattern.DebuggerToString();
+
+        // Assert
+        Assert.Equal("{controller}/Index/{id?}", result);
+    }
+
+    [Fact]
+    public void DebuggerToString_WithCatchAllParameter_ReplacesWithRequiredValue()
+    {
+        // Arrange
+        var pattern = RoutePatternFactory.Parse(
+            "{controller}/{*path}",
+            defaults: null,
+            parameterPolicies: null,
+            requiredValues: new { controller = "Files", path = "docs/readme.md" });
+
+        // Act
+        var result = pattern.DebuggerToString();
+
+        // Assert
+        Assert.Equal("Files/docs/readme.md", result);
+    }
+
+    [Fact]
+    public void DebuggerToString_WithComplexSegment_ReplacesMatchingParameters()
+    {
+        // Arrange
+        var pattern = RoutePatternFactory.Parse(
+            "{controller}-{action}",
+            defaults: null,
+            parameterPolicies: null,
+            requiredValues: new { controller = "Home", action = "Index" });
+
+        // Act
+        var result = pattern.DebuggerToString();
+
+        // Assert
+        Assert.Equal("Home-Index", result);
+    }
+
+    [Fact]
+    public void DebuggerToString_WithLiteralSegments_PreservesLiterals()
+    {
+        // Arrange
+        var pattern = RoutePatternFactory.Parse(
+            "api/{controller}/{id}",
+            defaults: null,
+            parameterPolicies: null,
+            requiredValues: new { controller = "Products" });
+
+        // Act
+        var result = pattern.DebuggerToString();
+
+        // Assert
+        Assert.Equal("api/Products/{id}", result);
+    }
+
+    [Fact]
+    public void DebuggerToString_WithConstraints_PreservesConstraintsForUnmatchedParameters()
+    {
+        // Arrange
+        var pattern = RoutePatternFactory.Parse(
+            "{controller}/{action}/{id:int}",
+            defaults: null,
+            parameterPolicies: null,
+            requiredValues: new { controller = "Store" });
+
+        // Act
+        var result = pattern.DebuggerToString();
+
+        // Assert
+        Assert.Equal("Store/{action}/{id:int}", result);
+    }
+
+    [Fact]
+    public void DebuggerToString_WithMultipleConstraints_PreservesAllConstraints()
+    {
+        // Arrange
+        var template = "{a:int}/{b:regex(^\\d+$)}/{c:int}";
+        var defaults = new { a = 0 }; // Required value needs a corresponding parameter or default
+        var constraints = new { b = "fizz", c = new object[] { new RegexRouteConstraint("foo"), new RegexRouteConstraint("bar"), "baz" } };
+        var requiredValues = new { a = "test" };
+
+        var pattern = RoutePatternFactory.Parse(template, defaults, constraints, requiredValues);
+
+        // Act
+        var result = pattern.DebuggerToString();
+
+        // Assert
+        // Constraints added via parameterPolicies come first, then inline constraints
+        // RegexRouteConstraint shows as regex(pattern) format
+        // String constraints like "fizz" are converted to RegexRouteConstraint with pattern "^(fizz)$"
+        // RegexRouteConstraint("foo") uses raw pattern "foo"
+        Assert.Equal("test/{b:regex(^(fizz)$):regex(^\\d+$)}/{c:regex(foo):regex(bar):regex(^(baz)$):int}", result);
+    }
+
+    [Theory]
+    [InlineData("{controller}/{action}/{id?}", "controller=Home,action=Index", "Home/Index/{id?}")]
+    [InlineData("{controller=Home}/{action=Index}/{id?}", "controller=Store,action=Index", "Store/Index/{id?}")]
+    [InlineData("{controller}/{action}", "controller=Products", "Products/{action}")]
+    [InlineData("{controller}/{id:int}", "controller=Orders", "Orders/{id:int}")]
+    [InlineData("{controller:alpha}/{action:alpha}", "controller=Home,action=Index", "Home/Index")]
+    [InlineData("{controller=Home}/{action=Index}", "controller=Blog", "Blog/{action=Index}")]
+    [InlineData("{controller}-{action}", "controller=Home,action=Index", "Home-Index")]
+    [InlineData("api-{version}-{controller}", "version=v1,controller=Users", "api-v1-Users")]
+    [InlineData("{controller}/{*path}", "controller=Files", "Files/{*path}")]
+    [InlineData("{controller}/{**path}", "controller=Files", "Files/{**path}")]
+    [InlineData("api/{controller}/{id}", "controller=Products", "api/Products/{id}")]
+    [InlineData("api/v1/{controller}", "controller=Users", "api/v1/Users")]
+    [InlineData("{id:int:range(1,100)}", "id=50", "50")]
+    [InlineData("{a}/{b}/{c}", "a=1,c=3", "1/{b}/3")]
+    [InlineData("prefix-{param}-suffix", "param=value", "prefix-value-suffix")]
+    [InlineData("{a:int}/{b:int}/{c:int}", "b=2", "{a:int}/2/{c:int}")]
+    [InlineData("{a:int}/{b:int}/{c:int}", "b=", "{a:int}/{b:int}/{c:int}")] // Empty string should not replace
+    public void DebuggerToString_FuzzTest_ProducesExpectedOutput(string template, string requiredValuesText, string expectedOutput)
+    {
+        // Arrange
+        var requiredValues = ParseRequiredValues(requiredValuesText);
+        var pattern = RoutePatternFactory.Parse(template, defaults: null, parameterPolicies: null, requiredValues: requiredValues);
+
+        // Act
+        var result = pattern.DebuggerToString();
+
+        // Assert
+        Assert.Equal(expectedOutput, result);
+    }
+
+    [Theory]
+    [InlineData("{controller}/{action}/{id?}", "controller=Home,action=Index")]
+    [InlineData("{controller=Home}/{action=Index}/{id?}", "controller=Store,action=Index")]
+    [InlineData("{controller}/{action}", "controller=Products")]
+    [InlineData("{controller}/{id:int}", "controller=Orders")]
+    [InlineData("{controller=Home}/{action=Index}", "controller=Blog")]
+    [InlineData("{controller}-{action}", "controller=Home,action=Index")]
+    [InlineData("api/{controller}/{id}", "controller=Products")]
+    [InlineData("api/v1/{controller}", "controller=Users")]
+    [InlineData("{a}/{b}/{c}", "a=1,c=3")]
+    public void DebuggerToString_FuzzTest_OutputCanBeParsed(string template, string requiredValuesText)
+    {
+        // Arrange
+        var requiredValues = ParseRequiredValues(requiredValuesText);
+        var pattern = RoutePatternFactory.Parse(template, defaults: null, parameterPolicies: null, requiredValues: requiredValues);
+
+        // Act
+        var debugString = pattern.DebuggerToString();
+
+        // Assert - the output should be parseable
+        var reparsed = RoutePatternFactory.Parse(debugString);
+        Assert.NotNull(reparsed);
+    }
+
+    private static RouteValueDictionary ParseRequiredValues(string requiredValuesText)
+    {
+        var requiredValues = new RouteValueDictionary();
+        foreach (var pair in requiredValuesText.Split(','))
+        {
+            var eqIndex = pair.IndexOf('=');
+            var key = pair.Substring(0, eqIndex);
+            var value = pair.Substring(eqIndex + 1);
+            requiredValues[key] = value;
+        }
+        return requiredValues;
+    }
+}

--- a/src/Mvc/Mvc.Core/test/ApplicationModels/EndpointMetadataProviderTest.cs
+++ b/src/Mvc/Mvc.Core/test/ApplicationModels/EndpointMetadataProviderTest.cs
@@ -126,7 +126,7 @@ public class EndpointMetadataProviderTest
             m => Assert.True(m is RouteNameMetadata),
             m => Assert.True(m is SuppressLinkGenerationMetadata),
             m => Assert.True(m is CustomEndpointMetadata { Source: MetadataSource.Finally }),
-            m => Assert.True(m is IRouteDiagnosticsMetadata { Route: "/{controller}/{action}/{id?}" }));
+            m => Assert.True(m is IRouteDiagnosticsMetadata { Route: "/Test/ActionWithParameterMetadata/{id?}" }));
     }
 
     [Theory]


### PR DESCRIPTION
OTEL `http.route` attributes have a new rule: static route parameters should be replaced with the static value.

In the context of ASP.NET Core that means [conventional routes](https://learn.microsoft.com/en-us/aspnet/core/mvc/controllers/routing) should have `{controller}`, `{action}`, `{area}` and `{page}` parameters replaced when the route is added to telemetry.

For example, with conventional route `{controller=Home}/{action=Index}/{id?}`, the `StoreController.Checkout()` endpoint should have a route of `Store/Checkout/{id?}`.

Fixes https://github.com/dotnet/aspnetcore/issues/64852