### PR TITLE
[wasm][coreCLR] do not use mono internals - alternate

### DIFF
--- a/src/Components/Components/src/Rendering/RenderTreeUpdater.cs
+++ b/src/Components/Components/src/Rendering/RenderTreeUpdater.cs
@@ -19,7 +19,7 @@ internal sealed class RenderTreeUpdater
             }
             else if (OperatingSystem.IsBrowser() && !boolValue)
             {
-                newFieldValue = "\u2400"; // Unicode symbol for null
+                newFieldValue = null!;
             }
         }
         else if (!(newFieldValue is string))

--- a/src/Components/Components/src/Rendering/RenderTreeUpdater.cs
+++ b/src/Components/Components/src/Rendering/RenderTreeUpdater.cs
@@ -11,7 +11,18 @@ internal sealed class RenderTreeUpdater
     {
         // We only allow the client to supply string or bool currently, since those are the only kinds of
         // values we output on attributes that go to the client
-        if (!(newFieldValue is string || newFieldValue is bool))
+        if (newFieldValue is bool boolValue)
+        {
+            if (OperatingSystem.IsBrowser() && boolValue)
+            {
+                newFieldValue = "\u22A8"; // Unicode symbol for true
+            }
+            else if (OperatingSystem.IsBrowser() && !boolValue)
+            {
+                newFieldValue = "\u2400"; // Unicode symbol for null
+            }
+        }
+        else if (!(newFieldValue is string))
         {
             return;
         }

--- a/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
@@ -98,8 +98,6 @@ export const monoPlatform: Platform = {
       // If the stored value is a bool, the behavior we want is empty string ('') for true, or null for false.
       if (value === '\u22A8') {
         return '';
-      } else if (value === '\u2400') {
-        return null;
       }
     }
     return value;


### PR DESCRIPTION
- detect Mono runtime and only use it's internal functions when available
- re-implement rendering raw memory walk for CoreCLR
- always serialize boolean as strings

Fixes https://github.com/dotnet/runtime/issues/122939
