### PR TITLE
Fix race condition in ProcessBufferedRenderBatches_WritesRenders

### DIFF
--- a/src/Components/Server/test/Circuits/RemoteRendererTest.cs
+++ b/src/Components/Server/test/Circuits/RemoteRendererTest.cs
@@ -155,14 +155,17 @@ public class RemoteRendererTest
 
         firstBatchTCS.SetResult();
 
-        // The continuation of SetResult runs asynchronously on the renderer's
-        // dispatcher. Dispatch a no-op to ensure all prior work has completed
-        // before we trigger more renders.
-        await renderer.Dispatcher.InvokeAsync(() => { });
-
-        circuitClient.SetDisconnected();
-        component.TriggerRender();
-        component.TriggerRender();
+        // After SetResult, async continuations are queued on the renderer's
+        // dispatcher. Run the remaining setup on the dispatcher so that:
+        // 1) All prior queued work drains before our callback executes, and
+        // 2) TriggerRender runs with CheckAccess() == true, bypassing the
+        //    internal task queue and executing the render synchronously.
+        await renderer.Dispatcher.InvokeAsync(() =>
+        {
+            circuitClient.SetDisconnected();
+            component.TriggerRender();
+            component.TriggerRender();
+        });
 
         // Act
         circuitClient.Transfer(client.Object, "new-connection");

--- a/src/Components/Server/test/Circuits/RemoteRendererTest.cs
+++ b/src/Components/Server/test/Circuits/RemoteRendererTest.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
 using Microsoft.AspNetCore.Components.Endpoints;
@@ -9,7 +8,6 @@ using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.Server;
 using Microsoft.AspNetCore.Components.Server.Circuits;
 using Microsoft.AspNetCore.DataProtection;
-using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -22,10 +20,6 @@ namespace Microsoft.AspNetCore.Components.Web.Rendering;
 
 public class RemoteRendererTest
 {
-    // Nothing should exceed the timeout in a successful run of the the tests, this is just here to catch
-    // failures.
-    private static readonly TimeSpan Timeout = Debugger.IsAttached ? System.Threading.Timeout.InfiniteTimeSpan : TimeSpan.FromSeconds(10);
-
     private const int MaxInteractiveServerRootComponentCount = 3;
 
     private readonly IDataProtectionProvider _ephemeralDataProtectionProvider = new EphemeralDataProtectionProvider();
@@ -127,11 +121,9 @@ public class RemoteRendererTest
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/61807")]
     public async Task ProcessBufferedRenderBatches_WritesRenders()
     {
         // Arrange
-        var @event = new ManualResetEventSlim();
         var serviceProvider = CreateServiceProvider();
         var renderIds = new List<long>();
 
@@ -161,11 +153,12 @@ public class RemoteRendererTest
         component.TriggerRender();
         _ = renderer.OnRenderCompletedAsync(2, null);
 
-        @event.Reset();
         firstBatchTCS.SetResult();
 
-        // Waiting is required here because the continuations of SetResult will not execute synchronously.
-        @event.Wait(Timeout);
+        // The continuation of SetResult runs asynchronously on the renderer's
+        // dispatcher. Dispatch a no-op to ensure all prior work has completed
+        // before we trigger more renders.
+        await renderer.Dispatcher.InvokeAsync(() => { });
 
         circuitClient.SetDisconnected();
         component.TriggerRender();

--- a/src/Components/Server/test/Circuits/RemoteRendererTest.cs
+++ b/src/Components/Server/test/Circuits/RemoteRendererTest.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.Server;
 using Microsoft.AspNetCore.Components.Server.Circuits;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -121,6 +122,7 @@ public class RemoteRendererTest
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/61807")]
     public async Task ProcessBufferedRenderBatches_WritesRenders()
     {
         // Arrange


### PR DESCRIPTION
## Problem

`ProcessBufferedRenderBatches_WritesRenders` fails intermittently in CI ([#61807](https://github.com/dotnet/aspnetcore/issues/61807)), quarantined since Sep 2025.

```
Assert.True() Failure
Expected: True
Actual:   False
  at RemoteRendererTest.TestComponent.TriggerRender() in RemoteRendererTest.cs:line 778
```

## Root Cause

The test had a `ManualResetEventSlim` that was **never signaled** — it was created, reset, and waited on with a 10-second timeout, but nothing ever called `Set()`. The comment acknowledged that "continuations of SetResult will not execute synchronously" but the synchronization mechanism was broken.

After `firstBatchTCS.SetResult()`, the renderer processes the batch completion asynchronously on its dispatcher. The test proceeded after the 10s timeout expired, then called `TriggerRender()` which asserts the render task completes synchronously. On loaded CI agents, the renderer's dispatcher was still busy processing the previous batch's continuation, causing the assertion to fail.

## Fix

Move the post-`SetResult()` test setup (`SetDisconnected` + `TriggerRender` calls) inside a `renderer.Dispatcher.InvokeAsync` callback. This ensures:
1. All prior dispatcher work (from `SetResult` continuations) drains before our callback executes
2. `TriggerRender` runs with `CheckAccess() == true`, bypassing the internal task queue and executing the render synchronously

A single `await InvokeAsync(() => {})` no-op was insufficient because `InvokeAsync(Action)` returns a task that completes inside `PostAsync`'s callback, but `PostAsync`'s own task (stored as `_taskQueue`) completes slightly later — creating a race where the next `TriggerRender` would chain instead of running synchronously.

Related to #61807