### PR TITLE
Fix investigation comments failing due to extra-quoted item_number

### DIFF
--- a/.github/workflows/test-quarantine.md
+++ b/.github/workflows/test-quarantine.md
@@ -305,6 +305,7 @@ You have a limited turn and token budget. **Reserve at least 15 turns for creati
 - It is always better to produce fewer but complete outputs (issue + PR + comment) than to investigate exhaustively and run out of budget before creating any outputs.
 - Deferred work will be handled by the next daily run — if you have identified candidates but fail to create any outputs for them, that is the worst outcome.
 - When creating outputs, you **must invoke the safe-output MCP tools** as actual tool calls. The callable MCP tool names are underscore-based (`create_pull_request`, `create_issue`, `add_comment`) and correspond to the hyphenated `safe-outputs` entries in the frontmatter. Writing JSON descriptions of intended calls in your text response does NOT create them.
+- When passing string parameters to safe-output tools (e.g., `item_number`, `temporary_id`), pass them as **plain strings without extra quoting**. For example, use `item_number: "aw_myid"` — not `item_number: "\"aw_myid\""`. Extra quote characters will cause the handler to reject the value.
 
 ---
 
@@ -325,7 +326,7 @@ For each quarantine/re-quarantine candidate, in priority order:
      - `## Logs` — console log content from the most recent failure, in a `<details>` block with ` ```text ``` `. Get this from the Helix work item files API: find the file named `{TestClassName}_{TestMethodName}.log` for the specific test. Prefer to include the full, verbatim log when it fits within GitHub issue size limits. If the log is very large or would exceed those limits, include a representative head and tail of the log in the issue and provide a direct link to the full Helix log file (and/or attach it as an artifact) so the complete output is still accessible.
      - `## Build` — link to the most recent failing build: `https://dev.azure.com/dnceng-public/public/_build/results?buildId={BUILD_ID}`
 
-2. **Post an investigation comment** on the issue. Examine all available failure logs for the test. Be concise but thorough:
+2. **Post an investigation comment** on the issue using `add_comment` with `item_number` set to the same `temporary_id` you used when calling `create_issue` (e.g., if you used `temporary_id: "aw_http2ign"`, pass `item_number: "aw_http2ign"`). **Important:** pass the temporary ID as a plain string — do not wrap it in extra quotes or other formatting. Examine all available failure logs for the test. Be concise but thorough:
    - If you can identify a root cause, explain it and suggest a fix if one is obvious.
    - If you cannot determine the root cause, say so.
    - You may reference Microsoft official docs or issues in other repos within the `dotnet` GitHub org if relevant, but do not include any other external links.

--- a/.github/workflows/test-quarantine.md
+++ b/.github/workflows/test-quarantine.md
@@ -317,7 +317,19 @@ Now that you have identified all candidates (Parts 1 and 2) and planned your bud
 
 ### Step 3.1 — Quarantine and re-quarantine (highest priority)
 
-For each quarantine/re-quarantine candidate, in priority order:
+For each quarantine/re-quarantine candidate, in priority order (Case B re-quarantines first, then Case A new quarantines — follow the matching case for each candidate):
+
+#### Case B — Re-quarantine of a recently unquarantined test
+
+For re-quarantines, **reuse the original quarantine issue** instead of creating a new one. You identified this issue in Step 1.2.
+
+1. **Post an investigation comment** on the **existing** issue using `add_comment` with `item_number` set to the existing numeric issue number (e.g., `item_number: 66035`). Explain that the test was unquarantined but is failing again, include the recent failure details, and note which unquarantine PR removed the attribute.
+
+2. **Create a PR** that:
+   - Adds `[QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/{ISSUE_NUMBER}")]` to the test method (or class), using the **existing issue's numeric URL** directly (e.g., `[QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/66035")]`) — not a temporary ID.
+   - Adds `using Microsoft.AspNetCore.InternalTesting;` if not already present in the file
+   - References the existing issue in the PR body with a literal issue reference (e.g., `Associated issue: #66035`).
+   - Adds the `re-quarantine` label to the PR.
 
 #### Case A — New quarantine
 
@@ -341,18 +353,6 @@ For each quarantine/re-quarantine candidate, in priority order:
    - Adds `using Microsoft.AspNetCore.InternalTesting;` if not already present in the file
    - References the issue in the PR body with `Associated issue: #{TEMPORARY_ID}` (using the same `temporary_id` from `create_issue`, e.g., `Associated issue: #aw_http2ign`). Do **not** use the word `Fixes` or `Closes` — quarantine PRs open tracking issues, they do not fix them, and GitHub would auto-close the issue when the PR merges.
    - When referencing build IDs in the PR body, always use full clickable URLs: `https://dev.azure.com/dnceng-public/public/_build/results?buildId={BUILD_ID}&view=results`. Never reference build IDs as plain numbers.
