### PR TITLE
Add FrameworkReference to Microsoft.Aspnetcore.App for non-SharedFx projects with SharedFx-only references

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -131,6 +131,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <_RemovedAspNetKnownFrameworkReference Include="@(KnownFrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App'))" />
     <KnownFrameworkReference Condition="'$(UseAspNetCoreSharedRuntime)' != 'true'" Remove="Microsoft.AspNetCore.App" />
     <KnownFrameworkReference Remove="Microsoft.WindowsDesktop.App" />
   </ItemGroup>

--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -180,7 +180,8 @@
   <!-- Remove Transtive Microsoft.Aspnetcore.App FrameworkReference, for projects referencing the affected projects above -->
   <Target Name="_RemoveAspNetCoreTransitiveFrameworkReference"
           BeforeTargets="AddTransitiveFrameworkReferences"
-          Condition="'@(TransitiveFrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count())' != '0'" >
+          Condition="'@(TransitiveFrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count())' != '0' AND 
+                     '$(UseAspNetCoreSharedRuntime)' != 'true'" >
     <ItemGroup>
       <TransitiveFrameworkReference Remove="Microsoft.AspNetCore.App" />
     </ItemGroup>

--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -168,7 +168,7 @@
   <Target Name="_RemoveAspNetCoreFrameworkReference" 
           BeforeTargets="ResolveFrameworkReferences" >
     <ItemGroup>
-      <FrameworkReference Remove="@(FrameworkReference->WithMetadataValue('DoNotResolve', 'true')" />
+      <FrameworkReference Remove="@(FrameworkReference->WithMetadataValue('DoNotResolve', 'true'))" />
     </ItemGroup>
   </Target>
 

--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -161,19 +161,14 @@
                  '@(FrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count())' == '0'">
     <KnownFrameworkReference Include="@(_RemovedAspNetKnownFrameworkReference)" />
     <!-- Mark as IsTransitiveFrameworkReference to exclude the pruning data: https://github.com/dotnet/sdk/issues/53106 -->
-    <FrameworkReference Include="Microsoft.AspNetCore.App" IsTransitiveFrameworkReference="true" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" IsTransitiveFrameworkReference="true" DoNotResolve="true" />
   </ItemGroup>
 
   <!-- Remove the referenced AspNetCore framework before it's resolved in ResolveFrameworkReferences.  This lets us use our own references. -->
   <Target Name="_RemoveAspNetCoreFrameworkReference" 
-          BeforeTargets="ResolveFrameworkReferences"
-          Condition="'$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' AND
-                     '$(IsPackable)' == 'true' AND
-                     '$(IsAspNetCoreApp)' != 'true' AND
-                     '@(_FrameworkProjectReference)' != '' AND
-                     '@(FrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count())' != '0'" >
+          BeforeTargets="ResolveFrameworkReferences" >
     <ItemGroup>
-      <FrameworkReference Remove="Microsoft.AspNetCore.App" />
+      <FrameworkReference Remove="@(FrameworkReference->WithMetadataValue('DoNotResolve', 'true')" />
     </ItemGroup>
   </Target>
 

--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -153,34 +153,29 @@
     NuGet pack reads framework references from restore assets. For affected SDK-pack projects, trigger a dedicated
     restore just before GenerateNuspec and include a temporary framework reference only in that restore.
   -->
-  <Target Name="_RestoreWithAspNetCoreAppFrameworkReferenceForNuspec"
-      BeforeTargets="GenerateNuspec"
-      Condition="'$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' AND
-                 '$(IsImplementationProject)' == 'true' AND
+
+  <ItemGroup Condition="'$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' AND
                  '$(IsPackable)' == 'true' AND
                  '$(IsAspNetCoreApp)' != 'true' AND
-                 '$(NuspecFile)' == '' AND
                  '@(_FrameworkProjectReference)' != '' AND
-                 '$(IncludeAspNetCoreAppFrameworkReferenceForNuspec)' != 'true'">
-    <MSBuild
-        Projects="$(MSBuildProjectFullPath)"
-        Targets="Restore"
-        Properties="IncludeAspNetCoreAppFrameworkReferenceForNuspec=true;
-                    BuildProjectReferences=false;RestoreForceEvaluate=true;NoWarn=$(NoWarn);NU1511;NU1510"
-        RemoveProperties="TargetFramework;TargetFrameworkIdentifier;TargetFrameworkVersion;TargetFrameworkMoniker" />
-  </Target>
-
-  <ItemGroup Condition="'$(IncludeAspNetCoreAppFrameworkReferenceForNuspec)' == 'true' AND
-                        '$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' AND
-                        '$(IsImplementationProject)' == 'true' AND
-                        '$(IsPackable)' == 'true' AND
-                        '$(IsAspNetCoreApp)' != 'true' AND
-                        '$(NuspecFile)' == '' AND
-                        '@(_FrameworkProjectReference)' != '' AND
-                        '@(FrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count())' == '0'">
+                 '@(FrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count())' == '0'">
     <KnownFrameworkReference Include="@(_RemovedAspNetKnownFrameworkReference)" />
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <!-- Mark as IsTransitiveFrameworkReference to exclude the pruning data -->
+    <FrameworkReference Include="Microsoft.AspNetCore.App" IsTransitiveFrameworkReference="true" />
   </ItemGroup>
