### PR TITLE
Fix NegotiationMatcherPolicy invalidating higher-priority endpoints

### DIFF
--- a/src/Http/Routing/src/Matching/NegotiationMatcherPolicy.cs
+++ b/src/Http/Routing/src/Matching/NegotiationMatcherPolicy.cs
@@ -97,9 +97,12 @@ internal abstract class NegotiationMatcherPolicy<TNegotiateMetadata> : MatcherPo
         var bestQualitySoFar = 0.0;
         var bestEndpointQualitySoFar = 0.0;
         // Track where the current score tier starts. Since candidates are sorted by ascending score,
-        // all candidates in [0, scoreTierStart) have a strictly lower score than candidates[scoreTierStart].
+        // all candidates in [0, scoreTierStart) have a strictly lower score than candidates in the current tier.
         // This lets us bound backward sweeps in EvaluateCandidate without per-element score comparisons.
+        // currentTierScore tracks the score value in a separate variable because SetValidity bitwise-negates
+        // the Score field, which would corrupt a tier-boundary check that reads candidates[scoreTierStart].Score.
         var scoreTierStart = 0;
+        var currentTierScore = int.MinValue;
         for (var i = 0; i < candidates.Count; i++)
         {
             if (!candidates.IsValidCandidate(i))
@@ -110,11 +113,13 @@ internal abstract class NegotiationMatcherPolicy<TNegotiateMetadata> : MatcherPo
 
             sawValidCandidate = true;
 
-            // Update score tier boundary. Since candidates are sorted by ascending score,
-            // once we see a higher score, everything before this index is in a lower tier.
-            if (candidates[i].Score != candidates[scoreTierStart].Score)
+            // candidates[i].Score is always non-negative here (candidate is valid).
+            // Since candidates are sorted by ascending score, a new score value means a new tier.
+            var candidateScore = candidates[i].Score;
+            if (candidateScore != currentTierScore)
             {
                 scoreTierStart = i;
+                currentTierScore = candidateScore;
             }
 
             ref var candidate = ref candidates[i];

--- a/src/Http/Routing/src/Matching/NegotiationMatcherPolicy.cs
+++ b/src/Http/Routing/src/Matching/NegotiationMatcherPolicy.cs
@@ -93,8 +93,13 @@ internal abstract class NegotiationMatcherPolicy<TNegotiateMetadata> : MatcherPo
         var sawCandidateWithoutMetadata = false;
         var sawValidCandidate = false;
         var bestMatchIndex = -1;
+        var bestMatchScore = -1;
         var bestQualitySoFar = 0.0;
         var bestEndpointQualitySoFar = 0.0;
+        // Track where the current score tier starts. Since candidates are sorted by ascending score,
+        // all candidates in [0, scoreTierStart) have a strictly lower score than candidates[scoreTierStart].
+        // This lets us bound backward sweeps in EvaluateCandidate without per-element score comparisons.
+        var scoreTierStart = 0;
         for (var i = 0; i < candidates.Count; i++)
         {
             if (!candidates.IsValidCandidate(i))
@@ -104,6 +109,13 @@ internal abstract class NegotiationMatcherPolicy<TNegotiateMetadata> : MatcherPo
             }
 
             sawValidCandidate = true;
+
+            // Update score tier boundary. Since candidates are sorted by ascending score,
+            // once we see a higher score, everything before this index is in a lower tier.
+            if (candidates[i].Score != candidates[scoreTierStart].Score)
+            {
+                scoreTierStart = i;
+            }
 
             ref var candidate = ref candidates[i];
             var metadata = GetMetadataValue(candidate.Endpoint);
@@ -120,7 +132,8 @@ internal abstract class NegotiationMatcherPolicy<TNegotiateMetadata> : MatcherPo
                 if (MemoryExtensions.Equals(metadata.AsSpan(), value.Value.AsSpan(), StringComparison.OrdinalIgnoreCase))
                 {
                     found = true;
-                    EvaluateCandidate(candidates, ref bestMatchIndex, ref bestQualitySoFar, ref bestEndpointQualitySoFar, i, value);
+                    EvaluateCandidate(candidates, ref bestMatchIndex, ref bestQualitySoFar, ref bestEndpointQualitySoFar, i, scoreTierStart, value);
+                    bestMatchScore = candidates[bestMatchIndex].Score;
                     break;
                 }
             }
@@ -129,6 +142,13 @@ internal abstract class NegotiationMatcherPolicy<TNegotiateMetadata> : MatcherPo
             {
                 // We already have at least a candidate, and the default value was not part of the header, so we won't be considering it
                 // at a later stage as a fallback.
+                // However, don't invalidate candidates with strictly better routing priority (lower score) than the current best match.
+                // Since candidates are sorted by ascending score, once i reaches the best match's score tier,
+                // all subsequent candidates have equal or worse priority.
+                if (bestMatchIndex >= 0 && candidates[i].Score < bestMatchScore)
+                {
+                    continue;
+                }
                 candidates.SetValidity(i, false);
             }
         }
@@ -150,6 +170,7 @@ internal abstract class NegotiationMatcherPolicy<TNegotiateMetadata> : MatcherPo
         ref double bestQualitySoFar,
         ref double bestEndpointQualitySoFar,
         int currentIndex,
