### PR TITLE
Use 1es ubuntu for Linux x64 job

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -330,6 +330,7 @@ extends:
           jobName: Linux_x64_build
           jobDisplayName: "Build: Linux x64"
           agentOs: Linux
+          use1ESUbuntu: true
           buildArgs:
             --arch x64
             --pack


### PR DESCRIPTION
The Ubunutu 22.04 image doesn't have Azure CLI installed, so it can't generate SAS delegation tokens