### PR TITLE
Restore trimming test projects serially

### DIFF
--- a/eng/testing/linker/trimmingTests.targets
+++ b/eng/testing/linker/trimmingTests.targets
@@ -104,7 +104,18 @@
     <MSBuild Projects="@(TestConsoleApps)"
              BuildInParallel="false"
              Targets="Restore"
+             ContinueOnError="ErrorAndContinue"
              Condition="'$(SkipTrimmingProjectsRestore)' != 'true'"
+             Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid());Configuration=$(Configuration);RestoreDisableParallel=true" />
+
+    <!-- Retry restore if the first attempt failed due to a concurrent NuGet file-move race on Windows (https://github.com/dotnet/aspnetcore/issues/61178).
+         Multiple trimming-test .proj files restore in parallel; their static-graph restores can race when
+         committing project.assets.json for shared ProjectReference targets. The retry succeeds because the
+         competing restore has finished by then, and already-restored projects are quick no-ops. -->
+    <MSBuild Projects="@(TestConsoleApps)"
+             BuildInParallel="false"
+             Targets="Restore"
+             Condition="'$(SkipTrimmingProjectsRestore)' != 'true' and '$(MSBuildLastTaskResult)' != 'true'"
              Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid());Configuration=$(Configuration);RestoreDisableParallel=true" />
 
     <MSBuild Projects="@(TestConsoleApps)"

--- a/eng/testing/linker/trimmingTests.targets
+++ b/eng/testing/linker/trimmingTests.targets
@@ -101,21 +101,22 @@
   <Target Name="PublishTrimmedProjects"
           DependsOnTargets="GenerateProjects">
 
+    <!-- Multiple trimming-test .proj files restore in parallel. Their NuGet static-graph restores can race when
+         committing project.assets.json for shared ProjectReference targets on Windows, producing
+         "Cannot create a file when that file already exists" (https://github.com/dotnet/aspnetcore/issues/61178).
+         WarnAndContinue absorbs the error so the build isn't failed, and the second invocation retries the
+         restore. Already-restored projects are quick no-ops; only the race-failed project is actually re-restored. -->
     <MSBuild Projects="@(TestConsoleApps)"
              BuildInParallel="false"
              Targets="Restore"
-             ContinueOnError="ErrorAndContinue"
+             ContinueOnError="WarnAndContinue"
              Condition="'$(SkipTrimmingProjectsRestore)' != 'true'"
              Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid());Configuration=$(Configuration);RestoreDisableParallel=true" />
 
-    <!-- Retry restore if the first attempt failed due to a concurrent NuGet file-move race on Windows (https://github.com/dotnet/aspnetcore/issues/61178).
-         Multiple trimming-test .proj files restore in parallel; their static-graph restores can race when
-         committing project.assets.json for shared ProjectReference targets. The retry succeeds because the
-         competing restore has finished by then, and already-restored projects are quick no-ops. -->
     <MSBuild Projects="@(TestConsoleApps)"
              BuildInParallel="false"
              Targets="Restore"
-             Condition="'$(SkipTrimmingProjectsRestore)' != 'true' and '$(MSBuildLastTaskResult)' != 'true'"
+             Condition="'$(SkipTrimmingProjectsRestore)' != 'true'"
              Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid());Configuration=$(Configuration);RestoreDisableParallel=true" />
 
     <MSBuild Projects="@(TestConsoleApps)"

--- a/eng/testing/linker/trimmingTests.targets
+++ b/eng/testing/linker/trimmingTests.targets
@@ -101,18 +101,6 @@
   <Target Name="PublishTrimmedProjects"
           DependsOnTargets="GenerateProjects">
 
-    <!-- Multiple trimming-test .proj files restore in parallel. Their NuGet static-graph restores can race when
-         committing project.assets.json for shared ProjectReference targets on Windows, producing
-         "Cannot create a file when that file already exists" (https://github.com/dotnet/aspnetcore/issues/61178).
-         WarnAndContinue absorbs the error so the build isn't failed, and the second invocation retries the
-         restore. Already-restored projects are quick no-ops; only the race-failed project is actually re-restored. -->
-    <MSBuild Projects="@(TestConsoleApps)"
-             BuildInParallel="false"
-             Targets="Restore"
-             ContinueOnError="WarnAndContinue"
-             Condition="'$(SkipTrimmingProjectsRestore)' != 'true'"
-             Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid());Configuration=$(Configuration);RestoreDisableParallel=true" />
-
     <MSBuild Projects="@(TestConsoleApps)"
              BuildInParallel="false"
              Targets="Restore"
@@ -141,7 +129,20 @@
   <Target Name="Test" DependsOnTargets="ExecuteApplications" />
   <Target Name="VSTest" DependsOnTargets="Test" />
 
-  <!-- define Restore/Build to do nothing, for this project only Test does the testing -->
-  <Target Name="Restore" />
+  <!--
+    The Restore target generates and restores the trimming test projects. BuildAfterTargetingPack.csproj calls
+    Restore on all delayed-build .proj files with BuildInParallel="false", which serializes these restores and
+    avoids a NuGet file-move race on Windows where concurrent static-graph restores race when committing
+    project.assets.json for shared ProjectReference targets (https://github.com/dotnet/aspnetcore/issues/61178).
+    PublishTrimmedProjects also restores as a fallback for local dev where Restore may not be called separately;
+    after the serialized Restore phase in CI those calls are fast no-ops.
+  -->
+  <Target Name="Restore" DependsOnTargets="GenerateProjects">
+    <MSBuild Projects="@(TestConsoleApps)"
+             BuildInParallel="false"
+             Targets="Restore"
+             Condition="'$(SkipTrimmingProjectsRestore)' != 'true'"
+             Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid());Configuration=$(Configuration);RestoreDisableParallel=true" />
+  </Target>
   <Target Name="Build" />
 </Project>


### PR DESCRIPTION
Should fix the last flavor of https://github.com/dotnet/aspnetcore/issues/61178. Trimming tests are built by `BuildAfterTargetingPack.csproj`, which first calls `Restore` serially, then calls `Test` in parallel. But the trimming test projects were overwriting `Restore` with a no-op target, so the actual restoring was happening in parallel, in `PublishTrimmedProjects`, which gets called in the target chain for `Test`. If we have `Restore` actually restore, it'll happen serially like we want.