### PR TITLE
Securely overwrite X-Content-Length for mitigating request smuggling via TransferEncoding & ContentLength headers

### DIFF
--- a/src/Servers/HttpSys/src/RequestProcessing/Request.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Request.cs
@@ -528,7 +528,9 @@ internal sealed partial class Request
         // We should remove the Content-Length request header in this case, for compatibility
         // reasons, include X-Content-Length so that the original Content-Length is still available.
         IHeaderDictionary headerDictionary = Headers;
-        headerDictionary.Add("X-Content-Length", headerDictionary[HeaderNames.ContentLength]);
+
+        // dont overwrite if user explicitly set X-Content-Length
+        _ = headerDictionary.TryAdd("X-Content-Length", headerDictionary[HeaderNames.ContentLength]);
         Headers.ContentLength = StringValues.Empty;
     }
 

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
@@ -389,7 +389,8 @@ internal abstract partial class IISHttpContext : NativeRequestContext, IThreadPo
             // reasons, include X-Content-Length so that the original Content-Length is still available.
             if (RequestHeaders.ContentLength.HasValue)
             {
-                RequestHeaders.Add("X-Content-Length", RequestHeaders[HeaderNames.ContentLength]);
+                // if user already passed X-Content-Length, we won't overwrite it
+                _ = RequestHeaders.TryAdd("X-Content-Length", RequestHeaders[HeaderNames.ContentLength]);
                 RequestHeaders.ContentLength = null;
             }
             return true;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1MessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1MessageBody.cs
@@ -182,7 +182,9 @@ internal abstract class Http1MessageBody : MessageBody
             if (headers.ContentLength.HasValue)
             {
                 IHeaderDictionary headerDictionary = headers;
-                headerDictionary.Add("X-Content-Length", headerDictionary[HeaderNames.ContentLength]);
+
+                // if user already passed X-Content-Length, we won't overwrite it
+                _ = headerDictionary.TryAdd("X-Content-Length", headerDictionary[HeaderNames.ContentLength]);
                 headers.ContentLength = null;
             }
 


### PR DESCRIPTION
Noticed that we are removing `Content-Length` header and writing the value to `X-Content-Length` in case of detecting request smuggling attempt via `Transfer-Encoding` and `Content-Length` headers.

However, if user has explicitly passed `X-Content-Length`, code will throw because we are doing a standard `dictionary.Add()` of `X-Content-Length`.

Changed to use `TryAdd()` to avoid unintended behavior.