### PR TITLE
Use TaskHostFactory in RepoTasks

### DIFF
--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -146,7 +146,6 @@ stages:
       - script: ./eng/build.cmd
                 -ci
                 -prepareMachine
-                -noBuildRepoTasks
                 -arch x86
                 -pack
                 -all
@@ -162,7 +161,6 @@ stages:
       - script: ./eng/build.cmd
                 -ci
                 -prepareMachine
-                -noBuildRepoTasks
                 -arch arm64
                 -sign
                 -pack
@@ -178,7 +176,6 @@ stages:
       - script: .\src\SiteExtensions\build.cmd
                 -ci
                 -prepareMachine
-                -noBuildRepoTasks
                 -pack
                 -noBuildDeps
                 -noBuildNative
@@ -192,7 +189,6 @@ stages:
       - script: ./eng/build.cmd
                 -ci
                 -prepareMachine
-                -noBuildRepoTasks
                 -noBuildNative
                 -noBuild
                 -sign
@@ -205,7 +201,6 @@ stages:
       - script: ./eng/build.cmd
                 -ci
                 -prepareMachine
-                -noBuildRepoTasks
                 -sign
                 -buildInstallers
                 -noBuildNative
@@ -578,8 +573,8 @@ stages:
                   /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
                   /p:VsTestUseMSBuildOutput=false $(HelixSubset1LogArgs)
           displayName: Build shared fx
-        # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
-        - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildRepoTasks -noBuildNative -noBuild -test
+        # -noBuildNative -noBuild to avoid repeating work done in the previous step.
+        - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildNative -noBuild -test
                   -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true
                   /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
                   /p:VsTestUseMSBuildOutput=false /p:RunTemplateTests=false /p:HelixSubset=1
@@ -607,8 +602,8 @@ stages:
                   /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
                   /p:VsTestUseMSBuildOutput=false $(HelixSubset2LogArgs)
           displayName: Build shared fx
-        # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
-        - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildRepoTasks -noBuildNative -noBuild -test
+        # -noBuildNative -noBuild to avoid repeating work done in the previous step.
+        - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildNative -noBuild -test
                   -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true
                   /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
                   /p:VsTestUseMSBuildOutput=false /p:RunTemplateTests=false /p:HelixSubset=2

--- a/.azure/pipelines/ci-unofficial.yml
+++ b/.azure/pipelines/ci-unofficial.yml
@@ -163,7 +163,6 @@ extends:
           - script: ./eng/build.cmd
                     -ci
                     -prepareMachine
-                    -noBuildRepoTasks
                     -arch x86
                     -pack
                     -all
@@ -181,7 +180,6 @@ extends:
           - script: ./eng/build.cmd
                     -ci
                     -prepareMachine
-                    -noBuildRepoTasks
                     -arch arm64
                     -pack
                     -noBuildJava
@@ -197,7 +195,6 @@ extends:
           - script: .\src\SiteExtensions\build.cmd
                     -ci
                     -prepareMachine
-                    -noBuildRepoTasks
                     -pack
                     -noBuildDeps
                     -noBuildNative
@@ -212,7 +209,6 @@ extends:
           - script: ./eng/build.cmd
                     -ci
                     -prepareMachine
-                    -noBuildRepoTasks
                     -sign
                     -buildInstallers
                     -noBuildNative
@@ -613,8 +609,8 @@ extends:
               env:
                 MSBUILDUSESERVER: "1"
               displayName: Build shared fx
-            # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
-            - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildRepoTasks -noBuildNative -noBuild -test
+            # -noBuildNative -noBuild to avoid repeating work done in the previous step.
+            - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildNative -noBuild -test
                       -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:HelixSubset=1
                       /p:CrossgenOutput=false /p:RunTemplateTests=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
               displayName: Run build.cmd helix target
@@ -645,8 +641,8 @@ extends:
               env:
                 MSBUILDUSESERVER: "1"
               displayName: Build shared fx
-            # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
-            - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildRepoTasks -noBuildNative -noBuild -test
+            # -noBuildNative -noBuild to avoid repeating work done in the previous step.
+            - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildNative -noBuild -test
                       -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:HelixSubset=2
                       /p:CrossgenOutput=false /p:RunTemplateTests=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
               displayName: Run build.cmd helix target

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -188,7 +188,6 @@ extends:
           - script: ./eng/build.cmd
                     -ci
                     -prepareMachine
