### PR TITLE
Decode route values from RawTarget (#11544)

### DIFF
--- a/src/Http/Routing/src/Matching/DfaMatcher.cs
+++ b/src/Http/Routing/src/Matching/DfaMatcher.cs
@@ -110,6 +110,10 @@ internal sealed partial class DfaMatcher : Matcher
         var candidateState = useFastPath && candidateCount <= CandidateSetStackSize
             ? ((Span<CandidateState>)candidateStateStackArray)[..candidateCount]
             : (candidateStateArray = new CandidateState[candidateCount]);
+
+        // Matching and constraints still operate on Request.Path. RawTarget is only used
+        // when materializing captured values so encoded '/' can be decoded once without
+        // changing which endpoint wins.
         PathTokenizer rawPathTokenizer = default;
         var rawSegmentOffset = 0;
         var useRawText = path.Contains('%') &&

--- a/src/Http/Routing/src/Matching/DfaMatcher.cs
+++ b/src/Http/Routing/src/Matching/DfaMatcher.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Routing.Matching;
 
@@ -109,6 +110,10 @@ internal sealed partial class DfaMatcher : Matcher
         var candidateState = useFastPath && candidateCount <= CandidateSetStackSize
             ? ((Span<CandidateState>)candidateStateStackArray)[..candidateCount]
             : (candidateStateArray = new CandidateState[candidateCount]);
+        PathTokenizer rawPathTokenizer = default;
+        var rawSegmentOffset = 0;
+        var useRawText = path.Contains('%') &&
+            RawTargetRouteValueDecoder.TryGetPathTokenizer(httpContext, out rawPathTokenizer, out rawSegmentOffset);
 
         for (var i = 0; i < candidateCount; i++)
         {
@@ -140,12 +145,12 @@ internal sealed partial class DfaMatcher : Matcher
 
                 if ((flags & Candidate.CandidateFlags.HasCaptures) != 0)
                 {
-                    ProcessCaptures(slots, candidate.Captures, path, segments);
+                    ProcessCaptures(slots, candidate.Captures, path, segments, rawPathTokenizer, rawSegmentOffset, useRawText);
                 }
 
                 if ((flags & Candidate.CandidateFlags.HasCatchAll) != 0)
                 {
-                    ProcessCatchAll(slots, candidate.CatchAll, path, segments);
+                    ProcessCatchAll(slots, candidate.CatchAll, path, segments, rawPathTokenizer, rawSegmentOffset, useRawText);
                 }
 
                 state.Values = RouteValueDictionary.FromArray(slots);
@@ -235,7 +240,10 @@ internal sealed partial class DfaMatcher : Matcher
         KeyValuePair<string, object?>[] slots,
         (string parameterName, int segmentIndex, int slotIndex)[] captures,
         string path,
-        ReadOnlySpan<PathSegment> segments)
+        ReadOnlySpan<PathSegment> segments,
+        PathTokenizer rawPathTokenizer,
+        int rawSegmentOffset,
+        bool useRawText)
     {
         for (var i = 0; i < captures.Length; i++)
         {
@@ -246,9 +254,19 @@ internal sealed partial class DfaMatcher : Matcher
                 var segment = segments[segmentIndex];
                 if (parameterName != null && segment.Length > 0)
                 {
+                    var value = path.Substring(segment.Start, segment.Length);
+                    if (useRawText)
+                    {
+                        var rawSegmentIndex = segmentIndex + rawSegmentOffset;
+                        if ((uint)rawSegmentIndex < (uint)rawPathTokenizer.Count)
+                        {
+                            value = RawTargetRouteValueDecoder.Decode(rawPathTokenizer[rawSegmentIndex]);
+                        }
+                    }
+
                     slots[slotIndex] = new KeyValuePair<string, object?>(
                         parameterName,
-                        path.Substring(segment.Start, segment.Length));
+                        value);
                 }
             }
         }
