### PR TITLE
Pool ResponseBufferingStream in HttpLoggingMiddleware

### DIFF
--- a/src/Middleware/HttpLogging/src/HttpLoggingMiddleware.cs
+++ b/src/Middleware/HttpLogging/src/HttpLoggingMiddleware.cs
@@ -193,7 +193,7 @@ internal sealed class HttpLoggingMiddleware
             {
                 originalUpgradeFeature = context.Features.Get<IHttpUpgradeFeature>();
 
-                if (originalUpgradeFeature != null && originalUpgradeFeature.IsUpgradableRequest)
+                if (originalUpgradeFeature is not null && originalUpgradeFeature.IsUpgradableRequest)
                 {
                     loggableUpgradeFeature = new UpgradeFeatureLoggingDecorator(originalUpgradeFeature,
                         logContext, options, _interceptors, _logger);
@@ -268,24 +268,24 @@ internal sealed class HttpLoggingMiddleware
         }
         finally
         {
-            if (responseBufferingStream != null)
+            if (responseBufferingStream is not null)
             {
                 _responseBufferingStreamPool.Return(responseBufferingStream);
             }
 
-            if (originalBodyFeature != null)
+            if (originalBodyFeature is not null)
             {
                 context.Features.Set(originalBodyFeature);
             }
 
             requestBufferingStream?.Dispose();
 
-            if (originalBody != null)
+            if (originalBody is not null)
             {
                 context.Request.Body = originalBody;
             }
 
-            if (loggableUpgradeFeature != null)
+            if (loggableUpgradeFeature is not null)
             {
                 context.Features.Set(originalUpgradeFeature);
             }
@@ -302,12 +302,12 @@ internal sealed class HttpLoggingMiddleware
 
     private static bool BodyNotYetWritten(ResponseBufferingStream? responseBufferingStream)
     {
-        return responseBufferingStream == null || responseBufferingStream.HeadersWritten == false;
+        return responseBufferingStream is null || responseBufferingStream.HeadersWritten == false;
     }
 
     private static bool NotUpgradeableRequestOrRequestNotUpgraded(UpgradeFeatureLoggingDecorator? upgradeFeatureLogging)
     {
-        return upgradeFeatureLogging == null || !upgradeFeatureLogging.IsUpgraded;
+        return upgradeFeatureLogging is null || !upgradeFeatureLogging.IsUpgraded;
     }
 
     // Called from the response body stream sync Write and Flush APIs. These are disabled by the server by default, so we're not as worried about the sync-over-async code needed here.

--- a/src/Middleware/HttpLogging/src/HttpLoggingServicesExtensions.cs
+++ b/src/Middleware/HttpLogging/src/HttpLoggingServicesExtensions.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.HttpLogging;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.ObjectPool;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -22,7 +23,7 @@ public static class HttpLoggingServicesExtensions
         ArgumentNullException.ThrowIfNull(services);
         
         services.TryAddSingleton(ObjectPool.ObjectPool.Create<HttpLoggingInterceptorContext>());
-        services.TryAddSingleton(ObjectPool.ObjectPool.Create(new ResponseBufferingStreamPooledObjectPolicy()));
+        services.TryAddSingleton(new DefaultObjectPoolProvider().Create(new ResponseBufferingStreamPooledObjectPolicy()));
         services.TryAddSingleton(TimeProvider.System);
         return services;
     }

--- a/src/Middleware/HttpLogging/src/HttpLoggingServicesExtensions.cs
+++ b/src/Middleware/HttpLogging/src/HttpLoggingServicesExtensions.cs
@@ -22,6 +22,7 @@ public static class HttpLoggingServicesExtensions
         ArgumentNullException.ThrowIfNull(services);
         
         services.TryAddSingleton(ObjectPool.ObjectPool.Create<HttpLoggingInterceptorContext>());
+        services.TryAddSingleton(ObjectPool.ObjectPool.Create(new ResponseBufferingStreamPooledObjectPolicy()));
         services.TryAddSingleton(TimeProvider.System);
         return services;
     }

