### PR TITLE
Fix race in RST_STREAM_IncompleteRequest_AdditionalResetFrame test

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -3602,9 +3602,10 @@ public class Http2ConnectionTests : Http2TestBase
         await SendDataAsync(1, new byte[1], endStream: false);
         await SendRstStreamAsync(1);
         await SendRstStreamAsync(1);
-        tcs.TrySetResult();
 
         await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+
+        tcs.TrySetResult(); // Don't let the response start until after the connection stops
 
         AssertConnectionNoError();
     }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -3588,6 +3588,7 @@ public class Http2ConnectionTests : Http2TestBase
     [Fact]
     public async Task RST_STREAM_IncompleteRequest_AdditionalResetFrame_IgnoreAdditionalReset()
     {
+        var abortedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var headers = new[]
@@ -3596,16 +3597,22 @@ public class Http2ConnectionTests : Http2TestBase
             new KeyValuePair<string, string>(InternalHeaderNames.Path, "/"),
             new KeyValuePair<string, string>(InternalHeaderNames.Scheme, "http"),
         };
-        await InitializeConnectionAsync(context => tcs.Task);
+        await InitializeConnectionAsync(context =>
+        {
+            context.RequestAborted.Register(() => abortedTcs.TrySetResult());
+            return tcs.Task;
+        });
 
         await StartStreamAsync(1, headers, endStream: false);
         await SendDataAsync(1, new byte[1], endStream: false);
         await SendRstStreamAsync(1);
         await SendRstStreamAsync(1);
 
-        await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+        await abortedTcs.Task;
 
-        tcs.TrySetResult(); // Don't let the response start until after the connection stops
+        tcs.TrySetResult(); // Don't let the response start until after the request aborts
+
+        await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
         AssertConnectionNoError();
     }


### PR DESCRIPTION
## Summary

Fix race condition in `RST_STREAM_IncompleteRequest_AdditionalResetFrame_IgnoreAdditionalReset` test.

## Problem

`tcs.TrySetResult()` was called before `StopConnectionAsync`, allowing the request handler to complete and write response HEADERS into the output pipe before the GOAWAY frame. Since `ignoreNonGoAwayFrames: false`, the test fails when it reads HEADERS instead of GOAWAY.

Example failure from [PR #65713 CI](https://github.com/dotnet/aspnetcore/pull/65713):
```
Assert.Equal() Failure: Values differ
Expected: GOAWAY
Actual:   HEADERS
```

## Fix

Move `tcs.TrySetResult()` after `StopConnectionAsync` so the response handler stays blocked until the connection has stopped and the GOAWAY frame has been sent and verified.

This is the same fix pattern applied in:
- #65454 for `AdditionalDataFrames` and `AdditionalTrailerFrames`
- #57450 for `AdditionalWindowUpdateFrame`

This was the last remaining test in the `RST_STREAM_IncompleteRequest` family with this race.