### PR TITLE
Ensure repeated hyphens are replaced with single hyphens in new projects' localhost host name prefixes

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/.template.config/template.json
@@ -208,6 +208,7 @@
       "steps": [
         "lowerCaseInvariant",
         "replaceDnsInvalidChars",
+        "replaceRepeatedHyphens",
         "trimLeadingHyphens",
         "trimTrailingHyphens"
       ]
@@ -215,6 +216,11 @@
     "replaceDnsInvalidChars": {
       "identifier": "replace",
       "pattern": "[^a-z0-9-]",
+      "replacement": "-"
+    },
+    "replaceRepeatedHyphens": {
+      "identifier": "replace",
+      "pattern": "-{2,}",
       "replacement": "-"
     },
     "trimLeadingHyphens": {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/template.json
@@ -54,6 +54,7 @@
       "steps": [
         "lowerCaseInvariant",
         "replaceDnsInvalidChars",
+        "replaceRepeatedHyphens",
         "trimLeadingHyphens",
         "trimTrailingHyphens"
       ]
@@ -61,6 +62,11 @@
     "replaceDnsInvalidChars": {
       "identifier": "replace",
       "pattern": "[^a-z0-9-]",
+      "replacement": "-"
+    },
+    "replaceRepeatedHyphens": {
+      "identifier": "replace",
+      "pattern": "-{2,}",
       "replacement": "-"
     },
     "trimLeadingHyphens": {

--- a/src/ProjectTemplates/test/Templates.Blazor.Tests/BlazorWebTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Blazor.Tests/BlazorWebTemplateTest.cs
@@ -95,8 +95,9 @@ public class BlazorWebTemplateTest(ProjectFactoryFixture projectFactory) : Blazo
     [InlineData("my.namespace.blazor", "my-namespace-blazor")]
     [InlineData(".StartWithDot", "startwithdot")]
     [InlineData("EndWithDot.", "endwithdot")]
-    [InlineData("My..Test__Project", "my--test--project")]
+    [InlineData("My..Test__Project", "my-test-project")]
     [InlineData("Project123.Test456", "project123-test456")]
+    [InlineData("xn--My.Test.Project", "xn-my-test-project")]
     [SkipOnHelix("Cert failure, https://github.com/dotnet/aspnetcore/issues/28090", Queues = "All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
     public async Task BlazorWebTemplateLocalhostTld_GeneratesDnsCompliantHostnames(string projectName, string expectedHostname)
     {

--- a/src/ProjectTemplates/test/Templates.Tests/EmptyWebTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Tests/EmptyWebTemplateTest.cs
@@ -78,8 +78,9 @@ public class EmptyWebTemplateTest : LoggedTest
     [InlineData("my.namespace.web", "my-namespace-web")]
     [InlineData(".StartWithDot", "startwithdot")]
     [InlineData("EndWithDot.", "endwithdot")]
-    [InlineData("My..Test__Project", "my--test--project")]
+    [InlineData("My..Test__Project", "my-test-project")]
     [InlineData("Project123.Test456", "project123-test456")]
+    [InlineData("xn--My.Test.Project", "xn-my-test-project")]
     [SkipOnHelix("Cert failure, https://github.com/dotnet/aspnetcore/issues/28090", Queues = "All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
     public async Task EmptyWebTemplateLocalhostTld_GeneratesDnsCompliantHostnames(string projectName, string expectedHostname)
     {


### PR DESCRIPTION
# Ensure repeated hyphens are replaced with single hyphens in new projects' localhost host name prefixes

## Description

Ensures that there are no repeated hyphens in the host name generated for new projects that opt-in to the `*.dev.localhost` host name.

Related to #64978
