### PR TITLE
Add UrlDecode option to FromRouteAttribute for full percent-decoding

### DIFF
--- a/src/Http/Http.Abstractions/src/Metadata/IFromRouteMetadata.cs
+++ b/src/Http/Http.Abstractions/src/Metadata/IFromRouteMetadata.cs
@@ -12,4 +12,23 @@ public interface IFromRouteMetadata
     /// The <see cref="HttpRequest.RouteValues"/> name.
     /// </summary>
     string? Name { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the route parameter value should be fully URL-decoded
+    /// using <see cref="System.Uri.UnescapeDataString(string)"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// By default, some characters such as <c>/</c> (<c>%2F</c>) are not decoded
+    /// in route values because they are decoded at the server level with special handling.
+    /// Setting this property to <c>true</c> ensures the value is fully percent-decoded
+    /// per RFC 3986.
+    /// </para>
+    /// <example>
+    /// <code>
+    /// app.MapGet("/users/{userId}", ([FromRoute(UrlDecode = true)] string userId) => userId);
+    /// </code>
+    /// </example>
+    /// </remarks>
+    bool UrlDecode => false;
 }

--- a/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Microsoft.AspNetCore.Http.Metadata.IFromRouteMetadata.UrlDecode.get -> bool

--- a/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator/StaticRouteHandlerModel/Emitters/EndpointParameterEmitter.cs
+++ b/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator/StaticRouteHandlerModel/Emitters/EndpointParameterEmitter.cs
@@ -204,6 +204,15 @@ internal static class EndpointParameterEmitter
         var assigningCode = $"(string?)httpContext.Request.RouteValues[\"{endpointParameter.LookupName}\"]";
         codeWriter.WriteLine($"var {endpointParameter.EmitAssigningCodeResult()} = {assigningCode};");
 
