### PR TITLE
[Blazor] Components.AI - 05 Multimodal attachments, conversation threads, and form input

### DIFF
--- a/src/Components/AI/src/Components/AgentBoundary.cs
+++ b/src/Components/AI/src/Components/AgentBoundary.cs
@@ -55,7 +55,11 @@ public class AgentBoundary : ComponentBase, IDisposable
 
     protected override async Task OnInitializedAsync()
     {
-        await Task.CompletedTask;
+        var thread = Agent.Options.Thread;
+        if (thread is not null && thread.GetUpdates().Count > 0)
+        {
+            await _context.RestoreAsync();
+        }
     }
 
     protected override void BuildRenderTree(RenderTreeBuilder builder)

--- a/src/Components/AI/src/Components/AgentFormBoundary.cs
+++ b/src/Components/AI/src/Components/AgentFormBoundary.cs
@@ -1,0 +1,147 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+[StreamRendering]
+public class AgentFormBoundary : ComponentBase, IDisposable
+{
+    public const string FormHandlerName = "ai-chat";
+
+    private readonly Func<Task> _handleSubmitDelegate;
+    private AgentContext _context = default!;
+
+    public AgentFormBoundary()
+    {
+        _handleSubmitDelegate = HandleSubmitAsync;
+    }
+
+    [Parameter, EditorRequired]
+    public UIAgent Agent { get; set; } = default!;
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    [SupplyParameterFromForm(FormName = FormHandlerName)]
+    internal string? UserMessage { get; set; }
+
+    [SupplyParameterFromForm(FormName = FormHandlerName)]
+    internal string? BlockAction { get; set; }
+
+    protected override void OnInitialized()
+    {
+        _context = new AgentContext(Agent);
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        var thread = Agent.Options.Thread;
+        if (thread is not null && thread.GetUpdates().Count > 0)
+        {
+            await _context.RestoreAsync();
+        }
+    }
+
+    private async Task HandleSubmitAsync()
+    {
+        if (!string.IsNullOrEmpty(BlockAction))
+        {
+            await ProcessBlockActionAsync();
+        }
+        else if (!string.IsNullOrEmpty(UserMessage))
+        {
+            await _context.SendMessageAsync(UserMessage);
+            UserMessage = null;
+        }
+    }
+
+    private async Task ProcessBlockActionAsync()
+    {
+        var separatorIndex = BlockAction!.IndexOf(':');
+        if (separatorIndex < 0)
+        {
+            return;
+        }
+
+        var action = BlockAction.AsSpan(0, separatorIndex);
+        var blockId = BlockAction.AsSpan(separatorIndex + 1);
+        var approved = action.Equals("approve", StringComparison.OrdinalIgnoreCase);
+
+        var thread = Agent.Options.Thread;
+        if (thread is null)
+        {
+            return;
+        }
+
+        // Find the pending approval request in stored updates by matching CallId.
+        ToolApprovalRequestContent? request = null;
+        foreach (var update in thread.GetUpdates())
+        {
+            foreach (var content in update.Contents)
+            {
+                if (content is ToolApprovalRequestContent tar
+                    && tar.ToolCall is FunctionCallContent fcc
+                    && blockId.Equals(fcc.CallId, StringComparison.Ordinal))
+                {
+                    request = tar;
+                    break;
+                }
+            }
+
+            if (request is not null)
+            {
+                break;
+            }
+        }
+
+        if (request is null)
+        {
+            return;
+        }
+
+        var response = request.CreateResponse(approved);
+        var message = new ChatMessage(ChatRole.User, [response]);
+        await _context.SendMessageAsync(message);
+    }
+
+    protected override void BuildRenderTree(RenderTreeBuilder builder)
+    {
+        builder.OpenComponent<CascadingValue<AgentContext>>(0);
+        builder.AddComponentParameter(1, "Value", _context);
+        builder.AddComponentParameter(2, "IsFixed", true);
+        builder.AddComponentParameter(3, "ChildContent", (RenderFragment)(inner =>
+        {
+            inner.OpenElement(10, "form");
+            inner.AddAttribute(11, "method", "post");
+            inner.AddAttribute(12, "data-enhance", true);
+            inner.AddAttribute(13, "onsubmit", _handleSubmitDelegate);
+            inner.AddNamedEvent("onsubmit", FormHandlerName);
+
+            inner.OpenComponent<AntiforgeryToken>(15);
+            inner.CloseComponent();
+
+            if (Agent.Options.Thread is not null)
+            {
+                inner.OpenElement(20, "input");
+                inner.AddAttribute(21, "type", "hidden");
+                inner.AddAttribute(22, "name", "ThreadId");
+                inner.AddAttribute(23, "value", Agent.Options.Thread.ThreadId);
+                inner.CloseElement();
+            }
+
+            inner.AddContent(30, ChildContent);
+
+            inner.CloseElement(); // form
+        }));
+        builder.CloseComponent();
+    }
+
+    public void Dispose()
+    {
+        _context?.Dispose();
+    }
+}

--- a/src/Components/AI/src/Components/FormMessageInput.cs
+++ b/src/Components/AI/src/Components/FormMessageInput.cs
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+[StreamRendering]
+public class FormMessageInput : IComponent, IDisposable
+{
+    private RenderHandle _renderHandle;
+    private AgentContext _agentContext = default!;
+    private string? _placeholder;
+    private IDisposable? _statusChangedSub;
+
+    [CascadingParameter]
+    public AgentContext AgentContext { get; set; } = default!;
+
+    [Parameter]
+    public string? Placeholder { get; set; }
+
+    void IComponent.Attach(RenderHandle renderHandle)
+    {
+        _renderHandle = renderHandle;
+    }
+
+    Task IComponent.SetParametersAsync(ParameterView parameters)
+    {
+        parameters.SetParameterProperties(this);
+        _agentContext = AgentContext
+            ?? throw new InvalidOperationException(
+                "FormMessageInput must be inside an AgentFormBoundary.");
+        _placeholder = Placeholder;
+
+        _statusChangedSub ??= _agentContext.RegisterOnStatusChanged(_ => Render());
+
+        Render();
+        return Task.CompletedTask;
+    }
+
+    private void Render()
+    {
+        _renderHandle.Render(builder =>
+        {
+            var isDisabled = _agentContext.Status == ConversationStatus.Streaming;
+
+            builder.OpenElement(0, "div");
+            builder.AddAttribute(1, "class", "sc-ai-input");
+
+            builder.OpenElement(2, "div");
+            builder.AddAttribute(3, "class", "sc-ai-input__body");
+
+            builder.OpenElement(4, "input");
+            builder.AddAttribute(5, "type", "text");
+            builder.AddAttribute(6, "name", "UserMessage");
+            builder.AddAttribute(7, "class", "sc-ai-input__textarea");
+            builder.AddAttribute(8, "placeholder", _placeholder ?? "Type a message...");
+            builder.AddAttribute(9, "disabled", isDisabled);
+            builder.AddAttribute(10, "autocomplete", "off");
+            builder.CloseElement(); // input
+
+            builder.CloseElement(); // body div
+
+            builder.OpenElement(20, "button");
+            builder.AddAttribute(21, "type", "submit");
+            builder.AddAttribute(22, "class", "sc-ai-input__send");
+            builder.AddAttribute(23, "disabled", isDisabled);
+            builder.AddAttribute(24, "aria-label", "Send message");
+            builder.AddMarkupContent(25,
+                "<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M22 2 11 13\"/><path d=\"M22 2 15 22 11 13 2 9z\"/></svg>");
+            builder.CloseElement(); // button
+
+            builder.CloseElement(); // outer div
+        });
+    }
+
+    public void Dispose()
+    {
+        _statusChangedSub?.Dispose();
+    }
+}

