### PR TITLE
Remove stale NETSDK1138 suppression (no more netcoreapp2.1 projects)

### DIFF
--- a/eng/Workarounds.props
+++ b/eng/Workarounds.props
@@ -25,9 +25,8 @@
     <UseSharedCompilation>true</UseSharedCompilation>
   </PropertyGroup>
 
-  <!-- Workaround continued use of netcoreapp2.1. -->
   <PropertyGroup>
-    <NoWarn>$(NoWarn);NETSDK1138;CS8969</NoWarn>
+    <NoWarn>$(NoWarn);CS8969</NoWarn>
   </PropertyGroup>
 
   <!-- Workaround obsolete X509Certificate ctor: https://github.com/dotnet/docs/issues/41662 -->


### PR DESCRIPTION
NETSDK1138 warns about targeting unsupported frameworks. This was suppressing it for netcoreapp2.1, but no projects in the repo target netcoreapp2.1 anymore. CS8969 is retained as there are still 88 multi-targeting projects.