### PR TITLE
fix: Allow pnpm execution without .cmd extension on Windows in SpaProxy

### DIFF
--- a/src/Middleware/Spa/SpaProxy/src/SpaProxyLaunchManager.cs
+++ b/src/Middleware/Spa/SpaProxy/src/SpaProxyLaunchManager.cs
@@ -180,7 +180,11 @@ internal sealed class SpaProxyLaunchManager : IDisposable
                 // On windows we transform npm/yarn to npm.cmd/yarn.cmd so that the command
                 // can actually be found when we start the process. This is overridable if
                 // necessary by explicitly setting up the extension on the command.
-                command = $"{command}.cmd";
+                if (string.Equals(command, "npm", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(command, "yarn", StringComparison.OrdinalIgnoreCase))
+                {
+                    command = $"{command}.cmd";
+                }
             }
 
             var info = new ProcessStartInfo(command, arguments)


### PR DESCRIPTION
## Description

This PR addresses issue #45700 by modifying `SpaProxyLaunchManager` to avoid blindly appending the `.cmd` extension to the launch command on Windows if it is not `npm` or `yarn`.

### Problem
Previously, any launch command without an extension on Windows would have `.cmd` appended to it. This prevented tools installed as standalone executables (such as `pnpm.exe`) from being launched correctly, as the system would look for `pnpm.cmd` which might not exist or be the intended target.

### Solution
The logic has been updated to only append `.cmd` for `npm` and `yarn` commands (maintaining backward compatibility and typical Windows behavior for these tools). For other commands, such as `pnpm`, the extension is not forced, allowing `Process.Start` with `UseShellExecute = true` to resolve the executable from `PATH` correctly (finding `.exe`, `.cmd`, `.bat`, etc.).

Fixes #45700
