### PR TITLE
Fix incorrect OpenAPI definition when using FromForm with IEnumerable

### DIFF
--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Frozen;
 using System.ComponentModel;
@@ -665,7 +666,11 @@ internal sealed class OpenApiDocumentService(
                     }
                     else
                     {
-                        if (isComplexType)
+                        // Identify if this is a collection (excluding string)
+                        var isCollection = typeof(IEnumerable).IsAssignableFrom(description.Type) && description.Type != typeof(string);
+
+                        // Only allow non-collection complex types (POCOs) to take over the root body
+                        if (isComplexType && !isCollection)
                         {
                             complexTypeSchema = parameterSchema;
                         }


### PR DESCRIPTION
Fix incorrect OpenAPI schema for single [FromForm] collections

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

Wrap single [FromForm] IEnumerable parameters in an object schema.

Description
This PR fixes a bug in the OpenAPI document generation where a single IEnumerable parameter decorated with [FromForm] was incorrectly serialized as a raw JSON array at the root of the request body.

Because application/x-www-form-urlencoded and multipart/form-data are key-value based formats, a collection must be associated with a field name (key). Previously, the logic identified IEnumerable types as "Complex Types" but failed to recognize that they cannot function as the root schema of a form, unlike POCOs.

Changes:

Added logic to GetFormRequestBody to detect IEnumerable types (excluding string).

Ensured that these collection types are always treated as properties of the form object rather than being assigned to the root complexTypeSchema.

Fixes #62328