### PR TITLE
Fix race in RST_STREAM_IncompleteRequest HTTP/2 tests

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -3549,10 +3549,11 @@ public class Http2ConnectionTests : Http2TestBase
         await SendDataAsync(1, new byte[2], endStream: false);
         await SendRstStreamAsync(1);
         await SendDataAsync(1, new byte[10], endStream: false);
-        tcs.TrySetResult();
 
         await WaitForConnectionErrorAsync<Http2ConnectionErrorException>(ignoreNonGoAwayFrames: false, expectedLastStreamId: 1,
             Http2ErrorCode.STREAM_CLOSED, CoreStrings.FormatHttp2ErrorStreamAborted(Http2FrameType.DATA, 1));
+
+        tcs.TrySetResult(); // Don't let the response start until after the abort
 
         AssertConnectionEndReason(ConnectionEndReason.FrameAfterStreamClose);
     }
@@ -3575,10 +3576,11 @@ public class Http2ConnectionTests : Http2TestBase
         await SendDataAsync(1, new byte[2], endStream: false);
         await SendRstStreamAsync(1);
         await SendHeadersAsync(1, Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM, _requestTrailers);
-        tcs.TrySetResult();
 
         await WaitForConnectionErrorAsync<Http2ConnectionErrorException>(ignoreNonGoAwayFrames: false, expectedLastStreamId: 1,
             Http2ErrorCode.STREAM_CLOSED, CoreStrings.FormatHttp2ErrorStreamAborted(Http2FrameType.HEADERS, 1));
+
+        tcs.TrySetResult(); // Don't let the response start until after the abort
 
         AssertConnectionEndReason(ConnectionEndReason.FrameAfterStreamClose);
     }


### PR DESCRIPTION
## Summary

Fix race condition in `RST_STREAM_IncompleteRequest_AdditionalDataFrames_ConnectionAborted` and `RST_STREAM_IncompleteRequest_AdditionalTrailerFrames_ConnectionAborted` tests.

## Problem

`tcs.TrySetResult()` was called before `WaitForConnectionErrorAsync`, allowing the request handler to complete and write response HEADERS into the output pipe before the GOAWAY frame. Since `ignoreNonGoAwayFrames: false`, the test fails when it reads HEADERS instead of GOAWAY.

## Fix

Move `tcs.TrySetResult()` after `WaitForConnectionErrorAsync` so the response handler stays blocked until the GOAWAY has been sent and verified. This is the same fix pattern applied in #57450 for the analogous `AdditionalWindowUpdateFrame` test.