### PR TITLE
Fix XML doc validation warnings

### DIFF
--- a/src/Components/Forms/src/DataAnnotationsValidator.cs
+++ b/src/Components/Forms/src/DataAnnotationsValidator.cs
@@ -15,7 +15,9 @@ public class DataAnnotationsValidator : ComponentBase, IDisposable
 
     [Inject] private IServiceProvider ServiceProvider { get; set; } = default!;
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Initializes the component and enables data annotations validation for the current <see cref="EditContext"/>.
+    /// </summary>
     protected override void OnInitialized()
     {
         if (CurrentEditContext == null)
@@ -29,7 +31,9 @@ public class DataAnnotationsValidator : ComponentBase, IDisposable
         _originalEditContext = CurrentEditContext;
     }
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Validates that the associated <see cref="EditContext"/> has not changed between parameter updates.
+    /// </summary>
     protected override void OnParametersSet()
     {
         if (CurrentEditContext != _originalEditContext)
@@ -41,7 +45,10 @@ public class DataAnnotationsValidator : ComponentBase, IDisposable
         }
     }
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Releases resources used by the validator.
+    /// </summary>
+    /// <param name="disposing"><see langword="true"/> if managed resources should be released; otherwise, <see langword="false"/>.</param>
     protected virtual void Dispose(bool disposing)
     {
     }

--- a/src/Components/Forms/src/DataAnnotationsValidator.cs
+++ b/src/Components/Forms/src/DataAnnotationsValidator.cs
@@ -15,9 +15,7 @@ public class DataAnnotationsValidator : ComponentBase, IDisposable
 
     [Inject] private IServiceProvider ServiceProvider { get; set; } = default!;
 
-    /// <summary>
-    /// Initializes the component and enables data annotations validation for the current <see cref="EditContext"/>.
-    /// </summary>
+    /// <inheritdoc />
     protected override void OnInitialized()
     {
         if (CurrentEditContext == null)
@@ -31,9 +29,7 @@ public class DataAnnotationsValidator : ComponentBase, IDisposable
         _originalEditContext = CurrentEditContext;
     }
 
