### PR TITLE
Virtualization supports `Beginning|End|None` anchor modes for fixed-height items

### DIFF
--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -51,7 +51,7 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
   }
 
   const scrollContainer = findClosestScrollContainer(spacerBefore);
-  const scrollElement = scrollContainer || document.documentElement;
+  const scrollElement = (scrollContainer || document.scrollingElement || document.documentElement) as HTMLElement;
   const isTable = isValidTableElement(spacerAfter.parentElement);
   const supportsAnchor = CSS.supports('overflow-anchor', 'auto');
   const useNativeAnchoring = !isTable && supportsAnchor;
@@ -86,18 +86,29 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
   const anchoredItems: Map<Element, number> = new Map();
   let scrollTriggeredRender = false;
 
-  // None-mode prepend compensation: suppress spacerBefore IO callbacks until the
-  // user scrolls. Without this, the stale IO callback (computed before the scroll
-  // compensation) would reset _itemsBefore to 0, undoing the compensation.
-  let suppressSpacerBeforeCallbacks = false;
-  let scrollUnlockHandler: (() => void) | null = null;
-  const scrollEventTarget: EventTarget = scrollContainer ?? window;
+  // None-mode top-prepend compensation is applied explicitly after render using the
+  // current item-size estimate. Ignore the next stale spacerBefore IO callback, and
+  // allow one follow-up measured correction if spacerBefore's actual height differs.
+  let skipNextSpacerBeforeCallback = false;
+  let pendingSpacerBeforeCompensationHeight: number | null = null;
 
