### PR TITLE
[Components][E2E] Fix and unquarantine CanElevateEffectiveMaxItemCount_WhenOverscanExceedsMax

### DIFF
--- a/src/Components/test/E2ETest/ServerExecutionTests/TestSubclasses.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/TestSubclasses.cs
@@ -104,10 +104,6 @@ public class ServerVirtualizationTest : VirtualizationTest
     public override void CanRenderHtmlTable()
         => base.CanRenderHtmlTable();
 
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/65962")]
-    public override void CanElevateEffectiveMaxItemCount_WhenOverscanExceedsMax()
-        => base.CanElevateEffectiveMaxItemCount_WhenOverscanExceedsMax();
-
     [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/66119")]
     public override void NonZeroStartIndex_ScrollToMiddleThenMeasure()
         => base.NonZeroStartIndex_ScrollToMiddleThenMeasure();

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -611,14 +611,18 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/65852")]
-    public virtual void CanElevateEffectiveMaxItemCount_WhenOverscanExceedsMax()
+    public void CanElevateEffectiveMaxItemCount_WhenOverscanExceedsMax()
     {
         Browser.MountTestComponent<VirtualizationLargeOverscan>();
         var container = Browser.Exists(By.Id("virtualize-large-overscan"));
-        // Ensure we have an initial contiguous batch and the elevated effective max has kicked in (>= OverscanCount)
-        var indices = GetVisibleItemIndices();
-        Browser.True(() => indices.Count >= 200);
+        // Wait for the elevated effective max to kick in (>= OverscanCount).
+        // Re-query inside the retry loop so we see new items as they render.
+        List<int> indices = null;
+        Browser.True(() =>
+        {
+            indices = GetVisibleItemIndices();
+            return indices.Count >= 200;
+        });
 
         // Give focus so PageDown works
         container.Click();
@@ -633,8 +637,13 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         var scrollTop = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
         while (scrollTop + clientHeight < scrollHeight)
         {
-            // Validate contiguity on the current page
-            Browser.True(() => IsCurrentViewContiguous(indices));
+            // Re-query visible items after each scroll so contiguity and
+            // progress checks reflect the current DOM state.
+            Browser.True(() =>
+            {
+                indices = GetVisibleItemIndices();
+                return IsCurrentViewContiguous(indices);
+            });
 
             // Track progress in indices
             var currentMax = indices.Max();


### PR DESCRIPTION
## Summary
Fix the root cause of flakiness in ServerVirtualizationTest.CanElevateEffectiveMaxItemCount_WhenOverscanExceedsMax and unquarantine it.

Fixes #65962

## Root cause
GetVisibleItemIndices() was called once and the resulting list was reused in all Browser.True() retry loops and across PageDown iterations. In server mode the async virtualization update had not finished when the snapshot was taken, so the retry loop kept checking a stale list that never reached 200 items, causing a timeout.

The same stale list was also used for contiguity and progress checks after each PageDown, meaning those checks operated on the initial view rather than the current DOM state.

## What changed
- Re-query GetVisibleItemIndices() inside each Browser.True() loop so retries reflect the current DOM state
- Remove the quarantine attributes from both the base class and the ServerVirtualizationTest override
- Remove the virtual modifier and override since they are no longer needed