### PR TITLE
Update Gradle wrapper to version 9.1.0 and update jdk version in innerloop script

### DIFF
--- a/eng/scripts/InstallJdk.ps1
+++ b/eng/scripts/InstallJdk.ps1
@@ -22,7 +22,7 @@ $installDir = "$repoRoot\.tools\jdk\win-x64\"
 $javacExe = "$installDir\bin\javac.exe"
 $tempDir = "$repoRoot\obj"
 if (-not $JdkVersion) {
-    $JdkVersion = "11.0.24"
+    $JdkVersion = "25.0.1"
 }
 
 if (Test-Path $javacExe) {

--- a/src/SignalR/clients/java/signalr/gradle/wrapper/gradle-wrapper.properties
+++ b/src/SignalR/clients/java/signalr/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=5b9c5eb3f9fc2c94abaea57d90bd78747ca117ddbbf96c859d3741181a12bf2a
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionSha256Sum=a17ddd85a26b6a7f5ddb71ff8b05fc5104c0202c6e64782429790c933686c806
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The Java version on the `windows.vs2022.amd64.open` image got updated from `21.0.8` to `25.0.1` yesterday. This causes build failures:

>   EXEC : error : A restricted method in java.lang.System has been called [D:\a\_work\1\s\src\aspnetcore\src\SignalR\clients\java\signalr\core\signalr.client.java.core.javaproj]
##[error]EXEC(0,0): error : (NETCORE_ENGINEERING_TELEMETRY=Build) A restricted method in java.lang.System has been called
  EXEC : error : java.lang.System::load has been called by net.rubygrapefruit.platform.internal.NativeLibraryLoader in an unnamed module (file:/C:/Users/cloudtest/.gradle/wrapper/dists/gradle-8.10-bin/deqhafrv1ntovfmgh0nh3npr9/gradle-8.10/lib/native-platform-0.22-milestone-26.jar) [D:\a\_work\1\s\src\aspnetcore\src\SignalR\clients\java\signalr\core\signalr.client.java.core.javaproj]
##[error]EXEC(0,0): error : (NETCORE_ENGINEERING_TELEMETRY=Build) java.lang.System::load has been called by net.rubygrapefruit.platform.internal.NativeLibraryLoader in an unnamed module (file:/C:/Users/cloudtest/.gradle/wrapper/dists/gradle-8.10-bin/deqhafrv1ntovfmgh0nh3npr9/gradle-8.10/lib/native-platform-0.22-milestone-26.jar)
  EXEC : error : Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module [D:\a\_work\1\s\src\aspnetcore\src\SignalR\clients\java\signalr\core\signalr.client.java.core.javaproj]
##[error]EXEC(0,0): error : (NETCORE_ENGINEERING_TELEMETRY=Build) Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
  EXEC : error : Restricted methods will be blocked in a future release unless native access is enabled [D:\a\_work\1\s\src\aspnetcore\src\SignalR\clients\java\signalr\core\signalr.client.java.core.javaproj]
##[error]EXEC(0,0): error : (NETCORE_ENGINEERING_TELEMETRY=Build) Restricted methods will be blocked in a future release unless native access is enabled

According to https://docs.gradle.org/current/userguide/compatibility.html, the gradle version needs to be updated to >= 9.1.0.