### PR TITLE
Surface primary constructor parameter attributes in OpenAPI schemas

### DIFF
--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -45,8 +45,16 @@ internal sealed class OpenApiSchemaService(
             {
                 var hasRequiredAttribute = propertyInfo.AttributeProvider?
                     .GetCustomAttributes(inherit: false)
-                    .Any(attr => attr is RequiredAttribute);
-                propertyInfo.IsRequired |= hasRequiredAttribute ?? false;
+                    .Any(attr => attr is RequiredAttribute)
+                    ?? false;
+                // Also check constructor parameter attributes for primary constructor classes
+                // where attributes are on the parameter, not the synthesized property.
+                hasRequiredAttribute = hasRequiredAttribute
+                    || (propertyInfo.AssociatedParameter?.AttributeProvider?
+                        .GetCustomAttributes(inherit: false)
+                        .Any(attr => attr is RequiredAttribute)
+                        ?? false);
+                propertyInfo.IsRequired |= hasRequiredAttribute;
             }
         })
     };
@@ -104,6 +112,37 @@ internal sealed class OpenApiSchemaService(
             {
                 schema[OpenApiSchemaKeywords.DescriptionKeyword] = typeDescriptionAttribute.Description;
             }
+            // Apply constructor parameter attributes first for primary constructor classes
+            // where attributes are on the parameter, not the synthesized property.
+            // Property-level attributes applied below will override these.
+            if (context.PropertyInfo is { AssociatedParameter.AttributeProvider: { } parameterAttributeProvider })
+            {
+                var parameterAttributes = parameterAttributeProvider.GetCustomAttributes(inherit: false);
+                if (parameterAttributes.OfType<ValidationAttribute>() is { } paramValidationAttributes)
+                {
+                    schema.ApplyValidationAttributes(paramValidationAttributes);
+                }
+                if (parameterAttributes.OfType<DefaultValueAttribute>().LastOrDefault() is { } paramDefaultValueAttribute)
+                {
+                    schema.ApplyDefaultValue(paramDefaultValueAttribute.Value, context.TypeInfo);
+                }
+                var isInlinedParamSchema = !schema.WillBeComponentized();
+                if (isInlinedParamSchema)
+                {
+                    if (parameterAttributes.OfType<DescriptionAttribute>().LastOrDefault() is { } paramDescriptionAttribute)
+                    {
+                        schema[OpenApiSchemaKeywords.DescriptionKeyword] = paramDescriptionAttribute.Description;
+                    }
+                }
+                else
+                {
+                    if (parameterAttributes.OfType<DescriptionAttribute>().LastOrDefault() is { } paramDescriptionAttribute)
+                    {
+                        schema[OpenApiConstants.RefDescriptionAnnotation] = paramDescriptionAttribute.Description;
+                    }
+                }
+            }
+            // Property-level attributes override constructor parameter attributes.
             if (context.PropertyInfo is { AttributeProvider: { } attributeProvider })
             {
                 var propertyAttributes = attributeProvider.GetCustomAttributes(inherit: false);

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.PropertySchemas.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.PropertySchemas.cs
@@ -711,6 +711,52 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
         });
     }
 
+    [Fact]
+    public async Task GetOpenApiSchema_HandlesDescriptionAttributeOnPrimaryConstructorParameters()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPost("/api", (PrimaryCtorWithDescription model) => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var schema = document.Paths["/api"].Operations[HttpMethod.Post].RequestBody.Content.First().Value.Schema;
+
+            // [Description] on constructor parameter should appear in schema
+            var ageProperty = schema.Properties["age"];
+            Assert.Equal("The user's age in years", ageProperty.Description);
+        });
+    }
+
+    [Fact]
+    public async Task GetOpenApiSchema_RecordWithValidationAttributesStillWorks()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPost("/api", (RecordWithValidationAttributes model) => { });
+
+        // Assert — records already had this working; verify no regression from the
+        // constructor-parameter fallback applying attributes a second time.
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var schema = document.Paths["/api"].Operations[HttpMethod.Post].RequestBody.Content.First().Value.Schema;
+
+            var scoreProperty = schema.Properties["score"];
+            Assert.Equal(JsonSchemaType.Integer, scoreProperty.Type);
+            Assert.Equal("1", scoreProperty.Minimum);
+            Assert.Equal("100", scoreProperty.Maximum);
+
+            var nameProperty = schema.Properties["name"];
+            Assert.Equal(JsonSchemaType.String, nameProperty.Type);
+            Assert.Equal(2, nameProperty.MinLength);
+        });
+    }
+
 #nullable enable
     // Primary constructor class (NOT a record) with validation attributes on constructor parameters.
     // Unlike records, C# does not synthesize property attributes for class primary constructors,
@@ -737,6 +783,19 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
         [Range(10, 50)]
         public int Score { get; set; } = score;
     }
+
+    private class PrimaryCtorWithDescription(
+        [Description("The user's age in years")] int age)
+    {
+        public int Age { get; set; } = age;
+    }
+
+    // Record type — the compiler copies constructor parameter attributes to the
+    // synthesized properties, so both AttributeProvider and AssociatedParameter
+    // return the same attributes. This test verifies no double-application regression.
+    private record RecordWithValidationAttributes(
+        [Range(1, 100)] int Score,
+        [MinLength(2)] string Name);
 
     private class NullablePropertiesTestModel
     {

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.PropertySchemas.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.PropertySchemas.cs
@@ -641,7 +641,99 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
         });
     }
 
