### PR TITLE
Fix WebTransport test hang by draining all settings before CONNECT request

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/WebTransport/WebTransportHandshakeTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/WebTransport/WebTransportHandshakeTests.cs
@@ -56,10 +56,16 @@ public class WebTransportHandshakeTests : Http3TestBase
             H3Datagram = 1,
         };
 
-        await controlStream.SendSettingsAsync(settings.GetNonProtocolDefaults());
+        var nonDefaultSettings = settings.GetNonProtocolDefaults();
+        await controlStream.SendSettingsAsync(nonDefaultSettings);
         var response1 = await controlStream2.ExpectSettingsAsync();
 
-        await Http3Api.ServerReceivedSettingsReader.ReadAsync().DefaultTimeout();
+        // Drain all received settings before sending the CONNECT request to avoid a race
+        // where the server processes the request before all settings (e.g. H3Datagram) are applied.
+        for (var i = 0; i < nonDefaultSettings.Count; i++)
+        {
+            await Http3Api.ServerReceivedSettingsReader.ReadAsync().DefaultTimeout();
+        }
 
         Assert.Equal(1, response1[(long)Http3SettingType.EnableWebTransport]);
 
@@ -122,10 +128,16 @@ public class WebTransportHandshakeTests : Http3TestBase
             H3Datagram = 1,
         };
 
-        await controlStream.SendSettingsAsync(settings.GetNonProtocolDefaults());
+        var nonDefaultSettings = settings.GetNonProtocolDefaults();
+        await controlStream.SendSettingsAsync(nonDefaultSettings);
         var response1 = await controlStream2.ExpectSettingsAsync();
 
-        await Http3Api.ServerReceivedSettingsReader.ReadAsync().DefaultTimeout();
+        // Drain all received settings before sending the CONNECT request to avoid a race
+        // where the server processes the request before all settings (e.g. H3Datagram) are applied.
+        for (var i = 0; i < nonDefaultSettings.Count; i++)
+        {
+            await Http3Api.ServerReceivedSettingsReader.ReadAsync().DefaultTimeout();
+        }
 
         Assert.Equal(1, response1[(long)Http3SettingType.EnableWebTransport]);
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/WebTransport/WebTransportTestUtilities.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/WebTransport/WebTransportTestUtilities.cs
@@ -39,7 +39,6 @@ internal class WebTransportTestUtilities
             {
                 appCompletedTcs.SetException(exception);
             }
-#pragma warning restore CA2252 // WebTransport is a preview feature
 
             // wait for the test to tell us to kill the application
             await exitSessionTcs.Task;
@@ -75,7 +74,6 @@ internal class WebTransportTestUtilities
             new KeyValuePair<string, string>(WebTransportSession.CurrentSupportedVersion, "1")
         });
 
-#pragma warning disable CA2252 // WebTransport is a preview feature
         return (WebTransportSession)await appCompletedTcs.Task.DefaultTimeout();
 #pragma warning restore CA2252 // WebTransport is a preview feature
     }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/WebTransport/WebTransportTestUtilities.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/WebTransport/WebTransportTestUtilities.cs
@@ -75,7 +75,9 @@ internal class WebTransportTestUtilities
             new KeyValuePair<string, string>(WebTransportSession.CurrentSupportedVersion, "1")
         });
 
-        return (WebTransportSession)await appCompletedTcs.Task;
+#pragma warning disable CA2252 // WebTransport is a preview feature
+        return (WebTransportSession)await appCompletedTcs.Task.DefaultTimeout();
+#pragma warning restore CA2252 // WebTransport is a preview feature
     }
 
     public static WebTransportStream CreateStream(WebTransportStreamType type, Memory<byte>? memory = null)


### PR DESCRIPTION
The WebTransport tests sent 2 settings (EnableWebTransport and H3Datagram) but only waited for 1 to be received via ServerReceivedSettingsReader.ReadAsync(). This race condition could cause the CONNECT request to be processed before the H3Datagram setting was applied, leading to a settings mismatch error that aborted the stream. Since the app delegate never executed, appCompletedTcs was never completed, causing the test to hang indefinitely. Specifically, saw `WebTransportSession_ClosesProperly` hang on a CI run.

Fix: drain all settings from the channel (based on the count of non-default settings sent) before creating the request stream.