### PR TITLE
Fix ClientErrorMapping 500 title to match RFC 9110

### DIFF
--- a/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
+++ b/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
@@ -560,7 +560,7 @@ public partial class DefaultProblemDetailsWriterTest
         Assert.NotNull(problemDetails);
         Assert.Equal(StatusCodes.Status500InternalServerError, problemDetails.Status);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", problemDetails.Type);
-        Assert.Equal("An error occurred while processing your request.", problemDetails.Title);
+        Assert.Equal("Internal Server Error", problemDetails.Title);
         Assert.Equal(expectedTraceId, problemDetails.Extensions["traceId"].ToString());
     }
 

--- a/src/Http/Http.Results/test/JsonResultTests.cs
+++ b/src/Http/Http.Results/test/JsonResultTests.cs
@@ -139,7 +139,7 @@ public class JsonResultTests
         stream.Position = 0;
         var responseDetails = JsonSerializer.Deserialize<ProblemDetails>(stream, JsonSerializerOptions.Web);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", responseDetails.Type);
-        Assert.Equal("An error occurred while processing your request.", responseDetails.Title);
+        Assert.Equal("Internal Server Error", responseDetails.Title);
         Assert.Equal(StatusCodes.Status500InternalServerError, responseDetails.Status);
     }
 

--- a/src/Http/Http.Results/test/ProblemResultTests.cs
+++ b/src/Http/Http.Results/test/ProblemResultTests.cs
@@ -37,7 +37,7 @@ public class ProblemResultTests
         stream.Position = 0;
         var responseDetails = JsonSerializer.Deserialize<ProblemDetails>(stream, JsonSerializerOptions.Web);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", responseDetails.Type);
-        Assert.Equal("An error occurred while processing your request.", responseDetails.Title);
+        Assert.Equal("Internal Server Error", responseDetails.Title);
         Assert.Equal(StatusCodes.Status500InternalServerError, responseDetails.Status);
     }
 
@@ -69,7 +69,7 @@ public class ProblemResultTests
         stream.Position = 0;
         var responseDetails = JsonSerializer.Deserialize<ProblemDetails>(stream, JsonSerializerOptions.Web);
         Assert.Null(responseDetails.Type);
-        Assert.Equal("An error occurred while processing your request.", responseDetails.Title);
+        Assert.Equal("Internal Server Error", responseDetails.Title);
         Assert.Equal(StatusCodes.Status500InternalServerError, responseDetails.Status);
     }
 

--- a/src/Http/Http.Results/test/ResultsTests.cs
+++ b/src/Http/Http.Results/test/ResultsTests.cs
@@ -1349,7 +1349,7 @@ public partial class ResultsTests
         Assert.Null(result.ProblemDetails.Instance);
         Assert.Equal("application/problem+json", result.ContentType);
         Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
-        Assert.Equal("An error occurred while processing your request.", result.ProblemDetails.Title);
+        Assert.Equal("Internal Server Error", result.ProblemDetails.Title);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", result.ProblemDetails.Type);
         Assert.Empty(result.ProblemDetails.Extensions);
     }

--- a/src/Http/Http.Results/test/TypedResultsTests.cs
+++ b/src/Http/Http.Results/test/TypedResultsTests.cs
@@ -1141,7 +1141,7 @@ public partial class TypedResultsTests
         Assert.Null(result.ProblemDetails.Instance);
         Assert.Equal("application/problem+json", result.ContentType);
         Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
-        Assert.Equal("An error occurred while processing your request.", result.ProblemDetails.Title);
+        Assert.Equal("Internal Server Error", result.ProblemDetails.Title);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", result.ProblemDetails.Type);
         Assert.Empty(result.ProblemDetails.Extensions);
     }

--- a/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs
+++ b/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs
@@ -2475,7 +2475,7 @@ public class ControllerBaseTest
         var problemDetails = Assert.IsType<ProblemDetails>(badRequestResult.Value);
         Assert.Equal(500, actionResult.StatusCode);
         Assert.Equal(500, problemDetails.Status);
-        Assert.Equal("An error occurred while processing your request.", problemDetails.Title);
+        Assert.Equal("Internal Server Error", problemDetails.Title);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", problemDetails.Type);
         Assert.Equal("some-trace", problemDetails.Extensions["traceId"]);
     }
@@ -2568,7 +2568,7 @@ public class ControllerBaseTest
                     },
                     [500] = new ClientErrorData
                     {
-                        Title = "An error occurred while processing your request.",
+                        Title = "Internal Server Error",
                         Link = "https://tools.ietf.org/html/rfc9110#section-15.6.1"
                     }
                 }

--- a/src/Mvc/Mvc.Core/test/Infrastructure/ProblemDetailsFactoryTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/ProblemDetailsFactoryTest.cs
@@ -20,7 +20,7 @@ public class ProblemDetailsFactoryTest
 
         // Assert
         Assert.Equal(500, problemDetails.Status);
-        Assert.Equal("An error occurred while processing your request.", problemDetails.Title);
+        Assert.Equal("Internal Server Error", problemDetails.Title);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", problemDetails.Type);
         Assert.Null(problemDetails.Instance);
         Assert.Null(problemDetails.Detail);

--- a/src/Shared/ProblemDetails/ProblemDetailsDefaults.cs
+++ b/src/Shared/ProblemDetails/ProblemDetailsDefaults.cs
@@ -133,7 +133,7 @@ internal static class ProblemDetailsDefaults
         [500] =
         (
             "https://tools.ietf.org/html/rfc9110#section-15.6.1",
-            "An error occurred while processing your request."
+            "Internal Server Error"
         ),
 
         [501] =


### PR DESCRIPTION
<!-- AI Summary -->

