### PR TITLE
 Fix Virtualize table-mode scrolling in CSS Grid layouts (e.g. Aspire Dashboard)

### DIFF
--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -357,6 +357,16 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
       return;
     }
 
+    // Re-render overwrites the entire style attribute that init/refreshObservedElements applied. Re-apply it.
+    if (isTable) {
+      if (spacerBefore.style.display !== 'table-row') {
+        spacerBefore.style.display = 'table-row';
+      }
+      if (spacerAfter.style.display !== 'table-row') {
+        spacerAfter.style.display = 'table-row';
+      }
+    }
+
     const intersectingEntries = entries.filter(entry => {
       if (entry.isIntersecting) {
         if (entry.target === spacerAfter) {
@@ -382,7 +392,17 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
 
     rangeBetweenSpacers.setStartAfter(spacerBefore);
     rangeBetweenSpacers.setEndBefore(spacerAfter);
-    const spacerSeparation = rangeBetweenSpacers.getBoundingClientRect().height / scaleFactor;
+    let spacerSeparation = rangeBetweenSpacers.getBoundingClientRect().height / scaleFactor;
+
+    if (isTable && spacerSeparation > 0) {
+      const firstTr = spacerBefore.nextElementSibling;
+      const lastTr = spacerAfter.previousElementSibling;
+      const fc = firstTr && firstTr !== spacerAfter ? firstTr.querySelector('td,th') as HTMLElement | null : null;
+      const lc = lastTr && lastTr !== spacerBefore ? lastTr.querySelector('td,th') as HTMLElement | null : null;
+      if (fc && lc) {
+        spacerSeparation = (lc.getBoundingClientRect().bottom - fc.getBoundingClientRect().top) / scaleFactor;
+      }
+    }
 
     intersectingEntries.forEach((entry): void => {
       const containerSize = (entry.rootBounds?.height ?? 0) / scaleFactor;

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -1729,6 +1729,68 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         Browser.True(isFirstRowId1);
     }
 
+    [Fact]
+    public void QuickGrid_AspireLikeThumbScrollToEnd_DoesNotLeaveBlankTail()
+    {
+        Browser.MountTestComponent<BasicTestApp.QuickGridTest.QuickGridAspireLikeComponent>();
+
+        var container = Browser.Exists(By.Id("aspire-like-grid"));
+        var totalItems = Browser.Exists(By.Id("aspire-total-items"));
+        var maxDepth = Browser.Exists(By.Id("aspire-max-depth"));
+        var js = (IJavaScriptExecutor)Browser;
+
+        Browser.Equal("Total items: 10000", () => totalItems.Text);
+        Browser.True(() => int.Parse(maxDepth.Text.Replace("Max depth: ", string.Empty, StringComparison.Ordinal), CultureInfo.InvariantCulture) >= 40);
+        WaitForQuickGridDataRows(container);
+
+        js.ExecuteScript("arguments[0].scrollTop = arguments[0].scrollHeight", container);
+
+        var diagnostics = new System.Text.StringBuilder();
+        var pollCount = 0;
+        Browser.True(() =>
+        {
+            pollCount++;
+            var metrics = (IReadOnlyDictionary<string, object>)js.ExecuteScript(
+                "var c = arguments[0];" +
+                "var spacers = c.querySelectorAll('[aria-hidden]');" +
+                "var rows = c.querySelectorAll('tbody tr:not([aria-hidden])');" +
+                "var firstId = -1;" +
+                "var lastId = -1;" +
+                "for (var i = 0; i < rows.length; i++) {" +
+                "  var marker = rows[i].querySelector('.aspire-row-id');" +
+                "  if (marker) { var parsed = parseInt(marker.textContent, 10); if (!Number.isNaN(parsed)) { firstId = parsed; break; } }" +
+                "}" +
+                "for (var i = rows.length - 1; i >= 0; i--) {" +
+                "  var marker = rows[i].querySelector('.aspire-row-id');" +
+                "  if (marker) { var parsed = parseInt(marker.textContent, 10); if (!Number.isNaN(parsed)) { lastId = parsed; break; } }" +
+                "}" +
+                "return {" +
+                "  remaining: c.scrollHeight - c.scrollTop - c.clientHeight," +
+                "  scrollTop: c.scrollTop," +
+                "  scrollHeight: c.scrollHeight," +
+                "  clientHeight: c.clientHeight," +
+                "  spacerBefore: spacers.length >= 1 ? spacers[0].offsetHeight : -1," +
+                "  spacerAfter: spacers.length >= 2 ? spacers[spacers.length - 1].offsetHeight : -1," +
+                "  firstId: firstId," +
+                "  lastId: lastId" +
+                "};",
+                container);
+
+            var remaining = Convert.ToDouble(metrics["remaining"], CultureInfo.InvariantCulture);
+            var scrollTop = Convert.ToDouble(metrics["scrollTop"], CultureInfo.InvariantCulture);
+            var scrollHeight = Convert.ToDouble(metrics["scrollHeight"], CultureInfo.InvariantCulture);
+            var clientHeight = Convert.ToDouble(metrics["clientHeight"], CultureInfo.InvariantCulture);
+            var spacerBefore = Convert.ToDouble(metrics["spacerBefore"], CultureInfo.InvariantCulture);
+            var spacerAfter = Convert.ToDouble(metrics["spacerAfter"], CultureInfo.InvariantCulture);
+            var firstId = Convert.ToInt32(metrics["firstId"], CultureInfo.InvariantCulture);
+            var lastId = Convert.ToInt32(metrics["lastId"], CultureInfo.InvariantCulture);
+
+            diagnostics.AppendLine(CultureInfo.InvariantCulture, $"poll #{pollCount}: scrollTop={scrollTop:F1}, scrollHeight={scrollHeight:F1}, clientHeight={clientHeight:F1}, remaining={remaining:F1}, spacerBefore={spacerBefore:F1}, spacerAfter={spacerAfter:F1}, firstId={firstId}, lastId={lastId}");
+
+            return spacerAfter < 1 && firstId > 9950 && lastId == 10000;
+        }, $"Aspire-like QuickGrid should not get stranded in a large blank tail after dragging the scrollbar thumb to the bottom.{Environment.NewLine}{diagnostics}");
+    }
+
     private void WaitForQuickGridDataRows(IWebElement container)
         => Browser.True(() => CheckQuickGridFirstRow(container, text => int.TryParse(text, out _)));
 

--- a/src/Components/test/testassets/BasicTestApp/QuickGridTest/QuickGridAspireLikeComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/QuickGridTest/QuickGridAspireLikeComponent.razor
@@ -1,0 +1,117 @@
+@using System.Globalization
+@using System.Linq
+@using System.Reflection
+@using Microsoft.AspNetCore.Components.QuickGrid
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+
+<style>
+    #aspire-like-grid {
+        height: 476px;
+        overflow: auto;
+    }
+</style>
+
+<p id="aspire-total-items">Total items: @_totalItemCount</p>
+<p id="aspire-max-depth">Max depth: @_maxDepth</p>
+
+<div id="aspire-like-grid">
+    <QuickGrid @ref="_grid" ItemsProvider="@_itemsProvider" Virtualize="true" ItemSize="32">
+        <TemplateColumn Title="Name">
+            <span class="aspire-row-id" hidden>@context.Id</span>
+            <span>@context.Name</span>
+        </TemplateColumn>
+        <PropertyColumn Property="@(r => r.Resource)" />
+        <PropertyColumn Property="@(r => r.Duration)" />
+    </QuickGrid>
+</div>
+
+@code {
+    private static readonly IReadOnlyList<AspireLikeRow> s_allRows = CreateRows();
+
+    private QuickGrid<AspireLikeRow> _grid = default!;
+    private GridItemsProvider<AspireLikeRow> _itemsProvider = default!;
+    private int _totalItemCount = s_allRows.Count;
+    private int _maxDepth = s_allRows.Max(r => r.Depth);
+
+    internal sealed class AspireLikeRow
+    {
+        public int Id { get; set; }
+        public int Depth { get; set; }
+        public bool HasChildren { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Resource { get; set; } = string.Empty;
+        public string Duration { get; set; } = string.Empty;
+    }
+
+    protected override void OnInitialized()
+    {
+        _itemsProvider = async request =>
+        {
+            await Task.Yield();
+
+            var items = s_allRows
+                .Skip(request.StartIndex)
+                .Take(request.Count ?? 100)
+                .ToList();
+
+            return GridItemsProviderResult.From(items, totalItemCount: _totalItemCount);
+        };
+    }
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (_grid is null)
+        {
+            return;
+        }
+
+        var virtualizeField = typeof(QuickGrid<AspireLikeRow>).GetField("_virtualizeComponent", BindingFlags.Instance | BindingFlags.NonPublic);
+        if (virtualizeField?.GetValue(_grid) is not Virtualize<(int, AspireLikeRow)> virtualize)
+        {
+            return;
+        }
+
+        if (virtualize.MaxItemCount != 10_000)
+        {
+            virtualize.MaxItemCount = 10_000;
+            StateHasChanged();
+        }
+    }
+
+    private static List<AspireLikeRow> CreateRows()
+    {
+        const int targetItemCount = 10_000;
+        var rows = new List<AspireLikeRow>(targetItemCount);
+        var nextId = 1;
+
+        for (var traceGroup = 0; rows.Count < targetItemCount; traceGroup++)
+        {
+            rows.Add(new AspireLikeRow
+            {
+                Id = nextId++,
+                Depth = 1,
+                HasChildren = true,
+                Name = $"GET /big-trace/{traceGroup}",
+                Resource = "Stress.ApiService",
+                Duration = "46.37s",
+            });
+
+            var depthLimit = 20 + (traceGroup % 28);
+
+            for (var depth = 1; depth <= depthLimit && rows.Count < targetItemCount; depth++)
+            {
+                rows.Add(new AspireLikeRow
+                {
+                    Id = nextId++,
+                    Depth = depth + 1,
+                    HasChildren = depth < depthLimit,
+                    Name = $"bigtrace-Span-{traceGroup}-{depth}",
+                    Resource = depth % 5 == 0 ? "Stress.Worker" : "Stress.ApiService",
+                    Duration = FormattableString.Invariant($"{Math.Max(0.03, 4.25 - (depth * 0.07)):0.00}s"),
+                });
+            }
+        }
+
+        return rows;
+    }
+}


### PR DESCRIPTION
# Problem

When Virtualize is used inside a `<table>` with CSS Grid layout (as FluentDataGrid / Aspire Dashboard does), scrolling past the initial viewport renders a completely blank grid. Thumb-dragging the scrollbar to the middle or bottom shows no content at all.

## Root cause:

 1. Spacer box lost after re-render. `FluentDataGrid` applies `tr { display: contents }` so that `<td>` cells participate directly in the CSS Grid. The spacer `<tr>` elements get this too. The JS `init()` sets `spacerAfter.style.display = 'table-row'` to give the spacer a real box, but Blazor's next re-render overwrites the entire style attribute, stripping the display override. If an `IntersectionObserver` callback fires before `refreshObservedElements` re-applies it, the spacer has `offsetHeight === 0` and the OnSpacerAfterVisible callback is skipped — so the virtual window never shifts and no new items load.
 2. Item height measurement drift. The `spacerSeparation` value (used to derive `_itemSize`) is measured via `Range.getBoundingClientRect().height` between the two spacer elements. In CSS Grid tables where `<tr>` has `display: contents`, the Range endpoints resolve to slightly wrong positions, producing a value ~1.7% shorter than the actual sum of cell heights (e.g. 755px instead of 768px for 24 × 32px rows). This underestimate compounds across large item counts (1185 ×  31.46 ≈ 37,280 vs actual 37,920), causing `itemsBefore` to oscillate on every render and trapping the component in a placeholder-only loop after a thumb jump.

## Fix

Two targeted changes in Virtualize.ts, table-mode (isTable) only. No C# changes, no API changes, no new DOM structure.

1. Re-apply display: table-row in processIntersectionEntries before any offsetHeight checks, closing the race window between Blazor's style overwrite and refreshObservedElements.

2. Cell-based measurement fallback. When `isTable`, measure `spacerSeparation` from the first rendered cell's top to the last rendered cell's bottom, instead of relying on Range endpoints that misalign in CSS Grid layouts. This produces the exact item height and eliminates the redistribution oscillation.

## Testing

 - New E2E test `QuickGrid_AspireLikeThumbScrollToEnd_DoesNotLeaveBlankTail`: 10,000-row QuickGrid with `ItemSize=32` and `MaxItemCount=10000`, scrolls to bottom and verifies rows 9950–10000 are rendered with no blank tail.
 - Manually verified against Aspire Stress Dashboard (GET /big-trace, 1185 spans): wheel scroll, thumb jump to middle, and thumb jump to bottom all render content correctly. Previously all showed blank grid.