--- a/src/Components/AI/src/Engine/AgentContext.cs
+++ b/src/Components/AI/src/Engine/AgentContext.cs
@@ -51,6 +51,38 @@ public class AgentContext : IDisposable
         await StreamIntoTurnAsync(message, turn, _streamingCts.Token);
     }
 
+    public async Task RestoreAsync(CancellationToken cancellationToken = default)
+    {
+        if (Status == ConversationStatus.Streaming)
+        {
+            throw new InvalidOperationException("A message is already being processed.");
+        }
+
+        var blocks = await _agent.RestoreAsync(cancellationToken);
+
+        ConversationTurn? currentTurn = null;
+
+        foreach (var block in blocks)
+        {
+            if (block.Role == ChatRole.User)
+            {
+                currentTurn = new ConversationTurn();
+                _turns.Add(currentTurn);
+                currentTurn.AddRequestBlock(block);
+            }
+            else
+            {
+                if (currentTurn is null)
+                {
+                    currentTurn = new ConversationTurn();
+                    _turns.Add(currentTurn);
+                }
+
+                currentTurn.AddResponseBlock(block);
+            }
+        }
+    }
+
     private async Task StreamIntoTurnAsync(
         ChatMessage message,
         ConversationTurn turn,

--- a/src/Components/AI/src/Engine/IConversationThread.cs
+++ b/src/Components/AI/src/Engine/IConversationThread.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents a persistent conversation thread that stores ChatResponseUpdates.
+/// Implementations control where and how updates are persisted.
+/// </summary>
+public interface IConversationThread
+{
+    /// <summary>
+    /// The unique identifier for this thread.
+    /// </summary>
+    string ThreadId { get; }
+
+    /// <summary>
+    /// Whether the remote LLM is stateful (manages its own history).
+    /// When true, the LLM returned a ConversationId, so the full message
+    /// history does not need to be sent on each turn.
+    /// </summary>
+    bool IsStateful { get; }
+
+    /// <summary>
+    /// The ConversationId returned by a stateful LLM, if any.
+    /// This is set on the ChatOptions.ConversationId for stateful LLMs.
+    /// </summary>
+    string? ConversationId { get; }
+
+    /// <summary>
+    /// Appends a user-initiated message as a ChatResponseUpdate to the thread.
+    /// Called before the LLM request to record what the user sent.
+    /// </summary>
+    void AppendUserMessage(ChatMessage message);
+
+    /// <summary>
+    /// Appends a single ChatResponseUpdate received during streaming.
+    /// Called as each update arrives from the LLM.
+    /// </summary>
+    void AppendUpdate(ChatResponseUpdate update);
+
+    /// <summary>
+    /// Commits the current turn to the stored history.
+    /// Only committed turns appear in <see cref="GetUpdates"/> and <see cref="GetMessageHistory"/>.
+    /// If a turn fails mid-stream, not calling CompleteTurn discards the partial turn.
+    /// </summary>
+    void CompleteTurn();
+
+    /// <summary>
+    /// Returns all committed updates as a flat list.
+    /// Turn boundaries can be detected by looking for updates with
+    /// a user Role (from <see cref="AppendUserMessage"/>) or by changes in ResponseId.
+    /// </summary>
+    IReadOnlyList<ChatResponseUpdate> GetUpdates();
+
+    /// <summary>
+    /// Returns the ChatMessage history suitable for sending to a stateless LLM.
+    /// This reconstructs ChatMessages from the stored updates.
+    /// </summary>
+    IReadOnlyList<ChatMessage> GetMessageHistory();
+}

--- a/src/Components/AI/src/Engine/UIAgent.cs
+++ b/src/Components/AI/src/Engine/UIAgent.cs
@@ -56,6 +56,9 @@ public class UIAgent : IDisposable
 
         _history.Add(message);
 
+        var thread = _options.Thread;
+        thread?.AppendUserMessage(message);
+
         var pipeline = new BlockMappingPipeline(_options, _logger);
 
         // Process user message through pipeline
@@ -79,6 +82,13 @@ public class UIAgent : IDisposable
         string? turnId = null;
         var chatOptions = BuildChatOptions();
 
+        // If the thread detected a stateful LLM, propagate the ConversationId
+        if (thread is { IsStateful: true, ConversationId: not null })
+        {
+            chatOptions ??= new ChatOptions();
+            chatOptions.ConversationId = thread.ConversationId;
+        }
+
         var updateIndex = 0;
         await foreach (var update in _chatClient.GetStreamingResponseAsync(
             _history, chatOptions, cancellationToken).ConfigureAwait(false))
@@ -88,6 +98,8 @@ public class UIAgent : IDisposable
 
             assistantUpdates.Add(update);
             turnId ??= update.ResponseId;
+
+            thread?.AppendUpdate(update);
 
             var processUpdate = ApplyStateMapper(update);
             if (processUpdate.Contents.Count == 0 && update.Contents.Count > 0)
@@ -116,10 +128,111 @@ public class UIAgent : IDisposable
             _history.Add(msg);
         }
 
+        thread?.CompleteTurn();
+
         UIAgentLog.AddedToHistory(_logger, response.Messages.Count);
     }
 
     internal virtual object? AgentStateObject => null;
