### PR TITLE
Blazor ComponentBase initialization state

### DIFF
--- a/src/Components/Components/src/ComponentBase.cs
+++ b/src/Components/Components/src/ComponentBase.cs
@@ -24,7 +24,7 @@ public abstract class ComponentBase : IComponent, IHandleEvent, IHandleAfterRend
     private readonly RenderFragment _renderFragment;
     private (IComponentRenderMode? mode, bool cached) _renderMode;
     private RenderHandle _renderHandle;
-    private bool _initialized;
+    private bool _wasInitAndSetParametersRun;
     private bool _hasNeverRendered = true;
     private bool _hasPendingQueuedRender;
     private bool _hasCalledOnAfterRender;
@@ -259,9 +259,9 @@ public abstract class ComponentBase : IComponent, IHandleEvent, IHandleAfterRend
     public virtual Task SetParametersAsync(ParameterView parameters)
     {
         parameters.SetParameterProperties(this);
-        if (!_initialized)
+        if (!_wasInitAndSetParametersRun)
         {
-            _initialized = true;
+            _wasInitAndSetParametersRun = true;
 
             return RunInitAndSetParametersAsync();
         }

--- a/src/Components/Components/src/ComponentBase.cs
+++ b/src/Components/Components/src/ComponentBase.cs
@@ -43,6 +43,11 @@ public abstract class ComponentBase : IComponent, IHandleEvent, IHandleAfterRend
     }
 
     /// <summary>
+    /// Indicates if the component finished calling the <see cref="OnInitialized"/> and <see cref="OnInitializedAsync"/>.
+    /// </summary>
+    protected bool IsAfterInitialization { get; private set; }
+
+    /// <summary>
     /// Gets the <see cref="Components.RendererInfo"/> the component is running on.
     /// </summary>
     protected RendererInfo RendererInfo => _renderHandle.RendererInfo;
@@ -306,6 +311,8 @@ public abstract class ComponentBase : IComponent, IHandleEvent, IHandleAfterRend
 
             // Don't call StateHasChanged here. CallOnParametersSetAsync should handle that for us.
         }
+
+        IsAfterInitialization = true;
 
         await CallOnParametersSetAsync();
     }

--- a/src/Components/Components/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Components/src/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+Microsoft.AspNetCore.Components.ComponentBase.IsAfterInitialization.get -> bool
 static Microsoft.AspNetCore.Components.NavigationManagerExtensions.GetUriWithHash(this Microsoft.AspNetCore.Components.NavigationManager! navigationManager, string! hash) -> string!
 Microsoft.AspNetCore.Components.NavigationOptions.RelativeToCurrentUri.get -> bool
 Microsoft.AspNetCore.Components.NavigationOptions.RelativeToCurrentUri.init -> void

--- a/src/Components/Components/test/ComponentBaseTest.cs
+++ b/src/Components/Components/test/ComponentBaseTest.cs
@@ -583,6 +583,153 @@ public class ComponentBaseTest
         Assert.Same(expected, actual);
     }
 
