### PR TITLE
Fix oversized record length handling in TlsListener

### DIFF
--- a/src/Servers/Kestrel/Core/src/HttpsConnectionAdapterOptions.cs
+++ b/src/Servers/Kestrel/Core/src/HttpsConnectionAdapterOptions.cs
@@ -98,11 +98,14 @@ public class HttpsConnectionAdapterOptions
     public Action<ConnectionContext, SslServerAuthenticationOptions>? OnAuthenticate { get; set; }
 
     /// <summary>
-    /// A callback to be invoked to get the TLS client hello bytes.
+    /// A callback to be invoked to get the TLS client hello bytes. The client hello bytes are still wrapped in the record layer fragment.
     /// Null by default.
     /// If you want to store the bytes from the <see cref="System.Buffers.ReadOnlySequence{T}"/>, 
     /// copy them into a buffer that you control rather than keeping a reference to the <see cref="ReadOnlySequence{T}"/> or <see cref="ReadOnlyMemory{T}"/> instances.
     /// </summary>
+    /// <remarks>
+    /// If a client hello spans multiple record fragments then this callback only gets the first fragment.
+    /// </remarks>
     public Action<ConnectionContext, ReadOnlySequence<byte>>? TlsClientHelloBytesCallback { get; set; }
 
     /// <summary>

--- a/src/Servers/Kestrel/Core/src/Middleware/TlsListener.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/TlsListener.cs
@@ -16,8 +16,8 @@ internal sealed class TlsListener
         _tlsClientHelloBytesCallback = tlsClientHelloBytesCallback;
     }
 
-    // TLS record length must not exceed 2^14 (16384) per RFC 5246/8446
-    internal const ushort MaxTlsRecordLength = 16384;
+    // TLS plaintext fragment length must not exceed 2^14 (16384) per RFC 5246/8446
+    internal const ushort MaxTlsPlaintextFragmentLength = 16384;
 
     /// <summary>
     /// Sniffs the TLS Client Hello message, and invokes a callback if found.
@@ -132,7 +132,7 @@ internal sealed class TlsListener
         // Convert to unsigned interpretation and cap at max TLS record size
         // If the record claims to be larger, we'll just pass what we can (up to 2^14 bytes)
         // We'll let SslStream decide how to handle the oversized record.
-        recordLength = (short)Math.Min((ushort)recordLength, MaxTlsRecordLength);
+        recordLength = (short)Math.Min((ushort)recordLength, MaxTlsPlaintextFragmentLength);
 
         // byte 6: handshake message type (must be 0x01 for ClientHello)
         if (!reader.TryRead(out byte handshakeType) || handshakeType != 0x01)

--- a/src/Servers/Kestrel/Core/src/Middleware/TlsListener.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/TlsListener.cs
@@ -16,6 +16,9 @@ internal sealed class TlsListener
         _tlsClientHelloBytesCallback = tlsClientHelloBytesCallback;
     }
 
+    // TLS record length must not exceed 2^14 (16384) per RFC 5246/8446
+    internal const ushort MaxTlsRecordLength = 16384;
+
     /// <summary>
     /// Sniffs the TLS Client Hello message, and invokes a callback if found.
     /// </summary>
@@ -120,11 +123,16 @@ internal sealed class TlsListener
             return ClientHelloParseState.NotTlsClientHello;
         }
 
-        // Record length
+        // Record length (unsigned 16-bit, read as signed and convert)
         if (!reader.TryReadBigEndian(out recordLength))
         {
             return ClientHelloParseState.NotTlsClientHello;
         }
+
+        // Convert to unsigned interpretation and cap at max TLS record size
+        // If the record claims to be larger, we'll just pass what we can (up to 2^14 bytes)
+        // We'll let SslStream decide how to handle the oversized record.
+        recordLength = (short)Math.Min((ushort)recordLength, MaxTlsRecordLength);
 
         // byte 6: handshake message type (must be 0x01 for ClientHello)
         if (!reader.TryRead(out byte handshakeType) || handshakeType != 0x01)

