### PR TITLE
[Blazor] Components.AI - 03 Blazor components: AgentBoundary, MessageList, MessageInput, rendering

### DIFF
--- a/src/Components/AI/src/Components/AgentBoundary.cs
+++ b/src/Components/AI/src/Components/AgentBoundary.cs
@@ -1,0 +1,100 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public class AgentBoundary : ComponentBase, IDisposable
+{
+    private AgentContext _context = default!;
+    private UIAgent _currentAgent = default!;
+    private object? _agentState;
+    private Type? _cascadingValueType;
+
+    [Parameter, EditorRequired]
+    public UIAgent Agent { get; set; } = default!;
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    protected override void OnInitialized()
+    {
+        _currentAgent = Agent;
+        _context = new AgentContext(Agent);
+        _agentState = Agent.AgentStateObject;
+
+        if (_agentState is not null)
+        {
+            _cascadingValueType = typeof(CascadingValue<>).MakeGenericType(_agentState.GetType());
+        }
+    }
+
+    protected override void OnParametersSet()
+    {
+        if (!ReferenceEquals(Agent, _currentAgent))
+        {
+            // Agent changed — tear down the old context and create a new one.
+            // BuildRenderTree uses OpenRegion keyed on the agent, so Blazor will
+            // also tear down and recreate all descendant components.
+            _context?.Dispose();
+            _currentAgent = Agent;
+            _context = new AgentContext(Agent);
+            _agentState = Agent.AgentStateObject;
+
+            if (_agentState is not null)
+            {
+                _cascadingValueType = typeof(CascadingValue<>).MakeGenericType(_agentState.GetType());
+            }
+            else
+            {
+                _cascadingValueType = null;
+            }
+        }
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await Task.CompletedTask;
+    }
+
+    protected override void BuildRenderTree(RenderTreeBuilder builder)
+    {
+        // If Agent changes, the region key changes, causing Blazor to tear down
+        // and recreate all descendants. This is the same trick EditForm uses with
+        // EditContext. It lets us safely use IsFixed=true on the CascadingValue.
+        builder.OpenRegion(_context.GetHashCode());
+
+        // Outer: cascade AgentContext
+        builder.OpenComponent<CascadingValue<AgentContext>>(0);
+        builder.AddComponentParameter(1, "Value", _context);
+        builder.AddComponentParameter(2, "IsFixed", true);
+        builder.AddComponentParameter(3, "ChildContent", (RenderFragment)(inner =>
+        {
+            if (_agentState is not null)
+            {
+                // Inner: cascade AgentState<TState> with the correct generic type
+                inner.OpenComponent(10, _cascadingValueType!);
+                inner.AddComponentParameter(11, "Value", _agentState);
+                inner.AddComponentParameter(12, "IsFixed", true);
+                inner.AddComponentParameter(13, "ChildContent", (RenderFragment)(stateInner =>
+                {
+                    stateInner.AddContent(20, ChildContent);
+                }));
+                inner.CloseComponent();
+            }
+            else
+            {
+                inner.AddContent(10, ChildContent);
+            }
+        }));
+        builder.CloseComponent();
+
+        builder.CloseRegion();
+    }
+
+    public void Dispose()
+    {
+        _context?.Dispose();
+    }
+}

--- a/src/Components/AI/src/Components/BlockContainer.cs
+++ b/src/Components/AI/src/Components/BlockContainer.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+internal class BlockContainer : IDisposable
+{
+    private readonly ContentBlock _block;
+    private readonly MessageListContext _listContext;
+    private readonly ContentBlockChangedSubscription _changedSub;
+
+    internal BlockContainer(ContentBlock block, MessageListContext listContext, Action requestRender)
+    {
+        _block = block;
+        _listContext = listContext;
+        _changedSub = block.OnChanged(requestRender);
+    }
+
+    internal void RenderTo(Rendering.RenderTreeBuilder builder, int seq)
+    {
+        var fragment = _listContext.RenderBlock(_block);
+        builder.AddContent(seq, fragment);
+    }
+
+    public void Dispose()
+    {
+        _changedSub.Dispose();
+    }
+}

