### PR TITLE
Respect AllowRefresh in SecurityStampValidator cookie renewal

### DIFF
--- a/src/Identity/Core/src/SecurityStampValidator.cs
+++ b/src/Identity/Core/src/SecurityStampValidator.cs
@@ -108,7 +108,12 @@ public class SecurityStampValidator<TUser> : ISecurityStampValidator where TUser
 
         // REVIEW: note we lost login authentication method
         context.ReplacePrincipal(newPrincipal);
-        context.ShouldRenew = true;
+
+        var allowRefresh = context.Properties.AllowRefresh ?? true;
+        if (allowRefresh)
+        {
+            context.ShouldRenew = true;
+        }
 
         if (!context.Options.SlidingExpiration)
         {

--- a/src/Identity/Core/src/SecurityStampValidator.cs
+++ b/src/Identity/Core/src/SecurityStampValidator.cs
@@ -113,13 +113,13 @@ public class SecurityStampValidator<TUser> : ISecurityStampValidator where TUser
         if (allowRefresh)
         {
             context.ShouldRenew = true;
-        }
 
-        if (!context.Options.SlidingExpiration)
-        {
-            // On renewal calculate the new ticket length relative to now to avoid
-            // extending the expiration.
-            context.Properties.IssuedUtc = TimeProvider.GetUtcNow();
+            if (!context.Options.SlidingExpiration)
+            {
+                // On renewal calculate the new ticket length relative to now to avoid
+                // extending the expiration.
+                context.Properties.IssuedUtc = TimeProvider.GetUtcNow();
+            }
         }
     }
 

--- a/src/Identity/Core/src/SecurityStampValidator.cs
+++ b/src/Identity/Core/src/SecurityStampValidator.cs
@@ -108,18 +108,13 @@ public class SecurityStampValidator<TUser> : ISecurityStampValidator where TUser
 
         // REVIEW: note we lost login authentication method
         context.ReplacePrincipal(newPrincipal);
+        context.ShouldRenew = context.Properties.AllowRefresh ?? true;
 
-        var allowRefresh = context.Properties.AllowRefresh ?? true;
-        if (allowRefresh)
+        if (context.ShouldRenew && !context.Options.SlidingExpiration)
         {
-            context.ShouldRenew = true;
-
-            if (!context.Options.SlidingExpiration)
-            {
-                // On renewal calculate the new ticket length relative to now to avoid
-                // extending the expiration.
-                context.Properties.IssuedUtc = TimeProvider.GetUtcNow();
-            }
+            // On renewal calculate the new ticket length relative to now to avoid
+            // extending the expiration.
+            context.Properties.IssuedUtc = TimeProvider.GetUtcNow();
         }
     }
 

--- a/src/Identity/test/Identity.Test/SecurityStampValidatorTest.cs
+++ b/src/Identity/test/Identity.Test/SecurityStampValidatorTest.cs
@@ -317,6 +317,53 @@ public class SecurityStampTest
         Assert.NotNull(context.Principal);
     }
 
+    [Fact]
+    public async Task OnValidateIdentityDoesNotRenewWhenAllowRefreshIsFalse()
+    {
+        var user = new PocoUser("test");
+        var timeProvider = new FakeTimeProvider();
+        var httpContext = new Mock<HttpContext>();
+        var userManager = MockHelpers.MockUserManager<PocoUser>();
+        var identityOptions = new Mock<IOptions<IdentityOptions>>();
+        identityOptions.Setup(a => a.Value).Returns(new IdentityOptions());
+        var claimsManager = new Mock<IUserClaimsPrincipalFactory<PocoUser>>();
+        var options = new Mock<IOptions<SecurityStampValidatorOptions>>();
+        options.Setup(a => a.Value).Returns(new SecurityStampValidatorOptions { ValidationInterval = TimeSpan.FromMinutes(1), TimeProvider = timeProvider });
+        var contextAccessor = new Mock<IHttpContextAccessor>();
+        contextAccessor.Setup(a => a.HttpContext).Returns(httpContext.Object);
+        var signInManager = new Mock<SignInManager<PocoUser>>(userManager.Object,
+            contextAccessor.Object, claimsManager.Object, identityOptions.Object, null, new Mock<IAuthenticationSchemeProvider>().Object, new DefaultUserConfirmation<PocoUser>());
+        signInManager.Setup(s => s.ValidateSecurityStampAsync(It.IsAny<ClaimsPrincipal>())).Returns(Task.FromResult(user));
+        signInManager.Setup(s => s.CreateUserPrincipalAsync(It.IsAny<PocoUser>())).Returns(Task.FromResult(new ClaimsPrincipal(new ClaimsIdentity("auth"))));
+        var services = new ServiceCollection();
+        services.AddSingleton(options.Object);
+        services.AddSingleton(signInManager.Object);
+        services.AddSingleton<ISecurityStampValidator>(new SecurityStampValidator<PocoUser>(options.Object, signInManager.Object, new LoggerFactory()));
+        httpContext.Setup(c => c.RequestServices).Returns(services.BuildServiceProvider());
+        var id = new ClaimsIdentity(IdentityConstants.ApplicationScheme);
+        id.AddClaim(new Claim(ClaimTypes.NameIdentifier, user.Id));
+
+        var ticket = new AuthenticationTicket(new ClaimsPrincipal(id),
+            new AuthenticationProperties
+            {
+                IssuedUtc = timeProvider.GetUtcNow() - TimeSpan.FromDays(1),
+                ExpiresUtc = timeProvider.GetUtcNow() + TimeSpan.FromDays(1),
+                AllowRefresh = false,
+            },
+            IdentityConstants.ApplicationScheme);
+        var context = new CookieValidatePrincipalContext(httpContext.Object, new AuthenticationSchemeBuilder(IdentityConstants.ApplicationScheme) { HandlerType = typeof(NoopHandler) }.Build(),
+            new CookieAuthenticationOptions(), ticket);
+        Assert.NotNull(context.Properties);
+        Assert.NotNull(context.Options);
+        Assert.NotNull(context.Principal);
+        await SecurityStampValidator.ValidatePrincipalAsync(context);
+
+        // Principal should still be replaced (claims updated in memory)
+        Assert.NotNull(context.Principal);
+        // But the cookie should NOT be renewed since AllowRefresh is false
+        Assert.False(context.ShouldRenew);
+    }
+
     private async Task RunRememberClientCookieTest(bool shouldStampValidate, bool validationSuccess)
     {
         var user = new PocoUser("test");

--- a/src/Identity/test/Identity.Test/SecurityStampValidatorTest.cs
+++ b/src/Identity/test/Identity.Test/SecurityStampValidatorTest.cs
@@ -364,6 +364,30 @@ public class SecurityStampTest
         Assert.False(context.ShouldRenew);
     }
 
