### PR TITLE
Pass the current `HttpContext` to `ISessionStore.Create()`

### DIFF
--- a/src/Middleware/Session/src/DistributedSessionStore.cs
+++ b/src/Middleware/Session/src/DistributedSessionStore.cs
@@ -30,7 +30,7 @@ public class DistributedSessionStore : ISessionStore
     }
 
     /// <inheritdoc />
-    public ISession Create(string sessionKey, TimeSpan idleTimeout, TimeSpan ioTimeout, Func<bool> tryEstablishSession, bool isNewSessionKey)
+    public ISession Create(string sessionKey, TimeSpan idleTimeout, TimeSpan ioTimeout, Func<bool> tryEstablishSession, bool isNewSessionKey, HttpContext context)
     {
         ArgumentException.ThrowIfNullOrEmpty(sessionKey);
         ArgumentNullException.ThrowIfNull(tryEstablishSession);

--- a/src/Middleware/Session/src/ISessionStore.cs
+++ b/src/Middleware/Session/src/ISessionStore.cs
@@ -26,6 +26,7 @@ public interface ISessionStore
     /// prior to sending the response.
     /// </param>
     /// <param name="isNewSessionKey"><see langword="true"/> if establishing a new session; <see langword="false"/> if resuming a session.</param>
+    /// <param name="context">The <see cref="HttpContext"/>.</param>
     /// <returns>The <see cref="ISession"/> that was created or resumed.</returns>
     ISession Create(string sessionKey, TimeSpan idleTimeout, TimeSpan ioTimeout, Func<bool> tryEstablishSession, bool isNewSessionKey, HttpContext context);
 }

--- a/src/Middleware/Session/src/ISessionStore.cs
+++ b/src/Middleware/Session/src/ISessionStore.cs
@@ -27,5 +27,5 @@ public interface ISessionStore
     /// </param>
     /// <param name="isNewSessionKey"><see langword="true"/> if establishing a new session; <see langword="false"/> if resuming a session.</param>
     /// <returns>The <see cref="ISession"/> that was created or resumed.</returns>
-    ISession Create(string sessionKey, TimeSpan idleTimeout, TimeSpan ioTimeout, Func<bool> tryEstablishSession, bool isNewSessionKey);
+    ISession Create(string sessionKey, TimeSpan idleTimeout, TimeSpan ioTimeout, Func<bool> tryEstablishSession, bool isNewSessionKey, HttpContext context);
 }

--- a/src/Middleware/Session/src/SessionMiddleware.cs
+++ b/src/Middleware/Session/src/SessionMiddleware.cs
@@ -82,7 +82,7 @@ public class SessionMiddleware
         }
 
         var feature = new SessionFeature();
-        feature.Session = _sessionStore.Create(sessionKey, _options.IdleTimeout, _options.IOTimeout, tryEstablishSession, isNewSessionKey);
+        feature.Session = _sessionStore.Create(sessionKey, _options.IdleTimeout, _options.IOTimeout, tryEstablishSession, isNewSessionKey, context);
         context.Features.Set<ISessionFeature>(feature);
 
         try


### PR DESCRIPTION
# Pass the current `HttpContext` to `ISessionStore.Create()`

`ISessionStore.Create()` now receives the current `HttpContext` object as an argument.

## Description

When implementing `ISessionStore`, occasionally it is necessary to access the `HttpContext` object for the current request in the `ISessionStore.Create()` method. `ISessionStore.Create()` returns the `ISession` object that is eventually attached to the `HttpContext.Session` property.

At the moment, the only way to access the current `HttpContext` in the `ISessionStore.Create()` method is to provide the `HttpContextAccessor` service to the `ISessionStore` constructor. A much cleaner alternative is to directly pass the readily available `HttpContext` object to the `ISessionStore.Create()` method, which is what this PR allows for.

I've noticed that ASP.NET does a pretty good job of making an `HttpContext` object available anywhere a method runs in the context of a request, however this is one place that I think it was overlooked.

Thank you for the opportunity to submit this PR.

Fixes #64926 
