### PR TITLE
[Blazor] Components.AI - 04 UI shells, theming, and CSS

### DIFF
--- a/src/Components/AI/src/Components/BubblePosition.cs
+++ b/src/Components/AI/src/Components/BubblePosition.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public enum BubblePosition
+{
+    BottomRight,
+    BottomLeft
+}

--- a/src/Components/AI/src/Components/ChatBubble.cs
+++ b/src/Components/AI/src/Components/ChatBubble.cs
@@ -1,0 +1,207 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public sealed class ChatBubble : ComponentBase
+{
+    private bool _isOpen;
+
+    [Parameter, EditorRequired]
+    public UIAgent Agent { get; set; } = default!;
+
+    [Parameter]
+    public BubblePosition Position { get; set; } = BubblePosition.BottomRight;
+
+    [Parameter]
+    public string Title { get; set; } = "Chat";
+
+    [Parameter]
+    public IReadOnlyList<Suggestion>? Suggestions { get; set; }
+
+    [Parameter]
+    public string? Placeholder { get; set; }
+
+    [Parameter]
+    public bool AllowAttachments { get; set; }
+
+    [Parameter]
+    public string? AcceptFileTypes { get; set; }
+
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    protected override void BuildRenderTree(RenderTreeBuilder builder)
+    {
+        builder.OpenElement(0, "div");
+        builder.AddMultipleAttributes(1, AdditionalAttributes);
+        builder.AddAttribute(2, "class", CssClass());
+
+        if (_isOpen)
+        {
+            RenderPanel(builder, 10);
+        }
+
+        RenderTrigger(builder, 200);
+
+        builder.CloseElement(); // root div
+    }
+
+    private void RenderPanel(RenderTreeBuilder builder, int seq)
+    {
+        builder.OpenElement(seq, "div");
+        builder.AddAttribute(seq + 1, "class", "sc-ai-bubble__panel");
+        builder.AddAttribute(seq + 2, "role", "dialog");
+        builder.AddAttribute(seq + 3, "aria-label", Title);
+
+        // Header
+        builder.OpenElement(seq + 10, "div");
+        builder.AddAttribute(seq + 11, "class", "sc-ai-bubble__header");
+
+        builder.OpenElement(seq + 12, "span");
+        builder.AddAttribute(seq + 13, "class", "sc-ai-bubble__title");
+        builder.AddContent(seq + 14, Title);
+        builder.CloseElement();
+
+        builder.OpenElement(seq + 15, "button");
+        builder.AddAttribute(seq + 16, "class", "sc-ai-bubble__close");
+        builder.AddAttribute(seq + 17, "aria-label", "Close chat");
+        builder.AddAttribute(seq + 18, "onclick", EventCallback.Factory.Create(this, Close));
+        builder.AddMarkupContent(seq + 19, "&#x2715;");
+        builder.CloseElement();
+
+        builder.CloseElement(); // header
+
+        // AgentBoundary
+        builder.OpenComponent<AgentBoundary>(seq + 30);
+        builder.AddComponentParameter(seq + 31, "Agent", Agent);
+        builder.AddComponentParameter(seq + 32, "ChildContent", (RenderFragment)(inner =>
+        {
+            // Body
+            inner.OpenElement(seq + 40, "div");
+            inner.AddAttribute(seq + 41, "class", "sc-ai-bubble__body");
+
+            inner.OpenComponent<MessageList>(seq + 42);
+            inner.AddComponentParameter(seq + 43, "Footer", (RenderFragment<AgentContext>)(ctx =>
+                (RenderFragment)(footerBuilder =>
+            {
+                RenderDefaultFooter(footerBuilder, ctx, 0);
+            })));
+            inner.CloseComponent();
+
+            inner.CloseElement(); // body
+
+            // Footer
+            inner.OpenElement(seq + 50, "div");
+            inner.AddAttribute(seq + 51, "class", "sc-ai-bubble__footer");
+
+            inner.OpenComponent<MessageInput>(seq + 52);
+            inner.AddComponentParameter(seq + 53, "Placeholder", Placeholder);
+            inner.AddComponentParameter(seq + 54, "AllowAttachments", AllowAttachments);
+            inner.AddComponentParameter(seq + 55, "AcceptFileTypes", AcceptFileTypes);
+            inner.CloseComponent();
+
+            inner.CloseElement(); // footer
+        }));
+        builder.CloseComponent(); // AgentBoundary
+
+        builder.CloseElement(); // panel
+    }
+
+    private void RenderDefaultFooter(RenderTreeBuilder builder, AgentContext ctx, int seq)
+    {
+        builder.OpenElement(seq, "div");
+        builder.AddAttribute(seq + 1, "class", "sc-ai-message-list__footer");
+
+        switch (ctx.Status)
+        {
+            case ConversationStatus.Streaming:
+                builder.OpenElement(seq + 2, "div");
+                builder.AddAttribute(seq + 3, "class", "sc-ai-typing");
+                builder.AddAttribute(seq + 4, "role", "status");
+                builder.AddAttribute(seq + 5, "aria-label", "Agent is typing");
+                for (var i = 0; i < 3; i++)
+                {
+                    builder.OpenElement(seq + 6 + i, "span");
+                    builder.AddAttribute(seq + 9 + i, "class", "sc-ai-typing__dot");
+                    builder.CloseElement();
+                }
+                builder.CloseElement();
+                break;
+
+            case ConversationStatus.Error:
+                builder.OpenElement(seq + 2, "div");
+                builder.AddAttribute(seq + 3, "class", "sc-ai-error");
+                builder.AddAttribute(seq + 4, "role", "alert");
+                builder.OpenElement(seq + 5, "span");
+                builder.AddAttribute(seq + 6, "class", "sc-ai-error__message");
+                builder.AddContent(seq + 7, ctx.Error?.Message ?? "Something went wrong.");
+                builder.CloseElement();
+                builder.OpenElement(seq + 8, "button");
+                builder.AddAttribute(seq + 9, "class", "sc-ai-btn sc-ai-btn--secondary");
+                builder.AddAttribute(seq + 10, "onclick",
+                    EventCallback.Factory.Create(this, () => ctx.RetryAsync()));
+                builder.AddContent(seq + 11, "Retry");
+                builder.CloseElement();
+                builder.CloseElement();
+                break;
+        }
+
+        if (Suggestions is { Count: > 0 } && ctx.Turns.Count == 0)
+        {
+            builder.OpenComponent<SuggestionList>(seq + 20);
+            builder.AddComponentParameter(seq + 21, "Suggestions", Suggestions);
+            builder.CloseComponent();
+        }
+
+        builder.CloseElement(); // footer div
+    }
+
+    private void RenderTrigger(RenderTreeBuilder builder, int seq)
+    {
+        builder.OpenElement(seq, "button");
+        builder.AddAttribute(seq + 1, "class", "sc-ai-bubble__trigger");
+        builder.AddAttribute(seq + 2, "aria-label", _isOpen ? "Close chat" : "Open chat");
+        builder.AddAttribute(seq + 3, "onclick", EventCallback.Factory.Create(this, Toggle));
+
+        if (_isOpen)
+        {
+            // Close X icon
+            builder.AddMarkupContent(seq + 4,
+                "<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">" +
+                "<path d=\"M18 6 6 18\"/><path d=\"M6 6 18 18\"/></svg>");
+        }
+        else
+        {
+            // Chat icon
+            builder.AddMarkupContent(seq + 4,
+                "<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">" +
+                "<path d=\"M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z\"/></svg>");
+        }
+
+        builder.CloseElement(); // button
+    }
+
+    private void Toggle()
+    {
+        _isOpen = !_isOpen;
+    }
+
+    private void Close()
+    {
+        _isOpen = false;
+    }
+
+    private string CssClass()
+    {
+        var position = Position == BubblePosition.BottomLeft ? "bottom-left" : "bottom-right";
+        var css = $"sc-ai-root sc-ai-bubble sc-ai-bubble--{position}";
+        if (AdditionalAttributes?.TryGetValue("class", out var existing) == true && existing is string s)
+        {
+            css = $"{css} {s}";
+        }
+        return css;
+    }
+}