@@ -258,7 +276,10 @@ internal sealed partial class DfaMatcher : Matcher
         KeyValuePair<string, object?>[] slots,
         in (string parameterName, int segmentIndex, int slotIndex) catchAll,
         string path,
-        ReadOnlySpan<PathSegment> segments)
+        ReadOnlySpan<PathSegment> segments,
+        PathTokenizer rawPathTokenizer,
+        int rawSegmentOffset,
+        bool useRawText)
     {
         // Read segmentIndex to local both to skip double read from stack value
         // and to use the same in-bounds validated variable to access the array.
@@ -266,9 +287,23 @@ internal sealed partial class DfaMatcher : Matcher
         if ((uint)segmentIndex < (uint)segments.Length)
         {
             var segment = segments[segmentIndex];
+            var value = path.Substring(segment.Start);
+            if (useRawText)
+            {
+                var rawSegmentIndex = segmentIndex + rawSegmentOffset;
+                if ((uint)rawSegmentIndex < (uint)rawPathTokenizer.Count)
+                {
+                    var rawSegment = rawPathTokenizer[rawSegmentIndex];
+                    value = RawTargetRouteValueDecoder.Decode(new StringSegment(
+                        rawSegment.Buffer!,
+                        rawSegment.Offset,
+                        rawSegment.Buffer!.Length - rawSegment.Offset));
+                }
+            }
+
             slots[catchAll.slotIndex] = new KeyValuePair<string, object?>(
                 catchAll.parameterName,
-                path.Substring(segment.Start));
+                value);
         }
     }
 

--- a/src/Http/Routing/src/Matching/RawTargetRouteValueDecoder.cs
+++ b/src/Http/Routing/src/Matching/RawTargetRouteValueDecoder.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.AspNetCore.Routing.Matching;
+
+internal static class RawTargetRouteValueDecoder
+{
+    public static bool TryGetPathTokenizer(HttpContext httpContext, out PathTokenizer tokenizer, out int segmentOffset)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        tokenizer = default;
+        segmentOffset = 0;
+
+        var rawTarget = httpContext.Features.Get<IHttpRequestFeature>()?.RawTarget;
+        if (string.IsNullOrEmpty(rawTarget) || rawTarget[0] != '/')
+        {
+            return false;
+        }
+
+        var queryIndex = rawTarget.IndexOf('?');
+        var rawPath = queryIndex >= 0 ? rawTarget[..queryIndex] : rawTarget;
+        if (!rawPath.Contains('%'))
+        {
+            return false;
+        }
+
+        tokenizer = new PathTokenizer(new PathString(rawPath));
+        if (httpContext.Request.PathBase.HasValue)
+        {
+            segmentOffset = new PathTokenizer(httpContext.Request.PathBase).Count;
+        }
+
+        return true;
+    }
+
+    public static string Decode(StringSegment segment)
+    {
+        var value = segment.AsSpan();
+        if (!value.Contains('%'))
+        {
+            return segment.ToString();
+        }
+
+        return Uri.UnescapeDataString(segment.ToString());
+    }
+}

--- a/src/Http/Routing/src/Matching/RawTargetRouteValueDecoder.cs
+++ b/src/Http/Routing/src/Matching/RawTargetRouteValueDecoder.cs
@@ -32,6 +32,8 @@ internal static class RawTargetRouteValueDecoder
         tokenizer = new PathTokenizer(new PathString(rawPath));
         if (httpContext.Request.PathBase.HasValue)
         {
+            // RawTarget still contains the original path base, so skip those segments
+            // when aligning raw segments with the matched route path.
             segmentOffset = new PathTokenizer(httpContext.Request.PathBase).Count;
         }
 

--- a/src/Http/Routing/src/Patterns/RoutePatternMatcher.cs
+++ b/src/Http/Routing/src/Patterns/RoutePatternMatcher.cs
@@ -67,19 +67,31 @@ internal sealed class RoutePatternMatcher
 
         if (httpContext.Request.Path.Value?.Contains('%') != true)
         {
-            return TryMatch(httpContext.Request.Path, values, httpContext: null);
+            return TryMatchCore(httpContext.Request.Path, values, httpContext: null);
         }
 
