### PR TITLE
 Implement `Circuit.RequestCircuitPauseAsync`

### DIFF
--- a/src/Components/Server/src/Circuits/Circuit.cs
+++ b/src/Components/Server/src/Circuits/Circuit.cs
@@ -19,4 +19,23 @@ public sealed class Circuit
     /// Gets the identifier for the <see cref="Circuit"/>.
     /// </summary>
     public string Id => _circuitHost.CircuitId.Id;
+
+    /// <summary>
+    /// Requests that the connected client begin the graceful circuit-pause flow.
+    /// </summary>
+    /// <remarks>
+    /// The operation is idempotent. Observe completion through
+    /// <see cref="CircuitHandler.OnConnectionDownAsync"/> and <see cref="CircuitHandler.OnCircuitClosedAsync"/>.
+    /// </remarks>
+    /// <param name="cancellationToken">
+    /// Cancels the request before it is accepted by the framework.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if the request was accepted and the client was asked to begin pausing;
+    /// otherwise <see langword="false"/>.
+    /// </returns>
+    public ValueTask<bool> RequestCircuitPauseAsync(CancellationToken cancellationToken = default)
+    {
+        return _circuitHost.RequestPauseAsync(cancellationToken);
+    }
 }

--- a/src/Components/Server/src/Circuits/CircuitHost.cs
+++ b/src/Components/Server/src/Circuits/CircuitHost.cs
@@ -34,6 +34,8 @@ internal partial class CircuitHost : IAsyncDisposable
     private bool _onConnectionDownFired;
     private bool _disposed;
     private long _startTime;
+    private int _activeInboundWork;
+    private TaskCompletionSource _inboundWorkDrained;
     private ResumedPersistedCircuitState _persistedCircuitState;
 
     // This event is fired when there's an unrecoverable exception coming from the circuit, and
@@ -651,15 +653,39 @@ internal partial class CircuitHost : IAsyncDisposable
     }
 
     // Internal for testing.
-    internal Task HandleInboundActivityAsync(Func<Task> handler)
-        => _dispatchInboundActivity(handler);
+    internal async Task HandleInboundActivityAsync(Func<Task> handler)
+    {
+        Interlocked.Increment(ref _activeInboundWork);
+        try
+        {
+            await _dispatchInboundActivity(handler);
+        }
+        finally
+        {
+            if (Interlocked.Decrement(ref _activeInboundWork) == 0)
+            {
+                _inboundWorkDrained?.TrySetResult();
+            }
+        }
+    }
 
     // Internal for testing.
     internal async Task<TResult> HandleInboundActivityAsync<TResult>(Func<Task<TResult>> handler)
     {
-        TResult result = default;
-        await _dispatchInboundActivity(async () => result = await handler());
-        return result;
+        Interlocked.Increment(ref _activeInboundWork);
+        try
+        {
+            TResult result = default;
+            await _dispatchInboundActivity(async () => result = await handler());
+            return result;
+        }
+        finally
+        {
+            if (Interlocked.Decrement(ref _activeInboundWork) == 0)
+            {
+                _inboundWorkDrained?.TrySetResult();
+            }
+        }
     }
 
     private static Func<Func<Task>, Task> BuildInboundActivityDispatcher(IReadOnlyList<CircuitHandler> circuitHandlers, Circuit circuit)
@@ -968,16 +994,48 @@ internal partial class CircuitHost : IAsyncDisposable
             return false;
         }
 
-        try
+        // If called from outside the dispatcher, wait for in-flight work to complete.
+        // This ensures async event handlers and their renders finish first.
+        if (!Renderer.Dispatcher.CheckAccess())
         {
-            await Client.SendCoreAsync("JS.RequestPause", Array.Empty<object>(), cancellationToken);
-            Log.ServerPauseAccepted(_logger, CircuitId);
-            return true;
+            await WaitForInboundWorkToDrainAsync(cancellationToken);
         }
-        catch (Exception ex)
+
+        return await Renderer.Dispatcher.InvokeAsync(async () =>
         {
-            Log.ServerPauseFailed(_logger, CircuitId, ex);
-            return false;
+            if (_disposed || !Client.Connected)
+            {
+                Log.ServerPauseRejected(_logger, CircuitId);
+                return false;
+            }
+
+            try
+            {
+                await Client.SendCoreAsync("JS.RequestPause", Array.Empty<object>(), cancellationToken);
+                Log.ServerPauseAccepted(_logger, CircuitId);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Log.ServerPauseFailed(_logger, CircuitId, ex);
+                return false;
+            }
+        });
+    }
+
+    private async Task WaitForInboundWorkToDrainAsync(CancellationToken cancellationToken)
+    {
+        while (Volatile.Read(ref _activeInboundWork) > 0)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            _inboundWorkDrained = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            // Re-check after creating the TCS to avoid a race where work completed
+            // between the while check and the TCS creation.
+            if (Volatile.Read(ref _activeInboundWork) == 0)
+            {
+                break;
+            }
+            await _inboundWorkDrained.Task.WaitAsync(cancellationToken);
         }
     }
 

--- a/src/Components/Server/src/Circuits/CircuitHost.cs
+++ b/src/Components/Server/src/Circuits/CircuitHost.cs
@@ -994,11 +994,25 @@ internal partial class CircuitHost : IAsyncDisposable
             return false;
         }
 
-        // If called from outside the dispatcher, wait for in-flight work to complete.
-        // This ensures async event handlers and their renders finish first.
-        if (!Renderer.Dispatcher.CheckAccess())
+        // Wait for in-flight work to complete before sending. If called from inside
+        // the dispatcher, exclude the caller's own HandleInboundActivityAsync from
+        // the counter to avoid self-deadlock while still waiting for other in-flight work.
+        var isOnDispatcher = Renderer.Dispatcher.CheckAccess();
+        if (isOnDispatcher)
+        {
+            Interlocked.Decrement(ref _activeInboundWork);
+        }
+
+        try
         {
             await WaitForInboundWorkToDrainAsync(cancellationToken);
+        }
+        finally
+        {
+            if (isOnDispatcher)
+            {
+                Interlocked.Increment(ref _activeInboundWork);
+            }
         }
 
         return await Renderer.Dispatcher.InvokeAsync(async () =>

--- a/src/Components/Server/src/Circuits/CircuitHost.cs
+++ b/src/Components/Server/src/Circuits/CircuitHost.cs
@@ -35,7 +35,7 @@ internal partial class CircuitHost : IAsyncDisposable
     private bool _disposed;
     private long _startTime;
     private int _activeInboundWork;
-    private TaskCompletionSource _inboundWorkDrained;
+    private TaskCompletionSource? _inboundWorkDrained;
     private ResumedPersistedCircuitState _persistedCircuitState;
 
     // This event is fired when there's an unrecoverable exception coming from the circuit, and
@@ -1007,6 +1007,11 @@ internal partial class CircuitHost : IAsyncDisposable
         {
             await WaitForInboundWorkToDrainAsync(cancellationToken);
         }
+        catch (OperationCanceledException)
+        {
+            Log.ServerPauseRejected(_logger, CircuitId);
+            return false;
+        }
         finally
         {
             if (isOnDispatcher)
@@ -1025,14 +1030,9 @@ internal partial class CircuitHost : IAsyncDisposable
 
             try
             {
-                await Client.SendCoreAsync("JS.RequestPause", Array.Empty<object>(), cancellationToken);
+                await Client.SendCoreAsync("JS.RequestPause", Array.Empty<object>(), CancellationToken.None);
                 Log.ServerPauseAccepted(_logger, CircuitId);
                 return true;
-            }
-            catch (OperationCanceledException)
-            {
-                Log.ServerPauseRejected(_logger, CircuitId);
-                return false;
             }
             catch (Exception ex)
             {
@@ -1044,17 +1044,26 @@ internal partial class CircuitHost : IAsyncDisposable
 
     private async Task WaitForInboundWorkToDrainAsync(CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         while (Volatile.Read(ref _activeInboundWork) > 0)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            _inboundWorkDrained = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            // Re-check after creating the TCS to avoid a race where work completed
-            // between the while check and the TCS creation.
+
+            var inboundWorkDrained = Volatile.Read(ref _inboundWorkDrained);
+            if (inboundWorkDrained is null || inboundWorkDrained.Task.IsCompleted)
+            {
+                var newTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                var existing = Interlocked.CompareExchange(ref _inboundWorkDrained, newTcs, inboundWorkDrained);
+                inboundWorkDrained = existing == inboundWorkDrained ? newTcs : existing;
+            }
+
             if (Volatile.Read(ref _activeInboundWork) == 0)
             {
                 break;
             }
-            await _inboundWorkDrained.Task.WaitAsync(cancellationToken);
+
+            await inboundWorkDrained.Task.WaitAsync(cancellationToken);
         }
     }
 

--- a/src/Components/Server/src/Circuits/CircuitHost.cs
+++ b/src/Components/Server/src/Circuits/CircuitHost.cs
@@ -30,6 +30,7 @@ internal partial class CircuitHost : IAsyncDisposable
     private CircuitHandler[] _circuitHandlers;
     private bool _initialized;
     private bool _isFirstUpdate = true;
+    private bool _onConnectionUpFired;
     private bool _onConnectionDownFired;
     private bool _disposed;
     private long _startTime;
@@ -280,6 +281,7 @@ internal partial class CircuitHost : IAsyncDisposable
 
     public async Task OnConnectionUpAsync(CancellationToken cancellationToken)
     {
+        _onConnectionUpFired = true;
         _onConnectionDownFired = false;
         Log.ConnectionUp(_logger, CircuitId, Client.ConnectionId);
         _circuitMetrics?.OnConnectionUp();
@@ -944,6 +946,41 @@ internal partial class CircuitHost : IAsyncDisposable
         return result;
     }
 
+    internal async ValueTask<bool> RequestPauseAsync(CancellationToken cancellationToken)
+    {
+        Log.ServerPauseRequested(_logger, CircuitId);
+
+        if (_disposed)
+        {
+            Log.ServerPauseRejected(_logger, CircuitId);
+            return false;
+        }
+
+        if (!_initialized || !_onConnectionUpFired)
+        {
+            Log.ServerPauseRejected(_logger, CircuitId);
+            return false;
+        }
+
+        if (!Client.Connected)
+        {
+            Log.ServerPauseRejected(_logger, CircuitId);
+            return false;
+        }
+
+        try
+        {
+            await Client.SendCoreAsync("JS.RequestPause", Array.Empty<object>(), cancellationToken);
+            Log.ServerPauseAccepted(_logger, CircuitId);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.ServerPauseFailed(_logger, CircuitId, ex);
+            return false;
+        }
+    }
+
     internal async Task<bool> SendPersistedStateToClient(string rootComponents, string applicationState, CancellationToken cancellation)
     {
         try
@@ -1121,5 +1158,17 @@ internal partial class CircuitHost : IAsyncDisposable
 
         [LoggerMessage(220, LogLevel.Debug, "Failed to save state to client in circuit '{CircuitId}'.", EventName = "FailedToSaveStateToClient")]
         public static partial void FailedToSaveStateToClient(ILogger logger, CircuitId circuitId, Exception exception);
+
+        [LoggerMessage(120, LogLevel.Debug, "Server-initiated pause requested for circuit '{CircuitId}'.", EventName = "ServerPauseRequested")]
+        public static partial void ServerPauseRequested(ILogger logger, CircuitId circuitId);
+
+        [LoggerMessage(121, LogLevel.Debug, "Server-initiated pause request accepted for circuit '{CircuitId}'. Client has been asked to begin pausing.", EventName = "ServerPauseAccepted")]
+        public static partial void ServerPauseAccepted(ILogger logger, CircuitId circuitId);
+
+        [LoggerMessage(122, LogLevel.Debug, "Server-initiated pause request rejected for circuit '{CircuitId}'. Circuit is not in a connected state.", EventName = "ServerPauseRejected")]
+        public static partial void ServerPauseRejected(ILogger logger, CircuitId circuitId);
+
+        [LoggerMessage(123, LogLevel.Debug, "Server-initiated pause request failed for circuit '{CircuitId}'.", EventName = "ServerPauseFailed")]
+        public static partial void ServerPauseFailed(ILogger logger, CircuitId circuitId, Exception exception);
     }
 }

--- a/src/Components/Server/src/Circuits/CircuitHost.cs
+++ b/src/Components/Server/src/Circuits/CircuitHost.cs
@@ -34,8 +34,6 @@ internal partial class CircuitHost : IAsyncDisposable
     private bool _onConnectionDownFired;
     private bool _disposed;
     private long _startTime;
-    private int _activeInboundWork;
-    private TaskCompletionSource? _inboundWorkDrained;
     private ResumedPersistedCircuitState _persistedCircuitState;
 
     // This event is fired when there's an unrecoverable exception coming from the circuit, and
@@ -653,39 +651,15 @@ internal partial class CircuitHost : IAsyncDisposable
     }
 
     // Internal for testing.
