### PR TITLE
Add -CentralizedRestore to avoid NuGet parallel restore race conditions

### DIFF
--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -129,6 +129,7 @@ stages:
                 -ci
                 -prepareMachine
                 -nativeToolsOnMachine
+                -CentralizedRestore
                 -arch x64
                 -pack
                 -all
@@ -570,7 +571,7 @@ stages:
         timeoutInMinutes: 240
         steps:
         # Build the shared framework
-        - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -nobl -all -pack -arch x64
+        - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -CentralizedRestore -nobl -all -pack -arch x64
                   /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
                   /p:VsTestUseMSBuildOutput=false
           displayName: Build shared fx
@@ -599,7 +600,7 @@ stages:
         timeoutInMinutes: 240
         steps:
         # Build the shared framework
-        - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -nobl -all -pack -arch x64
+        - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -CentralizedRestore -nobl -all -pack -arch x64
                   /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
                   /p:VsTestUseMSBuildOutput=false
           displayName: Build shared fx

--- a/.azure/pipelines/ci-unofficial.yml
+++ b/.azure/pipelines/ci-unofficial.yml
@@ -148,6 +148,7 @@ extends:
                     -ci
                     -prepareMachine
                     -nativeToolsOnMachine
+                    -CentralizedRestore
                     -arch x64
                     -pack
                     -all
@@ -608,7 +609,7 @@ extends:
               displayName: Update submodules
             steps:
             # Build the shared framework
-            - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -nobl -all -pack -arch x64
+            - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -CentralizedRestore -nobl -all -pack -arch x64
                       /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
               env:
                 MSBUILDUSESERVER: "1"
@@ -640,7 +641,7 @@ extends:
               displayName: Update submodules
             steps:
             # Build the shared framework
-            - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -nobl -all -pack -arch x64
+            - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -CentralizedRestore -nobl -all -pack -arch x64
                       /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
               env:
                 MSBUILDUSESERVER: "1"

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -169,6 +169,7 @@ extends:
                     -ci
                     -prepareMachine
                     -nativeToolsOnMachine
+                    -CentralizedRestore
                     -arch x64
                     -pack
                     -all
@@ -600,7 +601,7 @@ extends:
             timeoutInMinutes: 240
             steps:
             # Build the shared framework
-            - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -nobl -all -pack -arch x64
+            - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -CentralizedRestore -nobl -all -pack -arch x64
                       /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
               env:
                 MSBUILDUSESERVER: "1"
@@ -629,7 +630,7 @@ extends:
             timeoutInMinutes: 240
             steps:
             # Build the shared framework
-            - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -nobl -all -pack -arch x64
+            - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -CentralizedRestore -nobl -all -pack -arch x64
                       /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
               env:
                 MSBUILDUSESERVER: "1"

--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -57,7 +57,7 @@ jobs:
     timeoutInMinutes: 150
     steps:
     # Build the shared framework
-    - script: ./eng/build.cmd -ci -prepareMachine -nobl -all -noBuildJava -pack -arch x64
+    - script: ./eng/build.cmd -ci -prepareMachine -CentralizedRestore -nobl -all -noBuildJava -pack -arch x64
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Build shared fx
     # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
@@ -84,7 +84,7 @@ jobs:
     isAzDOTestingJob: true
     enablePublishTestResults: false
     steps:
-    - script: ./eng/build.cmd -ci -prepareMachine -nobl -all -noBuildJava -pack
+    - script: ./eng/build.cmd -ci -prepareMachine -CentralizedRestore -nobl -all -noBuildJava -pack
       displayName: Build
     - script: ./eng/build.cmd -ci -prepareMachine -nobl -all -noBuildRepoTasks -noBuildNative -NoBuild -noBuildJava -test
               /p:RunQuarantinedTests=true /p:SkipHelixReadyTests=true