--- a/src/Components/AI/src/Components/ChatDrawer.cs
+++ b/src/Components/AI/src/Components/ChatDrawer.cs
@@ -1,0 +1,180 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public sealed class ChatDrawer : ComponentBase
+{
+    [Parameter, EditorRequired]
+    public UIAgent Agent { get; set; } = default!;
+
+    [Parameter]
+    public bool Open { get; set; }
+
+    [Parameter]
+    public EventCallback<bool> OpenChanged { get; set; }
+
+    [Parameter]
+    public string Title { get; set; } = "Chat";
+
+    [Parameter]
+    public RenderFragment? HeaderActions { get; set; }
+
+    [Parameter]
+    public IReadOnlyList<Suggestion>? Suggestions { get; set; }
+
+    [Parameter]
+    public string? Placeholder { get; set; }
+
+    [Parameter]
+    public DrawerPosition Position { get; set; } = DrawerPosition.Right;
+
+    [Parameter]
+    public bool AllowAttachments { get; set; }
+
+    [Parameter]
+    public string? AcceptFileTypes { get; set; }
+
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    protected override void BuildRenderTree(RenderTreeBuilder builder)
+    {
+        if (!Open)
+        {
+            return;
+        }
+
+        builder.OpenElement(0, "div");
+        builder.AddMultipleAttributes(1, AdditionalAttributes);
+        builder.AddAttribute(2, "class", CssClass());
+        builder.AddAttribute(3, "role", "dialog");
+        builder.AddAttribute(4, "aria-label", Title);
+
+        // Header
+        builder.OpenElement(10, "div");
+        builder.AddAttribute(11, "class", "sc-ai-drawer__header");
+
+        builder.OpenElement(12, "span");
+        builder.AddAttribute(13, "class", "sc-ai-drawer__title");
+        builder.AddContent(14, Title);
+        builder.CloseElement(); // title
+
+        if (HeaderActions is not null)
+        {
+            builder.AddContent(15, HeaderActions);
+        }
+
+        builder.OpenElement(16, "button");
+        builder.AddAttribute(17, "class", "sc-ai-drawer__close");
+        builder.AddAttribute(18, "aria-label", "Close chat");
+        builder.AddAttribute(19, "onclick", EventCallback.Factory.Create(this, CloseAsync));
+        builder.AddMarkupContent(20, "&#x2715;");
+        builder.CloseElement(); // close button
+
+        builder.CloseElement(); // header
+
+        // AgentBoundary
+        builder.OpenComponent<AgentBoundary>(30);
+        builder.AddComponentParameter(31, "Agent", Agent);
+        builder.AddComponentParameter(32, "ChildContent", (RenderFragment)(inner =>
+        {
+            // Body
+            inner.OpenElement(40, "div");
+            inner.AddAttribute(41, "class", "sc-ai-drawer__body");
+
+            inner.OpenComponent<MessageList>(42);
+            inner.AddComponentParameter(43, "Footer", (RenderFragment<AgentContext>)(ctx =>
+                (RenderFragment)(footerBuilder =>
+            {
+                RenderDefaultFooter(footerBuilder, ctx, 0);
+            })));
+            inner.CloseComponent();
+
+            inner.CloseElement(); // body
+
+            // Footer
+            inner.OpenElement(50, "div");
+            inner.AddAttribute(51, "class", "sc-ai-drawer__footer");
+
+            inner.OpenComponent<MessageInput>(52);
+            inner.AddComponentParameter(53, "Placeholder", Placeholder);
+            inner.AddComponentParameter(54, "AllowAttachments", AllowAttachments);
+            inner.AddComponentParameter(55, "AcceptFileTypes", AcceptFileTypes);
+            inner.CloseComponent();
+
+            inner.CloseElement(); // footer
+        }));
+        builder.CloseComponent(); // AgentBoundary
+
+        builder.CloseElement(); // root div
+    }
+
+    private void RenderDefaultFooter(RenderTreeBuilder builder, AgentContext ctx, int seq)
+    {
+        builder.OpenElement(seq, "div");
+        builder.AddAttribute(seq + 1, "class", "sc-ai-message-list__footer");
+
+        switch (ctx.Status)
+        {
+            case ConversationStatus.Streaming:
+                builder.OpenElement(seq + 2, "div");
+                builder.AddAttribute(seq + 3, "class", "sc-ai-typing");
+                builder.AddAttribute(seq + 4, "role", "status");
+                builder.AddAttribute(seq + 5, "aria-label", "Agent is typing");
+                for (var i = 0; i < 3; i++)
+                {
+                    builder.OpenElement(seq + 6 + i, "span");
+                    builder.AddAttribute(seq + 9 + i, "class", "sc-ai-typing__dot");
+                    builder.CloseElement();
+                }
+                builder.CloseElement();
+                break;
+
+            case ConversationStatus.Error:
+                builder.OpenElement(seq + 2, "div");
+                builder.AddAttribute(seq + 3, "class", "sc-ai-error");
+                builder.AddAttribute(seq + 4, "role", "alert");
+                builder.OpenElement(seq + 5, "span");
+                builder.AddAttribute(seq + 6, "class", "sc-ai-error__message");
+                builder.AddContent(seq + 7, ctx.Error?.Message ?? "Something went wrong.");
+                builder.CloseElement();
+                builder.OpenElement(seq + 8, "button");
+                builder.AddAttribute(seq + 9, "class", "sc-ai-btn sc-ai-btn--secondary");
+                builder.AddAttribute(seq + 10, "onclick",
+                    EventCallback.Factory.Create(this, () => ctx.RetryAsync()));
+                builder.AddContent(seq + 11, "Retry");
+                builder.CloseElement();
+                builder.CloseElement();
+                break;
+        }
+
+        if (Suggestions is { Count: > 0 } && ctx.Turns.Count == 0)
+        {
+            builder.OpenComponent<SuggestionList>(seq + 20);
+            builder.AddComponentParameter(seq + 21, "Suggestions", Suggestions);
+            builder.CloseComponent();
+        }
+
+        builder.CloseElement(); // footer div
+    }
+
+    private async Task CloseAsync()
+    {
+        Open = false;
+        await OpenChanged.InvokeAsync(false);
+    }
+
+    private string CssClass()
+    {
+        var position = Position == DrawerPosition.Left ? "left" : "right";
+        var css = $"sc-ai-root sc-ai-drawer sc-ai-drawer--{position}";
+        if (AdditionalAttributes?.TryGetValue("class", out var existing) == true && existing is string s)
+        {
+            css = $"{css} {s}";
+        }
+        return css;
+    }
+}

