### PR TITLE
[Virtualization] Visible content does not shift when in-DOM items above the viewport change height

### DIFF
--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -157,8 +157,8 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
         anchoredItems.set(el, newHeight);
 
         if (oldHeight !== undefined && oldHeight !== newHeight) {
-          // Compensate only if the element is entirely above the viewport.
-          if (el.getBoundingClientRect().bottom <= containerTop) {
+          // Compensate if the element starts above the viewport (fully or partially above).
+          if (el.getBoundingClientRect().top < containerTop) {
             scrollDelta += (newHeight - oldHeight);
           }
         }

--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -49,18 +49,26 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     return;
   }
 
-  // Overflow anchoring can cause an ongoing scroll loop, because when we resize the spacers, the browser
-  // would update the scroll position to compensate. Then the spacer would remain visible and we'd keep on
-  // trying to resize it.
   const scrollContainer = findClosestScrollContainer(spacerBefore);
   const scrollElement = scrollContainer || document.documentElement;
-  scrollElement.style.overflowAnchor = 'none';
+  const isTable = isValidTableElement(spacerAfter.parentElement);
+  const supportsAnchor = CSS.supports('overflow-anchor', 'auto');
+  const useNativeAnchoring = !isTable && supportsAnchor;
 
   const rangeBetweenSpacers = document.createRange();
 
