### PR TITLE
Fix double-publish ILLink error in BasicTestApp

### DIFF
--- a/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj
+++ b/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj
@@ -99,7 +99,7 @@
 
     <ProjectReference Include="..\..\WebAssembly\testassets\ThreadingApp\ThreadingApp.csproj" Targets="Build;Publish" Properties="BuildProjectReferences=false;TestTrimmedOrMultithreadingApps=false;PublishDir=$(MSBuildThisFileDirectory)$(OutputPath)trimmed-or-threading\ThreadingApp\;" />
 
-    <ProjectReference Include="..\testassets\Components.TestServer\Components.TestServer.csproj" Targets="Build;Publish" Properties="BuildProjectReferences=false;TestTrimmedOrMultithreadingApps=true;PublishDir=$(MSBuildThisFileDirectory)$(OutputPath)trimmed-or-threading\Components.TestServer\;" />
+    <ProjectReference Include="..\testassets\Components.TestServer\Components.TestServer.csproj" Targets="Build;Publish" Properties="BuildProjectReferences=false;TestTrimmedOrMultithreadingApps=true;_SkipReferencedProjectPublishAssets=true;PublishDir=$(MSBuildThisFileDirectory)$(OutputPath)trimmed-or-threading\Components.TestServer\;" />
   </ItemGroup>
 
   <!-- Shared testing infrastructure for running E2E tests using selenium -->

--- a/src/Components/test/testassets/BasicTestApp/BasicTestApp.csproj
+++ b/src/Components/test/testassets/BasicTestApp/BasicTestApp.csproj
@@ -21,6 +21,17 @@
     <_BlazorBrotliCompressionLevel>NoCompression</_BlazorBrotliCompressionLevel>
   </PropertyGroup>
 
+  <!--
+    Allow publishing to be skipped when building via Microsoft.AspNetCore.Components.E2ETests.csproj.
+    This avoids a race condition where the build tries to publish this project twice concurrently.
+  -->
+  <PropertyGroup Condition="'$(_SkipReferencedProjectPublishAssets)' == 'true'">
+    <StaticWebAssetsGetPublishAssetsTargets>_SkipGetPublishAssetsForTrimmedBuild</StaticWebAssetsGetPublishAssetsTargets>
+  </PropertyGroup>
+
+  <!-- No-op target used to prevent the Static Web Assets SDK from triggering a redundant ILLink run. -->
+  <Target Name="_SkipGetPublishAssetsForTrimmedBuild" />
+
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Components.WebAssembly" />
     <Reference Include="Microsoft.AspNetCore.Components.CustomElements" />


### PR DESCRIPTION
Fixes errors like:

> ILLink : error IL1011: Failed to write 'D:\a\_work\1\s\artifacts\obj\BasicTestApp\Release\net11.0\linked\Microsoft.Extensions.Configuration.dll'. [D:\a\_work\1\s\src\Components\test\testassets\BasicTestApp\BasicTestApp.csproj]
C:\Users\cloudtest\.nuget\packages\microsoft.net.illink.tasks\11.0.0-preview.1.26104.118\build\Microsoft.NET.ILLink.targets(108,5): error NETSDK1144: Optimizing assemblies for size failed. [D:\a\_work\1\s\src\Components\test\testassets\BasicTestApp\BasicTestApp.csproj]

`Microsoft.AspNetCore.Components.E2ETests.csproj` references BasicTestApp twice - once directly, and once via `Components.TestServer.csproj`. Even though `BuildProjectReferences=false`, the latter will still try to publish BasicTestApp again due to https://github.com/dotnet/dotnet/blob/856f69955c79a685a753283ea03701c4d04264ba/src/sdk/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Publish.targets#L116-L137. To avoid this, we can set `StaticWebAssetsGetPublishAssetsTargets` to a dummy no-op target when BasicTestApp is being published via the `Components.TestServer.csproj` ProjectReference in `Microsoft.AspNetCore.Components.E2ETests.csproj`.