### PR TITLE
[Blazor] Components.AI - 02 Engine, tool calls, approval, reasoning, and state

### DIFF
--- a/src/Components/AI/src/Blocks/ApprovalStatus.cs
+++ b/src/Components/AI/src/Blocks/ApprovalStatus.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public enum ApprovalStatus
+{
+    Pending,
+    Approved,
+    Rejected
+}

--- a/src/Components/AI/src/Blocks/FunctionApprovalBlock.cs
+++ b/src/Components/AI/src/Blocks/FunctionApprovalBlock.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public class FunctionApprovalBlock : InteractiveFunctionBlock, IInteractiveBlock
+{
+    private readonly TaskCompletionSource<AIContent> _tcs = new();
+
+    internal FunctionApprovalBlock(
+        FunctionInvocationContentBlock innerBlock,
+        ToolApprovalRequestContent request)
+        : base(innerBlock)
+    {
+        ApprovalRequest = request;
+        Status = ApprovalStatus.Pending;
+    }
+
+    public ApprovalStatus Status { get; private set; }
+
+    public ToolApprovalRequestContent ApprovalRequest { get; }
+
+    public void Approve()
+    {
+        Status = ApprovalStatus.Approved;
+        var response = ApprovalRequest.CreateResponse(approved: true);
+        NotifyChanged();
+        _tcs.TrySetResult(response);
+    }
+
+    public void Reject(string? reason = null)
+    {
+        Status = ApprovalStatus.Rejected;
+        var response = ApprovalRequest.CreateResponse(approved: false);
+        NotifyChanged();
+        _tcs.TrySetResult(response);
+    }
+
+    public Task<AIContent> GetResultAsync(CancellationToken cancellationToken = default)
+        => _tcs.Task.WaitAsync(cancellationToken);
+}

--- a/src/Components/AI/src/Blocks/FunctionInvocationContentBlock.cs
+++ b/src/Components/AI/src/Blocks/FunctionInvocationContentBlock.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public class FunctionInvocationContentBlock : ContentBlock
+{
+    public FunctionCallContent? Call { get; set; }
+
+    public FunctionResultContent? Result { get; set; }
+
+    public string? ToolName => Call?.Name;
+
+    public IDictionary<string, object?>? Arguments => Call?.Arguments;
+
+    public bool HasResult => Result is not null;
+}

--- a/src/Components/AI/src/Blocks/IInteractiveBlock.cs
+++ b/src/Components/AI/src/Blocks/IInteractiveBlock.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public interface IInteractiveBlock
+{
+    Task<AIContent> GetResultAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Components/AI/src/Blocks/InteractiveFunctionBlock.cs
+++ b/src/Components/AI/src/Blocks/InteractiveFunctionBlock.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public abstract class InteractiveFunctionBlock : ContentBlock
+{
+    protected InteractiveFunctionBlock(FunctionInvocationContentBlock innerBlock)
+    {
+        InnerBlock = innerBlock;
+    }
+
+    public FunctionInvocationContentBlock InnerBlock { get; }
+
+    public FunctionCallContent? Call => InnerBlock.Call;
+
+    public FunctionResultContent? Result => InnerBlock.Result;
+
+    public string? ToolName => InnerBlock.ToolName;
+
+    public IDictionary<string, object?>? Arguments => InnerBlock.Arguments;
+
+    public bool HasResult => InnerBlock.HasResult;
+}

--- a/src/Components/AI/src/Blocks/MediaContentBlock.cs
+++ b/src/Components/AI/src/Blocks/MediaContentBlock.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public class MediaContentBlock : ContentBlock
+{
+    private readonly List<DataContent> _items = new();
+
+    public IReadOnlyList<DataContent> Items => _items;
+
+    public void AddContent(DataContent content)
+    {
+        _items.Add(content);
+    }
+}

--- a/src/Components/AI/src/Blocks/ReasoningContentBlock.cs
+++ b/src/Components/AI/src/Blocks/ReasoningContentBlock.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public class ReasoningContentBlock : ContentBlock
+{
+    private readonly StringBuilder _builder = new();
+
+    public string Text => _builder.ToString();
+
+    public string? ProtectedData { get; set; }
+
+    public bool IsEncrypted => ProtectedData is not null && _builder.Length == 0;
+
+    public void AppendText(string text)
+    {
+        _builder.Append(text);
+    }
+}

--- a/src/Components/AI/src/Blocks/UIActionBlock.cs
+++ b/src/Components/AI/src/Blocks/UIActionBlock.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public class UIActionBlock : InteractiveFunctionBlock, IInteractiveBlock
+{
+    private readonly AIFunction _function;
+    private readonly TaskCompletionSource<AIContent> _tcs = new();
+
+    internal UIActionBlock(AIFunction function, FunctionInvocationContentBlock innerBlock)
+        : base(innerBlock)
+    {
+        _function = function;
+    }
+
+    public bool IsComplete { get; private set; }
+
+    public async Task InvokeAsync(CancellationToken cancellationToken = default)
+    {
+        var arguments = Call?.Arguments is not null ? new AIFunctionArguments(Call.Arguments) : null;
+        var result = await _function.InvokeAsync(arguments, cancellationToken);
+        var frc = new FunctionResultContent(Call!.CallId, result);
+        InnerBlock.Result = frc;
+        IsComplete = true;
+        NotifyChanged();
+        _tcs.TrySetResult(frc);
+    }
+
+    public Task<AIContent> GetResultAsync(CancellationToken cancellationToken = default)
+        => _tcs.Task.WaitAsync(cancellationToken);
+}

--- a/src/Components/AI/src/Engine/AgentContext.cs
+++ b/src/Components/AI/src/Engine/AgentContext.cs
@@ -1,0 +1,277 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public class AgentContext : IDisposable
+{
+    private readonly UIAgent _agent;
+    private readonly List<ConversationTurn> _turns = new();
+    private readonly List<Action<ConversationTurn>> _turnAddedCallbacks = new();
+    private readonly List<Action<ConversationStatus>> _statusChangedCallbacks = new();
+    private readonly List<Action<ConversationTurn, ContentBlock>> _blockAddedCallbacks = new();
+    private CancellationTokenSource? _streamingCts;
+    private ChatMessage? _lastMessage;
+    private bool _disposed;
+
+    public AgentContext(UIAgent agent)
+    {
+        _agent = agent;
+    }
+
+    public IReadOnlyList<ConversationTurn> Turns => _turns;
+
+    public ConversationStatus Status { get; private set; }
+
+    public Exception? Error { get; private set; }
+
+    public Task SendMessageAsync(string text, CancellationToken cancellationToken = default)
+    {
+        return SendMessageAsync(new ChatMessage(ChatRole.User, text), cancellationToken);
+    }
+
+    public async Task SendMessageAsync(ChatMessage message, CancellationToken cancellationToken = default)
+    {
+        if (Status == ConversationStatus.Streaming)
+        {
+            throw new InvalidOperationException("A message is already being processed.");
+        }
+
+        _lastMessage = message;
+
+        var turn = new ConversationTurn();
+        _turns.Add(turn);
+        NotifyTurnAdded(turn);
+
+        _streamingCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        await StreamIntoTurnAsync(message, turn, _streamingCts.Token);
+    }
+
+    private async Task StreamIntoTurnAsync(
+        ChatMessage message,
+        ConversationTurn turn,
+        CancellationToken cancellationToken)
+    {
+        Status = ConversationStatus.Streaming;
+        Error = null;
+        NotifyStatusChanged();
+
+        try
+        {
+            ChatMessage? currentMessage = message;
+
+            while (currentMessage is not null)
+            {
+                var interactiveBlocks = new List<IInteractiveBlock>();
+                var uninvokedToolBlocks = new List<FunctionInvocationContentBlock>();
+
+                await foreach (var block in _agent.SendMessageAsync(currentMessage, cancellationToken)
+                    .WithCancellation(cancellationToken))
+                {
+                    if (block is IInteractiveBlock interactive)
+                    {
+                        interactiveBlocks.Add(interactive);
+                    }
+                    else if (block is FunctionInvocationContentBlock ficb
+                             && ficb.Call is { InformationalOnly: false }
+                             && ficb.Result is null)
+                    {
+                        uninvokedToolBlocks.Add(ficb);
+                    }
+
+                    if (block.Role == currentMessage.Role)
+                    {
+                        turn.AddRequestBlock(block);
+                    }
+                    else
+                    {
+                        turn.AddResponseBlock(block);
+                    }
+
+                    NotifyBlockAdded(turn, block);
+                }
+
+                currentMessage = null;
+
+                if (interactiveBlocks.Count == 0 && uninvokedToolBlocks.Count == 0)
+                {
+                    break;
+                }
+
+                // Build tasks for all pending work
+                var resultTasks = new List<Task<AIContent>>();
+
+                foreach (var interactive in interactiveBlocks)
+                {
+                    resultTasks.Add(interactive.GetResultAsync(cancellationToken));
+                }
+
+                foreach (var toolBlock in uninvokedToolBlocks)
+                {
+                    resultTasks.Add(InvokeBackendToolAsync(toolBlock, cancellationToken));
+                }
+
+                if (interactiveBlocks.Count > 0)
+                {
+                    Status = ConversationStatus.AwaitingInput;
+                    NotifyStatusChanged();
+                }
+
+                var results = await Task.WhenAll(resultTasks);
+
+                if (results.Length > 0)
+                {
+                    var role = results.Any(r => r is not FunctionResultContent)
+                        ? ChatRole.User
+                        : ChatRole.Tool;
+                    currentMessage = new ChatMessage(role, [.. results]);
+                }
+
+                Status = ConversationStatus.Streaming;
+                NotifyStatusChanged();
+            }
+
+            Status = ConversationStatus.Idle;
+            if (cancellationToken.IsCancellationRequested)
+            {
+                turn.ClearResponseBlocks();
+            }
+            NotifyStatusChanged();
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            turn.ClearResponseBlocks();
+            Status = ConversationStatus.Idle;
+            NotifyStatusChanged();
+        }
+        catch (Exception ex)
+        {
+            Error = ex;
+            Status = ConversationStatus.Error;
+            NotifyStatusChanged();
+        }
+    }
+
+    private async Task<AIContent> InvokeBackendToolAsync(
+        FunctionInvocationContentBlock block,
+        CancellationToken cancellationToken)
+    {
+        var result = await _agent.InvokeToolAsync(block.Call!, cancellationToken);
+        block.Result = result;
+        block.InvokeNotifyChanged();
+        return result;
+    }
+
+    public async Task RetryAsync(CancellationToken cancellationToken = default)
+    {
+        if (Status != ConversationStatus.Error)
+        {
+            throw new InvalidOperationException(
+                $"RetryAsync requires Status == Error, but Status is {Status}.");
+        }
+
+        var turn = _turns[^1];
+        turn.ClearResponseBlocks();
+
+        _streamingCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        await StreamIntoTurnAsync(_lastMessage!, turn, _streamingCts.Token);
+    }
+
+    public Task CancelAsync()
+    {
+        if (Status == ConversationStatus.Idle || Status == ConversationStatus.Error)
+        {
+            return Task.CompletedTask;
+        }
+
+        _streamingCts?.Cancel();
+        return Task.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _streamingCts?.Cancel();
+        _streamingCts?.Dispose();
+        _turnAddedCallbacks.Clear();
+        _statusChangedCallbacks.Clear();
+        _blockAddedCallbacks.Clear();
+    }
+
+    public IDisposable RegisterOnTurnAdded(Action<ConversationTurn> callback)
+    {
+        _turnAddedCallbacks.Add(callback);
+        return new CallbackRegistration<Action<ConversationTurn>>(_turnAddedCallbacks, callback);
+    }
+
+    public IDisposable RegisterOnStatusChanged(Action<ConversationStatus> callback)
+    {
+        _statusChangedCallbacks.Add(callback);
+        return new CallbackRegistration<Action<ConversationStatus>>(_statusChangedCallbacks, callback);
+    }
+
+    public IDisposable RegisterOnBlockAdded(Action<ConversationTurn, ContentBlock> callback)
+    {
+        _blockAddedCallbacks.Add(callback);
+        return new CallbackRegistration<Action<ConversationTurn, ContentBlock>>(_blockAddedCallbacks, callback);
+    }
+
+    private void NotifyStatusChanged()
+    {
+        var snapshot = _statusChangedCallbacks.ToArray();
+        foreach (var cb in snapshot)
+        {
+            cb(Status);
+        }
+    }
+
+    private void NotifyTurnAdded(ConversationTurn turn)
+    {
+        var snapshot = _turnAddedCallbacks.ToArray();
+        foreach (var cb in snapshot)
+        {
+            cb(turn);
+        }
+    }
+
+    private void NotifyBlockAdded(ConversationTurn turn, ContentBlock block)
+    {
+        var snapshot = _blockAddedCallbacks.ToArray();
+        foreach (var cb in snapshot)
+        {
+            cb(turn, block);
+        }
+    }
+
+    private sealed class CallbackRegistration<T> : IDisposable
+    {
+        private List<T>? _list;
+        private T? _callback;
+
+        internal CallbackRegistration(List<T> list, T callback)
+        {
+            _list = list;
+            _callback = callback;
+        }
+
+        public void Dispose()
+        {
+            if (_list is not null && _callback is not null)
+            {
+                _list.Remove(_callback);
+                _list = null;
+                _callback = default;
+            }
+        }
+    }
+}

--- a/src/Components/AI/src/Engine/AgentState.cs
+++ b/src/Components/AI/src/Engine/AgentState.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public class AgentState<T> where T : class, new()
+{
+    private T _value;
+    private readonly List<Action> _callbacks = new();
+
+    internal AgentState(T? initialValue = null)
+    {
+        _value = initialValue ?? new T();
+    }
+
+    public T Value
+    {
+        get => _value;
+        set
+        {
+            _value = value;
+            NotifyChanged();
+        }
+    }
+
+    public IDisposable OnChanged(Action callback)
+    {
+        _callbacks.Add(callback);
+        return new CallbackRegistration(_callbacks, callback);
+    }
+
+    internal void NotifyChanged()
+    {
+        var snapshot = _callbacks.ToArray();
+        foreach (var cb in snapshot)
+        {
+            cb();
+        }
+    }
+
+    private sealed class CallbackRegistration : IDisposable
+    {
+        private List<Action>? _list;
+        private Action? _callback;
+
+        internal CallbackRegistration(List<Action> list, Action callback)
+        {
+            _list = list;
+            _callback = callback;
+        }
+
+        public void Dispose()
+        {
+            if (_list is not null && _callback is not null)
+            {
+                _list.Remove(_callback);
+                _list = null;
+                _callback = null;
+            }
+        }
+    }
+}

--- a/src/Components/AI/src/Engine/ConversationStatus.cs
+++ b/src/Components/AI/src/Engine/ConversationStatus.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public enum ConversationStatus
+{
+    Idle,
+    Streaming,
+    AwaitingInput,
+    Error
+}

--- a/src/Components/AI/src/Engine/UIAgent.cs
+++ b/src/Components/AI/src/Engine/UIAgent.cs
@@ -1,8 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.AspNetCore.Components.AI;
 
@@ -10,6 +13,7 @@ public class UIAgent : IDisposable
 {
     private readonly IChatClient _chatClient;
     private readonly UIAgentOptions _options;
+    private readonly ILogger _logger;
     private readonly List<ChatMessage> _history = new();
     private bool _disposed;
 
@@ -25,12 +29,23 @@ public class UIAgent : IDisposable
     {
     }
 
+    public UIAgent(IChatClient chatClient, ChatOptions chatOptions, ILoggerFactory? loggerFactory)
+        : this(chatClient, options => options.ChatOptions = chatOptions, loggerFactory)
+    {
+    }
+
     public UIAgent(IChatClient chatClient, Action<UIAgentOptions>? configure)
+        : this(chatClient, configure, loggerFactory: null)
+    {
+    }
+
+    public UIAgent(IChatClient chatClient, Action<UIAgentOptions>? configure, ILoggerFactory? loggerFactory)
     {
         ArgumentNullException.ThrowIfNull(chatClient);
         _chatClient = chatClient;
         _options = new UIAgentOptions();
         configure?.Invoke(_options);
+        _logger = (ILogger?)loggerFactory?.CreateLogger<BlockMappingPipeline>() ?? NullLogger.Instance;
     }
 
     public async IAsyncEnumerable<ContentBlock> SendMessageAsync(
@@ -41,7 +56,7 @@ public class UIAgent : IDisposable
 
         _history.Add(message);
 
-        var pipeline = new BlockMappingPipeline(_options);
+        var pipeline = new BlockMappingPipeline(_options, _logger);
 
         // Process user message through pipeline
         var userUpdate = new ChatResponseUpdate
@@ -59,18 +74,35 @@ public class UIAgent : IDisposable
         }
 
         // Stream assistant response
+        UIAgentLog.StreamingAssistantResponse(_logger);
         var assistantUpdates = new List<ChatResponseUpdate>();
+        string? turnId = null;
+        var chatOptions = BuildChatOptions();
 
+        var updateIndex = 0;
         await foreach (var update in _chatClient.GetStreamingResponseAsync(
-            _history, _options.ChatOptions, cancellationToken).ConfigureAwait(false))
+            _history, chatOptions, cancellationToken).ConfigureAwait(false))
         {
-            assistantUpdates.Add(update);
+            var contentTypes = string.Join(", ", update.Contents.Select(c => c.GetType().Name));
+            UIAgentLog.ReceivedUpdate(_logger, updateIndex++, update.Role?.Value, contentTypes);
 
-            await foreach (var block in pipeline.Process(update, cancellationToken).ConfigureAwait(false))
+            assistantUpdates.Add(update);
+            turnId ??= update.ResponseId;
+
+            var processUpdate = ApplyStateMapper(update);
+            if (processUpdate.Contents.Count == 0 && update.Contents.Count > 0)
+            {
+                // State mapper consumed all content items — skip.
+                continue;
+            }
+
+            await foreach (var block in pipeline.Process(processUpdate, cancellationToken).ConfigureAwait(false))
             {
                 yield return block;
             }
         }
+
+        UIAgentLog.StreamComplete(_logger, assistantUpdates.Count);
 
         foreach (var block in pipeline.Finalize())
         {
@@ -83,6 +115,78 @@ public class UIAgent : IDisposable
         {
             _history.Add(msg);
         }
+
+        UIAgentLog.AddedToHistory(_logger, response.Messages.Count);
+    }
+
+    internal virtual object? AgentStateObject => null;
+
+    internal virtual ChatResponseUpdate ApplyStateMapper(ChatResponseUpdate update)
+    {
+        if (_options.StateMapper is null)
+        {
+            return update;
+        }
+
+        var context = new StateMapperContext(update);
+        _options.StateMapper(context);
+
+        return context.HasHandledContent ? context.GetFilteredUpdate() : update;
+    }
+
+    internal async Task<FunctionResultContent> InvokeToolAsync(
+        FunctionCallContent call, CancellationToken cancellationToken)
+    {
+        var function = FindBackendFunction(call.Name);
+        if (function is null)
+        {
+            UIAgentLog.BackendFunctionNotFound(_logger, call.Name);
+            return new FunctionResultContent(call.CallId, $"Error: Function '{call.Name}' not found.");
+        }
+
+        UIAgentLog.InvokingBackendFunction(_logger, call.Name, call.CallId);
+        var args = call.Arguments is not null ? new AIFunctionArguments(call.Arguments) : null;
+        var result = await function.InvokeAsync(args, cancellationToken);
+        return new FunctionResultContent(call.CallId, result);
+    }
+
+    private AIFunction? FindBackendFunction(string name)
+    {
+        if (_options.ChatOptions?.Tools is null)
+        {
+            return null;
+        }
+
+        foreach (var tool in _options.ChatOptions.Tools)
+        {
+            if (tool is AIFunction function && function.Name == name)
+            {
+                return function;
+            }
+        }
+
+        return null;
+    }
+
+    private ChatOptions? BuildChatOptions()
+    {
+        if (_options.UIActions.Count == 0)
+        {
+            return _options.ChatOptions;
+        }
+
+        var chatOptions = _options.ChatOptions?.Clone() ?? new ChatOptions();
+        var tools = new List<AITool>();
+        if (chatOptions.Tools is not null)
+        {
+            tools.AddRange(chatOptions.Tools);
+        }
+        foreach (var action in _options.UIActions.Values)
+        {
+            tools.Add(action.AsDeclarationOnly());
+        }
+        chatOptions.Tools = tools;
+        return chatOptions;
     }
 
     public void Dispose()

--- a/src/Components/AI/src/Engine/UIAgentLog.cs
+++ b/src/Components/AI/src/Engine/UIAgentLog.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+internal static partial class UIAgentLog
+{
+    [LoggerMessage(100, LogLevel.Information, "SendMessageAsync: Streaming assistant response")]
+    internal static partial void StreamingAssistantResponse(ILogger logger);
+
+    [LoggerMessage(101, LogLevel.Debug, "SendMessageAsync: Received update #{Index} Role={Role}, ContentTypes=[{ContentTypes}]")]
+    internal static partial void ReceivedUpdate(ILogger logger, int index, string? role, string contentTypes);
+
+    [LoggerMessage(102, LogLevel.Information, "SendMessageAsync: Stream complete. Total updates={UpdateCount}")]
+    internal static partial void StreamComplete(ILogger logger, int updateCount);
+
+    [LoggerMessage(103, LogLevel.Debug, "SendMessageAsync: Added {MessageCount} messages to history")]
+    internal static partial void AddedToHistory(ILogger logger, int messageCount);
+
+    [LoggerMessage(104, LogLevel.Warning, "InvokeToolAsync: Backend function '{FunctionName}' not found in ChatOptions.Tools")]
+    internal static partial void BackendFunctionNotFound(ILogger logger, string functionName);
+
+    [LoggerMessage(105, LogLevel.Debug, "InvokeToolAsync: Invoking backend function '{FunctionName}' (CallId={CallId})")]
+    internal static partial void InvokingBackendFunction(ILogger logger, string functionName, string callId);
+}

--- a/src/Components/AI/src/Engine/UIAgentOfT.cs
+++ b/src/Components/AI/src/Engine/UIAgentOfT.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public class UIAgent<TState> : UIAgent where TState : class, new()
+{
+    public UIAgent(IChatClient chatClient, TState? initialState = null)
+        : base(chatClient)
+    {
+        State = new AgentState<TState>(initialState);
+    }
+
+    public UIAgent(IChatClient chatClient, ChatOptions chatOptions, TState? initialState = null)
+        : base(chatClient, chatOptions)
+    {
+        State = new AgentState<TState>(initialState);
+    }
+
+    public UIAgent(IChatClient chatClient, Action<UIAgentOptions> configure, TState? initialState = null)
+        : base(chatClient, configure)
+    {
+        State = new AgentState<TState>(initialState);
+    }
+
+    public UIAgent(IChatClient chatClient, Action<UIAgentOptions> configure, ILoggerFactory? loggerFactory, TState? initialState = null)
+        : base(chatClient, configure, loggerFactory)
+    {
+        State = new AgentState<TState>(initialState);
+    }
+
+    public AgentState<TState> State { get; }
+
+    internal override object? AgentStateObject => State;
+
+    internal override ChatResponseUpdate ApplyStateMapper(ChatResponseUpdate update)
+    {
+        if (Options.StateMapper is null)
+        {
+            return update;
+        }
+
+        var context = new StateMapperContext(update);
+        Options.StateMapper(context);
+
+        if (context.StateValue is TState typedState)
+        {
+            State.Value = typedState;
+        }
+
+        return context.HasHandledContent ? context.GetFilteredUpdate() : update;
+    }
+}

--- a/src/Components/AI/src/Pipeline/BlockMappingPipeline.cs
+++ b/src/Components/AI/src/Pipeline/BlockMappingPipeline.cs
@@ -1,8 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.AspNetCore.Components.AI;
 