+        int scoreTierStart,
         StringWithQualityHeaderValue value)
     {
         var quality = value.Quality ?? 1.0;
@@ -161,7 +182,10 @@ internal abstract class NegotiationMatcherPolicy<TNegotiateMetadata> : MatcherPo
             bestEndpointQualitySoFar = GetMetadataQuality(candidates[currentIndex].Endpoint) ?? 1.0;
 
             // Since we found a better match, we can invalidate all the candidates from the current position to the new one.
-            for (var j = bestMatchIndex; j < currentIndex; j++)
+            // Only invalidate within the same score tier — candidates before scoreTierStart have strictly
+            // better routing priority and represent different resources that should not be eliminated by
+            // encoding preference. Since candidates are sorted by ascending score, this is a simple bound.
+            for (var j = Math.Max(bestMatchIndex, scoreTierStart); j < currentIndex; j++)
             {
                 candidates.SetValidity(j, false);
             }
@@ -181,7 +205,7 @@ internal abstract class NegotiationMatcherPolicy<TNegotiateMetadata> : MatcherPo
             if ((endpointQuality - bestEndpointQualitySoFar) > double.Epsilon)
             {
                 // Since we found a better match, we can invalidate all the candidates from the current position to the new one.
-                for (var j = bestMatchIndex; j < currentIndex; j++)
+                for (var j = Math.Max(bestMatchIndex, scoreTierStart); j < currentIndex; j++)
                 {
                     candidates.SetValidity(j, false);
                 }

--- a/src/Http/Routing/test/UnitTests/Matching/ContentEncodingNegotiationMatcherPolicyIEndpointSelectorPolicyIntegrationTest.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/ContentEncodingNegotiationMatcherPolicyIEndpointSelectorPolicyIntegrationTest.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Routing.Matching;
+
+// End-to-end tests for the content encoding negotiation matching functionality (IEndpointSelectorPolicy path)
+public class ContentEncodingNegotiationMatcherPolicyIEndpointSelectorPolicyIntegrationTest : ContentEncodingNegotiationMatcherPolicyIntegrationTestBase
+{
+    protected override bool HasDynamicMetadata => true;
+}

--- a/src/Http/Routing/test/UnitTests/Matching/ContentEncodingNegotiationMatcherPolicyINodeBuilderPolicyIntegrationTest.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/ContentEncodingNegotiationMatcherPolicyINodeBuilderPolicyIntegrationTest.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Routing.Matching;
+
+// End-to-end tests for the content encoding negotiation matching functionality (INodeBuilderPolicy path)
+public class ContentEncodingNegotiationMatcherPolicyINodeBuilderPolicyIntegrationTest : ContentEncodingNegotiationMatcherPolicyIntegrationTestBase
+{
+    protected override bool HasDynamicMetadata => false;
+}

--- a/src/Http/Routing/test/UnitTests/Matching/ContentEncodingNegotiationMatcherPolicyIntegrationTestBase.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/ContentEncodingNegotiationMatcherPolicyIntegrationTestBase.cs
@@ -81,6 +81,27 @@ public abstract class ContentEncodingNegotiationMatcherPolicyIntegrationTestBase
     }
 
     [Fact]
+    public async Task Match_ContentEncoding_AcceptQualityWins_WhenBothAcceptAndEndpointQualityDiffer()
+    {
+        // Arrange — Accept quality takes precedence over endpoint quality (the tie-breaker).
+        // Both endpoints have the same endpoint quality (equal server preference).
+        // The client's Accept-Encoding header assigns different qualities to each encoding.
+        // Even though endpoint quality would be used as a tie-breaker when Accept qualities are equal,
+        // here the Accept quality difference dictates the selection.
+        var gzipEndpoint = CreateEndpoint("/hello", contentEncoding: "gzip", quality: 0.9);
+        var brEndpoint = CreateEndpoint("/hello", contentEncoding: "br", quality: 0.9);
+
+        var matcher = CreateMatcher(gzipEndpoint, brEndpoint);
+        var httpContext = CreateContext("/hello", "gzip;q=0.3, br;q=0.9");
+
+        // Act
+        await matcher.MatchAsync(httpContext);
+
+        // Assert — br has higher Accept quality (0.9 > 0.3), so br is selected.
+        MatcherAssert.AssertMatch(httpContext, brEndpoint);
+    }
+
+    [Fact]
     public async Task Match_LiteralEndpointPreserved_WhenCatchAllHasEncodingMetadata()
     {
         // Arrange - This is the core scenario for the priority fix:

--- a/src/Http/Routing/test/UnitTests/Matching/ContentEncodingNegotiationMatcherPolicyIntegrationTestBase.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/ContentEncodingNegotiationMatcherPolicyIntegrationTestBase.cs
@@ -1,0 +1,294 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Routing.Matching;
+
+// End-to-end tests for the content encoding negotiation matching functionality
+public abstract class ContentEncodingNegotiationMatcherPolicyIntegrationTestBase
+{
+    protected abstract bool HasDynamicMetadata { get; }
+
+    [Fact]
+    public async Task Match_ContentEncoding_SelectsEndpointWithMatchingEncoding()
+    {
+        // Arrange
+        var gzipEndpoint = CreateEndpoint("/hello", contentEncoding: "gzip");
+        var identityEndpoint = CreateEndpoint("/hello");
+
+        var matcher = CreateMatcher(gzipEndpoint, identityEndpoint);
+        var httpContext = CreateContext("/hello", "gzip");
+
+        // Act
+        await matcher.MatchAsync(httpContext);
+
+        // Assert
+        MatcherAssert.AssertMatch(httpContext, gzipEndpoint);
+    }
+
+    [Fact]
+    public async Task Match_ContentEncoding_SelectsIdentityEndpoint_WhenEncodingNotInAcceptHeader()
+    {
+        // Arrange
+        var gzipEndpoint = CreateEndpoint("/hello", contentEncoding: "gzip");
+        var identityEndpoint = CreateEndpoint("/hello");
+
+        var matcher = CreateMatcher(gzipEndpoint, identityEndpoint);
+        var httpContext = CreateContext("/hello", "br");
+
+        // Act
+        await matcher.MatchAsync(httpContext);
+
+        // Assert
+        MatcherAssert.AssertMatch(httpContext, identityEndpoint);
+    }
+
+    [Fact]
+    public async Task Match_ContentEncoding_SelectsHigherAcceptQuality()
+    {
+        // Arrange
+        var gzipEndpoint = CreateEndpoint("/hello", contentEncoding: "gzip");
+        var brEndpoint = CreateEndpoint("/hello", contentEncoding: "br");
+
+        var matcher = CreateMatcher(gzipEndpoint, brEndpoint);
+        var httpContext = CreateContext("/hello", "gzip;q=0.5, br;q=1.0");
+
+        // Act
+        await matcher.MatchAsync(httpContext);
+
+        // Assert
+        MatcherAssert.AssertMatch(httpContext, brEndpoint);
+    }
+
+    [Fact]
+    public async Task Match_ContentEncoding_SelectsHigherEndpointQuality_WhenAcceptQualityEqual()
+    {
+        // Arrange
+        var gzipEndpoint = CreateEndpoint("/hello", contentEncoding: "gzip", quality: 0.9);
+        var brEndpoint = CreateEndpoint("/hello", contentEncoding: "br", quality: 0.5);
+
+        var matcher = CreateMatcher(gzipEndpoint, brEndpoint);
+        var httpContext = CreateContext("/hello", "gzip, br");
+
+        // Act
+        await matcher.MatchAsync(httpContext);
+
+        // Assert
+        MatcherAssert.AssertMatch(httpContext, gzipEndpoint);
+    }
+
+    [Fact]
+    public async Task Match_LiteralEndpointPreserved_WhenCatchAllHasEncodingMetadata()
+    {
+        // Arrange - This is the core scenario for the priority fix:
+        // A literal endpoint without encoding metadata must not be invalidated
+        // by a catch-all with encoding metadata.
+        var literalEndpoint = CreateEndpoint("/hello");
+        var catchAllGzip = CreateEndpoint("/{**path}", contentEncoding: "gzip");
+
+        var matcher = CreateMatcher(literalEndpoint, catchAllGzip);
+        var httpContext = CreateContext("/hello", "gzip, br");
+
+        // Act
+        await matcher.MatchAsync(httpContext);
+
+        // Assert - literal endpoint wins by route priority despite not matching gzip
+        MatcherAssert.AssertMatch(httpContext, literalEndpoint);
+    }
+
+    [Fact]
+    public async Task Match_LiteralEndpointPreserved_WhenCatchAllHasMultipleEncodingVariants()
+    {
+        // Arrange - Simulates MapStaticAssets: catch-all has identity, gzip, and br variants.
+        // The literal endpoint must survive.
+        var literalEndpoint = CreateEndpoint("/hello");
+        var catchAllIdentity = CreateEndpoint("/{**path}");
+        var catchAllGzip = CreateEndpoint("/{**path}", contentEncoding: "gzip");
+        var catchAllBr = CreateEndpoint("/{**path}", contentEncoding: "br");
+
+        var matcher = CreateMatcher(literalEndpoint, catchAllIdentity, catchAllGzip, catchAllBr);
+        var httpContext = CreateContext("/hello", "gzip, br");
+
+        // Act
+        await matcher.MatchAsync(httpContext);
+
+        // Assert - literal wins by route priority
+        MatcherAssert.AssertMatch(httpContext, literalEndpoint);
+    }
+
+    [Fact]
+    public async Task Match_ParameterizedEndpointPreserved_WhenCatchAllHasEncodingMetadata()
+    {
+        // Arrange
+        var paramEndpoint = CreateEndpoint("/hello/{name}");
+        var catchAllGzip = CreateEndpoint("/{**path}", contentEncoding: "gzip");
+
+        var matcher = CreateMatcher(paramEndpoint, catchAllGzip);
+        var httpContext = CreateContext("/hello/world", "gzip");
+
+        // Act
+        await matcher.MatchAsync(httpContext);
+
+        // Assert - parameterized endpoint wins by route priority
+        MatcherAssert.AssertMatch(httpContext, paramEndpoint, new { name = "world" });
+    }
+
+    [Fact]
+    public async Task Match_MixedPriorities_LiteralWinsOverParameterizedAndCatchAll()
+    {
+        // Arrange - Multiple priority tiers:
+        //   /literal/path           (exact, no metadata)
+        //   /literal/{param}        (parameterized, no metadata)
+        //   {**catchall} gzip       (catch-all with encoding metadata)
+        var literalEndpoint = CreateEndpoint("/literal/path");
+        var paramEndpoint = CreateEndpoint("/literal/{param}");
+        var catchAllGzip = CreateEndpoint("/{**path}", contentEncoding: "gzip");
+
+        var matcher = CreateMatcher(literalEndpoint, paramEndpoint, catchAllGzip);
+        var httpContext = CreateContext("/literal/path", "gzip, br");
+
+        // Act
+        await matcher.MatchAsync(httpContext);
+
+        // Assert - literal wins (highest priority)
+        MatcherAssert.AssertMatch(httpContext, literalEndpoint);
+    }
+
+    [Fact]
+    public async Task Match_EncodingNegotiationWorksWithinSamePriority()
+    {
+        // Arrange - Two variants of the same resource at the same route priority.
+        // Encoding negotiation should still pick the best encoding.
+        var gzipEndpoint = CreateEndpoint("/hello", contentEncoding: "gzip", quality: 0.8);
+        var identityEndpoint = CreateEndpoint("/hello");
+
+        var matcher = CreateMatcher(gzipEndpoint, identityEndpoint);
+        var httpContext = CreateContext("/hello", "gzip");
+
+        // Act
+        await matcher.MatchAsync(httpContext);
+
+        // Assert - gzip wins (encoding match within same priority)
+        MatcherAssert.AssertMatch(httpContext, gzipEndpoint);
+    }
+
+    [Fact]
+    public async Task Match_StaticFileEncodingVariants_CatchAllDoesNotInterfere()
+    {
+        // Arrange - Simulates a static file with encoding variants plus a catch-all:
+        //   /style.css identity    (no metadata)
+        //   /style.css gzip        (gzip metadata)
+        //   {**path}   gzip        (catch-all with gzip)
+        var styleIdentity = CreateEndpoint("/style.css");
+        var styleGzip = CreateEndpoint("/style.css", contentEncoding: "gzip", quality: 0.8);
+        var catchAllGzip = CreateEndpoint("/{**path}", contentEncoding: "gzip", quality: 0.8);
+
+        var matcher = CreateMatcher(styleIdentity, styleGzip, catchAllGzip);
+        var httpContext = CreateContext("/style.css", "gzip");
+
+        // Act
+        await matcher.MatchAsync(httpContext);
+
+        // Assert - style.css gzip wins (same priority as identity, better encoding match)
+        MatcherAssert.AssertMatch(httpContext, styleGzip);
+    }
+
+    [Fact]
+    public async Task Match_CatchAllSelected_WhenNoHigherPriorityMatch()
+    {
+        // Arrange - Request to a path that only matches the catch-all.
+        // Encoding negotiation should work normally.
+        var literalEndpoint = CreateEndpoint("/hello");
+        var catchAllGzip = CreateEndpoint("/{**path}", contentEncoding: "gzip");
+        var catchAllIdentity = CreateEndpoint("/{**path}");
+
+        var matcher = CreateMatcher(literalEndpoint, catchAllGzip, catchAllIdentity);
+        var httpContext = CreateContext("/other", "gzip");
+
+        // Act
+        await matcher.MatchAsync(httpContext);
+
+        // Assert - catch-all gzip wins (only catch-all matches this path)
+        MatcherAssert.AssertMatch(httpContext, catchAllGzip, new { path = "other" });
+    }
+
+    [Fact]
+    public async Task Match_Returns406_WhenNoEndpointMatchesEncoding_AndNoIdentityFallback()
+    {
+        // Arrange - Only encoded variants exist, none match the Accept-Encoding.
+        var gzipEndpoint = CreateEndpoint("/hello", contentEncoding: "gzip");
+        var brEndpoint = CreateEndpoint("/hello", contentEncoding: "br");
+
+        var matcher = CreateMatcher(gzipEndpoint, brEndpoint);
+        var httpContext = CreateContext("/hello", "zstd");
+
+        // Act
+        await matcher.MatchAsync(httpContext);
+
+        // Assert - 406 endpoint is selected (no match, no identity fallback)
+        Assert.NotNull(httpContext.GetEndpoint());
+        Assert.Equal(NegotiationMatcherPolicy<ContentEncodingMetadata>.Http406EndpointDisplayName, httpContext.GetEndpoint().DisplayName);
+    }
+
+    private static Matcher CreateMatcher(params RouteEndpoint[] endpoints)
+    {
+        var services = new ServiceCollection()
+            .AddOptions()
+            .AddLogging()
+            .AddRouting()
+            .BuildServiceProvider();
+
+        var builder = services.GetRequiredService<DfaMatcherBuilder>();
+        for (var i = 0; i < endpoints.Length; i++)
+        {
+            builder.AddEndpoint(endpoints[i]);
+        }
+
+        return builder.Build();
+    }
+
+    internal static HttpContext CreateContext(string path, string acceptEncoding)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Path = path;
+        httpContext.Request.Headers["Accept-Encoding"] = acceptEncoding;
+
+        return httpContext;
+    }
+
+    internal RouteEndpoint CreateEndpoint(
+        string template,
+        object defaults = null,
+        object constraints = null,
+        int order = 0,
+        string contentEncoding = null,
+        double quality = 1.0)
+    {
+        var metadata = new List<object>();
+        if (contentEncoding != null)
+        {
+            metadata.Add(new ContentEncodingMetadata(contentEncoding, quality));
+        }
+
+        if (HasDynamicMetadata)
+        {
+            metadata.Add(new DynamicEndpointMetadata());
+        }
+
+        var displayName = "endpoint: " + template + " " + (contentEncoding ?? "identity") + " q=" + quality;
+        return new RouteEndpoint(
+            TestConstants.EmptyRequestDelegate,
+            RoutePatternFactory.Parse(template, defaults, constraints),
+            order,
+            new EndpointMetadataCollection(metadata),
+            displayName);
+    }
+
+    private class DynamicEndpointMetadata : IDynamicEndpointMetadata
+    {
+        public bool IsDynamic => true;
+    }
+}

--- a/src/Http/Routing/test/UnitTests/Matching/ContentEncodingNegotiationMatcherPolicyTest.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/ContentEncodingNegotiationMatcherPolicyTest.cs
@@ -626,10 +626,341 @@ public class ContentEncodingNegotiationMatcherPolicyTest
         return (ContentEncodingNegotiationMatcherPolicy.NegotiationPolicyJumpTable)table;
     }
 