+        // Apply Uri.UnescapeDataString to fully decode percent-encoded route values (e.g. %2F → /)
+        if (endpointParameter.UrlDecode)
+        {
+            codeWriter.WriteLine($"if ({endpointParameter.EmitAssigningCodeResult()} is not null)");
+            codeWriter.StartBlock();
+            codeWriter.WriteLine($"{endpointParameter.EmitAssigningCodeResult()} = Uri.UnescapeDataString({endpointParameter.EmitAssigningCodeResult()});");
+            codeWriter.EndBlock();
+        }
+
         if (!endpointParameter.IsOptional)
         {
             codeWriter.WriteLine($"if ({endpointParameter.EmitAssigningCodeResult()} == null)");

--- a/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator/StaticRouteHandlerModel/Emitters/EndpointParameterEmitter.cs
+++ b/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator/StaticRouteHandlerModel/Emitters/EndpointParameterEmitter.cs
@@ -201,17 +201,10 @@ internal static class EndpointParameterEmitter
         codeWriter.WriteLine($$"""throw new InvalidOperationException($"'{{endpointParameter.LookupName}}' is not a route parameter.");""");
         codeWriter.EndBlock();
 
-        var assigningCode = $"(string?)httpContext.Request.RouteValues[\"{endpointParameter.LookupName}\"]";
+        var assigningCode = endpointParameter.UrlDecode
+            ? $"RouteValueUrlDecoder.GetUrlDecodedRouteValue(httpContext, \"{endpointParameter.LookupName}\")"
+            : $"(string?)httpContext.Request.RouteValues[\"{endpointParameter.LookupName}\"]";
         codeWriter.WriteLine($"var {endpointParameter.EmitAssigningCodeResult()} = {assigningCode};");
-
-        // Apply Uri.UnescapeDataString to fully decode percent-encoded route values (e.g. %2F → /)
-        if (endpointParameter.UrlDecode)
-        {
-            codeWriter.WriteLine($"if ({endpointParameter.EmitAssigningCodeResult()} is not null)");
-            codeWriter.StartBlock();
-            codeWriter.WriteLine($"{endpointParameter.EmitAssigningCodeResult()} = Uri.UnescapeDataString({endpointParameter.EmitAssigningCodeResult()});");
-            codeWriter.EndBlock();
-        }
 
         if (!endpointParameter.IsOptional)
         {

--- a/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator/StaticRouteHandlerModel/EndpointParameter.cs
+++ b/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator/StaticRouteHandlerModel/EndpointParameter.cs
@@ -73,6 +73,7 @@ internal class EndpointParameter
             LookupName = GetEscapedParameterName(fromRouteAttribute, symbol.Name);
             IsParsable = TryGetParsability(Type, wellKnownTypes, out var preferredTryParseInvocation);
             PreferredTryParseInvocation = preferredTryParseInvocation;
+            UrlDecode = fromRouteAttribute.TryGetNamedArgumentValue<bool>("UrlDecode", out var urlDecode) && urlDecode;
         }
         else if (attributes.TryGetAttributeImplementingInterface(wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Http_Metadata_IFromQueryMetadata), out var fromQueryAttribute))
         {
@@ -297,6 +298,7 @@ internal class EndpointParameter
     public bool IsParsable { get; set; }
     public Func<string, string, string>? PreferredTryParseInvocation { get; set; }
     public bool IsStringValues { get; set; }
+    public bool UrlDecode { get; set; }
 
     public BindabilityMethod? BindMethod { get; set; }
     public IMethodSymbol? BindableMethodSymbol { get; set; }
@@ -599,7 +601,8 @@ internal class EndpointParameter
         other.Ordinal == Ordinal &&
         other.IsOptional == IsOptional &&
         SymbolEqualityComparer.IncludeNullability.Equals(other.Type, Type) &&
-        other.KeyedServiceKey == KeyedServiceKey;
+        other.KeyedServiceKey == KeyedServiceKey &&
+        other.UrlDecode == UrlDecode;
 
     public bool SignatureEquals(object obj) =>
         obj is EndpointParameter other &&

--- a/src/Http/Http.Extensions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Extensions/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.AspNetCore.Http.RouteValueUrlDecoder
+static Microsoft.AspNetCore.Http.RouteValueUrlDecoder.GetUrlDecodedRouteValue(Microsoft.AspNetCore.Http.HttpContext! httpContext, string! parameterName) -> string?

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -60,7 +60,7 @@ public static partial class RequestDelegateFactory
     private static readonly MethodInfo ResultWriteResponseAsyncMethod = typeof(RequestDelegateFactory).GetMethod(nameof(ExecuteResultWriteResponse), BindingFlags.NonPublic | BindingFlags.Static)!;
     private static readonly MethodInfo StringResultWriteResponseAsyncMethod = typeof(RequestDelegateFactory).GetMethod(nameof(ExecuteWriteStringResponseAsync), BindingFlags.NonPublic | BindingFlags.Static)!;
     private static readonly MethodInfo StringIsNullOrEmptyMethod = typeof(string).GetMethod(nameof(string.IsNullOrEmpty), BindingFlags.Static | BindingFlags.Public)!;
-    private static readonly MethodInfo UriUnescapeDataStringMethod = typeof(Uri).GetMethod(nameof(Uri.UnescapeDataString), BindingFlags.Static | BindingFlags.Public, new[] { typeof(string) })!;
+    private static readonly MethodInfo GetUrlDecodedRouteValueMethod = typeof(RouteValueUrlDecoder).GetMethod(nameof(RouteValueUrlDecoder.GetUrlDecodedRouteValue), BindingFlags.Static | BindingFlags.Public)!;
     private static readonly MethodInfo WrapObjectAsValueTaskMethod = typeof(RequestDelegateFactory).GetMethod(nameof(WrapObjectAsValueTask), BindingFlags.NonPublic | BindingFlags.Static)!;
     private static readonly MethodInfo TaskOfTToValueTaskOfObjectMethod = typeof(RequestDelegateFactory).GetMethod(nameof(TaskOfTToValueTaskOfObject), BindingFlags.NonPublic | BindingFlags.Static)!;
     private static readonly MethodInfo ValueTaskOfTToValueTaskOfObjectMethod = typeof(RequestDelegateFactory).GetMethod(nameof(ValueTaskOfTToValueTaskOfObject), BindingFlags.NonPublic | BindingFlags.Static)!;
@@ -735,7 +735,14 @@ public static partial class RequestDelegateFactory
                 throw new InvalidOperationException($"'{routeName}' is not a route parameter.");
             }
 