-
-#### Case B — Re-quarantine of a recently unquarantined test
-
-For re-quarantines, **reuse the original quarantine issue** instead of creating a new one. You identified this issue in Step 1.2.
-
-1. **Post an investigation comment** on the **existing** issue using `add_comment` with `item_number` set to the existing numeric issue number (e.g., `item_number: 66035`). Explain that the test was unquarantined but is failing again, include the recent failure details, and note which unquarantine PR removed the attribute.
-
-2. **Create a PR** that:
-   - Adds `[QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/{EXISTING_ISSUE_NUMBER}")]` to the test method (or class), using the **existing issue's numeric URL** directly — not a temporary ID.
-   - Adds `using Microsoft.AspNetCore.InternalTesting;` if not already present in the file
-   - References the existing issue in the PR body with `Associated issue: #{EXISTING_ISSUE_NUMBER}`.
-   - Adds the `re-quarantine` label to the PR.
 
 ### Step 3.2 — Unquarantine (only after all quarantine work is done)
 

--- a/.github/workflows/test-quarantine.md
+++ b/.github/workflows/test-quarantine.md
@@ -136,7 +136,7 @@ All of the following are true:
 
 All of the following are true:
 - The test was **recently unquarantined** (had its `[QuarantinedTest]` attribute removed within the past 14 days, detectable via `git log --since="14 days ago" -G 'QuarantinedTest' -- '*.cs'`)
-- It has **at least one failure that occurred AFTER the unquarantine change landed on `main`**. Use the PR merge time when available, or otherwise use the **committer date of the first-parent commit on `main`** that introduced the removal of the `[QuarantinedTest]` attribute. Do **not** use the timestamp of the underlying topic-branch commit if it differs. Only count failures from builds that started after that `main`-branch landing time. Failures from before the unquarantine do not count — they are from when the test was still quarantined. For these tests, search for the original closed quarantine issue (title prefix "Quarantine" referencing the test name) and **reopen** it rather than creating a new one in Step&nbsp;3.1.
+- It has **at least one failure that occurred AFTER the unquarantine change landed on `main`**. Use the PR merge time when available, or otherwise use the **committer date of the first-parent commit on `main`** that introduced the removal of the `[QuarantinedTest]` attribute. Do **not** use the timestamp of the underlying topic-branch commit if it differs. Only count failures from builds that started after that `main`-branch landing time. Failures from before the unquarantine do not count — they are from when the test was still quarantined. For these tests, find the original quarantine issue (title prefix "Quarantine" referencing the test name) so it can be reused in Step&nbsp;3.1 — do not create a new issue.
 
 **Class-level quarantine (applies to both Case A and Case B)**
 
@@ -275,7 +275,8 @@ Never attempt to exceed these limits. You must plan your output usage carefully 
 Before creating any outputs, build a complete plan of all actions you intend to take. Count the totals for each output type:
 
 - **Unquarantine actions** each consume: 1 PR + 0-1 issue closures (only if no remaining tests reference the issue).
-- **Quarantine actions** each consume: 1 issue + 1 PR + 1 comment. These three outputs are **atomic** — never create a quarantine PR without its corresponding issue, and never create an issue without its corresponding PR. If you don't have budget remaining for all three, skip that test entirely and let the next day's run handle it.
+- **New quarantine actions (Case A)** each consume: 1 issue + 1 PR + 1 comment. These three outputs are **atomic** — never create a quarantine PR without its corresponding issue, and never create an issue without its corresponding PR. If you don't have budget remaining for all three, skip that test entirely and let the next day's run handle it.
+- **Re-quarantine actions (Case B)** each consume: 1 PR + 1 comment (no new issue — reuse the existing one). These two outputs are atomic — never create a re-quarantine PR without its investigation comment.
 
 If the total planned actions exceed any output limit, **trim from the bottom of the priority list** until all limits are satisfied. It is always safe to defer work to the next day's run.
 
@@ -291,9 +292,10 @@ Process items in this strict order:
 
 ### Atomicity rules
 
-- **Never create a quarantine PR without a corresponding issue.** If you've hit the issue limit, stop creating quarantine PRs too.
-- **Never create a quarantine issue without a corresponding PR.** If you've hit the PR limit, stop creating quarantine issues too.
-- **Never create a quarantine issue without its investigation comment.** If you've hit the comment limit, stop creating quarantine issues and PRs too.
+- **Never create a new quarantine PR (Case A) without a corresponding issue.** If you've hit the issue limit, stop creating new quarantine PRs too.
+- **Never create a new quarantine issue (Case A) without a corresponding PR.** If you've hit the PR limit, stop creating quarantine issues too.
+- **Never create a quarantine issue or re-quarantine PR without its investigation comment.** If you've hit the comment limit, stop creating quarantine issues/PRs too.
+- **Re-quarantine PRs (Case B) do not require a new issue** — they reuse the existing one. They still require an investigation comment.
 - **Unquarantine PRs do not require issues or comments**, so they can fill remaining PR budget after quarantine actions are complete.
 - **Issue closures are best-effort.** If you run out of close-issue budget, the issue simply stays open until the next run — this is harmless.
 
@@ -317,7 +319,9 @@ Now that you have identified all candidates (Parts 1 and 2) and planned your bud
 
 For each quarantine/re-quarantine candidate, in priority order:
 