@@ -10,14 +13,35 @@ internal class BlockMappingPipeline
 {
     private readonly List<IHandlerEntry> _handlers = new();
     private readonly List<IActiveEntry> _activeStack = new();
+    private readonly ILogger _logger;
 
-    internal BlockMappingPipeline(UIAgentOptions options)
+    internal BlockMappingPipeline(UIAgentOptions options, ILogger? logger = null)
     {
+        _logger = logger ?? NullLogger.Instance;
         // User-registered handlers go first so they can customize behavior
         foreach (var registration in options.HandlerRegistrations)
         {
             _handlers.Add(registration.CreateEntry());
         }
+
+        // Built-in UI action handler (claims FunctionCallContent for registered UI actions)
+        if (options.UIActions.Count > 0)
+        {
+            _handlers.Add(new HandlerEntry<UIActionHandler.UIActionHandlerState>(
+                new UIActionHandler(options.UIActions)));
+        }
+
+        // Built-in approval handler (before function invocation so it claims ToolApprovalRequestContent first)
+        _handlers.Add(new HandlerEntry<FunctionApprovalHandler.ApprovalHandlerState>(new FunctionApprovalHandler()));
+
+        // Built-in function invocation handler
+        _handlers.Add(new HandlerEntry<FunctionInvocationContentBlock>(new FunctionInvocationHandler()));
+
+        // Built-in reasoning handler (before text so reasoning completes before text takes over)
+        _handlers.Add(new HandlerEntry<ReasoningContentBlock>(new ReasoningHandler()));
+
+        // Built-in media handler (before text so DataContent is claimed before fallback)
+        _handlers.Add(new HandlerEntry<MediaContentBlock>(new MediaContentHandler()));
 
         // Built-in text handler is always last (fallback)
         _handlers.Add(new HandlerEntry<RichContentBlock>(new TextBlockHandler()));
@@ -29,6 +53,9 @@ internal class BlockMappingPipeline
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
 #pragma warning restore IDE0060
     {
+        var contentTypes = string.Join(", ", update.Contents.Select(c => c.GetType().Name));
+        BlockMappingPipelineLog.ProcessingUpdate(_logger, update.Role?.Value, update.Contents.Count, contentTypes);
+
         var context = new BlockMappingContext(update, _handlers);
 
         // Phase 1: Active entries get priority (most recent first)
@@ -41,6 +68,8 @@ internal class BlockMappingPipeline
 
             var active = _activeStack[i];
             var result = active.Invoke(context);
+
+            BlockMappingPipelineLog.ActiveHandlerResult(_logger, active.Block.GetType().Name, result.Kind.ToString(), active.Block.Id);
 
             switch (result.Kind)
             {
@@ -70,6 +99,7 @@ internal class BlockMappingPipeline
                 }
 
                 var handler = _handlers[i];
+                BlockMappingPipelineLog.TryingInactiveHandler(_logger, handler.GetType().Name);
 
                 while (!context.AllHandled)
                 {
@@ -83,6 +113,8 @@ internal class BlockMappingPipeline
                         emitBlock.LifecycleState = BlockLifecycleState.Active;
                         ThrowIfIdMissing(emitBlock);
                         _activeStack.Add(activeEntry);
+
+                        BlockMappingPipelineLog.EmittingBlock(_logger, emitBlock.GetType().Name, emitBlock.Id, emitBlock.Role?.Value);
 
                         yield return emitBlock;
 
@@ -100,11 +132,18 @@ internal class BlockMappingPipeline
                 }
             }
         }
+        else
+        {
+            BlockMappingPipelineLog.AllContentHandledAfterPhase1(_logger);
+        }
+
         await Task.CompletedTask;
     }
 
     internal IReadOnlyList<ContentBlock> Finalize()
     {
+        BlockMappingPipelineLog.Finalizing(_logger, _activeStack.Count);
+
         foreach (var active in _activeStack)
         {
             active.Block.LifecycleState = BlockLifecycleState.Inactive;

--- a/src/Components/AI/src/Pipeline/BlockMappingPipelineLog.cs
+++ b/src/Components/AI/src/Pipeline/BlockMappingPipelineLog.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+internal static partial class BlockMappingPipelineLog
+{
+    [LoggerMessage(1, LogLevel.Debug, "Processing update: Role={Role}, ContentCount={ContentCount}, ContentTypes=[{ContentTypes}]")]
+    internal static partial void ProcessingUpdate(ILogger logger, string? role, int contentCount, string contentTypes);
+
+    [LoggerMessage(2, LogLevel.Debug, "Active handler {HandlerType} returned {ResultKind} for block {BlockId}")]
+    internal static partial void ActiveHandlerResult(ILogger logger, string handlerType, string resultKind, string? blockId);
+
+    [LoggerMessage(3, LogLevel.Information, "Emitting new block: {BlockType} Id={BlockId} Role={Role}")]
+    internal static partial void EmittingBlock(ILogger logger, string blockType, string? blockId, string? role);
+
+    [LoggerMessage(4, LogLevel.Debug, "Phase 2: Trying inactive handler {HandlerType} to claim remaining content")]
+    internal static partial void TryingInactiveHandler(ILogger logger, string handlerType);
+
+    [LoggerMessage(5, LogLevel.Debug, "Finalize: Deactivating {ActiveCount} active blocks")]
+    internal static partial void Finalizing(ILogger logger, int activeCount);
+
+    [LoggerMessage(6, LogLevel.Debug, "All content handled after active handlers, skipping Phase 2")]
+    internal static partial void AllContentHandledAfterPhase1(ILogger logger);
+}

--- a/src/Components/AI/src/Pipeline/FunctionApprovalHandler.cs
+++ b/src/Components/AI/src/Pipeline/FunctionApprovalHandler.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+internal sealed class FunctionApprovalHandler : ContentBlockHandler<FunctionApprovalHandler.ApprovalHandlerState>
+{
+    public override BlockMappingResult<ApprovalHandlerState> Handle(
+        BlockMappingContext context, ApprovalHandlerState state)
+    {
+        ToolApprovalRequestContent? approvalRequest = null;
+        foreach (var content in context.UnhandledContents)
+        {
+            if (content is ToolApprovalRequestContent tar)
+            {
+                approvalRequest = tar;
+                break;
+            }
+        }
+
+        if (approvalRequest is null)
+        {
+            return BlockMappingResult<ApprovalHandlerState>.Pass();
+        }
+
+        context.MarkHandled(approvalRequest);
+
+        // Delegate the inner FunctionCallContent to produce a typed block
+        var innerBlock = context.CreateInnerBlock(approvalRequest.ToolCall)
+            as FunctionInvocationContentBlock;
+
+        if (innerBlock is null)
+        {
+            innerBlock = new FunctionInvocationContentBlock();
+            if (approvalRequest.ToolCall is FunctionCallContent fc)
+            {
+                innerBlock.Call = fc;
+            }
+        }
+
+        var block = new FunctionApprovalBlock(innerBlock, approvalRequest);
+        block.Id = approvalRequest.ToolCall is FunctionCallContent fcc
+            ? fcc.CallId
+            : Guid.NewGuid().ToString("N");
+
+        return BlockMappingResult<ApprovalHandlerState>.Emit(block, state);
+    }
+
+    internal sealed class ApprovalHandlerState
+    {
+    }
+}

--- a/src/Components/AI/src/Pipeline/FunctionInvocationHandler.cs
+++ b/src/Components/AI/src/Pipeline/FunctionInvocationHandler.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+internal sealed class FunctionInvocationHandler : ContentBlockHandler<FunctionInvocationContentBlock>
+{
+    public override BlockMappingResult<FunctionInvocationContentBlock> Handle(
+        BlockMappingContext context, FunctionInvocationContentBlock state)
+    {
+        // Check for FunctionCallContent — only when not already tracking a call
+        if (state.Call is null)
+        {
+            FunctionCallContent? callContent = null;
+            foreach (var content in context.UnhandledContents)
+            {
+                if (content is FunctionCallContent fc)
+                {
+                    callContent = fc;
+                    break;
+                }
+            }
+
+            if (callContent is not null)
+            {
+                context.MarkHandled(callContent);
+                state.Call = callContent;
+                state.Id = callContent.CallId;
+                return BlockMappingResult<FunctionInvocationContentBlock>.Emit(state, state);
+            }
+        }
+
+        // Check for FunctionResultContent matching our active block's CallId
+        FunctionResultContent? resultContent = null;
+        foreach (var content in context.UnhandledContents)
+        {
+            if (content is FunctionResultContent frc)
+            {
+                resultContent = frc;
+                break;
+            }
+        }
+
+        if (resultContent is not null && state.Call is not null && resultContent.CallId == state.Call.CallId)
+        {
+            context.MarkHandled(resultContent);
+            state.Result = resultContent;
+            return BlockMappingResult<FunctionInvocationContentBlock>.Complete();
+        }
+
+        // No matching content — wait
+        return BlockMappingResult<FunctionInvocationContentBlock>.Pass();
+    }
+}

--- a/src/Components/AI/src/Pipeline/MediaContentHandler.cs
+++ b/src/Components/AI/src/Pipeline/MediaContentHandler.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+internal sealed class MediaContentHandler : ContentBlockHandler<MediaContentBlock>
+{
+    public override BlockMappingResult<MediaContentBlock> Handle(
+        BlockMappingContext context, MediaContentBlock state)
+    {
+        DataContent? dataContent = null;
+        foreach (var content in context.UnhandledContents)
+        {
+            if (content is DataContent dc)
+            {
+                dataContent = dc;
+                break;
+            }
+        }
+
+        if (dataContent is null)
+        {
+            if (state.Items.Count > 0)
+            {
+                return BlockMappingResult<MediaContentBlock>.Complete();
+            }
+            return BlockMappingResult<MediaContentBlock>.Pass();
+        }
+
+        context.MarkHandled(dataContent);
+
+        if (state.Items.Count == 0)
+        {
+            state.AddContent(dataContent);
+            state.Id = context.Update.MessageId ?? Guid.NewGuid().ToString("N");
+            return BlockMappingResult<MediaContentBlock>.Emit(state, state);
+        }
+        else
+        {
+            state.AddContent(dataContent);
+            return BlockMappingResult<MediaContentBlock>.Update(state);
+        }
+    }
+}

--- a/src/Components/AI/src/Pipeline/ReasoningHandler.cs
+++ b/src/Components/AI/src/Pipeline/ReasoningHandler.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+internal sealed class ReasoningHandler : ContentBlockHandler<ReasoningContentBlock>
+{
+    public override BlockMappingResult<ReasoningContentBlock> Handle(
+        BlockMappingContext context, ReasoningContentBlock state)
+    {
+        TextReasoningContent? reasoningContent = null;
+        foreach (var content in context.UnhandledContents)
+        {
+            if (content is TextReasoningContent trc)
+            {
+                reasoningContent = trc;
+                break;
+            }
+        }
+
+        if (reasoningContent is null)
+        {
+            if (state.Text.Length > 0 || state.ProtectedData is not null)
+            {
+                return BlockMappingResult<ReasoningContentBlock>.Complete();
+            }
+
+            return BlockMappingResult<ReasoningContentBlock>.Pass();
+        }
+
+        context.MarkHandled(reasoningContent);
+
+        if (reasoningContent.ProtectedData is not null)
+        {
+            state.ProtectedData = reasoningContent.ProtectedData;
+        }
+
+        var text = reasoningContent.Text;
+        if (!string.IsNullOrEmpty(text))
+        {
+            state.AppendText(text);
+        }
+
+        if (state.Text.Length == 0 && state.ProtectedData is null)
+        {
+            return BlockMappingResult<ReasoningContentBlock>.Pass();
+        }
+
+        if (state.LifecycleState != BlockLifecycleState.Active)
+        {
+            state.Id = context.Update.MessageId ?? Guid.NewGuid().ToString("N");
+            return BlockMappingResult<ReasoningContentBlock>.Emit(state, state);
+        }
+        else
+        {
+            return BlockMappingResult<ReasoningContentBlock>.Update(state);
+        }
+    }
+}

--- a/src/Components/AI/src/Pipeline/StateMapperContext.cs
+++ b/src/Components/AI/src/Pipeline/StateMapperContext.cs
@@ -1,0 +1,89 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public class StateMapperContext
+{
+    private readonly bool[] _handled;
+    private int _handledCount;
+
+    internal StateMapperContext(ChatResponseUpdate update)
+    {
+        Update = update;
+        _handled = new bool[update.Contents.Count];
+    }
+
+    public ChatResponseUpdate Update { get; }
+
+    public IEnumerable<AIContent> UnhandledContents
+    {
+        get
+        {
+            var contents = Update.Contents;
+            for (var i = 0; i < contents.Count; i++)
+            {
+                if (!_handled[i])
+                {
+                    yield return contents[i];
+                }
+            }
+        }
+    }
+
+    public void MarkHandled(AIContent content)
+    {
+        var contents = Update.Contents;
+        for (var i = 0; i < contents.Count; i++)
+        {
+            if (ReferenceEquals(contents[i], content))
+            {
+                if (!_handled[i])
+                {
+                    _handled[i] = true;
+                    _handledCount++;
+                }
+                return;
+            }
+        }
+    }
+
+    public object? StateValue { get; private set; }
+
+    public void SetState(object value)
+    {
+        StateValue = value;
+    }
+
+    internal bool HasHandledContent => _handledCount > 0;
+
+    internal ChatResponseUpdate GetFilteredUpdate()
+    {
+        if (_handledCount == 0)
+        {
+            return Update;
+        }
+
+        var filtered = new List<AIContent>();
+        var contents = Update.Contents;
+        for (var i = 0; i < contents.Count; i++)
+        {
+            if (!_handled[i])
+            {
+                filtered.Add(contents[i]);
+            }
+        }
+
+        return new ChatResponseUpdate
+        {
+            Role = Update.Role,
+            AuthorName = Update.AuthorName,
+            MessageId = Update.MessageId,
+            ResponseId = Update.ResponseId,
+            FinishReason = Update.FinishReason,
+            Contents = filtered,
+        };
+    }
+}

--- a/src/Components/AI/src/Pipeline/UIActionHandler.cs
+++ b/src/Components/AI/src/Pipeline/UIActionHandler.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+internal sealed class UIActionHandler : ContentBlockHandler<UIActionHandler.UIActionHandlerState>
+{
+    private readonly IReadOnlyDictionary<string, AIFunction> _uiActions;
+
+    internal UIActionHandler(IReadOnlyDictionary<string, AIFunction> uiActions)
+    {
+        _uiActions = uiActions;
+    }
+
+    public override BlockMappingResult<UIActionHandlerState> Handle(
+        BlockMappingContext context, UIActionHandlerState state)
+    {
+        foreach (var content in context.UnhandledContents)
+        {
+            if (content is FunctionCallContent fcc && _uiActions.TryGetValue(fcc.Name, out var function))
+            {
+                context.MarkHandled(fcc);
+                var innerBlock = new FunctionInvocationContentBlock();
+                innerBlock.Call = fcc;
+                innerBlock.Id = fcc.CallId ?? Guid.NewGuid().ToString("N");
+                var block = new UIActionBlock(function, innerBlock);
+                block.Id = innerBlock.Id;
+                return BlockMappingResult<UIActionHandlerState>.Emit(block, state);
+            }
+        }
+
+        return BlockMappingResult<UIActionHandlerState>.Pass();
+    }
+
+    internal sealed class UIActionHandlerState
+    {
+    }
+}

--- a/src/Components/AI/src/Pipeline/UIAgentOptions.cs
+++ b/src/Components/AI/src/Pipeline/UIAgentOptions.cs
@@ -9,13 +9,22 @@ public class UIAgentOptions
 {
     public ChatOptions? ChatOptions { get; set; }
 
+    public Func<StateMapperContext, bool>? StateMapper { get; set; }
+
     internal List<IHandlerRegistration> HandlerRegistrations { get; } = new();
+
+    internal Dictionary<string, AIFunction> UIActions { get; } = new();
 
     public void AddBlockHandler<TState>(ContentBlockHandler<TState> handler)
         where TState : new()
     {
         ArgumentNullException.ThrowIfNull(handler);
         HandlerRegistrations.Add(new HandlerRegistration<TState>(handler));
+    }
+
+    public void RegisterUIAction(AIFunction function)
+    {
+        UIActions.Add(function.Name, function);
     }
 
     internal interface IHandlerRegistration

--- a/src/Components/AI/test/Baselines/MixedToolCall_BackendAndUIAction.recording.json
+++ b/src/Components/AI/test/Baselines/MixedToolCall_BackendAndUIAction.recording.json
@@ -1,0 +1,1654 @@
+[
+  [
+    {
+      "contents": [],
+      "responseId": "",
+      "messageId": "",
+      "createdAt": "1970-01-01T00:00:00+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DPBADO9F0m963wPBBxw0iejuq1lir",
+      "messageId": "chatcmpl-DPBADO9F0m963wPBBxw0iejuq1lir",
+      "createdAt": "2026-03-30T17:58:05+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DPBADO9F0m963wPBBxw0iejuq1lir",
+      "messageId": "chatcmpl-DPBADO9F0m963wPBBxw0iejuq1lir",
+      "createdAt": "2026-03-30T17:58:05+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DPBADO9F0m963wPBBxw0iejuq1lir",
+      "messageId": "chatcmpl-DPBADO9F0m963wPBBxw0iejuq1lir",
+      "createdAt": "2026-03-30T17:58:05+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DPBADO9F0m963wPBBxw0iejuq1lir",
+      "messageId": "chatcmpl-DPBADO9F0m963wPBBxw0iejuq1lir",
+      "createdAt": "2026-03-30T17:58:05+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DPBADO9F0m963wPBBxw0iejuq1lir",
+      "messageId": "chatcmpl-DPBADO9F0m963wPBBxw0iejuq1lir",
+      "createdAt": "2026-03-30T17:58:05+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DPBADO9F0m963wPBBxw0iejuq1lir",
+      "messageId": "chatcmpl-DPBADO9F0m963wPBBxw0iejuq1lir",
+      "createdAt": "2026-03-30T17:58:05+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DPBADO9F0m963wPBBxw0iejuq1lir",
+      "messageId": "chatcmpl-DPBADO9F0m963wPBBxw0iejuq1lir",
+      "createdAt": "2026-03-30T17:58:05+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DPBADO9F0m963wPBBxw0iejuq1lir",
+      "messageId": "chatcmpl-DPBADO9F0m963wPBBxw0iejuq1lir",
+      "createdAt": "2026-03-30T17:58:05+00:00",
+      "finishReason": "tool_calls",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "usage",
+          "details": {
+            "inputTokenCount": 177,
+            "outputTokenCount": 820,
+            "totalTokenCount": 997,
+            "cachedInputTokenCount": 0,
+            "reasoningTokenCount": 768,
+            "additionalCounts": {
+              "InputTokenDetails.AudioTokenCount": 0,
+              "OutputTokenDetails.AudioTokenCount": 0,
+              "OutputTokenDetails.AcceptedPredictionTokenCount": 0,
+              "OutputTokenDetails.RejectedPredictionTokenCount": 0
+            }
+          }
+        }
+      ],
+      "responseId": "chatcmpl-DPBADO9F0m963wPBBxw0iejuq1lir",
+      "messageId": "chatcmpl-DPBADO9F0m963wPBBxw0iejuq1lir",
+      "createdAt": "2026-03-30T17:58:05+00:00",
+      "finishReason": "tool_calls",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "functionCall",
+          "name": "GetUserLocation",
+          "arguments": {},
+          "informationalOnly": false,
+          "callId": "call_RyJU8kgNr6QAW1v1jA0XBHIz"
+        },
+        {
+          "$type": "functionCall",
+          "name": "GetWeather",
+          "arguments": {
+            "city": ""
+          },
+          "informationalOnly": false,
+          "callId": "call_cei0Dh7IshAHpChgGxqPet19"
+        }
+      ],
+      "responseId": "",
+      "messageId": "",
+      "createdAt": "1970-01-01T00:00:00+00:00",
+      "finishReason": "tool_calls",
+      "modelId": ""
+    }
+  ],
+  [
+    {
+      "contents": [],
+      "responseId": "",
+      "messageId": "",
+      "createdAt": "1970-01-01T00:00:00+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ""
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "I"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " ran"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " both"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " tools"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " in"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " parallel"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ".\n\n"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "-"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Get"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "User"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "Location"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " returned"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ":"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Seattle"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " WA"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " ("
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "47"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "."
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "61"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "°"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "N"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " "
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "122"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "."
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "33"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "°"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "W"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ").\n"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "-"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Get"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "Weather"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " returned"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ":"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " \""
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "The"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " weather"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " in"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " "
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " is"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " "
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "72"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "°F"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " and"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " sunny"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ".\"\n\n"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "Note"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ":"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Get"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "Weather"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " was"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " called"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " with"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " an"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " empty"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " city"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " parameter"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " so"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " its"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " output"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " omitted"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " the"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " city"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " name"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "."
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " It"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " reported"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " "
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "72"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "°F"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " and"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " sunny"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " —"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " which"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " likely"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " applies"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " to"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " your"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " location"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " ("
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "Seattle"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "),"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " but"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " if"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " you"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "’d"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " like"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " exact"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " I"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " can"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " re"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "-run"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Get"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "Weather"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " now"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " using"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " \""
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "Seattle"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " WA"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "\""
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " or"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " the"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " coordinates"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "."
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Which"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " do"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " you"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " prefer"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "?"
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "finishReason": "stop",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "usage",
+          "details": {
+            "inputTokenCount": 276,
+            "outputTokenCount": 635,
+            "totalTokenCount": 911,
+            "cachedInputTokenCount": 0,
+            "reasoningTokenCount": 512,
+            "additionalCounts": {
+              "InputTokenDetails.AudioTokenCount": 0,
+              "OutputTokenDetails.AudioTokenCount": 0,
+              "OutputTokenDetails.AcceptedPredictionTokenCount": 0,
+              "OutputTokenDetails.RejectedPredictionTokenCount": 0
+            }
+          }
+        }
+      ],
+      "responseId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "messageId": "chatcmpl-DPBAOqFtlYSYWnfUdRFbX30DxuHs8",
+      "createdAt": "2026-03-30T17:58:16+00:00",
+      "finishReason": "stop",
+      "modelId": ""
+    }
+  ]
+]

--- a/src/Components/AI/test/Baselines/Step01_GettingStartedTest.PostRun_MultiTurn_SynthesizesAssistantMessages.recording.json
+++ b/src/Components/AI/test/Baselines/Step01_GettingStartedTest.PostRun_MultiTurn_SynthesizesAssistantMessages.recording.json
@@ -1,0 +1,467 @@
+[
+  [
+    {
+      "contents": [],
+      "responseId": "",
+      "messageId": "",
+      "createdAt": "1970-01-01T00:00:00+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ""
+        }
+      ],
+      "responseId": "chatcmpl-DNK5f0tCXQyerIASnba3fxJp1X5yJ",
+      "messageId": "chatcmpl-DNK5f0tCXQyerIASnba3fxJp1X5yJ",
+      "createdAt": "2026-03-25T15:05:43+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "Hello"
+        }
+      ],
+      "responseId": "chatcmpl-DNK5f0tCXQyerIASnba3fxJp1X5yJ",
+      "messageId": "chatcmpl-DNK5f0tCXQyerIASnba3fxJp1X5yJ",
+      "createdAt": "2026-03-25T15:05:43+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "!"
+        }
+      ],
+      "responseId": "chatcmpl-DNK5f0tCXQyerIASnba3fxJp1X5yJ",
+      "messageId": "chatcmpl-DNK5f0tCXQyerIASnba3fxJp1X5yJ",
+      "createdAt": "2026-03-25T15:05:43+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " How"
+        }
+      ],
+      "responseId": "chatcmpl-DNK5f0tCXQyerIASnba3fxJp1X5yJ",
+      "messageId": "chatcmpl-DNK5f0tCXQyerIASnba3fxJp1X5yJ",
+      "createdAt": "2026-03-25T15:05:43+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " can"
+        }
+      ],
+      "responseId": "chatcmpl-DNK5f0tCXQyerIASnba3fxJp1X5yJ",
+      "messageId": "chatcmpl-DNK5f0tCXQyerIASnba3fxJp1X5yJ",
+      "createdAt": "2026-03-25T15:05:43+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " I"
+        }
+      ],
+      "responseId": "chatcmpl-DNK5f0tCXQyerIASnba3fxJp1X5yJ",
+      "messageId": "chatcmpl-DNK5f0tCXQyerIASnba3fxJp1X5yJ",
+      "createdAt": "2026-03-25T15:05:43+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " help"
+        }
+      ],
+      "responseId": "chatcmpl-DNK5f0tCXQyerIASnba3fxJp1X5yJ",
+      "messageId": "chatcmpl-DNK5f0tCXQyerIASnba3fxJp1X5yJ",
+      "createdAt": "2026-03-25T15:05:43+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " you"
+        }
+      ],
+      "responseId": "chatcmpl-DNK5f0tCXQyerIASnba3fxJp1X5yJ",
+      "messageId": "chatcmpl-DNK5f0tCXQyerIASnba3fxJp1X5yJ",
+      "createdAt": "2026-03-25T15:05:43+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " today"
+        }
+      ],
+      "responseId": "chatcmpl-DNK5f0tCXQyerIASnba3fxJp1X5yJ",
+      "messageId": "chatcmpl-DNK5f0tCXQyerIASnba3fxJp1X5yJ",
+      "createdAt": "2026-03-25T15:05:43+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "?"
+        }
+      ],
+      "responseId": "chatcmpl-DNK5f0tCXQyerIASnba3fxJp1X5yJ",
+      "messageId": "chatcmpl-DNK5f0tCXQyerIASnba3fxJp1X5yJ",
+      "createdAt": "2026-03-25T15:05:43+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DNK5f0tCXQyerIASnba3fxJp1X5yJ",
+      "messageId": "chatcmpl-DNK5f0tCXQyerIASnba3fxJp1X5yJ",
+      "createdAt": "2026-03-25T15:05:43+00:00",
+      "finishReason": "stop",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "usage",
+          "details": {
+            "inputTokenCount": 7,
+            "outputTokenCount": 83,
+            "totalTokenCount": 90,
+            "cachedInputTokenCount": 0,
+            "reasoningTokenCount": 64,
+            "additionalCounts": {
+              "InputTokenDetails.AudioTokenCount": 0,
+              "OutputTokenDetails.AudioTokenCount": 0,
+              "OutputTokenDetails.AcceptedPredictionTokenCount": 0,
+              "OutputTokenDetails.RejectedPredictionTokenCount": 0
+            }
+          }
+        }
+      ],
+      "responseId": "chatcmpl-DNK5f0tCXQyerIASnba3fxJp1X5yJ",
+      "messageId": "chatcmpl-DNK5f0tCXQyerIASnba3fxJp1X5yJ",
+      "createdAt": "2026-03-25T15:05:43+00:00",
+      "finishReason": "stop",
+      "modelId": ""
+    }
+  ],
+  [
+    {
+      "contents": [],
+      "responseId": "",
+      "messageId": "",
+      "createdAt": "1970-01-01T00:00:00+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ""
+        }
+      ],
+      "responseId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "messageId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "createdAt": "2026-03-25T15:05:45+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "I'm"
+        }
+      ],
+      "responseId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "messageId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "createdAt": "2026-03-25T15:05:45+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " doing"
+        }
+      ],
+      "responseId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "messageId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "createdAt": "2026-03-25T15:05:45+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " well"
+        }
+      ],
+      "responseId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "messageId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "createdAt": "2026-03-25T15:05:45+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "messageId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "createdAt": "2026-03-25T15:05:45+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " thanks"
+        }
+      ],
+      "responseId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "messageId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "createdAt": "2026-03-25T15:05:45+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " —"
+        }
+      ],
+      "responseId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "messageId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "createdAt": "2026-03-25T15:05:45+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " ready"
+        }
+      ],
+      "responseId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "messageId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "createdAt": "2026-03-25T15:05:45+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " to"
+        }
+      ],
+      "responseId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "messageId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "createdAt": "2026-03-25T15:05:45+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " help"
+        }
+      ],
+      "responseId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "messageId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "createdAt": "2026-03-25T15:05:45+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "."
+        }
+      ],
+      "responseId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "messageId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "createdAt": "2026-03-25T15:05:45+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " What"
+        }
+      ],
+      "responseId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "messageId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "createdAt": "2026-03-25T15:05:45+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " can"
+        }
+      ],
+      "responseId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "messageId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "createdAt": "2026-03-25T15:05:45+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " I"
+        }
+      ],
+      "responseId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "messageId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "createdAt": "2026-03-25T15:05:45+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " do"
+        }
+      ],
+      "responseId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "messageId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "createdAt": "2026-03-25T15:05:45+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " for"
+        }
+      ],
+      "responseId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "messageId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "createdAt": "2026-03-25T15:05:45+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " you"
+        }
+      ],
+      "responseId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "messageId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "createdAt": "2026-03-25T15:05:45+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " today"
+        }
+      ],
+      "responseId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "messageId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "createdAt": "2026-03-25T15:05:45+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "?"
+        }
+      ],
+      "responseId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "messageId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "createdAt": "2026-03-25T15:05:45+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "messageId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "createdAt": "2026-03-25T15:05:45+00:00",
+      "finishReason": "stop",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "usage",
+          "details": {
+            "inputTokenCount": 30,
+            "outputTokenCount": 28,
+            "totalTokenCount": 58,
+            "cachedInputTokenCount": 0,
+            "reasoningTokenCount": 0,
+            "additionalCounts": {
+              "InputTokenDetails.AudioTokenCount": 0,
+              "OutputTokenDetails.AudioTokenCount": 0,
+              "OutputTokenDetails.AcceptedPredictionTokenCount": 0,
+              "OutputTokenDetails.RejectedPredictionTokenCount": 0
+            }
+          }
+        }
+      ],
+      "responseId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "messageId": "chatcmpl-DNK5h9pDxGCZSqBJhGNGLHehCCJXG",
+      "createdAt": "2026-03-25T15:05:45+00:00",
+      "finishReason": "stop",
+      "modelId": ""
+    }
+  ]
+]

--- a/src/Components/AI/test/Baselines/Step02_BackendToolsTest.PostRun_WithBackendToolCall_InvokesToolAndStreamsResult.recording.json
+++ b/src/Components/AI/test/Baselines/Step02_BackendToolsTest.PostRun_WithBackendToolCall_InvokesToolAndStreamsResult.recording.json
@@ -1,0 +1,83 @@
+[
+  [
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "functionCall",
+          "name": "SearchRestaurants",
+          "arguments": {
+            "request": {
+              "location": "Seattle",
+              "cuisine": "Italian"
+            }
+          },
+          "informationalOnly": false,
+          "callId": "call_abc123"
+        }
+      ],
+      "messageId": "chatcmpl-tool1",
+      "finishReason": "toolCalls"
+    },
+    {
+      "contents": [
+        {
+          "$type": "functionResult",
+          "result": "{\"location\":\"Seattle\",\"cuisine\":\"Italian\",\"results\":[{\"name\":\"The Golden Fork\",\"cuisine\":\"Italian\",\"rating\":4.5,\"address\":\"123 Main St, Seattle\"},{\"name\":\"Spice Haven\",\"cuisine\":\"Indian\",\"rating\":4.7,\"address\":\"456 Oak Ave, Seattle\"},{\"name\":\"Green Leaf\",\"cuisine\":\"Vegetarian\",\"rating\":4.3,\"address\":\"789 Elm Rd, Seattle\"}]}",
+          "callId": "call_abc123"
+        }
+      ]
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "I found some great Italian restaurants in Seattle for you!\n\n"
+        }
+      ],
+      "messageId": "chatcmpl-text1"
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "1. **The Golden Fork** - Italian cuisine, rated 4.5/5, located at 123 Main St, Seattle\n"
+        }
+      ],
+      "messageId": "chatcmpl-text1"
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "2. **Spice Haven** - Indian cuisine, rated 4.7/5, located at 456 Oak Ave, Seattle\n"
+        }
+      ],
+      "messageId": "chatcmpl-text1"
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "3. **Green Leaf** - Vegetarian cuisine, rated 4.3/5, located at 789 Elm Rd, Seattle"
+        }
+      ],
+      "messageId": "chatcmpl-text1"
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ""
+        }
+      ],
+      "messageId": "chatcmpl-text1",
+      "finishReason": "stop"
+    }
+  ]
+]

--- a/src/Components/AI/test/Baselines/Step04_HumanInLoopTest.PostRun_WithApprovalRequired_ApprovesAndExecutesTool.recording.json
+++ b/src/Components/AI/test/Baselines/Step04_HumanInLoopTest.PostRun_WithApprovalRequired_ApprovesAndExecutesTool.recording.json
@@ -1,0 +1,20 @@
+[
+  [
+    {
+      "role": "Assistant",
+      "contents": [
+        {
+          "$type": "functionCall",
+          "name": "ApproveExpenseReport",
+          "arguments": {
+            "expenseReportId": "EXP-2024-001"
+          },
+          "informationalOnly": false,
+          "callId": "call_expense_001"
+        }
+      ],
+      "finishReason": "toolCalls",
+      "modelId": "gpt-4o-mini"
+    }
+  ]
+]

--- a/src/Components/AI/test/Baselines/Step05_StateManagementTest.PostRun_WithState_EmitsStateSnapshotAndSummary.recording.json
+++ b/src/Components/AI/test/Baselines/Step05_StateManagementTest.PostRun_WithState_EmitsStateSnapshotAndSummary.recording.json
@@ -1,0 +1,26 @@
+[
+  [
+    {
+      "role": "Assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "{\"recipe\":{\"title\":\"Classic Spaghetti Carbonara\",\"cuisine\":\"Italian\",\"ingredients\":[\"400g spaghetti\",\"200g guanciale or pancetta\",\"4 large egg yolks\",\"100g Pecorino Romano cheese, grated\",\"Freshly ground black pepper\",\"Salt for pasta water\"],\"steps\":[\"Bring a large pot of salted water to boil and cook spaghetti until al dente.\",\"While pasta cooks, cut guanciale into small strips and cook in a dry pan over medium heat until crispy.\",\"In a bowl, whisk together egg yolks and grated Pecorino Romano.\",\"Drain pasta, reserving 1 cup of pasta water.\",\"Toss hot pasta with guanciale, then remove from heat.\",\"Add egg and cheese mixture, tossing quickly to create a creamy sauce. Add pasta water as needed.\",\"Season generously with black pepper and serve immediately.\"],\"prep_time_minutes\":10,\"cook_time_minutes\":20,\"skill_level\":\"intermediate\"}}"
+        }
+      ],
+      "modelId": "gpt-4o-mini"
+    }
+  ],
+  [
+    {
+      "role": "Assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "Here's a Classic Spaghetti Carbonara recipe — an intermediate Italian dish with guanciale, egg yolks, and Pecorino Romano. It takes about 30 minutes total to prepare and cook."
+        }
+      ],
+      "modelId": "gpt-4o-mini"
+    }
+  ]
+]

--- a/src/Components/AI/test/Baselines/TextStreaming_MultiTurn.recording.json
+++ b/src/Components/AI/test/Baselines/TextStreaming_MultiTurn.recording.json
@@ -1,0 +1,181 @@
+[
+  [
+    {
+      "contents": [],
+      "responseId": "",
+      "messageId": "",
+      "createdAt": "1970-01-01T00:00:00+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ""
+        }
+      ],
+      "responseId": "chatcmpl-DP9gKSl59H5uAXksKRvNWmSGzLSE2",
+      "messageId": "chatcmpl-DP9gKSl59H5uAXksKRvNWmSGzLSE2",
+      "createdAt": "2026-03-30T16:23:08+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "Hello"
+        }
+      ],
+      "responseId": "chatcmpl-DP9gKSl59H5uAXksKRvNWmSGzLSE2",
+      "messageId": "chatcmpl-DP9gKSl59H5uAXksKRvNWmSGzLSE2",
+      "createdAt": "2026-03-30T16:23:08+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "!"
+        }
+      ],
+      "responseId": "chatcmpl-DP9gKSl59H5uAXksKRvNWmSGzLSE2",
+      "messageId": "chatcmpl-DP9gKSl59H5uAXksKRvNWmSGzLSE2",
+      "createdAt": "2026-03-30T16:23:08+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DP9gKSl59H5uAXksKRvNWmSGzLSE2",
+      "messageId": "chatcmpl-DP9gKSl59H5uAXksKRvNWmSGzLSE2",
+      "createdAt": "2026-03-30T16:23:08+00:00",
+      "finishReason": "stop",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "usage",
+          "details": {
+            "inputTokenCount": 12,
+            "outputTokenCount": 140,
+            "totalTokenCount": 152,
+            "cachedInputTokenCount": 0,
+            "reasoningTokenCount": 128,
+            "additionalCounts": {
+              "InputTokenDetails.AudioTokenCount": 0,
+              "OutputTokenDetails.AudioTokenCount": 0,
+              "OutputTokenDetails.AcceptedPredictionTokenCount": 0,
+              "OutputTokenDetails.RejectedPredictionTokenCount": 0
+            }
+          }
+        }
+      ],
+      "responseId": "chatcmpl-DP9gKSl59H5uAXksKRvNWmSGzLSE2",
+      "messageId": "chatcmpl-DP9gKSl59H5uAXksKRvNWmSGzLSE2",
+      "createdAt": "2026-03-30T16:23:08+00:00",
+      "finishReason": "stop",
+      "modelId": ""
+    }
+  ],
+  [
+    {
+      "contents": [],
+      "responseId": "",
+      "messageId": "",
+      "createdAt": "1970-01-01T00:00:00+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ""
+        }
+      ],
+      "responseId": "chatcmpl-DP9gOJsuvLblKULPhnLXcUtGJrCQ0",
+      "messageId": "chatcmpl-DP9gOJsuvLblKULPhnLXcUtGJrCQ0",
+      "createdAt": "2026-03-30T16:23:12+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "Good"
+        }
+      ],
+      "responseId": "chatcmpl-DP9gOJsuvLblKULPhnLXcUtGJrCQ0",
+      "messageId": "chatcmpl-DP9gOJsuvLblKULPhnLXcUtGJrCQ0",
+      "createdAt": "2026-03-30T16:23:12+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "bye"
+        }
+      ],
+      "responseId": "chatcmpl-DP9gOJsuvLblKULPhnLXcUtGJrCQ0",
+      "messageId": "chatcmpl-DP9gOJsuvLblKULPhnLXcUtGJrCQ0",
+      "createdAt": "2026-03-30T16:23:12+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "!"
+        }
+      ],
+      "responseId": "chatcmpl-DP9gOJsuvLblKULPhnLXcUtGJrCQ0",
+      "messageId": "chatcmpl-DP9gOJsuvLblKULPhnLXcUtGJrCQ0",
+      "createdAt": "2026-03-30T16:23:12+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DP9gOJsuvLblKULPhnLXcUtGJrCQ0",
+      "messageId": "chatcmpl-DP9gOJsuvLblKULPhnLXcUtGJrCQ0",
+      "createdAt": "2026-03-30T16:23:12+00:00",
+      "finishReason": "stop",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "usage",
+          "details": {
+            "inputTokenCount": 31,
+            "outputTokenCount": 77,
+            "totalTokenCount": 108,
+            "cachedInputTokenCount": 0,
+            "reasoningTokenCount": 64,
+            "additionalCounts": {
+              "InputTokenDetails.AudioTokenCount": 0,
+              "OutputTokenDetails.AudioTokenCount": 0,
+              "OutputTokenDetails.AcceptedPredictionTokenCount": 0,
+              "OutputTokenDetails.RejectedPredictionTokenCount": 0
+            }
+          }
+        }
+      ],
+      "responseId": "chatcmpl-DP9gOJsuvLblKULPhnLXcUtGJrCQ0",
+      "messageId": "chatcmpl-DP9gOJsuvLblKULPhnLXcUtGJrCQ0",
+      "createdAt": "2026-03-30T16:23:12+00:00",
+      "finishReason": "stop",
+      "modelId": ""
+    }
+  ]
+]

