### PR TITLE
Remove unnecessary cache freshness check

### DIFF
--- a/src/Middleware/OutputCaching/src/LoggerExtensions.cs
+++ b/src/Middleware/OutputCaching/src/LoggerExtensions.cs
@@ -45,9 +45,7 @@ internal static partial class LoggerExtensions
         EventName = "ResponseContentLengthMismatchNotCached")]
     internal static partial void ResponseContentLengthMismatchNotCached(this ILogger logger);
 
-    [LoggerMessage(11, LogLevel.Debug, "The response time of the entry is {ResponseTime} and has exceeded its expiry date.",
-        EventName = "ExpirationExpiresExceeded")]
-    internal static partial void ExpirationExpiresExceeded(this ILogger logger, DateTimeOffset responseTime);
+    // EventID 11 ExpirationExpiresExceeded retired.
 
     [LoggerMessage(12, LogLevel.Error, "Unable to query output cache.", EventName = "UnableToQueryOutputCache")]
     internal static partial void UnableToQueryOutputCache(this ILogger logger, Exception exception);

--- a/src/Middleware/OutputCaching/src/OutputCacheMiddleware.cs
+++ b/src/Middleware/OutputCaching/src/OutputCacheMiddleware.cs
@@ -277,13 +277,6 @@ internal sealed class OutputCacheMiddleware
 
         context.IsCacheEntryFresh = true;
 
-        // Validate expiration
-        if (context.CachedEntryAge <= TimeSpan.Zero)
-        {
-            _logger.ExpirationExpiresExceeded(context.ResponseTime!.Value);
-            context.IsCacheEntryFresh = false;
-        }
-
         var cachedResponse = context.CachedResponse;
         if (context.IsCacheEntryFresh)
         {

--- a/src/Middleware/OutputCaching/test/OutputCacheMiddlewareTests.cs
+++ b/src/Middleware/OutputCaching/test/OutputCacheMiddlewareTests.cs
@@ -492,6 +492,102 @@ public abstract class OutputCacheMiddlewareTests
         Assert.Empty(sink.Writes);
     }
 
+    [Fact]
+    public async Task TryServeFromCacheAsync_CachedResponseFresh_WhenResponseTimeEqualsCreated()
+    {
+        var cache = GetStore();
+        var sink = new TestSink();
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var options = new OutputCacheOptions { TimeProvider = timeProvider };
+        var middleware = TestUtils.CreateTestMiddleware(testSink: sink, cache: cache, options: options, keyProvider: new TestResponseCachingKeyProvider("BaseKey"));
+        var context = TestUtils.CreateTestContext(cache: cache, options: options);
+        middleware.TryGetRequestPolicies(context.HttpContext, out var policies);
+
+        using (var entry = new OutputCacheEntry(timeProvider.GetUtcNow(), StatusCodes.Status200OK))
+        {
+            await OutputCacheEntryFormatter.StoreAsync(
+                "BaseKey",
+                entry,
+                null,
+                TimeSpan.FromSeconds(10),
+                cache,
+                NullLogger.Instance,
+                default);
+        }
+
+        Assert.True(await middleware.TryServeFromCacheAsync(context, policies));
+        Assert.Equal(1, cache.GetCount);
+        TestUtils.AssertLoggedMessages(
+            sink.Writes,
+            LoggedMessage.CachedResponseServed);
+    }
+
+    [Fact]
+    public async Task TryServeFromCacheAsync_CachedResponseFresh_WhenResponseTimeIsAfterCreated()
+    {
+        var cache = GetStore();
+        var sink = new TestSink();
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var options = new OutputCacheOptions { TimeProvider = timeProvider };
+        var middleware = TestUtils.CreateTestMiddleware(testSink: sink, cache: cache, options: options, keyProvider: new TestResponseCachingKeyProvider("BaseKey"));
+        var context = TestUtils.CreateTestContext(cache: cache, options: options);
+        middleware.TryGetRequestPolicies(context.HttpContext, out var policies);
+
+        using (var entry = new OutputCacheEntry(timeProvider.GetUtcNow(), StatusCodes.Status200OK))
+        {
+            await OutputCacheEntryFormatter.StoreAsync(
+                "BaseKey",
+                entry,
+                null,
+                TimeSpan.FromSeconds(10),
+                cache,
+                NullLogger.Instance,
+                default);
+        }
+
+        timeProvider.Advance(TimeSpan.FromSeconds(5));
+
+        Assert.True(await middleware.TryServeFromCacheAsync(context, policies));
+        Assert.Equal(1, cache.GetCount);
+        TestUtils.AssertLoggedMessages(
+            sink.Writes,
+            LoggedMessage.CachedResponseServed);
+    }
+
+    [Fact]
+    // Technically not possible with the current code
+    // but no reason a response can't get the cached entry if there is a valid one
+    public async Task TryServeFromCacheAsync_CachedResponseFresh_WhenResponseTimeIsBeforeCreated()
+    {
+        var cache = GetStore();
+        var sink = new TestSink();
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var options = new OutputCacheOptions { TimeProvider = timeProvider };
+        var middleware = TestUtils.CreateTestMiddleware(testSink: sink, cache: cache, options: options, keyProvider: new TestResponseCachingKeyProvider("BaseKey"));
+        var context = TestUtils.CreateTestContext(cache: cache, options: options);
+        middleware.TryGetRequestPolicies(context.HttpContext, out var policies);
+
+        using (var entry = new OutputCacheEntry(timeProvider.GetUtcNow(), StatusCodes.Status200OK))
+        {
+            await OutputCacheEntryFormatter.StoreAsync(
+                "BaseKey",
+                entry,
+                null,
+                TimeSpan.FromSeconds(10),
+                cache,
+                NullLogger.Instance,
+                default);
+        }
+
+        timeProvider.AdjustTime(timeProvider.GetUtcNow() - TimeSpan.FromSeconds(5));
+
+        Assert.True(await middleware.TryServeFromCacheAsync(context, policies));
+        Assert.Equal(1, cache.GetCount);
+        TestUtils.AssertLoggedMessages(
+            sink.Writes,
+            LoggedMessage.CachedResponseServed);
+    }
+
     public static TheoryData<StringValues> NullOrEmptyVaryRules
     {
         get

--- a/src/Middleware/OutputCaching/test/TestUtils.cs
+++ b/src/Middleware/OutputCaching/test/TestUtils.cs
@@ -306,7 +306,6 @@ internal class LoggedMessage
     internal static LoggedMessage ResponseCached => new LoggedMessage(8, LogLevel.Information);
     internal static LoggedMessage ResponseNotCached => new LoggedMessage(9, LogLevel.Information);
     internal static LoggedMessage ResponseContentLengthMismatchNotCached => new LoggedMessage(10, LogLevel.Warning);
-    internal static LoggedMessage ExpirationExpiresExceeded => new LoggedMessage(11, LogLevel.Debug);
 
     private LoggedMessage(int evenId, LogLevel logLevel)
     {


### PR DESCRIPTION
Output caching tests could fail due to the second request happening too fast (the same tick) and failing the `timeDifference <= TimeSpan.Zero` check. If a request is processed at the same time as a cache entry is added, then it should be able to use the cached entry. Similarly, if we change our time calculation in the future to occur earlier in the request processing pipeline and compare with the cached entry age it could be negative and would fail the previously mentioned check. Again, I don't see a reason we can't serve the cached response in that case.