### PR TITLE
[Blazor] Components.AI - 01 Block model, pipeline, and text streaming

### DIFF
--- a/AspNetCore.slnx
+++ b/AspNetCore.slnx
@@ -106,6 +106,10 @@
     <Project Path="src/Components/Testing/testassets/TestApp.Client/TestApp.Client.csproj" />
     <Project Path="src/Components/Testing/testassets/TestApp.E2E.Tests/TestApp.E2E.Tests.csproj" />
   </Folder>
+  <Folder Name="/src/Components/AI/">
+    <Project Path="src/Components/AI/src/Microsoft.AspNetCore.Components.AI.csproj" />
+    <Project Path="src/Components/AI/test/Microsoft.AspNetCore.Components.AI.Tests.csproj" />
+  </Folder>
   <Folder Name="/src/Components/Web/">
     <Project Path="src/Components/Web/src/Microsoft.AspNetCore.Components.Web.csproj" />
     <Project Path="src/Components/Web/test/Microsoft.AspNetCore.Components.Web.Tests.csproj" />

--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -246,6 +246,9 @@ may be turned into `<PackageReference>` items in projects.
     <LatestPackageReference Include="xunit.v3.extensibility.core" Version="$(XunitV3ExtensibilityCoreVersion)" />
     <LatestPackageReference Include="Microsoft.Playwright.Xunit.v3" Version="$(MicrosoftPlaywrightXunitV3Version)" />
     <LatestPackageReference Include="Yarp.ReverseProxy" Version="$(YarpReverseProxyVersion)" />
+    <!-- Components.AI (Microsoft.Extensions.AI) -->
+    <LatestPackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="$(MicrosoftExtensionsAIAbstractionsVersion)" />
+    <LatestPackageReference Include="Microsoft.Extensions.AI" Version="$(MicrosoftExtensionsAIVersion)" />
     <LatestPackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
     <LatestPackageReference Include="Microsoft.Extensions.ServiceDiscovery.Yarp" />
   </ItemGroup>

--- a/eng/ProjectReferences.props
+++ b/eng/ProjectReferences.props
@@ -140,6 +140,7 @@
     <ProjectReferenceProvider Include="Microsoft.AspNetCore.SignalR.Specification.Tests" ProjectPath="$(RepoRoot)src\SignalR\server\Specification.Tests\src\Microsoft.AspNetCore.SignalR.Specification.Tests.csproj" />
     <ProjectReferenceProvider Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" ProjectPath="$(RepoRoot)src\SignalR\server\StackExchangeRedis\src\Microsoft.AspNetCore.SignalR.StackExchangeRedis.csproj" />
     <ProjectReferenceProvider Include="Microsoft.AspNetCore.StaticAssets" ProjectPath="$(RepoRoot)src\StaticAssets\src\Microsoft.AspNetCore.StaticAssets.csproj" />
+    <ProjectReferenceProvider Include="Microsoft.AspNetCore.Components.AI" ProjectPath="$(RepoRoot)src\Components\AI\src\Microsoft.AspNetCore.Components.AI.csproj" />
     <ProjectReferenceProvider Include="Microsoft.AspNetCore.Components.Authorization" ProjectPath="$(RepoRoot)src\Components\Authorization\src\Microsoft.AspNetCore.Components.Authorization.csproj" />
     <ProjectReferenceProvider Include="Microsoft.AspNetCore.Components" ProjectPath="$(RepoRoot)src\Components\Components\src\Microsoft.AspNetCore.Components.csproj" />
     <ProjectReferenceProvider Include="Microsoft.AspNetCore.Components.CustomElements" ProjectPath="$(RepoRoot)src\Components\CustomElements\src\Microsoft.AspNetCore.Components.CustomElements.csproj" />

--- a/eng/ShippingAssemblies.props
+++ b/eng/ShippingAssemblies.props
@@ -151,6 +151,7 @@
     <AspNetCoreShippingAssembly Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" />
     <AspNetCoreShippingAssembly Include="Microsoft.AspNetCore.SignalR.Specification.Tests" />
     <AspNetCoreShippingAssembly Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" />
+    <AspNetCoreShippingAssembly Include="Microsoft.AspNetCore.Components.AI" />
     <AspNetCoreShippingAssembly Include="Microsoft.AspNetCore.Components.CustomElements" />
     <AspNetCoreShippingAssembly Include="Microsoft.AspNetCore.Components.QuickGrid.EntityFrameworkAdapter" />
     <AspNetCoreShippingAssembly Include="Microsoft.AspNetCore.Components.QuickGrid" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -192,6 +192,9 @@
     <XunitV3Version>3.2.2</XunitV3Version>
     <XunitV3ExtensibilityCoreVersion>$(XunitV3Version)</XunitV3ExtensibilityCoreVersion>
     <MicrosoftPlaywrightXunitV3Version>1.58.0</MicrosoftPlaywrightXunitV3Version>
+    <!-- Components.AI dependencies -->
+    <MicrosoftExtensionsAIAbstractionsVersion>10.4.1</MicrosoftExtensionsAIAbstractionsVersion>
+    <MicrosoftExtensionsAIVersion>10.4.1</MicrosoftExtensionsAIVersion>
     <!-- Components.Testing dependencies -->
     <YarpReverseProxyVersion>2.3.0</YarpReverseProxyVersion>
     <MicrosoftExtensionsServiceDiscoveryYarpVersion>$(MicrosoftExtensionsServiceDiscoveryVersion)</MicrosoftExtensionsServiceDiscoveryYarpVersion>

--- a/src/Components/AI/src/Blocks/BlockLifecycleState.cs
+++ b/src/Components/AI/src/Blocks/BlockLifecycleState.cs
@@ -8,5 +8,4 @@ public enum BlockLifecycleState
     Pending,
     Active,
     Inactive,
-    Hidden
 }

--- a/src/Components/AI/src/Blocks/BlockLifecycleState.cs
+++ b/src/Components/AI/src/Blocks/BlockLifecycleState.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public enum BlockLifecycleState
+{
+    Pending,
+    Active,
+    Inactive,
+    Hidden
+}

