### PR TITLE
Disable parallel restore for BuildAfterTargetingPack projects

### DIFF
--- a/src/BuildAfterTargetingPack/BuildAfterTargetingPack.csproj
+++ b/src/BuildAfterTargetingPack/BuildAfterTargetingPack.csproj
@@ -49,8 +49,8 @@
       Condition=" '$(DotNetBuildSourceOnly)' != 'true' AND ('$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64') "
       Returns="@(TargetPathWithTargetPlatformMoniker)">
     <MSBuild Projects="@(RequiresDelayedBuild)"
-        BuildInParallel="$(BuildInParallel)"
-        Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid())"
+        BuildInParallel="false"
+        Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid());RestoreDisableParallel=true"
         Targets="Restore" />
     <MSBuild Projects="@(RequiresDelayedBuild)" BuildInParallel="$(BuildInParallel)" Targets="Build">
       <Output TaskParameter="TargetOutputs" ItemName="TargetPathWithTargetPlatformMoniker" />

--- a/src/Framework/Microsoft.Internal.Aspnetcore.DotNetApiDocs.Transport/src/Microsoft.Internal.Aspnetcore.DotNetApiDocs.Transport.csproj
+++ b/src/Framework/Microsoft.Internal.Aspnetcore.DotNetApiDocs.Transport/src/Microsoft.Internal.Aspnetcore.DotNetApiDocs.Transport.csproj
@@ -15,8 +15,6 @@
     <IsProjectReferenceProvider>false</IsProjectReferenceProvider>
     <BuildHelixPayload>false</BuildHelixPayload>
     <EnablePackageValidation>false</EnablePackageValidation>
-    <!-- Work around https://github.com/dotnet/aspnetcore/issues/61178 -->
-    <RestoreDisableParallel>true</RestoreDisableParallel>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Grpc/JsonTranscoding/Directory.Build.props
+++ b/src/Grpc/JsonTranscoding/Directory.Build.props
@@ -8,9 +8,6 @@
     <!-- Required because Swashbuckle.AspNetCore uses shared runtime -->
     <UseAspNetCoreSharedRuntime>true</UseAspNetCoreSharedRuntime>
 
-    <!-- Work around https://github.com/dotnet/aspnetcore/issues/61178 -->
-    <RestoreDisableParallel>true</RestoreDisableParallel>
-
     <!-- Workaround lack of Linux MUSL x64 support. -->
     <ExcludeFromBuild
         Condition=" '$(TargetOsName)' == 'linux-musl' and '$(TargetArchitecture)' == 'x64' ">true</ExcludeFromBuild>


### PR DESCRIPTION
Improvement on dotnet/aspnetcore#65040, inspired by https://github.com/dotnet/aspnetcore/pull/65069