--- a/src/Components/AI/src/Components/BlockRenderer.cs
+++ b/src/Components/AI/src/Components/BlockRenderer.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public class BlockRenderer<TBlock> : IComponent, IDisposable where TBlock : ContentBlock
+{
+    private RenderHandle _renderHandle;
+    private bool _initialized;
+    private BlockRendererRegistration? _registration;
+
+    [CascadingParameter]
+    public MessageListContext ListContext { get; set; } = default!;
+
+    [Parameter]
+    public RenderFragment<TBlock>? ChildContent { get; set; }
+
+    [Parameter]
+    public Func<TBlock, bool>? When { get; set; }
+
+    void IComponent.Attach(RenderHandle renderHandle)
+    {
+        _renderHandle = renderHandle;
+    }
+
+    Task IComponent.SetParametersAsync(ParameterView parameters)
+    {
+        parameters.SetParameterProperties(this);
+
+        if (ListContext is null)
+        {
+            throw new InvalidOperationException(
+                "BlockRenderer must be placed inside a MessageList.");
+        }
+
+        if (!_initialized)
+        {
+            _initialized = true;
+
+            _registration = new BlockRendererRegistration
+            {
+                BlockType = typeof(TBlock),
+                // Capture 'this' so the lambda reads the latest When/ChildContent at invocation time
+                When = block => block is TBlock typed && (When is null || When(typed)),
+                Render = block => ChildContent!((TBlock)block)
+            };
+
+            ListContext.AddRegistration(_registration);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        if (_registration is not null)
+        {
+            ListContext?.RemoveRegistration(_registration);
+        }
+    }
+}

--- a/src/Components/AI/src/Components/BlockRendererRegistration.cs
+++ b/src/Components/AI/src/Components/BlockRendererRegistration.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+internal class BlockRendererRegistration
+{
+    public required Type BlockType { get; init; }
+
+    public Func<ContentBlock, bool>? When { get; init; }
+
+    public required Func<ContentBlock, RenderFragment> Render { get; init; }
+}

--- a/src/Components/AI/src/Components/BlockRendererWithComponent.cs
+++ b/src/Components/AI/src/Components/BlockRendererWithComponent.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public class ComponentBlockRenderer<TBlock, TRenderer> : IComponent, IDisposable
+    where TBlock : ContentBlock
+    where TRenderer : IComponent
+{
+    private RenderHandle _renderHandle;
+    private bool _initialized;
+    private BlockRendererRegistration? _registration;
+
+    [CascadingParameter]
+    public MessageListContext ListContext { get; set; } = default!;
+
+    [Parameter]
+    public Func<TBlock, bool>? When { get; set; }
+
+    void IComponent.Attach(RenderHandle renderHandle)
+    {
+        _renderHandle = renderHandle;
+    }
+
+    Task IComponent.SetParametersAsync(ParameterView parameters)
+    {
+        parameters.SetParameterProperties(this);
+
+        if (ListContext is null)
+        {
+            throw new InvalidOperationException(
+                "ComponentBlockRenderer must be placed inside a MessageList.");
+        }
+
+        if (!_initialized)
+        {
+            _initialized = true;
+
+            _registration = new BlockRendererRegistration
+            {
+                BlockType = typeof(TBlock),
+                When = block => block is TBlock typed && (When is null || When(typed)),
+                Render = block => builder =>
+                {
+                    builder.OpenComponent<TRenderer>(0);
+                    builder.AddComponentParameter(1, "Block", (TBlock)block);
+                    builder.CloseComponent();
+                }
+            };
+
+            ListContext.AddRegistration(_registration);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        if (_registration is not null)
+        {
+            ListContext?.RemoveRegistration(_registration);
+        }
+    }
+}

--- a/src/Components/AI/src/Components/ConversationTurnRenderer.cs
+++ b/src/Components/AI/src/Components/ConversationTurnRenderer.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+internal class ConversationTurnRenderer : IDisposable
+{
+    private readonly ConversationTurn _turn;
+    private readonly MessageListContext _listContext;
+    private readonly Action _requestRender;
+    private readonly List<BlockContainer> _blockContainers = new();
+    private readonly IDisposable? _blockAddedSub;
+
+    internal ConversationTurnRenderer(
+        AgentContext agentContext,
+        ConversationTurn turn,
+        MessageListContext listContext,
+        Action requestRender)
+    {
+        _turn = turn;
+        _listContext = listContext;
+        _requestRender = requestRender;
+
+        _blockAddedSub = agentContext.RegisterOnBlockAdded((t, block) =>
+        {
+            if (ReferenceEquals(t, _turn))
+            {
+                OnBlockAdded(block);
+            }
+        });
+
+        foreach (var block in turn.RequestBlocks)
+        {
+            _blockContainers.Add(new BlockContainer(block, _listContext, _requestRender));
+        }
+        foreach (var block in turn.ResponseBlocks)
+        {
+            _blockContainers.Add(new BlockContainer(block, _listContext, _requestRender));
+        }
+    }
+
+    private void OnBlockAdded(ContentBlock block)
+    {
+        _blockContainers.Add(new BlockContainer(block, _listContext, _requestRender));
+        _requestRender();
+    }
+
+    internal void RenderTo(RenderTreeBuilder builder, int baseSeq)
+    {
+        // Determine role from request blocks (user turn) or response blocks
+        var role = _turn.RequestBlocks.Count > 0 ? "user" : "assistant";
+        builder.OpenElement(baseSeq, "div");
+        builder.AddAttribute(baseSeq + 1, "class", $"sc-ai-turn sc-ai-turn--{role}");
+        var seq = baseSeq + 10;
+        foreach (var container in _blockContainers)
+        {
+            container.RenderTo(builder, seq);
+            seq += 10;
+        }
+        builder.CloseElement();
+    }
+
+    public void Dispose()
+    {
+        _blockAddedSub?.Dispose();
+        foreach (var container in _blockContainers)
+        {
+            container.Dispose();
+        }
+    }
+}

--- a/src/Components/AI/src/Components/MessageInput.cs
+++ b/src/Components/AI/src/Components/MessageInput.cs
@@ -1,0 +1,268 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public class MessageInput : IComponent, IDisposable
+{
+    private RenderHandle _renderHandle;
+    private AgentContext _agentContext = default!;
+    private string? _placeholder;
+    private RenderFragment? _leadingActions;
+    private RenderFragment? _trailingActions;
+    private string _text = "";
+    private bool _isDisabled;
+    private IDisposable? _statusSub;
+    private bool _allowAttachments;
+    private string? _acceptFileTypes;
+    private readonly List<AttachedFile> _attachments = new();
+    private int _fileInputKey;
+
+    [CascadingParameter]
+    public AgentContext AgentContext { get; set; } = default!;
+
+    [Parameter]
+    public string? Placeholder { get; set; }
+
+    [Parameter]
+    public RenderFragment? LeadingActions { get; set; }
+
+    [Parameter]
+    public RenderFragment? TrailingActions { get; set; }
+
+    [Parameter]
+    public bool AllowAttachments { get; set; }
+
+    [Parameter]
+    public string? AcceptFileTypes { get; set; }
+
+    void IComponent.Attach(RenderHandle renderHandle)
+    {
+        _renderHandle = renderHandle;
+    }
+
+    Task IComponent.SetParametersAsync(ParameterView parameters)
+    {
+        parameters.SetParameterProperties(this);
+        _agentContext = AgentContext
+            ?? throw new InvalidOperationException(
+                "MessageInput must be inside an AgentBoundary.");
+        _placeholder = Placeholder;
+        _leadingActions = LeadingActions;
+        _trailingActions = TrailingActions;
+        _allowAttachments = AllowAttachments;
+        _acceptFileTypes = AcceptFileTypes;
+
+        _statusSub = _agentContext.RegisterOnStatusChanged(status =>
+        {
+            _isDisabled = status == ConversationStatus.Streaming;
+            Render();
+        });
+
+        Render();
+        return Task.CompletedTask;
+    }
+
+    private void Render()
+    {
+        _renderHandle.Render(builder =>
+        {
+            builder.OpenElement(0, "div");
+            builder.AddAttribute(1, "class", "sc-ai-input");
+
+            if (_leadingActions is not null)
+            {
+                builder.AddContent(2, _leadingActions);
+            }
+
+            // Attach button (left side) — label wrapping a hidden InputFile
+            if (_allowAttachments)
+            {
+                builder.OpenElement(20, "label");
+                builder.AddAttribute(21, "class", "sc-ai-input__attach");
+                builder.AddAttribute(22, "aria-label", "Attach file");
+
+                builder.OpenComponent<InputFile>(23);
+                builder.SetKey(_fileInputKey);
+                builder.AddComponentParameter(24, "OnChange",
+                    EventCallback.Factory.Create<InputFileChangeEventArgs>(this, OnFilesSelected));
+                builder.AddComponentParameter(25, "AdditionalAttributes",
+                    (IReadOnlyDictionary<string, object>)new Dictionary<string, object>
+                    {
+                        ["accept"] = _acceptFileTypes ?? "image/*",
+                        ["multiple"] = true,
+                        ["class"] = "sc-ai-input__file",
+                        ["aria-hidden"] = "true",
+                    });
+                builder.CloseComponent();
+
+                // Paperclip SVG icon
+                builder.AddMarkupContent(26,
+                    "<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\"/></svg>");
+                builder.CloseElement(); // label
+            }
+
+            // Main input area (file names + textarea)
+            builder.OpenElement(3, "div");
+            builder.AddAttribute(4, "class", "sc-ai-input__body");
+
+            // Attachment names
+            if (_attachments.Count > 0)
+            {
+                builder.OpenElement(5, "div");
+                builder.AddAttribute(6, "class", "sc-ai-input__attachments");
+
+                for (var i = 0; i < _attachments.Count; i++)
+                {
+                    var attachment = _attachments[i];
+                    var index = i;
+
+                    builder.OpenElement(7, "span");
+                    builder.AddAttribute(8, "class", "sc-ai-attachment-preview");
+
+                    builder.OpenElement(9, "span");
+                    builder.AddAttribute(10, "class", "sc-ai-attachment-preview__file");
+                    builder.AddContent(11, attachment.Name);
+                    builder.CloseElement();
+
+                    builder.OpenElement(13, "button");
+                    builder.AddAttribute(14, "type", "button");
+                    builder.AddAttribute(15, "class", "sc-ai-attachment-preview__remove");
+                    builder.AddAttribute(16, "aria-label", $"Remove {attachment.Name}");
+                    builder.AddAttribute(17, "onclick",
+                        EventCallback.Factory.Create(this, () => RemoveAttachment(index)));
+                    builder.AddContent(18, "\u00d7");
+                    builder.CloseElement(); // remove button
+
+                    builder.CloseElement(); // preview
+                }
+
+                builder.CloseElement(); // attachments container
+            }
+
+            builder.OpenElement(10, "textarea");
+            builder.AddAttribute(11, "class", "sc-ai-input__textarea");
+            builder.AddAttribute(12, "placeholder",
+                _placeholder ?? "Type a message...");
+            builder.AddAttribute(13, "disabled", _isDisabled);
+            builder.AddAttribute(14, "value", _text);
+            builder.AddAttribute(15, "aria-label", _placeholder ?? "Type a message...");
+            builder.AddAttribute(16, "oninput",
+                EventCallback.Factory.Create<ChangeEventArgs>(
+                    this, e => _text = e.Value?.ToString() ?? ""));
+            builder.AddAttribute(17, "onkeydown",
+                EventCallback.Factory.Create<KeyboardEventArgs>(
+                    this, OnKeyDown));
+            builder.CloseElement(); // textarea
+
+            builder.CloseElement(); // input body
+
+            if (_trailingActions is not null)
+            {
+                builder.AddContent(50, _trailingActions);
+            }
+            else
+            {
+                builder.OpenElement(50, "button");
+                builder.AddAttribute(51, "type", "button");
+                builder.AddAttribute(52, "class", "sc-ai-input__send");
+                builder.AddAttribute(53, "disabled", _isDisabled);
+                builder.AddAttribute(54, "aria-label", "Send message");
+                builder.AddAttribute(55, "onclick",
+                    EventCallback.Factory.Create(this, SubmitAsync));
+
+                // Send icon SVG
+                builder.AddMarkupContent(56,
+                    "<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M22 2 11 13\"/><path d=\"M22 2 15 22 11 13 2 9z\"/></svg>");
+
+                builder.CloseElement();
+            }
+
+            builder.CloseElement(); // div
+        });
+    }
+
+    private const long MaxFileSize = 10 * 1024 * 1024; // 10 MB
+
+    private async Task OnFilesSelected(InputFileChangeEventArgs e)
+    {
+        foreach (var file in e.GetMultipleFiles())
+        {
+            using var stream = file.OpenReadStream(MaxFileSize);
+            using var ms = new MemoryStream();
+            await stream.CopyToAsync(ms);
+            _attachments.Add(new AttachedFile(file.Name, file.ContentType, ms.ToArray()));
+        }
+
+        _fileInputKey++;
+        Render();
+    }
+
+    private void RemoveAttachment(int index)
+    {
+        if (index >= 0 && index < _attachments.Count)
+        {
+            _attachments.RemoveAt(index);
+            Render();
+        }
+    }
+
+    private async Task OnKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter" && !e.ShiftKey && !_isDisabled)
+        {
+            await SubmitAsync();
+        }
+    }
+
+    private async Task SubmitAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_text))
+        {
+            return;
+        }
+
+        if (_isDisabled)
+        {
+            return;
+        }
+
+        var contents = new List<AIContent>();
+        contents.Add(new TextContent(_text));
+
+        foreach (var attachment in _attachments)
+        {
+            contents.Add(new DataContent(attachment.Data, attachment.MediaType));
+        }
+
+        _text = "";
+        _attachments.Clear();
+        Render();
+
+        var message = new ChatMessage(ChatRole.User, contents);
+        await _agentContext.SendMessageAsync(message);
+    }
+
+    public void Dispose()
+    {
+        _statusSub?.Dispose();
+    }
+
+    internal sealed class AttachedFile
+    {
+        public AttachedFile(string name, string mediaType, byte[] data)
+        {
+            Name = name;
+            MediaType = mediaType;
+            Data = data;
+        }
+
+        public string Name { get; }
+        public string MediaType { get; }
+        public byte[] Data { get; }
+    }
+}

