### PR TITLE
Fix preserving %2F at HTTP/1 absolute-form request

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -673,7 +673,7 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
             // uri.LocalPath, which decodes %2F to '/' breaking path canonicalization.
             const int MaxPathBufferStackAllocSize = 256;
 
-            var absolutePath = uri!.AbsolutePath;
+            var absolutePath = uri.AbsolutePath;
             byte[]? rentedBuffer = null;
             Span<byte> pathBuffer = absolutePath.Length <= MaxPathBufferStackAllocSize
                 ? (stackalloc byte[MaxPathBufferStackAllocSize])
@@ -683,7 +683,7 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
             try
             {
                 Encoding.ASCII.GetBytes(absolutePath, pathBufferSliced);
-                Path = _parsedPath = PathDecoder.DecodePath(pathBufferSliced, targetPath.IsEncoded, absolutePath, query.Length);
+                Path = _parsedPath = PathDecoder.DecodePath(pathBufferSliced, targetPath.IsEncoded, absolutePath, queryLength: 0);
             }
             catch (InvalidOperationException)
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -674,7 +674,7 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
             const int MaxPathBufferStackAllocSize = 256;
 
             var absolutePath = uri!.AbsolutePath;
-            byte[] rentedBuffer = null!;
+            byte[]? rentedBuffer = null;
             Span<byte> pathBuffer = absolutePath.Length <= MaxPathBufferStackAllocSize
                 ? (stackalloc byte[MaxPathBufferStackAllocSize])
                 : (rentedBuffer = ArrayPool<byte>.Shared.Rent(absolutePath.Length));
@@ -684,6 +684,10 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
             {
                 Encoding.ASCII.GetBytes(absolutePath, pathBufferSliced);
                 Path = _parsedPath = PathDecoder.DecodePath(pathBufferSliced, targetPath.IsEncoded, absolutePath, query.Length);
+            }
+            catch (InvalidOperationException)
+            {
+                ThrowRequestTargetRejected(target);
             }
             finally
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -4,6 +4,7 @@
 using System.Buffers;
 using System.Diagnostics;
 using System.IO.Pipelines;
+using System.Text;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Http;
@@ -667,7 +668,20 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
             }
 
             _absoluteRequestTarget = _parsedAbsoluteRequestTarget = uri;
-            Path = _parsedPath = uri.LocalPath;
+
+            // Use the same path decoding as origin-form to ensure consistent
+            // canonicalization behavior. uri.LocalPath decodes %2F to '/' which
+            // differs from the origin-form path handling that preserves %2F.
+            // uri.AbsolutePath preserves percent-encoding, so we convert it to
+            // bytes and run it through PathDecoder.DecodePath for consistency.
+            var absolutePath = uri!.AbsolutePath;
+            var absolutePathLength = absolutePath.Length;
+            Span<byte> pathBuffer = absolutePathLength <= 256
+                ? stackalloc byte[absolutePathLength]
+                : new byte[absolutePathLength];
+            Encoding.ASCII.GetBytes(absolutePath, pathBuffer);
+            Path = _parsedPath = PathDecoder.DecodePath(pathBuffer, targetPath.IsEncoded, absolutePath, query.Length);
+
             // don't use uri.Query because we need the unescaped version
             previousValue = _parsedQueryString;
             if (disableStringReuse ||

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -4,6 +4,7 @@
 using System.Buffers;
 using System.Diagnostics;
 using System.IO.Pipelines;
+using System.Text;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Http;
@@ -667,7 +668,17 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
             }
 
             _absoluteRequestTarget = _parsedAbsoluteRequestTarget = uri;