-                    -noBuildRepoTasks
                     -arch x86
                     -pack
                     -all
@@ -206,7 +205,6 @@ extends:
           - script: ./eng/build.cmd
                     -ci
                     -prepareMachine
-                    -noBuildRepoTasks
                     -arch arm64
                     -pack
                     -noBuildJava
@@ -222,7 +220,6 @@ extends:
           - script: .\src\SiteExtensions\build.cmd
                     -ci
                     -prepareMachine
-                    -noBuildRepoTasks
                     -pack
                     -noBuildDeps
                     -noBuildNative
@@ -236,7 +233,6 @@ extends:
           - script: ./eng/build.cmd
                     -ci
                     -prepareMachine
-                    -noBuildRepoTasks
                     -sign
                     -buildInstallers
                     -noBuildNative
@@ -609,8 +605,8 @@ extends:
               env:
                 MSBUILDUSESERVER: "1"
               displayName: Build shared fx
-            # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
-            - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildRepoTasks -noBuildNative -noBuild -test
+            # -noBuildNative -noBuild to avoid repeating work done in the previous step.
+            - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildNative -noBuild -test
                       -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:HelixSubset=1
                       /p:CrossgenOutput=false /p:RunTemplateTests=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
               displayName: Run build.cmd helix target
@@ -638,8 +634,8 @@ extends:
               env:
                 MSBUILDUSESERVER: "1"
               displayName: Build shared fx
-            # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
-            - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildRepoTasks -noBuildNative -noBuild -test
+            # -noBuildNative -noBuild to avoid repeating work done in the previous step.
+            - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildNative -noBuild -test
                       -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:HelixSubset=2
                       /p:CrossgenOutput=false /p:RunTemplateTests=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
               displayName: Run build.cmd helix target

--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -34,8 +34,8 @@ jobs:
     - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -nobl -all -pack -arch x64
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Build shared fx
-    # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
-    - script: .\eng\build.cmd -ci -prepareMachine -nobl -all -noBuildRepoTasks -noBuildNative -noBuild -test
+    # -noBuildNative -noBuild to avoid repeating work done in the previous step.
+    - script: .\eng\build.cmd -ci -prepareMachine -nobl -all -noBuildNative -noBuild -test
               -projects eng\helix\helix.proj /p:IsHelixJob=true
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.cmd helix target

--- a/.azure/pipelines/identitymodel-helix-matrix.yml
+++ b/.azure/pipelines/identitymodel-helix-matrix.yml
@@ -59,28 +59,28 @@ extends:
             inputs:
               command: 'custom'
               arguments: 'install Microsoft.IdentityModel.Logging
-                          -Source https://pkgs.dev.azure.com/dnceng/internal/_packaging/identitymodel-nightlies/nuget/v3/index.json 
+                          -Source https://pkgs.dev.azure.com/dnceng/internal/_packaging/identitymodel-nightlies/nuget/v3/index.json
                           -DependencyVersion Highest -OutputDirectory $(Build.StagingDirectory) -PreRelease'
           - task: NuGetCommand@2
             displayName: Install Microsoft.IdentityModel.Protocols.OpenIdConnect
             inputs:
               command: 'custom'
               arguments: 'install Microsoft.IdentityModel.Protocols.OpenIdConnect
-                          -Source https://pkgs.dev.azure.com/dnceng/internal/_packaging/identitymodel-nightlies/nuget/v3/index.json 
+                          -Source https://pkgs.dev.azure.com/dnceng/internal/_packaging/identitymodel-nightlies/nuget/v3/index.json
                           -DependencyVersion Highest -OutputDirectory $(Build.StagingDirectory) -PreRelease'
           - task: NuGetCommand@2
             displayName: Install Microsoft.IdentityModel.Protocols.WsFederation
             inputs:
               command: 'custom'
               arguments: 'install Microsoft.IdentityModel.Protocols.WsFederation
-                          -Source https://pkgs.dev.azure.com/dnceng/internal/_packaging/identitymodel-nightlies/nuget/v3/index.json 
+                          -Source https://pkgs.dev.azure.com/dnceng/internal/_packaging/identitymodel-nightlies/nuget/v3/index.json
                           -DependencyVersion Highest -OutputDirectory $(Build.StagingDirectory) -PreRelease'
           - task: NuGetCommand@2
             displayName: System.IdentityModel.Tokens.Jwt
             inputs:
               command: 'custom'
               arguments: 'install System.IdentityModel.Tokens.Jwt
