### PR TITLE
Detach methods when disconnection confirmed.

### DIFF
--- a/src/Components/Web.JS/src/Platform/Circuits/CircuitManager.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/CircuitManager.ts
@@ -16,7 +16,7 @@ import { ConsoleLogger } from '../Logging/Loggers';
 import { RenderQueue } from './RenderQueue';
 import { Blazor } from '../../GlobalExports';
 import { showErrorNotification } from '../../BootErrors';
-import { attachWebRendererInterop, detachWebRendererInterop } from '../../Rendering/WebRendererInteropMethods';
+import { attachWebRendererInterop, detachWebRendererInterop, isRendererAttached } from '../../Rendering/WebRendererInteropMethods';
 import { sendJSDataStream } from './CircuitStreamingInterop';
 
 export class CircuitManager implements DotNet.DotNetCallDispatcher {
@@ -272,6 +272,9 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
     }
 
     if (!await this._connection!.invoke<boolean>('ConnectCircuit', this._circuitId)) {
+      if (isRendererAttached(WebRendererId.Server)) {
+        this._interopMethodsForReconnection = detachWebRendererInterop(WebRendererId.Server);
+      }
       return false;
     }
 

--- a/src/Components/Web.JS/test/WebRendererInteropMethods.test.ts
+++ b/src/Components/Web.JS/test/WebRendererInteropMethods.test.ts
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+import { expect, test, describe, beforeEach } from '@jest/globals';
+import {
+  attachWebRendererInterop,
+  detachWebRendererInterop,
+  isRendererAttached,
+} from '../src/Rendering/WebRendererInteropMethods';
+
+function createMockInteropMethods(label?: string): any {
+  return {
+    _label: label || 'mock',
+    invokeMethodAsync: () => Promise.resolve(),
+    dispose: () => {},
+    serializeAsArg: () => ({ __dotNetObject: 1 }),
+  };
+}
+
+const ServerRendererId = 1;
+
+describe('Issue #64738 - reconnect then resume double registration', () => {
+  beforeEach(() => {
+    if (isRendererAttached(ServerRendererId)) {
+      detachWebRendererInterop(ServerRendererId);
+    }
+  });
+
+  test('CircuitManager.reconnect detaches interop when ConnectCircuit fails, allowing resume to register new renderer', async () => {
+    // 1. Server creates initial RemoteRenderer → registers interop for renderer 1
+    const initialMethods = createMockInteropMethods('initial-circuit');
+    attachWebRendererInterop(ServerRendererId, initialMethods);
+
+    // 2. Connection drops → onclose detaches and saves interop methods
+    const savedMethods = detachWebRendererInterop(ServerRendererId);
+
+    // 3–4. CircuitManager.reconnect() runs: re-attaches saved methods,
+    //       then ConnectCircuit returns false. With the fix, reconnect()
+    //       detaches interop before returning false.
+    const { CircuitManager } = await import('../src/Platform/Circuits/CircuitManager');
+    const manager: any = Object.create(CircuitManager.prototype);
+    manager._circuitId = 'test-circuit-id';
+    manager._interopMethodsForReconnection = savedMethods;
+    manager._connection = { state: 'Disconnected' };
+    manager.startConnection = async () => ({
+      state: 'Connected',
+      invoke: async (method: string) => {
+        if (method === 'ConnectCircuit') {
+          return false; // Server rejects — circuit expired
+        }
+        return null;
+      },
+    });
+
+    const result = await manager.reconnect();
+    expect(result).toBe(false);
+
+    // After the fix, renderer 1 should be detached
+    expect(isRendererAttached(ServerRendererId)).toBe(false);
+
+    // 5–6. resume() fallback → server creates new RemoteRenderer whose
+    //       constructor calls attachWebRendererInterop(1, newMethods)
+    const newCircuitMethods = createMockInteropMethods('new-circuit-from-resume');
+    attachWebRendererInterop(ServerRendererId, newCircuitMethods);
+
+    // Must succeed — the new renderer registered without throwing
+    expect(isRendererAttached(ServerRendererId)).toBe(true);
+  });
+
+  test('CircuitManager.reconnect does not throw when ConnectCircuit fails and renderer is not attached', async () => {
+    // This covers the edge case where a custom reconnectionHandler calls
+    // Blazor.reconnect() without a prior connection drop, so
+    // _interopMethodsForReconnection is undefined and the renderer
+    // was never attached on the JS side.
+    const { CircuitManager } = await import('../src/Platform/Circuits/CircuitManager');
+    const manager: any = Object.create(CircuitManager.prototype);
+    manager._circuitId = 'test-circuit-id';
+    manager._interopMethodsForReconnection = undefined; // no saved methods
+    manager._connection = { state: 'Disconnected' };
+    manager.startConnection = async () => ({
+      state: 'Connected',
+      invoke: async (method: string) => {
+        if (method === 'ConnectCircuit') {
+          return false;
+        }
+        return null;
+      },
+    });
+
+    expect(isRendererAttached(ServerRendererId)).toBe(false);
+
+    // Must not throw — the guard skips detach when renderer isn't attached
+    const result = await manager.reconnect();
+    expect(result).toBe(false);
+    expect(isRendererAttached(ServerRendererId)).toBe(false);
+  });
+});

