### PR TITLE
Unquarantine RoutePatternCompletionProviderTests

### DIFF
--- a/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/RoutePatternCompletionProviderTests.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/RoutePatternCompletionProviderTests.cs
@@ -3,13 +3,11 @@
 
 using System.Text;
 using Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure;
-using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage;
 
-[QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/49126")]
 public partial class RoutePatternCompletionProviderTests
 {
     private TestDiagnosticAnalyzerRunner Runner { get; } = new(new RoutePatternAnalyzer());


### PR DESCRIPTION
The Roslyn upgrade that caused `RoutePatternCompletionProviderTests` to fail ([#49126](https://github.com/dotnet/aspnetcore/issues/49126)) was resolved and the issue was closed in Aug 2024, but the `[QuarantinedTest]` attribute was never removed.

This PR removes it so these tests run in CI again.