+    [Fact]
+    public async Task ApplyAsync_PreservesHigherPriorityEndpoint_WhenLowerPriorityEndpointMatchesEncoding()
+    {
+        // Arrange - simulates config endpoint (score=0, no encoding) vs catch-all (score=1, gzip)
+        var policy = new ContentEncodingNegotiationMatcherPolicy();
+        var configEndpoint = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(), "Config");
+        var catchAllGzip = CreateEndpoint("gzip");
+        var endpoints = CreateCandidateSet(
+            new[] { configEndpoint, catchAllGzip },
+            new[] { 0, 1 });
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["Accept-Encoding"] = "gzip, br";
+
+        // Act
+        await policy.ApplyAsync(httpContext, endpoints);
+
+        // Assert - config endpoint must survive despite not matching gzip
+        Assert.True(endpoints.IsValidCandidate(0));
+        Assert.True(endpoints.IsValidCandidate(1));
+        Assert.Null(httpContext.GetEndpoint());
+    }
+
+    [Fact]
+    public async Task ApplyAsync_PreservesHigherPriorityEndpoint_WhenLowerPriorityEndpointMatchesEncoding_MultipleEncodings()
+    {
+        // Arrange - config (score=0) + identity catch-all (score=1) + gzip catch-all (score=1) + br catch-all (score=1)
+        var policy = new ContentEncodingNegotiationMatcherPolicy();
+        var configEndpoint = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(), "Config");
+        var catchAllIdentity = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(), "CatchAll-Identity");
+        var catchAllGzip = CreateEndpoint("gzip");
+        var catchAllBr = CreateEndpoint("br");
+        var endpoints = CreateCandidateSet(
+            new[] { configEndpoint, catchAllIdentity, catchAllGzip, catchAllBr },
+            new[] { 0, 1, 1, 1 });
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["Accept-Encoding"] = "gzip, br";
+
+        // Act
+        await policy.ApplyAsync(httpContext, endpoints);
+
+        // Assert - config preserved, encoding negotiation works among same-score candidates
+        Assert.True(endpoints.IsValidCandidate(0));
+        Assert.False(endpoints.IsValidCandidate(1)); // identity catch-all — invalidated by gzip match
+        Assert.True(endpoints.IsValidCandidate(2));  // gzip match
+        Assert.False(endpoints.IsValidCandidate(3)); // br — invalidated (gzip matched first with same quality)
+        Assert.Null(httpContext.GetEndpoint());
+    }
+
+    [Fact]
+    public async Task ApplyAsync_InvalidatesSamePriorityEndpoints_WhenEncodingMatches()
+    {
+        // Arrange - both at same score: identity and gzip variants of the same resource
+        var policy = new ContentEncodingNegotiationMatcherPolicy();
+        var identity = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(), "Resource-Identity");
+        var gzip = CreateEndpoint("gzip");
+        var endpoints = CreateCandidateSet(
+            new[] { identity, gzip },
+            new[] { 0, 0 });
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["Accept-Encoding"] = "gzip";
+
+        // Act
+        await policy.ApplyAsync(httpContext, endpoints);
+
+        // Assert - same priority, encoding wins
+        Assert.False(endpoints.IsValidCandidate(0));
+        Assert.True(endpoints.IsValidCandidate(1));
+    }
+
+    [Fact]
+    public async Task ApplyAsync_PreservesHigherPriorityEndpoint_StaticFileAndCatchAll()
+    {
+        // Arrange - simulates: style.css(gzip,score=0) + style.css(identity,score=0) + catch-all(gzip,score=1)
+        var policy = new ContentEncodingNegotiationMatcherPolicy();
+        var styleGzip = CreateEndpoint("gzip", 0.8);
+        var styleIdentity = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(), "style.css-identity");
+        var catchAllGzip = CreateEndpoint("gzip", 0.8);
+        var endpoints = CreateCandidateSet(
+            new[] { styleGzip, styleIdentity, catchAllGzip },
+            new[] { 0, 0, 1 });
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["Accept-Encoding"] = "gzip";
+
+        // Act
+        await policy.ApplyAsync(httpContext, endpoints);
+
+        // Assert - style.css gzip wins, identity invalidated (same score), catchall invalidated (lost quality tie)
+        Assert.True(endpoints.IsValidCandidate(0));
+        Assert.False(endpoints.IsValidCandidate(1));
+        Assert.False(endpoints.IsValidCandidate(2));
+    }
+
+    [Fact]
+    public async Task ApplyAsync_PreservesHigherPriorityEndpoint_PostMatchInvalidation()
+    {
+        // Arrange - Encoding match found first, then a higher-priority default comes after in the list
+        // This tests the post-match invalidation path
+        var policy = new ContentEncodingNegotiationMatcherPolicy();
+        var gzipEndpoint = CreateEndpoint("gzip");
+        var higherPriorityDefault = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(), "HighPriority-Default");
+        // gzip at score=1, higher priority default at score=0
+        // Note: in practice candidates are sorted by score (lower first), but the fix must handle
+        // any ordering since candidates may be re-ordered by other policies
+        var endpoints = CreateCandidateSet(
+            new[] { gzipEndpoint, higherPriorityDefault },
+            new[] { 1, 0 });
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["Accept-Encoding"] = "gzip";
+
+        // Act
+        await policy.ApplyAsync(httpContext, endpoints);
+
+        // Assert - higher priority default preserved even though gzip was matched
+        Assert.True(endpoints.IsValidCandidate(0));  // gzip matched
+        Assert.True(endpoints.IsValidCandidate(1));   // higher priority preserved
+    }
+
+    [Fact]
+    public async Task ApplyAsync_PreservesHigherPriorityEndpoint_HigherQualityEqualTie()
+    {
+        // Arrange - tests the equal-quality branch in EvaluateCandidate with higher endpoint quality
+        var policy = new ContentEncodingNegotiationMatcherPolicy();
+        var configEndpoint = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(), "Config");
+        var gzipLowQuality = CreateEndpoint("gzip", 0.5);
+        var gzipHighQuality = CreateEndpoint("gzip", 0.9);
+        var endpoints = CreateCandidateSet(
+            new[] { configEndpoint, gzipLowQuality, gzipHighQuality },
+            new[] { 0, 1, 1 });
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["Accept-Encoding"] = "gzip";
+
+        // Act
+        await policy.ApplyAsync(httpContext, endpoints);
+
+        // Assert - config preserved (higher priority), gzip high quality wins among same-score
+        Assert.True(endpoints.IsValidCandidate(0));   // config preserved by priority
+        Assert.False(endpoints.IsValidCandidate(1));  // lower quality gzip invalidated
+        Assert.True(endpoints.IsValidCandidate(2));   // higher quality gzip wins
+    }
+
+    [Fact]
+    public async Task ApplyAsync_PreservesAllHigherPriorityEndpoints_MixedRoutePriorities()
+    {
+        // Arrange - simulates a DFA node where multiple endpoint types with different priorities
+        // coexist with a catch-all that has encoding metadata:
+        //   /literal/path               Score=0 (exact match, no metadata)
+        //   /literal/{parameter}         Score=1 (parameterized, no metadata)
+        //   /literal/{parameter:regex}   Score=2 (constrained parameter, no metadata)
+        //   {**catchall:regex}           Score=3 (constrained catch-all, no metadata)
+        //   {**catchall} gzip            Score=4 (unconstrained catch-all with encoding metadata)
+        var policy = new ContentEncodingNegotiationMatcherPolicy();
+        var literalPath = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(), "/literal/path");
+        var parameterized = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(), "/literal/{parameter}");
+        var constrainedParameter = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(), "/literal/{parameter:regex}");
+        var constrainedCatchAll = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(), "{**catchall:regex}");
+        var catchAllGzip = CreateEndpoint("gzip", 0.8);
+        var endpoints = CreateCandidateSet(
+            new[] { literalPath, parameterized, constrainedParameter, constrainedCatchAll, catchAllGzip },
+            new[] { 0, 1, 2, 3, 4 });
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["Accept-Encoding"] = "gzip, br";
+
+        // Act
+        await policy.ApplyAsync(httpContext, endpoints);
+
+        // Assert - all higher-priority endpoints preserved, catch-all gzip also valid (it matched)
+        Assert.True(endpoints.IsValidCandidate(0));   // /literal/path preserved (Score=0)
+        Assert.True(endpoints.IsValidCandidate(1));   // /literal/{parameter} preserved (Score=1)
+        Assert.True(endpoints.IsValidCandidate(2));   // /literal/{parameter:regex} preserved (Score=2)
+        Assert.True(endpoints.IsValidCandidate(3));   // {**catchall:regex} preserved (Score=3)
+        Assert.True(endpoints.IsValidCandidate(4));   // {**catchall} gzip matched
+    }
+
+    [Fact]
+    public async Task ApplyAsync_PreservesHigherPriority_MetadataOnIntermediateEndpoint()
+    {
+        // Encoding metadata is on a mid-priority endpoint, not the lowest-priority catch-all.
+        // Higher-priority literal and lower-priority catch-all both lack metadata.
+        //   /literal/path          Score=0 (no metadata)
+        //   /literal/{param} gzip  Score=1 (gzip metadata)
+        //   {**catchall}           Score=2 (no metadata)
+        var policy = new ContentEncodingNegotiationMatcherPolicy();
+        var literal = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(), "/literal/path");
+        var paramGzip = CreateEndpoint("gzip", 0.9);
+        var catchAll = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(), "{**catchall}");
+        var endpoints = CreateCandidateSet(
+            new[] { literal, paramGzip, catchAll },
+            new[] { 0, 1, 2 });
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["Accept-Encoding"] = "gzip, br";
+
+        // Act
+        await policy.ApplyAsync(httpContext, endpoints);
+
+        // Assert
+        Assert.True(endpoints.IsValidCandidate(0));   // /literal/path preserved (Score=0 < bestMatchScore=1)
+        Assert.True(endpoints.IsValidCandidate(1));   // gzip matched at Score=1
+        Assert.False(endpoints.IsValidCandidate(2));  // {**catchall} invalidated (Score=2 >= bestMatchScore, no match)
+    }
+
+    [Fact]
+    public async Task ApplyAsync_PreservesHigherPriority_DifferentMetadataValuesSameTier()
+    {
+        // Multiple endpoints with different encoding values at the same score tier.
+        // Gzip wins over br by endpoint quality. Higher-priority literal preserved.
+        //   /literal/path           Score=0 (no metadata)
+        //   /{param}/path gzip 0.9  Score=1 (gzip, higher endpoint quality)
+        //   /{param}/path br 0.7    Score=1 (br, lower endpoint quality)
+        //   {**catchall}            Score=2 (no metadata)
+        var policy = new ContentEncodingNegotiationMatcherPolicy();
+        var literal = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(), "/literal/path");
+        var paramGzip = CreateEndpoint("gzip", 0.9);
+        var paramBr = CreateEndpoint("br", 0.7);
+        var catchAll = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(), "{**catchall}");
+        var endpoints = CreateCandidateSet(
+            new[] { literal, paramGzip, paramBr, catchAll },
+            new[] { 0, 1, 1, 2 });
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["Accept-Encoding"] = "gzip, br";
+
+        // Act
+        await policy.ApplyAsync(httpContext, endpoints);
+
+        // Assert
+        Assert.True(endpoints.IsValidCandidate(0));   // /literal/path preserved (Score=0)
+        Assert.True(endpoints.IsValidCandidate(1));   // gzip wins (endpoint quality 0.9 > 0.7)
+        Assert.False(endpoints.IsValidCandidate(2));  // br loses endpoint quality tie
+        Assert.False(endpoints.IsValidCandidate(3));  // {**catchall} invalidated (no match, Score=2)
+    }
+
+    [Fact]
+    public async Task ApplyAsync_PreservesHigherPriority_MetadataAtMultipleScoreTiers()
+    {
+        // Encoding metadata at two different score tiers. The lower-priority tier matches with higher
+        // Accept quality, but the higher-priority match must still survive.
+        //   /literal/path            Score=0 (no metadata)
+        //   /literal/{param} gzip    Score=1 (gzip, endpoint quality 0.9)
+        //   {param}/{param2} br      Score=2 (br, endpoint quality 0.8)
+        //   {**catchall} gzip        Score=3 (gzip, endpoint quality 0.7)
+        // Accept-Encoding: gzip;q=0.5, br;q=1.0
+        //   → gzip at Score=1 matches first (Accept q=0.5), then br at Score=2 beats it (Accept q=1.0).
+        //   → But Score=1 must survive because it has better routing priority than the new best at Score=2.
+        var policy = new ContentEncodingNegotiationMatcherPolicy();
+        var literal = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(), "/literal/path");
+        var paramGzip = CreateEndpoint("gzip", 0.9);
+        var param2Br = CreateEndpoint("br", 0.8);
+        var catchAllGzip = CreateEndpoint("gzip", 0.7);
+        var endpoints = CreateCandidateSet(
+            new[] { literal, paramGzip, param2Br, catchAllGzip },
+            new[] { 0, 1, 2, 3 });
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["Accept-Encoding"] = "gzip;q=0.5, br;q=1.0";
+
+        // Act
+        await policy.ApplyAsync(httpContext, endpoints);
+
+        // Assert - Score=0 and Score=1 both preserved (better priority than bestMatch at Score=2)
+        Assert.True(endpoints.IsValidCandidate(0));   // /literal/path preserved (Score=0)
+        Assert.True(endpoints.IsValidCandidate(1));   // gzip preserved (Score=1, was previous best)
+        Assert.True(endpoints.IsValidCandidate(2));   // br wins (highest Accept quality at Score=2)
+        Assert.False(endpoints.IsValidCandidate(3));  // catch-all gzip invalidated (lower Accept quality)
+    }
+
+    [Fact]
+    public async Task ApplyAsync_PreservesHigherPriority_ParametersAtDifferentSegmentPositions()
+    {
+        // Parameters appear in different URL segments across priorities.
+        // Tests that the fix works regardless of which route segments are parameterized.
+        //   /a/b                    Score=0 (no metadata — exact literal)
+        //   /a/{param}              Score=1 (no metadata — param in second segment)
+        //   /{param}/b              Score=2 (no metadata — param in first segment)
+        //   /{p1}/{p2} gzip 0.9    Score=3 (gzip — both segments parameterized)
+        //   /{p1}/{p2} br 0.7      Score=3 (br — both segments parameterized)
+        //   {**catchall} gzip 0.8  Score=4 (gzip — catch-all)
+        var policy = new ContentEncodingNegotiationMatcherPolicy();
+        var literalAB = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(), "/a/b");
+        var aParam = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(), "/a/{param}");
+        var paramB = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(), "/{param}/b");
+        var p1p2Gzip = CreateEndpoint("gzip", 0.9);
+        var p1p2Br = CreateEndpoint("br", 0.7);
+        var catchAllGzip = CreateEndpoint("gzip", 0.8);
+        var endpoints = CreateCandidateSet(
+            new[] { literalAB, aParam, paramB, p1p2Gzip, p1p2Br, catchAllGzip },
+            new[] { 0, 1, 2, 3, 3, 4 });
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["Accept-Encoding"] = "gzip, br";
+
+        // Act
+        await policy.ApplyAsync(httpContext, endpoints);
+
+        // Assert — all three no-metadata endpoints preserved, gzip wins among encoded
+        Assert.True(endpoints.IsValidCandidate(0));   // /a/b preserved (Score=0)
+        Assert.True(endpoints.IsValidCandidate(1));   // /a/{param} preserved (Score=1)
+        Assert.True(endpoints.IsValidCandidate(2));   // /{param}/b preserved (Score=2)
+        Assert.True(endpoints.IsValidCandidate(3));   // gzip wins at Score=3 (endpoint quality 0.9 > 0.7)
+        Assert.False(endpoints.IsValidCandidate(4));  // br loses endpoint quality tie at Score=3
+        Assert.False(endpoints.IsValidCandidate(5));  // catch-all gzip invalidated (lower endpoint quality than Score=3 gzip)
+    }
+
+    [Fact]
+    public async Task ApplyAsync_InvalidatesLowerPriority_WhenMetadataAtHighestPriority()
+    {
+        // No regression: when the encoding match is at the highest priority, lower-priority
+        // endpoints should still be invalidated normally.
+        //   /literal/path gzip     Score=0 (gzip metadata — highest priority)
+        //   /literal/{param}       Score=1 (no metadata)
+        //   {**catchall}           Score=2 (no metadata)
+        var policy = new ContentEncodingNegotiationMatcherPolicy();
+        var literalGzip = CreateEndpoint("gzip");
+        var param = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(), "/literal/{param}");
+        var catchAll = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(), "{**catchall}");
+        var endpoints = CreateCandidateSet(
+            new[] { literalGzip, param, catchAll },
+            new[] { 0, 1, 2 });
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["Accept-Encoding"] = "gzip";
+
+        // Act
+        await policy.ApplyAsync(httpContext, endpoints);
+
+        // Assert — gzip at highest priority wins, everything else invalidated
+        Assert.True(endpoints.IsValidCandidate(0));   // gzip matched at Score=0
+        Assert.False(endpoints.IsValidCandidate(1));  // invalidated (no match, Score=1 >= bestMatchScore=0)
+        Assert.False(endpoints.IsValidCandidate(2));  // invalidated (no match, Score=2 >= bestMatchScore=0)
+    }
+
     private static CandidateSet CreateCandidateSet(params Endpoint[] endpoints) => new(
             endpoints,
             endpoints.Select(e => new RouteValueDictionary()).ToArray(),
             endpoints.Select(e => 1).ToArray());