--- a/.azure/pipelines/quarantined-tests.yml
+++ b/.azure/pipelines/quarantined-tests.yml
@@ -27,7 +27,7 @@ jobs:
     timeoutInMinutes: 480
     steps:
     # Build the shared framework
-    - script: ./eng/build.cmd -ci -prepareMachine -nobl -all -noBuildJava -pack -arch x64
+    - script: ./eng/build.cmd -ci -prepareMachine -CentralizedRestore -nobl -all -noBuildJava -pack -arch x64
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Build shared fx
     # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.

--- a/eng/CentralizedRestore.proj
+++ b/eng/CentralizedRestore.proj
@@ -1,0 +1,73 @@
+<Project>
+  <!--
+    Centralized restore project that restores ALL projects in a single MSBuild invocation.
+    This avoids the NuGet race condition (https://github.com/NuGet/Home/issues/7648) where
+    parallel restore of the same project from multiple callers causes "Cannot create a file
+    when that file already exists" errors.
+
+    Usage in CI:
+      ./eng/build.cmd -ci -CentralizedRestore ...
+
+    Or manually:
+      dotnet restore AspNetCore.slnx
+      dotnet msbuild eng/CentralizedRestore.proj /t:RestoreDelayedOnly /p:Configuration=Release
+      ./eng/build.cmd -ci -NoRestore /p:RestoreForTestAssets=false /p:RestoreForDelayedProjects=false ...
+  -->
+
+  <Import Project="RequiresDelayedBuildProjects.props" />
+
+  <PropertyGroup>
+    <RepoRoot Condition="'$(RepoRoot)' == ''">$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', '..'))</RepoRoot>
+  </PropertyGroup>
+
+  <!--
+    Restore only delayed build projects and test assets (projects not in the main solution).
+    Called after `dotnet restore AspNetCore.slnx` to complete the restore.
+  -->
+  <Target Name="RestoreDelayedOnly">
+    <Message Importance="High" Text="======================================" />
+    <Message Importance="High" Text="Restoring delayed build projects and test assets" />
+    <Message Importance="High" Text="======================================" />
+
+    <!-- Filter to only restorable projects (not .proj or .nodeproj) -->
+    <ItemGroup>
+      <_DelayedProjectsToRestore Include="@(RequiresDelayedBuild)"
+          Condition="'%(Extension)' != '.nodeproj' AND '%(Extension)' != '.proj'" />
+    </ItemGroup>
+
+    <MSBuild Projects="@(_DelayedProjectsToRestore)"
+        Targets="Restore"
+        BuildInParallel="false"
+        Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid())" />
+
+    <Message Importance="High" Text="======================================" />
+    <Message Importance="High" Text="Delayed projects restore complete" />
+    <Message Importance="High" Text="======================================" />
+  </Target>
+
+  <!--
+    Full restore of everything - alternative to solution-based restore.
+    Slower but more comprehensive.
+  -->
+  <Target Name="RestoreAll">
+    <Message Importance="High" Text="======================================" />
+    <Message Importance="High" Text="Centralized Restore - Restoring all projects" />
+    <Message Importance="High" Text="======================================" />
+
+    <Exec Command="dotnet restore &quot;$(RepoRoot)AspNetCore.slnx&quot;" />
+
+    <ItemGroup>
+      <_DelayedProjectsToRestore Include="@(RequiresDelayedBuild)"
+          Condition="'%(Extension)' != '.nodeproj' AND '%(Extension)' != '.proj'" />
+    </ItemGroup>
+
+    <MSBuild Projects="@(_DelayedProjectsToRestore)"
+        Targets="Restore"
+        BuildInParallel="false"
+        Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid())" />
+
+    <Message Importance="High" Text="======================================" />
+    <Message Importance="High" Text="Centralized Restore Complete" />
+    <Message Importance="High" Text="======================================" />
+  </Target>
+</Project>

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -497,6 +497,12 @@ try {
         Write-Host "===== Centralized Restore =====" -ForegroundColor Cyan
         Write-Host "Restoring all projects upfront to avoid NuGet parallel restore race conditions" -ForegroundColor Cyan
 
+        # Create artifacts package directories so projects that reference them as RestoreAdditionalProjectSources
+        # don't fail restore (e.g., InteropWebsite.csproj references ArtifactsShippingPackagesDir)
+        $packagesDir = "$RepoRoot\artifacts\packages\$Configuration"
+        New-Item -ItemType Directory -Force -Path "$packagesDir\Shipping" | Out-Null
+        New-Item -ItemType Directory -Force -Path "$packagesDir\NonShipping" | Out-Null
+
         # Restore via the solution file with --disable-parallel to avoid NuGet internal race conditions
         # NuGet's RestoreTask is not thread-safe when same project is restored in parallel
         Write-Host "Restoring AspNetCore.slnx (sequential)..." -ForegroundColor Yellow

--- a/eng/targets/FunctionalTestWithAssets.targets
+++ b/eng/targets/FunctionalTestWithAssets.targets
@@ -37,8 +37,13 @@
     <!--
       These are separate invocations to ensure Publish sees restored setup. Platform and PlatformTarget removals
       are to fix builds inside VS.
+
+      When CentralizedRestore is true, skip restore here because test assets are already restored via the
+      solution file. This avoids NuGet race condition where parallel restore of the same project causes
+      "Cannot create a file when that file already exists" errors. See https://github.com/NuGet/Home/issues/7648
     -->
     <MSBuild Projects="@(_ProjectsToPublish->WithMetadataValue('SkipBuild', 'false'))"
+        Condition="'$(CentralizedRestore)' != 'true'"
         BuildInParallel="$(BuildInParallel)"
         Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid())"
         RemoveProperties="Platform;PlatformTarget"