+
+    public async Task<IReadOnlyList<ContentBlock>> RestoreAsync(
+        CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        var thread = _options.Thread;
+        if (thread is null)
+        {
+            return Array.Empty<ContentBlock>();
+        }
+
+        var updates = thread.GetUpdates();
+        if (updates.Count == 0)
+        {
+            return Array.Empty<ContentBlock>();
+        }
+
+        _history.Clear();
+
+        var blocks = new List<ContentBlock>();
+        var pipeline = new BlockMappingPipeline(_options, _logger);
+        var assistantUpdates = new List<ChatResponseUpdate>();
+
+        foreach (var update in updates)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (update.Role == ChatRole.User)
+            {
+                // Flush previous assistant group into history
+                if (assistantUpdates.Count > 0)
+                {
+                    var response = assistantUpdates.ToChatResponse();
+                    foreach (var msg in response.Messages)
+                    {
+                        _history.Add(msg);
+                    }
+                    assistantUpdates.Clear();
+
+                    // Finalize the previous turn's pipeline and start a new one
+                    foreach (var block in pipeline.Finalize())
+                    {
+                        blocks.Add(block);
+                    }
+                    pipeline = new BlockMappingPipeline(_options, _logger);
+                }
+
+                // Add user message to history
+                var userMessage = new ChatMessage(update.Role ?? ChatRole.User, [.. update.Contents]);
+                _history.Add(userMessage);
+
+                // Process user update through pipeline
+                await foreach (var block in pipeline.Process(update, cancellationToken).ConfigureAwait(false))
+                {
+                    blocks.Add(block);
+                }
+                foreach (var block in pipeline.Finalize())
+                {
+                    blocks.Add(block);
+                }
+
+                // Start a new pipeline for the assistant response
+                pipeline = new BlockMappingPipeline(_options, _logger);
+            }
+            else
+            {
+                assistantUpdates.Add(update);
+
+                var processUpdate = ApplyStateMapper(update);
+                if (processUpdate.Contents.Count == 0 && update.Contents.Count > 0)
+                {
+                    continue;
+                }
+
+                await foreach (var block in pipeline.Process(processUpdate, cancellationToken).ConfigureAwait(false))
+                {
+                    blocks.Add(block);
+                }
+            }
+        }
+
+        // Flush trailing assistant group
+        if (assistantUpdates.Count > 0)
+        {
+            var response = assistantUpdates.ToChatResponse();
+            foreach (var msg in response.Messages)
+            {
+                _history.Add(msg);
+            }
+        }
+
+        foreach (var block in pipeline.Finalize())
+        {
+            blocks.Add(block);
+        }
+
+        return blocks;
+    }
 
     internal virtual ChatResponseUpdate ApplyStateMapper(ChatResponseUpdate update)
     {

--- a/src/Components/AI/src/Pipeline/UIAgentOptions.cs
+++ b/src/Components/AI/src/Pipeline/UIAgentOptions.cs
@@ -11,6 +11,8 @@ public class UIAgentOptions
 
     public Func<StateMapperContext, bool>? StateMapper { get; set; }
 
+    public IConversationThread? Thread { get; set; }
+
     internal List<IHandlerRegistration> HandlerRegistrations { get; } = new();
 
     internal Dictionary<string, AIFunction> UIActions { get; } = new();

--- a/src/Components/AI/test/Components/AgentFormBoundaryTests.cs
+++ b/src/Components/AI/test/Components/AgentFormBoundaryTests.cs
@@ -1,0 +1,187 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.AI.Tests.TestFramework;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Components;
+
+public class AgentFormBoundaryTests
+{
+    private static TestRenderer CreateRenderer()
+    {
+        var serviceProvider = new TestServiceProvider();
+        serviceProvider.AddService<AntiforgeryStateProvider>(new NullAntiforgeryStateProvider());
+        serviceProvider.AddService<IServiceProvider>(serviceProvider);
+        return new TestRenderer(serviceProvider);
+    }
+
+    [Fact]
+    public void RendersFormElement()
+    {
+        var client = new DelegatingStreamingChatClient();
+        var agent = new UIAgent(client);
+
+        var renderer = CreateRenderer();
+        var cut = renderer.RenderComponent<AgentFormBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenElement(0, "span");
+                b.AddContent(1, "child");
+                b.CloseElement();
+            });
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("<form", html);
+        Assert.Contains("method=\"post\"", html);
+        Assert.Contains("data-enhance", html);
+        Assert.Contains("child", html);
+    }
+
+    [Fact]
+    public void RendersThreadIdHiddenField_WhenThreadConfigured()
+    {
+        var client = new DelegatingStreamingChatClient();
+        var thread = new InMemoryConversationThread("my-thread-123");
+        var agent = new UIAgent(client, options => { options.Thread = thread; });
+
+        var renderer = CreateRenderer();
+        var cut = renderer.RenderComponent<AgentFormBoundary>(p =>
+        {
+            p["Agent"] = agent;
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("name=\"ThreadId\"", html);
+        Assert.Contains("value=\"my-thread-123\"", html);
+    }
+
+    [Fact]
+    public void DoesNotRenderThreadIdHiddenField_WhenNoThread()
+    {
+        var client = new DelegatingStreamingChatClient();
+        var agent = new UIAgent(client);
+
+        var renderer = CreateRenderer();
+        var cut = renderer.RenderComponent<AgentFormBoundary>(p =>
+        {
+            p["Agent"] = agent;
+        });
+
+        var html = cut.GetHtml();
+        Assert.DoesNotContain("name=\"ThreadId\"", html);
+    }
+
+    [Fact]
+    public void CascadesAgentContext()
+    {
+        var client = new DelegatingStreamingChatClient();
+        var agent = new UIAgent(client);
+
+        var renderer = CreateRenderer();
+        var cut = renderer.RenderComponent<AgentFormBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<ContextCapture>(0);
+                b.CloseComponent();
+            });
+        });
+
+        var captureComponent = cut.FindComponent<ContextCapture>();
+        Assert.NotNull(captureComponent.Instance.CapturedContext);
+    }
+
+    [Fact]
+    public async Task RestoresConversation_WhenThreadHasUpdates()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hello!", ct));
+
+        // Build a thread with existing updates
+        var thread = new InMemoryConversationThread("restore-thread");
+        var previousAgent = new UIAgent(client, options => { options.Thread = thread; });
+        var previousContext = new AgentContext(previousAgent);
+        await previousContext.SendMessageAsync("Hi");
+        previousContext.Dispose();
+        previousAgent.Dispose();
+
+        // Now render AgentFormBoundary with the same thread (simulating page reload)
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Second response", ct));
+        var agent = new UIAgent(client, options => { options.Thread = thread; });
+
+        var renderer = CreateRenderer();
+        var cut = renderer.RenderComponent<AgentFormBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<MessageList>(0);
+                b.CloseComponent();
+            });
+        });
+
+        var html = cut.GetHtml();
+        // Restored conversation should show the previous turn
+        Assert.Contains("Hi", html);
+        Assert.Contains("Hello!", html);
+    }
+
+    [Fact]
+    public void Dispose_DisposesContext()
+    {
+        var client = new DelegatingStreamingChatClient();
+        var agent = new UIAgent(client);
+
+        var renderer = CreateRenderer();
+        var cut = renderer.RenderComponent<AgentFormBoundary>(p =>
+        {
+            p["Agent"] = agent;
+        });
+
+        var context = GetAgentContext(cut);
+        var boundary = cut.Instance;
+        ((IDisposable)boundary).Dispose();
+
+        // Dispose should be idempotent — calling it again does not throw
+        ((IDisposable)boundary).Dispose();
+    }
+
+    private static AgentContext GetAgentContext(RenderedComponent<AgentFormBoundary> cut)
+    {
+        return (AgentContext)typeof(AgentFormBoundary)
+            .GetField("_context",
+                System.Reflection.BindingFlags.NonPublic
+                | System.Reflection.BindingFlags.Instance)!
+            .GetValue(cut.Instance)!;
+    }
+
+    internal class ContextCapture : IComponent
+    {
+        private RenderHandle _renderHandle;
+
+        [CascadingParameter]
+        public AgentContext? CapturedContext { get; set; }
+
+        void IComponent.Attach(RenderHandle renderHandle)
+        {
+            _renderHandle = renderHandle;
+        }
+
+        Task IComponent.SetParametersAsync(ParameterView parameters)
+        {
+            parameters.SetParameterProperties(this);
+            _renderHandle.Render(_ => { });
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Components/AI/test/Components/FormMessageInputTests.cs
+++ b/src/Components/AI/test/Components/FormMessageInputTests.cs
@@ -1,0 +1,120 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.AI.Tests.TestFramework;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Components;
+
+public class FormMessageInputTests
+{
+    private static TestRenderer CreateRenderer()
+    {
+        var serviceProvider = new TestServiceProvider();
+        serviceProvider.AddService<AntiforgeryStateProvider>(new NullAntiforgeryStateProvider());
+        serviceProvider.AddService<IServiceProvider>(serviceProvider);
+        return new TestRenderer(serviceProvider);
+    }
+
+    [Fact]
+    public void RendersTextInput()
+    {
+        var client = new DelegatingStreamingChatClient();
+        var agent = new UIAgent(client);
+
+        var renderer = CreateRenderer();
+        var cut = renderer.RenderComponent<AgentFormBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<FormMessageInput>(0);
+                b.CloseComponent();
+            });
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("type=\"text\"", html);
+        Assert.Contains("name=\"UserMessage\"", html);
+        Assert.Contains("sc-ai-input__textarea", html);
+    }
+
+    [Fact]
+    public void RendersSubmitButton()
+    {
+        var client = new DelegatingStreamingChatClient();
+        var agent = new UIAgent(client);
+
+        var renderer = CreateRenderer();
+        var cut = renderer.RenderComponent<AgentFormBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<FormMessageInput>(0);
+                b.CloseComponent();
+            });
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("type=\"submit\"", html);
+        Assert.Contains("sc-ai-input__send", html);
+        Assert.Contains("aria-label=\"Send message\"", html);
+    }
+
+    [Fact]
+    public void UsesCustomPlaceholder()
+    {
+        var client = new DelegatingStreamingChatClient();
+        var agent = new UIAgent(client);
+
+        var renderer = CreateRenderer();
+        var cut = renderer.RenderComponent<AgentFormBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<FormMessageInput>(0);
+                b.AddComponentParameter(1, "Placeholder", "Ask me anything...");
+                b.CloseComponent();
+            });
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("placeholder=\"Ask me anything...\"", html);
+    }
+
+    [Fact]
+    public void UsesDefaultPlaceholder()
+    {
+        var client = new DelegatingStreamingChatClient();
+        var agent = new UIAgent(client);
+
+        var renderer = CreateRenderer();
+        var cut = renderer.RenderComponent<AgentFormBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<FormMessageInput>(0);
+                b.CloseComponent();
+            });
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("placeholder=\"Type a message...\"", html);
+    }
+
+    [Fact]
+    public void FormMessageInput_OutsideAgentBoundary_Throws()
+    {
+        var renderer = new TestRenderer();
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            renderer.RenderComponent<FormMessageInput>();
+        });
+    }
+}