--- a/src/Components/AI/src/Components/MessageList.cs
+++ b/src/Components/AI/src/Components/MessageList.cs
@@ -1,0 +1,173 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+[StreamRendering]
+public class MessageList : IComponent, IDisposable
+{
+    private RenderHandle _renderHandle;
+    private AgentContext _agentContext = default!;
+    private RenderFragment? _childContent;
+    private RenderFragment<AgentContext>? _footer;
+    private readonly MessageListContext _listContext = new();
+    private readonly List<ConversationTurnRenderer> _turnRenderers = new();
+    private IDisposable? _turnAddedSub;
+    private IDisposable? _statusChangedSub;
+
+    [CascadingParameter]
+    public AgentContext AgentContext { get; set; } = default!;
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    [Parameter]
+    public RenderFragment<AgentContext>? Footer { get; set; }
+
+    void IComponent.Attach(RenderHandle renderHandle)
+    {
+        _renderHandle = renderHandle;
+    }
+
+    Task IComponent.SetParametersAsync(ParameterView parameters)
+    {
+        parameters.SetParameterProperties(this);
+        var newAgentContext = AgentContext
+            ?? throw new InvalidOperationException(
+                "MessageList must be inside an AgentBoundary.");
+
+        if (!ReferenceEquals(_agentContext, newAgentContext))
+        {
+            ResetRegistrations();
+            _agentContext = newAgentContext;
+            _listContext.OnRegistrationsChanged = Render;
+
+            _turnAddedSub = _agentContext.RegisterOnTurnAdded(OnTurnAdded);
+            _statusChangedSub = _agentContext.RegisterOnStatusChanged(_ => Render());
+
+            foreach (var turn in _agentContext.Turns)
+            {
+                var renderer = new ConversationTurnRenderer(
+                    _agentContext, turn, _listContext, Render);
+                _turnRenderers.Add(renderer);
+            }
+        }
+
+        _childContent = ChildContent;
+        _footer = Footer;
+
+        Render();
+        return Task.CompletedTask;
+    }
+
+    private void OnTurnAdded(ConversationTurn turn)
+    {
+        var renderer = new ConversationTurnRenderer(
+            _agentContext, turn, _listContext, Render);
+        _turnRenderers.Add(renderer);
+        Render();
+    }
+
+    private void Render()
+    {
+        _renderHandle.Render(builder =>
+        {
+            builder.OpenComponent<CascadingValue<MessageListContext>>(0);
+            builder.AddComponentParameter(1, "Value", _listContext);
+            builder.AddComponentParameter(2, "IsFixed", true);
+            builder.AddComponentParameter(3, "ChildContent",
+                (RenderFragment)(inner =>
+                {
+                    inner.OpenElement(3, "div");
+                    inner.AddAttribute(3, "class", "sc-ai-message-list");
+                    if (_childContent is not null)
+                    {
+                        inner.AddContent(4, _childContent);
+                    }
+
+                    var seq = 100;
+                    foreach (var turnRenderer in _turnRenderers)
+                    {
+                        turnRenderer.RenderTo(inner, seq);
+                        seq += 100;
+                    }
+
+                    inner.OpenElement(seq, "div");
+                    inner.AddAttribute(seq + 1, "class", "sc-ai-message-list__footer");
+                    if (_footer is not null)
+                    {
+                        inner.AddContent(seq + 2, _footer(_agentContext));
+                    }
+                    else
+                    {
+                        RenderDefaultFooter(inner, seq + 2);
+                    }
+                    inner.CloseElement(); // footer div
+
+                    inner.CloseElement(); // sc-ai-message-list div
+                }));
+            builder.CloseComponent();
+        });
+    }
+
+    private void RenderDefaultFooter(RenderTreeBuilder builder, int seq)
+    {
+        switch (_agentContext.Status)
+        {
+            case ConversationStatus.Streaming:
+                builder.OpenElement(seq, "div");
+                builder.AddAttribute(seq + 1, "class", "sc-ai-typing");
+                builder.AddAttribute(seq + 2, "role", "status");
+                builder.AddAttribute(seq + 3, "aria-label", "Agent is typing");
+                for (var i = 0; i < 3; i++)
+                {
+                    builder.OpenElement(seq + 4 + i, "span");
+                    builder.AddAttribute(seq + 7 + i, "class", "sc-ai-typing__dot");
+                    builder.CloseElement();
+                }
+                builder.CloseElement();
+                break;
+
+            case ConversationStatus.Error:
+                builder.OpenElement(seq, "div");
+                builder.AddAttribute(seq + 1, "class", "sc-ai-error");
+                builder.AddAttribute(seq + 2, "role", "alert");
+                builder.OpenElement(seq + 3, "span");
+                builder.AddAttribute(seq + 4, "class", "sc-ai-error__message");
+                builder.AddContent(seq + 5, _agentContext.Error?.Message ?? "Something went wrong.");
+                builder.CloseElement(); // span
+                builder.OpenElement(seq + 6, "button");
+                builder.AddAttribute(seq + 7, "class", "sc-ai-btn sc-ai-btn--secondary");
+                builder.AddAttribute(seq + 8, "onclick",
+                    EventCallback.Factory.Create(this,
+                        () => _agentContext.RetryAsync()));
+                builder.AddContent(seq + 9, "Retry");
+                builder.CloseElement(); // button
+                builder.CloseElement(); // div
+                break;
+        }
+    }
+
+    private void ResetRegistrations()
+    {
+        _turnAddedSub?.Dispose();
+        _turnAddedSub = null;
+
+        _statusChangedSub?.Dispose();
+        _statusChangedSub = null;
+
+        foreach (var renderer in _turnRenderers)
+        {
+            renderer.Dispose();
+        }
+
+        _turnRenderers.Clear();
+    }
+
+    public void Dispose()
+    {
+        ResetRegistrations();
+    }
+}

