### PR TITLE
Add non-throwing parser path for bad request handling

### DIFF
--- a/src/Servers/Kestrel/Core/src/CoreStrings.resx
+++ b/src/Servers/Kestrel/Core/src/CoreStrings.resx
@@ -150,6 +150,9 @@
   <data name="BadRequest_InvalidRequestHeadersNoCRLF" xml:space="preserve">
     <value>Invalid request headers: missing final CRLF in header fields.</value>
   </data>
+  <data name="BadRequest_InvalidRequestHeader" xml:space="preserve">
+    <value>Invalid request header.</value>
+  </data>
   <data name="BadRequest_InvalidRequestHeader_Detail" xml:space="preserve">
     <value>Invalid request header: '{detail}'</value>
   </data>
@@ -193,6 +196,9 @@
     <value>Unexpected end of request content.</value>
   </data>
   <data name="BadRequest_UnrecognizedHTTPVersion" xml:space="preserve">
+    <value>Unrecognized HTTP version.</value>
+  </data>
+  <data name="BadRequest_UnrecognizedHTTPVersion_Detail" xml:space="preserve">
     <value>Unrecognized HTTP version: '{detail}'</value>
   </data>
   <data name="FallbackToIPv4Any" xml:space="preserve">

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -28,6 +28,7 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
     private readonly HttpConnectionContext _context;
     private readonly IHttpParser<Http1ParsingHandler> _parser;
     private readonly Http1OutputProducer _http1Output;
+    private readonly bool _showErrorDetails;
 
     private volatile bool _requestTimedOut;
     private uint _requestCount;
@@ -53,6 +54,7 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
 
         _context = context;
         _parser = ServiceContext.HttpParser;
+        _showErrorDetails = Log.IsEnabled(LogLevel.Information);
 
         _http1Output = new Http1OutputProducer(
             _context.Transport.Output,
@@ -963,9 +965,9 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
             return KestrelBadHttpRequestException.GetException(parseResult.ErrorReason);
         }
 
-        // Extract error detail from buffer if available, but only when logging is enabled
+        // Extract error detail from buffer if available, but only when _showErrorDetails is enabled
         // to avoid leaking internal details in production.
