### PR TITLE
Rename microsoft.docs.mcp to microsoft-docs-mcp

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -7,7 +7,7 @@
         "@playwright/mcp@latest"
       ]
     },
-    "microsoft.docs.mcp": {
+    "microsoft-docs-mcp": {
       "type": "http",
       "url": "https://learn.microsoft.com/api/mcp"
     }


### PR DESCRIPTION
> Error: MCP server 'microsoft.docs.mcp' in C:/github/aspnetcore\.vscode/mcp.json contains invalid characters: '..'. Only alphanumeric characters, underscores, and hyphens are allowed.