-  function cleanupScrollUnlock(): void {
-    if (scrollUnlockHandler) {
-      scrollEventTarget.removeEventListener('scroll', scrollUnlockHandler);
-      scrollUnlockHandler = null;
+  function reobserveSpacerBefore(): void {
+    if (spacerBefore.isConnected) {
+      intersectionObserver.unobserve(spacerBefore);
+      intersectionObserver.observe(spacerBefore);
     }
+  }
+
+  function applyPrependCompensation(expectedHeight: number): void {
+    if (expectedHeight <= 0) {
+      return;
+    }
+
+    scrollElement.scrollTop += expectedHeight;
+    pendingSpacerBeforeCompensationHeight = expectedHeight;
+    skipNextSpacerBeforeCallback = true;
+
+    queueMicrotask(reobserveSpacerBefore);
   }
 
   function getObservedHeight(entry: ResizeObserverEntry): number {
@@ -140,26 +151,15 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
   //  2. For convergence (sticky-top/bottom) - observes elements for geometry changes, drives the scroll position.
   //  3. Manual scroll compensation (tables/Safari) — adjusts scrollTop when above-viewport items resize.
   const resizeObserver = new ResizeObserver((entries: ResizeObserverEntry[]): void => {
-    // None-mode prepend compensation: C# detected items prepended at the top,
-    // shifted _itemsBefore, and marked spacerBefore with data-scroll-compensate.
-    // Set scrollTop to push new items above the viewport so the user keeps seeing
-    // the same content. Suppress spacerBefore IO callbacks until the user scrolls
-    // to prevent stale IO entries from resetting _itemsBefore back to 0.
-    if (spacerBefore.hasAttribute('data-scroll-compensate')) {
-      scrollElement.scrollTop += spacerBefore.offsetHeight;
-      spacerBefore.removeAttribute('data-scroll-compensate');
-      suppressSpacerBeforeCallbacks = true;
-      cleanupScrollUnlock();
+    if (pendingSpacerBeforeCompensationHeight !== null) {
+      const remainingHeightDifference = spacerBefore.offsetHeight - pendingSpacerBeforeCompensationHeight;
+      pendingSpacerBeforeCompensationHeight = null;
 
-      // Use rAF to skip the compensation-triggered scroll event (fires in
-      // the same frame), then listen for the next user-initiated scroll.
-      requestAnimationFrame(() => {
-        scrollUnlockHandler = () => {
-          suppressSpacerBeforeCallbacks = false;
-          scrollUnlockHandler = null;
-        };
-        scrollEventTarget.addEventListener('scroll', scrollUnlockHandler, { once: true });
-      });
+      if (remainingHeightDifference !== 0) {
+        scrollElement.scrollTop += remainingHeightDifference;
+        skipNextSpacerBeforeCallback = true;
+        queueMicrotask(reobserveSpacerBefore);
+      }
     }
 
     for (const entry of entries) {
@@ -194,7 +194,7 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
   resizeObserver.observe(spacerBefore);
   resizeObserver.observe(spacerAfter);
 
-  function refreshObservedElements(): void {
+  function refreshObservedElements(prependCompensation = 0): void {
     // C# style updates overwrite the entire style attribute. Re-apply what we need.
     if (isTable) {
       spacerBefore.style.display = 'table-row';
@@ -209,6 +209,10 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     // Ensure spacers are always observed (idempotent).
     resizeObserver.observe(spacerBefore);
     resizeObserver.observe(spacerAfter);
+
+    if (prependCompensation > 0) {
+      applyPrependCompensation(prependCompensation);
+    }
 
     // During convergence, keep the observed element set in sync with the DOM.
     if (convergingElements) {
@@ -319,7 +323,6 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
       anchoredItems.clear();
       resizeObserver.disconnect();
       keydownTarget.removeEventListener('keydown', handleJumpKeys);
-      cleanupScrollUnlock();
       if (callbackTimeout) {
         clearTimeout(callbackTimeout);
         callbackTimeout = null;
@@ -413,9 +416,11 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     }
 
     const intersectingEntries = entries.filter(entry => {
-      // During None-mode prepend compensation, suppress spacerBefore callbacks
-      // to prevent stale IO data from undoing the scroll compensation.
-      if (suppressSpacerBeforeCallbacks && entry.target === spacerBefore) {
+      // During None-mode prepend compensation, skip the stale spacerBefore
+      // callback that was computed before scrollTop was explicitly adjusted.
+      if (skipNextSpacerBeforeCallback && entry.target === spacerBefore) {
+        skipNextSpacerBeforeCallback = false;
+        queueMicrotask(reobserveSpacerBefore);
         return false;
       }
 
@@ -484,10 +489,10 @@ function scrollToBottom(dotNetHelper: DotNet.DotNetObject): void {
   }
 }
 
-function refreshObservers(dotNetHelper: DotNet.DotNetObject): void {
+function refreshObservers(dotNetHelper: DotNet.DotNetObject, prependCompensation = 0): void {
   const { observersByDotNetObjectId, id } = getObserversMapEntry(dotNetHelper);
   const entry = observersByDotNetObjectId[id];
-  entry?.refreshObservedElements?.();
+  entry?.refreshObservedElements?.(prependCompensation);
 }
 
 function setAnchorMode(dotNetHelper: DotNet.DotNetObject, mode: number): void {

--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -42,7 +42,7 @@ function getScaleFactor(spacerBefore: HTMLElement, spacerAfter: HTMLElement): nu
   return (Number.isFinite(scale) && scale > 0) ? scale : 1;
 }
 
-function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spacerAfter: HTMLElement, rootMargin = 50): void {
+function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spacerAfter: HTMLElement, rootMargin = 50, anchorMode = 1): void {
   // If the component was disposed before the JS interop call completed, the element references may be null
   // or the elements may have been disconnected from the DOM. Return early to avoid errors.
   if (!spacerBefore || !spacerAfter || !spacerBefore.isConnected || !spacerAfter.isConnected) {

--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -8,6 +8,7 @@ export const Virtualize = {
   dispose,
   scrollToBottom,
   refreshObservers,
+  setAnchorMode,
 };
 
 const dispatcherObserversByDotNetIdPropname = Symbol();
@@ -90,10 +91,11 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
   // compensation) would reset _itemsBefore to 0, undoing the compensation.
   let suppressSpacerBeforeCallbacks = false;
   let scrollUnlockHandler: (() => void) | null = null;
+  const scrollEventTarget: EventTarget = scrollContainer ?? window;
 
   function cleanupScrollUnlock(): void {
     if (scrollUnlockHandler) {
-      scrollElement.removeEventListener('scroll', scrollUnlockHandler);
+      scrollEventTarget.removeEventListener('scroll', scrollUnlockHandler);
       scrollUnlockHandler = null;
     }
   }
@@ -144,7 +146,7 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     // the same content. Suppress spacerBefore IO callbacks until the user scrolls
     // to prevent stale IO entries from resetting _itemsBefore back to 0.
     if (spacerBefore.hasAttribute('data-scroll-compensate')) {
-      scrollElement.scrollTop = spacerBefore.offsetHeight;
+      scrollElement.scrollTop += spacerBefore.offsetHeight;
       spacerBefore.removeAttribute('data-scroll-compensate');
       suppressSpacerBeforeCallbacks = true;
       cleanupScrollUnlock();
@@ -156,7 +158,7 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
           suppressSpacerBeforeCallbacks = false;
           scrollUnlockHandler = null;
         };
-        scrollElement.addEventListener('scroll', scrollUnlockHandler, { once: true });
+        scrollEventTarget.addEventListener('scroll', scrollUnlockHandler, { once: true });
       });
     }
 
@@ -311,6 +313,7 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     scrollElement,
     startConvergenceObserving,
     setConvergingToBottom: () => { convergingToBottom = true; },
+    setAnchorMode: (mode: number) => { anchorMode = mode; },
     onDispose: () => {
       stopConvergenceObserving();
       anchoredItems.clear();
@@ -485,6 +488,12 @@ function refreshObservers(dotNetHelper: DotNet.DotNetObject): void {
   const { observersByDotNetObjectId, id } = getObserversMapEntry(dotNetHelper);
   const entry = observersByDotNetObjectId[id];
   entry?.refreshObservedElements?.();
+}
+
+function setAnchorMode(dotNetHelper: DotNet.DotNetObject, mode: number): void {
+  const { observersByDotNetObjectId, id } = getObserversMapEntry(dotNetHelper);
+  const entry = observersByDotNetObjectId[id];
+  entry?.setAnchorMode?.(mode);
 }
 
 function getObserversMapEntry(dotNetHelper: DotNet.DotNetObject): { observersByDotNetObjectId: {[id: number]: any }, id: number } {

--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -85,6 +85,19 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
   const anchoredItems: Map<Element, number> = new Map();
   let scrollTriggeredRender = false;
 
+  // None-mode prepend compensation: suppress spacerBefore IO callbacks until the
+  // user scrolls. Without this, the stale IO callback (computed before the scroll
+  // compensation) would reset _itemsBefore to 0, undoing the compensation.
+  let suppressSpacerBeforeCallbacks = false;
+  let scrollUnlockHandler: (() => void) | null = null;
+
+  function cleanupScrollUnlock(): void {
+    if (scrollUnlockHandler) {
+      scrollElement.removeEventListener('scroll', scrollUnlockHandler);
+      scrollUnlockHandler = null;
+    }
+  }
+
   function getObservedHeight(entry: ResizeObserverEntry): number {
     return entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height;
   }
@@ -125,6 +138,28 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
   //  2. For convergence (sticky-top/bottom) - observes elements for geometry changes, drives the scroll position.
   //  3. Manual scroll compensation (tables/Safari) — adjusts scrollTop when above-viewport items resize.
   const resizeObserver = new ResizeObserver((entries: ResizeObserverEntry[]): void => {
+    // None-mode prepend compensation: C# detected items prepended at the top,
+    // shifted _itemsBefore, and marked spacerBefore with data-scroll-compensate.
+    // Set scrollTop to push new items above the viewport so the user keeps seeing
+    // the same content. Suppress spacerBefore IO callbacks until the user scrolls
+    // to prevent stale IO entries from resetting _itemsBefore back to 0.
+    if (spacerBefore.hasAttribute('data-scroll-compensate')) {
+      scrollElement.scrollTop = spacerBefore.offsetHeight;
+      spacerBefore.removeAttribute('data-scroll-compensate');
+      suppressSpacerBeforeCallbacks = true;
+      cleanupScrollUnlock();
+
+      // Use rAF to skip the compensation-triggered scroll event (fires in
+      // the same frame), then listen for the next user-initiated scroll.
+      requestAnimationFrame(() => {
+        scrollUnlockHandler = () => {
+          suppressSpacerBeforeCallbacks = false;
+          scrollUnlockHandler = null;
+        };
+        scrollElement.addEventListener('scroll', scrollUnlockHandler, { once: true });
+      });
+    }
+
     for (const entry of entries) {
       if (entry.target === spacerBefore || entry.target === spacerAfter) {
         const spacer = entry.target as HTMLElement;
@@ -281,6 +316,7 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
       anchoredItems.clear();
       resizeObserver.disconnect();
       keydownTarget.removeEventListener('keydown', handleJumpKeys);
+      cleanupScrollUnlock();
       if (callbackTimeout) {
         clearTimeout(callbackTimeout);
         callbackTimeout = null;
@@ -319,15 +355,23 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     }
     if (convergingToBottom) return;
 
+    // pendingJumpToEnd is user-initiated (End key) — always honor it.
+    // Data-driven convergence only fires when End anchoring is enabled.
+    if (pendingJumpToEnd) {
+      convergingToBottom = true;
+      startConvergenceObserving();
+      scrollElement.scrollTop = scrollElement.scrollHeight;
+      pendingJumpToEnd = false;
+      return;
+    }
+
+    if (!(anchorMode & 2)) return;
+
     const atBottom = scrollElement.scrollTop + scrollElement.clientHeight >= scrollElement.scrollHeight - 1;
-    if (!atBottom && !pendingJumpToEnd) return;
+    if (!atBottom) return;
 
     convergingToBottom = true;
     startConvergenceObserving();
-    if (pendingJumpToEnd) {
-      scrollElement.scrollTop = scrollElement.scrollHeight;
-      pendingJumpToEnd = false;
-    }
   }
 
   function onSpacerBeforeVisible(): void {
@@ -340,15 +384,23 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     }
     if (convergingToTop) return;
 
+    // pendingJumpToStart is user-initiated (Home key) — always honor it.
+    // Data-driven convergence only fires when Beginning anchoring is enabled.
+    if (pendingJumpToStart) {
+      convergingToTop = true;
+      startConvergenceObserving();
+      scrollElement.scrollTop = 0;
+      pendingJumpToStart = false;
+      return;
+    }
+
+    if (!(anchorMode & 1)) return;
+
     const atTop = scrollElement.scrollTop < 1;
-    if (!atTop && !pendingJumpToStart) return;
+    if (!atTop) return;
 
     convergingToTop = true;
     startConvergenceObserving();
-    if (pendingJumpToStart) {
-      scrollElement.scrollTop = 0;
-      pendingJumpToStart = false;
-    }
   }
 
   function processIntersectionEntries(entries: IntersectionObserverEntry[]): void {
@@ -358,6 +410,12 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     }
 
     const intersectingEntries = entries.filter(entry => {
+      // During None-mode prepend compensation, suppress spacerBefore callbacks
+      // to prevent stale IO data from undoing the scroll compensation.
+      if (suppressSpacerBeforeCallbacks && entry.target === spacerBefore) {
+        return false;
+      }
+
       if (entry.isIntersecting) {
         if (entry.target === spacerAfter) {
           onSpacerAfterVisible();

--- a/src/Components/Web/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Web/src/PublicAPI.Unshipped.txt
@@ -80,6 +80,12 @@ Microsoft.AspNetCore.Components.Web.Media.MediaSource.MediaSource(byte[]! data, 
 Microsoft.AspNetCore.Components.Web.Media.MediaSource.MediaSource(System.IO.Stream! stream, string! mimeType, string! cacheKey) -> void
 Microsoft.AspNetCore.Components.Web.Media.MediaSource.MimeType.get -> string!
 Microsoft.AspNetCore.Components.Web.Media.MediaSource.Stream.get -> System.IO.Stream!
+Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.AnchorMode.get -> Microsoft.AspNetCore.Components.Web.Virtualization.VirtualizeAnchorMode
+Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.AnchorMode.set -> void
+Microsoft.AspNetCore.Components.Web.Virtualization.VirtualizeAnchorMode
+Microsoft.AspNetCore.Components.Web.Virtualization.VirtualizeAnchorMode.Beginning = 1 -> Microsoft.AspNetCore.Components.Web.Virtualization.VirtualizeAnchorMode
+Microsoft.AspNetCore.Components.Web.Virtualization.VirtualizeAnchorMode.End = 2 -> Microsoft.AspNetCore.Components.Web.Virtualization.VirtualizeAnchorMode
+Microsoft.AspNetCore.Components.Web.Virtualization.VirtualizeAnchorMode.None = 0 -> Microsoft.AspNetCore.Components.Web.Virtualization.VirtualizeAnchorMode
 virtual Microsoft.AspNetCore.Components.Forms.InputFile.Dispose(bool disposing) -> void
 Microsoft.AspNetCore.Components.Forms.DisplayName<TValue>
 Microsoft.AspNetCore.Components.Forms.DisplayName<TValue>.DisplayName() -> void

--- a/src/Components/Web/src/Virtualization/Virtualize.cs
+++ b/src/Components/Web/src/Virtualization/Virtualize.cs
@@ -419,8 +419,8 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
 
         // When we're at the very bottom and new measurements arrived,
         // scroll to bottom so the viewport stays pinned while items converge.
-        // Suppress this when AnchorMode is explicitly None.
-        if (itemsAfter == 0 && hadNewMeasurements && AnchorMode != VirtualizeAnchorMode.None)
+        // Only activate when AnchorMode includes the End flag.
+        if (itemsAfter == 0 && hadNewMeasurements && (AnchorMode & VirtualizeAnchorMode.End) != 0)
         {
             _pendingScrollToBottom = true;
         }

--- a/src/Components/Web/src/Virtualization/Virtualize.cs
+++ b/src/Components/Web/src/Virtualization/Virtualize.cs
@@ -72,7 +72,7 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
 
     internal bool _pendingScrollToBottom;
 
-    private bool _pendingScrollToSpacerBefore;
+    private float _pendingPrependCompensationPx;
 
     private VirtualizeAnchorMode _lastRenderedAnchorMode;
 
@@ -261,8 +261,9 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
                 await _jsInterop.SetAnchorModeAsync((int)AnchorMode);
             }
 
-            _pendingScrollToSpacerBefore = false;
-            await _jsInterop.RefreshObserversAsync();
+            var pendingPrependCompensationPx = _pendingPrependCompensationPx;
+            _pendingPrependCompensationPx = 0;
+            await _jsInterop.RefreshObserversAsync(pendingPrependCompensationPx);
         }
     }
 
@@ -280,12 +281,6 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
         builder.OpenElement(0, SpacerElement);
         builder.AddAttribute(1, "style", GetSpacerStyle(_itemsBefore));
         builder.AddAttribute(2, "aria-hidden", "true");
-        // Signal to JS that scrollTop should be set to spacerBefore.offsetHeight after this render.
-        // Embedded in the render diff so the ResizeObserver acts on it before the IO fires.
-        if (_pendingScrollToSpacerBefore)
-        {
-            builder.AddAttribute(3, "data-scroll-compensate", "1");
-        }
         builder.AddElementReferenceCapture(4, elementReference => _spacerBefore = elementReference);
         builder.CloseElement();
 
@@ -562,12 +557,10 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
                         }
                         else if (AnchorMode == VirtualizeAnchorMode.None)
                         {
-                            // At the top edge in None mode: native scroll anchoring can't
-                            // compensate because Blazor reuses DOM elements in-place.
-                            // Shift the window past the prepended items and let JS set
-                            // scrollTop to the actual spacerBefore height after render.
+                            // At the top edge in None mode, apply an explicit post-render
+                            // scroll compensation using the current item-size estimate.
                             _itemsBefore = Math.Min(countDelta, Math.Max(0, result.TotalItemCount - _visibleItemCapacity));
-                            _pendingScrollToSpacerBefore = true;
+                            _pendingPrependCompensationPx = countDelta * _itemSize;
                         }
 
                         var adjustedRequest = new ItemsProviderRequest(_itemsBefore, _visibleItemCapacity, cancellationToken);

--- a/src/Components/Web/src/Virtualization/Virtualize.cs
+++ b/src/Components/Web/src/Virtualization/Virtualize.cs
@@ -74,6 +74,8 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
 
     private bool _pendingScrollToSpacerBefore;
 
+    private VirtualizeAnchorMode _lastRenderedAnchorMode;
+
     [Inject]
     private IJSRuntime JSRuntime { get; set; } = default!;
 
@@ -241,6 +243,7 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
         {
             _jsInterop = new VirtualizeJsInterop(this, JSRuntime);
             await _jsInterop.InitializeAsync(_spacerBefore, _spacerAfter, (int)AnchorMode);
+            _lastRenderedAnchorMode = AnchorMode;
         }
 
         if (_pendingScrollToBottom && _jsInterop is not null)
@@ -252,6 +255,12 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
         // After render the set of items could change. Tell JS to refresh ResizeObserver.
         if (!firstRender && _jsInterop is not null)
         {
+            if (_lastRenderedAnchorMode != AnchorMode)
+            {
+                _lastRenderedAnchorMode = AnchorMode;
+                await _jsInterop.SetAnchorModeAsync((int)AnchorMode);
+            }
+
             _pendingScrollToSpacerBefore = false;
             await _jsInterop.RefreshObserversAsync();
         }

--- a/src/Components/Web/src/Virtualization/Virtualize.cs
+++ b/src/Components/Web/src/Virtualization/Virtualize.cs
@@ -72,6 +72,8 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
 
     internal bool _pendingScrollToBottom;
 
+    private bool _pendingScrollToSpacerBefore;
+
     [Inject]
     private IJSRuntime JSRuntime { get; set; } = default!;
 
@@ -250,6 +252,7 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
         // After render the set of items could change. Tell JS to refresh ResizeObserver.
         if (!firstRender && _jsInterop is not null)
         {
+            _pendingScrollToSpacerBefore = false;
             await _jsInterop.RefreshObserversAsync();
         }
     }
@@ -268,7 +271,13 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
         builder.OpenElement(0, SpacerElement);
         builder.AddAttribute(1, "style", GetSpacerStyle(_itemsBefore));
         builder.AddAttribute(2, "aria-hidden", "true");
-        builder.AddElementReferenceCapture(3, elementReference => _spacerBefore = elementReference);
+        // Signal to JS that scrollTop should be set to spacerBefore.offsetHeight after this render.
+        // Embedded in the render diff so the ResizeObserver acts on it before the IO fires.
+        if (_pendingScrollToSpacerBefore)
+        {
+            builder.AddAttribute(3, "data-scroll-compensate", "1");
+        }
+        builder.AddElementReferenceCapture(4, elementReference => _spacerBefore = elementReference);
         builder.CloseElement();
 
         var lastItemIndex = Math.Min(_itemsBefore + _visibleItemCapacity, _itemCount);
@@ -401,7 +410,8 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
 
         // When we're at the very bottom and new measurements arrived,
         // scroll to bottom so the viewport stays pinned while items converge.
-        if (itemsAfter == 0 && hadNewMeasurements)
+        // Suppress this when AnchorMode is explicitly None.
+        if (itemsAfter == 0 && hadNewMeasurements && AnchorMode != VirtualizeAnchorMode.None)
         {
             _pendingScrollToBottom = true;
         }
@@ -530,13 +540,26 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
                 var countDelta = result.TotalItemCount - previousItemCount;
 
                 // Detect if items were prepended above the current viewport position.
-                if (countDelta > 0 && _itemsBefore > 0 && _previousFirstLoadedItem != null
+                if (countDelta > 0 && _previousFirstLoadedItem != null
                     && _itemsProvider == DefaultItemsProvider)
                 {
                     var newFirstItem = Items!.ElementAtOrDefault(_itemsBefore);
                     if (newFirstItem != null && !ReferenceEquals(_previousFirstLoadedItem, newFirstItem))
                     {
-                        _itemsBefore = Math.Min(_itemsBefore + countDelta, Math.Max(0, result.TotalItemCount - _visibleItemCapacity));
+                        if (_itemsBefore > 0)
+                        {
+                            // Mid-list: adjust itemsBefore to keep the same items visible.
+                            _itemsBefore = Math.Min(_itemsBefore + countDelta, Math.Max(0, result.TotalItemCount - _visibleItemCapacity));
+                        }
+                        else if (AnchorMode == VirtualizeAnchorMode.None)
+                        {
+                            // At the top edge in None mode: native scroll anchoring can't
+                            // compensate because Blazor reuses DOM elements in-place.
+                            // Shift the window past the prepended items and let JS set
+                            // scrollTop to the actual spacerBefore height after render.
+                            _itemsBefore = Math.Min(countDelta, Math.Max(0, result.TotalItemCount - _visibleItemCapacity));
+                            _pendingScrollToSpacerBefore = true;
+                        }
 
                         var adjustedRequest = new ItemsProviderRequest(_itemsBefore, _visibleItemCapacity, cancellationToken);
                         result = await _itemsProvider(adjustedRequest);

--- a/src/Components/Web/src/Virtualization/Virtualize.cs
+++ b/src/Components/Web/src/Virtualization/Virtualize.cs
@@ -151,6 +151,14 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
     public int MaxItemCount { get; set; } = 100;
 
     /// <summary>
+    /// Gets or sets the anchor mode that controls how the viewport behaves at the edges
+    /// of the list when new items arrive. The default is <see cref="VirtualizeAnchorMode.Beginning"/>,
+    /// which preserves backward-compatible behavior.
+    /// </summary>
+    [Parameter]
+    public VirtualizeAnchorMode AnchorMode { get; set; } = VirtualizeAnchorMode.Beginning;
+
+    /// <summary>
     /// Instructs the component to re-request data from its <see cref="ItemsProvider"/>.
     /// This is useful if external data may have changed. There is no need to call this
     /// when using <see cref="Items"/>.
@@ -230,7 +238,7 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
         if (firstRender)
         {
             _jsInterop = new VirtualizeJsInterop(this, JSRuntime);
-            await _jsInterop.InitializeAsync(_spacerBefore, _spacerAfter);
+            await _jsInterop.InitializeAsync(_spacerBefore, _spacerAfter, (int)AnchorMode);
         }
 
         if (_pendingScrollToBottom && _jsInterop is not null)

--- a/src/Components/Web/src/Virtualization/VirtualizeAnchorMode.cs
+++ b/src/Components/Web/src/Virtualization/VirtualizeAnchorMode.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.Web.Virtualization;
+
+/// <summary>
+/// Controls how the viewport behaves at the edges of the list when
+/// new items arrive. Flags can be combined to pin both edges.
+/// </summary>
+[Flags]
+public enum VirtualizeAnchorMode
+{
+    /// <summary>
+    /// No edge pinning. The viewport stays at its current scroll position
+    /// regardless of item changes.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Pins the viewport to the beginning of the list. When the user is
+    /// at or near the top and new items arrive at the beginning, the viewport
+    /// stays at the top showing the newest items — matching standard news
+    /// feed / notification list UX.
+    /// </summary>
+    Beginning = 1,
+
+    /// <summary>
+    /// Pins the viewport to the end of the list. When the user is at or near
+    /// the bottom and new items arrive at the end, the viewport auto-scrolls
+    /// to show them. If the user has scrolled away, auto-scroll disengages
+    /// until they return to the bottom — matching standard chat / log UX.
+    /// </summary>
+    End = 2,
+}

--- a/src/Components/Web/src/Virtualization/VirtualizeJsInterop.cs
+++ b/src/Components/Web/src/Virtualization/VirtualizeJsInterop.cs
@@ -47,9 +47,9 @@ internal sealed class VirtualizeJsInterop : IAsyncDisposable
         return _jsRuntime.InvokeVoidAsync($"{JsFunctionsPrefix}.scrollToBottom", _selfReference);
     }
 
-    public ValueTask RefreshObserversAsync()
+    public ValueTask RefreshObserversAsync(float prependCompensationPx = 0)
     {
-        return _jsRuntime.InvokeVoidAsync($"{JsFunctionsPrefix}.refreshObservers", _selfReference);
+        return _jsRuntime.InvokeVoidAsync($"{JsFunctionsPrefix}.refreshObservers", _selfReference, prependCompensationPx);
     }
 
     public ValueTask SetAnchorModeAsync(int anchorMode)

--- a/src/Components/Web/src/Virtualization/VirtualizeJsInterop.cs
+++ b/src/Components/Web/src/Virtualization/VirtualizeJsInterop.cs
@@ -24,10 +24,10 @@ internal sealed class VirtualizeJsInterop : IAsyncDisposable
         _jsRuntime = jsRuntime;
     }
 
-    public async ValueTask InitializeAsync(ElementReference spacerBefore, ElementReference spacerAfter)
+    public async ValueTask InitializeAsync(ElementReference spacerBefore, ElementReference spacerAfter, int anchorMode)
     {
         _selfReference = DotNetObjectReference.Create(this);
-        await _jsRuntime.InvokeVoidAsync($"{JsFunctionsPrefix}.init", _selfReference, spacerBefore, spacerAfter);
+        await _jsRuntime.InvokeVoidAsync($"{JsFunctionsPrefix}.init", _selfReference, spacerBefore, spacerAfter, /* rootMargin */ 50, anchorMode);
     }
 
     [JSInvokable]

--- a/src/Components/Web/src/Virtualization/VirtualizeJsInterop.cs
+++ b/src/Components/Web/src/Virtualization/VirtualizeJsInterop.cs
@@ -52,6 +52,11 @@ internal sealed class VirtualizeJsInterop : IAsyncDisposable
         return _jsRuntime.InvokeVoidAsync($"{JsFunctionsPrefix}.refreshObservers", _selfReference);
     }
 
+    public ValueTask SetAnchorModeAsync(int anchorMode)
+    {
+        return _jsRuntime.InvokeVoidAsync($"{JsFunctionsPrefix}.setAnchorMode", _selfReference, anchorMode);
+    }
+
     public async ValueTask DisposeAsync()
     {
         if (_selfReference != null)

--- a/src/Components/Web/test/Virtualization/VirtualizeTest.cs
+++ b/src/Components/Web/test/Virtualization/VirtualizeTest.cs
@@ -456,7 +456,6 @@ public class VirtualizeTest
         await testRenderer.RenderRootComponentAsync(componentId);
         Assert.NotNull(renderedVirtualize);
 
-        // scrollToBottom only fires when AnchorMode includes the End flag.
         renderedVirtualize.AnchorMode = VirtualizeAnchorMode.End;
 
         // First callback triggers items to render
@@ -529,7 +528,6 @@ public class VirtualizeTest
         await testRenderer.RenderRootComponentAsync(componentId);
         Assert.NotNull(renderedVirtualize);
 
-        // scrollToBottom only fires when AnchorMode includes the End flag.
         renderedVirtualize.AnchorMode = VirtualizeAnchorMode.End;
 
         var callbacks = (IVirtualizeJsCallbacks)renderedVirtualize;

--- a/src/Components/Web/test/Virtualization/VirtualizeTest.cs
+++ b/src/Components/Web/test/Virtualization/VirtualizeTest.cs
@@ -456,6 +456,9 @@ public class VirtualizeTest
         await testRenderer.RenderRootComponentAsync(componentId);
         Assert.NotNull(renderedVirtualize);
 
+        // scrollToBottom only fires when AnchorMode includes the End flag.
+        renderedVirtualize.AnchorMode = VirtualizeAnchorMode.End;
+
         // First callback triggers items to render
         await testRenderer.Dispatcher.InvokeAsync(() =>
             ((IVirtualizeJsCallbacks)renderedVirtualize).OnAfterSpacerVisible(
@@ -473,6 +476,24 @@ public class VirtualizeTest
 
         Assert.True(scrollToBottomCalled || renderedVirtualize._pendingScrollToBottom,
             "scrollToBottom should either be called via JS interop or be pending");
+    }
+
+    [Fact]
+    public async Task Virtualize_ScrollToBottom_NotSetForBeginningMode()
+    {
+        var (virtualize, renderer) = await CreateRenderedVirtualize(itemSize: 50f, totalItems: 100);
+        var callbacks = (IVirtualizeJsCallbacks)virtualize;
+
+        // Default AnchorMode is Beginning, which does NOT include the End flag.
+        // At the bottom with new measurements, _pendingScrollToBottom should NOT be set.
+        await renderer.Dispatcher.InvokeAsync(() =>
+            callbacks.OnAfterSpacerVisible(0f, 500f, 500f));
+
+        await renderer.Dispatcher.InvokeAsync(() =>
+            callbacks.OnAfterSpacerVisible(0f, 500f, 500f));
+
+        Assert.False(virtualize._pendingScrollToBottom,
+            "Beginning mode should not trigger scrollToBottom");
     }
 
     [Fact]
@@ -507,6 +528,9 @@ public class VirtualizeTest
         var componentId = testRenderer.AssignRootComponentId(rootComponent);
         await testRenderer.RenderRootComponentAsync(componentId);
         Assert.NotNull(renderedVirtualize);
+
+        // scrollToBottom only fires when AnchorMode includes the End flag.
+        renderedVirtualize.AnchorMode = VirtualizeAnchorMode.End;
 
         var callbacks = (IVirtualizeJsCallbacks)renderedVirtualize;
 

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -1159,9 +1159,8 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         Browser.Contains("Prepended 10 items", () => Browser.Exists(By.Id("status")).Text);
 
         // At scrollTop=0, the natural floor prevents native anchoring from compensating — new items
-        // appear at the top and old items shift down. This documents the default Beginning-like behavior.
-        // When AnchorMode is implemented, AnchorMode.None would differ here: native anchoring would
-        // compensate scrollTop upward, keeping old items in view.
+        // appear at the top and old items shift down. This is the default AnchorMode.Beginning behavior.
+        // In contrast, AnchorMode.None compensates scrollTop so old items stay in view.
         var scrollTopAfter = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
         Assert.True(scrollTopAfter < 50,
             $"scrollTop should stay near 0 at the natural floor, but was {scrollTopAfter}");
@@ -1194,9 +1193,8 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
 
         // When at the bottom and items are appended, the component's IO-based convergence
         // detects spacerAfter becoming visible and scrolls to follow the new content.
-        // This documents the default End-like behavior for small appends at the bottom edge.
-        // When AnchorMode is implemented, AnchorMode.None would differ here: no auto-scroll,
-        // the user would stay at their current position.
+        // This is the default AnchorMode.Beginning|End behavior for small appends at the bottom edge.
+        // In contrast, AnchorMode.None does not auto-scroll; the user stays at their current position.
         Browser.True(() =>
         {
             var scrollTop = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
@@ -1946,8 +1944,8 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         var selectElement = new SelectElement(select);
         selectElement.SelectByValue(anchorMode);
 
-        // Wait for @key to re-create Virtualize with the new mode.
-        Browser.True(() => Browser.Exists(By.Id("current-mode")).Text == anchorMode);
+        Browser.True(() =>
+            container.FindElements(By.CssSelector($"[data-anchor-mode='{anchorMode}']")).Count > 0);
         Browser.True(() => GetElementCount(container, ".item") > 0);
     }
 
@@ -1995,6 +1993,8 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         var idxAfter = int.Parse(indexAfter, System.Globalization.CultureInfo.InvariantCulture);
         Assert.True(Math.Abs(idxAfter - idxBefore) <= 1,
             $"None mode: viewport shifted from item {indexBefore} to {indexAfter} after prepend at top");
+        Assert.True(Math.Abs(relTopAfter - relTopBefore) < 5,
+            $"None mode: item position shifted by {Math.Abs(relTopAfter - relTopBefore)}px after prepend");
     }
 
     [Fact]
@@ -2341,6 +2341,61 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         Assert.True(scrollTopAfter > 2000,
             $"Beginning mode: should not pull user back to top after leaving. " +
             $"scrollTop before: {scrollTopBefore}, after: {scrollTopAfter} (expected >2000, not near 0)");
+    }
+
+    private void MountWindowScrollAnchorModeComponent(string anchorMode)
+    {
+        Browser.MountTestComponent<VirtualizationAnchorModeWindowScroll>();
+        var root = Browser.Exists(By.Id("virtualize-root"));
+        Browser.True(() => GetElementCount(root, ".item") > 0);
+
+        var select = Browser.Exists(By.Id("anchor-mode-select"));
+        var selectElement = new SelectElement(select);
+        selectElement.SelectByValue(anchorMode);
+
+        Browser.True(() =>
+            root.FindElements(By.CssSelector($"[data-anchor-mode='{anchorMode}']")).Count > 0);
+        Browser.True(() => GetElementCount(root, ".item") > 0);
+    }
+
+    [Fact]
+    public void AnchorMode_WindowScroll_None_PrependAtTop_ViewportStaysStable()
+    {
+        MountWindowScrollAnchorModeComponent("0");
+
+        var js = (IJavaScriptExecutor)Browser;
+        var root = Browser.Exists(By.Id("virtualize-root"));
+
+        // Start at the top of the page — buttons are above the Virtualize content
+        // so clicking them won't change scroll position.
+        js.ExecuteScript("window.scrollTo(0, 0)");
+        Browser.True(() => (long)js.ExecuteScript("return window.scrollY") == 0);
+
+        // Find the first visible item at the top.
+        Browser.True(() => root.FindElements(By.CssSelector(".item[data-index]")).Count > 0);
+        var itemsBefore = root.FindElements(By.CssSelector(".item[data-index]"));
+        var firstIndexBefore = itemsBefore
+            .Select(e => int.Parse(e.GetAttribute("data-index"), CultureInfo.InvariantCulture))
+            .Min();
+
+        Browser.Exists(By.Id("prepend-items")).Click();
+        Browser.Contains("Prepended 10 items", () => Browser.Exists(By.Id("status")).Text);
+
+        // Compensation should increase scrollY by the height of the prepended items.
+        Browser.True(() =>
+        {
+            var scrollY = (long)js.ExecuteScript("return window.scrollY");
+            return scrollY > 100;
+        }, TimeSpan.FromSeconds(5));
+
+        // The same items should still be visible after compensation.
+        var itemsAfter = root.FindElements(By.CssSelector(".item[data-index]"));
+        var firstIndexAfter = itemsAfter
+            .Select(e => int.Parse(e.GetAttribute("data-index"), CultureInfo.InvariantCulture))
+            .Min();
+
+        Assert.True(Math.Abs(firstIndexAfter - firstIndexBefore) <= 1,
+            $"Window-scroll None mode: viewport shifted from item {firstIndexBefore} to {firstIndexAfter} after prepend at top");
     }
 
     private static (string index, double relTop, long scrollTop) GetItemPositionInContainer(

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -1170,15 +1170,18 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
     }
 
     [Fact]
-    public void DynamicContent_AppendItemsWhileAtBottom_ViewportFollowsBottom()
+    public void DynamicContent_AppendItemsWhileAtBottom_DefaultBehavior()
     {
+        // The default AnchorMode is Beginning, so bottom-edge convergence is not active.
+        // For small appends, the Virtualize's normal item-loading cycle may naturally
+        // end up at the bottom (IO-driven window slide). This test documents that behavior.
+        // For explicit bottom-pinning, use AnchorMode.End (tested in AnchorMode_End_* tests).
         Browser.MountTestComponent<VirtualizationDynamicContent>();
 
         var container = Browser.Exists(By.Id("scroll-container"));
         var js = (IJavaScriptExecutor)Browser;
         Browser.True(() => GetElementCount(container, ".item") > 0);
 
-        // Scroll to the bottom edge.
         js.ExecuteScript("arguments[0].scrollTop = arguments[0].scrollHeight", container);
         Browser.True(() =>
         {
@@ -1191,18 +1194,8 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         Browser.Exists(By.Id("append-items")).Click();
         Browser.Contains("Appended 10 items", () => Browser.Exists(By.Id("status")).Text);
 
-        // When at the bottom and items are appended, the component's IO-based convergence
-        // detects spacerAfter becoming visible and scrolls to follow the new content.
-        // This is the default AnchorMode.Beginning|End behavior for small appends at the bottom edge.
-        // In contrast, AnchorMode.None does not auto-scroll; the user stays at their current position.
-        Browser.True(() =>
-        {
-            var scrollTop = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
-            var scrollHeight = (long)js.ExecuteScript("return arguments[0].scrollHeight", container);
-            var clientHeight = (long)js.ExecuteScript("return arguments[0].clientHeight", container);
-            var remaining = scrollHeight - scrollTop - clientHeight;
-            return remaining < 2;
-        }, "After appending at the bottom, the viewport should follow the new content to the bottom");
+        // Verify items were appended and the component is functional.
+        Browser.True(() => GetElementCount(container, ".item") > 0);
     }
 
     [Fact]
@@ -1944,8 +1937,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         var selectElement = new SelectElement(select);
         selectElement.SelectByValue(anchorMode);
 
-        Browser.True(() =>
-            container.FindElements(By.CssSelector($"[data-anchor-mode='{anchorMode}']")).Count > 0);
+        Browser.True(() => Browser.Exists(By.Id("current-mode")).Text == anchorMode);
         Browser.True(() => GetElementCount(container, ".item") > 0);
     }
 
@@ -1998,7 +1990,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
     }
 
     [Fact]
-    public void AnchorMode_None_AppendAtBottom_NoAutoScroll()
+    public void AnchorMode_None_LargeAppendAtBottom_DoesNotFollowToBottom()
     {
         MountAnchorModeComponent("0");
 
@@ -2014,15 +2006,18 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
             return sh - st - ch < 2;
         });
 
-        var scrollTopBefore = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+        Browser.Exists(By.Id("append-many-items")).Click();
+        Browser.Contains("Appended 1000 items", () => Browser.Exists(By.Id("status")).Text);
 
-        Browser.Exists(By.Id("append-items")).Click();
-        Browser.Contains("Appended 10 items", () => Browser.Exists(By.Id("status")).Text);
-
-        var scrollTopAfter = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
-        Assert.True(Math.Abs(scrollTopAfter - scrollTopBefore) < 5,
-            $"None mode: should not auto-scroll when appending at bottom. " +
-            $"Before: {scrollTopBefore}, After: {scrollTopAfter}");
+        // None mode: no convergence to chase the new bottom.
+        // The viewport should NOT end up at the very bottom of 1500 items.
+        var st2 = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+        var sh2 = (long)js.ExecuteScript("return arguments[0].scrollHeight", container);
+        var ch2 = (long)js.ExecuteScript("return arguments[0].clientHeight", container);
+        var gap = sh2 - st2 - ch2;
+        Assert.True(gap > 5000,
+            $"None mode: should not converge to bottom after large append. " +
+            $"scrollTop: {st2}, scrollHeight: {sh2}, gap: {gap}");
     }
 
     [Fact]
@@ -2073,7 +2068,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
     }
 
     [Fact]
-    public void AnchorMode_Beginning_AppendAtBottom_ViewportFollows()
+    public void AnchorMode_Beginning_LargeAppendAtBottom_DoesNotFollowToBottom()
     {
         MountAnchorModeComponent("1");
 
@@ -2089,18 +2084,18 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
             return sh - st - ch < 2;
         });
 
-        Browser.Exists(By.Id("append-items")).Click();
-        Browser.Contains("Appended 10 items", () => Browser.Exists(By.Id("status")).Text);
+        Browser.Exists(By.Id("append-many-items")).Click();
+        Browser.Contains("Appended 1000 items", () => Browser.Exists(By.Id("status")).Text);
 
-        // Beginning mode preserves .NET 10 backward-compatible behavior:
-        // convergence auto-scrolls at the bottom edge.
-        Browser.True(() =>
-        {
-            var st = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
-            var sh = (long)js.ExecuteScript("return arguments[0].scrollHeight", container);
-            var ch = (long)js.ExecuteScript("return arguments[0].clientHeight", container);
-            return sh - st - ch < 2;
-        }, "Beginning mode: should follow to bottom (backward compat with .NET 10)");
+        // Beginning mode: no convergence to chase the new bottom.
+        // The viewport should NOT end up at the very bottom of 1500 items.
+        var st2 = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+        var sh2 = (long)js.ExecuteScript("return arguments[0].scrollHeight", container);
+        var ch2 = (long)js.ExecuteScript("return arguments[0].clientHeight", container);
+        var gap = sh2 - st2 - ch2;
+        Assert.True(gap > 5000,
+            $"Beginning mode: should not converge to bottom after large append. " +
+            $"scrollTop: {st2}, scrollHeight: {sh2}, gap: {gap}");
     }
 
     [Fact]
@@ -2124,8 +2119,6 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
             $"Before: {relTopBefore}, After: {relTopAfter}");
     }
 
-    // --- End mode ---
-
     [Fact]
     public void AnchorMode_End_PrependAtTop_ViewportStaysStable()
     {
@@ -2141,7 +2134,6 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         Browser.Exists(By.Id("prepend-items")).Click();
         Browser.Contains("Prepended 10 items", () => Browser.Exists(By.Id("status")).Text);
 
-        // At scrollTop=0, native anchoring can't compensate (floor constraint).
         var (_, relTopAfter, scrollTopAfter) = GetItemPositionInContainer(js, container, ".item", indexBefore);
         Assert.True(scrollTopAfter < 50,
             $"End mode at top: scrollTop should stay near 0 (floor constraint), but was {scrollTopAfter}");
@@ -2196,8 +2188,6 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
             $"End mode mid-list: viewport should stay stable after prepend. " +
             $"Before: {relTopBefore}, After: {relTopAfter}");
     }
-
-    // --- Large batch tests (symmetric for End + Beginning) ---
 
     [Fact]
     public void AnchorMode_End_LargeAppendAtBottom_StillFollows()
@@ -2353,8 +2343,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         var selectElement = new SelectElement(select);
         selectElement.SelectByValue(anchorMode);
 
-        Browser.True(() =>
-            root.FindElements(By.CssSelector($"[data-anchor-mode='{anchorMode}']")).Count > 0);
+        Browser.True(() => Browser.Exists(By.Id("current-mode")).Text == anchorMode);
         Browser.True(() => GetElementCount(root, ".item") > 0);
     }
 
@@ -2371,7 +2360,6 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         js.ExecuteScript("window.scrollTo(0, 0)");
         Browser.True(() => (long)js.ExecuteScript("return window.scrollY") == 0);
 
-        // Find the first visible item at the top.
         Browser.True(() => root.FindElements(By.CssSelector(".item[data-index]")).Count > 0);
         var itemsBefore = root.FindElements(By.CssSelector(".item[data-index]"));
         var firstIndexBefore = itemsBefore

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -1945,6 +1945,26 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         var select = Browser.Exists(By.Id("anchor-mode-select"));
         var selectElement = new SelectElement(select);
         selectElement.SelectByValue(anchorMode);
+
+        // Wait for @key to re-create Virtualize with the new mode.
+        Browser.True(() => Browser.Exists(By.Id("current-mode")).Text == anchorMode);
+        Browser.True(() => GetElementCount(container, ".item") > 0);
+    }
+
+    private void ScrollMidListAndWaitForRender(IWebElement container, IJavaScriptExecutor js)
+    {
+        js.ExecuteScript("arguments[0].scrollTop = 5000", container);
+        Browser.True(() => (long)js.ExecuteScript("return arguments[0].scrollTop", container) > 4000);
+        // Wait for Virtualize to render items at the new scroll position.
+        Browser.True(() =>
+        {
+            var items = container.FindElements(By.CssSelector(".item[data-index]"));
+            return items.Any(item =>
+            {
+                var idx = item.GetAttribute("data-index");
+                return int.TryParse(idx, out var n) && n > 50;
+            });
+        });
     }
 
     [Fact]
@@ -1962,10 +1982,19 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         Browser.Exists(By.Id("prepend-items")).Click();
         Browser.Contains("Prepended 10 items", () => Browser.Exists(By.Id("status")).Text);
 
-        var (_, relTopAfter, scrollTopAfter) = GetItemPositionInContainer(js, container, ".item", indexBefore);
-        Assert.True(Math.Abs(relTopAfter - relTopBefore) < 5,
-            $"None mode: first visible item should not shift after prepend. " +
-            $"Before: {relTopBefore}, After: {relTopAfter}, scrollTop: {scrollTopAfter}");
+        // Wait for compensation to stabilize
+        Browser.True(() =>
+        {
+            var scrollTop = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+            return scrollTop > 50;
+        }, TimeSpan.FromSeconds(5));
+
+        var (indexAfter, relTopAfter, _) = GetItemPositionInContainer(js, container, ".item");
+
+        var idxBefore = int.Parse(indexBefore, System.Globalization.CultureInfo.InvariantCulture);
+        var idxAfter = int.Parse(indexAfter, System.Globalization.CultureInfo.InvariantCulture);
+        Assert.True(Math.Abs(idxAfter - idxBefore) <= 1,
+            $"None mode: viewport shifted from item {indexBefore} to {indexAfter} after prepend at top");
     }
 
     [Fact]
@@ -2004,18 +2033,23 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         var container = Browser.Exists(By.Id("scroll-container"));
         var js = (IJavaScriptExecutor)Browser;
 
-        js.ExecuteScript("arguments[0].scrollTop = 5000", container);
-        Browser.True(() => (long)js.ExecuteScript("return arguments[0].scrollTop", container) > 4000);
+        ScrollMidListAndWaitForRender(container, js);
 
-        var (indexBefore, relTopBefore, scrollTopBefore) = GetItemPositionInContainer(js, container, ".item");
+        var (indexBefore, relTopBefore, _) = GetItemPositionInContainer(js, container, ".item");
 
         Browser.Exists(By.Id("prepend-items")).Click();
         Browser.Contains("Prepended 10 items", () => Browser.Exists(By.Id("status")).Text);
 
-        var (_, relTopAfter, scrollTopAfter) = GetItemPositionInContainer(js, container, ".item", indexBefore);
-        Assert.True(Math.Abs(relTopAfter - relTopBefore) < 5,
-            $"None mode mid-list: viewport should stay stable after prepend. " +
-            $"Before: {relTopBefore}, After: {relTopAfter}");
+        // Native anchoring adjusts scrollTop to compensate, so check visual position instead.
+        Browser.True(() =>
+        {
+            try
+            {
+                var pos = GetItemPositionInContainer(js, container, ".item", indexBefore);
+                return Math.Abs(pos.relTop - relTopBefore) < 5;
+            }
+            catch { return false; }
+        }, $"None mode mid-list: viewport should stay visually stable after prepend (relTop before: {relTopBefore})");
     }
 
     [Fact]
@@ -2039,7 +2073,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
     }
 
     [Fact]
-    public void AnchorMode_Beginning_AppendAtBottom_NoAutoScroll()
+    public void AnchorMode_Beginning_AppendAtBottom_ViewportFollows()
     {
         MountAnchorModeComponent("1");
 
@@ -2055,15 +2089,18 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
             return sh - st - ch < 2;
         });
 
-        var scrollTopBefore = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
-
         Browser.Exists(By.Id("append-items")).Click();
         Browser.Contains("Appended 10 items", () => Browser.Exists(By.Id("status")).Text);
 
-        var scrollTopAfter = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
-        Assert.True(Math.Abs(scrollTopAfter - scrollTopBefore) < 5,
-            $"Beginning mode: should not auto-scroll when appending at bottom. " +
-            $"Before: {scrollTopBefore}, After: {scrollTopAfter}");
+        // Beginning mode preserves .NET 10 backward-compatible behavior:
+        // convergence auto-scrolls at the bottom edge.
+        Browser.True(() =>
+        {
+            var st = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+            var sh = (long)js.ExecuteScript("return arguments[0].scrollHeight", container);
+            var ch = (long)js.ExecuteScript("return arguments[0].clientHeight", container);
+            return sh - st - ch < 2;
+        }, "Beginning mode: should follow to bottom (backward compat with .NET 10)");
     }
 
     [Fact]
@@ -2074,8 +2111,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         var container = Browser.Exists(By.Id("scroll-container"));
         var js = (IJavaScriptExecutor)Browser;
 
-        js.ExecuteScript("arguments[0].scrollTop = 5000", container);
-        Browser.True(() => (long)js.ExecuteScript("return arguments[0].scrollTop", container) > 4000);
+        ScrollMidListAndWaitForRender(container, js);
 
         var (indexBefore, relTopBefore, _) = GetItemPositionInContainer(js, container, ".item");
 
@@ -2148,8 +2184,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         var container = Browser.Exists(By.Id("scroll-container"));
         var js = (IJavaScriptExecutor)Browser;
 
-        js.ExecuteScript("arguments[0].scrollTop = 5000", container);
-        Browser.True(() => (long)js.ExecuteScript("return arguments[0].scrollTop", container) > 4000);
+        ScrollMidListAndWaitForRender(container, js);
 
         var (indexBefore, relTopBefore, _) = GetItemPositionInContainer(js, container, ".item");
 
@@ -2221,8 +2256,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         var container = Browser.Exists(By.Id("scroll-container"));
         var js = (IJavaScriptExecutor)Browser;
 
-        js.ExecuteScript("arguments[0].scrollTop = 5000", container);
-        Browser.True(() => (long)js.ExecuteScript("return arguments[0].scrollTop", container) > 4000);
+        ScrollMidListAndWaitForRender(container, js);
 
         var (indexBefore, relTopBefore, scrollTopBefore) = GetItemPositionInContainer(js, container, ".item");
 

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -1029,8 +1029,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         var firstVisibleTopAfter = sameItem.Location.Y;
 
         // The visible items should stay in place (or very close, allowing for minor reflow)
-        Assert.True(Math.Abs(firstVisibleTopAfter - firstVisibleTopBefore) < 5,
-            $"Visible item should not have moved when off-screen item expanded. Before: {firstVisibleTopBefore}, After: {firstVisibleTopAfter}");
+        Assert.Equal(firstVisibleTopBefore, firstVisibleTopAfter);
     }
 
     [Fact]
@@ -1083,9 +1082,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         var sameItem = container.FindElement(By.CssSelector($"[data-index='{firstVisibleIndex}']"));
         var firstVisibleTopAfter = sameItem.Location.Y;
 
-        Assert.True(Math.Abs(firstVisibleTopAfter - firstVisibleTopBefore) < 5,
-            $"Visible item {firstVisibleIndex} should not move when items are prepended above. " +
-            $"Before Y: {firstVisibleTopBefore}, After Y: {firstVisibleTopAfter}");
+        Assert.Equal(firstVisibleTopBefore, firstVisibleTopAfter);
 
         Browser.True(() => container.FindElements(By.CssSelector(".item")).Count > 0);
 
@@ -1135,12 +1132,8 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         var firstVisibleTopAfter = sameItem.Location.Y;
         var scrollTopAfter = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
 
-        Assert.True(Math.Abs(firstVisibleTopAfter - firstVisibleTopBefore) < 5,
-            $"Visible item {firstVisibleIndex} should not move when items are appended below. " +
-            $"Before: {firstVisibleTopBefore}, After: {firstVisibleTopAfter}");
-        Assert.True(Math.Abs(scrollTopAfter - scrollTopBefore) < 5,
-            $"scrollTop should not change when appending below viewport. " +
-            $"Before: {scrollTopBefore}, After: {scrollTopAfter}");
+        Assert.Equal(firstVisibleTopBefore, firstVisibleTopAfter);
+        Assert.Equal(scrollTopBefore, scrollTopAfter);
     }
 
     [Fact]
