### PR TITLE
Avoid re-throwing exception in bad request handling path

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -735,7 +735,12 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
         catch (BadHttpRequestException ex)
         {
             OnBadRequest(result.Buffer, ex);
-            throw;
+
+            // Avoid re-throwing - handle the bad request state directly here
+            // to eliminate exception propagation overhead through async state machines
+            SetBadRequestState(ex);
+            endConnection = true;
+            return true;
         }
 #pragma warning restore CS0618 // Type or member is obsolete
         catch (Exception)


### PR DESCRIPTION
Avoid re-throwing BadHttpRequestException in TryParseRequest. Instead of propagating the exception through async state machines, handle the bad request state directly at the catch site.

The re-thrown exception was never observable to user code. It was caught internally by ProcessRequestsAsync() and used only to call SetBadRequestState(ex) - the same call we now make directly.

This change preserves the external behavior:

- OnBadRequest() still called (logging, diagnostics)
- SetBadRequestState() still called (metrics, state management)
- TryProduceInvalidRequestResponse() still runs (HTTP 400 response)
- Connection still closed properly

User middleware and application code cannot catch this exception because it occurs during request line/header parsing, before the request is dispatched to the application pipeline.

In local testing, this shows an ~7-8% improvement in bad request RPS.