### PR TITLE
Don't wait for control stream before processing requests

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -345,6 +345,16 @@ internal sealed class Http3Connection : IHttp3StreamLifetimeHandler, IRequestPro
 
         try
         {
+            // https://datatracker.ietf.org/doc/html/rfc9114#section-7.2.4.2
+            // All settings begin at an initial value. Each endpoint SHOULD use
+            // these initial values to send messages before the peer's SETTINGS
+            // frame has arrived, as packets carrying the settings can be lost or
+            // delayed. When the SETTINGS frame arrives, any settings are changed to
+            // their new values.
+            //
+            // Clients SHOULD NOT wait indefinitely for SETTINGS to arrive before sending requests
+
+            // Which implies we shouldn't block on sending the SETTINGS frame before accepting and processing requests
             outboundControlStreamTask = CreateNewUnidirectionalStreamAsync(application);
 
             // Close the connection if we don't receive any request streams
@@ -742,7 +752,6 @@ internal sealed class Http3Connection : IHttp3StreamLifetimeHandler, IRequestPro
 
         OutboundControlStream = new Http3ControlStream<TContext>(application, httpConnectionContext, 0L);
 
-        // Don't delay on waiting to send outbound control stream settings.
         await ProcessOutboundControlStreamAsync(OutboundControlStream);
     }
 

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Interop.FunctionalTests.csproj
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Interop.FunctionalTests.csproj
@@ -16,6 +16,7 @@
     <Compile Include="$(SharedSourceRoot)NullScope.cs" />
     <Compile Include="$(SharedSourceRoot)SyncPoint\SyncPoint.cs" Link="SyncPoint.cs" />
     <Compile Include="$(SharedSourceRoot)runtime\Http3\Frames\Http3ErrorCode.cs" Link="Shared\runtime\Http3\%(Filename)%(Extension)" />
+    <Compile Include="$(SharedSourceRoot)runtime\Http3\Helpers\VariableLengthIntegerHelper.cs" Link="Shared\runtime\Http3\%(Filename)%(Extension)" />
     <Compile Include="$(KestrelSharedSourceRoot)test\StreamExtensions.cs" LinkBase="shared" />
     <Compile Include="$(KestrelSharedSourceRoot)test\TransportTestHelpers\IHostPortExtensions.cs" LinkBase="shared" />
     <Compile Include="$(KestrelSharedSourceRoot)test\TransportTestHelpers\IWebHostPortExtensions.cs" LinkBase="shared" />


### PR DESCRIPTION
HTTP/3 RFC implies requests can be processed before the SETTINGS frame is processed.
https://datatracker.ietf.org/doc/html/rfc9114#section-7.2.4.2

HttpClient is also already sending SETTINGS in a background task while starting the rest of it's processing: https://source.dot.net/#System.Net.Http/System/Net/Http/SocketsHttpHandler/[Http3Connection.cs](https://source.dot.net/#System.Net.Http/System/Net/Http/SocketsHttpHandler/Http3Connection.cs,103),103

This PR updates Kestrel to start the control stream and SETTINGS sending in a background thread and start processing incoming requests immediately.