--- a/src/Components/AI/src/Blocks/ContentBlock.cs
+++ b/src/Components/AI/src/Blocks/ContentBlock.cs
@@ -7,27 +7,30 @@ namespace Microsoft.AspNetCore.Components.AI;
 
 public abstract class ContentBlock
 {
-    public string Id { get; set; } = string.Empty;
+    public string Id { get; internal set; } = string.Empty;
 
-    public BlockLifecycleState LifecycleState { get; set; }
+    public BlockLifecycleState LifecycleState { get; internal set; }
 
-    public ChatRole? Role { get; set; }
+    public ChatRole? Role { get; internal set; }
 
-    public string? AuthorName { get; set; }
+    public string? AuthorName { get; internal set; }
 
     private readonly List<Action> _callbacks = new();
 
     public ContentBlockChangedSubscription OnChanged(Action callback)
     {
+        ArgumentNullException.ThrowIfNull(callback);
         _callbacks.Add(callback);
         return new ContentBlockChangedSubscription(this, callback);
     }
 
     protected void NotifyChanged()
     {
-        for (var i = 0; i < _callbacks.Count; i++)
+        // Snapshot the callbacks to allow safe removal during iteration
+        var snapshot = _callbacks.ToArray();
+        for (var i = 0; i < snapshot.Length; i++)
         {
-            _callbacks[i]();
+            snapshot[i]();
         }
     }
 

--- a/src/Components/AI/src/Blocks/ContentBlock.cs
+++ b/src/Components/AI/src/Blocks/ContentBlock.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public abstract class ContentBlock
+{
+    public string Id { get; set; } = string.Empty;
+
+    public BlockLifecycleState LifecycleState { get; set; }
+
+    public ChatRole? Role { get; set; }
+
+    public string? AuthorName { get; set; }
+
+    private readonly List<Action> _callbacks = new();
+
+    public ContentBlockChangedSubscription OnChanged(Action callback)
+    {
+        _callbacks.Add(callback);
+        return new ContentBlockChangedSubscription(this, callback);
+    }
+
+    protected void NotifyChanged()
+    {
+        for (var i = 0; i < _callbacks.Count; i++)
+        {
+            _callbacks[i]();
+        }
+    }
+
+    internal void InvokeNotifyChanged() => NotifyChanged();
+
+    internal void RemoveCallback(Action callback)
+    {
+        _callbacks.Remove(callback);
+    }
+}

--- a/src/Components/AI/src/Blocks/ContentBlockChangedSubscription.cs
+++ b/src/Components/AI/src/Blocks/ContentBlockChangedSubscription.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public readonly struct ContentBlockChangedSubscription : IDisposable
+{
+    private readonly ContentBlock _owner;
+    private readonly Action _callback;
+
+    internal ContentBlockChangedSubscription(ContentBlock owner, Action callback)
+    {
+        _owner = owner;
+        _callback = callback;
+    }
+
+    public void Dispose()
+    {
+        _owner?.RemoveCallback(_callback);
+    }
+}

--- a/src/Components/AI/src/Blocks/RichContentBlock.cs
+++ b/src/Components/AI/src/Blocks/RichContentBlock.cs
@@ -13,7 +13,7 @@ public class RichContentBlock : ContentBlock
 
     public string RawText => _cachedText ??= string.Concat(_segments);
 
-    public IReadOnlyList<RichTextNode> Content { get; set; } =
+    public IReadOnlyList<RichTextNode> Content { get; internal set; } =
         Array.Empty<RichTextNode>();
 
     public IReadOnlyList<AIContent> MediaItems => _mediaItems;

--- a/src/Components/AI/src/Blocks/RichContentBlock.cs
+++ b/src/Components/AI/src/Blocks/RichContentBlock.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public class RichContentBlock : ContentBlock
+{
+    private readonly List<string> _segments = new();
+    private string? _cachedText;
+    private readonly List<AIContent> _mediaItems = new();
+
+    public string RawText => _cachedText ??= string.Concat(_segments);
+
+    public IReadOnlyList<RichTextNode> Content { get; set; } =
+        Array.Empty<RichTextNode>();
+
+    public IReadOnlyList<AIContent> MediaItems => _mediaItems;
+
+    public void AppendText(string text)
+    {
+        _segments.Add(text);
+        _cachedText = null;
+    }
+
+    public void AddMedia(AIContent media)
+    {
+        _mediaItems.Add(media);
+    }
+}

--- a/src/Components/AI/src/Blocks/RichText/ParagraphNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/ParagraphNode.cs
@@ -1,0 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public class ParagraphNode : RichTextNode
+{
+}

--- a/src/Components/AI/src/Blocks/RichText/RichTextNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/RichTextNode.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public abstract class RichTextNode
+{
+    private List<RichTextNode>? _children;
+
+    public IReadOnlyList<RichTextNode> Children =>
+        _children ?? (IReadOnlyList<RichTextNode>)Array.Empty<RichTextNode>();
+
+    public void AddChild(RichTextNode child)
+    {
+        _children ??= new();
+        _children.Add(child);
+    }
+}

--- a/src/Components/AI/src/Blocks/RichText/TextNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/TextNode.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public class TextNode : RichTextNode
+{
+    public TextNode()
+    {
+    }
+
+    public TextNode(string text)
+    {
+        Text = text;
+    }
+
+    public string Text { get; set; } = string.Empty;
+}

--- a/src/Components/AI/src/Engine/ConversationTurn.cs
+++ b/src/Components/AI/src/Engine/ConversationTurn.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public class ConversationTurn
+{
+    private readonly List<ContentBlock> _requestBlocks = new();
+    private readonly List<ContentBlock> _responseBlocks = new();
+
+    public string Id { get; internal set; } = string.Empty;
+
+    public IReadOnlyList<ContentBlock> RequestBlocks => _requestBlocks;
+
+    public IReadOnlyList<ContentBlock> ResponseBlocks => _responseBlocks;
+
+    internal void AddRequestBlock(ContentBlock block)
+    {
+        _requestBlocks.Add(block);
+    }
+
+    internal void AddResponseBlock(ContentBlock block)
+    {
+        _responseBlocks.Add(block);
+    }
+
+    internal void ClearResponseBlocks()
+    {
+        _responseBlocks.Clear();
+    }
+}

--- a/src/Components/AI/src/Engine/UIAgent.cs
+++ b/src/Components/AI/src/Engine/UIAgent.cs
@@ -27,6 +27,7 @@ public class UIAgent : IDisposable
 
     public UIAgent(IChatClient chatClient, Action<UIAgentOptions>? configure)
     {
+        ArgumentNullException.ThrowIfNull(chatClient);
         _chatClient = chatClient;
         _options = new UIAgentOptions();
         configure?.Invoke(_options);

--- a/src/Components/AI/src/Engine/UIAgent.cs
+++ b/src/Components/AI/src/Engine/UIAgent.cs
@@ -1,0 +1,91 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public class UIAgent : IDisposable
+{
+    private readonly IChatClient _chatClient;
+    private readonly UIAgentOptions _options;
+    private readonly List<ChatMessage> _history = new();
+    private bool _disposed;
+
+    internal UIAgentOptions Options => _options;
+
+    public UIAgent(IChatClient chatClient)
+        : this(chatClient, configure: null)
+    {
+    }
+
+    public UIAgent(IChatClient chatClient, ChatOptions chatOptions)
+        : this(chatClient, options => options.ChatOptions = chatOptions)
+    {
+    }
+
+    public UIAgent(IChatClient chatClient, Action<UIAgentOptions>? configure)
+    {
+        _chatClient = chatClient;
+        _options = new UIAgentOptions();
+        configure?.Invoke(_options);
+    }
+
+    public async IAsyncEnumerable<ContentBlock> SendMessageAsync(
+        ChatMessage message,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        _history.Add(message);
+
+        var pipeline = new BlockMappingPipeline(_options);
+
+        // Process user message through pipeline
+        var userUpdate = new ChatResponseUpdate
+        {
+            Role = message.Role,
+            Contents = [.. message.Contents]
+        };
+        await foreach (var block in pipeline.Process(userUpdate, cancellationToken).ConfigureAwait(false))
+        {
+            yield return block;
+        }
+        foreach (var block in pipeline.Finalize())
+        {
+            yield return block;
+        }
+
+        // Stream assistant response
+        var assistantUpdates = new List<ChatResponseUpdate>();
+
+        await foreach (var update in _chatClient.GetStreamingResponseAsync(
+            _history, _options.ChatOptions, cancellationToken).ConfigureAwait(false))
+        {
+            assistantUpdates.Add(update);
+
+            await foreach (var block in pipeline.Process(update, cancellationToken).ConfigureAwait(false))
+            {
+                yield return block;
+            }
+        }
+
+        foreach (var block in pipeline.Finalize())
+        {
+            yield return block;
+        }
+
+        // Add assistant response to history
+        var response = assistantUpdates.ToChatResponse();
+        foreach (var msg in response.Messages)
+        {
+            _history.Add(msg);
+        }
+    }
+
+    public void Dispose()
+    {
+        _disposed = true;
+    }
+}

--- a/src/Components/AI/src/Microsoft.AspNetCore.Components.AI.csproj
+++ b/src/Components/AI/src/Microsoft.AspNetCore.Components.AI.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Description>Blazor component library for building AI conversational UIs on top of Microsoft.Extensions.AI.</Description>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsShippingPackage>true</IsShippingPackage>
+    <IsPackable>true</IsPackable>
+    <!-- TODO: Generate PublicAPI.txt files for public API tracking -->
+    <!-- TODO: Add XML documentation comments to all public APIs -->
+    <NoWarn>$(NoWarn);RS0016;RS0017;RS0026;RS0037;CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <SupportedPlatform Include="browser" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.AspNetCore.Components.AI.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.AspNetCore.Components.Web" />
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.Extensions.AI.Abstractions" />
+  </ItemGroup>
+
+</Project>

--- a/src/Components/AI/src/Pipeline/BlockMappingContext.cs
+++ b/src/Components/AI/src/Pipeline/BlockMappingContext.cs
@@ -1,0 +1,123 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public class BlockMappingContext
+{
+    private readonly bool[] _handled;
+    private int _handledCount;
+    private bool _updateHandled;
+    private readonly IReadOnlyList<IHandlerEntry>? _inactiveHandlers;
+
+    internal BlockMappingContext(ChatResponseUpdate update)
+        : this(update, inactiveHandlers: null)
+    {
+    }
+
+    internal BlockMappingContext(
+        ChatResponseUpdate update,
+        IReadOnlyList<IHandlerEntry>? inactiveHandlers)
+    {
+        Update = update;
+        _handled = new bool[update.Contents.Count];
+        _inactiveHandlers = inactiveHandlers;
+    }
+
+    public ChatResponseUpdate Update { get; }
+
+    public UnhandledContentsEnumerable UnhandledContents => new(Update.Contents, _handled);
+
+    public void MarkHandled(AIContent content)
+    {
+        var contents = Update.Contents;
+        for (var i = 0; i < contents.Count; i++)
+        {
+            if (ReferenceEquals(contents[i], content))
+            {
+                if (!_handled[i])
+                {
+                    _handled[i] = true;
+                    _handledCount++;
+                }
+                return;
+            }
+        }
+    }
+
+    public void MarkUpdateHandled()
+    {
+        _updateHandled = true;
+    }
+
+    public bool AllHandled =>
+        _handledCount >= Update.Contents.Count && (Update.Contents.Count > 0 || _updateHandled);
+
+    internal int HandledProgress => _handledCount + (_updateHandled ? 1 : 0);
+
+    public ContentBlock? CreateInnerBlock(AIContent content)
+    {
+        if (_inactiveHandlers is null)
+        {
+            return null;
+        }
+
+        var tempUpdate = new ChatResponseUpdate { Contents = [content] };
+        var tempContext = new BlockMappingContext(tempUpdate);
+
+        for (var i = 0; i < _inactiveHandlers.Count; i++)
+        {
+            var activeEntry = _inactiveHandlers[i].TryHandle(tempContext);
+            if (activeEntry is not null)
+            {
+                return activeEntry.Block;
+            }
+        }
+
+        return null;
+    }
+
+    public readonly struct UnhandledContentsEnumerable
+    {
+        private readonly IList<AIContent> _contents;
+        private readonly bool[] _handled;
+
+        internal UnhandledContentsEnumerable(IList<AIContent> contents, bool[] handled)
+        {
+            _contents = contents;
+            _handled = handled;
+        }
+
+        public UnhandledContentsEnumerator GetEnumerator() => new(_contents, _handled);
+    }
+
+    public struct UnhandledContentsEnumerator
+    {
+        private readonly IList<AIContent> _contents;
+        private readonly bool[] _handled;
+        private int _index;
+
+        internal UnhandledContentsEnumerator(IList<AIContent> contents, bool[] handled)
+        {
+            _contents = contents;
+            _handled = handled;
+            _index = -1;
+        }
+
+        public AIContent Current => _contents[_index];
+
+        public bool MoveNext()
+        {
+            while (++_index < _contents.Count)
+            {
+                if (!_handled[_index])
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/src/Components/AI/src/Pipeline/BlockMappingPipeline.cs
+++ b/src/Components/AI/src/Pipeline/BlockMappingPipeline.cs
@@ -1,0 +1,125 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+internal class BlockMappingPipeline
+{
+    private readonly List<IHandlerEntry> _handlers = new();
+    private readonly List<IActiveEntry> _activeStack = new();
+
+    internal BlockMappingPipeline(UIAgentOptions options)
+    {
+        // User-registered handlers go first so they can customize behavior
+        foreach (var registration in options.HandlerRegistrations)
+        {
+            _handlers.Add(registration.CreateEntry());
+        }
+
+        // Built-in text handler is always last (fallback)
+        _handlers.Add(new HandlerEntry<RichContentBlock>(new TextBlockHandler()));
+    }
+
+    internal async IAsyncEnumerable<ContentBlock> Process(
+        ChatResponseUpdate update,
+#pragma warning disable IDE0060 // cancellationToken reserved for future use
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+#pragma warning restore IDE0060
+    {
+        var context = new BlockMappingContext(update, _handlers);
+
+        // Phase 1: Active entries get priority (most recent first)
+        for (var i = _activeStack.Count - 1; i >= 0; i--)
+        {
+            if (context.AllHandled)
+            {
+                break;
+            }
+
+            var active = _activeStack[i];
+            var result = active.Invoke(context);
+
+            switch (result.Kind)
+            {
+                case HandleResult.ResultKind.Pass:
+                    break;
+
+                case HandleResult.ResultKind.Update:
+                    active.Block.InvokeNotifyChanged();
+                    break;
+
+                case HandleResult.ResultKind.Complete:
+                    active.Block.LifecycleState = BlockLifecycleState.Inactive;
+                    active.Block.InvokeNotifyChanged();
+                    _activeStack.RemoveAt(i);
+                    break;
+            }
+        }
+
+        // Phase 2: Inactive handlers try to claim remaining content
+        if (!context.AllHandled)
+        {
+            for (var i = 0; i < _handlers.Count; i++)
+            {
+                if (context.AllHandled)
+                {
+                    break;
+                }
+
+                var handler = _handlers[i];
+
+                while (!context.AllHandled)
+                {
+                    var progressBefore = context.HandledProgress;
+                    var activeEntry = handler.TryHandle(context);
+                    if (activeEntry is not null)
+                    {
+                        var emitBlock = activeEntry.Block;
+                        emitBlock.Role = update.Role;
+                        emitBlock.AuthorName = update.AuthorName;
+                        emitBlock.LifecycleState = BlockLifecycleState.Active;
+                        ThrowIfIdMissing(emitBlock);
+                        _activeStack.Add(activeEntry);
+
+                        yield return emitBlock;
+
+                        // If the handler emitted without consuming any content, stop
+                        // re-invoking it to prevent infinite loops.
+                        if (context.HandledProgress == progressBefore)
+                        {
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+        await Task.CompletedTask;
+    }
+
+    internal IReadOnlyList<ContentBlock> Finalize()
+    {
+        foreach (var active in _activeStack)
+        {
+            active.Block.LifecycleState = BlockLifecycleState.Inactive;
+        }
+        _activeStack.Clear();
+
+        return Array.Empty<ContentBlock>();
+    }
+
+    private static void ThrowIfIdMissing(ContentBlock block)
+    {
+        if (string.IsNullOrEmpty(block.Id))
+        {
+            throw new InvalidOperationException(
+                $"Block handler emitted a {block.GetType().Name} without assigning an Id.");
+        }
+    }
+}

--- a/src/Components/AI/src/Pipeline/BlockMappingResult.cs
+++ b/src/Components/AI/src/Pipeline/BlockMappingResult.cs
@@ -20,7 +20,11 @@ public readonly struct BlockMappingResult<TState>
 
     public static BlockMappingResult<TState> Pass() => new(ResultKind.Pass, null, default);
 
-    public static BlockMappingResult<TState> Emit(ContentBlock block, TState state) => new(ResultKind.Emit, block, state);
+    public static BlockMappingResult<TState> Emit(ContentBlock block, TState state)
+    {
+        ArgumentNullException.ThrowIfNull(block);
+        return new(ResultKind.Emit, block, state);
+    }
 
     public static BlockMappingResult<TState> Update(TState state) => new(ResultKind.Update, null, state);
 

--- a/src/Components/AI/src/Pipeline/BlockMappingResult.cs
+++ b/src/Components/AI/src/Pipeline/BlockMappingResult.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public readonly struct BlockMappingResult<TState>
+{
+    internal enum ResultKind { Pass, Emit, Update, Complete }
+
+    internal ResultKind Kind { get; }
+    internal ContentBlock? Block { get; }
+    internal TState? State { get; }
+
+    private BlockMappingResult(ResultKind kind, ContentBlock? block, TState? state)
+    {
+        Kind = kind;
+        Block = block;
+        State = state;
+    }
+
+    public static BlockMappingResult<TState> Pass() => new(ResultKind.Pass, null, default);
+
+    public static BlockMappingResult<TState> Emit(ContentBlock block, TState state) => new(ResultKind.Emit, block, state);
+
+    public static BlockMappingResult<TState> Update(TState state) => new(ResultKind.Update, null, state);
+
+    public static BlockMappingResult<TState> Complete() => new(ResultKind.Complete, null, default);
+}

--- a/src/Components/AI/src/Pipeline/ContentBlockHandler.cs
+++ b/src/Components/AI/src/Pipeline/ContentBlockHandler.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public abstract class ContentBlockHandler<TState> where TState : new()
+{
+    public abstract BlockMappingResult<TState> Handle(BlockMappingContext context, TState state);
+}

--- a/src/Components/AI/src/Pipeline/HandleResult.cs
+++ b/src/Components/AI/src/Pipeline/HandleResult.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+internal readonly struct HandleResult
+{
+    internal enum ResultKind { Pass, Update, Complete }
+
+    internal ResultKind Kind { get; }
+
+    private HandleResult(ResultKind kind)
+    {
+        Kind = kind;
+    }
+
+    internal static HandleResult Pass() => new(ResultKind.Pass);
+    internal static HandleResult Update() => new(ResultKind.Update);
+    internal static HandleResult Complete() => new(ResultKind.Complete);
+}

--- a/src/Components/AI/src/Pipeline/HandlerEntry.cs
+++ b/src/Components/AI/src/Pipeline/HandlerEntry.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+internal sealed class HandlerEntry<TState> : IHandlerEntry where TState : new()
+{
+    private readonly ContentBlockHandler<TState> _handler;
+
+    internal HandlerEntry(ContentBlockHandler<TState> handler)
+    {
+        _handler = handler;
+    }
+
+    public IActiveEntry? TryHandle(BlockMappingContext context)
+    {
+        var state = new TState();
+        var result = _handler.Handle(context, state);
+        if (result.Kind == BlockMappingResult<TState>.ResultKind.Emit)
+        {
+            return new ActiveEntry(_handler, result.State!, result.Block!);
+        }
+        return null;
+    }
+
+    private sealed class ActiveEntry : IActiveEntry
+    {
+        private readonly ContentBlockHandler<TState> _handler;
+        private TState _state;
+
+        internal ActiveEntry(
+            ContentBlockHandler<TState> handler,
+            TState state,
+            ContentBlock block)
+        {
+            _handler = handler;
+            _state = state;
+            Block = block;
+        }
+
+        public ContentBlock Block { get; }
+
+        public HandleResult Invoke(BlockMappingContext context)
+        {
+            var result = _handler.Handle(context, _state);
+            switch (result.Kind)
+            {
+                case BlockMappingResult<TState>.ResultKind.Update:
+                    _state = result.State!;
+                    return HandleResult.Update();
+
+                case BlockMappingResult<TState>.ResultKind.Complete:
+                    return HandleResult.Complete();
+
+                default:
+                    return HandleResult.Pass();
+            }
+        }
+    }
+}

--- a/src/Components/AI/src/Pipeline/IActiveEntry.cs
+++ b/src/Components/AI/src/Pipeline/IActiveEntry.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+internal interface IActiveEntry
+{
+    ContentBlock Block { get; }
+    HandleResult Invoke(BlockMappingContext context);
+}

--- a/src/Components/AI/src/Pipeline/IHandlerEntry.cs
+++ b/src/Components/AI/src/Pipeline/IHandlerEntry.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+internal interface IHandlerEntry
+{
+    IActiveEntry? TryHandle(BlockMappingContext context);
+}

--- a/src/Components/AI/src/Pipeline/TextBlockHandler.cs
+++ b/src/Components/AI/src/Pipeline/TextBlockHandler.cs
@@ -1,0 +1,91 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+internal sealed class TextBlockHandler : ContentBlockHandler<RichContentBlock>
+{
+    public override BlockMappingResult<RichContentBlock> Handle(
+        BlockMappingContext context, RichContentBlock state)
+    {
+        TextContent? textContent = null;
+        foreach (var content in context.UnhandledContents)
+        {
+            if (content is TextContent tc)
+            {
+                textContent = tc;
+                break;
+            }
+        }
+
+        if (textContent is null)
+        {
+            if (state.Id != string.Empty)
+            {
+                return BlockMappingResult<RichContentBlock>.Complete();
+            }
+
+            return BlockMappingResult<RichContentBlock>.Pass();
+        }
+
+        context.MarkHandled(textContent);
+        state.AppendText(textContent.Text ?? string.Empty);
+        RebuildParagraphs(state);
+
+        if (state.Id == string.Empty)
+        {
+            state.Id = context.Update.MessageId ?? Guid.NewGuid().ToString("N");
+            return BlockMappingResult<RichContentBlock>.Emit(state, state);
+        }
+        else
+        {
+            return BlockMappingResult<RichContentBlock>.Update(state);
+        }
+    }
+
+    internal static void RebuildParagraphs(RichContentBlock state)
+    {
+        var rawText = state.RawText;
+        if (rawText.Length == 0)
+        {
+            state.Content = Array.Empty<RichTextNode>();
+            return;
+        }
+
+        var paragraphs = new List<RichTextNode>();
+        var start = 0;
+        while (start < rawText.Length)
+        {
+            var breakIndex = rawText.IndexOf("\n\n", start, StringComparison.Ordinal);
+            if (breakIndex < 0)
+            {
+                AddParagraph(paragraphs, rawText.AsSpan(start));
+                break;
+            }
+
+            if (breakIndex > start)
+            {
+                AddParagraph(paragraphs, rawText.AsSpan(start, breakIndex - start));
+            }
+
+            start = breakIndex + 2;
+        }
+
+        state.Content = paragraphs;
+    }
+
+    private static void AddParagraph(List<RichTextNode> paragraphs, ReadOnlySpan<char> text)
+    {
+        var trimmed = text.TrimEnd("\r\n".AsSpan());
+        if (trimmed.Length == 0)
+        {
+            return;
+        }
+
+        var paragraph = new ParagraphNode();
+        paragraph.AddChild(new TextNode(trimmed.ToString()));
+        paragraphs.Add(paragraph);
+    }
+}

--- a/src/Components/AI/src/Pipeline/UIAgentOptions.cs
+++ b/src/Components/AI/src/Pipeline/UIAgentOptions.cs
@@ -14,6 +14,7 @@ public class UIAgentOptions
     public void AddBlockHandler<TState>(ContentBlockHandler<TState> handler)
         where TState : new()
     {
+        ArgumentNullException.ThrowIfNull(handler);
         HandlerRegistrations.Add(new HandlerRegistration<TState>(handler));
     }
 

--- a/src/Components/AI/src/Pipeline/UIAgentOptions.cs
+++ b/src/Components/AI/src/Pipeline/UIAgentOptions.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public class UIAgentOptions
+{
+    public ChatOptions? ChatOptions { get; set; }
+
+    internal List<IHandlerRegistration> HandlerRegistrations { get; } = new();
+
+    public void AddBlockHandler<TState>(ContentBlockHandler<TState> handler)
+        where TState : new()
+    {
+        HandlerRegistrations.Add(new HandlerRegistration<TState>(handler));
+    }
+
+    internal interface IHandlerRegistration
+    {
+        IHandlerEntry CreateEntry();
+    }
+
+    private sealed class HandlerRegistration<TState> : IHandlerRegistration where TState : new()
+    {
+        private readonly ContentBlockHandler<TState> _handler;
+
+        internal HandlerRegistration(ContentBlockHandler<TState> handler)
+        {
+            _handler = handler;
+        }
+
+        public IHandlerEntry CreateEntry() => new HandlerEntry<TState>(_handler);
+    }
+}

--- a/src/Components/AI/test/Blocks/ContentBlockTests.cs
+++ b/src/Components/AI/test/Blocks/ContentBlockTests.cs
@@ -1,0 +1,82 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Blocks;
+
+public class ContentBlockTests
+{
+    private class TestBlock : ContentBlock
+    {
+        public void TriggerChanged() => NotifyChanged();
+    }
+
+    [Fact]
+    public void OnChanged_CallbackFiresOnNotifyChanged()
+    {
+        var block = new TestBlock();
+        var fired = false;
+        block.OnChanged(() => fired = true);
+
+        block.TriggerChanged();
+
+        Assert.True(fired);
+    }
+
+    [Fact]
+    public void OnChanged_MultipleCallbacksAllFire()
+    {
+        var block = new TestBlock();
+        var count = 0;
+        block.OnChanged(() => count++);
+        block.OnChanged(() => count++);
+
+        block.TriggerChanged();
+
+        Assert.Equal(2, count);
+    }
+
+    [Fact]
+    public void OnChanged_DisposingStopsCallback()
+    {
+        var block = new TestBlock();
+        var count = 0;
+        var reg = block.OnChanged(() => count++);
+
+        block.TriggerChanged();
+        Assert.Equal(1, count);
+
+        reg.Dispose();
+        block.TriggerChanged();
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public void OnChanged_DoubleDisposeDoesNotThrow()
+    {
+        var block = new TestBlock();
+        var reg = block.OnChanged(() => { });
+
+        reg.Dispose();
+        reg.Dispose();
+    }
+
+    [Fact]
+    public void OnChanged_DisposingInsideCallbackDoesNotThrow()
+    {
+        var block = new TestBlock();
+        ContentBlockChangedSubscription reg = default;
+        reg = block.OnChanged(() => reg.Dispose());
+
+        block.TriggerChanged();
+    }
+
+    [Fact]
+    public void OnChanged_ReturnsConcreteStructType()
+    {
+        var block = new TestBlock();
+        ContentBlockChangedSubscription reg = block.OnChanged(() => { });
+
+        Assert.IsType<ContentBlockChangedSubscription>(reg);
+        reg.Dispose();
+    }
+}

--- a/src/Components/AI/test/Microsoft.AspNetCore.Components.AI.Tests.csproj
+++ b/src/Components/AI/test/Microsoft.AspNetCore.Components.AI.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.AspNetCore.Components.AI" />
+    <Reference Include="Microsoft.AspNetCore.Components.Web" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.Extensions.AI" />
+  </ItemGroup>
+
+</Project>

--- a/src/Components/AI/test/Pipeline/BlockMappingPipelineTests.cs
+++ b/src/Components/AI/test/Pipeline/BlockMappingPipelineTests.cs
@@ -1,0 +1,162 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Pipeline;
+
+public class BlockMappingPipelineTests
+{
+    private static BlockMappingPipeline CreatePipelineWithTextHandler()
+    {
+        var options = new UIAgentOptions();
+        return new BlockMappingPipeline(options);
+    }
+
+    private static async Task<List<ContentBlock>> ProcessAsync(
+        BlockMappingPipeline pipeline, ChatResponseUpdate update)
+    {
+        var blocks = new List<ContentBlock>();
+        await foreach (var block in pipeline.Process(update))
+        {
+            blocks.Add(block);
+        }
+        return blocks;
+    }
+
+    [Fact]
+    public async Task Process_SingleTextUpdate_EmitsOneRichContentBlock()
+    {
+        var pipeline = CreatePipelineWithTextHandler();
+        var update = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "msg-1",
+            Contents = [new TextContent("Hello")]
+        };
+
+        var blocks = await ProcessAsync(pipeline, update);
+
+        Assert.Single(blocks);
+        var block = Assert.IsType<RichContentBlock>(blocks[0]);
+        Assert.Equal("Hello", block.RawText);
+        Assert.Equal("msg-1", block.Id);
+        Assert.Equal(ChatRole.Assistant, block.Role);
+        Assert.Equal(BlockLifecycleState.Active, block.LifecycleState);
+    }
+
+    [Fact]
+    public async Task Process_MultipleTextUpdates_SameMessageId_SingleBlockAccumulates()
+    {
+        var pipeline = CreatePipelineWithTextHandler();
+        var update1 = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "msg-1",
+            Contents = [new TextContent("Hello")]
+        };
+        var update2 = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "msg-1",
+            Contents = [new TextContent(" world")]
+        };
+
+        var blocks1 = await ProcessAsync(pipeline, update1);
+        Assert.Single(blocks1);
+
+        var blocks2 = await ProcessAsync(pipeline, update2);
+        Assert.Empty(blocks2);
+
+        var block = Assert.IsType<RichContentBlock>(blocks1[0]);
+        Assert.Equal("Hello world", block.RawText);
+    }
+
+    [Fact]
+    public async Task Process_TextUpdate_NotifyChangedOnUpdate()
+    {
+        var pipeline = CreatePipelineWithTextHandler();
+        var update1 = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "msg-1",
+            Contents = [new TextContent("Hello")]
+        };
+        var blocks = await ProcessAsync(pipeline, update1);
+        var block = blocks[0];
+        var changeCount = 0;
+        block.OnChanged(() => changeCount++);
+
+        var update2 = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "msg-1",
+            Contents = [new TextContent(" world")]
+        };
+        await ProcessAsync(pipeline, update2);
+
+        Assert.Equal(1, changeCount);
+    }
+
+    [Fact]
+    public async Task Process_UpdateWithNoMatchingHandler_NoBlocksEmitted()
+    {
+        var pipeline = CreatePipelineWithTextHandler();
+        var update = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "msg-1",
+            Contents = [new UsageContent(new() { InputTokenCount = 10 })]
+        };
+
+        var blocks = await ProcessAsync(pipeline, update);
+        Assert.Empty(blocks);
+    }
+
+    [Fact]
+    public async Task Finalize_CompletesActiveHandlers_TransitionsBlocksToInactive()
+    {
+        var pipeline = CreatePipelineWithTextHandler();
+        var update = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "msg-1",
+            Contents = [new TextContent("Hello")]
+        };
+        var blocks = await ProcessAsync(pipeline, update);
+        var block = blocks[0];
+        Assert.Equal(BlockLifecycleState.Active, block.LifecycleState);
+
+        pipeline.Finalize();
+
+        Assert.Equal(BlockLifecycleState.Inactive, block.LifecycleState);
+    }
+
+    [Fact]
+    public async Task Process_AfterFinalize_NewTextEmitsNewBlock()
+    {
+        var pipeline = CreatePipelineWithTextHandler();
+
+        var update1 = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "msg-1",
+            Contents = [new TextContent("First")]
+        };
+        await ProcessAsync(pipeline, update1);
+        pipeline.Finalize();
+
+        var update2 = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "msg-2",
+            Contents = [new TextContent("Second")]
+        };
+        var blocks = await ProcessAsync(pipeline, update2);
+
+        Assert.Single(blocks);
+        var block = Assert.IsType<RichContentBlock>(blocks[0]);
+        Assert.Equal("Second", block.RawText);
+        Assert.Equal("msg-2", block.Id);
+    }
+}

--- a/src/Components/AI/test/Pipeline/TextBlockHandlerParagraphTests.cs
+++ b/src/Components/AI/test/Pipeline/TextBlockHandlerParagraphTests.cs
@@ -1,0 +1,128 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Pipeline;
+
+public class TextBlockHandlerParagraphTests
+{
+    [Fact]
+    public void RebuildParagraphs_SingleText_OneParagraph()
+    {
+        var block = new RichContentBlock();
+        block.AppendText("Hello world");
+        TextBlockHandler.RebuildParagraphs(block);
+
+        var paragraph = Assert.IsType<ParagraphNode>(Assert.Single(block.Content));
+        var text = Assert.IsType<TextNode>(Assert.Single(paragraph.Children));
+        Assert.Equal("Hello world", text.Text);
+    }
+
+    [Fact]
+    public void RebuildParagraphs_TwoParagraphs()
+    {
+        var block = new RichContentBlock();
+        block.AppendText("First\n\nSecond");
+        TextBlockHandler.RebuildParagraphs(block);
+
+        Assert.Equal(2, block.Content.Count);
+
+        var p1 = Assert.IsType<ParagraphNode>(block.Content[0]);
+        Assert.Equal("First", Assert.IsType<TextNode>(Assert.Single(p1.Children)).Text);
+
+        var p2 = Assert.IsType<ParagraphNode>(block.Content[1]);
+        Assert.Equal("Second", Assert.IsType<TextNode>(Assert.Single(p2.Children)).Text);
+    }
+
+    [Fact]
+    public void RebuildParagraphs_ThreeParagraphs()
+    {
+        var block = new RichContentBlock();
+        block.AppendText("A\n\nB\n\nC");
+        TextBlockHandler.RebuildParagraphs(block);
+
+        Assert.Equal(3, block.Content.Count);
+        Assert.Equal("A", Assert.IsType<TextNode>(Assert.Single(Assert.IsType<ParagraphNode>(block.Content[0]).Children)).Text);
+        Assert.Equal("B", Assert.IsType<TextNode>(Assert.Single(Assert.IsType<ParagraphNode>(block.Content[1]).Children)).Text);
+        Assert.Equal("C", Assert.IsType<TextNode>(Assert.Single(Assert.IsType<ParagraphNode>(block.Content[2]).Children)).Text);
+    }
+
+    [Fact]
+    public void RebuildParagraphs_TrailingDoubleNewline_NoEmptyParagraph()
+    {
+        var block = new RichContentBlock();
+        block.AppendText("Hello\n\n");
+        TextBlockHandler.RebuildParagraphs(block);
+
+        var paragraph = Assert.IsType<ParagraphNode>(Assert.Single(block.Content));
+        Assert.Equal("Hello", Assert.IsType<TextNode>(Assert.Single(paragraph.Children)).Text);
+    }
+
+    [Fact]
+    public void RebuildParagraphs_SingleNewlineNotAParagraphBreak()
+    {
+        var block = new RichContentBlock();
+        block.AppendText("Line one\nLine two");
+        TextBlockHandler.RebuildParagraphs(block);
+
+        // Single \n is NOT a paragraph break
+        var paragraph = Assert.IsType<ParagraphNode>(Assert.Single(block.Content));
+        Assert.Equal("Line one\nLine two", Assert.IsType<TextNode>(Assert.Single(paragraph.Children)).Text);
+    }
+
+    [Fact]
+    public void RebuildParagraphs_EmptyText_NoContent()
+    {
+        var block = new RichContentBlock();
+        TextBlockHandler.RebuildParagraphs(block);
+
+        Assert.Empty(block.Content);
+    }
+
+    [Fact]
+    public void RebuildParagraphs_OnlyDoubleNewlines_NoContent()
+    {
+        var block = new RichContentBlock();
+        block.AppendText("\n\n\n\n");
+        TextBlockHandler.RebuildParagraphs(block);
+
+        Assert.Empty(block.Content);
+    }
+
+    [Fact]
+    public void RebuildParagraphs_StreamingTokens_ParagraphsRebuilt()
+    {
+        var block = new RichContentBlock();
+
+        block.AppendText("Hello");
+        TextBlockHandler.RebuildParagraphs(block);
+        Assert.Single(block.Content);
+
+        block.AppendText(" world");
+        TextBlockHandler.RebuildParagraphs(block);
+        Assert.Single(block.Content);
+
+        block.AppendText("\n\n");
+        TextBlockHandler.RebuildParagraphs(block);
+        Assert.Single(block.Content); // trailing \n\n, no second paragraph yet
+
+        block.AppendText("Second");
+        TextBlockHandler.RebuildParagraphs(block);
+        Assert.Equal(2, block.Content.Count);
+
+        Assert.Equal("Hello world", Assert.IsType<TextNode>(
+            Assert.Single(Assert.IsType<ParagraphNode>(block.Content[0]).Children)).Text);
+        Assert.Equal("Second", Assert.IsType<TextNode>(
+            Assert.Single(Assert.IsType<ParagraphNode>(block.Content[1]).Children)).Text);
+    }
+
+    [Fact]
+    public void RebuildParagraphs_TrimsTrailingNewlinesFromParagraphs()
+    {
+        var block = new RichContentBlock();
+        block.AppendText("First\n\n\nSecond");
+        TextBlockHandler.RebuildParagraphs(block);
+
+        // The extra \n after the break is part of "Second" paragraph, not trimmed
+        Assert.Equal(2, block.Content.Count);
+    }
+}

--- a/src/Components/AI/test/TestFramework/CapturedBatch.cs
+++ b/src/Components/AI/test/TestFramework/CapturedBatch.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.TestFramework;
+
+internal sealed class CapturedBatch
+{
+    private readonly List<int> _updatedComponentIds = new();
+    private readonly List<int> _disposedComponentIds = new();
+
+    internal CapturedBatch(int index)
+    {
+        Index = index;
+    }
+
+    public int Index { get; }
+
+    public IReadOnlyList<int> UpdatedComponentIds => _updatedComponentIds;
+
+    public IReadOnlyList<int> DisposedComponentIds => _disposedComponentIds;
+
+    internal void AddUpdatedComponent(int componentId)
+    {
+        _updatedComponentIds.Add(componentId);
+    }
+
+    internal void AddDisposedComponent(int componentId)
+    {
+        _disposedComponentIds.Add(componentId);
+    }
+}

--- a/src/Components/AI/test/TestFramework/ComponentNode.cs
+++ b/src/Components/AI/test/TestFramework/ComponentNode.cs
@@ -1,0 +1,90 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.TestFramework;
+
+internal sealed class ComponentNode
+{
+    private readonly List<ComponentNode> _children = new();
+    private readonly List<ComponentRender> _renders = new();
+
+    internal ComponentNode(int componentId, Type componentType, IComponent instance)
+    {
+        ComponentId = componentId;
+        ComponentType = componentType;
+        Instance = instance;
+    }
+
+    public int ComponentId { get; }
+
+    public Type ComponentType { get; }
+
+    public IComponent Instance { get; }
+
+    public ComponentNode? Parent { get; internal set; }
+
+    public IReadOnlyList<ComponentNode> Children => _children;
+
+    public IReadOnlyList<ComponentRender> Renders => _renders;
+
+    public int RenderCount => _renders.Count;
+
+    internal void AddChild(ComponentNode child)
+    {
+        _children.Add(child);
+    }
+
+    internal void ClearChildren()
+    {
+        foreach (var child in _children)
+        {
+            child.Parent = null;
+        }
+
+        _children.Clear();
+    }
+
+    internal void AddRender(int batchIndex, string html)
+    {
+        _renders.Add(new ComponentRender(batchIndex, html));
+    }
+
+    public ComponentNode? FindDescendant<T>() where T : IComponent
+    {
+        foreach (var child in _children)
+        {
+            if (child.Instance is T)
+            {
+                return child;
+            }
+
+            var found = child.FindDescendant<T>();
+            if (found is not null)
+            {
+                return found;
+            }
+        }
+
+        return null;
+    }
+
+    public IReadOnlyList<ComponentNode> FindAllDescendants<T>() where T : IComponent
+    {
+        var results = new List<ComponentNode>();
+        CollectDescendants<T>(results);
+        return results;
+    }
+
+    private void CollectDescendants<T>(List<ComponentNode> results) where T : IComponent
+    {
+        foreach (var child in _children)
+        {
+            if (child.Instance is T)
+            {
+                results.Add(child);
+            }
+
+            child.CollectDescendants<T>(results);
+        }
+    }
+}

--- a/src/Components/AI/test/TestFramework/ComponentRender.cs
+++ b/src/Components/AI/test/TestFramework/ComponentRender.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.TestFramework;
+
+internal sealed class ComponentRender
+{
+    internal ComponentRender(int batchIndex, string html)
+    {
+        BatchIndex = batchIndex;
+        Html = html;
+    }
+
+    public int BatchIndex { get; }
+
+    public string Html { get; }
+}

--- a/src/Components/AI/test/TestFramework/ComponentTree.cs
+++ b/src/Components/AI/test/TestFramework/ComponentTree.cs
@@ -1,0 +1,137 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.RenderTree;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.TestFramework;
+
+internal sealed class ComponentTree
+{
+    private readonly TestRenderer _renderer;
+    private readonly Dictionary<int, ComponentNode> _nodes = new();
+    private readonly List<int> _rootIds = new();
+
+    internal ComponentTree(TestRenderer renderer)
+    {
+        _renderer = renderer;
+    }
+
+    public IReadOnlyList<ComponentNode> Roots
+    {
+        get
+        {
+            var roots = new List<ComponentNode>();
+            foreach (var id in _rootIds)
+            {
+                if (_nodes.TryGetValue(id, out var node))
+                {
+                    roots.Add(node);
+                }
+            }
+
+            return roots;
+        }
+    }
+
+    internal void AddRoot(int componentId, IComponent component)
+    {
+        _rootIds.Add(componentId);
+        _nodes[componentId] = new ComponentNode(componentId, component.GetType(), component);
+    }
+
+    internal void RemoveComponent(int componentId)
+    {
+        _nodes.Remove(componentId);
+        _rootIds.Remove(componentId);
+    }
+
+    internal bool HasNode(int componentId) => _nodes.ContainsKey(componentId);
+
+    internal ComponentNode GetNode(int componentId) => _nodes[componentId];
+
+    internal ComponentNode? FindDescendant<T>(int rootComponentId) where T : IComponent
+    {
+        if (_nodes.TryGetValue(rootComponentId, out var node))
+        {
+            // Check the node itself first
+            if (node.Instance is T)
+            {
+                return node;
+            }
+
+            return node.FindDescendant<T>();
+        }
+
+        return null;
+    }
+
+    internal void RebuildRelationships()
+    {
+        // Clear all parent-child relationships
+        foreach (var node in _nodes.Values)
+        {
+            node.ClearChildren();
+        }
+
+        // Rebuild from roots by scanning current render tree frames
+        foreach (var rootId in _rootIds)
+        {
+            if (_nodes.TryGetValue(rootId, out var rootNode))
+            {
+                ScanChildren(rootNode);
+            }
+        }
+    }
+
+    private void ScanChildren(ComponentNode parentNode)
+    {
+        var frames = _renderer.GetCurrentRenderTreeFrames(parentNode.ComponentId);
+        ScanFramesForChildren(frames, 0, frames.Count, parentNode);
+    }
+
+    private void ScanFramesForChildren(
+        ArrayRange<RenderTreeFrame> frames,
+        int start,
+        int end,
+        ComponentNode parentNode)
+    {
+        var i = start;
+        while (i < end)
+        {
+            ref var frame = ref frames.Array[i];
+            switch (frame.FrameType)
+            {
+                case RenderTreeFrameType.Component:
+                    var childId = frame.ComponentId;
+                    if (!_nodes.TryGetValue(childId, out var childNode))
+                    {
+                        childNode = new ComponentNode(childId, frame.ComponentType, frame.Component);
+                        _nodes[childId] = childNode;
+                    }
+
+                    parentNode.AddChild(childNode);
+                    childNode.Parent = parentNode;
+
+                    // Recurse into child component's own render tree
+                    ScanChildren(childNode);
+                    i += frame.ComponentSubtreeLength;
+                    break;
+
+                case RenderTreeFrameType.Element:
+                    // Scan inside elements for nested components
+                    ScanFramesForChildren(frames, i + 1, i + frame.ElementSubtreeLength, parentNode);
+                    i += frame.ElementSubtreeLength;
+                    break;
+
+                case RenderTreeFrameType.Region:
+                    ScanFramesForChildren(frames, i + 1, i + frame.RegionSubtreeLength, parentNode);
+                    i += frame.RegionSubtreeLength;
+                    break;
+
+                default:
+                    i++;
+                    break;
+            }
+        }
+    }
+}

--- a/src/Components/AI/test/TestFramework/HtmlContentWriter.cs
+++ b/src/Components/AI/test/TestFramework/HtmlContentWriter.cs
@@ -1,0 +1,151 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using System.Text;
+using Microsoft.AspNetCore.Components.RenderTree;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.TestFramework;
+
+internal sealed class HtmlContentWriter
+{
+    private static readonly HashSet<string> VoidElements = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "area", "base", "br", "col", "embed", "hr", "img", "input",
+        "link", "meta", "param", "source", "track", "wbr"
+    };
+
+    private readonly TestRenderer _renderer;
+    private readonly StringBuilder _sb = new();
+
+    internal HtmlContentWriter(TestRenderer renderer)
+    {
+        _renderer = renderer;
+    }
+
+    internal void WriteFrames(ArrayRange<RenderTreeFrame> frames, int start, int end)
+    {
+        var i = start;
+        while (i < end)
+        {
+            ref var frame = ref frames.Array[i];
+            switch (frame.FrameType)
+            {
+                case RenderTreeFrameType.Element:
+                    WriteElement(frames, ref i);
+                    break;
+                case RenderTreeFrameType.Text:
+                    _sb.Append(WebUtility.HtmlEncode(frame.TextContent));
+                    i++;
+                    break;
+                case RenderTreeFrameType.Markup:
+                    _sb.Append(frame.MarkupContent);
+                    i++;
+                    break;
+                case RenderTreeFrameType.Component:
+                    WriteComponentContent(frame.ComponentId);
+                    i += frame.ComponentSubtreeLength;
+                    break;
+                case RenderTreeFrameType.Region:
+                    WriteFrames(frames, i + 1, i + frame.RegionSubtreeLength);
+                    i += frame.RegionSubtreeLength;
+                    break;
+                default:
+                    i++;
+                    break;
+            }
+        }
+    }
+
+    internal string GetResult() => _sb.ToString();
+
+    private void WriteElement(ArrayRange<RenderTreeFrame> frames, ref int i)
+    {
+        ref var elementFrame = ref frames.Array[i];
+        var elementName = elementFrame.ElementName;
+        var subtreeEnd = i + elementFrame.ElementSubtreeLength;
+
+        _sb.Append('<');
+        _sb.Append(elementName);
+
+        // Write attributes (immediately follow the element frame)
+        var childStart = i + 1;
+        while (childStart < subtreeEnd
+            && frames.Array[childStart].FrameType == RenderTreeFrameType.Attribute)
+        {
+            WriteAttribute(ref frames.Array[childStart]);
+            childStart++;
+        }
+
+        if (VoidElements.Contains(elementName))
+        {
+            _sb.Append(" />");
+        }
+        else
+        {
+            _sb.Append('>');
+            WriteFrames(frames, childStart, subtreeEnd);
+            _sb.Append("</");
+            _sb.Append(elementName);
+            _sb.Append('>');
+        }
+
+        i = subtreeEnd;
+    }
+
+    private void WriteAttribute(ref RenderTreeFrame frame)
+    {
+        // Skip event handlers — they don't produce HTML attributes
+        if (frame.AttributeEventHandlerId > 0)
+        {
+            return;
+        }
+
+        var name = frame.AttributeName;
+        var value = frame.AttributeValue;
+
+        if (value is bool boolValue)
+        {
+            if (boolValue)
+            {
+                _sb.Append(' ');
+                _sb.Append(name);
+            }
+            // false → omit the attribute entirely
+        }
+        else if (value is string stringValue)
+        {
+            _sb.Append(' ');
+            _sb.Append(name);
+            _sb.Append("=\"");
+            _sb.Append(WebUtility.HtmlEncode(stringValue));
+            _sb.Append('"');
+        }
+        else if (value is null)
+        {
+            // Omit null attributes
+        }
+        else if (value is MulticastDelegate)
+        {
+            // Event handler delegate without an assigned handler ID — skip
+        }
+        else if (value is EventCallback)
+        {
+            // Unbound EventCallback — skip
+        }
+        else
+        {
+            _sb.Append(' ');
+            _sb.Append(name);
+            _sb.Append("=\"");
+            _sb.Append(WebUtility.HtmlEncode(value.ToString() ?? ""));
+            _sb.Append('"');
+        }
+    }
+
+    private void WriteComponentContent(int componentId)
+    {
+        var frames = _renderer.GetCurrentRenderTreeFrames(componentId);
+        WriteFrames(frames, 0, frames.Count);
+    }
+}

--- a/src/Components/AI/test/TestFramework/NullJSRuntime.cs
+++ b/src/Components/AI/test/TestFramework/NullJSRuntime.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.JSInterop;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.TestFramework;
+
+internal sealed class NullJSRuntime : IJSRuntime
+{
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+        => default;
+
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args)
+        => default;
+}

--- a/src/Components/AI/test/TestFramework/RenderedComponent.cs
+++ b/src/Components/AI/test/TestFramework/RenderedComponent.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.TestFramework;
+
+internal sealed class RenderedComponent<T> where T : IComponent
+{
+    private readonly TestRenderer _renderer;
+
+    internal RenderedComponent(TestRenderer renderer, int componentId, T instance)
+    {
+        _renderer = renderer;
+        ComponentId = componentId;
+        Instance = instance;
+    }
+
+    public int ComponentId { get; }
+
+    public T Instance { get; }
+
+    public string GetHtml() => _renderer.GetHtml(ComponentId);
+
+    public ComponentNode GetNode() => _renderer.Tree.GetNode(ComponentId);
+
+    public RenderedComponent<TChild> FindComponent<TChild>() where TChild : IComponent
+    {
+        var node = _renderer.Tree.FindDescendant<TChild>(ComponentId);
+        if (node is null)
+        {
+            throw new InvalidOperationException(
+                $"No component of type {typeof(TChild).Name} found in the tree rooted at {typeof(T).Name}.");
+        }
+
+        return new RenderedComponent<TChild>(_renderer, node.ComponentId, (TChild)node.Instance);
+    }
+
+    public IReadOnlyList<RenderedComponent<TChild>> FindAllComponents<TChild>()
+        where TChild : IComponent
+    {
+        var rootNode = _renderer.Tree.GetNode(ComponentId);
+        var childNodes = rootNode.FindAllDescendants<TChild>();
+        var results = new List<RenderedComponent<TChild>>();
+        foreach (var node in childNodes)
+        {
+            results.Add(new RenderedComponent<TChild>(_renderer, node.ComponentId, (TChild)node.Instance));
+        }
+
+        return results;
+    }
+
+    public Task InvokeAsync(Func<Task> callback)
+        => _renderer.Dispatcher.InvokeAsync(callback);
+
+    public Task InvokeAsync(Action callback)
+        => _renderer.Dispatcher.InvokeAsync(callback);
+}

--- a/src/Components/AI/test/TestFramework/TestRenderer.cs
+++ b/src/Components/AI/test/TestFramework/TestRenderer.cs
@@ -1,0 +1,132 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.ExceptionServices;
+using Microsoft.AspNetCore.Components.RenderTree;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.TestFramework;
+
+internal sealed class TestRenderer : Renderer
+{
+    private readonly List<CapturedBatch> _batches = new();
+    private readonly ComponentTree _tree;
+    private int _batchIndex;
+
+    internal TestRenderer() : this(new TestServiceProvider())
+    {
+    }
+
+    internal TestRenderer(IServiceProvider serviceProvider)
+        : base(serviceProvider, NullLoggerFactory.Instance)
+    {
+        Dispatcher = Dispatcher.CreateDefault();
+        _tree = new ComponentTree(this);
+    }
+
+    public override Dispatcher Dispatcher { get; }
+
+    public IReadOnlyList<CapturedBatch> Batches => _batches;
+
+    public ComponentTree Tree => _tree;
+
+    public new int AssignRootComponentId(IComponent component)
+    {
+        var id = base.AssignRootComponentId(component);
+        _tree.AddRoot(id, component);
+        return id;
+    }
+
+    public void RenderRootComponent(int componentId, ParameterView? parameters = null)
+    {
+        var task = Dispatcher.InvokeAsync(
+            () => base.RenderRootComponentAsync(componentId, parameters ?? ParameterView.Empty));
+        UnwrapTask(task);
+    }
+
+    public new Task RenderRootComponentAsync(int componentId, ParameterView parameters)
+        => Dispatcher.InvokeAsync(() => base.RenderRootComponentAsync(componentId, parameters));
+
+    public Task DispatchEventAsync(ulong eventHandlerId, EventArgs args)
+        => Dispatcher.InvokeAsync(() => base.DispatchEventAsync(eventHandlerId, null, args));
+
+    public new ArrayRange<RenderTreeFrame> GetCurrentRenderTreeFrames(int componentId)
+        => base.GetCurrentRenderTreeFrames(componentId);
+
+    public RenderedComponent<T> RenderComponent<T>(
+        Action<Dictionary<string, object?>>? configure = null) where T : IComponent
+    {
+        var component = InstantiateComponent(typeof(T));
+        var componentId = AssignRootComponentId(component);
+
+        var parameters = new Dictionary<string, object?>();
+        configure?.Invoke(parameters);
+
+        RenderRootComponent(componentId, ParameterView.FromDictionary(parameters));
+
+        return new RenderedComponent<T>(this, componentId, (T)component);
+    }
+
+    internal string GetHtml(int componentId)
+    {
+        var writer = new HtmlContentWriter(this);
+        var frames = GetCurrentRenderTreeFrames(componentId);
+        writer.WriteFrames(frames, 0, frames.Count);
+        return writer.GetResult();
+    }
+
+    protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)
+    {
+        var batch = new CapturedBatch(_batchIndex);
+
+        for (var i = 0; i < renderBatch.UpdatedComponents.Count; i++)
+        {
+            ref var diff = ref renderBatch.UpdatedComponents.Array[i];
+            batch.AddUpdatedComponent(diff.ComponentId);
+        }
+
+        for (var i = 0; i < renderBatch.DisposedComponentIDs.Count; i++)
+        {
+            batch.AddDisposedComponent(renderBatch.DisposedComponentIDs.Array[i]);
+        }
+
+        _batches.Add(batch);
+
+        // Remove disposed components from the tree
+        foreach (var id in batch.DisposedComponentIds)
+        {
+            _tree.RemoveComponent(id);
+        }
+
+        // Rebuild parent-child relationships from current render tree state
+        _tree.RebuildRelationships();
+
+        // Capture HTML snapshots for each updated component
+        foreach (var id in batch.UpdatedComponentIds)
+        {
+            if (_tree.HasNode(id))
+            {
+                var html = GetHtml(id);
+                _tree.GetNode(id).AddRender(_batchIndex, html);
+            }
+        }
+
+        _batchIndex++;
+        return Task.CompletedTask;
+    }
+
+    protected override void HandleException(Exception exception)
+    {
+        ExceptionDispatchInfo.Capture(exception).Throw();
+    }
+
+    private static void UnwrapTask(Task task)
+    {
+        Assert.True(task.IsCompleted);
+        if (task.IsFaulted)
+        {
+            var exception = task.Exception!.Flatten().InnerException!;
+            ExceptionDispatchInfo.Capture(exception).Throw();
+        }
+    }
+}

--- a/src/Components/AI/test/TestFramework/TestServiceProvider.cs
+++ b/src/Components/AI/test/TestFramework/TestServiceProvider.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.JSInterop;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.TestFramework;
+
+internal sealed class TestServiceProvider : IServiceProvider
+{
+    private readonly Dictionary<Type, Func<object?>> _factories = new();
+
+    internal TestServiceProvider()
+    {
+        AddService<IJSRuntime>(new NullJSRuntime());
+    }
+
+    public object? GetService(Type serviceType)
+    {
+        if (_factories.TryGetValue(serviceType, out var factory))
+        {
+            return factory();
+        }
+
+        return null;
+    }
+
+    internal void AddService<T>(T value) where T : notnull
+    {
+        _factories[typeof(T)] = () => value;
+    }
+}

--- a/src/Components/AI/test/TestFramework/Tests/TestRendererTests.cs
+++ b/src/Components/AI/test/TestFramework/Tests/TestRendererTests.cs
@@ -1,0 +1,235 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.AI.Tests.TestFramework;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.TestFramework.Tests;
+
+public class TestRendererTests
+{
+    [Fact]
+    public void RenderComponent_SimpleElement_ProducesHtml()
+    {
+        using var renderer = new TestRenderer();
+
+        var cut = renderer.RenderComponent<SimpleDiv>();
+
+        Assert.Equal("<div class=\"hello\">Hello world</div>", cut.GetHtml());
+    }
+
+    [Fact]
+    public void RenderComponent_NestedComponents_BuildsTree()
+    {
+        using var renderer = new TestRenderer();
+
+        var cut = renderer.RenderComponent<ParentComponent>();
+        var node = cut.GetNode();
+
+        Assert.Single(node.Children);
+        Assert.Equal(typeof(ChildComponent), node.Children[0].ComponentType);
+    }
+
+    [Fact]
+    public void RenderComponent_FindComponent_FindsDescendant()
+    {
+        using var renderer = new TestRenderer();
+
+        var cut = renderer.RenderComponent<ParentComponent>();
+        var child = cut.FindComponent<ChildComponent>();
+
+        Assert.NotNull(child);
+        Assert.Contains("child-content", child.GetHtml());
+    }
+
+    [Fact]
+    public void RenderComponent_WithParameters_PassesValues()
+    {
+        using var renderer = new TestRenderer();
+
+        var cut = renderer.RenderComponent<ParameterizedComponent>(p =>
+        {
+            p["Title"] = "Test Title";
+        });
+
+        Assert.Contains("Test Title", cut.GetHtml());
+    }
+
+    [Fact]
+    public void RenderComponent_CascadingValue_FlowsToDescendants()
+    {
+        using var renderer = new TestRenderer();
+
+        var cut = renderer.RenderComponent<CascadingParent>();
+        var html = cut.GetHtml();
+
+        Assert.Contains("Received: cascaded-value", html);
+    }
+
+    [Fact]
+    public async Task RenderComponent_ReRender_CapturesMultipleBatches()
+    {
+        using var renderer = new TestRenderer();
+
+        var component = new CounterComponent();
+        var componentId = renderer.AssignRootComponentId(component);
+        renderer.RenderRootComponent(componentId);
+
+        Assert.Single(renderer.Batches);
+        var node = renderer.Tree.GetNode(componentId);
+        Assert.Single(node.Renders);
+        Assert.Contains("Count: 0", node.Renders[0].Html);
+
+        // Trigger a re-render with updated state
+        await renderer.Dispatcher.InvokeAsync(() =>
+        {
+            component.Increment();
+        });
+
+        Assert.Equal(2, renderer.Batches.Count);
+        Assert.Equal(2, node.RenderCount);
+        Assert.Contains("Count: 1", node.Renders[1].Html);
+    }
+
+    [Fact]
+    public void RenderComponent_BooleanAttribute_RendersCorrectly()
+    {
+        using var renderer = new TestRenderer();
+
+        var cut = renderer.RenderComponent<DisabledInput>();
+
+        Assert.Equal("<input disabled />", cut.GetHtml());
+    }
+
+    [Fact]
+    public void RenderComponent_VoidElements_SelfClose()
+    {
+        using var renderer = new TestRenderer();
+
+        var cut = renderer.RenderComponent<VoidElementComponent>();
+        var html = cut.GetHtml();
+
+        Assert.Contains("<br />", html);
+        Assert.Contains("<hr />", html);
+        Assert.DoesNotContain("</br>", html);
+        Assert.DoesNotContain("</hr>", html);
+    }
+
+    // Test components
+
+    private class SimpleDiv : ComponentBase
+    {
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenElement(0, "div");
+            builder.AddAttribute(1, "class", "hello");
+            builder.AddContent(2, "Hello world");
+            builder.CloseElement();
+        }
+    }
+
+    private class ParentComponent : ComponentBase
+    {
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenElement(0, "div");
+            builder.AddAttribute(1, "class", "parent");
+            builder.OpenComponent<ChildComponent>(2);
+            builder.CloseComponent();
+            builder.CloseElement();
+        }
+    }
+
+    private class ChildComponent : ComponentBase
+    {
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenElement(0, "span");
+            builder.AddAttribute(1, "class", "child-content");
+            builder.AddContent(2, "I am a child");
+            builder.CloseElement();
+        }
+    }
+
+    private class ParameterizedComponent : ComponentBase
+    {
+        [Parameter]
+        public string Title { get; set; } = "";
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenElement(0, "h1");
+            builder.AddContent(1, Title);
+            builder.CloseElement();
+        }
+    }
+
+    private class CascadingParent : ComponentBase
+    {
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenComponent<CascadingValue<string>>(0);
+            builder.AddComponentParameter(1, "Value", "cascaded-value");
+            builder.AddComponentParameter(2, "ChildContent", (RenderFragment)(inner =>
+            {
+                inner.OpenComponent<CascadingChild>(0);
+                inner.CloseComponent();
+            }));
+            builder.CloseComponent();
+        }
+    }
+
+    private class CascadingChild : ComponentBase
+    {
+        [CascadingParameter]
+        public string? CascadedValue { get; set; }
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenElement(0, "p");
+            builder.AddContent(1, $"Received: {CascadedValue}");
+            builder.CloseElement();
+        }
+    }
+
+    private class CounterComponent : ComponentBase
+    {
+        private int _count;
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenElement(0, "div");
+            builder.AddContent(1, $"Count: {_count}");
+            builder.CloseElement();
+        }
+
+        public void Increment()
+        {
+            _count++;
+            StateHasChanged();
+        }
+    }
+
+    private class DisabledInput : ComponentBase
+    {
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenElement(0, "input");
+            builder.AddAttribute(1, "disabled", true);
+            builder.CloseElement();
+        }
+    }
+
+    private class VoidElementComponent : ComponentBase
+    {
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenElement(0, "div");
+            builder.OpenElement(1, "br");
+            builder.CloseElement();
+            builder.OpenElement(2, "hr");
+            builder.CloseElement();
+            builder.CloseElement();
+        }
+    }
+}

