### PR TITLE
[release/10.0] Backport fixes to templates derived *.dev.localhost hostnames in launch profiles

### DIFF
--- a/src/ProjectTemplates/Shared/ArgConstants.cs
+++ b/src/ProjectTemplates/Shared/ArgConstants.cs
@@ -24,6 +24,7 @@ internal static class ArgConstants
     public const string UseLocalDb = "-uld";
     public const string NoHttps = "--no-https";
     public const string PublishNativeAot = "--aot";
+    public const string LocalhostTld = "--localhost-tld";
     public const string NoInteractivity = "--interactivity none";
     public const string WebAssemblyInteractivity = "--interactivity WebAssembly";
     public const string AutoInteractivity = "--interactivity Auto";

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/.template.config/template.json
@@ -202,7 +202,39 @@
       ]
     }
   ],
+  "forms": {
+    "lowerCaseInvariantWithHyphens": {
+      "identifier": "chain",
+      "steps": [
+        "lowerCaseInvariant",
+        "replaceDnsInvalidChars",
+        "trimLeadingHyphens",
+        "trimTrailingHyphens"
+      ]
+    },
+    "replaceDnsInvalidChars": {
+      "identifier": "replace",
+      "pattern": "[^a-z0-9-]",
+      "replacement": "-"
+    },
+    "trimLeadingHyphens": {
+      "identifier": "replace",
+      "pattern": "^-+",
+      "replacement": ""
+    },
+    "trimTrailingHyphens": {
+      "identifier": "replace",
+      "pattern": "-+$",
+      "replacement": ""
+    }
+  },
   "symbols": {
+    "hostName": {
+      "type": "derived",
+      "valueSource": "name",
+      "valueTransform": "lowerCaseInvariantWithHyphens",
+      "replaces": "LocalhostTldHostNamePrefix"
+    },
     "Framework": {
       "type": "parameter",
       "description": "The target framework for the project.",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/.template.config/template.json
@@ -208,6 +208,7 @@
       "steps": [
         "lowerCaseInvariant",
         "replaceDnsInvalidChars",
+        "replaceRepeatedHyphens",
         "trimLeadingHyphens",
         "trimTrailingHyphens"
       ]
@@ -215,6 +216,11 @@
     "replaceDnsInvalidChars": {
       "identifier": "replace",
       "pattern": "[^a-z0-9-]",
+      "replacement": "-"
+    },
+    "replaceRepeatedHyphens": {
+      "identifier": "replace",
+      "pattern": "-{2,}",
       "replacement": "-"
     },
     "trimLeadingHyphens": {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Properties/launchSettings.json
@@ -10,7 +10,7 @@
         "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
         //#endif
         //#if (LocalhostTld)
-        "applicationUrl": "http://blazorwebcsharp__1.dev.localhost:5500",
+        "applicationUrl": "http://LocalhostTldHostNamePrefix.dev.localhost:5500",
         //#else
         "applicationUrl": "http://localhost:5500",
         //#endif
@@ -32,7 +32,7 @@
         "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
         //#endif
         //#if (LocalhostTld)
-        "applicationUrl": "https://blazorwebcsharp__1.dev.localhost:5501;http://blazorwebcsharp__1.dev.localhost:5500",
+        "applicationUrl": "https://LocalhostTldHostNamePrefix.dev.localhost:5501;http://LocalhostTldHostNamePrefix.dev.localhost:5500",
         //#else
         "applicationUrl": "https://localhost:5501;http://localhost:5500",
         //#endif

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/template.json
@@ -48,7 +48,39 @@
       ]
     }
   ],
