### PR TITLE
[blazor][wasm] optimize async JS interop via async JSImport/JSExport

### DIFF
--- a/src/Components/Web.JS/src/Boot.WebAssembly.Common.ts
+++ b/src/Components/Web.JS/src/Boot.WebAssembly.Common.ts
@@ -100,7 +100,7 @@ async function startCore(components: RootComponentManager<WebAssemblyComponentDe
 
   // Configure JS interop
   Blazor._internal.invokeJSJson = invokeJSJson;
-  Blazor._internal.endInvokeDotNetFromJS = endInvokeDotNetFromJS;
+  Blazor._internal.invokeJSJsonAsync = invokeJSJsonAsync;
   Blazor._internal.receiveWebAssemblyDotNetDataStream = receiveWebAssemblyDotNetDataStream;
   Blazor._internal.receiveByteArray = receiveByteArray;
 
@@ -254,17 +254,12 @@ async function scheduleAfterStarted(operations: string, webAssemblyState: string
   Blazor._internal.updateRootComponents(operations, webAssemblyState);
 }
 
-function invokeJSJson(identifier: string, targetInstanceId: number, resultType: number, argsJson: string, asyncHandle: number, callType: number): string | null {
-  if (asyncHandle !== 0) {
-    dispatcher.beginInvokeJSFromDotNet(asyncHandle, identifier, argsJson, resultType, targetInstanceId, callType);
-    return null;
-  } else {
-    return dispatcher.invokeJSFromDotNet(identifier, argsJson, resultType, targetInstanceId, callType);
-  }
+function invokeJSJson(identifier: string, targetInstanceId: number, resultType: number, argsJson: string, callType: number): string | null {
+  return dispatcher.invokeJSFromDotNet(identifier, argsJson, resultType, targetInstanceId, callType);
 }
 
-function endInvokeDotNetFromJS(callId: string, success: boolean, resultJsonOrErrorMessage: string): void {
-  dispatcher.endInvokeDotNetFromJS(callId, success, resultJsonOrErrorMessage);
+function invokeJSJsonAsync(identifier: string, targetInstanceId: number, resultType: number, argsJson: string, callType: number): Promise<string | null> {
+  return dispatcher.invokeJSFromDotNetAsync(identifier, argsJson, resultType, targetInstanceId, callType);
 }
 
 function receiveWebAssemblyDotNetDataStream(streamId: number, data: Uint8Array, bytesRead: number, errorMessage: string): void {

--- a/src/Components/Web.JS/src/GlobalExports.ts
+++ b/src/Components/Web.JS/src/GlobalExports.ts
@@ -57,8 +57,8 @@ export interface IBlazor {
     forceCloseConnection?: () => Promise<void>;
     InputFile?: typeof InputFile;
     NavigationLock: typeof NavigationLock;
-    invokeJSJson?: (identifier: string, targetInstanceId: number, resultType: number, argsJson: string, asyncHandle: number, callType: number) => string | null;
-    endInvokeDotNetFromJS?: (callId: string, success: boolean, resultJsonOrErrorMessage: string) => void;
+    invokeJSJson?: (identifier: string, targetInstanceId: number, resultType: number, argsJson: string, callType: number) => string | null;
+    invokeJSJsonAsync?: (identifier: string, targetInstanceId: number, resultType: number, argsJson: string, callType: number) => Promise<string | null>;
     receiveByteArray?: (id: number, data: Uint8Array) => void;
     getPersistedState?: () => string;
     getInitialComponentsUpdate?: () => Promise<string>;
@@ -89,8 +89,8 @@ export interface IBlazor {
     // JSExport APIs
     dotNetExports?: {
       InvokeDotNet: (assemblyName: string | null, methodIdentifier: string, dotNetObjectId: number, argsJson: string) => string | null;
+      InvokeDotNetAsync: (assemblyName: string | null, methodIdentifier: string, dotNetObjectId: number, argsJson: string) => Promise<string | null>;
       EndInvokeJS: (argsJson: string) => void;
-      BeginInvokeDotNet: (callId: string | null, assemblyNameOrDotNetObjectId: string, methodIdentifier: string, argsJson: string) => void;
       ReceiveByteArrayFromJS: (id: number, data: Uint8Array) => void;
       UpdateRootComponentsCore: (operationsJson: string, appState: string) => void;
     }

--- a/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
@@ -263,25 +263,13 @@ function getArrayDataPointer<T>(array: System_Array<T>): number {
 function attachInteropInvoker(): void {
   dispatcher = DotNet.attachDispatcher({
     beginInvokeDotNetFromJS: (callId: number, assemblyName: string | null, methodIdentifier: string, dotNetObjectId: any | null, argsJson: string): void => {
-      assertHeapIsNotLocked();
-      if (!dotNetObjectId && !assemblyName) {
-        throw new Error('Either assemblyName or dotNetObjectId must have a non null value.');
-      }
-      // As a current limitation, we can only pass 4 args. Fortunately we only need one of
-      // 'assemblyName' or 'dotNetObjectId', so overload them in a single slot
-      const assemblyNameOrDotNetObjectId: string = dotNetObjectId
-        ? dotNetObjectId.toString()
-        : assemblyName;
-
-      Blazor._internal.dotNetExports!.BeginInvokeDotNet!(
-        callId ? callId.toString() : null,
-        assemblyNameOrDotNetObjectId,
-        methodIdentifier,
-        argsJson,
-      );
+      // This method exists to satisfy the DotNetCallDispatcher interface but should not be called
+      // when invokeDotNetFromJSAsync is available. The async path uses InvokeDotNetAsync (JSExport)
+      // which returns a Promise directly, bypassing the begin/end callback pattern.
+      throw new Error('beginInvokeDotNetFromJS should not be called when invokeDotNetFromJSAsync is available.');
     },
-    endInvokeJSFromDotNet: (asyncHandle, succeeded, serializedArgs): void => {
-      Blazor._internal.dotNetExports!.EndInvokeJS(serializedArgs);
+    endInvokeJSFromDotNet: (_asyncHandle, _succeeded, _serializedArgs): void => {
+      // No-op: .NET→JS async results now flow via Promise→Task (InvokeJSJsonAsync).
     },
     sendByteArray: (id: number, data: Uint8Array): void => {
       Blazor._internal.dotNetExports!.ReceiveByteArrayFromJS(id, data);
@@ -294,6 +282,15 @@ function attachInteropInvoker(): void {
         dotNetObjectId ?? 0,
         argsJson,
       ) as string;
+    },
+    invokeDotNetFromJSAsync: (assemblyName, methodIdentifier, dotNetObjectId, argsJson) => {
+      assertHeapIsNotLocked();
+      return Blazor._internal.dotNetExports!.InvokeDotNetAsync(
+        assemblyName ? assemblyName : null,
+        methodIdentifier,
+        dotNetObjectId ?? 0,
+        argsJson,
+      );
     },
   });
 }

--- a/src/Components/WebAssembly/JSInterop/src/InternalCalls.cs
+++ b/src/Components/WebAssembly/JSInterop/src/InternalCalls.cs
@@ -13,14 +13,15 @@ internal static partial class InternalCalls
         [JSMarshalAs<JSType.Number>] long targetInstanceId,
         int resultType,
         string argsJson,
-        [JSMarshalAs<JSType.Number>] long asyncHandle,
         int callType);
 
-    [JSImport("Blazor._internal.endInvokeDotNetFromJS", "blazor-internal")]
-    public static partial void EndInvokeDotNetFromJS(
-        string? id,
-        bool success,
-        string jsonOrError);
+    [JSImport("Blazor._internal.invokeJSJsonAsync", "blazor-internal")]
+    public static partial Task<string?> InvokeJSJsonAsync(
+        string identifier,
+        [JSMarshalAs<JSType.Number>] long targetInstanceId,
+        int resultType,
+        string argsJson,
+        int callType);
 
     [JSImport("Blazor._internal.receiveByteArray", "blazor-internal")]
     public static partial void ReceiveByteArray(

--- a/src/Components/WebAssembly/JSInterop/src/PublicAPI.Unshipped.txt
+++ b/src/Components/WebAssembly/JSInterop/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+*REMOVED*override Microsoft.JSInterop.WebAssembly.WebAssemblyJSRuntime.BeginInvokeJS(in Microsoft.JSInterop.Infrastructure.JSInvocationInfo invocationInfo) -> void
+override Microsoft.JSInterop.WebAssembly.WebAssemblyJSRuntime.InvokeJSAsync(in Microsoft.JSInterop.Infrastructure.JSInvocationInfo invocationInfo) -> System.Threading.Tasks.Task<string?>?

--- a/src/Components/WebAssembly/JSInterop/src/WebAssemblyJSRuntime.cs
+++ b/src/Components/WebAssembly/JSInterop/src/WebAssemblyJSRuntime.cs
@@ -30,7 +30,6 @@ public abstract class WebAssemblyJSRuntime : JSInProcessRuntime
             targetInstanceId,
             (int)resultType,
             argsJson ?? "[]",
-            0,
             (int)JSCallType.FunctionCall
         );
     }
@@ -45,7 +44,6 @@ public abstract class WebAssemblyJSRuntime : JSInProcessRuntime
                 invocationInfo.TargetInstanceId,
                 (int)invocationInfo.ResultType,
                 invocationInfo.ArgsJson,
-                invocationInfo.AsyncHandle,
                 (int)invocationInfo.CallType
             );
         }
@@ -58,37 +56,28 @@ public abstract class WebAssemblyJSRuntime : JSInProcessRuntime
     /// <inheritdoc />
     protected override void BeginInvokeJS(long asyncHandle, string identifier, [StringSyntax(StringSyntaxAttribute.Json)] string? argsJson, JSCallResultType resultType, long targetInstanceId)
     {
-        InternalCalls.InvokeJSJson(
-            identifier,
-            targetInstanceId,
-            (int)resultType,
-            argsJson ?? "[]",
-            asyncHandle,
-            (int)JSCallType.FunctionCall
-        );
+        // Dead code: async JS calls now use InvokeJSAsync (direct Promise→Task path).
+        // This override is only retained because the base class declares it as abstract.
+        throw new NotSupportedException();
     }
 
     /// <inheritdoc />
-    protected override void BeginInvokeJS(in JSInvocationInfo invocationInfo)
+    protected override Task<string?>? InvokeJSAsync(in JSInvocationInfo invocationInfo)
     {
-        InternalCalls.InvokeJSJson(
+        return InternalCalls.InvokeJSJsonAsync(
             invocationInfo.Identifier,
             invocationInfo.TargetInstanceId,
             (int)invocationInfo.ResultType,
             invocationInfo.ArgsJson,
-            invocationInfo.AsyncHandle,
-            (int)invocationInfo.CallType
-        );
+            (int)invocationInfo.CallType);
     }
 
     /// <inheritdoc />
-    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "TODO: This should be in the xml suppressions file, but can't be because https://github.com/mono/linker/issues/2006")]
     protected override void EndInvokeDotNet(DotNetInvocationInfo callInfo, in DotNetInvocationResult dispatchResult)
     {
-        var resultJsonOrErrorMessage = dispatchResult.Success
-            ? dispatchResult.ResultJson!
-            : dispatchResult.Exception!.ToString();
-        InternalCalls.EndInvokeDotNetFromJS(callInfo.CallId, dispatchResult.Success, resultJsonOrErrorMessage);
+        // This is intentionally a no-op for WebAssembly. The JS→.NET async invocation path uses
+        // InvokeDotNetAsync (JSExport returning Task<string?>) which completes via Promise resolution,
+        // bypassing the begin/end callback pattern.
     }
 
     /// <inheritdoc />

--- a/src/Components/WebAssembly/WebAssembly/src/Services/DefaultWebAssemblyJSRuntime.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Services/DefaultWebAssemblyJSRuntime.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Runtime.InteropServices.JavaScript;
 using System.Runtime.Versioning;
 using System.Text.Json;

--- a/src/Components/WebAssembly/WebAssembly/src/Services/DefaultWebAssemblyJSRuntime.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Services/DefaultWebAssemblyJSRuntime.cs
@@ -27,8 +27,8 @@ internal sealed partial class DefaultWebAssemblyJSRuntime : WebAssemblyJSRuntime
     public event Action<RootComponentOperationBatch, string>? OnUpdateRootComponents;
 
     [DynamicDependency(nameof(InvokeDotNet))]
+    [DynamicDependency(nameof(InvokeDotNetAsync))]
     [DynamicDependency(nameof(EndInvokeJS))]
-    [DynamicDependency(nameof(BeginInvokeDotNet))]
     [DynamicDependency(nameof(ReceiveByteArrayFromJS))]
     [DynamicDependency(nameof(UpdateRootComponentsCore))]
     [DynamicDependency(JsonSerialized, typeof(KeyValuePair<,>))]
@@ -66,31 +66,54 @@ internal sealed partial class DefaultWebAssemblyJSRuntime : WebAssemblyJSRuntime
 
     [JSExport]
     [SupportedOSPlatform("browser")]
-    public static void BeginInvokeDotNet(string? callId, string assemblyNameOrDotNetObjectId, string methodIdentifier, string argsJson)
+    public static Task<string?> InvokeDotNetAsync(
+        string? assemblyName,
+        string methodIdentifier,
+        [JSMarshalAs<JSType.Number>] long dotNetObjectId,
+        string argsJson)
     {
-        // Figure out whether 'assemblyNameOrDotNetObjectId' is the assembly name or the instance ID
-        // We only need one for any given call. This helps to work around the limitation that we can
-        // only pass a maximum of 4 args in a call from JS to Mono WebAssembly.
-        string? assemblyName;
-        long dotNetObjectId;
-        if (char.IsDigit(assemblyNameOrDotNetObjectId[0]))
+        var tcs = new TaskCompletionSource<string?>();
+        WebAssemblyCallQueue.Schedule((tcs, assemblyName, methodIdentifier, dotNetObjectId, argsJson), static s =>
         {
-            dotNetObjectId = long.Parse(assemblyNameOrDotNetObjectId, CultureInfo.InvariantCulture);
-            assemblyName = null;
-        }
-        else
-        {
-            dotNetObjectId = default;
-            assemblyName = assemblyNameOrDotNetObjectId;
-        }
+            try
+            {
+                var callInfo = new DotNetInvocationInfo(s.assemblyName, s.methodIdentifier, s.dotNetObjectId, callId: null);
+                var task = DotNetDispatcher.InvokeAsync(Instance, callInfo, s.argsJson);
 
-        var callInfo = new DotNetInvocationInfo(assemblyName, methodIdentifier, dotNetObjectId, callId);
-        WebAssemblyCallQueue.Schedule((callInfo, argsJson), static state =>
-        {
-            // This is not expected to throw, as it takes care of converting any unhandled user code
-            // exceptions into a failure on the JS Promise object.
-            DotNetDispatcher.BeginInvokeDotNet(Instance, state.callInfo, state.argsJson);
+                if (task.IsCompletedSuccessfully)
+                {
+                    s.tcs.TrySetResult(task.Result);
+                }
+                else
+                {
+                    task.ContinueWith(static (t, state) =>
+                    {
+                        var tcs = (TaskCompletionSource<string?>)state!;
+                        if (t.IsFaulted)
+                        {
+                            // Use ToString() as the message so the JSExport marshaller includes
+                            // the exception type name, matching the old BeginInvokeDotNet error format.
+                            var baseEx = t.Exception!.GetBaseException();
+                            tcs.TrySetException(new InvalidOperationException(baseEx.ToString()));
+                        }
+                        else if (t.IsCanceled)
+                        {
+                            tcs.TrySetCanceled();
+                        }
+                        else
+                        {
+                            tcs.TrySetResult(t.Result);
+                        }
+                    }, s.tcs, TaskScheduler.Current);
+                }
+            }
+            catch (Exception ex)
+            {
+                s.tcs.TrySetException(new InvalidOperationException(ex.ToString()));
+            }
         });
+
+        return tcs.Task;
     }
 
     [SupportedOSPlatform("browser")]

--- a/src/Components/test/E2ETest/Infrastructure/ServerFixtures/BasicTestAppServerSiteFixture.cs
+++ b/src/Components/test/E2ETest/Infrastructure/ServerFixtures/BasicTestAppServerSiteFixture.cs
@@ -1,10 +1,17 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Reflection;
+
 namespace Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 
 public class BasicTestAppServerSiteFixture<TStartup> : AspNetSiteServerFixture where TStartup : class
 {
+    public readonly bool TestTrimmedOrMultithreadingApps = typeof(BasicTestAppServerSiteFixture<>).Assembly
+        .GetCustomAttributes<AssemblyMetadataAttribute>()
+        .First(m => m.Key == "Microsoft.AspNetCore.E2ETesting.TestTrimmedOrMultithreadingApps")
+        .Value == "true";
+
     public BasicTestAppServerSiteFixture()
     {
         ApplicationAssembly = typeof(TStartup).Assembly;

--- a/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts
+++ b/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts
@@ -65,14 +65,14 @@ export module DotNet {
       }
   }
 
-   /**
-   * Represents the type of operation that should be performed in JS.
-   */
+  /**
+  * Represents the type of operation that should be performed in JS.
+  */
   export enum JSCallType {
-      FunctionCall = 1,
-      ConstructorCall = 2,
-      GetValue = 3,
-      SetValue = 4
+    FunctionCall = 1,
+    ConstructorCall = 2,
+    GetValue = 3,
+    SetValue = 4
   }
 
   const windowJSObjectId = 0;
@@ -81,16 +81,18 @@ export module DotNet {
   };
 
   const windowObject = cachedJSObjectsById[windowJSObjectId];
-  windowObject._cachedHandlers.set("import", { [JSCallType.FunctionCall]: (url: any) => {
+  windowObject._cachedHandlers.set("import", {
+      [JSCallType.FunctionCall]: (url: any) => {
       // In most cases developers will want to resolve dynamic imports relative to the base HREF.
       // However since we're the one calling the import keyword, they would be resolved relative to
       // this framework bundle URL. Fix this by providing an absolute URL.
-      if (typeof url === "string" && url.startsWith("./")) {
-          url = new URL(url.substring(2), document.baseURI).toString();
-      }
+          if (typeof url === "string" && url.startsWith("./")) {
+              url = new URL(url.substring(2), document.baseURI).toString();
+          }
 
-      return import(/* webpackIgnore: true */ url);
-  }});
+          return import(/* webpackIgnore: true */ url);
+      }
+  });
 
   let nextJsObjectId = 1; // Start at 1 because zero is reserved for "window"
 
@@ -312,6 +314,18 @@ export module DotNet {
     endInvokeJSFromDotNet(callId: number, succeeded: boolean, resultOrError: any): void;
 
     /**
+     * Optional. If implemented, invoked by the runtime to perform an asynchronous call to a .NET method,
+     * returning the result directly as a Promise instead of using the begin/end callback pattern.
+     *
+     * @param assemblyName The short name (without key/version or .dll extension) of the .NET assembly holding the method to invoke. The value may be null when invoking instance methods.
+     * @param methodIdentifier The identifier of the method to invoke. The method must have a [JSInvokable] attribute specifying this identifier.
+     * @param dotNetObjectId If given, the call will be to an instance method on the specified DotNetObject. Pass null or undefined to call static methods.
+     * @param argsJson JSON representation of arguments to pass to the method.
+     * @returns A promise containing the JSON representation of the result of the invocation.
+     */
+    invokeDotNetFromJSAsync?(assemblyName: string | null, methodIdentifier: string, dotNetObjectId: number | null, argsJson: string): Promise<string | null>;
+
+    /**
      * Invoked by the runtime to transfer a byte array from JS to .NET.
      * @param id The identifier for the byte array used during revival.
      * @param data The byte array being transferred for eventual revival.
@@ -346,6 +360,19 @@ export module DotNet {
      * @param callType The type of operation that should be performed in JS.
      */
     beginInvokeJSFromDotNet(asyncHandle: number, identifier: string, argsJson: string | null, resultType: JSCallResultType, targetInstanceId: number, callType: JSCallType): Promise<any>;
+
+    /**
+     * Invokes the specified asynchronous JavaScript function, returning the serialized
+     * result directly as a Promise instead of using the begin/end callback pattern.
+     *
+     * @param identifier Identifies the globally-reachable function to invoke.
+     * @param argsJson JSON representation of arguments to be passed to the function.
+     * @param resultType The type of result expected from the JS interop call.
+     * @param targetInstanceId The instance ID of the target JS object.
+     * @param callType The type of operation that should be performed in JS.
+     * @returns A Promise containing the JSON serialized result of the invocation.
+     */
+    invokeJSFromDotNetAsync(identifier: string, argsJson: string | null, resultType: JSCallResultType, targetInstanceId: number, callType: JSCallType): Promise<string | null>;
 
     /**
      * Receives notification that an async call from JS to .NET has completed.
@@ -446,6 +473,16 @@ export module DotNet {
           }
       }
 
+      // this is WASM fast path called by JSImport
+      async invokeJSFromDotNetAsync(identifier: string, argsJson: string | null, resultType: JSCallResultType, targetInstanceId: number, callType: JSCallType): Promise<string | null> {
+          const result = await this.processJSCall(targetInstanceId, identifier, callType, argsJson);
+          const jsCallResult = createJSCallResult(result, resultType);
+
+          return jsCallResult === null || jsCallResult === undefined
+              ? null
+              : stringifyArgs(this, jsCallResult);
+      }
+
       processJSCall(targetInstanceId: number, identifier: string, callType: JSCallType, argsJson: string | null) {
           const args = parseJsonWithRevivers(this, argsJson) ?? [];
           const func = findJSFunction(identifier, targetInstanceId, callType);
@@ -482,13 +519,20 @@ export module DotNet {
               throw new Error(`For instance method calls, assemblyName should be null. Received '${assemblyName}'.`);
           }
 
+          const argsJson = stringifyArgs(this, args);
+
+          // this is WASM fast path calling into JSExport
+          if (this._dotNetCallDispatcher.invokeDotNetFromJSAsync) {
+              return this._dotNetCallDispatcher.invokeDotNetFromJSAsync(assemblyName, methodIdentifier, dotNetObjectId, argsJson)
+                  .then(resultJson => (resultJson ? parseJsonWithRevivers(this, resultJson) as T : null as unknown as T));
+          }
+
           const asyncCallId = this._nextAsyncCallId++;
           const resultPromise = new Promise<T>((resolve, reject) => {
               this._pendingAsyncCalls[asyncCallId] = { resolve, reject };
           });
 
           try {
-              const argsJson = stringifyArgs(this, args);
               this._dotNetCallDispatcher.beginInvokeDotNetFromJS(asyncCallId, assemblyName, methodIdentifier, dotNetObjectId, argsJson);
           } catch (ex) {
               // Synchronous failure

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
@@ -65,6 +65,60 @@ public static class DotNetDispatcher
     }
 
     /// <summary>
+    /// Receives a call from JS to .NET, locating and invoking the specified method.
+    /// If the target method returns a <see cref="Task"/> or <see cref="ValueTask"/>,
+    /// the result is awaited and the serialized result is returned asynchronously.
+    /// </summary>
+    /// <param name="jsRuntime">The <see cref="JSRuntime"/>.</param>
+    /// <param name="invocationInfo">The <see cref="DotNetInvocationInfo"/>.</param>
+    /// <param name="argsJson">A JSON representation of the parameters.</param>
+    /// <returns>A task representing the JSON-serialized return value, or null.</returns>
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "We expect application code is configured to ensure return types of JSInvokable methods are retained.")]
+    public static Task<string?> InvokeAsync(JSRuntime jsRuntime, in DotNetInvocationInfo invocationInfo, [StringSyntax(StringSyntaxAttribute.Json)] string argsJson)
+    {
+        IDotNetObjectReference? targetInstance = default;
+        if (invocationInfo.DotNetObjectId != default)
+        {
+            targetInstance = jsRuntime.GetObjectReference(invocationInfo.DotNetObjectId);
+        }
+
+        var syncResult = InvokeSynchronously(jsRuntime, invocationInfo, targetInstance, argsJson);
+
+        if (syncResult is null)
+        {
+            return Task.FromResult<string?>(null);
+        }
+
+        if (syncResult is Task task)
+        {
+            return AwaitAndSerializeTaskResult(task, jsRuntime);
+        }
+
+        if (syncResult is ValueTask valueTask)
+        {
+            return AwaitAndSerializeTaskResult(valueTask.AsTask(), jsRuntime);
+        }
+
+        if (syncResult.GetType() is { IsGenericType: true } resultType
+            && resultType.GetGenericTypeDefinition() == typeof(ValueTask<>))
+        {
+            var innerTask = GetTaskByType(resultType.GenericTypeArguments[0], syncResult);
+            return AwaitAndSerializeTaskResult(innerTask!, jsRuntime);
+        }
+
+        return Task.FromResult<string?>(JsonSerializer.Serialize(syncResult, jsRuntime.JsonSerializerOptions));
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "We expect application code is configured to ensure return types of JSInvokable methods are retained.")]
+    private static async Task<string?> AwaitAndSerializeTaskResult(Task task, JSRuntime jsRuntime)
+    {
+        await task;
+        var result = TaskGenericsUtil.GetTaskResult(task);
+
+        return result is null ? null : JsonSerializer.Serialize(result, jsRuntime.JsonSerializerOptions);
+    }
+
+    /// <summary>
     /// Receives a call from JS to .NET, locating and invoking the specified method asynchronously.
     /// </summary>
     /// <param name="jsRuntime">The <see cref="JSRuntime"/>.</param>
@@ -141,11 +195,19 @@ public static class DotNetDispatcher
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "We expect application code is configured to ensure return types of JSInvokable methods are retained.")]
     private static void EndInvokeDotNetAfterTask(Task task, JSRuntime jsRuntime, in DotNetInvocationInfo invocationInfo)
     {
-        if (task.Exception != null)
+        if (task.IsFaulted)
         {
-            var exceptionDispatchInfo = ExceptionDispatchInfo.Capture(task.Exception.GetBaseException());
+            var exceptionDispatchInfo = ExceptionDispatchInfo.Capture(task.Exception!.GetBaseException());
             var dispatchResult = new DotNetInvocationResult(exceptionDispatchInfo.SourceException, "InvocationFailure");
             jsRuntime.EndInvokeDotNet(invocationInfo, dispatchResult);
+            return;
+        }
+
+        if (task.IsCanceled)
+        {
+            var dispatchResult = new DotNetInvocationResult(new TaskCanceledException(task), "InvocationFailure");
+            jsRuntime.EndInvokeDotNet(invocationInfo, dispatchResult);
+            return;
         }
 
         var result = TaskGenericsUtil.GetTaskResult(task);

--- a/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
@@ -128,6 +128,28 @@ public abstract partial class JSRuntime : IJSRuntime, IDisposable
         CancellationToken cancellationToken,
         object?[]? args)
     {
+        var argsJson = args is not null && args.Length != 0 ? JsonSerializer.Serialize(args, JsonSerializerOptions) : "[]";
+        var resultType = JSCallResultTypeHelper.FromGeneric<TValue>();
+
+        if (OperatingSystem.IsBrowser())
+        {
+            return InvokeJSAsyncWasm<TValue>(targetInstanceId, identifier, callType, resultType, argsJson, cancellationToken);
+        }
+        else
+        {
+            return BeginInvokeJSAsync<TValue>(targetInstanceId, identifier, callType, resultType, argsJson, cancellationToken);
+        }
+    }
+
+    private ValueTask<TValue> BeginInvokeJSAsync<[DynamicallyAccessedMembers(JsonSerialized)] TValue>(
+        long targetInstanceId,
+        string identifier,
+        JSCallType callType,
+        JSCallResultType resultType,
+        string argsJson,
+        CancellationToken cancellationToken)
+    {
+        // Fall back to the begin/end callback pattern (Server, WebView)
         var taskId = Interlocked.Increment(ref _nextPendingTaskId);
         var tcs = new TaskCompletionSource<TValue>();
         if (cancellationToken.CanBeCanceled)
@@ -150,8 +172,6 @@ public abstract partial class JSRuntime : IJSRuntime, IDisposable
                 return new ValueTask<TValue>(tcs.Task);
             }
 
-            var argsJson = args is not null && args.Length != 0 ? JsonSerializer.Serialize(args, JsonSerializerOptions) : "[]";
-            var resultType = JSCallResultTypeHelper.FromGeneric<TValue>();
             var invocationInfo = new JSInvocationInfo
             {
                 AsyncHandle = taskId,
@@ -170,6 +190,54 @@ public abstract partial class JSRuntime : IJSRuntime, IDisposable
         {
             CleanupTasksAndRegistrations(taskId);
             throw;
+        }
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "We expect application code is configured to ensure JS interop arguments are linker friendly.")]
+    private async ValueTask<TValue> InvokeJSAsyncWasm<[DynamicallyAccessedMembers(JsonSerialized)] TValue>(
+        long targetInstanceId,
+        string identifier,
+        JSCallType callType,
+        JSCallResultType resultType,
+        string argsJson,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        try
+        {
+            var invocationInfo = new JSInvocationInfo
+            {
+                AsyncHandle = 0,
+                TargetInstanceId = targetInstanceId,
+                Identifier = identifier,
+                CallType = callType,
+                ResultType = resultType,
+                ArgsJson = argsJson,
+            };
+
+            var json = await InvokeJSAsync(invocationInfo)!;
+            if (json is null)
+            {
+                return default!;
+            }
+
+            return JsonSerializer.Deserialize<TValue>(json, JsonSerializerOptions)!;
+        }
+        catch (JSException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // The JSImport marshaller may prefix JS error messages with "Error: ".
+            // Strip this prefix to match the format produced by the begin/end callback path.
+            var message = ex.Message;
+            if (message.StartsWith("Error: ", StringComparison.Ordinal))
+            {
+                message = message["Error: ".Length..];
+            }
+
+            throw new JSException(message, ex);
         }
     }
 
@@ -210,6 +278,23 @@ public abstract partial class JSRuntime : IJSRuntime, IDisposable
     {
         BeginInvokeJS(invocationInfo.AsyncHandle, invocationInfo.Identifier, invocationInfo.ArgsJson, invocationInfo.ResultType, invocationInfo.TargetInstanceId);
     }
+
+    /// <summary>
+    /// Invokes the specified JavaScript function asynchronously, returning the JSON-serialized result
+    /// directly as a <see cref="Task{TResult}"/> instead of using the begin/end callback pattern.
+    /// </summary>
+    /// <param name="invocationInfo">Configuration of the interop call from .NET to JavaScript.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> representing the JSON-serialized result of the JS function call,
+    /// or <c>null</c> to fall back to the <see cref="BeginInvokeJS(in JSInvocationInfo)"/> callback pattern.
+    /// </returns>
+    /// <remarks>
+    /// The default implementation returns <c>null</c>, which causes the base class to use the
+    /// begin/end callback pattern with <see cref="BeginInvokeJS(in JSInvocationInfo)"/>.
+    /// Runtimes that support direct Promise-to-Task marshalling (e.g., WebAssembly via JSImport)
+    /// can override this to eliminate the callback round-trip.
+    /// </remarks>
+    protected virtual Task<string?>? InvokeJSAsync(in JSInvocationInfo invocationInfo) => null;
 
     /// <summary>
     /// Completes an async JS interop call from JavaScript to .NET

--- a/src/JSInterop/Microsoft.JSInterop/src/PublicAPI.Unshipped.txt
+++ b/src/JSInterop/Microsoft.JSInterop/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+static Microsoft.JSInterop.Infrastructure.DotNetDispatcher.InvokeAsync(Microsoft.JSInterop.JSRuntime! jsRuntime, in Microsoft.JSInterop.Infrastructure.DotNetInvocationInfo invocationInfo, string! argsJson) -> System.Threading.Tasks.Task<string?>!
+virtual Microsoft.JSInterop.JSRuntime.InvokeJSAsync(in Microsoft.JSInterop.Infrastructure.JSInvocationInfo invocationInfo) -> System.Threading.Tasks.Task<string?>?


### PR DESCRIPTION
# Replace begin/end callback pattern with direct Promise↔Task JS interop on WebAssembly

## Summary

This PR replaces the `BeginInvokeJS` / `EndInvokeJS` and `BeginInvokeDotNet` / `EndInvokeDotNet` callback-based async interop pattern on WebAssembly with direct Promise↔Task marshalling via JSImport/JSExport. The server and WebView paths are unchanged.

## Motivation

The existing async JS interop on WebAssembly uses a two-step callback pattern:

1. **.NET→JS**: `BeginInvokeJS` dispatches a call with an `asyncHandle`, JS executes the function, then calls back into .NET via `EndInvokeJS` with the serialized result.
2. **JS→.NET**: JS calls `BeginInvokeDotNet` with a `callId`, .NET executes the method, then calls back into JS via `endInvokeDotNetFromJS` with the result.

Each async interop call requires two cross-boundary transitions. On WebAssembly, where JS and .NET share a single thread and JSImport/JSExport natively support `Task`↔`Promise` marshalling, this round-trip is unnecessary overhead.

## Changes

### .NET→JS async calls (`InvokeAsync<T>`)

- Added `JSRuntime.InvokeJSAsync(in JSInvocationInfo)` — a new virtual method that returns `Task<string?>` directly. The default implementation returns `null` (meaning: fall back to `BeginInvokeJS`).
- `WebAssemblyJSRuntime` overrides `InvokeJSAsync` to call a new `[JSImport] InvokeJSJsonAsync` that returns a `Task<string?>` marshalled from the JS Promise.
- `JSRuntime.InvokeAsync<T>` uses `OperatingSystem.IsBrowser()` (a JIT intrinsic compiled away on each platform) to select the direct path on WASM or the begin/end path elsewhere.
- On the JS side, `invokeJSJsonAsync` calls `processJSCall`, awaits the result, serializes it, and returns it — no `asyncHandle` bookkeeping needed.

### JS→.NET async calls (`invokeMethodAsync`)

- Added `DotNetDispatcher.InvokeAsync` — a new public method that invokes the target `[JSInvokable]` method and, if it returns a Task/ValueTask, awaits and serializes the result into a `Task<string?>`.
- Added `[JSExport] InvokeDotNetAsync` on `DefaultWebAssemblyJSRuntime` that calls `DotNetDispatcher.InvokeAsync` and returns the `Task<string?>` directly to JS as a Promise.
- On the JS side, when the dispatcher has `invokeDotNetFromJSAsync` available, `invokeDotNetMethodAsync` calls it directly and deserializes the resolved Promise value — no `asyncCallId` / `endInvokeDotNetFromJS` bookkeeping needed.
- `BeginInvokeDotNet` / `endInvokeDotNetFromJS` are no longer called on WebAssembly. `beginInvokeDotNetFromJS` in MonoPlatform throws if called (defensive guard). `endInvokeJSFromDotNet` is a no-op.

### Cleanup

- Removed the `asyncHandle` parameter from `InvokeJSJson` (sync path only).
- Removed `InternalCalls.EndInvokeDotNetFromJS` — replaced by `InvokeJSJsonAsync`.
- `WebAssemblyJSRuntime.EndInvokeDotNet` is now a no-op (async JS→.NET results flow via Promise resolution).
- `WebAssemblyJSRuntime.BeginInvokeJS(long, string, string, ...)` throws `NotSupportedException` (retained only because the base class declares it abstract).

## Performance wins

- **Eliminates one cross-boundary round-trip per async interop call** in both directions. Each async .NET→JS and JS→.NET call previously required two managed↔JS transitions (begin + end); now each requires only one.
- **Removes per-call dictionary bookkeeping**: the `_pendingAsyncCalls` map in JS and `_pendingTasks` `ConcurrentDictionary` in .NET are no longer used on the WASM path. No allocation for the async handle, no dictionary insert/lookup/remove per call.
- **Reduces allocations**: no `TaskCompletionSource<T>` or `CancellationTokenRegistration` created in `JSRuntime` for the WASM path — the JSImport marshaller provides the `Task` directly.
- **Removes string encoding overhead for call IDs**: the old JS→.NET path packed `assemblyName` or `dotNetObjectId` into a single string parameter (workaround for the 4-arg JSExport limit) and parsed it back with `long.Parse`. The new path passes typed parameters directly.

## Public API changes

```
// Microsoft.JSInterop
+static Microsoft.JSInterop.Infrastructure.DotNetDispatcher.InvokeAsync(
    Microsoft.JSInterop.JSRuntime jsRuntime,
    in Microsoft.JSInterop.Infrastructure.DotNetInvocationInfo invocationInfo,
    string argsJson) -> Task<string?>

+virtual Microsoft.JSInterop.JSRuntime.InvokeJSAsync(
    in Microsoft.JSInterop.Infrastructure.JSInvocationInfo invocationInfo) -> Task<string?>?

// Microsoft.AspNetCore.Components.WebAssembly.JSInterop
*REMOVED* override WebAssemblyJSRuntime.BeginInvokeJS(in JSInvocationInfo) -> void
+override WebAssemblyJSRuntime.InvokeJSAsync(in JSInvocationInfo) -> Task<string?>?
```