--- a/src/Components/AI/src/Components/ChatPage.cs
+++ b/src/Components/AI/src/Components/ChatPage.cs
@@ -1,0 +1,160 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public sealed class ChatPage : ComponentBase, IDisposable
+{
+    [Parameter, EditorRequired]
+    public UIAgent Agent { get; set; } = default!;
+
+    [Parameter]
+    public RenderFragment? Header { get; set; }
+
+    [Parameter]
+    public RenderFragment? WelcomeContent { get; set; }
+
+    [Parameter]
+    public IReadOnlyList<Suggestion>? Suggestions { get; set; }
+
+    [Parameter]
+    public string? Placeholder { get; set; }
+
+    [Parameter]
+    public RenderFragment? InputLeadingActions { get; set; }
+
+    [Parameter]
+    public RenderFragment? InputTrailingActions { get; set; }
+
+    [Parameter]
+    public bool AllowAttachments { get; set; }
+
+    [Parameter]
+    public string? AcceptFileTypes { get; set; }
+
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    protected override void BuildRenderTree(RenderTreeBuilder builder)
+    {
+        builder.OpenElement(0, "div");
+        builder.AddMultipleAttributes(1, AdditionalAttributes);
+        builder.AddAttribute(2, "class", CssClass());
+
+        // Header
+        if (Header is not null)
+        {
+            builder.OpenElement(10, "div");
+            builder.AddAttribute(11, "class", "sc-ai-chat-page__header");
+            builder.AddContent(12, Header);
+            builder.CloseElement();
+        }
+
+        // AgentBoundary
+        builder.OpenComponent<AgentBoundary>(20);
+        builder.AddComponentParameter(21, "Agent", Agent);
+        builder.AddComponentParameter(22, "ChildContent", (RenderFragment)(inner =>
+        {
+            // Body (scrollable area)
+            inner.OpenElement(30, "div");
+            inner.AddAttribute(31, "class", "sc-ai-chat-page__body");
+
+            inner.OpenComponent<MessageList>(32);
+            inner.AddComponentParameter(33, "ChildContent", WelcomeContent);
+            inner.AddComponentParameter(34, "Footer", (RenderFragment<AgentContext>)(ctx =>
+                (RenderFragment)(footerBuilder =>
+            {
+                RenderDefaultFooter(footerBuilder, ctx, 0);
+            })));
+            inner.CloseComponent(); // MessageList
+
+            inner.CloseElement(); // body
+
+            // Footer (input area)
+            inner.OpenElement(50, "div");
+            inner.AddAttribute(51, "class", "sc-ai-chat-page__footer");
+            inner.OpenElement(52, "div");
+            inner.AddAttribute(53, "class", "sc-ai-chat-page__input-container");
+
+            inner.OpenComponent<MessageInput>(54);
+            inner.AddComponentParameter(55, "Placeholder", Placeholder);
+            inner.AddComponentParameter(56, "LeadingActions", InputLeadingActions);
+            inner.AddComponentParameter(57, "TrailingActions", InputTrailingActions);
+            inner.AddComponentParameter(58, "AllowAttachments", AllowAttachments);
+            inner.AddComponentParameter(59, "AcceptFileTypes", AcceptFileTypes);
+            inner.CloseComponent(); // MessageInput
+
+            inner.CloseElement(); // input-container
+            inner.CloseElement(); // footer
+        }));
+        builder.CloseComponent(); // AgentBoundary
+
+        builder.CloseElement(); // root div
+    }
+
+    private void RenderDefaultFooter(RenderTreeBuilder builder, AgentContext ctx, int seq)
+    {
+        builder.OpenElement(seq, "div");
+        builder.AddAttribute(seq + 1, "class", "sc-ai-message-list__footer");
+
+        switch (ctx.Status)
+        {
+            case ConversationStatus.Streaming:
+                builder.OpenElement(seq + 2, "div");
+                builder.AddAttribute(seq + 3, "class", "sc-ai-typing");
+                builder.AddAttribute(seq + 4, "role", "status");
+                builder.AddAttribute(seq + 5, "aria-label", "Agent is typing");
+                for (var i = 0; i < 3; i++)
+                {
+                    builder.OpenElement(seq + 6 + i, "span");
+                    builder.AddAttribute(seq + 9 + i, "class", "sc-ai-typing__dot");
+                    builder.CloseElement();
+                }
+                builder.CloseElement();
+                break;
+
+            case ConversationStatus.Error:
+                builder.OpenElement(seq + 2, "div");
+                builder.AddAttribute(seq + 3, "class", "sc-ai-error");
+                builder.AddAttribute(seq + 4, "role", "alert");
+                builder.OpenElement(seq + 5, "span");
+                builder.AddAttribute(seq + 6, "class", "sc-ai-error__message");
+                builder.AddContent(seq + 7, ctx.Error?.Message ?? "Something went wrong.");
+                builder.CloseElement();
+                builder.OpenElement(seq + 8, "button");
+                builder.AddAttribute(seq + 9, "class", "sc-ai-btn sc-ai-btn--secondary");
+                builder.AddAttribute(seq + 10, "onclick",
+                    EventCallback.Factory.Create(this, () => ctx.RetryAsync()));
+                builder.AddContent(seq + 11, "Retry");
+                builder.CloseElement();
+                builder.CloseElement();
+                break;
+        }
+
+        if (Suggestions is { Count: > 0 } && ctx.Turns.Count == 0)
+        {
+            builder.OpenComponent<SuggestionList>(seq + 20);
+            builder.AddComponentParameter(seq + 21, "Suggestions", Suggestions);
+            builder.CloseComponent();
+        }
+
+        builder.CloseElement(); // footer div
+    }
+
+    private string CssClass()
+    {
+        var css = "sc-ai-root sc-ai-chat-page";
+        if (AdditionalAttributes?.TryGetValue("class", out var existing) == true && existing is string s)
+        {
+            css = $"{css} {s}";
+        }
+        return css;
+    }
+
+    public void Dispose()
+    {
+        // Layout shell does not own the Agent — caller does.
+    }
+}

--- a/src/Components/AI/src/Components/DrawerPosition.cs
+++ b/src/Components/AI/src/Components/DrawerPosition.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public enum DrawerPosition
+{
+    Left,
+    Right
+}

--- a/src/Components/AI/src/Components/Suggestion.cs
+++ b/src/Components/AI/src/Components/Suggestion.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public sealed class Suggestion
+{
+    public required string Label { get; init; }
+
+    public required string Prompt { get; init; }
+
+    public string? Icon { get; init; }
+}

--- a/src/Components/AI/src/Components/SuggestionList.cs
+++ b/src/Components/AI/src/Components/SuggestionList.cs
@@ -1,0 +1,88 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+public sealed class SuggestionList : IComponent, IDisposable
+{
+    private RenderHandle _renderHandle;
+    private AgentContext _agentContext = default!;
+    private IReadOnlyList<Suggestion> _suggestions = [];
+    private bool _isDisabled;
+    private IDisposable? _statusSub;
+
+    [CascadingParameter]
+    public AgentContext AgentContext { get; set; } = default!;
+
+    [Parameter, EditorRequired]
+    public IReadOnlyList<Suggestion> Suggestions { get; set; } = [];
+
+    [Parameter]
+    public RenderFragment<Suggestion>? ItemTemplate { get; set; }
+
+    void IComponent.Attach(RenderHandle renderHandle)
+    {
+        _renderHandle = renderHandle;
+    }
+
+    Task IComponent.SetParametersAsync(ParameterView parameters)
+    {
+        parameters.SetParameterProperties(this);
+        _agentContext = AgentContext
+            ?? throw new InvalidOperationException(
+                "SuggestionList must be inside an AgentBoundary.");
+        _suggestions = Suggestions;
+
+        _statusSub = _agentContext.RegisterOnStatusChanged(status =>
+        {
+            _isDisabled = status == ConversationStatus.Streaming;
+            Render();
+        });
+
+        Render();
+        return Task.CompletedTask;
+    }
+
+    private void Render()
+    {
+        _renderHandle.Render(builder =>
+        {
+            builder.OpenElement(0, "div");
+            builder.AddAttribute(1, "class", "sc-ai-suggestions");
+            builder.AddAttribute(2, "role", "group");
+            builder.AddAttribute(3, "aria-label", "Suggestions");
+
+            var seq = 10;
+            foreach (var suggestion in _suggestions)
+            {
+                var prompt = suggestion.Prompt;
+                builder.OpenElement(seq, "button");
+                builder.AddAttribute(seq + 1, "class", "sc-ai-suggestions__chip");
+                builder.AddAttribute(seq + 2, "type", "button");
+                builder.AddAttribute(seq + 3, "disabled", _isDisabled);
+                builder.AddAttribute(seq + 4, "onclick",
+                    EventCallback.Factory.Create(this,
+                        () => _agentContext.SendMessageAsync(prompt)));
+
+                if (ItemTemplate is not null)
+                {
+                    builder.AddContent(seq + 5, ItemTemplate(suggestion));
+                }
+                else
+                {
+                    builder.AddContent(seq + 5, suggestion.Label);
+                }
+
+                builder.CloseElement(); // button
+                seq += 10;
+            }
+
+            builder.CloseElement(); // div
+        });
+    }
+
+    public void Dispose()
+    {
+        _statusSub?.Dispose();
+    }
+}