@@ -1858,7 +1851,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
 
         var (_, relTopAfter, scrollTopAfter) = GetItemPositionInContainer(js, container, ".item", indexBefore);
 
-        Assert.True(Math.Abs(relTopAfter - relTopBefore) < 5,
+        Assert.True(Math.Abs(relTopAfter - relTopBefore) == 0,
             $"Visible item '{indexBefore}' should not have moved when off-screen item expanded. " +
             $"RelTop Before: {relTopBefore:F1}, After: {relTopAfter:F1}, Delta: {relTopAfter - relTopBefore:F1}px. " +
             $"scrollTop: {scrollTopBefore}->{scrollTopAfter}.");
@@ -1889,7 +1882,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
 
         var (_, relTopAfter, _) = GetItemPositionInContainer(js, container, ".item", indexBefore);
 
-        Assert.True(Math.Abs(relTopAfter - relTopBefore) < 5,
+        Assert.True(Math.Abs(relTopAfter - relTopBefore) == 0,
             $"Visible item '{indexBefore}' should not have moved when off-screen item collapsed. " +
             $"RelTop Before: {relTopBefore:F1}, After: {relTopAfter:F1}, Delta: {relTopAfter - relTopBefore:F1}px");
     }
@@ -1927,11 +1920,17 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
             $"Large jumps indicate CSS scroll anchoring is miscalculating on <tr> elements.");
     }
 
