### PR TITLE
Fix form files when request buffering is enabled

### DIFF
--- a/src/Http/Http/src/Features/FormFeature.cs
+++ b/src/Http/Http/src/Features/FormFeature.cs
@@ -251,9 +251,11 @@ public class FormFeature : IFormFeature
                         var fileSection = new FileMultipartSection(section, contentDisposition);
 
                         // Enable buffering for the file if not already done for the full body
+                        // Only first file can be a reference to buffered body to avoid concurrency issues
                         section.EnableRewind(
                             _request.HttpContext.Response.RegisterForDispose,
-                            _options.MemoryBufferThreshold, _options.MultipartBodyLengthLimit);
+                            _options.MemoryBufferThreshold, _options.MultipartBodyLengthLimit,
+                            forceBuffering: files is not null);
 
                         // Find the end
                         await section.Body.DrainAsync(cancellationToken);

--- a/src/Http/Http/src/Internal/BufferingHelper.cs
+++ b/src/Http/Http/src/Internal/BufferingHelper.cs
@@ -25,16 +25,17 @@ internal static class BufferingHelper
     }
 
     public static MultipartSection EnableRewind(this MultipartSection section, Action<IDisposable> registerForDispose,
-        int bufferThreshold = DefaultBufferThreshold, long? bufferLimit = null)
+        int bufferThreshold = DefaultBufferThreshold, long? bufferLimit = null, bool forceBuffering = false)
     {
         ArgumentNullException.ThrowIfNull(section);
         ArgumentNullException.ThrowIfNull(registerForDispose);
 
         var body = section.Body;
-        if (!body.CanSeek)
+        if (!body.CanSeek || forceBuffering)
         {
             var fileStream = new FileBufferingReadStream(body, bufferThreshold, bufferLimit, AspNetCoreTempDirectory.TempDirectoryFactory);
             section.Body = fileStream;
+            section.BaseStreamOffset = null;
             registerForDispose(fileStream);
         }
         return section;


### PR DESCRIPTION
# Fix form files when request buffering is enabled

When request buffering is enabled, processing files in parallel throws an exception

## Description

When request body buffering is enabled, form files share a single underlying buffering stream. This causes a problem because a `Stream` cannot be read in parallel. When buffering is disabled, this issue does not occur, because each file is buffered separately.

The most straightforward solution is to buffer files regardless of how the request body is handled. However, to avoid negatively affecting performance for requests that contain only one file, the following optimization is applied:
- The first `FormFile` references the request body stream directly (no memory or disk allocation).
- All subsequent files are buffered.

Fixes #64843
