### PR TITLE
Fix HelixTestRunner using the wrong version of dotnet-ef

### DIFF
--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -69,15 +69,31 @@
       <SasToken>$([System.Environment]::GetEnvironmentVariable('DotNetBuildsInternalReadSasToken'))</SasToken>
     </AdditionalDotNetPackageFeed>
 
-    <!-- Grab the tool packages for what HelixTestRunner installs. -->
-    <HelixCorrelationPayload Include="$(NUGET_PACKAGES)\dotnet-dump\$(DotnetDumpVersion)\dotnet-dump.$(DotnetDumpVersion).nupkg" />
-    <HelixCorrelationPayload Include="$(NUGET_PACKAGES)\dotnet-ef\$(DotnetEfVersion)\dotnet-ef.$(DotnetEfVersion).nupkg" />
-    <HelixCorrelationPayload Include="$(NUGET_PACKAGES)\dotnet-serve\$(DotnetServeVersion)\dotnet-serve.$(DotnetServeVersion).nupkg" />
+    <!--
+      Tool nupkgs are included dynamically in the RestoreDotnetTools target below because
+      dotnet tool restore must run first to download them into the NuGet package cache.
+    -->
 
     <!-- Grab published `HelixTestRunner` project output. -->
     <HelixCorrelationPayload Include="$(ArtifactsBinDir)HelixTestRunner\$(Configuration)\net11.0\publish\"
         Destination="HelixTestRunner" />
   </ItemGroup>
+
+  <!--
+    Restore dotnet tools so their nupkgs are in the NuGet package cache, then include them
+    in the correlation payload. This must happen in a target (not a static ItemGroup) because
+    the nupkgs don't exist until after 'dotnet tool restore' runs.
+  -->
+  <Target Name="RestoreDotnetTools" BeforeTargets="IncludeAspNetRuntime">
+    <Exec Command="dotnet tool restore" WorkingDirectory="$(RepoRoot)" IgnoreExitCode="true" />
+    <ItemGroup>
+      <HelixCorrelationPayload Include="$(NUGET_PACKAGES)\dotnet-dump\$(DotnetDumpVersion)\dotnet-dump.$(DotnetDumpVersion).nupkg" />
+      <HelixCorrelationPayload Include="$(NUGET_PACKAGES)\dotnet-ef\$(DotnetEfVersion)\dotnet-ef.$(DotnetEfVersion).nupkg" />
+      <HelixCorrelationPayload Include="$(NUGET_PACKAGES)\dotnet-serve\$(DotnetServeVersion)\dotnet-serve.$(DotnetServeVersion).nupkg" />
+    </ItemGroup>
+    <Warning Text="dotnet-ef nupkg not found at '$(NUGET_PACKAGES)\dotnet-ef\$(DotnetEfVersion)\dotnet-ef.$(DotnetEfVersion).nupkg'. Helix template tests may install an incompatible version."
+        Condition="!Exists('$(NUGET_PACKAGES)\dotnet-ef\$(DotnetEfVersion)\dotnet-ef.$(DotnetEfVersion).nupkg')" />
+  </Target>
 
   <Choose>
     <When Condition=" '$(ContinuousIntegrationBuild)' == 'true' ">

--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -81,15 +81,15 @@
 
   <!--
     Restore dotnet tools so their nupkgs are in the NuGet package cache, then include them
-    in the correlation payload. This must happen in a target (not a static ItemGroup) because
-    the nupkgs don't exist until after 'dotnet tool restore' runs.
+    in the correlation payload with AsArchive="false" so the Helix SDK ships them as plain files
+    instead of extracting them (nupkgs are zip files and would otherwise be auto-extracted).
   -->
   <Target Name="RestoreDotnetTools" BeforeTargets="IncludeAspNetRuntime">
     <Exec Command="dotnet tool restore" WorkingDirectory="$(RepoRoot)" IgnoreExitCode="true" />
     <ItemGroup>
-      <HelixCorrelationPayload Include="$(NUGET_PACKAGES)\dotnet-dump\$(DotnetDumpVersion)\dotnet-dump.$(DotnetDumpVersion).nupkg" />
-      <HelixCorrelationPayload Include="$(NUGET_PACKAGES)\dotnet-ef\$(DotnetEfVersion)\dotnet-ef.$(DotnetEfVersion).nupkg" />
-      <HelixCorrelationPayload Include="$(NUGET_PACKAGES)\dotnet-serve\$(DotnetServeVersion)\dotnet-serve.$(DotnetServeVersion).nupkg" />
+      <HelixCorrelationPayload Include="$(NUGET_PACKAGES)\dotnet-dump\$(DotnetDumpVersion)\dotnet-dump.$(DotnetDumpVersion).nupkg" AsArchive="false" />
+      <HelixCorrelationPayload Include="$(NUGET_PACKAGES)\dotnet-ef\$(DotnetEfVersion)\dotnet-ef.$(DotnetEfVersion).nupkg" AsArchive="false" />
+      <HelixCorrelationPayload Include="$(NUGET_PACKAGES)\dotnet-serve\$(DotnetServeVersion)\dotnet-serve.$(DotnetServeVersion).nupkg" AsArchive="false" />
     </ItemGroup>
     <Warning Text="dotnet-ef nupkg not found at '$(NUGET_PACKAGES)\dotnet-ef\$(DotnetEfVersion)\dotnet-ef.$(DotnetEfVersion).nupkg'. Helix template tests may install an incompatible version."
         Condition="!Exists('$(NUGET_PACKAGES)\dotnet-ef\$(DotnetEfVersion)\dotnet-ef.$(DotnetEfVersion).nupkg')" />

