### PR TITLE
Add VS2026 coverage to Quarantine-test pipeline

### DIFF
--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -55,6 +55,7 @@
         <!-- Windows -->
         <HelixAvailableTargetQueue Include="Windows.Amd64.Server2022.Open" Platform="Windows" />
         <HelixAvailableTargetQueue Include="Windows.11.Amd64.Client.Open" Platform="Windows" />
+        <HelixAvailableTargetQueue Include="Windows.Amd64.VS2026.Pre.Scout.Open" Platform="Windows" />
 
         <!-- IIS Express isn't supported on arm64 and most of the IsWindowsOnlyTests depend on its setup scripts. -->
         <HelixAvailableTargetQueue Include="windows.11.arm64.open" Platform="Windows"


### PR DESCRIPTION
This brings us to parity with the regular CI pipeline