--- a/src/Components/AI/src/wwwroot/ai-chat.css
+++ b/src/Components/AI/src/wwwroot/ai-chat.css
@@ -1,0 +1,922 @@
+/* ==========================================================================
+   Microsoft.AspNetCore.Components.AI — Design Tokens & Default Styles
+   ========================================================================== */
+
+/* ---------- Root scope ---------- */
+.sc-ai-root {
+    /* ---- Typography ---- */
+    --sc-ai-font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    --sc-ai-font-size: 0.9375rem;
+    --sc-ai-font-size-sm: 0.8125rem;
+    --sc-ai-font-size-lg: 1.125rem;
+    --sc-ai-line-height: 1.5;
+    --sc-ai-font-weight-normal: 400;
+    --sc-ai-font-weight-medium: 500;
+    --sc-ai-font-weight-bold: 600;
+
+    /* ---- Colors — Surface & Background ---- */
+    --sc-ai-color-bg: #ffffff;
+    --sc-ai-color-surface: #ffffff;
+    --sc-ai-color-surface-hover: #f8f9fa;
+    --sc-ai-color-text: #212529;
+    --sc-ai-color-text-secondary: #6c757d;
+    --sc-ai-color-text-on-accent: #ffffff;
+    --sc-ai-color-accent: #0d6efd;
+    --sc-ai-color-accent-hover: #0b5ed7;
+    --sc-ai-color-border: #dee2e6;
+    --sc-ai-color-error: #dc3545;
+    --sc-ai-color-error-bg: #f8d7da;
+    --sc-ai-color-success: #198754;
+
+    /* ---- Colors — Message Bubbles ---- */
+    --sc-ai-color-bubble-user: #e9ecef;
+    --sc-ai-color-bubble-user-text: #212529;
+    --sc-ai-color-bubble-assistant: transparent;
+    --sc-ai-color-bubble-assistant-text: #212529;
+
+    /* ---- Layout & Spacing ---- */
+    --sc-ai-spacing-xs: 0.25rem;
+    --sc-ai-spacing-sm: 0.5rem;
+    --sc-ai-spacing-md: 1rem;
+    --sc-ai-spacing-lg: 1.5rem;
+    --sc-ai-spacing-xl: 2rem;
+    --sc-ai-max-width: 48rem;
+    --sc-ai-border-radius: 0.75rem;
+    --sc-ai-border-radius-sm: 0.375rem;
+    --sc-ai-border-radius-lg: 1.5rem;
+    --sc-ai-input-height: 3rem;
+    --sc-ai-drawer-width: 24rem;
+    --sc-ai-bubble-size: 3.5rem;
+
+    /* ---- Transitions ---- */
+    --sc-ai-transition-fast: 120ms ease;
+    --sc-ai-transition-normal: 200ms ease;
+    --sc-ai-transition-slow: 300ms ease-in-out;
+
+    /* ---- Focus & States ---- */
+    --sc-ai-focus-ring: 0 0 0 2px var(--sc-ai-color-accent);
+    --sc-ai-disabled-opacity: 0.5;
+
+    /* Apply base typography */
+    font-family: var(--sc-ai-font-family);
+    font-size: var(--sc-ai-font-size);
+    line-height: var(--sc-ai-line-height);
+    color: var(--sc-ai-color-text);
+    box-sizing: border-box;
+}
+
+.sc-ai-root *,
+.sc-ai-root *::before,
+.sc-ai-root *::after {
+    box-sizing: inherit;
+}
+
+/* ---------- Buttons ---------- */
+.sc-ai-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--sc-ai-spacing-xs);
+    padding: var(--sc-ai-spacing-sm) var(--sc-ai-spacing-md);
+    border: 1px solid transparent;
+    border-radius: var(--sc-ai-border-radius-sm);
+    font-family: inherit;
+    font-size: var(--sc-ai-font-size-sm);
+    font-weight: var(--sc-ai-font-weight-medium);
+    cursor: pointer;
+    transition: background var(--sc-ai-transition-fast),
+                color var(--sc-ai-transition-fast),
+                border-color var(--sc-ai-transition-fast),
+                opacity var(--sc-ai-transition-fast);
+    line-height: 1;
+}
+
+.sc-ai-btn:focus-visible {
+    outline: none;
+    box-shadow: var(--sc-ai-focus-ring);
+}
+
+.sc-ai-btn:disabled {
+    opacity: var(--sc-ai-disabled-opacity);
+    cursor: not-allowed;
+}
+
+.sc-ai-btn--primary {
+    background: var(--sc-ai-color-accent);
+    color: var(--sc-ai-color-text-on-accent);
+}
+
+.sc-ai-btn--primary:hover:not(:disabled) {
+    background: var(--sc-ai-color-accent-hover);
+}
+
+.sc-ai-btn--secondary {
+    background: var(--sc-ai-color-surface);
+    color: var(--sc-ai-color-text);
+    border-color: var(--sc-ai-color-border);
+}
+
+.sc-ai-btn--secondary:hover:not(:disabled) {
+    background: var(--sc-ai-color-surface-hover);
+}
+
+/* ---------- Message List ---------- */
+.sc-ai-message-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sc-ai-spacing-md);
+    max-width: var(--sc-ai-max-width);
+    margin: 0 auto;
+    padding: var(--sc-ai-spacing-lg);
+    width: 100%;
+}
+
+.sc-ai-message-list__footer {
+    min-height: var(--sc-ai-spacing-lg);
+}
+
+/* ---------- Turn ---------- */
+.sc-ai-turn {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sc-ai-spacing-sm);
+}
+
+/* ---------- Message Bubbles ---------- */
+.sc-ai-message {
+    display: flex;
+}
+
+.sc-ai-message--user {
+    justify-content: flex-end;
+}
+
+.sc-ai-message--assistant {
+    justify-content: flex-start;
+}
+
+.sc-ai-message__bubble {
+    max-width: 85%;
+    padding: var(--sc-ai-spacing-sm) var(--sc-ai-spacing-md);
+    border-radius: var(--sc-ai-border-radius-lg);
+    word-break: break-word;
+}
+
+.sc-ai-message--user .sc-ai-message__bubble {
+    background: var(--sc-ai-color-bubble-user);
+    color: var(--sc-ai-color-bubble-user-text);
+    border-bottom-right-radius: var(--sc-ai-border-radius-sm);
+}
+
+.sc-ai-message--assistant .sc-ai-message__bubble {
+    background: var(--sc-ai-color-bubble-assistant);
+    color: var(--sc-ai-color-bubble-assistant-text);
+    border-bottom-left-radius: var(--sc-ai-border-radius-sm);
+}
+
+.sc-ai-message__content {
+    white-space: pre-wrap;
+}
+
+/* Streaming cursor */
+.sc-ai-message__content--streaming::after {
+    content: "";
+    display: inline-block;
+    width: 2px;
+    height: 1em;
+    background: currentColor;
+    margin-left: 1px;
+    vertical-align: text-bottom;
+    animation: sc-ai-blink 1s step-end infinite;
+}
+
+@keyframes sc-ai-blink {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0; }
+}
+
+/* ---------- Tool Call ---------- */
+
+/* ---------- Reasoning ---------- */
+.sc-ai-reasoning {
+    padding: var(--sc-ai-spacing-sm) var(--sc-ai-spacing-md);
+    border: 1px solid var(--sc-ai-color-border);
+    border-radius: var(--sc-ai-border-radius-sm);
+    font-size: var(--sc-ai-font-size-sm);
+    color: var(--sc-ai-color-text-secondary);
+    background: var(--sc-ai-color-surface-hover);
+}
+
+.sc-ai-reasoning__header {
+    cursor: pointer;
+    user-select: none;
+    font-weight: var(--sc-ai-font-weight-medium);
+    color: var(--sc-ai-color-text-secondary);
+}
+
+.sc-ai-reasoning__content {
+    margin-top: var(--sc-ai-spacing-sm);
+    padding-top: var(--sc-ai-spacing-sm);
+    border-top: 1px solid var(--sc-ai-color-border);
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: var(--sc-ai-color-text-secondary);
+}
+
+/* ---------- Tool Call (after Reasoning) ---------- */
+.sc-ai-tool-call {
+    padding: var(--sc-ai-spacing-sm) var(--sc-ai-spacing-md);
+    border: 1px solid var(--sc-ai-color-border);
+    border-radius: var(--sc-ai-border-radius-sm);
+    font-size: var(--sc-ai-font-size-sm);
+    color: var(--sc-ai-color-text-secondary);
+}
+
+.sc-ai-tool-call__header {
+    display: flex;
+    align-items: center;
+    gap: var(--sc-ai-spacing-sm);
+}
+
+.sc-ai-tool-call__name {
+    font-weight: var(--sc-ai-font-weight-medium);
+    color: var(--sc-ai-color-text);
+}
+
+.sc-ai-tool-call__status--running {
+    display: inline-block;
+    width: 0.75em;
+    height: 0.75em;
+    border: 2px solid var(--sc-ai-color-text-secondary);
+    border-top-color: transparent;
+    border-radius: 50%;
+    animation: sc-ai-spin 0.8s linear infinite;
+}
+
+.sc-ai-tool-call__status--complete {
+    color: var(--sc-ai-color-success);
+}
+
+.sc-ai-tool-call__details {
+    margin-top: var(--sc-ai-spacing-xs);
+}
+
+.sc-ai-tool-call__details summary {
+    cursor: pointer;
+    font-size: var(--sc-ai-font-size-sm);
+    color: var(--sc-ai-color-text-secondary);
+    user-select: none;
+}
+
+.sc-ai-tool-call__pre {
+    margin: var(--sc-ai-spacing-xs) 0 0;
+    padding: var(--sc-ai-spacing-sm);
+    background: var(--sc-ai-color-surface-hover);
+    border-radius: var(--sc-ai-border-radius-sm);
+    font-size: 0.8125rem;
+    line-height: 1.4;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+@keyframes sc-ai-spin {
+    to { transform: rotate(360deg); }
+}
+
+/* ---------- Approval ---------- */
+.sc-ai-approval {
+    border: 1px solid var(--sc-ai-color-border);
+    border-radius: var(--sc-ai-border-radius-sm);
+    padding: var(--sc-ai-spacing-md);
+}
+
+.sc-ai-approval__header {
+    display: flex;
+    align-items: center;
+    gap: var(--sc-ai-spacing-sm);
+    margin-bottom: var(--sc-ai-spacing-sm);
+    font-weight: var(--sc-ai-font-weight-medium);
+}
+
+.sc-ai-approval__tool-name {
+    font-size: var(--sc-ai-font-size-sm);
+    color: var(--sc-ai-color-text-secondary);
+    margin-bottom: var(--sc-ai-spacing-md);
+}
+
+.sc-ai-approval__actions {
+    display: flex;
+    gap: var(--sc-ai-spacing-sm);
+}
+
+.sc-ai-approval__status {
+    font-size: var(--sc-ai-font-size-sm);
+    font-weight: var(--sc-ai-font-weight-medium);
+}
+
+.sc-ai-approval__status--approved {
+    color: var(--sc-ai-color-success);
+}
+
+.sc-ai-approval__status--rejected {
+    color: var(--sc-ai-color-error);
+}
+
+/* ---------- Reasoning ---------- */
+.sc-ai-reasoning {
+    font-size: var(--sc-ai-font-size-sm);
+    color: var(--sc-ai-color-text-secondary);
+    border: 1px solid var(--sc-ai-color-border);
+    border-radius: var(--sc-ai-border-radius-sm);
+    padding: var(--sc-ai-spacing-sm) var(--sc-ai-spacing-md);
+}
+
+.sc-ai-reasoning__summary {
+    display: flex;
+    align-items: center;
+    gap: var(--sc-ai-spacing-sm);
+    cursor: pointer;
+    font-weight: var(--sc-ai-font-weight-medium);
+    list-style: none;
+}
+
+.sc-ai-reasoning__summary::-webkit-details-marker {
+    display: none;
+}
+
+.sc-ai-reasoning__summary::before {
+    content: "▶";
+    font-size: 0.625em;
+    transition: transform var(--sc-ai-transition-fast);
+}
+
+.sc-ai-reasoning[open] .sc-ai-reasoning__summary::before {
+    transform: rotate(90deg);
+}
+
+.sc-ai-reasoning__content {
+    margin-top: var(--sc-ai-spacing-sm);
+    white-space: pre-wrap;
+}
+
+/* ---------- Typing Indicator ---------- */
+.sc-ai-typing {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: var(--sc-ai-spacing-sm) var(--sc-ai-spacing-md);
+}
+
+.sc-ai-typing__dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--sc-ai-color-text-secondary);
+    animation: sc-ai-bounce 1.4s ease-in-out infinite;
+}
+
+.sc-ai-typing__dot:nth-child(2) {
+    animation-delay: 0.2s;
+}
+
+.sc-ai-typing__dot:nth-child(3) {
+    animation-delay: 0.4s;
+}
+
+@keyframes sc-ai-bounce {
+    0%, 80%, 100% { transform: translateY(0); }
+    40% { transform: translateY(-6px); }
+}
+
+/* ---------- Error Banner ---------- */
+.sc-ai-error {
+    display: flex;
+    align-items: center;
+    gap: var(--sc-ai-spacing-sm);
+    padding: var(--sc-ai-spacing-sm) var(--sc-ai-spacing-md);
+    background: var(--sc-ai-color-error-bg);
+    color: var(--sc-ai-color-error);
+    border-radius: var(--sc-ai-border-radius-sm);
+    font-size: var(--sc-ai-font-size-sm);
+}
+
+.sc-ai-error__message {
+    flex: 1;
+}
+
+/* ---------- Suggestions ---------- */
+.sc-ai-suggestions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--sc-ai-spacing-sm);
+    padding: var(--sc-ai-spacing-sm) 0;
+}
+
+.sc-ai-suggestions__chip {
+    padding: var(--sc-ai-spacing-sm) var(--sc-ai-spacing-md);
+    border: 1px solid var(--sc-ai-color-border);
+    border-radius: var(--sc-ai-border-radius-lg);
+    background: var(--sc-ai-color-surface);
+    color: var(--sc-ai-color-text);
+    font-family: inherit;
+    font-size: var(--sc-ai-font-size-sm);
+    cursor: pointer;
+    transition: background var(--sc-ai-transition-fast),
+                border-color var(--sc-ai-transition-fast);
+}
+
+.sc-ai-suggestions__chip:hover:not(:disabled) {
+    background: var(--sc-ai-color-surface-hover);
+    border-color: var(--sc-ai-color-accent);
+}
+
+.sc-ai-suggestions__chip:focus-visible {
+    outline: none;
+    box-shadow: var(--sc-ai-focus-ring);
+}
+
+.sc-ai-suggestions__chip:disabled {
+    opacity: var(--sc-ai-disabled-opacity);
+    cursor: not-allowed;
+}
+
+/* ---------- Input ---------- */
+.sc-ai-input {
+    display: flex;
+    align-items: flex-end;
+    gap: var(--sc-ai-spacing-sm);
+    padding: var(--sc-ai-spacing-sm);
+    background: var(--sc-ai-color-surface);
+    border: 1px solid var(--sc-ai-color-border);
+    border-radius: var(--sc-ai-border-radius-lg);
+    transition: border-color var(--sc-ai-transition-fast);
+}
+
+.sc-ai-input:focus-within {
+    border-color: var(--sc-ai-color-accent);
+}
+
+.sc-ai-input__textarea {
+    flex: 1;
+    border: none;
+    outline: none;
+    resize: none;
+    font-family: inherit;
+    font-size: inherit;
+    line-height: var(--sc-ai-line-height);
+    color: var(--sc-ai-color-text);
+    background: transparent;
+    min-height: var(--sc-ai-input-height);
+    max-height: 10rem;
+    padding: var(--sc-ai-spacing-sm);
+}
+
+.sc-ai-input__textarea::placeholder {
+    color: var(--sc-ai-color-text-secondary);
+}
+
+.sc-ai-input__textarea:disabled {
+    opacity: var(--sc-ai-disabled-opacity);
+}
+
+.sc-ai-input__send {
+    width: 2.25rem;
+    height: 2.25rem;
+    padding: 0;
+    border: none;
+    border-radius: 50%;
+    background: var(--sc-ai-color-accent);
+    color: var(--sc-ai-color-text-on-accent);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    transition: background var(--sc-ai-transition-fast),
+                opacity var(--sc-ai-transition-fast);
+}
+
+.sc-ai-input__send:hover:not(:disabled) {
+    background: var(--sc-ai-color-accent-hover);
+}
+
+.sc-ai-input__send:focus-visible {
+    outline: none;
+    box-shadow: var(--sc-ai-focus-ring);
+}
+
+.sc-ai-input__send:disabled {
+    opacity: var(--sc-ai-disabled-opacity);
+    cursor: not-allowed;
+}
+
+.sc-ai-input__send svg {
+    width: 1.125rem;
+    height: 1.125rem;
+}
+
+/* ---------- Input Body (attachment previews + textarea wrapper) ---------- */
+.sc-ai-input__body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+/* ---------- Attach Button ---------- */
+.sc-ai-input__attach {
+    position: relative;
+    width: 2.25rem;
+    height: 2.25rem;
+    padding: 0;
+    border: none;
+    border-radius: 50%;
+    background: transparent;
+    color: var(--sc-ai-color-text-secondary);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    overflow: hidden;
+    transition: color var(--sc-ai-transition-fast),
+                background var(--sc-ai-transition-fast);
+}
+
+.sc-ai-input__file {
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    cursor: pointer;
+}
+
+.sc-ai-input__attach:hover {
+    color: var(--sc-ai-color-accent);
+    background: var(--sc-ai-color-surface-hover);
+}
+
+.sc-ai-input__attach svg {
+    width: 1.125rem;
+    height: 1.125rem;
+}
+
+/* ---------- Attachment Previews ---------- */
+.sc-ai-input__attachments {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--sc-ai-spacing-sm);
+    padding: var(--sc-ai-spacing-sm) var(--sc-ai-spacing-sm) 0;
+}
+
+.sc-ai-attachment-preview {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--sc-ai-spacing-xs);
+    padding: var(--sc-ai-spacing-xs) var(--sc-ai-spacing-sm);
+    background: var(--sc-ai-color-surface-hover);
+    border: 1px solid var(--sc-ai-color-border);
+    border-radius: var(--sc-ai-border-radius-sm);
+}
+
+.sc-ai-attachment-preview__file {
+    font-size: var(--sc-ai-font-size-sm);
+    color: var(--sc-ai-color-text-secondary);
+    max-width: 10rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.sc-ai-attachment-preview__remove {
+    width: 1.125rem;
+    height: 1.125rem;
+    border: none;
+    border-radius: 50%;
+    background: transparent;
+    color: var(--sc-ai-color-text-secondary);
+    font-size: 0.75rem;
+    line-height: 1;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+}
+
+.sc-ai-attachment-preview__remove:hover {
+    color: var(--sc-ai-color-error);
+}
+
+/* ---------- Media Content (in messages) ---------- */
+.sc-ai-media {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--sc-ai-spacing-sm);
+    max-width: 85%;
+}
+
+.sc-ai-media__image {
+    max-width: 20rem;
+    max-height: 16rem;
+    border-radius: var(--sc-ai-border-radius-sm);
+    object-fit: contain;
+}
+
+.sc-ai-media__audio {
+    max-width: 20rem;
+}
+
+.sc-ai-media__video {
+    max-width: 20rem;
+    max-height: 16rem;
+    border-radius: var(--sc-ai-border-radius-sm);
+}
+
+.sc-ai-media__file {
+    padding: var(--sc-ai-spacing-sm) var(--sc-ai-spacing-md);
+    border: 1px solid var(--sc-ai-color-border);
+    border-radius: var(--sc-ai-border-radius-sm);
+    font-size: var(--sc-ai-font-size-sm);
+    color: var(--sc-ai-color-text-secondary);
+}
+
+/* ---------- Chat Page ---------- */
+.sc-ai-chat-page {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    height: 100dvh;
+    background: var(--sc-ai-color-bg);
+}
+
+.sc-ai-chat-page__header {
+    flex-shrink: 0;
+}
+
+.sc-ai-chat-page__body {
+    flex: 1;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+.sc-ai-chat-page__footer {
+    flex-shrink: 0;
+    border-top: 1px solid var(--sc-ai-color-border);
+    background: var(--sc-ai-color-surface);
+    padding: var(--sc-ai-spacing-md);
+}
+
+.sc-ai-chat-page__input-container {
+    max-width: var(--sc-ai-max-width);
+    margin: 0 auto;
+}
+
+/* ---------- Drawer ---------- */
+.sc-ai-drawer {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    width: var(--sc-ai-drawer-width);
+    display: flex;
+    flex-direction: column;
+    background: var(--sc-ai-color-surface);
+    box-shadow: -4px 0 16px rgba(0, 0, 0, 0.08);
+    z-index: 1000;
+    animation: sc-ai-slide-in var(--sc-ai-transition-slow) forwards;
+}
+
+.sc-ai-drawer--right {
+    right: 0;
+    border-left: 1px solid var(--sc-ai-color-border);
+}
+
+.sc-ai-drawer--left {
+    left: 0;
+    border-right: 1px solid var(--sc-ai-color-border);
+}
+
+@keyframes sc-ai-slide-in {
+    from { transform: translateX(100%); }
+    to { transform: translateX(0); }
+}
+
+.sc-ai-drawer--left {
+    animation-name: sc-ai-slide-in-left;
+}
+
+@keyframes sc-ai-slide-in-left {
+    from { transform: translateX(-100%); }
+    to { transform: translateX(0); }
+}
+
+.sc-ai-drawer__header {
+    display: flex;
+    align-items: center;
+    padding: var(--sc-ai-spacing-md);
+    border-bottom: 1px solid var(--sc-ai-color-border);
+    flex-shrink: 0;
+}
+
+.sc-ai-drawer__title {
+    flex: 1;
+    font-weight: var(--sc-ai-font-weight-bold);
+    font-size: var(--sc-ai-font-size-lg);
+}
+
+.sc-ai-drawer__close {
+    width: 2rem;
+    height: 2rem;
+    padding: 0;
+    border: none;
+    border-radius: var(--sc-ai-border-radius-sm);
+    background: transparent;
+    color: var(--sc-ai-color-text-secondary);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.25rem;
+    transition: background var(--sc-ai-transition-fast),
+                color var(--sc-ai-transition-fast);
+}
+
+.sc-ai-drawer__close:hover {
+    background: var(--sc-ai-color-surface-hover);
+    color: var(--sc-ai-color-text);
+}
+
+.sc-ai-drawer__close:focus-visible {
+    outline: none;
+    box-shadow: var(--sc-ai-focus-ring);
+}
+
+.sc-ai-drawer__body {
+    flex: 1;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+.sc-ai-drawer__footer {
+    flex-shrink: 0;
+    border-top: 1px solid var(--sc-ai-color-border);
+    padding: var(--sc-ai-spacing-md);
+}
+
+/* ---------- Bubble ---------- */
+.sc-ai-bubble {
+    position: fixed;
+    z-index: 1000;
+}
+
+.sc-ai-bubble--bottom-right {
+    bottom: var(--sc-ai-spacing-lg);
+    right: var(--sc-ai-spacing-lg);
+}
+
+.sc-ai-bubble--bottom-left {
+    bottom: var(--sc-ai-spacing-lg);
+    left: var(--sc-ai-spacing-lg);
+}
+
+.sc-ai-bubble__trigger {
+    width: var(--sc-ai-bubble-size);
+    height: var(--sc-ai-bubble-size);
+    border-radius: 50%;
+    background: var(--sc-ai-color-accent);
+    color: var(--sc-ai-color-text-on-accent);
+    border: none;
+    cursor: pointer;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform var(--sc-ai-transition-fast),
+                background var(--sc-ai-transition-fast);
+}
+
+.sc-ai-bubble__trigger:hover {
+    background: var(--sc-ai-color-accent-hover);
+    transform: scale(1.05);
+}
+
+.sc-ai-bubble__trigger:focus-visible {
+    outline: none;
+    box-shadow: var(--sc-ai-focus-ring), 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.sc-ai-bubble__trigger svg {
+    width: 1.5rem;
+    height: 1.5rem;
+}
+
+.sc-ai-bubble__panel {
+    position: absolute;
+    bottom: calc(var(--sc-ai-bubble-size) + var(--sc-ai-spacing-md));
+    width: 24rem;
+    height: 32rem;
+    display: flex;
+    flex-direction: column;
+    background: var(--sc-ai-color-surface);
+    border-radius: var(--sc-ai-border-radius);
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+    overflow: hidden;
+    animation: sc-ai-panel-in var(--sc-ai-transition-normal) forwards;
+}
+
+.sc-ai-bubble--bottom-right .sc-ai-bubble__panel {
+    right: 0;
+}
+
+.sc-ai-bubble--bottom-left .sc-ai-bubble__panel {
+    left: 0;
+}
+
+@keyframes sc-ai-panel-in {
+    from {
+        opacity: 0;
+        transform: translateY(8px) scale(0.95);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+.sc-ai-bubble__header {
+    display: flex;
+    align-items: center;
+    padding: var(--sc-ai-spacing-md);
+    border-bottom: 1px solid var(--sc-ai-color-border);
+    flex-shrink: 0;
+}
+
+.sc-ai-bubble__title {
+    flex: 1;
+    font-weight: var(--sc-ai-font-weight-bold);
+}
+
+.sc-ai-bubble__close {
+    width: 1.75rem;
+    height: 1.75rem;
+    padding: 0;
+    border: none;
+    border-radius: var(--sc-ai-border-radius-sm);
+    background: transparent;
+    color: var(--sc-ai-color-text-secondary);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background var(--sc-ai-transition-fast),
+                color var(--sc-ai-transition-fast);
+}
+
+.sc-ai-bubble__close:hover {
+    background: var(--sc-ai-color-surface-hover);
+    color: var(--sc-ai-color-text);
+}
+
+.sc-ai-bubble__close:focus-visible {
+    outline: none;
+    box-shadow: var(--sc-ai-focus-ring);
+}
+
+.sc-ai-bubble__body {
+    flex: 1;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+.sc-ai-bubble__footer {
+    flex-shrink: 0;
+    border-top: 1px solid var(--sc-ai-color-border);
+    padding: var(--sc-ai-spacing-sm);
+}
+
+/* ---------- Scroll to Bottom ---------- */
+.sc-ai-scroll-bottom {
+    position: sticky;
+    bottom: var(--sc-ai-spacing-sm);
+    align-self: center;
+    padding: var(--sc-ai-spacing-xs) var(--sc-ai-spacing-md);
+    border: 1px solid var(--sc-ai-color-border);
+    border-radius: var(--sc-ai-border-radius-lg);
+    background: var(--sc-ai-color-surface);
+    color: var(--sc-ai-color-text-secondary);
+    font-family: inherit;
+    font-size: var(--sc-ai-font-size-sm);
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    transition: background var(--sc-ai-transition-fast);
+}
+
+.sc-ai-scroll-bottom:hover {
+    background: var(--sc-ai-color-surface-hover);
+}
+
+.sc-ai-scroll-bottom:focus-visible {
+    outline: none;
+    box-shadow: var(--sc-ai-focus-ring);
+}

--- a/src/Components/AI/test/Components/ApprovalBlockSsrTests.cs
+++ b/src/Components/AI/test/Components/ApprovalBlockSsrTests.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.AI.Tests.TestFramework;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Components;
+
+public class ApprovalBlockSsrTests
+{
+    [Fact]
+    public void ApprovalButtons_HaveFormSubmitAttributes()
+    {
+        var innerBlock = new FunctionInvocationContentBlock();
+        innerBlock.Call = new FunctionCallContent("call-xyz", "delete_file");
+        var request = new ToolApprovalRequestContent("req-1", innerBlock.Call);
+        var block = new FunctionApprovalBlock(innerBlock, request);
+        block.Id = "call-xyz";
+
+        var listContext = new MessageListContext();
+        var fragment = listContext.RenderBlock(block);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<FragmentHost>(p =>
+        {
+            p["Fragment"] = fragment;
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("type=\"submit\"", html);
+        Assert.Contains("name=\"BlockAction\"", html);
+        Assert.Contains("value=\"approve:call-xyz\"", html);
+        Assert.Contains("value=\"reject:call-xyz\"", html);
+    }
+
+    [Fact]
+    public void ApprovedBlock_DoesNotRenderFormButtons()
+    {
+        var innerBlock = new FunctionInvocationContentBlock();
+        innerBlock.Call = new FunctionCallContent("call-abc", "send_email");
+        var request = new ToolApprovalRequestContent("req-2", innerBlock.Call);
+        var block = new FunctionApprovalBlock(innerBlock, request);
+        block.Id = "call-abc";
+        block.Approve();
+
+        var listContext = new MessageListContext();
+        var fragment = listContext.RenderBlock(block);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<FragmentHost>(p =>
+        {
+            p["Fragment"] = fragment;
+        });
+
+        var html = cut.GetHtml();
+        Assert.DoesNotContain("name=\"BlockAction\"", html);
+        Assert.Contains("Approved", html);
+    }
+
+    internal class FragmentHost : IComponent
+    {
+        private RenderHandle _renderHandle;
+
+        [Parameter]
+        public RenderFragment? Fragment { get; set; }
+
+        void IComponent.Attach(RenderHandle renderHandle)
+        {
+            _renderHandle = renderHandle;
+        }
+
+        Task IComponent.SetParametersAsync(ParameterView parameters)
+        {
+            parameters.SetParameterProperties(this);
+            _renderHandle.Render(b => b.AddContent(0, Fragment));
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Components/AI/test/Components/ChatBubbleTests.cs
+++ b/src/Components/AI/test/Components/ChatBubbleTests.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.AI.Tests.TestFramework;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Components;
+
+public class ChatBubbleTests
+{
+    [Fact]
+    public void RendersTriggerButton_Always()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("OK", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<ChatBubble>(p =>
+        {
+            p["Agent"] = agent;
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("sc-ai-bubble__trigger", html);
+        Assert.Contains("sc-ai-bubble--bottom-right", html);
+    }
+
+    [Fact]
+    public void DoesNotRenderPanel_WhenClosed()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("OK", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<ChatBubble>(p =>
+        {
+            p["Agent"] = agent;
+        });
+
+        var html = cut.GetHtml();
+        Assert.DoesNotContain("sc-ai-bubble__panel", html);
+    }
+
+    [Fact]
+    public void RendersBottomLeftPosition()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("OK", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<ChatBubble>(p =>
+        {
+            p["Agent"] = agent;
+            p["Position"] = BubblePosition.BottomLeft;
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("sc-ai-bubble--bottom-left", html);
+    }
+
+    [Fact]
+    public void TriggerHasAccessibilityLabel()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("OK", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<ChatBubble>(p =>
+        {
+            p["Agent"] = agent;
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("aria-label=\"Open chat\"", html);
+    }
+
+    [Fact]
+    public void RendersRootClasses()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("OK", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<ChatBubble>(p =>
+        {
+            p["Agent"] = agent;
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("sc-ai-root", html);
+        Assert.Contains("sc-ai-bubble", html);
+    }
+}

--- a/src/Components/AI/test/Components/ChatDrawerTests.cs
+++ b/src/Components/AI/test/Components/ChatDrawerTests.cs
@@ -1,0 +1,134 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.AI.Tests.TestFramework;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Components;
+
+public class ChatDrawerTests
+{
+    [Fact]
+    public void RendersNothing_WhenClosed()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("OK", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<ChatDrawer>(p =>
+        {
+            p["Agent"] = agent;
+            p["Open"] = false;
+        });
+
+        var html = cut.GetHtml();
+        Assert.Empty(html);
+    }
+
+    [Fact]
+    public void RendersDrawerStructure_WhenOpen()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("OK", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<ChatDrawer>(p =>
+        {
+            p["Agent"] = agent;
+            p["Open"] = true;
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("sc-ai-root", html);
+        Assert.Contains("sc-ai-drawer", html);
+        Assert.Contains("sc-ai-drawer--right", html);
+        Assert.Contains("sc-ai-drawer__header", html);
+        Assert.Contains("sc-ai-drawer__body", html);
+        Assert.Contains("sc-ai-drawer__footer", html);
+    }
+
+    [Fact]
+    public void RendersTitle()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("OK", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<ChatDrawer>(p =>
+        {
+            p["Agent"] = agent;
+            p["Open"] = true;
+            p["Title"] = "Assistant";
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("Assistant", html);
+    }
+
+    [Fact]
+    public void RendersLeftPosition()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("OK", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<ChatDrawer>(p =>
+        {
+            p["Agent"] = agent;
+            p["Open"] = true;
+            p["Position"] = DrawerPosition.Left;
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("sc-ai-drawer--left", html);
+    }
+
+    [Fact]
+    public void HasAccessibilityAttributes()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("OK", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<ChatDrawer>(p =>
+        {
+            p["Agent"] = agent;
+            p["Open"] = true;
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("role=\"dialog\"", html);
+        Assert.Contains("aria-label=\"Chat\"", html);
+        Assert.Contains("aria-label=\"Close chat\"", html);
+    }
+
+    [Fact]
+    public void RendersCloseButton()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("OK", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<ChatDrawer>(p =>
+        {
+            p["Agent"] = agent;
+            p["Open"] = true;
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("sc-ai-drawer__close", html);
+    }
+}

--- a/src/Components/AI/test/Components/ChatPageTests.cs
+++ b/src/Components/AI/test/Components/ChatPageTests.cs
@@ -1,0 +1,145 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.AI.Tests.TestFramework;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Components;
+
+public class ChatPageTests
+{
+    [Fact]
+    public void RendersPageStructure()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("OK", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<ChatPage>(p =>
+        {
+            p["Agent"] = agent;
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("sc-ai-root", html);
+        Assert.Contains("sc-ai-chat-page", html);
+        Assert.Contains("sc-ai-chat-page__body", html);
+        Assert.Contains("sc-ai-chat-page__footer", html);
+        Assert.Contains("sc-ai-input", html);
+    }
+
+    [Fact]
+    public void RendersHeader()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("OK", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<ChatPage>(p =>
+        {
+            p["Agent"] = agent;
+            p["Header"] = (RenderFragment)(b =>
+            {
+                b.OpenElement(0, "h1");
+                b.AddContent(1, "My Chat");
+                b.CloseElement();
+            });
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("sc-ai-chat-page__header", html);
+        Assert.Contains("My Chat", html);
+    }
+
+    [Fact]
+    public void RendersWelcomeContent()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("OK", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<ChatPage>(p =>
+        {
+            p["Agent"] = agent;
+            p["WelcomeContent"] = (RenderFragment)(b =>
+            {
+                b.OpenElement(0, "p");
+                b.AddContent(1, "Welcome to the chat!");
+                b.CloseElement();
+            });
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("Welcome to the chat!", html);
+    }
+
+    [Fact]
+    public void RendersCustomPlaceholder()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("OK", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<ChatPage>(p =>
+        {
+            p["Agent"] = agent;
+            p["Placeholder"] = "Ask anything...";
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("Ask anything...", html);
+    }
+
+    [Fact]
+    public void RendersSuggestions_WhenNoTurns()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("OK", ct));
+        var agent = new UIAgent(client);
+
+        var suggestions = new List<Suggestion>
+        {
+            new() { Label = "Hello", Prompt = "Hello" },
+        };
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<ChatPage>(p =>
+        {
+            p["Agent"] = agent;
+            p["Suggestions"] = (IReadOnlyList<Suggestion>)suggestions;
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("sc-ai-suggestions", html);
+        Assert.Contains("Hello", html);
+    }
+
+    [Fact]
+    public void AcceptsAdditionalAttributes()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("OK", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<ChatPage>(p =>
+        {
+            p["Agent"] = agent;
+            p["id"] = "my-chat";
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("id=\"my-chat\"", html);
+    }
+}

--- a/src/Components/AI/test/Components/SuggestionListTests.cs
+++ b/src/Components/AI/test/Components/SuggestionListTests.cs
@@ -1,0 +1,90 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.AI.Tests.TestFramework;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Components;
+
+public class SuggestionListTests
+{
+    [Fact]
+    public void RendersSuggestionChips()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("OK", ct));
+        var agent = new UIAgent(client);
+
+        var suggestions = new List<Suggestion>
+        {
+            new() { Label = "Tell me a joke", Prompt = "Tell me a joke" },
+            new() { Label = "What is the weather", Prompt = "What is the weather today?" },
+        };
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<SuggestionList>(0);
+                b.AddComponentParameter(1, "Suggestions", (IReadOnlyList<Suggestion>)suggestions);
+                b.CloseComponent();
+            });
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("sc-ai-suggestions", html);
+        Assert.Contains("Tell me a joke", html);
+        Assert.Contains("What is the weather", html);
+    }
+
+    [Fact]
+    public void HasAccessibilityAttributes()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("OK", ct));
+        var agent = new UIAgent(client);
+
+        var suggestions = new List<Suggestion>
+        {
+            new() { Label = "Help", Prompt = "Help me" },
+        };
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<SuggestionList>(0);
+                b.AddComponentParameter(1, "Suggestions", (IReadOnlyList<Suggestion>)suggestions);
+                b.CloseComponent();
+            });
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("role=\"group\"", html);
+        Assert.Contains("aria-label=\"Suggestions\"", html);
+    }
+
+    [Fact]
+    public void SuggestionList_OutsideAgentBoundary_Throws()
+    {
+        var renderer = new TestRenderer();
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            var suggestions = new List<Suggestion>
+            {
+                new() { Label = "Test", Prompt = "Test" },
+            };
+            renderer.RenderComponent<SuggestionList>(p =>
+            {
+                p["Suggestions"] = (IReadOnlyList<Suggestion>)suggestions;
+            });
+        });
+    }
+}


### PR DESCRIPTION
Part of the overall Components.AI design: https://github.com/dotnet/aspnetcore/issues/66178

Builds on #66183

---

# Default UI Shells, Theming, and CSS

## Summary

Provide ready-to-use chat layouts (`ChatPage`, `ChatBubble`, `ChatDrawer`) and a CSS design token system so applications can drop in a full chat UI with a single component and customize its appearance entirely through CSS custom properties. Also adds `SuggestionList` for quick-reply chip buttons.

## Motivation

The core components (`AgentBoundary`, `MessageList`, `MessageInput`) are composable but require manual assembly. Most applications want one of three standard chat layouts:

- **Full-page chat** — the entire page is the conversation (like ChatGPT).
- **Floating bubble** — a small floating button that opens a chat panel (like customer support widgets).
- **Side drawer** — a panel that slides in from the left or right (like Copilot in VS Code).

Each layout composes the same core components but with different HTML structure, positioning, and interaction patterns.

## Goals

- Provide `ChatPage`, `ChatBubble`, and `ChatDrawer` shell components that compose core components into ready-to-use layouts.
- Provide `SuggestionList` for quick-reply chip buttons.
- Provide a CSS design token system using custom properties on `.sc-ai-root`.
- Namespace all CSS classes with `sc-ai-` to avoid collisions.
- Support both interactive and SSR render modes for approval buttons.

## Non-goals

- Dark mode theme (applications override CSS custom properties for dark mode).
- Responsive breakpoints (applications control responsive behavior via their own CSS).
- Component parameter-based styling (CSS custom properties are the styling mechanism).

## Detailed design

### Shell composition

All three shells compose the same core components:
- **ChatPage**: Full-page layout with header slot, MessageList, SuggestionList, and MessageInput.
- **ChatBubble**: Toggle button + dialog panel with MessageList and MessageInput.
- **ChatDrawer**: Sliding panel (left/right) with header, close button, MessageList, and MessageInput. Supports `@bind-Open`.

### SuggestionList

Quick-reply chips shown when the conversation is idle. Each `Suggestion` has a `Label`, `Prompt`, and optional `Icon`. Chips are disabled during `Streaming` status. On click, sends `suggestion.Prompt` as a message.

### CSS design token system

All visual properties driven by CSS custom properties on `.sc-ai-root`:
- Typography: `--sc-ai-font-family`, `--sc-ai-font-size`
- Colors: `--sc-ai-color-bg`, `--sc-ai-color-text`, `--sc-ai-color-accent`, `--sc-ai-color-error`
- Spacing: `--sc-ai-spacing-xs/sm/md/lg`
- Radius: `--sc-ai-radius-sm/md/lg`
- Shadows: `--sc-ai-shadow-sm/md/lg`
- Transitions: `--sc-ai-transition-speed`

### SSR dual-mode approval buttons

Approval buttons render both `<button type="submit">` (SSR) and `onclick` handlers (interactive). In SSR, `onclick` is a no-op. In interactive mode, `onclick` fires first.

## Risks

- **CSS specificity conflicts**: Mitigated by the `sc-ai-` namespace prefix.
- **Bubble z-index conflicts**: Mitigated by making the z-index a CSS custom property.

## Drawbacks

- Three shell components mean three similar implementations. However, their HTML structures are genuinely different.
- CSS custom properties require a modern browser (matches Blazor's requirements).

## Test coverage

242 tests (cumulative) covering:
- `ChatBubble` open/close toggle, panel rendering, trigger icon switching.
- `ChatDrawer` open/close binding, position classes, header actions.
- `ChatPage` header rendering, welcome content, input configuration passthrough.
- `SuggestionList` chip rendering, click-to-send, disable during streaming.
- SSR approval button rendering (dual-mode submit + onclick).