### PR TITLE
Disable parallel restore for BuildPass2 projects

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -94,9 +94,20 @@
     <!-- Projects to build in .NET product build pass 2 -->
     <When Condition="'$(DotNetBuildPass)' == '2'">
       <ItemGroup Condition=" '$(DotNetBuild)' == 'true' AND '$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'x64' ">
-        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\WindowsHostingBundle\WindowsHostingBundle.wixproj" BuildStep="bp2" DotNetBuildPass="$(DotNetBuildPass)" AdditionalProperties="Platform=x86" />
-        <ProjectToBuild Include="$(RepoRoot)src\Servers\IIS\IntegrationTesting.IIS\src\Microsoft.AspNetCore.Server.IntegrationTesting.IIS.csproj" BuildStep="bp2" DotNetBuildPass="$(DotNetBuildPass)" />
-        <ProjectToBuild Include="$(RepoRoot)src\SiteExtensions\LoggingAggregate\src\Microsoft.AspNetCore.AzureAppServices.SiteExtension\Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj" BuildStep="bp2" DotNetBuildPass="$(DotNetBuildPass)" />
+        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\WindowsHostingBundle\WindowsHostingBundle.wixproj"
+                        BuildStep="bp2"
+                        DotNetBuildPass="$(DotNetBuildPass)"
+                        AdditionalProperties="Platform=x86" />
+        <ProjectToBuild Include="$(RepoRoot)src\Servers\IIS\IntegrationTesting.IIS\src\Microsoft.AspNetCore.Server.IntegrationTesting.IIS.csproj"
+                        BuildStep="bp2"
+                        DotNetBuildPass="$(DotNetBuildPass)" />
+        <ProjectToBuild Include="$(RepoRoot)src\SiteExtensions\LoggingAggregate\src\Microsoft.AspNetCore.AzureAppServices.SiteExtension\Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj"
+                        BuildStep="bp2"
+                        DotNetBuildPass="$(DotNetBuildPass)" />
+      </ItemGroup>
+      <!-- Disable parallel restore for all pass-2 projects to mitigate https://github.com/dotnet/dotnet/issues/4558 -->
+      <ItemGroup>
+        <ProjectToBuild Update="@(ProjectToBuild)" RestoreInParallel="false" />
       </ItemGroup>
     </When>
     <Otherwise>

--- a/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
+++ b/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
@@ -12,9 +12,6 @@
     <SchemaVersion>2.0</SchemaVersion>
     <!-- We import D.B.T ourselves in this file -->
     <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
-    <!-- Should mitigate https://github.com/dotnet/dotnet/issues/4558 -->
-    <RestoreDisableParallel>true</RestoreDisableParallel>
-
     <!-- Namespace used to generate stable UUID3 GUIDs for MSI ProductCode, etc. DO NOT CHANGE THIS. -->
     <NamespaceGuid>$(HostingBundleNamespaceGuid)</NamespaceGuid>
 


### PR DESCRIPTION
Mitigate https://github.com/dotnet/dotnet/issues/4558. 

Graph restore is disabled in BuildPass 2 for aspnetcore, so Arcade just calls `Restore` on each project. The projects we restore have overlapping dependency closures, so a parallel restore can cause file conflicts. Setting `RestoreInParallel=false` on the Pass 2 projects will flow through to Arcade's build.proj here: https://github.com/dotnet/arcade/blob/291fa0852f49d984f72da872f52e9b492447d179/src/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj#L260-L266. This should cause the pass 2 projects to restore serially.