### PR TITLE
Fix intermittent circular dependency build failure

### DIFF
--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.sfxproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.sfxproj
@@ -136,6 +136,7 @@
   </Target>
 
   <Target Name="PublishToSharedLayoutRoot" BeforeTargets="Build">
+    <!-- Set _PublishingToLayout=true to differentiate global properties for this nested MSBuild call and avoid an intermittent circular dependency involving GetFilesToPublish. -->
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="PublishToDisk"
              Properties="OutputPath=$(SharedFrameworkLayoutRoot);_PublishingToLayout=true" />

--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.sfxproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.sfxproj
@@ -138,7 +138,7 @@
   <Target Name="PublishToSharedLayoutRoot" BeforeTargets="Build">
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="PublishToDisk"
-             Properties="OutputPath=$(SharedFrameworkLayoutRoot)" />
+             Properties="OutputPath=$(SharedFrameworkLayoutRoot);_PublishingToLayout=true" />
   </Target>
 
   <Target Name="ReturnProductVersion" Returns="$(Version)" />


### PR DESCRIPTION
We occasionally see failures like:

> /Users/runner/work/1/s/.packages/microsoft.dotnet.sharedframework.sdk/10.0.0-beta.26154.121/targets/sharedfx.targets(581,5): error MSB4006: There is a circular dependency in the target dependency graph involving target "GetFilesToPublish". [/Users/runner/work/1/s/src/Framework/App.Runtime/src/

The root cause of this is that `PublishToSharedLayoutRoot` calls MSBuild on its own process, which then calls `GetFilesToPublish`, which again MSbuild's itself, but removes the setting of `OutputPath` from line 141. So the inner-inner build has the same global properties as the outer build, which MSBuild detects as a circular dependency. If we set an arbitrary sentinel property in the MSBuild invocation in `PublishToSharedLayoutRoot`, then the global properties will no longer match.

https://github.com/dotnet/dotnet/blob/856f69955c79a685a753283ea03701c4d04264ba/src/arcade/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets#L578-L583