-        if (Log.IsEnabled(LogLevel.Information) &&
+        if (_showErrorDetails &&
             parseResult.ErrorLength > 0 &&
             parseResult.ErrorOffset + parseResult.ErrorLength <= buffer.Length)
         {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
@@ -370,7 +370,7 @@ public class HttpParser<TRequestHandler> : IHttpParser<TRequestHandler> where TR
 
         // Extract error detail from buffer if available, but only when _showErrorDetails is enabled
         // to avoid leaking internal details in production.
-        if (result.ErrorLength > 0 && result.ErrorOffset + result.ErrorLength <= buffer.Length)
+        if (_showErrorDetails && result.ErrorLength > 0 && result.ErrorOffset + result.ErrorLength <= buffer.Length)
         {
             var errorSlice = buffer.Slice(result.ErrorOffset, result.ErrorLength);
             var errorBytes = errorSlice.IsSingleSegment ? errorSlice.FirstSpan : errorSlice.ToArray().AsSpan();

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
@@ -361,8 +361,9 @@ public class HttpParser<TRequestHandler> : IHttpParser<TRequestHandler> where TR
             KestrelBadHttpRequestException.Throw(result.ErrorReason);
         }
 
-        // Extract error detail from buffer if available
-        if (result.ErrorLength > 0 && result.ErrorOffset + result.ErrorLength <= buffer.Length)
+        // Extract error detail from buffer if available, but only when _showErrorDetails is enabled
+        // to avoid leaking internal details in production.
+        if (_showErrorDetails && result.ErrorLength > 0 && result.ErrorOffset + result.ErrorLength <= buffer.Length)
         {
             var errorSlice = buffer.Slice(result.ErrorOffset, result.ErrorLength);
             var errorBytes = errorSlice.IsSingleSegment ? errorSlice.FirstSpan : errorSlice.ToArray().AsSpan();

--- a/src/Servers/Kestrel/Core/src/Internal/Http/IHttpParser.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/IHttpParser.cs
@@ -5,6 +5,54 @@ using System.Buffers;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 
+/// <summary>
+/// Result of non-throwing HTTP parsing operations.
+/// </summary>
+internal readonly struct HttpParseResult
+{
+    private enum ParseStatus : byte { Incomplete, Complete, Error }
+
+    private readonly ParseStatus _status;
+    private readonly RequestRejectionReason _errorReason;
+    private readonly int _errorOffset;
+    private readonly int _errorLength;
+
+    private HttpParseResult(ParseStatus status, RequestRejectionReason errorReason = default, int errorOffset = 0, int errorLength = 0)
+    {
+        _status = status;
+        _errorReason = errorReason;
+        _errorOffset = errorOffset;
+        _errorLength = errorLength;
+    }
+
+    /// <summary>True if parsing completed successfully.</summary>
+    public bool IsComplete => _status == ParseStatus.Complete;
+
+    /// <summary>True if a parse error occurred.</summary>
+    public bool HasError => _status == ParseStatus.Error;
+
+    /// <summary>The reason for rejection, if HasError is true.</summary>
+    public RequestRejectionReason ErrorReason => _errorReason;
+
+    /// <summary>Offset into the buffer where the error was detected.</summary>
+    public int ErrorOffset => _errorOffset;
+
+    /// <summary>Length of the problematic data, for error reporting.</summary>
+    public int ErrorLength => _errorLength;
+
+    /// <summary>Parsing needs more data.</summary>
+    public static HttpParseResult Incomplete => new(ParseStatus.Incomplete);
+
+    /// <summary>Parsing completed successfully.</summary>
+    public static HttpParseResult Complete => new(ParseStatus.Complete);
+
+    /// <summary>Parsing failed with the specified error.</summary>
+    public static HttpParseResult Error(RequestRejectionReason reason) => new(ParseStatus.Error, reason);
+
+    /// <summary>Parsing failed with the specified error and location info for detailed error messages.</summary>
+    public static HttpParseResult Error(RequestRejectionReason reason, int offset, int length) => new(ParseStatus.Error, reason, offset, length);
+}
+
 internal interface IHttpParser<TRequestHandler> where TRequestHandler : IHttpHeadersHandler, IHttpRequestLineHandler
 {
     bool ParseRequestLine(TRequestHandler handler, ref SequenceReader<byte> reader);

--- a/src/Servers/Kestrel/Core/src/Internal/Http/IHttpParser.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/IHttpParser.cs
@@ -58,4 +58,8 @@ internal interface IHttpParser<TRequestHandler> where TRequestHandler : IHttpHea
     bool ParseRequestLine(TRequestHandler handler, ref SequenceReader<byte> reader);
 
     bool ParseHeaders(TRequestHandler handler, ref SequenceReader<byte> reader);
+
+    HttpParseResult TryParseRequestLine(TRequestHandler handler, ref SequenceReader<byte> reader);
+
+    HttpParseResult TryParseHeaders(TRequestHandler handler, ref SequenceReader<byte> reader);
 }

--- a/src/Servers/Kestrel/Core/src/KestrelBadHttpRequestException.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelBadHttpRequestException.cs
@@ -88,6 +88,12 @@ internal static class KestrelBadHttpRequestException
             case RequestRejectionReason.InvalidHostHeader:
                 ex = new BadHttpRequestException(CoreStrings.BadRequest_InvalidHostHeader, StatusCodes.Status400BadRequest, reason);
                 break;
+            case RequestRejectionReason.UnrecognizedHTTPVersion:
+                ex = new BadHttpRequestException(CoreStrings.BadRequest_UnrecognizedHTTPVersion, StatusCodes.Status505HttpVersionNotsupported, reason);
+                break;
+            case RequestRejectionReason.InvalidRequestHeader:
+                ex = new BadHttpRequestException(CoreStrings.BadRequest_InvalidRequestHeader, StatusCodes.Status400BadRequest, reason);
+                break;
             default:
                 ex = new BadHttpRequestException(CoreStrings.BadRequest, StatusCodes.Status400BadRequest, reason);
                 break;
@@ -131,7 +137,7 @@ internal static class KestrelBadHttpRequestException
                 ex = new BadHttpRequestException(CoreStrings.FormatBadRequest_InvalidContentLength_Detail(detail), StatusCodes.Status400BadRequest, reason);
                 break;
             case RequestRejectionReason.UnrecognizedHTTPVersion:
-                ex = new BadHttpRequestException(CoreStrings.FormatBadRequest_UnrecognizedHTTPVersion(detail), StatusCodes.Status505HttpVersionNotsupported, reason);
+                ex = new BadHttpRequestException(CoreStrings.FormatBadRequest_UnrecognizedHTTPVersion_Detail(detail), StatusCodes.Status505HttpVersionNotsupported, reason);
                 break;
             case RequestRejectionReason.FinalTransferCodingNotChunked:
                 ex = new BadHttpRequestException(CoreStrings.FormatBadRequest_FinalTransferCodingNotChunked(detail), StatusCodes.Status400BadRequest, reason);

--- a/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTests.cs
@@ -446,6 +446,15 @@ public class Http1ConnectionTests : Http1ConnectionTestsBase
     }
 
     [Fact]
+    public void TryParseRequestStartsRequestHeadersTimeoutOnFirstByteAvailable()
+    {
+        // Simulate the first byte being available and the connection starting to parse
+        _http1Connection.SimulateReadRequestStart();
+
+        _timeoutControl.Verify(cc => cc.ResetTimeout(_serviceContext.ServerOptions.Limits.RequestHeadersTimeout, TimeoutReason.RequestHeaders));
+    }
+
+    [Fact]
     public async Task TakeStartLineThrowsWhenTooLong()
     {
         _serviceContext.ServerOptions.Limits.MaxRequestLineSize = "GET / HTTP/1.1\r\n".Length;

--- a/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTests.cs
@@ -53,7 +53,10 @@ public class Http1ConnectionTests : Http1ConnectionTestsBase
         await _application.Output.WriteAsync(extendedAsciiEncoding.GetBytes("\r\n\r\n"));
         var readableBuffer = (await _transport.Input.ReadAsync()).Buffer;
 
-        var exception = Assert.Throws<InvalidOperationException>(() => TakeMessageHeaders(readableBuffer, trailers: false, out _consumed, out _examined));
+#pragma warning disable CS0618 // Type or member is obsolete
+        var exception = Assert.Throws<BadHttpRequestException>(() => TakeMessageHeaders(readableBuffer, trailers: false, out _consumed, out _examined));
+#pragma warning restore CS0618 // Type or member is obsolete
+        Assert.Equal(RequestRejectionReason.MalformedRequestInvalidHeaders, exception.Reason);
     }
 
     [Fact]

--- a/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTests.cs
@@ -446,17 +446,6 @@ public class Http1ConnectionTests : Http1ConnectionTestsBase
     }
 
     [Fact]
-    public async Task ParseRequestStartsRequestHeadersTimeoutOnFirstByteAvailable()
-    {
-        await _application.Output.WriteAsync(Encoding.ASCII.GetBytes("G"));
-
-        ParseRequest((await _transport.Input.ReadAsync()).Buffer, out _consumed, out _examined);
-        _transport.Input.AdvanceTo(_consumed, _examined);
-
-        _timeoutControl.Verify(cc => cc.ResetTimeout(_serviceContext.ServerOptions.Limits.RequestHeadersTimeout, TimeoutReason.RequestHeaders));
-    }
-
-    [Fact]
     public async Task TakeStartLineThrowsWhenTooLong()
     {
         _serviceContext.ServerOptions.Limits.MaxRequestLineSize = "GET / HTTP/1.1\r\n".Length;
@@ -1061,23 +1050,6 @@ public class Http1ConnectionTests : Http1ConnectionTestsBase
     {
         var reader = new SequenceReader<byte>(readableBuffer);
         if (_http1Connection.TakeStartLine(ref reader))
-        {
-            consumed = reader.Position;
-            examined = reader.Position;
-            return true;
-        }
-        else
-        {
-            consumed = reader.Position;
-            examined = readableBuffer.End;
-            return false;
-        }
-    }
-
-    private bool ParseRequest(ReadOnlySequence<byte> readableBuffer, out SequencePosition consumed, out SequencePosition examined)
-    {
-        var reader = new SequenceReader<byte>(readableBuffer);
-        if (_http1Connection.ParseRequest(ref reader))
         {
             consumed = reader.Position;
             examined = reader.Position;

--- a/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTests.cs
@@ -446,15 +446,6 @@ public class Http1ConnectionTests : Http1ConnectionTestsBase
     }
 
     [Fact]
-    public void TryParseRequestStartsRequestHeadersTimeoutOnFirstByteAvailable()
-    {
-        // Simulate the first byte being available and the connection starting to parse
-        _http1Connection.SimulateReadRequestStart();
-
-        _timeoutControl.Verify(cc => cc.ResetTimeout(_serviceContext.ServerOptions.Limits.RequestHeadersTimeout, TimeoutReason.RequestHeaders));
-    }
-
-    [Fact]
     public async Task TakeStartLineThrowsWhenTooLong()
     {
         _serviceContext.ServerOptions.Limits.MaxRequestLineSize = "GET / HTTP/1.1\r\n".Length;

--- a/src/Servers/Kestrel/Core/test/HttpParserTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpParserTests.cs
@@ -168,7 +168,7 @@ public class HttpParserTests : LoggedTest
 #pragma warning restore CS0618 // Type or member is obsolete
             ParseRequestLine(parser, requestHandler, buffer, out var consumed, out var examined));
 
-        Assert.Equal(CoreStrings.FormatBadRequest_UnrecognizedHTTPVersion(httpVersion), exception.Message);
+        Assert.Equal(CoreStrings.FormatBadRequest_UnrecognizedHTTPVersion_Detail(httpVersion), exception.Message);
         Assert.Equal(StatusCodes.Status505HttpVersionNotsupported, exception.StatusCode);
     }
 
@@ -529,7 +529,7 @@ public class HttpParserTests : LoggedTest
 #pragma warning restore CS0618 // Type or member is obsolete
             ParseRequestLine(parser, requestHandler, buffer, out var consumed, out var examined));
 
-        Assert.Equal("Invalid request line: ''", exception.Message);
+        Assert.Equal(CoreStrings.BadRequest_InvalidRequestLine, exception.Message);
         Assert.Equal(StatusCodes.Status400BadRequest, exception.StatusCode);
 
         // Unrecognized HTTP version
@@ -540,7 +540,7 @@ public class HttpParserTests : LoggedTest
 #pragma warning restore CS0618 // Type or member is obsolete
             ParseRequestLine(parser, requestHandler, buffer, out var consumed, out var examined));
 
