### PR TITLE
Update Markdownlint npm versions

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -20,9 +20,9 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
-        node-version: 16.x
+        node-version: 24.x
     - name: Run Markdownlint
       run: |
         echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"
-        npm i -g markdownlint-cli@0.45.0
+        npm i -g markdownlint-cli@0.48.0
         markdownlint "docs/**/*.md"


### PR DESCRIPTION
The linter has started failing because we need at least an 18.x version of node:

> SyntaxError: The requested module 'node:diagnostics_channel' does not provide an export named 'tracingChannel'

This goes along w/ what @javiercn 