### PR TITLE
Throw meaningful exception when async JSInvokable method is called synchronously from JS

### DIFF
--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
@@ -61,6 +61,24 @@ public static class DotNetDispatcher
             return null;
         }
 
+        // When an async [JSInvokable] method is called synchronously via invokeMethod(), the raw
+        // Task/ValueTask is returned and serialization produces misleading JSON errors. Detect this
+        // and throw a clear exception instead.
+        if (syncResult is Task || syncResult is ValueTask)
+        {
+            throw new InvalidOperationException(
+                $"The method '{invocationInfo.MethodIdentifier}' returns an asynchronous type and cannot be invoked " +
+                $"synchronously from JavaScript. Use 'invokeMethodAsync' instead of 'invokeMethod'.");
+        }
+
+        var resultType = syncResult.GetType();
+        if (resultType.IsValueType && resultType.IsGenericType && resultType.GetGenericTypeDefinition() == typeof(ValueTask<>))
+        {
+            throw new InvalidOperationException(
+                $"The method '{invocationInfo.MethodIdentifier}' returns an asynchronous type and cannot be invoked " +
+                $"synchronously from JavaScript. Use 'invokeMethodAsync' instead of 'invokeMethod'.");
+        }
+
         return JsonSerializer.Serialize(syncResult, jsRuntime.JsonSerializerOptions);
     }
 

--- a/src/JSInterop/Microsoft.JSInterop/test/Infrastructure/DotNetDispatcherTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/Infrastructure/DotNetDispatcherTest.cs
@@ -617,6 +617,44 @@ public class DotNetDispatcherTest
     }
 
     [Fact]
+    public void SyncInvokeOfAsyncMethod_Task_ThrowsMeaningfulException()
+    {
+        // Arrange: Track an instance with an async method
+        var jsRuntime = new TestJSRuntime();
+        var targetInstance = new SomePublicType();
+        var objectRef = DotNetObjectReference.Create(targetInstance);
+        jsRuntime.Invoke<object>("unimportant", objectRef);
+
+        // Act & Assert: Synchronously invoking an async method should throw a clear error
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+        {
+            DotNetDispatcher.Invoke(jsRuntime, new DotNetInvocationInfo(null, nameof(SomePublicType.InvokableAsyncReturningTask), 1, default), null);
+        });
+
+        Assert.Contains("invokeMethodAsync", ex.Message);
+        Assert.Contains("InvokableAsyncReturningTask", ex.Message);
+    }
+
+    [Fact]
+    public void SyncInvokeOfAsyncMethod_ValueTask_ThrowsMeaningfulException()
+    {
+        // Arrange: Track an instance with an async method returning ValueTask
+        var jsRuntime = new TestJSRuntime();
+        var targetInstance = new SomePublicType();
+        var objectRef = DotNetObjectReference.Create(targetInstance);
+        jsRuntime.Invoke<object>("unimportant", objectRef);
+
+        // Act & Assert: Synchronously invoking an async method should throw a clear error
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+        {
+            DotNetDispatcher.Invoke(jsRuntime, new DotNetInvocationInfo(null, nameof(SomePublicType.InvokableAsyncMethodReturningValueTaskNonGeneric), 1, default), null);
+        });
+
+        Assert.Contains("invokeMethodAsync", ex.Message);
+        Assert.Contains("InvokableAsyncMethodReturningValueTaskNonGeneric", ex.Message);
+    }
+
+    [Fact]
     public async Task CanInvokeAsyncMethod()
     {
         // Arrange: Track some instance plus another object we'll pass as a param
@@ -999,6 +1037,12 @@ public class DotNetDispatcherTest
                     IntVal = dtoByRef.IntVal * 2,
                 })
             });
+        }
+
+        [JSInvokable]
+        public async Task InvokableAsyncReturningTask()
+        {
+            await Task.CompletedTask;
         }
 
         [JSInvokable]


### PR DESCRIPTION
## Summary

Fixes #46811

When a `[JSInvokable]` method that returns `Task` or `ValueTask` is invoked synchronously from JavaScript via `invokeMethod()`, the raw Task/ValueTask object gets serialized, producing misleading JSON errors like:

- `"SerializeTypeInstanceNotSupported, System.Action"`
- `"ConstructorContainsNullParameterNames, System.Threading.Tasks.Task'1"`

These errors make debugging difficult as they are unrelated to the actual problem.

### Changes

**`DotNetDispatcher.cs`** -  In the `Invoke()` method (sync code path), added a check after `InvokeSynchronously()` returns to detect async return types (`Task`, `ValueTask`, `ValueTask<T>`). When detected, throws an `InvalidOperationException` with a clear message:

> *"The method 'MethodName' returns an asynchronous type and cannot be invoked synchronously from JavaScript. Use 'invokeMethodAsync' instead of 'invokeMethod'."*

**`DotNetDispatcherTest.cs`** - Added 2 tests and 1 test helper:
- `SyncInvokeOfAsyncMethod_Task_ThrowsMeaningfulException`
- `SyncInvokeOfAsyncMethod_ValueTask_ThrowsMeaningfulException`
- `InvokableAsyncReturningTask()` - simple `[JSInvokable]` test method

### Test results

All 148 JSInterop tests pass with 0 failures.

## Test plan

- [x] `SyncInvokeOfAsyncMethod_Task` - verifies Task-returning methods throw clear error
- [x] `SyncInvokeOfAsyncMethod_ValueTask` - verifies ValueTask-returning methods throw clear error
- [x] Full JSInterop test suite passes (148/148)
