### PR TITLE
Remove stale netstandard2.1 KnownFrameworkReference workaround

### DIFF
--- a/eng/Workarounds.targets
+++ b/eng/Workarounds.targets
@@ -20,13 +20,6 @@
       '$(GenerateRazorAssemblyInfo)' == 'true'" />
   </ItemGroup>
 
-  <!-- Workaround for netstandard2.1 projects until we can get a preview 8 SDK containing https://github.com/dotnet/sdk/pull/3463 fix. -->
-  <ItemGroup>
-    <KnownFrameworkReference Update="NETStandard.Library">
-      <RuntimeFrameworkName>NETStandard.Library</RuntimeFrameworkName>
-    </KnownFrameworkReference>
-  </ItemGroup>
-
   <!-- Work around https://github.com/dotnet/cli/issues/11378. -->
   <Target Name="_WorkaroundNetStandard" AfterTargets="ResolvePackageAssets">
     <ItemGroup>


### PR DESCRIPTION
This workaround was added in 2019 for SDK PR dotnet/sdk#3463 which was merged for preview 8 of .NET Core 3.0. It has been unnecessary for over 6 years.