### PR TITLE
Fix SignalR Java client memory leak in stream() due to unbounded ReplaySubject

### DIFF
--- a/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/InvocationRequest.java
+++ b/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/InvocationRequest.java
@@ -6,12 +6,12 @@ package com.microsoft.signalr;
 import java.lang.reflect.Type;
 import java.util.concurrent.CancellationException;
 
-import io.reactivex.rxjava3.subjects.ReplaySubject;
 import io.reactivex.rxjava3.subjects.Subject;
+import io.reactivex.rxjava3.subjects.UnicastSubject;
 
 class InvocationRequest {
     private final Type returnType;
-    private final Subject<Object> pendingCall = ReplaySubject.create();
+    private final Subject<Object> pendingCall = UnicastSubject.<Object>create().toSerialized();
     private final String invocationId;
 
     InvocationRequest(Type returnType, String invocationId) {


### PR DESCRIPTION
<!-- AI Summary -->

## 🤖 AI Summary

<!-- SECTION:PR-REVIEW -->
<details>
<summary><b>🔍 Automated Fix Report</b></summary>

---

<details>
<summary><b>🔍 Pre-Flight — Context & Validation</b></summary>

**Issue:** #63134 — SignalR Java client memory leak in stream() due to unbounded ReplaySubject
**Area:** area-signalr (`src/SignalR/clients/java/`)

### Root Cause
The SignalR Java client has a memory leak when using the `stream()` method for real-time data streaming. The root cause is the use of unbounded `ReplaySubject.create()` in two places, which caches **all** emitted items indefinitely in memory.

### Team Guidance
Per @BrennanConroy's [guidance](https://github.com/dotnet/aspnetcore/issues/63134#issuecomment-3156924952):
> I think we should change this one to a UnicastSubject and then the internals of the Stream method should be refactored to not call subscribe on the Subject from getPendingCall until user code calls subscribe.

</details>

---

<details>
<summary><b>🧪 Test — Bug Reproduction</b></summary>

### Test Result: ✅ TESTS CREATED

**Tests Updated:** 15 existing tests refactored to single-subscription patterns + 1 new test

#### Tests Written
- Updated 15 tests to use single-subscription patterns (capture values via `AtomicReference`/`ArrayList` instead of re-subscribing with `blockingFirst()`/`blockingLast()`)
- Added `streamDoesNotCacheAllItemsInMemory` test that sends 1000 stream items and verifies all are processed

</details>

---

<details>
<summary><b>🚦 Gate — Test Verification & Regression</b></summary>

### Gate Result: ✅ PASSED

All 291 existing Java SignalR client tests pass.

</details>

---

<details>
<summary><b>🔧 Fix — Multi-Model Exploration (✅ 6 passed)</b></summary>

### Fix Exploration Summary

**Total Attempts:** 6
**Passing Candidates:** 6
**Selected Fix:** UnicastSubject + remove intermediate subject

#### Attempt Results
| # | Model | Approach | Result | Key Insight |
|---|-------|----------|--------|-------------|
| PR | claude-opus-4.6 | `UnicastSubject` + remove intermediate subject | ✅ Pass | Fully eliminates caching. Single-subscriber. |
| 1 | claude-sonnet-4.6 | `PublishSubject` for pendingCall only | ✅ Pass | Minimal change but only fixes 1 of 2 leak sites. |
| 2 | claude-opus-4.6 | `PublishSubject` + `.replay().autoConnect(0)` | ✅ Pass | Reduces 2N→1N but `.replay()` still unbounded. |
| 3 | gpt-5.2 | `PublishSubject` for BOTH locations | ✅ Pass | Fully fixes leak. Same test changes as PR. |
| 4 | gpt-5.3-codex | `ReplaySubject.createWithSize(1)` for BOTH | ✅ Pass | Bounded buffer. Preserves some replay. |
| 5 | gemini-3-pro-preview | `PublishSubject` + time-bounded replay (10min) | ✅ Pass | Arbitrary time window. Still leaks within window. |

### Selected Fix Rationale
1. Fully eliminates unbounded caching (zero retained items after subscription)
2. Directly follows team member @BrennanConroy's recommendation
3. Clean architecture — no intermediate subject needed
4. Multi-subscriber was never a documented API contract

### Changes
| File | Change |
|------|--------|
| `InvocationRequest.java` | Replaced `ReplaySubject.create()` with `UnicastSubject.create().toSerialized()` |
| `HubConnection.java` | Removed intermediate `ReplaySubject<T>`, map directly from `pendingCall`, updated Javadoc for single-subscriber semantics |
| `HubConnectionTest.java` | Updated 15 tests to single-subscription + added memory leak regression test |

### Breaking Change
The returned `Observable<T>` from `stream()` now only supports a single subscriber (previously supported multiple via `ReplaySubject`). This is a necessary trade-off to fix the memory leak.

</details>

</details>
<!-- /SECTION:PR-REVIEW -->