### PR TITLE
Fixing JsonPatchDocument bug 

### DIFF
--- a/src/Features/JsonPatch.SystemTextJson/src/Internal/ListAdapter.cs
+++ b/src/Features/JsonPatch.SystemTextJson/src/Internal/ListAdapter.cs
@@ -154,15 +154,21 @@ internal class ListAdapter : IAdapter
 
         var count = GenericListOrJsonArrayUtilities.GetCount(target);
 
-        if (!TryGetPositionInfo(count, segment, OperationType.Get, out var positionInfo, out errorMessage))
+        if (!int.TryParse(segment, out var index))
         {
             value = null;
+            errorMessage = Resources.FormatInvalidIndexValue(segment);
             return false;
         }
 
-        var index = positionInfo.Type == PositionType.EndOfList ? count - 1 : positionInfo.Index;
-        value = GenericListOrJsonArrayUtilities.GetElementAt(target, index);
+        if (index < 0 || index >= count)
+        {
+            value = null;
+            errorMessage = Resources.FormatIndexOutOfBounds(segment);
+            return false;
+        }
 
+        value = GenericListOrJsonArrayUtilities.GetElementAt(target, index);
         errorMessage = null;
         return true;
     }

--- a/src/Features/JsonPatch.SystemTextJson/src/Internal/ListAdapter.cs
+++ b/src/Features/JsonPatch.SystemTextJson/src/Internal/ListAdapter.cs
@@ -147,6 +147,7 @@ internal class ListAdapter : IAdapter
 
     public virtual bool TryTraverse(object target, string segment, JsonSerializerOptions serializerOptions, out object value, out string errorMessage)
     {
+        throw new NotImplementedException();
         var list = target as IList;
         if (list == null)
         {

--- a/src/Features/JsonPatch.SystemTextJson/src/Internal/ListAdapter.cs
+++ b/src/Features/JsonPatch.SystemTextJson/src/Internal/ListAdapter.cs
@@ -146,13 +146,11 @@ internal class ListAdapter : IAdapter
 
     public virtual bool TryTraverse(object target, string segment, JsonSerializerOptions serializerOptions, out object value, out string errorMessage)
     {
-        if(!TryGetListTypeArgument(target, out _, out errorMessage))
+        if (!TryGetListTypeArgument(target, out _, out errorMessage))
         {
             value = null;
             return false;
         }
-
-        var count = GenericListOrJsonArrayUtilities.GetCount(target);
 
         if (!int.TryParse(segment, out var index))
         {
@@ -160,6 +158,8 @@ internal class ListAdapter : IAdapter
             errorMessage = Resources.FormatInvalidIndexValue(segment);
             return false;
         }
+
+        var count = GenericListOrJsonArrayUtilities.GetCount(target);
 
         if (index < 0 || index >= count)
         {

--- a/src/Features/JsonPatch.SystemTextJson/src/Internal/ListAdapter.cs
+++ b/src/Features/JsonPatch.SystemTextJson/src/Internal/ListAdapter.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using Microsoft.AspNetCore.JsonPatch.SystemTextJson.Helpers;
 using Microsoft.Extensions.Internal;
 

--- a/src/Features/JsonPatch.SystemTextJson/test/Internal/ListAdapterTest.cs
+++ b/src/Features/JsonPatch.SystemTextJson/test/Internal/ListAdapterTest.cs
@@ -534,7 +534,7 @@ public class ListAdapterTest
         Assert.True(success);
         var jsonValue = Assert.IsAssignableFrom<JsonValue>(value);
         Assert.Equal(expectedValue, jsonValue.GetValue<int>());
-        Assert.Null(message);;
+        Assert.Null(message);
     }
 
     [Theory]


### PR DESCRIPTION
# Fixing JsonPatchDocument bug with Replace json array item

There was a bug when try using 
```csharp
JsonPatchDocument.Replace("/SomeArray/0/SomeField/", "new value"); 
```
during apply attempt the exception was thrown: 
```csharp
Microsoft.AspNetCore.JsonPatch.SystemTextJson.Exceptions.JsonPatchException: "For operation 'replace', the target location specified by path '/items/0/id/' was not found."
```


## Description
Problem was in ListAdapter file, method TryTraverse consumed target parameter as "object" type and then tried to cast it to IList, but JsonArray implements only generic IList<JsonNode> (not non-generic IList), so I added condition to proccess it any IList<JsonNode> implementations correctly (instead of just returning null).

Also added one test to demonstrate problem (it runs with my insertations).


Fixes #65409