--- a/src/Components/AI/test/Components/MessageInputAttachmentTests.cs
+++ b/src/Components/AI/test/Components/MessageInputAttachmentTests.cs
@@ -1,0 +1,159 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.AI.Tests.TestFramework;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Components;
+
+public class MessageInputAttachmentTests
+{
+    [Fact]
+    public void AllowAttachments_False_NoAttachButton()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hi", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<MessageInput>(0);
+                b.CloseComponent();
+            });
+        });
+
+        var html = cut.GetHtml();
+        Assert.DoesNotContain("sc-ai-input__attach", html);
+        Assert.DoesNotContain("type=\"file\"", html);
+    }
+
+    [Fact]
+    public void AllowAttachments_True_RendersAttachButton()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hi", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<MessageInput>(0);
+                b.AddComponentParameter(1, "AllowAttachments", true);
+                b.CloseComponent();
+            });
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("sc-ai-input__attach", html);
+        Assert.Contains("type=\"file\"", html);
+    }
+
+    [Fact]
+    public void AllowAttachments_True_HasHiddenFileInput()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hi", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<MessageInput>(0);
+                b.AddComponentParameter(1, "AllowAttachments", true);
+                b.CloseComponent();
+            });
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("sc-ai-input__file", html);
+        Assert.Contains("multiple", html);
+    }
+
+    [Fact]
+    public void AcceptFileTypes_CustomValue_SetsAcceptAttribute()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hi", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<MessageInput>(0);
+                b.AddComponentParameter(1, "AllowAttachments", true);
+                b.AddComponentParameter(2, "AcceptFileTypes", "image/*,audio/*");
+                b.CloseComponent();
+            });
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("accept=\"image/*,audio/*\"", html);
+    }
+
+    [Fact]
+    public void AllowAttachments_True_DefaultAcceptIsImageOnly()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hi", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<MessageInput>(0);
+                b.AddComponentParameter(1, "AllowAttachments", true);
+                b.CloseComponent();
+            });
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("accept=\"image/*\"", html);
+    }
+
+    [Fact]
+    public void InputBody_RendersWithCorrectClass()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hi", ct));
+        var agent = new UIAgent(client);
+
+        var renderer = new TestRenderer();
+        var cut = renderer.RenderComponent<AgentBoundary>(p =>
+        {
+            p["Agent"] = agent;
+            p["ChildContent"] = (RenderFragment)(b =>
+            {
+                b.OpenComponent<MessageInput>(0);
+                b.CloseComponent();
+            });
+        });
+
+        var html = cut.GetHtml();
+        Assert.Contains("sc-ai-input__body", html);
+    }
+}