--- a/src/Middleware/HttpLogging/src/ResponseBufferingStream.cs
+++ b/src/Middleware/HttpLogging/src/ResponseBufferingStream.cs
@@ -6,18 +6,19 @@ using System.IO.Pipelines;
 using System.Text;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.AspNetCore.HttpLogging;
 
 internal sealed class ResponseBufferingStream : BufferingStream, IHttpResponseBodyFeature
 {
-    private readonly IHttpResponseBodyFeature _innerBodyFeature;
+    private IHttpResponseBodyFeature _innerBodyFeature = null!;
     private int _limit;
     private PipeWriter? _pipeAdapter;
 
-    private readonly HttpLoggingInterceptorContext _logContext;
-    private readonly HttpLoggingOptions _options;
-    private readonly IHttpLoggingInterceptor[] _interceptors;
+    private HttpLoggingInterceptorContext _logContext = null!;
+    private HttpLoggingOptions _options = null!;
+    private IHttpLoggingInterceptor[] _interceptors = Array.Empty<IHttpLoggingInterceptor>();
     private bool _logBody;
     private bool _hasLogged;
     private Encoding? _encoding;
@@ -25,18 +26,60 @@ internal sealed class ResponseBufferingStream : BufferingStream, IHttpResponseBo
 
     private static readonly StreamPipeWriterOptions _pipeWriterOptions = new StreamPipeWriterOptions(leaveOpen: true);
 
-    internal ResponseBufferingStream(IHttpResponseBodyFeature innerBodyFeature,
+    /// <summary>
+    /// Parameterless constructor for object pooling.
+    /// </summary>
+    internal ResponseBufferingStream()
+        : base(Stream.Null, NullLogger.Instance)
+    {
+    }
+
+    /// <summary>
+    /// Initializes the stream for a new request. Call this after obtaining from the pool.
+    /// </summary>
+    internal void Initialize(
+        IHttpResponseBodyFeature innerBodyFeature,
         ILogger logger,
         HttpLoggingInterceptorContext logContext,
         HttpLoggingOptions options,
         IHttpLoggingInterceptor[] interceptors)
-        : base(innerBodyFeature.Stream, logger)
     {
         _innerBodyFeature = innerBodyFeature;
         _innerStream = innerBodyFeature.Stream;
+        _logger = logger;
         _logContext = logContext;
         _options = options;
         _interceptors = interceptors;
+        // Reset transient state
+        _limit = 0;
+        _pipeAdapter = null;
+        _logBody = false;
+        _hasLogged = false;
+        _encoding = null;
+        _bodyBeforeClose = null;
+        HeadersWritten = false;
+    }
+
+    /// <summary>
+    /// Resets the stream state for returning to the pool.
+    /// </summary>
+    internal void ResetForPool()
+    {
+        _innerBodyFeature = null!;
+        _innerStream = Stream.Null;
+        _logger = NullLogger.Instance;
+        _logContext = null!;
+        _options = null!;
+        _interceptors = Array.Empty<IHttpLoggingInterceptor>();
+        _pipeAdapter = null;
+        _encoding = null;
+        _bodyBeforeClose = null;
+        _limit = 0;
+        _logBody = false;
+        _hasLogged = false;
+        HeadersWritten = false;
+        // Reset base class buffer state
+        Reset();
     }
 
     public bool HeadersWritten { get; private set; }

--- a/src/Middleware/HttpLogging/src/ResponseBufferingStream.cs
+++ b/src/Middleware/HttpLogging/src/ResponseBufferingStream.cs
@@ -18,7 +18,7 @@ internal sealed class ResponseBufferingStream : BufferingStream, IHttpResponseBo
 
     private HttpLoggingInterceptorContext _logContext = null!;
     private HttpLoggingOptions _options = null!;
-    private IHttpLoggingInterceptor[] _interceptors = Array.Empty<IHttpLoggingInterceptor>();
+    private IHttpLoggingInterceptor[] _interceptors = [];
     private bool _logBody;
     private bool _hasLogged;
     private Encoding? _encoding;
@@ -70,7 +70,7 @@ internal sealed class ResponseBufferingStream : BufferingStream, IHttpResponseBo
         _logger = NullLogger.Instance;
         _logContext = null!;
         _options = null!;
-        _interceptors = Array.Empty<IHttpLoggingInterceptor>();
+        _interceptors = [];
         _pipeAdapter = null;
         _encoding = null;
         _bodyBeforeClose = null;

--- a/src/Middleware/HttpLogging/src/ResponseBufferingStreamPooledObjectPolicy.cs
+++ b/src/Middleware/HttpLogging/src/ResponseBufferingStreamPooledObjectPolicy.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.ObjectPool;
+
+namespace Microsoft.AspNetCore.HttpLogging;
+
+/// <summary>
+/// A <see cref="PooledObjectPolicy{T}"/> for <see cref="ResponseBufferingStream"/>.
+/// </summary>
+internal sealed class ResponseBufferingStreamPooledObjectPolicy : PooledObjectPolicy<ResponseBufferingStream>
+{
+    /// <inheritdoc />
+    public override ResponseBufferingStream Create()
+    {
+        return new ResponseBufferingStream();
+    }
+
+    /// <inheritdoc />
+    public override bool Return(ResponseBufferingStream obj)
+    {
+        obj.ResetForPool();
+        return true;
+    }
+}

--- a/src/Middleware/HttpLogging/test/HttpLoggingMiddlewareTests.cs
+++ b/src/Middleware/HttpLogging/test/HttpLoggingMiddlewareTests.cs
@@ -44,6 +44,7 @@ public class HttpLoggingMiddlewareTests : LoggedTest
             LoggerFactory.CreateLogger<HttpLoggingMiddleware>(),
             Array.Empty<IHttpLoggingInterceptor>(),
             ObjectPool.Create<HttpLoggingInterceptorContext>(),
+            ObjectPool.Create(new ResponseBufferingStreamPooledObjectPolicy()),
             TimeProvider.System));
 
         Assert.Throws<ArgumentNullException>(() => new HttpLoggingMiddleware(c =>
@@ -54,6 +55,7 @@ public class HttpLoggingMiddlewareTests : LoggedTest
             LoggerFactory.CreateLogger<HttpLoggingMiddleware>(),
             Array.Empty<IHttpLoggingInterceptor>(),
             ObjectPool.Create<HttpLoggingInterceptorContext>(),
+            ObjectPool.Create(new ResponseBufferingStreamPooledObjectPolicy()),
             TimeProvider.System));
 
         Assert.Throws<ArgumentNullException>(() => new HttpLoggingMiddleware(c =>
@@ -64,6 +66,7 @@ public class HttpLoggingMiddlewareTests : LoggedTest
             null,
             Array.Empty<IHttpLoggingInterceptor>(),
             ObjectPool.Create<HttpLoggingInterceptorContext>(),
+            ObjectPool.Create(new ResponseBufferingStreamPooledObjectPolicy()),
             TimeProvider.System));
 
         Assert.Throws<ArgumentNullException>(() => new HttpLoggingMiddleware(c =>
@@ -74,6 +77,7 @@ public class HttpLoggingMiddlewareTests : LoggedTest
             LoggerFactory.CreateLogger<HttpLoggingMiddleware>(),
             null,
             ObjectPool.Create<HttpLoggingInterceptorContext>(),
+            ObjectPool.Create(new ResponseBufferingStreamPooledObjectPolicy()),
             TimeProvider.System));
 
         Assert.Throws<ArgumentNullException>(() => new HttpLoggingMiddleware(c =>
@@ -83,6 +87,18 @@ public class HttpLoggingMiddlewareTests : LoggedTest
             CreateOptionsAccessor(),
             LoggerFactory.CreateLogger<HttpLoggingMiddleware>(),
             Array.Empty<IHttpLoggingInterceptor>(),
+            null,
+            ObjectPool.Create(new ResponseBufferingStreamPooledObjectPolicy()),
+            TimeProvider.System));
+
+        Assert.Throws<ArgumentNullException>(() => new HttpLoggingMiddleware(c =>
+        {
+            return Task.CompletedTask;
+        },
+            CreateOptionsAccessor(),
+            LoggerFactory.CreateLogger<HttpLoggingMiddleware>(),
+            Array.Empty<IHttpLoggingInterceptor>(),
+            ObjectPool.Create<HttpLoggingInterceptorContext>(),
             null,
             TimeProvider.System));
 
