### PR TITLE
Add dotnet/skills marketplace and enable plugins

### DIFF
--- a/.github/copilot/settings.json
+++ b/.github/copilot/settings.json
@@ -5,9 +5,17 @@
         "source": "github",
         "repo": "dotnet/arcade-skills"
       }
+    },
+    "dotnet-skills": {
+      "source": {
+        "source": "github",
+        "repo": "dotnet/skills"
+      }
     }
   },
   "enabledPlugins": {
-    "dotnet-dnceng@dotnet-arcade-skills": true
+    "dotnet-dnceng@dotnet-arcade-skills": true,
+    "dotnet@dotnet-skills": true,
+    "dotnet-test@dotnet-skills": true
   }
 }


### PR DESCRIPTION
Add `dotnet/skills` marketplace to `.github/copilot/settings.json` and enable the following additional Copilot plugins:

- `dotnet` (from dotnet-skills)
- `dotnet-test` (from dotnet-skills)