### PR TITLE
Upgrade IIS NewShim tests from 2.2 packages to shared framework

### DIFF
--- a/src/Servers/IIS/IIS/test/Common.LongTests/ShutdownTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.LongTests/ShutdownTests.cs
@@ -27,9 +27,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 
 // Contains all tests related to shutdown, including app_offline, abort, and app recycle
 [Collection(PublishedSitesCollection.Name)]
-#if NEWSHIM_FUNCTIONALS
-[QuarantinedTest("https://github.com/dotnet/runtime/issues/126925")]
-#endif
 public class ShutdownTests : IISFunctionalTestBase
 {
     public ShutdownTests(PublishedSitesFixture fixture) : base(fixture)

--- a/src/Servers/IIS/IIS/test/Common.LongTests/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.LongTests/StartupTests.cs
@@ -31,9 +31,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 
 // Contains all tests related to Startup, requiring starting ANCM/IIS every time.
 [Collection(PublishedSitesCollection.Name)]
-#if NEWSHIM_FUNCTIONALS
-[QuarantinedTest("https://github.com/dotnet/runtime/issues/126925")]
-#endif
 public class StartupTests : IISFunctionalTestBase
 {
     public StartupTests(PublishedSitesFixture fixture) : base(fixture)
@@ -1189,7 +1186,6 @@ public class StartupTests : IISFunctionalTestBase
     public Task AuthHeaderEnvironmentVariableRemoved_InProcess() => AuthHeaderEnvironmentVariableRemoved(HostingModel.InProcess);
 
     [ConditionalFact]
-    [QuarantinedTest("https://github.com/dotnet/runtime/issues/126925")]
     public Task AuthHeaderEnvironmentVariableRemoved_OutOfProcess() => AuthHeaderEnvironmentVariableRemoved(HostingModel.OutOfProcess);
 
     private async Task AuthHeaderEnvironmentVariableRemoved(HostingModel hostingModel)

--- a/src/Servers/IIS/IIS/test/IIS.NewShim.FunctionalTests/IIS.NewShim.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IIS.NewShim.FunctionalTests/IIS.NewShim.FunctionalTests.csproj
@@ -5,9 +5,6 @@
     <TestGroupName>IISNewShim.FunctionalTests</TestGroupName>
     <DefineConstants>NEWSHIM_FUNCTIONALS</DefineConstants>
     <SkipTests Condition=" '$(SkipIISNewShimTests)' == 'true' ">true</SkipTests>
-    <!-- Skip these in all internal builds to avoid restoring vulnerable packages for CG -->
-    <SkipTests Condition="'$(SYSTEM_TEAMPROJECT)' == 'internal' ">true</SkipTests>
-    <ExcludeFromBuild Condition="'$(SYSTEM_TEAMPROJECT)' == 'internal' ">true</ExcludeFromBuild>
     <DisableFastUpToDateCheck>True</DisableFastUpToDateCheck>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/Servers/IIS/IIS/test/IIS.NewShim.FunctionalTests/NewShimTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.NewShim.FunctionalTests/NewShimTests.cs
@@ -27,7 +27,9 @@ public class NewShimTests : IISFunctionalTestBase
         {
             if (handle.ModuleName == "aspnetcorev2_inprocess.dll")
             {
-                Assert.Equal("12.2.19169.6", handle.FileVersionInfo.FileVersion);
+                // Verify the in-process handler is loaded. The version will vary
+                // depending on the build, so just confirm the module is present.
+                Assert.NotNull(handle.FileVersionInfo.FileVersion);
                 return;
             }
         }

--- a/src/Servers/IIS/IIS/test/testassets/InProcessNewShimWebSite/InProcessNewShimWebSite.csproj
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessNewShimWebSite/InProcessNewShimWebSite.csproj
@@ -58,12 +58,15 @@
     <Reference Include="Microsoft.AspNetCore.Server.IISIntegration" />
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel" />
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Core" />
+    <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes" />
+    <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Quic" />
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" />
     <Reference Include="Microsoft.AspNetCore.WebSockets" />
     <Reference Include="Microsoft.AspNetCore.WebUtilities" />
     <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
     <Reference Include="Microsoft.Extensions.Configuration.Json" />
     <Reference Include="Microsoft.Extensions.Hosting" />
+    <Reference Include="Microsoft.Extensions.Http" />
     <Reference Include="Microsoft.Extensions.Logging.Console" />
     <Reference Include="xunit.assert" />
   </ItemGroup>

--- a/src/Servers/IIS/IIS/test/testassets/InProcessNewShimWebSite/InProcessNewShimWebSite.csproj
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessNewShimWebSite/InProcessNewShimWebSite.csproj
@@ -8,8 +8,6 @@
     <CompileUsingReferenceAssemblies>false</CompileUsingReferenceAssemblies>
     <ImplicitUsings>disable</ImplicitUsings>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- Skip these in all internal builds to avoid restoring vulnerable packages for CG -->
-    <ExcludeFromBuild Condition="'$(SYSTEM_TEAMPROJECT)' == 'internal' ">true</ExcludeFromBuild>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
@@ -30,37 +28,24 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- This package is hard-coded to the 2.2.0 package as a part of ensuring ANCM stays forward compatible.  -->
-    <PackageReference Include="Microsoft.AspNetCore.Server.IIS" Version="2.2.6">
-      <AllowExplicitReference>true</AllowExplicitReference>
-    </PackageReference>
-  </ItemGroup>
+    <!--
+      These packages were previously hard-coded to 2.2.0 to verify ANCM forward compatibility
+      with the oldest supported version. Updated to use shared framework references since
+      ASP.NET Core packages were consolidated into the shared framework in 3.0, and the
+      old 2.2 Microsoft.Extensions.* packages cause TypeLoadException on .NET 11+ due to
+      PackageOverrides.txt (see dotnet/dotnet#5206).
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.0" >
-      <AllowExplicitReference>true</AllowExplicitReference>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.ResponseCompression" Version="2.2.0" >
-      <AllowExplicitReference>true</AllowExplicitReference>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.2.0" >
-      <AllowExplicitReference>true</AllowExplicitReference>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" >
-      <AllowExplicitReference>true</AllowExplicitReference>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.HttpsPolicy" Version="2.2.0" >
-      <AllowExplicitReference>true</AllowExplicitReference>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" >
-      <AllowExplicitReference>true</AllowExplicitReference>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" >
-      <AllowExplicitReference>true</AllowExplicitReference>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" >
-      <AllowExplicitReference>true</AllowExplicitReference>
-    </PackageReference>
+      The FORWARDCOMPAT define is kept to exercise the old-style WebHostBuilder code paths.
+    -->
+    <Reference Include="Microsoft.AspNetCore.Server.IIS" />
+    <Reference Include="Microsoft.AspNetCore.Hosting" />
+    <Reference Include="Microsoft.AspNetCore.ResponseCompression" />
+    <Reference Include="Microsoft.AspNetCore.Server.IISIntegration" />
+    <Reference Include="Microsoft.AspNetCore.Server.Kestrel" />
+    <Reference Include="Microsoft.AspNetCore.HttpsPolicy" />
+    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+    <Reference Include="Microsoft.Extensions.Configuration.Json" />
+    <Reference Include="Microsoft.Extensions.Logging.Console" />
     <Reference Include="xunit.assert" />
   </ItemGroup>
 </Project>

--- a/src/Servers/IIS/IIS/test/testassets/InProcessNewShimWebSite/InProcessNewShimWebSite.csproj
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessNewShimWebSite/InProcessNewShimWebSite.csproj
@@ -41,6 +41,8 @@
       The FORWARDCOMPAT define is kept to exercise the old-style WebHostBuilder code paths.
     -->
     <Reference Include="Microsoft.AspNetCore.Authentication" />
+    <Reference Include="Microsoft.AspNetCore.Authentication.Abstractions" />
+    <Reference Include="Microsoft.AspNetCore.Authentication.Core" />
     <Reference Include="Microsoft.AspNetCore.Hosting" />
     <Reference Include="Microsoft.AspNetCore.Hosting.Abstractions" />
     <Reference Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" />

--- a/src/Servers/IIS/IIS/test/testassets/InProcessNewShimWebSite/InProcessNewShimWebSite.csproj
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessNewShimWebSite/InProcessNewShimWebSite.csproj
@@ -8,6 +8,9 @@
     <CompileUsingReferenceAssemblies>false</CompileUsingReferenceAssemblies>
     <ImplicitUsings>disable</ImplicitUsings>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Suppress obsolete warnings: FORWARDCOMPAT blocks intentionally use old APIs
+         (IHostingEnvironment, IApplicationLifetime) to exercise legacy code paths -->
+    <NoWarn>$(NoWarn);CS0618;CS0612</NoWarn>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">

--- a/src/Servers/IIS/IIS/test/testassets/InProcessNewShimWebSite/InProcessNewShimWebSite.csproj
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessNewShimWebSite/InProcessNewShimWebSite.csproj
@@ -38,12 +38,13 @@
       The FORWARDCOMPAT define is kept to exercise the old-style WebHostBuilder code paths.
     -->
     <Reference Include="Microsoft.AspNetCore.Authentication" />
+    <Reference Include="Microsoft.AspNetCore.Hosting" />
+    <Reference Include="Microsoft.AspNetCore.Hosting.Abstractions" />
+    <Reference Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" />
     <Reference Include="Microsoft.AspNetCore.Http" />
     <Reference Include="Microsoft.AspNetCore.Http.Abstractions" />
     <Reference Include="Microsoft.AspNetCore.Http.Extensions" />
     <Reference Include="Microsoft.AspNetCore.Http.Features" />
-    <Reference Include="Microsoft.AspNetCore.Hosting" />
-    <Reference Include="Microsoft.AspNetCore.Hosting.Abstractions" />
     <Reference Include="Microsoft.AspNetCore.HttpOverrides" />
     <Reference Include="Microsoft.AspNetCore.HttpsPolicy" />
     <Reference Include="Microsoft.AspNetCore.ResponseCompression" />

--- a/src/Servers/IIS/IIS/test/testassets/InProcessNewShimWebSite/InProcessNewShimWebSite.csproj
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessNewShimWebSite/InProcessNewShimWebSite.csproj
@@ -37,14 +37,27 @@
 
       The FORWARDCOMPAT define is kept to exercise the old-style WebHostBuilder code paths.
     -->
-    <Reference Include="Microsoft.AspNetCore.Server.IIS" />
+    <Reference Include="Microsoft.AspNetCore.Authentication" />
+    <Reference Include="Microsoft.AspNetCore.Http" />
+    <Reference Include="Microsoft.AspNetCore.Http.Abstractions" />
+    <Reference Include="Microsoft.AspNetCore.Http.Extensions" />
+    <Reference Include="Microsoft.AspNetCore.Http.Features" />
     <Reference Include="Microsoft.AspNetCore.Hosting" />
+    <Reference Include="Microsoft.AspNetCore.Hosting.Abstractions" />
+    <Reference Include="Microsoft.AspNetCore.HttpOverrides" />
+    <Reference Include="Microsoft.AspNetCore.HttpsPolicy" />
     <Reference Include="Microsoft.AspNetCore.ResponseCompression" />
+    <Reference Include="Microsoft.AspNetCore.Server.HttpSys" />
+    <Reference Include="Microsoft.AspNetCore.Server.IIS" />
     <Reference Include="Microsoft.AspNetCore.Server.IISIntegration" />
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel" />
-    <Reference Include="Microsoft.AspNetCore.HttpsPolicy" />
+    <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Core" />
+    <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" />
+    <Reference Include="Microsoft.AspNetCore.WebSockets" />
+    <Reference Include="Microsoft.AspNetCore.WebUtilities" />
     <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
     <Reference Include="Microsoft.Extensions.Configuration.Json" />
+    <Reference Include="Microsoft.Extensions.Hosting" />
     <Reference Include="Microsoft.Extensions.Logging.Console" />
     <Reference Include="xunit.assert" />
   </ItemGroup>

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
@@ -679,12 +679,9 @@ public partial class Startup
 
     private async Task ReadAndWriteEchoLinesNoBuffering(HttpContext ctx)
     {
-#if FORWARDCOMPAT
-        var feature = ctx.Features.Get<IHttpBufferingFeature>();
-        feature.DisableResponseBuffering();
-#else
         var feature = ctx.Features.Get<IHttpResponseBodyFeature>();
         feature.DisableBuffering();
+#if !FORWARDCOMPAT
         Assert.True(ctx.Request.CanHaveBody());
 #endif
 


### PR DESCRIPTION
## Summary

Replace 2.2.0 `PackageReference` items in `InProcessNewShimWebSite` with shared framework `Reference` items to fix `TypeLoadException` on .NET 11+ caused by `PackageOverrides.txt` ([dotnet/dotnet#5206](https://github.com/dotnet/dotnet/pull/5206)).

## Problem

PR dotnet/dotnet#5206 added `Microsoft.Extensions.*.Abstractions` packages to the shared framework's `PackageOverrides.txt`. When old code (compiled against M.E.Logging 2.2.0) runs on .NET 11, the shared framework overrides `Microsoft.Extensions.Logging.Abstractions` with v11.x. The old `Logger.BeginScope()` references `NullScope` — a type that was public in v2.2 but removed in v3.0 — causing `TypeLoadException`.

Repro: https://github.com/wtgodbe/package-overrides-typeload-repro

## Changes

- **`InProcessNewShimWebSite.csproj`**: Replace 9 `PackageReference` items (2.2.0) with shared framework `Reference` items. Remove `ExcludeFromBuild` for internal builds (no more vulnerable packages).
- **`IIS.NewShim.FunctionalTests.csproj`**: Remove internal-build `SkipTests`/`ExcludeFromBuild` (no more vulnerable packages).
- **`NewShimTests.cs`**: Relax ANCM version assertion from hard-coded `12.2.19169.6` to `Assert.NotNull` (no longer pinned to 2.2-era ANCM).
- **`ShutdownTests.cs`**, **`StartupTests.cs`**: Remove `[QuarantinedTest]` annotations added in #66239 since the root cause is now addressed.

## Notes

- The `FORWARDCOMPAT` define is **kept** so the test app continues to exercise old-style `WebHostBuilder` code paths.
- `IIS.NewHandler.FunctionalTests` is **not touched** — it references `Microsoft.AspNetCore.AspNetCoreModuleV2 2.2.0` (a native ANCM package, different failure mode).