--- a/src/Components/AI/test/TestHelpers/XunitLoggerFactory.cs
+++ b/src/Components/AI/test/TestHelpers/XunitLoggerFactory.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+
+internal sealed class XunitLoggerFactory : ILoggerFactory
+{
+    private readonly ITestOutputHelper _output;
+
+    internal XunitLoggerFactory(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public ILogger CreateLogger(string categoryName)
+    {
+        return new XunitLogger(_output, categoryName);
+    }
+
+    public void AddProvider(ILoggerProvider provider)
+    {
+    }
+
+    public void Dispose()
+    {
+    }
+}
+
+internal sealed class XunitLogger : ILogger
+{
+    private readonly ITestOutputHelper _output;
+    private readonly string _category;
+
+    internal XunitLogger(ITestOutputHelper output, string category)
+    {
+        _output = output;
+        _category = category;
+    }
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        _output.WriteLine($"[{logLevel,-12}] {_category}: {formatter(state, exception)}");
+        if (exception is not null)
+        {
+            _output.WriteLine($"  Exception: {exception}");
+        }
+    }
+}

--- a/src/Components/Components.slnf
+++ b/src/Components/Components.slnf
@@ -72,6 +72,8 @@
       "src\\Components\\Testing\\testassets\\TestApp\\TestApp.csproj",
       "src\\Components\\Testing\\testassets\\TestApp.Client\\TestApp.Client.csproj",
       "src\\Components\\Testing\\testassets\\TestApp.E2E.Tests\\TestApp.E2E.Tests.csproj",
