### PR TITLE
fix http/2 header payload padding parsing

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -795,7 +795,7 @@ internal sealed partial class Http2Connection : IHttp2StreamLifetimeHandler, IHt
             throw CreateStreamIdZeroException();
         }
 
-        if (_incomingFrame.HeadersHasPadding && _incomingFrame.HeadersPadLength >= _incomingFrame.PayloadLength - _incomingFrame.HeadersPayloadOffset)
+        if (_incomingFrame.HeadersHasPadding && _incomingFrame.HeadersPayloadLength <= 0)
         {
             throw new Http2ConnectionErrorException(CoreStrings.FormatHttp2ErrorPaddingTooLong(_incomingFrame.Type), Http2ErrorCode.PROTOCOL_ERROR, ConnectionEndReason.InvalidDataPadding);
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -795,7 +795,7 @@ internal sealed partial class Http2Connection : IHttp2StreamLifetimeHandler, IHt
             throw CreateStreamIdZeroException();
         }
 
-        if (_incomingFrame.HeadersHasPadding && _incomingFrame.HeadersPadLength >= _incomingFrame.PayloadLength - 1)
+        if (_incomingFrame.HeadersHasPadding && _incomingFrame.HeadersPadLength >= _incomingFrame.PayloadLength - _incomingFrame.HeadersPayloadOffset)
         {
             throw new Http2ConnectionErrorException(CoreStrings.FormatHttp2ErrorPaddingTooLong(_incomingFrame.Type), Http2ErrorCode.PROTOCOL_ERROR, ConnectionEndReason.InvalidDataPadding);
         }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -2686,6 +2686,59 @@ public class Http2ConnectionTests : Http2TestBase
     }
 
     [Fact]
+    public async Task HEADERS_Received_WithPaddingAndPriority_PaddingExceedsAvailablePayload_ConnectionError()
+    {
+        await InitializeConnectionAsync(_noopApplication);
+
+        /*
+         Frame header (bytes 0-8):
+         ----------------------------------------------------------------------------
+         00 00 06  → Length = 6
+         01        → Type = HEADERS (0x01)
+         2D        → Flags = 0x2D = 0b00101101
+                     = END_STREAM (0x01) | END_HEADERS (0x04) | PADDED (0x08) | PRIORITY (0x20)
+         00 00 00 01 → StreamId = 1
+
+         Payload (9-14):
+         ----------------------------------------------------------------------------
+         01        → HeadersPadLength = 1     ← parsed because PADDED flag is set
+         00 00 00 00 → StreamDependency = 0  ← parsed because PRIORITY flag is set
+         10        → Weight = 16             ← parsed because PRIORITY flag is set
+         (nothing) → 0 bytes of HPACK data
+         (nothing) → 0 bytes of padding (but PadLength says 1!)
+        */
+
+        // Send a HEADERS frame with both PADDED and PRIORITY flags.
+        // PayloadLength=6 means all bytes are consumed by metadata (1 pad length + 4 stream dependency + 1 weight).
+        // PadLength=1 claims 1 byte of padding, but there are 0 bytes left for HPACK data + padding.
+        // This should be rejected as a PROTOCOL_ERROR because the padding exceeds available space.
+        var outputWriter = _pair.Application.Output;
+        var frame = new Http2Frame();
+
+        var payloadLength = 6;
+
+        frame.PrepareHeaders(Http2HeadersFrameFlags.END_STREAM | Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.PADDED | Http2HeadersFrameFlags.PRIORITY, 1 /* streamId */);
+        frame.PayloadLength = payloadLength;
+        var payload = new byte[payloadLength];
+
+        // Pad Length (1 byte) + Stream Dependency (4 bytes) + Weight (1 byte) = 6 bytes minimum
+        payload[0] = 1 /* PadLength */;
+        Bitshifter.WriteUInt31BigEndian(payload.AsSpan(1), (uint)0 /* zeros as streamDependency */);
+        payload[5] = 16 /* Priority */;
+
+        Http2FrameWriter.WriteHeader(frame, outputWriter);
+        await SendAsync(payload);
+
+        await WaitForConnectionErrorAsync<Http2ConnectionErrorException>(
+            ignoreNonGoAwayFrames: true,
+            expectedLastStreamId: 0,
+            expectedErrorCode: Http2ErrorCode.PROTOCOL_ERROR,
+            expectedErrorMessage: CoreStrings.FormatHttp2ErrorPaddingTooLong(Http2FrameType.HEADERS));
+
+        AssertConnectionEndReason(ConnectionEndReason.InvalidDataPadding);
+    }
+
+    [Fact]
     public async Task HEADERS_Received_InterleavedWithHeaders_ConnectionError()
     {
         await InitializeConnectionAsync(_noopApplication);

--- a/src/Shared/ServerInfrastructure/Http2/Http2Frame.Headers.cs
+++ b/src/Shared/ServerInfrastructure/Http2/Http2Frame.Headers.cs
@@ -38,7 +38,7 @@ internal partial class Http2Frame
 
     public byte HeadersPriorityWeight { get; set; }
 
-    private int HeadersPayloadOffset => (HeadersHasPadding ? 1 : 0) + (HeadersHasPriority ? 5 : 0);
+    public int HeadersPayloadOffset => (HeadersHasPadding ? 1 : 0) + (HeadersHasPriority ? 5 : 0);
 
     public int HeadersPayloadLength => PayloadLength - HeadersPayloadOffset - HeadersPadLength;
 

--- a/src/Shared/ServerInfrastructure/Http2/Http2FrameReader.cs
+++ b/src/Shared/ServerInfrastructure/Http2/Http2FrameReader.cs
@@ -205,7 +205,7 @@ internal static class Http2FrameReader
             case Http2FrameType.DATA: // Variable 0 or 1
                 return frame.DataHasPadding ? 1 : 0;
             case Http2FrameType.HEADERS:
-                return (frame.HeadersHasPadding ? 1 : 0) + (frame.HeadersHasPriority ? 5 : 0); // Variable 0 to 6
+                return frame.HeadersPayloadOffset; // Variable 0 to 6
             case Http2FrameType.GOAWAY:
                 return 8; // Last stream id and error code.
             case Http2FrameType.PRIORITY:


### PR DESCRIPTION
The padding length check for HTTP/2 HEADERS frames did not account for the extra 5 bytes consumed by the PRIORITY flag (4-byte stream dependency + 1-byte weight).

Kestrel was throwing an exception later instead of validating the bytes properly and rejecting immediately:
```
Frame header (bytes 0-8):
----------------------------------------------------------------------------
00 00 06  → Length = 6
01        → Type = HEADERS (0x01)
2D        → Flags = 0x2D = 0b00101101
            = END_STREAM (0x01) | END_HEADERS (0x04) | PADDED (0x08) | PRIORITY (0x20)
00 00 00 01 → StreamId = 1

Payload (9-14):
----------------------------------------------------------------------------
01        → HeadersPadLength = 1     ← parsed because PADDED flag is set
00 00 00 00 → StreamDependency = 0  ← parsed because PRIORITY flag is set
10        → Weight = 16             ← parsed because PRIORITY flag is set
(nothing) → 0 bytes of HPACK data
(nothing) → 0 bytes of padding (but PadLength says 1!)
```
  