--- a/eng/tools/HelixTestRunner/TestRunner.cs
+++ b/eng/tools/HelixTestRunner/TestRunner.cs
@@ -148,7 +148,7 @@ public class TestRunner
                 // Extract version from filename: dotnet-ef.{version}.nupkg
                 var fileName = Path.GetFileNameWithoutExtension(efPackages[0]);
                 var version = fileName["dotnet-ef.".Length..];
-                efVersionArg = $"--version {version}";
+                efVersionArg = $"--version {version} ";
                 ProcessUtil.PrintMessage($"Found dotnet-ef package in payload: {efPackages[0]}, version: {version}");
             }
             else
@@ -157,7 +157,7 @@ public class TestRunner
             }
 
             await ProcessUtil.RunAsync($"{Options.DotnetRoot}/dotnet",
-                $"tool install dotnet-ef {efVersionArg} --tool-path {Options.HELIX_WORKITEM_ROOT} --add-source {correlationPayload}",
+                $"tool install dotnet-ef {efVersionArg}--tool-path {Options.HELIX_WORKITEM_ROOT} --add-source {correlationPayload}",
                 environmentVariables: EnvironmentVariables,
                 outputDataReceived: ProcessUtil.PrintMessage,
                 errorDataReceived: ProcessUtil.PrintErrorMessage,

--- a/eng/tools/HelixTestRunner/TestRunner.cs
+++ b/eng/tools/HelixTestRunner/TestRunner.cs
@@ -140,7 +140,7 @@ public class TestRunner
                 cancellationToken: new CancellationTokenSource(TimeSpan.FromMinutes(2)).Token);
 
             await ProcessUtil.RunAsync($"{Options.DotnetRoot}/dotnet",
-                $"tool install dotnet-ef --tool-path {Options.HELIX_WORKITEM_ROOT} --add-source {correlationPayload}",
+                $"tool install dotnet-ef --prerelease --tool-path {Options.HELIX_WORKITEM_ROOT} --add-source {correlationPayload}",
                 environmentVariables: EnvironmentVariables,
                 outputDataReceived: ProcessUtil.PrintMessage,
                 errorDataReceived: ProcessUtil.PrintErrorMessage,

--- a/eng/tools/HelixTestRunner/TestRunner.cs
+++ b/eng/tools/HelixTestRunner/TestRunner.cs
@@ -139,8 +139,25 @@ public class TestRunner
                 throwOnError: false,
                 cancellationToken: new CancellationTokenSource(TimeSpan.FromMinutes(2)).Token);
 