-    /// <summary>
-    /// Validates that the associated <see cref="EditContext"/> has not changed between parameter updates.
-    /// </summary>
+    /// <inheritdoc />
     protected override void OnParametersSet()
     {
         if (CurrentEditContext != _originalEditContext)

--- a/src/Components/Forms/src/FieldIdentifier.cs
+++ b/src/Components/Forms/src/FieldIdentifier.cs
@@ -70,7 +70,10 @@ public readonly struct FieldIdentifier : IEquatable<FieldIdentifier>
     /// </summary>
     public string FieldName { get; }
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Returns the hash code for this field identifier.
+    /// </summary>
+    /// <returns>A hash code based on the model instance and field name.</returns>
     public override int GetHashCode()
     {
         // We want to compare Model instances by reference. RuntimeHelpers.GetHashCode returns identical hashes for equal object references (ignoring any `Equals`/`GetHashCode` overrides) which is what we want.
@@ -83,12 +86,20 @@ public readonly struct FieldIdentifier : IEquatable<FieldIdentifier>
         .GetHashCode();
     }
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Determines whether the specified object is equal to the current field identifier.
+    /// </summary>
+    /// <param name="obj">The object to compare with the current field identifier.</param>
+    /// <returns><see langword="true"/> if the specified object is equal to the current field identifier; otherwise, <see langword="false"/>.</returns>
     public override bool Equals(object? obj)
         => obj is FieldIdentifier otherIdentifier
         && Equals(otherIdentifier);
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Determines whether the specified <see cref="FieldIdentifier"/> is equal to the current field identifier.
+    /// </summary>
+    /// <param name="otherIdentifier">The field identifier to compare with the current instance.</param>
+    /// <returns><see langword="true"/> if the two instances are equal; otherwise, <see langword="false"/>.</returns>
     public bool Equals(FieldIdentifier otherIdentifier)
     {
         return ReferenceEquals(otherIdentifier.Model, Model) &&

--- a/src/Components/Web/src/WebRenderer.cs
+++ b/src/Components/Web/src/WebRenderer.cs
@@ -86,7 +86,10 @@ public abstract class WebRenderer : Renderer
     /// <param name="domElementSelector">A CSS selector that uniquely identifies a DOM element.</param>
     protected abstract void AttachRootComponentToBrowser(int componentId, string domElementSelector);
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Releases the resources used by the current <see cref="WebRenderer"/> instance.
+    /// </summary>
+    /// <param name="disposing"><see langword="true"/> to release managed resources; otherwise, <see langword="false"/>.</param>
     protected override void Dispose(bool disposing)
     {
         if (disposing)

--- a/src/Http/Routing/src/Builder/EndpointRoutingApplicationBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/EndpointRoutingApplicationBuilderExtensions.cs
@@ -18,7 +18,7 @@ public static class EndpointRoutingApplicationBuilderExtensions
     private const string UseRoutingKey = "__UseRouting";
 
     /// <summary>
-    /// Adds a <see cref="EndpointRoutingMiddleware"/> middleware to the specified <see cref="IApplicationBuilder"/>.
+    /// Adds routing to the specified <see cref="IApplicationBuilder"/> so that incoming requests can be matched to endpoints.
     /// </summary>
     /// <param name="builder">The <see cref="IApplicationBuilder"/> to add the middleware to.</param>
     /// <returns>A reference to this instance after the operation has completed.</returns>
@@ -29,10 +29,9 @@ public static class EndpointRoutingApplicationBuilderExtensions
     /// instance.
     /// </para>
     /// <para>
-    /// The <see cref="EndpointRoutingMiddleware"/> defines a point in the middleware pipeline where routing decisions are
-    /// made, and an <see cref="Endpoint"/> is associated with the <see cref="HttpContext"/>. The <see cref="EndpointMiddleware"/>
-    /// defines a point in the middleware pipeline where the current <see cref="Endpoint"/> is executed. Middleware between
-    /// the <see cref="EndpointRoutingMiddleware"/> and <see cref="EndpointMiddleware"/> may observe or change the
+    /// Routing adds a point in the middleware pipeline where routing decisions are made and an <see cref="Endpoint"/>
+    /// is associated with the <see cref="HttpContext"/>. Middleware between <see cref="UseRouting(IApplicationBuilder)"/>
+    /// and <see cref="UseEndpoints(IApplicationBuilder, Action{IEndpointRouteBuilder})"/> may observe or change the
     /// <see cref="Endpoint"/> associated with the <see cref="HttpContext"/>.
     /// </para>
     /// </remarks>
@@ -63,10 +62,9 @@ public static class EndpointRoutingApplicationBuilderExtensions
     }
 
     /// <summary>
-    /// Adds a <see cref="EndpointMiddleware"/> middleware to the specified <see cref="IApplicationBuilder"/>
-    /// with the <see cref="EndpointDataSource"/> instances built from configured <see cref="IEndpointRouteBuilder"/>.
-    /// The <see cref="EndpointMiddleware"/> will execute the <see cref="Endpoint"/> associated with the current
-    /// request.
+    /// Adds endpoint execution to the specified <see cref="IApplicationBuilder"/> with the
+    /// <see cref="EndpointDataSource"/> instances built from the configured <see cref="IEndpointRouteBuilder"/>.
+    /// This middleware executes the <see cref="Endpoint"/> associated with the current request.
     /// </summary>
     /// <param name="builder">The <see cref="IApplicationBuilder"/> to add the middleware to.</param>
     /// <param name="configure">An <see cref="Action{IEndpointRouteBuilder}"/> to configure the provided <see cref="IEndpointRouteBuilder"/>.</param>
@@ -78,10 +76,9 @@ public static class EndpointRoutingApplicationBuilderExtensions
     /// instance.
     /// </para>
     /// <para>
-    /// The <see cref="EndpointRoutingMiddleware"/> defines a point in the middleware pipeline where routing decisions are
-    /// made, and an <see cref="Endpoint"/> is associated with the <see cref="HttpContext"/>. The <see cref="EndpointMiddleware"/>
-    /// defines a point in the middleware pipeline where the current <see cref="Endpoint"/> is executed. Middleware between
-    /// the <see cref="EndpointRoutingMiddleware"/> and <see cref="EndpointMiddleware"/> may observe or change the
+    /// Routing adds a point in the middleware pipeline where routing decisions are made and an <see cref="Endpoint"/>
+    /// is associated with the <see cref="HttpContext"/>. Middleware between <see cref="UseRouting(IApplicationBuilder)"/>
+    /// and <see cref="UseEndpoints(IApplicationBuilder, Action{IEndpointRouteBuilder})"/> may observe or change the
     /// <see cref="Endpoint"/> associated with the <see cref="HttpContext"/>.
     /// </para>
     /// </remarks>

--- a/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
@@ -199,7 +199,7 @@ public static class RoutingEndpointConventionBuilderExtensions
     }
 
     /// <summary>
-    /// Configures form-processing options for all endpoints produced
+    /// Configures <see cref="IFormOptionsMetadata"/> for all endpoints produced
     /// on the target <see cref="IEndpointConventionBuilder"/>.
     /// </summary>
     /// <param name="builder">The <see cref="IEndpointConventionBuilder"/>.</param>

--- a/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
@@ -199,7 +199,7 @@ public static class RoutingEndpointConventionBuilderExtensions
     }
 
     /// <summary>
