### PR TITLE
fix: Q/HPackDecoder limit validation after decoding

### DIFF
--- a/src/Shared/runtime/Http2/Hpack/HPackDecoder.cs
+++ b/src/Shared/runtime/Http2/Hpack/HPackDecoder.cs
@@ -611,11 +611,19 @@ namespace System.Net.Http.HPack
                 if (_state == State.HeaderName)
                 {
                     _headerNameLength = Decode(ref _headerNameOctets);
+                    if (_headerNameLength > _maxHeadersLength)
+                    {
+                        throw new HPackDecodingException(SR.Format(SR.net_http_headers_exceeded_length, _maxHeadersLength));
+                    }
                     _headerName = _headerNameOctets;
                 }
                 else
                 {
                     _headerValueLength = Decode(ref _headerValueOctets);
+                    if (_headerValueLength > _maxHeadersLength)
+                    {
+                        throw new HPackDecodingException(SR.Format(SR.net_http_headers_exceeded_length, _maxHeadersLength));
+                    }
                 }
             }
             catch (HuffmanDecodingException ex)

--- a/src/Shared/runtime/Http2/Hpack/HPackDecoder.cs
+++ b/src/Shared/runtime/Http2/Hpack/HPackDecoder.cs
@@ -596,10 +596,16 @@ namespace System.Net.Http.HPack
             {
                 if (_huffman)
                 {
-                    return Huffman.Decode(new ReadOnlySpan<byte>(_stringOctets, 0, _stringLength), ref dst);
+                    int decodedLength = Huffman.Decode(new ReadOnlySpan<byte>(_stringOctets, 0, _stringLength), ref dst);
+                    if (decodedLength > _maxHeadersLength)
+                    {
+                        throw new HPackDecodingException(SR.Format(SR.net_http_headers_exceeded_length, _maxHeadersLength));
+                    }
+                    return decodedLength;
                 }
                 else
                 {
+                    Debug.Assert(_stringLength <= _maxHeadersLength, "String length should have been checked prior to decode.");
                     EnsureStringCapacity(ref dst);
                     Buffer.BlockCopy(_stringOctets, 0, dst, 0, _stringLength);
                     return _stringLength;
@@ -611,19 +617,11 @@ namespace System.Net.Http.HPack
                 if (_state == State.HeaderName)
                 {
                     _headerNameLength = Decode(ref _headerNameOctets);
-                    if (_headerNameLength > _maxHeadersLength)
-                    {
-                        throw new HPackDecodingException(SR.Format(SR.net_http_headers_exceeded_length, _maxHeadersLength));
-                    }
                     _headerName = _headerNameOctets;
                 }
                 else
                 {
                     _headerValueLength = Decode(ref _headerValueOctets);
-                    if (_headerValueLength > _maxHeadersLength)
-                    {
-                        throw new HPackDecodingException(SR.Format(SR.net_http_headers_exceeded_length, _maxHeadersLength));
-                    }
                 }
             }
             catch (HuffmanDecodingException ex)

--- a/src/Shared/runtime/Http3/QPack/QPackDecoder.cs
+++ b/src/Shared/runtime/Http3/QPack/QPackDecoder.cs
@@ -634,10 +634,16 @@ namespace System.Net.Http.QPack
 
                 if (_huffman)
                 {
-                    return Huffman.Decode(new ReadOnlySpan<byte>(_stringOctets, 0, _stringLength), ref dst);
+                    int decodedLength = Huffman.Decode(new ReadOnlySpan<byte>(_stringOctets, 0, _stringLength), ref dst);
+                    if (decodedLength > _maxHeadersLength)
+                    {
+                        throw new QPackDecodingException(SR.Format(SR.net_http_headers_exceeded_length, _maxHeadersLength));
+                    }
+                    return decodedLength;
                 }
                 else
                 {
+                    Debug.Assert(_stringLength <= _maxHeadersLength, "String length should have been checked prior to decode.");
                     Buffer.BlockCopy(_stringOctets, 0, dst, 0, _stringLength);
                     return _stringLength;
                 }
@@ -650,19 +656,11 @@ namespace System.Net.Http.QPack
                 if (_state == State.HeaderName)
                 {
                     _headerNameLength = Decode(ref _headerNameOctets);
-                    if (_headerNameLength > _maxHeadersLength)
-                    {
-                        throw new QPackDecodingException(SR.Format(SR.net_http_headers_exceeded_length, _maxHeadersLength));
-                    }
                     _headerName = _headerNameOctets;
                 }
                 else
                 {
                     _headerValueLength = Decode(ref _headerValueOctets);
-                    if (_headerValueLength > _maxHeadersLength)
-                    {
-                        throw new QPackDecodingException(SR.Format(SR.net_http_headers_exceeded_length, _maxHeadersLength));
-                    }
                 }
             }
             catch (HuffmanDecodingException ex)