--- a/src/Servers/Kestrel/Core/test/TlsListenerTests.cs
+++ b/src/Servers/Kestrel/Core/test/TlsListenerTests.cs
@@ -203,7 +203,7 @@ public class TlsListenerTests
         await listener.OnTlsClientHelloAsync(transportConnection, CancellationToken.None);
 
         Assert.True(tlsClientHelloCallbackInvoked, "Expected TLS ClientHello callback to be invoked");
-        Assert.Equal(5 + TlsListener.MaxTlsRecordLength, receivedBytes.Length);
+        Assert.Equal(5 + TlsListener.MaxTlsPlaintextFragmentLength, receivedBytes.Length);
     }
 
     private async Task RunTlsClientHelloCallbackTest_WithMultipleSegments(

--- a/src/Servers/Kestrel/Core/test/TlsListenerTests.cs
+++ b/src/Servers/Kestrel/Core/test/TlsListenerTests.cs
@@ -173,7 +173,6 @@ public class TlsListenerTests
 
         // Handshake message header (part of payload):
         // - 1 byte: handshake type (0x01 = ClientHello)
-        // - 3 bytes: length of handshake message
         var handshakeHeader = new byte[]
         {
             0x01,             // HandshakeType: ClientHello

--- a/src/Servers/Kestrel/Core/test/TlsListenerTests.cs
+++ b/src/Servers/Kestrel/Core/test/TlsListenerTests.cs
@@ -158,6 +158,55 @@ public class TlsListenerTests
             $"Expected ReadAsync() to happen about 2-5 times. Actually happened {reader.ReadAsyncCounter} times.");
     }
 
+    // Regression test for making sure we don't throw for values of length greater than short.MaxValue (32767)
+    // we should cap at MaxTlsRecordLength and pass what we can to the callback
+    [Fact]
+    public async Task OversizedTlsRecord_DoesNotThrow_CapsAtMaxLength()
+    {
+        const int oversizedLength = 32768; // > 2^14 (16384) max TLS record size
+        var recordHeader = new byte[]
+        {
+            0x16,             // ContentType: Handshake
+            0x03, 0x01,       // Version: TLS 1.0
+            (byte)(oversizedLength >> 8), (byte)(oversizedLength & 0xFF), // Length: 32768
+        };
+
+        // Handshake message header (part of payload):
+        // - 1 byte: handshake type (0x01 = ClientHello)
+        // - 3 bytes: length of handshake message
+        var handshakeHeader = new byte[]
+        {
+            0x01,             // HandshakeType: ClientHello
+        };
+
+        // Build the complete oversized TLS record
+        var tlsRecord = new byte[5 + oversizedLength];
+        recordHeader.CopyTo(tlsRecord, 0);
+        handshakeHeader.CopyTo(tlsRecord, 5);
+
+        var pipe = new Pipe();
+        var writer = pipe.Writer;
+
+        var transport = new DuplexPipe(pipe.Reader, writer);
+        var transportConnection = new DefaultConnectionContext("test", transport, transport);
+
+        ReadOnlySequence<byte> receivedBytes = default;
+        var tlsClientHelloCallbackInvoked = false;
+        var listener = new TlsListener((ctx, data) =>
+        {
+            tlsClientHelloCallbackInvoked = true;
+            receivedBytes = data;
+        });
+
+        await writer.WriteAsync(tlsRecord);
+        await writer.CompleteAsync();
+
+        await listener.OnTlsClientHelloAsync(transportConnection, CancellationToken.None);
+
+        Assert.True(tlsClientHelloCallbackInvoked, "Expected TLS ClientHello callback to be invoked");
+        Assert.Equal(5 + TlsListener.MaxTlsRecordLength, receivedBytes.Length);
+    }
+
     private async Task RunTlsClientHelloCallbackTest_WithMultipleSegments(
         int id,
         List<byte[]> packets,


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc8446#section-5.1
> The length (in bytes) of the following
      TLSPlaintext.fragment.  The length MUST NOT exceed 2^14 bytes.  An
      endpoint that receives a record that exceeds this length MUST
      terminate the connection with a "record_overflow" alert.

We probably shouldn't throw the "record_overflow" alert here and let SslStream handle it, but we should make sure to handle cases where the length is greater than 2^14 (16k).

I chose to still pass the client hello to the user provided callback with a max of 2^14 bytes so applications can still observe the client hello.