--- a/src/Components/AI/test/Engine/AgentContextThreadTests.cs
+++ b/src/Components/AI/test/Engine/AgentContextThreadTests.cs
@@ -1,0 +1,198 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Engine;
+
+public class AgentContextThreadTests
+{
+    [Fact]
+    public async Task RestoreAsync_CreatesTurns()
+    {
+        var (agent, client, thread) = CreateAgentWithThread();
+
+        // Record 2 turns
+        client.SetHandler(CreateCountingHandler());
+        var context1 = new AgentContext(agent);
+        await context1.SendMessageAsync("First");
+        await context1.SendMessageAsync("Second");
+
+        Assert.NotEmpty(thread.GetUpdates());
+
+        // Restore on fresh agent
+        var (agent2, _, _) = CreateAgentWithExistingThread(thread, client);
+        var context2 = new AgentContext(agent2);
+        await context2.RestoreAsync();
+
+        Assert.Equal(2, context2.Turns.Count);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_DoesNotFireCallbacks()
+    {
+        var (agent, client, thread) = CreateAgentWithThread();
+
+        // Record 2 turns
+        client.SetHandler(CreateCountingHandler());
+        var context1 = new AgentContext(agent);
+        await context1.SendMessageAsync("First");
+        await context1.SendMessageAsync("Second");
+
+        // Restore on fresh agent with callbacks
+        var (agent2, _, _) = CreateAgentWithExistingThread(thread, client);
+        var context2 = new AgentContext(agent2);
+
+        var turnAddedCount = 0;
+        var blockAddedCount = 0;
+        var statusChangedCount = 0;
+        context2.RegisterOnTurnAdded(_ => turnAddedCount++);
+        context2.RegisterOnBlockAdded((_, _) => blockAddedCount++);
+        context2.RegisterOnStatusChanged(_ => statusChangedCount++);
+
+        await context2.RestoreAsync();
+
+        // RestoreAsync populates turns without firing callbacks
+        Assert.Equal(2, context2.Turns.Count);
+        Assert.Equal(0, turnAddedCount);
+        Assert.Equal(0, blockAddedCount);
+        Assert.Equal(0, statusChangedCount);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_PopulatesRequestAndResponseBlocks()
+    {
+        var (agent, client, thread) = CreateAgentWithThread();
+
+        // Record 1 turn
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hi!"));
+        var context1 = new AgentContext(agent);
+        await context1.SendMessageAsync("Hello");
+
+        // Restore on fresh agent
+        var (agent2, _, _) = CreateAgentWithExistingThread(thread, client);
+        var context2 = new AgentContext(agent2);
+
+        await context2.RestoreAsync();
+
+        Assert.Single(context2.Turns);
+        var turn = context2.Turns[0];
+        Assert.NotEmpty(turn.RequestBlocks);
+        Assert.NotEmpty(turn.ResponseBlocks);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_StatusRemainsIdle()
+    {
+        var (agent, client, thread) = CreateAgentWithThread();
+
+        // Record 1 turn
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("ok"));
+        var context1 = new AgentContext(agent);
+        await context1.SendMessageAsync("hi");
+
+        // Restore with status tracking
+        var (agent2, _, _) = CreateAgentWithExistingThread(thread, client);
+        var context2 = new AgentContext(agent2);
+
+        await context2.RestoreAsync();
+
+        Assert.Equal(ConversationStatus.Idle, context2.Status);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_ThenSendMessage_AppendsNewTurn()
+    {
+        var (agent, client, thread) = CreateAgentWithThread();
+
+        // Record 1 turn
+        client.SetHandler(CreateCountingHandler());
+        var context1 = new AgentContext(agent);
+        await context1.SendMessageAsync("First");
+
+        // Restore then send new message
+        var (agent2, client2, _) = CreateAgentWithExistingThread(thread, client);
+        var context2 = new AgentContext(agent2);
+        await context2.RestoreAsync();
+
+        Assert.Single(context2.Turns);
+
+        client2.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("New reply"));
+
+        await context2.SendMessageAsync("Second");
+
+        Assert.Equal(2, context2.Turns.Count);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_EmptyThread_RemainsIdle()
+    {
+        var thread = new InMemoryConversationThread("t1");
+        var client = new DelegatingStreamingChatClient();
+        var agent = new UIAgent(client, options =>
+        {
+            options.Thread = thread;
+        });
+
+        var context = new AgentContext(agent);
+        await context.RestoreAsync();
+
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+        Assert.Empty(context.Turns);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_RequestBlocksAreUserRole_ResponseBlocksAreAssistant()
+    {
+        var (agent, client, thread) = CreateAgentWithThread();
+
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Reply"));
+        var context1 = new AgentContext(agent);
+        await context1.SendMessageAsync("Question");
+
+        var (agent2, _, _) = CreateAgentWithExistingThread(thread, client);
+        var context2 = new AgentContext(agent2);
+        await context2.RestoreAsync();
+
+        var turn = context2.Turns[0];
+        Assert.All(turn.RequestBlocks, b => Assert.Equal(ChatRole.User, b.Role));
+        Assert.All(turn.ResponseBlocks, b => Assert.Equal(ChatRole.Assistant, b.Role));
+    }
+
+    private static (UIAgent agent, DelegatingStreamingChatClient client, InMemoryConversationThread thread) CreateAgentWithThread()
+    {
+        var thread = new InMemoryConversationThread(Guid.NewGuid().ToString("N"));
+        var client = new DelegatingStreamingChatClient();
+        var agent = new UIAgent(client, options =>
+        {
+            options.Thread = thread;
+        });
+        return (agent, client, thread);
+    }
+
+    private static (UIAgent agent, DelegatingStreamingChatClient client, InMemoryConversationThread thread) CreateAgentWithExistingThread(
+        InMemoryConversationThread thread,
+        DelegatingStreamingChatClient existingClient)
+    {
+        var agent = new UIAgent(existingClient, options =>
+        {
+            options.Thread = thread;
+        });
+        return (agent, existingClient, thread);
+    }
+
+    private static Func<IEnumerable<ChatMessage>, ChatOptions?, CancellationToken, IAsyncEnumerable<ChatResponseUpdate>> CreateCountingHandler()
+    {
+        var count = 0;
+        return (msgs, opts, ct) =>
+        {
+            count++;
+            return ResponseEmitters.EmitTextResponse($"Reply {count}");
+        };
+    }
+}

--- a/src/Components/AI/test/Engine/ConversationThreadTests.cs
+++ b/src/Components/AI/test/Engine/ConversationThreadTests.cs
@@ -1,0 +1,243 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Engine;
+
+public class ConversationThreadTests
+{
+    [Fact]
+    public void AppendUserMessage_CompleteTurn_StoresUpdate()
+    {
+        var thread = new InMemoryConversationThread("t1");
+
+        thread.AppendUserMessage(new ChatMessage(ChatRole.User, "Hello"));
+        thread.CompleteTurn();
+
+        var updates = thread.GetUpdates();
+        Assert.Single(updates);
+        Assert.Equal(ChatRole.User, updates[0].Role);
+        var text = Assert.IsType<TextContent>(updates[0].Contents[0]);
+        Assert.Equal("Hello", text.Text);
+    }
+
+    [Fact]
+    public void AppendUpdate_WithCompleteTurn_StoresAssistantUpdates()
+    {
+        var thread = new InMemoryConversationThread("t1");
+
+        thread.AppendUserMessage(new ChatMessage(ChatRole.User, "Hi"));
+        thread.AppendUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [new TextContent("Hello")]
+        });
+        thread.AppendUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [new TextContent(" there")]
+        });
+        thread.CompleteTurn();
+
+        var updates = thread.GetUpdates();
+        Assert.Equal(3, updates.Count); // 1 user + 2 assistant
+    }
+
+    [Fact]
+    public void MultiTurn_TracksAllTurns()
+    {
+        var thread = new InMemoryConversationThread("t1");
+
+        // Turn 1
+        thread.AppendUserMessage(new ChatMessage(ChatRole.User, "First"));
+        thread.AppendUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [new TextContent("Reply 1")]
+        });
+        thread.CompleteTurn();
+
+        // Turn 2
+        thread.AppendUserMessage(new ChatMessage(ChatRole.User, "Second"));
+        thread.AppendUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [new TextContent("Reply 2")]
+        });
+        thread.CompleteTurn();
+
+        // Turn 3
+        thread.AppendUserMessage(new ChatMessage(ChatRole.User, "Third"));
+        thread.AppendUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [new TextContent("Reply 3")]
+        });
+        thread.CompleteTurn();
+
+        var updates = thread.GetUpdates();
+        Assert.Equal(6, updates.Count); // 3 user + 3 assistant
+
+        // Verify turn boundaries by counting user-role updates
+        var userUpdates = updates.Where(u => u.Role == ChatRole.User).ToList();
+        Assert.Equal(3, userUpdates.Count);
+    }
+
+    [Fact]
+    public void IncompleteTurn_NotInHistory()
+    {
+        var thread = new InMemoryConversationThread("t1");
+
+        thread.AppendUserMessage(new ChatMessage(ChatRole.User, "Hello"));
+        thread.AppendUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [new TextContent("partial")]
+        });
+        // No CompleteTurn call — simulates a failed turn
+
+        Assert.Empty(thread.GetUpdates());
+    }
+
+    [Fact]
+    public void GetMessageHistory_ReconstructsMessages()
+    {
+        var thread = new InMemoryConversationThread("t1");
+
+        thread.AppendUserMessage(new ChatMessage(ChatRole.User, "What is 2+2?"));
+        thread.AppendUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "msg-1",
+            Contents = [new TextContent("4")]
+        });
+        thread.CompleteTurn();
+
+        var history = thread.GetMessageHistory();
+        Assert.Equal(2, history.Count);
+
+        Assert.Equal(ChatRole.User, history[0].Role);
+        var userText = Assert.IsType<TextContent>(history[0].Contents[0]);
+        Assert.Equal("What is 2+2?", userText.Text);
+
+        Assert.Equal(ChatRole.Assistant, history[1].Role);
+    }
+
+    [Fact]
+    public void DetectsStatefulLLM_WhenConversationIdPresent()
+    {
+        var thread = new InMemoryConversationThread("t1");
+
+        Assert.False(thread.IsStateful);
+        Assert.Null(thread.ConversationId);
+
+        thread.AppendUserMessage(new ChatMessage(ChatRole.User, "Hi"));
+        thread.AppendUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            ConversationId = "conv-abc",
+            Contents = [new TextContent("Hello")]
+        });
+        thread.CompleteTurn();
+
+        Assert.True(thread.IsStateful);
+        Assert.Equal("conv-abc", thread.ConversationId);
+    }
+
+    [Fact]
+    public void RemainsStateless_WhenNoConversationId()
+    {
+        var thread = new InMemoryConversationThread("t1");
+
+        thread.AppendUserMessage(new ChatMessage(ChatRole.User, "Hi"));
+        thread.AppendUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [new TextContent("Hello")]
+        });
+        thread.CompleteTurn();
+
+        Assert.False(thread.IsStateful);
+        Assert.Null(thread.ConversationId);
+    }
+
+    [Fact]
+    public void ThreadId_IsPreserved()
+    {
+        var thread = new InMemoryConversationThread("my-thread-123");
+        Assert.Equal("my-thread-123", thread.ThreadId);
+    }
+
+    [Fact]
+    public void CompleteTurn_WithoutAppend_DoesNothing()
+    {
+        var thread = new InMemoryConversationThread("t1");
+        thread.CompleteTurn(); // No AppendUserMessage was called
+
+        Assert.Empty(thread.GetUpdates());
+    }
+
+    [Fact]
+    public void IncompleteTurn_ThenNewTurn_DiscardsIncomplete()
+    {
+        var thread = new InMemoryConversationThread("t1");
+
+        // Incomplete turn
+        thread.AppendUserMessage(new ChatMessage(ChatRole.User, "First"));
+        thread.AppendUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [new TextContent("partial")]
+        });
+        // No CompleteTurn — discard
+
+        // New complete turn
+        thread.AppendUserMessage(new ChatMessage(ChatRole.User, "Second"));
+        thread.AppendUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [new TextContent("complete")]
+        });
+        thread.CompleteTurn();
+
+        var updates = thread.GetUpdates();
+        Assert.Equal(2, updates.Count);
+
+        var userText = Assert.IsType<TextContent>(updates[0].Contents[0]);
+        Assert.Equal("Second", userText.Text);
+    }
+
+    [Fact]
+    public void GetMessageHistory_MultiTurn_ReconstructsCorrectly()
+    {
+        var thread = new InMemoryConversationThread("t1");
+
+        thread.AppendUserMessage(new ChatMessage(ChatRole.User, "Q1"));
+        thread.AppendUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "msg-1",
+            Contents = [new TextContent("A1")]
+        });
+        thread.CompleteTurn();
+
+        thread.AppendUserMessage(new ChatMessage(ChatRole.User, "Q2"));
+        thread.AppendUpdate(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "msg-2",
+            Contents = [new TextContent("A2")]
+        });
+        thread.CompleteTurn();
+
+        var history = thread.GetMessageHistory();
+        Assert.Equal(4, history.Count);
+
+        Assert.Equal(ChatRole.User, history[0].Role);
+        Assert.Equal(ChatRole.Assistant, history[1].Role);
+        Assert.Equal(ChatRole.User, history[2].Role);
+        Assert.Equal(ChatRole.Assistant, history[3].Role);
+    }
+}

