### PR TITLE
Limit ITlsHandshakeFeature.Exception on Connections.Abstractions for #if NETCOREAPP

### DIFF
--- a/src/Servers/Connections.Abstractions/src/Features/ITlsHandshakeFeature.cs
+++ b/src/Servers/Connections.Abstractions/src/Features/ITlsHandshakeFeature.cs
@@ -83,7 +83,7 @@ public interface ITlsHandshakeFeature
 #endif
     int KeyExchangeStrength { get; }
 
-#if NET11_0_OR_GREATER
+#if NETCOREAPP
     /// <summary>
     /// Gets the exception that occurred during the TLS handshake, if any.
     /// <see langword="null"/> if the handshake succeeded or has not yet completed.

--- a/src/Servers/Connections.Abstractions/src/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Servers/Connections.Abstractions/src/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Microsoft.AspNetCore.Connections.Features.ITlsHandshakeFeature.Exception.get -> System.Exception?


### PR DESCRIPTION
https://github.com/dotnet/aspnetcore/pull/65807 introduced `Exception` property with `#if NET_11_OR_GREATER` which makes release of Connections.Abstractions be TFM dependant as well. We should make the APIs match across different TFMs for same NuGet version.

I think simply returning `null` is ok here. I do not like the idea of throwing an exception as DIM, because that's an extra thing for the user to handle. For net10 apps referncing net11 NuGet package it will throw everytime, which is impacting perf for no reason