### PR TITLE
Make report-green.yml run on agentless server job

### DIFF
--- a/.azure/pipelines/report-green.yml
+++ b/.azure/pipelines/report-green.yml
@@ -22,16 +22,10 @@ pr:
 
 # ABG - Always Be Green
 jobs:
-- template: /eng/common/templates/jobs/jobs.yml
-  parameters:
-    enableTelemetry: true
-    helixRepo: dotnet/aspnetcore
-    jobs:
-    - job: Report_Green
-      enableSBOM: false
-      pool:
-        vmImage: ubuntu-22.04
-      steps:
-      - powershell: |
-          exit 0
-        displayName: Exit 0
+  - job: Report_Green
+    pool: server
+    steps:
+    # This is a documentation-only change. Use no-op task to exit successfully.
+    - task: Delay@1
+      inputs:
+        delayForMinutes: '0'


### PR DESCRIPTION
We only need to no-op and can avoid allocating a CI machine. Same as https://github.com/dotnet/runtime/pull/124442