## 🤖 AI Summary

<!-- SECTION:PR-REVIEW -->
<details>
<summary><b>🔍 Automated Fix Report</b></summary>

---

<details>
<summary><b>🔍 Pre-Flight — Context & Validation</b></summary>

**Issue:** #16880 - Inconsistency between ApiBehaviorOptions.ClientErrorMapping and ReasonPhrases using 500
**Area:** area-mvc (`src/Shared/ProblemDetails/`, `src/Mvc/Mvc.Core/`)
**PR:** None — will create

### Key Findings
- `ProblemDetailsDefaults.cs` line 136: 500 title is "An error occurred while processing your request."
- `ReasonPhrases.GetReasonPhrase(500)` returns "Internal Server Error" (RFC 9110)
- All other status codes in ProblemDetailsDefaults use RFC standard reason phrases
- Team member @pranavkm confirmed: "we should update MVC to do the same for 500"
- @Tratcher confirmed: "ReasonPhrases are RFC defined values and should not be modified"

### Fix Approach
Change the 500 title in `ProblemDetailsDefaults.cs` from "An error occurred..." to "Internal Server Error" to match RFC 9110 and `ReasonPhrases`.

### Test Command
`dotnet test src/Mvc/Mvc.Core/test/Microsoft.AspNetCore.Mvc.Core.Test.csproj --filter "ProblemDetailsFactoryTest"`

</details>

---

<details>
<summary><b>🧪 Test — Bug Reproduction</b></summary>

### Test Result: ✅ TESTS UPDATED

Existing tests already verify the 500 title value. Updated 9 test assertions across 7 files to expect "Internal Server Error" instead of "An error occurred while processing your request."

</details>

---

<details>
<summary><b>🚦 Gate — Test Verification & Regression</b></summary>

### Gate Result: ✅ PASSED

All affected tests pass with the updated title string.

</details>

---

<details>
<summary><b>🔧 Fix — Analysis & Comparison (✅ 5 passed)</b></summary>

### Fix Exploration Summary

**Total Attempts:** 5
**Passing Candidates:** 5
**Selected Fix:** Change "An error occurred while processing your request." to "Internal Server Error"

#### Attempt Results
| # | Model | Approach | Result | Key Insight |
|---|-------|----------|--------|-------------|
| 0 | claude-opus-4.6-fast | Change string constant to RFC 9110 value | ✅ Pass | Only correct fix |
| 1 | claude-sonnet-4.6 | Same — string constant fix | ✅ Pass | Converges to same fix |
| 2 | gpt-5.2 | Same — string constant fix | ✅ Pass | Converges to same fix |
| 3 | gpt-5.3-codex | Same — string constant fix | ✅ Pass | Converges to same fix |
| 4 | gemini-3-pro-preview | Same — string constant fix | ✅ Pass | Converges to same fix |

#### Cross-Pollination
All models agree: there is exactly one correct value — "Internal Server Error" from RFC 9110.

**Exhausted:** Yes

#### Recommendation
This is a trivial fix with only one correct answer. All models converge to the same solution.

<details>
<summary>✅ <b>Attempt 0: PASS</b></summary>

## Attempt 0 — Baseline (claude-opus-4.6-fast)

**Approach:** Change ProblemDetailsDefaults.cs line 136 from "An error occurred while processing your request." to "Internal Server Error"

Simple one-line fix + 9 test assertion updates.

<details>
<summary>📄 Diff</summary>

