### PR TITLE
Fix InputSelect not handling null for nullable bool

### DIFF
--- a/src/Components/Web/src/Forms/InputSelect.cs
+++ b/src/Components/Web/src/Forms/InputSelect.cs
@@ -77,7 +77,11 @@ public class InputSelect<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTy
         }
         else if (typeof(TValue) == typeof(bool?))
         {
-            return value is not null && (bool)(object)value ? "true" : "false";
+            if (value is null)
+            {
+                return null;
+            }
+            return (bool)(object)value ? "true" : "false";
         }
 
         return base.FormatValueAsString(value);

--- a/src/Components/Web/test/Forms/InputSelectTest.cs
+++ b/src/Components/Web/test/Forms/InputSelectTest.cs
@@ -168,6 +168,26 @@ public class InputSelectTest
         Assert.Equal(42, inputSelectComponent.CurrentValue);
     }
 
+    // See: https://github.com/dotnet/aspnetcore/pull/54565
+    [Fact]
+    public async Task ParsesNullWhenUsingNullableBool()
+    {
+        // Arrange
+        var model = new TestModel();
+        var rootComponent = new TestInputHostComponent<bool?, TestInputSelect<bool?>>
+        {
+            EditContext = new EditContext(model),
+            ValueExpression = () => model.NullableBool
+        };
+        var inputSelectComponent = await InputRenderer.RenderAndGetComponent(rootComponent);
+
+        // Act
+        inputSelectComponent.CurrentValueAsString = null;
+
+        // Assert
+        Assert.Null(inputSelectComponent.CurrentValue);
+    }
+
     [Fact]
     public async Task ValidationErrorUsesDisplayAttributeName()
     {
@@ -276,6 +296,7 @@ public class InputSelectTest
         public int NotNullableInt { get; set; }
 
         public int? NullableInt { get; set; }
+        public bool? NullableBool { get; set; }
     }
 
     class TestInputSelect<TValue> : InputSelect<TValue>


### PR DESCRIPTION
# Fix nullable bool parsing on InputSelect component

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

### Summary
This PR fixes an issue in `InputSelect` where setting the value to `null` for a nullable boolean (`bool?`) would fail to correctly parse a null value.

The root cause was that `InputSelect` did not handle `null` values correctly. This fix adds a null check in `InputSelect` to allow `CurrentValue` to be set to `null`.

## Description

When binding a `bool?` to a InputSelect compoenent, the current implementation of `FormatValueAsString(TValue value)` does not handle null values and always returns `true` or `false`.

### Changes:
- Added null handling in `InputSelect` for `bool?`.
- Updated `ParsesNullWhenUsingNullableBool` test to confirm `null` is correctly handled.
- Minor test model adjustment (`NullableBool`) 

Fixes #54565  

