### PR TITLE
Fix `Failed to load resource: net::ERR_CONNECTION_RESET`.

### DIFF
--- a/src/Components/benchmarkapps/Wasm.Performance/Driver/Program.cs
+++ b/src/Components/benchmarkapps/Wasm.Performance/Driver/Program.cs
@@ -86,42 +86,48 @@ public class Program
         await page.GotoAsync(launchUrl);
         page.Console += WriteBrowserConsoleMessage;
 
-        do
+        try
         {
-            BenchmarkResultTask = new TaskCompletionSource<BenchmarkResult>();
-            using var runCancellationToken = new CancellationTokenSource(timeForEachRun);
-            using var registration = runCancellationToken.Token.Register(async () =>
+            do
             {
-                var exceptionMessage = $"Timed out after {timeForEachRun}.";
-                try
+                BenchmarkResultTask = new TaskCompletionSource<BenchmarkResult>();
+                using var runCancellationToken = new CancellationTokenSource(timeForEachRun);
+                using var registration = runCancellationToken.Token.Register(async () =>
                 {
-                    var innerHtml = await page.GetAttributeAsync(":first-child", "innerHTML");
-                    exceptionMessage += Environment.NewLine + "Browser state: " + Environment.NewLine + innerHtml;
-                }
-                catch
+                    var exceptionMessage = $"Timed out after {timeForEachRun}.";
+                    try
+                    {
+                        var innerHtml = await page.GetAttributeAsync(":first-child", "innerHTML");
+                        exceptionMessage += Environment.NewLine + "Browser state: " + Environment.NewLine + innerHtml;
+                    }
+                    catch
+                    {
+                        // Do nothing;
+                    }
+                    BenchmarkResultTask.TrySetException(new TimeoutException(exceptionMessage));
+                });
+
+                var results = await BenchmarkResultTask.Task;
+
+                FormatAsBenchmarksOutput(results,
+                    includeMetadata: firstRun,
+                    isStressRun: isStressRun);
+
+                if (!isStressRun)
                 {
-                    // Do nothing;
+                    PrettyPrint(results);
                 }
-                BenchmarkResultTask.TrySetException(new TimeoutException(exceptionMessage));
-            });
 
-            var results = await BenchmarkResultTask.Task;
+                firstRun = false;
+            } while (isStressRun && !stressRunCancellation.IsCancellationRequested);
 
-            FormatAsBenchmarksOutput(results,
-                includeMetadata: firstRun,
-                isStressRun: isStressRun);
-
-            if (!isStressRun)
-            {
-                PrettyPrint(results);
-            }
-
-            firstRun = false;
-        } while (isStressRun && !stressRunCancellation.IsCancellationRequested);
-
-        Console.WriteLine("Done executing benchmark");
-        await page.CloseAsync();
-        return 0;
+            Console.WriteLine("Done executing benchmark");
+            return 0;
+        }
+        finally
+        {
+            await page.CloseAsync();
+        }
     }
 
     private static void WriteBrowserConsoleMessage(object sender, IConsoleMessage message)

--- a/src/Components/benchmarkapps/Wasm.Performance/Driver/Program.cs
+++ b/src/Components/benchmarkapps/Wasm.Performance/Driver/Program.cs
@@ -120,6 +120,7 @@ public class Program
         } while (isStressRun && !stressRunCancellation.IsCancellationRequested);
 
         Console.WriteLine("Done executing benchmark");
+        await page.CloseAsync();
         return 0;
     }
 


### PR DESCRIPTION
Without the fix: when return 0 executes, C# disposes `benchmarkReceiver` and testApp, which calls `Host.Dispose()` -> Kestrel stops -> forcefully closes TCP connections. But the browser page is still open with a live connection to the test app server
  (port A). When Kestrel kills that TCP socket, the browser detects the reset and logs `Failed to load resource: net::ERR_CONNECTION_RESET.`

  With `await page.CloseAsync()` the browser page is closed before the using disposals run. Chromium cleanly terminates its HTTP connections (sends proper TCP FIN). By the time the servers dispose, there are no open connections left to reset.

Fixes #https://github.com/dotnet/aspnetcore/issues/64832

ref: https://github.com/dotnet/aspnetcore/pull/64801#issuecomment-3674773392