-        Assert.Equal(CoreStrings.FormatBadRequest_UnrecognizedHTTPVersion(string.Empty), exception.Message);
+        Assert.Equal(CoreStrings.BadRequest_UnrecognizedHTTPVersion, exception.Message);
         Assert.Equal(StatusCodes.Status505HttpVersionNotsupported, exception.StatusCode);
 
         // Invalid request header
@@ -554,7 +554,7 @@ public class HttpParserTests : LoggedTest
             parser.ParseHeaders(requestHandler, ref reader);
         });
 
-        Assert.Equal(CoreStrings.FormatBadRequest_InvalidRequestHeader_Detail(string.Empty), exception.Message);
+        Assert.Equal(CoreStrings.BadRequest_InvalidRequestHeader, exception.Message);
         Assert.Equal(StatusCodes.Status400BadRequest, exception.StatusCode);
     }
 

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Mocks/NullParser.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Mocks/NullParser.cs
@@ -43,6 +43,18 @@ internal sealed class NullParser<TRequestHandler> : IHttpParser<TRequestHandler>
         return true;
     }
 
+    HttpParseResult IHttpParser<TRequestHandler>.TryParseRequestLine(TRequestHandler handler, ref SequenceReader<byte> reader)
+    {
+        ParseRequestLine(handler, ref reader);
+        return HttpParseResult.Complete;
+    }
+
+    HttpParseResult IHttpParser<TRequestHandler>.TryParseHeaders(TRequestHandler handler, ref SequenceReader<byte> reader)
+    {
+        ParseHeaders(handler, ref reader);
+        return HttpParseResult.Complete;
+    }
+
     public void Reset()
     {
     }