-    internal async Task HandleInboundActivityAsync(Func<Task> handler)
-    {
-        Interlocked.Increment(ref _activeInboundWork);
-        try
-        {
-            await _dispatchInboundActivity(handler);
-        }
-        finally
-        {
-            if (Interlocked.Decrement(ref _activeInboundWork) == 0)
-            {
-                _inboundWorkDrained?.TrySetResult();
-            }
-        }
-    }
+    internal Task HandleInboundActivityAsync(Func<Task> handler)
+        => _dispatchInboundActivity(handler);
 
     // Internal for testing.
     internal async Task<TResult> HandleInboundActivityAsync<TResult>(Func<Task<TResult>> handler)
     {
-        Interlocked.Increment(ref _activeInboundWork);
-        try
-        {
-            TResult result = default;
-            await _dispatchInboundActivity(async () => result = await handler());
-            return result;
-        }
-        finally
-        {
-            if (Interlocked.Decrement(ref _activeInboundWork) == 0)
-            {
-                _inboundWorkDrained?.TrySetResult();
-            }
-        }
+        TResult result = default;
+        await _dispatchInboundActivity(async () => result = await handler());
+        return result;
     }
 
     private static Func<Func<Task>, Task> BuildInboundActivityDispatcher(IReadOnlyList<CircuitHandler> circuitHandlers, Circuit circuit)
@@ -994,32 +968,10 @@ internal partial class CircuitHost : IAsyncDisposable
             return false;
         }
 
-        // Wait for in-flight work to complete before sending. If called from inside
-        // the dispatcher, exclude the caller's own HandleInboundActivityAsync from
-        // the counter to avoid self-deadlock while still waiting for other in-flight work.
-        var isOnDispatcher = Renderer.Dispatcher.CheckAccess();
-        if (isOnDispatcher)
-        {
-            Interlocked.Decrement(ref _activeInboundWork);
-        }
-
-        try
-        {
-            await WaitForInboundWorkToDrainAsync(cancellationToken);
-        }
-        catch (OperationCanceledException)
-        {
-            Log.ServerPauseRejected(_logger, CircuitId);
-            return false;
-        }
-        finally
-        {
-            if (isOnDispatcher)
-            {
-                Interlocked.Increment(ref _activeInboundWork);
-            }
-        }
-
+        // Dispatch the send onto the dispatcher to serialize with any sync work
+        // (renders, event handlers) that may be in progress.
+        // The client receives the message and decides when to actually pause via
+        // an optional onPauseRequested callback in CircuitStartOptions.
         return await Renderer.Dispatcher.InvokeAsync(async () =>
         {
             if (_disposed || !Client.Connected)
@@ -1028,11 +980,25 @@ internal partial class CircuitHost : IAsyncDisposable
                 return false;
             }
 
+            // Check cancellation before sending. The dispatcher may have queued
+            // this work item while the token was still valid, but by the time
+            // it runs the caller may have cancelled.
+            if (cancellationToken.IsCancellationRequested)
+            {
+                Log.ServerPauseRejected(_logger, CircuitId);
+                return false;
+            }
+
             try
             {
-                await Client.SendCoreAsync("JS.RequestPause", Array.Empty<object>(), CancellationToken.None);
+                await Client.SendCoreAsync("JS.RequestPause", Array.Empty<object>(), cancellationToken);
                 Log.ServerPauseAccepted(_logger, CircuitId);
                 return true;
+            }
+            catch (OperationCanceledException)
+            {
+                Log.ServerPauseRejected(_logger, CircuitId);
+                return false;
             }
             catch (Exception ex)
             {
@@ -1040,31 +1006,6 @@ internal partial class CircuitHost : IAsyncDisposable
                 return false;
             }
         });
-    }
-
-    private async Task WaitForInboundWorkToDrainAsync(CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        while (Volatile.Read(ref _activeInboundWork) > 0)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            var inboundWorkDrained = Volatile.Read(ref _inboundWorkDrained);
-            if (inboundWorkDrained is null || inboundWorkDrained.Task.IsCompleted)
-            {
-                var newTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-                var existing = Interlocked.CompareExchange(ref _inboundWorkDrained, newTcs, inboundWorkDrained);
-                inboundWorkDrained = existing == inboundWorkDrained ? newTcs : existing;
-            }
-
-            if (Volatile.Read(ref _activeInboundWork) == 0)
-            {
-                break;
-            }
-
-            await inboundWorkDrained.Task.WaitAsync(cancellationToken);
-        }
     }
 
     internal async Task<bool> SendPersistedStateToClient(string rootComponents, string applicationState, CancellationToken cancellation)

--- a/src/Components/Server/src/Circuits/CircuitHost.cs
+++ b/src/Components/Server/src/Circuits/CircuitHost.cs
@@ -1015,6 +1015,11 @@ internal partial class CircuitHost : IAsyncDisposable
                 Log.ServerPauseAccepted(_logger, CircuitId);
                 return true;
             }
+            catch (OperationCanceledException)
+            {
+                Log.ServerPauseRejected(_logger, CircuitId);
+                return false;
+            }
             catch (Exception ex)
             {
                 Log.ServerPauseFailed(_logger, CircuitId, ex);

--- a/src/Components/Server/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Server/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 #nullable enable
+Microsoft.AspNetCore.Components.Server.Circuits.Circuit.RequestCircuitPauseAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<bool>
 Microsoft.AspNetCore.Components.Server.ServerComponentsEndpointOptions.ConfigureConnection.get -> System.Action<Microsoft.AspNetCore.Http.Connections.HttpConnectionDispatcherOptions!>?
 Microsoft.AspNetCore.Components.Server.ServerComponentsEndpointOptions.ConfigureConnection.set -> void

--- a/src/Components/Server/test/Circuits/CircuitHostTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitHostTest.cs
@@ -553,7 +553,7 @@ public class CircuitHostTest
     }
 
     [Fact]
