### PR TITLE
Remove always-auth from npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 registry=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
-always-auth=true


### PR DESCRIPTION
always-auth was removed long ago in https://github.com/npm/cli/commit/72a7eeb493e0e71cba3af36490cb245030ed31a3

Today, it produces a warning:

> npm warn Unknown project config "always-auth". This will stop working in the next major version of npm. See `npm help npmrc` for supported config options.