### PR TITLE
Gitignore agentic workflow log artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ UpgradeLog.htm
 .idea
 mono_crash.*.json
 mono_crash.*.blob
+
+# Agentic workflow log artifacts
+.github/workflows/.github/aw/logs/


### PR DESCRIPTION
The gh-aw framework writes debug artifacts to `.github/workflows/.github/aw/logs/`. These are transient and should not be committed.