### PR TITLE
fix HTTP/2: Content-Length mismatch with trailers split across CONTINUATION frames

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -1251,12 +1251,21 @@ internal sealed partial class Http2Connection : IHttp2StreamLifetimeHandler, IHt
     {
         Debug.Assert(_currentHeadersStream != null);
 
-        _hpackDecoder.Decode(payload, endHeaders, handler: this);
-
-        if (endHeaders)
+        try
         {
-            _currentHeadersStream.OnEndStreamReceived();
+            _hpackDecoder.Decode(payload, endHeaders, handler: this);
+
+            if (endHeaders)
+            {
+                _currentHeadersStream.OnEndStreamReceived();
+                ResetRequestHeaderParsingState();
+            }
+        }
+        catch (Http2StreamErrorException)
+        {
+            // stream will be correctly aborted by the caller
             ResetRequestHeaderParsingState();
+            throw;
         }
 
         return Task.CompletedTask;

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -1263,7 +1263,7 @@ internal sealed partial class Http2Connection : IHttp2StreamLifetimeHandler, IHt
         }
         catch (Http2StreamErrorException)
         {
-            // stream will be correctly aborted by the caller
+            _currentHeadersStream.Dispose();
             ResetRequestHeaderParsingState();
             throw;
         }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -2271,6 +2271,7 @@ public class Http2ConnectionTests : Http2TestBase
         // (via HEADERS + CONTINUATION) results in a stream reset, not a connection error.
         // A second stream on the same connection should complete successfully.
         var stream1RequestReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var stream3RequestReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         await InitializeConnectionAsync(async context =>
         {
@@ -2288,6 +2289,10 @@ public class Http2ConnectionTests : Http2TestBase
                 {
                     // Expected when the stream is reset
                 }
+            }
+            else if (context.Features.Get<IHttp2StreamIdFeature>().StreamId == 3)
+            {
+                stream3RequestReceived.SetResult();
             }
         });
 
@@ -2319,6 +2324,7 @@ public class Http2ConnectionTests : Http2TestBase
 
         // Stream 3: Verify the connection is still alive by opening a new stream
         await StartStreamAsync(3, _browserRequestHeaders, endStream: true);
+        await stream3RequestReceived.Task.DefaultTimeout();
 
         await ExpectAsync(Http2FrameType.HEADERS,
             withLength: 36,

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -2265,6 +2265,70 @@ public class Http2ConnectionTests : Http2TestBase
     }
 
     [Fact]
+    public async Task CONTINUATION_Received_WithTrailers_ContentLengthMismatch_StreamError()
+    {
+        // Verify that a Content-Length mismatch detected during trailer decoding
+        // (via HEADERS + CONTINUATION) results in a stream reset, not a connection error.
+        // A second stream on the same connection should complete successfully.
+        var stream1RequestReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await InitializeConnectionAsync(async context =>
+        {
+            if (context.Features.Get<IHttp2StreamIdFeature>().StreamId == 1)
+            {
+                stream1RequestReceived.SetResult();
+
+                // Read the body — will be interrupted by the stream error
+                var buffer = new byte[100];
+                try
+                {
+                    while (await context.Request.Body.ReadAsync(buffer, 0, buffer.Length) > 0) { }
+                }
+                catch (IOException)
+                {
+                    // Expected when the stream is reset
+                }
+            }
+        });
+
+        // Stream 1: POST with Content-Length: 12 but only send 5 bytes of body data
+        var headers = new[]
+        {
+            new KeyValuePair<string, string>(InternalHeaderNames.Method, "POST"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Path, "/"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Scheme, "http"),
+            new KeyValuePair<string, string>(HeaderNames.ContentLength, "12"),
+        };
+
+        await SendHeadersAsync(1, Http2HeadersFrameFlags.END_HEADERS, headers);
+        await SendDataAsync(1, _helloBytes, endStream: false);
+
+        await stream1RequestReceived.Task.DefaultTimeout();
+
+        // Send trailers for stream 1 as HEADERS (no END_HEADERS) + CONTINUATION (END_HEADERS).
+        // OnEndStreamReceived will detect InputRemaining != 0 and throw Http2StreamErrorException.
+        var trailers = new byte[] { 0x00, 0x09 }
+            .Concat(Encoding.ASCII.GetBytes("trailer-1"))
+            .Concat(new byte[] { 0x01, (byte)'1' })
+            .ToArray();
+        await SendHeadersAsync(1, Http2HeadersFrameFlags.END_STREAM, new byte[0]);
+        await SendContinuationAsync(1, Http2ContinuationFrameFlags.END_HEADERS, trailers);
+
+        // Should get RST_STREAM for stream 1 only, not GOAWAY
+        await WaitForStreamErrorAsync(1, Http2ErrorCode.PROTOCOL_ERROR, CoreStrings.Http2StreamErrorLessDataThanLength);
+
+        // Stream 3: Verify the connection is still alive by opening a new stream
+        await StartStreamAsync(3, _browserRequestHeaders, endStream: true);
+
+        await ExpectAsync(Http2FrameType.HEADERS,
+            withLength: 36,
+            withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM),
+            withStreamId: 3);
+
+        await StopConnectionAsync(expectedLastStreamId: 3, ignoreNonGoAwayFrames: false);
+    }
+
+    [Fact]
     public async Task HEADERS_Received_ContainsExpect100Continue_100ContinueSent()
     {
         await InitializeConnectionAsync(_echoApplication);


### PR DESCRIPTION
`DecodeTrailersAsync` does not catch the error on mismatch of ContentLength with header-provided value and may throw `Http2StreamErrorException` which is not caught immediately resulting in connection-level error.

Similar pattern already exists for `DecodeHeadersAsync` which handles this case and disposes the stream.