--- a/src/Components/AI/test/Engine/UIAgentThreadTests.cs
+++ b/src/Components/AI/test/Engine/UIAgentThreadTests.cs
@@ -1,0 +1,412 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Engine;
+
+public class UIAgentThreadTests
+{
+    [Fact]
+    public async Task SendMessage_WithThread_AppendsUserMessage()
+    {
+        var thread = new InMemoryConversationThread("t1");
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hi!"));
+
+        var agent = new UIAgent(client, options =>
+        {
+            options.Thread = thread;
+        });
+
+        await foreach (var _ in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "Hello")))
+        {
+        }
+
+        var updates = thread.GetUpdates();
+        Assert.True(updates.Count >= 1);
+        Assert.Equal(ChatRole.User, updates[0].Role);
+        var text = Assert.IsType<TextContent>(updates[0].Contents[0]);
+        Assert.Equal("Hello", text.Text);
+    }
+
+    [Fact]
+    public async Task SendMessage_WithThread_AppendsAllUpdates()
+    {
+        var thread = new InMemoryConversationThread("t1");
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitMultiTokenTextResponse(ct, "A", "B", "C"));
+
+        var agent = new UIAgent(client, options =>
+        {
+            options.Thread = thread;
+        });
+
+        await foreach (var _ in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "Hi")))
+        {
+        }
+
+        var updates = thread.GetUpdates();
+        // 1 user + 3 assistant tokens
+        Assert.Equal(4, updates.Count);
+        Assert.Equal(ChatRole.User, updates[0].Role);
+        Assert.Equal(ChatRole.Assistant, updates[1].Role);
+        Assert.Equal(ChatRole.Assistant, updates[2].Role);
+        Assert.Equal(ChatRole.Assistant, updates[3].Role);
+    }
+
+    [Fact]
+    public async Task SendMessage_WithThread_CallsCompleteTurn()
+    {
+        var thread = new InMemoryConversationThread("t1");
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("ok"));
+
+        var agent = new UIAgent(client, options =>
+        {
+            options.Thread = thread;
+        });
+
+        await foreach (var _ in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "go")))
+        {
+        }
+
+        // CompleteTurn was called, so updates should be visible
+        Assert.NotEmpty(thread.GetUpdates());
+    }
+
+    [Fact]
+    public async Task SendMessage_WithThread_FailedStream_DoesNotCommitTurn()
+    {
+        var thread = new InMemoryConversationThread("t1");
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitErrorAfterTokens(["partial"], new InvalidOperationException("boom")));
+
+        var agent = new UIAgent(client, options =>
+        {
+            options.Thread = thread;
+        });
+
+        var blocks = new List<ContentBlock>();
+        try
+        {
+            await foreach (var block in agent.SendMessageAsync(
+                new ChatMessage(ChatRole.User, "go")))
+            {
+                blocks.Add(block);
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            // Expected
+        }
+
+        // CompleteTurn was NOT called because the stream threw
+        Assert.Empty(thread.GetUpdates());
+    }
+
+    [Fact]
+    public async Task SendMessage_WithStatefulThread_SetsConversationId()
+    {
+        var thread = new InMemoryConversationThread("t1");
+        var client = new DelegatingStreamingChatClient();
+        ChatOptions? capturedOptions = null;
+        var callCount = 0;
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return EmitWithConversationId("conv-123", ct);
+            }
+            capturedOptions = opts;
+            return ResponseEmitters.EmitTextResponse("reply2");
+        });
+
+        var agent = new UIAgent(client, options =>
+        {
+            options.Thread = thread;
+        });
+
+        // First call — LLM returns ConversationId
+        await foreach (var _ in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "First")))
+        {
+        }
+
+        Assert.True(thread.IsStateful);
+        Assert.Equal("conv-123", thread.ConversationId);
+
+        // Second call — ConversationId should be set on ChatOptions
+        await foreach (var _ in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "Second")))
+        {
+        }
+
+        Assert.NotNull(capturedOptions);
+        Assert.Equal("conv-123", capturedOptions!.ConversationId);
+    }
+
+    [Fact]
+    public async Task SendMessage_WithoutThread_WorksAsNormal()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) =>
+            ResponseEmitters.EmitTextResponse("Hi!"));
+
+        var agent = new UIAgent(client);
+
+        var blocks = new List<ContentBlock>();
+        await foreach (var block in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "Hello")))
+        {
+            blocks.Add(block);
+        }
+
+        Assert.True(blocks.Count >= 2);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_ProducesCorrectBlocks()
+    {
+        // Step 1: Record a multi-turn conversation
+        var thread = new InMemoryConversationThread("t1");
+        var client = new DelegatingStreamingChatClient();
+        var callCount = 0;
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            return ResponseEmitters.EmitTextResponse($"Reply {callCount}");
+        });
+
+        var agent1 = new UIAgent(client, options =>
+        {
+            options.Thread = thread;
+        });
+
+        await foreach (var _ in agent1.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "First")))
+        {
+        }
+        await foreach (var _ in agent1.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "Second")))
+        {
+        }
+
+        Assert.NotEmpty(thread.GetUpdates());
+
+        // Step 2: Restore on a fresh agent with same thread
+        var agent2 = new UIAgent(client, options =>
+        {
+            options.Thread = thread;
+        });
+
+        var restoredBlocks = await agent2.RestoreAsync();
+
+        // Should have user blocks and assistant blocks for both turns
+        var userBlocks = restoredBlocks.Where(b => b.Role == ChatRole.User).ToList();
+        var assistantBlocks = restoredBlocks.Where(b => b.Role == ChatRole.Assistant).ToList();
+        Assert.Equal(2, userBlocks.Count);
+        Assert.Equal(2, assistantBlocks.Count);
+
+        // Verify user messages
+        var user1 = Assert.IsType<RichContentBlock>(userBlocks[0]);
+        Assert.Equal("First", user1.RawText);
+        var user2 = Assert.IsType<RichContentBlock>(userBlocks[1]);
+        Assert.Equal("Second", user2.RawText);
+
+        // Verify assistant responses
+        var asst1 = Assert.IsType<RichContentBlock>(assistantBlocks[0]);
+        Assert.Equal("Reply 1", asst1.RawText);
+        var asst2 = Assert.IsType<RichContentBlock>(assistantBlocks[1]);
+        Assert.Equal("Reply 2", asst2.RawText);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_RestoresState()
+    {
+        // Record a conversation with state content
+        var thread = new InMemoryConversationThread("t1");
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((msgs, opts, ct) => EmitStateAndText(ct));
+
+        var agent1 = new UIAgent<TestState>(client,
+            configure: options =>
+            {
+                options.Thread = thread;
+                options.StateMapper = ctx =>
+                {
+                    foreach (var content in ctx.UnhandledContents)
+                    {
+                        if (content is TestStateContent sc)
+                        {
+                            ctx.MarkHandled(sc);
+                            ctx.SetState(sc.StateValue);
+                            return true;
+                        }
+                    }
+                    return false;
+                };
+            });
+
+        await foreach (var _ in agent1.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "Give me state")))
+        {
+        }
+
+        Assert.Equal("Updated", agent1.State.Value.Name);
+
+        // Restore on fresh agent
+        var agent2 = new UIAgent<TestState>(client,
+            configure: options =>
+            {
+                options.Thread = thread;
+                options.StateMapper = ctx =>
+                {
+                    foreach (var content in ctx.UnhandledContents)
+                    {
+                        if (content is TestStateContent sc)
+                        {
+                            ctx.MarkHandled(sc);
+                            ctx.SetState(sc.StateValue);
+                            return true;
+                        }
+                    }
+                    return false;
+                };
+            });
+
+        await agent2.RestoreAsync();
+
+        Assert.Equal("Updated", agent2.State.Value.Name);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_ThenSendMessage_ContinuesConversation()
+    {
+        var thread = new InMemoryConversationThread("t1");
+        var client = new DelegatingStreamingChatClient();
+        var callCount = 0;
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            callCount++;
+            return ResponseEmitters.EmitTextResponse($"Reply {callCount}");
+        });
+
+        // Record 1 turn
+        var agent1 = new UIAgent(client, options =>
+        {
+            options.Thread = thread;
+        });
+
+        await foreach (var _ in agent1.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "First")))
+        {
+        }
+
+        // Restore and then send a new message
+        var agent2 = new UIAgent(client, options =>
+        {
+            options.Thread = thread;
+        });
+
+        await agent2.RestoreAsync();
+
+        // New message after restore
+        IEnumerable<ChatMessage>? capturedMessages = null;
+        client.SetHandler((msgs, opts, ct) =>
+        {
+            capturedMessages = msgs.ToList();
+            return ResponseEmitters.EmitTextResponse("Reply after restore");
+        });
+
+        await foreach (var _ in agent2.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "Second")))
+        {
+        }
+
+        // The history sent to the LLM should include both the restored turn and the new message
+        Assert.NotNull(capturedMessages);
+        var messageList = capturedMessages!.ToList();
+        Assert.True(messageList.Count >= 3, $"Expected at least 3 messages, got {messageList.Count}");
+    }
+
+    [Fact]
+    public async Task RestoreAsync_NoThread_ReturnsEmpty()
+    {
+        var client = new DelegatingStreamingChatClient();
+        var agent = new UIAgent(client);
+
+        var blocks = await agent.RestoreAsync();
+
+        Assert.Empty(blocks);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_EmptyThread_ReturnsEmpty()
+    {
+        var thread = new InMemoryConversationThread("t1");
+        var client = new DelegatingStreamingChatClient();
+        var agent = new UIAgent(client, options =>
+        {
+            options.Thread = thread;
+        });
+
+        var blocks = await agent.RestoreAsync();
+
+        Assert.Empty(blocks);
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> EmitWithConversationId(
+        string conversationId,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            ConversationId = conversationId,
+            MessageId = Guid.NewGuid().ToString("N"),
+            Contents = [new TextContent("reply1")]
+        };
+        await Task.CompletedTask;
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> EmitStateAndText(
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [new TestStateContent
+            {
+                StateValue = new TestState { Name = "Updated" }
+            }]
+        };
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "msg-1",
+            Contents = [new TextContent("Here's the result")]
+        };
+        await Task.CompletedTask;
+    }
+
+    internal class TestState
+    {
+        public string Name { get; set; } = "";
+    }
+
+    internal class TestStateContent : AIContent
+    {
+        public TestState StateValue { get; set; } = new();
+    }
+}