--- a/src/Servers/Kestrel/shared/test/TestHttp1Connection.cs
+++ b/src/Servers/Kestrel/shared/test/TestHttp1Connection.cs
@@ -4,7 +4,6 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
-using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.InternalTesting;
 
@@ -32,19 +31,6 @@ internal class TestHttp1Connection : Http1Connection
     public Task ProduceEndAsync()
     {
         return ProduceEnd();
-    }
-
-    /// <summary>
-    /// Simulates the beginning of request parsing to test timeout behavior.
-    /// This triggers the same timeout logic as the real parsing path without the full parsing overhead.
-    /// </summary>
-    public void SimulateReadRequestStart()
-    {
-        if (_requestProcessingStatus == RequestProcessingStatus.RequestPending)
-        {
-            TimeoutControl.ResetTimeout(ServerOptions.Limits.RequestHeadersTimeout, TimeoutReason.RequestHeaders);
-            _requestProcessingStatus = RequestProcessingStatus.ParsingRequestLine;
-        }
     }
 
     protected override MessageBody CreateMessageBody()

--- a/src/Servers/Kestrel/shared/test/TestHttp1Connection.cs
+++ b/src/Servers/Kestrel/shared/test/TestHttp1Connection.cs
@@ -4,6 +4,7 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.InternalTesting;
 