+
+  <!-- Remove the referenced AspNetCore framework before it's resolved in ResolveFrameworkReferences.  This lets us use our own references. -->
+  <Target Name="_RemoveAspNetCoreFrameworkReference" 
+          BeforeTargets="ResolveFrameworkReferences"
+          Condition="'$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' AND
+                     '$(IsPackable)' == 'true' AND
+                     '$(IsAspNetCoreApp)' != 'true' AND
+                     '@(_FrameworkProjectReference)' != '' AND
+                     '@(FrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count())' != '0'" >
+    <ItemGroup>
+      <FrameworkReference Remove="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+  </Target>
 
   <!--
     This target resolves remaining Reference items to Packages, if possible. If not, they are left as Reference

--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -174,7 +174,7 @@
 
   <!-- Remove Transtive Microsoft.Aspnetcore.App FrameworkReference, for projects referencing the affected projects above -->
   <Target Name="_RemoveAspNetCoreTransitiveFrameworkReference"
-          AfterTargets="ResolvePackageAssets"
+          BeforeTargets="AddTransitiveFrameworkReferences"
           Condition="'@(TransitiveFrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count())' != '0'">
     <ItemGroup>
       <TransitiveFrameworkReference Remove="Microsoft.AspNetCore.App" />

--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -160,7 +160,7 @@
                  '@(_FrameworkProjectReference)' != '' AND
                  '@(FrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count())' == '0'">
     <KnownFrameworkReference Include="@(_RemovedAspNetKnownFrameworkReference)" />
-    <!-- Mark as IsTransitiveFrameworkReference to exclude the pruning data -->
+    <!-- Mark as IsTransitiveFrameworkReference to exclude the pruning data: https://github.com/dotnet/sdk/issues/53106 -->
     <FrameworkReference Include="Microsoft.AspNetCore.App" IsTransitiveFrameworkReference="true" />
   </ItemGroup>
 
@@ -180,9 +180,7 @@
   <!-- Remove Transtive Microsoft.Aspnetcore.App FrameworkReference, for projects referencing the affected projects above -->
   <Target Name="_RemoveAspNetCoreTransitiveFrameworkReference"
           BeforeTargets="AddTransitiveFrameworkReferences"
-          AfterTargets="ResolvePackageAssets"
-          Condition="'@(TransitiveFrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count())' != '0' AND 
-                     '$(UseAspNetCoreSharedRuntime)' != 'true'" >
+          Condition="'$(UseAspNetCoreSharedRuntime)' != 'true'" >
     <ItemGroup>
       <TransitiveFrameworkReference Remove="Microsoft.AspNetCore.App" />
     </ItemGroup>

--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -174,7 +174,7 @@
 
   <!-- Remove Transtive Microsoft.Aspnetcore.App FrameworkReference, for projects referencing the affected projects above -->
   <Target Name="_RemoveAspNetCoreTransitiveFrameworkReference"
-          BeforeTargets="AddTransitiveFrameworkReferences"
+          AfterTargets="ResolvePackageAssets"
           Condition="'@(TransitiveFrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count())' != '0'">
     <ItemGroup>
       <TransitiveFrameworkReference Remove="Microsoft.AspNetCore.App" />

--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -150,8 +150,8 @@
   </Target>
 
   <!--
-    NuGet pack reads framework references from restore assets. For affected SDK-pack projects, trigger a dedicated
-    restore just before GenerateNuspec and include a temporary framework reference only in that restore.
+    NuGet pack reads framework references from restore assets. For affected SDK-pack projects, add a temporary
+    framework reference during project evaluation so that it flows into the restore assets used by pack / GenerateNuspec.
   -->
 
   <ItemGroup Condition="'$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' AND

--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -180,6 +180,7 @@
   <!-- Remove Transtive Microsoft.Aspnetcore.App FrameworkReference, for projects referencing the affected projects above -->
   <Target Name="_RemoveAspNetCoreTransitiveFrameworkReference"
           BeforeTargets="AddTransitiveFrameworkReferences"