--- a/src/BuildAfterTargetingPack/BuildAfterTargetingPack.csproj
+++ b/src/BuildAfterTargetingPack/BuildAfterTargetingPack.csproj
@@ -4,6 +4,13 @@
     <IsUnitTestProject Condition=" '$(SkipTestBuild)' == 'true' ">false</IsUnitTestProject>
     <IsUnitTestProject Condition=" '$(SkipTestBuild)' != 'true' ">true</IsUnitTestProject>
     <IsTestProject>$(IsUnitTestProject)</IsTestProject>
+    <!--
+      Use sequential restore when CentralizedRestore is enabled to avoid NuGet race condition where
+      parallel restore of the same project causes "Cannot create a file when that file already exists" errors.
+      See https://github.com/NuGet/Home/issues/7648
+    -->
+    <_RestoreInParallel Condition="'$(CentralizedRestore)' != 'true'">true</_RestoreInParallel>
+    <_RestoreInParallel Condition="'$(CentralizedRestore)' == 'true'">false</_RestoreInParallel>
   </PropertyGroup>
 
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
@@ -44,13 +51,8 @@
       BeforeTargets="Build"
       Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64') "
       Returns="@(TargetPathWithTargetPlatformMoniker)">
-    <!--
-      Use sequential restore when CentralizedRestore is enabled to avoid NuGet race condition where
-      parallel restore of the same project causes "Cannot create a file when that file already exists" errors.
-      See https://github.com/NuGet/Home/issues/7648
-    -->
     <MSBuild Projects="@(RequiresDelayedBuild)"
-        BuildInParallel="'$(CentralizedRestore)' != 'true'"
+        BuildInParallel="$(_RestoreInParallel)"
         Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid())"
         Targets="Restore" />
     <MSBuild Projects="@(RequiresDelayedBuild)" BuildInParallel="$(BuildInParallel)" Targets="Build">

--- a/src/BuildAfterTargetingPack/BuildAfterTargetingPack.csproj
+++ b/src/BuildAfterTargetingPack/BuildAfterTargetingPack.csproj
@@ -44,8 +44,13 @@
       BeforeTargets="Build"
       Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64') "
       Returns="@(TargetPathWithTargetPlatformMoniker)">
