### PR TITLE
Fix flaky Http2 test by using consistent ConnectionEndReason for closed streams

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -754,7 +754,7 @@ internal sealed partial class Http2Connection : IHttp2StreamLifetimeHandler, IHt
         //
         // We choose to do that here so we don't have to keep state to track implicitly closed
         // streams vs. streams closed with END_STREAM or RST_STREAM.
-        throw new Http2ConnectionErrorException(CoreStrings.FormatHttp2ErrorStreamClosed(_incomingFrame.Type, _incomingFrame.StreamId), Http2ErrorCode.STREAM_CLOSED, ConnectionEndReason.UnknownStream);
+        throw new Http2ConnectionErrorException(CoreStrings.FormatHttp2ErrorStreamClosed(_incomingFrame.Type, _incomingFrame.StreamId), Http2ErrorCode.STREAM_CLOSED, ConnectionEndReason.FrameAfterStreamClose);
     }
 
     private Http2ConnectionErrorException CreateReceivedFrameStreamAbortedException(Http2Stream stream)

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -5835,7 +5835,7 @@ public class Http2ConnectionTests : Http2TestBase
         switch (finalFrameType)
         {
             case Http2FrameType.DATA:
-                AssertConnectionEndReason(ConnectionEndReason.UnknownStream);
+                AssertConnectionEndReason(ConnectionEndReason.FrameAfterStreamClose);
                 break;
 
             case Http2FrameType.HEADERS:

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -1639,7 +1639,7 @@ public class Http2ConnectionTests : Http2TestBase
                     CoreStrings.FormatHttp2ErrorStreamClosed(Http2FrameType.DATA, streamId: 1),
                     CoreStrings.FormatHttp2ErrorStreamHalfClosedRemote(Http2FrameType.DATA, streamId: 1)
             });
-        AssertConnectionEndReason(ConnectionEndReason.UnknownStream);
+        AssertConnectionEndReason(ConnectionEndReason.FrameAfterStreamClose);
     }
 
     [Fact]
@@ -1853,7 +1853,7 @@ public class Http2ConnectionTests : Http2TestBase
             expectedErrorCode: Http2ErrorCode.STREAM_CLOSED,
             expectedErrorMessage: CoreStrings.FormatHttp2ErrorStreamClosed(Http2FrameType.DATA, streamId: 1));
 
-        AssertConnectionEndReason(ConnectionEndReason.UnknownStream);
+        AssertConnectionEndReason(ConnectionEndReason.FrameAfterStreamClose);
     }
 
     [Fact]
@@ -5744,7 +5744,7 @@ public class Http2ConnectionTests : Http2TestBase
                             CoreStrings.FormatHttp2ErrorStreamClosed(Http2FrameType.DATA, streamId: 1),
                             CoreStrings.FormatHttp2ErrorStreamHalfClosedRemote(Http2FrameType.DATA, streamId: 1)
                     });
-                AssertConnectionEndReason(ConnectionEndReason.UnknownStream);
+                AssertConnectionEndReason(ConnectionEndReason.FrameAfterStreamClose);
                 break;
 
             case Http2FrameType.HEADERS:

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -3549,10 +3549,11 @@ public class Http2ConnectionTests : Http2TestBase
         await SendDataAsync(1, new byte[2], endStream: false);
         await SendRstStreamAsync(1);
         await SendDataAsync(1, new byte[10], endStream: false);
-        tcs.TrySetResult();
 
         await WaitForConnectionErrorAsync<Http2ConnectionErrorException>(ignoreNonGoAwayFrames: false, expectedLastStreamId: 1,
             Http2ErrorCode.STREAM_CLOSED, CoreStrings.FormatHttp2ErrorStreamAborted(Http2FrameType.DATA, 1));
+
+        tcs.TrySetResult(); // Don't let the response start until after the abort
 
         AssertConnectionEndReason(ConnectionEndReason.FrameAfterStreamClose);
     }
@@ -3575,10 +3576,11 @@ public class Http2ConnectionTests : Http2TestBase
         await SendDataAsync(1, new byte[2], endStream: false);
         await SendRstStreamAsync(1);
         await SendHeadersAsync(1, Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM, _requestTrailers);
-        tcs.TrySetResult();
 
         await WaitForConnectionErrorAsync<Http2ConnectionErrorException>(ignoreNonGoAwayFrames: false, expectedLastStreamId: 1,
             Http2ErrorCode.STREAM_CLOSED, CoreStrings.FormatHttp2ErrorStreamAborted(Http2FrameType.HEADERS, 1));
+
+        tcs.TrySetResult(); // Don't let the response start until after the abort
 
         AssertConnectionEndReason(ConnectionEndReason.FrameAfterStreamClose);
     }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TimeoutTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TimeoutTests.cs
@@ -304,7 +304,7 @@ public class Http2TimeoutTests : Http2TestBase
         switch (finalFrameType)
         {
             case Http2FrameType.DATA:
-                AssertConnectionEndReason(ConnectionEndReason.UnknownStream);
+                AssertConnectionEndReason(ConnectionEndReason.FrameAfterStreamClose);
                 break;
 
             case Http2FrameType.CONTINUATION:


### PR DESCRIPTION
## Summary

`ProcessDataFrameAsync`'s "stream not found" path used `ConnectionEndReason.UnknownStream`, but the stream was known-and-closed (`ThrowIfIncomingFrameSentToIdleStream` already rejects truly unknown streams). This was inconsistent with the `RstStreamReceived` and `EndStreamReceived` paths which both use `FrameAfterStreamClose`, causing a flaky test (`AbortedStream_ResetsAndDrainsRequest_RefusesFramesAfterClientReset`) depending on whether stream cleanup completed before the next frame arrived.

## Changes

- **`Http2Connection.cs`**: Changed `ConnectionEndReason.UnknownStream` → `FrameAfterStreamClose` in `ProcessDataFrameAsync`'s "stream not found" path, making it consistent with the other closed-stream code paths.
- **`Http2ConnectionTests.cs`**: Updated the test assertion to expect `FrameAfterStreamClose` deterministically.

## Impact

Metrics-only change. Same exception type, HTTP/2 error code (`STREAM_CLOSED`), error message, and GOAWAY behavior. Only the `ConnectionEndReason` metric tag on `kestrel.connection.duration` changes.