### PR TITLE
Set SignalR WebSocketFactory for all environments

### DIFF
--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnectionFactory.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnectionFactory.cs
@@ -90,6 +90,7 @@ public class HttpConnectionFactory : IConnectionFactory
             ApplicationMaxBufferSize = options.ApplicationMaxBufferSize,
             TransportMaxBufferSize = options.TransportMaxBufferSize,
             UseStatefulReconnect = options.UseStatefulReconnect,
+            WebSocketFactory = options.WebSocketFactory,
         };
 
         if (!OperatingSystem.IsBrowser())
@@ -100,7 +101,6 @@ public class HttpConnectionFactory : IConnectionFactory
             newOptions.Proxy = options.Proxy;
             newOptions.UseDefaultCredentials = options.UseDefaultCredentials;
             newOptions.WebSocketConfiguration = options.WebSocketConfiguration;
-            newOptions.WebSocketFactory = options.WebSocketFactory;
         }
 
         return newOptions;


### PR DESCRIPTION
# Set SignalR WebSocketFactory for all environments
This pull request makes a minor adjustment to the handling of the `WebSocketFactory` property in the `HttpConnectionFactory` class. The change ensures that `WebSocketFactory` is always set in the shallow copy of `HttpConnectionOptions`, regardless of the operating system.

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

Summary of the changes:
Always assign `WebSocketFactory` when creating a shallow copy of `HttpConnectionOptions`, not only on non-browser platforms. Previously it was only assigned inside the `!OperatingSystem.IsBrowser()` block.

## Description

Fixes #63742 