+    [Fact]
+    public async Task OnValidateIdentityRenewsWhenAllowRefreshIsNotSet()
+    {
+        var user = new PocoUser("test");
+        var httpContext = new Mock<HttpContext>();
+
+        await RunApplicationCookieTest(user, httpContext, /*shouldStampValidate*/true, async () =>
+        {
+            var id = new ClaimsIdentity(IdentityConstants.ApplicationScheme);
+            id.AddClaim(new Claim(ClaimTypes.NameIdentifier, user.Id));
+            var ticket = new AuthenticationTicket(new ClaimsPrincipal(id),
+                new AuthenticationProperties { IssuedUtc = DateTimeOffset.UtcNow.AddSeconds(-1) },
+                IdentityConstants.ApplicationScheme);
+
+            var context = new CookieValidatePrincipalContext(httpContext.Object, new AuthenticationSchemeBuilder(IdentityConstants.ApplicationScheme) { HandlerType = typeof(NoopHandler) }.Build(), new CookieAuthenticationOptions(), ticket);
+            // AllowRefresh is null (not set) — should default to true
+            Assert.Null(context.Properties.AllowRefresh);
+            await SecurityStampValidator.ValidatePrincipalAsync(context);
+
+            Assert.NotNull(context.Principal);
+            Assert.True(context.ShouldRenew);
+        });
+    }
+
     private async Task RunRememberClientCookieTest(bool shouldStampValidate, bool validationSuccess)
     {
         var user = new PocoUser("test");


### PR DESCRIPTION
## Summary

`SecurityStampValidator.SecurityStampVerified()` unconditionally sets `context.ShouldRenew = true` after verifying the security stamp. This means the authentication cookie gets rewritten on every validation cycle — even when `AllowRefresh` is explicitly set to `false` on the authentication properties.

This is inconsistent with `CookieAuthenticationHandler.CheckForRefreshAsync()`, which guards its renewal logic behind `var allowRefresh = ticket.Properties.AllowRefresh ?? true`. A user who sets `AllowRefresh = false` expects fixed-lifetime sessions that don't get extended by background activity, but the security stamp validator silently overrides that intent.

The fix mirrors the handler's pattern:

```csharp
context.ShouldRenew = context.Properties.AllowRefresh ?? true;
```

The in-memory principal is still replaced regardless — `ReplacePrincipal` is not gated — so the user's claims stay fresh within the request. Only the cookie rewrite (session extension) is suppressed.

The `IssuedUtc` recalculation for non-sliding expiration is also gated on `ShouldRenew`, since it serves the renewal path and has no effect when the cookie isn't rewritten.

## Test plan

- [x] `OnValidateIdentityDoesNotRenewWhenAllowRefreshIsFalse` — explicit `AllowRefresh = false` produces `ShouldRenew == false`, principal still replaced
- [x] `OnValidateIdentityRenewsWhenAllowRefreshIsNotSet` — null `AllowRefresh` (the common case) defaults to `ShouldRenew == true`, preserving existing behavior
- [x] Existing `OnValidateIdentityDoesNotExtendExpirationWhenSlidingIsDisabled` still passes — `IssuedUtc` adjustment unaffected when `AllowRefresh` is not set

Fixes #64301