### PR TITLE
Quarantine RazorBuildTest flaky tests (issue #56553)

### DIFF
--- a/src/Mvc/test/Mvc.FunctionalTests/RazorBuildTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RazorBuildTest.cs
@@ -102,6 +102,7 @@ public class RazorBuildTest : LoggedTest
 
     [Fact]
     [LogLevel(LogLevel.Trace)]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/56553")]
     public async Task RazorViews_AreUpdatedOnChange()
     {
         // Arrange
@@ -140,6 +141,7 @@ public class RazorBuildTest : LoggedTest
 
     [Fact]
     [LogLevel(LogLevel.Trace)]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/56553")]
     public async Task RazorPages_AreUpdatedOnChange()
     {
         // Arrange


### PR DESCRIPTION
## Problem

Tests in `RazorBuildTest` were unquarantined in #65864 after appearing stable for 30+ days. However, they are still failing intermittently across unrelated PRs.

Evidence of failure:
- #65885 — [Helix x64 Subset 2 failed](https://dev.azure.com/dnceng-public/cbb18261-c48f-4abb-8651-8cdcb5474649/_build/results?buildId=1348183&view=logs&jobId=20c8654b-a0e9-54f4-572b-eb62886e678e) (build 1348183)

This PR touches a completely different area (Blazor WASM web workers), confirming the failure is a test infrastructure issue.

## Fix

Re-quarantine the 2 test methods in `RazorBuildTest` that were unquarantined in #65864:
- `RazorViews_AreUpdatedOnChange`
- `RazorPages_AreUpdatedOnChange`

The 2 tests in `RazorRuntimeCompilationHostingStartupTest` were already re-quarantined in #65881.

Tracked by https://github.com/dotnet/aspnetcore/issues/56553