+          AfterTargets="ResolvePackageAssets"
           Condition="'@(TransitiveFrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count())' != '0' AND 
                      '$(UseAspNetCoreSharedRuntime)' != 'true'" >
     <ItemGroup>

--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -160,22 +160,29 @@
                  '@(_FrameworkProjectReference)' != '' AND
                  '@(FrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count())' == '0'">
     <KnownFrameworkReference Include="@(_RemovedAspNetKnownFrameworkReference)" />
-    <!-- Mark as IsTransitiveFrameworkReference to exclude the pruning data: https://github.com/dotnet/sdk/issues/53106  -->
-    <FrameworkReference Include="Microsoft.AspNetCore.App" IsTransitiveFrameworkReference="true" DoNotResolve="true" />
+    <!-- Mark as IsTransitiveFrameworkReference to exclude the pruning data -->
+    <FrameworkReference Include="Microsoft.AspNetCore.App" IsTransitiveFrameworkReference="true" />
   </ItemGroup>
 
   <!-- Remove the referenced AspNetCore framework before it's resolved in ResolveFrameworkReferences.  This lets us use our own references. -->
   <Target Name="_RemoveAspNetCoreFrameworkReference" 
-          BeforeTargets="ResolveFrameworkReferences" >
+          BeforeTargets="ResolveFrameworkReferences"
+          Condition="'$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' AND
+                     '$(IsPackable)' == 'true' AND
+                     '$(IsAspNetCoreApp)' != 'true' AND
+                     '@(_FrameworkProjectReference)' != '' AND
+                     '@(FrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count())' != '0'" >
     <ItemGroup>
-      <FrameworkReference Remove="@(FrameworkReference->WithMetadataValue('DoNotResolve', 'true')" />
+      <FrameworkReference Remove="Microsoft.AspNetCore.App" />
     </ItemGroup>
   </Target>
 
   <!-- Remove Transtive Microsoft.Aspnetcore.App FrameworkReference, for projects referencing the affected projects above -->
   <Target Name="_RemoveAspNetCoreTransitiveFrameworkReference"
           BeforeTargets="AddTransitiveFrameworkReferences"
-          Condition="'$(UseAspNetCoreSharedRuntime)' != 'true'" >
+          AfterTargets="ResolvePackageAssets"
+          Condition="'@(TransitiveFrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count())' != '0' AND 
+                     '$(UseAspNetCoreSharedRuntime)' != 'true'" >
     <ItemGroup>
       <TransitiveFrameworkReference Remove="Microsoft.AspNetCore.App" />
     </ItemGroup>

--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -160,29 +160,22 @@
                  '@(_FrameworkProjectReference)' != '' AND
                  '@(FrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count())' == '0'">
     <KnownFrameworkReference Include="@(_RemovedAspNetKnownFrameworkReference)" />
-    <!-- Mark as IsTransitiveFrameworkReference to exclude the pruning data -->
-    <FrameworkReference Include="Microsoft.AspNetCore.App" IsTransitiveFrameworkReference="true" />
+    <!-- Mark as IsTransitiveFrameworkReference to exclude the pruning data: https://github.com/dotnet/sdk/issues/53106 -->
+    <FrameworkReference Include="Microsoft.AspNetCore.App" IsTransitiveFrameworkReference="true" DoNotResolve="true" />
   </ItemGroup>
 
   <!-- Remove the referenced AspNetCore framework before it's resolved in ResolveFrameworkReferences.  This lets us use our own references. -->
   <Target Name="_RemoveAspNetCoreFrameworkReference" 
-          BeforeTargets="ResolveFrameworkReferences"
-          Condition="'$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' AND
-                     '$(IsPackable)' == 'true' AND
-                     '$(IsAspNetCoreApp)' != 'true' AND
-                     '@(_FrameworkProjectReference)' != '' AND
-                     '@(FrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count())' != '0'" >
+          BeforeTargets="ResolveFrameworkReferences" >
     <ItemGroup>
-      <FrameworkReference Remove="Microsoft.AspNetCore.App" />
+      <FrameworkReference Remove="@(FrameworkReference->WithMetadataValue('DoNotResolve', 'true')" />
     </ItemGroup>
   </Target>
 
   <!-- Remove Transtive Microsoft.Aspnetcore.App FrameworkReference, for projects referencing the affected projects above -->
   <Target Name="_RemoveAspNetCoreTransitiveFrameworkReference"
           BeforeTargets="AddTransitiveFrameworkReferences"