--- a/src/Components/AI/test/Baselines/TextStreaming_SingleTurn.recording.json
+++ b/src/Components/AI/test/Baselines/TextStreaming_SingleTurn.recording.json
@@ -1,0 +1,189 @@
+[
+  [
+    {
+      "contents": [],
+      "responseId": "",
+      "messageId": "",
+      "createdAt": "1970-01-01T00:00:00+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ""
+        }
+      ],
+      "responseId": "chatcmpl-DP9g4YZDnQ9mmK9hJeubou7W7b9iR",
+      "messageId": "chatcmpl-DP9g4YZDnQ9mmK9hJeubou7W7b9iR",
+      "createdAt": "2026-03-30T16:22:52+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "Hello"
+        }
+      ],
+      "responseId": "chatcmpl-DP9g4YZDnQ9mmK9hJeubou7W7b9iR",
+      "messageId": "chatcmpl-DP9g4YZDnQ9mmK9hJeubou7W7b9iR",
+      "createdAt": "2026-03-30T16:22:52+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " —"
+        }
+      ],
+      "responseId": "chatcmpl-DP9g4YZDnQ9mmK9hJeubou7W7b9iR",
+      "messageId": "chatcmpl-DP9g4YZDnQ9mmK9hJeubou7W7b9iR",
+      "createdAt": "2026-03-30T16:22:52+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " I"
+        }
+      ],
+      "responseId": "chatcmpl-DP9g4YZDnQ9mmK9hJeubou7W7b9iR",
+      "messageId": "chatcmpl-DP9g4YZDnQ9mmK9hJeubou7W7b9iR",
+      "createdAt": "2026-03-30T16:22:52+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " hope"
+        }
+      ],
+      "responseId": "chatcmpl-DP9g4YZDnQ9mmK9hJeubou7W7b9iR",
+      "messageId": "chatcmpl-DP9g4YZDnQ9mmK9hJeubou7W7b9iR",
+      "createdAt": "2026-03-30T16:22:52+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " you're"
+        }
+      ],
+      "responseId": "chatcmpl-DP9g4YZDnQ9mmK9hJeubou7W7b9iR",
+      "messageId": "chatcmpl-DP9g4YZDnQ9mmK9hJeubou7W7b9iR",
+      "createdAt": "2026-03-30T16:22:52+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " having"
+        }
+      ],
+      "responseId": "chatcmpl-DP9g4YZDnQ9mmK9hJeubou7W7b9iR",
+      "messageId": "chatcmpl-DP9g4YZDnQ9mmK9hJeubou7W7b9iR",
+      "createdAt": "2026-03-30T16:22:52+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " a"
+        }
+      ],
+      "responseId": "chatcmpl-DP9g4YZDnQ9mmK9hJeubou7W7b9iR",
+      "messageId": "chatcmpl-DP9g4YZDnQ9mmK9hJeubou7W7b9iR",
+      "createdAt": "2026-03-30T16:22:52+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " great"
+        }
+      ],
+      "responseId": "chatcmpl-DP9g4YZDnQ9mmK9hJeubou7W7b9iR",
+      "messageId": "chatcmpl-DP9g4YZDnQ9mmK9hJeubou7W7b9iR",
+      "createdAt": "2026-03-30T16:22:52+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " day"
+        }
+      ],
+      "responseId": "chatcmpl-DP9g4YZDnQ9mmK9hJeubou7W7b9iR",
+      "messageId": "chatcmpl-DP9g4YZDnQ9mmK9hJeubou7W7b9iR",
+      "createdAt": "2026-03-30T16:22:52+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "!"
+        }
+      ],
+      "responseId": "chatcmpl-DP9g4YZDnQ9mmK9hJeubou7W7b9iR",
+      "messageId": "chatcmpl-DP9g4YZDnQ9mmK9hJeubou7W7b9iR",
+      "createdAt": "2026-03-30T16:22:52+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DP9g4YZDnQ9mmK9hJeubou7W7b9iR",
+      "messageId": "chatcmpl-DP9g4YZDnQ9mmK9hJeubou7W7b9iR",
+      "createdAt": "2026-03-30T16:22:52+00:00",
+      "finishReason": "stop",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "usage",
+          "details": {
+            "inputTokenCount": 12,
+            "outputTokenCount": 212,
+            "totalTokenCount": 224,
+            "cachedInputTokenCount": 0,
+            "reasoningTokenCount": 192,
+            "additionalCounts": {
+              "InputTokenDetails.AudioTokenCount": 0,
+              "OutputTokenDetails.AudioTokenCount": 0,
+              "OutputTokenDetails.AcceptedPredictionTokenCount": 0,
+              "OutputTokenDetails.RejectedPredictionTokenCount": 0
+            }
+          }
+        }
+      ],
+      "responseId": "chatcmpl-DP9g4YZDnQ9mmK9hJeubou7W7b9iR",
+      "messageId": "chatcmpl-DP9g4YZDnQ9mmK9hJeubou7W7b9iR",
+      "createdAt": "2026-03-30T16:22:52+00:00",
+      "finishReason": "stop",
+      "modelId": ""
+    }
+  ]
+]

--- a/src/Components/AI/test/Baselines/ToolApproval_HumanInLoop.recording.json
+++ b/src/Components/AI/test/Baselines/ToolApproval_HumanInLoop.recording.json
@@ -1,0 +1,281 @@
+[
+  [
+    {
+      "contents": [],
+      "responseId": "",
+      "messageId": "",
+      "createdAt": "1970-01-01T00:00:00+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DP9gmCztP9RTJdetFqkdXyBuRpM2l",
+      "messageId": "chatcmpl-DP9gmCztP9RTJdetFqkdXyBuRpM2l",
+      "createdAt": "2026-03-30T16:23:36+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DP9gmCztP9RTJdetFqkdXyBuRpM2l",
+      "messageId": "chatcmpl-DP9gmCztP9RTJdetFqkdXyBuRpM2l",
+      "createdAt": "2026-03-30T16:23:36+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DP9gmCztP9RTJdetFqkdXyBuRpM2l",
+      "messageId": "chatcmpl-DP9gmCztP9RTJdetFqkdXyBuRpM2l",
+      "createdAt": "2026-03-30T16:23:36+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DP9gmCztP9RTJdetFqkdXyBuRpM2l",
+      "messageId": "chatcmpl-DP9gmCztP9RTJdetFqkdXyBuRpM2l",
+      "createdAt": "2026-03-30T16:23:36+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DP9gmCztP9RTJdetFqkdXyBuRpM2l",
+      "messageId": "chatcmpl-DP9gmCztP9RTJdetFqkdXyBuRpM2l",
+      "createdAt": "2026-03-30T16:23:36+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DP9gmCztP9RTJdetFqkdXyBuRpM2l",
+      "messageId": "chatcmpl-DP9gmCztP9RTJdetFqkdXyBuRpM2l",
+      "createdAt": "2026-03-30T16:23:36+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DP9gmCztP9RTJdetFqkdXyBuRpM2l",
+      "messageId": "chatcmpl-DP9gmCztP9RTJdetFqkdXyBuRpM2l",
+      "createdAt": "2026-03-30T16:23:36+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DP9gmCztP9RTJdetFqkdXyBuRpM2l",
+      "messageId": "chatcmpl-DP9gmCztP9RTJdetFqkdXyBuRpM2l",
+      "createdAt": "2026-03-30T16:23:36+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DP9gmCztP9RTJdetFqkdXyBuRpM2l",
+      "messageId": "chatcmpl-DP9gmCztP9RTJdetFqkdXyBuRpM2l",
+      "createdAt": "2026-03-30T16:23:36+00:00",
+      "finishReason": "tool_calls",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "usage",
+          "details": {
+            "inputTokenCount": 138,
+            "outputTokenCount": 90,
+            "totalTokenCount": 228,
+            "cachedInputTokenCount": 0,
+            "reasoningTokenCount": 64,
+            "additionalCounts": {
+              "InputTokenDetails.AudioTokenCount": 0,
+              "OutputTokenDetails.AudioTokenCount": 0,
+              "OutputTokenDetails.AcceptedPredictionTokenCount": 0,
+              "OutputTokenDetails.RejectedPredictionTokenCount": 0
+            }
+          }
+        }
+      ],
+      "responseId": "chatcmpl-DP9gmCztP9RTJdetFqkdXyBuRpM2l",
+      "messageId": "chatcmpl-DP9gmCztP9RTJdetFqkdXyBuRpM2l",
+      "createdAt": "2026-03-30T16:23:36+00:00",
+      "finishReason": "tool_calls",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "toolApprovalRequest",
+          "toolCall": {
+            "$type": "functionCall",
+            "name": "DeleteFile",
+            "arguments": {
+              "fileName": "test.txt"
+            },
+            "informationalOnly": false,
+            "callId": "call_K2gGVaWM6bo9vVD5ncDAMlEl"
+          },
+          "requestId": "ficc_call_K2gGVaWM6bo9vVD5ncDAMlEl"
+        }
+      ],
+      "responseId": "",
+      "messageId": "",
+      "createdAt": "1970-01-01T00:00:00+00:00",
+      "finishReason": "tool_calls",
+      "modelId": ""
+    }
+  ],
+  [
+    {
+      "contents": [],
+      "responseId": "",
+      "messageId": "",
+      "createdAt": "1970-01-01T00:00:00+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ""
+        }
+      ],
+      "responseId": "chatcmpl-DP9gpaYj7kLUNvousC32jpxgcVxic",
+      "messageId": "chatcmpl-DP9gpaYj7kLUNvousC32jpxgcVxic",
+      "createdAt": "2026-03-30T16:23:39+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "Done"
+        }
+      ],
+      "responseId": "chatcmpl-DP9gpaYj7kLUNvousC32jpxgcVxic",
+      "messageId": "chatcmpl-DP9gpaYj7kLUNvousC32jpxgcVxic",
+      "createdAt": "2026-03-30T16:23:39+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " —"
+        }
+      ],
+      "responseId": "chatcmpl-DP9gpaYj7kLUNvousC32jpxgcVxic",
+      "messageId": "chatcmpl-DP9gpaYj7kLUNvousC32jpxgcVxic",
+      "createdAt": "2026-03-30T16:23:39+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " I"
+        }
+      ],
+      "responseId": "chatcmpl-DP9gpaYj7kLUNvousC32jpxgcVxic",
+      "messageId": "chatcmpl-DP9gpaYj7kLUNvousC32jpxgcVxic",
+      "createdAt": "2026-03-30T16:23:39+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " deleted"
+        }
+      ],
+      "responseId": "chatcmpl-DP9gpaYj7kLUNvousC32jpxgcVxic",
+      "messageId": "chatcmpl-DP9gpaYj7kLUNvousC32jpxgcVxic",
+      "createdAt": "2026-03-30T16:23:39+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " test"
+        }
+      ],
+      "responseId": "chatcmpl-DP9gpaYj7kLUNvousC32jpxgcVxic",
+      "messageId": "chatcmpl-DP9gpaYj7kLUNvousC32jpxgcVxic",
+      "createdAt": "2026-03-30T16:23:39+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ".txt"
+        }
+      ],
+      "responseId": "chatcmpl-DP9gpaYj7kLUNvousC32jpxgcVxic",
+      "messageId": "chatcmpl-DP9gpaYj7kLUNvousC32jpxgcVxic",
+      "createdAt": "2026-03-30T16:23:39+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "."
+        }
+      ],
+      "responseId": "chatcmpl-DP9gpaYj7kLUNvousC32jpxgcVxic",
+      "messageId": "chatcmpl-DP9gpaYj7kLUNvousC32jpxgcVxic",
+      "createdAt": "2026-03-30T16:23:39+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DP9gpaYj7kLUNvousC32jpxgcVxic",
+      "messageId": "chatcmpl-DP9gpaYj7kLUNvousC32jpxgcVxic",
+      "createdAt": "2026-03-30T16:23:39+00:00",
+      "finishReason": "stop",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "usage",
+          "details": {
+            "inputTokenCount": 178,
+            "outputTokenCount": 11,
+            "totalTokenCount": 189,
+            "cachedInputTokenCount": 0,
+            "reasoningTokenCount": 0,
+            "additionalCounts": {
+              "InputTokenDetails.AudioTokenCount": 0,
+              "OutputTokenDetails.AudioTokenCount": 0,
+              "OutputTokenDetails.AcceptedPredictionTokenCount": 0,
+              "OutputTokenDetails.RejectedPredictionTokenCount": 0
+            }
+          }
+        }
+      ],
+      "responseId": "chatcmpl-DP9gpaYj7kLUNvousC32jpxgcVxic",
+      "messageId": "chatcmpl-DP9gpaYj7kLUNvousC32jpxgcVxic",
+      "createdAt": "2026-03-30T16:23:39+00:00",
+      "finishReason": "stop",
+      "modelId": ""
+    }
+  ]
+]

--- a/src/Components/AI/test/Baselines/ToolCall_BackendTool.recording.json
+++ b/src/Components/AI/test/Baselines/ToolCall_BackendTool.recording.json
@@ -1,0 +1,313 @@
+[
+  [
+    {
+      "contents": [],
+      "responseId": "",
+      "messageId": "",
+      "createdAt": "1970-01-01T00:00:00+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DP9gb2AOOy5yHyzcH2y4p1MZDGaV1",
+      "messageId": "chatcmpl-DP9gb2AOOy5yHyzcH2y4p1MZDGaV1",
+      "createdAt": "2026-03-30T16:23:25+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DP9gb2AOOy5yHyzcH2y4p1MZDGaV1",
+      "messageId": "chatcmpl-DP9gb2AOOy5yHyzcH2y4p1MZDGaV1",
+      "createdAt": "2026-03-30T16:23:25+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DP9gb2AOOy5yHyzcH2y4p1MZDGaV1",
+      "messageId": "chatcmpl-DP9gb2AOOy5yHyzcH2y4p1MZDGaV1",
+      "createdAt": "2026-03-30T16:23:25+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DP9gb2AOOy5yHyzcH2y4p1MZDGaV1",
+      "messageId": "chatcmpl-DP9gb2AOOy5yHyzcH2y4p1MZDGaV1",
+      "createdAt": "2026-03-30T16:23:25+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DP9gb2AOOy5yHyzcH2y4p1MZDGaV1",
+      "messageId": "chatcmpl-DP9gb2AOOy5yHyzcH2y4p1MZDGaV1",
+      "createdAt": "2026-03-30T16:23:25+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DP9gb2AOOy5yHyzcH2y4p1MZDGaV1",
+      "messageId": "chatcmpl-DP9gb2AOOy5yHyzcH2y4p1MZDGaV1",
+      "createdAt": "2026-03-30T16:23:25+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DP9gb2AOOy5yHyzcH2y4p1MZDGaV1",
+      "messageId": "chatcmpl-DP9gb2AOOy5yHyzcH2y4p1MZDGaV1",
+      "createdAt": "2026-03-30T16:23:25+00:00",
+      "finishReason": "tool_calls",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "usage",
+          "details": {
+            "inputTokenCount": 137,
+            "outputTokenCount": 24,
+            "totalTokenCount": 161,
+            "cachedInputTokenCount": 0,
+            "reasoningTokenCount": 0,
+            "additionalCounts": {
+              "InputTokenDetails.AudioTokenCount": 0,
+              "OutputTokenDetails.AudioTokenCount": 0,
+              "OutputTokenDetails.AcceptedPredictionTokenCount": 0,
+              "OutputTokenDetails.RejectedPredictionTokenCount": 0
+            }
+          }
+        }
+      ],
+      "responseId": "chatcmpl-DP9gb2AOOy5yHyzcH2y4p1MZDGaV1",
+      "messageId": "chatcmpl-DP9gb2AOOy5yHyzcH2y4p1MZDGaV1",
+      "createdAt": "2026-03-30T16:23:25+00:00",
+      "finishReason": "tool_calls",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "functionCall",
+          "name": "GetWeather",
+          "arguments": {
+            "city": "Seattle"
+          },
+          "informationalOnly": false,
+          "callId": "call_nopXKO9quzfBylxH4lD0N5Sv"
+        }
+      ],
+      "responseId": "",
+      "messageId": "",
+      "createdAt": "1970-01-01T00:00:00+00:00",
+      "finishReason": "tool_calls",
+      "modelId": ""
+    }
+  ],
+  [
+    {
+      "contents": [],
+      "responseId": "",
+      "messageId": "",
+      "createdAt": "1970-01-01T00:00:00+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ""
+        }
+      ],
+      "responseId": "chatcmpl-DP9gdtsHbb86rkonYf3UguwPiAixX",
+      "messageId": "chatcmpl-DP9gdtsHbb86rkonYf3UguwPiAixX",
+      "createdAt": "2026-03-30T16:23:27+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "The"
+        }
+      ],
+      "responseId": "chatcmpl-DP9gdtsHbb86rkonYf3UguwPiAixX",
+      "messageId": "chatcmpl-DP9gdtsHbb86rkonYf3UguwPiAixX",
+      "createdAt": "2026-03-30T16:23:27+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " weather"
+        }
+      ],
+      "responseId": "chatcmpl-DP9gdtsHbb86rkonYf3UguwPiAixX",
+      "messageId": "chatcmpl-DP9gdtsHbb86rkonYf3UguwPiAixX",
+      "createdAt": "2026-03-30T16:23:27+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " in"
+        }
+      ],
+      "responseId": "chatcmpl-DP9gdtsHbb86rkonYf3UguwPiAixX",
+      "messageId": "chatcmpl-DP9gdtsHbb86rkonYf3UguwPiAixX",
+      "createdAt": "2026-03-30T16:23:27+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Seattle"
+        }
+      ],
+      "responseId": "chatcmpl-DP9gdtsHbb86rkonYf3UguwPiAixX",
+      "messageId": "chatcmpl-DP9gdtsHbb86rkonYf3UguwPiAixX",
+      "createdAt": "2026-03-30T16:23:27+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " is"
+        }
+      ],
+      "responseId": "chatcmpl-DP9gdtsHbb86rkonYf3UguwPiAixX",
+      "messageId": "chatcmpl-DP9gdtsHbb86rkonYf3UguwPiAixX",
+      "createdAt": "2026-03-30T16:23:27+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " "
+        }
+      ],
+      "responseId": "chatcmpl-DP9gdtsHbb86rkonYf3UguwPiAixX",
+      "messageId": "chatcmpl-DP9gdtsHbb86rkonYf3UguwPiAixX",
+      "createdAt": "2026-03-30T16:23:27+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "72"
+        }
+      ],
+      "responseId": "chatcmpl-DP9gdtsHbb86rkonYf3UguwPiAixX",
+      "messageId": "chatcmpl-DP9gdtsHbb86rkonYf3UguwPiAixX",
+      "createdAt": "2026-03-30T16:23:27+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "°F"
+        }
+      ],
+      "responseId": "chatcmpl-DP9gdtsHbb86rkonYf3UguwPiAixX",
+      "messageId": "chatcmpl-DP9gdtsHbb86rkonYf3UguwPiAixX",
+      "createdAt": "2026-03-30T16:23:27+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " and"
+        }
+      ],
+      "responseId": "chatcmpl-DP9gdtsHbb86rkonYf3UguwPiAixX",
+      "messageId": "chatcmpl-DP9gdtsHbb86rkonYf3UguwPiAixX",
+      "createdAt": "2026-03-30T16:23:27+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " sunny"
+        }
+      ],
+      "responseId": "chatcmpl-DP9gdtsHbb86rkonYf3UguwPiAixX",
+      "messageId": "chatcmpl-DP9gdtsHbb86rkonYf3UguwPiAixX",
+      "createdAt": "2026-03-30T16:23:27+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "."
+        }
+      ],
+      "responseId": "chatcmpl-DP9gdtsHbb86rkonYf3UguwPiAixX",
+      "messageId": "chatcmpl-DP9gdtsHbb86rkonYf3UguwPiAixX",
+      "createdAt": "2026-03-30T16:23:27+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DP9gdtsHbb86rkonYf3UguwPiAixX",
+      "messageId": "chatcmpl-DP9gdtsHbb86rkonYf3UguwPiAixX",
+      "createdAt": "2026-03-30T16:23:27+00:00",
+      "finishReason": "stop",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "usage",
+          "details": {
+            "inputTokenCount": 176,
+            "outputTokenCount": 15,
+            "totalTokenCount": 191,
+            "cachedInputTokenCount": 0,
+            "reasoningTokenCount": 0,
+            "additionalCounts": {
+              "InputTokenDetails.AudioTokenCount": 0,
+              "OutputTokenDetails.AudioTokenCount": 0,
+              "OutputTokenDetails.AcceptedPredictionTokenCount": 0,
+              "OutputTokenDetails.RejectedPredictionTokenCount": 0
+            }
+          }
+        }
+      ],
+      "responseId": "chatcmpl-DP9gdtsHbb86rkonYf3UguwPiAixX",
+      "messageId": "chatcmpl-DP9gdtsHbb86rkonYf3UguwPiAixX",
+      "createdAt": "2026-03-30T16:23:27+00:00",
+      "finishReason": "stop",
+      "modelId": ""
+    }
+  ]
+]

