### PR TITLE
Remove stale TBD diagnostic suppression from Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -144,9 +144,6 @@
     <!-- don't warn about unnecessary trim warning suppressions. can be removed with preview 6. -->
     <NoWarn>$(NoWarn);IL2121</NoWarn>
 
-    <!-- // Temporary diagnostic code from https://github.com/dotnet/extensions/pull/4130 for metrics APIs used in test. -->
-    <NoWarn>$(NoWarn);TBD</NoWarn>
-
     <NoWarn Condition="'$(_DevBuild)' == 'true'">$(NoWarn);NU3027</NoWarn>
   </PropertyGroup>
 


### PR DESCRIPTION
The TBD diagnostic code from dotnet/extensions#4130 was a placeholder that was never assigned an actual diagnostic ID. This suppression has no effect.