### PR TITLE
Remove stale _WorkaroundNetStandard workaround target

### DIFF
--- a/eng/Workarounds.targets
+++ b/eng/Workarounds.targets
@@ -27,13 +27,6 @@
     </KnownFrameworkReference>
   </ItemGroup>
 
-  <!-- Work around https://github.com/dotnet/cli/issues/11378. -->
-  <Target Name="_WorkaroundNetStandard" AfterTargets="ResolvePackageAssets">
-    <ItemGroup>
-      <TransitiveFrameworkReference Remove="NETStandard.Library" />
-    </ItemGroup>
-  </Target>
-
   <!-- Work around https://github.com/dotnet/aspnetcore/issues/18393 -->
   <Target Name="_UpdateRazorGenerateAssemblyReferences"
           AfterTargets="ResolveAssemblyReferenceRazorGenerateInputs"


### PR DESCRIPTION
This target was a workaround for dotnet/cli#11378, filed in 2019. The CLI repo was archived and the issue is long resolved. This workaround has been unnecessary for years.