### PR TITLE
docs(azure): fix placeholder title in README.md

### DIFF
--- a/src/Azure/README.md
+++ b/src/Azure/README.md
@@ -1,4 +1,4 @@
-# ProjectName
+# Azure
 
 These projects enable diagnostics integration for apps deployed in Azure App Service. For additional detail see the [App Service docs](https://learn.microsoft.com/aspnet/core/host-and-deploy/azure-apps/).
 


### PR DESCRIPTION
Update README title from placeholder to "Azure"

## Description

The README.md file in the `src/Azure` directory was using a generic `# ProjectName` placeholder title. This PR updates it to `# Azure` to correctly reflect the directory context and content.

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making.