+    <!--
+      Use sequential restore when CentralizedRestore is enabled to avoid NuGet race condition where
+      parallel restore of the same project causes "Cannot create a file when that file already exists" errors.
+      See https://github.com/NuGet/Home/issues/7648
+    -->
     <MSBuild Projects="@(RequiresDelayedBuild)"
-        BuildInParallel="$(BuildInParallel)"
+        BuildInParallel="'$(CentralizedRestore)' != 'true'"
         Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid())"
         Targets="Restore" />
     <MSBuild Projects="@(RequiresDelayedBuild)" BuildInParallel="$(BuildInParallel)" Targets="Build">


### PR DESCRIPTION
# Avoid "Cannot create a file when that file already exists" on CI

```
.dotnet\sdk\11.0.100-alpha.1.25618.104\NuGet.targets(196,5): error : (NETCORE_ENGINEERING_TELEMETRY=Build) Cannot create a file when that file already exists.
```
[parallel-restore-log.txt](https://github.com/user-attachments/files/24642658/parallel-restore-log.txt)

This happens very often on our CI, e.g. [build](https://github.com/dotnet/aspnetcore/pull/65058/checks?check_run_id=60453843952). Rerun fixes it but it also prolongs the time from posting PR to merging it and is annoying. The issue is reported here: https://github.com/NuGet/Home/issues/7648.

## Description

By default, we are restoring in parallel. `BuildInParallel=true` is set in `dotnet\sdk\*.*.*\Microsoft.Common.CurrentVersion.targets` shipped with the sdk:
```
<BuildInParallel Condition="'$(BuildInParallel)' == ''">true</BuildInParallel>
```

When `BuildInParallel="true"`, MSBuild invokes restore on multiple projects simultaneously. NuGet's `RestoreTask` is not thread-safe when:

- Multiple projects share the same dependency
- NuGet tries to download/extract the same package to the same location concurrently
- Two threads race to create the same file in the global packages folder

It is known and reported in https://github.com/NuGet/Home/issues/7648.

The NuGet issue mentions a workaround. If we managed to perform a single coordinated restore of all projects upfront before the build starts, then run the actual build with restore disabled, it would avoid NuGet's internal race condition where parallel restores of projects with shared dependencies can conflict.

## Details

There are 5 places with `Targets="Restore"`:

| File | What it restores | Fix when CentralizedRestore=true |
|------|------------------|----------------------------------|
| **FunctionalTestWithAssets.targets** | Test asset projects (in solution) | **Skip** - already restored by upfront `dotnet restore AspNetCore.slnx --disable-parallel` |
| **BuildAfterTargetingPack.csproj** | `RequiresDelayedBuild` projects (need targeting pack first) | **Sequential** - can't restore upfront, so use `BuildInParallel=false` to avoid race condition |
| **trimmingTests.targets** | Trimming test console apps | No change needed - already sequential (batched with `%`) |
| **SiteExtension.targets** | Hosting startup packages | No change needed - already sequential (batched with `%`) |
| **Tools.props** | GenerateFiles.csproj (single project) | No change needed - single project, no race condition |

1) `CentralizedRestore` flag in build.ps1 - When it is set, it:

* Restores AspNetCore.slnx with --disable-parallel
* Generates build files (GenerateFiles.csproj)
* Disables per-project restore during build (/p:Restore=false)
* FunctionalTestWithAssets.targets - Skip test asset restore when CentralizedRestore=true (already restored upfront)

2) `BuildAfterTargetingPack.csproj` - Use sequential restore (`BuildInParallel=false`) for delayed projects when `CentralizedRestore=true` (these projects can't be restored upfront because they depend on the targeting pack being built first)

## Performance impact

Running locally (always after `./clean.cmd`) it's actually faster but I took only 1 sample:
Originally: 131.6s
`CentralizedRestore=true`: 111.8s

## Does it fix the issue?

It's hard to reproduce the race but we could re-run this PR a few times.