### PR TITLE
fix: Kestrel Http3 LoadDevelopmentCertificateViaConfiguration test stabilization

### DIFF
--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3TlsTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3TlsTests.cs
@@ -442,7 +442,7 @@ public class Http3TlsTests : LoggedTest
 
         try
         {
-            var expectedCertificate = new X509Certificate2(TestResources.GetCertPath("aspnetdevcert.pfx"), "testPassword", X509KeyStorageFlags.Exportable);
+            using var expectedCertificate = new X509Certificate2(TestResources.GetCertPath("aspnetdevcert.pfx"), "testPassword", X509KeyStorageFlags.Exportable);
             var bytes = expectedCertificate.Export(X509ContentType.Pkcs12, "1234");
             Directory.CreateDirectory(Path.GetDirectoryName(path));
             File.WriteAllBytes(path, bytes);


### PR DESCRIPTION
Spotted test failing multiple times in an unrelated to Http3 \ certs PR change:
https://github.com/dotnet/aspnetcore/pull/65186

Test uses the hardcoded path to save\load the certificate:
```csharp
private static string GetCertificatePath()
{
    var appData = Environment.GetEnvironmentVariable("APPDATA");
    var home = Environment.GetEnvironmentVariable("HOME");
    var basePath = appData != null ? Path.Combine(appData, "ASP.NET", "https") : null;
    basePath = basePath ?? (home != null ? Path.Combine(home, ".aspnet", "https") : null);
    return Path.Combine(basePath, $"{typeof(Http3TlsTests).Assembly.GetName().Name}.pfx");
}
```

and the guess is that it is corrupted between the runs. I added saving and deleting the cert after test is finished to ensure there is no effect on this between the runs. If that does not help, we should quarantine it and fix later

Fixes #65248
