### PR TITLE
Fix Http3 connection close metric sometimes remaining Unset

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -468,6 +468,10 @@ internal sealed class Http3Connection : IHttp3StreamLifetimeHandler, IRequestPro
                     Log.RequestProcessingError(_context.ConnectionId, ex);
                     reason = ConnectionEndReason.ConnectionReset;
                 }
+                else
+                {
+                    reason = ConnectionEndReason.TransportCompleted;
+                }
             }
             error = ex;
             clientAbort = true;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3ConnectionTests.cs
@@ -898,60 +898,6 @@ public class Http3ConnectionTests : Http3TestBase
         return streamContext;
     }
 
-    [Fact]
-    public async Task ConnectionResetWithNoActiveRequests_ReportsTransportCompleted()
-    {
-        // When a ConnectionResetException occurs with no active requests (e.g., the client
-        // disconnects after all requests have completed), the connection end reason should be
-        // TransportCompleted, not Unset.
-
-        var abortTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        // skipCount: 0 means the first AcceptAsync throws ConnectionResetException immediately.
-        // The outbound control stream is created via ConnectAsync (not AcceptAsync) so it still succeeds.
-        Http3Api.MultiplexedConnectionContext = new ConnectionResetMultiplexedConnectionContext(Http3Api, skipCount: 0, abortTcs);
-        await Http3Api.InitializeConnectionAsync(_noopApplication);
-
-        // Wait for the connection to be aborted (ProcessRequestsAsync calls Abort which sets metrics
-        // before calling _multiplexedContext.Abort, which signals abortTcs).
-        await abortTcs.Task.DefaultTimeout();
-
-        MetricsAssert.NoError(Http3Api.ConnectionTags);
-    }
-
-    private sealed class ConnectionResetMultiplexedConnectionContext : TestMultiplexedConnectionContext
-    {
-        private int _skipCount;
-        private readonly TaskCompletionSource _abortTcs;
-
-        /// <summary>
-        /// After <paramref name="skipCount"/> calls to <see cref="AcceptAsync"/>, the next call will throw a <see cref="ConnectionResetException"/>.
-        ///
-        /// <paramref name="abortTcs"/> lets this type signal that <see cref="Abort(ConnectionAbortedException)"/> has been called.
-        /// </summary>
-        public ConnectionResetMultiplexedConnectionContext(Http3InMemory testBase, int skipCount, TaskCompletionSource abortTcs)
-            : base(testBase)
-        {
-            _skipCount = skipCount;
-            _abortTcs = abortTcs;
-        }
-
-        public override async ValueTask<ConnectionContext> AcceptAsync(CancellationToken cancellationToken = default)
-        {
-            if (_skipCount-- <= 0)
-            {
-                throw new ConnectionResetException("Connection reset by peer.");
-            }
-            return await base.AcceptAsync(cancellationToken);
-        }
-
-        public override void Abort(ConnectionAbortedException abortReason)
-        {
-            _abortTcs.TrySetResult();
-            base.Abort(abortReason);
-        }
-    }
-
     private class ResponseTrailersWrapper : IHeaderDictionary
     {
         readonly IHeaderDictionary _innerHeaders;


### PR DESCRIPTION
Closes https://github.com/dotnet/aspnetcore/issues/57579

This is the same as what Http2 does:
https://github.com/dotnet/aspnetcore/blob/07ad803981a7cf5af03aa96d58f4509da309fb2d/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs#L390-L401