-        return TryMatch(httpContext.Request.Path, values, httpContext);
+        return TryMatchCore(httpContext.Request.Path, values, httpContext);
     }
 #endif
 
     public bool TryMatch(PathString path, RouteValueDictionary values)
     {
-        return TryMatch(path, values, httpContext: null);
+        return TryMatchCore(
+            path,
+            values
+#if !COMPONENTS
+            , httpContext: null
+#endif
+        );
     }
 
-    private bool TryMatch(PathString path, RouteValueDictionary values, HttpContext httpContext)
+    private bool TryMatchCore(
+        PathString path,
+        RouteValueDictionary values
+#if !COMPONENTS
+        , HttpContext httpContext
+#endif
+    )
     {
         ArgumentNullException.ThrowIfNull(values);
 
@@ -163,9 +175,15 @@ internal sealed class RoutePatternMatcher
 
         // At this point we've very likely got a match, so start capturing values for real.
         i = 0;
+#if !COMPONENTS
         PathTokenizer rawPathTokenizer = default;
         var rawSegmentIndex = 0;
         var useRawText = httpContext != null && Matching.RawTargetRouteValueDecoder.TryGetPathTokenizer(httpContext, out rawPathTokenizer, out rawSegmentIndex);
+#else
+        PathTokenizer rawPathTokenizer = default;
+        var rawSegmentIndex = 0;
+        const bool useRawText = false;
+#endif
         foreach (var requestSegment in pathTokenizer)
         {
             var pathSegment = RoutePattern.PathSegments[i++];
@@ -284,12 +302,16 @@ internal sealed class RoutePatternMatcher
         if (pathSegment.IsSimple && pathSegment.Parts[0] is RoutePatternParameterPart parameter && parameter.IsCatchAll)
         {
             // A catch-all captures til the end of the string.
-            var captured = useRawText
-                ? Matching.RawTargetRouteValueDecoder.Decode(new StringSegment(
+            var captured = requestSegment.Buffer.Substring(requestSegment.Offset);
+#if !COMPONENTS
+            if (useRawText)
+            {
+                captured = Matching.RawTargetRouteValueDecoder.Decode(new StringSegment(
                     rawRequestSegment.Buffer,
                     rawRequestSegment.Offset,
-                    rawRequestSegment.Buffer.Length - rawRequestSegment.Offset))
-                : requestSegment.Buffer.Substring(requestSegment.Offset);
+                    rawRequestSegment.Buffer.Length - rawRequestSegment.Offset));
+            }
+#endif
             if (captured.Length > 0)
             {
                 values[parameter.Name] = captured;
@@ -310,9 +332,14 @@ internal sealed class RoutePatternMatcher
             parameter = (RoutePatternParameterPart)pathSegment.Parts[0];
             if (requestSegment.Length > 0)
             {
-                values[parameter.Name] = useRawText
-                    ? Matching.RawTargetRouteValueDecoder.Decode(rawRequestSegment)
-                    : requestSegment.ToString();
+                var captured = requestSegment.ToString();
+#if !COMPONENTS
+                if (useRawText)
+                {
+                    captured = Matching.RawTargetRouteValueDecoder.Decode(rawRequestSegment);
+                }
+#endif
+                values[parameter.Name] = captured;
             }
             else
             {

--- a/src/Http/Routing/src/Patterns/RoutePatternMatcher.cs
+++ b/src/Http/Routing/src/Patterns/RoutePatternMatcher.cs
@@ -61,6 +61,9 @@ internal sealed class RoutePatternMatcher
     public RoutePattern RoutePattern { get; }
 
 #if !COMPONENTS
+    // This matcher is also compiled into the Components routing build, where there is
+    // no HttpContext or RawTarget. Keep the PathString-only path working there and only
+    // light up the RawTarget-aware overload for server-side routing.
     public bool TryMatch(HttpContext httpContext, RouteValueDictionary values)
     {
         ArgumentNullException.ThrowIfNull(httpContext);
@@ -176,6 +179,8 @@ internal sealed class RoutePatternMatcher
         // At this point we've very likely got a match, so start capturing values for real.
         i = 0;
 #if !COMPONENTS
+        // The match above already used PathString semantics. RawTarget is only consulted
+        // here so the captured route value can reflect the original encoded segment.
         PathTokenizer rawPathTokenizer = default;
         var rawSegmentIndex = 0;
         var useRawText = httpContext != null && Matching.RawTargetRouteValueDecoder.TryGetPathTokenizer(httpContext, out rawPathTokenizer, out rawSegmentIndex);

--- a/src/Http/Routing/src/Patterns/RoutePatternMatcher.cs
+++ b/src/Http/Routing/src/Patterns/RoutePatternMatcher.cs
@@ -60,7 +60,26 @@ internal sealed class RoutePatternMatcher
 
     public RoutePattern RoutePattern { get; }
 
+#if !COMPONENTS
+    public bool TryMatch(HttpContext httpContext, RouteValueDictionary values)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        if (httpContext.Request.Path.Value?.Contains('%') != true)
+        {
+            return TryMatch(httpContext.Request.Path, values, httpContext: null);
+        }
+
+        return TryMatch(httpContext.Request.Path, values, httpContext);
+    }
+#endif
+
     public bool TryMatch(PathString path, RouteValueDictionary values)
+    {
+        return TryMatch(path, values, httpContext: null);
+    }
+
+    private bool TryMatch(PathString path, RouteValueDictionary values, HttpContext httpContext)
     {
         ArgumentNullException.ThrowIfNull(values);
 
@@ -144,10 +163,20 @@ internal sealed class RoutePatternMatcher
 
         // At this point we've very likely got a match, so start capturing values for real.
         i = 0;
+        PathTokenizer rawPathTokenizer = default;
+        var rawSegmentIndex = 0;
+        var useRawText = httpContext != null && Matching.RawTargetRouteValueDecoder.TryGetPathTokenizer(httpContext, out rawPathTokenizer, out rawSegmentIndex);
         foreach (var requestSegment in pathTokenizer)
         {
             var pathSegment = RoutePattern.PathSegments[i++];
-            if (SavePathSegmentsAsValues(i, values, requestSegment, pathSegment))
+            var rawRequestSegment = default(StringSegment);
+            var hasRawRequestSegment = useRawText && (uint)rawSegmentIndex < (uint)rawPathTokenizer.Count;
+            if (hasRawRequestSegment)
+            {
+                rawRequestSegment = rawPathTokenizer[rawSegmentIndex++];
+            }
+
+            if (SavePathSegmentsAsValues(i, values, requestSegment, rawRequestSegment, hasRawRequestSegment, pathSegment))
             {
                 break;
             }
@@ -244,12 +273,23 @@ internal sealed class RoutePatternMatcher
         return true;
     }
 
-    private bool SavePathSegmentsAsValues(int index, RouteValueDictionary values, StringSegment requestSegment, RoutePatternPathSegment pathSegment)
+    private bool SavePathSegmentsAsValues(
+        int index,
+        RouteValueDictionary values,
+        StringSegment requestSegment,
+        StringSegment rawRequestSegment,
+        bool useRawText,
+        RoutePatternPathSegment pathSegment)
     {
         if (pathSegment.IsSimple && pathSegment.Parts[0] is RoutePatternParameterPart parameter && parameter.IsCatchAll)
         {
             // A catch-all captures til the end of the string.
-            var captured = requestSegment.Buffer.Substring(requestSegment.Offset);
+            var captured = useRawText
+                ? Matching.RawTargetRouteValueDecoder.Decode(new StringSegment(
+                    rawRequestSegment.Buffer,
+                    rawRequestSegment.Offset,
+                    rawRequestSegment.Buffer.Length - rawRequestSegment.Offset))
+                : requestSegment.Buffer.Substring(requestSegment.Offset);
             if (captured.Length > 0)
             {
                 values[parameter.Name] = captured;
@@ -270,7 +310,9 @@ internal sealed class RoutePatternMatcher
             parameter = (RoutePatternParameterPart)pathSegment.Parts[0];
             if (requestSegment.Length > 0)
             {
-                values[parameter.Name] = requestSegment.ToString();
+                values[parameter.Name] = useRawText
+                    ? Matching.RawTargetRouteValueDecoder.Decode(rawRequestSegment)
+                    : requestSegment.ToString();
             }
             else
             {

--- a/src/Http/Routing/src/RouteBase.cs
+++ b/src/Http/Routing/src/RouteBase.cs
@@ -110,9 +110,7 @@ public abstract partial class RouteBase : IRouter, INamedRouter
         EnsureMatcher();
         EnsureLoggers(context.HttpContext);
 
-        var requestPath = context.HttpContext.Request.Path;
-
-        if (!_matcher.TryMatch(requestPath, context.RouteData.Values))
+        if (!_matcher.TryMatch(context.HttpContext, context.RouteData.Values))
         {
             // If we got back a null value set, that means the URI did not match
             return Task.CompletedTask;

--- a/src/Http/Routing/src/Template/TemplateMatcher.cs
+++ b/src/Http/Routing/src/Template/TemplateMatcher.cs
@@ -84,4 +84,12 @@ public class TemplateMatcher
 
         return _routePatternMatcher.TryMatch(path, values);
     }
+
+    internal bool TryMatch(HttpContext httpContext, RouteValueDictionary values)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+        ArgumentNullException.ThrowIfNull(values);
+
+        return _routePatternMatcher.TryMatch(httpContext, values);
+    }
 }

--- a/src/Http/Routing/src/Tree/TreeRouter.cs
+++ b/src/Http/Routing/src/Tree/TreeRouter.cs
@@ -193,7 +193,7 @@ internal partial class TreeRouter
                     var matcher = item.TemplateMatcher;
                     try
                     {
-                        if (!matcher.TryMatch(context.HttpContext.Request.Path, context.RouteData.Values))
+                        if (!matcher.TryMatch(context.HttpContext, context.RouteData.Values))
                         {
                             continue;
                         }

--- a/src/Http/Routing/test/UnitTests/Matching/DfaMatcherTest.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/DfaMatcherTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing.Constraints;
 using Microsoft.AspNetCore.Routing.TestObjects;
 using Microsoft.Extensions.DependencyInjection;
@@ -98,6 +99,56 @@ public class DfaMatcherTest
 
         // Assert
         Assert.Null(httpContext.GetEndpoint());
+    }
+
+    [Theory]
+    [InlineData("/foo%2Fbar", "/foo%2Fbar", "foo/bar")]
+    [InlineData("/foo%2Fbar", "/foo%252Fbar", "foo%2Fbar")]
+    [InlineData("/http:%2F%2Fexample.com", "/http:%2F%2Fexample.com", "http://example.com")]
+    public async Task MatchAsync_UsesRawTargetToDecodeRouteValues(string path, string rawTarget, string expected)
+    {
+        // Arrange
+        var endpointDataSource = new DefaultEndpointDataSource(new List<Endpoint>
+            {
+                CreateEndpoint("/{value}", 0)
+            });
+
+        var matcher = CreateDfaMatcher(endpointDataSource);
+
+        var httpContext = CreateContext();
+        httpContext.Request.Path = path;
+        httpContext.Features.Get<IHttpRequestFeature>()!.RawTarget = rawTarget;
+
+        // Act
+        await matcher.MatchAsync(httpContext);
+
+        // Assert
+        Assert.NotNull(httpContext.GetEndpoint());
+        Assert.Equal(expected, httpContext.Request.RouteValues["value"]);
+    }
+
+    [Fact]
+    public async Task MatchAsync_UsesRawTargetToDecodeRouteValues_AfterPathBase()
+    {
+        // Arrange
+        var endpointDataSource = new DefaultEndpointDataSource(new List<Endpoint>
+            {
+                CreateEndpoint("/{value}", 0)
+            });
+
+        var matcher = CreateDfaMatcher(endpointDataSource);
+
+        var httpContext = CreateContext();
+        httpContext.Request.PathBase = "/base";
+        httpContext.Request.Path = "/foo%2Fbar";
+        httpContext.Features.Get<IHttpRequestFeature>()!.RawTarget = "/base/foo%2Fbar";
+
+        // Act
+        await matcher.MatchAsync(httpContext);
+
+        // Assert
+        Assert.NotNull(httpContext.GetEndpoint());
+        Assert.Equal("foo/bar", httpContext.Request.RouteValues["value"]);
     }
 
     [Theory]

--- a/src/Http/Routing/test/UnitTests/RouteTest.cs
+++ b/src/Http/Routing/test/UnitTests/RouteTest.cs
@@ -4,6 +4,7 @@
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing.Constraints;
 using Microsoft.AspNetCore.Routing.TestObjects;
 using Microsoft.AspNetCore.InternalTesting;
@@ -101,6 +102,54 @@ public class RouteTest
         Assert.Equal("Contoso", context.RouteData.DataTokens["company"]);
         Assert.Equal("Friday", context.RouteData.DataTokens["today"]);
         Assert.Same(originalDataTokens, context.RouteData.DataTokens);
+    }
+
+    [Theory]
+    [InlineData("{value}", "/foo%2Fbar", "/foo%2Fbar", "foo/bar")]
+    [InlineData("{value}", "/foo%2Fbar", "/foo%252Fbar", "foo%2Fbar")]
+    [InlineData("{*value}", "/foo%2Fbar/baz%2Fqux", "/foo%2Fbar/baz%2Fqux", "foo/bar/baz/qux")]
+    public async Task RouteAsync_UsesRawTargetToDecodeRouteValues(string template, string path, string rawTarget, string expected)
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+        services.AddOptions();
+        services.AddRouting();
+
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider(),
+        };
+        httpContext.Request.Path = path;
+        httpContext.Features.Get<IHttpRequestFeature>()!.RawTarget = rawTarget;
+
+        var context = new RouteContext(httpContext);
+
+        IDictionary<string, object> routeValues = null;
+        var mockTarget = new Mock<IRouter>(MockBehavior.Strict);
+        mockTarget
+            .Setup(s => s.RouteAsync(It.IsAny<RouteContext>()))
+            .Callback<RouteContext>(ctx =>
+            {
+                routeValues = ctx.RouteData.Values;
+                ctx.Handler = NullHandler;
+            })
+            .Returns(Task.FromResult(true));
+
+        var route = new Route(
+            mockTarget.Object,
+            template,
+            defaults: null,
+            constraints: null,
+            dataTokens: null,
+            inlineConstraintResolver: _inlineConstraintResolver);
+
+        // Act
+        await route.RouteAsync(context);
+
+        // Assert
+        Assert.NotNull(routeValues);
+        Assert.Equal(expected, routeValues["value"]);
     }
 
     [Fact]


### PR DESCRIPTION
# Decode route values from RawTarget (#11544)

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

Use RawTarget for route value capture and decoding

## Description

This change fixes the partially decoded route value behavior described in #11544 by moving the decode logic into routing itself.

Routing still matches endpoints and evaluates constraints against `Request.Path`, preserving existing precedence and selection behavior. Once a route is known to match, endpoint and legacy routing now use `IHttpRequestFeature.RawTarget` to recover the raw segment and decode the captured route value exactly once.

This fixes MVC and minimal API route parameters without adding a new opt-in API, and includes regression tests covering `%2F`, `%252F`, catch-all parameters, and `PathBase`.

Fixes #11544