-                          -Source https://pkgs.dev.azure.com/dnceng/internal/_packaging/identitymodel-nightlies/nuget/v3/index.json 
+                          -Source https://pkgs.dev.azure.com/dnceng/internal/_packaging/identitymodel-nightlies/nuget/v3/index.json
                           -DependencyVersion Highest -OutputDirectory $(Build.StagingDirectory) -PreRelease'
           - task: PowerShell@2
             displayName: Add IdentityModel feel to NuGet.config
@@ -91,8 +91,8 @@ extends:
           - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -pack -arch x64
                     /p:CrossgenOutput=false /p:IsIdentityModelTestJob=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
             displayName: Build shared fx
-          # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
-          - script: .\eng\build.cmd -ci -prepareMachine -nobl -all -noBuildRepoTasks -noBuildNative -noBuild -test
+          # -noBuildNative -noBuild to avoid repeating work done in the previous step.
+          - script: .\eng\build.cmd -ci -prepareMachine -nobl -all -noBuildNative -noBuild -test
                     -projects eng\helix\helix.proj /p:IsHelixJob=true /p:RunTemplateTests=false
                     /p:CrossgenOutput=false /p:IsIdentityModelTestJob=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
             displayName: Run build.cmd helix target

--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -39,10 +39,10 @@ schedules:
 variables:
 - name: _UseHelixOpenQueues
   value: ${{ ne(variables['System.TeamProject'], 'internal') }}
-- name: Codeql.Enabled 
-  value: false 
-- name: Codeql.SkipTaskAutoInjection 
-  value: true 
+- name: Codeql.Enabled
+  value: false
+- name: Codeql.SkipTaskAutoInjection
+  value: true
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-HelixApi-Access
 - template: /eng/common/templates/variables/pool-providers.yml
@@ -60,8 +60,8 @@ jobs:
     - script: ./eng/build.cmd -ci -prepareMachine -nobl -all -noBuildJava -pack -arch x64
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Build shared fx
-    # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
-    - script: ./eng/build.cmd -ci -prepareMachine -nobl -all -noBuildRepoTasks -noBuildNative -noBuild -noBuildJava -test
+    # -noBuildNative -noBuild to avoid repeating work done in the previous step.
+    - script: ./eng/build.cmd -ci -prepareMachine -nobl -all -noBuildNative -noBuild -noBuildJava -test
               -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:RunQuarantinedTests=true /p:IsHelixJob=true
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.cmd helix target
@@ -86,7 +86,7 @@ jobs:
     steps:
     - script: ./eng/build.cmd -ci -prepareMachine -nobl -all -noBuildJava -pack
       displayName: Build
-    - script: ./eng/build.cmd -ci -prepareMachine -nobl -all -noBuildRepoTasks -noBuildNative -NoBuild -noBuildJava -test
+    - script: ./eng/build.cmd -ci -prepareMachine -nobl -all -noBuildNative -NoBuild -noBuildJava -test
               /p:RunQuarantinedTests=true /p:SkipHelixReadyTests=true
       displayName: Run Quarantined Tests
       continueOnError: true
@@ -120,7 +120,7 @@ jobs:
     steps:
     - bash: ./eng/build.sh --ci --nobl --all --no-build-java --pack
       displayName: Build
-    - bash: ./eng/build.sh --ci --nobl --all --no-build-repo-tasks --no-build --no-build-java --test
+    - bash: ./eng/build.sh --ci --nobl --all --no-build --no-build-java --test
             -p:RunQuarantinedTests=true -p:SkipHelixReadyTests=true
       displayName: Run Quarantined Tests
       continueOnError: true
@@ -155,7 +155,7 @@ jobs:
     steps:
     - bash: ./eng/build.sh --ci --nobl --all --no-build-java --pack
       displayName: Build
-    - bash: ./eng/build.sh --ci --nobl --all --no-build-repo-tasks --no-build --no-build-java --test
+    - bash: ./eng/build.sh --ci --nobl --all --no-build --no-build-java --test
             -p:RunQuarantinedTests=true -p:SkipHelixReadyTests=true
       displayName: Run Quarantined Tests
       continueOnError: true