--- a/src/Shared/runtime/Http3/QPack/QPackDecoder.cs
+++ b/src/Shared/runtime/Http3/QPack/QPackDecoder.cs
@@ -650,11 +650,19 @@ namespace System.Net.Http.QPack
                 if (_state == State.HeaderName)
                 {
                     _headerNameLength = Decode(ref _headerNameOctets);
+                    if (_headerNameLength > _maxHeadersLength)
+                    {
+                        throw new QPackDecodingException(SR.Format(SR.net_http_headers_exceeded_length, _maxHeadersLength));
+                    }
                     _headerName = _headerNameOctets;
                 }
                 else
                 {
                     _headerValueLength = Decode(ref _headerValueOctets);
+                    if (_headerValueLength > _maxHeadersLength)
+                    {
+                        throw new QPackDecodingException(SR.Format(SR.net_http_headers_exceeded_length, _maxHeadersLength));
+                    }
                 }
             }
             catch (HuffmanDecodingException ex)

--- a/src/Shared/test/Shared.Tests/runtime/Http2/HPackDecoderTest.cs
+++ b/src/Shared/test/Shared.Tests/runtime/Http2/HPackDecoderTest.cs
@@ -679,6 +679,45 @@ namespace System.Net.Http.Unit.Tests.HPack
         }
 
         [Fact]
+        public void HuffmanDecodedHeaderName_ExceedsLimitAfterDecoding_Throws()
+        {
+            // '0' (ASCII 48) has a 5-bit Huffman code (00000).
+            // 16 '0' characters = 80 Huffman bits = 10 encoded bytes, but decodes to 16 bytes.
+            // Encoded length (10) passes the pre-decode check (<= 10), but decoded length (16) exceeds the limit.
+            HPackDecoder decoder = new HPackDecoder(DynamicTableInitialMaxSize, maxHeadersLength: 10);
+
+            byte[] encoded = [
+                0x00,       // Literal header field without indexing, new name
+                0x8a,       // Huffman flag set (0x80) + string length 10 (7-bit prefix)
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 10 bytes Huffman -> 16 '0' chars
+                0x01,       // String length = 1 (no Huffman)
+                0x61        // Value = "a"
+            ];
+
+            HPackDecodingException exception = Assert.Throws<HPackDecodingException>(() => decoder.Decode(encoded, endHeaders: true, handler: _handler));
+            Assert.Equal(SR.Format(SR.net_http_headers_exceeded_length, 10), exception.Message);
+            Assert.Empty(_handler.DecodedHeaders);
+        }
+
+        [Fact]
+        public void HuffmanDecodedHeaderValue_ExceedsLimitAfterDecoding_Throws()
+        {
+            HPackDecoder decoder = new HPackDecoder(DynamicTableInitialMaxSize, maxHeadersLength: 10);
+
+            byte[] encoded = [
+                0x00,       // Literal header field without indexing, new name
+                0x01,       // String length = 1 (no Huffman)
+                0x61,       // Name = "a"
+                0x8a,       // Huffman flag set (0x80) + string length 10 (7-bit prefix)
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00  // 10 bytes Huffman -> 16 '0' chars
+            ];
+
+            HPackDecodingException exception = Assert.Throws<HPackDecodingException>(() => decoder.Decode(encoded, endHeaders: true, handler: _handler));
+            Assert.Equal(SR.Format(SR.net_http_headers_exceeded_length, 10), exception.Message);
+            Assert.Empty(_handler.DecodedHeaders);
+        }
+
+        [Fact]
         public void DecodesStringLength_LimitConfigurable()
         {
             HPackDecoder decoder = new HPackDecoder(DynamicTableInitialMaxSize, MaxHeaderFieldSize + 1);

--- a/src/Shared/test/Shared.Tests/runtime/Http3/QPackDecoderTest.cs
+++ b/src/Shared/test/Shared.Tests/runtime/Http3/QPackDecoderTest.cs
@@ -273,6 +273,49 @@ namespace System.Net.Http.Unit.Tests.QPack
             Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderFieldString]);
         }
 