```diff
diff --git a/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs b/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
index 2afabbec3f..b36499ee52 100644
--- a/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
+++ b/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
@@ -560,7 +560,7 @@ public partial class DefaultProblemDetailsWriterTest
         Assert.NotNull(problemDetails);
         Assert.Equal(StatusCodes.Status500InternalServerError, problemDetails.Status);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", problemDetails.Type);
-        Assert.Equal("An error occurred while processing your request.", problemDetails.Title);
+        Assert.Equal("Internal Server Error", problemDetails.Title);
         Assert.Equal(expectedTraceId, problemDetails.Extensions["traceId"].ToString());
     }
 
diff --git a/src/Http/Http.Results/test/JsonResultTests.cs b/src/Http/Http.Results/test/JsonResultTests.cs
index 6e2b05dbcc..3af14f6f24 100644
--- a/src/Http/Http.Results/test/JsonResultTests.cs
+++ b/src/Http/Http.Results/test/JsonResultTests.cs
@@ -139,7 +139,7 @@ public class JsonResultTests
         stream.Position = 0;
         var responseDetails = JsonSerializer.Deserialize<ProblemDetails>(stream, JsonSerializerOptions.Web);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", responseDetails.Type);
-        Assert.Equal("An error occurred while processing your request.", responseDetails.Title);
+        Assert.Equal("Internal Server Error", responseDetails.Title);
         Assert.Equal(StatusCodes.Status500InternalServerError, responseDetails.Status);
     }
 
diff --git a/src/Http/Http.Results/test/ProblemResultTests.cs b/src/Http/Http.Results/test/ProblemResultTests.cs
index c01c42a5d2..8e41555548 100644
--- a/src/Http/Http.Results/test/ProblemResultTests.cs
+++ b/src/Http/Http.Results/test/ProblemResultTests.cs
@@ -37,7 +37,7 @@ public class ProblemResultTests
         stream.Position = 0;
         var responseDetails = JsonSerializer.Deserialize<ProblemDetails>(stream, JsonSerializerOptions.Web);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", responseDetails.Type);
-        Assert.Equal("An error occurred while processing your request.", responseDetails.Title);
+        Assert.Equal("Internal Server Error", responseDetails.Title);
         Assert.Equal(StatusCodes.Status500InternalServerError, responseDetails.Status);
     }
 
@@ -69,7 +69,7 @@ public class ProblemResultTests
         stream.Position = 0;
         var responseDetails = JsonSerializer.Deserialize<ProblemDetails>(stream, JsonSerializerOptions.Web);
         Assert.Null(responseDetails.Type);
-        Assert.Equal("An error occurred while processing your request.", responseDetails.Title);
+        Assert.Equal("Internal Server Error", responseDetails.Title);
         Assert.Equal(StatusCodes.Status500InternalServerError, responseDetails.Status);
     }
 
diff --git a/src/Http/Http.Results/test/ResultsTests.cs b/src/Http/Http.Results/test/ResultsTests.cs
index ce87ee10e9..e21d097b48 100644
--- a/src/Http/Http.Results/test/ResultsTests.cs
+++ b/src/Http/Http.Results/test/ResultsTests.cs
@@ -1349,7 +1349,7 @@ public partial class ResultsTests
         Assert.Null(result.ProblemDetails.Instance);
         Assert.Equal("application/problem+json", result.ContentType);
         Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
-        Assert.Equal("An error occurred while processing your request.", result.ProblemDetails.Title);
+        Assert.Equal("Internal Server Error", result.ProblemDetails.Title);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", result.ProblemDetails.Type);
         Assert.Empty(result.ProblemDetails.Extensions);
     }
diff --git a/src/Http/Http.Results/test/TypedResultsTests.cs b/src/Http/Http.Results/test/TypedResultsTests.cs
index acee20c4d1..cef21cda67 100644
--- a/src/Http/Http.Results/test/TypedResultsTests.cs
+++ b/src/Http/Http.Results/test/TypedResultsTests.cs
@@ -1141,7 +1141,7 @@ public partial class TypedResultsTests
         Assert.Null(result.ProblemDetails.Instance);
         Assert.Equal("application/problem+json", result.ContentType);
         Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
-        Assert.Equal("An error occurred while processing your request.", result.ProblemDetails.Title);
+        Assert.Equal("Internal Server Error", result.ProblemDetails.Title);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", result.ProblemDetails.Type);
         Assert.Empty(result.ProblemDetails.Extensions);
     }
diff --git a/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs b/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs
index fd502060bf..c9a97ed0f3 100644
--- a/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs
+++ b/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs
@@ -2475,7 +2475,7 @@ public class ControllerBaseTest
         var problemDetails = Assert.IsType<ProblemDetails>(badRequestResult.Value);
         Assert.Equal(500, actionResult.StatusCode);
         Assert.Equal(500, problemDetails.Status);
-        Assert.Equal("An error occurred while processing your request.", problemDetails.Title);
+        Assert.Equal("Internal Server Error", problemDetails.Title);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", problemDetails.Type);
         Assert.Equal("some-trace", problemDetails.Extensions["traceId"]);
     }
@@ -2568,7 +2568,7 @@ public class ControllerBaseTest
                     },
                     [500] = new ClientErrorData
                     {
-                        Title = "An error occurred while processing your request.",
+                        Title = "Internal Server Error",
                         Link = "https://tools.ietf.org/html/rfc9110#section-15.6.1"
                     }
                 }
diff --git a/src/Mvc/Mvc.Core/test/Infrastructure/ProblemDetailsFactoryTest.cs b/src/Mvc/Mvc.Core/test/Infrastructure/ProblemDetailsFactoryTest.cs
index 2695b167ff..d8aa6ac0e8 100644
--- a/src/Mvc/Mvc.Core/test/Infrastructure/ProblemDetailsFactoryTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/ProblemDetailsFactoryTest.cs
@@ -20,7 +20,7 @@ public class ProblemDetailsFactoryTest
 
         // Assert
         Assert.Equal(500, problemDetails.Status);
-        Assert.Equal("An error occurred while processing your request.", problemDetails.Title);
+        Assert.Equal("Internal Server Error", problemDetails.Title);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", problemDetails.Type);
         Assert.Null(problemDetails.Instance);
         Assert.Null(problemDetails.Detail);
diff --git a/src/Shared/ProblemDetails/ProblemDetailsDefaults.cs b/src/Shared/ProblemDetails/ProblemDetailsDefaults.cs
index 967c1aa486..b8d3a18fe2 100644
--- a/src/Shared/ProblemDetails/ProblemDetailsDefaults.cs
+++ b/src/Shared/ProblemDetails/ProblemDetailsDefaults.cs
@@ -133,7 +133,7 @@ internal static class ProblemDetailsDefaults
         [500] =
         (
             "https://tools.ietf.org/html/rfc9110#section-15.6.1",
-            "An error occurred while processing your request."
+            "Internal Server Error"
         ),
 
         [501] =
```

</details>

</details>
<details>
<summary>✅ <b>Attempt 1: PASS</b></summary>

## Attempt 1 — Model exploration

**Approach:** Same as attempt 0 — this is a string constant fix with only one correct value.
The 500 title must match RFC 9110: "Internal Server Error". There is no alternative approach.

<details>
<summary>📄 Diff</summary>