-    /// Configures <see cref="FormOptionsMetadata"/> for all endpoints produced
+    /// Configures form-processing options for all endpoints produced
     /// on the target <see cref="IEndpointConventionBuilder"/>.
     /// </summary>
     /// <param name="builder">The <see cref="IEndpointConventionBuilder"/>.</param>

--- a/src/Middleware/OutputCaching/src/OutputCacheApplicationBuilderExtensions.cs
+++ b/src/Middleware/OutputCaching/src/OutputCacheApplicationBuilderExtensions.cs
@@ -6,12 +6,12 @@ using Microsoft.AspNetCore.OutputCaching;
 namespace Microsoft.AspNetCore.Builder;
 
 /// <summary>
-/// Extension methods for adding the <see cref="OutputCacheMiddleware"/> to an application.
+/// Extension methods for adding output caching to an application.
 /// </summary>
 public static class OutputCacheApplicationBuilderExtensions
 {
     /// <summary>
-    /// Adds the <see cref="OutputCacheMiddleware"/> for caching HTTP responses.
+    /// Adds the output caching middleware for caching HTTP responses.
     /// </summary>
     /// <param name="app">The <see cref="IApplicationBuilder"/>.</param>
     public static IApplicationBuilder UseOutputCache(this IApplicationBuilder app)

--- a/src/OpenApi/src/Extensions/OpenApiEndpointConventionBuilderExtensions.cs
+++ b/src/OpenApi/src/Extensions/OpenApiEndpointConventionBuilderExtensions.cs
@@ -48,7 +48,7 @@ public static class OpenApiEndpointConventionBuilderExtensions
     /// and is primarily intended for consumption along-side Swashbuckle.AspNetCore.
     /// </remarks>
     /// <param name="builder">The <see cref="IEndpointConventionBuilder"/>.</param>
-    /// <param name="configureOperation">An <see cref="Func{T, TResult}"/> that returns a new OpenAPI annotation given a generated operation.</param>
+    /// <param name="configureOperation">A delegate that customizes the generated OpenAPI operation metadata for the endpoint.</param>
     /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
     [Obsolete("WithOpenApi is deprecated and will be removed in a future release. For more information, visit https://aka.ms/aspnet/deprecate/002.", DiagnosticId = "ASPDEPR002", UrlFormat = Obsoletions.AspNetCoreDeprecate002Url)]
     [RequiresDynamicCode(TrimWarningMessage)]
@@ -129,7 +129,7 @@ public static class OpenApiEndpointConventionBuilderExtensions
     /// with the current endpoint.
     /// </summary>
     /// <param name="builder">The <see cref="IEndpointConventionBuilder"/>.</param>
-    /// <param name="transformer">The <see cref="Func{OpenApiOperation, OpenApiOperationTransformerContext, CancellationToken, Task}"/> that modifies the operation in the <see cref="OpenApiDocument"/>.</param>
+    /// <param name="transformer">A delegate that modifies the generated OpenAPI operation in the <see cref="OpenApiDocument"/>.</param>
     /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
     public static TBuilder AddOpenApiOperationTransformer<TBuilder>(this TBuilder builder, Func<OpenApiOperation, OpenApiOperationTransformerContext, CancellationToken, Task> transformer) where TBuilder : IEndpointConventionBuilder
     {

--- a/src/Security/Authentication/Core/src/PropertiesSerializer.cs
+++ b/src/Security/Authentication/Core/src/PropertiesSerializer.cs
@@ -15,11 +15,7 @@ public class PropertiesSerializer : IDataSerializer<AuthenticationProperties>
     /// </summary>
     public static PropertiesSerializer Default { get; } = new PropertiesSerializer();
 
-    /// <summary>
-    /// Serializes the specified authentication properties.
-    /// </summary>
-    /// <param name="model">The authentication properties to serialize.</param>
-    /// <returns>The serialized representation of <paramref name="model"/>.</returns>
+    /// <inheritdoc />
     public virtual byte[] Serialize(AuthenticationProperties model)
     {
         using (var memory = new MemoryStream())
@@ -33,11 +29,7 @@ public class PropertiesSerializer : IDataSerializer<AuthenticationProperties>
         }
     }
 
-    /// <summary>
-    /// Deserializes the specified authentication properties payload.
-    /// </summary>
-    /// <param name="data">The serialized authentication properties.</param>
-    /// <returns>The deserialized <see cref="AuthenticationProperties"/>, or <see langword="null"/> if the format is unsupported.</returns>
+    /// <inheritdoc />
     public virtual AuthenticationProperties? Deserialize(byte[] data)
     {
         using (var memory = new MemoryStream(data))
@@ -49,11 +41,7 @@ public class PropertiesSerializer : IDataSerializer<AuthenticationProperties>
         }
     }
 
