### PR TITLE
Replace `OwnsOne()` with `ComplexProperty()` for passkey data

### DIFF
--- a/src/Identity/EntityFrameworkCore/src/IdentityUserContext.cs
+++ b/src/Identity/EntityFrameworkCore/src/IdentityUserContext.cs
@@ -287,7 +287,7 @@ public abstract class IdentityUserContext<TUser, TKey, TUserClaim, TUserLogin, T
             b.HasKey(p => p.CredentialId);
             b.ToTable("AspNetUserPasskeys");
             b.Property(p => p.CredentialId).HasMaxLength(1024); // Defined in WebAuthn spec to be no longer than 1023 bytes
-            b.OwnsOne(p => p.Data).ToJson();
+            b.ComplexProperty(p => p.Data).ToJson();
         });
     }
 


### PR DESCRIPTION
Addresses `ToJson()` being deprecated for owned entities.

This change doesn't require customers to migrate their databases, so it's safe to modify the existing schema without introducing a new Identity store schema version.

Fixes https://github.com/dotnet/aspnetcore/issues/65018