--- a/.azure/pipelines/quarantined-tests.yml
+++ b/.azure/pipelines/quarantined-tests.yml
@@ -30,8 +30,8 @@ jobs:
     - script: ./eng/build.cmd -ci -prepareMachine -nobl -all -noBuildJava -pack -arch x64
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Build shared fx
-    # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
-    - script: ./eng/build.cmd -ci -prepareMachine -nobl -all -noBuildRepoTasks -noBuildNative -noBuild -noBuildJava -test
+    # -noBuildNative -noBuild to avoid repeating work done in the previous step.
+    - script: ./eng/build.cmd -ci -prepareMachine -nobl -all -noBuildNative -noBuild -noBuildJava -test
               -projects eng\helix\helix.proj /p:RunQuarantinedTests=true /p:IsHelixJob=true
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.cmd helix target

--- a/.azure/pipelines/template-tests-pr.yml
+++ b/.azure/pipelines/template-tests-pr.yml
@@ -41,8 +41,8 @@ jobs:
     - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -nobl -all -pack -arch x64
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log /p:VsTestUseMSBuildOutput=false
       displayName: Build shared fx
-    # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
-    - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildRepoTasks -noBuildNative -noBuild -test
+    # -noBuildNative -noBuild to avoid repeating work done in the previous step.
+    - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildNative -noBuild -test
               -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
               /p:VsTestUseMSBuildOutput=false /p:OnlyTestProjectTemplates=true

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -70,6 +70,11 @@
                       Condition=" '$(TargetOsName)' == 'win' and '$(DotNetBuild)' == 'true' and ('$(DotNetBuildPass)' == '' or '$(DotNetBuildPass)' == '1') " />
   </ItemGroup>
 
+  <!-- Build the RepoTasks before anything else -->
+  <ItemGroup>
+    <ProjectToBuild Include="$(RepoRoot)eng\tools\RepoTasks\RepoTasks.csproj" BuildStep="repotasks" SkipProjectList="true" />
+  </ItemGroup>
+
   <Choose>
     <!-- Project selection can be overridden on the command line by passing in -projects. -->
     <When Condition="'$(ProjectToBuild)' != '' and '$(DotNetBuildPass)' != '2'">
@@ -159,8 +164,8 @@
           the entire pattern will silently fail to evaluate correctly.
         -->
 
-        <!-- 
-          When adding new projects to this file, add them to either ProjectsWithTestsSubset1 or 
+        <!--
+          When adding new projects to this file, add them to either ProjectsWithTestsSubset1 or
           ProjectsWithTestsSubset2 - whichever has fewer entries.
         -->
 

--- a/eng/CodeGen.proj
+++ b/eng/CodeGen.proj
@@ -9,9 +9,14 @@
   <Import Project="Build.props" />
 
   <Target Name="GenerateProjectList">
-    <Message Importance="High" Text="Analyzing @(ProjectToBuild->Count()) projects" />
+    <ItemGroup>
+      <ProjectToBuildForProjectList Include="@(ProjectToBuild)" />
+      <ProjectToBuildForProjectList Remove="@(ProjectToBuildForProjectList->WithMetadataValue('SkipProjectList', 'true'))" />
+    </ItemGroup>
 
-    <MSBuild Projects="@(ProjectToBuild);@(ExplicitRequiresDelay)"
+    <Message Importance="High" Text="Analyzing @(ProjectToBuildForProjectList->Count()) projects" />
+
+    <MSBuild Projects="@(ProjectToBuildForProjectList);@(ExplicitRequiresDelay)"
              Targets="GetReferencesProvided"
              BuildInParallel="true"
              SkipNonexistentTargets="true"

--- a/eng/tools/RepoTasks/RepoTasks.tasks
+++ b/eng/tools/RepoTasks/RepoTasks.tasks
@@ -5,10 +5,11 @@
     <_RepoTaskAssembly>$(ArtifactsBinDir)RepoTasks\Release\$(_RepoTaskAssemblyFolder)\RepoTasks.dll</_RepoTaskAssembly>
   </PropertyGroup>
 
