### PR TITLE
[release/8.0] Update @azure/msal-browser from 2.x to 4.x

### DIFF
--- a/src/Components/WebAssembly/Authentication.Msal/src/Interop/AuthenticationService.ts
+++ b/src/Components/WebAssembly/Authentication.Msal/src/Interop/AuthenticationService.ts
@@ -144,6 +144,10 @@ class MsalAuthorizeService implements AuthorizeService {
         this._msalApplication = new Msal.PublicClientApplication(this._settings);
     }
 
+    async initialize(): Promise<void> {
+        await this._msalApplication.initialize();
+    }
+
     getAccount() {
         if (this._account) {
             return this._account;
@@ -283,7 +287,7 @@ class MsalAuthorizeService implements AuthorizeService {
             return await this._msalApplication.loginPopup(request);
         } catch (e) {
             // If the user explicitly cancelled the pop-up, avoid performing a redirect.
-            if (this.isMsalError(e) && e.errorCode !== Msal.BrowserAuthErrorMessage.userCancelledError.code) {
+            if (this.isMsalError(e) && e.errorCode !== Msal.BrowserAuthErrorCodes.userCancelled) {
                 this.debug('User canceled sign-in pop-up');
                 this.signInWithRedirect(request);
             } else {
@@ -466,6 +470,7 @@ export class AuthenticationService {
     public static async init(settings: AuthorizeServiceConfiguration, jsLoggingOptions: JavaScriptLoggingOptions) {
         if (!AuthenticationService._initialized) {
             AuthenticationService.instance = new MsalAuthorizeService(settings, new Logger(jsLoggingOptions));
+            await AuthenticationService.instance.initialize();
             AuthenticationService.instance.initializeMsalHandler();
             AuthenticationService._initialized = true;
         }

--- a/src/Components/WebAssembly/Authentication.Msal/src/Interop/package.json
+++ b/src/Components/WebAssembly/Authentication.Msal/src/Interop/package.json
@@ -26,7 +26,7 @@
     "webpack-cli": "^4.9.2"
   },
   "dependencies": {
-    "@azure/msal-browser": "^2.39.0"
+    "@azure/msal-browser": "^4.30.0"
   },
   "resolutions": {
     "ansi-regex": "5.0.1",

--- a/src/Components/WebAssembly/Authentication.Msal/src/Interop/yarn.lock
+++ b/src/Components/WebAssembly/Authentication.Msal/src/Interop/yarn.lock
@@ -10,17 +10,17 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@azure/msal-browser@^2.39.0":
-  version "2.39.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/msal-browser/-/msal-browser-2.39.0.tgz#684fd3974c2628b2dffd04a4c8416a0945b42b69"
-  integrity sha1-aE/Tl0wmKLLf/QSkyEFqCUW0K2k=
+"@azure/msal-browser@^4.30.0":
+  version "4.30.0"
+  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/msal-browser/-/msal-browser-4.30.0.tgz"
+  integrity sha1-MPuveuJtmrdnGqvKPUH5xS0qOTc=
   dependencies:
-    "@azure/msal-common" "13.3.3"
+    "@azure/msal-common" "15.17.0"
 
-"@azure/msal-common@13.3.3":
-  version "13.3.3"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/msal-common/-/msal-common-13.3.3.tgz#b4963c9e5a164ed890b204becb036303ccf4f6ac"
-  integrity sha1-tJY8nloWTtiQsgS+ywNjA8z09qw=
+"@azure/msal-common@15.17.0":
+  version "15.17.0"
+  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/msal-common/-/msal-common-15.17.0.tgz"
+  integrity sha1-rjwDN4yFJkKxyaMDOA6UXCuJfwI=
 
 "@babel/code-frame@^7.18.6":
   version "7.18.6"


### PR DESCRIPTION
Fixes CVE in @azure/msal-browser by upgrading to 4.30.0 (LTS).

Changes:
- package.json: ^2.39.0 -> ^4.30.0
- AuthenticationService.ts: Add required initialize() call (MSAL 3.x+), update BrowserAuthErrorMessage to BrowserAuthErrorCodes
- yarn.lock: Updated msal-browser and msal-common entries