-            return BindParameterFromProperty(parameter, RouteValuesExpr, RouteValuesIndexerProperty, routeName, factoryContext, "route", urlDecode: routeAttribute.UrlDecode);
+            if (routeAttribute.UrlDecode)
+            {
+                // Decode from the raw request target to avoid double-decoding.
+                var valueExpression = Expression.Call(GetUrlDecodedRouteValueMethod, HttpContextExpr, Expression.Constant(routeName));
+                return BindParameterFromValue(parameter, valueExpression, factoryContext, "route");
+            }
+
+            return BindParameterFromProperty(parameter, RouteValuesExpr, RouteValuesIndexerProperty, routeName, factoryContext, "route");
         }
         else if (parameterCustomAttributes.OfType<IFromQueryMetadata>().FirstOrDefault() is { } queryAttribute)
         {
@@ -1569,20 +1576,6 @@ public static partial class RequestDelegateFactory
         return Expression.Convert(indexExpression, returnType ?? typeof(string));
     }
 
-    // Wraps a string expression with null-safe Uri.UnescapeDataString: value is null ? null : Uri.UnescapeDataString(value)
-    private static Expression ApplyUrlDecode(Expression valueExpression)
-    {
-        var tempVar = Expression.Variable(typeof(string), "routeValue");
-        return Expression.Block(
-            typeof(string),
-            new[] { tempVar },
-            Expression.Assign(tempVar, valueExpression),
-            Expression.Condition(
-                Expression.Equal(tempVar, Expression.Constant(null, typeof(string))),
-                Expression.Constant(null, typeof(string)),
-                Expression.Call(UriUnescapeDataStringMethod, tempVar)));
-    }
-
     private static Expression BindParameterFromProperties(ParameterInfo parameter, RequestDelegateFactoryContext factoryContext)
     {
         var parameterType = parameter.ParameterType;
@@ -1982,17 +1975,11 @@ public static partial class RequestDelegateFactory
                 Expression.Convert(CreateDefaultValueExpression(parameter.DefaultValue, parameter.ParameterType), parameter.ParameterType)));
     }
 
-    private static Expression BindParameterFromProperty(ParameterInfo parameter, MemberExpression property, PropertyInfo itemProperty, string key, RequestDelegateFactoryContext factoryContext, string source, bool urlDecode = false)
+    private static Expression BindParameterFromProperty(ParameterInfo parameter, MemberExpression property, PropertyInfo itemProperty, string key, RequestDelegateFactoryContext factoryContext, string source)
     {
         var valueExpression = (source == "header" && parameter.ParameterType.IsArray)
             ? Expression.Call(GetHeaderSplitMethod, property, Expression.Constant(key))
             : GetValueFromProperty(property, itemProperty, key, GetExpressionType(parameter.ParameterType));
-
-        // Apply Uri.UnescapeDataString to fully decode percent-encoded route values (e.g. %2F → /)
-        if (urlDecode)
-        {
-            valueExpression = ApplyUrlDecode(valueExpression);
-        }
 
         return BindParameterFromValue(parameter, valueExpression, factoryContext, source);
     }

