### PR TITLE
[main] Fix Blazor WASM template tests NU1603 with DevServer version pinning

### DIFF
--- a/src/ProjectTemplates/TestInfrastructure/Directory.Build.targets.in
+++ b/src/ProjectTemplates/TestInfrastructure/Directory.Build.targets.in
@@ -6,4 +6,15 @@
     <!-- This sets an option which prevents the tests from rolling forward into a newer shared framework. -->
     <UserRuntimeConfig Condition="'$(PublishAot)' != 'true'">$(MSBuildThisFileDirectory)runtimeconfig.norollforward.json</UserRuntimeConfig>
   </PropertyGroup>
+
+  <!--
+    Pin the DevServer package to the exact locally-built version so that stable versions from
+    darc feeds (which outrank prerelease in SemVer) don't cause NU1603 with TreatWarningsAsErrors.
+    PackageReference Update must be in .targets (not .props) so it runs after the project's items.
+    See https://github.com/dotnet/aspnetcore/issues/65701
+  -->
+  <ItemGroup Condition="'${MicrosoftAspNetCoreComponentsWebAssemblyDevServerVersion}' != ''">
+    <PackageReference Update="Microsoft.AspNetCore.Components.WebAssembly.DevServer"
+                      Version="[${MicrosoftAspNetCoreComponentsWebAssemblyDevServerVersion}]" />
+  </ItemGroup>
 </Project>

--- a/src/ProjectTemplates/TestInfrastructure/PrepareForTest.targets
+++ b/src/ProjectTemplates/TestInfrastructure/PrepareForTest.targets
@@ -136,7 +136,7 @@
     <GenerateFileFromTemplate
       TemplateFile="$(MSBuildThisFileDirectory)..\TestInfrastructure\Directory.Build.targets.in"
       Properties="Configuration=$(Configuration);
-          RestoreAdditionalProjectSources=$([MSBuild]::Escape('$(RestoreAdditionalProjectSources);$(ArtifactsShippingPackagesDir);$(ArtifactsNonShippingPackagesDir)'))"
+          RestoreAdditionalProjectSources=$([MSBuild]::Escape('$(RestoreAdditionalProjectSources);$(ArtifactsShippingPackagesDir);$(ArtifactsNonShippingPackagesDir)'));MicrosoftAspNetCoreComponentsWebAssemblyDevServerVersion=$(MicrosoftAspNetCoreComponentsWebAssemblyDevServerVersion)"
       OutputPath="$(TestTemplateCreationFolder)Directory.Build.targets" />
 
     <GenerateFileFromTemplate


### PR DESCRIPTION
Forward port of #65781 to main.

Preventive fix — the NU1603 currently only hits `release/10.0` (stable servicing packages from darc feeds outrank prerelease `-ci` builds). On `main` all versions are prerelease so the conflict does not occur today, but this will be needed when `main` branches for `release/11.0`.

Same fix: pin the DevServer package to the exact locally-built version in `Directory.Build.targets.in` via `PrepareForTest.targets`.

Fixes #65701