### PR TITLE
Fix .devcontainer references to archived repo

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/dotnet/.devcontainer/base.Dockerfile
+# See here for image contents: https://github.com/devcontainers/images/tree/main/src/dotnet
 
-FROM mcr.microsoft.com/vscode/devcontainers/dotnet:latest
+FROM mcr.microsoft.com/devcontainers/dotnet:latest
 
 # [Option] Install Node.js
 ARG INSTALL_NODE="true"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/dotnet
+// https://github.com/devcontainers/templates/tree/main/src/dotnet
 {
   "name": "C# (.NET)",
   "build": {


### PR DESCRIPTION
Update links and Docker image from the archived microsoft/vscode-dev-containers repo to the successor repos under the devcontainers GitHub org.