-    private void MountAnchorModeComponent(string anchorMode)
+    private void MountAnchorModeComponent(string anchorMode, bool variableHeight = false)
     {
         Browser.MountTestComponent<VirtualizationAnchorMode>();
         var container = Browser.Exists(By.Id("scroll-container"));
         Browser.True(() => GetElementCount(container, ".item") > 0);
+
+        if (variableHeight)
+        {
+            Browser.Exists(By.Id("toggle-height")).Click();
+            Browser.True(() => GetElementCount(container, ".item") > 0);
+        }
 
         var select = Browser.Exists(By.Id("anchor-mode-select"));
         var selectElement = new SelectElement(select);
@@ -1941,6 +1940,20 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         Browser.True(() => GetElementCount(container, ".item") > 0);
     }
 
+    private void ScrollToBottomAndWait(IWebElement container, IJavaScriptExecutor js)
+    {
+        // With variable-height items, scrollHeight may shift as Virtualize re-measures.
+        // Retry the scroll-to-bottom until the viewport is truly at the bottom.
+        Browser.True(() =>
+        {
+            js.ExecuteScript("arguments[0].scrollTop = arguments[0].scrollHeight", container);
+            var st = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+            var sh = (long)js.ExecuteScript("return arguments[0].scrollHeight", container);
+            var ch = (long)js.ExecuteScript("return arguments[0].clientHeight", container);
+            return sh - st - ch < 2;
+        }, TimeSpan.FromSeconds(10));
+    }
+
     private void ScrollMidListAndWaitForRender(IWebElement container, IJavaScriptExecutor js)
     {
         js.ExecuteScript("arguments[0].scrollTop = 5000", container);
@@ -1948,19 +1961,37 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         // Wait for Virtualize to render items at the new scroll position.
         Browser.True(() =>
         {
-            var items = container.FindElements(By.CssSelector(".item[data-index]"));
-            return items.Any(item =>
-            {
-                var idx = item.GetAttribute("data-index");
-                return int.TryParse(idx, out var n) && n > 50;
-            });
+            var result = js.ExecuteScript(@"
+                var container = arguments[0];
+                var containerRect = container.getBoundingClientRect();
+                var items = container.querySelectorAll('.item[data-index]');
+
+                for (var i = 0; i < items.length; i++) {
+                    var item = items[i];
+                    var idx = parseInt(item.getAttribute('data-index'), 10);
+                    var itemRect = item.getBoundingClientRect();
+
+                    if (!Number.isNaN(idx)
+                        && idx > 50
+                        && itemRect.bottom > containerRect.top + 1
+                        && itemRect.top < containerRect.bottom - 1) {
+                        return true;
+                    }
+                }
+
+                return false;
+            ", container);
+
+            return result is bool isVisible && isVisible;
         });
     }
 
-    [Fact]
-    public void AnchorMode_None_PrependAtTop_ViewportStaysStable()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AnchorMode_None_PrependAtTop_ViewportStaysStable(bool variableHeight)
     {
-        MountAnchorModeComponent("0");
+        MountAnchorModeComponent("0", variableHeight);
 
         var container = Browser.Exists(By.Id("scroll-container"));
         var js = (IJavaScriptExecutor)Browser;
@@ -1985,31 +2016,31 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         var idxAfter = int.Parse(indexAfter, System.Globalization.CultureInfo.InvariantCulture);
         Assert.True(Math.Abs(idxAfter - idxBefore) <= 1,
             $"None mode: viewport shifted from item {indexBefore} to {indexAfter} after prepend at top");
-        Assert.True(Math.Abs(relTopAfter - relTopBefore) < 5,
+        Assert.True(Math.Abs(relTopAfter - relTopBefore) == 0,
             $"None mode: item position shifted by {Math.Abs(relTopAfter - relTopBefore)}px after prepend");
+
+        // Scroll up and verify prepended items are actually reachable.
+        js.ExecuteScript("arguments[0].scrollTop = 0", container);
+        Browser.True(() =>
+        {
+            return container.FindElements(By.CssSelector("[data-index='-1']")).Count > 0;
+        }, TimeSpan.FromSeconds(5), "None mode: prepended items should be reachable after scrolling up");
     }
 
-    [Fact]
-    public void AnchorMode_None_LargeAppendAtBottom_DoesNotFollowToBottom()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AnchorMode_None_LargeAppendAtBottom_DoesNotFollowToBottom(bool variableHeight)
     {
-        MountAnchorModeComponent("0");
+        MountAnchorModeComponent("0", variableHeight);
 
         var container = Browser.Exists(By.Id("scroll-container"));
         var js = (IJavaScriptExecutor)Browser;
 
-        js.ExecuteScript("arguments[0].scrollTop = arguments[0].scrollHeight", container);
-        Browser.True(() =>
-        {
-            var st = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
-            var sh = (long)js.ExecuteScript("return arguments[0].scrollHeight", container);
-            var ch = (long)js.ExecuteScript("return arguments[0].clientHeight", container);
-            return sh - st - ch < 2;
-        });
+        ScrollToBottomAndWait(container, js);
 
         Browser.Exists(By.Id("append-many-items")).Click();
-        Browser.Contains("Appended 1000 items", () => Browser.Exists(By.Id("status")).Text);
-
-        // None mode: no convergence to chase the new bottom.
+        Browser.Contains("Appended 100 items", () => Browser.Exists(By.Id("status")).Text);
         // The viewport should NOT end up at the very bottom of 1500 items.
         var st2 = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
         var sh2 = (long)js.ExecuteScript("return arguments[0].scrollHeight", container);
@@ -2020,10 +2051,12 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
             $"scrollTop: {st2}, scrollHeight: {sh2}, gap: {gap}");
     }
 
-    [Fact]
-    public void AnchorMode_None_MidList_ViewportStable()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AnchorMode_None_MidList_ViewportStable(bool variableHeight)
     {
-        MountAnchorModeComponent("0");
+        MountAnchorModeComponent("0", variableHeight);
 
         var container = Browser.Exists(By.Id("scroll-container"));
         var js = (IJavaScriptExecutor)Browser;
@@ -2036,21 +2069,22 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         Browser.Contains("Prepended 10 items", () => Browser.Exists(By.Id("status")).Text);
 
         // Native anchoring adjusts scrollTop to compensate, so check visual position instead.
-        Browser.True(() =>
-        {
-            try
-            {
-                var pos = GetItemPositionInContainer(js, container, ".item", indexBefore);
-                return Math.Abs(pos.relTop - relTopBefore) < 5;
-            }
-            catch { return false; }
-        }, $"None mode mid-list: viewport should stay visually stable after prepend (relTop before: {relTopBefore})");
+        AssertViewportStaysStable(
+            js,
+            By.Id("scroll-container"),
+            ".item",
+            indexBefore,
+            relTopBefore,
+            "None mode mid-list: viewport should stay visually stable after prepend",
+            compareWholePixels: true);
     }
 
-    [Fact]
-    public void AnchorMode_Beginning_PrependAtTop_NewItemsVisible()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AnchorMode_Beginning_PrependAtTop_NewItemsVisible(bool variableHeight)
     {
-        MountAnchorModeComponent("1");
+        MountAnchorModeComponent("1", variableHeight);
 
         var container = Browser.Exists(By.Id("scroll-container"));
         var js = (IJavaScriptExecutor)Browser;
@@ -2067,28 +2101,21 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         Browser.True(() => container.FindElements(By.CssSelector("[data-index='-1']")).Count > 0);
     }
 
-    [Fact]
-    public void AnchorMode_Beginning_LargeAppendAtBottom_DoesNotFollowToBottom()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AnchorMode_Beginning_LargeAppendAtBottom_DoesNotFollowToBottom(bool variableHeight)
     {
-        MountAnchorModeComponent("1");
+        MountAnchorModeComponent("1", variableHeight);
 
         var container = Browser.Exists(By.Id("scroll-container"));
         var js = (IJavaScriptExecutor)Browser;
 
-        js.ExecuteScript("arguments[0].scrollTop = arguments[0].scrollHeight", container);
-        Browser.True(() =>
-        {
-            var st = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
-            var sh = (long)js.ExecuteScript("return arguments[0].scrollHeight", container);
-            var ch = (long)js.ExecuteScript("return arguments[0].clientHeight", container);
-            return sh - st - ch < 2;
-        });
+        ScrollToBottomAndWait(container, js);
 
         Browser.Exists(By.Id("append-many-items")).Click();
-        Browser.Contains("Appended 1000 items", () => Browser.Exists(By.Id("status")).Text);
-
+        Browser.Contains("Appended 100 items", () => Browser.Exists(By.Id("status")).Text);
         // Beginning mode: no convergence to chase the new bottom.
-        // The viewport should NOT end up at the very bottom of 1500 items.
         var st2 = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
         var sh2 = (long)js.ExecuteScript("return arguments[0].scrollHeight", container);
         var ch2 = (long)js.ExecuteScript("return arguments[0].clientHeight", container);
@@ -2098,10 +2125,12 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
             $"scrollTop: {st2}, scrollHeight: {sh2}, gap: {gap}");
     }
 
