### PR TITLE
Update HttpSys shutdown logic

### DIFF
--- a/src/Servers/HttpSys/src/NativeInterop/RequestQueue.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/RequestQueue.cs
@@ -190,8 +190,8 @@ internal sealed partial class RequestQueue
     }
 
     /// <summary>
-    /// Closes the request queue handle to cancel any pending IO operations,
-    /// but does not dispose the BoundHandle. This allows pending operations
+    /// Shuts down the request queue to cancel any pending IO operations,
+    /// but does not close the handle or dispose the BoundHandle. This allows pending operations
     /// to be properly cleaned up before disposing the BoundHandle.
     /// </summary>
     internal void StopProcessingRequests()

--- a/src/Servers/HttpSys/src/NativeInterop/RequestQueue.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/RequestQueue.cs
@@ -180,10 +180,23 @@ internal sealed partial class RequestQueue
 
         _disposed = true;
 
+        // Close the request queue handle first to cancel any pending IO operations.
+        // This must happen before disposing BoundHandle, as pending operations need
+        // to be cancelled and cleaned up using the BoundHandle.
         PInvoke.HttpCloseRequestQueue(Handle);
 
         BoundHandle.Dispose();
-        Handle.Dispose();
+        Handle.SetHandleAsInvalid();
+    }
+
+    /// <summary>
+    /// Closes the request queue handle to cancel any pending IO operations,
+    /// but does not dispose the BoundHandle. This allows pending operations
+    /// to be properly cleaned up before disposing the BoundHandle.
+    /// </summary>
+    internal void StopProcessingRequests()
+    {
+        PInvoke.HttpShutdownRequestQueue(Handle);
     }
 
     private void CheckDisposed()

--- a/src/Servers/HttpSys/src/NativeMethods.txt
+++ b/src/Servers/HttpSys/src/NativeMethods.txt
@@ -57,6 +57,7 @@ HttpSendResponseEntityBody
 HttpSetRequestQueueProperty
 HttpSetUrlGroupProperty
 HttpSetUrlGroupProperty
+HttpShutdownRequestQueue
 SetFileCompletionNotificationModes
 SOCKADDR_IN
 SOCKADDR_IN6

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestContextOfT.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestContextOfT.cs
@@ -42,7 +42,6 @@ internal sealed partial class RequestContext<TContext> : RequestContext where TC
 
             TContext? context = default;
             Exception? applicationException = null;
-            messagePump.IncrementOutstandingRequest();
             try
             {
                 context = application.CreateContext(Features);
@@ -107,15 +106,9 @@ internal sealed partial class RequestContext<TContext> : RequestContext where TC
             }
             finally
             {
-                if (context != null)
+                if (context is not null)
                 {
                     application.DisposeContext(context, applicationException);
-                }
-
-                if (messagePump.DecrementOutstandingRequest() == 0 && messagePump.Stopping)
-                {
-                    Log.RequestsDrained(Logger);
-                    messagePump.SetShutdownSignal();
                 }
 
                 Dispose();

--- a/src/Servers/HttpSys/test/FunctionalTests/RequestTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/RequestTests.cs
@@ -50,6 +50,8 @@ public class RequestTests : LoggedTest
             Assert.NotNull(requestIdentifierFeature.TraceIdentifier);
 
             // Note: Response keys are validated in the ResponseTests
+            
+            return Task.CompletedTask;
         }, options => { }, LoggerFactory))
         {
             string response = await SendRequestAsync(root + "/basepath/SomePath?SomeQuery");

--- a/src/Servers/HttpSys/test/FunctionalTests/RequestTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/RequestTests.cs
@@ -21,7 +21,7 @@ public class RequestTests : LoggedTest
     public async Task Request_SimpleGet_ExpectedFieldsSet()
     {
         string root;
-        using (Utilities.CreateHttpServerReturnRoot("/basepath", out root, async httpContext =>
+        using (Utilities.CreateHttpServerReturnRoot("/basepath", out root, httpContext =>
         {
             var requestInfo = httpContext.Features.Get<IHttpRequestFeature>();
 

--- a/src/Servers/HttpSys/test/FunctionalTests/ServerTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/ServerTests.cs
@@ -477,8 +477,7 @@ public class ServerTests : LoggedTest
 
             run.SetResult();
 
-            string response = await responseTask;
-            Assert.Equal("Hello World", response);
+            await Assert.ThrowsAnyAsync<Exception>(() => responseTask);
         }
     }
 
@@ -514,8 +513,7 @@ public class ServerTests : LoggedTest
 
             run.SetResult();
 
-            string response = await responseTask;
-            Assert.Equal("Hello World", response);
+            await Assert.ThrowsAnyAsync<Exception>(() => responseTask);
         }
     }
 
@@ -551,8 +549,7 @@ public class ServerTests : LoggedTest
 
             run.SetResult();
 
-            string response = await responseTask;
-            Assert.Equal("Hello World", response);
+            await Assert.ThrowsAnyAsync<Exception>(() => responseTask);
         }
     }
 

--- a/src/Servers/HttpSys/test/FunctionalTests/Utilities.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Utilities.cs
@@ -53,10 +53,10 @@ internal static class Utilities
         return CreateDynamicHttpServer(string.Empty, out root, out baseAddress, configureOptions, app, loggerFactory);
     }
 
-    internal static IServer CreateHttpServerReturnRoot(string path, out string root, RequestDelegate app, ILoggerFactory loggerFactory)
+    internal static IServer CreateHttpServerReturnRoot(string path, out string root, RequestDelegate app, Action<HttpSysOptions> configureOptions, ILoggerFactory loggerFactory)
     {
         string baseAddress;
-        return CreateDynamicHttpServer(path, out root, out baseAddress, options => { }, app, loggerFactory);
+        return CreateDynamicHttpServer(path, out root, out baseAddress, configureOptions, app, loggerFactory);
     }
 
     internal static IServer CreateHttpAuthServer(AuthenticationSchemes authType, bool allowAnonymous, out string baseAddress, RequestDelegate app, ILoggerFactory loggerFactory)


### PR DESCRIPTION
Updated HttpSys's shutdown logic to be more like Kestrels.
IServer.Dispose calls IServer.StopAsync with an already canceled token.
StopAsync now waits for the accept loops to complete, before it only waited for active requests to finish which left open a race where we dispose the request queue handle while the accept loops were still active.

In the ungraceful close case, we still wait for the accept loops to complete, but don't wait for any blocked request processing to complete (imagine app logic taking a long time to finish). The only case where this would be slightly problematic is when using [UnsafePreferInlineScheduling](https://source.dot.net/Microsoft.AspNetCore.Server.HttpSys/R/e1d404bc4c750c1d.html) and app code was holding onto request processing, then the accept loop wouldn't complete and shutdown would hang until the app code completed.

This should hopefully reduce/eliminate problems we've seen in test code with handles being invalid when they shouldn't be.