### PR TITLE
Disable parallel restore for linker tests

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -87,6 +87,11 @@
      <DisableLogTaskParameterItemMetadata_Csc_References>$(TrimTaskParameters)</DisableLogTaskParameterItemMetadata_Csc_References>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(IsTrimmingTestProject)' == 'true'">
+    <!-- Should mitigate https://github.com/dotnet/aspnetcore/issues/61178 -->
+    <RestoreDisableParallel>true</RestoreDisableParallel>
+  </PropertyGroup
+
   <Import Project="eng\QuarantinedTests.BeforeArcade.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
   <Import Project="eng\QuarantinedTests.AfterArcade.props" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -90,7 +90,7 @@
   <PropertyGroup Condition="'$(IsTrimmingTestProject)' == 'true'">
     <!-- Should mitigate https://github.com/dotnet/aspnetcore/issues/61178 -->
     <RestoreDisableParallel>true</RestoreDisableParallel>
-  </PropertyGroup
+  </PropertyGroup>
 
   <Import Project="eng\QuarantinedTests.BeforeArcade.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />

--- a/eng/testing/linker/project.csproj.template
+++ b/eng/testing/linker/project.csproj.template
@@ -15,6 +15,8 @@
     <InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.AspNetCore.Http.Generated;Microsoft.Extensions.Validation.Generated</InterceptorsPreviewNamespaces>
     <!-- Ensure individual warnings are shown when publishing -->
     <TrimmerSingleWarn>false</TrimmerSingleWarn>
+    <!-- Should mitigate https://github.com/dotnet/dotnet/issues/4558 -->
+    <RestoreDisableParallel>true</RestoreDisableParallel>
     {AdditionalProperties}
   </PropertyGroup>
 

--- a/eng/testing/linker/project.csproj.template
+++ b/eng/testing/linker/project.csproj.template
@@ -15,7 +15,7 @@
     <InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.AspNetCore.Http.Generated;Microsoft.Extensions.Validation.Generated</InterceptorsPreviewNamespaces>
     <!-- Ensure individual warnings are shown when publishing -->
     <TrimmerSingleWarn>false</TrimmerSingleWarn>
-    <!-- Should mitigate https://github.com/dotnet/dotnet/issues/4558 -->
+    <!-- Should mitigate https://github.com/dotnet/aspnetcore/issues/61178 -->
     <RestoreDisableParallel>true</RestoreDisableParallel>
     {AdditionalProperties}
   </PropertyGroup>

--- a/eng/testing/linker/trimmingTests.targets
+++ b/eng/testing/linker/trimmingTests.targets
@@ -102,6 +102,7 @@
           DependsOnTargets="GenerateProjects">
 
     <MSBuild Projects="@(TestConsoleApps)"
+             BuildInParallel="false"
              Targets="Restore"
              Condition="'$(SkipTrimmingProjectsRestore)' != 'true'"
              Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid());Configuration=$(Configuration);RestoreDisableParallel=true" />

--- a/eng/testing/linker/trimmingTests.targets
+++ b/eng/testing/linker/trimmingTests.targets
@@ -104,7 +104,7 @@
     <MSBuild Projects="@(TestConsoleApps)"
              Targets="Restore"
              Condition="'$(SkipTrimmingProjectsRestore)' != 'true'"
-             Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid());Configuration=$(Configuration)" />
+             Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid());Configuration=$(Configuration);RestoreDisableParallel=true" />
 
     <MSBuild Projects="@(TestConsoleApps)"
              Targets="Publish"


### PR DESCRIPTION
All remaining instances of https://github.com/dotnet/aspnetcore/issues/61178 are in the linker tests. This workaround has fixed all the other instances of it, so we should add it here too.