### PR TITLE
Fix DevServer version pin in template test infrastructure

### DIFF
--- a/src/ProjectTemplates/TestInfrastructure/PrepareForTest.targets
+++ b/src/ProjectTemplates/TestInfrastructure/PrepareForTest.targets
@@ -136,7 +136,7 @@
     <GenerateFileFromTemplate
       TemplateFile="$(MSBuildThisFileDirectory)..\TestInfrastructure\Directory.Build.targets.in"
       Properties="Configuration=$(Configuration);
-          RestoreAdditionalProjectSources=$([MSBuild]::Escape('$(RestoreAdditionalProjectSources);$(ArtifactsShippingPackagesDir);$(ArtifactsNonShippingPackagesDir)'));MicrosoftAspNetCoreComponentsWebAssemblyDevServerVersion=$(MicrosoftAspNetCoreComponentsWebAssemblyDevServerVersion)"
+          RestoreAdditionalProjectSources=$([MSBuild]::Escape('$(RestoreAdditionalProjectSources);$(ArtifactsShippingPackagesDir);$(ArtifactsNonShippingPackagesDir)'));MicrosoftAspNetCoreComponentsWebAssemblyDevServerVersion=$(PackageVersion)"
       OutputPath="$(TestTemplateCreationFolder)Directory.Build.targets" />
 
     <GenerateFileFromTemplate

--- a/src/ProjectTemplates/test/Templates.Blazor.Tests/BlazorWasmTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Blazor.Tests/BlazorWasmTemplateTest.cs
@@ -6,7 +6,6 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.BrowserTesting;
 using Microsoft.AspNetCore.Internal;
-using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.CommandLineUtils;
 using Microsoft.Playwright;
 using Templates.Test.Helpers;
@@ -15,7 +14,6 @@ namespace BlazorTemplates.Tests;
 
 #pragma warning disable xUnit1041 // Fixture arguments to test classes must have fixture sources
 
-[QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/#66293")]
 public class BlazorWasmTemplateTest(ProjectFactoryFixture projectFactory) : BlazorTemplateTest(projectFactory)
 {
     public override string ProjectType { get; } = "blazorwasm";

--- a/src/ProjectTemplates/test/Templates.Blazor.Tests/WebWorkerTemplateE2ETest.cs
+++ b/src/ProjectTemplates/test/Templates.Blazor.Tests/WebWorkerTemplateE2ETest.cs
@@ -15,7 +15,6 @@ namespace BlazorTemplates.Tests;
 
 #pragma warning disable xUnit1041 // Fixture arguments to test classes must have fixture sources
 
-[QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/#66292")]
 public class WebWorkerTemplateE2ETest(ProjectFactoryFixture projectFactory) : BlazorTemplateTest(projectFactory)
 {
     public override string ProjectType => "blazorwasm";


### PR DESCRIPTION
## Summary

Fixes #66293
Fixes #66292

The version pin added in #65784 to prevent NU1603 errors during Blazor WASM template tests **never worked** because `$(MicrosoftAspNetCoreComponentsWebAssemblyDevServerVersion)` is not an MSBuild property available in the test build context - it is only computed dynamically during template packing by `GenerateContent.targets` via `_GetPackageVersionInfo`.

This caused the generated `Directory.Build.targets` to contain:

```xml
<!-- Condition is always false - pin is a no-op -->
<ItemGroup Condition="'' != ''">
    <PackageReference Update="Microsoft.AspNetCore.Components.WebAssembly.DevServer"
                      Version="[]" />
</ItemGroup>
```

When a darc feed contains a preview-versioned DevServer package that outranks the locally-built CI package in SemVer (e.g. `11.0.0-preview.1` > `11.0.0-ci`), NuGet resolves to the feed version, triggering NU1603 which is fatal with `TreatWarningsAsErrors`.

## Fix

1. **Fix version pin**: Use `$(PackageVersion)` instead of the undefined property. `$(PackageVersion)` is always available in the build context and matches the DevServer package version (all aspnetcore packages share the same version from `eng/Versions.props`).

2. **Unquarantine tests**: Remove quarantine attributes from `BlazorWasmTemplateTest` and `WebWorkerTemplateE2ETest` (added in #66294) since the root cause is fixed.

After the fix, the generated file correctly contains:

```xml
<ItemGroup Condition="'11.0.0-dev' != ''">
    <PackageReference Update="Microsoft.AspNetCore.Components.WebAssembly.DevServer"
                      Version="[11.0.0-dev]" />
</ItemGroup>
```

## Testing

- Built the repo and verified the generated `Directory.Build.targets` now has the correct version pin
- Ran `BlazorWasmStandaloneTemplate_Works` - passes
