### PR TITLE
Run Helix tests on VS2026

### DIFF
--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -31,7 +31,7 @@
       <ItemGroup>
         <HelixAvailableTargetQueue Include="Ubuntu.2204.Amd64.Open" Platform="Linux" />
         <HelixAvailableTargetQueue Include="OSX.15.Amd64.Open" Platform="OSX" />
-        <HelixAvailableTargetQueue Include="Windows.Amd64.VS2022.Pre.Open" Platform="Windows" />
+        <HelixAvailableTargetQueue Include="Windows.Amd64.VS2026.Pre.Scout.Open" Platform="Windows" />
       </ItemGroup>
     </When>
     <Otherwise>

--- a/src/Servers/HttpSys/test/FunctionalTests/Http2Tests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Http2Tests.cs
@@ -544,7 +544,7 @@ public class Http2Tests : LoggedTest
     [ConditionalFact]
     [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10, SkipReason = "Http2 requires Win10")]
     [MaximumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10_20H1, SkipReason = "This is last version without custom Reset support")]
-    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/50916", Queues = "Windows.Amd64.VS2022.Pre")]
+    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/50916", Queues = "Windows.Amd64.VS2026.Pre")]
     public async Task AppException_AfterHeaders_PriorOSVersions_ResetCancel()
     {
         using var server = Utilities.CreateDynamicHttpsServer(out var address, async httpContext =>
@@ -629,7 +629,7 @@ public class Http2Tests : LoggedTest
     [ConditionalFact]
     [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10, SkipReason = "Http2 requires Win10")]
     [MaximumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10_20H2, SkipReason = "This is last version without Reset support")]
-    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/50916", Queues = "Windows.Amd64.VS2022.Pre")]
+    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/50916", Queues = "Windows.Amd64.VS2026.Pre")]
     public async Task Reset_PriorOSVersions_NotSupported()
     {
         using var server = Utilities.CreateDynamicHttpsServer(out var address, httpContext =>

--- a/src/Servers/HttpSys/test/FunctionalTests/Http2Tests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Http2Tests.cs
@@ -544,7 +544,7 @@ public class Http2Tests : LoggedTest
     [ConditionalFact]
     [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10, SkipReason = "Http2 requires Win10")]
     [MaximumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10_20H1, SkipReason = "This is last version without custom Reset support")]
-    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/50916", Queues = "Windows.Amd64.VS2026.Pre")]
+    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/50916", Queues = "Windows.Amd64.VS2026.Pre.Scout.Open")]
     public async Task AppException_AfterHeaders_PriorOSVersions_ResetCancel()
     {
         using var server = Utilities.CreateDynamicHttpsServer(out var address, async httpContext =>

--- a/src/Servers/HttpSys/test/FunctionalTests/Http2Tests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Http2Tests.cs
@@ -629,7 +629,7 @@ public class Http2Tests : LoggedTest
     [ConditionalFact]
     [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10, SkipReason = "Http2 requires Win10")]
     [MaximumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10_20H2, SkipReason = "This is last version without Reset support")]
-    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/50916", Queues = "Windows.Amd64.VS2026.Pre")]
+    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/50916", Queues = "Windows.Amd64.VS2026.Pre.Scout.Open")]
     public async Task Reset_PriorOSVersions_NotSupported()
     {
         using var server = Utilities.CreateDynamicHttpsServer(out var address, httpContext =>

--- a/src/Servers/IIS/IIS/test/Common.LongTests/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.LongTests/StartupTests.cs
@@ -1298,7 +1298,7 @@ public class StartupTests : IISFunctionalTestBase
     [ConditionalFact]
     [RequiresNewHandler]
     [RequiresNewShim]
-    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/62787", Queues = "Windows.Amd64.VS2026.Pre.Open;" + "Windows.Amd64.VS2026.Pre;")]
+    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/62787", Queues = "Windows.Amd64.VS2026.Pre.Scout.Open;" + "Windows.Amd64.VS2026.Pre.Scout;")]
     public async Task ServerAddressesIncludesBaseAddress()
     {
         var appName = "\u041C\u043E\u0451\u041F\u0440\u0438\u043B\u043E\u0436\u0435\u043D\u0438\u0435";

--- a/src/Servers/IIS/IIS/test/Common.LongTests/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.LongTests/StartupTests.cs
@@ -1298,7 +1298,7 @@ public class StartupTests : IISFunctionalTestBase
     [ConditionalFact]
     [RequiresNewHandler]
     [RequiresNewShim]
-    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/62787", Queues = "Windows.Amd64.VS2022.Pre.Open;" + "Windows.Amd64.VS2022.Pre;")]
+    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/62787", Queues = "Windows.Amd64.VS2026.Pre.Open;" + "Windows.Amd64.VS2026.Pre;")]
     public async Task ServerAddressesIncludesBaseAddress()
     {
         var appName = "\u041C\u043E\u0451\u041F\u0440\u0438\u043B\u043E\u0436\u0435\u043D\u0438\u0435";


### PR DESCRIPTION
Counterpart of https://github.com/dotnet/aspnetcore/pull/65088. VS2026 is the in-support version now