-1. **Create a test-failure issue** (or **reopen** the original issue for Case B re-quarantines) with this exact structure:
+#### Case A — New quarantine
+
+1. **Create a test-failure issue** via `create_issue` with a `temporary_id` (e.g., `aw_http2ign`). Use this exact structure:
    - **Title**: `Quarantine {FULLY_QUALIFIED_TEST_NAME}`
    - **Body**: Use the `50_test_failure.md` template format:
      - `## Failing Test(s)` — fully qualified test name(s)
@@ -326,7 +330,7 @@ For each quarantine/re-quarantine candidate, in priority order:
      - `## Logs` — console log content from the most recent failure, in a `<details>` block with ` ```text ``` `. Get this from the Helix work item files API: find the file named `{TestClassName}_{TestMethodName}.log` for the specific test. Prefer to include the full, verbatim log when it fits within GitHub issue size limits. If the log is very large or would exceed those limits, include a representative head and tail of the log in the issue and provide a direct link to the full Helix log file (and/or attach it as an artifact) so the complete output is still accessible.
      - `## Build` — link to the most recent failing build: `https://dev.azure.com/dnceng-public/public/_build/results?buildId={BUILD_ID}`
 
-2. **Post an investigation comment** on the issue using `add_comment` with `item_number` set to the same `temporary_id` you used when calling `create_issue` (e.g., if you used `temporary_id: "aw_http2ign"`, pass `item_number: "aw_http2ign"`). **Important:** pass the temporary ID as a plain string — do not wrap it in extra quotes or other formatting. Examine all available failure logs for the test. Be concise but thorough:
+2. **Post an investigation comment** on the issue using `add_comment` with `item_number` set to the same `temporary_id` (e.g., `item_number: "aw_http2ign"`). **Important:** pass the temporary ID as a plain string — do not wrap it in extra quotes or other formatting. Examine all available failure logs for the test. Be concise but thorough:
    - If you can identify a root cause, explain it and suggest a fix if one is obvious.
    - If you cannot determine the root cause, say so.
    - You may reference Microsoft official docs or issues in other repos within the `dotnet` GitHub org if relevant, but do not include any other external links.
@@ -337,7 +341,18 @@ For each quarantine/re-quarantine candidate, in priority order:
    - Adds `using Microsoft.AspNetCore.InternalTesting;` if not already present in the file
    - References the issue in the PR body with `Associated issue: #{TEMPORARY_ID}` (using the same `temporary_id` from `create_issue`, e.g., `Associated issue: #aw_http2ign`). Do **not** use the word `Fixes` or `Closes` — quarantine PRs open tracking issues, they do not fix them, and GitHub would auto-close the issue when the PR merges.
    - When referencing build IDs in the PR body, always use full clickable URLs: `https://dev.azure.com/dnceng-public/public/_build/results?buildId={BUILD_ID}&view=results`. Never reference build IDs as plain numbers.
-   - If the test matched **Case B** (re-quarantine of a recently unquarantined test), add the `re-quarantine` label to the PR.
+
+#### Case B — Re-quarantine of a recently unquarantined test
+
+For re-quarantines, **reuse the original quarantine issue** instead of creating a new one. You identified this issue in Step 1.2.
+
+1. **Post an investigation comment** on the **existing** issue using `add_comment` with `item_number` set to the existing numeric issue number (e.g., `item_number: 66035`). Explain that the test was unquarantined but is failing again, include the recent failure details, and note which unquarantine PR removed the attribute.
+
+2. **Create a PR** that:
+   - Adds `[QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/{EXISTING_ISSUE_NUMBER}")]` to the test method (or class), using the **existing issue's numeric URL** directly — not a temporary ID.
+   - Adds `using Microsoft.AspNetCore.InternalTesting;` if not already present in the file
+   - References the existing issue in the PR body with `Associated issue: #{EXISTING_ISSUE_NUMBER}`.
+   - Adds the `re-quarantine` label to the PR.
 
 ### Step 3.2 — Unquarantine (only after all quarantine work is done)
 


### PR DESCRIPTION
## Summary

In [workflow run 24338805833](https://github.com/dotnet/aspnetcore/actions/runs/24338805833), investigation comments on [#66292](https://github.com/dotnet/aspnetcore/issues/66292) and [#66293](https://github.com/dotnet/aspnetcore/issues/66293) failed because the agent passed `item_number` with embedded quote characters (`"aw_blazwasm"` instead of `aw_blazwasm`), causing the safe_outputs handler to reject the value.

This is agent non-determinism — a defensive fix in gh-aw is also being requested upstream (https://github.com/github/gh-aw/issues/26057), but in the meantime we can mitigate by being explicit in the prompt.

## Changes

1. **Step 3.1** — Clarified how to pass `item_number` when calling `add_comment` for investigation comments (use the same `temporary_id` from `create_issue`, as a plain string)
2. **Turn budget awareness** — Added general rule: pass string parameters to safe-output tools as plain strings without extra quoting