+
+    private static CandidateSet CreateCandidateSet(Endpoint[] endpoints, int[] scores) => new(
+            endpoints,
+            endpoints.Select(e => new RouteValueDictionary()).ToArray(),
+            scores);
 
     private static Endpoint CreateEndpoint(string contentEncoding, double quality = 1.0d)
     {

--- a/src/Http/Routing/test/UnitTests/Matching/ContentEncodingNegotiationMatcherPolicyTest.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/ContentEncodingNegotiationMatcherPolicyTest.cs
@@ -719,31 +719,6 @@ public class ContentEncodingNegotiationMatcherPolicyTest
     }
 
     [Fact]
-    public async Task ApplyAsync_PreservesHigherPriorityEndpoint_PostMatchInvalidation()
-    {
-        // Arrange - Encoding match found first, then a higher-priority default comes after in the list
-        // This tests the post-match invalidation path
-        var policy = new ContentEncodingNegotiationMatcherPolicy();
-        var gzipEndpoint = CreateEndpoint("gzip");
-        var higherPriorityDefault = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(), "HighPriority-Default");
-        // gzip at score=1, higher priority default at score=0
-        // Note: in practice candidates are sorted by score (lower first), but the fix must handle
-        // any ordering since candidates may be re-ordered by other policies
-        var endpoints = CreateCandidateSet(
-            new[] { gzipEndpoint, higherPriorityDefault },
-            new[] { 1, 0 });
-        var httpContext = new DefaultHttpContext();
-        httpContext.Request.Headers["Accept-Encoding"] = "gzip";
-
-        // Act
-        await policy.ApplyAsync(httpContext, endpoints);
-
-        // Assert - higher priority default preserved even though gzip was matched
-        Assert.True(endpoints.IsValidCandidate(0));  // gzip matched
-        Assert.True(endpoints.IsValidCandidate(1));   // higher priority preserved
-    }
-
-    [Fact]
     public async Task ApplyAsync_PreservesHigherPriorityEndpoint_HigherQualityEqualTie()
     {
         // Arrange - tests the equal-quality branch in EvaluateCandidate with higher endpoint quality
@@ -764,39 +739,6 @@ public class ContentEncodingNegotiationMatcherPolicyTest
         Assert.True(endpoints.IsValidCandidate(0));   // config preserved by priority
         Assert.False(endpoints.IsValidCandidate(1));  // lower quality gzip invalidated
         Assert.True(endpoints.IsValidCandidate(2));   // higher quality gzip wins
-    }
-
-    [Fact]
-    public async Task ApplyAsync_PreservesAllHigherPriorityEndpoints_MixedRoutePriorities()
-    {
-        // Arrange - simulates a DFA node where multiple endpoint types with different priorities
-        // coexist with a catch-all that has encoding metadata:
-        //   /literal/path               Score=0 (exact match, no metadata)
-        //   /literal/{parameter}         Score=1 (parameterized, no metadata)
-        //   /literal/{parameter:regex}   Score=2 (constrained parameter, no metadata)
-        //   {**catchall:regex}           Score=3 (constrained catch-all, no metadata)
-        //   {**catchall} gzip            Score=4 (unconstrained catch-all with encoding metadata)
-        var policy = new ContentEncodingNegotiationMatcherPolicy();
-        var literalPath = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(), "/literal/path");
-        var parameterized = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(), "/literal/{parameter}");
-        var constrainedParameter = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(), "/literal/{parameter:regex}");
-        var constrainedCatchAll = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(), "{**catchall:regex}");
-        var catchAllGzip = CreateEndpoint("gzip", 0.8);
-        var endpoints = CreateCandidateSet(
-            new[] { literalPath, parameterized, constrainedParameter, constrainedCatchAll, catchAllGzip },
-            new[] { 0, 1, 2, 3, 4 });
-        var httpContext = new DefaultHttpContext();
-        httpContext.Request.Headers["Accept-Encoding"] = "gzip, br";
-
-        // Act
-        await policy.ApplyAsync(httpContext, endpoints);
-
-        // Assert - all higher-priority endpoints preserved, catch-all gzip also valid (it matched)
-        Assert.True(endpoints.IsValidCandidate(0));   // /literal/path preserved (Score=0)
-        Assert.True(endpoints.IsValidCandidate(1));   // /literal/{parameter} preserved (Score=1)
-        Assert.True(endpoints.IsValidCandidate(2));   // /literal/{parameter:regex} preserved (Score=2)
-        Assert.True(endpoints.IsValidCandidate(3));   // {**catchall:regex} preserved (Score=3)
-        Assert.True(endpoints.IsValidCandidate(4));   // {**catchall} gzip matched
     }
 
     [Fact]
