### PR TITLE
Cleanup ValidatableInfoResolverTests

### DIFF
--- a/src/Validation/test/Microsoft.Extensions.Validation.Tests/ValidatableInfoResolverTests.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.Tests/ValidatableInfoResolverTests.cs
@@ -14,99 +14,6 @@ namespace Microsoft.Extensions.Validation.Tests;
 public class ValidatableInfoResolverTests
 {
     public delegate void TryGetValidatableTypeInfoCallback(Type type, out IValidatableInfo? validatableInfo);
-    public delegate void TryGetValidatableParameterInfoCallback(ParameterInfo parameter, out IValidatableInfo? validatableInfo);
-
-    [Fact]
-    public void GetValidatableTypeInfo_ReturnsNull_ForNonValidatableType()
-    {
-        // Arrange
-        var resolver = new Mock<IValidatableInfoResolver>();
-        IValidatableInfo? validatableInfo = null;
-        resolver.Setup(r => r.TryGetValidatableTypeInfo(It.IsAny<Type>(), out validatableInfo)).Returns(false);
-
-        // Act
-        var result = resolver.Object.TryGetValidatableTypeInfo(typeof(NonValidatableType), out validatableInfo);
-
-        // Assert
-        Assert.False(result);
-        Assert.Null(validatableInfo);
-    }
-
-    [Fact]
-    public void GetValidatableTypeInfo_ReturnsTypeInfo_ForValidatableType()
-    {
-        // Arrange
-        var mockTypeInfo = new Mock<ValidatableTypeInfo>(
-            typeof(ValidatableType),
-            Array.Empty<ValidatablePropertyInfo>()).Object;
-
-        var resolver = new Mock<IValidatableInfoResolver>();
-        IValidatableInfo? validatableInfo = null;
-        resolver
-            .Setup(r => r.TryGetValidatableTypeInfo(typeof(ValidatableType), out validatableInfo))
-            .Callback(new TryGetValidatableTypeInfoCallback((t, out info) =>
-            {
-                info = mockTypeInfo; // Set the out parameter to our mock
-            }))
-            .Returns(true);
-
-        // Act
-        var result = resolver.Object.TryGetValidatableTypeInfo(typeof(ValidatableType), out validatableInfo);
-
-        // Assert
-        Assert.True(result);
-        var validatableTypeInfo = Assert.IsAssignableFrom<ValidatableTypeInfo>(validatableInfo);
-        Assert.Equal(typeof(ValidatableType), validatableTypeInfo.Type);
-    }
-
-    [Fact]
-    public void GetValidatableParameterInfo_ReturnsNull_ForNonValidatableParameter()
-    {
-        // Arrange
-        var method = typeof(TestMethods).GetMethod(nameof(TestMethods.MethodWithNonValidatableParam))!;
-        var parameter = method.GetParameters()[0];
-
-        var resolver = new Mock<IValidatableInfoResolver>();
-        IValidatableInfo? validatableInfo = null;
-        resolver.Setup(r => r.TryGetValidatableParameterInfo(It.IsAny<ParameterInfo>(), out validatableInfo)).Returns(false);
-
-        // Act
-        var result = resolver.Object.TryGetValidatableParameterInfo(parameter, out validatableInfo);
-
-        // Assert
-        Assert.False(result);
-    }
-
-    [Fact]
-    public void GetValidatableParameterInfo_ReturnsParameterInfo_ForValidatableParameter()
-    {
-        // Arrange
-        var method = typeof(TestMethods).GetMethod(nameof(TestMethods.MethodWithValidatableParam))!;
-        var parameter = method.GetParameters()[0];
-
-        var mockParamInfo = new Mock<ValidatableParameterInfo>(
-            typeof(string),
-            "model",
-            "model").Object;
-
-        var resolver = new Mock<IValidatableInfoResolver>();
-
-        // Setup using the same pattern as in the type info test
-        resolver.Setup(r => r.TryGetValidatableParameterInfo(parameter, out It.Ref<IValidatableInfo?>.IsAny))
-            .Callback(new TryGetValidatableParameterInfoCallback((ParameterInfo p, out IValidatableInfo? info) =>
-            {
-                info = mockParamInfo; // Set the out parameter to our mock
-            }))
-            .Returns(true);
-
-        // Act
-        var result = resolver.Object.TryGetValidatableParameterInfo(parameter, out var validatableInfo);
-
-        // Assert
-        Assert.True(result);
-        var validatableParamInfo = Assert.IsAssignableFrom<ValidatableParameterInfo>(validatableInfo);
-        Assert.Equal("model", validatableParamInfo.Name);
-    }
 
     [Fact]
     public void ResolversChain_ProcessesInCorrectOrder()
@@ -164,54 +71,11 @@ public class ValidatableInfoResolverTests
     }
 
     // Test types
-    private class NonValidatableType { }
 
     [ValidatableType]
     private class ValidatableType
     {
         [Required]
         public string Name { get; set; } = "";
-    }
-
-    private static class TestMethods
-    {
-        public static void MethodWithNonValidatableParam(NonValidatableType param) { }
-        public static void MethodWithValidatableParam(ValidatableType model) { }
-    }
-
-    // Test implementations
-    private class TestValidatablePropertyInfo : ValidatablePropertyInfo
-    {
-        private readonly ValidationAttribute[] _validationAttributes;
-
-        public TestValidatablePropertyInfo(
-            Type containingType,
-            Type propertyType,
-            string name,
-            string displayName,
-            ValidationAttribute[] validationAttributes)
-            : base(containingType, propertyType, name, displayName)
-        {
-            _validationAttributes = validationAttributes;
-        }
-
-        protected override ValidationAttribute[] GetValidationAttributes() => _validationAttributes;
-    }
-
-    private class TestValidatableParameterInfo : ValidatableParameterInfo
-    {
-        private readonly ValidationAttribute[] _validationAttributes;
-
-        public TestValidatableParameterInfo(
-            Type parameterType,
-            string name,
-            string displayName,
-            ValidationAttribute[] validationAttributes)
-            : base(parameterType, name, displayName)
-        {
-            _validationAttributes = validationAttributes;
-        }
-
-        protected override ValidationAttribute[] GetValidationAttributes() => _validationAttributes;
     }
 }


### PR DESCRIPTION
The tests in this class used to set up a mock and asserts it, essentially testing zero production code and only asserts that the moq library works. They serve no value. So deleting them
