### PR TITLE
Add SSH, GitHub CLI and Copilot CLI devcontainer features

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,7 @@
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/sshd:1": {},
-		"ghcr.io/devcontainers/features/copilot-cli:1": {}
+    "ghcr.io/devcontainers/features/copilot-cli:1": {}
   },
   // Use 'postCreateCommand' to run commands after the container is created.
   "onCreateCommand": "bash -i ${containerWorkspaceFolder}/.devcontainer/scripts/container-creation.sh",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,6 +25,11 @@
     "omnisharp.enableEditorConfigSupport": true,
     "omnisharp.enableImportCompletion": true,
   },
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/sshd:1": {},
+		"ghcr.io/devcontainers/features/copilot-cli:1": {}
+  },
   // Use 'postCreateCommand' to run commands after the container is created.
   "onCreateCommand": "bash -i ${containerWorkspaceFolder}/.devcontainer/scripts/container-creation.sh",
   // Add the locally installed dotnet to the path to ensure that it is activated


### PR DESCRIPTION
## Summary

Adds two devcontainer features to `.devcontainer/devcontainer.json`:

- **`ghcr.io/devcontainers/features/sshd:1`** — SSH server for remote access to the dev container
- **`ghcr.io/devcontainers/features/github-cli:1`** — GitHub CLI
- **`ghcr.io/devcontainers/features/copilot-cli:1`** — Copilot CLI

These features are installed automatically when the container is built/rebuilt.