--- a/src/Http/Http.Extensions/src/RouteValueUrlDecoder.cs
+++ b/src/Http/Http.Extensions/src/RouteValueUrlDecoder.cs
@@ -1,0 +1,214 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Http.Metadata;
+
+namespace Microsoft.AspNetCore.Http;
+
+/// <summary>
+/// Provides methods for extracting and decoding route parameter values from the raw request target
+/// to avoid double-decoding that would occur when applying <see cref="Uri.UnescapeDataString(string)"/>
+/// to already partially-decoded route values.
+/// </summary>
+/// <remarks>
+/// This type is intended for use by generated code and should not be used directly.
+/// </remarks>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static class RouteValueUrlDecoder
+{
+    /// <summary>
+    /// Gets a fully URL-decoded route parameter value by extracting it from the raw request target
+    /// and applying a single pass of <see cref="Uri.UnescapeDataString(string)"/>.
+    /// </summary>
+    /// <param name="httpContext">The <see cref="HttpContext"/> for the current request.</param>
+    /// <param name="parameterName">The name of the route parameter to decode.</param>
+    /// <returns>The fully decoded route parameter value, or <c>null</c> if the parameter is not found.</returns>
+    public static string? GetUrlDecodedRouteValue(HttpContext httpContext, string parameterName)
+    {
+        var routeValue = httpContext.Request.RouteValues[parameterName]?.ToString();
+        if (routeValue is null)
+        {
+            return null;
+        }
+
+        // Try to get the raw (undecoded) request target.
+        var rawTarget = httpContext.Features.Get<IHttpRequestFeature>()?.RawTarget;
+        if (rawTarget is null)
+        {
+            // Raw target not available (e.g. non-Kestrel server).
+            // Return the route value without additional decoding to avoid double-decode risk.
+            return routeValue;
+        }
+
+        // Get the route template from endpoint diagnostics metadata.
+        var endpoint = httpContext.GetEndpoint();
+        var routeTemplate = endpoint?.Metadata.GetMetadata<IRouteDiagnosticsMetadata>()?.Route;
+        if (routeTemplate is null)
+        {
+            return routeValue;
+        }
+
+        // Find the parameter's segment index in the route template.
+        var (segmentIndex, isSimple, isCatchAll) = FindParameterSegment(routeTemplate, parameterName);
+        if (segmentIndex < 0 || !isSimple)
+        {
+            // Complex segment (e.g. {action}.{format}) or parameter not found.
+            // Cannot safely extract from the raw target.
+            return routeValue;
+        }
+
+        // Strip the query string from the raw target.
+        var rawPath = rawTarget.AsSpan();
+        var queryIndex = rawPath.IndexOf('?');
+        if (queryIndex >= 0)
+        {
+            rawPath = rawPath[..queryIndex];
+        }
+
+        // Strip PathBase from the raw path.
+        var pathBase = httpContext.Request.PathBase.Value;
+        if (!string.IsNullOrEmpty(pathBase) && rawPath.StartsWith(pathBase.AsSpan(), StringComparison.OrdinalIgnoreCase))
+        {
+            rawPath = rawPath[pathBase.Length..];
+        }
+
+        // Extract the raw segment at the computed index and decode it.
+        var rawSegment = ExtractSegment(rawPath, segmentIndex, isCatchAll);
+        if (rawSegment.IsEmpty)
+        {
+            return routeValue;
+        }
+
+        return Uri.UnescapeDataString(rawSegment.ToString());
+    }
+
+    internal static (int segmentIndex, bool isSimple, bool isCatchAll) FindParameterSegment(string template, string parameterName)
+    {
+        var segmentIndex = 0;
+        var i = 0;
+
+        // Skip leading '/'.
+        if (i < template.Length && template[i] == '/')
+        {
+            i++;
+        }
+
+        while (i < template.Length)
+        {
+            var segStart = i;
+
+            // Find the end of the current segment.
+            while (i < template.Length && template[i] != '/')
+            {
+                i++;
+            }
+
+            var segment = template.AsSpan(segStart, i - segStart);
+            if (TryMatchParameter(segment, parameterName, out var isSimple, out var isCatchAll))
+            {
+                return (segmentIndex, isSimple, isCatchAll);
+            }
+
+            segmentIndex++;
+
+            // Skip '/'.
+            if (i < template.Length)
+            {
+                i++;
+            }
+        }
+
+        return (-1, false, false);
+    }
+
+    private static bool TryMatchParameter(ReadOnlySpan<char> segment, string parameterName, out bool isSimple, out bool isCatchAll)
+    {
+        isSimple = false;
+        isCatchAll = false;
+
+        var braceStart = segment.IndexOf('{');
+        if (braceStart < 0)
+        {
+            return false;
+        }
+
+        var braceEnd = segment.LastIndexOf('}');
+        if (braceEnd < 0)
+        {
+            return false;
+        }
+
+        // Extract the content between braces.
+        var content = segment[(braceStart + 1)..braceEnd];
+
+        // Handle catch-all prefix (** or *).
+        if (content.StartsWith("**"))
+        {
+            content = content[2..];
+            isCatchAll = true;
+        }
+        else if (content.StartsWith("*"))
+        {
+            content = content[1..];
+            isCatchAll = true;
+        }
+
+        // Strip constraints (everything after ':').
+        var colonIndex = content.IndexOf(':');
+        if (colonIndex >= 0)
+        {
+            content = content[..colonIndex];
+        }
+
+        // Strip optional marker '?'.
+        if (content.EndsWith("?"))
+        {
+            content = content[..^1];
+        }
+
+        // Compare parameter name (case-insensitive).
+        if (!content.Equals(parameterName.AsSpan(), StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        // A segment is "simple" if it consists entirely of this one parameter.
+        isSimple = braceStart == 0 && braceEnd == segment.Length - 1;
+
+        return true;
+    }
+
+    private static ReadOnlySpan<char> ExtractSegment(ReadOnlySpan<char> rawPath, int targetIndex, bool isCatchAll)
+    {
+        var currentIndex = 0;
+        var i = 0;
+
+        // Skip leading '/'.
+        if (i < rawPath.Length && rawPath[i] == '/')
+        {
+            i++;
+        }
+
+        var segStart = i;
+
+        while (i <= rawPath.Length)
+        {
+            if (i == rawPath.Length || rawPath[i] == '/')
+            {
+                if (currentIndex == targetIndex)
+                {
+                    return isCatchAll ? rawPath[segStart..] : rawPath[segStart..i];
+                }
+
+                currentIndex++;
+                segStart = i + 1;
+            }
+
+            i++;
+        }
+
+        return ReadOnlySpan<char>.Empty;
+    }
+}

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -300,8 +300,9 @@ public partial class RequestDelegateFactoryTests : LoggedTest
         var responseBodyStream = new MemoryStream();
         httpContext.Response.Body = responseBodyStream;
 
-        // %2F is preserved by the server's path decoder, so route values contain literal "%2F"
+        // Simulate what Kestrel does: %2F is preserved in route values, raw target has the original encoding
         httpContext.Request.RouteValues["userId"] = "domain%2Fuser";
+        SetupRawTargetAndEndpoint(httpContext, "/users/domain%2Fuser", "/users/{userId}");
 
         var factoryResult = RequestDelegateFactory.Create(
             ([FromRoute(UrlDecode = true)] string userId) => userId,
@@ -360,6 +361,7 @@ public partial class RequestDelegateFactoryTests : LoggedTest
 
         // Multiple encoded characters: %2F (/) and %2B (+) and %20 (space)
         httpContext.Request.RouteValues["value"] = "a%2Fb%2Bc%20d";
+        SetupRawTargetAndEndpoint(httpContext, "/items/a%2Fb%2Bc%20d", "/items/{value}");
 
         var factoryResult = RequestDelegateFactory.Create(
             ([FromRoute(UrlDecode = true)] string value) => value,
@@ -370,6 +372,52 @@ public partial class RequestDelegateFactoryTests : LoggedTest
         Assert.Equal(200, httpContext.Response.StatusCode);
         var body = Encoding.UTF8.GetString(responseBodyStream.ToArray());
         Assert.Equal("a/b+c d", body);
+    }
+
+    [Fact]
+    public async Task FromRouteWithUrlDecodeDoesNotDoubleDecodePercentEncoding()
+    {
+        var httpContext = CreateHttpContext();
+        var responseBodyStream = new MemoryStream();
+        httpContext.Response.Body = responseBodyStream;
+
+        // Simulate double-encoding: original URL had %252F, Kestrel decoded %25 to %, leaving %2F in route value
+        httpContext.Request.RouteValues["userId"] = "domain%2Fuser";
+        // Raw target still has %252F (the original encoding)
+        SetupRawTargetAndEndpoint(httpContext, "/users/domain%252Fuser", "/users/{userId}");
+
+        var factoryResult = RequestDelegateFactory.Create(
+            ([FromRoute(UrlDecode = true)] string userId) => userId,
+            new() { RouteParameterNames = new[] { "userId" } });
+
+        await factoryResult.RequestDelegate(httpContext);
+
+        Assert.Equal(200, httpContext.Response.StatusCode);
+        var body = Encoding.UTF8.GetString(responseBodyStream.ToArray());
+        // Single decode of %252F should yield %2F, NOT /
+        Assert.Equal("domain%2Fuser", body);
+    }
+
+    [Fact]
+    public async Task FromRouteWithUrlDecodeFallsBackWhenRawTargetUnavailable()
+    {
+        var httpContext = CreateHttpContext();
+        var responseBodyStream = new MemoryStream();
+        httpContext.Response.Body = responseBodyStream;
+
+        // No raw target or endpoint set — should fall back to the route value without decoding
+        httpContext.Request.RouteValues["userId"] = "domain%2Fuser";
+
+        var factoryResult = RequestDelegateFactory.Create(
+            ([FromRoute(UrlDecode = true)] string userId) => userId,
+            new() { RouteParameterNames = new[] { "userId" } });
+
+        await factoryResult.RequestDelegate(httpContext);
+
+        Assert.Equal(200, httpContext.Response.StatusCode);
+        var body = Encoding.UTF8.GetString(responseBodyStream.ToArray());
+        // Without raw target, falls back to the route value as-is
+        Assert.Equal("domain%2Fuser", body);
     }
 
     public static object?[][] TryParsableArrayParameters
@@ -3443,6 +3491,13 @@ public partial class RequestDelegateFactoryTests : LoggedTest
         var builder = new RouteEndpointBuilder(null, RoutePatternFactory.Parse("/"), 0);
         ((List<Func<EndpointFilterFactoryContext, EndpointFilterDelegate, EndpointFilterDelegate>>)builder.FilterFactories).AddRange(filterFactories);
         return builder;
+    }
+
+    private static void SetupRawTargetAndEndpoint(DefaultHttpContext httpContext, string rawTarget, string routeTemplate)
+    {
+        httpContext.Features.Set<IHttpRequestFeature>(new HttpRequestFeature { RawTarget = rawTarget });
+        var endpointBuilder = new RouteEndpointBuilder(_ => Task.CompletedTask, RoutePatternFactory.Parse(routeTemplate), 0);
+        httpContext.SetEndpoint(endpointBuilder.Build());
     }
 
     private record MetadataService;

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.RouteParameter.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.RouteParameter.cs
@@ -1,5 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Primitives;
 using System.Globalization;
@@ -241,6 +242,8 @@ app.MapGet("/{value}", (string value, HttpContext httpContext) => value);
 
         var httpContext = CreateHttpContext();
         httpContext.Request.RouteValues["userId"] = "domain%2Fuser";
+        httpContext.Features.Set<IHttpRequestFeature>(new HttpRequestFeature { RawTarget = "/domain%2Fuser" });
+        httpContext.SetEndpoint(endpoint);
 
         await endpoint.RequestDelegate(httpContext);
 
@@ -271,6 +274,8 @@ app.MapGet("/{value}", (string value, HttpContext httpContext) => value);
 
         var httpContext = CreateHttpContext();
         httpContext.Request.RouteValues["value"] = "a%2Fb%2Bc%20d";
+        httpContext.Features.Set<IHttpRequestFeature>(new HttpRequestFeature { RawTarget = "/a%2Fb%2Bc%20d" });
+        httpContext.SetEndpoint(endpoint);
 
         await endpoint.RequestDelegate(httpContext);
 

--- a/src/Mvc/Mvc.Core/src/FromRouteAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/FromRouteAttribute.cs
@@ -34,4 +34,19 @@ public class FromRouteAttribute : Attribute, IBindingSourceMetadata, IModelNameP
     /// The <see cref="HttpRequest.RouteValues"/> name.
     /// </summary>
     public string? Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the route parameter value should be fully URL-decoded
+    /// using <see cref="Uri.UnescapeDataString(string)"/>.
+    /// </summary>
+    /// <remarks>
+    /// When set to <see langword="true"/>, characters such as <c>%2F</c> (forward slash) that
+    /// are normally preserved in route values will be decoded. Defaults to <see langword="false"/>.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// app.MapGet("/users/{userId}", ([FromRoute(UrlDecode = true)] string userId) => userId);
+    /// </code>
+    /// </example>
+    public bool UrlDecode { get; set; }
 }

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/SimpleTypeModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/SimpleTypeModelBinder.cs
@@ -5,6 +5,7 @@
 
 using System.ComponentModel;
 using System.Runtime.ExceptionServices;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.Extensions.Logging;
 
@@ -57,10 +58,11 @@ public class SimpleTypeModelBinder : IModelBinder
                 ? valueProviderResult.Values.ToString()
                 : valueProviderResult.FirstValue;
 
-            // Apply URL decoding when FromRoute(UrlDecode = true) is specified
+            // Apply URL decoding when FromRoute(UrlDecode = true) is specified.
+            // Decode from the raw request target to avoid double-decoding.
             if (value is not null && ShouldUrlDecodeRouteValue(bindingContext))
             {
-                value = Uri.UnescapeDataString(value);
+                value = RouteValueUrlDecoder.GetUrlDecodedRouteValue(bindingContext.HttpContext, bindingContext.ModelName) ?? value;
             }
 
             object? model;

--- a/src/Mvc/Mvc.Core/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.Core/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.AspNetCore.Mvc.FromRouteAttribute.UrlDecode.get -> bool
+Microsoft.AspNetCore.Mvc.FromRouteAttribute.UrlDecode.set -> void

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Binders/SimpleTypeModelBinderTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Binders/SimpleTypeModelBinderTest.cs
@@ -2,8 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Testing;
 
@@ -495,7 +499,7 @@ public class SimpleTypeModelBinderTest
         };
     }
 