-          AfterTargets="ResolvePackageAssets"
-          Condition="'@(TransitiveFrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count())' != '0' AND 
-                     '$(UseAspNetCoreSharedRuntime)' != 'true'" >
+          Condition="'@(TransitiveFrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count())' != '0'">
     <ItemGroup>
       <TransitiveFrameworkReference Remove="Microsoft.AspNetCore.App" />
     </ItemGroup>

--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -160,22 +160,29 @@
                  '@(_FrameworkProjectReference)' != '' AND
                  '@(FrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count())' == '0'">
     <KnownFrameworkReference Include="@(_RemovedAspNetKnownFrameworkReference)" />
-    <!-- Mark as IsTransitiveFrameworkReference to exclude the pruning data: https://github.com/dotnet/sdk/issues/53106 -->
-    <FrameworkReference Include="Microsoft.AspNetCore.App" IsTransitiveFrameworkReference="true" DoNotResolve="true" />
+    <!-- Mark as IsTransitiveFrameworkReference to exclude the pruning data -->
+    <FrameworkReference Include="Microsoft.AspNetCore.App" IsTransitiveFrameworkReference="true" />
   </ItemGroup>
 
   <!-- Remove the referenced AspNetCore framework before it's resolved in ResolveFrameworkReferences.  This lets us use our own references. -->
   <Target Name="_RemoveAspNetCoreFrameworkReference" 
-          BeforeTargets="ResolveFrameworkReferences" >
+          BeforeTargets="ResolveFrameworkReferences"
+          Condition="'$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' AND
+                     '$(IsPackable)' == 'true' AND
+                     '$(IsAspNetCoreApp)' != 'true' AND
+                     '@(_FrameworkProjectReference)' != '' AND
+                     '@(FrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count())' != '0'" >
     <ItemGroup>
-      <FrameworkReference Remove="@(FrameworkReference->WithMetadataValue('DoNotResolve', 'true')" />
+      <FrameworkReference Remove="Microsoft.AspNetCore.App" />
     </ItemGroup>
   </Target>
 
   <!-- Remove Transtive Microsoft.Aspnetcore.App FrameworkReference, for projects referencing the affected projects above -->
   <Target Name="_RemoveAspNetCoreTransitiveFrameworkReference"
           BeforeTargets="AddTransitiveFrameworkReferences"
-          Condition="'@(TransitiveFrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count())' != '0'">
+          AfterTargets="ResolvePackageAssets"
+          Condition="'@(TransitiveFrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count())' != '0' AND 
+                     '$(UseAspNetCoreSharedRuntime)' != 'true'" >
     <ItemGroup>
       <TransitiveFrameworkReference Remove="Microsoft.AspNetCore.App" />
     </ItemGroup>

--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -177,6 +177,15 @@
     </ItemGroup>
   </Target>
 
+  <!-- Remove Transtive Microsoft.Aspnetcore.App FrameworkReference, for projects referencing the affected projects above -->
+  <Target Name="_RemoveAspNetCoreTransitiveFrameworkReference"
+          BeforeTargets="AddTransitiveFrameworkReferences"
+          Condition="'@(TransitiveFrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count())' != '0'" >
+    <ItemGroup>
+      <TransitiveFrameworkReference Remove="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+  </Target>
+
   <!--
     This target resolves remaining Reference items to Packages, if possible. If not, they are left as Reference
     items for the SDK to resolve. This executes on NuGet restore and during DesignTimeBuild. It should not run in

--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -160,29 +160,22 @@
                  '@(_FrameworkProjectReference)' != '' AND
                  '@(FrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count())' == '0'">
     <KnownFrameworkReference Include="@(_RemovedAspNetKnownFrameworkReference)" />
-    <!-- Mark as IsTransitiveFrameworkReference to exclude the pruning data -->
-    <FrameworkReference Include="Microsoft.AspNetCore.App" IsTransitiveFrameworkReference="true" />
+    <!-- Mark as IsTransitiveFrameworkReference to exclude the pruning data: https://github.com/dotnet/sdk/issues/53106  -->
+    <FrameworkReference Include="Microsoft.AspNetCore.App" IsTransitiveFrameworkReference="true" DoNotResolve="true" />
   </ItemGroup>
 
   <!-- Remove the referenced AspNetCore framework before it's resolved in ResolveFrameworkReferences.  This lets us use our own references. -->
   <Target Name="_RemoveAspNetCoreFrameworkReference" 
