### PR TITLE
Add null validation httpsclientslim

### DIFF
--- a/src/Testing/src/HttpClientSlim.cs
+++ b/src/Testing/src/HttpClientSlim.cs
@@ -25,7 +25,6 @@ public static class HttpClientSlim
     public static async Task<string> GetStringAsync(string requestUri, bool validateCertificate = true)
         => await GetStringAsync(new Uri(requestUri), validateCertificate).ConfigureAwait(false);
 
-
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
     public static async Task<string> GetStringAsync(Uri requestUri, bool validateCertificate = true)
     {

--- a/src/Testing/src/HttpClientSlim.cs
+++ b/src/Testing/src/HttpClientSlim.cs
@@ -25,9 +25,11 @@ public static class HttpClientSlim
     public static async Task<string> GetStringAsync(string requestUri, bool validateCertificate = true)
         => await GetStringAsync(new Uri(requestUri), validateCertificate).ConfigureAwait(false);
 
+
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
     public static async Task<string> GetStringAsync(Uri requestUri, bool validateCertificate = true)
     {
+        ArgumentNullException.ThrowIfNull(requestUri);
         return await RetryRequest(async () =>
         {
             using (var stream = await GetStream(requestUri, validateCertificate).ConfigureAwait(false))
@@ -71,6 +73,7 @@ public static class HttpClientSlim
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
     public static async Task<string> PostAsync(Uri requestUri, HttpContent content, bool validateCertificate = true)
     {
+        ArgumentNullException.ThrowIfNull(requestUri);
         return await RetryRequest(async () =>
         {
             using (var stream = await GetStream(requestUri, validateCertificate).ConfigureAwait(false))
@@ -149,6 +152,8 @@ public static class HttpClientSlim
 
     private static async Task<Stream> GetStream(Uri requestUri, bool validateCertificate)
     {
+        ArgumentNullException.ThrowIfNull(requestUri);
+
         var socket = await GetSocket(requestUri).ConfigureAwait(false);
         var stream = new NetworkStream(socket, ownsSocket: true);
 
@@ -170,6 +175,7 @@ public static class HttpClientSlim
 
     public static async Task<Socket> GetSocket(Uri requestUri)
     {
+        ArgumentNullException.ThrowIfNull(requestUri);
         var tcs = new TaskCompletionSource<Socket>();
 
         var socketArgs = new SocketAsyncEventArgs();


### PR DESCRIPTION
# Add null validation to HttpClientSlim Uri parameters

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.


<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Add null validation for Uri parameters in public API methods

## Description

This PR adds `ArgumentNullException.ThrowIfNull(requestUri)` validation to public methods in `HttpClientSlim` that accept `Uri` parameters but don't currently validate them.

**Methods updated:**
- `GetStringAsync(Uri requestUri, bool validateCertificate)`
- `PostAsync(Uri requestUri, HttpContent content, bool validateCertificate)`
- `GetStream(Uri requestUri, bool validateCertificate)` (private helper)
- `GetSocket(Uri requestUri)`

**Rationale to updating:**
Without null validation, callers passing `null` would receive a `NullReferenceException` deep in the method implementation. This change provides feedback with `ArgumentNullException` instead which can improving diagnostics to make the API contract better explicit.

**Impact:**
- No breaking changes, only adds validation
- Better erroring for invalid input
- Should be consistent with the .NET API design guidelines