--- a/src/Components/AI/src/Components/MessageListContext.cs
+++ b/src/Components/AI/src/Components/MessageListContext.cs
@@ -1,0 +1,267 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public class MessageListContext
+{
+    private static readonly JsonSerializerOptions IndentedJsonOptions = new()
+    {
+        WriteIndented = true,
+    };
+
+    private readonly List<BlockRendererRegistration> _registrations = new();
+
+    public RenderFragment RenderBlock(ContentBlock block)
+    {
+        foreach (var reg in _registrations)
+        {
+            if (reg.BlockType.IsAssignableFrom(block.GetType())
+                && (reg.When is null || reg.When(block)))
+            {
+                return reg.Render(block);
+            }
+        }
+
+        return builder =>
+        {
+            if (block is RichContentBlock rich)
+            {
+                var role = block.Role == Microsoft.Extensions.AI.ChatRole.User ? "user" : "assistant";
+                builder.OpenElement(0, "div");
+                builder.AddAttribute(1, "class", $"sc-ai-message sc-ai-message--{role}");
+                builder.OpenElement(2, "div");
+                builder.AddAttribute(3, "class", "sc-ai-message__bubble");
+                builder.OpenElement(4, "div");
+                var contentClass = block.LifecycleState == BlockLifecycleState.Active
+                    ? "sc-ai-message__content sc-ai-message__content--streaming"
+                    : "sc-ai-message__content";
+                builder.AddAttribute(5, "class", contentClass);
+                builder.AddContent(6, rich.RawText);
+                builder.CloseElement(); // content div
+                builder.CloseElement(); // bubble div
+                builder.CloseElement(); // message div
+            }
+            else if (block is FunctionApprovalBlock approval)
+            {
+                RenderApprovalBlock(builder, approval);
+            }
+            else if (block is FunctionInvocationContentBlock)
+            {
+                // Not rendered by default. Register a BlockRenderer<FunctionInvocationContentBlock>
+                // to display tool call blocks.
+            }
+            else if (block is ReasoningContentBlock reasoning)
+            {
+                RenderReasoningBlock(builder, reasoning);
+            }
+            else if (block is MediaContentBlock media)
+            {
+                RenderMediaBlock(builder, media);
+            }
+            else
+            {
+                builder.OpenElement(0, "div");
+                builder.AddAttribute(1, "class", "sc-ai-tool-call");
+                builder.AddContent(2, block.GetType().Name);
+                builder.CloseElement();
+            }
+        };
+    }
+
+    internal Action? OnRegistrationsChanged { get; set; }
+
+    internal void AddRegistration(BlockRendererRegistration registration)
+    {
+        _registrations.Add(registration);
+        OnRegistrationsChanged?.Invoke();
+    }
+
+    internal void RemoveRegistration(BlockRendererRegistration registration)
+    {
+        _registrations.Remove(registration);
+        OnRegistrationsChanged?.Invoke();
+    }
+
+    private static void RenderReasoningBlock(RenderTreeBuilder builder, ReasoningContentBlock block)
+    {
+        var isStreaming = block.LifecycleState == BlockLifecycleState.Active;
+
+        builder.OpenElement(0, "details");
+        builder.AddAttribute(1, "class", "sc-ai-reasoning");
+        if (isStreaming)
+        {
+            builder.AddAttribute(2, "open", true);
+        }
+
+        builder.OpenElement(3, "summary");
+        builder.AddAttribute(4, "class", "sc-ai-reasoning__header");
+        if (isStreaming)
+        {
+            builder.AddContent(5, "\ud83d\udca1 Thinking\u2026");
+        }
+        else
+        {
+            builder.AddContent(5, "\ud83d\udca1 Thought process");
+        }
+        builder.CloseElement(); // summary
+
+        builder.OpenElement(6, "div");
+        builder.AddAttribute(7, "class", "sc-ai-reasoning__content");
+        builder.AddContent(8, block.Text);
+        builder.CloseElement(); // content div
+
+        builder.CloseElement(); // details
+    }
+
+    private static void RenderMediaBlock(RenderTreeBuilder builder, MediaContentBlock block)
+    {
+        var role = block.Role == Microsoft.Extensions.AI.ChatRole.User ? "user" : "assistant";
+
+        builder.OpenElement(0, "div");
+        builder.AddAttribute(1, "class", $"sc-ai-message sc-ai-message--{role}");
+
+        builder.OpenElement(2, "div");
+        builder.AddAttribute(3, "class", "sc-ai-media");
+
+        foreach (var item in block.Items)
+        {
+            var mediaType = item.MediaType ?? "application/octet-stream";
+            if (mediaType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+            {
+                var src = GetDataContentUri(item);
+                builder.OpenElement(4, "img");
+                builder.AddAttribute(5, "src", src);
+                builder.AddAttribute(6, "alt", "Attached image");
+                builder.AddAttribute(7, "class", "sc-ai-media__image");
+                builder.CloseElement();
+            }
+            else if (mediaType.StartsWith("audio/", StringComparison.OrdinalIgnoreCase))
+            {
+                var src = GetDataContentUri(item);
+                builder.OpenElement(4, "audio");
+                builder.AddAttribute(5, "controls", true);
+                builder.AddAttribute(6, "class", "sc-ai-media__audio");
+                builder.OpenElement(7, "source");
+                builder.AddAttribute(8, "src", src);
+                builder.AddAttribute(9, "type", mediaType);
+                builder.CloseElement();
+                builder.CloseElement();
+            }
+            else if (mediaType.StartsWith("video/", StringComparison.OrdinalIgnoreCase))
+            {
+                var src = GetDataContentUri(item);
+                builder.OpenElement(4, "video");
+                builder.AddAttribute(5, "controls", true);
+                builder.AddAttribute(6, "class", "sc-ai-media__video");
+                builder.OpenElement(7, "source");
+                builder.AddAttribute(8, "src", src);
+                builder.AddAttribute(9, "type", mediaType);
+                builder.CloseElement();
+                builder.CloseElement();
+            }
+            else
+            {
+                builder.OpenElement(4, "div");
+                builder.AddAttribute(5, "class", "sc-ai-media__file");
+                builder.AddContent(6, $"\ud83d\udcce {mediaType}");
+                builder.CloseElement();
+            }
+        }
+
+        builder.CloseElement(); // sc-ai-media
+        builder.CloseElement(); // message
+    }
+
+    private static string GetDataContentUri(Microsoft.Extensions.AI.DataContent content)
+    {
+        if (content.Uri is not null && content.Uri.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+        {
+            return content.Uri;
+        }
+
+        if (content.Data is { Length: > 0 } data)
+        {
+            var mediaType = content.MediaType ?? "application/octet-stream";
+            return $"data:{mediaType};base64,{Convert.ToBase64String(data.ToArray())}";
+        }
+
+        return content.Uri ?? "";
+    }
+
+    private static void RenderApprovalBlock(RenderTreeBuilder builder, FunctionApprovalBlock block)
+    {
+        builder.OpenElement(0, "div");
+        builder.AddAttribute(1, "class", "sc-ai-approval");
+
+        // Header
+        builder.OpenElement(2, "div");
+        builder.AddAttribute(3, "class", "sc-ai-approval__header");
+        builder.AddContent(4, "\u26a0\ufe0f Approval Required");
+        builder.CloseElement();
+
+        // Tool name
+        builder.OpenElement(5, "div");
+        builder.AddAttribute(6, "class", "sc-ai-approval__tool-name");
+        builder.AddContent(7, block.ToolName ?? "unknown");
+        builder.CloseElement();
+
+        // Arguments
+        if (block.Arguments is { Count: > 0 })
+        {
+            builder.OpenElement(10, "pre");
+            builder.AddAttribute(11, "class", "sc-ai-tool-call__pre");
+            builder.AddContent(12, JsonSerializer.Serialize(block.Arguments, IndentedJsonOptions));
+            builder.CloseElement();
+        }
+
+        // Actions or status
+        if (block.Status == ApprovalStatus.Pending)
+        {
+            builder.OpenElement(20, "div");
+            builder.AddAttribute(21, "class", "sc-ai-approval__actions");
+
+            // type="submit" + name/value enables form-based approval in SSR mode.
+            // onclick enables interactive approval in Server/WebAssembly mode.
+            // Both attributes coexist safely: in interactive mode there is no parent
+            // form so submit is a no-op; in SSR mode there is no circuit so onclick
+            // is ignored.
+            builder.OpenElement(22, "button");
+            builder.AddAttribute(23, "type", "submit");
+            builder.AddAttribute(24, "name", "BlockAction");
+            builder.AddAttribute(25, "value", $"approve:{block.Id}");
+            builder.AddAttribute(26, "class", "sc-ai-btn sc-ai-btn--primary");
+            builder.AddAttribute(27, "onclick", (Action)block.Approve);
+            builder.AddContent(28, "Approve");
+            builder.CloseElement();
+
+            builder.OpenElement(30, "button");
+            builder.AddAttribute(31, "type", "submit");
+            builder.AddAttribute(32, "name", "BlockAction");
+            builder.AddAttribute(33, "value", $"reject:{block.Id}");
+            builder.AddAttribute(34, "class", "sc-ai-btn sc-ai-btn--secondary");
+            builder.AddAttribute(35, "onclick", (Action)(() => block.Reject()));
+            builder.AddContent(36, "Reject");
+            builder.CloseElement();
+
+            builder.CloseElement(); // actions
+        }
+        else
+        {
+            var statusClass = block.Status == ApprovalStatus.Approved
+                ? "sc-ai-approval__status sc-ai-approval__status--approved"
+                : "sc-ai-approval__status sc-ai-approval__status--rejected";
+            var statusText = block.Status == ApprovalStatus.Approved ? "\u2713 Approved" : "\u2717 Rejected";
+
+            builder.OpenElement(30, "div");
+            builder.AddAttribute(31, "class", statusClass);
+            builder.AddContent(32, statusText);
+            builder.CloseElement();
+        }
+
+        builder.CloseElement(); // sc-ai-approval
+    }
+}

--- a/src/Components/AI/test/Components/AgentBoundaryTests.cs
+++ b/src/Components/AI/test/Components/AgentBoundaryTests.cs
@@ -1,0 +1,196 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.AI.Tests.TestFramework;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Components;
+
+public class AgentBoundaryTests
+{
+    [Fact]
+    public void CascadesAgentContext_ToChildren()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hi", ct));
+        var agent = new UIAgent(client);
+
+        AgentContext? received = null;
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(builder =>
+            {
+                builder.OpenComponent<CascadingReceiver>(0);
+                builder.AddComponentParameter(1, "OnReceived",
+                    EventCallback.Factory.Create<AgentContext>(
+                        new object(), ctx => received = ctx));
+                builder.CloseComponent();
+            });
+        });
+
+        Assert.NotNull(received);
+    }
+
+    [Fact]
+    public void WithUIAgentTState_CascadesAgentState()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hi", ct));
+        var agent = new UIAgent<TestState>(client, new TestState { Value = "initial" });
+
+        AgentState<TestState>? receivedState = null;
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(builder =>
+            {
+                builder.OpenComponent<TypedStateReceiver>(0);
+                builder.AddComponentParameter(1, "OnReceived",
+                    EventCallback.Factory.Create<AgentState<TestState>>(
+                        new object(), s => receivedState = s));
+                builder.CloseComponent();
+            });
+        });
+
+        Assert.NotNull(receivedState);
+        Assert.Equal("initial", receivedState.Value.Value);
+    }
+
+    [Fact]
+    public void WithPlainUIAgent_DoesNotCascadeAgentState()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hi", ct));
+        var agent = new UIAgent(client);
+
+        AgentState<TestState>? receivedState = null;
+        bool receiverInitialized = false;
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(builder =>
+            {
+                builder.OpenComponent<TypedStateReceiver>(0);
+                builder.AddComponentParameter(1, "OnReceived",
+                    EventCallback.Factory.Create<AgentState<TestState>>(
+                        new object(), s => receivedState = s));
+                builder.AddComponentParameter(2, "OnInitializedCallback",
+                    EventCallback.Factory.Create(
+                        new object(), () => receiverInitialized = true));
+                builder.CloseComponent();
+            });
+        });
+
+        Assert.True(receiverInitialized);
+        Assert.Null(receivedState);
+    }
+
+    [Fact]
+    public void Dispose_DisposesContext()
+    {
+        var client = new DelegatingStreamingChatClient();
+        var agent = new UIAgent(client);
+
+        AgentContext? received = null;
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(builder =>
+            {
+                builder.OpenComponent<CascadingReceiver>(0);
+                builder.AddComponentParameter(1, "OnReceived",
+                    EventCallback.Factory.Create<AgentContext>(
+                        new object(), ctx => received = ctx));
+                builder.CloseComponent();
+            });
+        });
+
+        Assert.NotNull(received);
+
+        // Dispose the boundary
+        ((IDisposable)cut.Instance).Dispose();
+
+        // After dispose, SendMessageAsync should throw because context is disposed
+        // (the CTS was cancelled/disposed in Dispose)
+        // Verify it doesn't throw during dispose itself — that's the main contract.
+    }
+
+    [Fact]
+    public void RendersChildContent()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hi", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(builder =>
+            {
+                builder.OpenElement(0, "div");
+                builder.AddAttribute(1, "class", "child-content");
+                builder.AddContent(2, "Hello from child");
+                builder.CloseElement();
+            });
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("class=\"child-content\"", html);
+        Assert.Contains("Hello from child", html);
+    }
+}
+
+internal class CascadingReceiver : ComponentBase
+{
+    [CascadingParameter]
+    public AgentContext? Context { get; set; }
+
+    [Parameter]
+    public EventCallback<AgentContext> OnReceived { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (Context is not null)
+        {
+            await OnReceived.InvokeAsync(Context);
+        }
+    }
+}
+
+internal class TypedStateReceiver : ComponentBase
+{
+    [CascadingParameter]
+    public AgentState<TestState>? State { get; set; }
+
+    [Parameter]
+    public EventCallback<AgentState<TestState>> OnReceived { get; set; }
+
+    [Parameter]
+    public EventCallback OnInitializedCallback { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await OnInitializedCallback.InvokeAsync();
+        if (State is not null)
+        {
+            await OnReceived.InvokeAsync(State);
+        }
+    }
+}
+
+internal class TestState
+{
+    public string Value { get; set; } = "";
+}

