### PR TITLE
Revert "[test-quarantine] Quarantine RoutingTest.NavigationLock_CanExternalNavigation"

### DIFF
--- a/src/Components/test/E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/E2ETest/Tests/RoutingTest.cs
@@ -1156,8 +1156,7 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
         Browser.Equal("1", () => app.FindElement(By.Id("location-changed-count"))?.Text);
     }
 
-    [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/66041")]
+    [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/57153")]
     public void NavigationLock_CanBlockExternalNavigation()
     {
         SetUrlViaPushState("/");


### PR DESCRIPTION
Reverts dotnet/aspnetcore#66042