### PR TITLE
Fix ShallowCopy DateFormatString side effect overriding DateFormatHandling

### DIFF
--- a/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonOutputFormatter.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonOutputFormatter.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
-using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.AspNetCore.Mvc.NewtonsoftJson;
 using Microsoft.AspNetCore.WebUtilities;
@@ -191,8 +191,8 @@ public partial class NewtonsoftJsonOutputFormatter : TextOutputFormatter
         }
     }
 
-    private static readonly FieldInfo? DateFormatStringSetField =
-        typeof(JsonSerializerSettings).GetField("_dateFormatStringSet", BindingFlags.Instance | BindingFlags.NonPublic);
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_dateFormatStringSet")]
+    private static extern ref bool DateFormatStringSetField(JsonSerializerSettings settings);
 
     private static JsonSerializerSettings ShallowCopy(JsonSerializerSettings settings)
     {
@@ -232,7 +232,7 @@ public partial class NewtonsoftJsonOutputFormatter : TextOutputFormatter
         // The JsonSerializerSettings.DateFormatString setter marks an internal
         // _dateFormatStringSet flag that causes DateFormatString to take precedence
         // over DateFormatHandling, even when the value is the default.
-        if (DateFormatStringSetField?.GetValue(settings) is true)
+        if (DateFormatStringSetField(settings))
         {
             copiedSettings.DateFormatString = settings.DateFormatString;
         }


### PR DESCRIPTION
<!-- AI Summary -->

## 🤖 AI Summary

<!-- SECTION:PR-REVIEW -->
<details>
<summary><b>🔍 Automated Fix Report</b></summary>

---

<details>
<summary><b>🔍 Pre-Flight — Context & Validation</b></summary>

**Issue:** [#29532](https://github.com/dotnet/aspnetcore/issues/29532) — Newtonsoft `ShallowCopy` sets `DateFormatString` side effect overriding `DateFormatHandling`

**Area:** `src/Mvc/Mvc.NewtonsoftJson/`

**Root Cause:** `NewtonsoftJsonOutputFormatter.ShallowCopy` copies `DateFormatString` via the property setter, which triggers an internal `_dateFormatStringSet` flag in Newtonsoft.Json's `JsonSerializerSettings`. When this flag is set, `DateFormatString` takes precedence over `DateFormatHandling` — so users who set `DateFormatHandling.MicrosoftDateFormat` still get ISO 8601 output.

**Classification:** Bug — unintended side effect from property copy

</details>

---

<details>
<summary><b>🧪 Test — Bug Reproduction</b></summary>

**Test File:** `src/Mvc/Mvc.NewtonsoftJson/test/NewtonsoftJsonOutputFormatterTest.cs`

**Test Added:** `DateFormatHandling_IsRespected_WhenDateFormatStringNotExplicitlySet` — verifies that `DateFormatHandling.MicrosoftDateFormat` produces `\/Date(...)\/` output when `DateFormatString` is not explicitly set.

**Strategy:** Created settings with only `DateFormatHandling = MicrosoftDateFormat`, formatted a date object, and asserted the output contains the Microsoft date format pattern.

</details>

---

<details>
<summary><b>🚦 Gate — Test Verification & Regression</b></summary>

**Gate Result:** ✅ All 250 NewtonsoftJson tests pass

**Test Command:**
```bash
dotnet test src/Mvc/Mvc.NewtonsoftJson/test/Microsoft.AspNetCore.Mvc.NewtonsoftJson.Test.csproj --no-restore -v q
```

**Regression:** No failures in existing test suite.

</details>

---

<details>
<summary><b>🔧 Fix — Analysis & Comparison (✅ 3 passed)</b></summary>

**Fix:** Avoid triggering `_dateFormatStringSet` flag during ShallowCopy when user hasn't explicitly set DateFormatString.

| Attempt | Approach | Result |
|---------|----------|--------|
| 0 | Reflection check on `_dateFormatStringSet` field | ✅ Pass |
| 1 | Omit DateFormatString from copy entirely | ✅ Pass (but loses custom values) |
| 2 | Compare to cached default, only copy when different | ✅ Pass |

<details>
<summary>✅ <b>Attempt 0: PASS</b></summary>

**Approach:** Reflection check on `_dateFormatStringSet` field, conditionally copy DateFormatString.

Added static `FieldInfo` for the internal `_dateFormatStringSet` field. In `ShallowCopy`, removed DateFormatString from initializer and only copy it when the field is `true` (user explicitly set it).

<details>
<summary>📄 Diff</summary>

```diff
diff --git a/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonOutputFormatter.cs b/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonOutputFormatter.cs
index faa2909506..3deb9ec8c7 100644
--- a/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonOutputFormatter.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonOutputFormatter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.Reflection;
 using System.Text;
 using Microsoft.AspNetCore.Mvc.NewtonsoftJson;
 using Microsoft.AspNetCore.WebUtilities;
@@ -190,6 +191,9 @@ public partial class NewtonsoftJsonOutputFormatter : TextOutputFormatter
         }
     }
 
+    private static readonly FieldInfo? DateFormatStringSetField =
+        typeof(JsonSerializerSettings).GetField("_dateFormatStringSet", BindingFlags.Instance | BindingFlags.NonPublic);
+
     private static JsonSerializerSettings ShallowCopy(JsonSerializerSettings settings)
     {
         var copiedSettings = new JsonSerializerSettings
@@ -201,7 +205,6 @@ public partial class NewtonsoftJsonOutputFormatter : TextOutputFormatter
             DateFormatHandling = settings.DateFormatHandling,
             Formatting = settings.Formatting,
             MaxDepth = settings.MaxDepth,
-            DateFormatString = settings.DateFormatString,
             Context = settings.Context,
             Error = settings.Error,
             SerializationBinder = settings.SerializationBinder,
@@ -225,6 +228,15 @@ public partial class NewtonsoftJsonOutputFormatter : TextOutputFormatter
             StringEscapeHandling = settings.StringEscapeHandling,
         };
 
+        // Only copy DateFormatString when it was explicitly set by the user.
+        // The JsonSerializerSettings.DateFormatString setter marks an internal
+        // _dateFormatStringSet flag that causes DateFormatString to take precedence
+        // over DateFormatHandling, even when the value is the default.
+        if (DateFormatStringSetField?.GetValue(settings) is true)
+        {
+            copiedSettings.DateFormatString = settings.DateFormatString;
+        }
+
         return copiedSettings;
     }
 
```

</details>

</details>
<details>
<summary>✅ <b>Attempt 1: PASS</b></summary>

**Approach:** Simply omit DateFormatString from ShallowCopy entirely.

Remove `DateFormatString = settings.DateFormatString` from the initializer. The default value is the same ISO 8601 format, so this works for the common case. Caveat: if a user explicitly sets a custom DateFormatString, it won't be copied to the shallow copy. All 250 tests pass.

<details>
<summary>📄 Diff</summary>

```diff
diff --git a/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonOutputFormatter.cs b/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonOutputFormatter.cs
index faa2909506..a303a6894c 100644
--- a/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonOutputFormatter.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonOutputFormatter.cs
@@ -201,7 +201,9 @@ public partial class NewtonsoftJsonOutputFormatter : TextOutputFormatter
             DateFormatHandling = settings.DateFormatHandling,
             Formatting = settings.Formatting,
             MaxDepth = settings.MaxDepth,
-            DateFormatString = settings.DateFormatString,
+            // DateFormatString intentionally omitted to avoid triggering
+            // the internal _dateFormatStringSet flag which overrides DateFormatHandling.
+            // The default value is already "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK".
             Context = settings.Context,
             Error = settings.Error,
             SerializationBinder = settings.SerializationBinder,
```

</details>

</details>
<details>
<summary>✅ <b>Attempt 2: PASS</b></summary>

**Approach:** Compare DateFormatString to a cached default value, only copy when different.

Created `DefaultDateFormatString` static field from `new JsonSerializerSettings().DateFormatString`. In ShallowCopy, only copy DateFormatString via property setter when it differs from the default. This avoids reflection while correctly preserving custom format strings.

<details>
<summary>📄 Diff</summary>

```diff
diff --git a/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonOutputFormatter.cs b/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonOutputFormatter.cs
index faa2909506..574e23b82c 100644
--- a/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonOutputFormatter.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonOutputFormatter.cs
@@ -190,6 +190,8 @@ public partial class NewtonsoftJsonOutputFormatter : TextOutputFormatter
         }
     }
 
+    private static readonly string DefaultDateFormatString = new JsonSerializerSettings().DateFormatString;
+
     private static JsonSerializerSettings ShallowCopy(JsonSerializerSettings settings)
     {
         var copiedSettings = new JsonSerializerSettings
@@ -201,7 +203,6 @@ public partial class NewtonsoftJsonOutputFormatter : TextOutputFormatter
             DateFormatHandling = settings.DateFormatHandling,
             Formatting = settings.Formatting,
             MaxDepth = settings.MaxDepth,
-            DateFormatString = settings.DateFormatString,
             Context = settings.Context,
             Error = settings.Error,
             SerializationBinder = settings.SerializationBinder,
@@ -225,6 +226,14 @@ public partial class NewtonsoftJsonOutputFormatter : TextOutputFormatter
             StringEscapeHandling = settings.StringEscapeHandling,
         };
 
+        // Only copy DateFormatString when it differs from the default.
+        // Using the property setter triggers an internal _dateFormatStringSet flag
+        // that causes DateFormatString to override DateFormatHandling.
+        if (!string.Equals(settings.DateFormatString, DefaultDateFormatString, StringComparison.Ordinal))
+        {
+            copiedSettings.DateFormatString = settings.DateFormatString;
+        }
+
         return copiedSettings;
     }
 
```

</details>

</details>


</details>

</details>
<!-- /SECTION:PR-REVIEW -->