--- a/src/Components/AI/test/Baselines/UIAction_ClientTool.recording.json
+++ b/src/Components/AI/test/Baselines/UIAction_ClientTool.recording.json
@@ -1,0 +1,7598 @@
+[
+  [
+    {
+      "contents": [],
+      "responseId": "",
+      "messageId": "",
+      "createdAt": "1970-01-01T00:00:00+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DP9htb0ZdaPoHHdl0ESZQK0DcdPeF",
+      "messageId": "chatcmpl-DP9htb0ZdaPoHHdl0ESZQK0DcdPeF",
+      "createdAt": "2026-03-30T16:24:45+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DP9htb0ZdaPoHHdl0ESZQK0DcdPeF",
+      "messageId": "chatcmpl-DP9htb0ZdaPoHHdl0ESZQK0DcdPeF",
+      "createdAt": "2026-03-30T16:24:45+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DP9htb0ZdaPoHHdl0ESZQK0DcdPeF",
+      "messageId": "chatcmpl-DP9htb0ZdaPoHHdl0ESZQK0DcdPeF",
+      "createdAt": "2026-03-30T16:24:45+00:00",
+      "finishReason": "tool_calls",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "usage",
+          "details": {
+            "inputTokenCount": 140,
+            "outputTokenCount": 85,
+            "totalTokenCount": 225,
+            "cachedInputTokenCount": 0,
+            "reasoningTokenCount": 64,
+            "additionalCounts": {
+              "InputTokenDetails.AudioTokenCount": 0,
+              "OutputTokenDetails.AudioTokenCount": 0,
+              "OutputTokenDetails.AcceptedPredictionTokenCount": 0,
+              "OutputTokenDetails.RejectedPredictionTokenCount": 0
+            }
+          }
+        }
+      ],
+      "responseId": "chatcmpl-DP9htb0ZdaPoHHdl0ESZQK0DcdPeF",
+      "messageId": "chatcmpl-DP9htb0ZdaPoHHdl0ESZQK0DcdPeF",
+      "createdAt": "2026-03-30T16:24:45+00:00",
+      "finishReason": "tool_calls",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "functionCall",
+          "name": "GetUserLocation",
+          "arguments": {},
+          "informationalOnly": false,
+          "callId": "call_QokxWGzsiPsm8mETmf1PMXVz"
+        }
+      ],
+      "responseId": "",
+      "messageId": "",
+      "createdAt": "1970-01-01T00:00:00+00:00",
+      "finishReason": "tool_calls",
+      "modelId": ""
+    }
+  ],
+  [
+    {
+      "contents": [],
+      "responseId": "",
+      "messageId": "",
+      "createdAt": "1970-01-01T00:00:00+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ""
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "I"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " found"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " your"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " location"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ":"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Seattle"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " WA"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " ("
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "47"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "."
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "61"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "°"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "N"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " "
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "122"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "."
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "33"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "°"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "W"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ")."
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Here"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " are"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " fun"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " varied"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " things"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " to"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " do"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " nearby"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " —"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " pick"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " what"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " fits"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " your"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " time"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " energy"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " and"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " interests"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ".\n\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "Top"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " downtown"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " &"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " waterfront"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " picks"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "-"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Pike"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Place"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Market"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " —"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " iconic"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " stalls"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " fresh"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " seafood"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " the"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " original"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Starbucks"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " and"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " the"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " gum"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " wall"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " alley"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " nearby"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ".\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "-"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Seattle"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Aquarium"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " and"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " the"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Waterfront"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Park"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " —"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " easy"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " scenic"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " walk"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " along"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Elliott"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Bay"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ".\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "-"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Take"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " the"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Seattle"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Great"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Wheel"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " for"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " skyline"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "/w"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "ater"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " views"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ".\n\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "Classic"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Seattle"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " attractions"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "-"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Space"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Needle"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " +"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Seattle"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Center"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " —"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " combine"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " with"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Ch"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "ih"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "uly"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Garden"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " and"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Glass"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " for"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " spectacular"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " glass"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " art"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ".\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "-"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Museum"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " of"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Pop"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Culture"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " ("
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "Mo"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "POP"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ")"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " right"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " next"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " door"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " if"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " you"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " like"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " music"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " sci"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "‑"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "fi"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " and"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " interactive"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " exhibits"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ".\n\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "Neighborhood"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "s"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " &"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " viewpoints"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "-"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Kerry"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Park"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " ("
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "Queen"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Anne"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ")"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " —"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " small"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " park"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " with"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " the"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " classic"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " skyline"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " photo"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " op"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ".\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "-"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Capitol"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Hill"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " —"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " cafés"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " nightlife"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " record"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " shops"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " and"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Volunteer"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Park"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Conserv"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "atory"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ".\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "-"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Fremont"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " —"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " see"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " the"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Fremont"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Troll"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " quirky"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " shops"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " and"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Sunday"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " market"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ".\n\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "Outdoor"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " &"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " active"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " options"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "-"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Ferry"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " to"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Bain"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "bridge"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Island"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " —"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " "
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "35"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "-minute"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " ride"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " with"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " great"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " views"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ";"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " explore"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " shops"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " cafes"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " and"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " waterfront"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " parks"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ".\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "-"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Kay"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "ak"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " or"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " paddle"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "board"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " on"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Lake"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Union"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " ("
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "rent"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "als"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " available"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ")"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " —"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " good"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " skyline"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " and"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " house"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "boat"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " views"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ".\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "-"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Discovery"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Park"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " —"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " big"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " coastal"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " bluff"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " trails"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " and"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " easy"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " beach"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " access"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ".\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "-"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Ball"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "ard"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Locks"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " and"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " fish"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " ladder"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " —"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " interesting"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " for"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " nature"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " and"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " boats"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ".\n\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "Food"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " coffee"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " &"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " breweries"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "-"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Try"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " seafood"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " ("
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "clam"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " chow"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "der"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " oysters"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ")"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " along"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " the"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " waterfront"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " or"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " in"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Ball"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "ard"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "."
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "  \n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "-"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Coffee"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " crawl"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " —"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " dozens"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " of"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " independent"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " shops"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " plus"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " the"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " original"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Starbucks"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " at"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Pike"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Place"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ".\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "-"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Ball"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "ard"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " and"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Georgetown"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " have"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " many"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " craft"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " breweries"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " and"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " dist"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "iller"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "ies"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ".\n\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "Day"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " trips"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " ("
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "if"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " you"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " have"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " a"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " car"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " or"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " a"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " full"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " day"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ")\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "-"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Mt"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "."
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Rain"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "ier"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " National"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Park"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " —"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " alpine"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " scenery"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " and"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " hiking"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ".\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "-"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Sno"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "qual"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "mie"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Falls"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " —"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " easy"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " dramatic"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " waterfall"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " ("
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "30"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "–"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "45"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " min"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " east"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ").\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "-"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Wine"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " tasting"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " in"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Wood"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "in"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "ville"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " —"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " about"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " "
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "30"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "–"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "40"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " minutes"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " northeast"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ".\n\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "Pr"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "actical"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " tips"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "-"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Weather"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ":"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " bring"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " layers"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " and"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " a"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " light"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " rain"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " jacket"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "—"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "Fre"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "quent"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " cool"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " dr"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "izzly"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " days"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " outside"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " of"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " mid"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "-s"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "ummer"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ".\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "-"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Transit"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ":"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Link"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " light"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " rail"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " buses"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " and"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " ferr"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "ies"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " are"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " convenient"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ";"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " driving"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " and"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " parking"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " downtown"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " can"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " be"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " slow"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "/"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "exp"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "ensive"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ".\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "-"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Book"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " popular"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " tours"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "/"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "Space"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Needle"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "/"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "Ch"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "ih"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "uly"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " tickets"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " in"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " advance"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " on"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " weekends"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ".\n\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "Quick"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " sample"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " plans"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "-"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " "
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "4"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " hours"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ":"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Pike"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Place"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " +"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " waterfront"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " +"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Great"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Wheel"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " +"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " coffee"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " stop"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ".\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "-"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Full"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " day"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ":"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Space"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Needle"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " +"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Ch"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "ih"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "uly"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " +"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Mo"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "POP"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " +"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Kerry"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Park"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " sunset"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ".\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "-"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " "
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "2"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "–"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "3"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " days"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ":"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Add"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Bain"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "bridge"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Island"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " ferry"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " and"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " a"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " hike"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " or"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " day"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " trip"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " ("
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "S"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "no"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "qual"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "mie"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " or"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Mt"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "."
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Rain"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "ier"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ").\n\n"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "Want"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " a"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " custom"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " plan"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "?"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " Tell"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " me"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ":"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " how"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " much"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " time"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " you"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " have"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " your"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " mobility"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " level"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " weather"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " preference"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " and"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " interests"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " ("
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "food"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " outdoors"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " museums"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ","
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " nightlife"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": ")."
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " I"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " can"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " map"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " a"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " walking"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " route"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " or"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " suggest"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": " reservations"
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "text",
+          "text": "."
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "finishReason": "stop",
+      "modelId": ""
+    },
+    {
+      "role": "assistant",
+      "contents": [
+        {
+          "$type": "usage",
+          "details": {
+            "inputTokenCount": 184,
+            "outputTokenCount": 904,
+            "totalTokenCount": 1088,
+            "cachedInputTokenCount": 0,
+            "reasoningTokenCount": 320,
+            "additionalCounts": {
+              "InputTokenDetails.AudioTokenCount": 0,
+              "OutputTokenDetails.AudioTokenCount": 0,
+              "OutputTokenDetails.AcceptedPredictionTokenCount": 0,
+              "OutputTokenDetails.RejectedPredictionTokenCount": 0
+            }
+          }
+        }
+      ],
+      "responseId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "messageId": "chatcmpl-DP9hvuGtHjrmpLnFWgAV841wRqJEn",
+      "createdAt": "2026-03-30T16:24:47+00:00",
+      "finishReason": "stop",
+      "modelId": ""
+    }
+  ]
+]

--- a/src/Components/AI/test/Blocks/FunctionApprovalBlockTests.cs
+++ b/src/Components/AI/test/Blocks/FunctionApprovalBlockTests.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Blocks;
+
+public class FunctionApprovalBlockTests
+{
+    [Fact]
+    public void CreatedWithPendingStatus()
+    {
+        var innerBlock = new FunctionInvocationContentBlock
+        {
+            Call = new FunctionCallContent("call-1", "DeleteFile", null)
+        };
+        var request = new ToolApprovalRequestContent("req-1", innerBlock.Call);
+        var block = new FunctionApprovalBlock(innerBlock, request);
+
+        Assert.Equal(ApprovalStatus.Pending, block.Status);
+        Assert.Same(innerBlock, block.InnerBlock);
+        Assert.Same(request, block.ApprovalRequest);
+    }
+
+    [Fact]
+    public async Task Approve_SetsStatusAndSignalsResume()
+    {
+        var block = CreateBlock();
+
+        block.Approve();
+
+        Assert.Equal(ApprovalStatus.Approved, block.Status);
+        var resultTask = block.GetResultAsync();
+        Assert.True(resultTask.IsCompleted);
+        var result = await resultTask;
+        Assert.IsType<ToolApprovalResponseContent>(result);
+    }
+
+    [Fact]
+    public void Reject_SetsStatusAndSignalsResume()
+    {
+        var block = CreateBlock();
+
+        block.Reject("Not safe");
+
+        Assert.Equal(ApprovalStatus.Rejected, block.Status);
+        Assert.True(block.GetResultAsync().IsCompleted);
+    }
+
+    [Fact]
+    public void Approve_FiresNotifyChanged()
+    {
+        var block = CreateBlock();
+        var changed = false;
+        block.OnChanged(() => changed = true);
+
+        block.Approve();
+
+        Assert.True(changed);
+    }
+
+    [Fact]
+    public void Reject_FiresNotifyChanged()
+    {
+        var block = CreateBlock();
+        var changed = false;
+        block.OnChanged(() => changed = true);
+
+        block.Reject();
+
+        Assert.True(changed);
+    }
+
+    [Fact]
+    public void Approve_WithoutAgentContext_Succeeds()
+    {
+        var block = CreateBlock();
+
+        block.Approve();
+
+        Assert.Equal(ApprovalStatus.Approved, block.Status);
+        Assert.True(block.GetResultAsync().IsCompleted);
+    }
+
+    private static FunctionApprovalBlock CreateBlock()
+    {
+        var innerBlock = new FunctionInvocationContentBlock
+        {
+            Call = new FunctionCallContent("call-1", "DeleteFile", null)
+        };
+        var request = new ToolApprovalRequestContent("req-1", innerBlock.Call);
+        return new FunctionApprovalBlock(innerBlock, request);
+    }
+}

--- a/src/Components/AI/test/Blocks/FunctionInvocationContentBlockTests.cs
+++ b/src/Components/AI/test/Blocks/FunctionInvocationContentBlockTests.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Blocks;
+
+public class FunctionInvocationContentBlockTests
+{
+    [Fact]
+    public void ToolName_DelegatesToCallName()
+    {
+        var block = new FunctionInvocationContentBlock
+        {
+            Call = new FunctionCallContent("call-1", "GetWeather",
+                new Dictionary<string, object?> { ["city"] = "Seattle" })
+        };
+
+        Assert.Equal("GetWeather", block.ToolName);
+    }
+
+    [Fact]
+    public void Arguments_DelegatesToCallArguments()
+    {
+        var args = new Dictionary<string, object?> { ["city"] = "Seattle" };
+        var block = new FunctionInvocationContentBlock
+        {
+            Call = new FunctionCallContent("call-1", "GetWeather", args)
+        };
+
+        Assert.Same(args, block.Arguments);
+    }
+
+    [Fact]
+    public void HasResult_FalseByDefault()
+    {
+        var block = new FunctionInvocationContentBlock();
+        Assert.False(block.HasResult);
+    }
+
+    [Fact]
+    public void HasResult_TrueAfterResultSet()
+    {
+        var block = new FunctionInvocationContentBlock
+        {
+            Result = new FunctionResultContent("call-1", "sunny")
+        };
+        Assert.True(block.HasResult);
+    }
+
+    [Fact]
+    public void ToolName_NullWhenCallNotSet()
+    {
+        var block = new FunctionInvocationContentBlock();
+        Assert.Null(block.ToolName);
+    }
+
+    [Fact]
+    public void Arguments_NullWhenCallNotSet()
+    {
+        var block = new FunctionInvocationContentBlock();
+        Assert.Null(block.Arguments);
+    }
+}

--- a/src/Components/AI/test/Blocks/ReasoningContentBlockTests.cs
+++ b/src/Components/AI/test/Blocks/ReasoningContentBlockTests.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Blocks;
+
+public class ReasoningContentBlockTests
+{
+    [Fact]
+    public void AppendText_AccumulatesReasoningTokens()
+    {
+        var block = new ReasoningContentBlock();
+        block.AppendText("Let me think...");
+        block.AppendText(" The answer is ");
+        block.AppendText("42.");
+
+        Assert.Equal("Let me think... The answer is 42.", block.Text);
+    }
+
+    [Fact]
+    public void Text_EmptyByDefault()
+    {
+        var block = new ReasoningContentBlock();
+        Assert.Equal(string.Empty, block.Text);
+    }
+
+    [Fact]
+    public void IsEncrypted_TrueWhenOnlyProtectedData()
+    {
+        var block = new ReasoningContentBlock
+        {
+            ProtectedData = "encrypted-blob"
+        };
+        Assert.True(block.IsEncrypted);
+    }
+
+    [Fact]
+    public void IsEncrypted_FalseWhenTextPresent()
+    {
+        var block = new ReasoningContentBlock
+        {
+            ProtectedData = "encrypted-blob"
+        };
+        block.AppendText("visible reasoning");
+        Assert.False(block.IsEncrypted);
+    }
+
+    [Fact]
+    public void IsEncrypted_FalseWhenNoProtectedData()
+    {
+        var block = new ReasoningContentBlock();
+        block.AppendText("reasoning");
+        Assert.False(block.IsEncrypted);
+    }
+
+    [Fact]
+    public void IsEncrypted_FalseByDefault()
+    {
+        var block = new ReasoningContentBlock();
+        Assert.False(block.IsEncrypted);
+    }
+}

--- a/src/Components/AI/test/Engine/AgentContextApprovalTests.cs
+++ b/src/Components/AI/test/Engine/AgentContextApprovalTests.cs
@@ -1,0 +1,202 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Engine;
+
+public class AgentContextApprovalTests
+{
+    private static (UIAgent agent, DelegatingStreamingChatClient client) CreateAgent()
+    {
+        var client = new DelegatingStreamingChatClient();
+        var agent = new UIAgent(client);
+        return (agent, client);
+    }
+
+    [Fact]
+    public async Task ApprovalBlock_SetsStatusToAwaitingInput()
+    {
+        var (agent, client) = CreateAgent();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitApprovalRequest("call-1", "DeleteFile"));
+        var context = new AgentContext(agent);
+
+        var statuses = new List<ConversationStatus>();
+        context.RegisterOnStatusChanged(s =>
+        {
+            statuses.Add(s);
+            // Auto-approve when awaiting to unblock SendMessageAsync
+            if (s == ConversationStatus.AwaitingInput)
+            {
+                var turn = context.Turns[^1];
+                var block = turn.ResponseBlocks.OfType<FunctionApprovalBlock>().Single();
+                block.Approve();
+            }
+        });
+
+        await context.SendMessageAsync("Delete the file");
+
+        Assert.Contains(ConversationStatus.AwaitingInput, statuses);
+    }
+
+    [Fact]
+    public async Task ApprovalBlock_EmittedAsFunctionApprovalBlock()
+    {
+        var (agent, client) = CreateAgent();
+        var callCount = 0;
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return ResponseEmitters.EmitApprovalRequest("call-1", "DeleteFile");
+            }
+            return ResponseEmitters.EmitTextResponse("Done");
+        });
+        var context = new AgentContext(agent);
+
+        FunctionApprovalBlock? capturedBlock = null;
+        context.RegisterOnStatusChanged(s =>
+        {
+            if (s == ConversationStatus.AwaitingInput)
+            {
+                var turn = context.Turns[^1];
+                capturedBlock = turn.ResponseBlocks.OfType<FunctionApprovalBlock>().First();
+                capturedBlock.Approve();
+            }
+        });
+
+        await context.SendMessageAsync("Delete the file");
+
+        Assert.NotNull(capturedBlock);
+        Assert.Equal(ApprovalStatus.Approved, capturedBlock!.Status);
+        Assert.Equal("DeleteFile", capturedBlock.InnerBlock.ToolName);
+    }
+
+    [Fact]
+    public async Task Approve_ResumesStreamingThenIdle()
+    {
+        var (agent, client) = CreateAgent();
+        var callCount = 0;
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return ResponseEmitters.EmitApprovalRequest("call-1", "DeleteFile");
+            }
+            return ResponseEmitters.EmitTextResponse("File deleted successfully.");
+        });
+        var context = new AgentContext(agent);
+
+        var statuses = new List<ConversationStatus>();
+        context.RegisterOnStatusChanged(s =>
+        {
+            statuses.Add(s);
+            if (s == ConversationStatus.AwaitingInput)
+            {
+                var turn = context.Turns[^1];
+                turn.ResponseBlocks.OfType<FunctionApprovalBlock>().Single().Approve();
+            }
+        });
+
+        await context.SendMessageAsync("Delete the file");
+
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+
+        // Verify the status transitions: Streaming → AwaitingInput → Streaming → Idle
+        Assert.Equal(new[]
+        {
+            ConversationStatus.Streaming,
+            ConversationStatus.AwaitingInput,
+            ConversationStatus.Streaming,
+            ConversationStatus.Idle,
+        }, statuses);
+    }
+
+    [Fact]
+    public async Task Reject_SetsStatusToIdle()
+    {
+        var (agent, client) = CreateAgent();
+        var callCount = 0;
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return ResponseEmitters.EmitApprovalRequest("call-1", "DeleteFile");
+            }
+            return ResponseEmitters.EmitTextResponse("Operation cancelled.");
+        });
+        var context = new AgentContext(agent);
+
+        context.RegisterOnStatusChanged(s =>
+        {
+            if (s == ConversationStatus.AwaitingInput)
+            {
+                var turn = context.Turns[^1];
+                turn.ResponseBlocks.OfType<FunctionApprovalBlock>().Single().Reject("Not safe");
+            }
+        });
+
+        await context.SendMessageAsync("Delete the file");
+
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+        var turn = Assert.Single(context.Turns);
+        var approvalBlock = turn.ResponseBlocks.OfType<FunctionApprovalBlock>().Single();
+        Assert.Equal(ApprovalStatus.Rejected, approvalBlock.Status);
+    }
+
+    [Fact]
+    public async Task Approve_ContinuationBlocksAddedToSameTurn()
+    {
+        var (agent, client) = CreateAgent();
+        var callCount = 0;
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return ResponseEmitters.EmitApprovalRequest("call-1", "DeleteFile");
+            }
+            return ResponseEmitters.EmitTextResponse("Done!");
+        });
+        var context = new AgentContext(agent);
+
+        context.RegisterOnStatusChanged(s =>
+        {
+            if (s == ConversationStatus.AwaitingInput)
+            {
+                var turn = context.Turns[^1];
+                turn.ResponseBlocks.OfType<FunctionApprovalBlock>().Single().Approve();
+            }
+        });
+
+        await context.SendMessageAsync("Delete the file");
+
+        // Same turn should have both the approval block and the continuation text
+        Assert.Single(context.Turns);
+        var turn = context.Turns[0];
+        var textBlock = turn.ResponseBlocks.OfType<RichContentBlock>().SingleOrDefault();
+        Assert.NotNull(textBlock);
+        Assert.Equal("Done!", textBlock!.RawText);
+    }
+
+    [Fact]
+    public async Task StatusTransitions_NoApproval_RemainsStreamingToIdle()
+    {
+        var (agent, client) = CreateAgent();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Just text"));
+        var context = new AgentContext(agent);
+
+        var statuses = new List<ConversationStatus>();
+        context.RegisterOnStatusChanged(s => statuses.Add(s));
+
+        await context.SendMessageAsync("Hello");
+
+        Assert.Equal(new[] { ConversationStatus.Streaming, ConversationStatus.Idle }, statuses);
+    }
+}

--- a/src/Components/AI/test/Engine/AgentContextBaselineTests.cs
+++ b/src/Components/AI/test/Engine/AgentContextBaselineTests.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Engine;
+
+public class AgentContextBaselineTests
+{
+    [Fact]
+    public async Task Step01_MultiTurnTextStreaming_FullOrchestration()
+    {
+        var client = RecordingLoader.CreateReplayClient(
+            "Step01_GettingStartedTest.PostRun_MultiTurn_SynthesizesAssistantMessages.recording.json");
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+
+        var statuses = new List<ConversationStatus>();
+        var turnCount = 0;
+        var blockCount = 0;
+        context.RegisterOnStatusChanged(s => statuses.Add(s));
+        context.RegisterOnTurnAdded(_ => turnCount++);
+        context.RegisterOnBlockAdded((_, _) => blockCount++);
+
+        // Turn 1
+        await context.SendMessageAsync("Hello");
+        Assert.Single(context.Turns);
+        Assert.NotEmpty(context.Turns[0].ResponseBlocks);
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+
+        // Turn 2
+        await context.SendMessageAsync("Tell me more");
+        Assert.Equal(2, context.Turns.Count);
+        Assert.NotEmpty(context.Turns[1].ResponseBlocks);
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+
+        // Notifications
+        Assert.Equal(2, turnCount);
+        Assert.True(blockCount >= 4); // at least 2 user + 2 assistant blocks
+        // Statuses: Streaming, Idle, Streaming, Idle
+        Assert.Equal(4, statuses.Count);
+    }
+}

--- a/src/Components/AI/test/Engine/AgentContextErrorHandlingTests.cs
+++ b/src/Components/AI/test/Engine/AgentContextErrorHandlingTests.cs
@@ -1,0 +1,338 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Engine;
+
+public class AgentContextErrorHandlingTests
+{
+    // ---- Error during iteration ----
+
+    [Fact]
+    public async Task Error_DuringStreaming_SetsStatusToError()
+    {
+        var expectedError = new InvalidOperationException("LLM failure");
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitErrorAfterTokens([], expectedError, ct));
+
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+
+        await context.SendMessageAsync("Hello");
+
+        Assert.Equal(ConversationStatus.Error, context.Status);
+        Assert.Same(expectedError, context.Error);
+    }
+
+    [Fact]
+    public async Task Error_DuringStreaming_FiresStatusChangedCallback()
+    {
+        var statusChanges = new List<ConversationStatus>();
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitErrorAfterTokens([], new Exception("fail"), ct));
+
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+        context.RegisterOnStatusChanged(s => statusChanges.Add(s));
+
+        await context.SendMessageAsync("Hello");
+
+        Assert.Contains(ConversationStatus.Streaming, statusChanges);
+        Assert.Contains(ConversationStatus.Error, statusChanges);
+        Assert.Equal(ConversationStatus.Error, statusChanges[^1]);
+    }
+
+    [Fact]
+    public async Task Error_AfterPartialTokens_PreservesPartialBlocks()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitErrorAfterTokens(
+                ["Hello", " world"], new Exception("mid-stream fail"), ct));
+
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+
+        await context.SendMessageAsync("Hi");
+
+        Assert.Equal(ConversationStatus.Error, context.Status);
+
+        Assert.Single(context.Turns);
+        var turn = context.Turns[0];
+
+        Assert.NotEmpty(turn.RequestBlocks);
+        Assert.NotEmpty(turn.ResponseBlocks);
+    }
+
+    [Fact]
+    public async Task Error_SuccessfulBlocksBeforeError_Unaffected()
+    {
+        var callCount = 0;
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return ResponseEmitters.EmitErrorAfterTokens(
+                    ["partial"], new Exception("fail"), ct);
+            }
+            return ResponseEmitters.EmitTextResponse("OK", ct);
+        });
+
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+
+        await context.SendMessageAsync("First");
+        Assert.Equal(ConversationStatus.Error, context.Status);
+
+        var turn = context.Turns[0];
+        Assert.NotEmpty(turn.ResponseBlocks);
+    }
+
+    // ---- RetryAsync ----
+
+    [Fact]
+    public async Task RetryAsync_WhenNotInError_ThrowsInvalidOperation()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("OK", ct));
+
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+
+        await context.SendMessageAsync("Hello");
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => context.RetryAsync());
+    }
+
+    [Fact]
+    public async Task RetryAsync_ClearsResponseBlocks_AndResubmits()
+    {
+        var callCount = 0;
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return ResponseEmitters.EmitErrorAfterTokens(
+                    ["partial"], new Exception("fail"), ct);
+            }
+            return ResponseEmitters.EmitTextResponse("Success!", ct);
+        });
+
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+
+        await context.SendMessageAsync("Hello");
+        Assert.Equal(ConversationStatus.Error, context.Status);
+        Assert.NotNull(context.Error);
+
+        await context.RetryAsync();
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+        Assert.Null(context.Error);
+
+        Assert.Single(context.Turns);
+
+        var turn = context.Turns[0];
+        Assert.NotEmpty(turn.ResponseBlocks);
+        Assert.NotEmpty(turn.RequestBlocks);
+    }
+
+    [Fact]
+    public async Task RetryAsync_StatusTransitions_ErrorToStreamingToIdle()
+    {
+        var statusChanges = new List<ConversationStatus>();
+        var callCount = 0;
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return ResponseEmitters.EmitErrorAfterTokens(
+                    [], new Exception("fail"), ct);
+            }
+            return ResponseEmitters.EmitTextResponse("OK", ct);
+        });
+
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+        context.RegisterOnStatusChanged(s => statusChanges.Add(s));
+
+        await context.SendMessageAsync("Hello");
+
+        statusChanges.Clear();
+
+        await context.RetryAsync();
+
+        Assert.Equal(ConversationStatus.Streaming, statusChanges[0]);
+        Assert.Equal(ConversationStatus.Idle, statusChanges[^1]);
+    }
+
+    [Fact]
+    public async Task RetryAsync_SameUserMessage_ResentToAgent()
+    {
+        var receivedMessages = new List<List<ChatMessage>>();
+        var callCount = 0;
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            receivedMessages.Add(msgs.ToList());
+            if (callCount == 1)
+            {
+                return ResponseEmitters.EmitErrorAfterTokens(
+                    [], new Exception("fail"), ct);
+            }
+            return ResponseEmitters.EmitTextResponse("OK", ct);
+        });
+
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+
+        await context.SendMessageAsync("My question");
+        await context.RetryAsync();
+
+        Assert.Equal(2, receivedMessages.Count);
+        Assert.Equal(
+            receivedMessages[0][^1].Text,
+            receivedMessages[1][^1].Text);
+    }
+
+    // ---- CancelAsync ----
+
+    [Fact]
+    public async Task CancelAsync_WhenNotStreaming_IsNoOp()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("OK", ct));
+
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+
+        await context.SendMessageAsync("Hello");
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+
+        await context.CancelAsync();
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+    }
+
+    [Fact]
+    public async Task CancelAsync_DuringStreaming_StopsAndGoesIdle()
+    {
+        var streamStarted = new TaskCompletionSource();
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) => SlowStream(streamStarted, ct));
+
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+
+        var sendTask = context.SendMessageAsync("Hello");
+
+        await streamStarted.Task;
+        Assert.Equal(ConversationStatus.Streaming, context.Status);
+
+        await context.CancelAsync();
+        await sendTask;
+
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+        Assert.Null(context.Error);
+
+        static async IAsyncEnumerable<ChatResponseUpdate> SlowStream(
+            TaskCompletionSource streamStarted,
+            [EnumeratorCancellation] CancellationToken ct)
+        {
+            yield return new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                MessageId = Guid.NewGuid().ToString("N"),
+                Contents = [new TextContent("tok1")]
+            };
+            streamStarted.TrySetResult();
+            try { await Task.Delay(Timeout.Infinite, ct); }
+            catch (OperationCanceledException) { yield break; }
+        }
+    }
+
+    [Fact]
+    public async Task CancelAsync_DiscardsResponseBlocks()
+    {
+        var streamStarted = new TaskCompletionSource();
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) => SlowStream(streamStarted, ct));
+
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+
+        var sendTask = context.SendMessageAsync("Hello");
+        await streamStarted.Task;
+
+        await context.CancelAsync();
+        await sendTask;
+
+        var turn = context.Turns[0];
+        Assert.Empty(turn.ResponseBlocks);
+
+        static async IAsyncEnumerable<ChatResponseUpdate> SlowStream(
+            TaskCompletionSource streamStarted,
+            [EnumeratorCancellation] CancellationToken ct)
+        {
+            yield return new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                MessageId = Guid.NewGuid().ToString("N"),
+                Contents = [new TextContent("partial")]
+            };
+            streamStarted.TrySetResult();
+            try { await Task.Delay(Timeout.Infinite, ct); }
+            catch (OperationCanceledException) { yield break; }
+        }
+    }
+
+    // ---- Integration: Error recovery flow ----
+
+    [Fact]
+    public async Task ErrorRecovery_PartialFailure_RetrySucceeds()
+    {
+        var callCount = 0;
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return ResponseEmitters.EmitErrorAfterTokens(
+                    ["Hello", " wor"], new Exception("Connection lost"), ct);
+            }
+            return ResponseEmitters.EmitMultiTokenTextResponse(
+                ct, "Hello", " world", "!");
+        });
+
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+
+        await context.SendMessageAsync("Greet me");
+        Assert.Equal(ConversationStatus.Error, context.Status);
+        Assert.Single(context.Turns);
+
+        await context.RetryAsync();
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+        Assert.Null(context.Error);
+        Assert.Single(context.Turns);
+
+        var turn = context.Turns[0];
+        var textBlock = turn.ResponseBlocks.OfType<RichContentBlock>().Single();
+        Assert.Contains("Hello", textBlock.RawText);
+    }
+}

--- a/src/Components/AI/test/Engine/AgentContextTests.cs
+++ b/src/Components/AI/test/Engine/AgentContextTests.cs
@@ -1,0 +1,250 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Engine;
+
+public class AgentContextTests
+{
+    private static (UIAgent agent, DelegatingStreamingChatClient client) CreateAgent()
+    {
+        var client = new DelegatingStreamingChatClient();
+        var agent = new UIAgent(client);
+        return (agent, client);
+    }
+
+    // ---- Turn Assembly ----
+
+    [Fact]
+    public async Task SendMessageAsync_CreatesTurnWithUserAndAssistantBlocks()
+    {
+        var (agent, client) = CreateAgent();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hi!"));
+        var context = new AgentContext(agent);
+
+        await context.SendMessageAsync("Hello");
+
+        Assert.Single(context.Turns);
+        var turn = context.Turns[0];
+        Assert.NotEmpty(turn.RequestBlocks);
+        Assert.All(turn.RequestBlocks, b => Assert.Equal(ChatRole.User, b.Role));
+        Assert.NotEmpty(turn.ResponseBlocks);
+        Assert.All(turn.ResponseBlocks, b => Assert.Equal(ChatRole.Assistant, b.Role));
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_MultipleCalls_CreatesMultipleTurns()
+    {
+        var (agent, client) = CreateAgent();
+        var callCount = 0;
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            return ResponseEmitters.EmitTextResponse($"Response {callCount}");
+        });
+        var context = new AgentContext(agent);
+
+        await context.SendMessageAsync("First");
+        await context.SendMessageAsync("Second");
+
+        Assert.Equal(2, context.Turns.Count);
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_RequestBlocksContainUserText()
+    {
+        var (agent, client) = CreateAgent();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Reply"));
+        var context = new AgentContext(agent);
+
+        await context.SendMessageAsync("My message");
+
+        var userBlock = Assert.IsType<RichContentBlock>(context.Turns[0].RequestBlocks[0]);
+        Assert.Equal("My message", userBlock.RawText);
+    }
+
+    // ---- Status Transitions ----
+
+    [Fact]
+    public async Task Status_StartsAsIdle()
+    {
+        var (agent, _) = CreateAgent();
+        var context = new AgentContext(agent);
+
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+        Assert.Null(context.Error);
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_StatusTransitions_IdleToStreamingToIdle()
+    {
+        var (agent, client) = CreateAgent();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("ok"));
+        var context = new AgentContext(agent);
+
+        var statuses = new List<ConversationStatus>();
+        context.RegisterOnStatusChanged(s => statuses.Add(s));
+
+        await context.SendMessageAsync("hi");
+
+        Assert.Equal(new[] { ConversationStatus.Streaming, ConversationStatus.Idle }, statuses);
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_OnException_StatusIsError()
+    {
+        var (agent, client) = CreateAgent();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitErrorAfterTokens([], new InvalidOperationException("boom")));
+        var context = new AgentContext(agent);
+
+        await context.SendMessageAsync("hi");
+
+        Assert.Equal(ConversationStatus.Error, context.Status);
+        Assert.NotNull(context.Error);
+        Assert.Equal("boom", context.Error!.Message);
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_OnException_StatusTransitions_IdleToStreamingToError()
+    {
+        var (agent, client) = CreateAgent();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitErrorAfterTokens(["partial"], new Exception("fail")));
+        var context = new AgentContext(agent);
+
+        var statuses = new List<ConversationStatus>();
+        context.RegisterOnStatusChanged(s => statuses.Add(s));
+
+        await context.SendMessageAsync("hi");
+
+        Assert.Equal(
+            new[] { ConversationStatus.Streaming, ConversationStatus.Error },
+            statuses);
+    }
+
+    // ---- Notifications ----
+
+    [Fact]
+    public async Task RegisterOnTurnAdded_FiresWhenTurnCreated()
+    {
+        var (agent, client) = CreateAgent();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("ok"));
+        var context = new AgentContext(agent);
+
+        ConversationTurn? receivedTurn = null;
+        context.RegisterOnTurnAdded(t => receivedTurn = t);
+
+        await context.SendMessageAsync("hi");
+
+        Assert.NotNull(receivedTurn);
+        Assert.Same(context.Turns[0], receivedTurn);
+    }
+
+    [Fact]
+    public async Task RegisterOnBlockAdded_FiresForEachBlock()
+    {
+        var (agent, client) = CreateAgent();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("ok"));
+        var context = new AgentContext(agent);
+
+        var receivedBlocks = new List<(ConversationTurn turn, ContentBlock block)>();
+        context.RegisterOnBlockAdded((t, b) => receivedBlocks.Add((t, b)));
+
+        await context.SendMessageAsync("hi");
+
+        Assert.True(receivedBlocks.Count >= 2);
+        Assert.All(receivedBlocks, x => Assert.Same(context.Turns[0], x.turn));
+    }
+
+    [Fact]
+    public async Task RegisterOnStatusChanged_DisposingStopsCallbacks()
+    {
+        var (agent, client) = CreateAgent();
+        var callCount = 0;
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            return ResponseEmitters.EmitTextResponse($"Reply {callCount}");
+        });
+        var context = new AgentContext(agent);
+
+        var statusCount = 0;
+        var reg = context.RegisterOnStatusChanged(_ => statusCount++);
+
+        await context.SendMessageAsync("first");
+        var countAfterFirst = statusCount;
+
+        reg.Dispose();
+
+        await context.SendMessageAsync("second");
+        Assert.Equal(countAfterFirst, statusCount);
+    }
+
+    [Fact]
+    public async Task MultipleRegistrations_AllReceiveCallbacks()
+    {
+        var (agent, client) = CreateAgent();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("ok"));
+        var context = new AgentContext(agent);
+
+        var count1 = 0;
+        var count2 = 0;
+        context.RegisterOnStatusChanged(_ => count1++);
+        context.RegisterOnStatusChanged(_ => count2++);
+
+        await context.SendMessageAsync("hi");
+
+        Assert.Equal(count1, count2);
+        Assert.True(count1 > 0);
+    }
+
+    // ---- Notification Ordering ----
+
+    [Fact]
+    public async Task Notifications_FireInCorrectOrder()
+    {
+        var (agent, client) = CreateAgent();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("ok"));
+        var context = new AgentContext(agent);
+
+        var events = new List<string>();
+        context.RegisterOnStatusChanged(s => events.Add($"status:{s}"));
+        context.RegisterOnTurnAdded(_ => events.Add("turn-added"));
+        context.RegisterOnBlockAdded((_, b) => events.Add($"block:{b.Role}"));
+
+        await context.SendMessageAsync("hi");
+
+        Assert.Equal("turn-added", events[0]);
+        Assert.Equal("status:Streaming", events[1]);
+        Assert.Equal("status:Idle", events[^1]);
+
+        var blockEvents = events.Where(e => e.StartsWith("block:", StringComparison.Ordinal)).ToList();
+        Assert.True(blockEvents.Count >= 2);
+    }
+
+    // ---- String overload ----
+
+    [Fact]
+    public async Task SendMessageAsync_StringOverload_CreatesProperChatMessage()
+    {
+        var (agent, client) = CreateAgent();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("ok"));
+        var context = new AgentContext(agent);
+
+        await context.SendMessageAsync("Hello world");
+
+        var userBlock = Assert.IsType<RichContentBlock>(context.Turns[0].RequestBlocks[0]);
+        Assert.Equal("Hello world", userBlock.RawText);
+    }
+}