@@ -887,42 +829,6 @@ public class ContentEncodingNegotiationMatcherPolicyTest
         Assert.True(endpoints.IsValidCandidate(1));   // gzip preserved (Score=1, was previous best)
         Assert.True(endpoints.IsValidCandidate(2));   // br wins (highest Accept quality at Score=2)
         Assert.False(endpoints.IsValidCandidate(3));  // catch-all gzip invalidated (lower Accept quality)
-    }
-
-    [Fact]
-    public async Task ApplyAsync_PreservesHigherPriority_ParametersAtDifferentSegmentPositions()
-    {
-        // Parameters appear in different URL segments across priorities.
-        // Tests that the fix works regardless of which route segments are parameterized.
-        //   /a/b                    Score=0 (no metadata — exact literal)
-        //   /a/{param}              Score=1 (no metadata — param in second segment)
-        //   /{param}/b              Score=2 (no metadata — param in first segment)
-        //   /{p1}/{p2} gzip 0.9    Score=3 (gzip — both segments parameterized)
-        //   /{p1}/{p2} br 0.7      Score=3 (br — both segments parameterized)
-        //   {**catchall} gzip 0.8  Score=4 (gzip — catch-all)
-        var policy = new ContentEncodingNegotiationMatcherPolicy();
-        var literalAB = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(), "/a/b");
-        var aParam = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(), "/a/{param}");
-        var paramB = new Endpoint(_ => Task.CompletedTask, new EndpointMetadataCollection(), "/{param}/b");
-        var p1p2Gzip = CreateEndpoint("gzip", 0.9);
-        var p1p2Br = CreateEndpoint("br", 0.7);
-        var catchAllGzip = CreateEndpoint("gzip", 0.8);
-        var endpoints = CreateCandidateSet(
-            new[] { literalAB, aParam, paramB, p1p2Gzip, p1p2Br, catchAllGzip },
-            new[] { 0, 1, 2, 3, 3, 4 });
-        var httpContext = new DefaultHttpContext();
-        httpContext.Request.Headers["Accept-Encoding"] = "gzip, br";
-
-        // Act
-        await policy.ApplyAsync(httpContext, endpoints);
-
-        // Assert — all three no-metadata endpoints preserved, gzip wins among encoded
-        Assert.True(endpoints.IsValidCandidate(0));   // /a/b preserved (Score=0)
-        Assert.True(endpoints.IsValidCandidate(1));   // /a/{param} preserved (Score=1)
-        Assert.True(endpoints.IsValidCandidate(2));   // /{param}/b preserved (Score=2)
-        Assert.True(endpoints.IsValidCandidate(3));   // gzip wins at Score=3 (endpoint quality 0.9 > 0.7)
-        Assert.False(endpoints.IsValidCandidate(4));  // br loses endpoint quality tie at Score=3
-        Assert.False(endpoints.IsValidCandidate(5));  // catch-all gzip invalidated (lower endpoint quality than Score=3 gzip)
     }
 
     [Fact]


