### PR TITLE
Make `registerCustomEventType` idempotent for duplicate registrations.

### DIFF
--- a/src/Components/Web.JS/src/Rendering/Events/EventTypes.ts
+++ b/src/Components/Web.JS/src/Rendering/Events/EventTypes.ts
@@ -16,11 +16,13 @@ export function registerCustomEventType(eventName: string, options: EventTypeOpt
   if (!options) {
     throw new Error('The options parameter is required.');
   }
-
-  // There can't be more than one registration for the same event name because then we wouldn't
-  // know which eventargs data to supply.
+// Duplicate registrations can occur legitimately when JS initializers (lib.module.js)
+// re-execute after enhanced navigation or circuit reconnection.
   if (eventTypeRegistry.has(eventName)) {
-    throw new Error(`The event '${eventName}' is already registered.`);
+    console.warn(`The event '${eventName}' is being registered more than once. ` +
+      'Duplicate registrations will be ignored. ' +
+      'This may indicate that a JS initializer is running multiple times.');
+    return;
   }
 
   // When aliasing a browser event, the custom event name must be different from the browser event name

--- a/src/Components/Web.JS/src/Rendering/Events/EventTypes.ts
+++ b/src/Components/Web.JS/src/Rendering/Events/EventTypes.ts
@@ -16,6 +16,7 @@ export function registerCustomEventType(eventName: string, options: EventTypeOpt
   if (!options) {
     throw new Error('The options parameter is required.');
   }
+
 // Duplicate registrations can occur legitimately when JS initializers (lib.module.js)
 // re-execute after enhanced navigation or circuit reconnection.
   if (eventTypeRegistry.has(eventName)) {

--- a/src/Components/Web.JS/src/Rendering/Events/EventTypes.ts
+++ b/src/Components/Web.JS/src/Rendering/Events/EventTypes.ts
@@ -17,8 +17,8 @@ export function registerCustomEventType(eventName: string, options: EventTypeOpt
     throw new Error('The options parameter is required.');
   }
 
-// Duplicate registrations can occur legitimately when JS initializers (lib.module.js)
-// re-execute after enhanced navigation or circuit reconnection.
+  // Duplicate registrations can occur legitimately when JS initializers (lib.module.js)
+  // re-execute after enhanced navigation or circuit reconnection.
   if (eventTypeRegistry.has(eventName)) {
     console.warn(`The event '${eventName}' is being registered more than once. ` +
       'Duplicate registrations will be ignored. ' +

--- a/src/Components/Web.JS/test/EventTypes.test.ts
+++ b/src/Components/Web.JS/test/EventTypes.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, describe, jest } from '@jest/globals';
+import { expect, test, describe, afterEach, jest } from '@jest/globals';
 import { registerCustomEventType, getEventTypeOptions, getEventNameAliases } from '../src/Rendering/Events/EventTypes';
 
 // The eventTypeRegistry is module-scoped and persists across tests, so we need
@@ -6,7 +6,11 @@ import { registerCustomEventType, getEventTypeOptions, getEventNameAliases } fro
 // and other tests.
 
 describe('registerCustomEventType duplicate registration', () => {
-  test('duplicate registration with same browserEventName is silently ignored', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('duplicate registration with same browserEventName warns and is ignored', () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     const options1 = {
@@ -38,11 +42,9 @@ describe('registerCustomEventType duplicate registration', () => {
     const aliases = getEventNameAliases('change');
     const count = aliases!.filter(a => a === 'mycheckedchange').length;
     expect(count).toBe(1);
-
-    warnSpy.mockRestore();
   });
 
-  test('duplicate registration with different browserEventName is silently ignored', () => {
+  test('duplicate registration with different browserEventName warns and is ignored', () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     registerCustomEventType('myevent-diffbrowser', {
@@ -61,12 +63,10 @@ describe('registerCustomEventType duplicate registration', () => {
     // First registration wins
     const registered = getEventTypeOptions('myevent-diffbrowser');
     expect(registered!.browserEventName).toBe('click');
-
-    warnSpy.mockRestore();
   });
 
   test('duplicate registration does not cause double alias entries', () => {
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     registerCustomEventType('mytabchange', {
       browserEventName: 'change',
@@ -89,16 +89,9 @@ describe('registerCustomEventType duplicate registration', () => {
     const aliases = getEventNameAliases('change');
     const count = aliases!.filter(a => a === 'mytabchange').length;
     expect(count).toBe(1);
-
-    warnSpy.mockRestore();
   });
 
   test('simulates FluentUI re-initialization scenario', () => {
-    // This simulates what happens when FluentUI's afterStarted hook fires
-    // multiple times (e.g., after enhanced navigation or circuit reconnection).
-    // FluentUI registers ~18 custom events. On re-initialization, it tries
-    // to register them all again.
-
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     const fluentEvents = [
@@ -130,7 +123,5 @@ describe('registerCustomEventType duplicate registration', () => {
 
     // Should have warned for each duplicate
     expect(warnSpy).toHaveBeenCalledTimes(fluentEvents.length);
-
-    warnSpy.mockRestore();
   });
 });

--- a/src/Components/Web.JS/test/EventTypes.test.ts
+++ b/src/Components/Web.JS/test/EventTypes.test.ts
@@ -1,0 +1,136 @@
+import { expect, test, describe, jest } from '@jest/globals';
+import { registerCustomEventType, getEventTypeOptions, getEventNameAliases } from '../src/Rendering/Events/EventTypes';
+
+// The eventTypeRegistry is module-scoped and persists across tests, so we need
+// unique event names per test to avoid interference from built-in registrations
+// and other tests.
+
+describe('registerCustomEventType duplicate registration', () => {
+  test('duplicate registration with same browserEventName is silently ignored', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const options1 = {
+      browserEventName: 'change',
+      createEventArgs: (e: Event) => ({ checked: true }),
+    };
+
+    const options2 = {
+      browserEventName: 'change',
+      createEventArgs: (e: Event) => ({ checked: false, extra: 'data' }),
+    };
+
+    // First registration succeeds
+    registerCustomEventType('mycheckedchange', options1);
+
+    // Second registration with same browserEventName — should NOT throw
+    registerCustomEventType('mycheckedchange', options2);
+
+    // Should have warned
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('mycheckedchange')
+    );
+
+    // First registration wins (the registry entry is not overwritten)
+    const registered = getEventTypeOptions('mycheckedchange');
+    expect(registered).toBe(options1);
+
+    // The alias array should only have one entry, not two
+    const aliases = getEventNameAliases('change');
+    const count = aliases!.filter(a => a === 'mycheckedchange').length;
+    expect(count).toBe(1);
+
+    warnSpy.mockRestore();
+  });
+
+  test('duplicate registration with different browserEventName is silently ignored', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    registerCustomEventType('myevent-diffbrowser', {
+      browserEventName: 'click',
+      createEventArgs: (e: Event) => ({}),
+    });
+
+    // Different browserEventName — still should NOT throw, just warn
+    registerCustomEventType('myevent-diffbrowser', {
+      browserEventName: 'mouseover',
+      createEventArgs: (e: Event) => ({}),
+    });
+
+    expect(warnSpy).toHaveBeenCalled();
+
+    // First registration wins
+    const registered = getEventTypeOptions('myevent-diffbrowser');
+    expect(registered!.browserEventName).toBe('click');
+
+    warnSpy.mockRestore();
+  });
+
+  test('duplicate registration does not cause double alias entries', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    registerCustomEventType('mytabchange', {
+      browserEventName: 'change',
+      createEventArgs: (e: Event) => ({ activeId: 'tab1' }),
+    });
+
+    // Register again — simulates JS initializer re-firing
+    registerCustomEventType('mytabchange', {
+      browserEventName: 'change',
+      createEventArgs: (e: Event) => ({ activeId: 'tab2' }),
+    });
+
+    // Register a third time
+    registerCustomEventType('mytabchange', {
+      browserEventName: 'change',
+      createEventArgs: (e: Event) => ({ activeId: 'tab3' }),
+    });
+
+    // The alias for 'change' should only contain 'mytabchange' once
+    const aliases = getEventNameAliases('change');
+    const count = aliases!.filter(a => a === 'mytabchange').length;
+    expect(count).toBe(1);
+
+    warnSpy.mockRestore();
+  });
+
+  test('simulates FluentUI re-initialization scenario', () => {
+    // This simulates what happens when FluentUI's afterStarted hook fires
+    // multiple times (e.g., after enhanced navigation or circuit reconnection).
+    // FluentUI registers ~18 custom events. On re-initialization, it tries
+    // to register them all again.
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const fluentEvents = [
+      { name: 'flu-checkedchange', browserEventName: 'change' },
+      { name: 'flu-switchcheckedchange', browserEventName: 'change' },
+      { name: 'flu-sliderchange', browserEventName: 'change' },
+      { name: 'flu-accordionchange', browserEventName: 'change' },
+      { name: 'flu-tabchange', browserEventName: 'change' },
+    ];
+
+    // First initialization — all should register successfully
+    for (const evt of fluentEvents) {
+      registerCustomEventType(evt.name, {
+        browserEventName: evt.browserEventName,
+        createEventArgs: (e: Event) => ({}),
+      });
+    }
+
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    // Second initialization (simulates enhanced nav / circuit reconnect)
+    // — should NOT throw, just warn
+    for (const evt of fluentEvents) {
+      registerCustomEventType(evt.name, {
+        browserEventName: evt.browserEventName,
+        createEventArgs: (e: Event) => ({}),
+      });
+    }
+
+    // Should have warned for each duplicate
+    expect(warnSpy).toHaveBeenCalledTimes(fluentEvents.length);
+
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

Change `Blazor.registerCustomEventType()` from throwing on duplicate event name registration to warning and ignoring the duplicate. The first registration wins.

This is a prerequisite change for adding proper `FluentUI` tests to E2E.

## Problem

`Blazor.registerCustomEventType()` throws an unconditional error when called with an event name that is already registered:

```
The event '${eventName}' is already registered.
```

This causes failures for libraries like **FluentUI Blazor** (`Microsoft.FluentUI.AspNetCore.Components`) under specific conditions. FluentUI registers ~18 custom events in its JS initializer `afterStarted` hook. On first load, everything works fine. However, when the initializer fires a second time in the same page context all re-registrations throw and the app breaks.

### What happens if duplicates are allowed through without guarding?

If the code does NOT early-return and lets a duplicate registration run to completion, the `browserEventNamesToAliases` map gets the same event name pushed into its alias array a second time (line 43: `aliasGroup.push(eventName)`). This causes **double event dispatching** - each native DOM event would trigger the Blazor handler twice. The `eventNameAliasRegisteredCallbacks` (line 52) would also fire redundantly, causing additional duplicate listener setup.

The early-return before these lines prevents both problems.

## History

The throw was introduced in #29993.

At the time:
- **JS initializer hooks (`lib.module.js` with `beforeStart`/`afterStarted`) did NOT exist** - they were introduced in .NET 7
- There was **no scenario** where the function would be called twice.

The PR review comment on the throw said: *"I'd err on the side of strictness. We can always loosen such rules later, but can't tighten them."* - explicitly acknowledging the rule could be relaxed in the future.

## How other frameworks handle this

| Framework / API | Behavior on duplicate registration |
|---|---|
| **`customElements.define()`** (Web standard) | **Throws** `DOMException`. Community convention is to guard with `customElements.get()` before calling. |
| **Vue** (`Vue.component`) | **Silently overwrites** — last registration wins, no error. |
| **React** | No registry — components are JS values, last assignment wins. |
| **Angular** (`@NgModule`) | **Throws** at compile/runtime. |
| **Lit / FAST** (web component libs) | Libraries guard with `customElements.get()` before `define()`. |

Vue and React are permissive. Angular and the Web Components spec are strict. However, the strict frameworks don't have an equivalent of Blazor's JS initializer hooks that can re-fire - their registration points run exactly once.

## Change

- **First registration wins** - the original `createEventArgs` function is preserved
- **No double dispatching** - the alias array is not modified on duplicate
- **Console warning** - developers can see when duplicates occur (visible in browser DevTools)
- **Other validations preserved** - the `eventName === options.browserEventName` check still throws etc.