### PR TITLE
Use pre-allocated static responses for fast-path bad request handling

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -60,7 +60,7 @@ internal abstract partial class HttpProtocol : IHttpResponseControl
     private bool _hasAdvanced;
     private bool _isLeasedMemoryInvalid = true;
     protected Exception? _applicationException;
-    private BadHttpRequestException? _requestRejectedException;
+    protected BadHttpRequestException? _requestRejectedException;
 
     protected HttpVersion _httpVersion;
     // This should only be used by the application, not the server. This is settable on HttpRequest but we don't want that to affect

--- a/src/Servers/Kestrel/Core/src/KestrelBadHttpRequestException.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelBadHttpRequestException.cs
@@ -23,6 +23,8 @@ internal static class KestrelBadHttpRequestException
 
     [MethodImpl(MethodImplOptions.NoInlining)]
 #pragma warning disable CS0618 // Type or member is obsolete
+    // Keep in sync with the pre-allocated response prefixes in
+    // Http1Connection.GetStaticErrorResponsePrefix().
     internal static BadHttpRequestException GetException(RequestRejectionReason reason)
     {
         BadHttpRequestException ex;


### PR DESCRIPTION
When a bad request is rejected before the app starts processing, bypass the normal response machinery (CreateResponseHeaders, header serialization, lock acquisition, WriteSuffix) and write static response fragments directly to the transport output.

The cached Date header from DateHeaderValueManager and the conditional Server header are inserted between the static prefix and suffix to maintain full HTTP compliance and response parity with the normal path.

This change adds another ~7% RPS improvement on the single-core bad request test in our perf lab. That's on top of the ~24% improvement done in #65256. The cumulative RPS improvement is ~30%.

We have pretty good test coverage already in this area and all the tests are passing.