### PR TITLE
Avoid disposing invalid handle in HttpSys server close

### DIFF
--- a/src/Servers/HttpSys/src/NativeInterop/RequestQueue.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/RequestQueue.cs
@@ -180,10 +180,13 @@ internal sealed partial class RequestQueue
 
         _disposed = true;
 
+        // Close the request queue handle first to cancel any pending IO operations.
+        // This must happen before disposing BoundHandle, as pending operations need
+        // to be cancelled and cleaned up using the BoundHandle.
         PInvoke.HttpCloseRequestQueue(Handle);
 
         BoundHandle.Dispose();
-        Handle.Dispose();
+        Handle.SetHandleAsInvalid();
     }
 
     private void CheckDisposed()


### PR DESCRIPTION
# Avoid disposing invalid handle in HttpSys server close

## Description

[HttpSys docs](https://learn.microsoft.com/en-us/windows/win32/api/http/nf-http-httpcloserequestqueue#remarks) say we should close the request queue with `HttpCloseRequestQueue` and not with `CloseHandle`. So the PR https://github.com/dotnet/aspnetcore/pull/61325 noticed this while making an unrelated change and updated the code to call `HttpCloseRequestQueue`. Unfortunately, we kept the old `Handle.Dispose()` code which is effectively a double free.

The fix is to mark the handle as invalid after closing the request queue so we avoid the double free.

Fixes #65259 

## Customer Impact

Error log (and exception from `Dispose`) when cleaning up HttpSys server.
Issue: https://github.com/dotnet/aspnetcore/issues/65259

## Regression?

- [x] Yes
- [ ] No

Regressed in https://github.com/dotnet/aspnetcore/pull/61325 (10.0-p5)

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Customer reported exception was easy to repro and thus easy to verify it was fixed with the change.

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A