--- a/src/Components/AI/test/Engine/AgentContextUIActionTests.cs
+++ b/src/Components/AI/test/Engine/AgentContextUIActionTests.cs
@@ -1,0 +1,464 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Engine;
+
+public class AgentContextUIActionTests
+{
+    private static (UIAgent agent, DelegatingStreamingChatClient client) CreateAgentWithUIAction(
+        AIFunction uiAction)
+    {
+        var chatClient = new DelegatingStreamingChatClient();
+        var agent = new UIAgent(chatClient, options =>
+        {
+            options.RegisterUIAction(uiAction);
+        });
+        return (agent, chatClient);
+    }
+
+    [Fact]
+    public async Task UIAction_SetsStatusToAwaitingInput()
+    {
+        var action = AIFunctionFactory.Create(() => "result", "GetClientData", "Gets client data");
+        var (agent, client) = CreateAgentWithUIAction(action);
+        client.SetHandler((msgs, opts, ct) =>
+            EmitUIActionCall("call-1", "GetClientData", ct));
+
+        var context = new AgentContext(agent);
+        var statuses = new List<ConversationStatus>();
+        context.RegisterOnStatusChanged(s =>
+        {
+            statuses.Add(s);
+            if (s == ConversationStatus.AwaitingInput)
+            {
+                var turn = context.Turns[^1];
+                var block = turn.ResponseBlocks.OfType<UIActionBlock>().Single();
+                block.InvokeAsync().GetAwaiter().GetResult();
+            }
+        });
+
+        await context.SendMessageAsync("Get data");
+
+        Assert.Contains(ConversationStatus.AwaitingInput, statuses);
+    }
+
+    [Fact]
+    public async Task UIAction_ParksUntilInvoked()
+    {
+        var action = AIFunctionFactory.Create(() => "value", "GetValue", "Gets a value");
+        var (agent, client) = CreateAgentWithUIAction(action);
+        var callCount = 0;
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return EmitUIActionCall("call-1", "GetValue", ct);
+            }
+            return ResponseEmitters.EmitTextResponse("Done");
+        });
+
+        var context = new AgentContext(agent);
+        var statuses = new List<ConversationStatus>();
+        context.RegisterOnStatusChanged(s =>
+        {
+            statuses.Add(s);
+            if (s == ConversationStatus.AwaitingInput)
+            {
+                var turn = context.Turns[^1];
+                turn.ResponseBlocks.OfType<UIActionBlock>().Single()
+                    .InvokeAsync().GetAwaiter().GetResult();
+            }
+        });
+
+        await context.SendMessageAsync("Go");
+
+        // Streaming → AwaitingInput → Streaming → Idle
+        Assert.Equal(new[]
+        {
+            ConversationStatus.Streaming,
+            ConversationStatus.AwaitingInput,
+            ConversationStatus.Streaming,
+            ConversationStatus.Idle,
+        }, statuses);
+    }
+
+    [Fact]
+    public async Task UIAction_ResultSentBackToLLM()
+    {
+        var action = AIFunctionFactory.Create(() => "42", "GetAnswer", "Gets the answer");
+        var (agent, client) = CreateAgentWithUIAction(action);
+        var callCount = 0;
+        IEnumerable<ChatMessage>? resumeMessages = null;
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return EmitUIActionCall("call-1", "GetAnswer", ct);
+            }
+            resumeMessages = msgs;
+            return ResponseEmitters.EmitTextResponse("The answer is 42.");
+        });
+
+        var context = new AgentContext(agent);
+        context.RegisterOnStatusChanged(s =>
+        {
+            if (s == ConversationStatus.AwaitingInput)
+            {
+                var turn = context.Turns[^1];
+                turn.ResponseBlocks.OfType<UIActionBlock>().Single()
+                    .InvokeAsync().GetAwaiter().GetResult();
+            }
+        });
+
+        await context.SendMessageAsync("What is the answer?");
+
+        Assert.NotNull(resumeMessages);
+        var toolMessage = resumeMessages!.LastOrDefault(m => m.Role == ChatRole.Tool);
+        Assert.NotNull(toolMessage);
+        var resultContent = toolMessage!.Contents.OfType<FunctionResultContent>().Single();
+        Assert.Equal("call-1", resultContent.CallId);
+    }
+
+    [Fact]
+    public async Task UIAction_BlockEmittedWithCorrectProperties()
+    {
+        var action = AIFunctionFactory.Create(
+            (string city) => $"sunny in {city}",
+            "GetWeather", "Gets weather");
+        var (agent, client) = CreateAgentWithUIAction(action);
+        var callCount = 0;
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return EmitUIActionCall("call-1", "GetWeather", ct,
+                    new Dictionary<string, object?> { ["city"] = "Seattle" });
+            }
+            return ResponseEmitters.EmitTextResponse("It's sunny.");
+        });
+
+        var context = new AgentContext(agent);
+        UIActionBlock? capturedBlock = null;
+        context.RegisterOnStatusChanged(s =>
+        {
+            if (s == ConversationStatus.AwaitingInput)
+            {
+                var turn = context.Turns[^1];
+                capturedBlock = turn.ResponseBlocks.OfType<UIActionBlock>().First();
+                capturedBlock.InvokeAsync().GetAwaiter().GetResult();
+            }
+        });
+
+        await context.SendMessageAsync("Weather?");
+
+        Assert.NotNull(capturedBlock);
+        Assert.Equal("GetWeather", capturedBlock!.ToolName);
+        Assert.Equal("call-1", capturedBlock.Id);
+        Assert.True(capturedBlock.IsComplete);
+        Assert.True(capturedBlock.HasResult);
+    }
+
+    [Fact]
+    public async Task UIAction_ContinuationBlocksAddedToSameTurn()
+    {
+        var action = AIFunctionFactory.Create(() => "data", "Fetch", "Fetches data");
+        var (agent, client) = CreateAgentWithUIAction(action);
+        var callCount = 0;
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return EmitUIActionCall("call-1", "Fetch", ct);
+            }
+            return ResponseEmitters.EmitTextResponse("Here is the data.");
+        });
+
+        var context = new AgentContext(agent);
+        context.RegisterOnStatusChanged(s =>
+        {
+            if (s == ConversationStatus.AwaitingInput)
+            {
+                var turn = context.Turns[^1];
+                turn.ResponseBlocks.OfType<UIActionBlock>().Single()
+                    .InvokeAsync().GetAwaiter().GetResult();
+            }
+        });
+
+        await context.SendMessageAsync("Fetch data");
+
+        Assert.Single(context.Turns);
+        var turn = context.Turns[0];
+        var uiBlock = turn.ResponseBlocks.OfType<UIActionBlock>().SingleOrDefault();
+        var textBlock = turn.ResponseBlocks.OfType<RichContentBlock>().SingleOrDefault();
+        Assert.NotNull(uiBlock);
+        Assert.NotNull(textBlock);
+        Assert.Equal("Here is the data.", textBlock!.RawText);
+    }
+
+    [Fact]
+    public async Task UIAction_DeclarationsMergedIntoChatOptions()
+    {
+        var action = AIFunctionFactory.Create(() => "ok", "MyTool", "My tool");
+        var (agent, client) = CreateAgentWithUIAction(action);
+        ChatOptions? capturedOptions = null;
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            capturedOptions = opts;
+            return ResponseEmitters.EmitTextResponse("Hello");
+        });
+
+        var context = new AgentContext(agent);
+        await context.SendMessageAsync("Hi");
+
+        Assert.NotNull(capturedOptions);
+        Assert.NotNull(capturedOptions!.Tools);
+        Assert.Single(capturedOptions.Tools!);
+        var tool = capturedOptions.Tools![0];
+        // Should be a declaration-only (AIFunctionDeclaration but not AIFunction)
+        Assert.False(tool is AIFunction);
+        Assert.IsAssignableFrom<AIFunctionDeclaration>(tool);
+    }
+
+    [Fact]
+    public async Task UIAction_ExistingToolsPreserved()
+    {
+        var action = AIFunctionFactory.Create(() => "client", "ClientTool", "Client tool");
+        var serverTool = AIFunctionFactory.Create(() => "server", "ServerTool", "Server tool");
+
+        var chatClient = new DelegatingStreamingChatClient();
+        var agent = new UIAgent(chatClient, options =>
+        {
+            options.ChatOptions = new ChatOptions { Tools = [serverTool] };
+            options.RegisterUIAction(action);
+        });
+
+        ChatOptions? capturedOptions = null;
+        chatClient.SetHandler((msgs, opts, ct) =>
+        {
+            capturedOptions = opts;
+            return ResponseEmitters.EmitTextResponse("Hello");
+        });
+
+        var context = new AgentContext(agent);
+        await context.SendMessageAsync("Hi");
+
+        Assert.NotNull(capturedOptions);
+        Assert.Equal(2, capturedOptions!.Tools!.Count);
+    }
+
+    [Fact]
+    public async Task UIAction_IsAFunctionInvocationContentBlock()
+    {
+        var action = AIFunctionFactory.Create(() => "result", "DoThing", "Does a thing");
+        var (agent, client) = CreateAgentWithUIAction(action);
+        var callCount = 0;
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return EmitUIActionCall("call-1", "DoThing", ct);
+            }
+            return ResponseEmitters.EmitTextResponse("Done");
+        });
+
+        var context = new AgentContext(agent);
+        ContentBlock? capturedBlock = null;
+        context.RegisterOnStatusChanged(s =>
+        {
+            if (s == ConversationStatus.AwaitingInput)
+            {
+                var turn = context.Turns[^1];
+                capturedBlock = turn.ResponseBlocks.First(b => b is UIActionBlock);
+                ((UIActionBlock)capturedBlock).InvokeAsync().GetAwaiter().GetResult();
+            }
+        });
+
+        await context.SendMessageAsync("Do it");
+
+        // UIActionBlock IS-A InteractiveFunctionBlock with an InnerBlock
+        Assert.IsAssignableFrom<InteractiveFunctionBlock>(capturedBlock);
+        Assert.IsType<UIActionBlock>(capturedBlock);
+        var uiBlock = (UIActionBlock)capturedBlock!;
+        Assert.NotNull(uiBlock.InnerBlock);
+        Assert.IsType<FunctionInvocationContentBlock>(uiBlock.InnerBlock);
+    }
+
+    [Fact]
+    public async Task UIAction_InvokeAsync_WorksWithoutAgentContext()
+    {
+        var action = AIFunctionFactory.Create(() => "v", "F", "desc");
+        var innerBlock = new FunctionInvocationContentBlock { Call = new FunctionCallContent("c1", "F") };
+        var block = new UIActionBlock(action, innerBlock);
+
+        await block.InvokeAsync();
+
+        Assert.True(block.IsComplete);
+        Assert.True(block.HasResult);
+    }
+
+    [Fact]
+    public async Task MixedToolCall_BackendAndUIAction_BothInvoked()
+    {
+        // Backend tool: invoked automatically by AgentContext
+        var backendTool = AIFunctionFactory.Create(
+            (string city) => $"72°F and sunny in {city}",
+            "GetWeather", "Gets weather");
+
+        // UIAction: invoked by the user via AgentContext callback
+        var uiAction = AIFunctionFactory.Create(
+            () => "Seattle, WA",
+            "GetUserLocation", "Gets location");
+
+        var chatClient = new DelegatingStreamingChatClient();
+        var agent = new UIAgent(chatClient, options =>
+        {
+            options.ChatOptions = new ChatOptions { Tools = [backendTool] };
+            options.RegisterUIAction(uiAction);
+        });
+
+        var callCount = 0;
+        IEnumerable<ChatMessage>? resumeMessages = null;
+        chatClient.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                // Emit both tool calls in the same response (parallel tool calls)
+                return ResponseEmitters.EmitMultipleToolCallResponse(ct,
+                    new FunctionCallContent("call-weather", "GetWeather",
+                        new Dictionary<string, object?> { ["city"] = "Seattle" }),
+                    new FunctionCallContent("call-location", "GetUserLocation"));
+            }
+            resumeMessages = msgs;
+            return ResponseEmitters.EmitTextResponse("It's 72°F and sunny in Seattle, WA.");
+        });
+
+        var context = new AgentContext(agent);
+        var statuses = new List<ConversationStatus>();
+        context.RegisterOnStatusChanged(s =>
+        {
+            statuses.Add(s);
+            if (s == ConversationStatus.AwaitingInput)
+            {
+                var turn = context.Turns[^1];
+                var actionBlock = turn.ResponseBlocks.OfType<UIActionBlock>().Single();
+                actionBlock.InvokeAsync().GetAwaiter().GetResult();
+            }
+        });
+
+        await context.SendMessageAsync("What's the weather at my location?");
+
+        // Should have both block types in the response
+        var turn = context.Turns[0];
+        var uiBlock = turn.ResponseBlocks.OfType<UIActionBlock>().Single();
+        var toolBlock = turn.ResponseBlocks.OfType<FunctionInvocationContentBlock>().Single();
+
+        // Both should have results
+        Assert.True(uiBlock.HasResult);
+        Assert.True(toolBlock.HasResult);
+        Assert.Equal("GetUserLocation", uiBlock.ToolName);
+        Assert.Equal("GetWeather", toolBlock.ToolName);
+
+        // Status should flow: Streaming → AwaitingInput → Streaming → Idle
+        Assert.Equal(new[]
+        {
+            ConversationStatus.Streaming,
+            ConversationStatus.AwaitingInput,
+            ConversationStatus.Streaming,
+            ConversationStatus.Idle,
+        }, statuses);
+
+        // The resume should send BOTH results to the LLM
+        Assert.NotNull(resumeMessages);
+        var toolMessage = resumeMessages!.Last(m => m.Role == ChatRole.Tool);
+        var results = toolMessage.Contents.OfType<FunctionResultContent>().ToList();
+        Assert.Equal(2, results.Count);
+        Assert.Contains(results, r => r.CallId == "call-weather");
+        Assert.Contains(results, r => r.CallId == "call-location");
+
+        // Should have text response after resume
+        var textBlock = turn.ResponseBlocks.OfType<RichContentBlock>().LastOrDefault();
+        Assert.NotNull(textBlock);
+    }
+
+    [Fact]
+    public async Task MixedToolCall_BackendToolResultsSetOnBlock()
+    {
+        var backendTool = AIFunctionFactory.Create(
+            (string city) => $"Weather: sunny in {city}",
+            "GetWeather", "Gets weather");
+        var uiAction = AIFunctionFactory.Create(
+            () => "Portland, OR",
+            "GetLocation", "Gets location");
+
+        var chatClient = new DelegatingStreamingChatClient();
+        var agent = new UIAgent(chatClient, options =>
+        {
+            options.ChatOptions = new ChatOptions { Tools = [backendTool] };
+            options.RegisterUIAction(uiAction);
+        });
+
+        var callCount = 0;
+        chatClient.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return ResponseEmitters.EmitMultipleToolCallResponse(ct,
+                    new FunctionCallContent("call-w", "GetWeather",
+                        new Dictionary<string, object?> { ["city"] = "Portland" }),
+                    new FunctionCallContent("call-l", "GetLocation"));
+            }
+            return ResponseEmitters.EmitTextResponse("Done");
+        });
+
+        var context = new AgentContext(agent);
+        FunctionInvocationContentBlock? capturedToolBlock = null;
+        context.RegisterOnStatusChanged(s =>
+        {
+            if (s == ConversationStatus.AwaitingInput)
+            {
+                var turn = context.Turns[^1];
+                capturedToolBlock = turn.ResponseBlocks
+                    .OfType<FunctionInvocationContentBlock>()
+                    .First();
+
+                // The backend tool should already have its result set
+                // because AgentContext invokes it immediately
+                turn.ResponseBlocks.OfType<UIActionBlock>().Single()
+                    .InvokeAsync().GetAwaiter().GetResult();
+            }
+        });
+
+        await context.SendMessageAsync("Go");
+
+        Assert.NotNull(capturedToolBlock);
+        Assert.True(capturedToolBlock!.HasResult);
+        Assert.Contains("sunny in Portland", capturedToolBlock.Result!.Result?.ToString());
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> EmitUIActionCall(
+        string callId,
+        string name,
+        [EnumeratorCancellation] CancellationToken ct = default,
+        IDictionary<string, object?>? arguments = null)
+    {
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = Guid.NewGuid().ToString("N"),
+            Contents = [new FunctionCallContent(callId, name, arguments)],
+            FinishReason = ChatFinishReason.ToolCalls
+        };
+        await Task.CompletedTask;
+    }
+}

--- a/src/Components/AI/test/Engine/AgentStateTests.cs
+++ b/src/Components/AI/test/Engine/AgentStateTests.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Engine;
+
+public class AgentStateTests
+{
+    private class TestState
+    {
+        public string Name { get; set; } = "";
+        public int Count { get; set; }
+    }
+
+    [Fact]
+    public void Value_DefaultsToNewT()
+    {
+        var state = new AgentState<TestState>();
+        Assert.NotNull(state.Value);
+        Assert.Equal("", state.Value.Name);
+        Assert.Equal(0, state.Value.Count);
+    }
+
+    [Fact]
+    public void Value_UsesInitialValueWhenProvided()
+    {
+        var initial = new TestState { Name = "initial", Count = 5 };
+        var state = new AgentState<TestState>(initial);
+        Assert.Same(initial, state.Value);
+    }
+
+    [Fact]
+    public void Value_Setter_InvokesOnChangedCallbacks()
+    {
+        var state = new AgentState<TestState>();
+        var fired = false;
+        state.OnChanged(() => fired = true);
+
+        state.Value = new TestState { Name = "updated" };
+
+        Assert.True(fired);
+    }
+
+    [Fact]
+    public void OnChanged_MultipleCallbacksAllFire()
+    {
+        var state = new AgentState<TestState>();
+        var count = 0;
+        state.OnChanged(() => count++);
+        state.OnChanged(() => count++);
+
+        state.Value = new TestState();
+
+        Assert.Equal(2, count);
+    }
+
+    [Fact]
+    public void OnChanged_DisposingStopsCallbacks()
+    {
+        var state = new AgentState<TestState>();
+        var count = 0;
+        var reg = state.OnChanged(() => count++);
+
+        state.Value = new TestState();
+        Assert.Equal(1, count);
+
+        reg.Dispose();
+        state.Value = new TestState();
+        Assert.Equal(1, count);
+    }
+}

--- a/src/Components/AI/test/Engine/UIAgentBaselineTests.cs
+++ b/src/Components/AI/test/Engine/UIAgentBaselineTests.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Engine;
+
+public class UIAgentBaselineTests
+{
+    [Fact]
+    public async Task Step01_MultiTurnTextStreaming_ProducesCorrectBlocks()
+    {
+        var client = RecordingLoader.CreateReplayClient(
+            "Step01_GettingStartedTest.PostRun_MultiTurn_SynthesizesAssistantMessages.recording.json");
+
+        var agent = new UIAgent(client);
+
+        // Turn 1
+        var turn1Blocks = new List<ContentBlock>();
+        await foreach (var block in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "Hello")))
+        {
+            turn1Blocks.Add(block);
+        }
+
+        var assistantBlocks1 = turn1Blocks.Where(b => b.Role == ChatRole.Assistant).ToList();
+        Assert.NotEmpty(assistantBlocks1);
+        var text1 = Assert.IsType<RichContentBlock>(assistantBlocks1[0]);
+        Assert.False(string.IsNullOrEmpty(text1.RawText));
+        Assert.Equal(BlockLifecycleState.Inactive, text1.LifecycleState);
+
+        // Turn 2
+        var turn2Blocks = new List<ContentBlock>();
+        await foreach (var block in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "Tell me more")))
+        {
+            turn2Blocks.Add(block);
+        }
+
+        var assistantBlocks2 = turn2Blocks.Where(b => b.Role == ChatRole.Assistant).ToList();
+        Assert.NotEmpty(assistantBlocks2);
+        var text2 = Assert.IsType<RichContentBlock>(assistantBlocks2[0]);
+        Assert.False(string.IsNullOrEmpty(text2.RawText));
+        Assert.Equal(BlockLifecycleState.Inactive, text2.LifecycleState);
+    }
+}

--- a/src/Components/AI/test/Engine/UIAgentCustomHandlerTests.cs
+++ b/src/Components/AI/test/Engine/UIAgentCustomHandlerTests.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Components.AI.Tests.Pipeline;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Engine;
+
+public class UIAgentCustomHandlerTests
+{
+    private sealed class CitationRaw
+    {
+        public string Source { get; set; } = "";
+        public string Quote { get; set; } = "";
+    }
+
+    [Fact]
+    public async Task UIAgent_WithCustomHandler_ProducesCustomBlocks()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) => EmitCitations(ct));
+
+        var agent = new UIAgent(client, configure: options =>
+        {
+            options.AddBlockHandler(new DelegateBlockHandler<CitationBlock>((context, state) =>
+            {
+                if (context.Update.RawRepresentation is not CitationRaw raw)
+                {
+                    return BlockMappingResult<CitationBlock>.Pass();
+                }
+                context.MarkUpdateHandled();
+                state.Source = raw.Source;
+                state.Quote = raw.Quote;
+                state.Id = Guid.NewGuid().ToString("N");
+                return BlockMappingResult<CitationBlock>.Emit(state, state);
+            }));
+        });
+
+        var blocks = new List<ContentBlock>();
+        await foreach (var block in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "Find sources")))
+        {
+            blocks.Add(block);
+        }
+
+        var assistantBlocks = blocks.Where(b => b.Role == ChatRole.Assistant).ToList();
+        Assert.Contains(assistantBlocks, b => b is CitationBlock);
+        Assert.Contains(assistantBlocks, b => b is RichContentBlock);
+
+        static async IAsyncEnumerable<ChatResponseUpdate> EmitCitations(
+            [EnumeratorCancellation] CancellationToken ct)
+        {
+            yield return new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                RawRepresentation = new CitationRaw { Source = "Journal", Quote = "Data shows..." }
+            };
+            yield return new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                MessageId = "msg-1",
+                Contents = [new TextContent("Based on the research...")]
+            };
+            await Task.CompletedTask;
+        }
+    }
+}

--- a/src/Components/AI/test/Engine/UIAgentReasoningTests.cs
+++ b/src/Components/AI/test/Engine/UIAgentReasoningTests.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Engine;
+
+public class UIAgentReasoningTests
+{
+    [Fact]
+    public async Task SendMessageAsync_ReasoningThenText_YieldsBothBlocks()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitReasoningThenTextResponse(
+                "Let me think...", "The answer is 42."));
+        var agent = new UIAgent(client);
+
+        var blocks = new List<ContentBlock>();
+        await foreach (var block in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "What is the meaning of life?")))
+        {
+            blocks.Add(block);
+        }
+
+        var assistantBlocks = blocks.Where(b => b.Role == ChatRole.Assistant).ToList();
+        Assert.Equal(2, assistantBlocks.Count);
+
+        var reasoning = Assert.IsType<ReasoningContentBlock>(assistantBlocks[0]);
+        Assert.Equal("Let me think...", reasoning.Text);
+        Assert.Equal(BlockLifecycleState.Inactive, reasoning.LifecycleState);
+
+        var text = Assert.IsType<RichContentBlock>(assistantBlocks[1]);
+        Assert.Equal("The answer is 42.", text.RawText);
+        Assert.Equal(BlockLifecycleState.Inactive, text.LifecycleState);
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_ReasoningOnly_YieldsReasoningBlock()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) => YieldReasoningOnly(ct));
+        var agent = new UIAgent(client);
+
+        var blocks = new List<ContentBlock>();
+        await foreach (var block in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "Think about this")))
+        {
+            blocks.Add(block);
+        }
+
+        var assistantBlocks = blocks.Where(b => b.Role == ChatRole.Assistant).ToList();
+        Assert.Single(assistantBlocks);
+        var reasoning = Assert.IsType<ReasoningContentBlock>(assistantBlocks[0]);
+        Assert.Equal("Deep thoughts...", reasoning.Text);
+        Assert.Equal(BlockLifecycleState.Inactive, reasoning.LifecycleState);
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> YieldReasoningOnly(
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "msg-1",
+            Contents = [new TextReasoningContent("Deep thoughts...")]
+        };
+        await Task.CompletedTask;
+    }
+}

--- a/src/Components/AI/test/Engine/UIAgentRecordedTests.cs
+++ b/src/Components/AI/test/Engine/UIAgentRecordedTests.cs
@@ -1,0 +1,338 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+using Azure.AI.OpenAI;
+using Azure.Identity;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Engine;
+
+public class UIAgentRecordedTests
+{
+    private const string Endpoint = "https://your-resource.cognitiveservices.azure.com/";
+    private const string DeploymentName = "your-deployment-name";
+
+    private readonly ITestOutputHelper _output;
+    private readonly ILoggerFactory _loggerFactory;
+
+    public UIAgentRecordedTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _loggerFactory = new XunitLoggerFactory(output);
+    }
+
+    private static string GetBaselinePath(string fileName)
+    {
+        return Path.Combine(
+            AppContext.BaseDirectory,
+            "Baselines",
+            fileName);
+    }
+
+    private static string GetSourceBaselinePath(string fileName)
+    {
+        // Navigate from bin output back to source Baselines folder
+        var projectDir = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..", "..", ".."));
+        return Path.Combine(projectDir, "Baselines", fileName);
+    }
+
+    private static IChatClient CreateAzureOpenAIClient()
+    {
+        var azureClient = new AzureOpenAIClient(
+            new Uri(Endpoint),
+            new DefaultAzureCredential());
+        return azureClient.GetChatClient(DeploymentName).AsIChatClient();
+    }
+
+    private static IChatClient CreateReplayOrRecordClient(string baselineFileName)
+    {
+        var baselinePath = GetBaselinePath(baselineFileName);
+        if (File.Exists(baselinePath))
+        {
+            return RecordingLoader.CreateReplayClient(baselineFileName);
+        }
+
+        // Record mode: wrap real LLM
+        var inner = CreateAzureOpenAIClient();
+        return new RecordingChatClient(inner);
+    }
+
+    private static void SaveIfRecording(IChatClient client, string baselineFileName)
+    {
+        if (client is RecordingChatClient recorder)
+        {
+            var sourcePath = GetSourceBaselinePath(baselineFileName);
+            recorder.SaveRecording(sourcePath);
+
+            // Also save to output dir so subsequent test runs in the same session can find it
+            var outputPath = GetBaselinePath(baselineFileName);
+            recorder.SaveRecording(outputPath);
+        }
+    }
+
+    [Fact]
+    public async Task TextStreaming_SingleTurn_ProducesRichContentBlock()
+    {
+        const string baseline = "TextStreaming_SingleTurn.recording.json";
+        var client = CreateReplayOrRecordClient(baseline);
+        var agent = new UIAgent(client, configure: null, _loggerFactory);
+
+        var blocks = new List<ContentBlock>();
+        await foreach (var block in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "Say hello in one sentence.")))
+        {
+            blocks.Add(block);
+        }
+
+        SaveIfRecording(client, baseline);
+
+        var assistantBlocks = blocks.Where(b => b.Role == ChatRole.Assistant).ToList();
+        Assert.NotEmpty(assistantBlocks);
+        var textBlock = Assert.IsType<RichContentBlock>(assistantBlocks[0]);
+        Assert.False(string.IsNullOrEmpty(textBlock.RawText));
+        Assert.Equal(BlockLifecycleState.Inactive, textBlock.LifecycleState);
+    }
+
+    [Fact]
+    public async Task TextStreaming_MultiTurn_ProducesBlocksPerTurn()
+    {
+        const string baseline = "TextStreaming_MultiTurn.recording.json";
+        var client = CreateReplayOrRecordClient(baseline);
+        var agent = new UIAgent(client, configure: null, _loggerFactory);
+
+        // Turn 1
+        var turn1Blocks = new List<ContentBlock>();
+        await foreach (var block in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "Say hello in one sentence.")))
+        {
+            turn1Blocks.Add(block);
+        }
+
+        var text1 = turn1Blocks.OfType<RichContentBlock>()
+            .First(b => b.Role == ChatRole.Assistant);
+        Assert.False(string.IsNullOrEmpty(text1.RawText));
+        Assert.Equal(BlockLifecycleState.Inactive, text1.LifecycleState);
+
+        // Turn 2
+        var turn2Blocks = new List<ContentBlock>();
+        await foreach (var block in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "Now say goodbye in one sentence.")))
+        {
+            turn2Blocks.Add(block);
+        }
+
+        var text2 = turn2Blocks.OfType<RichContentBlock>()
+            .First(b => b.Role == ChatRole.Assistant);
+        Assert.False(string.IsNullOrEmpty(text2.RawText));
+        Assert.Equal(BlockLifecycleState.Inactive, text2.LifecycleState);
+
+        SaveIfRecording(client, baseline);
+    }
+
+    [Fact]
+    public async Task ToolCall_ProducesFunctionInvocationBlock()
+    {
+        const string baseline = "ToolCall_BackendTool.recording.json";
+        var client = CreateReplayOrRecordClient(baseline);
+
+        var tool = AIFunctionFactory.Create(GetWeather);
+        var chatClient = client.AsBuilder()
+            .UseFunctionInvocation(_loggerFactory)
+            .Build();
+        var agent = new UIAgent(chatClient, new ChatOptions { Tools = [tool] }, _loggerFactory);
+
+        var blocks = new List<ContentBlock>();
+        await foreach (var block in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "What's the weather in Seattle?")))
+        {
+            blocks.Add(block);
+        }
+
+        SaveIfRecording(client, baseline);
+
+        var assistantBlocks = blocks.Where(b => b.Role == ChatRole.Assistant).ToList();
+
+        // FunctionInvokingChatClient handles the tool call loop internally.
+        // It yields the tool call updates, invokes the tool, then yields the text response.
+        Assert.NotEmpty(assistantBlocks);
+
+        // Should have a FunctionInvocationContentBlock for the tool call
+        var toolBlock = assistantBlocks.OfType<FunctionInvocationContentBlock>().FirstOrDefault();
+        Assert.NotNull(toolBlock);
+        Assert.Equal("GetWeather", toolBlock!.ToolName);
+
+        // Should have text content after the tool call completes
+        var hasText = assistantBlocks.OfType<RichContentBlock>().Any(b => !string.IsNullOrEmpty(b.RawText));
+        Assert.True(hasText, $"Expected text content. Block types: {string.Join(", ", assistantBlocks.Select(b => b.GetType().Name))}");
+    }
+
+    [Fact]
+    public async Task ToolApproval_ProducesApprovalBlockAndResumes()
+    {
+        const string baseline = "ToolApproval_HumanInLoop.recording.json";
+        var client = CreateReplayOrRecordClient(baseline);
+
+        var tool = new ApprovalRequiredAIFunction(AIFunctionFactory.Create(DeleteFile));
+        var chatClient = client.AsBuilder()
+            .UseFunctionInvocation(_loggerFactory)
+            .Build();
+        var agent = new UIAgent(chatClient, options => options.ChatOptions = new ChatOptions { Tools = [tool] }, _loggerFactory);
+
+        var context = new AgentContext(agent);
+        FunctionApprovalBlock? approvalBlock = null;
+        context.RegisterOnStatusChanged(s =>
+        {
+            if (s == ConversationStatus.AwaitingInput)
+            {
+                var turn = context.Turns[^1];
+                approvalBlock = turn.ResponseBlocks.OfType<FunctionApprovalBlock>().FirstOrDefault();
+                approvalBlock?.Approve();
+            }
+        });
+
+        await context.SendMessageAsync("Delete the file named test.txt");
+
+        SaveIfRecording(client, baseline);
+
+        Assert.NotNull(approvalBlock);
+        Assert.Equal(ApprovalStatus.Approved, approvalBlock!.Status);
+        Assert.Equal("DeleteFile", approvalBlock.InnerBlock.ToolName);
+
+        // After approval, should have continued to produce text
+        var lastTurn = context.Turns[^1];
+        var textBlock = lastTurn.ResponseBlocks.OfType<RichContentBlock>().LastOrDefault();
+        Assert.NotNull(textBlock);
+        Assert.False(string.IsNullOrEmpty(textBlock!.RawText));
+    }
+
+    [Fact]
+    public async Task UIAction_ProducesUIActionBlockAndResumes()
+    {
+        const string baseline = "UIAction_ClientTool.recording.json";
+        var client = CreateReplayOrRecordClient(baseline);
+
+        var action = AIFunctionFactory.Create(GetUserLocation);
+        var agent = new UIAgent(client, options =>
+        {
+            options.RegisterUIAction(action);
+        }, _loggerFactory);
+
+        var context = new AgentContext(agent);
+        UIActionBlock? actionBlock = null;
+        context.RegisterOnStatusChanged(s =>
+        {
+            if (s == ConversationStatus.AwaitingInput)
+            {
+                var turn = context.Turns[^1];
+                actionBlock = turn.ResponseBlocks.OfType<UIActionBlock>().FirstOrDefault();
+                if (actionBlock is not null)
+                {
+                    actionBlock.InvokeAsync().GetAwaiter().GetResult();
+                }
+            }
+        });
+
+        await context.SendMessageAsync(
+            "Use the GetUserLocation tool to find my location, " +
+            "then suggest fun things to do there.");
+
+        SaveIfRecording(client, baseline);
+
+        Assert.NotNull(actionBlock);
+        Assert.Equal("GetUserLocation", actionBlock!.ToolName);
+        Assert.True(actionBlock.IsComplete);
+        Assert.True(actionBlock.HasResult);
+
+        // After UIAction resume, should have text response
+        var lastTurn = context.Turns[^1];
+        var textBlock = lastTurn.ResponseBlocks.OfType<RichContentBlock>().LastOrDefault();
+        Assert.NotNull(textBlock);
+        Assert.False(string.IsNullOrEmpty(textBlock!.RawText));
+    }
+
+    [Description("Get the current weather for a city.")]
+    private static string GetWeather([Description("The city name")] string city)
+    {
+        return $"The weather in {city} is 72°F and sunny.";
+    }
+
+    [Description("Delete a file by name.")]
+    private static string DeleteFile([Description("The file name to delete")] string fileName)
+    {
+        return $"File '{fileName}' has been deleted.";
+    }
+
+    [Description("Get the user's current location from GPS.")]
+    private static string GetUserLocation()
+    {
+        return "Seattle, WA (47.61°N, 122.33°W)";
+    }
+
+    [Fact]
+    public async Task MixedToolCall_BackendAndUIAction_BothInvoked()
+    {
+        const string baseline = "MixedToolCall_BackendAndUIAction.recording.json";
+        var client = CreateReplayOrRecordClient(baseline);
+
+        var backendTool = AIFunctionFactory.Create(GetWeather);
+        var uiAction = AIFunctionFactory.Create(GetUserLocation);
+
+        var chatClient = client.AsBuilder()
+            .UseFunctionInvocation(_loggerFactory)
+            .Build();
+        var agent = new UIAgent(chatClient, options =>
+        {
+            options.ChatOptions = new ChatOptions { Tools = [backendTool] };
+            options.RegisterUIAction(uiAction);
+        }, _loggerFactory);
+
+        var context = new AgentContext(agent);
+        UIActionBlock? actionBlock = null;
+        FunctionInvocationContentBlock? weatherBlock = null;
+        context.RegisterOnStatusChanged(s =>
+        {
+            if (s == ConversationStatus.AwaitingInput)
+            {
+                var turn = context.Turns[^1];
+                actionBlock = turn.ResponseBlocks.OfType<UIActionBlock>().FirstOrDefault();
+                weatherBlock = turn.ResponseBlocks
+                    .OfType<FunctionInvocationContentBlock>()
+                    .FirstOrDefault();
+                if (actionBlock is not null)
+                {
+                    actionBlock.InvokeAsync().GetAwaiter().GetResult();
+                }
+            }
+        });
+
+        await context.SendMessageAsync(
+            "Use the GetUserLocation tool to get my location, " +
+            "then use GetWeather to check the weather there. " +
+            "Call both tools at the same time.");
+
+        SaveIfRecording(client, baseline);
+
+        // UIAction should have been invoked
+        Assert.NotNull(actionBlock);
+        Assert.Equal("GetUserLocation", actionBlock!.ToolName);
+        Assert.True(actionBlock.IsComplete);
+        Assert.True(actionBlock.HasResult);
+
+        // Backend tool should have been invoked automatically
+        Assert.NotNull(weatherBlock);
+        Assert.Equal("GetWeather", weatherBlock!.ToolName);
+        Assert.True(weatherBlock.HasResult);
+
+        // Should have text response after both tools complete
+        var lastTurn = context.Turns[^1];
+        var textBlock = lastTurn.ResponseBlocks.OfType<RichContentBlock>().LastOrDefault();
+        Assert.NotNull(textBlock);
+        Assert.False(string.IsNullOrEmpty(textBlock!.RawText));
+    }
+}