--- a/src/Components/AI/test/TestHelpers/InMemoryConversationThread.cs
+++ b/src/Components/AI/test/TestHelpers/InMemoryConversationThread.cs
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+
+internal sealed class InMemoryConversationThread : IConversationThread
+{
+    private readonly List<ChatResponseUpdate> _updates = new();
+    private List<ChatResponseUpdate>? _currentTurn;
+
+    internal InMemoryConversationThread(string threadId)
+    {
+        ThreadId = threadId;
+    }
+
+    public string ThreadId { get; }
+    public bool IsStateful { get; private set; }
+    public string? ConversationId { get; private set; }
+
+    public void AppendUserMessage(ChatMessage message)
+    {
+        _currentTurn = new List<ChatResponseUpdate>();
+
+        _currentTurn.Add(new ChatResponseUpdate
+        {
+            Role = message.Role,
+            Contents = [.. message.Contents]
+        });
+    }
+
+    public void AppendUpdate(ChatResponseUpdate update)
+    {
+        _currentTurn?.Add(update);
+
+        if (!IsStateful && update.ConversationId is not null)
+        {
+            IsStateful = true;
+            ConversationId = update.ConversationId;
+        }
+    }
+
+    public void CompleteTurn()
+    {
+        if (_currentTurn is not null)
+        {
+            _updates.AddRange(_currentTurn);
+            _currentTurn = null;
+        }
+    }
+
+    public IReadOnlyList<ChatResponseUpdate> GetUpdates() => _updates;
+
+    public IReadOnlyList<ChatMessage> GetMessageHistory()
+    {
+        var messages = new List<ChatMessage>();
+        List<ChatResponseUpdate>? currentGroup = null;
+
+        foreach (var update in _updates)
+        {
+            // A user-role update marks the start of a new turn
+            if (update.Role == ChatRole.User)
+            {
+                // Flush previous assistant group
+                if (currentGroup is { Count: > 0 })
+                {
+                    var response = currentGroup.ToChatResponse();
+                    foreach (var msg in response.Messages)
+                    {
+                        messages.Add(msg);
+                    }
+                }
+
+                messages.Add(new ChatMessage(ChatRole.User, [.. update.Contents]));
+                currentGroup = new List<ChatResponseUpdate>();
+            }
+            else
+            {
+                currentGroup ??= new List<ChatResponseUpdate>();
+                currentGroup.Add(update);
+            }
+        }
+
+        // Flush trailing assistant group
+        if (currentGroup is { Count: > 0 })
+        {
+            var response = currentGroup.ToChatResponse();
+            foreach (var msg in response.Messages)
+            {
+                messages.Add(msg);
+            }
+        }
+
+        return messages;
+    }
+}

