### PR TITLE
Avoid using [IterationSetup] in microbenchmarks

### DIFF
--- a/src/Http/Http/perf/Microbenchmarks/AdaptiveCapacityDictionaryBenchmark.cs
+++ b/src/Http/Http/perf/Microbenchmarks/AdaptiveCapacityDictionaryBenchmark.cs
@@ -8,16 +8,12 @@ namespace Microsoft.AspNetCore.Http;
 
 public class AdaptiveCapacityDictionaryBenchmark
 {
-    private AdaptiveCapacityDictionary<string, string> _smallCapDict;
-    private AdaptiveCapacityDictionary<string, string> _smallCapDictTen;
     private AdaptiveCapacityDictionary<string, string> _filledSmallDictionary;
-    private Dictionary<string, string> _dict;
-    private Dictionary<string, string> _dictTen;
     private Dictionary<string, string> _filledDictTen;
     private KeyValuePair<string, string> _oneValue;
     private List<KeyValuePair<string, string>> _tenValues;
 
-    [IterationSetup]
+    [GlobalSetup]
     public void Setup()
     {
         _oneValue = new KeyValuePair<string, string>("a", "b");
@@ -36,16 +32,12 @@ public class AdaptiveCapacityDictionaryBenchmark
                 new KeyValuePair<string, string>("s", "t"),
             };
 
-        _smallCapDict = new AdaptiveCapacityDictionary<string, string>(capacity: 1, StringComparer.OrdinalIgnoreCase);
-        _smallCapDictTen = new AdaptiveCapacityDictionary<string, string>(capacity: 10, StringComparer.OrdinalIgnoreCase);
         _filledSmallDictionary = new AdaptiveCapacityDictionary<string, string>(capacity: 10, StringComparer.OrdinalIgnoreCase);
         foreach (var a in _tenValues)
         {
             _filledSmallDictionary[a.Key] = a.Value;
         }
 
-        _dict = new Dictionary<string, string>(1, StringComparer.OrdinalIgnoreCase);
-        _dictTen = new Dictionary<string, string>(10, StringComparer.OrdinalIgnoreCase);
         _filledDictTen = new Dictionary<string, string>(10, StringComparer.OrdinalIgnoreCase);
 
         foreach (var a in _tenValues)
@@ -57,188 +49,208 @@ public class AdaptiveCapacityDictionaryBenchmark
     [Benchmark]
     public void OneValue_SmallDict()
     {
-        _smallCapDict[_oneValue.Key] = _oneValue.Value;
-        _ = _smallCapDict[_oneValue.Key];
+        var smallCapDict = new AdaptiveCapacityDictionary<string, string>(capacity: 1, StringComparer.OrdinalIgnoreCase);
+        smallCapDict[_oneValue.Key] = _oneValue.Value;
+        _ = smallCapDict[_oneValue.Key];
     }
 
     [Benchmark]
     public void OneValue_Dict()
     {
-        _dict[_oneValue.Key] = _oneValue.Value;
-        _ = _dict[_oneValue.Key];
+        var dict = new Dictionary<string, string>(1, StringComparer.OrdinalIgnoreCase);
+        dict[_oneValue.Key] = _oneValue.Value;
+        _ = dict[_oneValue.Key];
     }
 
     [Benchmark]
     public void OneValue_SmallDict_Set()
     {
-        _smallCapDict[_oneValue.Key] = _oneValue.Value;
+        var smallCapDict = new AdaptiveCapacityDictionary<string, string>(capacity: 1, StringComparer.OrdinalIgnoreCase);
+        smallCapDict[_oneValue.Key] = _oneValue.Value;
     }
 
     [Benchmark]
     public void OneValue_Dict_Set()
     {
-        _dict[_oneValue.Key] = _oneValue.Value;
+        var dict = new Dictionary<string, string>(1, StringComparer.OrdinalIgnoreCase);
+        dict[_oneValue.Key] = _oneValue.Value;
     }
 
     [Benchmark]
     public void OneValue_SmallDict_Get()
     {
-        _smallCapDict.TryGetValue("test", out var val);
+        var smallCapDict = new AdaptiveCapacityDictionary<string, string>(capacity: 1, StringComparer.OrdinalIgnoreCase);
+        smallCapDict.TryGetValue("test", out var val);
     }
 
     [Benchmark]
     public void OneValue_Dict_Get()
     {
-        _dict.TryGetValue("test", out var val);
+        var dict = new Dictionary<string, string>(1, StringComparer.OrdinalIgnoreCase);
+        dict.TryGetValue("test", out var val);
     }
 
     [Benchmark]
     public void FourValues_SmallDict()
     {
+        var smallCapDictTen = new AdaptiveCapacityDictionary<string, string>(capacity: 10, StringComparer.OrdinalIgnoreCase);
         for (var i = 0; i < 4; i++)
         {
             var val = _tenValues[i];
-            _smallCapDictTen[val.Key] = val.Value;
-            _ = _smallCapDictTen[val.Key];
+            smallCapDictTen[val.Key] = val.Value;
+            _ = smallCapDictTen[val.Key];
         }
     }
 
     [Benchmark]
     public void FiveValues_SmallDict()
     {
+        var smallCapDictTen = new AdaptiveCapacityDictionary<string, string>(capacity: 10, StringComparer.OrdinalIgnoreCase);
         for (var i = 0; i < 5; i++)
         {
             var val = _tenValues[i];
-            _smallCapDictTen[val.Key] = val.Value;
-            _ = _smallCapDictTen[val.Key];
+            smallCapDictTen[val.Key] = val.Value;
+            _ = smallCapDictTen[val.Key];
         }
     }
 
     [Benchmark]
     public void SixValues_SmallDict()
     {
+        var smallCapDictTen = new AdaptiveCapacityDictionary<string, string>(capacity: 10, StringComparer.OrdinalIgnoreCase);
         for (var i = 0; i < 6; i++)
         {
             var val = _tenValues[i];
-            _smallCapDictTen[val.Key] = val.Value;
-            _ = _smallCapDictTen[val.Key];
+            smallCapDictTen[val.Key] = val.Value;
+            _ = smallCapDictTen[val.Key];
         }
     }
 
     [Benchmark]
     public void SevenValues_SmallDict()
     {
+        var smallCapDictTen = new AdaptiveCapacityDictionary<string, string>(capacity: 10, StringComparer.OrdinalIgnoreCase);
         for (var i = 0; i < 7; i++)
         {
             var val = _tenValues[i];
-            _smallCapDictTen[val.Key] = val.Value;
-            _ = _smallCapDictTen[val.Key];
+            smallCapDictTen[val.Key] = val.Value;
+            _ = smallCapDictTen[val.Key];
         }
     }
 
     [Benchmark]
     public void EightValues_SmallDict()
     {
+        var smallCapDictTen = new AdaptiveCapacityDictionary<string, string>(capacity: 10, StringComparer.OrdinalIgnoreCase);
         for (var i = 0; i < 8; i++)
         {
             var val = _tenValues[i];
-            _smallCapDictTen[val.Key] = val.Value;
-            _ = _smallCapDictTen[val.Key];
+            smallCapDictTen[val.Key] = val.Value;
+            _ = smallCapDictTen[val.Key];
         }
     }
 
     [Benchmark]
     public void NineValues_SmallDict()
     {
+        var smallCapDictTen = new AdaptiveCapacityDictionary<string, string>(capacity: 10, StringComparer.OrdinalIgnoreCase);
         for (var i = 0; i < 9; i++)
         {
             var val = _tenValues[i];
-            _smallCapDictTen[val.Key] = val.Value;
-            _ = _smallCapDictTen[val.Key];
+            smallCapDictTen[val.Key] = val.Value;
+            _ = smallCapDictTen[val.Key];
         }
     }
 
     [Benchmark]
     public void TenValues_SmallDict()
     {
+        var smallCapDictTen = new AdaptiveCapacityDictionary<string, string>(capacity: 10, StringComparer.OrdinalIgnoreCase);
         for (var i = 0; i < 10; i++)
         {
             var val = _tenValues[i];
-            _smallCapDictTen[val.Key] = val.Value;
-            _ = _smallCapDictTen[val.Key];
+            smallCapDictTen[val.Key] = val.Value;
+            _ = smallCapDictTen[val.Key];
         }
     }
 
     [Benchmark]
     public void FourValues_Dict()
     {
+        var dictTen = new Dictionary<string, string>(10, StringComparer.OrdinalIgnoreCase);
         for (var i = 0; i < 4; i++)
         {
             var val = _tenValues[i];
-            _dictTen[val.Key] = val.Value;
-            _ = _dictTen[val.Key];
+            dictTen[val.Key] = val.Value;
+            _ = dictTen[val.Key];
         }
     }
 
     [Benchmark]
     public void FiveValues_Dict()
     {
+        var dictTen = new Dictionary<string, string>(10, StringComparer.OrdinalIgnoreCase);
         for (var i = 0; i < 5; i++)
         {
             var val = _tenValues[i];
-            _dictTen[val.Key] = val.Value;
-            _ = _dictTen[val.Key];
+            dictTen[val.Key] = val.Value;
+            _ = dictTen[val.Key];
         }
     }
     [Benchmark]
     public void SixValues_Dict()
     {
+        var dictTen = new Dictionary<string, string>(10, StringComparer.OrdinalIgnoreCase);
         for (var i = 0; i < 6; i++)
         {
             var val = _tenValues[i];
-            _dictTen[val.Key] = val.Value;
-            _ = _dictTen[val.Key];
+            dictTen[val.Key] = val.Value;
+            _ = dictTen[val.Key];
         }
     }
     [Benchmark]
     public void SevenValues_Dict()
     {
+        var dictTen = new Dictionary<string, string>(10, StringComparer.OrdinalIgnoreCase);
         for (var i = 0; i < 7; i++)
         {
             var val = _tenValues[i];
-            _dictTen[val.Key] = val.Value;
-            _ = _dictTen[val.Key];
+            dictTen[val.Key] = val.Value;
+            _ = dictTen[val.Key];
         }
     }
     [Benchmark]
     public void EightValues_Dict()
     {
+        var dictTen = new Dictionary<string, string>(10, StringComparer.OrdinalIgnoreCase);
         for (var i = 0; i < 8; i++)
         {
             var val = _tenValues[i];
-            _dictTen[val.Key] = val.Value;
-            _ = _dictTen[val.Key];
+            dictTen[val.Key] = val.Value;
+            _ = dictTen[val.Key];
         }
     }
     [Benchmark]
     public void NineValues_Dict()
     {
+        var dictTen = new Dictionary<string, string>(10, StringComparer.OrdinalIgnoreCase);
         for (var i = 0; i < 9; i++)
         {
             var val = _tenValues[i];
-            _dictTen[val.Key] = val.Value;
-            _ = _dictTen[val.Key];
+            dictTen[val.Key] = val.Value;
+            _ = dictTen[val.Key];
         }
     }
 
     [Benchmark]
     public void TenValues_Dict()
     {
+        var dictTen = new Dictionary<string, string>(10, StringComparer.OrdinalIgnoreCase);
         for (var i = 0; i < 10; i++)
         {
             var val = _tenValues[i];
-            _dictTen[val.Key] = val.Value;
-            _ = _dictTen[val.Key];
+            dictTen[val.Key] = val.Value;
+            _ = dictTen[val.Key];
         }
     }
 

--- a/src/Http/Http/perf/Microbenchmarks/RequestCookieCollectionBenchmarks.cs
+++ b/src/Http/Http/perf/Microbenchmarks/RequestCookieCollectionBenchmarks.cs
@@ -10,7 +10,7 @@ public class RequestCookieCollectionBenchmarks
 {
     private StringValues _cookie;
 
-    [IterationSetup]
+    [GlobalSetup]
     public void Setup()
     {
         _cookie = ".AspNetCore.Cookies=CfDJ8BAklVa9EYREk8_ipRUUYJYhRsleKr485k18s_q5XD6vcRJ-DtowUuLCwwMiY728zRZ3rVFY3DEcXDAQUOTtg1e4tkSIVmYLX38Q6mqdFFyw-8dksclDywe9vnN84cEWvfV0wP3EgOsJGHaND7kTJ47gr7Pc1tLHWOm4Pe7Q1vrT9EkcTMr1Wts3aptBl3bdOLLqjmSdgk-OI7qG7uQGz1OGdnSer6-KLUPBcfXblzs4YCjvwu3bGnM42xLGtkZNIF8izPpyqKkIf7ec6O6LEHMp4gcq86PGHCXHn5NKuNSD";

--- a/src/Http/Http/perf/Microbenchmarks/RouteValueDictionaryBenchmark.cs
+++ b/src/Http/Http/perf/Microbenchmarks/RouteValueDictionaryBenchmark.cs
@@ -11,8 +11,7 @@ public class RouteValueDictionaryBenchmark
     private RouteValueDictionary _propertyValues;
     private RouteValueDictionary _arrayValuesEmpty;
 
-    // We modify the route value dictionaries in many of these benchmarks.
-    [IterationSetup]
+    [GlobalSetup]
     public void Setup()
     {
         _arrayValues = new RouteValueDictionary()
@@ -94,7 +93,7 @@ public class RouteValueDictionaryBenchmark
     public void TryAdd_Properties_AtCapacity_KeyDoesNotExist()
     {
         var propertyValues = new RouteValueDictionary(new { action = "Index", controller = "Home", id = "17", area = "root" });
-        _propertyValues.TryAdd("name", "Service");
+        propertyValues.TryAdd("name", "Service");
     }
 
     [Benchmark]
@@ -108,7 +107,7 @@ public class RouteValueDictionaryBenchmark
     public void TryAdd_Properties_NotAtCapacity_KeyDoesNotExist()
     {
         var propertyValues = new RouteValueDictionary(new { action = "Index", controller = "Home", id = "17" });
-        _propertyValues.TryAdd("name", "Service");
+        propertyValues.TryAdd("name", "Service");
     }
 
     [Benchmark]
@@ -191,7 +190,12 @@ public class RouteValueDictionaryBenchmark
     [Benchmark]
     public RouteValueDictionary ConditionalAdd_ContainsKey_Array()
     {
-        var dictionary = _arrayValues;
+        var dictionary = new RouteValueDictionary()
+            {
+                { "action", "Index" },
+                { "controller", "Home" },
+                { "id", "17" },
+            };
 
         if (!dictionary.ContainsKey("action"))
         {
@@ -214,7 +218,12 @@ public class RouteValueDictionaryBenchmark
     [Benchmark]
     public RouteValueDictionary ConditionalAdd_TryAdd()
     {
-        var dictionary = _arrayValues;
+        var dictionary = new RouteValueDictionary()
+            {
+                { "action", "Index" },
+                { "controller", "Home" },
+                { "id", "17" },
+            };
 
         dictionary.TryAdd("action", "Index");
         dictionary.TryAdd("controller", "Home");

--- a/src/Http/WebUtilities/perf/Microbenchmarks/FormPipeReaderInternalsBenchmark.cs
+++ b/src/Http/WebUtilities/perf/Microbenchmarks/FormPipeReaderInternalsBenchmark.cs
@@ -17,7 +17,7 @@ public class FormPipeReaderInternalsBenchmark
     private readonly byte[] _secondUtf8 = Encoding.UTF8.GetBytes("o&haha=hehe&lol=temp");
     private FormPipeReader _formPipeReader;
 
-    [IterationSetup]
+    [GlobalSetup]
     public void Setup()
     {
         _formPipeReader = new FormPipeReader(null);

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http1LargeWritingBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http1LargeWritingBenchmark.cs
@@ -33,23 +33,23 @@ public class Http1LargeWritingBenchmark
         _consumeResponseBodyTask = ConsumeResponseBody();
     }
 
-    [IterationSetup]
-    public void Setup()
+    [Benchmark]
+    public Task WriteAsync()
     {
         _http1Connection.Reset();
         _http1Connection.RequestHeaders.ContentLength = _writeData.Length;
         _http1Connection.FlushAsync().GetAwaiter().GetResult();
-    }
 
-    [Benchmark]
-    public Task WriteAsync()
-    {
         return _http1Connection.ResponseBody.WriteAsync(_writeData, 0, _writeData.Length, default);
     }
 
     [Benchmark]
     public Task WriteSegmentsUnawaitedAsync()
     {
+        _http1Connection.Reset();
+        _http1Connection.RequestHeaders.ContentLength = _writeData.Length;
+        _http1Connection.FlushAsync().GetAwaiter().GetResult();
+
         // Write a 10th the of the data at a time
         var segmentSize = _writeData.Length / 10;
 

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http1WritingBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http1WritingBenchmark.cs
@@ -49,8 +49,8 @@ public class Http1WritingBenchmark
     [Params(Startup.None, Startup.Sync, Startup.Async)]
     public Startup OnStarting { get; set; }
 
-    [IterationSetup]
-    public void Setup()
+    [Benchmark]
+    public Task WriteAsync()
     {
         _http1Connection.Reset();
         if (Chunked)
@@ -67,11 +67,6 @@ public class Http1WritingBenchmark
             _http1Connection.FlushAsync().GetAwaiter().GetResult();
         }
 
-        ResetState();
-    }
-
-    private void ResetState()
-    {
         if (WithHeaders)
         {
             _http1Connection.ResetState();
@@ -86,12 +81,6 @@ public class Http1WritingBenchmark
                     break;
             }
         }
-    }
-
-    [Benchmark]
-    public Task WriteAsync()
-    {
-        ResetState();
 
         return _http1Connection.ResponseBody.WriteAsync(_writeData, 0, _writeData.Length, default(CancellationToken));
     }

--- a/src/Servers/Kestrel/perf/Microbenchmarks/ResponseHeadersWritingBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/ResponseHeadersWritingBenchmark.cs
@@ -43,6 +43,10 @@ public class ResponseHeadersWritingBenchmark
     [Benchmark(OperationsPerInvoke = Iterations)]
     public void Output()
     {
+        _responseHeaders.Reset();
+        _responseHeaders.SetRawServer(Constants.ServerName, _bytesServer);
+        _responseHeaders.SetRawDate(DateHeaderValues.String, DateHeaderValues.Bytes);
+
         switch (Type)
         {
             case BenchmarkTypes.TechEmpowerPlaintext:
@@ -182,14 +186,6 @@ public class ResponseHeadersWritingBenchmark
         _dateHeaderValueManager = new DateHeaderValueManager(TimeProvider.System);
         _dateHeaderValueManager.OnHeartbeat();
         _writer = new Writer();
-    }
-
-    [IterationSetup]
-    public void IterationSetup()
-    {
-        _responseHeaders.Reset();
-        _responseHeaders.SetRawServer(Constants.ServerName, _bytesServer);
-        _responseHeaders.SetRawDate(DateHeaderValues.String, DateHeaderValues.Bytes);
     }
 
     public class Writer : PipeWriter

--- a/src/Servers/Kestrel/perf/Microbenchmarks/SchedulerBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/SchedulerBenchmark.cs
@@ -55,17 +55,6 @@ public class SchedulerBenchmark
         }
     }
 
-    [IterationSetup]
-    public void IterationSetup()
-    {
-        _totalToReport = OuterLoopCount;
-
-        for (var i = 0; i < _counters.Length; i++)
-        {
-            _counters[i].Remaining = InnerLoopCount;
-        }
-    }
-
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke, Baseline = true)]
     public void ThreadPoolScheduler() => Schedule(_threadPoolSchedulers);
 
@@ -77,6 +66,13 @@ public class SchedulerBenchmark
 
     private void Schedule(PipeScheduler[] schedulers)
     {
+        _totalToReport = OuterLoopCount;
+
+        for (var i = 0; i < _counters.Length; i++)
+        {
+            _counters[i].Remaining = InnerLoopCount;
+        }
+
         Parallel.For(0, OuterLoopCount, () => schedulers, _parallelAction, (s) => { });
 
         while (_totalToReport > 0)


### PR DESCRIPTION
Per https://benchmarkdotnet.org/articles/samples/IntroSetupCleanupIteration.html
> A method which is marked by the [[IterationSetup]](https://benchmarkdotnet.org/api/BenchmarkDotNet.Attributes.IterationSetupAttribute.html) attribute will be executed exactly once before each benchmark invocation, forcing UnrollFactor=1 and InvocationCount=1 (we have changed that in 0.11.0). It's not recommended to use this attribute in microbenchmarks because it can spoil the results.

Moved a bunch of benchmarks to reset state in the benchmarked method. This does technically change what's being measured, so we might want to add `OperationsPerInvoke` to some of the benchmarks (some already use this) to amortize the setup costs.

There are a few I haven't changed yet (e.g. https://github.com/dotnet/aspnetcore/blob/main/src/Servers/Kestrel/perf/Microbenchmarks/HeaderCollectionBenchmark.cs) as they seemed a little more involved in what the setup code was doing.