-    private static DefaultModelBindingContext GetBindingContextForParameter(Type controllerType, string methodName, string paramName)
+    private static DefaultModelBindingContext GetBindingContextForParameter(Type controllerType, string methodName, string paramName, string rawTarget = null, string routeTemplate = null, string routeValue = null)
     {
         var provider = new Metadata.DefaultModelMetadataProvider(
             new DefaultCompositeMetadataDetailsProvider(new IMetadataDetailsProvider[]
@@ -506,13 +510,29 @@ public class SimpleTypeModelBinderTest
         var parameter = method.GetParameters().First(p => p.Name == paramName);
         var metadata = provider.GetMetadataForParameter(parameter);
 
+        var httpContext = new DefaultHttpContext();
+        if (rawTarget is not null)
+        {
+            httpContext.Features.Set<IHttpRequestFeature>(new HttpRequestFeature { RawTarget = rawTarget });
+        }
+        if (routeTemplate is not null)
+        {
+            var endpointBuilder = new RouteEndpointBuilder(_ => Task.CompletedTask, RoutePatternFactory.Parse(routeTemplate), 0);
+            httpContext.SetEndpoint(endpointBuilder.Build());
+        }
+        if (routeValue is not null)
+        {
+            httpContext.Request.RouteValues[paramName] = routeValue;
+        }
+
         return new DefaultModelBindingContext
         {
             ModelMetadata = metadata,
             ModelName = paramName,
             ModelState = new ModelStateDictionary(),
             BindingSource = metadata.BindingSource,
-            ValueProvider = new SimpleValueProvider()
+            ValueProvider = new SimpleValueProvider(),
+            ActionContext = new ActionContext { HttpContext = httpContext },
         };
     }
 
@@ -520,7 +540,8 @@ public class SimpleTypeModelBinderTest
     public async Task BindModelAsync_UrlDecodesRouteValue_WhenFromRouteUrlDecodeIsTrue()
     {
         var bindingContext = GetBindingContextForParameter(
-            typeof(UrlDecodeTestController), nameof(UrlDecodeTestController.WithUrlDecode), "userId");
+            typeof(UrlDecodeTestController), nameof(UrlDecodeTestController.WithUrlDecode), "userId",
+            rawTarget: "/users/domain%2Fuser", routeTemplate: "/users/{userId}", routeValue: "domain%2Fuser");
         bindingContext.ValueProvider = new SimpleValueProvider
         {
             { "userId", "domain%2Fuser" }
@@ -556,7 +577,8 @@ public class SimpleTypeModelBinderTest
     public async Task BindModelAsync_UrlDecodesMultipleEncodedCharacters()
     {
         var bindingContext = GetBindingContextForParameter(
-            typeof(UrlDecodeTestController), nameof(UrlDecodeTestController.WithUrlDecode), "userId");
+            typeof(UrlDecodeTestController), nameof(UrlDecodeTestController.WithUrlDecode), "userId",
+            rawTarget: "/users/a%2Fb%2Bc%20d", routeTemplate: "/users/{userId}", routeValue: "a%2Fb%2Bc%20d");
         bindingContext.ValueProvider = new SimpleValueProvider
         {
             { "userId", "a%2Fb%2Bc%20d" }


### PR DESCRIPTION
Adds a `UrlDecode` property to `IFromRouteMetadata` and `FromRouteAttribute` that enables full RFC 3986 percent-decoding of route parameter values using `Uri.UnescapeDataString()`. This addresses the inconsistent decoding behavior where some characters (like `%2F`) are preserved while others (like `%2B`) are decoded by the server's path decoder.

The feature is opt-in (defaults to `false`) to maintain backward compatibility. Users enable it with `[FromRoute(UrlDecode = true)]`.

**Implementation covers:**
- `IFromRouteMetadata` interface (default interface method)
- `FromRouteAttribute` (new `UrlDecode` property)
- Minimal APIs runtime path (`RequestDelegateFactory`)
- Minimal APIs source generator path (RDG `EndpointParameterEmitter`)
- MVC model binding (`SimpleTypeModelBinder`)

**Tests added:** 10 new tests across Minimal APIs (runtime + RDG) and MVC covering decode-on, decode-off, null handling, and multi-character encoding.

Fixes #11544