### PR TITLE
Use `UseNode@1` instead of the deprecated `NodeTool@0`

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -707,10 +707,10 @@ extends:
             sourceIndexBuildCommand: ./eng/build.cmd -Configuration Release -ci -prepareMachine -noBuildJava -binaryLog /p:OnlyPackPlatformSpecificPackages=true
             binlogPath: artifacts/log/Release/Build.binlog
             presteps:
-            - task: NodeTool@0
+            - task: UseNode@1
               displayName: Install Node 24.x
               inputs:
-                versionSpec: 24.x
+                version: 24.x
             pool:
               name: $(DncEngInternalBuildPool)
               demands: ImageOverride -equals windows.vs2026preview.scout.amd64

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -178,10 +178,10 @@ jobs:
         - powershell: ./eng/scripts/StartDumpCollectionForHangingBuilds.ps1 $(ProcDumpPath)procdump.exe artifacts/dumps/ (Get-Date).AddMinutes(160) dotnet
           displayName: Start background dump collection
       - ${{ if eq(parameters.installNodeJs, 'true') }}:
-        - task: NodeTool@0
+        - task: UseNode@1
           displayName: Install Node 24.x
           inputs:
-            versionSpec: 24.x
+            version: 24.x
       - ${{ if and(eq(parameters.agentOs, 'Windows'), eq(parameters.isAzDOTestingJob, true)) }}:
         - powershell: |
             Write-Host "##vso[task.setvariable variable=SeleniumProcessTrackingFolder]$(Build.SourcesDirectory)\artifacts\tmp\selenium\"
@@ -412,10 +412,10 @@ jobs:
         - powershell: ./eng/scripts/StartDumpCollectionForHangingBuilds.ps1 $(ProcDumpPath)procdump.exe artifacts/dumps/ (Get-Date).AddMinutes(160) dotnet
           displayName: Start background dump collection
       - ${{ if eq(parameters.installNodeJs, 'true') }}:
-        - task: NodeTool@0
+        - task: UseNode@1
           displayName: Install Node 24.x
           inputs:
-            versionSpec: 24.x
+            version: 24.x
       - ${{ if eq(parameters.agentOs, 'Windows') }}:
         - powershell: Write-Host "##vso[task.prependpath]$(DOTNET_CLI_HOME)\.dotnet\tools"
           displayName: Add dotnet tools to path


### PR DESCRIPTION
Current pipeline has warnings:

<img width="990" height="176" alt="image" src="https://github.com/user-attachments/assets/43604f8e-d106-4f5e-a3fc-45691f5282fb" />

This PR moves from [`NodeTool@0`](https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/node-tool-v0?view=azure-pipelines) to [`UseNode@1`](https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/use-node-v1?view=azure-pipelines).