--- a/src/Components/AI/test/Components/BlockRendererTests.cs
+++ b/src/Components/AI/test/Components/BlockRendererTests.cs
@@ -1,0 +1,372 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.AI.Tests.TestFramework;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Components;
+
+public class BlockRendererTests
+{
+    [Fact]
+    public async Task InlineRenderer_OverridesDefaultRendering()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hello!", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<MessageList>(0);
+                b.AddComponentParameter(1, "ChildContent", (RenderFragment)(inner =>
+                {
+                    inner.OpenComponent<BlockRenderer<RichContentBlock>>(0);
+                    inner.AddComponentParameter(1, "ChildContent",
+                        new RenderFragment<RichContentBlock>(block => builder =>
+                        {
+                            builder.OpenElement(0, "span");
+                            builder.AddAttribute(1, "class", "custom-text");
+                            builder.AddContent(2, block.RawText);
+                            builder.CloseElement();
+                        }));
+                    inner.CloseComponent();
+                }));
+                b.CloseComponent();
+            });
+        });
+
+        var context = GetAgentContext(cut);
+        await cut.InvokeAsync(() => context.SendMessageAsync("Hi"));
+
+        var html = cut.GetHtml();
+        Assert.Contains("custom-text", html);
+        Assert.Contains("Hello!", html);
+        Assert.DoesNotContain("sc-ai-message__bubble", html);
+    }
+
+    [Fact]
+    public async Task ComponentRenderer_RendersViaComponent()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hello!", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<MessageList>(0);
+                b.AddComponentParameter(1, "ChildContent", (RenderFragment)(inner =>
+                {
+                    inner.OpenComponent<ComponentBlockRenderer<RichContentBlock, CustomBubbleView>>(0);
+                    inner.CloseComponent();
+                }));
+                b.CloseComponent();
+            });
+        });
+
+        var context = GetAgentContext(cut);
+        await cut.InvokeAsync(() => context.SendMessageAsync("Hi"));
+
+        var html = cut.GetHtml();
+        Assert.Contains("custom-bubble", html);
+        Assert.Contains("Hello!", html);
+        Assert.DoesNotContain("sc-ai-message__bubble", html);
+    }
+
+    [Fact]
+    public async Task WhenPredicate_RoutesToCorrectRenderer()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Reply", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<MessageList>(0);
+                b.AddComponentParameter(1, "ChildContent", (RenderFragment)(inner =>
+                {
+                    // Renderer for user messages
+                    inner.OpenComponent<BlockRenderer<RichContentBlock>>(0);
+                    inner.AddComponentParameter(1, "When",
+                        new Func<RichContentBlock, bool>(block =>
+                            block.Role == ChatRole.User));
+                    inner.AddComponentParameter(2, "ChildContent",
+                        new RenderFragment<RichContentBlock>(block => builder =>
+                        {
+                            builder.OpenElement(0, "div");
+                            builder.AddAttribute(1, "class", "user-bubble");
+                            builder.AddContent(2, block.RawText);
+                            builder.CloseElement();
+                        }));
+                    inner.CloseComponent();
+
+                    // Renderer for assistant messages
+                    inner.OpenComponent<BlockRenderer<RichContentBlock>>(10);
+                    inner.AddComponentParameter(11, "When",
+                        new Func<RichContentBlock, bool>(block =>
+                            block.Role == ChatRole.Assistant));
+                    inner.AddComponentParameter(12, "ChildContent",
+                        new RenderFragment<RichContentBlock>(block => builder =>
+                        {
+                            builder.OpenElement(0, "div");
+                            builder.AddAttribute(1, "class", "assistant-bubble");
+                            builder.AddContent(2, block.RawText);
+                            builder.CloseElement();
+                        }));
+                    inner.CloseComponent();
+                }));
+                b.CloseComponent();
+            });
+        });
+
+        var context = GetAgentContext(cut);
+        await cut.InvokeAsync(() => context.SendMessageAsync("Hi"));
+
+        var html = cut.GetHtml();
+        // User message uses user-bubble renderer
+        Assert.Contains("user-bubble", html);
+        // Assistant message uses assistant-bubble renderer
+        Assert.Contains("assistant-bubble", html);
+        // Default renderer not used
+        Assert.DoesNotContain("sc-ai-message__bubble", html);
+    }
+
+    [Fact]
+    public async Task ResolutionOrder_FirstMatchWins()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hello", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<MessageList>(0);
+                b.AddComponentParameter(1, "ChildContent", (RenderFragment)(inner =>
+                {
+                    // First renderer
+                    inner.OpenComponent<BlockRenderer<RichContentBlock>>(0);
+                    inner.AddComponentParameter(1, "ChildContent",
+                        new RenderFragment<RichContentBlock>(block => builder =>
+                        {
+                            builder.OpenElement(0, "span");
+                            builder.AddAttribute(1, "class", "first-renderer");
+                            builder.CloseElement();
+                        }));
+                    inner.CloseComponent();
+
+                    // Second renderer for same type
+                    inner.OpenComponent<BlockRenderer<RichContentBlock>>(10);
+                    inner.AddComponentParameter(11, "ChildContent",
+                        new RenderFragment<RichContentBlock>(block => builder =>
+                        {
+                            builder.OpenElement(0, "span");
+                            builder.AddAttribute(1, "class", "second-renderer");
+                            builder.CloseElement();
+                        }));
+                    inner.CloseComponent();
+                }));
+                b.CloseComponent();
+            });
+        });
+
+        var context = GetAgentContext(cut);
+        await cut.InvokeAsync(() => context.SendMessageAsync("Hi"));
+
+        var html = cut.GetHtml();
+        Assert.Contains("first-renderer", html);
+        Assert.DoesNotContain("second-renderer", html);
+    }
+
+    [Fact]
+    public async Task NoCustomRenderer_UsesBuiltInDefault()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hello!", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<MessageList>(0);
+                b.CloseComponent();
+            });
+        });
+
+        var context = GetAgentContext(cut);
+        await cut.InvokeAsync(() => context.SendMessageAsync("Hi"));
+
+        var html = cut.GetHtml();
+        Assert.Contains("sc-ai-message", html);
+        Assert.Contains("Hello!", html);
+    }
+
+    [Fact]
+    public void GenericFallback_UnknownBlockType_ShowsTypeName()
+    {
+        var context = new MessageListContext();
+        var block = new TestUnknownBlock();
+
+        var renderer = new TestRenderer();
+        var rendered = renderer.RenderComponent<FragmentHost>(p =>
+        {
+            p["Fragment"] = context.RenderBlock(block);
+        });
+
+        var html = rendered.GetHtml();
+        Assert.Contains("sc-ai-tool-call", html);
+        Assert.Contains("TestUnknownBlock", html);
+    }
+
+    [Fact]
+    public async Task WhenPredicate_NoMatch_FallsToDefault()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hello!", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<MessageList>(0);
+                b.AddComponentParameter(1, "ChildContent", (RenderFragment)(inner =>
+                {
+                    // Renderer that only matches blocks containing "special"
+                    inner.OpenComponent<BlockRenderer<RichContentBlock>>(0);
+                    inner.AddComponentParameter(1, "When",
+                        new Func<RichContentBlock, bool>(block =>
+                            block.RawText.Contains("special")));
+                    inner.AddComponentParameter(2, "ChildContent",
+                        new RenderFragment<RichContentBlock>(block => builder =>
+                        {
+                            builder.OpenElement(0, "div");
+                            builder.AddAttribute(1, "class", "special-render");
+                            builder.CloseElement();
+                        }));
+                    inner.CloseComponent();
+                }));
+                b.CloseComponent();
+            });
+        });
+
+        var context = GetAgentContext(cut);
+        await cut.InvokeAsync(() => context.SendMessageAsync("Hi"));
+
+        var html = cut.GetHtml();
+        // "Hello!" doesn't contain "special", so falls to default
+        Assert.DoesNotContain("special-render", html);
+        Assert.Contains("sc-ai-message", html);
+    }
+
+    [Fact]
+    public async Task BaseTypeRenderer_MatchesDerivedBlocks()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hello!", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<MessageList>(0);
+                b.AddComponentParameter(1, "ChildContent", (RenderFragment)(inner =>
+                {
+                    // Catch-all renderer for ContentBlock base type
+                    inner.OpenComponent<BlockRenderer<ContentBlock>>(0);
+                    inner.AddComponentParameter(1, "ChildContent",
+                        new RenderFragment<ContentBlock>(block => builder =>
+                        {
+                            builder.OpenElement(0, "div");
+                            builder.AddAttribute(1, "class", "catch-all");
+                            builder.AddContent(2, block.GetType().Name);
+                            builder.CloseElement();
+                        }));
+                    inner.CloseComponent();
+                }));
+                b.CloseComponent();
+            });
+        });
+
+        var context = GetAgentContext(cut);
+        await cut.InvokeAsync(() => context.SendMessageAsync("Hi"));
+
+        var html = cut.GetHtml();
+        Assert.Contains("catch-all", html);
+        Assert.Contains("RichContentBlock", html);
+    }
+
+    private static AgentContext GetAgentContext(RenderedComponent<AgentBoundary> cut)
+    {
+        return (AgentContext)typeof(AgentBoundary)
+            .GetField("_context",
+                System.Reflection.BindingFlags.NonPublic
+                | System.Reflection.BindingFlags.Instance)!
+            .GetValue(cut.Instance)!;
+    }
+
+    // Helper component to render a RenderFragment
+    private class FragmentHost : ComponentBase
+    {
+        [Parameter]
+        public RenderFragment? Fragment { get; set; }
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            if (Fragment is not null)
+            {
+                builder.AddContent(0, Fragment);
+            }
+        }
+    }
+
+    // Test component that renders a RichContentBlock with custom markup
+    internal class CustomBubbleView : ComponentBase
+    {
+        [Parameter]
+        public RichContentBlock Block { get; set; } = default!;
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenElement(0, "div");
+            builder.AddAttribute(1, "class", "custom-bubble");
+            builder.AddContent(2, Block.RawText);
+            builder.CloseElement();
+        }
+    }
+
+    private class TestUnknownBlock : ContentBlock
+    {
+    }
+}