```diff
diff --git a/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs b/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
index 2afabbec3f..b36499ee52 100644
--- a/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
+++ b/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
@@ -560,7 +560,7 @@ public partial class DefaultProblemDetailsWriterTest
         Assert.NotNull(problemDetails);
         Assert.Equal(StatusCodes.Status500InternalServerError, problemDetails.Status);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", problemDetails.Type);
-        Assert.Equal("An error occurred while processing your request.", problemDetails.Title);
+        Assert.Equal("Internal Server Error", problemDetails.Title);
         Assert.Equal(expectedTraceId, problemDetails.Extensions["traceId"].ToString());
     }
 
diff --git a/src/Http/Http.Results/test/JsonResultTests.cs b/src/Http/Http.Results/test/JsonResultTests.cs
index 6e2b05dbcc..3af14f6f24 100644
--- a/src/Http/Http.Results/test/JsonResultTests.cs
+++ b/src/Http/Http.Results/test/JsonResultTests.cs
@@ -139,7 +139,7 @@ public class JsonResultTests
         stream.Position = 0;
         var responseDetails = JsonSerializer.Deserialize<ProblemDetails>(stream, JsonSerializerOptions.Web);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", responseDetails.Type);
-        Assert.Equal("An error occurred while processing your request.", responseDetails.Title);
+        Assert.Equal("Internal Server Error", responseDetails.Title);
         Assert.Equal(StatusCodes.Status500InternalServerError, responseDetails.Status);
     }
 
diff --git a/src/Http/Http.Results/test/ProblemResultTests.cs b/src/Http/Http.Results/test/ProblemResultTests.cs
index c01c42a5d2..8e41555548 100644
--- a/src/Http/Http.Results/test/ProblemResultTests.cs
+++ b/src/Http/Http.Results/test/ProblemResultTests.cs
@@ -37,7 +37,7 @@ public class ProblemResultTests
         stream.Position = 0;
         var responseDetails = JsonSerializer.Deserialize<ProblemDetails>(stream, JsonSerializerOptions.Web);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", responseDetails.Type);
-        Assert.Equal("An error occurred while processing your request.", responseDetails.Title);
+        Assert.Equal("Internal Server Error", responseDetails.Title);
         Assert.Equal(StatusCodes.Status500InternalServerError, responseDetails.Status);
     }
 
@@ -69,7 +69,7 @@ public class ProblemResultTests
         stream.Position = 0;
         var responseDetails = JsonSerializer.Deserialize<ProblemDetails>(stream, JsonSerializerOptions.Web);
         Assert.Null(responseDetails.Type);
-        Assert.Equal("An error occurred while processing your request.", responseDetails.Title);
+        Assert.Equal("Internal Server Error", responseDetails.Title);
         Assert.Equal(StatusCodes.Status500InternalServerError, responseDetails.Status);
     }
 
diff --git a/src/Http/Http.Results/test/ResultsTests.cs b/src/Http/Http.Results/test/ResultsTests.cs
index ce87ee10e9..e21d097b48 100644
--- a/src/Http/Http.Results/test/ResultsTests.cs
+++ b/src/Http/Http.Results/test/ResultsTests.cs
@@ -1349,7 +1349,7 @@ public partial class ResultsTests
         Assert.Null(result.ProblemDetails.Instance);
         Assert.Equal("application/problem+json", result.ContentType);
         Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
-        Assert.Equal("An error occurred while processing your request.", result.ProblemDetails.Title);
+        Assert.Equal("Internal Server Error", result.ProblemDetails.Title);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", result.ProblemDetails.Type);
         Assert.Empty(result.ProblemDetails.Extensions);
     }
diff --git a/src/Http/Http.Results/test/TypedResultsTests.cs b/src/Http/Http.Results/test/TypedResultsTests.cs
index acee20c4d1..cef21cda67 100644
--- a/src/Http/Http.Results/test/TypedResultsTests.cs
+++ b/src/Http/Http.Results/test/TypedResultsTests.cs
@@ -1141,7 +1141,7 @@ public partial class TypedResultsTests
         Assert.Null(result.ProblemDetails.Instance);
         Assert.Equal("application/problem+json", result.ContentType);
         Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
-        Assert.Equal("An error occurred while processing your request.", result.ProblemDetails.Title);
+        Assert.Equal("Internal Server Error", result.ProblemDetails.Title);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", result.ProblemDetails.Type);
         Assert.Empty(result.ProblemDetails.Extensions);
     }
diff --git a/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs b/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs
index fd502060bf..c9a97ed0f3 100644
--- a/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs
+++ b/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs
@@ -2475,7 +2475,7 @@ public class ControllerBaseTest
         var problemDetails = Assert.IsType<ProblemDetails>(badRequestResult.Value);
         Assert.Equal(500, actionResult.StatusCode);
         Assert.Equal(500, problemDetails.Status);
-        Assert.Equal("An error occurred while processing your request.", problemDetails.Title);
+        Assert.Equal("Internal Server Error", problemDetails.Title);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", problemDetails.Type);
         Assert.Equal("some-trace", problemDetails.Extensions["traceId"]);
     }
@@ -2568,7 +2568,7 @@ public class ControllerBaseTest
                     },
                     [500] = new ClientErrorData
                     {
-                        Title = "An error occurred while processing your request.",
+                        Title = "Internal Server Error",
                         Link = "https://tools.ietf.org/html/rfc9110#section-15.6.1"
                     }
                 }
diff --git a/src/Mvc/Mvc.Core/test/Infrastructure/ProblemDetailsFactoryTest.cs b/src/Mvc/Mvc.Core/test/Infrastructure/ProblemDetailsFactoryTest.cs
index 2695b167ff..d8aa6ac0e8 100644
--- a/src/Mvc/Mvc.Core/test/Infrastructure/ProblemDetailsFactoryTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/ProblemDetailsFactoryTest.cs
@@ -20,7 +20,7 @@ public class ProblemDetailsFactoryTest
 
         // Assert
         Assert.Equal(500, problemDetails.Status);
-        Assert.Equal("An error occurred while processing your request.", problemDetails.Title);
+        Assert.Equal("Internal Server Error", problemDetails.Title);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", problemDetails.Type);
         Assert.Null(problemDetails.Instance);
         Assert.Null(problemDetails.Detail);
diff --git a/src/Shared/ProblemDetails/ProblemDetailsDefaults.cs b/src/Shared/ProblemDetails/ProblemDetailsDefaults.cs
index 967c1aa486..b8d3a18fe2 100644
--- a/src/Shared/ProblemDetails/ProblemDetailsDefaults.cs
+++ b/src/Shared/ProblemDetails/ProblemDetailsDefaults.cs
@@ -133,7 +133,7 @@ internal static class ProblemDetailsDefaults
         [500] =
         (
             "https://tools.ietf.org/html/rfc9110#section-15.6.1",
-            "An error occurred while processing your request."
+            "Internal Server Error"
         ),
 
         [501] =
```