### PR DESCRIPTION
Fix `NegotiationMatcherPolicy<T>.ApplyAsync` invalidating higher-priority endpoints when a lower-priority endpoint has matching negotiation metadata (e.g. `ContentEncodingMetadata`).

- [ ] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

`NegotiationMatcherPolicy<T>.ApplyAsync` invalidates higher-priority endpoints when a lower-priority endpoint has matching negotiation metadata (e.g. `ContentEncodingMetadata`). Content-encoding negotiation should only disambiguate between representations of the *same resource*, not override the routing system's priority-based selection across *different resources*.

### The Problem

When a catch-all endpoint (e.g. `{**path}`) carries `ContentEncodingMetadata` and shares a DFA path node with a higher-priority literal endpoint that has no encoding metadata, `ApplyAsync` incorrectly invalidates the literal endpoint.

This happens because `GetEdges` correctly adds endpoints **without** encoding metadata to **all** DFA branches as "parent" endpoints. So the literal endpoint appears in the gzip branch alongside the catch-all's gzip variant. When `ApplyAsync` finds the catch-all as an encoding match, it blindly invalidates all preceding candidates — including the higher-priority literal endpoint that represents a completely different resource.

### Root Cause

`ApplyAsync` has two invalidation points that don't account for routing priority (`CandidateState.Score`):

