### PR TITLE
Fix Virtualize scroll container detection with horizontal overflow

### DIFF
--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -21,7 +21,8 @@ function findClosestScrollContainer(element: HTMLElement | null): HTMLElement | 
 
   const style = getComputedStyle(element);
 
-  if (style.overflowY !== 'visible') {
+  // https://github.com/dotnet/aspnetcore/issues/58200
+  if (style.overflowY !== 'visible' && style.overflowY !== 'hidden' && style.overflowY !== 'clip') {
     return element;
   }
 

--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -21,7 +21,6 @@ function findClosestScrollContainer(element: HTMLElement | null): HTMLElement | 
 
   const style = getComputedStyle(element);
 
-  // https://github.com/dotnet/aspnetcore/issues/58200
   if (style.overflowY !== 'visible' && style.overflowY !== 'hidden' && style.overflowY !== 'clip') {
     return element;
   }

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -691,4 +691,18 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         var js = (IJavaScriptExecutor)Browser;
         js.ExecuteScript("arguments[0].scrollLeft = arguments[0].scrollWidth", elem);
     }
+
+    [Fact]
+    public void VirtualizeWorksInsideHorizontalOverflowContainer()
+    {
+        Browser.MountTestComponent<VirtualizationHorizontalOverflow>();
+
+        Browser.True(() => Browser.FindElements(By.CssSelector("#horizontal-overflow-table tbody tr[id^='horizontal-overflow-row-']")).Count > 0);
+        Browser.DoesNotExist(By.Id("horizontal-overflow-row-999"));
+
+        Browser.ExecuteJavaScript("window.scrollTo(0, document.body.scrollHeight);");
+
+        var lastElement = Browser.Exists(By.Id("horizontal-overflow-row-999"));
+        Browser.True(() => lastElement.Displayed);
+    }
 }

--- a/src/Components/test/testassets/BasicTestApp/Index.razor
+++ b/src/Components/test/testassets/BasicTestApp/Index.razor
@@ -128,6 +128,7 @@
         <option value="BasicTestApp.VirtualizationMaxItemCount_AppContext">Virtualization MaxItemCount (via AppContext)</option>
         <option value="BasicTestApp.VirtualizationTable">Virtualization HTML table</option>
         <option value="BasicTestApp.VirtualizationLargeOverscan">Virtualization large overscan</option>
+        <option value="BasicTestApp.VirtualizationHorizontalOverflow">Virtualization horizontal overflow</option>
         <option value="BasicTestApp.HotReload.RenderOnHotReload">Render on hot reload</option>
         <option value="BasicTestApp.SectionsTest.ParentComponentWithTwoChildren">Sections test</option>
         <option value="BasicTestApp.SectionsTest.SectionsWithCascadingParameters">Sections with Cascading parameters test</option>

--- a/src/Components/test/testassets/BasicTestApp/VirtualizationHorizontalOverflow.razor
+++ b/src/Components/test/testassets/BasicTestApp/VirtualizationHorizontalOverflow.razor
@@ -1,0 +1,29 @@
+<style>
+    html, body { overflow-y: scroll }
+</style>
+
+<div style="overflow-x: auto; overflow-y: hidden;">
+    <table id="horizontal-overflow-table" style="width: 100%; table-layout: auto;">
+        <thead style="position: sticky; top: 0; background-color: silver">
+            <tr>
+                <th>Item</th>
+                @for (var i = 0; i < 20; i++)
+                {
+                    <th style="text-wrap: nowrap">Another column</th>
+                }
+            </tr>
+        </thead>
+        <tbody>
+            <Virtualize Items="@fixedItems" ItemSize="30" SpacerElement="tr">
+                <tr @key="context" style="height: 30px;" id="horizontal-overflow-row-@context">
+                    <td>Item @context</td>
+                    <td>Another value</td>
+                </tr>
+            </Virtualize>
+        </tbody>
+    </table>
+</div>
+
+@code {
+    List<int> fixedItems = Enumerable.Range(0, 1000).ToList();
+}


### PR DESCRIPTION
`findClosestScrollContainer()` incorrectly selected elements with `overflow-x` set to a non-visible value as the vertical scroll root.
 Per the CSS spec, setting `overflow-x` to a non-visible value promotes `overflow-y` from 'visible' to 'auto', causing the heuristic to pick containers that don't actually scroll vertically.

## Description

The fix adds a check that the candidate element can actually scroll vertically (`scrollHeight > clientHeight`) or has overflow-y explicitly set to 'scroll' before selecting it as the scroll container.

Proposal https://github.com/dotnet/aspnetcore/issues/58200#issuecomment-3563363304 works the issue around and can be used until this fix gets in.

Fixes #58200