+    [Fact]
+    public async Task GetOpenApiSchema_HandlesValidationAttributesOnPrimaryConstructorParameters()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPost("/api", (PrimaryCtorWithValidationAttributes model) => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var schema = document.Paths["/api"].Operations[HttpMethod.Post].RequestBody.Content.First().Value.Schema;
+
+            // [Range(0, 120)] on constructor parameter should produce minimum/maximum
+            var ageProperty = schema.Properties["age"];
+            Assert.Equal(JsonSchemaType.Integer, ageProperty.Type);
+            Assert.Equal("0", ageProperty.Minimum);
+            Assert.Equal("120", ageProperty.Maximum);
+
+            // [MinLength(1), MaxLength(100)] on constructor parameter should produce minLength/maxLength
+            var nameProperty = schema.Properties["name"];
+            Assert.Equal(JsonSchemaType.String, nameProperty.Type);
+            Assert.Equal(1, nameProperty.MinLength);
+            Assert.Equal(100, nameProperty.MaxLength);
+        });
+    }
+
+    [Fact]
+    public async Task GetOpenApiSchema_HandlesRequiredAttributeOnPrimaryConstructorParameters()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPost("/api", (PrimaryCtorWithRequiredAttribute model) => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var schema = document.Paths["/api"].Operations[HttpMethod.Post].RequestBody.Content.First().Value.Schema;
+
+            // [Required] on constructor parameter should mark the property as required
+            Assert.Contains("email", schema.Required);
+        });
+    }
+
+    [Fact]
+    public async Task GetOpenApiSchema_PropertyAttributeOverridesConstructorParameterAttribute()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPost("/api", (PrimaryCtorWithPropertyOverride model) => { });
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var schema = document.Paths["/api"].Operations[HttpMethod.Post].RequestBody.Content.First().Value.Schema;
+
+            // Property-level [Range(10, 50)] should override constructor parameter [Range(0, 100)]
+            var scoreProperty = schema.Properties["score"];
+            Assert.Equal("10", scoreProperty.Minimum);
+            Assert.Equal("50", scoreProperty.Maximum);
+        });
+    }
+
 #nullable enable
+    // Primary constructor class (NOT a record) with validation attributes on constructor parameters.
+    // Unlike records, C# does not synthesize property attributes for class primary constructors,
+    // so these attributes are only on the ParameterInfo, not the PropertyInfo.
+    private class PrimaryCtorWithValidationAttributes(
+        [Range(0, 120)] int age,
+        [MinLength(1), MaxLength(100)] string name)
+    {
+        public int Age { get; set; } = age;
+        public string Name { get; set; } = name;
+    }
+
+    private class PrimaryCtorWithRequiredAttribute(
+        [Required] string email)
+    {
+        public string Email { get; set; } = email;
+    }
+
+    private class PrimaryCtorWithPropertyOverride(
+        [Range(0, 100)] int score)
+    {
+        [Range(10, 50)]
+        public int Score { get; set; } = score;
+    }
+
     private class NullablePropertiesTestModel
     {
         public int? NullableInt { get; set; }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.PropertySchemas.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.PropertySchemas.cs
@@ -685,6 +685,8 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
 
             // [Required] on constructor parameter should mark the property as required
             Assert.Contains("email", schema.Required);
+            // Property without [Required] should not be in the required list
+            Assert.DoesNotContain("optionalNote", schema.Required);
         });
     }
 
@@ -722,9 +724,11 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
     }
 
     private class PrimaryCtorWithRequiredAttribute(
-        [Required] string email)
+        [Required] string email,
+        string? optionalNote = null)
     {
         public string Email { get; set; } = email;
+        public string? OptionalNote { get; set; } = optionalNote;
     }
 
     private class PrimaryCtorWithPropertyOverride(


### PR DESCRIPTION
## Summary

C# 12 primary constructor parameters on classes carry their validation attributes (`[Range]`, `[Required]`, `[MinLength]`, etc.) only on the `ParameterInfo` — unlike records, the compiler doesn't copy them to the synthesized property. The OpenAPI schema generator reads attributes exclusively from `JsonPropertyInfo.AttributeProvider` (the `PropertyInfo`), so these constraints are silently dropped from the generated schema.

This adds a fallback that checks `JsonPropertyInfo.AssociatedParameter.AttributeProvider` for constructor parameter attributes in two places:

1. **`TypeInfoResolver` modifier** — picks up `[Required]` from constructor parameters
2. **`TransformSchemaNode` callback** — picks up `ValidationAttribute`, `DefaultValueAttribute`, and `DescriptionAttribute` from constructor parameters

Constructor parameter attributes are applied first; property-level attributes are applied second and take precedence. This means existing types with attributes on both (like records) continue to work correctly — the property-level copy wins, and idempotent re-application of the same values is harmless.

### AOT considerations

`AssociatedParameter.AttributeProvider` follows the same reflection pattern already used by the existing `propertyInfo.AttributeProvider` path. Under source-generated serialization contexts, `AssociatedParameter.AttributeProvider` is `null` (same as `AttributeProvider`), so the new block is safely skipped. No new trimming or AOT risk surface is introduced.

## Test plan

- [x] `HandlesValidationAttributesOnPrimaryConstructorParameters` — `[Range(0, 120)]` and `[MinLength(1), MaxLength(100)]` on class primary constructor params produce correct schema constraints
- [x] `HandlesRequiredAttributeOnPrimaryConstructorParameters` — `[Required]` on constructor param marks property as required, with negative assertion on non-required property
- [x] `PropertyAttributeOverridesConstructorParameterAttribute` — property-level `[Range(10, 50)]` correctly overrides constructor-level `[Range(0, 100)]`
- [x] `HandlesDescriptionAttributeOnPrimaryConstructorParameters` — `[Description]` on constructor param appears in schema
- [x] `RecordWithValidationAttributesStillWorks` — record types are unaffected by the fallback (no double-application regression)

Fixes #61538