### PR TITLE
Remove stale EnableSingleFileAnalyzer workaround

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -6,8 +6,6 @@
     <!-- Disable IsTrimmable on non-DefaultNetCoreTargetFrameworks even if explicitly enabled or else we'll get NETSDK1195 and NETSDK1210 errors -->
     <IsTrimmable Condition="'$(TargetFramework)' != '$(DefaultNetCoreTargetFramework)'"></IsTrimmable>
     <EnableAOTAnalyzer Condition=" '$(EnableAOTAnalyzer)' == '' ">$([MSBuild]::ValueOrDefault($(IsTrimmable),'false'))</EnableAOTAnalyzer>
-    <!-- TODO: Remove when analyzer is enabled by default with AOT in SDK. See https://github.com/dotnet/sdk/issues/31284 -->
-    <EnableSingleFileAnalyzer Condition=" '$(EnableSingleFileAnalyzer)' == '' ">$(EnableAOTAnalyzer)</EnableSingleFileAnalyzer>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
The SDK now automatically enables `EnableSingleFileAnalyzer` when `PublishAot=true` or `IsAotCompatible=true` (see dotnet/sdk#31284). This manual workaround that copied `EnableAOTAnalyzer` to `EnableSingleFileAnalyzer` has been unnecessary since .NET 8.