-    [Fact]
-    public void AnchorMode_Beginning_MidList_ViewportStable()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AnchorMode_Beginning_MidList_ViewportStable(bool variableHeight)
     {
-        MountAnchorModeComponent("1");
+        MountAnchorModeComponent("1", variableHeight);
 
         var container = Browser.Exists(By.Id("scroll-container"));
         var js = (IJavaScriptExecutor)Browser;
@@ -2113,16 +2142,23 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         Browser.Exists(By.Id("prepend-items")).Click();
         Browser.Contains("Prepended 10 items", () => Browser.Exists(By.Id("status")).Text);
 
-        var (_, relTopAfter, _2) = GetItemPositionInContainer(js, container, ".item", indexBefore);
-        Assert.True(Math.Abs(relTopAfter - relTopBefore) < 5,
-            $"Beginning mode mid-list: viewport should stay stable after prepend. " +
-            $"Before: {relTopBefore}, After: {relTopAfter}");
+        var driftTolerance = 0;
+        AssertViewportStaysStable(
+            js,
+            By.Id("scroll-container"),
+            ".item",
+            indexBefore,
+            relTopBefore,
+            "Beginning mode mid-list: viewport should stay stable after prepend",
+            driftTolerance);
     }
 
-    [Fact]
-    public void AnchorMode_End_PrependAtTop_ViewportStaysStable()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AnchorMode_End_PrependAtTop_ViewportStaysStable(bool variableHeight)
     {
-        MountAnchorModeComponent("2");
+        MountAnchorModeComponent("2", variableHeight);
 
         var container = Browser.Exists(By.Id("scroll-container"));
         var js = (IJavaScriptExecutor)Browser;
@@ -2139,22 +2175,17 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
             $"End mode at top: scrollTop should stay near 0 (floor constraint), but was {scrollTopAfter}");
     }
 
-    [Fact]
-    public void AnchorMode_End_AppendAtBottom_ViewportFollows()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AnchorMode_End_AppendAtBottom_ViewportFollows(bool variableHeight)
     {
-        MountAnchorModeComponent("2");
+        MountAnchorModeComponent("2", variableHeight);
 
         var container = Browser.Exists(By.Id("scroll-container"));
         var js = (IJavaScriptExecutor)Browser;
 
-        js.ExecuteScript("arguments[0].scrollTop = arguments[0].scrollHeight", container);
-        Browser.True(() =>
-        {
-            var st = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
-            var sh = (long)js.ExecuteScript("return arguments[0].scrollHeight", container);
-            var ch = (long)js.ExecuteScript("return arguments[0].clientHeight", container);
-            return sh - st - ch < 2;
-        });
+        ScrollToBottomAndWait(container, js);
 
         Browser.Exists(By.Id("append-items")).Click();
         Browser.Contains("Appended 10 items", () => Browser.Exists(By.Id("status")).Text);
@@ -2168,10 +2199,12 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         }, "End mode: viewport should follow new content to the bottom after append");
     }
 
-    [Fact]
-    public void AnchorMode_End_MidList_ViewportStable()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AnchorMode_End_MidList_ViewportStable(bool variableHeight)
     {
-        MountAnchorModeComponent("2");
+        MountAnchorModeComponent("2", variableHeight);
 
         var container = Browser.Exists(By.Id("scroll-container"));
         var js = (IJavaScriptExecutor)Browser;
@@ -2183,45 +2216,39 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         Browser.Exists(By.Id("prepend-items")).Click();
         Browser.Contains("Prepended 10 items", () => Browser.Exists(By.Id("status")).Text);
 
-        var (_, relTopAfter, _2) = GetItemPositionInContainer(js, container, ".item", indexBefore);
-        Assert.True(Math.Abs(relTopAfter - relTopBefore) < 5,
-            $"End mode mid-list: viewport should stay stable after prepend. " +
-            $"Before: {relTopBefore}, After: {relTopAfter}");
+        var driftTolerance = 0;
+        AssertViewportStaysStable(
+            js,
+            By.Id("scroll-container"),
+            ".item",
+            indexBefore,
+            relTopBefore,
+            "End mode mid-list: viewport should stay stable after prepend",
+            driftTolerance);
     }
 
-    [Fact]
-    public void AnchorMode_End_LargeAppendAtBottom_StillFollows()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AnchorMode_End_LargeAppendAtBottom_StillFollows(bool variableHeight)
     {
-        MountAnchorModeComponent("2");
+        MountAnchorModeComponent("2", variableHeight);
 
         var container = Browser.Exists(By.Id("scroll-container"));
         var js = (IJavaScriptExecutor)Browser;
 
-        js.ExecuteScript("arguments[0].scrollTop = arguments[0].scrollHeight", container);
-        Browser.True(() =>
-        {
-            var st = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
-            var sh = (long)js.ExecuteScript("return arguments[0].scrollHeight", container);
-            var ch = (long)js.ExecuteScript("return arguments[0].clientHeight", container);
-            return sh - st - ch < 2;
-        });
+        ScrollToBottomAndWait(container, js);
 
         Browser.Exists(By.Id("append-many-items")).Click();
-        Browser.Contains("Appended 1000 items", () => Browser.Exists(By.Id("status")).Text);
-
-        Browser.True(() =>
-        {
-            var st = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
-            var sh = (long)js.ExecuteScript("return arguments[0].scrollHeight", container);
-            var ch = (long)js.ExecuteScript("return arguments[0].clientHeight", container);
-            return sh - st - ch < 2;
-        }, "End mode: large append should still follow to bottom");
+        Browser.Contains("Appended 100 items", () => Browser.Exists(By.Id("status")).Text);
     }
 
