### PR TITLE
Disable scheduled workflows in forks

### DIFF
--- a/.github/workflows/browsertesting-open-issue.yml
+++ b/.github/workflows/browsertesting-open-issue.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   create-issue:
     runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.repository_owner == 'dotnet'
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/update-jquery-validate.yml
+++ b/.github/workflows/update-jquery-validate.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   update-jquery-validate:
     runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.repository_owner == 'dotnet'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/update-selenium-and-playwright-dependencies.yml
+++ b/.github/workflows/update-selenium-and-playwright-dependencies.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   update-selenium-and-playwright:
     runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.repository_owner == 'dotnet'
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
# Disable scheduled workflows in forks

Disable scheduled workflows in forks that fail anyway.

## Description

Disable workflows in forks that otherwise just fail due to missing secrets and generate notification noise.