+        [Fact]
+        public void HuffmanDecodedHeaderName_ExceedsLimitAfterDecoding_Throws()
+        {
+            // '0' (ASCII 48) has a 5-bit Huffman code (00000).
+            // 16 '0' characters = 80 Huffman bits = 10 encoded bytes, but decodes to 16 bytes.
+            // Encoded length (10) passes the pre-decode check (<= 10), but decoded length (16) exceeds the limit.
+            using QPackDecoder decoder = new QPackDecoder(maxHeadersLength: 10);
+            TestHttpHeadersHandler handler = new TestHttpHeadersHandler();
+
+            byte[] encoded = new byte[]
+            {
+                0x00, 0x00, // Required insert count (0) and base (0)
+                0x2f, 0x03, // Literal field with literal name: N=0, H=1, name length = 10 (3-bit prefix: 7 + 3)
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 10 bytes Huffman -> 16 '0' chars
+                0x01,       // Value length = 1 (no Huffman)
+                0x61        // Value = "a"
+            };
+
+            QPackDecodingException exception = Assert.Throws<QPackDecodingException>(() => decoder.Decode(encoded, endHeaders: true, handler: handler));
+            Assert.Equal(SR.Format(SR.net_http_headers_exceeded_length, 10), exception.Message);
+            Assert.Empty(handler.DecodedHeaders);
+        }
+
+        [Fact]
+        public void HuffmanDecodedHeaderValue_ExceedsLimitAfterDecoding_Throws()
+        {
+            using QPackDecoder decoder = new QPackDecoder(maxHeadersLength: 10);
+            TestHttpHeadersHandler handler = new TestHttpHeadersHandler();
+
+            byte[] encoded = new byte[]
+            {
+                0x00, 0x00, // Required insert count (0) and base (0)
+                0x21,       // Literal field with literal name: N=0, H=0, name length = 1 (3-bit prefix)
+                0x61,       // Name = "a"
+                0x8a,       // Huffman flag set (0x80) + value length 10 (7-bit prefix)
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00  // 10 bytes Huffman -> 16 '0' chars
+            };
+
+            QPackDecodingException exception = Assert.Throws<QPackDecodingException>(() => decoder.Decode(encoded, endHeaders: true, handler: handler));
+            Assert.Equal(SR.Format(SR.net_http_headers_exceeded_length, 10), exception.Message);
+            Assert.Empty(handler.DecodedHeaders);
+        }
+
         public static readonly TheoryData<byte[]> _incompleteHeaderBlockData = new TheoryData<byte[]>
         {
             // Incomplete header


### PR DESCRIPTION
There is a discrepancy between `Http2Limits.MaxRequestHeaderFieldSize` documentation and actual Q/HPackDecoders behavior:
https://github.com/dotnet/aspnetcore/blob/ae31b22278392015250b3c53666991058cd1138c/src/Servers/Kestrel/Core/src/Http2Limits.cs#L84-L90

`MaxRequestHeaderFieldSize` clearly states that limits apply to **both** compressed and uncompressed data, but decoders dont check uncompressed length.

Current PR adds a validation check on uncompressed state and throws a corresponding exception per type.