### PR TITLE
Fix for Issue #65523

### DIFF
--- a/src/DataProtection/DataProtection/src/Managed/ManagedAuthenticatedEncryptor.cs
+++ b/src/DataProtection/DataProtection/src/Managed/ManagedAuthenticatedEncryptor.cs
@@ -487,17 +487,16 @@ internal sealed unsafe class ManagedAuthenticatedEncryptor : IAuthenticatedEncry
         using var validationAlgorithm = CreateValidationAlgorithm();
         var hashSize = validationAlgorithm.GetDigestSizeInBytes();
 
-        byte[]? correctHashArray = null;
         Span<byte> correctHash = hashSize <= 128
             ? stackalloc byte[128].Slice(0, hashSize)
-            : (correctHashArray = new byte[hashSize]);
+            : new byte[hashSize];
 
         try
         {
-#if NET10_0_OR_GREATER
             var hashSource = payloadArray!.AsSpan(ivOffset, macOffset - ivOffset);
 
             int bytesWritten;
+#if NET10_0_OR_GREATER
             if (validationAlgorithm is HMACSHA256)
             {
                 bytesWritten = HMACSHA256.HashData(key: validationSubkey, source: hashSource, destination: correctHash);
@@ -518,7 +517,9 @@ internal sealed unsafe class ManagedAuthenticatedEncryptor : IAuthenticatedEncry
 #else
             // if validationSubkey is stackalloc'ed, there is no way we avoid an alloc here
             validationAlgorithm.Key = validationSubkeyArray ?? validationSubkey.ToArray();
-            correctHashArray = validationAlgorithm.ComputeHash(payloadArray, macOffset, eofOffset - macOffset);
+            var success = validationAlgorithm.TryComputeHash(hashSource, correctHash, out bytesWritten);
+            Debug.Assert(success);
+            Debug.Assert(bytesWritten == hashSize);
 #endif
 
             // Step 4: Validate the MAC provided as part of the payload.


### PR DESCRIPTION
# Bugfix for hash validation logic in ManagedAuthenticatedEncryptor

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

Compared the hash using the correct part of the payload, and stored it in the correct reference.

## Description

{Detail}

Unit test already exists in [ManagedAuthenticatedEncryptorTests.cs](https://github.com/dotnet/aspnetcore/blob/e657463d811e673891cf5560f3009eadd2254dbc/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/Managed/ManagedAuthenticatedEncryptorTests.cs#L12-L29), but this does not appear to be run for older .NET versions and `IF` conditional directive only runs on one branch.

Fixes #65523
