### PR TITLE
[test-quarantine] Re-quarantine QuicStreamContextTests.BidirectionalStream_ServerReadsDataAndCompletes_GracefullyClosed

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/test/QuicStreamContextTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicStreamContextTests.cs
@@ -27,6 +27,7 @@ public class QuicStreamContextTests : TestApplicationErrorLoggerLoggedTest
 
     [ConditionalFact]
     [MsQuicSupported]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/52462")]
     public async Task BidirectionalStream_ServerReadsDataAndCompletes_GracefullyClosed()
     {
         // Arrange


### PR DESCRIPTION
Associated issue: #52462