--- a/src/Components/AI/test/Engine/UIAgentTests.cs
+++ b/src/Components/AI/test/Engine/UIAgentTests.cs
@@ -1,0 +1,137 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Engine;
+
+public class UIAgentTests
+{
+    [Fact]
+    public async Task SendMessageAsync_TextResponse_YieldsUserThenAssistantBlocks()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hi there!"));
+        var agent = new UIAgent(client);
+
+        var blocks = new List<ContentBlock>();
+        await foreach (var block in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "Hello")))
+        {
+            blocks.Add(block);
+        }
+
+        Assert.True(blocks.Count >= 2);
+
+        var userBlocks = blocks.Where(b => b.Role == ChatRole.User).ToList();
+        Assert.NotEmpty(userBlocks);
+        var userBlock = Assert.IsType<RichContentBlock>(userBlocks[0]);
+        Assert.Equal("Hello", userBlock.RawText);
+
+        var assistantBlocks = blocks.Where(b => b.Role == ChatRole.Assistant).ToList();
+        Assert.NotEmpty(assistantBlocks);
+        var assistantBlock = Assert.IsType<RichContentBlock>(assistantBlocks[0]);
+        Assert.Equal("Hi there!", assistantBlock.RawText);
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_MultiTokenStreaming_SingleBlockWithAccumulatedText()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitMultiTokenTextResponse(ct, "Hello", " ", "world", "!"));
+        var agent = new UIAgent(client);
+
+        var blocks = new List<ContentBlock>();
+        await foreach (var block in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "Hi")))
+        {
+            blocks.Add(block);
+        }
+
+        var assistantBlocks = blocks.Where(b => b.Role == ChatRole.Assistant).ToList();
+        Assert.Single(assistantBlocks);
+        var rich = Assert.IsType<RichContentBlock>(assistantBlocks[0]);
+        Assert.Equal("Hello world!", rich.RawText);
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_MultiTokenStreaming_OnChangedFiresPerToken()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitMultiTokenTextResponse(ct, "A", "B", "C"));
+        var agent = new UIAgent(client);
+
+        var changeCount = 0;
+        ContentBlock? firstBlock = null;
+
+        await foreach (var block in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "Hi")))
+        {
+            if (block.Role == ChatRole.Assistant && firstBlock is null)
+            {
+                firstBlock = block;
+                block.OnChanged(() => changeCount++);
+            }
+        }
+
+        Assert.Equal(2, changeCount);
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_AllBlocksInactiveAfterIteration()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Done"));
+        var agent = new UIAgent(client);
+
+        var blocks = new List<ContentBlock>();
+        await foreach (var block in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "Go")))
+        {
+            blocks.Add(block);
+        }
+
+        Assert.All(blocks, b => Assert.Equal(BlockLifecycleState.Inactive, b.LifecycleState));
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_EmptyResponse_YieldsUserBlockOnly()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) => ResponseEmitters.EmitEmptyResponse());
+        var agent = new UIAgent(client);
+
+        var blocks = new List<ContentBlock>();
+        await foreach (var block in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "Hello")))
+        {
+            blocks.Add(block);
+        }
+
+        Assert.All(blocks, b => Assert.Equal(ChatRole.User, b.Role));
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_PassesChatOptions_ToIChatClient()
+    {
+        ChatOptions? capturedOptions = null;
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            capturedOptions = opts;
+            return ResponseEmitters.EmitTextResponse("ok");
+        });
+        var expectedOptions = new ChatOptions { Temperature = 0.5f };
+        var agent = new UIAgent(client, expectedOptions);
+
+        await foreach (var _ in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "test"))) { }
+
+        Assert.Same(expectedOptions, capturedOptions);
+    }
+}

--- a/src/Components/AI/test/Engine/UIAgentToolCallBaselineTests.cs
+++ b/src/Components/AI/test/Engine/UIAgentToolCallBaselineTests.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Engine;
+
+public class UIAgentToolCallBaselineTests
+{
+    [Fact]
+    public async Task Step02_BackendToolCall_ProducesCorrectBlocks()
+    {
+        var client = RecordingLoader.CreateReplayClient(
+            "Step02_BackendToolsTest.PostRun_WithBackendToolCall_InvokesToolAndStreamsResult.recording.json");
+        var agent = new UIAgent(client);
+
+        var blocks = new List<ContentBlock>();
+        await foreach (var block in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "Find Italian restaurants in Seattle")))
+        {
+            blocks.Add(block);
+        }
+
+        var assistantBlocks = blocks.Where(b => b.Role == ChatRole.Assistant).ToList();
+
+        // Should have a FunctionInvocationContentBlock (SearchRestaurants call)
+        var toolBlock = assistantBlocks.OfType<FunctionInvocationContentBlock>().FirstOrDefault();
+        Assert.NotNull(toolBlock);
+        Assert.Equal("SearchRestaurants", toolBlock.ToolName);
+        Assert.Equal("call_abc123", toolBlock.Id);
+        Assert.True(toolBlock.HasResult);
+
+        // Should also have a RichContentBlock (text response describing results)
+        var textBlock = assistantBlocks.OfType<RichContentBlock>().FirstOrDefault();
+        Assert.NotNull(textBlock);
+        Assert.False(string.IsNullOrEmpty(textBlock.RawText));
+    }
+}

--- a/src/Components/AI/test/Engine/UIAgentToolCallTests.cs
+++ b/src/Components/AI/test/Engine/UIAgentToolCallTests.cs
@@ -1,0 +1,152 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Engine;
+
+public class UIAgentToolCallTests
+{
+    [Fact]
+    public async Task SendMessageAsync_ToolCallWithResult_ProducesSingleBlock()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitToolCallWithResultResponse(
+                "call-1", "GetWeather",
+                new Dictionary<string, object?> { ["city"] = "Seattle" },
+                "sunny, 72°F"));
+        var agent = new UIAgent(client);
+
+        var blocks = new List<ContentBlock>();
+        await foreach (var block in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "What's the weather?")))
+        {
+            blocks.Add(block);
+        }
+
+        var toolBlocks = blocks.OfType<FunctionInvocationContentBlock>().ToList();
+        Assert.Single(toolBlocks);
+        Assert.Equal("GetWeather", toolBlocks[0].ToolName);
+        Assert.True(toolBlocks[0].HasResult);
+        Assert.Equal(BlockLifecycleState.Inactive, toolBlocks[0].LifecycleState);
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_ToolCallOnly_BlockBecomesInactiveAfterFinalize()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitToolCallResponse("call-1", "GetWeather"));
+        var agent = new UIAgent(client);
+
+        var blocks = new List<ContentBlock>();
+        await foreach (var block in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "weather?")))
+        {
+            blocks.Add(block);
+        }
+
+        var toolBlocks = blocks.OfType<FunctionInvocationContentBlock>().ToList();
+        Assert.Single(toolBlocks);
+        Assert.False(toolBlocks[0].HasResult);
+        // Block should be Inactive after stream ends (Finalize transitions it)
+        Assert.Equal(BlockLifecycleState.Inactive, toolBlocks[0].LifecycleState);
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_MixedTextAndToolCall_ProducesCorrectBlocks()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) => YieldMixed(ct));
+        var agent = new UIAgent(client);
+
+        var blocks = new List<ContentBlock>();
+        await foreach (var block in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "Search and explain")))
+        {
+            blocks.Add(block);
+        }
+
+        var assistantBlocks = blocks.Where(b => b.Role == ChatRole.Assistant).ToList();
+        // Should have at least a FunctionInvocationContentBlock and a RichContentBlock
+        Assert.Contains(assistantBlocks, b => b is FunctionInvocationContentBlock);
+        Assert.Contains(assistantBlocks, b => b is RichContentBlock);
+
+        static async IAsyncEnumerable<ChatResponseUpdate> YieldMixed(
+            [EnumeratorCancellation] CancellationToken ct)
+        {
+            // Tool call
+            yield return new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                Contents = [new FunctionCallContent("call-1", "Search",
+                    new Dictionary<string, object?> { ["q"] = "test" })],
+                FinishReason = ChatFinishReason.ToolCalls
+            };
+            // Tool result
+            yield return new ChatResponseUpdate
+            {
+                Contents = [new FunctionResultContent("call-1", "found 3 results")]
+            };
+            // Text
+            yield return new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                MessageId = "msg-2",
+                Contents = [new TextContent("Here are the results...")]
+            };
+            await Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_SequentialToolCalls_ProducesSeparateBlocks()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) => YieldSequentialCalls(ct));
+        var agent = new UIAgent(client);
+
+        var blocks = new List<ContentBlock>();
+        await foreach (var block in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "Get weather and news")))
+        {
+            blocks.Add(block);
+        }
+
+        var toolBlocks = blocks.OfType<FunctionInvocationContentBlock>().ToList();
+        Assert.Equal(2, toolBlocks.Count);
+        Assert.Equal("call-A", toolBlocks[0].Id);
+        Assert.Equal("call-B", toolBlocks[1].Id);
+        Assert.True(toolBlocks[0].HasResult);
+        Assert.True(toolBlocks[1].HasResult);
+
+        static async IAsyncEnumerable<ChatResponseUpdate> YieldSequentialCalls(
+            [EnumeratorCancellation] CancellationToken ct)
+        {
+            yield return new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                Contents = [new FunctionCallContent("call-A", "GetWeather", null)],
+                FinishReason = ChatFinishReason.ToolCalls
+            };
+            yield return new ChatResponseUpdate
+            {
+                Contents = [new FunctionResultContent("call-A", "sunny")]
+            };
+            yield return new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                Contents = [new FunctionCallContent("call-B", "GetNews", null)],
+                FinishReason = ChatFinishReason.ToolCalls
+            };
+            yield return new ChatResponseUpdate
+            {
+                Contents = [new FunctionResultContent("call-B", "headlines")]
+            };
+            await Task.CompletedTask;
+        }
+    }
+}

--- a/src/Components/AI/test/Microsoft.AspNetCore.Components.AI.Tests.csproj
+++ b/src/Components/AI/test/Microsoft.AspNetCore.Components.AI.Tests.csproj
@@ -7,12 +7,23 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Exclude Azure-dependent integration tests that need Azure.AI.OpenAI -->
+    <Compile Remove="Engine\UIAgentRecordedTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Components.AI" />
     <Reference Include="Microsoft.AspNetCore.Components.Web" />
   </ItemGroup>
 
   <ItemGroup>
     <Reference Include="Microsoft.Extensions.AI" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="Baselines\**\*.recording.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/Components/AI/test/Pipeline/CustomBlockHandlerTests.cs
+++ b/src/Components/AI/test/Pipeline/CustomBlockHandlerTests.cs
@@ -1,0 +1,235 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Pipeline;
+
+public class CustomBlockHandlerTests
+{
+    private sealed class CitationRaw
+    {
+        public string Source { get; set; } = "";
+        public string Quote { get; set; } = "";
+    }
+
+    private static async Task<List<ContentBlock>> ProcessAsync(
+        BlockMappingPipeline pipeline, ChatResponseUpdate update)
+    {
+        var blocks = new List<ContentBlock>();
+        await foreach (var block in pipeline.Process(update))
+        {
+            blocks.Add(block);
+        }
+        return blocks;
+    }
+
+    private static DelegateBlockHandler<CitationBlock> CreateCitationHandler()
+    {
+        return new DelegateBlockHandler<CitationBlock>((context, state) =>
+        {
+            if (context.Update.RawRepresentation is not CitationRaw raw)
+            {
+                if (state.Source.Length > 0)
+                {
+                    return BlockMappingResult<CitationBlock>.Complete();
+                }
+                return BlockMappingResult<CitationBlock>.Pass();
+            }
+
+            context.MarkUpdateHandled();
+
+            if (state.Source.Length == 0)
+            {
+                state.Source = raw.Source;
+                state.Quote = raw.Quote;
+                state.Id = context.Update.MessageId ?? Guid.NewGuid().ToString("N");
+                return BlockMappingResult<CitationBlock>.Emit(state, state);
+            }
+            else
+            {
+                state.Quote += "; " + raw.Quote;
+                return BlockMappingResult<CitationBlock>.Update(state);
+            }
+        });
+    }
+
+    private static ChatResponseUpdate CreateCitationUpdate(string source, string quote, string? messageId = null)
+    {
+        return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = messageId ?? Guid.NewGuid().ToString("N"),
+            RawRepresentation = new CitationRaw { Source = source, Quote = quote }
+        };
+    }
+
+    private static bool HasTextContent(BlockMappingContext context)
+    {
+        foreach (var content in context.UnhandledContents)
+        {
+            if (content is TextContent)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    [Fact]
+    public async Task CustomHandler_RecognizesRawRepresentation_EmitsCustomBlock()
+    {
+        var options = new UIAgentOptions();
+        options.AddBlockHandler(CreateCitationHandler());
+
+        var pipeline = new BlockMappingPipeline(options);
+        var update = CreateCitationUpdate("Wikipedia", "The sky is blue.");
+
+        var blocks = await ProcessAsync(pipeline, update);
+
+        Assert.Single(blocks);
+        var block = Assert.IsType<CitationBlock>(blocks[0]);
+        Assert.Equal("Wikipedia", block.Source);
+        Assert.Equal("The sky is blue.", block.Quote);
+    }
+
+    [Fact]
+    public async Task CustomHandler_PassesOnTextContent_BuiltInHandlerClaims()
+    {
+        var customHandlerSawText = false;
+        var options = new UIAgentOptions();
+        options.AddBlockHandler(new DelegateBlockHandler<CitationBlock>((context, state) =>
+        {
+            if (HasTextContent(context))
+            {
+                customHandlerSawText = true;
+            }
+            return BlockMappingResult<CitationBlock>.Pass();
+        }));
+
+        var pipeline = new BlockMappingPipeline(options);
+        var update = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "msg-1",
+            Contents = [new TextContent("Hello")]
+        };
+
+        var blocks = await ProcessAsync(pipeline, update);
+
+        // Custom handler runs first and sees TextContent (since it has priority),
+        // but passes on it. Built-in text handler then claims it.
+        Assert.True(customHandlerSawText);
+        Assert.Single(blocks);
+        Assert.IsType<RichContentBlock>(blocks[0]);
+    }
+
+    [Fact]
+    public async Task RawRepresentation_BuiltInHandlersPass_CustomHandlerClaims()
+    {
+        var options = new UIAgentOptions();
+        options.AddBlockHandler(CreateCitationHandler());
+
+        var pipeline = new BlockMappingPipeline(options);
+        var update = CreateCitationUpdate("Nature", "Water is wet.");
+
+        var blocks = await ProcessAsync(pipeline, update);
+        Assert.Single(blocks);
+        Assert.IsType<CitationBlock>(blocks[0]);
+    }
+
+    [Fact]
+    public async Task MixedContent_TextAndRawRepresentation_BothHandlersClaim()
+    {
+        var options = new UIAgentOptions();
+        // This handler only claims content when RawRepresentation is CitationRaw
+        // and does NOT mark TextContent as handled
+        options.AddBlockHandler(new DelegateBlockHandler<CitationBlock>((context, state) =>
+        {
+            if (context.Update.RawRepresentation is not CitationRaw raw)
+            {
+                return BlockMappingResult<CitationBlock>.Pass();
+            }
+
+            state.Source = raw.Source;
+            state.Id = Guid.NewGuid().ToString("N");
+            return BlockMappingResult<CitationBlock>.Emit(state, state);
+        }));
+
+        var pipeline = new BlockMappingPipeline(options);
+        var update = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "msg-1",
+            Contents = [new TextContent("Here's a fact: ")],
+            RawRepresentation = new CitationRaw { Source = "Science", Quote = "E=mc²" }
+        };
+
+        var blocks = await ProcessAsync(pipeline, update);
+
+        Assert.Equal(2, blocks.Count);
+        Assert.Contains(blocks, b => b is RichContentBlock);
+        Assert.Contains(blocks, b => b is CitationBlock);
+    }
+
+    [Fact]
+    public async Task CustomHandler_MultiUpdateLifecycle_EmitUpdateComplete()
+    {
+        var options = new UIAgentOptions();
+        options.AddBlockHandler(CreateCitationHandler());
+
+        var pipeline = new BlockMappingPipeline(options);
+
+        // First update — Emit
+        var blocks1 = await ProcessAsync(pipeline, CreateCitationUpdate("Book", "Quote 1"));
+        Assert.Single(blocks1);
+        var block = Assert.IsType<CitationBlock>(blocks1[0]);
+        Assert.Equal("Quote 1", block.Quote);
+
+        // Second update — Update
+        var changeCount = 0;
+        block.OnChanged(() => changeCount++);
+        await ProcessAsync(pipeline, CreateCitationUpdate("Book", "Quote 2"));
+        Assert.Equal("Quote 1; Quote 2", block.Quote);
+        Assert.Equal(1, changeCount);
+
+        // Third update — no RawRepresentation → Complete
+        await ProcessAsync(pipeline, new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "msg-2",
+            Contents = [new TextContent("Summary")]
+        });
+        Assert.Equal(BlockLifecycleState.Inactive, block.LifecycleState);
+    }
+
+    [Fact]
+    public async Task ActiveHandler_GetsPriority_OverInactiveHandlers()
+    {
+        var options = new UIAgentOptions();
+        options.AddBlockHandler(CreateCitationHandler());
+
+        var pipeline = new BlockMappingPipeline(options);
+
+        // Emit — handler becomes active
+        await ProcessAsync(pipeline, CreateCitationUpdate("A", "a"));
+
+        // Update — active handler gets priority
+        await ProcessAsync(pipeline, CreateCitationUpdate("A", "b"));
+
+        // Complete — handler returns to inactive
+        await ProcessAsync(pipeline, new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "msg-1",
+            Contents = [new TextContent("done")]
+        });
+
+        // After complete, a new citation should create a new block
+        var newBlocks = await ProcessAsync(pipeline, CreateCitationUpdate("C", "c"));
+
+        Assert.Single(newBlocks);
+        var newBlock = Assert.IsType<CitationBlock>(newBlocks[0]);
+        Assert.Equal("C", newBlock.Source);
+    }
+}

--- a/src/Components/AI/test/Pipeline/FunctionApprovalHandlerTests.cs
+++ b/src/Components/AI/test/Pipeline/FunctionApprovalHandlerTests.cs
@@ -1,0 +1,110 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Pipeline;
+
+public class FunctionApprovalHandlerTests
+{
+    [Fact]
+    public void ToolApprovalRequestContent_EmitsFunctionApprovalBlock()
+    {
+        var handler = new FunctionApprovalHandler();
+
+        var toolCall = new FunctionCallContent("call-1", "DeleteFile",
+            new Dictionary<string, object?> { ["path"] = "/data.txt" });
+        var approvalRequest = new ToolApprovalRequestContent("req-1", toolCall);
+        var update = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [approvalRequest]
+        };
+        var context = new BlockMappingContext(update);
+        var state = new FunctionApprovalHandler.ApprovalHandlerState();
+
+        var result = handler.Handle(context, state);
+
+        Assert.Equal(BlockMappingResult<FunctionApprovalHandler.ApprovalHandlerState>.ResultKind.Emit,
+            result.Kind);
+        var block = Assert.IsType<FunctionApprovalBlock>(result.Block);
+        Assert.Equal(ApprovalStatus.Pending, block.Status);
+        Assert.Equal("DeleteFile", block.InnerBlock.ToolName);
+        Assert.Equal("call-1", block.Id);
+    }
+
+    [Fact]
+    public async Task CreateInnerBlock_ProducesCorrectFunctionInvocationBlock()
+    {
+        // The handler needs access to inactive handlers for CreateInnerBlock
+        var options = new UIAgentOptions();
+        var pipeline = new BlockMappingPipeline(options);
+
+        var toolCall = new FunctionCallContent("call-1", "GetWeather",
+            new Dictionary<string, object?> { ["city"] = "Seattle" });
+        var approvalRequest = new ToolApprovalRequestContent("req-1", toolCall);
+        var update = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [approvalRequest]
+        };
+
+        var blocks = new List<ContentBlock>();
+        await foreach (var block in pipeline.Process(update))
+        {
+            blocks.Add(block);
+        }
+
+        Assert.Single(blocks);
+        var approvalBlock = Assert.IsType<FunctionApprovalBlock>(blocks[0]);
+        Assert.NotNull(approvalBlock.InnerBlock);
+        Assert.Equal("GetWeather", approvalBlock.InnerBlock.ToolName);
+        Assert.NotNull(approvalBlock.InnerBlock.Call);
+        Assert.Equal("call-1", approvalBlock.InnerBlock.Call!.CallId);
+    }
+
+    [Fact]
+    public void NonApprovalContent_PassesThrough()
+    {
+        var handler = new FunctionApprovalHandler();
+
+        var update = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [new TextContent("Hello")]
+        };
+        var context = new BlockMappingContext(update);
+        var state = new FunctionApprovalHandler.ApprovalHandlerState();
+
+        var result = handler.Handle(context, state);
+
+        Assert.Equal(BlockMappingResult<FunctionApprovalHandler.ApprovalHandlerState>.ResultKind.Pass,
+            result.Kind);
+    }
+
+    [Fact]
+    public void FallbackInnerBlock_WhenNoHandlerMatches()
+    {
+        // Without inactive handlers, CreateInnerBlock returns null → fallback path
+        var handler = new FunctionApprovalHandler();
+
+        var toolCall = new FunctionCallContent("call-1", "DeleteFile", null);
+        var approvalRequest = new ToolApprovalRequestContent("req-1", toolCall);
+        var update = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [approvalRequest]
+        };
+        // Context without inactive handlers (no pipeline)
+        var context = new BlockMappingContext(update);
+        var state = new FunctionApprovalHandler.ApprovalHandlerState();
+
+        var result = handler.Handle(context, state);
+
+        Assert.Equal(BlockMappingResult<FunctionApprovalHandler.ApprovalHandlerState>.ResultKind.Emit,
+            result.Kind);
+        var block = Assert.IsType<FunctionApprovalBlock>(result.Block);
+        Assert.NotNull(block.InnerBlock);
+        Assert.Equal("DeleteFile", block.InnerBlock.ToolName);
+    }
+}

--- a/src/Components/AI/test/Pipeline/FunctionInvocationHandlerTests.cs
+++ b/src/Components/AI/test/Pipeline/FunctionInvocationHandlerTests.cs
@@ -1,0 +1,207 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Pipeline;
+
+public class FunctionInvocationHandlerTests
+{
+    private static BlockMappingPipeline CreatePipeline()
+    {
+        var options = new UIAgentOptions();
+        return new BlockMappingPipeline(options);
+    }
+
+    private static async Task<List<ContentBlock>> CollectBlocks(
+        BlockMappingPipeline pipeline, ChatResponseUpdate update)
+    {
+        var blocks = new List<ContentBlock>();
+        await foreach (var block in pipeline.Process(update))
+        {
+            blocks.Add(block);
+        }
+        return blocks;
+    }
+
+    [Fact]
+    public async Task FunctionCallContent_EmitsFunctionInvocationContentBlock()
+    {
+        var pipeline = CreatePipeline();
+        var update = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [new FunctionCallContent("call-1", "GetWeather",
+                new Dictionary<string, object?> { ["city"] = "Seattle" })],
+            FinishReason = ChatFinishReason.ToolCalls
+        };
+
+        var blocks = await CollectBlocks(pipeline, update);
+
+        Assert.Single(blocks);
+        var block = Assert.IsType<FunctionInvocationContentBlock>(blocks[0]);
+        Assert.Equal("GetWeather", block.ToolName);
+        Assert.Equal("call-1", block.Id);
+        Assert.Equal(BlockLifecycleState.Active, block.LifecycleState);
+        Assert.False(block.HasResult);
+    }
+
+    [Fact]
+    public async Task FunctionResultContent_MatchingCallId_CompletesBlock()
+    {
+        var pipeline = CreatePipeline();
+
+        // Emit the call
+        var callUpdate = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [new FunctionCallContent("call-1", "GetWeather",
+                new Dictionary<string, object?> { ["city"] = "Seattle" })],
+            FinishReason = ChatFinishReason.ToolCalls
+        };
+        var blocks = await CollectBlocks(pipeline, callUpdate);
+        var block = Assert.IsType<FunctionInvocationContentBlock>(blocks[0]);
+
+        // Track NotifyChanged
+        var changed = false;
+        block.OnChanged(() => changed = true);
+
+        // Process the result
+        var resultUpdate = new ChatResponseUpdate
+        {
+            Contents = [new FunctionResultContent("call-1", "sunny, 72°F")]
+        };
+        await CollectBlocks(pipeline, resultUpdate);
+
+        Assert.True(block.HasResult);
+        Assert.Equal("sunny, 72°F", block.Result?.Result?.ToString());
+        Assert.Equal(BlockLifecycleState.Inactive, block.LifecycleState);
+        Assert.True(changed);
+    }
+
+    [Fact]
+    public async Task FunctionResultContent_WrongCallId_DoesNotAffectBlock()
+    {
+        var pipeline = CreatePipeline();
+
+        // Emit block for call-1
+        var callUpdate = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [new FunctionCallContent("call-1", "GetWeather", null)],
+            FinishReason = ChatFinishReason.ToolCalls
+        };
+        await CollectBlocks(pipeline, callUpdate);
+
+        // Result for call-99 (doesn't match)
+        var resultUpdate = new ChatResponseUpdate
+        {
+            Contents = [new FunctionResultContent("call-99", "wrong")]
+        };
+        var emitted = await CollectBlocks(pipeline, resultUpdate);
+
+        // No new block emitted
+        Assert.Empty(emitted);
+    }
+
+    [Fact]
+    public async Task SequentialToolCalls_ProduceSeparateBlocks()
+    {
+        var pipeline = CreatePipeline();
+
+        // First tool call
+        var call1 = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [new FunctionCallContent("call-A", "GetWeather", null)],
+            FinishReason = ChatFinishReason.ToolCalls
+        };
+        var blocks1 = await CollectBlocks(pipeline, call1);
+
+        // Second tool call
+        var call2 = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [new FunctionCallContent("call-B", "GetNews", null)],
+            FinishReason = ChatFinishReason.ToolCalls
+        };
+        var blocks2 = await CollectBlocks(pipeline, call2);
+
+        Assert.Single(blocks1);
+        Assert.Single(blocks2);
+        Assert.NotSame(blocks1[0], blocks2[0]);
+
+        var blockA = Assert.IsType<FunctionInvocationContentBlock>(blocks1[0]);
+        var blockB = Assert.IsType<FunctionInvocationContentBlock>(blocks2[0]);
+        Assert.Equal("call-A", blockA.Id);
+        Assert.Equal("call-B", blockB.Id);
+    }
+
+    [Fact]
+    public async Task SequentialToolCalls_ResultsMatchCorrectBlocks()
+    {
+        var pipeline = CreatePipeline();
+
+        // Two tool calls
+        var call1 = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [new FunctionCallContent("call-A", "GetWeather", null)],
+            FinishReason = ChatFinishReason.ToolCalls
+        };
+        var blocks1 = await CollectBlocks(pipeline, call1);
+        var blockA = Assert.IsType<FunctionInvocationContentBlock>(blocks1[0]);
+
+        var call2 = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [new FunctionCallContent("call-B", "GetNews", null)],
+            FinishReason = ChatFinishReason.ToolCalls
+        };
+        var blocks2 = await CollectBlocks(pipeline, call2);
+        var blockB = Assert.IsType<FunctionInvocationContentBlock>(blocks2[0]);
+
+        // Result for call-A
+        var result1 = new ChatResponseUpdate
+        {
+            Contents = [new FunctionResultContent("call-A", "sunny")]
+        };
+        await CollectBlocks(pipeline, result1);
+
+        Assert.True(blockA.HasResult);
+        Assert.Equal("sunny", blockA.Result?.Result?.ToString());
+        Assert.False(blockB.HasResult);
+
+        // Result for call-B
+        var result2 = new ChatResponseUpdate
+        {
+            Contents = [new FunctionResultContent("call-B", "headlines")]
+        };
+        await CollectBlocks(pipeline, result2);
+
+        Assert.True(blockB.HasResult);
+        Assert.Equal("headlines", blockB.Result?.Result?.ToString());
+    }
+
+    [Fact]
+    public async Task Finalize_ActiveToolCallBlock_BecomesInactive()
+    {
+        var pipeline = CreatePipeline();
+
+        var callUpdate = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [new FunctionCallContent("call-1", "GetWeather", null)],
+            FinishReason = ChatFinishReason.ToolCalls
+        };
+        var blocks = await CollectBlocks(pipeline, callUpdate);
+        var block = Assert.IsType<FunctionInvocationContentBlock>(blocks[0]);
+
+        Assert.Equal(BlockLifecycleState.Active, block.LifecycleState);
+
+        pipeline.Finalize();
+
+        Assert.Equal(BlockLifecycleState.Inactive, block.LifecycleState);
+        Assert.False(block.HasResult);
+    }
+}

