### PR TITLE
Update browser testing dependencies: Selenium 4.41.0, Playwright 1.58.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -173,11 +173,11 @@
     <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     <NSwagApiDescriptionClientVersion>13.0.4</NSwagApiDescriptionClientVersion>
     <PhotinoNETVersion>2.5.2</PhotinoNETVersion>
-    <MicrosoftPlaywrightVersion>1.57.0</MicrosoftPlaywrightVersion>
+    <MicrosoftPlaywrightVersion>1.58.0</MicrosoftPlaywrightVersion>
     <PollyExtensionsHttpVersion>3.0.0</PollyExtensionsHttpVersion>
     <PollyVersion>7.2.4</PollyVersion>
-    <SeleniumSupportVersion>4.40.0</SeleniumSupportVersion>
-    <SeleniumWebDriverVersion>4.40.0</SeleniumWebDriverVersion>
+    <SeleniumSupportVersion>4.41.0</SeleniumSupportVersion>
+    <SeleniumWebDriverVersion>4.41.0</SeleniumWebDriverVersion>
     <SerilogExtensionsLoggingVersion>1.4.0</SerilogExtensionsLoggingVersion>
     <SerilogSinksFileVersion>4.0.0</SerilogSinksFileVersion>
     <StackExchangeRedisVersion>2.7.27</StackExchangeRedisVersion>

--- a/src/Components/benchmarkapps/Wasm.Performance/dockerfile
+++ b/src/Components/benchmarkapps/Wasm.Performance/dockerfile
@@ -29,7 +29,7 @@ RUN .dotnet/dotnet publish -c Release -r linux-x64 --sc true -o /app ./src/Compo
 RUN chmod +x /app/Wasm.Performance.Driver
 
 WORKDIR /app
-FROM mcr.microsoft.com/playwright/dotnet:v1.57.0-jammy-amd64 AS final
+FROM mcr.microsoft.com/playwright/dotnet:v1.58.0-jammy-amd64 AS final
 COPY --from=build ./app ./
 COPY ./exec.sh ./
 


### PR DESCRIPTION
# Update browser testing dependencies: Selenium 4.41.0, Playwright 1.58.0

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md)
- [x] You've included unit or integration tests for the changes, or they are not applicable
- [x] You've included inline docs or they are not applicable
- [x] There's an open issue for the PR that you are making here

Update Selenium and Playwright to latest stable versions.

## Description

Updates browser automation dependencies across E2E tests and benchmarking infrastructure:

- **Selenium**: 4.40.0 → 4.41.0 (`Selenium.WebDriver`, `Selenium.Support`)
- **Playwright**: 1.57.0 → 1.58.0 (NuGet package and Docker image)

**Files modified:**
- `eng/Versions.props`: Package version properties
- `src/Components/benchmarkapps/Wasm.Performance/dockerfile`: Docker image tag `v1.57.0-jammy-amd64` → `v1.58.0-jammy-amd64`

Docker image version aligned with NuGet package version.

cc @dotnet/aspnet-build

<details>
<summary>Original issue</summary>

This PR addresses the monthly browser testing dependencies update tracked in #65572.
Created by the build-ops rotation engineer using the selenium-update skill.
</details>

Fixes #65572