### PR TITLE
Fix Copilot not working in forks

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -6,7 +6,7 @@ on: workflow_dispatch
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   copilot-setup-steps:
-    runs-on: ${{ github.event.repository.fork == false && '8-core-ubuntu-latest' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository_owner == 'dotnet' && '8-core-ubuntu-latest' || 'ubuntu-latest' }}
 
     permissions:
       contents: read

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -6,7 +6,7 @@ on: workflow_dispatch
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   copilot-setup-steps:
-    runs-on: 8-core-ubuntu-latest
+    runs-on: ${{ github.event.repository.fork == false && '8-core-ubuntu-latest' || 'ubuntu-latest' }}
 
     permissions:
       contents: read


### PR DESCRIPTION
# Fix Copilot not working on forks

Use a public runner image to allow Copilot setup steps to run in forks of this repository.

## Description

While looking into https://github.com/dotnet/aspnetcore/issues/65371#issuecomment-3935595746 in my fork, I found that Agent workflows would hang indefinitely waiting for a GitHub Actions runner with the custom label to be available (because my account has no such custom runner).

Once I manually updated my main branch to use a public runner image label, things started to work.

This change should allow for .NET team members to continue to benefit from the beefier runner, while community members get something that works, even if it's slower.

If this change is taken, it should probably be applied to at least [aspire](https://github.com/dotnet/aspire/blob/7922bfe45a19b312350678571c919cae2f10274a/.github/workflows/copilot-setup-steps.yml#L9), and maybe any other dotnet repos that might use the same label?