-            Path = _parsedPath = uri.LocalPath;
+
+            // Use PathDecoder.DecodePath (same as origin-form and HTTP/2/3) instead of
+            // uri.LocalPath, which decodes %2F to '/' breaking path canonicalization.
+            var absolutePath = uri!.AbsolutePath;
+            const int MaxPathBufferStackAllocSize = 256;
+            Span<byte> pathBuffer = absolutePath.Length <= MaxPathBufferStackAllocSize
+                ? stackalloc byte[MaxPathBufferStackAllocSize].Slice(0, absolutePath.Length)
+                : new byte[absolutePath.Length];
+            Encoding.ASCII.GetBytes(absolutePath, pathBuffer);
+            Path = _parsedPath = PathDecoder.DecodePath(pathBuffer, targetPath.IsEncoded, absolutePath, query.Length);
+
             // don't use uri.Query because we need the unescaped version
             previousValue = _parsedQueryString;
             if (disableStringReuse ||

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -671,13 +671,27 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
 
             // Use PathDecoder.DecodePath (same as origin-form and HTTP/2/3) instead of
             // uri.LocalPath, which decodes %2F to '/' breaking path canonicalization.
-            var absolutePath = uri!.AbsolutePath;
             const int MaxPathBufferStackAllocSize = 256;
+
+            var absolutePath = uri!.AbsolutePath;
+            byte[] rentedBuffer = null!;
             Span<byte> pathBuffer = absolutePath.Length <= MaxPathBufferStackAllocSize
-                ? stackalloc byte[MaxPathBufferStackAllocSize].Slice(0, absolutePath.Length)
-                : new byte[absolutePath.Length];
-            Encoding.ASCII.GetBytes(absolutePath, pathBuffer);
-            Path = _parsedPath = PathDecoder.DecodePath(pathBuffer, targetPath.IsEncoded, absolutePath, query.Length);
+                ? (stackalloc byte[MaxPathBufferStackAllocSize])
+                : (rentedBuffer = ArrayPool<byte>.Shared.Rent(absolutePath.Length));
+            var pathBufferSliced = pathBuffer[..absolutePath.Length];
+
+            try
+            {
+                Encoding.ASCII.GetBytes(absolutePath, pathBufferSliced);
+                Path = _parsedPath = PathDecoder.DecodePath(pathBufferSliced, targetPath.IsEncoded, absolutePath, query.Length);
+            }
+            finally
+            {
+                if (rentedBuffer is not null)
+                {
+                    ArrayPool<byte>.Shared.Return(rentedBuffer);
+                }
+            }
 
             // don't use uri.Query because we need the unescaped version
             previousValue = _parsedQueryString;

--- a/src/Servers/Kestrel/Core/test/StartLineTests.cs
+++ b/src/Servers/Kestrel/Core/test/StartLineTests.cs
@@ -183,6 +183,8 @@ public class StartLineTests : IDisposable
     [InlineData("/?q=123&w=xyz", "/", "?q=123&w=xyz")]
     [InlineData("/path?q=123&w=xyz", "/path", "?q=123&w=xyz")]
     [InlineData("/path%20with%20space?q=abc%20123", "/path with space", "?q=abc%20123")]
+    [InlineData("/a%2Fb", "/a%2Fb", "")]
+    [InlineData("/a%2Fb?q=1", "/a%2Fb", "?q=1")]
     public void OriginForms(string rawTarget, string path, string query)
     {
         Http1Connection.Reset();
@@ -277,6 +279,8 @@ public class StartLineTests : IDisposable
     [InlineData("http://localhost/?q=123&w=xyz", "/", "?q=123&w=xyz")]
     [InlineData("http://localhost/path?q=123&w=xyz", "/path", "?q=123&w=xyz")]
     [InlineData("http://localhost/path%20with%20space?q=abc%20123", "/path with space", "?q=abc%20123")]
+    [InlineData("http://localhost/a%2Fb", "/a%2Fb", "")]
+    [InlineData("http://localhost/a%2Fb?q=1", "/a%2Fb", "?q=1")]
     public void AbsoluteForms(string rawTarget, string path, string query)
     {
         Http1Connection.Reset();


### PR DESCRIPTION
Fixes an inconsistency in HTTP/1.1 request-target parsing where `%2F` in the path produces different 
HttpRequest.Path values depending on the request-target form:

| Request | Before | After |
| --- | --- | --- |
| GET /a%2Fb (origin-form) | /a%2Fb | /a%2Fb |
| GET http://host/a%2Fb (absolute-form)| /a/b | /a%2Fb |