</details>

</details>
<details>
<summary>✅ <b>Attempt 2: PASS</b></summary>

## Attempt 2 — Model exploration

**Approach:** Same as attempt 0 — this is a string constant fix with only one correct value.
The 500 title must match RFC 9110: "Internal Server Error". There is no alternative approach.

<details>
<summary>📄 Diff</summary>

```diff
diff --git a/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs b/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
index 2afabbec3f..b36499ee52 100644
--- a/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
+++ b/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
@@ -560,7 +560,7 @@ public partial class DefaultProblemDetailsWriterTest
         Assert.NotNull(problemDetails);
         Assert.Equal(StatusCodes.Status500InternalServerError, problemDetails.Status);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", problemDetails.Type);
-        Assert.Equal("An error occurred while processing your request.", problemDetails.Title);
+        Assert.Equal("Internal Server Error", problemDetails.Title);
         Assert.Equal(expectedTraceId, problemDetails.Extensions["traceId"].ToString());
     }
 
diff --git a/src/Http/Http.Results/test/JsonResultTests.cs b/src/Http/Http.Results/test/JsonResultTests.cs
index 6e2b05dbcc..3af14f6f24 100644
--- a/src/Http/Http.Results/test/JsonResultTests.cs
+++ b/src/Http/Http.Results/test/JsonResultTests.cs
@@ -139,7 +139,7 @@ public class JsonResultTests
         stream.Position = 0;
         var responseDetails = JsonSerializer.Deserialize<ProblemDetails>(stream, JsonSerializerOptions.Web);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", responseDetails.Type);
-        Assert.Equal("An error occurred while processing your request.", responseDetails.Title);
+        Assert.Equal("Internal Server Error", responseDetails.Title);
         Assert.Equal(StatusCodes.Status500InternalServerError, responseDetails.Status);
     }
 
diff --git a/src/Http/Http.Results/test/ProblemResultTests.cs b/src/Http/Http.Results/test/ProblemResultTests.cs
index c01c42a5d2..8e41555548 100644
--- a/src/Http/Http.Results/test/ProblemResultTests.cs
+++ b/src/Http/Http.Results/test/ProblemResultTests.cs
@@ -37,7 +37,7 @@ public class ProblemResultTests
         stream.Position = 0;
         var responseDetails = JsonSerializer.Deserialize<ProblemDetails>(stream, JsonSerializerOptions.Web);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", responseDetails.Type);
-        Assert.Equal("An error occurred while processing your request.", responseDetails.Title);
+        Assert.Equal("Internal Server Error", responseDetails.Title);
         Assert.Equal(StatusCodes.Status500InternalServerError, responseDetails.Status);
     }
 
@@ -69,7 +69,7 @@ public class ProblemResultTests
         stream.Position = 0;
         var responseDetails = JsonSerializer.Deserialize<ProblemDetails>(stream, JsonSerializerOptions.Web);
         Assert.Null(responseDetails.Type);
-        Assert.Equal("An error occurred while processing your request.", responseDetails.Title);
+        Assert.Equal("Internal Server Error", responseDetails.Title);
         Assert.Equal(StatusCodes.Status500InternalServerError, responseDetails.Status);
     }
 
diff --git a/src/Http/Http.Results/test/ResultsTests.cs b/src/Http/Http.Results/test/ResultsTests.cs
index ce87ee10e9..e21d097b48 100644
--- a/src/Http/Http.Results/test/ResultsTests.cs
+++ b/src/Http/Http.Results/test/ResultsTests.cs
@@ -1349,7 +1349,7 @@ public partial class ResultsTests
         Assert.Null(result.ProblemDetails.Instance);
         Assert.Equal("application/problem+json", result.ContentType);
         Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
-        Assert.Equal("An error occurred while processing your request.", result.ProblemDetails.Title);
+        Assert.Equal("Internal Server Error", result.ProblemDetails.Title);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", result.ProblemDetails.Type);
         Assert.Empty(result.ProblemDetails.Extensions);
     }
diff --git a/src/Http/Http.Results/test/TypedResultsTests.cs b/src/Http/Http.Results/test/TypedResultsTests.cs
index acee20c4d1..cef21cda67 100644
--- a/src/Http/Http.Results/test/TypedResultsTests.cs
+++ b/src/Http/Http.Results/test/TypedResultsTests.cs
@@ -1141,7 +1141,7 @@ public partial class TypedResultsTests
         Assert.Null(result.ProblemDetails.Instance);
         Assert.Equal("application/problem+json", result.ContentType);
         Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
-        Assert.Equal("An error occurred while processing your request.", result.ProblemDetails.Title);
+        Assert.Equal("Internal Server Error", result.ProblemDetails.Title);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", result.ProblemDetails.Type);
         Assert.Empty(result.ProblemDetails.Extensions);
     }
diff --git a/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs b/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs
index fd502060bf..c9a97ed0f3 100644
--- a/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs
+++ b/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs
@@ -2475,7 +2475,7 @@ public class ControllerBaseTest
         var problemDetails = Assert.IsType<ProblemDetails>(badRequestResult.Value);
         Assert.Equal(500, actionResult.StatusCode);
         Assert.Equal(500, problemDetails.Status);
-        Assert.Equal("An error occurred while processing your request.", problemDetails.Title);
+        Assert.Equal("Internal Server Error", problemDetails.Title);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", problemDetails.Type);
         Assert.Equal("some-trace", problemDetails.Extensions["traceId"]);
     }
@@ -2568,7 +2568,7 @@ public class ControllerBaseTest
                     },
                     [500] = new ClientErrorData
                     {
-                        Title = "An error occurred while processing your request.",
+                        Title = "Internal Server Error",
                         Link = "https://tools.ietf.org/html/rfc9110#section-15.6.1"
                     }
                 }
diff --git a/src/Mvc/Mvc.Core/test/Infrastructure/ProblemDetailsFactoryTest.cs b/src/Mvc/Mvc.Core/test/Infrastructure/ProblemDetailsFactoryTest.cs
index 2695b167ff..d8aa6ac0e8 100644
--- a/src/Mvc/Mvc.Core/test/Infrastructure/ProblemDetailsFactoryTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/ProblemDetailsFactoryTest.cs
@@ -20,7 +20,7 @@ public class ProblemDetailsFactoryTest
 
         // Assert
         Assert.Equal(500, problemDetails.Status);
-        Assert.Equal("An error occurred while processing your request.", problemDetails.Title);
+        Assert.Equal("Internal Server Error", problemDetails.Title);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", problemDetails.Type);
         Assert.Null(problemDetails.Instance);
         Assert.Null(problemDetails.Detail);
diff --git a/src/Shared/ProblemDetails/ProblemDetailsDefaults.cs b/src/Shared/ProblemDetails/ProblemDetailsDefaults.cs
index 967c1aa486..b8d3a18fe2 100644
--- a/src/Shared/ProblemDetails/ProblemDetailsDefaults.cs
+++ b/src/Shared/ProblemDetails/ProblemDetailsDefaults.cs
@@ -133,7 +133,7 @@ internal static class ProblemDetailsDefaults
         [500] =
         (
             "https://tools.ietf.org/html/rfc9110#section-15.6.1",
-            "An error occurred while processing your request."
+            "Internal Server Error"
         ),
 
         [501] =
```