-          BeforeTargets="ResolveFrameworkReferences"
-          Condition="'$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' AND
-                     '$(IsPackable)' == 'true' AND
-                     '$(IsAspNetCoreApp)' != 'true' AND
-                     '@(_FrameworkProjectReference)' != '' AND
-                     '@(FrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count())' != '0'" >
+          BeforeTargets="ResolveFrameworkReferences" >
     <ItemGroup>
-      <FrameworkReference Remove="Microsoft.AspNetCore.App" />
+      <FrameworkReference Remove="@(FrameworkReference->WithMetadataValue('DoNotResolve', 'true')" />
     </ItemGroup>
   </Target>
 
   <!-- Remove Transtive Microsoft.Aspnetcore.App FrameworkReference, for projects referencing the affected projects above -->
   <Target Name="_RemoveAspNetCoreTransitiveFrameworkReference"
           BeforeTargets="AddTransitiveFrameworkReferences"
-          AfterTargets="ResolvePackageAssets"
-          Condition="'@(TransitiveFrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count())' != '0' AND 
-                     '$(UseAspNetCoreSharedRuntime)' != 'true'" >
+          Condition="'$(UseAspNetCoreSharedRuntime)' != 'true'" >
     <ItemGroup>
       <TransitiveFrameworkReference Remove="Microsoft.AspNetCore.App" />
     </ItemGroup>

--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -150,6 +150,39 @@
   </Target>
 
   <!--
+    NuGet pack reads framework references from restore assets. For affected SDK-pack projects, trigger a dedicated
+    restore just before GenerateNuspec and include a temporary framework reference only in that restore.
+  -->
+  <Target Name="_RestoreWithAspNetCoreAppFrameworkReferenceForNuspec"
+      BeforeTargets="GenerateNuspec"
+      Condition="'$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' AND
+                 '$(IsImplementationProject)' == 'true' AND
+                 '$(IsPackable)' == 'true' AND
+                 '$(IsAspNetCoreApp)' != 'true' AND
+                 '$(NuspecFile)' == '' AND
+                 '@(_FrameworkProjectReference)' != '' AND
+                 '$(IncludeAspNetCoreAppFrameworkReferenceForNuspec)' != 'true'">
+    <MSBuild
+        Projects="$(MSBuildProjectFullPath)"
+        Targets="Restore"
+        Properties="IncludeAspNetCoreAppFrameworkReferenceForNuspec=true;
+                    BuildProjectReferences=false;RestoreForceEvaluate=true;NoWarn=$(NoWarn);NU1511;NU1510"
+        RemoveProperties="TargetFramework;TargetFrameworkIdentifier;TargetFrameworkVersion;TargetFrameworkMoniker" />
+  </Target>
+
+  <ItemGroup Condition="'$(IncludeAspNetCoreAppFrameworkReferenceForNuspec)' == 'true' AND
+                        '$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' AND
+                        '$(IsImplementationProject)' == 'true' AND
+                        '$(IsPackable)' == 'true' AND
+                        '$(IsAspNetCoreApp)' != 'true' AND
+                        '$(NuspecFile)' == '' AND
+                        '@(_FrameworkProjectReference)' != '' AND
+                        '@(FrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count())' == '0'">
+    <KnownFrameworkReference Include="@(_RemovedAspNetKnownFrameworkReference)" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <!--
     This target resolves remaining Reference items to Packages, if possible. If not, they are left as Reference
     items for the SDK to resolve. This executes on NuGet restore and during DesignTimeBuild. It should not run in
     outer, cross-targeting build.


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/65410

Projects that are are not in the shared framework, ship as packages, and have references to libraries that _only_ ship in the shared framework, should wind up with a FrameworkReference to Microsoft.AspNetCore.App in their .nuspec. We used to have a custom post-build task that injected that FrameworkReference, but that went away in https://github.com/dotnet/aspnetcore/pull/64863.

This is a bit of a hack - we add a FrameworkReference to the affected projects, so that Restore can put that FrameworkRef into the generated assets file. Then we remove that FrameworkReference prior to `ResolveFrameworkReferences` so that the ProjectReferences get used instead. We also have to add a `IsTransitiveFrameworkReference=true` metadata to the FrameworkReference so that pruning warnings don't kick in: https://github.com/dotnet/sdk/blob/e90c4413024970eca97d05122243737aa207af11/src/Tasks/Microsoft.NET.Build.Tasks/GetPackagesToPrune.cs#L103-L104. It would be great if there was metadata we could set on the FrameworkReference (something like "NuspecOnly"), so that none of the references from the FrameworkReference would actually be raised, and pruning warnings wouldn't fire, but the FrameworkRef would still wind up in project.assets.json & the .nuspec.