--- a/src/Components/Web.JS/test/WebRendererInteropMethods.test.ts
+++ b/src/Components/Web.JS/test/WebRendererInteropMethods.test.ts
@@ -7,6 +7,7 @@ import {
   detachWebRendererInterop,
   isRendererAttached,
 } from '../src/Rendering/WebRendererInteropMethods';
+import { WebRendererId } from '../src/Rendering/WebRendererId';
 
 function createMockInteropMethods(label?: string): any {
   return {
@@ -17,22 +18,20 @@ function createMockInteropMethods(label?: string): any {
   };
 }
 
-const ServerRendererId = 1;
-
 describe('Issue #64738 - reconnect then resume double registration', () => {
   beforeEach(() => {
-    if (isRendererAttached(ServerRendererId)) {
-      detachWebRendererInterop(ServerRendererId);
+    if (isRendererAttached(WebRendererId.Server)) {
+      detachWebRendererInterop(WebRendererId.Server);
     }
   });
 
   test('CircuitManager.reconnect detaches interop when ConnectCircuit fails, allowing resume to register new renderer', async () => {
     // 1. Server creates initial RemoteRenderer → registers interop for renderer 1
     const initialMethods = createMockInteropMethods('initial-circuit');
-    attachWebRendererInterop(ServerRendererId, initialMethods);
+    attachWebRendererInterop(WebRendererId.Server, initialMethods);
 
     // 2. Connection drops → onclose detaches and saves interop methods
-    const savedMethods = detachWebRendererInterop(ServerRendererId);
+    const savedMethods = detachWebRendererInterop(WebRendererId.Server);
 
     // 3–4. CircuitManager.reconnect() runs: re-attaches saved methods,
     //       then ConnectCircuit returns false. With the fix, reconnect()
@@ -56,15 +55,15 @@ describe('Issue #64738 - reconnect then resume double registration', () => {
     expect(result).toBe(false);
 
     // After the fix, renderer 1 should be detached
-    expect(isRendererAttached(ServerRendererId)).toBe(false);
+    expect(isRendererAttached(WebRendererId.Server)).toBe(false);
 
     // 5–6. resume() fallback → server creates new RemoteRenderer whose
     //       constructor calls attachWebRendererInterop(1, newMethods)
     const newCircuitMethods = createMockInteropMethods('new-circuit-from-resume');
-    attachWebRendererInterop(ServerRendererId, newCircuitMethods);
+    attachWebRendererInterop(WebRendererId.Server, newCircuitMethods);
 
     // Must succeed — the new renderer registered without throwing
-    expect(isRendererAttached(ServerRendererId)).toBe(true);
+    expect(isRendererAttached(WebRendererId.Server)).toBe(true);
   });
 
   test('CircuitManager.reconnect does not throw when ConnectCircuit fails and renderer is not attached', async () => {
@@ -87,11 +86,11 @@ describe('Issue #64738 - reconnect then resume double registration', () => {
       },
     });
 
-    expect(isRendererAttached(ServerRendererId)).toBe(false);
+    expect(isRendererAttached(WebRendererId.Server)).toBe(false);
 
     // Must not throw — the guard skips detach when renderer isn't attached
     const result = await manager.reconnect();
     expect(result).toBe(false);
-    expect(isRendererAttached(ServerRendererId)).toBe(false);
+    expect(isRendererAttached(WebRendererId.Server)).toBe(false);
   });
 });


### PR DESCRIPTION
When a Blazor Server client loses connection, `DefaultReconnectionHandler` calls `CircuitManager.reconnect()`. If `ConnectCircuit` fails (circuit expired), it falls back to `resume()`, which creates a new RemoteRenderer on the server.
That renderer's constructor calls `attachWebRendererInterop(1, newMethods)` via JS interop. But reconnect() re-attached saved interop methods and didn't clean them up when ConnectCircuit returned false — causing:
```
"Interop methods are already registered for renderer 1"
```

The fix: `CircuitManager.reconnect()` calls `detachWebRendererInterop` when `ConnectCircuit` returns false.

The test exercises reconnect() on a `CircuitManager` with mocked internals to verify the fix, then confirms the server can register new interop methods.

Fixes https://github.com/dotnet/aspnetcore/issues/64738.