### PR TITLE
Add [StringSyntax(Json)] to string parameters that accept JSON

### DIFF
--- a/src/Components/Server/src/Circuits/CircuitHost.cs
+++ b/src/Components/Server/src/Circuits/CircuitHost.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Security.Claims;
@@ -397,7 +398,7 @@ internal partial class CircuitHost : IAsyncDisposable
 
     // BeginInvokeDotNetFromJS is used in a fire-and-forget context, so it's responsible for its own
     // error handling.
-    public async Task BeginInvokeDotNetFromJS(string callId, string assemblyName, string methodIdentifier, long dotNetObjectId, string argsJson)
+    public async Task BeginInvokeDotNetFromJS(string callId, string assemblyName, string methodIdentifier, long dotNetObjectId, [StringSyntax(StringSyntaxAttribute.Json)] string argsJson)
     {
         AssertInitialized();
         AssertNotDisposed();

--- a/src/Components/Server/src/ComponentHub.cs
+++ b/src/Components/Server/src/ComponentHub.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Components.Server.Circuits;
 using Microsoft.AspNetCore.DataProtection;
@@ -458,7 +459,7 @@ internal sealed partial class ComponentHub : Hub
         return true;
     }
 
-    public async ValueTask BeginInvokeDotNetFromJS(string callId, string assemblyName, string methodIdentifier, long dotNetObjectId, string argsJson)
+    public async ValueTask BeginInvokeDotNetFromJS(string callId, string assemblyName, string methodIdentifier, long dotNetObjectId, [StringSyntax(StringSyntaxAttribute.Json)] string argsJson)
     {
         var circuitHost = await GetActiveCircuitAsync();
         if (circuitHost == null)

--- a/src/Components/WebAssembly/WebAssembly/src/Services/DefaultWebAssemblyJSRuntime.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Services/DefaultWebAssemblyJSRuntime.cs
@@ -54,7 +54,7 @@ internal sealed partial class DefaultWebAssemblyJSRuntime : WebAssemblyJSRuntime
 
     [JSExport]
     [SupportedOSPlatform("browser")]
-    public static void EndInvokeJS(string argsJson)
+    public static void EndInvokeJS([StringSyntax(StringSyntaxAttribute.Json)] string argsJson)
     {
         WebAssemblyCallQueue.Schedule(argsJson, static argsJson =>
         {
@@ -66,7 +66,7 @@ internal sealed partial class DefaultWebAssemblyJSRuntime : WebAssemblyJSRuntime
 
     [JSExport]
     [SupportedOSPlatform("browser")]
-    public static void BeginInvokeDotNet(string? callId, string assemblyNameOrDotNetObjectId, string methodIdentifier, string argsJson)
+    public static void BeginInvokeDotNet(string? callId, string assemblyNameOrDotNetObjectId, string methodIdentifier, [StringSyntax(StringSyntaxAttribute.Json)] string argsJson)
     {
         // Figure out whether 'assemblyNameOrDotNetObjectId' is the assembly name or the instance ID
         // We only need one for any given call. This helps to work around the limitation that we can
@@ -95,7 +95,7 @@ internal sealed partial class DefaultWebAssemblyJSRuntime : WebAssemblyJSRuntime
 
     [SupportedOSPlatform("browser")]
     [JSExport]
-    public static void UpdateRootComponentsCore(string operationsJson, string appState)
+    public static void UpdateRootComponentsCore([StringSyntax(StringSyntaxAttribute.Json)] string operationsJson, string appState)
     {
         try
         {

--- a/src/Identity/Core/src/SignInManager.cs
+++ b/src/Identity/Core/src/SignInManager.cs
@@ -552,7 +552,7 @@ public class SignInManager<TUser> where TUser : class
     /// <returns>
     /// A task object representing the asynchronous operation containing the <see cref="PasskeyAttestationResult"/>.
     /// </returns>
-    public virtual async Task<PasskeyAttestationResult> PerformPasskeyAttestationAsync(string credentialJson)
+    public virtual async Task<PasskeyAttestationResult> PerformPasskeyAttestationAsync([StringSyntax(StringSyntaxAttribute.Json)] string credentialJson)
     {
         ThrowIfNoPasskeyHandler();
         ArgumentException.ThrowIfNullOrEmpty(credentialJson);
@@ -596,7 +596,7 @@ public class SignInManager<TUser> where TUser : class
     /// <returns>
     /// A task object representing the asynchronous operation containing the <see cref="PasskeyAssertionResult{TUser}"/>.
     /// </returns>
-    public virtual async Task<PasskeyAssertionResult<TUser>> PerformPasskeyAssertionAsync(string credentialJson)
+    public virtual async Task<PasskeyAssertionResult<TUser>> PerformPasskeyAssertionAsync([StringSyntax(StringSyntaxAttribute.Json)] string credentialJson)
     {
         ThrowIfNoPasskeyHandler();
         ArgumentException.ThrowIfNullOrEmpty(credentialJson);
@@ -639,7 +639,7 @@ public class SignInManager<TUser> where TUser : class
     /// The task object representing the asynchronous operation containing the <see cref="SignInResult"/>
     /// for the sign-in attempt.
     /// </returns>
-    public virtual async Task<SignInResult> PasskeySignInAsync(string credentialJson)
+    public virtual async Task<SignInResult> PasskeySignInAsync([StringSyntax(StringSyntaxAttribute.Json)] string credentialJson)
     {
         var startTimestamp = Stopwatch.GetTimestamp();
         try

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
@@ -303,7 +303,7 @@ public static class DotNetDispatcher
     /// This method can throw any exception either from the argument received or as a result
     /// of executing any callback synchronously upon completion.
     /// </exception>
-    public static void EndInvokeJS(JSRuntime jsRuntime, string arguments)
+    public static void EndInvokeJS(JSRuntime jsRuntime, [StringSyntax(StringSyntaxAttribute.Json)] string arguments)
     {
         var utf8JsonBytes = Encoding.UTF8.GetBytes(arguments);
 


### PR DESCRIPTION
Add [StringSyntax(Json)] to Blazor/Identity params accepting raw JSON.                                                                                                                                                                                                                
                                                                        
Description                                                                                                                                                                                                                                                                           
-----------                                                                                                                                                                                                                                                                           
Annotates string parameters that accept JSON payloads with                                                                                                                                                                                                                            
`[StringSyntax(StringSyntaxAttribute.Json)]` so IDEs and analyzers                                                                                                                                                                                                                    
provide JSON syntax highlighting and validation. No runtime behavior change.                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                        
  Affected APIs:                                                                                                                                                                                                                                                                        
  - `SignInManager.PerformPasskeyAttestationAsync(credentialJson)`                                                                                                                                                                                                                      
  - `SignInManager.PerformPasskeyAssertionAsync(credentialJson)`                                                                                                                                                                                                                        
  - `SignInManager.PasskeySignInAsync(credentialJson)`          
  - `DefaultWebAssemblyJSRuntime.EndInvokeJS(argsJson)`                                                                                                                                                                                                                                 
  - `DefaultWebAssemblyJSRuntime.BeginInvokeDotNet(argsJson)`
  - `DefaultWebAssemblyJSRuntime.UpdateRootComponentsCore(operationsJson)`                                                                                                                                                                                                              
  - `ComponentHub.BeginInvokeDotNetFromJS(argsJson)`                      
  - `CircuitHost.BeginInvokeDotNetFromJS(argsJson)`                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                        
  Follows the existing pattern used in `NavigationManager`,                                                                                                                                                                                                                             
  `IInternalWebJSInProcessRuntime`, and `WebViewManager` in this repo,                                                                                                                                                                                                                  
  and mirrors JamesNK's previous PR #45146 that added the same        
  attribute to other call sites.                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                        
  - [x] Contributor Guide and Code of Conduct read                                                                                                                                                                                                                                      
  - [x] Inline docs unchanged (attribute is inert at runtime)                                                                                                                                                                                                                           
  - [x] No tests needed (compile-time analyzer hint only, no behavior)                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                        
  Contributes to #44535                                                                