@@ -94,6 +110,7 @@ public class HttpLoggingMiddlewareTests : LoggedTest
             LoggerFactory.CreateLogger<HttpLoggingMiddleware>(),
             Array.Empty<IHttpLoggingInterceptor>(),
             ObjectPool.Create<HttpLoggingInterceptorContext>(),
+            ObjectPool.Create(new ResponseBufferingStreamPooledObjectPolicy()),
             null));
     }
 
@@ -2114,6 +2131,7 @@ public class HttpLoggingMiddlewareTests : LoggedTest
             LoggerFactory.CreateLogger<HttpLoggingMiddleware>(),
             interceptor == null ? Array.Empty<IHttpLoggingInterceptor>() : [interceptor],
             ObjectPool.Create<HttpLoggingInterceptorContext>(),
+            ObjectPool.Create(new ResponseBufferingStreamPooledObjectPolicy()),
             TimeProvider.System);
     }
 

--- a/src/Middleware/HttpLogging/test/HttpLoggingMiddlewareTests.cs
+++ b/src/Middleware/HttpLogging/test/HttpLoggingMiddlewareTests.cs
@@ -44,7 +44,7 @@ public class HttpLoggingMiddlewareTests : LoggedTest
             LoggerFactory.CreateLogger<HttpLoggingMiddleware>(),
             Array.Empty<IHttpLoggingInterceptor>(),
             ObjectPool.Create<HttpLoggingInterceptorContext>(),
