### PR TITLE
Suppress MSB3026 warnings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -133,6 +133,11 @@
     <!-- xUnit1004 = warns about skipped tests. Make this a non-fatal build warning. -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);xUnit1004</WarningsNotAsErrors>
 
+    <!-- MSB3026 is logged at error level for each copy-retry attempt during parallel builds, even when the
+         retry succeeds. This can fail CI despite the build completing successfully. Suppress to message level;
+         genuine copy failures still surface as MSB3021 when all retries are exhausted. -->
+    <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);MSB3026</MSBuildWarningsAsMessages>
+
     <!-- don't warn about calling ConfigureAwait in test methods. we already commonly get off the xunit threads because they cause issues. -->
     <NoWarn>$(NoWarn);xUnit1030</NoWarn>
 


### PR DESCRIPTION
MSBuild logs a copy failure as `MSB3026`, and then retries. We often see this surface as:

> D:\a\_work\1\s\.dotnet\sdk\11.0.100-preview.1.26104.118\Microsoft.Common.CurrentVersion.targets(5094,5): error MSB3026: Could not copy "D:\a\_work\1\s\artifacts\bin\Microsoft.AspNetCore.Hosting.Abstractions\Release\net11.0\Microsoft.AspNetCore.Hosting.Abstractions.xml" to "D:\a\_work\1\s\artifacts\bin\AzureAppServicesHostingStartupSample\Release\net11.0\Microsoft.AspNetCore.Hosting.Abstractions.xml". Beginning retry 1 in 1000ms. The process cannot access the file 'D:\a\_work\1\s\artifacts\bin\Microsoft.AspNetCore.Hosting.Abstractions\Release\net11.0\Microsoft.AspNetCore.Hosting.Abstractions.xml' because it is being used by another process.  [D:\a\_work\1\s\src\Azure\samples\AzureAppServicesHostingStartupSample\AzureAppServicesHostingStartupSample.csproj]

The build then retries the copy, and it usually succeeds, but CI still reports red due to `MSB3026`. We can NoWarn it, since a subsequent copy failure in the retry gets logged as a different warning (`MSB3021`), so the build will still correctly fail in those cases.