### PR TITLE
Remove duplicate @ prefix from issueAuthor in GitOps

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -128,7 +128,7 @@ configuration:
       actions:
       - addReply:
           reply: >-
-            Hi @${issueAuthor}.
+            Hi ${issueAuthor}.
 
             It seems you haven't touched this PR for the last two weeks. To avoid accumulating old PRs, we're marking it as `stale`.  As a result, it will be closed if no further activity occurs **within 4 days of this comment**. You can learn more about our Issue Management Policies [here](https://aka.ms/aspnet/issue-policies).
       - addLabel:
@@ -430,7 +430,7 @@ configuration:
       - addLabel:
           label: community-contribution
       - addReply:
-          reply: Thanks for your PR, @${issueAuthor}. Someone from the team will get assigned to your PR shortly and we'll get it reviewed.
+          reply: Thanks for your PR, ${issueAuthor}. Someone from the team will get assigned to your PR shortly and we'll get it reviewed.
       description: Label community PRs with `community contribution` label
     - if:
       - payloadType: Pull_Request
@@ -497,7 +497,7 @@ configuration:
       then:
       - addReply:
           reply: >-
-            Hi @${issueAuthor}. Please make sure you've updated the PR description to use the [Shiproom Template](https://aka.ms/aspnet/servicing/template). Also, make sure this PR is not marked as a draft and is ready-to-merge.
+            Hi ${issueAuthor}. Please make sure you've updated the PR description to use the [Shiproom Template](https://aka.ms/aspnet/servicing/template). Also, make sure this PR is not marked as a draft and is ready-to-merge.
 
 
             To learn more about how to prepare a servicing PR [click here](https://aka.ms/aspnet/servicing).
@@ -518,7 +518,7 @@ configuration:
           label: 'Needs: Author Feedback'
       then:
       - addReply:
-          reply: 'Hi @${issueAuthor}. We have added the "Needs: Author Feedback" label to this issue, which indicates that we have an open question for you before we can take further action. This issue will be closed automatically in 7 days if we do not hear back from you by then - please feel free to re-open it if you come back to this issue after that time.'
+          reply: 'Hi ${issueAuthor}. We have added the "Needs: Author Feedback" label to this issue, which indicates that we have an open question for you before we can take further action. This issue will be closed automatically in 7 days if we do not hear back from you by then - please feel free to re-open it if you come back to this issue after that time.'
       description: Add comment when 'Needs Author Feedback' is applied to issue
     - if:
       - payloadType: Pull_Request
@@ -531,7 +531,7 @@ configuration:
           milestone: 9.0.x
       - addReply:
           reply: >-
-            Hi @${issueAuthor}. If this is not a tell-mode PR, please make sure to follow the instructions laid out in the [servicing process](https://aka.ms/aspnet/servicing) document.
+            Hi ${issueAuthor}. If this is not a tell-mode PR, please make sure to follow the instructions laid out in the [servicing process](https://aka.ms/aspnet/servicing) document.
 
             Otherwise, please add `tell-mode` label.
       description: Add release/9.0 targeting PRs to the servicing project
@@ -546,7 +546,7 @@ configuration:
           milestone: 8.0.x
       - addReply:
           reply: >-
-            Hi @${issueAuthor}. If this is not a tell-mode PR, please make sure to follow the instructions laid out in the [servicing process](https://aka.ms/aspnet/servicing) document.
+            Hi ${issueAuthor}. If this is not a tell-mode PR, please make sure to follow the instructions laid out in the [servicing process](https://aka.ms/aspnet/servicing) document.
 
             Otherwise, please add `tell-mode` label.
       description: Add release/8.0 targeting PRs to the servicing project
@@ -561,7 +561,7 @@ configuration:
           milestone: 2.3.x
       - addReply:
           reply: >-
-            Hi @${issueAuthor}. If this is not a tell-mode PR, please make sure to follow the instructions laid out in the [servicing process](https://aka.ms/aspnet/servicing) document.
+            Hi ${issueAuthor}. If this is not a tell-mode PR, please make sure to follow the instructions laid out in the [servicing process](https://aka.ms/aspnet/servicing) document.
 
             Otherwise, please add `tell-mode` label.
       description: Add release/2.3 targeting PRs to the servicing project
@@ -604,7 +604,7 @@ configuration:
       then:
       - addReply:
           reply: >-
-            @${issueAuthor}, this change will be considered for inclusion in the blog post for the release it'll ship in. Nice work!
+            ${issueAuthor}, this change will be considered for inclusion in the blog post for the release it'll ship in. Nice work!
 
 
             Please ensure that the original comment in this thread contains a clear explanation of what the change does, why it's important (what problem does it solve?), and, if relevant, include things like code samples and/or performance numbers.
@@ -621,7 +621,7 @@ configuration:
           label: Servicing-approved
       then:
       - addReply:
-          reply: Hi @${issueAuthor}. This PR was just approved to be included in the upcoming servicing release. Somebody from the @dotnet/aspnet-build team will get it merged when the branches are open. Until then, please make sure all the CI checks pass and the PR is reviewed.
+          reply: Hi ${issueAuthor}. This PR was just approved to be included in the upcoming servicing release. Somebody from the @dotnet/aspnet-build team will get it merged when the branches are open. Until then, please make sure all the CI checks pass and the PR is reviewed.
       description: '[Servicing PR Approved] Let the author know that the PR will be merged by the build team'
     - if:
       - payloadType: Pull_Request


### PR DESCRIPTION
https://github.com/GitOps-microsoft/GitOps.PullRequestIssueManagement/pull/262 (internal Microsoft link) changed the `${issueAuthor}` placeholder to include the `@` character.

Remove the one we added so we don't duplicate it.