-    /// <summary>
-    /// Writes the specified authentication properties to the provided binary writer.
-    /// </summary>
-    /// <param name="writer">The binary writer to write to.</param>
-    /// <param name="properties">The authentication properties to write.</param>
+    /// <inheritdoc />
     public virtual void Write(BinaryWriter writer, AuthenticationProperties properties)
     {
         ArgumentNullException.ThrowIfNull(writer);
@@ -69,11 +57,7 @@ public class PropertiesSerializer : IDataSerializer<AuthenticationProperties>
         }
     }
 
-    /// <summary>
-    /// Reads authentication properties from the provided binary reader.
-    /// </summary>
-    /// <param name="reader">The binary reader to read from.</param>
-    /// <returns>The deserialized <see cref="AuthenticationProperties"/>, or <see langword="null"/> if the format is unsupported.</returns>
+    /// <inheritdoc />
     public virtual AuthenticationProperties? Read(BinaryReader reader)
     {
         ArgumentNullException.ThrowIfNull(reader);

--- a/src/Security/Authentication/Core/src/PropertiesSerializer.cs
+++ b/src/Security/Authentication/Core/src/PropertiesSerializer.cs
@@ -15,7 +15,11 @@ public class PropertiesSerializer : IDataSerializer<AuthenticationProperties>
     /// </summary>
     public static PropertiesSerializer Default { get; } = new PropertiesSerializer();
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Serializes the specified authentication properties.
+    /// </summary>
+    /// <param name="model">The authentication properties to serialize.</param>
+    /// <returns>The serialized representation of <paramref name="model"/>.</returns>
     public virtual byte[] Serialize(AuthenticationProperties model)
     {
         using (var memory = new MemoryStream())
@@ -29,7 +33,11 @@ public class PropertiesSerializer : IDataSerializer<AuthenticationProperties>
         }
     }
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Deserializes the specified authentication properties payload.
+    /// </summary>
+    /// <param name="data">The serialized authentication properties.</param>
+    /// <returns>The deserialized <see cref="AuthenticationProperties"/>, or <see langword="null"/> if the format is unsupported.</returns>
     public virtual AuthenticationProperties? Deserialize(byte[] data)
     {
         using (var memory = new MemoryStream(data))
@@ -41,7 +49,11 @@ public class PropertiesSerializer : IDataSerializer<AuthenticationProperties>
         }
     }
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Writes the specified authentication properties to the provided binary writer.
+    /// </summary>
+    /// <param name="writer">The binary writer to write to.</param>
+    /// <param name="properties">The authentication properties to write.</param>
     public virtual void Write(BinaryWriter writer, AuthenticationProperties properties)
     {
         ArgumentNullException.ThrowIfNull(writer);
@@ -57,7 +69,11 @@ public class PropertiesSerializer : IDataSerializer<AuthenticationProperties>
         }
     }
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Reads authentication properties from the provided binary reader.
+    /// </summary>
+    /// <param name="reader">The binary reader to read from.</param>
+    /// <returns>The deserialized <see cref="AuthenticationProperties"/>, or <see langword="null"/> if the format is unsupported.</returns>
     public virtual AuthenticationProperties? Read(BinaryReader reader)
     {
         ArgumentNullException.ThrowIfNull(reader);

--- a/src/Security/Authentication/Core/src/TicketSerializer.cs
+++ b/src/Security/Authentication/Core/src/TicketSerializer.cs
@@ -20,7 +20,11 @@ public class TicketSerializer : IDataSerializer<AuthenticationTicket>
     /// </summary>
     public static TicketSerializer Default { get; } = new TicketSerializer();
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Serializes the specified authentication ticket.
+    /// </summary>
+    /// <param name="ticket">The authentication ticket to serialize.</param>
+    /// <returns>The serialized representation of <paramref name="ticket"/>.</returns>
     public virtual byte[] Serialize(AuthenticationTicket ticket)
     {
         using (var memory = new MemoryStream())
@@ -33,7 +37,11 @@ public class TicketSerializer : IDataSerializer<AuthenticationTicket>
         }
     }
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Deserializes the specified authentication ticket payload.
+    /// </summary>
+    /// <param name="data">The serialized authentication ticket.</param>
+    /// <returns>The deserialized <see cref="AuthenticationTicket"/>, or <see langword="null"/> if the format is unsupported.</returns>
     public virtual AuthenticationTicket? Deserialize(byte[] data)
     {
         using (var memory = new MemoryStream(data))
@@ -116,7 +124,11 @@ public class TicketSerializer : IDataSerializer<AuthenticationTicket>
         }
     }
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Writes the specified claim using the provided binary writer.
+    /// </summary>
+    /// <param name="writer">The binary writer to write to.</param>
+    /// <param name="claim">The claim to serialize.</param>
     protected virtual void WriteClaim(BinaryWriter writer, Claim claim)
     {
         ArgumentNullException.ThrowIfNull(writer);

--- a/src/Security/Authentication/Negotiate/src/Events/AuthenticationFailedContext.cs
+++ b/src/Security/Authentication/Negotiate/src/Events/AuthenticationFailedContext.cs
@@ -13,7 +13,9 @@ public class AuthenticationFailedContext : RemoteAuthenticationContext<Negotiate
     /// <summary>
     /// Creates a <see cref="AuthenticationFailedContext"/>.
     /// </summary>
-    /// <inheritdoc />
+    /// <param name="context">The HTTP request context.</param>
+    /// <param name="scheme">The authentication scheme.</param>
+    /// <param name="options">The negotiate authentication options.</param>
     public AuthenticationFailedContext(
         HttpContext context,
         AuthenticationScheme scheme,

--- a/src/Security/Authentication/Negotiate/src/Events/LdapContext.cs
+++ b/src/Security/Authentication/Negotiate/src/Events/LdapContext.cs
@@ -13,7 +13,10 @@ public class LdapContext : ResultContext<NegotiateOptions>
     /// <summary>
     /// Creates a new <see cref="LdapContext"/>.
     /// </summary>
-    /// <inheritdoc />
+    /// <param name="context">The HTTP request context.</param>
+    /// <param name="scheme">The authentication scheme.</param>
+    /// <param name="options">The negotiate authentication options.</param>
+    /// <param name="settings">The LDAP settings to apply.</param>
     public LdapContext(
         HttpContext context,
         AuthenticationScheme scheme,

--- a/src/Security/Authentication/OpenIdConnect/src/Events/AuthenticationFailedContext.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/Events/AuthenticationFailedContext.cs
@@ -14,7 +14,9 @@ public class AuthenticationFailedContext : RemoteAuthenticationContext<OpenIdCon
     /// <summary>
     /// Initializes a new instance of <see cref="AuthenticationFailedContext"/>.
     /// </summary>
-    /// <inheritdoc />
+    /// <param name="context">The HTTP request context.</param>
+    /// <param name="scheme">The authentication scheme.</param>
+    /// <param name="options">The OpenID Connect authentication options.</param>
     public AuthenticationFailedContext(HttpContext context, AuthenticationScheme scheme, OpenIdConnectOptions options)
         : base(context, scheme, options, new AuthenticationProperties())
     { }

--- a/src/Security/Authentication/OpenIdConnect/src/Events/PushedAuthorizationContext.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/Events/PushedAuthorizationContext.cs
@@ -15,7 +15,11 @@ public sealed class PushedAuthorizationContext : PropertiesContext<OpenIdConnect
     /// <summary>
     /// Initializes a new instance of <see cref="PushedAuthorizationContext"/>.
     /// </summary>
-    /// <inheritdoc />
+    /// <param name="context">The HTTP request context.</param>
+    /// <param name="scheme">The authentication scheme.</param>
+    /// <param name="options">The OpenID Connect authentication options.</param>
+    /// <param name="parRequest">The pushed authorization request message.</param>
+    /// <param name="properties">The authentication properties for the request.</param>
     public PushedAuthorizationContext(HttpContext context, AuthenticationScheme scheme, OpenIdConnectOptions options, OpenIdConnectMessage parRequest, AuthenticationProperties properties)
         : base(context, scheme, options, properties)
     {
@@ -103,4 +107,3 @@ public sealed class PushedAuthorizationContext : PropertiesContext<OpenIdConnect
         HandledClientAuthentication = true;
     }
 }
-

--- a/src/Security/Authentication/OpenIdConnect/src/Events/RemoteSignoutContext.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/Events/RemoteSignoutContext.cs
@@ -14,7 +14,10 @@ public class RemoteSignOutContext : RemoteAuthenticationContext<OpenIdConnectOpt
     /// <summary>
     /// Initializes a new instance of <see cref="RemoteSignOutContext"/>.
     /// </summary>
-    /// <inheritdoc />
+    /// <param name="context">The HTTP request context.</param>
+    /// <param name="scheme">The authentication scheme.</param>
+    /// <param name="options">The OpenID Connect authentication options.</param>
+    /// <param name="message">The remote sign-out message sent by the identity provider.</param>
     public RemoteSignOutContext(HttpContext context, AuthenticationScheme scheme, OpenIdConnectOptions options, OpenIdConnectMessage? message)
         : base(context, scheme, options, new AuthenticationProperties())
         => ProtocolMessage = message;

--- a/src/Security/Authentication/OpenIdConnect/src/Events/TokenValidatedContext.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/Events/TokenValidatedContext.cs
@@ -14,9 +14,13 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect;
 public class TokenValidatedContext : RemoteAuthenticationContext<OpenIdConnectOptions>
 {
     /// <summary>
-    /// Creates a <see cref="TokenValidatedContext"/>
+    /// Creates a <see cref="TokenValidatedContext"/>.
     /// </summary>
-    /// <inheritdoc />
+    /// <param name="context">The HTTP request context.</param>
+    /// <param name="scheme">The authentication scheme.</param>
+    /// <param name="options">The OpenID Connect authentication options.</param>
+    /// <param name="principal">The authenticated user principal.</param>
+    /// <param name="properties">The authentication properties for the request.</param>
     public TokenValidatedContext(HttpContext context, AuthenticationScheme scheme, OpenIdConnectOptions options, ClaimsPrincipal principal, AuthenticationProperties properties)
         : base(context, scheme, options, properties)
         => Principal = principal;

--- a/src/Security/Authentication/OpenIdConnect/src/Events/UserInformationReceivedContext.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/Events/UserInformationReceivedContext.cs
@@ -16,7 +16,11 @@ public class UserInformationReceivedContext : RemoteAuthenticationContext<OpenId
     /// <summary>
     /// Initializes a new instance of <see cref="UserInformationReceivedContext"/>.
     /// </summary>
-    /// <inheritdoc />
+    /// <param name="context">The HTTP request context.</param>
+    /// <param name="scheme">The authentication scheme.</param>
+    /// <param name="options">The OpenID Connect authentication options.</param>
+    /// <param name="principal">The authenticated user principal.</param>
+    /// <param name="properties">The authentication properties for the request.</param>
     public UserInformationReceivedContext(HttpContext context, AuthenticationScheme scheme, OpenIdConnectOptions options, ClaimsPrincipal principal, AuthenticationProperties properties)
         : base(context, scheme, options, properties)
         => Principal = principal;

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
@@ -100,7 +100,12 @@ public class OpenIdConnectHandler : RemoteAuthenticationHandler<OpenIdConnectOpt
         return base.HandleRequestAsync();
     }
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Handles remote sign-out requests sent by the identity provider.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> if the request was handled by the OpenID Connect handler; otherwise, <see langword="false"/>.
+    /// </returns>
     protected virtual async Task<bool> HandleRemoteSignOutAsync()
     {
         OpenIdConnectMessage? message = null;

--- a/src/Security/Authorization/Core/src/AllowAnonymousAttribute.cs
+++ b/src/Security/Authorization/Core/src/AllowAnonymousAttribute.cs
@@ -13,7 +13,10 @@ namespace Microsoft.AspNetCore.Authorization;
 [DebuggerDisplay("{ToString(),nq}")]
 public class AllowAnonymousAttribute : Attribute, IAllowAnonymous
 {
-    /// <inheritdoc/>
+    /// <summary>
+    /// Returns a string that represents the current attribute.
+    /// </summary>
+    /// <returns>The string <c>AllowAnonymous</c>.</returns>
     public override string ToString()
     {
         return "AllowAnonymous";

--- a/src/Security/Authorization/Core/src/AssertionRequirement.cs
+++ b/src/Security/Authorization/Core/src/AssertionRequirement.cs
@@ -52,7 +52,10 @@ public class AssertionRequirement : IAuthorizationHandler, IAuthorizationRequire
         }
     }
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Returns a string representation of the requirement.
+    /// </summary>
+    /// <returns>A description of the assertion requirement.</returns>
     public override string ToString()
     {
         return $"{nameof(Handler)} assertion should evaluate to true.";

--- a/src/Security/Authorization/Core/src/AuthorizeAttribute.cs
+++ b/src/Security/Authorization/Core/src/AuthorizeAttribute.cs
@@ -43,7 +43,10 @@ public class AuthorizeAttribute : Attribute, IAuthorizeData
     /// </summary>
     public string? AuthenticationSchemes { get; set; }
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Returns a string that represents the current attribute.
+    /// </summary>
+    /// <returns>A string that describes the configured authorization data.</returns>
     public override string ToString()
     {
         return DebuggerHelpers.GetDebugText(nameof(Policy), Policy, nameof(Roles), Roles, nameof(AuthenticationSchemes), AuthenticationSchemes, includeNullValues: false, prefix: "Authorize");

--- a/src/Security/Authorization/Core/src/ClaimsAuthorizationRequirement.cs
+++ b/src/Security/Authorization/Core/src/ClaimsAuthorizationRequirement.cs
@@ -84,7 +84,10 @@ public class ClaimsAuthorizationRequirement : AuthorizationHandler<ClaimsAuthori
         return Task.CompletedTask;
     }
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Returns a string representation of the requirement.
+    /// </summary>
+    /// <returns>A description of the claim requirement.</returns>
     public override string ToString()
     {
         var value = (_emptyAllowedValues)

--- a/src/Security/Authorization/Core/src/DenyAnonymousAuthorizationRequirement.cs
+++ b/src/Security/Authorization/Core/src/DenyAnonymousAuthorizationRequirement.cs
@@ -32,7 +32,10 @@ public class DenyAnonymousAuthorizationRequirement : AuthorizationHandler<DenyAn
         return Task.CompletedTask;
     }
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Returns a string representation of the requirement.
+    /// </summary>
+    /// <returns>A description of the anonymous-user restriction.</returns>
     public override string ToString()
     {
         return $"{nameof(DenyAnonymousAuthorizationRequirement)}: Requires an authenticated user.";

--- a/src/Security/Authorization/Core/src/NameAuthorizationRequirement.cs
+++ b/src/Security/Authorization/Core/src/NameAuthorizationRequirement.cs
@@ -58,7 +58,10 @@ public class NameAuthorizationRequirement : AuthorizationHandler<NameAuthorizati
         return Task.CompletedTask;
     }
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Returns a string representation of the requirement.
+    /// </summary>
+    /// <returns>A description of the required user name.</returns>
     public override string ToString()
     {
         return $"{nameof(NameAuthorizationRequirement)}:Requires a user identity with Name equal to {RequiredName}";

--- a/src/Security/Authorization/Core/src/OperationAuthorizationRequirement.cs
+++ b/src/Security/Authorization/Core/src/OperationAuthorizationRequirement.cs
@@ -14,7 +14,10 @@ public class OperationAuthorizationRequirement : IAuthorizationRequirement
     /// </summary>
     public string Name { get; set; } = default!;
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Returns a string representation of the requirement.
+    /// </summary>
+    /// <returns>A description of the named operation requirement.</returns>
     public override string ToString()
     {
         return $"{nameof(OperationAuthorizationRequirement)}:Name={Name}";

--- a/src/Security/Authorization/Core/src/RolesAuthorizationRequirement.cs
+++ b/src/Security/Authorization/Core/src/RolesAuthorizationRequirement.cs
@@ -63,7 +63,10 @@ public class RolesAuthorizationRequirement : AuthorizationHandler<RolesAuthoriza
         return Task.CompletedTask;
     }
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Returns a string representation of the requirement.
+    /// </summary>
+    /// <returns>A description of the allowed roles.</returns>
     public override string ToString()
     {
         var roles = $"User.IsInRole must be true for one of the following roles: ({string.Join("|", AllowedRoles)})";


### PR DESCRIPTION
## Summary
Fix the XML documentation issues called out in the AspNetApiDocs validation report by replacing broken `<inheritdoc/>`/`cref` usage with explicit, resolvable documentation.

## Why these changes were needed
`<inheritdoc/>` did not work in these cases because the docs pipeline can only expand it when it can resolve an exact published API member to inherit from. In this set of warnings, that failed for three main reasons:

1. Some members do not actually have an inheritable parent doc source, such as constructors and newly introduced virtual methods.
2. Some parent members or xref targets existed in code, but were not resolvable by the Learn/ECMA2Yaml xref map used for API publishing.
3. Some `<see cref="...">` links targeted internal or otherwise non-published types, which produced xref-not-found warnings during doc generation.

## Result
This PR makes the generated API docs stable by using explicit summaries/parameter docs or by rewording descriptions to avoid non-resolvable references while preserving the original intent.

This should fix all the warnings in the recent API docs generation PR dotnet/AspNetApiDocs#313.