**Point 1 — `EvaluateCandidate` backward sweep** (when a higher-quality encoding match is found):

```csharp
for (var j = bestMatchIndex; j < currentIndex; j++)
{
    candidates.SetValidity(j, false);  // ← No priority check
}
```

**Point 2 — Post-match invalidation** (when a candidate doesn't match and a best match already exists):

```csharp
if (!found && (bestMatchIndex >= 0 || metadata != DefaultNegotiationValue))
{
    candidates.SetValidity(i, false);  // ← No priority check
}
```

Neither point checks whether the candidate being invalidated has better routing priority (lower Score) than the one being promoted. A catch-all with `Score=1` defeats a literal endpoint with `Score=0`.

### The Fix

Candidates are already sorted by ascending `Score` (from `DfaMatcherBuilder.ApplyPolicies` using `EndpointComparer`). The fix leverages this sorted order:

1. **`scoreTierStart` and `currentTierScore` tracking** — The outer loop tracks where the current score tier begins and stores the tier's score value in a separate `currentTierScore` variable. This is necessary because `SetValidity` bitwise-negates `CandidateState.Score` when marking candidates invalid; reading `candidates[scoreTierStart].Score` after invalidation would corrupt the tier boundary. Using a dedicated `currentTierScore` variable avoids this.

2. **Bounded backward sweeps** — `EvaluateCandidate`'s backward sweeps use `Math.Max(bestMatchIndex, scoreTierStart)` as the start bound, skipping all higher-priority score tiers entirely without per-element Score comparisons.

3. **Post-match guard** — The post-match invalidation checks `candidates[i].Score < bestMatchScore` before invalidating, preserving higher-priority endpoints that represent different resources.

This ensures content-encoding negotiation only disambiguates within the same score tier (same routing priority), preserving the routing system's priority ordering across different resources.

### Tests

- Extensive unit tests for `ContentEncodingNegotiationMatcherPolicy.ApplyAsync` covering priority preservation scenarios.
- End-to-end integration tests for both the `INodeBuilderPolicy` and `IEndpointSelectorPolicy` paths.
- Added `Match_ContentEncoding_AcceptQualityWins_WhenBothAcceptAndEndpointQualityDiffer`: verifies that when two encoding variants of the same route have the same endpoint quality (tie-breaker), the client's `Accept-Encoding` preference correctly determines the winner. Covers both the `INodeBuilderPolicy` and `IEndpointSelectorPolicy` (`HasDynamicMetadata == true`) paths.

<!-- START COPILOT CODING AGENT TIPS -->
---

✨ Let Copilot coding agent [set things up for you](https://github.com/dotnet/aspnetcore/issues/new?title=✨+Set+up+Copilot+instructions&body=Configure%20instructions%20for%20this%20repository%20as%20documented%20in%20%5BBest%20practices%20for%20Copilot%20coding%20agent%20in%20your%20repository%5D%28https://gh.io/copilot-coding-agent-tips%29%2E%0A%0A%3COnboard%20this%20repo%3E&assignees=copilot) — coding agent works faster and does higher quality work when set up for your repo.