+    [Fact]
+    public void IsAfterInitialization_FalseBeforeRendering()
+    {
+        // Arrange
+        var component = new TestComponent();
+
+        // Assert
+        Assert.False(component.ExposedIsAfterInitialization);
+    }
+
+    [Fact]
+    public void IsAfterInitialization_TrueAfterSyncInit()
+    {
+        // Arrange
+        var renderer = new TestRenderer();
+        var component = new TestComponent();
+
+        // Act
+        var componentId = renderer.AssignRootComponentId(component);
+        renderer.RenderRootComponent(componentId);
+
+        // Assert
+        Assert.True(component.ExposedIsAfterInitialization);
+    }
+
+    [Fact]
+    public void IsAfterInitialization_FalseDuringAsyncInit()
+    {
+        // Arrange
+        var renderer = new TestRenderer();
+        var component = new TestComponent();
+        var initTask = new TaskCompletionSource<bool>();
+
+        bool? valueDuringInit = null;
+        component.OnInitAsyncLogic = c =>
+        {
+            valueDuringInit = c.ExposedIsAfterInitialization;
+            return initTask.Task;
+        };
+
+        // Act
+        var componentId = renderer.AssignRootComponentId(component);
+        renderer.RenderRootComponentAsync(componentId);
+
+        // Assert
+        Assert.False(valueDuringInit);
+        Assert.False(component.ExposedIsAfterInitialization);
+    }
+
+    [Fact]
+    public async Task IsAfterInitialization_TrueAfterAsyncInitCompletes()
+    {
+        // Arrange
+        var renderer = new TestRenderer();
+        var component = new TestComponent();
+        var initTask = new TaskCompletionSource<bool>();
+
+        component.OnInitAsyncLogic = _ => initTask.Task;
+
+        // Act
+        var componentId = renderer.AssignRootComponentId(component);
+        var renderTask = renderer.RenderRootComponentAsync(componentId);
+
+        Assert.False(component.ExposedIsAfterInitialization);
+
+        initTask.SetResult(true);
+        await renderTask;
+
+        // Assert
+        Assert.True(component.ExposedIsAfterInitialization);
+    }
+
+    [Fact]
+    public async Task IsAfterInitialization_TrueOnSubsequentParameterSets()
+    {
+        // Arrange
+        var renderer = new TestRenderer();
+        var component = new TestComponent();
+
+        var componentId = renderer.AssignRootComponentId(component);
+        await renderer.RenderRootComponentAsync(componentId);
+        Assert.True(component.ExposedIsAfterInitialization);
+
+        // Act — trigger a subsequent render (re-enters SetParametersAsync)
+        await renderer.RenderRootComponentAsync(componentId);
+
+        // Assert
+        Assert.True(component.ExposedIsAfterInitialization);
+    }
+
+    [Fact]
+    public async Task IsAfterInitialization_FalseWhenOnInitAsyncThrows()
+    {
+        // Arrange
+        var renderer = new TestRenderer();
+        renderer.ShouldHandleExceptions = true;
+        var component = new TestComponent();
+
+        component.OnInitAsyncLogic = _ => Task.FromException(new InvalidTimeZoneException());
+
+        // Act
+        var componentId = renderer.AssignRootComponentId(component);
+        await renderer.RenderRootComponentAsync(componentId);
+
+        // Assert
+        Assert.False(component.ExposedIsAfterInitialization);
+    }
+
+    [Fact]
+    public async Task IsAfterInitialization_FalseWhenOnInitThrows()
+    {
+        // Arrange
+        var renderer = new TestRenderer();
+        var component = new TestComponent();
+
+        component.OnInitLogic = _ => throw new InvalidTimeZoneException();
+
+        // Act
+        var componentId = renderer.AssignRootComponentId(component);
+        await Assert.ThrowsAsync<InvalidTimeZoneException>(
+            () => renderer.RenderRootComponentAsync(componentId));
+
+        // Assert
+        Assert.False(component.ExposedIsAfterInitialization);
+    }
+
+    [Fact]
+    public async Task IsAfterInitialization_TrueWhenOnInitAsyncCancelled()
+    {
+        // Arrange
+        var renderer = new TestRenderer();
+        var component = new TestComponent();
+        var initTask = new TaskCompletionSource();
+
+        component.OnInitAsyncLogic = _ => initTask.Task;
+
+        // Act
+        var componentId = renderer.AssignRootComponentId(component);
+        var renderTask = renderer.RenderRootComponentAsync(componentId);
+
+        initTask.SetCanceled();
+        await renderTask;
+
+        // Assert
+        Assert.True(component.ExposedIsAfterInitialization);
+    }
+
     private class TestComponent : ComponentBase
     {
         public bool RunsBaseOnInit { get; set; } = true;
@@ -610,6 +757,8 @@ public class ComponentBaseTest
         public Func<TestComponent, bool, Task> OnAfterRenderAsyncLogic { get; set; }
 
         public int Counter { get; set; }
+
+        public bool ExposedIsAfterInitialization => IsAfterInitialization;
 
         public RenderFragment ChildContent { get; set; }
 

--- a/src/Components/Components/test/ComponentBaseTest.cs
+++ b/src/Components/Components/test/ComponentBaseTest.cs
@@ -688,6 +688,8 @@ public class ComponentBaseTest
         await renderer.RenderRootComponentAsync(componentId);
 
         // Assert
+        Assert.Single(renderer.HandledExceptions);
+        Assert.IsType<InvalidTimeZoneException>(renderer.HandledExceptions[0]);
         Assert.False(component.ExposedIsAfterInitialization);
     }
 


### PR DESCRIPTION
# Blazor ComponentBase initialization state

These two commits rename an internal field for clarity and introduce a new IsAfterInitialization
property so Blazor components can check whether their initialization phase is complete.

## Description
- Renamed the private field _initialized to _wasInitAndSetParametersRun in ComponentBase.cs to better describe
  what the flag actually tracks (that both OnInitialized and SetParameters have been run, not just initialization).
- Added a new protected property IsAfterInitialization to ComponentBase with a private set.
  - It's set to true after OnInitialized/OnInitializedAsync completes (both in the normal flow and in the exception
   path when the task isn't cancelled).
  - This lets derived components know whether the initialization lifecycle methods have finished running.
  - Registered the new API in PublicAPI.Unshipped.txt.

Implements #65665 
