### PR TITLE
Exotic object function call - JSInterop

### DIFF
--- a/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts
+++ b/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts
@@ -616,7 +616,7 @@ export module DotNet {
       switch (callType) {
           case JSCallType.FunctionCall:
               const func = parent[memberName];
-              if (func instanceof Function) {
+              if (typeof func === 'function') {
                   return func.bind(parent);
               } else {
                   throw new Error(`The value '${identifier}' is not a function.`);


### PR DESCRIPTION

# Exotic object function call 
Allow calling functions on exotic objects

## Description
Calling functions on exotic js objects leads to an exception, that the member is not a function. Example: postMessage of WindowProxy.
I fixed the issue by using typeof instead of instanceof.
typeof checks if the object is callable [(has [[Call]])](https://tc39.es/ecma262/#sec-typeof-operator)