@@ -31,6 +32,19 @@ internal class TestHttp1Connection : Http1Connection
     public Task ProduceEndAsync()
     {
         return ProduceEnd();
+    }
+
+    /// <summary>
+    /// Simulates the beginning of request parsing to test timeout behavior.
+    /// This triggers the same timeout logic as the real parsing path without the full parsing overhead.
+    /// </summary>
+    public void SimulateReadRequestStart()
+    {
+        if (_requestProcessingStatus == RequestProcessingStatus.RequestPending)
+        {
+            TimeoutControl.ResetTimeout(ServerOptions.Limits.RequestHeadersTimeout, TimeoutReason.RequestHeaders);
+            _requestProcessingStatus = RequestProcessingStatus.ParsingRequestLine;
+        }
     }
 
     protected override MessageBody CreateMessageBody()

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
@@ -39,7 +39,7 @@ public class BadHttpRequestTests : LoggedTest
         return TestBadRequest(
             $"GET / {httpVersion}\r\n",
             "505 HTTP Version Not Supported",
-            CoreStrings.FormatBadRequest_UnrecognizedHTTPVersion(httpVersion),
+            CoreStrings.FormatBadRequest_UnrecognizedHTTPVersion_Detail(httpVersion),
             ConnectionEndReason.InvalidHttpVersion);
     }
 


### PR DESCRIPTION
Introduces a non-throwing code path for HTTP/1.1 request parsing. Instead of using try/catch to handle malformed requests, the parser now returns a result struct indicating success, incomplete, or error states.

Exception handling is expensive, and in scenarios with many malformed requests (port scanning, malicious traffic, misconfigured clients), throwing `BadHttpRequestException` on every parse failure added unnecessary overhead. This eliminates exceptions from the normal bad-request handling path.

In my testing using a client sending bad requests, throughput is up ~20% on an Azure Linux VM. When pinning to 2 cores on my physical machine (to make it CPU bound), I can see RPS increase by over 40%, and a perf trace shows that the time spent in exception handling goes from ~10% to ~0.2%. There's no impact on valid requests.