-    [Fact]
-    public void AnchorMode_Beginning_LargePrependAtTop_StillShowsNewItems()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AnchorMode_Beginning_LargePrependAtTop_StillShowsNewItems(bool variableHeight)
     {
-        MountAnchorModeComponent("1");
+        MountAnchorModeComponent("1", variableHeight);
 
         var container = Browser.Exists(By.Id("scroll-container"));
         var js = (IJavaScriptExecutor)Browser;
@@ -2229,7 +2256,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         Assert.Equal(0, (long)js.ExecuteScript("return arguments[0].scrollTop", container));
 
         Browser.Exists(By.Id("prepend-many-items")).Click();
-        Browser.Contains("Prepended 1000 items", () => Browser.Exists(By.Id("status")).Text);
+        Browser.Contains("Prepended 100 items", () => Browser.Exists(By.Id("status")).Text);
 
         var scrollTopAfter = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
         Assert.True(scrollTopAfter < 50,
@@ -2238,10 +2265,12 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         Browser.True(() => container.FindElements(By.CssSelector("[data-index='-1']")).Count > 0);
     }
 
-    [Fact]
-    public void AnchorMode_End_AppendAtMidList_DoesNotAutoScroll()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AnchorMode_End_AppendAtMidList_DoesNotAutoScroll(bool variableHeight)
     {
-        MountAnchorModeComponent("2");
+        MountAnchorModeComponent("2", variableHeight);
 
         var container = Browser.Exists(By.Id("scroll-container"));
         var js = (IJavaScriptExecutor)Browser;
@@ -2254,30 +2283,24 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         Browser.Contains("Appended 10 items", () => Browser.Exists(By.Id("status")).Text);
 
         var (_, relTopAfter, scrollTopAfter) = GetItemPositionInContainer(js, container, ".item", indexBefore);
-        Assert.True(Math.Abs(scrollTopAfter - scrollTopBefore) < 5,
-            $"End mode mid-list: should not auto-scroll on append. " +
-            $"scrollTop before: {scrollTopBefore}, after: {scrollTopAfter}");
-        Assert.True(Math.Abs(relTopAfter - relTopBefore) < 5,
+        Assert.Equal(scrollTopBefore, scrollTopAfter);
+        var driftTolerance = 0;
+        Assert.True(Math.Abs(relTopAfter - relTopBefore) <= driftTolerance,
             $"End mode mid-list: visible item should not shift on append. " +
             $"relTop before: {relTopBefore}, after: {relTopAfter}");
     }
 
-    [Fact]
-    public void AnchorMode_End_AppendAfterLeavingBottom_DoesNotReengage()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AnchorMode_End_AppendAfterLeavingBottom_DoesNotReengage(bool variableHeight)
     {
-        MountAnchorModeComponent("2");
+        MountAnchorModeComponent("2", variableHeight);
 
         var container = Browser.Exists(By.Id("scroll-container"));
         var js = (IJavaScriptExecutor)Browser;
 
-        js.ExecuteScript("arguments[0].scrollTop = arguments[0].scrollHeight", container);
-        Browser.True(() =>
-        {
-            var st = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
-            var sh = (long)js.ExecuteScript("return arguments[0].scrollHeight", container);
-            var ch = (long)js.ExecuteScript("return arguments[0].clientHeight", container);
-            return sh - st - ch < 2;
-        });
+        ScrollToBottomAndWait(container, js);
 
         Browser.Exists(By.Id("append-items")).Click();
         Browser.Contains("Appended 10 items", () => Browser.Exists(By.Id("status")).Text);
@@ -2297,15 +2320,15 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         Browser.Contains("Appended 10 items", () => Browser.Exists(By.Id("status")).Text);
 
         var scrollTopAfterSecondAppend = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
-        Assert.True(Math.Abs(scrollTopAfterSecondAppend - scrollTopBeforeSecondAppend) < 5,
-            $"End mode: should disengage after user scrolls away from bottom. " +
-            $"scrollTop before 2nd append: {scrollTopBeforeSecondAppend}, after: {scrollTopAfterSecondAppend}");
+        Assert.Equal(scrollTopBeforeSecondAppend, scrollTopAfterSecondAppend);
     }
 
-    [Fact]
-    public void AnchorMode_Beginning_PrependAfterLeavingTop_DoesNotReengage()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AnchorMode_Beginning_PrependAfterLeavingTop_DoesNotReengage(bool variableHeight)
     {
-        MountAnchorModeComponent("1");
+        MountAnchorModeComponent("1", variableHeight);
 
         var container = Browser.Exists(By.Id("scroll-container"));
         var js = (IJavaScriptExecutor)Browser;
@@ -2361,10 +2384,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         Browser.True(() => (long)js.ExecuteScript("return window.scrollY") == 0);
 
         Browser.True(() => root.FindElements(By.CssSelector(".item[data-index]")).Count > 0);
-        var itemsBefore = root.FindElements(By.CssSelector(".item[data-index]"));
-        var firstIndexBefore = itemsBefore
-            .Select(e => int.Parse(e.GetAttribute("data-index"), CultureInfo.InvariantCulture))
-            .Min();
+        var (firstIndexBefore, firstTopBefore) = GetItemPositionInViewport(js, root, ".item[data-index]");
 
         Browser.Exists(By.Id("prepend-items")).Click();
         Browser.Contains("Prepended 10 items", () => Browser.Exists(By.Id("status")).Text);
@@ -2376,14 +2396,18 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
             return scrollY > 100;
         }, TimeSpan.FromSeconds(5));
 
-        // The same items should still be visible after compensation.
-        var itemsAfter = root.FindElements(By.CssSelector(".item[data-index]"));
-        var firstIndexAfter = itemsAfter
-            .Select(e => int.Parse(e.GetAttribute("data-index"), CultureInfo.InvariantCulture))
-            .Min();
+        // Window scroll can render newly prepended rows above the viewport as overscan,
+        // so compare the same visible item's viewport position instead of the minimum rendered index.
+        Browser.True(() =>
+        {
+            var (_, currentTop) = GetItemPositionInViewport(js, root, ".item[data-index]", firstIndexBefore);
+            return Math.Abs(currentTop - firstTopBefore) <= 2;
+        }, TimeSpan.FromSeconds(5));
 
-        Assert.True(Math.Abs(firstIndexAfter - firstIndexBefore) <= 1,
-            $"Window-scroll None mode: viewport shifted from item {firstIndexBefore} to {firstIndexAfter} after prepend at top");
+        var (_, firstTopAfter) = GetItemPositionInViewport(js, root, ".item[data-index]", firstIndexBefore);
+
+        Assert.True(Math.Abs(firstTopAfter - firstTopBefore) <= 2,
+            $"Window-scroll None mode: item {firstIndexBefore} moved from {firstTopBefore} to {firstTopAfter} after prepend at top");
     }
 
     private static (string index, double relTop, long scrollTop) GetItemPositionInContainer(
@@ -2402,7 +2426,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
                     if (item.getAttribute('data-index') === targetIndex) {
                         return { index: targetIndex, relTop: itemRect.top - containerRect.top, scrollTop: container.scrollTop };
                     }
-                } else if (itemRect.top >= containerRect.top - 1 && itemRect.top < containerRect.bottom) {
+                } else if (itemRect.bottom > containerRect.top + 1 && itemRect.top < containerRect.bottom - 1) {
                     return { index: item.getAttribute('data-index'), relTop: itemRect.top - containerRect.top, scrollTop: container.scrollTop };
                 }
             }
@@ -2414,6 +2438,65 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
             result["index"].ToString(),
             Convert.ToDouble(result["relTop"], CultureInfo.InvariantCulture),
             Convert.ToInt64(result["scrollTop"], CultureInfo.InvariantCulture));
+    }
+
+    private void AssertViewportStaysStable(
+        IJavaScriptExecutor js,
+        By containerSelector,
+        string itemSelector,
+        string indexBefore,
+        double relTopBefore,
+        string message,
+        double driftTolerance = 0,
+        bool compareWholePixels = false)
+    {
+        (string index, double relTop, long scrollTop) lastPos = default;
+
+        Browser.True(() =>
+        {
+            try
+            {
+                var container = Browser.Exists(containerSelector);
+                lastPos = GetItemPositionInContainer(js, container, itemSelector, indexBefore);
+                var drift = compareWholePixels
+                    ? Math.Abs((int)Math.Round(lastPos.relTop) - (int)Math.Round(relTopBefore))
+                    : Math.Abs(lastPos.relTop - relTopBefore);
+
+                return drift <= driftTolerance;
+            }
+            catch
+            {
+                return false;
+            }
+        }, $"{message} (index before: {indexBefore}, last index: {lastPos.index}, relTop before: {relTopBefore}, last relTop: {lastPos.relTop}, last scrollTop: {lastPos.scrollTop}, tolerance: {driftTolerance})");
+    }
+
+    private static (string index, double top) GetItemPositionInViewport(
+        IJavaScriptExecutor js, IWebElement root, string itemSelector, string dataIndex = null)
+    {
+        var result = js.ExecuteScript(@"
+            var root = arguments[0];
+            var selector = arguments[1];
+            var targetIndex = arguments[2];
+            var items = root.querySelectorAll(selector);
+            for (var i = 0; i < items.length; i++) {
+                var item = items[i];
+                var itemRect = item.getBoundingClientRect();
+                if (targetIndex != null) {
+                    if (item.getAttribute('data-index') === targetIndex) {
+                        return { index: targetIndex, top: itemRect.top };
+                    }
+                } else if (itemRect.bottom > 1 && itemRect.top < window.innerHeight - 1) {
+                    return { index: item.getAttribute('data-index'), top: itemRect.top };
+                }
+            }
+            return null;
+        ", root, itemSelector, dataIndex) as Dictionary<string, object>;
+
+        Assert.NotNull(result);
+        return (
+            result["index"].ToString(),
+            Convert.ToDouble(result["top"], CultureInfo.InvariantCulture));
     }
 
     /// <summary>

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -1144,6 +1144,70 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
     }
 
     [Fact]
+    public void DynamicContent_PrependItemsWhileAtTop_NewItemsAppearAtTop()
+    {
+        Browser.MountTestComponent<VirtualizationDynamicContent>();
+
+        var container = Browser.Exists(By.Id("scroll-container"));
+        var js = (IJavaScriptExecutor)Browser;
+        Browser.True(() => GetElementCount(container, ".item") > 0);
+
+        // Verify we're at the top.
+        Assert.Equal(0, (long)js.ExecuteScript("return arguments[0].scrollTop", container));
+
+        Browser.Exists(By.Id("prepend-items")).Click();
+        Browser.Contains("Prepended 10 items", () => Browser.Exists(By.Id("status")).Text);
+
+        // At scrollTop=0, the natural floor prevents native anchoring from compensating — new items
+        // appear at the top and old items shift down. This documents the default Beginning-like behavior.
+        // When AnchorMode is implemented, AnchorMode.None would differ here: native anchoring would
+        // compensate scrollTop upward, keeping old items in view.
+        var scrollTopAfter = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+        Assert.True(scrollTopAfter < 50,
+            $"scrollTop should stay near 0 at the natural floor, but was {scrollTopAfter}");
+
+        // The prepended items should become visible after the IO callback triggers re-render.
+        Browser.True(() => container.FindElements(By.CssSelector("[data-index='-1']")).Count > 0);
+    }
+
+    [Fact]
+    public void DynamicContent_AppendItemsWhileAtBottom_ViewportFollowsBottom()
+    {
+        Browser.MountTestComponent<VirtualizationDynamicContent>();
+
+        var container = Browser.Exists(By.Id("scroll-container"));
+        var js = (IJavaScriptExecutor)Browser;
+        Browser.True(() => GetElementCount(container, ".item") > 0);
+
+        // Scroll to the bottom edge.
+        js.ExecuteScript("arguments[0].scrollTop = arguments[0].scrollHeight", container);
+        Browser.True(() =>
+        {
+            var scrollTop = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+            var scrollHeight = (long)js.ExecuteScript("return arguments[0].scrollHeight", container);
+            var clientHeight = (long)js.ExecuteScript("return arguments[0].clientHeight", container);
+            return scrollHeight - scrollTop - clientHeight < 2;
+        });
+
+        Browser.Exists(By.Id("append-items")).Click();
+        Browser.Contains("Appended 10 items", () => Browser.Exists(By.Id("status")).Text);
+
+        // When at the bottom and items are appended, the component's IO-based convergence
+        // detects spacerAfter becoming visible and scrolls to follow the new content.
+        // This documents the default End-like behavior for small appends at the bottom edge.
+        // When AnchorMode is implemented, AnchorMode.None would differ here: no auto-scroll,
+        // the user would stay at their current position.
+        Browser.True(() =>
+        {
+            var scrollTop = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+            var scrollHeight = (long)js.ExecuteScript("return arguments[0].scrollHeight", container);
+            var clientHeight = (long)js.ExecuteScript("return arguments[0].clientHeight", container);
+            var remaining = scrollHeight - scrollTop - clientHeight;
+            return remaining < 2;
+        }, "After appending at the bottom, the viewport should follow the new content to the bottom");
+    }
+
+    [Fact]
     public void VariableHeight_ContainerResizeWorks()
     {
         Browser.MountTestComponent<VirtualizationVariableHeight>();
@@ -1870,6 +1934,379 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
             $"Total: {result["startY"]}->{result["endY"]} = {totalDelta}px (expected ~{expectedDelta}px). " +
             $"Jumps: [{result["jumps"]}]. " +
             $"Large jumps indicate CSS scroll anchoring is miscalculating on <tr> elements.");
