### PR TITLE
Fix unresolved #aw_ temporary_id in QuarantinedTest URL

### DIFF
--- a/src/SignalR/clients/csharp/Client/test/UnitTests/TestServerTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/TestServerTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests;
 public class TestServerTests : VerifiableLoggedTest
 {
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/#aw_wswrks1")]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/65914")]
     public async Task WebSocketsWorks()
     {
         using (StartVerifiableLog())


### PR DESCRIPTION
Replace unresolved `#aw_wswrks1` placeholder with the actual issue number `65914` in `TestServerTests.cs`. This was left behind by PR #65916 where the safeoutputs framework failed to resolve the temporary_id reference in the patch content.