--- a/src/Components/AI/test/Components/ConversationTurnRendererTests.cs
+++ b/src/Components/AI/test/Components/ConversationTurnRendererTests.cs
@@ -1,0 +1,183 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.AI.Tests.TestFramework;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Components;
+
+public class ConversationTurnRendererTests
+{
+    [Fact]
+    public void RenderTo_EmptyTurn_RendersEmptyTurnDiv()
+    {
+        var client = new DelegatingStreamingChatClient();
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+        var turn = new ConversationTurn();
+        var listContext = new MessageListContext();
+        var renderCount = 0;
+
+        var renderer = new ConversationTurnRenderer(
+            context, turn, listContext, () => renderCount++);
+
+        var testRenderer = new TestRenderer();
+        var rendered = testRenderer.RenderComponent<RenderDelegateComponent>(p =>
+        {
+            p["RenderAction"] = (Action<RenderTreeBuilder>)(builder =>
+            {
+                renderer.RenderTo(builder, 0);
+            });
+        });
+
+        var html = rendered.GetHtml();
+        Assert.Contains("class=\"sc-ai-turn", html);
+
+        renderer.Dispose();
+        context.Dispose();
+    }
+
+    [Fact]
+    public void RenderTo_TurnWithExistingBlocks_RendersAllBlocks()
+    {
+        var client = new DelegatingStreamingChatClient();
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+        var turn = new ConversationTurn();
+
+        var requestBlock = new RichContentBlock { Role = ChatRole.User };
+        requestBlock.AppendText("Hello");
+        turn.AddRequestBlock(requestBlock);
+
+        var responseBlock = new RichContentBlock { Role = ChatRole.Assistant };
+        responseBlock.AppendText("Hi there");
+        turn.AddResponseBlock(responseBlock);
+
+        var listContext = new MessageListContext();
+        var renderCount = 0;
+
+        var renderer = new ConversationTurnRenderer(
+            context, turn, listContext, () => renderCount++);
+
+        var testRenderer = new TestRenderer();
+        var rendered = testRenderer.RenderComponent<RenderDelegateComponent>(p =>
+        {
+            p["RenderAction"] = (Action<RenderTreeBuilder>)(builder =>
+            {
+                renderer.RenderTo(builder, 0);
+            });
+        });
+
+        var html = rendered.GetHtml();
+        Assert.Contains("Hello", html);
+        Assert.Contains("Hi there", html);
+
+        renderer.Dispose();
+        context.Dispose();
+    }
+
+    [Fact]
+    public async Task OnBlockAdded_NewBlock_TriggersRequestRender()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Response", ct));
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+
+        var listContext = new MessageListContext();
+        var renderCount = 0;
+        ConversationTurnRenderer? renderer = null;
+
+        // Listen for the turn the context creates, then create a renderer for it
+        context.RegisterOnTurnAdded(turn =>
+        {
+            renderer = new ConversationTurnRenderer(
+                context, turn, listContext, () => renderCount++);
+        });
+
+        await context.SendMessageAsync("Hello");
+
+        // The renderer should have been notified about new blocks added during streaming
+        Assert.NotNull(renderer);
+        Assert.True(renderCount > 0);
+
+        renderer!.Dispose();
+        context.Dispose();
+    }
+
+    [Fact]
+    public void BlockContainer_SubscribesToOnChanged()
+    {
+        var block = new RichContentBlock { Role = ChatRole.Assistant };
+        block.AppendText("Initial");
+
+        var listContext = new MessageListContext();
+        var renderCount = 0;
+
+        var container = new BlockContainer(block, listContext, () => renderCount++);
+
+        // Modify the block — should trigger the render callback
+        block.AppendText(" more");
+        block.InvokeNotifyChanged();
+
+        Assert.Equal(1, renderCount);
+
+        // Modify again
+        block.AppendText(" text");
+        block.InvokeNotifyChanged();
+
+        Assert.Equal(2, renderCount);
+
+        container.Dispose();
+
+        // After dispose, changes should NOT trigger callback
+        block.AppendText(" after dispose");
+        block.InvokeNotifyChanged();
+
+        Assert.Equal(2, renderCount);
+    }
+
+    [Fact]
+    public void Dispose_CleansUpSubscriptions()
+    {
+        var client = new DelegatingStreamingChatClient();
+        var agent = new UIAgent(client);
+        var context = new AgentContext(agent);
+        var turn = new ConversationTurn();
+
+        var block = new RichContentBlock { Role = ChatRole.Assistant };
+        block.AppendText("Test");
+        turn.AddResponseBlock(block);
+
+        var listContext = new MessageListContext();
+        var renderCount = 0;
+
+        var renderer = new ConversationTurnRenderer(
+            context, turn, listContext, () => renderCount++);
+
+        renderer.Dispose();
+
+        // After dispose, block changes should not trigger render
+        block.AppendText(" more");
+        block.InvokeNotifyChanged();
+
+        Assert.Equal(0, renderCount);
+
+        context.Dispose();
+    }
+
+    // Helper component that delegates BuildRenderTree to an Action
+    private class RenderDelegateComponent : ComponentBase
+    {
+        [Parameter]
+        public Action<RenderTreeBuilder>? RenderAction { get; set; }
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            RenderAction?.Invoke(builder);
+        }
+    }
+}

--- a/src/Components/AI/test/Components/MessageInputTests.cs
+++ b/src/Components/AI/test/Components/MessageInputTests.cs
@@ -1,0 +1,252 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.AI.Tests.TestFramework;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Components;
+
+public class MessageInputTests
+{
+    [Fact]
+    public void RendersTextarea_WithPlaceholder()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hi", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<MessageInput>(0);
+                b.AddComponentParameter(1, "Placeholder", "Ask me anything...");
+                b.CloseComponent();
+            });
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("<textarea", html);
+        Assert.Contains("placeholder=\"Ask me anything...\"", html);
+    }
+
+    [Fact]
+    public void RendersTextarea_WithDefaultPlaceholder()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hi", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<MessageInput>(0);
+                b.CloseComponent();
+            });
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("placeholder=\"Type a message...\"", html);
+    }
+
+    [Fact]
+    public void DefaultSendButton_Rendered()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hi", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<MessageInput>(0);
+                b.CloseComponent();
+            });
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("<button", html);
+        Assert.Contains("sc-ai-input__send", html);
+    }
+
+    [Fact]
+    public async Task DisabledDuringStreaming()
+    {
+        var streamingStarted = new TaskCompletionSource();
+        var streamGate = new TaskCompletionSource();
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            SlowStream(streamingStarted, streamGate, ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<MessageInput>(0);
+                b.CloseComponent();
+            });
+        });
+
+        var context = GetAgentContext(cut);
+        Task sendTask = null!;
+        await cut.InvokeAsync(() =>
+        {
+            sendTask = context.SendMessageAsync("Hello");
+        });
+
+        await streamingStarted.Task;
+
+        var html = cut.GetHtml();
+        // During streaming, textarea and button should be disabled
+        Assert.Contains("disabled", html);
+
+        streamGate.TrySetResult();
+        await sendTask;
+
+        html = cut.GetHtml();
+        // After streaming completes, should no longer be disabled
+        // (disabled="false" or no disabled attribute for non-boolean rendering)
+    }
+
+    [Fact]
+    public async Task Submit_CallsSendMessage()
+    {
+        var messagesReceived = new List<string>();
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            var lastMsg = msgs.Last().Text;
+            if (lastMsg is not null)
+            {
+                messagesReceived.Add(lastMsg);
+            }
+            return ResponseEmitters.EmitTextResponse("OK", ct);
+        });
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<MessageInput>(0);
+                b.CloseComponent();
+            });
+        });
+
+        var context = GetAgentContext(cut);
+        await cut.InvokeAsync(() => context.SendMessageAsync("Test message"));
+
+        Assert.Single(messagesReceived);
+        Assert.Equal("Test message", messagesReceived[0]);
+    }
+
+    [Fact]
+    public void CustomTrailingActions_OverridesDefaultButton()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hi", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<MessageInput>(0);
+                b.AddComponentParameter(1, "TrailingActions", (RenderFragment)(inner =>
+                {
+                    inner.OpenElement(0, "button");
+                    inner.AddAttribute(1, "class", "custom-send");
+                    inner.AddContent(2, "Custom Send");
+                    inner.CloseElement();
+                }));
+                b.CloseComponent();
+            });
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("class=\"custom-send\"", html);
+        Assert.Contains("Custom Send", html);
+        // Default "Send" button text should not appear outside the custom one
+        Assert.DoesNotContain(">Send<", html);
+    }
+
+    [Fact]
+    public void RendersMessageInputContainer()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hi", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<MessageInput>(0);
+                b.CloseComponent();
+            });
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("class=\"sc-ai-input\"", html);
+    }
+
+    [Fact]
+    public void MessageInput_OutsideAgentBoundary_Throws()
+    {
+        var renderer = new TestRenderer();
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            renderer.RenderComponent<MessageInput>();
+        });
+    }
+
+    private static AgentContext GetAgentContext(RenderedComponent<AgentBoundary> cut)
+    {
+        return (AgentContext)typeof(AgentBoundary)
+            .GetField("_context",
+                System.Reflection.BindingFlags.NonPublic
+                | System.Reflection.BindingFlags.Instance)!
+            .GetValue(cut.Instance)!;
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> SlowStream(
+        TaskCompletionSource started,
+        TaskCompletionSource gate,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [new TextContent("tok")]
+        };
+        started.TrySetResult();
+        try { await gate.Task.WaitAsync(ct); }
+        catch (OperationCanceledException) { yield break; }
+    }
+}

