### PR TITLE
fix: issue-triage agent to not post noop-issue

### DIFF
--- a/.github/workflows/issue-triage-agent.md
+++ b/.github/workflows/issue-triage-agent.md
@@ -30,6 +30,8 @@ tools:
   bash: ["cat", "head", "tail", "grep", "wc", "jq"]
 
 safe-outputs:
+  noop:
+    report-as-issue: false
   add-labels:
     allowed:
       - area-auth


### PR DESCRIPTION
In order to not polute the repo with workflow runs messages in this issue https://github.com/dotnet/aspnetcore/issues/65812, disabling "report-as-issue"