### PR TITLE
Remove xcopy-msbuild & vs entries from global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -16,15 +16,6 @@
       "dotnet": [
         "$(MicrosoftInternalRuntimeAspNetCoreTransportVersion)"
       ]
-    },
-    "vs": {
-      "version": "17.14",
-      "components": [
-        "Microsoft.VisualStudio.Component.VC.ATL",
-        "Microsoft.VisualStudio.Component.VC.ATL.ARM64",
-        "Microsoft.VisualStudio.Component.VC.Tools.ARM64",
-        "Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
-      ]
     }
   },
   "native-tools": {

--- a/global.json
+++ b/global.json
@@ -25,8 +25,7 @@
         "Microsoft.VisualStudio.Component.VC.Tools.ARM64",
         "Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
       ]
-    },
-    "xcopy-msbuild": "17.14.16"
+    }
   },
   "native-tools": {
     "jdk": "latest"


### PR DESCRIPTION
We probably don't use this anymore