</details>

</details>
<details>
<summary>✅ <b>Attempt 3: PASS</b></summary>

## Attempt 3 — Model exploration

**Approach:** Same as attempt 0 — this is a string constant fix with only one correct value.
The 500 title must match RFC 9110: "Internal Server Error". There is no alternative approach.

<details>
<summary>📄 Diff</summary>

```diff
diff --git a/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs b/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
index 2afabbec3f..b36499ee52 100644
--- a/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
+++ b/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
@@ -560,7 +560,7 @@ public partial class DefaultProblemDetailsWriterTest
         Assert.NotNull(problemDetails);
         Assert.Equal(StatusCodes.Status500InternalServerError, problemDetails.Status);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", problemDetails.Type);
-        Assert.Equal("An error occurred while processing your request.", problemDetails.Title);
+        Assert.Equal("Internal Server Error", problemDetails.Title);
         Assert.Equal(expectedTraceId, problemDetails.Extensions["traceId"].ToString());
     }
 
diff --git a/src/Http/Http.Results/test/JsonResultTests.cs b/src/Http/Http.Results/test/JsonResultTests.cs
index 6e2b05dbcc..3af14f6f24 100644
--- a/src/Http/Http.Results/test/JsonResultTests.cs
+++ b/src/Http/Http.Results/test/JsonResultTests.cs
@@ -139,7 +139,7 @@ public class JsonResultTests
         stream.Position = 0;
         var responseDetails = JsonSerializer.Deserialize<ProblemDetails>(stream, JsonSerializerOptions.Web);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", responseDetails.Type);
-        Assert.Equal("An error occurred while processing your request.", responseDetails.Title);
+        Assert.Equal("Internal Server Error", responseDetails.Title);
         Assert.Equal(StatusCodes.Status500InternalServerError, responseDetails.Status);
     }
 
diff --git a/src/Http/Http.Results/test/ProblemResultTests.cs b/src/Http/Http.Results/test/ProblemResultTests.cs
index c01c42a5d2..8e41555548 100644
--- a/src/Http/Http.Results/test/ProblemResultTests.cs
+++ b/src/Http/Http.Results/test/ProblemResultTests.cs
@@ -37,7 +37,7 @@ public class ProblemResultTests
         stream.Position = 0;
         var responseDetails = JsonSerializer.Deserialize<ProblemDetails>(stream, JsonSerializerOptions.Web);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", responseDetails.Type);
-        Assert.Equal("An error occurred while processing your request.", responseDetails.Title);
+        Assert.Equal("Internal Server Error", responseDetails.Title);
         Assert.Equal(StatusCodes.Status500InternalServerError, responseDetails.Status);
     }
 
@@ -69,7 +69,7 @@ public class ProblemResultTests
         stream.Position = 0;
         var responseDetails = JsonSerializer.Deserialize<ProblemDetails>(stream, JsonSerializerOptions.Web);
         Assert.Null(responseDetails.Type);
-        Assert.Equal("An error occurred while processing your request.", responseDetails.Title);
+        Assert.Equal("Internal Server Error", responseDetails.Title);
         Assert.Equal(StatusCodes.Status500InternalServerError, responseDetails.Status);
     }
 
diff --git a/src/Http/Http.Results/test/ResultsTests.cs b/src/Http/Http.Results/test/ResultsTests.cs
index ce87ee10e9..e21d097b48 100644
--- a/src/Http/Http.Results/test/ResultsTests.cs
+++ b/src/Http/Http.Results/test/ResultsTests.cs
@@ -1349,7 +1349,7 @@ public partial class ResultsTests
         Assert.Null(result.ProblemDetails.Instance);
         Assert.Equal("application/problem+json", result.ContentType);
         Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
-        Assert.Equal("An error occurred while processing your request.", result.ProblemDetails.Title);
+        Assert.Equal("Internal Server Error", result.ProblemDetails.Title);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", result.ProblemDetails.Type);
         Assert.Empty(result.ProblemDetails.Extensions);
     }
diff --git a/src/Http/Http.Results/test/TypedResultsTests.cs b/src/Http/Http.Results/test/TypedResultsTests.cs
index acee20c4d1..cef21cda67 100644
--- a/src/Http/Http.Results/test/TypedResultsTests.cs
+++ b/src/Http/Http.Results/test/TypedResultsTests.cs
@@ -1141,7 +1141,7 @@ public partial class TypedResultsTests
         Assert.Null(result.ProblemDetails.Instance);
         Assert.Equal("application/problem+json", result.ContentType);
         Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
-        Assert.Equal("An error occurred while processing your request.", result.ProblemDetails.Title);
+        Assert.Equal("Internal Server Error", result.ProblemDetails.Title);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", result.ProblemDetails.Type);
         Assert.Empty(result.ProblemDetails.Extensions);
     }
diff --git a/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs b/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs
index fd502060bf..c9a97ed0f3 100644
--- a/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs
+++ b/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs
@@ -2475,7 +2475,7 @@ public class ControllerBaseTest
         var problemDetails = Assert.IsType<ProblemDetails>(badRequestResult.Value);
         Assert.Equal(500, actionResult.StatusCode);
         Assert.Equal(500, problemDetails.Status);
-        Assert.Equal("An error occurred while processing your request.", problemDetails.Title);
+        Assert.Equal("Internal Server Error", problemDetails.Title);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", problemDetails.Type);
         Assert.Equal("some-trace", problemDetails.Extensions["traceId"]);
     }
@@ -2568,7 +2568,7 @@ public class ControllerBaseTest
                     },
                     [500] = new ClientErrorData
                     {
-                        Title = "An error occurred while processing your request.",
+                        Title = "Internal Server Error",
                         Link = "https://tools.ietf.org/html/rfc9110#section-15.6.1"
                     }
                 }
diff --git a/src/Mvc/Mvc.Core/test/Infrastructure/ProblemDetailsFactoryTest.cs b/src/Mvc/Mvc.Core/test/Infrastructure/ProblemDetailsFactoryTest.cs
index 2695b167ff..d8aa6ac0e8 100644
--- a/src/Mvc/Mvc.Core/test/Infrastructure/ProblemDetailsFactoryTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/ProblemDetailsFactoryTest.cs
@@ -20,7 +20,7 @@ public class ProblemDetailsFactoryTest
 
         // Assert
         Assert.Equal(500, problemDetails.Status);
-        Assert.Equal("An error occurred while processing your request.", problemDetails.Title);
+        Assert.Equal("Internal Server Error", problemDetails.Title);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", problemDetails.Type);
         Assert.Null(problemDetails.Instance);
         Assert.Null(problemDetails.Detail);
diff --git a/src/Shared/ProblemDetails/ProblemDetailsDefaults.cs b/src/Shared/ProblemDetails/ProblemDetailsDefaults.cs
index 967c1aa486..b8d3a18fe2 100644
--- a/src/Shared/ProblemDetails/ProblemDetailsDefaults.cs
+++ b/src/Shared/ProblemDetails/ProblemDetailsDefaults.cs
@@ -133,7 +133,7 @@ internal static class ProblemDetailsDefaults
         [500] =
         (
             "https://tools.ietf.org/html/rfc9110#section-15.6.1",
-            "An error occurred while processing your request."
+            "Internal Server Error"
         ),
 
         [501] =
```

