### PR TITLE
Add PreSignInCheck to PasskeySignInCoreAsync and add unit tests

### DIFF
--- a/src/Identity/Core/src/SignInManager.cs
+++ b/src/Identity/Core/src/SignInManager.cs
@@ -666,6 +666,12 @@ public class SignInManager<TUser> where TUser : class
             return SignInResult.Failed;
         }
 
+        var error = await PreSignInCheck(assertionResult.User);
+        if (error != null)
+        {
+            return error;
+        }
+
         // After a successful assertion, we need to update the passkey so that it has the latest
         // sign count and authenticator data.
         var setPasskeyResult = await UserManager.AddOrUpdatePasskeyAsync(assertionResult.User, assertionResult.Passkey);


### PR DESCRIPTION
# Fix PasskeySignInAsync to enforce email/phone confirmation and lockout checks

Ensure `PasskeySignInAsync()` respects sign-in options and lockout

## Description

`SignInManager.PasskeySignInAsync()` did not run `PreSignInCheck()` prior to completing sign-in. As a result, passkey sign-in could succeed in cases where configured sign-in requirements would otherwise prevent sign-in (e.g., requiring confirmed email/phone, or when the user is locked out). This change adds the missing `PreSignInCheck()` call to the passkey sign-in path to match the behavior of other sign-in methods, and adds unit tests covering confirmed email, confirmed phone number, and lockout scenarios.

Fixes #65020

## Customer Impact

This bug primarily affects apps that implement passwordless/passkey-first sign-in flows (not implemented in the Blazor Web App template), where passkeys can be registered pre-authentication. While we expect current customer impact to be limited, fixing this ensures passkey sign-in consistently honors configured sign-in requirements and lockout behavior.

## Regression?

- [ ] Yes
- [x] No

Passkey authentication is a new feature in .NET 10.
## Risk

- [ ] High
- [ ] Medium
- [x] Low

Small, targeted logic change in the passkey sign-in flow. New automated tests are added and manual verification has been performed.

## Verification

- [X] Manual (required)
- [x] Automated