+      "src\\Components\\AI\\src\\Microsoft.AspNetCore.Components.AI.csproj",
+      "src\\Components\\AI\\test\\Microsoft.AspNetCore.Components.AI.Tests.csproj",
       "src\\DataProtection\\Abstractions\\src\\Microsoft.AspNetCore.DataProtection.Abstractions.csproj",
       "src\\DataProtection\\Cryptography.Internal\\src\\Microsoft.AspNetCore.Cryptography.Internal.csproj",
       "src\\DataProtection\\Cryptography.KeyDerivation\\src\\Microsoft.AspNetCore.Cryptography.KeyDerivation.csproj",


### PR DESCRIPTION
Part of the overall Components.AI design: https://github.com/dotnet/aspnetcore/issues/66178

---

# Block Model, Pipeline, and Text Streaming

## Summary

Establish the foundational content transformation system: the block model that defines what the UI renders, the two-phase pipeline that routes LLM content into blocks, and the text handler that converts streaming text into rich content.

This introduces `ContentBlock`, `BlockMappingPipeline`, `TextBlockHandler`, and an initial `UIAgent` — the minimal set needed to transform an `IChatClient` text stream into structured, observable content blocks.

## Motivation

LLM responses arrive as a flat stream of `ChatResponseUpdate` objects, each containing one or more `AIContent` items. A single response can interleave text fragments, tool calls, reasoning tokens, and media — all in an unpredictable order.