</details>

</details>
<details>
<summary>✅ <b>Attempt 4: PASS</b></summary>

## Attempt 4 — Model exploration

**Approach:** Same as attempt 0 — this is a string constant fix with only one correct value.
The 500 title must match RFC 9110: "Internal Server Error". There is no alternative approach.

<details>
<summary>📄 Diff</summary>

```diff
diff --git a/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs b/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
index 2afabbec3f..b36499ee52 100644
--- a/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
+++ b/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
@@ -560,7 +560,7 @@ public partial class DefaultProblemDetailsWriterTest
         Assert.NotNull(problemDetails);
         Assert.Equal(StatusCodes.Status500InternalServerError, problemDetails.Status);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", problemDetails.Type);
-        Assert.Equal("An error occurred while processing your request.", problemDetails.Title);
+        Assert.Equal("Internal Server Error", problemDetails.Title);
         Assert.Equal(expectedTraceId, problemDetails.Extensions["traceId"].ToString());
     }
 
diff --git a/src/Http/Http.Results/test/JsonResultTests.cs b/src/Http/Http.Results/test/JsonResultTests.cs
index 6e2b05dbcc..3af14f6f24 100644
--- a/src/Http/Http.Results/test/JsonResultTests.cs
+++ b/src/Http/Http.Results/test/JsonResultTests.cs
@@ -139,7 +139,7 @@ public class JsonResultTests
         stream.Position = 0;
         var responseDetails = JsonSerializer.Deserialize<ProblemDetails>(stream, JsonSerializerOptions.Web);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", responseDetails.Type);
-        Assert.Equal("An error occurred while processing your request.", responseDetails.Title);
+        Assert.Equal("Internal Server Error", responseDetails.Title);
         Assert.Equal(StatusCodes.Status500InternalServerError, responseDetails.Status);
     }
 
diff --git a/src/Http/Http.Results/test/ProblemResultTests.cs b/src/Http/Http.Results/test/ProblemResultTests.cs
index c01c42a5d2..8e41555548 100644
--- a/src/Http/Http.Results/test/ProblemResultTests.cs
+++ b/src/Http/Http.Results/test/ProblemResultTests.cs
@@ -37,7 +37,7 @@ public class ProblemResultTests
         stream.Position = 0;
         var responseDetails = JsonSerializer.Deserialize<ProblemDetails>(stream, JsonSerializerOptions.Web);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", responseDetails.Type);
-        Assert.Equal("An error occurred while processing your request.", responseDetails.Title);
+        Assert.Equal("Internal Server Error", responseDetails.Title);
         Assert.Equal(StatusCodes.Status500InternalServerError, responseDetails.Status);
     }
 
@@ -69,7 +69,7 @@ public class ProblemResultTests
         stream.Position = 0;
         var responseDetails = JsonSerializer.Deserialize<ProblemDetails>(stream, JsonSerializerOptions.Web);
         Assert.Null(responseDetails.Type);
-        Assert.Equal("An error occurred while processing your request.", responseDetails.Title);
+        Assert.Equal("Internal Server Error", responseDetails.Title);
         Assert.Equal(StatusCodes.Status500InternalServerError, responseDetails.Status);
     }
 
diff --git a/src/Http/Http.Results/test/ResultsTests.cs b/src/Http/Http.Results/test/ResultsTests.cs
index ce87ee10e9..e21d097b48 100644
--- a/src/Http/Http.Results/test/ResultsTests.cs
+++ b/src/Http/Http.Results/test/ResultsTests.cs
@@ -1349,7 +1349,7 @@ public partial class ResultsTests
         Assert.Null(result.ProblemDetails.Instance);
         Assert.Equal("application/problem+json", result.ContentType);
         Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
-        Assert.Equal("An error occurred while processing your request.", result.ProblemDetails.Title);
+        Assert.Equal("Internal Server Error", result.ProblemDetails.Title);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", result.ProblemDetails.Type);
         Assert.Empty(result.ProblemDetails.Extensions);
     }
diff --git a/src/Http/Http.Results/test/TypedResultsTests.cs b/src/Http/Http.Results/test/TypedResultsTests.cs
index acee20c4d1..cef21cda67 100644
--- a/src/Http/Http.Results/test/TypedResultsTests.cs
+++ b/src/Http/Http.Results/test/TypedResultsTests.cs
@@ -1141,7 +1141,7 @@ public partial class TypedResultsTests
         Assert.Null(result.ProblemDetails.Instance);
         Assert.Equal("application/problem+json", result.ContentType);
         Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
-        Assert.Equal("An error occurred while processing your request.", result.ProblemDetails.Title);
+        Assert.Equal("Internal Server Error", result.ProblemDetails.Title);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", result.ProblemDetails.Type);
         Assert.Empty(result.ProblemDetails.Extensions);
     }
diff --git a/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs b/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs
index fd502060bf..c9a97ed0f3 100644
--- a/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs
+++ b/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs
@@ -2475,7 +2475,7 @@ public class ControllerBaseTest
         var problemDetails = Assert.IsType<ProblemDetails>(badRequestResult.Value);
         Assert.Equal(500, actionResult.StatusCode);
         Assert.Equal(500, problemDetails.Status);
-        Assert.Equal("An error occurred while processing your request.", problemDetails.Title);
+        Assert.Equal("Internal Server Error", problemDetails.Title);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", problemDetails.Type);
         Assert.Equal("some-trace", problemDetails.Extensions["traceId"]);
     }
@@ -2568,7 +2568,7 @@ public class ControllerBaseTest
                     },
                     [500] = new ClientErrorData
                     {
-                        Title = "An error occurred while processing your request.",
+                        Title = "Internal Server Error",
                         Link = "https://tools.ietf.org/html/rfc9110#section-15.6.1"
                     }
                 }
diff --git a/src/Mvc/Mvc.Core/test/Infrastructure/ProblemDetailsFactoryTest.cs b/src/Mvc/Mvc.Core/test/Infrastructure/ProblemDetailsFactoryTest.cs
index 2695b167ff..d8aa6ac0e8 100644
--- a/src/Mvc/Mvc.Core/test/Infrastructure/ProblemDetailsFactoryTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/ProblemDetailsFactoryTest.cs
@@ -20,7 +20,7 @@ public class ProblemDetailsFactoryTest
 
         // Assert
         Assert.Equal(500, problemDetails.Status);
-        Assert.Equal("An error occurred while processing your request.", problemDetails.Title);
+        Assert.Equal("Internal Server Error", problemDetails.Title);
         Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.6.1", problemDetails.Type);
         Assert.Null(problemDetails.Instance);
         Assert.Null(problemDetails.Detail);
diff --git a/src/Shared/ProblemDetails/ProblemDetailsDefaults.cs b/src/Shared/ProblemDetails/ProblemDetailsDefaults.cs
index 967c1aa486..b8d3a18fe2 100644
--- a/src/Shared/ProblemDetails/ProblemDetailsDefaults.cs
+++ b/src/Shared/ProblemDetails/ProblemDetailsDefaults.cs
@@ -133,7 +133,7 @@ internal static class ProblemDetailsDefaults
         [500] =
         (
             "https://tools.ietf.org/html/rfc9110#section-15.6.1",
-            "An error occurred while processing your request."
+            "Internal Server Error"
         ),
 
         [501] =
```

</details>

</details>


</details>

</details>
<!-- /SECTION:PR-REVIEW -->