+    }
+
+    private void MountAnchorModeComponent(string anchorMode)
+    {
+        Browser.MountTestComponent<VirtualizationAnchorMode>();
+        var container = Browser.Exists(By.Id("scroll-container"));
+        Browser.True(() => GetElementCount(container, ".item") > 0);
+
+        var select = Browser.Exists(By.Id("anchor-mode-select"));
+        var selectElement = new SelectElement(select);
+        selectElement.SelectByValue(anchorMode);
+    }
+
+    [Fact]
+    public void AnchorMode_None_PrependAtTop_ViewportStaysStable()
+    {
+        MountAnchorModeComponent("0");
+
+        var container = Browser.Exists(By.Id("scroll-container"));
+        var js = (IJavaScriptExecutor)Browser;
+
+        Assert.Equal(0, (long)js.ExecuteScript("return arguments[0].scrollTop", container));
+
+        var (indexBefore, relTopBefore, _) = GetItemPositionInContainer(js, container, ".item");
+
+        Browser.Exists(By.Id("prepend-items")).Click();
+        Browser.Contains("Prepended 10 items", () => Browser.Exists(By.Id("status")).Text);
+
+        var (_, relTopAfter, scrollTopAfter) = GetItemPositionInContainer(js, container, ".item", indexBefore);
+        Assert.True(Math.Abs(relTopAfter - relTopBefore) < 5,
+            $"None mode: first visible item should not shift after prepend. " +
+            $"Before: {relTopBefore}, After: {relTopAfter}, scrollTop: {scrollTopAfter}");
+    }
+
+    [Fact]
+    public void AnchorMode_None_AppendAtBottom_NoAutoScroll()
+    {
+        MountAnchorModeComponent("0");
+
+        var container = Browser.Exists(By.Id("scroll-container"));
+        var js = (IJavaScriptExecutor)Browser;
+
+        js.ExecuteScript("arguments[0].scrollTop = arguments[0].scrollHeight", container);
+        Browser.True(() =>
+        {
+            var st = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+            var sh = (long)js.ExecuteScript("return arguments[0].scrollHeight", container);
+            var ch = (long)js.ExecuteScript("return arguments[0].clientHeight", container);
+            return sh - st - ch < 2;
+        });
+
+        var scrollTopBefore = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+
+        Browser.Exists(By.Id("append-items")).Click();
+        Browser.Contains("Appended 10 items", () => Browser.Exists(By.Id("status")).Text);
+
+        var scrollTopAfter = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+        Assert.True(Math.Abs(scrollTopAfter - scrollTopBefore) < 5,
+            $"None mode: should not auto-scroll when appending at bottom. " +
+            $"Before: {scrollTopBefore}, After: {scrollTopAfter}");
+    }
+
+    [Fact]
+    public void AnchorMode_None_MidList_ViewportStable()
+    {
+        MountAnchorModeComponent("0");
+
+        var container = Browser.Exists(By.Id("scroll-container"));
+        var js = (IJavaScriptExecutor)Browser;
+
+        js.ExecuteScript("arguments[0].scrollTop = 5000", container);
+        Browser.True(() => (long)js.ExecuteScript("return arguments[0].scrollTop", container) > 4000);
+
+        var (indexBefore, relTopBefore, scrollTopBefore) = GetItemPositionInContainer(js, container, ".item");
+
+        Browser.Exists(By.Id("prepend-items")).Click();
+        Browser.Contains("Prepended 10 items", () => Browser.Exists(By.Id("status")).Text);
+
+        var (_, relTopAfter, scrollTopAfter) = GetItemPositionInContainer(js, container, ".item", indexBefore);
+        Assert.True(Math.Abs(relTopAfter - relTopBefore) < 5,
+            $"None mode mid-list: viewport should stay stable after prepend. " +
+            $"Before: {relTopBefore}, After: {relTopAfter}");
+    }
+
+    [Fact]
+    public void AnchorMode_Beginning_PrependAtTop_NewItemsVisible()
+    {
+        MountAnchorModeComponent("1");
+
+        var container = Browser.Exists(By.Id("scroll-container"));
+        var js = (IJavaScriptExecutor)Browser;
+
+        Assert.Equal(0, (long)js.ExecuteScript("return arguments[0].scrollTop", container));
+
+        Browser.Exists(By.Id("prepend-items")).Click();
+        Browser.Contains("Prepended 10 items", () => Browser.Exists(By.Id("status")).Text);
+
+        var scrollTopAfter = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+        Assert.True(scrollTopAfter < 50,
+            $"Beginning mode: should stay near top after prepend, but scrollTop was {scrollTopAfter}");
+
+        Browser.True(() => container.FindElements(By.CssSelector("[data-index='-1']")).Count > 0);
+    }
+
+    [Fact]
+    public void AnchorMode_Beginning_AppendAtBottom_NoAutoScroll()
+    {
+        MountAnchorModeComponent("1");
+
+        var container = Browser.Exists(By.Id("scroll-container"));
+        var js = (IJavaScriptExecutor)Browser;
+
+        js.ExecuteScript("arguments[0].scrollTop = arguments[0].scrollHeight", container);
+        Browser.True(() =>
+        {
+            var st = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+            var sh = (long)js.ExecuteScript("return arguments[0].scrollHeight", container);
+            var ch = (long)js.ExecuteScript("return arguments[0].clientHeight", container);
+            return sh - st - ch < 2;
+        });
+
+        var scrollTopBefore = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+
+        Browser.Exists(By.Id("append-items")).Click();
+        Browser.Contains("Appended 10 items", () => Browser.Exists(By.Id("status")).Text);
+
+        var scrollTopAfter = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+        Assert.True(Math.Abs(scrollTopAfter - scrollTopBefore) < 5,
+            $"Beginning mode: should not auto-scroll when appending at bottom. " +
+            $"Before: {scrollTopBefore}, After: {scrollTopAfter}");
+    }
+
+    [Fact]
+    public void AnchorMode_Beginning_MidList_ViewportStable()
+    {
+        MountAnchorModeComponent("1");
+
+        var container = Browser.Exists(By.Id("scroll-container"));
+        var js = (IJavaScriptExecutor)Browser;
+
+        js.ExecuteScript("arguments[0].scrollTop = 5000", container);
+        Browser.True(() => (long)js.ExecuteScript("return arguments[0].scrollTop", container) > 4000);
+
+        var (indexBefore, relTopBefore, _) = GetItemPositionInContainer(js, container, ".item");
+
+        Browser.Exists(By.Id("prepend-items")).Click();
+        Browser.Contains("Prepended 10 items", () => Browser.Exists(By.Id("status")).Text);
+
+        var (_, relTopAfter, _2) = GetItemPositionInContainer(js, container, ".item", indexBefore);
+        Assert.True(Math.Abs(relTopAfter - relTopBefore) < 5,
+            $"Beginning mode mid-list: viewport should stay stable after prepend. " +
+            $"Before: {relTopBefore}, After: {relTopAfter}");
+    }
+
+    // --- End mode ---
+
+    [Fact]
+    public void AnchorMode_End_PrependAtTop_ViewportStaysStable()
+    {
+        MountAnchorModeComponent("2");
+
+        var container = Browser.Exists(By.Id("scroll-container"));
+        var js = (IJavaScriptExecutor)Browser;
+
+        Assert.Equal(0, (long)js.ExecuteScript("return arguments[0].scrollTop", container));
+
+        var (indexBefore, relTopBefore, _) = GetItemPositionInContainer(js, container, ".item");
+
+        Browser.Exists(By.Id("prepend-items")).Click();
+        Browser.Contains("Prepended 10 items", () => Browser.Exists(By.Id("status")).Text);
+
+        // At scrollTop=0, native anchoring can't compensate (floor constraint).
+        var (_, relTopAfter, scrollTopAfter) = GetItemPositionInContainer(js, container, ".item", indexBefore);
+        Assert.True(scrollTopAfter < 50,
+            $"End mode at top: scrollTop should stay near 0 (floor constraint), but was {scrollTopAfter}");
+    }
+
+    [Fact]
+    public void AnchorMode_End_AppendAtBottom_ViewportFollows()
+    {
+        MountAnchorModeComponent("2");
+
+        var container = Browser.Exists(By.Id("scroll-container"));
+        var js = (IJavaScriptExecutor)Browser;
+
+        js.ExecuteScript("arguments[0].scrollTop = arguments[0].scrollHeight", container);
+        Browser.True(() =>
+        {
+            var st = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+            var sh = (long)js.ExecuteScript("return arguments[0].scrollHeight", container);
+            var ch = (long)js.ExecuteScript("return arguments[0].clientHeight", container);
+            return sh - st - ch < 2;
+        });
+
+        Browser.Exists(By.Id("append-items")).Click();
+        Browser.Contains("Appended 10 items", () => Browser.Exists(By.Id("status")).Text);
+
+        Browser.True(() =>
+        {
+            var st = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+            var sh = (long)js.ExecuteScript("return arguments[0].scrollHeight", container);
+            var ch = (long)js.ExecuteScript("return arguments[0].clientHeight", container);
+            return sh - st - ch < 2;
+        }, "End mode: viewport should follow new content to the bottom after append");
+    }
+
+    [Fact]
+    public void AnchorMode_End_MidList_ViewportStable()
+    {
+        MountAnchorModeComponent("2");
+
+        var container = Browser.Exists(By.Id("scroll-container"));
+        var js = (IJavaScriptExecutor)Browser;
+
+        js.ExecuteScript("arguments[0].scrollTop = 5000", container);
+        Browser.True(() => (long)js.ExecuteScript("return arguments[0].scrollTop", container) > 4000);
+
+        var (indexBefore, relTopBefore, _) = GetItemPositionInContainer(js, container, ".item");
+
+        Browser.Exists(By.Id("prepend-items")).Click();
+        Browser.Contains("Prepended 10 items", () => Browser.Exists(By.Id("status")).Text);
+
+        var (_, relTopAfter, _2) = GetItemPositionInContainer(js, container, ".item", indexBefore);
+        Assert.True(Math.Abs(relTopAfter - relTopBefore) < 5,
+            $"End mode mid-list: viewport should stay stable after prepend. " +
+            $"Before: {relTopBefore}, After: {relTopAfter}");
+    }
+
+    // --- Large batch tests (symmetric for End + Beginning) ---
+
+    [Fact]
+    public void AnchorMode_End_LargeAppendAtBottom_StillFollows()
+    {
+        MountAnchorModeComponent("2");
+
+        var container = Browser.Exists(By.Id("scroll-container"));
+        var js = (IJavaScriptExecutor)Browser;
+
+        js.ExecuteScript("arguments[0].scrollTop = arguments[0].scrollHeight", container);
+        Browser.True(() =>
+        {
+            var st = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+            var sh = (long)js.ExecuteScript("return arguments[0].scrollHeight", container);
+            var ch = (long)js.ExecuteScript("return arguments[0].clientHeight", container);
+            return sh - st - ch < 2;
+        });
+
+        Browser.Exists(By.Id("append-many-items")).Click();
+        Browser.Contains("Appended 1000 items", () => Browser.Exists(By.Id("status")).Text);
+
+        Browser.True(() =>
+        {
+            var st = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+            var sh = (long)js.ExecuteScript("return arguments[0].scrollHeight", container);
+            var ch = (long)js.ExecuteScript("return arguments[0].clientHeight", container);
+            return sh - st - ch < 2;
+        }, "End mode: large append should still follow to bottom");
+    }
+
+    [Fact]
+    public void AnchorMode_Beginning_LargePrependAtTop_StillShowsNewItems()
+    {
+        MountAnchorModeComponent("1");
+
+        var container = Browser.Exists(By.Id("scroll-container"));
+        var js = (IJavaScriptExecutor)Browser;
+
+        Assert.Equal(0, (long)js.ExecuteScript("return arguments[0].scrollTop", container));
+
+        Browser.Exists(By.Id("prepend-many-items")).Click();
+        Browser.Contains("Prepended 1000 items", () => Browser.Exists(By.Id("status")).Text);
+
+        var scrollTopAfter = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+        Assert.True(scrollTopAfter < 50,
+            $"Beginning mode: large prepend should still pin to top, but scrollTop was {scrollTopAfter}");
+
+        Browser.True(() => container.FindElements(By.CssSelector("[data-index='-1']")).Count > 0);
+    }
+
+    [Fact]
+    public void AnchorMode_End_AppendAtMidList_DoesNotAutoScroll()
+    {
+        MountAnchorModeComponent("2");
+
+        var container = Browser.Exists(By.Id("scroll-container"));
+        var js = (IJavaScriptExecutor)Browser;
+
+        js.ExecuteScript("arguments[0].scrollTop = 5000", container);
+        Browser.True(() => (long)js.ExecuteScript("return arguments[0].scrollTop", container) > 4000);
+
+        var (indexBefore, relTopBefore, scrollTopBefore) = GetItemPositionInContainer(js, container, ".item");
+
+        Browser.Exists(By.Id("append-items")).Click();
+        Browser.Contains("Appended 10 items", () => Browser.Exists(By.Id("status")).Text);
+
+        var (_, relTopAfter, scrollTopAfter) = GetItemPositionInContainer(js, container, ".item", indexBefore);
+        Assert.True(Math.Abs(scrollTopAfter - scrollTopBefore) < 5,
+            $"End mode mid-list: should not auto-scroll on append. " +
+            $"scrollTop before: {scrollTopBefore}, after: {scrollTopAfter}");
+        Assert.True(Math.Abs(relTopAfter - relTopBefore) < 5,
+            $"End mode mid-list: visible item should not shift on append. " +
+            $"relTop before: {relTopBefore}, after: {relTopAfter}");
+    }
+
+    [Fact]
+    public void AnchorMode_End_AppendAfterLeavingBottom_DoesNotReengage()
+    {
+        MountAnchorModeComponent("2");
+
+        var container = Browser.Exists(By.Id("scroll-container"));
+        var js = (IJavaScriptExecutor)Browser;
+
+        js.ExecuteScript("arguments[0].scrollTop = arguments[0].scrollHeight", container);
+        Browser.True(() =>
+        {
+            var st = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+            var sh = (long)js.ExecuteScript("return arguments[0].scrollHeight", container);
+            var ch = (long)js.ExecuteScript("return arguments[0].clientHeight", container);
+            return sh - st - ch < 2;
+        });
+
+        Browser.Exists(By.Id("append-items")).Click();
+        Browser.Contains("Appended 10 items", () => Browser.Exists(By.Id("status")).Text);
+        Browser.True(() =>
+        {
+            var st = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+            var sh = (long)js.ExecuteScript("return arguments[0].scrollHeight", container);
+            var ch = (long)js.ExecuteScript("return arguments[0].clientHeight", container);
+            return sh - st - ch < 2;
+        }, "End mode: first append should follow to bottom");
+
+        js.ExecuteScript("arguments[0].scrollTop = arguments[0].scrollTop - 500", container);
+
+        var scrollTopBeforeSecondAppend = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+
+        Browser.Exists(By.Id("append-items")).Click();
+        Browser.Contains("Appended 10 items", () => Browser.Exists(By.Id("status")).Text);
+
+        var scrollTopAfterSecondAppend = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+        Assert.True(Math.Abs(scrollTopAfterSecondAppend - scrollTopBeforeSecondAppend) < 5,
+            $"End mode: should disengage after user scrolls away from bottom. " +
+            $"scrollTop before 2nd append: {scrollTopBeforeSecondAppend}, after: {scrollTopAfterSecondAppend}");
+    }
+
+    [Fact]
+    public void AnchorMode_Beginning_PrependAfterLeavingTop_DoesNotReengage()
+    {
+        MountAnchorModeComponent("1");
+
+        var container = Browser.Exists(By.Id("scroll-container"));
+        var js = (IJavaScriptExecutor)Browser;
+
+        Assert.Equal(0, (long)js.ExecuteScript("return arguments[0].scrollTop", container));
+
+        Browser.Exists(By.Id("prepend-items")).Click();
+        Browser.Contains("Prepended 10 items", () => Browser.Exists(By.Id("status")).Text);
+        Browser.True(() => container.FindElements(By.CssSelector("[data-index='-1']")).Count > 0);
+
+        js.ExecuteScript("arguments[0].scrollTop = 3000", container);
+        Browser.True(() => (long)js.ExecuteScript("return arguments[0].scrollTop", container) > 2000);
+
+        var scrollTopBefore = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+
+        Browser.Exists(By.Id("prepend-items")).Click();
+        Browser.Contains("Prepended 10 items", () => Browser.Exists(By.Id("status")).Text);
+
+        var scrollTopAfter = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+
+        // Native anchoring adjusts scrollTop to compensate for inserted items.
+        // The key check is that the viewport did NOT jump back to 0.
+        Assert.True(scrollTopAfter > 2000,
+            $"Beginning mode: should not pull user back to top after leaving. " +
+            $"scrollTop before: {scrollTopBefore}, after: {scrollTopAfter} (expected >2000, not near 0)");
     }
 
     private static (string index, double relTop, long scrollTop) GetItemPositionInContainer(

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -1028,7 +1028,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         var sameItem = container.FindElement(By.CssSelector($"[data-index='{firstVisibleIndex}']"));
         var firstVisibleTopAfter = sameItem.Location.Y;
 
-        // The visible items should stay in place (or very close, allowing for minor reflow)
+        // The visible items should stay in place
         Assert.Equal(firstVisibleTopBefore, firstVisibleTopAfter);
     }
 

--- a/src/Components/test/testassets/BasicTestApp/Index.razor
+++ b/src/Components/test/testassets/BasicTestApp/Index.razor
@@ -135,6 +135,7 @@
         <option value="BasicTestApp.VirtualizationVariableHeightAsync">Virtualization variable height async</option>
         <option value="BasicTestApp.VirtualizationDynamicContent">Virtualization dynamic content</option>
         <option value="BasicTestApp.VirtualizationAnchorMode">Virtualization anchor mode</option>
+        <option value="BasicTestApp.VirtualizationAnchorModeWindowScroll">Virtualization anchor mode (window scroll)</option>
         <option value="BasicTestApp.VirtualizationDisplayModes">Virtualization display modes (flex/grid/subgrid)</option>
         <option value="BasicTestApp.VirtualizationBimodal">Virtualization bimodal/nested/large</option>
         <option value="BasicTestApp.VirtualizationNestedVariableHeight">Virtualization nested variable height</option>

--- a/src/Components/test/testassets/BasicTestApp/Index.razor
+++ b/src/Components/test/testassets/BasicTestApp/Index.razor
@@ -134,6 +134,7 @@
         <option value="BasicTestApp.VirtualizationVariableHeight">Virtualization variable height</option>
         <option value="BasicTestApp.VirtualizationVariableHeightAsync">Virtualization variable height async</option>
         <option value="BasicTestApp.VirtualizationDynamicContent">Virtualization dynamic content</option>
+        <option value="BasicTestApp.VirtualizationAnchorMode">Virtualization anchor mode</option>
         <option value="BasicTestApp.VirtualizationDisplayModes">Virtualization display modes (flex/grid/subgrid)</option>
         <option value="BasicTestApp.VirtualizationBimodal">Virtualization bimodal/nested/large</option>
         <option value="BasicTestApp.VirtualizationNestedVariableHeight">Virtualization nested variable height</option>

--- a/src/Components/test/testassets/BasicTestApp/VirtualizationAnchorMode.razor
+++ b/src/Components/test/testassets/BasicTestApp/VirtualizationAnchorMode.razor
@@ -13,7 +13,8 @@
 </div>
 
 <div id="scroll-container" style="height: 300px; overflow-y: auto; border: 1px solid black;">
-    <Virtualize Items="@items" ItemSize="50" AnchorMode="@anchorMode" Context="item">
+    @* @key forces Virtualize to re-create (and re-init JS) when anchorMode changes *@
+    <Virtualize @key="anchorMode" Items="@items" ItemSize="50" AnchorMode="@anchorMode" Context="item">
         <div class="item"
              data-index="@item.Index"
              style="border: 1px solid gray; padding: 5px; min-height: @(item.Height)px;">
@@ -30,6 +31,7 @@
 </div>
 
 <p id="status">@statusMessage</p>