-  if (isValidTableElement(spacerAfter.parentElement)) {
+  if (isTable) {
     spacerBefore.style.display = 'table-row';
     spacerAfter.style.display = 'table-row';
+  }
+
+  if (useNativeAnchoring) {
+    // Applied to rendered items - keeps viewport stable when spacer heights change.
+    spacerBefore.style.overflowAnchor = 'none';
+    spacerAfter.style.overflowAnchor = 'none';
+  } else {
+    // Manual compensation path for tables and browsers without native anchoring.
+    scrollElement.style.overflowAnchor = 'none';
   }
 
   const intersectionObserver = new IntersectionObserver(intersectionCallback, {
@@ -73,6 +81,12 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
 
   const anchoredItems: Map<Element, number> = new Map();
 
+  // Track whether the current render was triggered by scrolling (IntersectionObserver
+  // → C# recalculates → render). During scroll-triggered renders, observing table items
+  // with ResizeObserver causes layout interference that creates scroll drift. We only
+  // observe items during data-triggered renders (dynamic content changes).
+  let scrollTriggeredRender = false;
+
   function getObservedHeight(entry: ResizeObserverEntry): number {
     return entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height;
   }
@@ -80,8 +94,9 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
   // ResizeObserver roles:
   //  1. Always observes both spacers so that when a spacer resizes we re-trigger the
   //     IntersectionObserver — which otherwise won't fire again for an element that is already visible.
-  //  2. For convergence (sticky-top/bottom) - drives the scroll position to top/bottom.
-  //  3. Viewport anchoring - compensates scroll position when content above the viewport resizes.
+  //  2. Viewport anchoring — compensates scroll position when content above the viewport resizes.
+  //     When native anchoring is available (non-table + supported browser), the browser handles this.
+  //     Otherwise (tables, Safari), we use manual compensation via item height tracking.
   const resizeObserver = new ResizeObserver((entries: ResizeObserverEntry[]): void => {
     // 1. Re-trigger IntersectionObserver for spacer resizes.
     for (const entry of entries) {
@@ -94,17 +109,7 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
       }
     }
 
-    // 2. Convergence: pin scroll to top/bottom while items load.
-    if (convergingToBottom || convergingToTop) {
-      scrollElement.scrollTop = convergingToBottom ? scrollElement.scrollHeight : 0;
-      const spacer = convergingToBottom ? spacerAfter : spacerBefore;
-      if (spacer.offsetHeight === 0) {
-        convergingToBottom = convergingToTop = false;
-      }
-      return; // Skip scroll compensation during convergence.
-    }
-
-    // 3. Viewport anchoring: compensate scroll for above-viewport item changes.
+    // 2. Viewport anchoring: compensate scroll for above-viewport item resizes.
     let scrollDelta = 0;
     const containerTop = scrollContainer
       ? scrollContainer.getBoundingClientRect().top
@@ -124,7 +129,7 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
         anchoredItems.set(el, newHeight);
 
         if (oldHeight !== undefined && oldHeight !== newHeight) {
-          // Compensate if the element starts above the viewport (fully or partially above).
+          // Compensate if the element is above the viewport (fully or partially).
           if (el.getBoundingClientRect().top < containerTop) {
             scrollDelta += (newHeight - oldHeight);
           }
@@ -142,18 +147,35 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
   resizeObserver.observe(spacerAfter);
 
   function refreshObservedElements(): void {
-    // C# style updates overwrite the entire style attribute, losing display: table-row.
-    // Re-apply it so spacers participate in table layout alongside bare <tr> items.
-    if (isValidTableElement(spacerAfter.parentElement)) {
+    // C# style updates overwrite the entire style attribute. Re-apply what we need.
+    if (isTable) {
       spacerBefore.style.display = 'table-row';
       spacerAfter.style.display = 'table-row';
+    }
+
+    if (useNativeAnchoring) {
+      // Re-apply overflow-anchor: none on spacers after C# re-renders.
+      spacerBefore.style.overflowAnchor = 'none';
+      spacerAfter.style.overflowAnchor = 'none';
     }
 
     // Ensure spacers are always observed (idempotent).
     resizeObserver.observe(spacerBefore);
     resizeObserver.observe(spacerAfter);
 
-    // Always observe all rendered items for viewport anchoring. When an item
+    // Item observation for manual scroll compensation:
+    // - When using native anchoring: browser handles above-viewport resizes
+    //   automatically. Observing items here would cause double compensation.
+    // - When using manual compensation (tables + unsupported browsers): observe items
+    //   so the ResizeObserver can compensate scrollTop. But only during data-triggered
+    //   renders — observing during scroll-triggered renders causes layout interference.
+    if (useNativeAnchoring || scrollTriggeredRender) {
+      scrollTriggeredRender = false;
+      return;
+    }
+    scrollTriggeredRender = false;
+
+    // Observe all rendered items for viewport anchoring. When an item
     // resizes above the viewport, the ResizeObserver callback compensates scrollTop.
     const currentItems = new Set<Element>();
     for (let el = spacerBefore.nextElementSibling; el && el !== spacerAfter; el = el.nextElementSibling) {
@@ -168,29 +190,7 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
         anchoredItems.delete(el);
       }
     }
-
-    // Don't re-trigger IntersectionObserver here — ResizeObserver handles that
-    // when spacers actually resize. Doing it on every render causes feedback loops.
   }
-
-  let convergingToBottom = false;
-  let convergingToTop = false;
-
-  let pendingJumpToEnd = false;
-  let pendingJumpToStart = false;
-
-  const keydownTarget: EventTarget = scrollContainer || document;
-  function handleJumpKeys(e: Event): void {
-    const ke = e as KeyboardEvent;
-    if (ke.key === 'End') {
-      pendingJumpToEnd = true;
-      pendingJumpToStart = false;
-    } else if (ke.key === 'Home') {
-      pendingJumpToStart = true;
-      pendingJumpToEnd = false;
-    }
-  }
-  keydownTarget.addEventListener('keydown', handleJumpKeys);
 
   const { observersByDotNetObjectId, id } = getObserversMapEntry(dotNetHelper);
   let pendingCallbacks: Map<Element, IntersectionObserverEntry> = new Map();
@@ -204,7 +204,6 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     onDispose: () => {
       anchoredItems.clear();
       resizeObserver.disconnect();
-      keydownTarget.removeEventListener('keydown', handleJumpKeys);
       if (callbackTimeout) {
         clearTimeout(callbackTimeout);
         callbackTimeout = null;
@@ -233,66 +232,13 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     }
   }
 
-  function onSpacerAfterVisible(): void {
-    if (spacerAfter.offsetHeight === 0) {
-      if (convergingToBottom) {
-        convergingToBottom = false;
-      }
-      return;
-    }
-    if (convergingToBottom) return;
-
-    const atBottom = scrollElement.scrollTop + scrollElement.clientHeight >= scrollElement.scrollHeight - 1;
-    if (!atBottom && !pendingJumpToEnd) return;
-
-    convergingToBottom = true;
-    if (pendingJumpToEnd) {
-      scrollElement.scrollTop = scrollElement.scrollHeight;
-      pendingJumpToEnd = false;
-    }
-  }
-
-  function onSpacerBeforeVisible(): void {
-    if (spacerBefore.offsetHeight === 0) {
-      if (convergingToTop) {
-        convergingToTop = false;
-      }
-      return;
-    }
-    if (convergingToTop) return;
-
-    const atTop = scrollElement.scrollTop < 1;
-    if (!atTop && !pendingJumpToStart) return;
-
-    convergingToTop = true;
-    if (pendingJumpToStart) {
-      scrollElement.scrollTop = 0;
-      pendingJumpToStart = false;
-    }
-  }
-
   function processIntersectionEntries(entries: IntersectionObserverEntry[]): void {
     // Check if the spacers are still in the DOM. They may have been removed if the component was disposed.
     if (!spacerBefore.isConnected || !spacerAfter.isConnected) {
       return;
     }
 
-    const intersectingEntries = entries.filter(entry => {
-      if (entry.isIntersecting) {
-        if (entry.target === spacerAfter) {
-          onSpacerAfterVisible();
-        } else if (entry.target === spacerBefore) {
-          onSpacerBeforeVisible();
-        }
-        return true;
-      }
-      if (entry.target === spacerAfter && convergingToBottom && spacerAfter.offsetHeight > 0) {
-        scrollElement.scrollTop = scrollElement.scrollHeight;
-      } else if (entry.target === spacerBefore && convergingToTop && spacerBefore.offsetHeight > 0) {
-        scrollElement.scrollTop = 0;
-      }
-      return false;
-    });
+    const intersectingEntries = entries.filter(entry => entry.isIntersecting);
 
     if (intersectingEntries.length === 0) {
       return;
@@ -306,6 +252,10 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
 
     intersectingEntries.forEach((entry): void => {
       const containerSize = (entry.rootBounds?.height ?? 0) / scaleFactor;
+
+      // Mark the upcoming render as scroll-triggered so refreshObservedElements
+      // skips item observation for tables (avoids layout interference drift).
+      scrollTriggeredRender = true;
 
       if (entry.target === spacerBefore) {
         const spacerSize = (entry.intersectionRect.top - entry.boundingClientRect.top) / scaleFactor;

--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -81,6 +81,8 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
 
   const anchoredItems: Map<Element, number> = new Map();
   let scrollTriggeredRender = false;
+  let isConverging = false;
+  let scrollToBottomPending = false;
 
   function getObservedHeight(entry: ResizeObserverEntry): number {
     return entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height;
@@ -149,9 +151,16 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     }
 
     if (useNativeAnchoring) {
-      // Re-apply overflow-anchor: none on spacers after C# re-renders.
       spacerBefore.style.overflowAnchor = 'none';
       spacerAfter.style.overflowAnchor = 'none';
+
+      if (isConverging && !scrollToBottomPending) {
+        isConverging = false;
+      }
+      scrollToBottomPending = false;
+
+      // Prevent browser anchoring fighting with convergence.
+      scrollElement.style.overflowAnchor = isConverging ? 'none' : '';
     }
 
     // Ensure spacers are always observed (idempotent).
@@ -192,6 +201,10 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     resizeObserver,
     refreshObservedElements,
     scrollElement,
+    setConverging(converging: boolean, pending: boolean) {
+      isConverging = converging;
+      scrollToBottomPending = pending;
+    },
     onDispose: () => {
       anchoredItems.clear();
       resizeObserver.disconnect();
@@ -275,6 +288,7 @@ function scrollToBottom(dotNetHelper: DotNet.DotNetObject): void {
   const { observersByDotNetObjectId, id } = getObserversMapEntry(dotNetHelper);
   const entry = observersByDotNetObjectId[id];
   if (entry) {
+    entry.setConverging(true, true);
     entry.scrollElement.scrollTop = entry.scrollElement.scrollHeight;
   }
 }

--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -159,9 +159,6 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     for (let el = spacerBefore.nextElementSibling; el && el !== spacerAfter; el = el.nextElementSibling) {
       resizeObserver.observe(el);
       currentItems.add(el);
-      if (!anchoredItems.has(el)) {
-        anchoredItems.set(el, (el as HTMLElement).offsetHeight);
-      }
     }
 
     // Unobserve items removed during re-render and clean up height tracking.

--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -80,11 +80,6 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
   intersectionObserver.observe(spacerAfter);
 
   const anchoredItems: Map<Element, number> = new Map();
-
-  // Track whether the current render was triggered by scrolling (IntersectionObserver
-  // → C# recalculates → render). During scroll-triggered renders, observing table items
-  // with ResizeObserver causes layout interference that creates scroll drift. We only
-  // observe items during data-triggered renders (dynamic content changes).
   let scrollTriggeredRender = false;
 
   function getObservedHeight(entry: ResizeObserverEntry): number {
@@ -163,12 +158,8 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     resizeObserver.observe(spacerBefore);
     resizeObserver.observe(spacerAfter);
 
-    // Item observation for manual scroll compensation:
-    // - When using native anchoring: browser handles above-viewport resizes
-    //   automatically. Observing items here would cause double compensation.
-    // - When using manual compensation (tables + unsupported browsers): observe items
-    //   so the ResizeObserver can compensate scrollTop. But only during data-triggered
-    //   renders — observing during scroll-triggered renders causes layout interference.
+    // - Native anchoring: browser handles above-viewport resizes automatically.
+    // - Manual compensation: observe items on data-triggered renders to compensate.
     if (useNativeAnchoring || scrollTriggeredRender) {
       scrollTriggeredRender = false;
       return;

--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -120,6 +120,23 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
       }
     }
 
+    // During convergence, any item resize should re-scroll to the target
+    // extremity. This mirrors what the old code did — the ResizeObserver drives
+    // convergence by keeping scrollTop pinned while items load and resize.
+    if (convergingToEnd || convergingToStart) {
+      if (convergingToEnd) {
+        scrollElement.scrollTop = scrollElement.scrollHeight;
+      } else {
+        scrollElement.scrollTop = 0;
+      }
+      const spacer = convergingToEnd ? spacerAfter : spacerBefore;
+      if (spacer.offsetHeight < 1) {
+        console.log(`[Virtualize:ResizeObs] convergence complete — spacer height=0`);
+        convergingToEnd = convergingToStart = false;
+      }
+      return;
+    }
+
     // 2. Viewport anchoring: compensate scroll for above-viewport item resizes.
     let scrollDelta = 0;
     const containerTop = scrollContainer
@@ -181,6 +198,16 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
 
       const isConverging = convergingToEnd || convergingToStart;
       scrollElement.style.overflowAnchor = isConverging ? 'none' : '';
+
+      if (convergingToEnd) {
+        console.log(`[Virtualize:refresh] convergingToEnd: scrolling to bottom (scrollTop ${scrollElement.scrollTop} → ${scrollElement.scrollHeight})`);
+        scrollElement.scrollTop = scrollElement.scrollHeight;
+      }
+      if (convergingToStart) {
+        console.log(`[Virtualize:refresh] convergingToStart: scrolling to top (scrollTop ${scrollElement.scrollTop} → 0)`);
+        scrollElement.scrollTop = 0;
+      }
+
       console.log(`[Virtualize:refresh] convergingToEnd=${convergingToEnd}, convergingToStart=${convergingToStart}, overflowAnchor=${scrollElement.style.overflowAnchor}, scrollTop=${scrollElement.scrollTop}, scrollHeight=${scrollElement.scrollHeight}, clientHeight=${scrollElement.clientHeight}, spacerAfter.h=${spacerAfter.offsetHeight}, spacerBefore.h=${spacerBefore.offsetHeight}`);
     }
 
@@ -190,14 +217,17 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
 
     // - Native anchoring: browser handles above-viewport resizes automatically.
     // - Manual compensation: observe items on data-triggered renders to compensate.
-    if (useNativeAnchoring || scrollTriggeredRender) {
+    // - During convergence: observe items so ResizeObserver can drive re-scrolling.
+    const isConvergingNow = convergingToEnd || convergingToStart;
+    if ((useNativeAnchoring && !isConvergingNow) || scrollTriggeredRender) {
       scrollTriggeredRender = false;
       return;
     }
     scrollTriggeredRender = false;
 
-    // Observe all rendered items for viewport anchoring. When an item
-    // resizes above the viewport, the ResizeObserver callback compensates scrollTop.
+    // Observe all rendered items. During normal manual-compensation mode, the
+    // ResizeObserver callback compensates scrollTop. During convergence, it
+    // re-scrolls to the target extremity.
     const currentItems = new Set<Element>();
     for (let el = spacerBefore.nextElementSibling; el && el !== spacerAfter; el = el.nextElementSibling) {
       resizeObserver.observe(el);

--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -82,13 +82,41 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
   let convergingElements = false;
   let convergenceItems: Set<Element> = new Set();
 
-  // Manual scroll compensation state — tracks item heights so we can adjust scrollTop
-  // when above-viewport items resize. Only used when native anchoring is unavailable.
   const anchoredItems: Map<Element, number> = new Map();
   let scrollTriggeredRender = false;
 
   function getObservedHeight(entry: ResizeObserverEntry): number {
     return entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height;
+  }
+
+  function compensateScrollForItemResizes(entries: ResizeObserverEntry[]): void {
+    let scrollDelta = 0;
+    const containerTop = scrollContainer
+      ? scrollContainer.getBoundingClientRect().top
+      : 0;
+
+    for (const entry of entries) {
+      if (entry.target === spacerBefore || entry.target === spacerAfter) {
+        continue;
+      }
+
+      if (entry.target.isConnected) {
+        const el = entry.target as HTMLElement;
+        const oldHeight = anchoredItems.get(el);
+        const newHeight = getObservedHeight(entry);
+        anchoredItems.set(el, newHeight);
+
+        if (oldHeight !== undefined && oldHeight !== newHeight) {
+          if (el.getBoundingClientRect().top < containerTop) {
+            scrollDelta += (newHeight - oldHeight);
+          }
+        }
+      }
+    }
+
+    if (scrollDelta !== 0 && scrollElement.scrollTop > 0) {
+      scrollElement.scrollTop += scrollDelta;
+    }
   }
 
   // ResizeObserver roles:
@@ -115,41 +143,13 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
         convergingToBottom = convergingToTop = false;
         stopConvergenceObserving();
       }
-      return;
     } else if (convergingElements) {
       stopConvergenceObserving();
     }
 
-    // Manual scroll compensation: adjust scrollTop for above-viewport item resizes.
-    // When native anchoring is available, the browser handles this automatically.
+    // Manual scroll compensation: adjust scrollTop for above-viewport resizes.
     if (!useNativeAnchoring) {
-      let scrollDelta = 0;
-      const containerTop = scrollContainer
-        ? scrollContainer.getBoundingClientRect().top
-        : 0;
-
-      for (const entry of entries) {
-        if (entry.target === spacerBefore || entry.target === spacerAfter) {
-          continue;
-        }
-
-        if (entry.target.isConnected) {
-          const el = entry.target as HTMLElement;
-          const oldHeight = anchoredItems.get(el);
-          const newHeight = getObservedHeight(entry);
-          anchoredItems.set(el, newHeight);
-
-          if (oldHeight !== undefined && oldHeight !== newHeight) {
-            if (el.getBoundingClientRect().top < containerTop) {
-              scrollDelta += (newHeight - oldHeight);
-            }
-          }
-        }
-      }
-
-      if (scrollDelta !== 0 && scrollElement.scrollTop > 0) {
-        scrollElement.scrollTop += scrollDelta;
-      }
+      compensateScrollForItemResizes(entries);
     }
   });
 
@@ -216,6 +216,9 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
   function startConvergenceObserving(): void {
     if (convergingElements) return;
     convergingElements = true;
+    if (useNativeAnchoring) {
+      scrollElement.style.overflowAnchor = 'none';
+    }
     for (let el = spacerBefore.nextElementSibling; el && el !== spacerAfter; el = el.nextElementSibling) {
       resizeObserver.observe(el);
       convergenceItems.add(el);
@@ -241,35 +244,23 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
   let pendingJumpToEnd = false;
   let pendingJumpToStart = false;
 
-  function startConvergence(toBottom: boolean): void {
-    if (toBottom) {
-      if (convergingToBottom || spacerAfter.offsetHeight === 0) return;
-      convergingToBottom = true;
-    } else {
-      if (convergingToTop || spacerBefore.offsetHeight === 0) return;
-      convergingToTop = true;
-    }
-    startConvergenceObserving();
-    if (useNativeAnchoring) {
-      scrollElement.style.overflowAnchor = 'none';
-    }
-  }
-
-  // Detect End/Home key presses to begin convergence immediately, before the
-  // browser's scroll position updates. With native CSS scroll anchoring enabled,
-  // the browser may prevent scrollTop from reaching the absolute extremity, so
-  // the IO-based detection in onSpacerAfterVisible alone is not sufficient.
   const keydownTarget: EventTarget = scrollContainer || document;
   function handleJumpKeys(e: Event): void {
     const ke = e as KeyboardEvent;
     if (ke.key === 'End') {
       pendingJumpToEnd = true;
       pendingJumpToStart = false;
-      startConvergence(true);
+      if (!convergingToBottom && spacerAfter.offsetHeight > 0) {
+        convergingToBottom = true;
+        startConvergenceObserving();
+      }
     } else if (ke.key === 'Home') {
       pendingJumpToStart = true;
       pendingJumpToEnd = false;
-      startConvergence(false);
+      if (!convergingToTop && spacerBefore.offsetHeight > 0) {
+        convergingToTop = true;
+        startConvergenceObserving();
+      }
     }
   }
   keydownTarget.addEventListener('keydown', handleJumpKeys);
@@ -283,7 +274,8 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     resizeObserver,
     refreshObservedElements,
     scrollElement,
-    startConvergence,
+    startConvergenceObserving,
+    setConvergingToBottom: () => { convergingToBottom = true; },
     onDispose: () => {
       stopConvergenceObserving();
       anchoredItems.clear();
@@ -330,7 +322,8 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     const atBottom = scrollElement.scrollTop + scrollElement.clientHeight >= scrollElement.scrollHeight - 1;
     if (!atBottom && !pendingJumpToEnd) return;
 
-    startConvergence(true);
+    convergingToBottom = true;
+    startConvergenceObserving();
     if (pendingJumpToEnd) {
       scrollElement.scrollTop = scrollElement.scrollHeight;
       pendingJumpToEnd = false;
@@ -350,7 +343,8 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     const atTop = scrollElement.scrollTop < 1;
     if (!atTop && !pendingJumpToStart) return;
 
-    startConvergence(false);
+    convergingToTop = true;
+    startConvergenceObserving();
     if (pendingJumpToStart) {
       scrollElement.scrollTop = 0;
       pendingJumpToStart = false;
@@ -393,8 +387,7 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     intersectingEntries.forEach((entry): void => {
       const containerSize = (entry.rootBounds?.height ?? 0) / scaleFactor;
 
-      // Mark the upcoming render as scroll-triggered so refreshObservedElements
-      // skips item observation (avoids layout interference drift).
+      // So that RefreshObservedElements can skip item observation (avoids layout interference drift).
       scrollTriggeredRender = true;
 
       if (entry.target === spacerBefore) {
@@ -424,8 +417,9 @@ function scrollToBottom(dotNetHelper: DotNet.DotNetObject): void {
   const { observersByDotNetObjectId, id } = getObserversMapEntry(dotNetHelper);
   const entry = observersByDotNetObjectId[id];
   if (entry) {
-    entry.startConvergence?.(true);
+    entry.setConvergingToBottom?.();
     entry.scrollElement.scrollTop = entry.scrollElement.scrollHeight;
+    entry.startConvergenceObserving?.();
   }
 }
 

--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -82,8 +82,21 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
 
   const anchoredItems: Map<Element, number> = new Map();
   let scrollTriggeredRender = false;
-  let isConverging = false;
-  let scrollToBottomPending = false;
+
+  let convergingToEnd = false;
+  let convergingToStart = false;
+
+  scrollElement.addEventListener('scroll', () => {
+    const remaining = scrollElement.scrollHeight - scrollElement.scrollTop - scrollElement.clientHeight;
+    if (remaining < 1 && spacerAfter.offsetHeight > 0) {
+      console.log(`[Virtualize:scroll] At bottom, spacerAfter=${spacerAfter.offsetHeight} → convergingToEnd=true`);
+      convergingToEnd = true;
+    }
+    if (scrollElement.scrollTop < 1 && spacerBefore.offsetHeight > 0) {
+      console.log(`[Virtualize:scroll] At top, spacerBefore=${spacerBefore.offsetHeight} → convergingToStart=true`);
+      convergingToStart = true;
+    }
+  }, { passive: true });
 
   function getObservedHeight(entry: ResizeObserverEntry): number {
     return entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height;
@@ -135,8 +148,8 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
       }
     }
 
-    if (scrollDelta !== 0 && scrollElement.scrollTop > 0 && !isConverging) {
-      console.log(`[Virtualize:ResizeObs] scrollDelta=${scrollDelta}, scrollTop=${scrollElement.scrollTop}, isConverging=${isConverging}`);
+    if (scrollDelta !== 0 && scrollElement.scrollTop > 0 && !convergingToEnd && !convergingToStart) {
+      console.log(`[Virtualize:ResizeObs] scrollDelta=${scrollDelta}, scrollTop=${scrollElement.scrollTop}`);
       scrollElement.scrollTop += scrollDelta;
     }
   });
@@ -156,14 +169,19 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
       spacerBefore.style.overflowAnchor = 'none';
       spacerAfter.style.overflowAnchor = 'none';
 
-      if (isConverging && !scrollToBottomPending) {
-        isConverging = false;
+      // Clear convergence flags once the target spacer reaches zero height.
+      if (convergingToEnd && spacerAfter.offsetHeight < 1) {
+        console.log('[Virtualize:refresh] convergingToEnd complete — spacerAfter=0');
+        convergingToEnd = false;
       }
-      scrollToBottomPending = false;
+      if (convergingToStart && spacerBefore.offsetHeight < 1) {
+        console.log('[Virtualize:refresh] convergingToStart complete — spacerBefore=0');
+        convergingToStart = false;
+      }
 
-      // Prevent browser anchoring fighting with convergence.
+      const isConverging = convergingToEnd || convergingToStart;
       scrollElement.style.overflowAnchor = isConverging ? 'none' : '';
-      console.log(`[Virtualize:refresh] isConverging=${isConverging}, scrollTop=${scrollElement.scrollTop}, scrollHeight=${scrollElement.scrollHeight}, clientHeight=${scrollElement.clientHeight}, spacerAfter.h=${spacerAfter.offsetHeight}, spacerBefore.h=${spacerBefore.offsetHeight}, anchor=${scrollElement.style.overflowAnchor}`);
+      console.log(`[Virtualize:refresh] convergingToEnd=${convergingToEnd}, convergingToStart=${convergingToStart}, overflowAnchor=${scrollElement.style.overflowAnchor}, scrollTop=${scrollElement.scrollTop}, scrollHeight=${scrollElement.scrollHeight}, clientHeight=${scrollElement.clientHeight}, spacerAfter.h=${spacerAfter.offsetHeight}, spacerBefore.h=${spacerBefore.offsetHeight}`);
     }
 
     // Ensure spacers are always observed (idempotent).
@@ -204,10 +222,6 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     resizeObserver,
     refreshObservedElements,
     scrollElement,
-    setConverging(converging: boolean, pending: boolean) {
-      isConverging = converging;
-      scrollToBottomPending = pending;
-    },
     onDispose: () => {
       anchoredItems.clear();
       resizeObserver.disconnect();
@@ -266,14 +280,12 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
 
       if (entry.target === spacerBefore) {
         const spacerSize = (entry.intersectionRect.top - entry.boundingClientRect.top) / scaleFactor;
-        console.log(`[Virtualize:IO] spacerBefore visible, spacerSize=${spacerSize.toFixed(1)}, scrollTop=${scrollElement.scrollTop}`);
         dotNetHelper.invokeMethodAsync('OnSpacerBeforeVisible', spacerSize, spacerSeparation, containerSize);
       } else if (entry.target === spacerAfter && spacerAfter.offsetHeight > 0) {
         // When we first start up, both the "before" and "after" spacers will be visible, but it's only relevant to raise a
         // single event to load the initial data. To avoid raising two events, skip the one for the "after" spacer if we know
         // it's meaningless to talk about any overlap into it.
         const spacerSize = (entry.boundingClientRect.bottom - entry.intersectionRect.bottom) / scaleFactor;
-        console.log(`[Virtualize:IO] spacerAfter visible, spacerSize=${spacerSize.toFixed(1)}, offsetHeight=${spacerAfter.offsetHeight}, scrollTop=${scrollElement.scrollTop}`);
         dotNetHelper.invokeMethodAsync('OnSpacerAfterVisible', spacerSize, spacerSeparation, containerSize);
       }
     });
@@ -293,11 +305,7 @@ function scrollToBottom(dotNetHelper: DotNet.DotNetObject): void {
   const { observersByDotNetObjectId, id } = getObserversMapEntry(dotNetHelper);
   const entry = observersByDotNetObjectId[id];
   if (entry) {
-    const el = entry.scrollElement;
-    console.log(`[Virtualize:scrollToBottom] before: scrollTop=${el.scrollTop}, scrollHeight=${el.scrollHeight}`);
-    entry.setConverging(true, true);
     entry.scrollElement.scrollTop = entry.scrollElement.scrollHeight;
-    console.log(`[Virtualize:scrollToBottom] after: scrollTop=${el.scrollTop}`);
   }
 }
 

--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -104,14 +104,19 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
   intersectionObserver.observe(spacerBefore);
   intersectionObserver.observe(spacerAfter);
 
-  let convergingElements = false;
-  let convergenceItems: Set<Element> = new Set();
+  const anchoredItems: Map<Element, number> = new Map();
 
- // ResizeObserver roles:
+  function getObservedHeight(entry: ResizeObserverEntry): number {
+    return entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height;
+  }
+
+  // ResizeObserver roles:
   //  1. Always observes both spacers so that when a spacer resizes we re-trigger the
   //     IntersectionObserver — which otherwise won't fire again for an element that is already visible.
-  //  2. For convergence (sticky-top/bottom) - observes elements for geometry changes, drives the scroll position.
+  //  2. For convergence (sticky-top/bottom) - drives the scroll position to top/bottom.
+  //  3. Viewport anchoring - compensates scroll position when content above the viewport resizes.
   const resizeObserver = new ResizeObserver((entries: ResizeObserverEntry[]): void => {
+    // 1. Re-trigger IntersectionObserver for spacer resizes.
     for (const entry of entries) {
       if (entry.target === spacerBefore || entry.target === spacerAfter) {
         const spacer = entry.target as HTMLElement;
@@ -122,16 +127,46 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
       }
     }
 
-    // Convergence logic: keep scroll pinned to top/bottom while items load.
+    // 2. Convergence: pin scroll to top/bottom while items load.
     if (convergingToBottom || convergingToTop) {
       scrollElement.scrollTop = convergingToBottom ? scrollElement.scrollHeight : 0;
       const spacer = convergingToBottom ? spacerAfter : spacerBefore;
       if (spacer.offsetHeight === 0) {
         convergingToBottom = convergingToTop = false;
-        stopConvergenceObserving();
       }
-    } else if (convergingElements) {
-      stopConvergenceObserving();
+      return; // Skip scroll compensation during convergence.
+    }
+
+    // 3. Viewport anchoring: compensate scroll for above-viewport item changes.
+    let scrollDelta = 0;
+    const containerTop = scrollContainer
+      ? scrollContainer.getBoundingClientRect().top
+      : 0;
+
+    for (const entry of entries) {
+      if (entry.target === spacerBefore || entry.target === spacerAfter) {
+        // Skip spacer entries — spacers resize during normal scroll-driven
+        // rendering. Compensating here would undo normal scrolling.
+        continue;
+      }
+
+      if (entry.target.isConnected) {
+        const el = entry.target as HTMLElement;
+        const oldHeight = anchoredItems.get(el);
+        const newHeight = getObservedHeight(entry);
+        anchoredItems.set(el, newHeight);
+
+        if (oldHeight !== undefined && oldHeight !== newHeight) {
+          // Compensate only if the element is entirely above the viewport.
+          if (el.getBoundingClientRect().bottom <= containerTop) {
+            scrollDelta += (newHeight - oldHeight);
+          }
+        }
+      }
+    }
+
+    if (scrollDelta !== 0 && scrollElement.scrollTop > 0) {
+      scrollElement.scrollTop += scrollDelta;
     }
   });
 
@@ -151,42 +186,27 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     resizeObserver.observe(spacerBefore);
     resizeObserver.observe(spacerAfter);
 
-    // During convergence, keep the observed element set in sync with the DOM.
-    if (convergingElements) {
-      const currentItems: Set<Element> = new Set();
-      for (let el = spacerBefore.nextElementSibling; el && el !== spacerAfter; el = el.nextElementSibling) {
-        resizeObserver.observe(el);
-        currentItems.add(el);
+    // Always observe all rendered items for viewport anchoring. When an item
+    // resizes above the viewport, the ResizeObserver callback compensates scrollTop.
+    const currentItems = new Set<Element>();
+    for (let el = spacerBefore.nextElementSibling; el && el !== spacerAfter; el = el.nextElementSibling) {
+      resizeObserver.observe(el);
+      currentItems.add(el);
+      if (!anchoredItems.has(el)) {
+        anchoredItems.set(el, (el as HTMLElement).offsetHeight);
       }
-      // Unobserve items removed during re-render.
-      for (const el of convergenceItems) {
-        if (!currentItems.has(el)) {
-          resizeObserver.unobserve(el);
-        }
+    }
+
+    // Unobserve items removed during re-render and clean up height tracking.
+    for (const [el] of anchoredItems) {
+      if (!currentItems.has(el)) {
+        resizeObserver.unobserve(el);
+        anchoredItems.delete(el);
       }
-      convergenceItems = currentItems;
     }
 
     // Don't re-trigger IntersectionObserver here — ResizeObserver handles that
     // when spacers actually resize. Doing it on every render causes feedback loops.
-  }
-
-  function startConvergenceObserving(): void {
-    if (convergingElements) return;
-    convergingElements = true;
-    for (let el = spacerBefore.nextElementSibling; el && el !== spacerAfter; el = el.nextElementSibling) {
-      resizeObserver.observe(el);
-      convergenceItems.add(el);
-    }
-  }
-
-  function stopConvergenceObserving(): void {
-    if (!convergingElements) return;
-    convergingElements = false;
-    for (const el of convergenceItems) {
-      resizeObserver.unobserve(el);
-    }
-    convergenceItems.clear();
   }
 
   let convergingToBottom = false;
@@ -217,9 +237,8 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     resizeObserver,
     refreshObservedElements,
     scrollElement,
-    startConvergenceObserving,
     onDispose: () => {
-      stopConvergenceObserving();
+      anchoredItems.clear();
       resizeObserver.disconnect();
       keydownTarget.removeEventListener('keydown', handleJumpKeys);
       if (callbackTimeout) {
@@ -254,7 +273,6 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     if (spacerAfter.offsetHeight === 0) {
       if (convergingToBottom) {
         convergingToBottom = false;
-        stopConvergenceObserving();
       }
       return;
     }
@@ -264,7 +282,6 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     if (!atBottom && !pendingJumpToEnd) return;
 
     convergingToBottom = true;
-    startConvergenceObserving();
     if (pendingJumpToEnd) {
       scrollElement.scrollTop = scrollElement.scrollHeight;
       pendingJumpToEnd = false;
@@ -275,7 +292,6 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     if (spacerBefore.offsetHeight === 0) {
       if (convergingToTop) {
         convergingToTop = false;
-        stopConvergenceObserving();
       }
       return;
     }
@@ -285,7 +301,6 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     if (!atTop && !pendingJumpToStart) return;
 
     convergingToTop = true;
-    startConvergenceObserving();
     if (pendingJumpToStart) {
       scrollElement.scrollTop = 0;
       pendingJumpToStart = false;
@@ -356,7 +371,6 @@ function scrollToBottom(dotNetHelper: DotNet.DotNetObject): void {
   const entry = observersByDotNetObjectId[id];
   if (entry) {
     entry.scrollElement.scrollTop = entry.scrollElement.scrollHeight;
-    entry.startConvergenceObserving?.();
   }
 }
 

--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -63,14 +63,13 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
   }
 
   if (useNativeAnchoring) {
-    // Applied to rendered items - keeps viewport stable when spacer heights change.
+    // Prevent spacers from being used as scroll anchors — only rendered items should anchor.
     spacerBefore.style.overflowAnchor = 'none';
     spacerAfter.style.overflowAnchor = 'none';
   } else {
     // Manual compensation path for tables and browsers without native anchoring.
     scrollElement.style.overflowAnchor = 'none';
   }
-  console.log(`[Virtualize:init] useNativeAnchoring=${useNativeAnchoring}, isTable=${isTable}, supportsAnchor=${supportsAnchor}`);
 
   const intersectionObserver = new IntersectionObserver(intersectionCallback, {
     root: scrollContainer,
@@ -80,47 +79,13 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
   intersectionObserver.observe(spacerBefore);
   intersectionObserver.observe(spacerAfter);
 
+  let convergingElements = false;
+  let convergenceItems: Set<Element> = new Set();
+
+  // Manual scroll compensation state — tracks item heights so we can adjust scrollTop
+  // when above-viewport items resize. Only used when native anchoring is unavailable.
   const anchoredItems: Map<Element, number> = new Map();
   let scrollTriggeredRender = false;
-
-  let convergingToEnd = false;
-  let convergingToStart = false;
-
-  // Detect End/Home key presses to begin convergence immediately, before the
-  // browser's scroll position even updates. This mirrors the old code's keydown
-  // listener. Without this, CSS scroll anchoring can prevent scrollTop from
-  // reaching the absolute bottom, so the scroll-event-based detection below
-  // would never fire.
-  const keyTarget = scrollContainer || document;
-  keyTarget.addEventListener('keydown', (e: Event) => {
-    const ke = e as KeyboardEvent;
-    if (ke.key === 'End' && !convergingToEnd && spacerAfter.offsetHeight > 0) {
-      console.log(`[Virtualize:keydown] End key → convergingToEnd=true, spacerAfter=${spacerAfter.offsetHeight}`);
-      convergingToEnd = true;
-      scrollElement.style.overflowAnchor = 'none';
-    }
-    if (ke.key === 'Home' && !convergingToStart && spacerBefore.offsetHeight > 0) {
-      console.log(`[Virtualize:keydown] Home key → convergingToStart=true, spacerBefore=${spacerBefore.offsetHeight}`);
-      convergingToStart = true;
-      scrollElement.style.overflowAnchor = 'none';
-    }
-  });
-
-  // Also detect via scroll events — catches programmatic scrollToBottom
-  // and any other path that reaches the extremity.
-  scrollElement.addEventListener('scroll', () => {
-    const remaining = scrollElement.scrollHeight - scrollElement.scrollTop - scrollElement.clientHeight;
-    if (remaining < 1 && spacerAfter.offsetHeight > 0 && !convergingToEnd) {
-      console.log(`[Virtualize:scroll] At bottom, spacerAfter=${spacerAfter.offsetHeight} → convergingToEnd=true`);
-      convergingToEnd = true;
-      scrollElement.style.overflowAnchor = 'none';
-    }
-    if (scrollElement.scrollTop < 1 && spacerBefore.offsetHeight > 0 && !convergingToStart) {
-      console.log(`[Virtualize:scroll] At top, spacerBefore=${spacerBefore.offsetHeight} → convergingToStart=true`);
-      convergingToStart = true;
-      scrollElement.style.overflowAnchor = 'none';
-    }
-  }, { passive: true });
 
   function getObservedHeight(entry: ResizeObserverEntry): number {
     return entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height;
@@ -129,11 +94,9 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
   // ResizeObserver roles:
   //  1. Always observes both spacers so that when a spacer resizes we re-trigger the
   //     IntersectionObserver — which otherwise won't fire again for an element that is already visible.
-  //  2. Viewport anchoring — compensates scroll position when content above the viewport resizes.
-  //     When native anchoring is available (non-table + supported browser), the browser handles this.
-  //     Otherwise (tables, Safari), we use manual compensation via item height tracking.
+  //  2. For convergence (sticky-top/bottom) - observes elements for geometry changes, drives the scroll position.
+  //  3. Manual scroll compensation (tables/Safari) — adjusts scrollTop when above-viewport items resize.
   const resizeObserver = new ResizeObserver((entries: ResizeObserverEntry[]): void => {
-    // 1. Re-trigger IntersectionObserver for spacer resizes.
     for (const entry of entries) {
       if (entry.target === spacerBefore || entry.target === spacerAfter) {
         const spacer = entry.target as HTMLElement;
@@ -144,54 +107,49 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
       }
     }
 
-    // During convergence, any item resize should re-scroll to the target
-    // extremity. This mirrors what the old code did — the ResizeObserver drives
-    // convergence by keeping scrollTop pinned while items load and resize.
-    if (convergingToEnd || convergingToStart) {
-      if (convergingToEnd) {
-        scrollElement.scrollTop = scrollElement.scrollHeight;
-      } else {
-        scrollElement.scrollTop = 0;
-      }
-      const spacer = convergingToEnd ? spacerAfter : spacerBefore;
-      if (spacer.offsetHeight < 1) {
-        console.log(`[Virtualize:ResizeObs] convergence complete — spacer height=0`);
-        convergingToEnd = convergingToStart = false;
+    // Convergence logic: keep scroll pinned to top/bottom while items load.
+    if (convergingToBottom || convergingToTop) {
+      scrollElement.scrollTop = convergingToBottom ? scrollElement.scrollHeight : 0;
+      const spacer = convergingToBottom ? spacerAfter : spacerBefore;
+      if (spacer.offsetHeight === 0) {
+        convergingToBottom = convergingToTop = false;
+        stopConvergenceObserving();
       }
       return;
+    } else if (convergingElements) {
+      stopConvergenceObserving();
     }
 
-    // 2. Viewport anchoring: compensate scroll for above-viewport item resizes.
-    let scrollDelta = 0;
-    const containerTop = scrollContainer
-      ? scrollContainer.getBoundingClientRect().top
-      : 0;
+    // Manual scroll compensation: adjust scrollTop for above-viewport item resizes.
+    // When native anchoring is available, the browser handles this automatically.
+    if (!useNativeAnchoring) {
+      let scrollDelta = 0;
+      const containerTop = scrollContainer
+        ? scrollContainer.getBoundingClientRect().top
+        : 0;
 
-    for (const entry of entries) {
-      if (entry.target === spacerBefore || entry.target === spacerAfter) {
-        // Skip spacer entries — spacers resize during normal scroll-driven
-        // rendering. Compensating here would undo normal scrolling.
-        continue;
-      }
+      for (const entry of entries) {
+        if (entry.target === spacerBefore || entry.target === spacerAfter) {
+          continue;
+        }
 
-      if (entry.target.isConnected) {
-        const el = entry.target as HTMLElement;
-        const oldHeight = anchoredItems.get(el);
-        const newHeight = getObservedHeight(entry);
-        anchoredItems.set(el, newHeight);
+        if (entry.target.isConnected) {
+          const el = entry.target as HTMLElement;
+          const oldHeight = anchoredItems.get(el);
+          const newHeight = getObservedHeight(entry);
+          anchoredItems.set(el, newHeight);
 
-        if (oldHeight !== undefined && oldHeight !== newHeight) {
-          // Compensate if the element is above the viewport (fully or partially).
-          if (el.getBoundingClientRect().top < containerTop) {
-            scrollDelta += (newHeight - oldHeight);
+          if (oldHeight !== undefined && oldHeight !== newHeight) {
+            if (el.getBoundingClientRect().top < containerTop) {
+              scrollDelta += (newHeight - oldHeight);
+            }
           }
         }
       }
-    }
 
-    if (scrollDelta !== 0 && scrollElement.scrollTop > 0 && !convergingToEnd && !convergingToStart) {
-      console.log(`[Virtualize:ResizeObs] scrollDelta=${scrollDelta}, scrollTop=${scrollElement.scrollTop}`);
-      scrollElement.scrollTop += scrollDelta;
+      if (scrollDelta !== 0 && scrollElement.scrollTop > 0) {
+        scrollElement.scrollTop += scrollDelta;
+      }
     }
   });
 
@@ -209,63 +167,112 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     if (useNativeAnchoring) {
       spacerBefore.style.overflowAnchor = 'none';
       spacerAfter.style.overflowAnchor = 'none';
-
-      // Clear convergence flags once the target spacer reaches zero height.
-      if (convergingToEnd && spacerAfter.offsetHeight < 1) {
-        console.log('[Virtualize:refresh] convergingToEnd complete — spacerAfter=0');
-        convergingToEnd = false;
-      }
-      if (convergingToStart && spacerBefore.offsetHeight < 1) {
-        console.log('[Virtualize:refresh] convergingToStart complete — spacerBefore=0');
-        convergingToStart = false;
-      }
-
-      const isConverging = convergingToEnd || convergingToStart;
-      scrollElement.style.overflowAnchor = isConverging ? 'none' : '';
-
-      if (convergingToEnd) {
-        console.log(`[Virtualize:refresh] convergingToEnd: scrolling to bottom (scrollTop ${scrollElement.scrollTop} → ${scrollElement.scrollHeight})`);
-        scrollElement.scrollTop = scrollElement.scrollHeight;
-      }
-      if (convergingToStart) {
-        console.log(`[Virtualize:refresh] convergingToStart: scrolling to top (scrollTop ${scrollElement.scrollTop} → 0)`);
-        scrollElement.scrollTop = 0;
-      }
-
-      console.log(`[Virtualize:refresh] convergingToEnd=${convergingToEnd}, convergingToStart=${convergingToStart}, overflowAnchor=${scrollElement.style.overflowAnchor}, scrollTop=${scrollElement.scrollTop}, scrollHeight=${scrollElement.scrollHeight}, clientHeight=${scrollElement.clientHeight}, spacerAfter.h=${spacerAfter.offsetHeight}, spacerBefore.h=${spacerBefore.offsetHeight}`);
     }
 
     // Ensure spacers are always observed (idempotent).
     resizeObserver.observe(spacerBefore);
     resizeObserver.observe(spacerAfter);
 
-    // - Native anchoring: browser handles above-viewport resizes automatically.
-    // - Manual compensation: observe items on data-triggered renders to compensate.
-    // - During convergence: observe items so ResizeObserver can drive re-scrolling.
-    const isConvergingNow = convergingToEnd || convergingToStart;
-    if ((useNativeAnchoring && !isConvergingNow) || scrollTriggeredRender) {
-      scrollTriggeredRender = false;
+    // During convergence, keep the observed element set in sync with the DOM.
+    if (convergingElements) {
+      const currentItems: Set<Element> = new Set();
+      for (let el = spacerBefore.nextElementSibling; el && el !== spacerAfter; el = el.nextElementSibling) {
+        resizeObserver.observe(el);
+        currentItems.add(el);
+      }
+      // Unobserve items removed during re-render.
+      for (const el of convergenceItems) {
+        if (!currentItems.has(el)) {
+          resizeObserver.unobserve(el);
+        }
+      }
+      convergenceItems = currentItems;
       return;
+    }
+
+    // Manual compensation: observe items so ResizeObserver can compensate scrollTop.
+    // Skip for native anchoring (browser handles it) and scroll-triggered renders
+    // (avoids layout interference drift).
+    if (!useNativeAnchoring && !scrollTriggeredRender) {
+      const currentItems = new Set<Element>();
+      for (let el = spacerBefore.nextElementSibling; el && el !== spacerAfter; el = el.nextElementSibling) {
+        resizeObserver.observe(el);
+        currentItems.add(el);
+      }
+
+      for (const [el] of anchoredItems) {
+        if (!currentItems.has(el)) {
+          resizeObserver.unobserve(el);
+          anchoredItems.delete(el);
+        }
+      }
     }
     scrollTriggeredRender = false;
 
-    // Observe all rendered items. During normal manual-compensation mode, the
-    // ResizeObserver callback compensates scrollTop. During convergence, it
-    // re-scrolls to the target extremity.
-    const currentItems = new Set<Element>();
+    // Don't re-trigger IntersectionObserver here — ResizeObserver handles that
+    // when spacers actually resize. Doing it on every render causes feedback loops.
+  }
+
+  function startConvergenceObserving(): void {
+    if (convergingElements) return;
+    convergingElements = true;
     for (let el = spacerBefore.nextElementSibling; el && el !== spacerAfter; el = el.nextElementSibling) {
       resizeObserver.observe(el);
-      currentItems.add(el);
-    }
-
-    // Unobserve items removed during re-render and clean up height tracking.
-    for (const [el] of anchoredItems) {
-      if (!currentItems.has(el)) {
-        resizeObserver.unobserve(el);
-        anchoredItems.delete(el);
-      }
+      convergenceItems.add(el);
     }
   }
+
+  function stopConvergenceObserving(): void {
+    if (!convergingElements) return;
+    convergingElements = false;
+    for (const el of convergenceItems) {
+      resizeObserver.unobserve(el);
+    }
+    convergenceItems.clear();
+    if (useNativeAnchoring) {
+      scrollElement.style.overflowAnchor = '';
+    }
+    anchoredItems.clear();
+  }
+
+  let convergingToBottom = false;
+  let convergingToTop = false;
+
+  let pendingJumpToEnd = false;
+  let pendingJumpToStart = false;
+
+  function startConvergence(toBottom: boolean): void {
+    if (toBottom) {
+      if (convergingToBottom || spacerAfter.offsetHeight === 0) return;
+      convergingToBottom = true;
+    } else {
+      if (convergingToTop || spacerBefore.offsetHeight === 0) return;
+      convergingToTop = true;
+    }
+    startConvergenceObserving();
+    if (useNativeAnchoring) {
+      scrollElement.style.overflowAnchor = 'none';
+    }
+  }
+
+  // Detect End/Home key presses to begin convergence immediately, before the
+  // browser's scroll position updates. With native CSS scroll anchoring enabled,
+  // the browser may prevent scrollTop from reaching the absolute extremity, so
+  // the IO-based detection in onSpacerAfterVisible alone is not sufficient.
+  const keydownTarget: EventTarget = scrollContainer || document;
+  function handleJumpKeys(e: Event): void {
+    const ke = e as KeyboardEvent;
+    if (ke.key === 'End') {
+      pendingJumpToEnd = true;
+      pendingJumpToStart = false;
+      startConvergence(true);
+    } else if (ke.key === 'Home') {
+      pendingJumpToStart = true;
+      pendingJumpToEnd = false;
+      startConvergence(false);
+    }
+  }
+  keydownTarget.addEventListener('keydown', handleJumpKeys);
 
   const { observersByDotNetObjectId, id } = getObserversMapEntry(dotNetHelper);
   let pendingCallbacks: Map<Element, IntersectionObserverEntry> = new Map();
@@ -276,16 +283,12 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     resizeObserver,
     refreshObservedElements,
     scrollElement,
-    startConvergingToEnd: () => {
-      if (!convergingToEnd && spacerAfter.offsetHeight > 0) {
-        console.log(`[Virtualize:scrollToBottom] → convergingToEnd=true, spacerAfter=${spacerAfter.offsetHeight}`);
-        convergingToEnd = true;
-        scrollElement.style.overflowAnchor = 'none';
-      }
-    },
+    startConvergence,
     onDispose: () => {
+      stopConvergenceObserving();
       anchoredItems.clear();
       resizeObserver.disconnect();
+      keydownTarget.removeEventListener('keydown', handleJumpKeys);
       if (callbackTimeout) {
         clearTimeout(callbackTimeout);
         callbackTimeout = null;
@@ -314,13 +317,68 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     }
   }
 
+  function onSpacerAfterVisible(): void {
+    if (spacerAfter.offsetHeight === 0) {
+      if (convergingToBottom) {
+        convergingToBottom = false;
+        stopConvergenceObserving();
+      }
+      return;
+    }
+    if (convergingToBottom) return;
+
+    const atBottom = scrollElement.scrollTop + scrollElement.clientHeight >= scrollElement.scrollHeight - 1;
+    if (!atBottom && !pendingJumpToEnd) return;
+
+    startConvergence(true);
+    if (pendingJumpToEnd) {
+      scrollElement.scrollTop = scrollElement.scrollHeight;
+      pendingJumpToEnd = false;
+    }
+  }
+
+  function onSpacerBeforeVisible(): void {
+    if (spacerBefore.offsetHeight === 0) {
+      if (convergingToTop) {
+        convergingToTop = false;
+        stopConvergenceObserving();
+      }
+      return;
+    }
+    if (convergingToTop) return;
+
+    const atTop = scrollElement.scrollTop < 1;
+    if (!atTop && !pendingJumpToStart) return;
+
+    startConvergence(false);
+    if (pendingJumpToStart) {
+      scrollElement.scrollTop = 0;
+      pendingJumpToStart = false;
+    }
+  }
+
   function processIntersectionEntries(entries: IntersectionObserverEntry[]): void {
     // Check if the spacers are still in the DOM. They may have been removed if the component was disposed.
     if (!spacerBefore.isConnected || !spacerAfter.isConnected) {
       return;
     }
 
-    const intersectingEntries = entries.filter(entry => entry.isIntersecting);
+    const intersectingEntries = entries.filter(entry => {
+      if (entry.isIntersecting) {
+        if (entry.target === spacerAfter) {
+          onSpacerAfterVisible();
+        } else if (entry.target === spacerBefore) {
+          onSpacerBeforeVisible();
+        }
+        return true;
+      }
+      if (entry.target === spacerAfter && convergingToBottom && spacerAfter.offsetHeight > 0) {
+        scrollElement.scrollTop = scrollElement.scrollHeight;
+      } else if (entry.target === spacerBefore && convergingToTop && spacerBefore.offsetHeight > 0) {
+        scrollElement.scrollTop = 0;
+      }
+      return false;
+    });
 
     if (intersectingEntries.length === 0) {
       return;
@@ -336,7 +394,7 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
       const containerSize = (entry.rootBounds?.height ?? 0) / scaleFactor;
 
       // Mark the upcoming render as scroll-triggered so refreshObservedElements
-      // skips item observation for tables (avoids layout interference drift).
+      // skips item observation (avoids layout interference drift).
       scrollTriggeredRender = true;
 
       if (entry.target === spacerBefore) {
@@ -366,7 +424,7 @@ function scrollToBottom(dotNetHelper: DotNet.DotNetObject): void {
   const { observersByDotNetObjectId, id } = getObserversMapEntry(dotNetHelper);
   const entry = observersByDotNetObjectId[id];
   if (entry) {
-    entry.startConvergingToEnd?.();
+    entry.startConvergence?.(true);
     entry.scrollElement.scrollTop = entry.scrollElement.scrollHeight;
   }
 }

--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -134,7 +134,7 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
       }
     }
 
-    if (scrollDelta !== 0 && scrollElement.scrollTop > 0) {
+    if (scrollDelta !== 0 && scrollElement.scrollTop > 0 && !isConverging) {
       scrollElement.scrollTop += scrollDelta;
     }
   });

--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -86,15 +86,39 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
   let convergingToEnd = false;
   let convergingToStart = false;
 
+  // Detect End/Home key presses to begin convergence immediately, before the
+  // browser's scroll position even updates. This mirrors the old code's keydown
+  // listener. Without this, CSS scroll anchoring can prevent scrollTop from
+  // reaching the absolute bottom, so the scroll-event-based detection below
+  // would never fire.
+  const keyTarget = scrollContainer || document;
+  keyTarget.addEventListener('keydown', (e: Event) => {
+    const ke = e as KeyboardEvent;
+    if (ke.key === 'End' && !convergingToEnd && spacerAfter.offsetHeight > 0) {
+      console.log(`[Virtualize:keydown] End key → convergingToEnd=true, spacerAfter=${spacerAfter.offsetHeight}`);
+      convergingToEnd = true;
+      scrollElement.style.overflowAnchor = 'none';
+    }
+    if (ke.key === 'Home' && !convergingToStart && spacerBefore.offsetHeight > 0) {
+      console.log(`[Virtualize:keydown] Home key → convergingToStart=true, spacerBefore=${spacerBefore.offsetHeight}`);
+      convergingToStart = true;
+      scrollElement.style.overflowAnchor = 'none';
+    }
+  });
+
+  // Also detect via scroll events — catches programmatic scrollToBottom
+  // and any other path that reaches the extremity.
   scrollElement.addEventListener('scroll', () => {
     const remaining = scrollElement.scrollHeight - scrollElement.scrollTop - scrollElement.clientHeight;
-    if (remaining < 1 && spacerAfter.offsetHeight > 0) {
+    if (remaining < 1 && spacerAfter.offsetHeight > 0 && !convergingToEnd) {
       console.log(`[Virtualize:scroll] At bottom, spacerAfter=${spacerAfter.offsetHeight} → convergingToEnd=true`);
       convergingToEnd = true;
+      scrollElement.style.overflowAnchor = 'none';
     }
-    if (scrollElement.scrollTop < 1 && spacerBefore.offsetHeight > 0) {
+    if (scrollElement.scrollTop < 1 && spacerBefore.offsetHeight > 0 && !convergingToStart) {
       console.log(`[Virtualize:scroll] At top, spacerBefore=${spacerBefore.offsetHeight} → convergingToStart=true`);
       convergingToStart = true;
+      scrollElement.style.overflowAnchor = 'none';
     }
   }, { passive: true });
 
@@ -252,6 +276,13 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     resizeObserver,
     refreshObservedElements,
     scrollElement,
+    startConvergingToEnd: () => {
+      if (!convergingToEnd && spacerAfter.offsetHeight > 0) {
+        console.log(`[Virtualize:scrollToBottom] → convergingToEnd=true, spacerAfter=${spacerAfter.offsetHeight}`);
+        convergingToEnd = true;
+        scrollElement.style.overflowAnchor = 'none';
+      }
+    },
     onDispose: () => {
       anchoredItems.clear();
       resizeObserver.disconnect();
@@ -335,6 +366,7 @@ function scrollToBottom(dotNetHelper: DotNet.DotNetObject): void {
   const { observersByDotNetObjectId, id } = getObserversMapEntry(dotNetHelper);
   const entry = observersByDotNetObjectId[id];
   if (entry) {
+    entry.startConvergingToEnd?.();
     entry.scrollElement.scrollTop = entry.scrollElement.scrollHeight;
   }
 }

--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -70,6 +70,7 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     // Manual compensation path for tables and browsers without native anchoring.
     scrollElement.style.overflowAnchor = 'none';
   }
+  console.log(`[Virtualize:init] useNativeAnchoring=${useNativeAnchoring}, isTable=${isTable}, supportsAnchor=${supportsAnchor}`);
 
   const intersectionObserver = new IntersectionObserver(intersectionCallback, {
     root: scrollContainer,
@@ -135,6 +136,7 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     }
 
     if (scrollDelta !== 0 && scrollElement.scrollTop > 0 && !isConverging) {
+      console.log(`[Virtualize:ResizeObs] scrollDelta=${scrollDelta}, scrollTop=${scrollElement.scrollTop}, isConverging=${isConverging}`);
       scrollElement.scrollTop += scrollDelta;
     }
   });
@@ -161,6 +163,7 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
 
       // Prevent browser anchoring fighting with convergence.
       scrollElement.style.overflowAnchor = isConverging ? 'none' : '';
+      console.log(`[Virtualize:refresh] isConverging=${isConverging}, scrollTop=${scrollElement.scrollTop}, scrollHeight=${scrollElement.scrollHeight}, clientHeight=${scrollElement.clientHeight}, spacerAfter.h=${spacerAfter.offsetHeight}, spacerBefore.h=${spacerBefore.offsetHeight}, anchor=${scrollElement.style.overflowAnchor}`);
     }
 
     // Ensure spacers are always observed (idempotent).
@@ -263,12 +266,14 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
 
       if (entry.target === spacerBefore) {
         const spacerSize = (entry.intersectionRect.top - entry.boundingClientRect.top) / scaleFactor;
+        console.log(`[Virtualize:IO] spacerBefore visible, spacerSize=${spacerSize.toFixed(1)}, scrollTop=${scrollElement.scrollTop}`);
         dotNetHelper.invokeMethodAsync('OnSpacerBeforeVisible', spacerSize, spacerSeparation, containerSize);
       } else if (entry.target === spacerAfter && spacerAfter.offsetHeight > 0) {
         // When we first start up, both the "before" and "after" spacers will be visible, but it's only relevant to raise a
         // single event to load the initial data. To avoid raising two events, skip the one for the "after" spacer if we know
         // it's meaningless to talk about any overlap into it.
         const spacerSize = (entry.boundingClientRect.bottom - entry.intersectionRect.bottom) / scaleFactor;
+        console.log(`[Virtualize:IO] spacerAfter visible, spacerSize=${spacerSize.toFixed(1)}, offsetHeight=${spacerAfter.offsetHeight}, scrollTop=${scrollElement.scrollTop}`);
         dotNetHelper.invokeMethodAsync('OnSpacerAfterVisible', spacerSize, spacerSeparation, containerSize);
       }
     });
@@ -288,8 +293,11 @@ function scrollToBottom(dotNetHelper: DotNet.DotNetObject): void {
   const { observersByDotNetObjectId, id } = getObserversMapEntry(dotNetHelper);
   const entry = observersByDotNetObjectId[id];
   if (entry) {
+    const el = entry.scrollElement;
+    console.log(`[Virtualize:scrollToBottom] before: scrollTop=${el.scrollTop}, scrollHeight=${el.scrollHeight}`);
     entry.setConverging(true, true);
     entry.scrollElement.scrollTop = entry.scrollElement.scrollHeight;
+    console.log(`[Virtualize:scrollToBottom] after: scrollTop=${el.scrollTop}`);
   }
 }
 

--- a/src/Components/Web/src/Virtualization/Virtualize.cs
+++ b/src/Components/Web/src/Virtualization/Virtualize.cs
@@ -47,6 +47,9 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
 
     private IEnumerable<TItem>? _loadedItems;
 
+    // For in-memory Items where objects have stable identity
+    private TItem? _previousFirstLoadedItem;
+
     private CancellationTokenSource? _refreshCts;
 
     private bool _skipNextDistributionRefresh;
@@ -515,9 +518,34 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
             // Only apply result if the task was not canceled.
             if (!cancellationToken.IsCancellationRequested)
             {
+                var previousItemCount = _itemCount;
+                var countDelta = result.TotalItemCount - previousItemCount;
+
+                // Detect if items were prepended above the current viewport position.
+                if (countDelta > 0 && _itemsBefore > 0 && _previousFirstLoadedItem != null
+                    && _itemsProvider == DefaultItemsProvider)
+                {
+                    var newFirstItem = Items!.ElementAtOrDefault(_itemsBefore);
+                    if (newFirstItem != null && !ReferenceEquals(_previousFirstLoadedItem, newFirstItem))
+                    {
+                        _itemsBefore = Math.Min(_itemsBefore + countDelta, Math.Max(0, result.TotalItemCount - _visibleItemCapacity));
+
+                        var adjustedRequest = new ItemsProviderRequest(_itemsBefore, _visibleItemCapacity, cancellationToken);
+                        result = await _itemsProvider(adjustedRequest);
+                    }
+                }
+
                 _itemCount = result.TotalItemCount;
                 _loadedItems = result.Items;
-                _loadedItemsStartIndex = request.StartIndex;
+                _loadedItemsStartIndex = _itemsBefore;
+
+                // Only needed for DefaultItemsProvider; custom providers return new instances
+                // per request, making ReferenceEquals unreliable.
+                _previousFirstLoadedItem = _itemsProvider == DefaultItemsProvider
+                    && Items != null && _itemsBefore < Items.Count
+                    ? Items.ElementAtOrDefault(_itemsBefore)
+                    : default;
+
                 _loading = false;
                 _skipNextDistributionRefresh = request.Count > 0;
 

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -777,14 +777,18 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
                 var metrics = (IReadOnlyDictionary<string, object>)js.ExecuteScript(
                     "var c = arguments[0]; var spacers = c.querySelectorAll('[aria-hidden]');" +
                     "return { spacerAfterHeight: spacers.length >= 2 ? spacers[spacers.length - 1].offsetHeight : 999," +
+                    "  spacerBeforeHeight: spacers.length >= 1 ? spacers[0].offsetHeight : -1," +
+                    "  overflowAnchor: getComputedStyle(c).overflowAnchor || 'N/A'," +
                     "  scrollTop: c.scrollTop, scrollHeight: c.scrollHeight, clientHeight: c.clientHeight };",
                     container);
                 var spacerAfterHeight = Convert.ToDouble(metrics["spacerAfterHeight"], CultureInfo.InvariantCulture);
+                var spacerBeforeHeight = Convert.ToDouble(metrics["spacerBeforeHeight"], CultureInfo.InvariantCulture);
+                var overflowAnchor = metrics["overflowAnchor"]?.ToString() ?? "N/A";
                 var scrollTop = Convert.ToDouble(metrics["scrollTop"], CultureInfo.InvariantCulture);
                 var scrollHeight = Convert.ToDouble(metrics["scrollHeight"], CultureInfo.InvariantCulture);
                 var clientHeight = Convert.ToDouble(metrics["clientHeight"], CultureInfo.InvariantCulture);
                 var remaining = scrollHeight - scrollTop - clientHeight;
-                endDiagnostics.AppendLine(CultureInfo.InvariantCulture, $"  poll #{endPollCount}: spacerAfter={spacerAfterHeight:F1}, scrollTop={scrollTop:F1}, scrollHeight={scrollHeight:F1}, clientHeight={clientHeight:F1}, remaining={remaining:F1}");
+                endDiagnostics.AppendLine(CultureInfo.InvariantCulture, $"  poll #{endPollCount}: spacerAfter={spacerAfterHeight:F1}, spacerBefore={spacerBeforeHeight:F1}, scrollTop={scrollTop:F1}, scrollHeight={scrollHeight:F1}, clientHeight={clientHeight:F1}, remaining={remaining:F1}, overflowAnchor={overflowAnchor}");
 
                 return spacerAfterHeight < 1;
             });

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -39,7 +39,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
     {
         Browser.MountTestComponent<VirtualizationComponent>();
         var topSpacer = Browser.Exists(By.Id("sync-container")).FindElement(By.TagName("div"));
-        var expectedInitialSpacerStyle = "height: 0px; flex-shrink: 0;";
+        var expectedInitialSpacerStyle = "height: 0px; flex-shrink: 0; overflow-anchor: none;";
 
         int initialItemCount = 0;
 
@@ -202,7 +202,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
     public void CanUseViewportAsContainer()
     {
         Browser.MountTestComponent<VirtualizationComponent>();
-        var expectedInitialSpacerStyle = "height: 0px; flex-shrink: 0;";
+        var expectedInitialSpacerStyle = "height: 0px; flex-shrink: 0; overflow-anchor: none;";
         var topSpacer = Browser.Exists(By.Id("viewport-as-root")).FindElement(By.TagName("div"));
 
         Browser.ExecuteJavaScript("const element = document.getElementById('viewport-as-root'); element.scrollIntoView();");
@@ -226,7 +226,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
     {
         Browser.MountTestComponent<VirtualizationComponent>();
         var topSpacer = Browser.Exists(By.Id("incorrect-size-container")).FindElement(By.TagName("div"));
-        var expectedInitialSpacerStyle = "height: 0px; flex-shrink: 0;";
+        var expectedInitialSpacerStyle = "height: 0px; flex-shrink: 0; overflow-anchor: none;";
 
         // Wait until items have been rendered.
         Browser.True(() => GetItemCount() > 0);
@@ -1725,6 +1725,39 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
             $"RelTop Before: {relTopBefore:F1}, After: {relTopAfter:F1}, Delta: {relTopAfter - relTopBefore:F1}px");
     }
 
+    [Fact]
+    public void Table_VariableHeight_IncrementalScrollDoesNotCauseWildJumps()
+    {
+        // Guards against a browser-level CSS Scroll Anchoring bug with <table> layout.
+        // When overflow-anchor is allowed on <tr> elements, the anchoring algorithm
+        // miscalculates row positions causing 3000-8000px jumps per 300px scroll.
+        // The fix disables browser anchoring for tables and uses manual JS compensation.
+        Browser.MountTestComponent<VirtualizationVariableHeightTable>();
+
+        var js = (IJavaScriptExecutor)Browser;
+        Browser.Equal("Total items: 500", () => Browser.Exists(By.Id("vht-total-items")).Text);
+        Browser.True(() => Browser.Exists(By.Id("vht-row-0")).Displayed);
+
+        // Scroll to initial offset and wait deterministically for re-render
+        js.ExecuteScript("window.scrollTo(0, 1000)");
+        Browser.True(() => Browser.FindElements(By.Id("vht-row-10")).Count > 0);
+
+        var result = ExecuteViewportScrollJumpDetectionScript("variable-height-table");
+
+        var maxJump = Convert.ToInt64(result["maxJump"], CultureInfo.InvariantCulture);
+        var totalDelta = Convert.ToInt64(result["totalDelta"], CultureInfo.InvariantCulture);
+        var expectedDelta = Convert.ToInt64(result["expected"], CultureInfo.InvariantCulture);
+
+        // Without the fix: individual jumps of 3000-8000px, total drift 30,000+.
+        // With the fix: ~300px per step, total ~4500px.
+        Assert.True(maxJump < 1500,
+            $"Table scroll should not produce wild jumps. " +
+            $"Max single jump was {maxJump}px (expected ~300px each). " +
+            $"Total: {result["startY"]}->{result["endY"]} = {totalDelta}px (expected ~{expectedDelta}px). " +
+            $"Jumps: [{result["jumps"]}]. " +
+            $"Large jumps indicate CSS scroll anchoring is miscalculating on <tr> elements.");
+    }
+
     private static (string index, double relTop, long scrollTop) GetItemPositionInContainer(
         IJavaScriptExecutor js, IWebElement container, string itemSelector, string dataIndex = null)
     {
@@ -1973,6 +2006,79 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
                     maxBackwardJump: maxBackwardJump,
                     finalScrollTop: container.scrollTop,
                     finalItemCount: container.querySelectorAll('{itemSelector}').length
+                }});
+            }})();";
+
+        return (Dictionary<string, object>)((IJavaScriptExecutor)Browser).ExecuteAsyncScript(script);
+    }
+
+    /// <summary>
+    /// Performs incremental viewport-level scrolls (window.scrollBy) on a table element,
+    /// using MutationObserver + requestAnimationFrame to deterministically wait for each
+    /// render cycle to settle. Measures per-step scroll jumps to detect CSS Scroll Anchoring
+    /// miscalculations on &lt;tr&gt; elements.
+    /// Returns startY, endY, totalDelta, expected, maxJump, and comma-separated jumps.
+    /// </summary>
+    private Dictionary<string, object> ExecuteViewportScrollJumpDetectionScript(
+        string tableId, int scrollCount = 15, int scrollDelta = 300)
+    {
+        var script = $@"
+            var done = arguments[0];
+            (async () => {{
+                const tbody = document.querySelector('#{tableId} > tbody');
+
+                // Event-driven wait: watches for DOM mutations from C# re-renders,
+                // then waits 3 animation frames with no new mutations (layout settled).
+                // Falls back after 30 frames if no mutations occur.
+                const waitForRenderSettle = () => new Promise(resolve => {{
+                    let mutationSeen = false;
+                    let framesSinceLastMutation = 0;
+                    let totalFrames = 0;
+
+                    const mo = new MutationObserver(() => {{
+                        mutationSeen = true;
+                        framesSinceLastMutation = 0;
+                    }});
+                    mo.observe(tbody, {{ childList: true, subtree: true }});
+
+                    const checkSettle = () => {{
+                        totalFrames++;
+                        framesSinceLastMutation++;
+                        if ((mutationSeen && framesSinceLastMutation >= 3) || totalFrames >= 30) {{
+                            mo.disconnect();
+                            resolve();
+                        }} else {{
+                            requestAnimationFrame(checkSettle);
+                        }}
+                    }};
+                    requestAnimationFrame(checkSettle);
+                }});
+
+                const scrollCount = {scrollCount};
+                const scrollDelta = {scrollDelta};
+                const startY = Math.round(window.scrollY);
+                let maxJump = 0;
+                let prevY = startY;
+                const jumps = [];
+
+                for (let i = 0; i < scrollCount; i++) {{
+                    window.scrollBy(0, scrollDelta);
+                    await waitForRenderSettle();
+
+                    const currentY = Math.round(window.scrollY);
+                    const jump = currentY - prevY;
+                    jumps.push(jump);
+                    if (Math.abs(jump) > Math.abs(maxJump)) maxJump = jump;
+                    prevY = currentY;
+                }}
+
+                done({{
+                    startY: startY,
+                    endY: Math.round(window.scrollY),
+                    totalDelta: Math.round(window.scrollY) - startY,
+                    expected: scrollCount * scrollDelta,
+                    maxJump: maxJump,
+                    jumps: jumps.join(',')
                 }});
             }})();";
 

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -1030,6 +1030,116 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
     }
 
     [Fact]
+    public void DynamicContent_PrependItemsWhileScrolledToMiddle_VisibleItemsStayInPlace()
+    {
+        Browser.MountTestComponent<VirtualizationDynamicContent>();
+
+        var container = Browser.Exists(By.Id("scroll-container"));
+        var js = (IJavaScriptExecutor)Browser;
+        Browser.True(() => GetElementCount(container, ".item") > 0);
+
+        // Scroll past the overscan window to force true virtualization.
+        js.ExecuteScript("arguments[0].scrollTop = 5000", container);
+        Browser.True(() => (long)js.ExecuteScript("return arguments[0].scrollTop", container) >= 5000);
+
+        Browser.True(() =>
+        {
+            var items = container.FindElements(By.CssSelector(".item"));
+            if (items.Count == 0)
+            {
+                return false;
+            }
+
+            var idx = items.First().GetDomAttribute("data-index");
+            return idx != null && int.Parse(idx, CultureInfo.InvariantCulture) > 10;
+        });
+
+        // Record the first visible item and its Y position.
+        var containerRect = container.Location;
+        var containerHeight = container.Size.Height;
+        var visibleItems = container.FindElements(By.CssSelector(".item"));
+        string firstVisibleIndex = null;
+        int firstVisibleTopBefore = 0;
+        foreach (var item in visibleItems)
+        {
+            var relativeY = item.Location.Y - containerRect.Y;
+            if (relativeY >= 0 && relativeY < containerHeight)
+            {
+                firstVisibleIndex = item.GetDomAttribute("data-index");
+                firstVisibleTopBefore = item.Location.Y;
+                break;
+            }
+        }
+        Assert.NotNull(firstVisibleIndex);
+
+        Browser.Exists(By.Id("prepend-items")).Click();
+        Browser.Contains("Prepended 10 items", () => Browser.Exists(By.Id("status")).Text);
+
+        // The visible item should stay in place after prepend.
+        var sameItem = container.FindElement(By.CssSelector($"[data-index='{firstVisibleIndex}']"));
+        var firstVisibleTopAfter = sameItem.Location.Y;
+
+        Assert.True(Math.Abs(firstVisibleTopAfter - firstVisibleTopBefore) < 5,
+            $"Visible item {firstVisibleIndex} should not move when items are prepended above. " +
+            $"Before Y: {firstVisibleTopBefore}, After Y: {firstVisibleTopAfter}");
+
+        Browser.True(() => container.FindElements(By.CssSelector(".item")).Count > 0);
+
+        // Verify prepended items are reachable at the top.
+        js.ExecuteScript("arguments[0].scrollTop = 0", container);
+        Browser.True(() => (long)js.ExecuteScript("return arguments[0].scrollTop", container) == 0);
+        Browser.True(() => container.FindElements(By.CssSelector("[data-index='-10']")).Count > 0);
+        var topItems = container.FindElements(By.CssSelector(".item"));
+        Assert.True(topItems.Count > 0, "Should render items after scrolling back to top.");
+    }
+
+    [Fact]
+    public void DynamicContent_AppendItemsWhileScrolledToMiddle_VisibleItemsStayInPlace()
+    {
+        Browser.MountTestComponent<VirtualizationDynamicContent>();
+
+        var container = Browser.Exists(By.Id("scroll-container"));
+        var js = (IJavaScriptExecutor)Browser;
+        Browser.True(() => GetElementCount(container, ".item") > 0);
+
+        // Scroll past the overscan window to force true virtualization.
+        js.ExecuteScript("arguments[0].scrollTop = 5000", container);
+        Browser.True(() => (long)js.ExecuteScript("return arguments[0].scrollTop", container) >= 5000);
+
+        Browser.True(() =>
+        {
+            var items = container.FindElements(By.CssSelector(".item"));
+            if (items.Count == 0)
+            {
+                return false;
+            }
+
+            var idx = items.First().GetDomAttribute("data-index");
+            return idx != null && int.Parse(idx, CultureInfo.InvariantCulture) > 10;
+        });
+        var visibleItems = container.FindElements(By.CssSelector(".item"));
+        var firstVisible = visibleItems.First();
+        var firstVisibleIndex = firstVisible.GetDomAttribute("data-index");
+        var firstVisibleTopBefore = firstVisible.Location.Y;
+        var scrollTopBefore = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+
+        Browser.Exists(By.Id("append-items")).Click();
+        Browser.Contains("Appended 10 items", () => Browser.Exists(By.Id("status")).Text);
+
+        // Appending below the viewport should not affect visible items.
+        var sameItem = container.FindElement(By.CssSelector($"[data-index='{firstVisibleIndex}']"));
+        var firstVisibleTopAfter = sameItem.Location.Y;
+        var scrollTopAfter = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+
+        Assert.True(Math.Abs(firstVisibleTopAfter - firstVisibleTopBefore) < 5,
+            $"Visible item {firstVisibleIndex} should not move when items are appended below. " +
+            $"Before: {firstVisibleTopBefore}, After: {firstVisibleTopAfter}");
+        Assert.True(Math.Abs(scrollTopAfter - scrollTopBefore) < 5,
+            $"scrollTop should not change when appending below viewport. " +
+            $"Before: {scrollTopBefore}, After: {scrollTopAfter}");
+    }
+
+    [Fact]
     public void VariableHeight_ContainerResizeWorks()
     {
         Browser.MountTestComponent<VirtualizationVariableHeight>();

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -1844,4 +1844,97 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         var lastElement = Browser.Exists(By.Id("horizontal-overflow-row-999"));
         Browser.True(() => lastElement.Displayed);
     }
+
+    [Fact]
+    public void ViewportAnchoring_ExpandAboveViewport_VisibleItemStaysInPlace()
+    {
+        Browser.MountTestComponent<VirtualizationDynamicContent>();
+
+        var container = Browser.Exists(By.Id("scroll-container"));
+        var js = (IJavaScriptExecutor)Browser;
+        Browser.True(() => GetElementCount(container, ".item") > 0);
+
+        // Scroll down so item 5 is above the viewport but still in DOM an verify its position
+        js.ExecuteScript("arguments[0].scrollTop = 500", container);
+        Browser.True(() => (long)js.ExecuteScript("return arguments[0].scrollTop", container) >= 500);
+        Browser.True(() => container.FindElements(By.CssSelector("[data-index='5']")).Count > 0);
+
+        // Record the first visible item and its position relative to the container.
+        var (indexBefore, relTopBefore, _) = GetItemPositionInContainer(js, container, ".item");
+
+        var scrollTopBefore = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+
+        Browser.Exists(By.Id("expand-item-5")).Click();
+        Browser.Contains("Item 5 expanded via button", () => Browser.Exists(By.Id("status")).Text);
+
+        // Wait for the expanded the 5th item content to appear in DOM
+        Browser.True(() => container.FindElements(By.CssSelector("[data-index='5'] .expanded-content")).Count > 0);
+
+        var (_, relTopAfter, scrollTopAfter) = GetItemPositionInContainer(js, container, ".item", indexBefore);
+
+        Assert.True(Math.Abs(relTopAfter - relTopBefore) < 5,
+            $"Visible item '{indexBefore}' should not have moved when off-screen item expanded. " +
+            $"RelTop Before: {relTopBefore:F1}, After: {relTopAfter:F1}, Delta: {relTopAfter - relTopBefore:F1}px. " +
+            $"scrollTop: {scrollTopBefore}->{scrollTopAfter}.");
+    }
+
+    [Fact]
+    public void ViewportAnchoring_CollapseAboveViewport_VisibleItemStaysInPlace()
+    {
+        Browser.MountTestComponent<VirtualizationDynamicContent>();
+
+        var container = Browser.Exists(By.Id("scroll-container"));
+        var js = (IJavaScriptExecutor)Browser;
+        Browser.True(() => GetElementCount(container, ".item") > 0);
+
+        // Expand item 5 while it's visible (at the top)
+        Browser.Exists(By.Id("expand-item-5")).Click();
+        Browser.Contains("Item 5 expanded via button", () => Browser.Exists(By.Id("status")).Text);
+
+        // Scroll down past item 5 so it's in overscan above viewport
+        js.ExecuteScript("arguments[0].scrollTop = 600", container);
+        Browser.True(() => (long)js.ExecuteScript("return arguments[0].scrollTop", container) >= 600);
+
+        // Record first visible item position relative to container
+        var (indexBefore, relTopBefore, _) = GetItemPositionInContainer(js, container, ".item");
+
+        Browser.Exists(By.Id("collapse-all")).Click();
+        Browser.Contains("All items collapsed", () => Browser.Exists(By.Id("status")).Text);
+
+        var (_, relTopAfter, _) = GetItemPositionInContainer(js, container, ".item", indexBefore);
+
+        Assert.True(Math.Abs(relTopAfter - relTopBefore) < 5,
+            $"Visible item '{indexBefore}' should not have moved when off-screen item collapsed. " +
+            $"RelTop Before: {relTopBefore:F1}, After: {relTopAfter:F1}, Delta: {relTopAfter - relTopBefore:F1}px");
+    }
+
+    private static (string index, double relTop, long scrollTop) GetItemPositionInContainer(
+        IJavaScriptExecutor js, IWebElement container, string itemSelector, string dataIndex = null)
+    {
+        var result = js.ExecuteScript(@"
+            var container = arguments[0];
+            var selector = arguments[1];
+            var targetIndex = arguments[2];
+            var containerRect = container.getBoundingClientRect();
+            var items = container.querySelectorAll(selector);
+            for (var i = 0; i < items.length; i++) {
+                var item = items[i];
+                var itemRect = item.getBoundingClientRect();
+                if (targetIndex != null) {
+                    if (item.getAttribute('data-index') === targetIndex) {
+                        return { index: targetIndex, relTop: itemRect.top - containerRect.top, scrollTop: container.scrollTop };
+                    }
+                } else if (itemRect.top >= containerRect.top - 1 && itemRect.top < containerRect.bottom) {
+                    return { index: item.getAttribute('data-index'), relTop: itemRect.top - containerRect.top, scrollTop: container.scrollTop };
+                }
+            }
+            return null;
+        ", container, itemSelector, dataIndex) as Dictionary<string, object>;
+
+        Assert.NotNull(result);
+        return (
+            result["index"].ToString(),
+            Convert.ToDouble(result["relTop"], CultureInfo.InvariantCulture),
+            Convert.ToInt64(result["scrollTop"], CultureInfo.InvariantCulture));
+    }
 }

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -1671,7 +1671,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         var js = (IJavaScriptExecutor)Browser;
         Browser.True(() => GetElementCount(container, ".item") > 0);
 
-        // Scroll down so item 5 is above the viewport but still in DOM an verify its position
+        // Scroll down so item 5 is above the viewport but still in DOM and verify its position
         js.ExecuteScript("arguments[0].scrollTop = 500", container);
         Browser.True(() => (long)js.ExecuteScript("return arguments[0].scrollTop", container) >= 500);
         Browser.True(() => container.FindElements(By.CssSelector("[data-index='5']")).Count > 0);
@@ -1684,7 +1684,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         Browser.Exists(By.Id("expand-item-5")).Click();
         Browser.Contains("Item 5 expanded via button", () => Browser.Exists(By.Id("status")).Text);
 
-        // Wait for the expanded the 5th item content to appear in DOM
+        // Wait for the expanded content for item 5 to appear in the DOM
         Browser.True(() => container.FindElements(By.CssSelector("[data-index='5'] .expanded-content")).Count > 0);
 
         var (_, relTopAfter, scrollTopAfter) = GetItemPositionInContainer(js, container, ".item", indexBefore);

--- a/src/Components/test/testassets/BasicTestApp/VirtualizationDynamicContent.razor
+++ b/src/Components/test/testassets/BasicTestApp/VirtualizationDynamicContent.razor
@@ -35,8 +35,8 @@
 
     protected override void OnInitialized()
     {
-        // Create 30 items with initial height of 50px
-        items = Enumerable.Range(0, 30)
+        // 75 items with initial height of 50px (enough for true off-screen virtualization)
+        items = Enumerable.Range(0, 75)
             .Select(i => new DynamicItem { Index = i, Height = 50, IsExpanded = false })
             .ToList();
     }

--- a/src/Components/test/testassets/BasicTestApp/VirtualizationDynamicContent.razor
+++ b/src/Components/test/testassets/BasicTestApp/VirtualizationDynamicContent.razor
@@ -25,6 +25,8 @@
     <button id="expand-item-5" @onclick="() => ExpandItem(5)">Expand Item 5</button>
     <button id="collapse-all" @onclick="CollapseAll">Collapse All</button>
     <button id="simulate-image-load" @onclick="SimulateImageLoad">Simulate Image Load (Item 3)</button>
+    <button id="prepend-items" @onclick="PrependItems">Prepend 10 Items</button>
+    <button id="append-items" @onclick="AppendItems">Append 10 Items</button>
 </div>
 
 <p id="status">@statusMessage</p>
@@ -35,8 +37,10 @@
 
     protected override void OnInitialized()
     {
-        // 75 items with initial height of 50px (enough for true off-screen virtualization)
-        items = Enumerable.Range(0, 75)
+        // 500 items with initial height of 50px.
+        // With OverscanCount=15 (default), the initial render covers ~37 items (~2300px).
+        // 500 items provides enough content to force true virtualization when scrolling.
+        items = Enumerable.Range(0, 500)
             .Select(i => new DynamicItem { Index = i, Height = 50, IsExpanded = false })
             .ToList();
     }
@@ -79,6 +83,30 @@
             statusMessage = "Item 3 height changed (simulated image load)";
             StateHasChanged();
         }
+    }
+
+    private int nextPrependIndex = -1;
+    private int nextAppendIndex = 500;
+
+    private void PrependItems()
+    {
+        var newItems = Enumerable.Range(0, 10)
+            .Select(i => new DynamicItem { Index = nextPrependIndex - i, Height = 50, IsExpanded = false })
+            .ToList();
+        items.InsertRange(0, newItems);
+        nextPrependIndex -= 10;
+        statusMessage = $"Prepended 10 items (indices {newItems.Last().Index}..{newItems.First().Index})";
+    }
+
+    private void AppendItems()
+    {
+        var startIndex = nextAppendIndex;
+        var newItems = Enumerable.Range(startIndex, 10)
+            .Select(i => new DynamicItem { Index = i, Height = 50, IsExpanded = false })
+            .ToList();
+        items.AddRange(newItems);
+        nextAppendIndex += 10;
+        statusMessage = $"Appended 10 items (indices {startIndex}..{startIndex + 9})";
     }
 
     private class DynamicItem


### PR DESCRIPTION
 Adds viewport stability to the Virtualize component: visible items stay in place when content above the viewport changes height, and when items are prepended to the collection.

## Problem

The Virtualize component disables the browser's native scroll anchoring (`overflow-anchor: none`) to prevent an infinite rendering loop. This means any height change above the viewport (item expansion, data updates, etc.) causes visible content to shift ("scroll jumps").  (see issue for more details)
Additionally, prepending items to the collection silently shifts what the user sees with no compensation.

## Approach: Hybrid scroll anchoring

 Uses browser-native CSS Scroll Anchoring where available, with manual JS compensation as fallback.

   **Why not pure manual compensation like other frameworks?**
   Every major virtual scroll library (TanStack Virtual, react-window, react-virtualized) uses manual `scrollTop` adjustment and requires the developer to handle prepend scenarios. Our hybrid approach gives:
   - Flash-free compensation via native anchoring (no SignalR round-trip needed)
   - Transparent prepend handling for `Items` (zero developer effort)
   - Safari/table support via manual fallback.
   
   **Why native anchoring can't work for `<table>` layout?**
   CSS Scroll Anchoring [miscalculates positions](https://stackoverflow.com/questions/51843534) when `<tr>` elements are anchor candidates, causing 3000-8000px jumps per scroll event. Tested 9 CSS approaches — all fail. The fix disables browser anchoring for tables.
 
## Description

 **C# (Virtualize.cs) - prepend detection for `Items`:**
 - Detects when items are inserted before the viewport by comparing the first loaded item reference across renders (`ReferenceEquals` + `ElementAtOrDefault` for O(1) access).
 - Adjusts `_itemsBefore` so `spacerBefore` grows, creating a real DOM shift that the browser (or manual path) compensates automatically.
 - Scoped to `DefaultItemsProvider` - custom `ItemsProvider` returns new instances per request, making reference comparison unreliable. We would have to add new API for developers to inform virtualization component that they prepended. Other frameworks either do not support it at all (`TanStack`) or have additional manual step that is considered "convoluted" even by the maintainers and it [still causes table jumps](https://stackoverflow.com/questions/79499011)  (e.g. `react-virtuoso` and its `firstItemIndex`; `react-window` with `scrollOffset` adjustments; `react-virtualized` that requires calling `scrollToPosition()`).
 
 **JS (Virtualize.ts) - two compensation mechanisms:**
 - **Native path** (Chrome/Firefox/Edge + non-table): Set `overflow-anchor: none` only on spacers. The browser anchors on rendered items and compensates `scrollTop` atomically during layout.
 - **Manual path** (tables + Safari): Disable browser anchoring on the scroll container. Track item heights via `ResizeObserver`; compensate `scrollTop` when items above the viewport resize.
  
Manual path details:
 - Always observe all rendered items between the spacers (not just during convergence).
 - Track item heights in a Map; on resize, compute the delta.
 - Compensate `scrollTop` when the resized item is entirely above the viewport.
 - Skip compensation during convergence to avoid fighting with convergence pinning.

Convergence changes:
 - `End`/`Home` keydown listener starts convergence immediately, before the browser updates scroll position. With native anchoring enabled the browser may prevent `scrollTop` from reaching the absolute extremity, so IO-based detection alone (`onSpacerAfterVisible`) is not sufficient.
 - `IntersectionObserver` callbacks are throttled via a pending-entries map to deduplicate rapid intersection events.

https://github.com/user-attachments/assets/485e81f5-78a5-4683-87a0-2eb63963cc80

Fixes #65939