To render this incrementally, the UI needs:
- **Classification**: Which content handler owns which `AIContent` items?
- **Accumulation**: Text from 20 sequential updates must build into a single paragraph, not 20 separate blocks.
- **Lifecycle tracking**: A block must know whether it's still receiving updates (Active) or complete (Inactive) so the UI can show streaming indicators.
- **Change notification**: Blazor components need to re-render when a block's content changes mid-stream.

Without a pipeline, every component must solve these problems independently. The pipeline provides the shared solution.

## Goals

- Define a `ContentBlock` base class with identity, lifecycle state, role, and observable change notifications.
- Define a `BlockMappingPipeline` that routes `ChatResponseUpdate` content through stateful handlers using a two-phase (active-first, then inactive) strategy.
- Provide a `TextBlockHandler` that accumulates text fragments into a `RichContentBlock` with a paragraph-based AST.
- Provide an initial `UIAgent` that wraps `IChatClient` and yields `ContentBlock` objects via `IAsyncEnumerable`.

## Non-goals

- Tool invocation, approval workflows, or interactive blocks.
- Blazor components or rendering.
- Rich text markdown nodes beyond paragraphs and text.
- Conversation persistence.

## Detailed design

### ContentBlock lifecycle

Every block moves through a defined lifecycle. The state determines how the UI treats it (e.g., show a streaming cursor while `Active`).