+            // Install dotnet-ef with the exact version from the correlation payload to avoid
+            // picking up a mismatched version from the global NuGet cache.
+            var efVersionArg = "";
+            var efPackages = Directory.GetFiles(correlationPayload, "dotnet-ef.*.nupkg");
+            if (efPackages.Length > 0)
+            {
+                // Extract version from filename: dotnet-ef.{version}.nupkg
+                var fileName = Path.GetFileNameWithoutExtension(efPackages[0]);
+                var version = fileName["dotnet-ef.".Length..];
+                efVersionArg = $"--version {version}";
+                ProcessUtil.PrintMessage($"Found dotnet-ef package in payload: {efPackages[0]}, version: {version}");
+            }
+            else
+            {
+                ProcessUtil.PrintMessage("Warning: No dotnet-ef nupkg found in correlation payload. Tool install may pick an incompatible version.");
+            }
+
             await ProcessUtil.RunAsync($"{Options.DotnetRoot}/dotnet",
-                $"tool install dotnet-ef --prerelease --tool-path {Options.HELIX_WORKITEM_ROOT} --add-source {correlationPayload}",
+                $"tool install dotnet-ef {efVersionArg} --tool-path {Options.HELIX_WORKITEM_ROOT} --add-source {correlationPayload}",
                 environmentVariables: EnvironmentVariables,
                 outputDataReceived: ProcessUtil.PrintMessage,
                 errorDataReceived: ProcessUtil.PrintErrorMessage,

--- a/src/ProjectTemplates/Web.ProjectTemplates/BlazorWebCSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/BlazorWebCSharp.csproj.in
@@ -25,6 +25,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="${MicrosoftAspNetCoreIdentityEntityFrameworkCoreVersion}" Condition="'$(IndividualLocalAuth)' == 'True'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="${MicrosoftEntityFrameworkCoreSqliteVersion}" Condition="'$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' != 'True'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="${MicrosoftEntityFrameworkCoreSqlServerVersion}" Condition="'$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' == 'True'" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="${MicrosoftEntityFrameworkCoreDesignVersion}" PrivateAssets="all" Condition="'$(IndividualLocalAuth)' == 'True'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="${MicrosoftEntityFrameworkCoreToolsVersion}" Condition="'$(IndividualLocalAuth)' == 'True'" />
   </ItemGroup>
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/Microsoft.DotNet.Web.ProjectTemplates.csproj
+++ b/src/ProjectTemplates/Web.ProjectTemplates/Microsoft.DotNet.Web.ProjectTemplates.csproj
@@ -14,6 +14,7 @@
       DefaultNetCoreTargetFramework=$(DefaultNetCoreTargetFramework);
       GrpcAspNetCoreVersion=$(GrpcAspNetCoreVersion);
       MicrosoftAspNetCoreMvcRazorRuntimeCompilationVersion=$(MicrosoftAspNetCoreMvcRazorRuntimeCompilationVersion);
+      MicrosoftEntityFrameworkCoreDesignVersion=$(MicrosoftEntityFrameworkCoreDesignVersion);
       MicrosoftEntityFrameworkCoreSqliteVersion=$(MicrosoftEntityFrameworkCoreSqliteVersion);
       MicrosoftEntityFrameworkCoreSqlServerVersion=$(MicrosoftEntityFrameworkCoreSqlServerVersion);
       MicrosoftEntityFrameworkCoreToolsVersion=$(MicrosoftEntityFrameworkCoreToolsVersion);

--- a/src/ProjectTemplates/Web.ProjectTemplates/RazorPagesWeb-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/RazorPagesWeb-CSharp.csproj.in
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="${MicrosoftAspNetCoreIdentityUIVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' " />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="${MicrosoftEntityFrameworkCoreSqliteVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' != 'True'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="${MicrosoftEntityFrameworkCoreSqlServerVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' == 'True'" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="${MicrosoftEntityFrameworkCoreDesignVersion}" PrivateAssets="all" Condition=" '$(IndividualLocalAuth)' == 'True' " />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="${MicrosoftEntityFrameworkCoreToolsVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' " />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="${MicrosoftAspNetCoreAuthenticationJwtBearerVersion}" Condition=" '$(IndividualB2CAuth)' == 'True' OR '$(OrganizationalAuth)' == 'True'" NoWarn="NU1605" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="${MicrosoftAspNetCoreAuthenticationNegotiateVersion}" Condition="'$(WindowsAuth)' == 'True'" />

--- a/src/ProjectTemplates/Web.ProjectTemplates/StarterWeb-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/StarterWeb-CSharp.csproj.in
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="${MicrosoftAspNetCoreIdentityUIVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' " />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="${MicrosoftEntityFrameworkCoreSqlServerVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' == 'True'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="${MicrosoftEntityFrameworkCoreSqliteVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' != 'True'" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="${MicrosoftEntityFrameworkCoreDesignVersion}" PrivateAssets="all" Condition=" '$(IndividualLocalAuth)' == 'True' " />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="${MicrosoftEntityFrameworkCoreToolsVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' " />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="${MicrosoftAspNetCoreAuthenticationJwtBearerVersion}" Condition=" '$(IndividualB2CAuth)' == 'True' OR '$(OrganizationalAuth)' == 'True'" NoWarn="NU1605" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="${MicrosoftAspNetCoreAuthenticationNegotiateVersion}" Condition="'$(WindowsAuth)' == 'True'" />


### PR DESCRIPTION
We attempt to bundle the latest version of `dotnet-ef` with the Helix correlation payload, so that the tests can use it. However, `dotnet-ef` was never actually getting restored, and we had no check for whether or not it existed on disk when we tried to bundle it with the Helix payload. As a result, `dotnet tool install` would just use the latest stable version on nuget.org. This just started causing some template tests to fail because there was recently an API breaking change in EF that's incompatible with the latest stable `dotnet-ef`.

Additionally, some of the templates explicitly depend on `Microsoft.EntityFrameworkCore.Tools`, which references `Microsoft.EntityFrameworkCore.Design >= 8.0.0`. That 8.0.0 version was the one actually being restored - we just never noticed because until now, it was compatible with the latest version of the package. But there was a breaking change in 11, which surfaced the fact that we were using the 8.0.0 version. The fix for that is to add an explicit `PrivateAssets=all` PackageRef to the current version of `Microsoft.EntityFrameworkCore.Design`.