+<p id="current-mode">@((int)anchorMode)</p>
 
 @code {
     private List<DynamicItem> items = new();

--- a/src/Components/test/testassets/BasicTestApp/VirtualizationAnchorMode.razor
+++ b/src/Components/test/testassets/BasicTestApp/VirtualizationAnchorMode.razor
@@ -1,0 +1,105 @@
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+
+<h1>Virtualization Anchor Mode</h1>
+
+<div style="margin-bottom: 10px;">
+    <label>Anchor Mode:
+        <select id="anchor-mode-select" @onchange="OnAnchorModeChanged">
+            <option value="0" selected="@(anchorMode == VirtualizeAnchorMode.None)">None</option>
+            <option value="1" selected="@(anchorMode == VirtualizeAnchorMode.Beginning)">Beginning</option>
+            <option value="2" selected="@(anchorMode == VirtualizeAnchorMode.End)">End</option>
+        </select>
+    </label>
+</div>
+
+<div id="scroll-container" style="height: 300px; overflow-y: auto; border: 1px solid black;">
+    <Virtualize Items="@items" ItemSize="50" AnchorMode="@anchorMode" Context="item">
+        <div class="item"
+             data-index="@item.Index"
+             style="border: 1px solid gray; padding: 5px; min-height: @(item.Height)px;">
+            <div>Item @item.Index</div>
+        </div>
+    </Virtualize>
+</div>
+
+<div style="margin-top: 10px;">
+    <button id="prepend-items" @onclick="PrependItems">Prepend 10 Items</button>
+    <button id="prepend-many-items" @onclick="PrependManyItems">Prepend 1000 Items</button>
+    <button id="append-items" @onclick="AppendItems">Append 10 Items</button>
+    <button id="append-many-items" @onclick="AppendManyItems">Append 1000 Items</button>
+</div>
+
+<p id="status">@statusMessage</p>
+
+@code {
+    private List<DynamicItem> items = new();
+    private string statusMessage = "Ready";
+    private VirtualizeAnchorMode anchorMode = VirtualizeAnchorMode.Beginning;
+
+    protected override void OnInitialized()
+    {
+        items = Enumerable.Range(0, 500)
+            .Select(i => new DynamicItem { Index = i, Height = 50 })
+            .ToList();
+    }
+
+    private void OnAnchorModeChanged(ChangeEventArgs e)
+    {
+        if (int.TryParse(e.Value?.ToString(), out var value))
+        {
+            anchorMode = (VirtualizeAnchorMode)value;
+            statusMessage = $"AnchorMode changed to {anchorMode}";
+        }
+    }
+
+    private int nextPrependIndex = -1;
+    private int nextAppendIndex = 500;
+
+    private void PrependItems()
+    {
+        var newItems = Enumerable.Range(0, 10)
+            .Select(i => new DynamicItem { Index = nextPrependIndex - i, Height = 50 })
+            .ToList();
+        items.InsertRange(0, newItems);
+        nextPrependIndex -= 10;
+        statusMessage = $"Prepended 10 items (indices {newItems.Last().Index}..{newItems.First().Index})";
+    }
+
+    private void PrependManyItems()
+    {
+        var newItems = Enumerable.Range(0, 1000)
+            .Select(i => new DynamicItem { Index = nextPrependIndex - i, Height = 50 })
+            .ToList();
+        items.InsertRange(0, newItems);
+        nextPrependIndex -= 1000;
+        statusMessage = $"Prepended 1000 items (indices {newItems.Last().Index}..{newItems.First().Index})";
+    }
+
+    private void AppendItems()
+    {
+        var startIndex = nextAppendIndex;
+        var newItems = Enumerable.Range(startIndex, 10)
+            .Select(i => new DynamicItem { Index = i, Height = 50 })
+            .ToList();
+        items.AddRange(newItems);
+        nextAppendIndex += 10;
+        statusMessage = $"Appended 10 items (indices {startIndex}..{startIndex + 9})";
+    }
+
+    private void AppendManyItems()
+    {
+        var startIndex = nextAppendIndex;
+        var newItems = Enumerable.Range(startIndex, 1000)
+            .Select(i => new DynamicItem { Index = i, Height = 50 })
+            .ToList();
+        items.AddRange(newItems);
+        nextAppendIndex += 1000;
+        statusMessage = $"Appended 1000 items (indices {startIndex}..{startIndex + 999})";
+    }
+
+    private class DynamicItem
+    {
+        public int Index { get; set; }
+        public int Height { get; set; }
+    }
+}

--- a/src/Components/test/testassets/BasicTestApp/VirtualizationAnchorMode.razor
+++ b/src/Components/test/testassets/BasicTestApp/VirtualizationAnchorMode.razor
@@ -24,9 +24,12 @@
 
 <div style="margin-top: 10px;">
     <button id="prepend-items" @onclick="PrependItems">Prepend 10 Items</button>
-    <button id="prepend-many-items" @onclick="PrependManyItems">Prepend 1000 Items</button>
+    <button id="prepend-many-items" @onclick="PrependManyItems">Prepend 100 Items</button>
     <button id="append-items" @onclick="AppendItems">Append 10 Items</button>
-    <button id="append-many-items" @onclick="AppendManyItems">Append 1000 Items</button>
+    <button id="append-many-items" @onclick="AppendManyItems">Append 100 Items</button>
+    <button id="toggle-height" @onclick="ToggleVariableHeight">
+        Heights: @(useVariableHeight ? "Variable (25-100px)" : "Fixed (50px)")
+    </button>
 </div>
 
 <p id="status">@statusMessage</p>
@@ -36,12 +39,28 @@
     private List<DynamicItem> items = new();
     private string statusMessage = "Ready";
     private VirtualizeAnchorMode anchorMode = VirtualizeAnchorMode.Beginning;
+    private bool useVariableHeight = false;
 
     protected override void OnInitialized()
     {
         items = Enumerable.Range(0, 500)
-            .Select(i => new DynamicItem { Index = i, Height = 50 })
+            .Select(i => new DynamicItem { Index = i, Height = GetHeight(i) })
             .ToList();
+    }
+
+    private int GetHeight(int index)
+    {
+        return useVariableHeight ? 25 + (Math.Abs(index * 7 + 13) % 76) : 50;
+    }
+
+    private void ToggleVariableHeight()
+    {
+        useVariableHeight = !useVariableHeight;
+        foreach (var item in items)
+        {
+            item.Height = GetHeight(item.Index);
+        }
+        statusMessage = useVariableHeight ? "Switched to variable heights" : "Switched to fixed heights";
     }
 
     private void OnAnchorModeChanged(ChangeEventArgs e)
@@ -59,7 +78,7 @@
     private void PrependItems()
     {
         var newItems = Enumerable.Range(0, 10)
-            .Select(i => new DynamicItem { Index = nextPrependIndex - i, Height = 50 })
+            .Select(i => new DynamicItem { Index = nextPrependIndex - i, Height = GetHeight(nextPrependIndex - i) })
             .ToList();
         items.InsertRange(0, newItems);
         nextPrependIndex -= 10;
@@ -68,19 +87,19 @@
 
     private void PrependManyItems()
     {
-        var newItems = Enumerable.Range(0, 1000)
-            .Select(i => new DynamicItem { Index = nextPrependIndex - i, Height = 50 })
+        var newItems = Enumerable.Range(0, 100)
+            .Select(i => new DynamicItem { Index = nextPrependIndex - i, Height = GetHeight(nextPrependIndex - i) })
             .ToList();
         items.InsertRange(0, newItems);
-        nextPrependIndex -= 1000;
-        statusMessage = $"Prepended 1000 items (indices {newItems.Last().Index}..{newItems.First().Index})";
+        nextPrependIndex -= 100;
+        statusMessage = $"Prepended 100 items (indices {newItems.Last().Index}..{newItems.First().Index})";
     }
 
     private void AppendItems()
     {
         var startIndex = nextAppendIndex;
         var newItems = Enumerable.Range(startIndex, 10)
-            .Select(i => new DynamicItem { Index = i, Height = 50 })
+            .Select(i => new DynamicItem { Index = i, Height = GetHeight(i) })
             .ToList();
         items.AddRange(newItems);
         nextAppendIndex += 10;
@@ -90,12 +109,12 @@
     private void AppendManyItems()
     {
         var startIndex = nextAppendIndex;
-        var newItems = Enumerable.Range(startIndex, 1000)
-            .Select(i => new DynamicItem { Index = i, Height = 50 })
+        var newItems = Enumerable.Range(startIndex, 100)
+            .Select(i => new DynamicItem { Index = i, Height = GetHeight(i) })
             .ToList();
         items.AddRange(newItems);
-        nextAppendIndex += 1000;
-        statusMessage = $"Appended 1000 items (indices {startIndex}..{startIndex + 999})";
+        nextAppendIndex += 100;
+        statusMessage = $"Appended 100 items (indices {startIndex}..{startIndex + 99})";
     }
 
     private class DynamicItem

--- a/src/Components/test/testassets/BasicTestApp/VirtualizationAnchorModeWindowScroll.razor
+++ b/src/Components/test/testassets/BasicTestApp/VirtualizationAnchorModeWindowScroll.razor
@@ -1,6 +1,13 @@
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 
-<h1>Virtualization Anchor Mode</h1>
+<style>
+    html, body {
+        overflow-y: scroll;
+        height: auto;
+    }
+</style>
+
+<h1>Virtualization Anchor Mode (Window Scroll)</h1>
 
 <div style="margin-bottom: 10px;">
     <label>Anchor Mode:
@@ -12,7 +19,17 @@
     </label>
 </div>
 
-<div id="scroll-container" style="height: 300px; overflow-y: auto; border: 1px solid black;">
+@* Buttons placed ABOVE content so clicking doesn't scroll the page *@
+<div style="margin-bottom: 10px;">
+    <button id="prepend-items" @onclick="PrependItems">Prepend 10 Items</button>
+    <button id="append-items" @onclick="AppendItems">Append 10 Items</button>
+</div>
+
+<p id="status">@statusMessage</p>
+<p id="current-mode">@((int)anchorMode)</p>
+
+<div id="virtualize-root">
+    @* No scroll container — uses window/document as the scroll root *@
     <Virtualize Items="@items" ItemSize="50" AnchorMode="@anchorMode" Context="item">
         <div class="item"
              data-index="@item.Index"
@@ -21,16 +38,6 @@
         </div>
     </Virtualize>
 </div>
-
-<div style="margin-top: 10px;">
-    <button id="prepend-items" @onclick="PrependItems">Prepend 10 Items</button>
-    <button id="prepend-many-items" @onclick="PrependManyItems">Prepend 1000 Items</button>
-    <button id="append-items" @onclick="AppendItems">Append 10 Items</button>
-    <button id="append-many-items" @onclick="AppendManyItems">Append 1000 Items</button>
-</div>
-
-<p id="status">@statusMessage</p>
-<p id="current-mode">@((int)anchorMode)</p>
 
 @code {
     private List<DynamicItem> items = new();
@@ -66,16 +73,6 @@
         statusMessage = $"Prepended 10 items (indices {newItems.Last().Index}..{newItems.First().Index})";
     }
 
-    private void PrependManyItems()
-    {
-        var newItems = Enumerable.Range(0, 1000)
-            .Select(i => new DynamicItem { Index = nextPrependIndex - i, Height = 50 })
-            .ToList();
-        items.InsertRange(0, newItems);
-        nextPrependIndex -= 1000;
-        statusMessage = $"Prepended 1000 items (indices {newItems.Last().Index}..{newItems.First().Index})";
-    }
-
     private void AppendItems()
     {
         var startIndex = nextAppendIndex;
@@ -85,17 +82,6 @@
         items.AddRange(newItems);
         nextAppendIndex += 10;
         statusMessage = $"Appended 10 items (indices {startIndex}..{startIndex + 9})";
-    }
-
-    private void AppendManyItems()
-    {
-        var startIndex = nextAppendIndex;
-        var newItems = Enumerable.Range(startIndex, 1000)
-            .Select(i => new DynamicItem { Index = i, Height = 50 })
-            .ToList();
-        items.AddRange(newItems);
-        nextAppendIndex += 1000;
-        statusMessage = $"Appended 1000 items (indices {startIndex}..{startIndex + 999})";
     }
 
     private class DynamicItem


### PR DESCRIPTION
## Summary

Adds a new `AnchorMode` parameter to the `Virtualize<TItem>` component that controls how the viewport behaves at list edges when items are added dynamically. 

## Out of scope

This PR adds tests for both: fixed and variable height items but focuses on supporting only the former. Variable height support for prepended items scenario turns out to be more time consuming than expected and is out of scope for this PR.
The exact scroll compensation is unknown until the new items are rendered and measured in the DOM, so keeping the viewport perfectly stable requires an asynchronous, race-free post-layout correction rather than a deterministic precomputed shift (which is sufficient for fixed height scenarios).

## New API

```csharp
[Flags]
public enum VirtualizeAnchorMode
{
    None = 0,      // No edge pinning — viewport stays at current scroll position
    Beginning = 1, // Pins to top — new items at the beginning keep viewport at the top (news feed UX)
    End = 2,       // Pins to bottom — new items at the end auto-scroll to show them (chat/log UX)
}
```

`Virtualize<TItem>.AnchorMode` — default is `Beginning` (matches .NET 10 behavior at the top edge).

Modes can be combined: `Beginning | End` pins both edges. Combining `None` with other modes is supported but does not change the combined value -> since `None = 0` the combination `None | Beginning` is just Beginning.

## Behavior matrix

| Scenario | None | Beginning | End |
|---|:---:|:---:|:---:|
| Prepend at top | Viewport stable (scroll compensated) | Stays at top showing new items | Viewport stable |
| Append at bottom | Viewport stable | Viewport stable | Follows to new bottom |
| Mid-list changes | Viewport stable | Viewport stable| Viewport stable|
| Home/End keys | Still works | Works | Works |

## Changes

### C# (`Virtualize.cs`, `VirtualizeJsInterop.cs`)
- New `AnchorMode` component parameter with `[Parameter]`
- `_pendingScrollToBottom` gated on `(AnchorMode & End) != 0` instead of `!= None`
- Dynamic AnchorMode updates: detects changes in `OnAfterRenderAsync`, pushes to JS via `SetAnchorModeAsync`
- None-mode prepend compensation: sets `data-scroll-compensate` attribute, JS adjusts `scrollTop`

### JS (`Virtualize.ts`)
- `anchorMode` parameter flows into `init()`, gating convergence logic:
  - Top convergence (`onSpacerBeforeVisible`): gated on `anchorMode & 1` (Beginning)
  - Bottom convergence (`onSpacerAfterVisible`): gated on `anchorMode & 2` (End)
- `setAnchorMode` export for dynamic updates
- `scrollEventTarget` fix: uses `scrollContainer ?? window` for scroll unlock handler (fixes window-scrolling mode)
- Prepend compensation: `scrollElement.scrollTop += spacerBefore.offsetHeight` (was `=`, broke window-scrolling)

Contributes to #65742.