### PR TITLE
Fix @onclick:preventDefault not working with enhanced navigation

### DIFF
--- a/src/Components/Web.JS/src/Rendering/BrowserRenderer.ts
+++ b/src/Components/Web.JS/src/Rendering/BrowserRenderer.ts
@@ -6,6 +6,7 @@ import { EventDelegator } from './Events/EventDelegator';
 import { LogicalElement, PermutationListEntry, toLogicalElement, insertLogicalChild, removeLogicalChild, getLogicalParent, getLogicalChild, createAndInsertLogicalContainer, isSvgElement, isMathMLElement, permuteLogicalChildren, getClosestDomElement, emptyLogicalElement, getLogicalChildrenArray, depthFirstNodeTreeTraversal } from './LogicalElements';
 import { applyCaptureIdToElement } from './ElementReferenceCapture';
 import { attachToEventDelegator as attachNavigationManagerToEventDelegator } from '../Services/NavigationManager';
+import { attachEnhancedNavigationClickHandlerToEventDelegator } from '../Services/NavigationEnhancement';
 import { applyAnyDeferredValue, tryApplySpecialProperty } from './DomSpecialPropertyUtil';
 const sharedTemplateElemForParsing = document.createElement('template');
 const sharedSvgElemForParsing = document.createElementNS('http://www.w3.org/2000/svg', 'g');
@@ -31,6 +32,11 @@ export class BrowserRenderer {
     // we wire up the navigation manager to the event delegator so it has the option to participate
     // in the synthetic event bubbling process later
     attachNavigationManagerToEventDelegator(this.eventDelegator);
+
+    // Similarly, wire up enhanced navigation so that @onclick:preventDefault can be respected.
+    // This ensures enhanced navigation click handling runs after EventDelegator processes Blazor event handlers.
+    // See https://github.com/dotnet/aspnetcore/issues/52514
+    attachEnhancedNavigationClickHandlerToEventDelegator(this.eventDelegator.notifyAfterClick.bind(this.eventDelegator));
   }
 
   public getRootComponentCount(): number {

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/EnhancedNav/PageWithPreventDefaultLink.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/EnhancedNav/PageWithPreventDefaultLink.razor
@@ -1,0 +1,45 @@
+@page "/nav/prevent-default-link"
+@rendermode RenderMode.InteractiveServer
+
+<PageTitle>PreventDefault Link Test</PageTitle>
+
+<h1>PreventDefault Link Test</h1>
+
+<p>
+    This page tests whether <code>@@onclick:preventDefault</code> works correctly with enhanced navigation.
+    See <a href="https://github.com/dotnet/aspnetcore/issues/52514">issue #52514</a>.
+</p>
+
+<h3>Current Count: <span id="current-count">@currentCount</span></h3>
+
+<h4>Test Case 1: Link with preventDefault</h4>
+<p>Click the link below. The counter should increment and you should NOT navigate away.</p>
+<p>
+    <a id="prevent-default-link" href="#" @onclick="IncrementCount" @onclick:preventDefault>
+        Click me (with preventDefault)
+    </a>
+</p>
+
+<h4>Test Case 2: Link with preventDefault AND data-enhance-nav="false" (Workaround)</h4>
+<p>Click the link below. This uses the known workaround.</p>
+<p>
+    <a id="prevent-default-link-with-workaround" href="#" @onclick="IncrementCount" @onclick:preventDefault data-enhance-nav="false">
+        Click me (with workaround)
+    </a>
+</p>
+
+<h4>Test Case 3: Button (Reference)</h4>
+<p>
+    <button id="increment-button" @onclick="IncrementCount">Click me (button)</button>
+</p>
+
+<p id="current-url">Current URL should stay at /nav/prevent-default-link</p>
+
+@code {
+    private int currentCount = 0;
+
+    private void IncrementCount()
+    {
+        currentCount++;
+    }
+}

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Shared/EnhancedNavLayout.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Shared/EnhancedNavLayout.razor
@@ -25,6 +25,7 @@
     <NavLink href="nav/location-changed/server-and-wasm">LocationChanged/LocationChanging event (server-and-wasm)</NavLink>
     <NavLink href="nav/null-parameter/server">Null component parameter (server)</NavLink>
     <NavLink href="nav/null-parameter/wasm">Null component parameter (wasm)</NavLink>
+    <NavLink href="nav/prevent-default-link">PreventDefault link test</NavLink>
     <br />
     <a href="nav/other" data-enhance-nav="false">
         <svg width="100" height="100" id="svg-in-anchor-not-enhanced-nav-link">


### PR DESCRIPTION
## Summary

Fixes #52514

`@onclick:preventDefault` was not functioning when enhanced navigation was enabled. Clicking a link with `@onclick:preventDefault` would still navigate away instead of preventing the default behavior.

## Root Cause

Enhanced navigation's native click handler (`document.addEventListener('click', onDocumentClick)`) was intercepting clicks **before** Blazor's EventDelegator could call `event.preventDefault()` via the `@onclick:preventDefault` directive.

## Solution

Defer enhanced navigation's click handling to EventDelegator's `notifyAfterClick` callback, ensuring it runs **after** Blazor's event handlers have processed the click (including calling `preventDefault` if specified). This follows the same pattern used by `NavigationManager.ts`.

When an EventDelegator is available (interactive scenarios), click handling is deferred to the callback. In pure SSR scenarios without EventDelegator, the native click handler continues to work as before.

## Changes

- **NavigationEnhancement.ts**: Added `attachEnhancedNavigationClickHandlerToEventDelegator()` to register enhanced nav click handling via EventDelegator's `notifyAfterClick` callback
- **BrowserRenderer.ts**: Wire up enhanced navigation to use EventDelegator when a renderer is created
- **E2E test**: Added `PreventDefaultOnClickIsRespectedWithEnhancedNavigation` test to verify the fix
- **Test page**: Added `PageWithPreventDefaultLink.razor` for the E2E test