--- a/src/Components/AI/test/Components/MessageListContextTests.cs
+++ b/src/Components/AI/test/Components/MessageListContextTests.cs
@@ -1,0 +1,299 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.AI.Tests.TestFramework;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Components;
+
+public class MessageListContextTests
+{
+    [Fact]
+    public void RenderBlock_RichContentBlock_RendersRawText()
+    {
+        var context = new MessageListContext();
+        var block = new RichContentBlock { Role = ChatRole.Assistant };
+        block.AppendText("Hello ");
+        block.AppendText("world");
+
+        var renderer = new TestRenderer();
+        var rendered = renderer.RenderComponent<FragmentHost>(p =>
+        {
+            p["Fragment"] = context.RenderBlock(block);
+        });
+
+        var html = rendered.GetHtml();
+        Assert.Contains("sc-ai-message", html);
+        Assert.Contains("Hello world", html);
+    }
+
+    [Fact]
+    public void RenderBlock_NonRichBlock_RendersTypeName()
+    {
+        var context = new MessageListContext();
+        var block = new TestContentBlock();
+
+        var renderer = new TestRenderer();
+        var rendered = renderer.RenderComponent<FragmentHost>(p =>
+        {
+            p["Fragment"] = context.RenderBlock(block);
+        });
+
+        var html = rendered.GetHtml();
+        Assert.Contains("sc-ai-tool-call", html);
+        Assert.Contains("TestContentBlock", html);
+    }
+
+    [Fact]
+    public void RenderBlock_CustomRegistration_MatchesByType()
+    {
+        var context = new MessageListContext();
+        context.AddRegistration(new BlockRendererRegistration
+        {
+            BlockType = typeof(RichContentBlock),
+            Render = block => builder =>
+            {
+                builder.OpenElement(0, "span");
+                builder.AddAttribute(1, "class", "custom");
+                builder.AddContent(2, ((RichContentBlock)block).RawText);
+                builder.CloseElement();
+            }
+        });
+
+        var block = new RichContentBlock { Role = ChatRole.Assistant };
+        block.AppendText("Custom render");
+
+        var renderer = new TestRenderer();
+        var rendered = renderer.RenderComponent<FragmentHost>(p =>
+        {
+            p["Fragment"] = context.RenderBlock(block);
+        });
+
+        var html = rendered.GetHtml();
+        Assert.Contains("class=\"custom\"", html);
+        Assert.Contains("Custom render", html);
+        Assert.DoesNotContain("class=\"block\"", html);
+    }
+
+    [Fact]
+    public void RenderBlock_CustomRegistration_WithWhenPredicate_OnlyMatchesWhenTrue()
+    {
+        var context = new MessageListContext();
+        context.AddRegistration(new BlockRendererRegistration
+        {
+            BlockType = typeof(RichContentBlock),
+            When = block => ((RichContentBlock)block).RawText.Contains("special"),
+            Render = block => builder =>
+            {
+                builder.OpenElement(0, "span");
+                builder.AddAttribute(1, "class", "special");
+                builder.AddContent(2, ((RichContentBlock)block).RawText);
+                builder.CloseElement();
+            }
+        });
+
+        // Block that doesn't match the predicate - should fall through to default
+        var normalBlock = new RichContentBlock { Role = ChatRole.Assistant };
+        normalBlock.AppendText("Normal text");
+
+        var renderer = new TestRenderer();
+        var normalRendered = renderer.RenderComponent<FragmentHost>(p =>
+        {
+            p["Fragment"] = context.RenderBlock(normalBlock);
+        });
+        Assert.Contains("sc-ai-message", normalRendered.GetHtml());
+        Assert.DoesNotContain("class=\"special\"", normalRendered.GetHtml());
+
+        // Block that matches the predicate - should use custom renderer
+        var specialBlock = new RichContentBlock { Role = ChatRole.Assistant };
+        specialBlock.AppendText("special content");
+
+        var specialRendered = renderer.RenderComponent<FragmentHost>(p =>
+        {
+            p["Fragment"] = context.RenderBlock(specialBlock);
+        });
+        Assert.Contains("class=\"special\"", specialRendered.GetHtml());
+    }
+
+    [Fact]
+    public void RenderBlock_MultipleRegistrations_FirstMatchWins()
+    {
+        var context = new MessageListContext();
+        context.AddRegistration(new BlockRendererRegistration
+        {
+            BlockType = typeof(RichContentBlock),
+            Render = block => builder =>
+            {
+                builder.OpenElement(0, "span");
+                builder.AddAttribute(1, "class", "first");
+                builder.CloseElement();
+            }
+        });
+        context.AddRegistration(new BlockRendererRegistration
+        {
+            BlockType = typeof(RichContentBlock),
+            Render = block => builder =>
+            {
+                builder.OpenElement(0, "span");
+                builder.AddAttribute(1, "class", "second");
+                builder.CloseElement();
+            }
+        });
+
+        var block = new RichContentBlock { Role = ChatRole.Assistant };
+        block.AppendText("test");
+
+        var renderer = new TestRenderer();
+        var rendered = renderer.RenderComponent<FragmentHost>(p =>
+        {
+            p["Fragment"] = context.RenderBlock(block);
+        });
+
+        var html = rendered.GetHtml();
+        Assert.Contains("class=\"first\"", html);
+        Assert.DoesNotContain("class=\"second\"", html);
+    }
+
+    [Fact]
+    public void RenderBlock_BaseTypeRegistration_MatchesDerivedBlocks()
+    {
+        var context = new MessageListContext();
+        context.AddRegistration(new BlockRendererRegistration
+        {
+            BlockType = typeof(ContentBlock),
+            Render = block => builder =>
+            {
+                builder.OpenElement(0, "div");
+                builder.AddAttribute(1, "class", "catch-all");
+                builder.AddContent(2, block.GetType().Name);
+                builder.CloseElement();
+            }
+        });
+
+        var block = new RichContentBlock { Role = ChatRole.Assistant };
+        block.AppendText("test");
+
+        var renderer = new TestRenderer();
+        var rendered = renderer.RenderComponent<FragmentHost>(p =>
+        {
+            p["Fragment"] = context.RenderBlock(block);
+        });
+
+        var html = rendered.GetHtml();
+        Assert.Contains("class=\"catch-all\"", html);
+        Assert.Contains("RichContentBlock", html);
+    }
+
+    [Fact]
+    public void RenderBlock_MediaContentBlock_RendersImage()
+    {
+        var context = new MessageListContext();
+        var block = new MediaContentBlock { Role = ChatRole.User };
+        block.AddContent(new DataContent(new byte[] { 1, 2, 3 }, "image/png"));
+
+        var renderer = new TestRenderer();
+        var rendered = renderer.RenderComponent<FragmentHost>(p =>
+        {
+            p["Fragment"] = context.RenderBlock(block);
+        });
+
+        var html = rendered.GetHtml();
+        Assert.Contains("sc-ai-media", html);
+        Assert.Contains("sc-ai-media__image", html);
+        Assert.Contains("<img", html);
+        Assert.Contains("data:image/png;base64,", html);
+    }
+
+    [Fact]
+    public void RenderBlock_MediaContentBlock_RendersAudio()
+    {
+        var context = new MessageListContext();
+        var block = new MediaContentBlock { Role = ChatRole.Assistant };
+        block.AddContent(new DataContent(new byte[] { 0xFF, 0xFB }, "audio/mpeg"));
+
+        var renderer = new TestRenderer();
+        var rendered = renderer.RenderComponent<FragmentHost>(p =>
+        {
+            p["Fragment"] = context.RenderBlock(block);
+        });
+
+        var html = rendered.GetHtml();
+        Assert.Contains("sc-ai-media__audio", html);
+        Assert.Contains("<audio", html);
+        Assert.Contains("controls", html);
+    }
+
+    [Fact]
+    public void RenderBlock_MediaContentBlock_RendersVideo()
+    {
+        var context = new MessageListContext();
+        var block = new MediaContentBlock { Role = ChatRole.User };
+        block.AddContent(new DataContent(new byte[] { 0, 0 }, "video/mp4"));
+
+        var renderer = new TestRenderer();
+        var rendered = renderer.RenderComponent<FragmentHost>(p =>
+        {
+            p["Fragment"] = context.RenderBlock(block);
+        });
+
+        var html = rendered.GetHtml();
+        Assert.Contains("sc-ai-media__video", html);
+        Assert.Contains("<video", html);
+    }
+
+    [Fact]
+    public void RenderBlock_MediaContentBlock_UnknownType_RendersFileIndicator()
+    {
+        var context = new MessageListContext();
+        var block = new MediaContentBlock { Role = ChatRole.User };
+        block.AddContent(new DataContent(new byte[] { 0 }, "application/pdf"));
+
+        var renderer = new TestRenderer();
+        var rendered = renderer.RenderComponent<FragmentHost>(p =>
+        {
+            p["Fragment"] = context.RenderBlock(block);
+        });
+
+        var html = rendered.GetHtml();
+        Assert.Contains("sc-ai-media__file", html);
+        Assert.Contains("application/pdf", html);
+    }
+
+    [Fact]
+    public void RenderBlock_MediaContentBlock_UserRole_HasUserClass()
+    {
+        var context = new MessageListContext();
+        var block = new MediaContentBlock { Role = ChatRole.User };
+        block.AddContent(new DataContent(new byte[] { 1 }, "image/png"));
+
+        var renderer = new TestRenderer();
+        var rendered = renderer.RenderComponent<FragmentHost>(p =>
+        {
+            p["Fragment"] = context.RenderBlock(block);
+        });
+
+        var html = rendered.GetHtml();
+        Assert.Contains("sc-ai-message--user", html);
+    }
+
+    // Helper component to render a RenderFragment
+    private class FragmentHost : ComponentBase
+    {
+        [Parameter]
+        public RenderFragment? Fragment { get; set; }
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            if (Fragment is not null)
+            {
+                builder.AddContent(0, Fragment);
+            }
+        }
+    }
+
+    private class TestContentBlock : ContentBlock
+    {
+    }
+}