--- a/src/Components/AI/test/TestHelpers/NullAntiforgeryStateProvider.cs
+++ b/src/Components/AI/test/TestHelpers/NullAntiforgeryStateProvider.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.Forms;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+
+internal sealed class NullAntiforgeryStateProvider : AntiforgeryStateProvider
+{
+    public override AntiforgeryRequestToken? GetAntiforgeryToken() => null;
+}


### PR DESCRIPTION
Part of the overall Components.AI design: https://github.com/dotnet/aspnetcore/issues/66178

Builds on #66184

---

# Conversation Threads, Form Input, and Multimodal Attachments

## Summary

Add three capabilities that complete the conversation experience: persistent conversation history via `IConversationThread`, SSR-compatible form-based input via `AgentFormBoundary` and `FormMessageInput`, and file attachment support in messages.

## Motivation

### Conversation persistence

Without persistence, refreshing the page or navigating away loses the entire conversation. Applications need to store and restore conversation history. The storage mechanism varies, so the library defines a minimal interface rather than a specific implementation.

### Static SSR support

Not all Blazor applications use interactive render modes. Static SSR applications render HTML on the server and accept user input via form POST. The core `MessageInput` uses `onclick` events requiring an interactive circuit. SSR applications need a form-based alternative.

### File attachments

Users frequently need to share images, documents, and files in chat. The LLM receives these as `DataContent` items alongside text.

## Goals

- Define `IConversationThread` as a pluggable interface for conversation persistence.
- Integrate `IConversationThread` into `UIAgent`: record messages and updates, restore from history.
- Provide `AgentFormBoundary` for SSR form-based chat interactions.
- Provide `FormMessageInput` for SSR text input.
- Support multimodal message submission (text + file attachments).
- Automatically restore conversation on `AgentBoundary` initialization when a thread has history.
- Support stateful LLMs: when `ConversationId` is set, send only the latest message.

## Non-goals

- Built-in storage implementations (Redis, Cosmos DB, etc.).
- Real-time synchronization across multiple clients.
- File upload progress indicators.
- Server-side file storage — attachments are sent inline as `DataContent`.

## Detailed design

### IConversationThread interface

```csharp
public interface IConversationThread
{
    string ThreadId { get; }
    bool IsStateful { get; }
    string? ConversationId { get; }
    void AppendUserMessage(ChatMessage message);
    void AppendUpdate(ChatResponseUpdate update);
    void CompleteTurn();
    IReadOnlyList<ChatResponseUpdate> GetUpdates();
    IReadOnlyList<ChatMessage> GetMessageHistory();
}
```

### Conversation restore flow

When `AgentBoundary` initializes with a thread that has persisted updates, it calls `RestoreAsync()` which replays persisted `ChatResponseUpdate` objects through the pipeline, rebuilding the conversation turns.

### SSR form-based input

`AgentFormBoundary` binds via `[SupplyParameterFromForm]`:
- `UserMessage` — text from the input.
- `BlockAction` — approval actions (format: `"approve:blockId"` or `"reject:blockId"`).

### Multimodal attachment flow

`MessageInput` supports file attachments when `AllowAttachments=true`. Files are read as `byte[]`, stored as `AttachedFile` objects, and sent as `DataContent` items alongside `TextContent`. Max 10MB per file.

### Stateful LLM support

When `IConversationThread.IsStateful` is `true` and `ConversationId` is set, `UIAgent` sends only the latest message. The LLM service manages history server-side.

## Risks

- **Thread data consistency**: Mitigated by `CompleteTurn()` acting as a commit marker.
- **SSR approval race**: Mitigated by Blazor's streaming rendering.
- **Large attachment memory**: Mitigated by the 10MB limit.

## Drawbacks

- `AgentFormBoundary` duplicates some logic from `AgentBoundary`. Accepted because the form boundary has genuinely different initialization logic.
- `FormMessageInput` is a separate component from `MessageInput` because the rendering is fundamentally different.

## Test coverage

288 tests (cumulative) covering:
- `IConversationThread` contract: append, read, commit lifecycle.
- `UIAgent` thread integration: message recording, update recording, restore replay.
- `AgentContext` restore: turn reconstruction from thread history.
- `AgentFormBoundary` form submission: text messages, approval actions, rejection actions.
- `FormMessageInput` rendering: disabled state, placeholder, name attribute.
- `MessageInput` attachments: file selection, preview, removal, size limit, submission with `DataContent`.
- Stateful LLM scenario: `ConversationId` propagation.