--- a/src/Components/AI/test/Pipeline/MediaContentHandlerTests.cs
+++ b/src/Components/AI/test/Pipeline/MediaContentHandlerTests.cs
@@ -1,0 +1,156 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Pipeline;
+
+public class MediaContentHandlerTests
+{
+    private static BlockMappingPipeline CreatePipeline()
+    {
+        var options = new UIAgentOptions();
+        return new BlockMappingPipeline(options);
+    }
+
+    private static async Task<List<ContentBlock>> ProcessAsync(
+        BlockMappingPipeline pipeline, ChatResponseUpdate update)
+    {
+        var blocks = new List<ContentBlock>();
+        await foreach (var block in pipeline.Process(update))
+        {
+            blocks.Add(block);
+        }
+        return blocks;
+    }
+
+    [Fact]
+    public async Task DataContent_EmitsMediaContentBlock()
+    {
+        var pipeline = CreatePipeline();
+        var imageBytes = new byte[] { 0x89, 0x50, 0x4E, 0x47 };
+        var update = new ChatResponseUpdate
+        {
+            Role = ChatRole.User,
+            MessageId = "msg-1",
+            Contents = [new DataContent(imageBytes, "image/png")]
+        };
+
+        var blocks = await ProcessAsync(pipeline, update);
+
+        Assert.Single(blocks);
+        var block = Assert.IsType<MediaContentBlock>(blocks[0]);
+        Assert.Single(block.Items);
+        Assert.Equal("image/png", block.Items[0].MediaType);
+    }
+
+    [Fact]
+    public async Task MultipleDataContents_SingleBlockAccumulates()
+    {
+        var pipeline = CreatePipeline();
+        var update1 = new ChatResponseUpdate
+        {
+            Role = ChatRole.User,
+            MessageId = "msg-1",
+            Contents = [new DataContent(new byte[] { 1, 2, 3 }, "image/png")]
+        };
+        var update2 = new ChatResponseUpdate
+        {
+            Role = ChatRole.User,
+            MessageId = "msg-1",
+            Contents = [new DataContent(new byte[] { 4, 5, 6 }, "image/jpeg")]
+        };
+
+        var blocks1 = await ProcessAsync(pipeline, update1);
+        Assert.Single(blocks1);
+        await ProcessAsync(pipeline, update2);
+
+        var block = Assert.IsType<MediaContentBlock>(blocks1[0]);
+        Assert.Equal(2, block.Items.Count);
+    }
+
+    [Fact]
+    public async Task TextAndDataContent_ProducesSeparateBlocks()
+    {
+        var pipeline = CreatePipeline();
+        var update = new ChatResponseUpdate
+        {
+            Role = ChatRole.User,
+            MessageId = "msg-1",
+            Contents =
+            [
+                new TextContent("Check this image"),
+                new DataContent(new byte[] { 1, 2, 3 }, "image/png")
+            ]
+        };
+
+        var blocks = await ProcessAsync(pipeline, update);
+
+        Assert.Equal(2, blocks.Count);
+        Assert.IsType<MediaContentBlock>(blocks[0]);
+        Assert.IsType<RichContentBlock>(blocks[1]);
+    }
+
+    [Fact]
+    public async Task DataContentFollowedByText_CompletesMediaEmitsText()
+    {
+        var pipeline = CreatePipeline();
+
+        var mediaUpdate = new ChatResponseUpdate
+        {
+            Role = ChatRole.User,
+            MessageId = "msg-1",
+            Contents = [new DataContent(new byte[] { 1, 2, 3 }, "image/png")]
+        };
+        var mediaBlocks = await ProcessAsync(pipeline, mediaUpdate);
+
+        var textUpdate = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "msg-2",
+            Contents = [new TextContent("I see an image.")]
+        };
+        var textBlocks = await ProcessAsync(pipeline, textUpdate);
+
+        var mediaBlock = Assert.IsType<MediaContentBlock>(mediaBlocks[0]);
+        Assert.Equal(BlockLifecycleState.Inactive, mediaBlock.LifecycleState);
+
+        Assert.Single(textBlocks);
+        Assert.IsType<RichContentBlock>(textBlocks[0]);
+    }
+
+    [Fact]
+    public async Task AudioDataContent_EmitsMediaContentBlock()
+    {
+        var pipeline = CreatePipeline();
+        var update = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "msg-1",
+            Contents = [new DataContent(new byte[] { 0xFF, 0xFB }, "audio/mpeg")]
+        };
+
+        var blocks = await ProcessAsync(pipeline, update);
+
+        Assert.Single(blocks);
+        var block = Assert.IsType<MediaContentBlock>(blocks[0]);
+        Assert.Equal("audio/mpeg", block.Items[0].MediaType);
+    }
+
+    [Fact]
+    public async Task MediaBlock_SetsId_FromMessageId()
+    {
+        var pipeline = CreatePipeline();
+        var update = new ChatResponseUpdate
+        {
+            Role = ChatRole.User,
+            MessageId = "test-msg-id",
+            Contents = [new DataContent(new byte[] { 1 }, "image/png")]
+        };
+
+        var blocks = await ProcessAsync(pipeline, update);
+
+        var block = Assert.IsType<MediaContentBlock>(blocks[0]);
+        Assert.Equal("test-msg-id", block.Id);
+    }
+}

--- a/src/Components/AI/test/Pipeline/ReasoningHandlerTests.cs
+++ b/src/Components/AI/test/Pipeline/ReasoningHandlerTests.cs
@@ -1,0 +1,144 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Pipeline;
+
+public class ReasoningHandlerTests
+{
+    private static BlockMappingPipeline CreatePipeline()
+    {
+        var options = new UIAgentOptions();
+        return new BlockMappingPipeline(options);
+    }
+
+    private static async Task<List<ContentBlock>> ProcessAsync(
+        BlockMappingPipeline pipeline, ChatResponseUpdate update)
+    {
+        var blocks = new List<ContentBlock>();
+        await foreach (var block in pipeline.Process(update))
+        {
+            blocks.Add(block);
+        }
+        return blocks;
+    }
+
+    [Fact]
+    public async Task TextReasoningContent_EmitsReasoningContentBlock()
+    {
+        var pipeline = CreatePipeline();
+        var update = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "msg-1",
+            Contents = [new TextReasoningContent("Thinking about this...")]
+        };
+
+        var blocks = await ProcessAsync(pipeline, update);
+
+        Assert.Single(blocks);
+        var block = Assert.IsType<ReasoningContentBlock>(blocks[0]);
+        Assert.Equal("Thinking about this...", block.Text);
+        Assert.Equal(BlockLifecycleState.Active, block.LifecycleState);
+    }
+
+    [Fact]
+    public async Task MultipleReasoningTokens_SingleBlockAccumulates()
+    {
+        var pipeline = CreatePipeline();
+
+        var update1 = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "msg-1",
+            Contents = [new TextReasoningContent("Step 1: ")]
+        };
+        var update2 = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "msg-1",
+            Contents = [new TextReasoningContent("analyze the problem")]
+        };
+
+        var blocks1 = await ProcessAsync(pipeline, update1);
+        Assert.Single(blocks1);
+        await ProcessAsync(pipeline, update2);
+
+        var block = Assert.IsType<ReasoningContentBlock>(blocks1[0]);
+        Assert.Equal("Step 1: analyze the problem", block.Text);
+    }
+
+    [Fact]
+    public async Task ReasoningFollowedByText_CompletesReasoningEmitsText()
+    {
+        var pipeline = CreatePipeline();
+
+        var reasoningUpdate = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "msg-1",
+            Contents = [new TextReasoningContent("Thinking...")]
+        };
+        var reasoningBlocks = await ProcessAsync(pipeline, reasoningUpdate);
+
+        var textUpdate = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "msg-1",
+            Contents = [new TextContent("The answer is 42.")]
+        };
+        var textBlocks = await ProcessAsync(pipeline, textUpdate);
+
+        var reasoningBlock = Assert.IsType<ReasoningContentBlock>(reasoningBlocks[0]);
+        Assert.Equal(BlockLifecycleState.Inactive, reasoningBlock.LifecycleState);
+
+        Assert.Single(textBlocks);
+        var textBlock = Assert.IsType<RichContentBlock>(textBlocks[0]);
+        Assert.Equal("The answer is 42.", textBlock.RawText);
+    }
+
+    [Fact]
+    public async Task ProtectedData_SetsIsEncrypted()
+    {
+        var pipeline = CreatePipeline();
+        var update = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "msg-1",
+            Contents = [new TextReasoningContent(null) { ProtectedData = "encrypted-data" }]
+        };
+
+        var blocks = await ProcessAsync(pipeline, update);
+        var block = Assert.IsType<ReasoningContentBlock>(blocks[0]);
+        Assert.True(block.IsEncrypted);
+        Assert.Equal("encrypted-data", block.ProtectedData);
+    }
+
+    [Fact]
+    public async Task OnChanged_FiresOnSubsequentReasoningTokens()
+    {
+        var pipeline = CreatePipeline();
+
+        var update1 = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "msg-1",
+            Contents = [new TextReasoningContent("A")]
+        };
+        var blocks = await ProcessAsync(pipeline, update1);
+        var block = blocks[0];
+        var changeCount = 0;
+        block.OnChanged(() => changeCount++);
+
+        var update2 = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "msg-1",
+            Contents = [new TextReasoningContent("B")]
+        };
+        await ProcessAsync(pipeline, update2);
+
+        Assert.Equal(1, changeCount);
+    }
+}

--- a/src/Components/AI/test/Pipeline/StateMapperTests.cs
+++ b/src/Components/AI/test/Pipeline/StateMapperTests.cs
@@ -1,0 +1,169 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Pipeline;
+
+public class StateMapperTests
+{
+    private class RecipeState
+    {
+        public string Title { get; set; } = "";
+        public string Cuisine { get; set; } = "";
+    }
+
+    private class StateContent : AIContent
+    {
+        public object StateValue { get; set; } = new();
+    }
+
+    [Fact]
+    public async Task StateMapper_ExtractsState_FiltersFromPipeline()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) => EmitStateAndText(ct));
+
+        var agent = new UIAgent<RecipeState>(client,
+            configure: options =>
+            {
+                options.StateMapper = ctx =>
+                {
+                    foreach (var content in ctx.UnhandledContents)
+                    {
+                        if (content is StateContent sc)
+                        {
+                            ctx.MarkHandled(sc);
+                            ctx.SetState(sc.StateValue);
+                            return true;
+                        }
+                    }
+                    return false;
+                };
+            });
+
+        var blocks = new List<ContentBlock>();
+        await foreach (var block in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "Give me a recipe")))
+        {
+            blocks.Add(block);
+        }
+
+        Assert.Equal("Spaghetti Carbonara", agent.State.Value.Title);
+
+        var assistantBlocks = blocks.Where(b => b.Role == ChatRole.Assistant).ToList();
+        Assert.All(assistantBlocks, b => Assert.IsType<RichContentBlock>(b));
+
+        static async IAsyncEnumerable<ChatResponseUpdate> EmitStateAndText(
+            [EnumeratorCancellation] CancellationToken ct)
+        {
+            yield return new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                Contents = [new StateContent
+                {
+                    StateValue = new RecipeState
+                    {
+                        Title = "Spaghetti Carbonara",
+                        Cuisine = "Italian"
+                    }
+                }]
+            };
+            yield return new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                MessageId = "msg-1",
+                Contents = [new TextContent("Here's a classic Italian recipe!")]
+            };
+            await Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task StateMapper_MixedContentInOneUpdate_OnlyStateFiltered()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) => EmitMixed(ct));
+
+        var agent = new UIAgent<RecipeState>(client,
+            configure: options =>
+            {
+                options.StateMapper = ctx =>
+                {
+                    foreach (var content in ctx.UnhandledContents)
+                    {
+                        if (content is StateContent sc)
+                        {
+                            ctx.MarkHandled(sc);
+                            ctx.SetState(sc.StateValue);
+                            return true;
+                        }
+                    }
+                    return false;
+                };
+            });
+
+        var blocks = new List<ContentBlock>();
+        await foreach (var block in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "Recipe?")))
+        {
+            blocks.Add(block);
+        }
+
+        var textBlocks = blocks.OfType<RichContentBlock>()
+            .Where(b => b.Role == ChatRole.Assistant).ToList();
+        Assert.NotEmpty(textBlocks);
+
+        Assert.Equal("Pasta", agent.State.Value.Title);
+
+        static async IAsyncEnumerable<ChatResponseUpdate> EmitMixed(
+            [EnumeratorCancellation] CancellationToken ct)
+        {
+            yield return new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                MessageId = "msg-1",
+                Contents =
+                [
+                    new StateContent { StateValue = new RecipeState { Title = "Pasta" } },
+                    new TextContent("Enjoy this recipe!")
+                ]
+            };
+            await Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task NoStateMapper_AllContentFlowsToPipeline()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Just text"));
+
+        var agent = new UIAgent(client);
+
+        var blocks = new List<ContentBlock>();
+        await foreach (var block in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "hi")))
+        {
+            blocks.Add(block);
+        }
+
+        var assistantBlocks = blocks.Where(b => b.Role == ChatRole.Assistant).ToList();
+        Assert.NotEmpty(assistantBlocks);
+    }
+
+    [Fact]
+    public void AgentState_OnChanged_FiresWhenStateMapperUpdatesValue()
+    {
+        var state = new AgentState<RecipeState>();
+        var changed = false;
+        state.OnChanged(() => changed = true);
+
+        state.Value = new RecipeState { Title = "Test" };
+
+        Assert.True(changed);
+    }
+}

--- a/src/Components/AI/test/Pipeline/TestTypes/CitationBlock.cs
+++ b/src/Components/AI/test/Pipeline/TestTypes/CitationBlock.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Pipeline;
+
+internal class CitationBlock : ContentBlock
+{
+    public string Source { get; set; } = "";
+    public string Quote { get; set; } = "";
+}

--- a/src/Components/AI/test/Pipeline/TestTypes/DelegateBlockHandler.cs
+++ b/src/Components/AI/test/Pipeline/TestTypes/DelegateBlockHandler.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Pipeline;
+
+internal sealed class DelegateBlockHandler<TState> : ContentBlockHandler<TState> where TState : new()
+{
+    private readonly Func<BlockMappingContext, TState, BlockMappingResult<TState>> _handler;
+
+    internal DelegateBlockHandler(Func<BlockMappingContext, TState, BlockMappingResult<TState>> handler)
+    {
+        _handler = handler;
+    }
+
+    public override BlockMappingResult<TState> Handle(BlockMappingContext context, TState state)
+    {
+        return _handler(context, state);
+    }
+}

--- a/src/Components/AI/test/Samples/S01_BasicChatTest.cs
+++ b/src/Components/AI/test/Samples/S01_BasicChatTest.cs
@@ -1,0 +1,118 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Samples;
+
+public class S01_BasicChatTest
+{
+    [Fact]
+    public async Task SingleMessage_ProducesTextBlock()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hello! How can I help you?"));
+
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+
+        await context.SendMessageAsync("Hi there");
+
+        Assert.Single(context.Turns);
+        var turn = context.Turns[0];
+
+        // Request side: user text block
+        Assert.Single(turn.RequestBlocks);
+        var requestBlock = Assert.IsType<RichContentBlock>(turn.RequestBlocks[0]);
+        Assert.Equal(ChatRole.User, requestBlock.Role);
+        Assert.Equal("Hi there", requestBlock.RawText);
+
+        // Response side: assistant text block
+        Assert.Single(turn.ResponseBlocks);
+        var responseBlock = Assert.IsType<RichContentBlock>(turn.ResponseBlocks[0]);
+        Assert.Equal(ChatRole.Assistant, responseBlock.Role);
+        Assert.Equal("Hello! How can I help you?", responseBlock.RawText);
+    }
+
+    [Fact]
+    public async Task MultiTokenStreaming_AccumulatesInSingleBlock()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitMultiTokenTextResponse(ct, "The ", "weather ", "is ", "sunny."));
+
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+
+        await context.SendMessageAsync("What's the weather?");
+
+        var turn = context.Turns[0];
+        var responseBlock = Assert.IsType<RichContentBlock>(turn.ResponseBlocks.Single());
+        Assert.Equal("The weather is sunny.", responseBlock.RawText);
+        // 4 tokens form a single paragraph
+        var paragraph = Assert.IsType<ParagraphNode>(Assert.Single(responseBlock.Content));
+        var textNode = Assert.IsType<TextNode>(Assert.Single(paragraph.Children));
+        Assert.Equal("The weather is sunny.", textNode.Text);
+    }
+
+    [Fact]
+    public async Task StatusTransitions_IdleToStreamingToIdle()
+    {
+        var statuses = new List<ConversationStatus>();
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("OK"));
+
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+        context.RegisterOnStatusChanged(s => statuses.Add(s));
+
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+
+        await context.SendMessageAsync("Hello");
+
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+        Assert.Equal(ConversationStatus.Streaming, statuses[0]);
+        Assert.Equal(ConversationStatus.Idle, statuses[^1]);
+    }
+
+    [Fact]
+    public async Task MultiTurn_EachMessageCreatesNewTurn()
+    {
+        var callCount = 0;
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            return ResponseEmitters.EmitTextResponse(callCount == 1 ? "Hi!" : "I'm fine!");
+        });
+
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+
+        await context.SendMessageAsync("Hello");
+        await context.SendMessageAsync("How are you?");
+
+        Assert.Equal(2, context.Turns.Count);
+        Assert.Equal("Hi!", context.Turns[0].ResponseBlocks.OfType<RichContentBlock>().Single().RawText);
+        Assert.Equal("I'm fine!", context.Turns[1].ResponseBlocks.OfType<RichContentBlock>().Single().RawText);
+    }
+
+    [Fact]
+    public async Task BlockLifecycle_ActiveThenInactive()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("response"));
+
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+
+        await context.SendMessageAsync("test");
+
+        var block = context.Turns[0].ResponseBlocks.Single();
+        Assert.Equal(BlockLifecycleState.Inactive, block.LifecycleState);
+    }
+}

--- a/src/Components/AI/test/Samples/S02_BackendToolsTest.cs
+++ b/src/Components/AI/test/Samples/S02_BackendToolsTest.cs
@@ -1,0 +1,140 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Samples;
+
+public class S02_BackendToolsTest
+{
+    [Fact]
+    public async Task BackendTool_AutoExecuted_ProducesInvocationBlock()
+    {
+        var searchCalled = false;
+        var searchFunction = AIFunctionFactory.Create(
+            (string location, string cuisine) =>
+            {
+                searchCalled = true;
+                return new { Name = "Pizza Place", Rating = 4.5 };
+            },
+            "SearchRestaurants",
+            "Search for restaurants");
+
+        var callCount = 0;
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return ResponseEmitters.EmitToolCallResponse(
+                    "call-1", "SearchRestaurants",
+                    new Dictionary<string, object?> { ["location"] = "NYC", ["cuisine"] = "Italian" });
+            }
+            return ResponseEmitters.EmitTextResponse("I found Pizza Place rated 4.5!");
+        });
+
+        var chatOptions = new ChatOptions { Tools = [searchFunction] };
+        var agent = new UIAgent(client, chatOptions);
+        var context = new AgentContext(agent);
+
+        await context.SendMessageAsync("Find Italian restaurants in NYC");
+
+        Assert.True(searchCalled);
+
+        var turn = context.Turns[0];
+        var invocationBlock = turn.ResponseBlocks.OfType<FunctionInvocationContentBlock>().Single();
+        Assert.Equal("SearchRestaurants", invocationBlock.ToolName);
+        Assert.True(invocationBlock.HasResult);
+
+        var textBlock = turn.ResponseBlocks.OfType<RichContentBlock>().Single();
+        Assert.Contains("Pizza Place", textBlock.RawText);
+    }
+
+    [Fact]
+    public async Task BackendTool_MultipleToolCalls_AllExecuted()
+    {
+        var callLog = new List<string>();
+
+        var getWeather = AIFunctionFactory.Create(
+            (string city) =>
+            {
+                callLog.Add($"weather:{city}");
+                return $"{city}: 72°F";
+            },
+            "GetWeather",
+            "Get weather for a city");
+
+        var getTime = AIFunctionFactory.Create(
+            (string city) =>
+            {
+                callLog.Add($"time:{city}");
+                return $"{city}: 2:30 PM";
+            },
+            "GetTime",
+            "Get time for a city");
+
+        var callCount = 0;
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return ResponseEmitters.EmitMultipleToolCallResponse(ct,
+                    new FunctionCallContent("c1", "GetWeather",
+                        new Dictionary<string, object?> { ["city"] = "London" }),
+                    new FunctionCallContent("c2", "GetTime",
+                        new Dictionary<string, object?> { ["city"] = "London" }));
+            }
+            return ResponseEmitters.EmitTextResponse("London: 72°F at 2:30 PM");
+        });
+
+        var chatOptions = new ChatOptions { Tools = [getWeather, getTime] };
+        var agent = new UIAgent(client, chatOptions);
+        var context = new AgentContext(agent);
+
+        await context.SendMessageAsync("Weather and time in London?");
+
+        Assert.Equal(2, callLog.Count);
+        Assert.Contains("weather:London", callLog);
+        Assert.Contains("time:London", callLog);
+
+        var turn = context.Turns[0];
+        var invocations = turn.ResponseBlocks.OfType<FunctionInvocationContentBlock>().ToList();
+        Assert.Equal(2, invocations.Count);
+        Assert.All(invocations, b => Assert.True(b.HasResult));
+    }
+
+    [Fact]
+    public async Task BackendTool_StatusRemainsStreaming_DuringAutoExecution()
+    {
+        var statuses = new List<ConversationStatus>();
+
+        var tool = AIFunctionFactory.Create(() => "result", "DoWork", "Does work");
+        var callCount = 0;
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return ResponseEmitters.EmitToolCallResponse("c1", "DoWork");
+            }
+            return ResponseEmitters.EmitTextResponse("Done");
+        });
+
+        var chatOptions = new ChatOptions { Tools = [tool] };
+        var agent = new UIAgent(client, chatOptions);
+        var context = new AgentContext(agent);
+        context.RegisterOnStatusChanged(s => statuses.Add(s));
+
+        await context.SendMessageAsync("Do it");
+
+        // Backend tools don't cause AwaitingInput — stays Streaming throughout
+        Assert.DoesNotContain(ConversationStatus.AwaitingInput, statuses);
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+    }
+}

--- a/src/Components/AI/test/Samples/S03_FrontendToolsTest.cs
+++ b/src/Components/AI/test/Samples/S03_FrontendToolsTest.cs
@@ -1,0 +1,122 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Samples;
+
+public class S03_FrontendToolsTest
+{
+    // AG-UI "frontend tools" map to UIActions in components-ai.
+    // The LLM emits a FunctionCallContent for a client-side tool;
+    // the engine parks at AwaitingInput and the UI invokes the action.
+    // This differs from backend tools which auto-execute.
+
+    [Fact]
+    public async Task FrontendTool_SurfacesAsUIActionBlock()
+    {
+        var showChart = AIFunctionFactory.Create(
+            (string data) => $"chart-rendered:{data}",
+            "ShowChart", "Renders a chart on the client");
+
+        var client = new DelegatingStreamingChatClient();
+        var agent = new UIAgent(client, options =>
+        {
+            options.RegisterUIAction(showChart);
+        });
+
+        var callCount = 0;
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return EmitFrontendToolCall("call-1", "ShowChart", ct,
+                    new Dictionary<string, object?> { ["data"] = "sales-q4" });
+            }
+            return ResponseEmitters.EmitTextResponse("Chart displayed.", ct);
+        });
+
+        var context = new AgentContext(agent);
+        context.RegisterOnStatusChanged(s =>
+        {
+            if (s == ConversationStatus.AwaitingInput)
+            {
+                context.Turns[^1].ResponseBlocks.OfType<UIActionBlock>().Single()
+                    .InvokeAsync().GetAwaiter().GetResult();
+            }
+        });
+
+        await context.SendMessageAsync("Show me Q4 sales chart");
+
+        var turn = context.Turns[0];
+        var uiBlock = turn.ResponseBlocks.OfType<UIActionBlock>().Single();
+        Assert.Equal("ShowChart", uiBlock.ToolName);
+        Assert.True(uiBlock.IsComplete);
+    }
+
+    [Fact]
+    public async Task FrontendTool_ArgumentsPreserved()
+    {
+        var navigateTo = AIFunctionFactory.Create(
+            (string url, bool newTab) => $"navigated to {url}",
+            "NavigateTo", "Navigates client browser");
+
+        var client = new DelegatingStreamingChatClient();
+        var agent = new UIAgent(client, options =>
+        {
+            options.RegisterUIAction(navigateTo);
+        });
+
+        var callCount = 0;
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return EmitFrontendToolCall("call-2", "NavigateTo", ct,
+                    new Dictionary<string, object?>
+                    {
+                        ["url"] = "/dashboard",
+                        ["newTab"] = true
+                    });
+            }
+            return ResponseEmitters.EmitTextResponse("Navigated.", ct);
+        });
+
+        var context = new AgentContext(agent);
+        UIActionBlock? captured = null;
+        context.RegisterOnStatusChanged(s =>
+        {
+            if (s == ConversationStatus.AwaitingInput)
+            {
+                captured = context.Turns[^1].ResponseBlocks.OfType<UIActionBlock>().Single();
+                captured.InvokeAsync().GetAwaiter().GetResult();
+            }
+        });
+
+        await context.SendMessageAsync("Go to dashboard");
+
+        Assert.NotNull(captured);
+        Assert.Equal("NavigateTo", captured!.ToolName);
+        Assert.Equal("call-2", captured.Id);
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> EmitFrontendToolCall(
+        string callId,
+        string name,
+        [EnumeratorCancellation] CancellationToken ct,
+        IDictionary<string, object?>? arguments = null)
+    {
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = Guid.NewGuid().ToString("N"),
+            Contents = [new FunctionCallContent(callId, name, arguments)],
+            FinishReason = ChatFinishReason.ToolCalls
+        };
+        await Task.CompletedTask;
+    }
+}

--- a/src/Components/AI/test/Samples/S04_ToolApprovalTest.cs
+++ b/src/Components/AI/test/Samples/S04_ToolApprovalTest.cs
@@ -1,0 +1,96 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Samples;
+
+public class S04_ToolApprovalTest
+{
+    [Fact]
+    public async Task Approval_Required_PausesAndResumeOnApprove()
+    {
+        var callCount = 0;
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return ResponseEmitters.EmitApprovalRequest(
+                    "call-1", "DeleteFile",
+                    new Dictionary<string, object?> { ["path"] = "/tmp/data.csv" });
+            }
+            return ResponseEmitters.EmitTextResponse("File deleted successfully.");
+        });
+
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+
+        var statuses = new List<ConversationStatus>();
+        context.RegisterOnStatusChanged(s =>
+        {
+            statuses.Add(s);
+            if (s == ConversationStatus.AwaitingInput)
+            {
+                var block = context.Turns[^1].ResponseBlocks
+                    .OfType<FunctionApprovalBlock>().Single();
+                Assert.Equal(ApprovalStatus.Pending, block.Status);
+                Assert.Equal("DeleteFile", block.ToolName);
+                block.Approve();
+            }
+        });
+
+        await context.SendMessageAsync("Delete /tmp/data.csv");
+
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+        Assert.Equal(new[]
+        {
+            ConversationStatus.Streaming,
+            ConversationStatus.AwaitingInput,
+            ConversationStatus.Streaming,
+            ConversationStatus.Idle,
+        }, statuses);
+
+        var textBlock = context.Turns[0].ResponseBlocks.OfType<RichContentBlock>().Single();
+        Assert.Contains("deleted", textBlock.RawText);
+    }
+
+    [Fact]
+    public async Task Approval_Rejected_CompletesWithoutExecution()
+    {
+        var callCount = 0;
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return ResponseEmitters.EmitApprovalRequest("call-1", "SendEmail");
+            }
+            return ResponseEmitters.EmitTextResponse("Understood, email not sent.");
+        });
+
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+
+        context.RegisterOnStatusChanged(s =>
+        {
+            if (s == ConversationStatus.AwaitingInput)
+            {
+                context.Turns[^1].ResponseBlocks
+                    .OfType<FunctionApprovalBlock>().Single()
+                    .Reject("User declined");
+            }
+        });
+
+        await context.SendMessageAsync("Send the email");
+
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+
+        var approvalBlock = context.Turns[0].ResponseBlocks
+            .OfType<FunctionApprovalBlock>().Single();
+        Assert.Equal(ApprovalStatus.Rejected, approvalBlock.Status);
+    }
+}