-  <UsingTask TaskName="RepoTasks.GenerateGuid" AssemblyFile="$(_RepoTaskAssembly)" Condition="'$(MSBuildRuntimeType)' != 'core'" />
-  <UsingTask TaskName="RepoTasks.GetMsiProperty" AssemblyFile="$(_RepoTaskAssembly)" Condition="'$(MSBuildRuntimeType)' != 'core'" />
-  <UsingTask TaskName="RepoTasks.GenerateSharedFrameworkDepsFile" AssemblyFile="$(_RepoTaskAssembly)" />
-  <UsingTask TaskName="RepoTasks.CreateFrameworkListFile" AssemblyFile="$(_RepoTaskAssembly)" />
-  <UsingTask TaskName="RepoTasks.GenerateTestDevCert" AssemblyFile="$(_RepoTaskAssembly)" />
+  <UsingTask TaskName="RepoTasks.GenerateGuid" AssemblyFile="$(_RepoTaskAssembly)" TaskFactory="TaskHostFactory" Condition="'$(MSBuildRuntimeType)' != 'core'" />
+  <UsingTask TaskName="RepoTasks.GetMsiProperty" AssemblyFile="$(_RepoTaskAssembly)" TaskFactory="TaskHostFactory" Condition="'$(MSBuildRuntimeType)' != 'core'" />
+  <UsingTask TaskName="RepoTasks.GenerateSharedFrameworkDepsFile" AssemblyFile="$(_RepoTaskAssembly)" TaskFactory="TaskHostFactory" />
+  <UsingTask TaskName="RepoTasks.CreateFrameworkListFile" AssemblyFile="$(_RepoTaskAssembly)" TaskFactory="TaskHostFactory" />
+  <UsingTask TaskName="RepoTasks.GenerateTestDevCert" AssemblyFile="$(_RepoTaskAssembly)" TaskFactory="TaskHostFactory" />
+
   <UsingTask TaskName="DownloadFile" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
 </Project>

--- a/eng/tools/RepoTasks/RepoTasks.tasks
+++ b/eng/tools/RepoTasks/RepoTasks.tasks
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <_RepoTaskAssemblyFolder Condition="'$(MSBuildRuntimeType)' == 'core'">net11.0</_RepoTaskAssemblyFolder>
     <_RepoTaskAssemblyFolder Condition="'$(MSBuildRuntimeType)' != 'core'">net472</_RepoTaskAssemblyFolder>
-    <_RepoTaskAssembly>$(ArtifactsBinDir)RepoTasks\Release\$(_RepoTaskAssemblyFolder)\RepoTasks.dll</_RepoTaskAssembly>
+    <_RepoTaskAssembly>$(ArtifactsBinDir)RepoTasks\$(Configuration)\$(_RepoTaskAssemblyFolder)\RepoTasks.dll</_RepoTaskAssembly>
   </PropertyGroup>
 
   <UsingTask TaskName="RepoTasks.GenerateGuid" AssemblyFile="$(_RepoTaskAssembly)" TaskFactory="TaskHostFactory" Condition="'$(MSBuildRuntimeType)' != 'core'" />

--- a/src/Components/AGENTS.md
+++ b/src/Components/AGENTS.md
@@ -83,7 +83,7 @@ dotnet build --no-restore -v:q
 
 Or with `eng\build.cmd`:
 ```bash
-.\eng\build.cmd -NoRestore -NoBuildDeps -NoBuildRepoTasks -NoBuildNative -NoBuildNodeJS -NoBuildJava -NoBuildInstallers -verbosity:quiet
+.\eng\build.cmd -NoRestore -NoBuildDeps -NoBuildNative -NoBuildNodeJS -NoBuildJava -NoBuildInstallers -verbosity:quiet
 ```
 
 **When you've added/changed project references or package dependencies:**


### PR DESCRIPTION
[TaskHostFactory](https://learn.microsoft.com/en-us/visualstudio/msbuild/how-to-configure-targets-and-tasks?view=visualstudio#taskhostfactory) creates short lived processes which exit immediately after the work is completed and release all locks. The primary target for these are repo build tasks that would otherwise keep running in the background and not release locks. This is important so that a subsequent repo build doesn't fail when it tries to copy RepoTasks.dll to the output directory. We already use these in the runtime and a few other repositories.

This allows to remove a ton of workarounds and just always (incrementally) build the RepoTasks.csproj. Net positive: No extra binlog, no shenanigans in the build entry point in the YMLs or in the VMR. Simplified infrastructure.

---

The errors show up because aspnetcore still uses the vs2022 image. This needs to get updated regardless now as the VMR is currently in the process of updating: https://github.com/dotnet/dotnet/pull/4279