Blocks expose `OnChanged(Action)` returning a disposable `ContentBlockChangedSubscription`. Internally, callbacks are stored in a `List<Action>` and snapshot-copied before invocation, allowing safe concurrent unsubscribe during notification.

### Two-phase pipeline routing

- **Phase 1 — Active blocks**: Handlers that have already emitted a block get first chance to update or complete it (newest → oldest).
- **Phase 2 — Inactive handlers**: If Phase 1 doesn't consume all content items, inactive handlers try to claim them (registration order). The first handler that returns `Emit` enters the active stack with its new block.

The `BlockMappingContext` wraps a `ChatResponseUpdate` and tracks consumed `AIContent` items via `UnhandledContents` — a zero-allocation struct enumerator that skips already-claimed content.

### Handler state model

Each handler is generic over `TState`. The pipeline creates a fresh `TState` when a handler first claims content. That state persists across all future updates to the same block.

### TextBlockHandler

The built-in text handler:
1. Scan `UnhandledContents` for `TextContent` items.
2. On first match: create a `RichContentBlock`, return `Emit`.
3. On subsequent matches: call `block.AppendText()`, return `Update`.
4. If no `TextContent` found: return `Pass`.
5. On finalize: the pipeline deactivates the block.

Text parsing builds paragraph structure by splitting on `\n\n` boundaries.

### UIAgent — initial version

`UIAgent` wraps `IChatClient` and orchestrates the conversation. Returns `IAsyncEnumerable<ContentBlock>` — blocks are yielded as they are emitted or updated.

### UIAgentOptions

Configuration container:
- `ChatOptions` — Passed through to `IChatClient`.
- `AddBlockHandler<TState>()` — Register custom handlers (prepended, tried before built-in handlers in Phase 2).

## Risks

- **Handler starvation**: A handler that returns `Update` for every content type would starve all handlers below it. Mitigated by convention: handlers should only claim content types they understand.
- **Active stack ordering**: Newest-first active stack ordering means a recently emitted handler can shadow an older one. This is intentional but could surprise developers with custom handlers.

## Drawbacks

- The two-phase pipeline adds indirection compared to a simple switch statement over content types.
- `ContentBlock` uses mutable state with change callbacks rather than immutable records. Chosen for streaming performance.

## Test coverage

31 tests covering:
- `BlockMappingPipeline` routing logic (active/inactive phases, handler ordering, finalization).
- `TextBlockHandler` streaming accumulation and paragraph parsing.
- `ContentBlock` lifecycle states and change notifications.
- `UIAgent` end-to-end text streaming with a mock `IChatClient`.