--- a/src/Components/AI/test/Components/MessageListTests.cs
+++ b/src/Components/AI/test/Components/MessageListTests.cs
@@ -1,0 +1,253 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.AI.Tests.TestFramework;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Components;
+
+public class MessageListTests
+{
+    [Fact]
+    public async Task RendersTurns_AfterMessageSent()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hello!", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<MessageList>(0);
+                b.CloseComponent();
+            });
+        });
+
+        var context = GetAgentContext(cut);
+        await cut.InvokeAsync(() => context.SendMessageAsync("Hi"));
+
+        var html = cut.GetHtml();
+        Assert.Contains("sc-ai-turn", html);
+        Assert.Contains("Hello!", html);
+    }
+
+    [Fact]
+    public async Task MultipleTurns_AllRendered()
+    {
+        var callCount = 0;
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            return ResponseEmitters.EmitTextResponse($"Response {callCount}", ct);
+        });
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<MessageList>(0);
+                b.CloseComponent();
+            });
+        });
+
+        var context = GetAgentContext(cut);
+        await cut.InvokeAsync(() => context.SendMessageAsync("First"));
+        await cut.InvokeAsync(() => context.SendMessageAsync("Second"));
+
+        var html = cut.GetHtml();
+        // Count turn divs
+        var turnCount = CountOccurrences(html, "sc-ai-turn sc-ai-turn--");
+        Assert.Equal(2, turnCount);
+        Assert.Contains("Response 1", html);
+        Assert.Contains("Response 2", html);
+    }
+
+    [Fact]
+    public async Task DefaultFooter_ShowsTypingDuringStreaming()
+    {
+        var streamingStarted = new TaskCompletionSource();
+        var streamGate = new TaskCompletionSource();
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            SlowStream(streamingStarted, streamGate, ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<MessageList>(0);
+                b.CloseComponent();
+            });
+        });
+
+        var context = GetAgentContext(cut);
+        Task sendTask = null!;
+        await cut.InvokeAsync(() =>
+        {
+            sendTask = context.SendMessageAsync("Hi");
+        });
+
+        await streamingStarted.Task;
+
+        var html = cut.GetHtml();
+        Assert.Contains("sc-ai-typing", html);
+
+        streamGate.TrySetResult();
+        await sendTask;
+
+        html = cut.GetHtml();
+        Assert.DoesNotContain("sc-ai-typing", html);
+    }
+
+    [Fact]
+    public async Task DefaultFooter_ShowsErrorBannerOnError()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitErrorAfterTokens(
+                [], new InvalidOperationException("Server error"), ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<MessageList>(0);
+                b.CloseComponent();
+            });
+        });
+
+        var context = GetAgentContext(cut);
+        await cut.InvokeAsync(() => context.SendMessageAsync("Hi"));
+
+        var html = cut.GetHtml();
+        Assert.Contains("sc-ai-error", html);
+        Assert.Contains("Server error", html);
+        Assert.Contains("Retry", html);
+    }
+
+    [Fact]
+    public async Task CustomFooter_OverridesDefault()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hi", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<MessageList>(0);
+                b.AddComponentParameter(1, "Footer",
+                    (RenderFragment<AgentContext>)(ctx => builder =>
+                    {
+                        builder.OpenElement(0, "span");
+                        builder.AddAttribute(1, "class", "custom-footer");
+                        builder.AddContent(2, $"Status: {ctx.Status}");
+                        builder.CloseElement();
+                    }));
+                b.CloseComponent();
+            });
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("class=\"custom-footer\"", html);
+        Assert.Contains("Status: Idle", html);
+        Assert.DoesNotContain("sc-ai-typing", html);
+        Assert.DoesNotContain("sc-ai-error", html);
+    }
+
+    [Fact]
+    public async Task StreamingBlock_ShowsAccumulatedText()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitMultiTokenTextResponse(ct, "Hello", " world", "!"));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<MessageList>(0);
+                b.CloseComponent();
+            });
+        });
+
+        var context = GetAgentContext(cut);
+        await cut.InvokeAsync(() => context.SendMessageAsync("Hi"));
+
+        var html = cut.GetHtml();
+        Assert.Contains("sc-ai-turn", html);
+        Assert.Contains("sc-ai-message", html);
+        Assert.Contains("Hello world!", html);
+    }
+
+    [Fact]
+    public void MessageList_OutsideAgentBoundary_Throws()
+    {
+        var renderer = new TestRenderer();
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            renderer.RenderComponent<MessageList>();
+        });
+    }
+
+    private static AgentContext GetAgentContext(RenderedComponent<AgentBoundary> cut)
+    {
+        return (AgentContext)typeof(AgentBoundary)
+            .GetField("_context",
+                System.Reflection.BindingFlags.NonPublic
+                | System.Reflection.BindingFlags.Instance)!
+            .GetValue(cut.Instance)!;
+    }
+
+    private static int CountOccurrences(string text, string pattern)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = text.IndexOf(pattern, index, StringComparison.Ordinal)) != -1)
+        {
+            count++;
+            index += pattern.Length;
+        }
+        return count;
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> SlowStream(
+        TaskCompletionSource started,
+        TaskCompletionSource gate,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [new TextContent("tok")]
+        };
+        started.TrySetResult();
+        try { await gate.Task.WaitAsync(ct); }
+        catch (OperationCanceledException) { yield break; }
+    }
+}


### PR DESCRIPTION
Part of the overall Components.AI design: https://github.com/dotnet/aspnetcore/issues/66178

Builds on #66182

---

# Blazor Components: AgentBoundary, MessageList, MessageInput, and Block Rendering

## Summary

Provide the core Blazor component layer that wires the headless engine to the browser. This adds `AgentBoundary` (the root component that creates and cascades `AgentContext`), `MessageList` (conversation display with streaming updates), `MessageInput` (text input with keyboard handling), and the extensible `BlockRenderer<T>` system for custom content rendering.

## Motivation

The engine operates entirely in C# without any Blazor dependency. Applications need Blazor components to display conversations and collect input. These components must:

- **Subscribe to engine events** (new turns, new blocks, status changes) and trigger Blazor re-renders.
- **Provide defaults** so a basic chat works with no custom rendering, while allowing applications to override how any block type is displayed.
- **Minimize render overhead** by using non-component render objects for turns and blocks, and implementing `IComponent` directly instead of `ComponentBase` where performance matters.
- **Use cascading values** to pass engine state through the component tree without prop-drilling.

## Goals

- Provide `AgentBoundary` as the root component that creates `AgentContext` and cascades it down the tree.
- Provide `MessageList` for displaying conversation turns with streaming updates.
- Provide `MessageInput` for text input with Enter-to-send, Shift+Enter for newline, and optional file attachment UI.
- Provide `BlockRenderer<T>` and `ComponentBlockRenderer<T, TComponent>` for declarative custom block rendering.
- Provide `MessageListContext` as a registry of block renderers with fallback rendering for all built-in block types.
- Use `IComponent` directly (instead of `ComponentBase`) for hot-path components.
- Use region keying on `AgentBoundary` so changing the `Agent` parameter tears down and rebuilds the subtree.

## Non-goals

- Shell layouts like `ChatPage`, `ChatBubble`, `ChatDrawer`.
- CSS styling or theming.
- SSR form-based input.
- File attachment handling in sent messages.

## Detailed design

### Component composition

The component tree follows a strict hierarchy: `AgentBoundary` → `CascadingValue<AgentContext>` → `CascadingValue<AgentState<T>>` → `MessageList` → `CascadingValue<MessageListContext>` → `BlockRenderer<T>` → `ConversationTurnRenderer` → `BlockContainer`.

All cascading values are `IsFixed=true`. When the `Agent` parameter changes, `AgentBoundary` uses region keying (`OpenRegion`) to tear down and rebuild the entire subtree.

### AgentBoundary — creation and region keying

Region keying follows the same pattern as `EditForm` in Blazor. When the agent changes, all subscriptions, turn state, and component state reset automatically.

### MessageList — subscription and rendering

`MessageList` implements `IComponent` directly for performance. Subscribes to `RegisterOnTurnAdded` and `RegisterOnStatusChanged`.

**Footer logic**: `Streaming` → typing animation. `Error` → error alert with retry button. `Idle` with no turns → welcome content.

### ConversationTurnRenderer and BlockContainer — non-component rendering

Plain C# classes, not Blazor components. Render directly into the parent's render tree via `RenderTo(RenderTreeBuilder, int)`. Avoids component overhead for conversations with many messages.

### Block renderer registry

`MessageListContext` maintains a list of `BlockRendererRegistration` entries. Resolution order is last-wins. The `When` predicate enables conditional overrides.

**Built-in fallback renderers**:

| Block Type | Fallback Rendering |
|---|---|
| `RichContentBlock` | `div.sc-ai-message--{role}` with text, streaming cursor while Active |
| `FunctionApprovalBlock` | `div.sc-ai-approval` with tool name, JSON args, Approve/Reject buttons |
| `ReasoningContentBlock` | `<details>` with "Thinking…" or "Thought process" summary |
| `MediaContentBlock` | `<img>`, `<audio>`, or `<video>` by MIME type |
| Other | `div.sc-ai-tool-call` with block type name |

### MessageInput — text entry and submission

Enter submits, Shift+Enter inserts newline. Input is disabled during `Streaming` status.

## Risks

- **Direct `IComponent` implementation**: Mitigated by the contract being stable since Blazor 3.1.
- **Callback lifetime**: Mitigated by disposing in `IAsyncDisposable.DisposeAsync()` and using snapshot-copy for safe unsubscribe.

## Drawbacks

- Components that implement `IComponent` directly are harder to maintain than `ComponentBase`-derived components. Accepted for the rendering hot path.
- Cascading value architecture means components must be nested in the correct order.

## Test coverage

220 tests (cumulative) covering:
- `AgentBoundary` cascading value creation and region keying on agent change.
- `MessageList` turn rendering, footer states, subscription lifecycle.
- `MessageListContext` registration ordering, fallback rendering for each block type.
- `BlockRenderer<T>` custom rendering, `When` filtering, registration/deregistration.
- `ConversationTurnRenderer` block segregation by role.
- `MessageInput` text submission, keyboard handling, disable during streaming.