-    public async Task A1_AliveConnectedIdle_ReturnsTrueAndSendsMessage()
+    public async Task AliveConnectedIdle_ReturnsTrueAndSendsMessage()
     {
         var proxy = new Mock<ISingleClientProxy>();
         proxy.Setup(c => c.SendCoreAsync("JS.RequestPause", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
@@ -568,7 +568,7 @@ public class CircuitHostTest
     }
 
     [Fact]
-    public async Task A2_A9_ConnectedWhileDispatcherBusy_ReturnsTrueAndSendsMessage()
+    public async Task ConnectedWhileDispatcherBusy_ReturnsTrueAndSendsMessage()
     {
         var proxy = new Mock<ISingleClientProxy>();
         proxy.Setup(c => c.SendCoreAsync("JS.RequestPause", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
@@ -589,7 +589,7 @@ public class CircuitHostTest
     }
 
     [Fact]
-    public async Task A3_PauseWhileAsyncHandlerSuspended_NoUnobservedExceptions()
+    public async Task PauseWhileAsyncHandlerSuspended_NoUnobservedExceptions()
     {
         var proxy = new Mock<ISingleClientProxy>();
         proxy.Setup(c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
@@ -633,7 +633,7 @@ public class CircuitHostTest
     }
 
     [Fact]
-    public async Task A4_PauseFromHandler_PauseMessageSentBeforeRenderBatch()
+    public async Task PauseFromHandler_PauseMessageSentBeforeRenderBatch()
     {
         var messageOrder = new List<string>();
         var proxy = new Mock<ISingleClientProxy>();
@@ -680,7 +680,7 @@ public class CircuitHostTest
     }
 
     [Fact]
-    public async Task A17_PauseFromOutside_WhileSyncRenderBlocked_PauseWaitsForRender()
+    public async Task PauseFromOutside_WhileSyncRenderBlocked_PauseWaitsForRender()
     {
         var renderReleased = false;
         var pauseSentAfterRelease = false;
@@ -721,7 +721,7 @@ public class CircuitHostTest
     }
 
     [Fact]
-    public async Task A17_DispatchedPause_WhileSyncWorkBlocked_PauseWaitsForSyncWork()
+    public async Task DispatchedPause_WhileSyncWorkBlocked_PauseWaitsForSyncWork()
     {
         var syncWorkReleased = false;
         var pauseSentAfterRelease = false;
@@ -755,7 +755,7 @@ public class CircuitHostTest
     }
 
     [Fact]
-    public async Task A10_Disposed_ReturnsFalseNoMessage()
+    public async Task Disposed_ReturnsFalseNoMessage()
     {
         var proxy = new Mock<ISingleClientProxy>();
         var circuitHost = await CreateConnectedCircuitHostAsync(proxy);
@@ -767,7 +767,7 @@ public class CircuitHostTest
     }
 
     [Fact]
-    public async Task A11_Disconnected_ReturnsFalse()
+    public async Task Disconnected_ReturnsFalse()
     {
         var proxy = new Mock<ISingleClientProxy>();
         var client = new CircuitClientProxy(proxy.Object, "connection-id");
@@ -786,7 +786,7 @@ public class CircuitHostTest
     }
 
     [Fact]
-    public async Task A12_NotInitialized_ReturnsFalse()
+    public async Task NotInitialized_ReturnsFalse()
     {
         var circuitHost = await CreateConnectedCircuitHostAsync(initialize: false);
 
@@ -794,7 +794,7 @@ public class CircuitHostTest
     }
 
     [Fact]
-    public async Task A13_AlreadyPausedAndDisposed_ReturnsFalse()
+    public async Task AlreadyPausedAndDisposed_ReturnsFalse()
     {
         var circuitHost = await CreateConnectedCircuitHostAsync();
         Assert.True(await circuitHost.RequestPauseAsync(CancellationToken.None));
@@ -805,7 +805,7 @@ public class CircuitHostTest
     }
 
     [Fact]
-    public async Task A14_PauseInProgress_IdempotentReturnsTrue()
+    public async Task PauseInProgress_IdempotentReturnsTrue()
     {
         var proxy = new Mock<ISingleClientProxy>();
         proxy.Setup(c => c.SendCoreAsync("JS.RequestPause", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
@@ -820,7 +820,7 @@ public class CircuitHostTest
     }
 
     [Fact]
-    public async Task A15_CancelledBeforeSend_ReturnsFalse()
+    public async Task CancelledBeforeSend_ReturnsFalse()
     {
         var circuitHost = await CreateConnectedCircuitHostAsync();
 
@@ -831,7 +831,7 @@ public class CircuitHostTest
     }
 
     [Fact]
-    public async Task A16_CancelledAfterSend_ReturnsTrue()
+    public async Task CancelledAfterSend_ReturnsTrue()
     {
         using var cts = new CancellationTokenSource();
         var proxy = new Mock<ISingleClientProxy>();
@@ -846,7 +846,7 @@ public class CircuitHostTest
     }
 
     [Fact]
-    public async Task C1_SendSucceeds_ReturnsTrue_EvenIfClientNeverReceives()
+    public async Task SendSucceeds_ReturnsTrue_EvenIfClientNeverReceives()
     {
         var circuitHost = await CreateConnectedCircuitHostAsync();
 
@@ -854,7 +854,7 @@ public class CircuitHostTest
     }
 
     [Fact]
-    public async Task C1_SendThrows_ReturnsFalse()
+    public async Task SendThrows_ReturnsFalse()
     {
         var proxy = new Mock<ISingleClientProxy>();
         proxy.Setup(c => c.SendCoreAsync("JS.RequestPause", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
@@ -865,7 +865,7 @@ public class CircuitHostTest
     }
 
     [Fact]
-    public async Task D1_AfterReconnect_SendsOnNewConnection()
+    public async Task AfterReconnect_SendsOnNewConnection()
     {
         var oldProxy = new Mock<ISingleClientProxy>();
         var newProxy = new Mock<ISingleClientProxy>();
@@ -890,7 +890,7 @@ public class CircuitHostTest
     }
 
     [Fact]
-    public async Task D3_DisconnectedCache_ReturnsFalse()
+    public async Task DisconnectedCache_ReturnsFalse()
     {
         var client = new CircuitClientProxy(Mock.Of<ISingleClientProxy>(), "conn");
         var circuitHost = TestCircuitHost.Create(clientProxy: client);
@@ -906,7 +906,7 @@ public class CircuitHostTest
     }
 
     [Fact]
-    public async Task E1_MultipleConcurrentCalls_AllReturnTrue()
+    public async Task MultipleConcurrentCalls_AllReturnTrue()
     {
         var circuitHost = await CreateConnectedCircuitHostAsync();
 
@@ -919,7 +919,7 @@ public class CircuitHostTest
     }
 
     [Fact]
-    public async Task E2_PauseDisposeRepause_OldRefReturnsFalse()
+    public async Task PauseDisposeRepause_OldRefReturnsFalse()
     {
         var circuitHost = await CreateConnectedCircuitHostAsync();
         Assert.True(await circuitHost.RequestPauseAsync(CancellationToken.None));
@@ -930,7 +930,7 @@ public class CircuitHostTest
     }
 
     [Fact]
-    public async Task E3_StaleReference_ReturnsFalse()
+    public async Task StaleReference_ReturnsFalse()
     {
         var circuitHost = await CreateConnectedCircuitHostAsync();
         var circuit = circuitHost.Circuit;
@@ -940,7 +940,7 @@ public class CircuitHostTest
     }
 
     [Fact]
-    public async Task F1_DrainMultipleCircuits_AllAccepted()
+    public async Task DrainMultipleCircuits_AllAccepted()
     {
         var hosts = new List<CircuitHost>();
         for (var i = 0; i < 5; i++)
@@ -955,7 +955,7 @@ public class CircuitHostTest
     }
 
     [Fact]
-    public async Task F2_HostShutdownCancels_ReturnsFalse()
+    public async Task HostShutdownCancels_ReturnsFalse()
     {
         var tcs = new TaskCompletionSource();
         var proxy = new Mock<ISingleClientProxy>();
@@ -977,7 +977,7 @@ public class CircuitHostTest
     }
 
     [Fact]
-    public async Task I1_RecoverableRenderingError_StillConnected_ReturnsTrue()
+    public async Task RecoverableRenderingError_StillConnected_ReturnsTrue()
     {
         var circuitHost = await CreateConnectedCircuitHostAsync();
 
@@ -985,7 +985,7 @@ public class CircuitHostTest
     }
 
     [Fact]
-    public async Task I2_FatalRenderingError_Disposed_ReturnsFalse()
+    public async Task FatalRenderingError_Disposed_ReturnsFalse()
     {
         var circuitHost = await CreateConnectedCircuitHostAsync();
         await circuitHost.DisposeAsync();
@@ -995,7 +995,7 @@ public class CircuitHostTest
 
     // Initialized but OnConnectionUpAsync not yet fired (Blazor Web path without descriptors).
     [Fact]
-    public async Task I3_DuringOnCircuitOpenedAsync_ReturnsFalse()
+    public async Task DuringOnCircuitOpenedAsync_ReturnsFalse()
     {
         var proxy = new Mock<ISingleClientProxy>();
         proxy.Setup(c => c.SendCoreAsync("JS.RequestPause", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
@@ -1015,7 +1015,7 @@ public class CircuitHostTest
     }
 
     [Fact]
-    public async Task I4_ClientUnresponsive_ServerReturnsTrue()
+    public async Task ClientUnresponsive_ServerReturnsTrue()
     {
         var circuitHost = await CreateConnectedCircuitHostAsync();
 

--- a/src/Components/Server/test/Circuits/CircuitHostTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitHostTest.cs
@@ -589,6 +589,151 @@ public class CircuitHostTest
     }
 
     [Fact]
+    public async Task A3_PauseWhileAsyncHandlerSuspended_NoUnobservedExceptions()
+    {
+        var proxy = new Mock<ISingleClientProxy>();
+        proxy.Setup(c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+             .Returns(Task.CompletedTask);
+        var circuitHost = await CreateConnectedCircuitHostAsync(proxy);
+
+        var unhandledExceptions = new List<Exception>();
+        circuitHost.UnhandledException += (_, e) =>
+            unhandledExceptions.Add((Exception)e.ExceptionObject);
+
+        // Simulate an async event handler that suspends at an await point.
+        var asyncWorkTcs = new TaskCompletionSource();
+        var handlerStarted = new TaskCompletionSource();
+        var handlerTask = circuitHost.Renderer.Dispatcher.InvokeAsync(async () =>
+        {
+            handlerStarted.SetResult();
+            // Simulates: await Http.GetAsync(...) — dispatcher is released here.
+            await asyncWorkTcs.Task;
+            // This continuation runs after the circuit is disposed.
+            // Any attempt to render or use JSRuntime will fail.
+        });
+
+        // Wait for the handler to reach the await point.
+        await handlerStarted.Task;
+
+        // Pause succeeds — the dispatcher is free (handler is suspended).
+        var result = await circuitHost.RequestPauseAsync(CancellationToken.None);
+        Assert.True(result);
+
+        // Dispose the circuit (simulating what PauseCircuitAsync does after persistence).
+        await circuitHost.DisposeAsync();
+
+        // Release the async work — continuation runs on a disposed circuit.
+        asyncWorkTcs.SetResult();
+
+        // Wait for the handler to complete.
+        // The continuation should not throw unobserved exceptions.
+        await handlerTask;
+
+        Assert.Empty(unhandledExceptions);
+    }
+
+    [Fact]
+    public async Task A4_PauseFromHandler_PauseMessageSentBeforeRenderBatch()
+    {
+        var messageOrder = new List<string>();
+        var proxy = new Mock<ISingleClientProxy>();
+        proxy.Setup(c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+             .Callback((string method, object[] _, CancellationToken _) => messageOrder.Add(method))
+             .Returns(Task.CompletedTask);
+
+        var client = new CircuitClientProxy(proxy.Object, "connection-id");
+        var remoteRenderer = GetRemoteRenderer();
+        var circuitHost = TestCircuitHost.Create(clientProxy: client, remoteRenderer: remoteRenderer);
+        await circuitHost.InitializeAsync(
+            new ProtectedPrerenderComponentApplicationStore(new EphemeralDataProtectionProvider()),
+            default, CancellationToken.None);
+        await circuitHost.Renderer.Dispatcher.InvokeAsync(
+            () => circuitHost.OnConnectionUpAsync(CancellationToken.None));
+
+        messageOrder.Clear();
+
+        // Simulate an event handler that mutates state and triggers pause.
+        await circuitHost.Renderer.Dispatcher.InvokeAsync(async () =>
+        {
+            // Mutate state — this will cause a render after the handler returns.
+            var component = new TestComponent(builder =>
+            {
+                builder.AddContent(0, "rendered");
+            });
+            circuitHost.Renderer.AssignRootComponentId(component);
+
+            // Trigger pause — SendCoreAsync("JS.RequestPause") is called NOW.
+            await circuitHost.RequestPauseAsync(CancellationToken.None);
+        });
+
+        // JS.RequestPause is sent inside the handler.
+        // JS.RenderBatch (if sent) comes after the handler completes.
+        var pauseIndex = messageOrder.IndexOf("JS.RequestPause");
+        Assert.True(pauseIndex >= 0, "JS.RequestPause should have been sent");
+
+        var renderIndex = messageOrder.IndexOf("JS.RenderBatch");
+        if (renderIndex >= 0)
+        {
+            Assert.True(pauseIndex < renderIndex,
+                "JS.RequestPause should be sent before JS.RenderBatch");
+        }
+    }
+
+    [Fact]
+    public async Task A17_PauseFromOutsideDispatcher_WhileRenderBlocked_PauseBeatsRender()
+    {
+        var messageOrder = new List<string>();
+        var proxy = new Mock<ISingleClientProxy>();
+        proxy.Setup(c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+             .Callback((string method, object[] _, CancellationToken _) =>
+             {
+                 lock (messageOrder)
+                 {
+                     messageOrder.Add(method);
+                 }
+             })
+             .Returns(Task.CompletedTask);
+
+        var client = new CircuitClientProxy(proxy.Object, "connection-id");
+        var circuitHost = TestCircuitHost.Create(clientProxy: client);
+        await circuitHost.InitializeAsync(
+            new ProtectedPrerenderComponentApplicationStore(new EphemeralDataProtectionProvider()),
+            default, CancellationToken.None);
+        await circuitHost.Renderer.Dispatcher.InvokeAsync(
+            () => circuitHost.OnConnectionUpAsync(CancellationToken.None));
+
+        messageOrder.Clear();
+
+        // Block the dispatcher to simulate a render in progress.
+        var renderStarted = new TaskCompletionSource();
+        var releaseTcs = new TaskCompletionSource();
+        var dispatcherTask = circuitHost.Renderer.Dispatcher.InvokeAsync(async () =>
+        {
+            renderStarted.SetResult();
+            await releaseTcs.Task;
+        });
+
+        // Wait until the dispatcher is confirmed blocked.
+        await renderStarted.Task;
+
+        // Call RequestPauseAsync from outside the dispatcher.
+        // This sends JS.RequestPause directly, bypassing the blocked dispatcher.
+        var result = await circuitHost.RequestPauseAsync(CancellationToken.None);
+        Assert.True(result);
+
+        // Release the dispatcher — any pending render can now complete.
+        releaseTcs.SetResult();
+        await dispatcherTask;
+
+        // Verify JS.RequestPause was sent while the dispatcher was blocked.
+        lock (messageOrder)
+        {
+            var pauseIndex = messageOrder.IndexOf("JS.RequestPause");
+            Assert.True(pauseIndex >= 0, "JS.RequestPause should have been sent");
+        }
+    }
+
+    [Fact]
     public async Task A10_Disposed_ReturnsFalseNoMessage()
     {
         var proxy = new Mock<ISingleClientProxy>();
@@ -1313,7 +1458,7 @@ public class CircuitHostTest
                   NullLogger.Instance,
                   CreateJSRuntime(new CircuitOptions()),
                   new CircuitJSComponentInterop(new CircuitOptions()))
-        {            
+        {
         }
 
         public ComponentState GetTestComponentState(int id)

--- a/src/Components/Server/test/Circuits/CircuitHostTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitHostTest.cs
@@ -520,6 +520,407 @@ public class CircuitHostTest
         Assert.False(await circuitHost.SendPersistedStateToClient(rootComponents, applicationState, cancellationToken));
     }
 
+    private static async Task<CircuitHost> CreateConnectedCircuitHostAsync(
+        Mock<ISingleClientProxy> mockProxy = null,
+        bool initialize = true)
+    {
+        var ownsProxy = mockProxy is null;
+        mockProxy ??= new Mock<ISingleClientProxy>();
+
+        if (ownsProxy)
+        {
+            mockProxy
+                .Setup(c => c.SendCoreAsync("JS.RequestPause", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+        }
+
+        var client = new CircuitClientProxy(mockProxy.Object, "connection-id");
+        var circuitHost = TestCircuitHost.Create(clientProxy: client);
+
+        if (initialize)
+        {
+            await circuitHost.InitializeAsync(
+                new ProtectedPrerenderComponentApplicationStore(new EphemeralDataProtectionProvider()),
+                default,
+                CancellationToken.None);
+
+            // TestCircuitHost has no descriptors so InitializeAsync skips OnConnectionUpAsync.
+            await circuitHost.Renderer.Dispatcher.InvokeAsync(
+                () => circuitHost.OnConnectionUpAsync(CancellationToken.None));
+        }
+
+        return circuitHost;
+    }
+
+    [Fact]
+    public async Task A1_AliveConnectedIdle_ReturnsTrueAndSendsMessage()
+    {
+        var proxy = new Mock<ISingleClientProxy>();
+        proxy.Setup(c => c.SendCoreAsync("JS.RequestPause", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+             .Returns(Task.CompletedTask);
+        var circuitHost = await CreateConnectedCircuitHostAsync(proxy);
+
+        var result = await circuitHost.RequestPauseAsync(CancellationToken.None);
+
+        Assert.True(result);
+        proxy.Verify(c => c.SendCoreAsync("JS.RequestPause",
+            It.Is<object[]>(a => a.Length == 0), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task A2_A9_ConnectedWhileDispatcherBusy_ReturnsTrueAndSendsMessage()
+    {
+        var proxy = new Mock<ISingleClientProxy>();
+        proxy.Setup(c => c.SendCoreAsync("JS.RequestPause", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+             .Returns(Task.CompletedTask);
+        var circuitHost = await CreateConnectedCircuitHostAsync(proxy);
+
+        var tcs = new TaskCompletionSource();
+        var dispatcherTask = circuitHost.Renderer.Dispatcher.InvokeAsync(() => tcs.Task);
+
+        var result = await circuitHost.RequestPauseAsync(CancellationToken.None);
+
+        Assert.True(result);
+        proxy.Verify(c => c.SendCoreAsync("JS.RequestPause",
+            It.IsAny<object[]>(), It.IsAny<CancellationToken>()), Times.Once);
+
+        tcs.SetResult();
+        await dispatcherTask;
+    }
+
+    [Fact]
+    public async Task A10_Disposed_ReturnsFalseNoMessage()
+    {
+        var proxy = new Mock<ISingleClientProxy>();
+        var circuitHost = await CreateConnectedCircuitHostAsync(proxy);
+        await circuitHost.DisposeAsync();
+
+        Assert.False(await circuitHost.RequestPauseAsync(CancellationToken.None));
+        proxy.Verify(c => c.SendCoreAsync(It.IsAny<string>(),
+            It.IsAny<object[]>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task A11_Disconnected_ReturnsFalse()
+    {
+        var proxy = new Mock<ISingleClientProxy>();
+        var client = new CircuitClientProxy(proxy.Object, "connection-id");
+        var circuitHost = TestCircuitHost.Create(clientProxy: client);
+        await circuitHost.InitializeAsync(
+            new ProtectedPrerenderComponentApplicationStore(new EphemeralDataProtectionProvider()),
+            default, CancellationToken.None);
+        await circuitHost.Renderer.Dispatcher.InvokeAsync(
+            () => circuitHost.OnConnectionUpAsync(CancellationToken.None));
+
+        client.SetDisconnected();
+
+        Assert.False(await circuitHost.RequestPauseAsync(CancellationToken.None));
+        proxy.Verify(c => c.SendCoreAsync(It.IsAny<string>(),
+            It.IsAny<object[]>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task A12_NotInitialized_ReturnsFalse()
+    {
+        var circuitHost = await CreateConnectedCircuitHostAsync(initialize: false);
+
+        Assert.False(await circuitHost.RequestPauseAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task A13_AlreadyPausedAndDisposed_ReturnsFalse()
+    {
+        var circuitHost = await CreateConnectedCircuitHostAsync();
+        Assert.True(await circuitHost.RequestPauseAsync(CancellationToken.None));
+
+        await circuitHost.DisposeAsync();
+
+        Assert.False(await circuitHost.RequestPauseAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task A14_PauseInProgress_IdempotentReturnsTrue()
+    {
+        var proxy = new Mock<ISingleClientProxy>();
+        proxy.Setup(c => c.SendCoreAsync("JS.RequestPause", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+             .Returns(Task.CompletedTask);
+        var circuitHost = await CreateConnectedCircuitHostAsync(proxy);
+
+        Assert.True(await circuitHost.RequestPauseAsync(CancellationToken.None));
+        Assert.True(await circuitHost.RequestPauseAsync(CancellationToken.None));
+
+        proxy.Verify(c => c.SendCoreAsync("JS.RequestPause",
+            It.IsAny<object[]>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task A15_CancelledBeforeSend_ReturnsFalse()
+    {
+        var proxy = new Mock<ISingleClientProxy>();
+        proxy.Setup(c => c.SendCoreAsync("JS.RequestPause", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+             .Returns((string _, object[] _, CancellationToken ct) =>
+             {
+                 ct.ThrowIfCancellationRequested();
+                 return Task.CompletedTask;
+             });
+        var circuitHost = await CreateConnectedCircuitHostAsync(proxy);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.False(await circuitHost.RequestPauseAsync(cts.Token));
+    }
+
+    [Fact]
+    public async Task A16_CancelledAfterSend_ReturnsTrue()
+    {
+        using var cts = new CancellationTokenSource();
+        var proxy = new Mock<ISingleClientProxy>();
+        proxy.Setup(c => c.SendCoreAsync("JS.RequestPause", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+             .Returns(Task.CompletedTask);
+        var circuitHost = await CreateConnectedCircuitHostAsync(proxy);
+
+        var result = await circuitHost.RequestPauseAsync(cts.Token);
+        cts.Cancel();
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task C1_SendSucceeds_ReturnsTrue_EvenIfClientNeverReceives()
+    {
+        var circuitHost = await CreateConnectedCircuitHostAsync();
+
+        Assert.True(await circuitHost.RequestPauseAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task C1_SendThrows_ReturnsFalse()
+    {
+        var proxy = new Mock<ISingleClientProxy>();
+        proxy.Setup(c => c.SendCoreAsync("JS.RequestPause", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+             .ThrowsAsync(new IOException("Connection reset"));
+        var circuitHost = await CreateConnectedCircuitHostAsync(proxy);
+
+        Assert.False(await circuitHost.RequestPauseAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task D1_AfterReconnect_SendsOnNewConnection()
+    {
+        var oldProxy = new Mock<ISingleClientProxy>();
+        var newProxy = new Mock<ISingleClientProxy>();
+        newProxy.Setup(c => c.SendCoreAsync("JS.RequestPause", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+        var client = new CircuitClientProxy(oldProxy.Object, "old-connection");
+        var circuitHost = TestCircuitHost.Create(clientProxy: client);
+        await circuitHost.InitializeAsync(
+            new ProtectedPrerenderComponentApplicationStore(new EphemeralDataProtectionProvider()),
+            default, CancellationToken.None);
+        await circuitHost.Renderer.Dispatcher.InvokeAsync(
+            () => circuitHost.OnConnectionUpAsync(CancellationToken.None));
+
+        client.Transfer(newProxy.Object, "new-connection");
+
+        Assert.True(await circuitHost.RequestPauseAsync(CancellationToken.None));
+        newProxy.Verify(c => c.SendCoreAsync("JS.RequestPause",
+            It.IsAny<object[]>(), It.IsAny<CancellationToken>()), Times.Once);
+        oldProxy.Verify(c => c.SendCoreAsync(It.IsAny<string>(),
+            It.IsAny<object[]>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task D3_DisconnectedCache_ReturnsFalse()
+    {
+        var client = new CircuitClientProxy(Mock.Of<ISingleClientProxy>(), "conn");
+        var circuitHost = TestCircuitHost.Create(clientProxy: client);
+        await circuitHost.InitializeAsync(
+            new ProtectedPrerenderComponentApplicationStore(new EphemeralDataProtectionProvider()),
+            default, CancellationToken.None);
+        await circuitHost.Renderer.Dispatcher.InvokeAsync(
+            () => circuitHost.OnConnectionUpAsync(CancellationToken.None));
+
+        client.SetDisconnected();
+
+        Assert.False(await circuitHost.RequestPauseAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task E1_MultipleConcurrentCalls_AllReturnTrue()
+    {
+        var circuitHost = await CreateConnectedCircuitHostAsync();
+
+        var tasks = Enumerable.Range(0, 10)
+            .Select(_ => circuitHost.RequestPauseAsync(CancellationToken.None).AsTask())
+            .ToArray();
+        var results = await Task.WhenAll(tasks);
+
+        Assert.All(results, Assert.True);
+    }
+
+    [Fact]
+    public async Task E2_PauseDisposeRepause_OldRefReturnsFalse()
+    {
+        var circuitHost = await CreateConnectedCircuitHostAsync();
+        Assert.True(await circuitHost.RequestPauseAsync(CancellationToken.None));
+
+        await circuitHost.DisposeAsync();
+
+        Assert.False(await circuitHost.RequestPauseAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task E3_StaleReference_ReturnsFalse()
+    {
+        var circuitHost = await CreateConnectedCircuitHostAsync();
+        var circuit = circuitHost.Circuit;
+        await circuitHost.DisposeAsync();
+
+        Assert.False(await circuit.RequestCircuitPauseAsync());
+    }
+
+    [Fact]
+    public async Task F1_DrainMultipleCircuits_AllAccepted()
+    {
+        var hosts = new List<CircuitHost>();
+        for (var i = 0; i < 5; i++)
+        {
+            hosts.Add(await CreateConnectedCircuitHostAsync());
+        }
+
+        var tasks = hosts.Select(h => h.RequestPauseAsync(CancellationToken.None).AsTask()).ToArray();
+        var results = await Task.WhenAll(tasks);
+
+        Assert.All(results, Assert.True);
+    }
+
+    [Fact]
+    public async Task F2_HostShutdownCancels_ReturnsFalse()
+    {
+        var tcs = new TaskCompletionSource();
+        var proxy = new Mock<ISingleClientProxy>();
+        proxy.Setup(c => c.SendCoreAsync("JS.RequestPause", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+             .Returns((string _, object[] _, CancellationToken ct) =>
+             {
+                 ct.ThrowIfCancellationRequested();
+                 return tcs.Task;
+             });
+        var circuitHost = await CreateConnectedCircuitHostAsync(proxy);
+
+        using var cts = new CancellationTokenSource();
+        var pauseTask = circuitHost.RequestPauseAsync(cts.Token);
+
+        cts.Cancel();
+        tcs.SetCanceled();
+
+        Assert.False(await pauseTask);
+    }
+
+    [Fact]
+    public async Task I1_RecoverableRenderingError_StillConnected_ReturnsTrue()
+    {
+        var circuitHost = await CreateConnectedCircuitHostAsync();
+
+        Assert.True(await circuitHost.RequestPauseAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task I2_FatalRenderingError_Disposed_ReturnsFalse()
+    {
+        var circuitHost = await CreateConnectedCircuitHostAsync();
+        await circuitHost.DisposeAsync();
+
+        Assert.False(await circuitHost.RequestPauseAsync(CancellationToken.None));
+    }
+
+    // Initialized but OnConnectionUpAsync not yet fired (Blazor Web path without descriptors).
+    [Fact]
+    public async Task I3_DuringOnCircuitOpenedAsync_ReturnsFalse()
+    {
+        var proxy = new Mock<ISingleClientProxy>();
+        proxy.Setup(c => c.SendCoreAsync("JS.RequestPause", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+             .Returns(Task.CompletedTask);
+
+        var circuitHost = await CreateConnectedCircuitHostAsync(proxy, initialize: false);
+        await circuitHost.InitializeAsync(
+            new ProtectedPrerenderComponentApplicationStore(new EphemeralDataProtectionProvider()),
+            default,
+            CancellationToken.None);
+
+        var result = await circuitHost.RequestPauseAsync(CancellationToken.None);
+        Assert.False(result);
+
+        proxy.Verify(c => c.SendCoreAsync(It.IsAny<string>(),
+            It.IsAny<object[]>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task I4_ClientUnresponsive_ServerReturnsTrue()
+    {
+        var circuitHost = await CreateConnectedCircuitHostAsync();
+
+        Assert.True(await circuitHost.RequestPauseAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task PublicApi_DelegatesToCircuitHost_Connected()
+    {
+        var proxy = new Mock<ISingleClientProxy>();
+        proxy.Setup(c => c.SendCoreAsync("JS.RequestPause", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+             .Returns(Task.CompletedTask);
+        var circuitHost = await CreateConnectedCircuitHostAsync(proxy);
+
+        Assert.True(await circuitHost.Circuit.RequestCircuitPauseAsync());
+        proxy.Verify(c => c.SendCoreAsync("JS.RequestPause",
+            It.IsAny<object[]>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task PublicApi_DelegatesToCircuitHost_Disconnected()
+    {
+        var client = new CircuitClientProxy();
+        var circuitHost = TestCircuitHost.Create(clientProxy: client);
+
+        Assert.False(await circuitHost.Circuit.RequestCircuitPauseAsync());
+    }
+
+    [Fact]
+    public async Task PublicApi_ForwardsCancellationToken()
+    {
+        using var cts = new CancellationTokenSource();
+        CancellationToken received = default;
+        var proxy = new Mock<ISingleClientProxy>();
+        proxy.Setup(c => c.SendCoreAsync("JS.RequestPause", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+             .Callback((string _, object[] _, CancellationToken ct) => received = ct)
+             .Returns(Task.CompletedTask);
+        var circuitHost = await CreateConnectedCircuitHostAsync(proxy);
+
+        await circuitHost.Circuit.RequestCircuitPauseAsync(cts.Token);
+        Assert.Equal(cts.Token, received);
+    }
+
+    [Fact]
+    public async Task CalledFromDispatcher_NoDeadlock_ReturnsTrue()
+    {
+        var circuitHost = await CreateConnectedCircuitHostAsync();
+
+        var result = await circuitHost.Renderer.Dispatcher.InvokeAsync(
+            async () => await circuitHost.Circuit.RequestCircuitPauseAsync());
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task CalledFromBackgroundThread_ReturnsTrue()
+    {
+        var circuitHost = await CreateConnectedCircuitHostAsync();
+
+        var result = await Task.Run(() => circuitHost.Circuit.RequestCircuitPauseAsync().AsTask());
+
+        Assert.True(result);
+    }
+
     [Fact]
     public async Task UpdateRootComponents_CanAddNewRootComponent()
     {

--- a/src/Components/Server/test/Circuits/CircuitHostTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitHostTest.cs
@@ -680,18 +680,10 @@ public class CircuitHostTest
     }
 
     [Fact]
-    public async Task A17_PauseFromOutsideDispatcher_WhileRenderBlocked_PauseBeatsRender()
+    public async Task A17_PauseFromOutsideDispatcher_WhileRenderBlocked_PauseSentImmediately()
     {
-        var messageOrder = new List<string>();
         var proxy = new Mock<ISingleClientProxy>();
         proxy.Setup(c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
-             .Callback((string method, object[] _, CancellationToken _) =>
-             {
-                 lock (messageOrder)
-                 {
-                     messageOrder.Add(method);
-                 }
-             })
              .Returns(Task.CompletedTask);
 
         var client = new CircuitClientProxy(proxy.Object, "connection-id");
@@ -702,9 +694,6 @@ public class CircuitHostTest
         await circuitHost.Renderer.Dispatcher.InvokeAsync(
             () => circuitHost.OnConnectionUpAsync(CancellationToken.None));
 
-        messageOrder.Clear();
-
-        // Block the dispatcher to simulate a render in progress.
         var renderStarted = new TaskCompletionSource();
         var releaseTcs = new TaskCompletionSource();
         var dispatcherTask = circuitHost.Renderer.Dispatcher.InvokeAsync(async () =>
@@ -713,24 +702,89 @@ public class CircuitHostTest
             await releaseTcs.Task;
         });
 
-        // Wait until the dispatcher is confirmed blocked.
         await renderStarted.Task;
 
-        // Call RequestPauseAsync from outside the dispatcher.
-        // This sends JS.RequestPause directly, bypassing the blocked dispatcher.
+        // Pause sends immediately even though the dispatcher is blocked.
         var result = await circuitHost.RequestPauseAsync(CancellationToken.None);
         Assert.True(result);
+        proxy.Verify(c => c.SendCoreAsync("JS.RequestPause",
+            It.IsAny<object[]>(), It.IsAny<CancellationToken>()), Times.Once);
 
-        // Release the dispatcher — any pending render can now complete.
         releaseTcs.SetResult();
         await dispatcherTask;
+    }
 
-        // Verify JS.RequestPause was sent while the dispatcher was blocked.
-        lock (messageOrder)
+    [Fact]
+    public async Task A17_DispatchedPause_WhileSyncWorkBlocked_PauseWaitsForSyncWork()
+    {
+        var pauseSent = false;
+        var proxy = new Mock<ISingleClientProxy>();
+        proxy.Setup(c => c.SendCoreAsync("JS.RequestPause", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+             .Callback(() => pauseSent = true)
+             .Returns(Task.CompletedTask);
+        var circuitHost = await CreateConnectedCircuitHostAsync(proxy);
+
+        var syncWorkStarted = new ManualResetEventSlim();
+        var releaseSyncWork = new ManualResetEventSlim();
+
+        // Block the dispatcher with synchronous work.
+        var dispatcherTask = Task.Run(() => circuitHost.Renderer.Dispatcher.InvokeAsync(() =>
         {
-            var pauseIndex = messageOrder.IndexOf("JS.RequestPause");
-            Assert.True(pauseIndex >= 0, "JS.RequestPause should have been sent");
-        }
+            syncWorkStarted.Set();
+            releaseSyncWork.Wait();
+        }));
+
+        syncWorkStarted.Wait();
+
+        // Dispatch pause onto the dispatcher — queues behind the sync work.
+        var pauseTask = Task.Run(() => circuitHost.Renderer.Dispatcher.InvokeAsync(
+            async () => await circuitHost.RequestPauseAsync(CancellationToken.None)));
+
+        await Task.Delay(100);
+
+        // Pause has NOT been sent — sync work is blocking the dispatcher.
+        Assert.False(pauseSent);
+
+        releaseSyncWork.Set();
+        await dispatcherTask;
+
+        var result = await pauseTask;
+        Assert.True(result);
+        Assert.True(pauseSent);
+    }
+
+    [Fact]
+    public async Task A17_DispatchedPause_WhileAsyncWorkSuspended_PauseRunsImmediately()
+    {
+        var pauseSent = false;
+        var proxy = new Mock<ISingleClientProxy>();
+        proxy.Setup(c => c.SendCoreAsync("JS.RequestPause", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+             .Callback(() => pauseSent = true)
+             .Returns(Task.CompletedTask);
+        var circuitHost = await CreateConnectedCircuitHostAsync(proxy);
+
+        var asyncWorkStarted = new TaskCompletionSource();
+        var releaseAsyncWork = new TaskCompletionSource();
+
+        // Start async work on the dispatcher — it suspends at the await.
+        var dispatcherTask = circuitHost.Renderer.Dispatcher.InvokeAsync(async () =>
+        {
+            asyncWorkStarted.SetResult();
+            await releaseAsyncWork.Task;
+        });
+
+        await asyncWorkStarted.Task;
+
+        // Dispatch pause onto the dispatcher. The async work is suspended,
+        // so the dispatcher runs the pause immediately.
+        var result = await Task.Run(() => circuitHost.Renderer.Dispatcher.InvokeAsync(
+            async () => await circuitHost.RequestPauseAsync(CancellationToken.None)));
+
+        Assert.True(result);
+        Assert.True(pauseSent);
+
+        releaseAsyncWork.SetResult();
+        await dispatcherTask;
     }
 
     [Fact]

--- a/src/Components/Server/test/Circuits/CircuitHostTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitHostTest.cs
@@ -721,39 +721,6 @@ public class CircuitHostTest
     }
 
     [Fact]
-    public async Task A17_PauseFromOutside_WhileAsyncInboundWorkActive_PauseWaitsForCompletion()
-    {
-        var asyncWorkReleased = false;
-        var pauseSentAfterRelease = false;
-        var proxy = new Mock<ISingleClientProxy>();
-        proxy.Setup(c => c.SendCoreAsync("JS.RequestPause", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
-             .Callback(() => pauseSentAfterRelease = asyncWorkReleased)
-             .Returns(Task.CompletedTask);
-        var circuitHost = await CreateConnectedCircuitHostAsync(proxy);
-
-        var asyncWorkStarted = new TaskCompletionSource();
-        var releaseAsyncWork = new TaskCompletionSource();
-
-        var inboundTask = circuitHost.HandleInboundActivityAsync(async () =>
-        {
-            asyncWorkStarted.SetResult();
-            await releaseAsyncWork.Task;
-        });
-
-        await asyncWorkStarted.Task;
-
-        var pauseTask = Task.Run(() => circuitHost.RequestPauseAsync(CancellationToken.None).AsTask());
-
-        asyncWorkReleased = true;
-        releaseAsyncWork.SetResult();
-        await inboundTask;
-
-        var result = await pauseTask;
-        Assert.True(result);
-        Assert.True(pauseSentAfterRelease, "Pause should be sent after async inbound work completes");
-    }
-
-    [Fact]
     public async Task A17_DispatchedPause_WhileSyncWorkBlocked_PauseWaitsForSyncWork()
     {
         var syncWorkReleased = false;
@@ -785,45 +752,6 @@ public class CircuitHostTest
         var result = await pauseTask;
         Assert.True(result);
         Assert.True(pauseSentAfterRelease, "Pause should be sent after sync work finishes");
-    }
-
-    [Fact]
-    public async Task A17_PauseFromInsideHandler_WhileOtherAsyncWorkActive_WaitsForOtherWork()
-    {
-        var otherWorkReleased = false;
-        var pauseSentAfterRelease = false;
-        var proxy = new Mock<ISingleClientProxy>();
-        proxy.Setup(c => c.SendCoreAsync("JS.RequestPause", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
-             .Callback(() => pauseSentAfterRelease = otherWorkReleased)
-             .Returns(Task.CompletedTask);
-        var circuitHost = await CreateConnectedCircuitHostAsync(proxy);
-
-        var otherWorkStarted = new TaskCompletionSource();
-        var releaseOtherWork = new TaskCompletionSource();
-
-        // Start another async inbound handler.
-        var otherHandlerTask = circuitHost.HandleInboundActivityAsync(async () =>
-        {
-            otherWorkStarted.SetResult();
-            await releaseOtherWork.Task;
-        });
-
-        await otherWorkStarted.Task;
-
-        // Simulate a component event handler calling RequestPauseAsync directly.
-        // This is ONE HandleInboundActivityAsync wrapping the dispatcher call +
-        // the pause call inside it — NOT a nested HandleInboundActivityAsync.
-        var pauseTask = circuitHost.HandleInboundActivityAsync(
-            () => circuitHost.Renderer.Dispatcher.InvokeAsync(
-                () => circuitHost.RequestPauseAsync(CancellationToken.None).AsTask()));
-
-        // Release the other handler.
-        otherWorkReleased = true;
-        releaseOtherWork.SetResult();
-        await otherHandlerTask;
-
-        await pauseTask;
-        Assert.True(pauseSentAfterRelease, "Pause should be sent after other async work completes");
     }
 
     [Fact]
@@ -1114,38 +1042,6 @@ public class CircuitHostTest
         var circuitHost = TestCircuitHost.Create(clientProxy: client);
 
         Assert.False(await circuitHost.Circuit.RequestCircuitPauseAsync());
-    }
-
-    [Fact]
-    public async Task PublicApi_CancellationTokenRejectsDuringDrainWait()
-    {
-        var proxy = new Mock<ISingleClientProxy>();
-        proxy.Setup(c => c.SendCoreAsync("JS.RequestPause", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
-             .Returns(Task.CompletedTask);
-        var circuitHost = await CreateConnectedCircuitHostAsync(proxy);
-
-        var asyncWorkStarted = new TaskCompletionSource();
-        var releaseAsyncWork = new TaskCompletionSource();
-
-        var inboundTask = circuitHost.HandleInboundActivityAsync(async () =>
-        {
-            asyncWorkStarted.SetResult();
-            await releaseAsyncWork.Task;
-        });
-
-        await asyncWorkStarted.Task;
-
-        using var cts = new CancellationTokenSource();
-        var pauseTask = Task.Run(() => circuitHost.RequestPauseAsync(cts.Token).AsTask());
-
-        // Cancel while waiting for drain — should return false.
-        cts.Cancel();
-
-        var result = await pauseTask;
-        Assert.False(result);
-
-        releaseAsyncWork.SetResult();
-        await inboundTask;
     }
 
     [Fact]

--- a/src/Components/Server/test/Circuits/CircuitHostTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitHostTest.cs
@@ -680,10 +680,13 @@ public class CircuitHostTest
     }
 
     [Fact]
-    public async Task A17_PauseFromOutsideDispatcher_WhileRenderBlocked_PauseSentImmediately()
+    public async Task A17_PauseFromOutside_WhileSyncRenderBlocked_PauseWaitsForRender()
     {
+        var renderReleased = false;
+        var pauseSentAfterRelease = false;
         var proxy = new Mock<ISingleClientProxy>();
-        proxy.Setup(c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+        proxy.Setup(c => c.SendCoreAsync("JS.RequestPause", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+             .Callback(() => pauseSentAfterRelease = renderReleased)
              .Returns(Task.CompletedTask);
 
         var client = new CircuitClientProxy(proxy.Object, "connection-id");
@@ -694,40 +697,76 @@ public class CircuitHostTest
         await circuitHost.Renderer.Dispatcher.InvokeAsync(
             () => circuitHost.OnConnectionUpAsync(CancellationToken.None));
 
-        var renderStarted = new TaskCompletionSource();
-        var releaseTcs = new TaskCompletionSource();
-        var dispatcherTask = circuitHost.Renderer.Dispatcher.InvokeAsync(async () =>
+        // ManualResetEventSlim is used because the callback is synchronous (simulating sync rendering).
+        var renderStarted = new ManualResetEventSlim();
+        var releaseRender = new ManualResetEventSlim();
+
+        var dispatcherTask = Task.Run(() => circuitHost.Renderer.Dispatcher.InvokeAsync(() =>
         {
-            renderStarted.SetResult();
-            await releaseTcs.Task;
+            renderStarted.Set();
+            releaseRender.Wait();
+        }));
+
+        renderStarted.Wait();
+
+        var pauseTask = Task.Run(() => circuitHost.RequestPauseAsync(CancellationToken.None).AsTask());
+
+        renderReleased = true;
+        releaseRender.Set();
+        await dispatcherTask;
+
+        var result = await pauseTask;
+        Assert.True(result);
+        Assert.True(pauseSentAfterRelease, "Pause should be sent after sync render finishes");
+    }
+
+    [Fact]
+    public async Task A17_PauseFromOutside_WhileAsyncInboundWorkActive_PauseWaitsForCompletion()
+    {
+        var asyncWorkReleased = false;
+        var pauseSentAfterRelease = false;
+        var proxy = new Mock<ISingleClientProxy>();
+        proxy.Setup(c => c.SendCoreAsync("JS.RequestPause", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+             .Callback(() => pauseSentAfterRelease = asyncWorkReleased)
+             .Returns(Task.CompletedTask);
+        var circuitHost = await CreateConnectedCircuitHostAsync(proxy);
+
+        var asyncWorkStarted = new TaskCompletionSource();
+        var releaseAsyncWork = new TaskCompletionSource();
+
+        var inboundTask = circuitHost.HandleInboundActivityAsync(async () =>
+        {
+            asyncWorkStarted.SetResult();
+            await releaseAsyncWork.Task;
         });
 
-        await renderStarted.Task;
+        await asyncWorkStarted.Task;
 
-        // Pause sends immediately even though the dispatcher is blocked.
-        var result = await circuitHost.RequestPauseAsync(CancellationToken.None);
+        var pauseTask = Task.Run(() => circuitHost.RequestPauseAsync(CancellationToken.None).AsTask());
+
+        asyncWorkReleased = true;
+        releaseAsyncWork.SetResult();
+        await inboundTask;
+
+        var result = await pauseTask;
         Assert.True(result);
-        proxy.Verify(c => c.SendCoreAsync("JS.RequestPause",
-            It.IsAny<object[]>(), It.IsAny<CancellationToken>()), Times.Once);
-
-        releaseTcs.SetResult();
-        await dispatcherTask;
+        Assert.True(pauseSentAfterRelease, "Pause should be sent after async inbound work completes");
     }
 
     [Fact]
     public async Task A17_DispatchedPause_WhileSyncWorkBlocked_PauseWaitsForSyncWork()
     {
-        var pauseSent = false;
+        var syncWorkReleased = false;
+        var pauseSentAfterRelease = false;
         var proxy = new Mock<ISingleClientProxy>();
         proxy.Setup(c => c.SendCoreAsync("JS.RequestPause", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
-             .Callback(() => pauseSent = true)
+             .Callback(() => pauseSentAfterRelease = syncWorkReleased)
              .Returns(Task.CompletedTask);
         var circuitHost = await CreateConnectedCircuitHostAsync(proxy);
 
         var syncWorkStarted = new ManualResetEventSlim();
         var releaseSyncWork = new ManualResetEventSlim();
 
-        // Block the dispatcher with synchronous work.
         var dispatcherTask = Task.Run(() => circuitHost.Renderer.Dispatcher.InvokeAsync(() =>
         {
             syncWorkStarted.Set();
@@ -736,55 +775,16 @@ public class CircuitHostTest
 
         syncWorkStarted.Wait();
 
-        // Dispatch pause onto the dispatcher — queues behind the sync work.
         var pauseTask = Task.Run(() => circuitHost.Renderer.Dispatcher.InvokeAsync(
             async () => await circuitHost.RequestPauseAsync(CancellationToken.None)));
 
-        await Task.Delay(100);
-
-        // Pause has NOT been sent — sync work is blocking the dispatcher.
-        Assert.False(pauseSent);
-
+        syncWorkReleased = true;
         releaseSyncWork.Set();
         await dispatcherTask;
 
         var result = await pauseTask;
         Assert.True(result);
-        Assert.True(pauseSent);
-    }
-
-    [Fact]
-    public async Task A17_DispatchedPause_WhileAsyncWorkSuspended_PauseRunsImmediately()
-    {
-        var pauseSent = false;
-        var proxy = new Mock<ISingleClientProxy>();
-        proxy.Setup(c => c.SendCoreAsync("JS.RequestPause", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
-             .Callback(() => pauseSent = true)
-             .Returns(Task.CompletedTask);
-        var circuitHost = await CreateConnectedCircuitHostAsync(proxy);
-
-        var asyncWorkStarted = new TaskCompletionSource();
-        var releaseAsyncWork = new TaskCompletionSource();
-
-        // Start async work on the dispatcher — it suspends at the await.
-        var dispatcherTask = circuitHost.Renderer.Dispatcher.InvokeAsync(async () =>
-        {
-            asyncWorkStarted.SetResult();
-            await releaseAsyncWork.Task;
-        });
-
-        await asyncWorkStarted.Task;
-
-        // Dispatch pause onto the dispatcher. The async work is suspended,
-        // so the dispatcher runs the pause immediately.
-        var result = await Task.Run(() => circuitHost.Renderer.Dispatcher.InvokeAsync(
-            async () => await circuitHost.RequestPauseAsync(CancellationToken.None)));
-
-        Assert.True(result);
-        Assert.True(pauseSent);
-
-        releaseAsyncWork.SetResult();
-        await dispatcherTask;
+        Assert.True(pauseSentAfterRelease, "Pause should be sent after sync work finishes");
     }
 
     [Fact]

--- a/src/Components/Server/test/Circuits/CircuitHostTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitHostTest.cs
@@ -788,6 +788,45 @@ public class CircuitHostTest
     }
 
     [Fact]
+    public async Task A17_PauseFromInsideHandler_WhileOtherAsyncWorkActive_WaitsForOtherWork()
+    {
+        var otherWorkReleased = false;
+        var pauseSentAfterRelease = false;
+        var proxy = new Mock<ISingleClientProxy>();
+        proxy.Setup(c => c.SendCoreAsync("JS.RequestPause", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+             .Callback(() => pauseSentAfterRelease = otherWorkReleased)
+             .Returns(Task.CompletedTask);
+        var circuitHost = await CreateConnectedCircuitHostAsync(proxy);
+
+        var otherWorkStarted = new TaskCompletionSource();
+        var releaseOtherWork = new TaskCompletionSource();
+
+        // Start another async inbound handler.
+        var otherHandlerTask = circuitHost.HandleInboundActivityAsync(async () =>
+        {
+            otherWorkStarted.SetResult();
+            await releaseOtherWork.Task;
+        });
+
+        await otherWorkStarted.Task;
+
+        // Simulate a component event handler calling RequestPauseAsync directly.
+        // This is ONE HandleInboundActivityAsync wrapping the dispatcher call +
+        // the pause call inside it — NOT a nested HandleInboundActivityAsync.
+        var pauseTask = circuitHost.HandleInboundActivityAsync(
+            () => circuitHost.Renderer.Dispatcher.InvokeAsync(
+                () => circuitHost.RequestPauseAsync(CancellationToken.None).AsTask()));
+
+        // Release the other handler.
+        otherWorkReleased = true;
+        releaseOtherWork.SetResult();
+        await otherHandlerTask;
+
+        await pauseTask;
+        Assert.True(pauseSentAfterRelease, "Pause should be sent after other async work completes");
+    }
+
+    [Fact]
     public async Task A10_Disposed_ReturnsFalseNoMessage()
     {
         var proxy = new Mock<ISingleClientProxy>();

--- a/src/Components/Server/test/Circuits/CircuitHostTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitHostTest.cs
@@ -894,14 +894,7 @@ public class CircuitHostTest
     [Fact]
     public async Task A15_CancelledBeforeSend_ReturnsFalse()
     {
-        var proxy = new Mock<ISingleClientProxy>();
-        proxy.Setup(c => c.SendCoreAsync("JS.RequestPause", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
-             .Returns((string _, object[] _, CancellationToken ct) =>
-             {
-                 ct.ThrowIfCancellationRequested();
-                 return Task.CompletedTask;
-             });
-        var circuitHost = await CreateConnectedCircuitHostAsync(proxy);
+        var circuitHost = await CreateConnectedCircuitHostAsync();
 
         using var cts = new CancellationTokenSource();
         cts.Cancel();
@@ -1124,18 +1117,35 @@ public class CircuitHostTest
     }
 
     [Fact]
-    public async Task PublicApi_ForwardsCancellationToken()
+    public async Task PublicApi_CancellationTokenRejectsDuringDrainWait()
     {
-        using var cts = new CancellationTokenSource();
-        CancellationToken received = default;
         var proxy = new Mock<ISingleClientProxy>();
         proxy.Setup(c => c.SendCoreAsync("JS.RequestPause", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
-             .Callback((string _, object[] _, CancellationToken ct) => received = ct)
              .Returns(Task.CompletedTask);
         var circuitHost = await CreateConnectedCircuitHostAsync(proxy);
 
-        await circuitHost.Circuit.RequestCircuitPauseAsync(cts.Token);
-        Assert.Equal(cts.Token, received);
+        var asyncWorkStarted = new TaskCompletionSource();
+        var releaseAsyncWork = new TaskCompletionSource();
+
+        var inboundTask = circuitHost.HandleInboundActivityAsync(async () =>
+        {
+            asyncWorkStarted.SetResult();
+            await releaseAsyncWork.Task;
+        });
+
+        await asyncWorkStarted.Task;
+
+        using var cts = new CancellationTokenSource();
+        var pauseTask = Task.Run(() => circuitHost.RequestPauseAsync(cts.Token).AsTask());
+
+        // Cancel while waiting for drain — should return false.
+        cts.Cancel();
+
+        var result = await pauseTask;
+        Assert.False(result);
+
+        releaseAsyncWork.SetResult();
+        await inboundTask;
     }
 
     [Fact]

--- a/src/Components/Server/test/Circuits/CircuitRegistryTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitRegistryTest.cs
@@ -566,6 +566,28 @@ public class CircuitRegistryTest
         Assert.False(persistenceProvider.PersistCalled);
     }
 
+    [Fact]
+    public async Task D2_PauseWithStaleConnectionId_AfterReconnect_DoesNotPause()
+    {
+        var circuitIdFactory = TestCircuitIdFactory.CreateTestFactory();
+        var (registry, persistenceProvider) = CreateRegistryWithProvider(circuitIdFactory);
+        var circuitHost = TestCircuitHost.Create(circuitIdFactory.CreateCircuitId());
+        registry.Register(circuitHost);
+        var originalConnectionId = circuitHost.Client.ConnectionId;
+
+        // Client reconnects on connection B
+        await registry.ConnectAsync(circuitHost.CircuitId, Mock.Of<ISingleClientProxy>(), "connection-B", default);
+
+        // Stale pause from connection A arrives
+        await registry.PauseCircuitAsync(circuitHost, originalConnectionId);
+
+        // Circuit remains connected on connection B
+        Assert.True(registry.ConnectedCircuits.TryGetValue(circuitHost.CircuitId, out var connected));
+        Assert.Same(circuitHost, connected);
+        Assert.Equal("connection-B", circuitHost.Client.ConnectionId);
+        Assert.False(persistenceProvider.PersistCalled);
+    }
+
     private class TestCircuitRegistry : CircuitRegistry
     {
         public TestCircuitRegistry(

--- a/src/Components/Server/test/Circuits/CircuitRegistryTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitRegistryTest.cs
@@ -567,7 +567,7 @@ public class CircuitRegistryTest
     }
 
     [Fact]
-    public async Task D2_PauseWithStaleConnectionId_AfterReconnect_DoesNotPause()
+    public async Task PauseWithStaleConnectionId_AfterReconnect_DoesNotPause()
     {
         var circuitIdFactory = TestCircuitIdFactory.CreateTestFactory();
         var (registry, persistenceProvider) = CreateRegistryWithProvider(circuitIdFactory);

--- a/src/Components/Web.JS/src/Platform/Circuits/CircuitManager.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/CircuitManager.ts
@@ -174,8 +174,12 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
       this._componentManager.onAfterUpdateRootComponents?.(batchId);
     });
 
-    connection.on('JS.RequestPause', () => {
-      this.pause(true);
+    connection.on('JS.RequestPause', async () => {
+      try {
+        await this.pause(true);
+      } catch (error) {
+        this._logger.log(LogLevel.Error, `Failed to handle server-initiated pause: ${error}`);
+      }
     });
     connection.on('JS.EndLocationChanging', Blazor._internal.navigationManager.endLocationChanging);
     connection.onclose(error => {

--- a/src/Components/Web.JS/src/Platform/Circuits/CircuitManager.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/CircuitManager.ts
@@ -174,6 +174,9 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
       this._componentManager.onAfterUpdateRootComponents?.(batchId);
     });
 
+    connection.on('JS.RequestPause', () => {
+      this.pause(true);
+    });
     connection.on('JS.EndLocationChanging', Blazor._internal.navigationManager.endLocationChanging);
     connection.onclose(error => {
       this._interopMethodsForReconnection = detachWebRendererInterop(WebRendererId.Server);

--- a/src/Components/Web.JS/src/Platform/Circuits/CircuitManager.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/CircuitManager.ts
@@ -177,11 +177,7 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
     connection.on('JS.RequestPause', async () => {
       try {
         if (this._options.onPauseRequested) {
-          const shouldPause = await this._options.onPauseRequested();
-          if (!shouldPause) {
-            this._logger.log(LogLevel.Trace, 'Server-initiated pause was deferred by onPauseRequested callback.');
-            return;
-          }
+          await this._options.onPauseRequested();
         }
         await this.pause(true);
       } catch (error) {

--- a/src/Components/Web.JS/src/Platform/Circuits/CircuitManager.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/CircuitManager.ts
@@ -176,6 +176,13 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
 
     connection.on('JS.RequestPause', async () => {
       try {
+        if (this._options.onPauseRequested) {
+          const shouldPause = await this._options.onPauseRequested();
+          if (!shouldPause) {
+            this._logger.log(LogLevel.Trace, 'Server-initiated pause was deferred by onPauseRequested callback.');
+            return;
+          }
+        }
         await this.pause(true);
       } catch (error) {
         this._logger.log(LogLevel.Error, `Failed to handle server-initiated pause: ${error}`);

--- a/src/Components/Web.JS/src/Platform/Circuits/CircuitStartOptions.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/CircuitStartOptions.ts
@@ -20,6 +20,7 @@ export interface CircuitStartOptions {
   reconnectionHandler?: ReconnectionHandler;
   initializers : ServerInitializers;
   circuitHandlers: CircuitHandler[];
+  onPauseRequested?: () => Promise<boolean> | boolean;
 }
 
 export function resolveOptions(userOptions?: Partial<CircuitStartOptions>): CircuitStartOptions {

--- a/src/Components/Web.JS/src/Platform/Circuits/CircuitStartOptions.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/CircuitStartOptions.ts
@@ -20,7 +20,7 @@ export interface CircuitStartOptions {
   reconnectionHandler?: ReconnectionHandler;
   initializers : ServerInitializers;
   circuitHandlers: CircuitHandler[];
-  onPauseRequested?: () => Promise<boolean> | boolean;
+  onPauseRequested?: () => Promise<void>;
 }
 
 export function resolveOptions(userOptions?: Partial<CircuitStartOptions>): CircuitStartOptions {

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerTriggeredPauseTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerTriggeredPauseTest.cs
@@ -1,0 +1,295 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Components.TestServer.RazorComponents;
+using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
+using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
+using Microsoft.AspNetCore.E2ETesting;
+using OpenQA.Selenium;
+using TestServer;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests;
+
+public class ServerTriggeredPauseTest : ServerTestBase<BasicTestAppServerSiteFixture<RazorComponentEndpointsStartup<Root>>>
+{
+    public ServerTriggeredPauseTest(
+        BrowserFixture browserFixture,
+        BasicTestAppServerSiteFixture<RazorComponentEndpointsStartup<Root>> serverFixture,
+        ITestOutputHelper output)
+        : base(browserFixture, serverFixture, output)
+    {
+        serverFixture.AdditionalArguments.AddRange("--DisableReconnectionCache", "true");
+    }
+
+    protected override void InitializeAsyncCore()
+    {
+        Navigate("/subdir/persistent-state/server-pause");
+        Browser.Exists(By.Id("render-mode-interactive"));
+    }
+
+    [Fact]
+    public void A1_ServerPause_StateRestoredAfterResume()
+    {
+        Browser.Exists(By.Id("increment-persistent-counter-count")).Click();
+        Browser.Equal("1", () => Browser.Exists(By.Id("persistent-counter-count")).Text);
+
+        var previousRender = Browser.Exists(By.Id("persistent-counter-render")).Text;
+
+        TriggerServerPauseAndResume();
+
+        var newRender = Browser.Exists(By.Id("persistent-counter-render")).Text;
+        Assert.NotEqual(previousRender, newRender);
+        Browser.Equal("1", () => Browser.Exists(By.Id("persistent-counter-count")).Text);
+
+        Browser.Exists(By.Id("increment-persistent-counter-count")).Click();
+        Browser.Equal("2", () => Browser.Exists(By.Id("persistent-counter-count")).Text);
+    }
+
+    // B1: Client pause + server pause in the same JS turn.
+    // Blazor.pauseCircuit() synchronously sends PauseCircuit to the hub.
+    // TriggerServerPause is queued after it. SignalR processes PauseCircuit first,
+    // removing the circuit from ConnectedCircuits. The server pause interop call
+    // arrives at a dead circuit and is dropped. The client pause always wins.
+    [Fact]
+    public void B1_ConcurrentClientAndServerPause_ClientPauseWins()
+    {
+        Browser.Exists(By.Id("increment-persistent-counter-count")).Click();
+        Browser.Equal("1", () => Browser.Exists(By.Id("persistent-counter-count")).Text);
+
+        var circuitId = GetCircuitId();
+        var javascript = (IJavaScriptExecutor)Browser;
+        javascript.ExecuteScript($@"
+            Blazor.pauseCircuit();
+            DotNet.invokeMethodAsync('Components.TestServer', 'TriggerServerPause', '{circuitId}');
+        ");
+
+        WaitForPausedUI();
+        ClickResumeButton();
+        WaitForResumedUI();
+
+        // State preserved: exactly one pause happened (the client one).
+        Browser.Equal("1", () => Browser.Exists(By.Id("persistent-counter-count")).Text);
+    }
+
+    // click() fires beginInvokeDotNetFromJS first, then TriggerServerPause fires second.
+    // SignalR delivers them in order → click processed, then pause.
+    [Fact]
+    public void B2_EventDispatchDuringPause_EventProcessedBeforePause()
+    {
+        Browser.Exists(By.Id("increment-persistent-counter-count")).Click();
+        Browser.Equal("1", () => Browser.Exists(By.Id("persistent-counter-count")).Text);
+
+        var circuitId = GetCircuitId();
+        var javascript = (IJavaScriptExecutor)Browser;
+        javascript.ExecuteScript($@"
+            document.getElementById('increment-persistent-counter-count').click();
+            DotNet.invokeMethodAsync('Components.TestServer', 'TriggerServerPause', '{circuitId}');
+        ");
+
+        WaitForPausedUI();
+        ClickResumeButton();
+        WaitForResumedUI();
+
+        Browser.Equal("2", () => Browser.Exists(By.Id("persistent-counter-count")).Text);
+    }
+
+    [Fact]
+    public void B5_ResumeWhilePausing_ResumeRejectedThenSucceedsAfterPause()
+    {
+        TriggerServerPause();
+        WaitForPausedUI();
+
+        var javascript = (IJavaScriptExecutor)Browser;
+        var resumed = (bool)javascript.ExecuteScript("return await Blazor.resumeCircuit()");
+        Assert.True(resumed);
+
+        WaitForResumedUI();
+    }
+
+    // SignalR ordering: 3 beginInvokeDotNetFromJS calls queued before the pause interop.
+    [Fact]
+    public void B6_MultipleEventsBeforePause_CircuitPausesCleanly()
+    {
+        var circuitId = GetCircuitId();
+        var javascript = (IJavaScriptExecutor)Browser;
+        javascript.ExecuteScript($@"
+            document.getElementById('increment-persistent-counter-count').click();
+            document.getElementById('increment-persistent-counter-count').click();
+            document.getElementById('increment-persistent-counter-count').click();
+            DotNet.invokeMethodAsync('Components.TestServer', 'TriggerServerPause', '{circuitId}');
+        ");
+
+        WaitForPausedUI();
+        ClickResumeButton();
+        WaitForResumedUI();
+
+        Browser.Equal("3", () => Browser.Exists(By.Id("persistent-counter-count")).Text);
+    }
+
+    [Fact]
+    public void F3_NewCircuitConnectsDuringDrain()
+    {
+        TriggerServerPause();
+        WaitForPausedUI();
+        ClickResumeButton();
+        WaitForResumedUI();
+
+        Browser.Exists(By.Id("increment-persistent-counter-count")).Click();
+        Browser.Exists(By.Id("increment-persistent-counter-count")).Click();
+        Browser.Equal("2", () => Browser.Exists(By.Id("persistent-counter-count")).Text);
+    }
+
+    // resumeCircuit() sets _resumingState synchronously. pauseCircuit() checks it next.
+    // JS single-threading guarantees the order.
+    [Fact]
+    public void G1_PauseDuringResume_PauseRejectedByClient()
+    {
+        TriggerServerPause();
+        WaitForPausedUI();
+
+        var javascript = (IJavaScriptExecutor)Browser;
+        var pauseRejected = (bool)javascript.ExecuteScript(@"
+            const resumePromise = Blazor.resumeCircuit();
+            const pauseResult = await Blazor.pauseCircuit();
+            await resumePromise;
+            return !pauseResult;
+        ");
+
+        Assert.True(pauseRejected);
+        WaitForResumedUI();
+    }
+
+    [Fact]
+    public void G3_PauseAfterRender_StateIncludesPriorMutations()
+    {
+        Browser.Exists(By.Id("increment-persistent-counter-count")).Click();
+        Browser.Equal("1", () => Browser.Exists(By.Id("persistent-counter-count")).Text);
+
+        Browser.Exists(By.Id("increment-persistent-counter-count")).Click();
+        Browser.Equal("2", () => Browser.Exists(By.Id("persistent-counter-count")).Text);
+
+        TriggerServerPauseAndResume();
+
+        Browser.Equal("2", () => Browser.Exists(By.Id("persistent-counter-count")).Text);
+    }
+
+    [Fact]
+    public void H1_PausedUI_ShowsResumeButtonNotRetry()
+    {
+        TriggerServerPause();
+        WaitForPausedUI();
+
+        Browser.Equal(
+            (false, true),
+            () => Browser.Exists(
+                () =>
+                {
+                    var buttons = GetReconnectModalButtons();
+                    Assert.Equal(2, buttons.Count);
+                    return (buttons.ElementAt(0).Displayed, buttons.ElementAt(1).Displayed);
+                },
+                TimeSpan.FromSeconds(1)));
+
+        ClickResumeButton();
+        WaitForResumedUI();
+    }
+
+    private string GetCircuitId()
+    {
+        return Browser.Exists(By.Id("circuit-id")).Text;
+    }
+
+    private void TriggerServerPause()
+    {
+        var circuitId = GetCircuitId();
+        var javascript = (IJavaScriptExecutor)Browser;
+        // This JS interop call goes to the server as a hub call (beginInvokeDotNetFromJS).
+        // The server calls RequestCircuitPauseAsync() which sends JS.RequestPause back.
+        // The hub call completes, then the client processes JS.RequestPause deterministically.
+        javascript.ExecuteScript(
+            $"DotNet.invokeMethodAsync('Components.TestServer', 'TriggerServerPause', '{circuitId}')");
+    }
+
+    private void TriggerServerPauseAndResume()
+    {
+        TriggerServerPause();
+        WaitForPausedUI();
+        ClickResumeButton();
+        WaitForResumedUI();
+    }
+
+    private void WaitForPausedUI()
+    {
+        Browser.Equal("block", () =>
+            Browser.Exists(By.Id("components-reconnect-modal")).GetCssValue("display"));
+    }
+
+    private void WaitForResumedUI()
+    {
+        Browser.Equal("none", () =>
+            Browser.Exists(By.Id("components-reconnect-modal")).GetCssValue("display"));
+    }
+
+    private IReadOnlyCollection<IWebElement> GetReconnectModalButtons()
+    {
+        return Browser.Exists(By.Id("components-reconnect-modal"))
+            .GetShadowRoot()
+            .FindElements(By.CssSelector(".components-reconnect-dialog button"));
+    }
+
+    private void ClickResumeButton()
+    {
+        Browser.Exists(
+            () =>
+            {
+                var buttons = GetReconnectModalButtons();
+                return buttons.Count >= 2 ? buttons.ElementAt(1) : null;
+            },
+            TimeSpan.FromSeconds(1)).Click();
+    }
+}
+
+// H2: Custom reconnect UI handles server-triggered pause.
+// The custom element receives the state change event with pause-specific state.
+public class H2_CustomUIServerTriggeredPauseTest : ServerTestBase<BasicTestAppServerSiteFixture<RazorComponentEndpointsStartup<Root>>>
+{
+    public H2_CustomUIServerTriggeredPauseTest(
+        BrowserFixture browserFixture,
+        BasicTestAppServerSiteFixture<RazorComponentEndpointsStartup<Root>> serverFixture,
+        ITestOutputHelper output)
+        : base(browserFixture, serverFixture, output)
+    {
+        serverFixture.AdditionalArguments.AddRange("--DisableReconnectionCache", "true");
+    }
+
+    protected override void InitializeAsyncCore()
+    {
+        Navigate("/subdir/persistent-state/server-pause?custom-reconnect-ui=true");
+        Browser.Exists(By.Id("render-mode-interactive"));
+        Browser.Exists(By.CssSelector("#components-reconnect-modal[data-nosnippet]"));
+    }
+
+    [Fact]
+    public void H2_CustomReconnectUI_HandlesServerPause()
+    {
+        Browser.Exists(By.Id("increment-persistent-counter-count")).Click();
+        Browser.Equal("1", () => Browser.Exists(By.Id("persistent-counter-count")).Text);
+
+        var circuitId = Browser.Exists(By.Id("circuit-id")).Text;
+        var javascript = (IJavaScriptExecutor)Browser;
+        javascript.ExecuteScript(
+            $"DotNet.invokeMethodAsync('Components.TestServer', 'TriggerServerPause', '{circuitId}')");
+
+        // Custom reconnect modal uses a <dialog> element — when open, it has the `open` attribute
+        Browser.True(() => Browser.Exists(By.Id("components-reconnect-modal")).GetAttribute("open") is not null);
+
+        // Resume via the custom Resume button
+        Browser.Exists(By.Id("components-resume-button")).Click();
+
+        // Dialog should close
+        Browser.True(() => Browser.Exists(By.Id("components-reconnect-modal")).GetAttribute("open") is null);
+
+        Browser.Equal("1", () => Browser.Exists(By.Id("persistent-counter-count")).Text);
+    }
+}

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerTriggeredPauseTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerTriggeredPauseTest.cs
@@ -29,7 +29,7 @@ public class ServerTriggeredPauseTest : ServerTestBase<BasicTestAppServerSiteFix
     }
 
     [Fact]
-    public void A1_ServerPause_StateRestoredAfterResume()
+    public void ServerPause_StateRestoredAfterResume()
     {
         Browser.Exists(By.Id("increment-persistent-counter-count")).Click();
         Browser.Equal("1", () => Browser.Exists(By.Id("persistent-counter-count")).Text);
@@ -47,7 +47,7 @@ public class ServerTriggeredPauseTest : ServerTestBase<BasicTestAppServerSiteFix
     }
 
     [Fact]
-    public void A4_PauseDuringRender_StateMutationPreservedAfterResume()
+    public void PauseDuringRender_StateMutationPreservedAfterResume()
     {
         Browser.Equal("0", () => Browser.Exists(By.Id("inline-count")).Text);
 
@@ -76,7 +76,7 @@ public class ServerTriggeredPauseTest : ServerTestBase<BasicTestAppServerSiteFix
     // removing the circuit from ConnectedCircuits. The server pause interop call
     // arrives at a dead circuit and is dropped. The client pause always wins.
     [Fact]
-    public void B1_ConcurrentClientAndServerPause_ClientPauseWins()
+    public void ConcurrentClientAndServerPause_ClientPauseWins()
     {
         Browser.Exists(By.Id("increment-persistent-counter-count")).Click();
         Browser.Equal("1", () => Browser.Exists(By.Id("persistent-counter-count")).Text);
@@ -99,7 +99,7 @@ public class ServerTriggeredPauseTest : ServerTestBase<BasicTestAppServerSiteFix
     // click() fires beginInvokeDotNetFromJS first, then TriggerServerPause fires second.
     // SignalR delivers them in order → click processed, then pause.
     [Fact]
-    public void B2_EventDispatchDuringPause_EventProcessedBeforePause()
+    public void EventDispatchDuringPause_EventProcessedBeforePause()
     {
         Browser.Exists(By.Id("increment-persistent-counter-count")).Click();
         Browser.Equal("1", () => Browser.Exists(By.Id("persistent-counter-count")).Text);
@@ -119,7 +119,7 @@ public class ServerTriggeredPauseTest : ServerTestBase<BasicTestAppServerSiteFix
     }
 
     [Fact]
-    public void B5_ResumeWhilePausing_ResumeRejectedThenSucceedsAfterPause()
+    public void ResumeWhilePausing_ResumeRejectedThenSucceedsAfterPause()
     {
         TriggerServerPause();
         WaitForPausedUI();
@@ -136,7 +136,7 @@ public class ServerTriggeredPauseTest : ServerTestBase<BasicTestAppServerSiteFix
 
     // SignalR ordering: 3 beginInvokeDotNetFromJS calls queued before the pause interop.
     [Fact]
-    public void B6_MultipleEventsBeforePause_CircuitPausesCleanly()
+    public void MultipleEventsBeforePause_CircuitPausesCleanly()
     {
         var circuitId = GetCircuitId();
         var javascript = (IJavaScriptExecutor)Browser;
@@ -155,7 +155,7 @@ public class ServerTriggeredPauseTest : ServerTestBase<BasicTestAppServerSiteFix
     }
 
     [Fact]
-    public void F3_NewCircuitConnectsDuringDrain()
+    public void NewCircuitConnectsDuringDrain()
     {
         TriggerServerPause();
         WaitForPausedUI();
@@ -170,7 +170,7 @@ public class ServerTriggeredPauseTest : ServerTestBase<BasicTestAppServerSiteFix
     // resumeCircuit() sets _resumingState synchronously. pauseCircuit() checks it next.
     // JS single-threading guarantees the order.
     [Fact]
-    public void G1_PauseDuringResume_PauseRejectedByClient()
+    public void PauseDuringResume_PauseRejectedByClient()
     {
         TriggerServerPause();
         WaitForPausedUI();
@@ -191,7 +191,7 @@ public class ServerTriggeredPauseTest : ServerTestBase<BasicTestAppServerSiteFix
     }
 
     [Fact]
-    public void G3_PauseAfterRender_StateIncludesPriorMutations()
+    public void PauseAfterRender_StateIncludesPriorMutations()
     {
         Browser.Exists(By.Id("increment-persistent-counter-count")).Click();
         Browser.Equal("1", () => Browser.Exists(By.Id("persistent-counter-count")).Text);
@@ -205,7 +205,7 @@ public class ServerTriggeredPauseTest : ServerTestBase<BasicTestAppServerSiteFix
     }
 
     [Fact]
-    public void H1_PausedUI_ShowsResumeButtonNotRetry()
+    public void PausedUI_ShowsResumeButtonNotRetry()
     {
         TriggerServerPause();
         WaitForPausedUI();
@@ -301,7 +301,7 @@ public class H2_CustomUIServerTriggeredPauseTest : ServerTestBase<BasicTestAppSe
     }
 
     [Fact]
-    public void H2_CustomReconnectUI_HandlesServerPause()
+    public void CustomReconnectUI_HandlesServerPause()
     {
         Browser.Exists(By.Id("increment-persistent-counter-count")).Click();
         Browser.Equal("1", () => Browser.Exists(By.Id("persistent-counter-count")).Text);

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerTriggeredPauseTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerTriggeredPauseTest.cs
@@ -46,6 +46,30 @@ public class ServerTriggeredPauseTest : ServerTestBase<BasicTestAppServerSiteFix
         Browser.Equal("2", () => Browser.Exists(By.Id("persistent-counter-count")).Text);
     }
 
+    [Fact]
+    public void A4_PauseDuringRender_StateMutationPreservedAfterResume()
+    {
+        Browser.Equal("0", () => Browser.Exists(By.Id("inline-count")).Text);
+
+        // Click the button that increments AND pauses in the same handler.
+        Browser.Exists(By.Id("increment-and-pause")).Click();
+
+        WaitForPausedUI();
+        ClickResumeButton();
+        WaitForResumedUI();
+
+        // The state mutation from the handler (count incremented to 1) should be preserved.
+        Browser.Equal("1", () => Browser.Exists(By.Id("inline-count")).Text);
+
+        // Can continue interacting after resume.
+        Browser.Exists(By.Id("increment-and-pause")).Click();
+        WaitForPausedUI();
+        ClickResumeButton();
+        WaitForResumedUI();
+
+        Browser.Equal("2", () => Browser.Exists(By.Id("inline-count")).Text);
+    }
+
     // B1: Client pause + server pause in the same JS turn.
     // Blazor.pauseCircuit() synchronously sends PauseCircuit to the hub.
     // TriggerServerPause is queued after it. SignalR processes PauseCircuit first,

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerTriggeredPauseTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerTriggeredPauseTest.cs
@@ -101,7 +101,10 @@ public class ServerTriggeredPauseTest : ServerTestBase<BasicTestAppServerSiteFix
         WaitForPausedUI();
 
         var javascript = (IJavaScriptExecutor)Browser;
-        var resumed = (bool)javascript.ExecuteScript("return await Blazor.resumeCircuit()");
+        var resumed = (bool)javascript.ExecuteAsyncScript(@"
+            const callback = arguments[arguments.length - 1];
+            Blazor.resumeCircuit().then(callback);
+        ");
         Assert.True(resumed);
 
         WaitForResumedUI();
@@ -149,11 +152,14 @@ public class ServerTriggeredPauseTest : ServerTestBase<BasicTestAppServerSiteFix
         WaitForPausedUI();
 
         var javascript = (IJavaScriptExecutor)Browser;
-        var pauseRejected = (bool)javascript.ExecuteScript(@"
-            const resumePromise = Blazor.resumeCircuit();
-            const pauseResult = await Blazor.pauseCircuit();
-            await resumePromise;
-            return !pauseResult;
+        var pauseRejected = (bool)javascript.ExecuteAsyncScript(@"
+            const callback = arguments[arguments.length - 1];
+            (async function() {
+                const resumePromise = Blazor.resumeCircuit();
+                const pauseResult = await Blazor.pauseCircuit();
+                await resumePromise;
+                callback(!pauseResult);
+            })();
         ");
 
         Assert.True(pauseRejected);

--- a/src/Components/test/testassets/Components.TestServer/PauseTrackingHandler.cs
+++ b/src/Components/test/testassets/Components.TestServer/PauseTrackingHandler.cs
@@ -10,9 +10,9 @@ public class PauseTrackingHandler : CircuitHandler
 {
     private static readonly ConcurrentDictionary<string, Circuit> _circuits = new();
 
-    public Circuit CurrentCircuit { get; private set; }
+    public Circuit? CurrentCircuit { get; private set; }
 
-    public static Circuit GetCircuit(string id)
+    public static Circuit? GetCircuit(string id)
         => _circuits.TryGetValue(id, out var c) ? c : null;
 
     public override Task OnConnectionUpAsync(Circuit circuit, CancellationToken cancellationToken)
@@ -25,6 +25,12 @@ public class PauseTrackingHandler : CircuitHandler
     public override Task OnConnectionDownAsync(Circuit circuit, CancellationToken cancellationToken)
     {
         CurrentCircuit = null;
+        _circuits.TryRemove(circuit.Id, out _);
+        return Task.CompletedTask;
+    }
+
+    public override Task OnCircuitClosedAsync(Circuit circuit, CancellationToken cancellationToken)
+    {
         _circuits.TryRemove(circuit.Id, out _);
         return Task.CompletedTask;
     }

--- a/src/Components/test/testassets/Components.TestServer/PauseTrackingHandler.cs
+++ b/src/Components/test/testassets/Components.TestServer/PauseTrackingHandler.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using Microsoft.AspNetCore.Components.Server.Circuits;
+
+namespace TestServer;
+
+public class PauseTrackingHandler : CircuitHandler
+{
+    private static readonly ConcurrentDictionary<string, Circuit> _circuits = new();
+
+    public Circuit CurrentCircuit { get; private set; }
+
+    public static Circuit GetCircuit(string id)
+        => _circuits.TryGetValue(id, out var c) ? c : null;
+
+    public override Task OnConnectionUpAsync(Circuit circuit, CancellationToken cancellationToken)
+    {
+        CurrentCircuit = circuit;
+        _circuits[circuit.Id] = circuit;
+        return Task.CompletedTask;
+    }
+
+    public override Task OnConnectionDownAsync(Circuit circuit, CancellationToken cancellationToken)
+    {
+        CurrentCircuit = null;
+        _circuits.TryRemove(circuit.Id, out _);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Components/test/testassets/Components.TestServer/RazorComponentEndpointsStartup.cs
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponentEndpointsStartup.cs
@@ -95,6 +95,9 @@ public class RazorComponentEndpointsStartup<TRootComponent>
         var circuitContextAccessor = new TestCircuitContextAccessor();
         services.AddSingleton<CircuitHandler>(circuitContextAccessor);
         services.AddSingleton(circuitContextAccessor);
+
+        services.AddScoped<PauseTrackingHandler>();
+        services.AddScoped<CircuitHandler>(sp => sp.GetRequiredService<PauseTrackingHandler>());
     }
 
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/PersistentState/ServerPauseTest.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/PersistentState/ServerPauseTest.razor
@@ -1,0 +1,39 @@
+@page "/persistent-state/server-pause"
+@rendermode RenderMode.InteractiveServer
+@using Microsoft.AspNetCore.Components.Server.Circuits
+@using Microsoft.JSInterop
+@using TestServer
+
+@inject PauseTrackingHandler PauseTracker
+
+<p>Validates server-triggered circuit pause via RequestCircuitPauseAsync()</p>
+
+<TestContentPackage.PersistentCounter />
+
+<p>Circuit ID: <span id="circuit-id">@_circuitId</span></p>
+
+@code {
+    private string _circuitId = "";
+
+    protected override void OnInitialized()
+    {
+        _circuitId = PauseTracker.CurrentCircuit?.Id ?? "";
+    }
+
+    /// <summary>
+    /// Static JSInvokable method that E2E tests call via
+    /// DotNet.invokeMethodAsync('Components.TestServer', 'TriggerServerPause', circuitId).
+    /// This runs on the circuit's dispatcher, calls RequestCircuitPauseAsync(), then returns.
+    /// The JS.RequestPause message is sent to the client during this call.
+    /// </summary>
+    [JSInvokable]
+    public static async Task<bool> TriggerServerPause(string circuitId)
+    {
+        var circuit = PauseTrackingHandler.GetCircuit(circuitId);
+        if (circuit is null)
+        {
+            return false;
+        }
+        return await circuit.RequestCircuitPauseAsync();
+    }
+}

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/PersistentState/ServerPauseTest.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/PersistentState/ServerPauseTest.razor
@@ -11,21 +11,41 @@
 <TestContentPackage.PersistentCounter />
 
 <p>Circuit ID: <span id="circuit-id">@_circuitId</span></p>
+<p>Inline count: <span id="inline-count">@_inlineState.Count</span></p>
+<button id="increment-and-pause" @onclick="IncrementAndPause">Increment + Pause</button>
 
 @code {
     private string _circuitId = "";
 
+    [PersistentState]
+    public CounterState _inlineState { get; set; }
+
+    public class CounterState
+    {
+        public int Count { get; set; } = 0;
+    }
+
     protected override void OnInitialized()
     {
         _circuitId = PauseTracker.CurrentCircuit?.Id ?? "";
+        _inlineState ??= new CounterState();
     }
 
-    /// <summary>
-    /// Static JSInvokable method that E2E tests call via
-    /// DotNet.invokeMethodAsync('Components.TestServer', 'TriggerServerPause', circuitId).
-    /// This runs on the circuit's dispatcher, calls RequestCircuitPauseAsync(), then returns.
-    /// The JS.RequestPause message is sent to the client during this call.
-    /// </summary>
+    private async Task IncrementAndPause()
+    {
+        // Mutate state — this triggers StateHasChanged and a render batch.
+        _inlineState.Count++;
+
+        // Request pause while the render batch from the mutation above
+        // is being generated/queued. The JS.RequestPause message is sent
+        // after the render batch on the same connection.
+        var circuit = PauseTracker.CurrentCircuit;
+        if (circuit is not null)
+        {
+            await circuit.RequestCircuitPauseAsync();
+        }
+    }
+
     [JSInvokable]
     public static async Task<bool> TriggerServerPause(string circuitId)
     {


### PR DESCRIPTION
Design doc: https://github.com/dotnet/aspnetcore/issues/66244

Test scenarios covered: https://github.com/dotnet/aspnetcore/issues/66244#issuecomment-4213637865.  G2 remains uncovered: the scenario describes a correct existing behavior that can't be deterministically tested without a framework-internal hook in JS, which we chose not to add.

Fixes https://github.com/dotnet/aspnetcore/issues/62327.

## New API

```csharp
 namespace Microsoft.AspNetCore.Components.Server.Circuits;
 
 public sealed class Circuit
 {
     /// <summary>
     /// Requests that the connected client begin the graceful circuit-pause flow.
     /// </summary>
     /// <remarks>
     /// The operation is idempotent. Observe completion through
     /// CircuitHandler.OnConnectionDownAsync and CircuitHandler.OnCircuitClosedAsync.
     /// </remarks>
     public ValueTask<bool> RequestCircuitPauseAsync(CancellationToken cancellationToken = default);
```

## How it works

**Dispatcher scheduling for sync work**: `RequestCircuitPauseAsync` dispatches the `JS.RequestPause` send onto the circuit's dispatcher via `Renderer.Dispatcher.InvokeAsync`. This serializes it with any current sync work (rendering, synchronous event handlers) — the pause message is never sent while a render batch is being produced.

**Client hook for async work**: The dispatcher cannot reliably detect completion of async work (event handlers at `await` points, async component lifecycle methods). A child component's async `OnParametersSetAsync`, for example, creates a new renderer work item outside the scope of the original inbound handler. Instead of tracking this on the server, the client receives `JS.RequestPause` and can defer the actual pause via an optional `onPauseRequested` callback in `CircuitStartOptions`:

```javascript
Blazor.start({
    circuit: {
        onPauseRequested: async () => {
            await currentPayment; // wait for critical work
            return true;          // now safe to pause
        }
    }
});
```

If the callback returns `false`, the pause is deferred — the client does not call `PauseCircuit`. The server's `RequestCircuitPauseAsync` still returns `true` (the message was accepted and sent). Without a callback, the client pauses immediately upon receiving `JS.RequestPause`.

**State validation**: The method checks four conditions before accepting:
- Circuit is not disposed
- Circuit completed initialization (`_initialized`)
- `OnConnectionUpAsync` has fired (`_onConnectionUpFired`)
- Client transport is connected

**Telemetry**: 4 log events — `ServerPauseRequested` (120), `ServerPauseAccepted` (121), `ServerPauseRejected` (122), `ServerPauseFailed` (123). `OperationCanceledException` logs as rejected, other exceptions log as failed.
