### PR TITLE
Update create-pull-request action version

### DIFF
--- a/.github/workflows/runtime-sync.yml
+++ b/.github/workflows/runtime-sync.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Send PR
       if: steps.check.outputs.sendpr == 'true'
       # https://github.com/marketplace/actions/create-pull-request
-      uses: dotnet/actions-create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # v4.2.3
+      uses: dotnet/actions-create-pull-request@e8d799aa1f8b17f324f9513832811b0a62f1e0b1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         path: .\aspnetcore

--- a/.github/workflows/runtime-sync.yml
+++ b/.github/workflows/runtime-sync.yml
@@ -27,6 +27,7 @@ jobs:
         repository: 'dotnet/aspnetcore'
         path: aspnetcore
         ref: main
+        persist-credentials: false
     - name: Checkout runtime
       uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v4.2.2
       with:
@@ -34,6 +35,7 @@ jobs:
         repository: 'dotnet/runtime'
         path: runtime
         ref: main
+        persist-credentials: false
     - name: Copy
       shell: cmd
       working-directory: .\runtime\src\libraries\Common\src\System\Net\Http\aspnetcore\


### PR DESCRIPTION
The action ran into an issue, updating to the version that e.g. aspire uses too. Also adds workaround for https://github.com/actions/checkout/issues/2299