+  "forms": {
+    "lowerCaseInvariantWithHyphens": {
+      "identifier": "chain",
+      "steps": [
+        "lowerCaseInvariant",
+        "replaceDnsInvalidChars",
+        "trimLeadingHyphens",
+        "trimTrailingHyphens"
+      ]
+    },
+    "replaceDnsInvalidChars": {
+      "identifier": "replace",
+      "pattern": "[^a-z0-9-]",
+      "replacement": "-"
+    },
+    "trimLeadingHyphens": {
+      "identifier": "replace",
+      "pattern": "^-+",
+      "replacement": ""
+    },
+    "trimTrailingHyphens": {
+      "identifier": "replace",
+      "pattern": "-+$",
+      "replacement": ""
+    }
+  },
   "symbols": {
+    "hostName": {
+      "type": "derived",
+      "valueSource": "name",
+      "valueTransform": "lowerCaseInvariantWithHyphens",
+      "replaces": "LocalhostTldHostNamePrefix"
+    },
     "ExcludeLaunchSettings": {
       "type": "parameter",
       "datatype": "bool",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/template.json
@@ -54,6 +54,7 @@
       "steps": [
         "lowerCaseInvariant",
         "replaceDnsInvalidChars",
+        "replaceRepeatedHyphens",
         "trimLeadingHyphens",
         "trimTrailingHyphens"
       ]
@@ -61,6 +62,11 @@
     "replaceDnsInvalidChars": {
       "identifier": "replace",
       "pattern": "[^a-z0-9-]",
+      "replacement": "-"
+    },
+    "replaceRepeatedHyphens": {
+      "identifier": "replace",
+      "pattern": "-{2,}",
       "replacement": "-"
     },
     "trimLeadingHyphens": {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       //#if (LocalhostTld)
-      "applicationUrl": "http://company_webapplication1.dev.localhost:5000",
+      "applicationUrl": "http://LocalhostTldHostNamePrefix.dev.localhost:5000",
       //#else
       "applicationUrl": "http://localhost:5000",
       //#endif
@@ -24,7 +24,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       //#if (LocalhostTld)
-      "applicationUrl": "https://company_webapplication1.dev.localhost:5001;http://company_webapplication1.dev.localhost:5000",
+      "applicationUrl": "https://LocalhostTldHostNamePrefix.dev.localhost:5001;http://LocalhostTldHostNamePrefix.dev.localhost:5000",
       //#else
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       //#endif

--- a/src/ProjectTemplates/test/Templates.Blazor.Tests/BlazorWebTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Blazor.Tests/BlazorWebTemplateTest.cs
@@ -95,8 +95,9 @@ public class BlazorWebTemplateTest(ProjectFactoryFixture projectFactory) : Blazo
     [InlineData("my.namespace.blazor", "my-namespace-blazor")]
     [InlineData(".StartWithDot", "startwithdot")]
     [InlineData("EndWithDot.", "endwithdot")]
-    [InlineData("My..Test__Project", "my--test--project")]
+    [InlineData("My..Test__Project", "my-test-project")]
     [InlineData("Project123.Test456", "project123-test456")]
+    [InlineData("xn--My.Test.Project", "xn-my-test-project")]
     [SkipOnHelix("Cert failure, https://github.com/dotnet/aspnetcore/issues/28090", Queues = "All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
     public async Task BlazorWebTemplateLocalhostTld_GeneratesDnsCompliantHostnames(string projectName, string expectedHostname)
     {

--- a/src/ProjectTemplates/test/Templates.Tests/EmptyWebTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Tests/EmptyWebTemplateTest.cs
@@ -78,8 +78,9 @@ public class EmptyWebTemplateTest : LoggedTest
     [InlineData("my.namespace.web", "my-namespace-web")]
     [InlineData(".StartWithDot", "startwithdot")]
     [InlineData("EndWithDot.", "endwithdot")]
-    [InlineData("My..Test__Project", "my--test--project")]
+    [InlineData("My..Test__Project", "my-test-project")]
     [InlineData("Project123.Test456", "project123-test456")]
+    [InlineData("xn--My.Test.Project", "xn-my-test-project")]
     [SkipOnHelix("Cert failure, https://github.com/dotnet/aspnetcore/issues/28090", Queues = "All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
     public async Task EmptyWebTemplateLocalhostTld_GeneratesDnsCompliantHostnames(string projectName, string expectedHostname)
     {

--- a/src/ProjectTemplates/test/Templates.Tests/ItemTemplateTests/BlazorServerTests.cs
+++ b/src/ProjectTemplates/test/Templates.Tests/ItemTemplateTests/BlazorServerTests.cs
@@ -29,7 +29,7 @@ public class BlazorServerTest
     {
         Project = await ProjectFactory.CreateProject(Output);
 
-        await Project.RunDotNetNewAsync("razorcomponent --name Different", isItemTemplate: true);
+        await Project.RunDotNetNewAsync("razorcomponent", isItemTemplate: true, args: ["--name", "Different"]);
 
         Project.AssertFileExists("Different.razor", shouldExist: true);
         Assert.Contains("<h3>Different</h3>", Project.ReadFile("Different.razor"));


### PR DESCRIPTION
# Backport fixes to templates derived *.dev.localhost hostnames in launch profiles

Backports fixes to the empty and blazor web templates that ensure that host name prefixes generated for new projects that opt-in to the `--localhost-tld` option don't violate RFC 952/1123.

## Description

The template/tooling generates DNS names (e.g., hostnames or domain labels) that contain underscores (_) when the user opts-in to the `--localhost-tld` template option and the project name includes characters that are invalid in a C# class name. According to DNS hostname specifications (RFC 952 and RFC 1123), underscores are not valid characters in hostnames. This causes failures in environments and libraries that strictly validate DNS names (e.g., Kubernetes, Docker, cloud DNS, and DNS client libraries).

Fixes #64978

## Customer Impact

Currently when opting in to using `*.dev.localhost` host names for a new project using the empty or blazor web project templates, depending on the name given to the project the generated host name prefix used in the project launch profiles may violate rules in RFC 952/1123 which can lead to it causing errors or being rejected in other systems during local development, e.g.:

- DNS resolution errors in client libraries.
- Browser can refuse to parse the host name if it starts with `xn--` and is followed by characters that would make it an invalid IDN name.
- Operational inconsistencies if environments silently mutate invalid names.
- Developer confusion when template output contradicts DNS standards.

The generated host name can be edited directly in the project's `Properties/launchSettings.json` file to workaround this issue once the project is created.

## Regression?

- [x] No

The option was newly added in .NET 10 and has had this behavior since its inclusion.

## Risk

- [x] Low

Change to the template declared symbols and transforms only using established templating system capabilities.

## Verification

- [x] Manual (required)
- [x] Automated

Unit tests are included.

## Packaging changes reviewed?

- [x] N/A