-            ObjectPool.Create(new ResponseBufferingStreamPooledObjectPolicy()),
+            new DefaultObjectPoolProvider().Create(new ResponseBufferingStreamPooledObjectPolicy()),
             TimeProvider.System));
 
         Assert.Throws<ArgumentNullException>(() => new HttpLoggingMiddleware(c =>
@@ -55,7 +55,7 @@ public class HttpLoggingMiddlewareTests : LoggedTest
             LoggerFactory.CreateLogger<HttpLoggingMiddleware>(),
             Array.Empty<IHttpLoggingInterceptor>(),
             ObjectPool.Create<HttpLoggingInterceptorContext>(),
-            ObjectPool.Create(new ResponseBufferingStreamPooledObjectPolicy()),
+            new DefaultObjectPoolProvider().Create(new ResponseBufferingStreamPooledObjectPolicy()),
             TimeProvider.System));
 
         Assert.Throws<ArgumentNullException>(() => new HttpLoggingMiddleware(c =>
@@ -66,7 +66,7 @@ public class HttpLoggingMiddlewareTests : LoggedTest
             null,
             Array.Empty<IHttpLoggingInterceptor>(),
             ObjectPool.Create<HttpLoggingInterceptorContext>(),
-            ObjectPool.Create(new ResponseBufferingStreamPooledObjectPolicy()),
+            new DefaultObjectPoolProvider().Create(new ResponseBufferingStreamPooledObjectPolicy()),
             TimeProvider.System));
 
         Assert.Throws<ArgumentNullException>(() => new HttpLoggingMiddleware(c =>
@@ -77,7 +77,7 @@ public class HttpLoggingMiddlewareTests : LoggedTest
             LoggerFactory.CreateLogger<HttpLoggingMiddleware>(),
             null,
             ObjectPool.Create<HttpLoggingInterceptorContext>(),
-            ObjectPool.Create(new ResponseBufferingStreamPooledObjectPolicy()),
+            new DefaultObjectPoolProvider().Create(new ResponseBufferingStreamPooledObjectPolicy()),
             TimeProvider.System));
 
         Assert.Throws<ArgumentNullException>(() => new HttpLoggingMiddleware(c =>
@@ -88,7 +88,7 @@ public class HttpLoggingMiddlewareTests : LoggedTest
             LoggerFactory.CreateLogger<HttpLoggingMiddleware>(),
             Array.Empty<IHttpLoggingInterceptor>(),
             null,
-            ObjectPool.Create(new ResponseBufferingStreamPooledObjectPolicy()),
+            new DefaultObjectPoolProvider().Create(new ResponseBufferingStreamPooledObjectPolicy()),
             TimeProvider.System));
 
         Assert.Throws<ArgumentNullException>(() => new HttpLoggingMiddleware(c =>
@@ -110,7 +110,7 @@ public class HttpLoggingMiddlewareTests : LoggedTest
             LoggerFactory.CreateLogger<HttpLoggingMiddleware>(),
             Array.Empty<IHttpLoggingInterceptor>(),
             ObjectPool.Create<HttpLoggingInterceptorContext>(),
-            ObjectPool.Create(new ResponseBufferingStreamPooledObjectPolicy()),
+            new DefaultObjectPoolProvider().Create(new ResponseBufferingStreamPooledObjectPolicy()),
             null));
     }
 
@@ -2131,7 +2131,7 @@ public class HttpLoggingMiddlewareTests : LoggedTest
             LoggerFactory.CreateLogger<HttpLoggingMiddleware>(),
             interceptor == null ? Array.Empty<IHttpLoggingInterceptor>() : [interceptor],
             ObjectPool.Create<HttpLoggingInterceptorContext>(),
-            ObjectPool.Create(new ResponseBufferingStreamPooledObjectPolicy()),
+            new DefaultObjectPoolProvider().Create(new ResponseBufferingStreamPooledObjectPolicy()),
             TimeProvider.System);
     }
 


### PR DESCRIPTION
The `ResponseBufferingStream` was being instantiated on every request where response body logging is enabled or interceptors are present. This change uses object pooling to reduce those allocations.