### PR TITLE
[release/8.0] Replace dn-bot-dnceng-build-rw-code-rw PAT with WIF service connection in mirror-within-azdo

### DIFF
--- a/.azure/pipelines/azure-pipelines-mirror-within-azdo.yml
+++ b/.azure/pipelines/azure-pipelines-mirror-within-azdo.yml
@@ -13,7 +13,6 @@ parameters:
   type: boolean
 
 variables:
-- group: Mirror-Credentials
 - template: /eng/common/templates/variables/pool-providers.yml
 
 # Merges code from one AzDO branch into another
@@ -41,15 +40,35 @@ jobs:
             Write-Host "##vso[task.setvariable variable=BranchToMirror]$branch"
             Write-Host "##vso[task.setvariable variable=TargetBranchName]$branch$suffix"
           displayName: Calculate Mirrored Branch Names
+        - task: AzureCLI@2
+          displayName: Mint AzDO token (WIF)
+          inputs:
+            azureSubscription: dnceng-build-rw-code-rw-wif
+            scriptType: pscore
+            scriptLocation: inlineScript
+            inlineScript: |
+              # Azure DevOps AAD resource ID
+              $azureDevOpsResourceId = "499b84ac-1321-427f-aa17-267ca6975798"
+              $token = az account get-access-token --resource $azureDevOpsResourceId --query accessToken -o tsv
+              if ($LASTEXITCODE -ne 0) {
+                Write-Error "Failed to acquire Azure DevOps token via 'az account get-access-token'. Exit code: $LASTEXITCODE"
+                exit 1
+              }
+              $token = $token.Trim()
+              if ([string]::IsNullOrWhiteSpace($token)) {
+                Write-Error "Received an empty Azure DevOps token from 'az account get-access-token'."
+                exit 1
+              }
+              Write-Host "##vso[task.setvariable variable=WifAzdoToken;issecret=true]$token"
         - script: |
-            git clone https://dn-bot:$(dn-bot-dnceng-build-rw-code-rw)@dev.azure.com/dnceng/internal/_git/$(AzdoRepo) $(WorkingDirectoryName) --recursive --no-tags --branch $(TargetBranchName)
+            git -c http.https://dev.azure.com/.extraheader="Authorization: Bearer $(WifAzdoToken)" clone https://dev.azure.com/dnceng/internal/_git/$(AzdoRepo) $(WorkingDirectoryName) --recursive --no-tags --branch $(TargetBranchName)
           displayName: Clone AzDO repo
         - script: |
             git -c user.email="dotnet-bot@microsoft.com" -c user.name="dotnet-bot" merge origin/$(BranchToMirror) -m "Merge in '$(BranchToMirror)' changes"
           displayName: Merge head branch to target branch
           workingDirectory: $(WorkingDirectoryName)
         - script: |
-            git push origin $(TargetBranchName)
+            git -c http.https://dev.azure.com/.extraheader="Authorization: Bearer $(WifAzdoToken)" push origin $(TargetBranchName)
           displayName: Push changes to Azure DevOps repo
           workingDirectory: $(WorkingDirectoryName)
 


### PR DESCRIPTION
## Summary

Migrate the `azure-pipelines-mirror-within-azdo.yml` pipeline from using the `dn-bot-dnceng-build-rw-code-rw` PAT (from the `Mirror-Credentials` variable group) to the `dnceng-build-rw-code-rw-wif` Workload Identity Federation service connection.

This is the same change as #66074 (merged to `main`), ported to the `release/8.0` branch.

## Changes

- Remove `Mirror-Credentials` variable group reference
- New `AzureCLI@2` step – mints an AzDO bearer token via `az account get-access-token` using the `dnceng-build-rw-code-rw-wif` WIF service connection and stores it as the secret pipeline variable `WifAzdoToken`
- Clone step now uses header-based auth (`http.extraheader`) instead of PAT embedded in the URL
- Push step now uses header-based auth as well

## Related

- Part of PAT migration work item [WI 10139](https://dev.azure.com/dnceng/internal/_workitems/edit/10139)
- Service connection: `dnceng-build-rw-code-rw-wif` (Entra app `21f66e0-bb35-4fd3-bc70-ba084d1e7a52`)