--- a/src/Components/AI/test/Samples/S05_StateManagementTest.cs
+++ b/src/Components/AI/test/Samples/S05_StateManagementTest.cs
@@ -1,0 +1,173 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Samples;
+
+public class S05_StateManagementTest
+{
+    private sealed class RecipeState
+    {
+        public string Title { get; set; } = string.Empty;
+        public string Cuisine { get; set; } = string.Empty;
+        public List<string> Ingredients { get; set; } = [];
+    }
+
+    [Fact]
+    public async Task StateMapper_ExtractsStructuredState()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) => EmitStateResponse(ct));
+
+        var agent = new UIAgent<RecipeState>(client, options =>
+        {
+            options.StateMapper = context =>
+            {
+                foreach (var content in context.UnhandledContents)
+                {
+                    if (content is TextContent tc && tc.Text?.StartsWith("{", StringComparison.Ordinal) == true)
+                    {
+                        var state = JsonSerializer.Deserialize<RecipeState>(tc.Text);
+                        if (state is not null)
+                        {
+                            context.MarkHandled(content);
+                            context.SetState(state);
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            };
+        });
+
+        var context = new AgentContext(agent);
+
+        await context.SendMessageAsync("Make me a pasta recipe");
+
+        Assert.Equal("Spaghetti Carbonara", agent.State.Value.Title);
+        Assert.Equal("Italian", agent.State.Value.Cuisine);
+        Assert.Contains("Spaghetti", agent.State.Value.Ingredients);
+    }
+
+    [Fact]
+    public async Task StateMapper_FiresOnChanged()
+    {
+        var changeCount = 0;
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) => EmitStateResponse(ct));
+
+        var agent = new UIAgent<RecipeState>(client, options =>
+        {
+            options.StateMapper = context =>
+            {
+                foreach (var content in context.UnhandledContents)
+                {
+                    if (content is TextContent tc && tc.Text?.StartsWith("{", StringComparison.Ordinal) == true)
+                    {
+                        var state = JsonSerializer.Deserialize<RecipeState>(tc.Text);
+                        if (state is not null)
+                        {
+                            context.MarkHandled(content);
+                            context.SetState(state);
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            };
+        });
+        agent.State.OnChanged(() => changeCount++);
+
+        var context = new AgentContext(agent);
+        await context.SendMessageAsync("Make me a recipe");
+
+        Assert.True(changeCount > 0);
+    }
+
+    [Fact]
+    public async Task StateMapper_ConsumedContent_NotInBlocks()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) => EmitMixedResponse(ct));
+
+        var agent = new UIAgent<RecipeState>(client, options =>
+        {
+            options.StateMapper = context =>
+            {
+                foreach (var content in context.UnhandledContents)
+                {
+                    if (content is TextContent tc && tc.Text?.StartsWith("{", StringComparison.Ordinal) == true)
+                    {
+                        var state = JsonSerializer.Deserialize<RecipeState>(tc.Text);
+                        if (state is not null)
+                        {
+                            context.MarkHandled(content);
+                            context.SetState(state);
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            };
+        });
+
+        var context = new AgentContext(agent);
+        await context.SendMessageAsync("Recipe please");
+
+        // State mapper consumed the JSON, visible block has only the text
+        var textBlock = context.Turns[0].ResponseBlocks.OfType<RichContentBlock>().Single();
+        Assert.Equal("Here's your recipe!", textBlock.RawText);
+        Assert.Equal("Spaghetti Carbonara", agent.State.Value.Title);
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> EmitStateResponse(
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        var json = JsonSerializer.Serialize(new RecipeState
+        {
+            Title = "Spaghetti Carbonara",
+            Cuisine = "Italian",
+            Ingredients = ["Spaghetti", "Eggs", "Pancetta", "Parmesan"]
+        });
+
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = Guid.NewGuid().ToString("N"),
+            Contents = [new TextContent(json)]
+        };
+        await Task.CompletedTask;
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> EmitMixedResponse(
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        var json = JsonSerializer.Serialize(new RecipeState
+        {
+            Title = "Spaghetti Carbonara",
+            Cuisine = "Italian",
+            Ingredients = ["Spaghetti", "Eggs"]
+        });
+
+        var messageId = Guid.NewGuid().ToString("N");
+        // First update: state JSON (consumed by mapper)
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = messageId,
+            Contents = [new TextContent(json)]
+        };
+        // Second update: visible text (not consumed)
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = Guid.NewGuid().ToString("N"),
+            Contents = [new TextContent("Here's your recipe!")]
+        };
+        await Task.CompletedTask;
+    }
+}

--- a/src/Components/AI/test/Samples/S06_CustomEventsTest.cs
+++ b/src/Components/AI/test/Samples/S06_CustomEventsTest.cs
@@ -1,0 +1,119 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Components.AI.Tests.Pipeline;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Samples;
+
+public class S06_CustomEventsTest
+{
+    // AG-UI "custom events" map to custom ContentBlockHandlers in components-ai.
+    // A handler inspects RawRepresentation on ChatResponseUpdate and emits a domain block.
+
+    private sealed class NotificationPayload
+    {
+        public string Level { get; set; } = "";
+        public string Message { get; set; } = "";
+    }
+
+    private sealed class NotificationBlock : ContentBlock
+    {
+        public string Level { get; set; } = "";
+        public string Message { get; set; } = "";
+    }
+
+    [Fact]
+    public async Task CustomHandler_EmitsDomainBlock()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) => EmitNotificationThenText(ct));
+
+        var agent = new UIAgent(client, options =>
+        {
+            options.AddBlockHandler(new DelegateBlockHandler<NotificationBlock>((context, state) =>
+            {
+                if (context.Update.RawRepresentation is not NotificationPayload payload)
+                {
+                    return BlockMappingResult<NotificationBlock>.Pass();
+                }
+                context.MarkUpdateHandled();
+                state.Id = Guid.NewGuid().ToString("N");
+                state.Level = payload.Level;
+                state.Message = payload.Message;
+                return BlockMappingResult<NotificationBlock>.Emit(state, state);
+            }));
+        });
+
+        var context = new AgentContext(agent);
+        await context.SendMessageAsync("Run task");
+
+        var turn = context.Turns[0];
+        var notification = turn.ResponseBlocks.OfType<NotificationBlock>().Single();
+        Assert.Equal("info", notification.Level);
+        Assert.Equal("Task started", notification.Message);
+
+        var textBlock = turn.ResponseBlocks.OfType<RichContentBlock>().Single();
+        Assert.Equal("Task complete.", textBlock.RawText);
+    }
+
+    [Fact]
+    public async Task CustomHandler_UnmatchedUpdates_FallThroughToBuiltIn()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) => EmitOnlyText(ct));
+
+        var agent = new UIAgent(client, options =>
+        {
+            options.AddBlockHandler(new DelegateBlockHandler<NotificationBlock>((context, state) =>
+            {
+                if (context.Update.RawRepresentation is not NotificationPayload)
+                {
+                    return BlockMappingResult<NotificationBlock>.Pass();
+                }
+                context.MarkUpdateHandled();
+                state.Id = Guid.NewGuid().ToString("N");
+                return BlockMappingResult<NotificationBlock>.Emit(state, state);
+            }));
+        });
+
+        var context = new AgentContext(agent);
+        await context.SendMessageAsync("Say hello");
+
+        var turn = context.Turns[0];
+        Assert.Empty(turn.ResponseBlocks.OfType<NotificationBlock>());
+        var textBlock = turn.ResponseBlocks.OfType<RichContentBlock>().Single();
+        Assert.Equal("Hello!", textBlock.RawText);
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> EmitNotificationThenText(
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            RawRepresentation = new NotificationPayload { Level = "info", Message = "Task started" }
+        };
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = Guid.NewGuid().ToString("N"),
+            Contents = [new TextContent("Task complete.")]
+        };
+        await Task.CompletedTask;
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> EmitOnlyText(
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = Guid.NewGuid().ToString("N"),
+            Contents = [new TextContent("Hello!")]
+        };
+        await Task.CompletedTask;
+    }
+}

--- a/src/Components/AI/test/Samples/S07_ReasoningTest.cs
+++ b/src/Components/AI/test/Samples/S07_ReasoningTest.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Samples;
+
+public class S07_ReasoningTest
+{
+    // AG-UI "thought" / reasoning content maps to ReasoningContentBlock in components-ai.
+    // The LLM emits TextReasoningContent before the visible text.
+
+    [Fact]
+    public async Task ReasoningThenText_ProducesBothBlocks()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitReasoningThenTextResponse(
+                "Let me think about this step by step...",
+                "The answer is 42.",
+                ct));
+
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+
+        await context.SendMessageAsync("What is the meaning of life?");
+
+        var turn = context.Turns[0];
+        var reasoning = turn.ResponseBlocks.OfType<ReasoningContentBlock>().Single();
+        Assert.Equal("Let me think about this step by step...", reasoning.Text);
+
+        var text = turn.ResponseBlocks.OfType<RichContentBlock>().Single();
+        Assert.Equal("The answer is 42.", text.RawText);
+    }
+
+    [Fact]
+    public async Task ReasoningBlock_IsBeforeTextBlock_InOrder()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitReasoningThenTextResponse("Thinking...", "Done.", ct));
+
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+        await context.SendMessageAsync("Think");
+
+        var turn = context.Turns[0];
+        var blocks = turn.ResponseBlocks.ToList();
+
+        var reasoningIdx = blocks.FindIndex(b => b is ReasoningContentBlock);
+        var textIdx = blocks.FindIndex(b => b is RichContentBlock);
+
+        Assert.True(reasoningIdx < textIdx,
+            "Reasoning block should appear before text block.");
+    }
+}

--- a/src/Components/AI/test/Samples/S08_ErrorRetryTest.cs
+++ b/src/Components/AI/test/Samples/S08_ErrorRetryTest.cs
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Samples;
+
+public class S08_ErrorRetryTest
+{
+    // AG-UI error recovery maps to AgentContext error/retry in components-ai.
+    // An LLM failure mid-stream sets Error status; RetryAsync re-submits the same turn.
+
+    [Fact]
+    public async Task ErrorDuringStreaming_SetsErrorStatus_WithPartialBlocks()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitErrorAfterTokens(
+                ["Partial", " response"],
+                new InvalidOperationException("LLM rate limited"),
+                ct));
+
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+
+        await context.SendMessageAsync("Summarize this document");
+
+        Assert.Equal(ConversationStatus.Error, context.Status);
+        Assert.IsType<InvalidOperationException>(context.Error);
+        Assert.Single(context.Turns);
+        Assert.NotEmpty(context.Turns[0].ResponseBlocks);
+    }
+
+    [Fact]
+    public async Task RetryAsync_ClearsErrorAndResubmits()
+    {
+        var callCount = 0;
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return ResponseEmitters.EmitErrorAfterTokens(
+                    ["Partial"], new Exception("Connection lost"), ct);
+            }
+            return ResponseEmitters.EmitTextResponse("Full summary of the document.", ct);
+        });
+
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+
+        await context.SendMessageAsync("Summarize");
+        Assert.Equal(ConversationStatus.Error, context.Status);
+
+        await context.RetryAsync();
+
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+        Assert.Null(context.Error);
+        Assert.Single(context.Turns);
+
+        var text = context.Turns[0].ResponseBlocks.OfType<RichContentBlock>().Single();
+        Assert.Equal("Full summary of the document.", text.RawText);
+    }
+
+    [Fact]
+    public async Task RetryAsync_StatusTransitions_ErrorStreamingIdle()
+    {
+        var statuses = new List<ConversationStatus>();
+        var callCount = 0;
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return ResponseEmitters.EmitErrorAfterTokens(
+                    [], new Exception("fail"), ct);
+            }
+            return ResponseEmitters.EmitTextResponse("OK", ct);
+        });
+
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+        context.RegisterOnStatusChanged(s => statuses.Add(s));
+
+        await context.SendMessageAsync("Go");
+        // Streaming → Error
+        statuses.Clear();
+
+        await context.RetryAsync();
+        // Should see Streaming → Idle
+        Assert.Equal(ConversationStatus.Streaming, statuses[0]);
+        Assert.Equal(ConversationStatus.Idle, statuses[^1]);
+    }
+}

--- a/src/Components/AI/test/Samples/S09_CancelTest.cs
+++ b/src/Components/AI/test/Samples/S09_CancelTest.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Samples;
+
+public class S09_CancelTest
+{
+    // AG-UI cancellation maps to AgentContext.CancelAsync in components-ai.
+    // Cancelling discards partial response blocks and returns to Idle.
+
+    [Fact]
+    public async Task CancelAsync_DiscardsPartialBlocks_ReturnsIdle()
+    {
+        var streamStarted = new TaskCompletionSource();
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) => SlowStream(streamStarted, ct));
+
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+
+        var sendTask = context.SendMessageAsync("Write a long essay");
+        await streamStarted.Task;
+
+        Assert.Equal(ConversationStatus.Streaming, context.Status);
+
+        await context.CancelAsync();
+        await sendTask;
+
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+        Assert.Null(context.Error);
+
+        var turn = context.Turns[0];
+        Assert.Empty(turn.ResponseBlocks);
+    }
+
+    [Fact]
+    public async Task CancelAsync_WhenIdle_IsNoOp()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Done", ct));
+
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+        await context.SendMessageAsync("Hi");
+
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+        await context.CancelAsync();
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> SlowStream(
+        TaskCompletionSource streamStarted,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = Guid.NewGuid().ToString("N"),
+            Contents = [new TextContent("Once upon a time")]
+        };
+        streamStarted.TrySetResult();
+        try
+        {
+            await Task.Delay(Timeout.Infinite, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            yield break;
+        }
+    }
+}

--- a/src/Components/AI/test/Samples/S10_UIActionsTest.cs
+++ b/src/Components/AI/test/Samples/S10_UIActionsTest.cs
@@ -1,0 +1,215 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Samples;
+
+public class S10_UIActionsTest
+{
+    // AG-UI "frontend actions" map to UIActionBlock in components-ai.
+    // The LLM emits a FunctionCallContent for a registered UIAction.
+    // The engine parks at AwaitingInput until the action is invoked.
+
+    [Fact]
+    public async Task UIAction_ParksAtAwaitingInput_ThenResumes()
+    {
+        var action = AIFunctionFactory.Create(
+            () => "user-confirmed",
+            "ConfirmOrder", "Asks the user to confirm the order");
+
+        var client = new DelegatingStreamingChatClient();
+        var agent = new UIAgent(client, options =>
+        {
+            options.RegisterUIAction(action);
+        });
+
+        var callCount = 0;
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return EmitUIActionCall("call-1", "ConfirmOrder", ct);
+            }
+            return ResponseEmitters.EmitTextResponse("Order confirmed! Processing now.", ct);
+        });
+
+        var context = new AgentContext(agent);
+        var statuses = new List<ConversationStatus>();
+        context.RegisterOnStatusChanged(s =>
+        {
+            statuses.Add(s);
+            if (s == ConversationStatus.AwaitingInput)
+            {
+                var turn = context.Turns[^1];
+                var block = turn.ResponseBlocks.OfType<UIActionBlock>().Single();
+                block.InvokeAsync().GetAwaiter().GetResult();
+            }
+        });
+
+        await context.SendMessageAsync("Place my order");
+
+        Assert.Contains(ConversationStatus.AwaitingInput, statuses);
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+
+        var turn = context.Turns[0];
+        var uiBlock = turn.ResponseBlocks.OfType<UIActionBlock>().Single();
+        Assert.Equal("ConfirmOrder", uiBlock.ToolName);
+        Assert.True(uiBlock.IsComplete);
+        Assert.True(uiBlock.HasResult);
+
+        var textBlock = turn.ResponseBlocks.OfType<RichContentBlock>().Single();
+        Assert.Equal("Order confirmed! Processing now.", textBlock.RawText);
+    }
+
+    [Fact]
+    public async Task UIAction_WithArguments_ArgumentsAvailableOnBlock()
+    {
+        var action = AIFunctionFactory.Create(
+            (string product, int quantity) => $"Added {quantity}x {product}",
+            "AddToCart", "Adds item to cart");
+
+        var client = new DelegatingStreamingChatClient();
+        var agent = new UIAgent(client, options =>
+        {
+            options.RegisterUIAction(action);
+        });
+
+        var callCount = 0;
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return EmitUIActionCall("call-1", "AddToCart", ct,
+                    new Dictionary<string, object?> { ["product"] = "Widget", ["quantity"] = 3 });
+            }
+            return ResponseEmitters.EmitTextResponse("Added to cart.", ct);
+        });
+
+        var context = new AgentContext(agent);
+        UIActionBlock? captured = null;
+        context.RegisterOnStatusChanged(s =>
+        {
+            if (s == ConversationStatus.AwaitingInput)
+            {
+                var turn = context.Turns[^1];
+                captured = turn.ResponseBlocks.OfType<UIActionBlock>().Single();
+                captured.InvokeAsync().GetAwaiter().GetResult();
+            }
+        });
+
+        await context.SendMessageAsync("Add widgets");
+
+        Assert.NotNull(captured);
+        Assert.Equal("AddToCart", captured!.ToolName);
+        Assert.Equal("call-1", captured.Id);
+    }
+
+    [Fact]
+    public async Task UIAction_ResultSentBackToLLM()
+    {
+        var action = AIFunctionFactory.Create(
+            () => "Seattle, WA",
+            "GetLocation", "Gets user location");
+
+        var client = new DelegatingStreamingChatClient();
+        var agent = new UIAgent(client, options =>
+        {
+            options.RegisterUIAction(action);
+        });
+
+        var callCount = 0;
+        IEnumerable<ChatMessage>? resumeMessages = null;
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return EmitUIActionCall("loc-1", "GetLocation", ct);
+            }
+            resumeMessages = msgs;
+            return ResponseEmitters.EmitTextResponse("You are in Seattle, WA.", ct);
+        });
+
+        var context = new AgentContext(agent);
+        context.RegisterOnStatusChanged(s =>
+        {
+            if (s == ConversationStatus.AwaitingInput)
+            {
+                context.Turns[^1].ResponseBlocks.OfType<UIActionBlock>().Single()
+                    .InvokeAsync().GetAwaiter().GetResult();
+            }
+        });
+
+        await context.SendMessageAsync("Where am I?");
+
+        Assert.NotNull(resumeMessages);
+        var toolMsg = resumeMessages!.Last(m => m.Role == ChatRole.Tool);
+        var result = toolMsg.Contents.OfType<FunctionResultContent>().Single();
+        Assert.Equal("loc-1", result.CallId);
+    }
+
+    [Fact]
+    public async Task UIAction_StatusFlow_StreamingAwaitingStreamingIdle()
+    {
+        var action = AIFunctionFactory.Create(() => "ok", "Confirm", "Confirms");
+        var client = new DelegatingStreamingChatClient();
+        var agent = new UIAgent(client, options =>
+        {
+            options.RegisterUIAction(action);
+        });
+
+        var callCount = 0;
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return EmitUIActionCall("c1", "Confirm", ct);
+            }
+            return ResponseEmitters.EmitTextResponse("Done.", ct);
+        });
+
+        var context = new AgentContext(agent);
+        var statuses = new List<ConversationStatus>();
+        context.RegisterOnStatusChanged(s =>
+        {
+            statuses.Add(s);
+            if (s == ConversationStatus.AwaitingInput)
+            {
+                context.Turns[^1].ResponseBlocks.OfType<UIActionBlock>().Single()
+                    .InvokeAsync().GetAwaiter().GetResult();
+            }
+        });
+
+        await context.SendMessageAsync("Go");
+
+        Assert.Equal(new[]
+        {
+            ConversationStatus.Streaming,
+            ConversationStatus.AwaitingInput,
+            ConversationStatus.Streaming,
+            ConversationStatus.Idle,
+        }, statuses);
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> EmitUIActionCall(
+        string callId,
+        string name,
+        [EnumeratorCancellation] CancellationToken ct,
+        IDictionary<string, object?>? arguments = null)
+    {
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = Guid.NewGuid().ToString("N"),
+            Contents = [new FunctionCallContent(callId, name, arguments)],
+            FinishReason = ChatFinishReason.ToolCalls
+        };
+        await Task.CompletedTask;
+    }
+}

--- a/src/Components/AI/test/TestHelpers/DelegatingStreamingChatClient.cs
+++ b/src/Components/AI/test/TestHelpers/DelegatingStreamingChatClient.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+
+internal sealed class DelegatingStreamingChatClient : IChatClient
+{
+    private Func<IEnumerable<ChatMessage>, ChatOptions?, CancellationToken,
+        IAsyncEnumerable<ChatResponseUpdate>>? _handler;
+
+    internal void SetHandler(
+        Func<IEnumerable<ChatMessage>, ChatOptions?, CancellationToken,
+            IAsyncEnumerable<ChatResponseUpdate>> handler)
+    {
+        _handler = handler;
+    }
+
+    public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (_handler is null)
+        {
+            throw new InvalidOperationException(
+                "No handler configured. Call SetHandler before GetStreamingResponseAsync.");
+        }
+
+        return _handler(messages, options, cancellationToken);
+    }
+
+    public Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException(
+            "DelegatingStreamingChatClient only supports streaming. Use GetStreamingResponseAsync.");
+
+    public object? GetService(Type serviceType, object? serviceKey = null)
+        => serviceType == typeof(IChatClient) ? this : null;
+
+    public void Dispose() { }
+}

--- a/src/Components/AI/test/TestHelpers/RecordingChatClient.cs
+++ b/src/Components/AI/test/TestHelpers/RecordingChatClient.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+
+internal sealed class RecordingChatClient : IChatClient
+{
+    private readonly IChatClient _inner;
+    private readonly List<List<ChatResponseUpdate>> _recordedTurns = new();
+
+    internal RecordingChatClient(IChatClient inner)
+    {
+        _inner = inner;
+    }
+
+    internal IReadOnlyList<List<ChatResponseUpdate>> RecordedTurns => _recordedTurns;
+
+    public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var turnUpdates = new List<ChatResponseUpdate>();
+
+        await foreach (var update in _inner.GetStreamingResponseAsync(
+            messages, options, cancellationToken).ConfigureAwait(false))
+        {
+            // Snapshot via round-trip serialization so downstream mutations
+            // (e.g. FunctionInvokingChatClient setting InformationalOnly = true)
+            // don't pollute the recording.
+            var json = JsonSerializer.Serialize(update, AIJsonUtilities.DefaultOptions);
+            var snapshot = JsonSerializer.Deserialize<ChatResponseUpdate>(json, AIJsonUtilities.DefaultOptions)!;
+            turnUpdates.Add(snapshot);
+            yield return update;
+        }
+
+        _recordedTurns.Add(turnUpdates);
+    }
+
+    public Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("Only streaming is supported for recording.");
+
+    public object? GetService(Type serviceType, object? serviceKey = null)
+        => _inner.GetService(serviceType, serviceKey);
+
+    public void Dispose() => _inner.Dispose();
+
+    internal void SaveRecording(string path)
+    {
+        var json = JsonSerializer.Serialize(_recordedTurns, AIJsonUtilities.DefaultOptions);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, json);
+    }
+}

--- a/src/Components/AI/test/TestHelpers/RecordingLoader.cs
+++ b/src/Components/AI/test/TestHelpers/RecordingLoader.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+
+internal static class RecordingLoader
+{
+    internal static List<List<ChatResponseUpdate>> Load(string recordingFileName)
+    {
+        var basePath = Path.Combine(AppContext.BaseDirectory, "Baselines", recordingFileName);
+        if (!File.Exists(basePath))
+        {
+            throw new FileNotFoundException(
+                $"Recording baseline not found: {basePath}. " +
+                "Ensure the file is copied to output (CopyToOutputDirectory = PreserveNewest).");
+        }
+
+        var json = File.ReadAllText(basePath);
+        var turns = JsonSerializer.Deserialize<List<List<ChatResponseUpdate>>>(
+            json, AIJsonUtilities.DefaultOptions);
+
+        return turns ?? throw new InvalidOperationException(
+            $"Recording file deserialized to null: {recordingFileName}");
+    }
+
+    internal static DelegatingStreamingChatClient CreateReplayClient(string recordingFileName)
+    {
+        var turns = Load(recordingFileName);
+        var turnIndex = 0;
+
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((messages, options, ct) =>
+        {
+            if (turnIndex >= turns.Count)
+            {
+                throw new InvalidOperationException(
+                    $"Recording has {turns.Count} turns but GetStreamingResponseAsync " +
+                    $"was called {turnIndex + 1} times.");
+            }
+
+            var currentTurn = turns[turnIndex];
+            turnIndex++;
+            return YieldUpdates(currentTurn, ct);
+        });
+
+        return client;
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> YieldUpdates(
+        List<ChatResponseUpdate> updates,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        foreach (var update in updates)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return update;
+        }
+
+        await Task.CompletedTask;
+    }
+}

--- a/src/Components/AI/test/TestHelpers/RecordingLoaderTests.cs
+++ b/src/Components/AI/test/TestHelpers/RecordingLoaderTests.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests;
+
+public class RecordingLoaderTests
+{
+    [Theory]
+    [InlineData("Step01_GettingStartedTest.PostRun_MultiTurn_SynthesizesAssistantMessages.recording.json", 2)]
+    [InlineData("Step02_BackendToolsTest.PostRun_WithBackendToolCall_InvokesToolAndStreamsResult.recording.json", 1)]
+    [InlineData("Step04_HumanInLoopTest.PostRun_WithApprovalRequired_ApprovesAndExecutesTool.recording.json", 1)]
+    [InlineData("Step05_StateManagementTest.PostRun_WithState_EmitsStateSnapshotAndSummary.recording.json", 2)]
+    public void Load_DeserializesExpectedTurnCount(string fileName, int expectedTurns)
+    {
+        var turns = RecordingLoader.Load(fileName);
+        Assert.Equal(expectedTurns, turns.Count);
+        Assert.All(turns, turn => Assert.NotEmpty(turn));
+    }
+
+    [Fact]
+    public void CreateReplayClient_YieldsTurnsInOrder()
+    {
+        var client = RecordingLoader.CreateReplayClient(
+            "Step01_GettingStartedTest.PostRun_MultiTurn_SynthesizesAssistantMessages.recording.json");
+
+        var enumerator = client.GetStreamingResponseAsync(
+            [new ChatMessage(ChatRole.User, "test")]).GetAsyncEnumerator();
+        Assert.NotNull(enumerator);
+    }
+}

--- a/src/Components/AI/test/TestHelpers/ResponseEmitters.cs
+++ b/src/Components/AI/test/TestHelpers/ResponseEmitters.cs
@@ -1,0 +1,157 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+
+internal static class ResponseEmitters
+{
+    internal static async IAsyncEnumerable<ChatResponseUpdate> EmitTextResponse(
+        string text,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = Guid.NewGuid().ToString("N"),
+            Contents = [new TextContent(text)]
+        };
+        await Task.CompletedTask;
+    }
+
+    internal static async IAsyncEnumerable<ChatResponseUpdate> EmitMultiTokenTextResponse(
+        [EnumeratorCancellation] CancellationToken ct = default,
+        params string[] tokens)
+    {
+        var messageId = Guid.NewGuid().ToString("N");
+        foreach (var token in tokens)
+        {
+            ct.ThrowIfCancellationRequested();
+            yield return new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                MessageId = messageId,
+                Contents = [new TextContent(token)]
+            };
+        }
+        await Task.CompletedTask;
+    }
+
+    internal static async IAsyncEnumerable<ChatResponseUpdate> EmitEmptyResponse(
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await Task.CompletedTask;
+        yield break;
+    }
+
+    internal static async IAsyncEnumerable<ChatResponseUpdate> EmitToolCallResponse(
+        string callId,
+        string name,
+        IDictionary<string, object?>? arguments = null,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = Guid.NewGuid().ToString("N"),
+            Contents = [new FunctionCallContent(callId, name, arguments)],
+            FinishReason = ChatFinishReason.ToolCalls
+        };
+        await Task.CompletedTask;
+    }
+
+    internal static async IAsyncEnumerable<ChatResponseUpdate> EmitMultipleToolCallResponse(
+        [EnumeratorCancellation] CancellationToken ct = default,
+        params FunctionCallContent[] calls)
+    {
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = Guid.NewGuid().ToString("N"),
+            Contents = [.. calls],
+            FinishReason = ChatFinishReason.ToolCalls
+        };
+        await Task.CompletedTask;
+    }
+
+    internal static async IAsyncEnumerable<ChatResponseUpdate> EmitToolCallWithResultResponse(
+        string callId,
+        string name,
+        IDictionary<string, object?>? arguments,
+        object? result,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = Guid.NewGuid().ToString("N"),
+            Contents = [new FunctionCallContent(callId, name, arguments)],
+            FinishReason = ChatFinishReason.ToolCalls
+        };
+        yield return new ChatResponseUpdate
+        {
+            Contents = [new FunctionResultContent(callId, result)]
+        };
+        await Task.CompletedTask;
+    }
+
+    internal static async IAsyncEnumerable<ChatResponseUpdate> EmitReasoningThenTextResponse(
+        string reasoning,
+        string text,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        var messageId = Guid.NewGuid().ToString("N");
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = messageId,
+            Contents = [new TextReasoningContent(reasoning)]
+        };
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = messageId,
+            Contents = [new TextContent(text)]
+        };
+        await Task.CompletedTask;
+    }
+
+    internal static async IAsyncEnumerable<ChatResponseUpdate> EmitErrorAfterTokens(
+        string[] tokens,
+        Exception error,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        var messageId = Guid.NewGuid().ToString("N");
+        foreach (var token in tokens)
+        {
+            ct.ThrowIfCancellationRequested();
+            yield return new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                MessageId = messageId,
+                Contents = [new TextContent(token)]
+            };
+        }
+
+        await Task.CompletedTask;
+        throw error;
+    }
+
+    internal static async IAsyncEnumerable<ChatResponseUpdate> EmitApprovalRequest(
+        string callId,
+        string name,
+        IDictionary<string, object?>? arguments = null,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        var toolCall = new FunctionCallContent(callId, name, arguments);
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = Guid.NewGuid().ToString("N"),
+            Contents = [new ToolApprovalRequestContent(Guid.NewGuid().ToString("N"), toolCall)]
+        };
+        await Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
Part of the overall Components.AI design: https://github.com/dotnet/aspnetcore/issues/66178

Builds on #66181

---

# Engine: AgentContext, Tool Calls, Approval, Reasoning, and State

## Summary

Build the interactive conversation engine on top of the block model and pipeline. This adds `AgentContext` — the state machine that manages conversation turns, tool invocation workflows, user approval gates, and error recovery. It also adds all remaining built-in pipeline handlers (tool invocation, approval, UI actions, reasoning, media) and typed state extraction via `UIAgent<TState>`.

## Motivation

LLM-powered applications frequently use tool calling: the model emits a `FunctionCallContent` requesting that the application run a function, then waits for the `FunctionResultContent` before continuing. This creates a multi-turn loop:

1. User sends message → LLM responds with tool call.
2. Application invokes tool → sends result back to LLM.
3. LLM responds with text (or another tool call).

Some tool calls require **user approval** before execution. Others are **UI-side actions** that execute on the client, not the server.

The engine must orchestrate all of these patterns transparently, handling multiple concurrent tool calls within a single response, and looping until the LLM is satisfied.

## Goals

- Provide `AgentContext` as a state machine managing the conversation lifecycle (Idle → Streaming → AwaitingInput → Error).
- Auto-invoke backend tools registered in `ChatOptions.Tools` and loop tool results back to the LLM.
- Support approval gates: tool calls that pause the conversation until the user approves or rejects.
- Support UI actions: tool calls that execute client-side logic without LLM round-trips.
- Handle `TextReasoningContent` (LLM thinking/reasoning output) via a dedicated block and handler.
- Handle `DataContent` (images, audio, video) via a dedicated block and handler.
- Provide typed state extraction via `UIAgent<TState>` and `AgentState<T>`.
- Expose turn-level pub/sub callbacks for UI integration: `OnTurnAdded`, `OnStatusChanged`, `OnBlockAdded`.
- Provide error recovery via `RetryAsync()` and `CancelAsync()`.

## Non-goals

- Blazor component rendering.
- Conversation persistence / thread support.
- Source-generated tool block handlers.

## Detailed design

### AgentContext state machine

`AgentContext` wraps `UIAgent` and adds conversation lifecycle management. Status transitions:
- `Idle → Streaming`: `SendMessageAsync()` called.
- `Streaming → Idle`: Stream complete, no interactive blocks.
- `Streaming → AwaitingInput`: Interactive blocks found (approval, UI action).
- `Streaming → Error`: Exception thrown.
- `AwaitingInput → Streaming`: All interactive blocks resolved.
- `Error → Streaming`: `RetryAsync()`.
- `Error → Idle`: `CancelAsync()`.

### Interactive block loop

The core multi-turn tool workflow collects emitted `ContentBlock` objects, checks for `IInteractiveBlock` or uninvoked tool calls, waits for user actions, builds continuation messages, and loops back to the LLM until no more interactive blocks remain.

### Pipeline handler ordering

Handlers are registered in priority order:
1. Custom handlers (user-registered)
2. `UIActionHandler` (client-side tools)
3. `FunctionApprovalHandler` (approval gates)
4. `FunctionInvocationHandler` (general tool calls)
5. `ReasoningHandler` (thinking output)
6. `MediaContentHandler` (images, audio, video)
7. `TextBlockHandler` (text fallback)

### New block types

| Block Type | Content Claimed | Lifecycle |
|---|---|---|
| `FunctionInvocationContentBlock` | `FunctionCallContent` → later `FunctionResultContent` (by `CallId`) | Emit on call, Complete on result |
| `FunctionApprovalBlock` | `ToolApprovalRequestContent` | Emit on request, resolves via `Approve()`/`Reject()` |
| `UIActionBlock` | `FunctionCallContent` matching registered UI action name | Emit, auto-invokes `AIFunction`, Complete |
| `ReasoningContentBlock` | `TextReasoningContent` | Emit, Update (accumulate text), Complete |
| `MediaContentBlock` | `DataContent` | Emit, Update (accumulate items), Complete |

### State extraction — UIAgent\<TState\>

`UIAgent<TState>` adds an `AgentState<T>` property — an observable container. Applications supply a `StateMapper` function that inspects each `ChatResponseUpdate`, extracts typed state, and optionally marks content as handled.

## Risks

- **Infinite tool loops**: Mitigated by `ChatOptions.MaxOutputTokens` and application-level safeguards.
- **Approval deadlock**: Mitigated by `CancelAsync()` and fallback rendering.
- **State mapper side effects**: Mitigated by documentation guidance.

## Drawbacks

- `AgentContext` is a large class with many responsibilities. The alternative of splitting into smaller pieces would increase the number of cascaded values and complicate the component integration.

## Test coverage

176 tests (cumulative) covering:
- `AgentContext` state machine transitions.
- Tool invocation end-to-end with mock `IChatClient`.
- `FunctionApprovalBlock` Approve/Reject → result propagation.
- `UIActionBlock` execution → result.
- `ReasoningHandler` accumulation.
- `MediaContentHandler` accumulation.
- `StateMapperContext` content filtering.
- `UIAgent<TState>` state extraction.
- Error recovery (`RetryAsync`, `CancelAsync`).
- Pipeline handler ordering and priority.