### PR TITLE
Always run self test on encryptors

### DIFF
--- a/src/DataProtection/Cryptography.Internal/src/CryptoUtil.cs
+++ b/src/DataProtection/Cryptography.Internal/src/CryptoUtil.cs
@@ -58,6 +58,7 @@ internal static unsafe class CryptoUtil
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static Exception Fail(string message)
     {
+        Debug.Fail(message);
         throw new CryptographicException("Assertion failed: " + message);
     }
 

--- a/src/DataProtection/Cryptography.Internal/src/CryptoUtil.cs
+++ b/src/DataProtection/Cryptography.Internal/src/CryptoUtil.cs
@@ -58,7 +58,6 @@ internal static unsafe class CryptoUtil
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static Exception Fail(string message)
     {
-        Debug.Fail(message);
         throw new CryptographicException("Assertion failed: " + message);
     }
 

--- a/src/DataProtection/DataProtection/src/Cng/CbcAuthenticatedEncryptor.cs
+++ b/src/DataProtection/DataProtection/src/Cng/CbcAuthenticatedEncryptor.cs
@@ -58,6 +58,8 @@ internal sealed unsafe class CbcAuthenticatedEncryptor : IOptimizedAuthenticated
         AlgorithmAssert.IsAllowableValidationAlgorithmDigestSize(checked(_hmacAlgorithmDigestLengthInBytes * 8));
 
         _contextHeader = CreateContextHeader();
+
+        this.PerformSelfTest();
     }
 
     public void Decrypt<TWriter>(ReadOnlySpan<byte> ciphertext, ReadOnlySpan<byte> additionalAuthenticatedData, ref TWriter destination) where TWriter : IBufferWriter<byte>

--- a/src/DataProtection/DataProtection/src/Cng/CbcAuthenticatedEncryptor.cs
+++ b/src/DataProtection/DataProtection/src/Cng/CbcAuthenticatedEncryptor.cs
@@ -59,7 +59,15 @@ internal sealed unsafe class CbcAuthenticatedEncryptor : IOptimizedAuthenticated
 
         _contextHeader = CreateContextHeader();
 
-        this.PerformSelfTest();
+        try
+        {
+            this.PerformSelfTest();
+        }
+        catch
+        {
+            _sp800_108_ctr_hmac_provider.Dispose();
+            throw;
+        }
     }
 
     public void Decrypt<TWriter>(ReadOnlySpan<byte> ciphertext, ReadOnlySpan<byte> additionalAuthenticatedData, ref TWriter destination) where TWriter : IBufferWriter<byte>

--- a/src/DataProtection/DataProtection/src/Cng/CngGcmAuthenticatedEncryptor.cs
+++ b/src/DataProtection/DataProtection/src/Cng/CngGcmAuthenticatedEncryptor.cs
@@ -53,6 +53,8 @@ internal sealed unsafe class CngGcmAuthenticatedEncryptor : IOptimizedAuthentica
         _symmetricAlgorithmHandle = symmetricAlgorithmHandle;
         _symmetricAlgorithmSubkeyLengthInBytes = symmetricAlgorithmKeySizeInBytes;
         _contextHeader = CreateContextHeader();
+
+        this.PerformSelfTest();
     }
 
     public void Decrypt<TWriter>(ReadOnlySpan<byte> ciphertext, ReadOnlySpan<byte> additionalAuthenticatedData, ref TWriter destination) where TWriter : IBufferWriter<byte>

--- a/src/DataProtection/DataProtection/src/Cng/CngGcmAuthenticatedEncryptor.cs
+++ b/src/DataProtection/DataProtection/src/Cng/CngGcmAuthenticatedEncryptor.cs
@@ -54,7 +54,15 @@ internal sealed unsafe class CngGcmAuthenticatedEncryptor : IOptimizedAuthentica
         _symmetricAlgorithmSubkeyLengthInBytes = symmetricAlgorithmKeySizeInBytes;
         _contextHeader = CreateContextHeader();
 
-        this.PerformSelfTest();
+        try
+        {
+            this.PerformSelfTest();
+        }
+        catch
+        {
+            _sp800_108_ctr_hmac_provider.Dispose();
+            throw;
+        }
     }
 
     public void Decrypt<TWriter>(ReadOnlySpan<byte> ciphertext, ReadOnlySpan<byte> additionalAuthenticatedData, ref TWriter destination) where TWriter : IBufferWriter<byte>

--- a/src/DataProtection/DataProtection/src/Managed/AesGcmAuthenticatedEncryptor.cs
+++ b/src/DataProtection/DataProtection/src/Managed/AesGcmAuthenticatedEncryptor.cs
@@ -64,7 +64,15 @@ internal sealed unsafe class AesGcmAuthenticatedEncryptor : IOptimizedAuthentica
 
         _genRandom = genRandom ?? ManagedGenRandomImpl.Instance;
 
-        this.PerformSelfTest();
+        try
+        {
+            this.PerformSelfTest();
+        }
+        catch
+        {
+            _keyDerivationKey.Dispose();
+            throw;
+        }
     }
 
     public void Decrypt<TWriter>(ReadOnlySpan<byte> ciphertext, ReadOnlySpan<byte> additionalAuthenticatedData, ref TWriter destination)

--- a/src/DataProtection/DataProtection/src/Managed/AesGcmAuthenticatedEncryptor.cs
+++ b/src/DataProtection/DataProtection/src/Managed/AesGcmAuthenticatedEncryptor.cs
@@ -63,6 +63,8 @@ internal sealed unsafe class AesGcmAuthenticatedEncryptor : IOptimizedAuthentica
         }
 
         _genRandom = genRandom ?? ManagedGenRandomImpl.Instance;
+
+        this.PerformSelfTest();
     }
 
     public void Decrypt<TWriter>(ReadOnlySpan<byte> ciphertext, ReadOnlySpan<byte> additionalAuthenticatedData, ref TWriter destination)

--- a/src/DataProtection/DataProtection/src/Managed/ManagedAuthenticatedEncryptor.cs
+++ b/src/DataProtection/DataProtection/src/Managed/ManagedAuthenticatedEncryptor.cs
@@ -71,7 +71,15 @@ internal sealed unsafe class ManagedAuthenticatedEncryptor : IAuthenticatedEncry
 
         _contextHeader = CreateContextHeader();
 
-        this.PerformSelfTest();
+        try
+        {
+            this.PerformSelfTest();
+        }
+        catch
+        {
+            _keyDerivationKey.Dispose();
+            throw;
+        }
     }
 
 #if NET

--- a/src/DataProtection/DataProtection/src/Managed/ManagedAuthenticatedEncryptor.cs
+++ b/src/DataProtection/DataProtection/src/Managed/ManagedAuthenticatedEncryptor.cs
@@ -70,6 +70,8 @@ internal sealed unsafe class ManagedAuthenticatedEncryptor : IAuthenticatedEncry
         AlgorithmAssert.IsAllowableValidationAlgorithmDigestSize(checked((uint)_validationAlgorithmDigestLengthInBytes * 8));
 
         _contextHeader = CreateContextHeader();
+
+        this.PerformSelfTest();
     }
 
 #if NET

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/Aes/AesAuthenticatedEncryptorTests.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/Aes/AesAuthenticatedEncryptorTests.cs
@@ -27,6 +27,21 @@ public class AesAuthenticatedEncryptorTests
 
         RoundtripEncryptionHelpers.AssertTryEncryptTryDecryptParity(encryptor, plaintext, aad);
     }
+
+    [Fact]
+    public void Constructor_PerformsSelfTest_ConsumesRandomBytes()
+    {
+        var genRandom = new SequentialGenRandom();
+        byte initialValue = genRandom.CurrentValue;
+
+        Secret kdk = new Secret(new byte[512 / 8]);
+        _ = new AesGcmAuthenticatedEncryptor(kdk,
+            derivedKeySizeInBytes: 256 / 8,
+            genRandom: genRandom);
+
+        // Indirectly testing that SelfTest ran by checking that random bytes were consumed
+        Assert.NotEqual(initialValue, genRandom.CurrentValue);
+    }
 }
 
 #endif

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/Cng/CbcAuthenticatedEncryptorTests.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/Cng/CbcAuthenticatedEncryptorTests.cs
@@ -96,11 +96,13 @@ public class CbcAuthenticatedEncryptorTests
     {
         // Arrange
         Secret kdk = new Secret(Encoding.UTF8.GetBytes("master key"));
+        var genRandom = new SequentialGenRandom();
         CbcAuthenticatedEncryptor encryptor = new CbcAuthenticatedEncryptor(kdk,
             symmetricAlgorithmHandle: CachedAlgorithmHandles.AES_CBC,
             symmetricAlgorithmKeySizeInBytes: 256 / 8,
             hmacAlgorithmHandle: CachedAlgorithmHandles.HMAC_SHA256,
-            genRandom: new SequentialGenRandom());
+            genRandom: genRandom);
+        genRandom.Reset();
         ArraySegment<byte> plaintext = new ArraySegment<byte>(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7 }, 2, 3);
         ArraySegment<byte> aad = new ArraySegment<byte>(new byte[] { 7, 6, 5, 4, 3, 2, 1, 0 }, 1, 4);
 
@@ -165,4 +167,22 @@ public class CbcAuthenticatedEncryptorTests
         RoundtripEncryptionHelpers.AssertTryEncryptTryDecryptParity(encryptor, plaintext, aad);
     }
 #endif
+
+    [ConditionalFact]
+    [ConditionalRunTestOnlyOnWindows]
+    public void Constructor_PerformsSelfTest_ConsumesRandomBytes()
+    {
+        var genRandom = new SequentialGenRandom();
+        byte initialValue = genRandom.CurrentValue;
+
+        Secret kdk = new Secret(new byte[512 / 8]);
+        _ = new CbcAuthenticatedEncryptor(kdk,
+            symmetricAlgorithmHandle: CachedAlgorithmHandles.AES_CBC,
+            symmetricAlgorithmKeySizeInBytes: 256 / 8,
+            hmacAlgorithmHandle: CachedAlgorithmHandles.HMAC_SHA256,
+            genRandom: genRandom);
+
+        // Indirectly testing that SelfTest ran by checking that random bytes were consumed
+        Assert.NotEqual(initialValue, genRandom.CurrentValue);
+    }
 }

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/Cng/GcmAuthenticatedEncryptorTests.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/Cng/GcmAuthenticatedEncryptorTests.cs
@@ -87,7 +87,9 @@ public class GcmAuthenticatedEncryptorTests
     {
         // Arrange
         Secret kdk = new Secret(Encoding.UTF8.GetBytes("master key"));
-        CngGcmAuthenticatedEncryptor encryptor = new CngGcmAuthenticatedEncryptor(kdk, CachedAlgorithmHandles.AES_GCM, symmetricAlgorithmKeySizeInBytes: 128 / 8, genRandom: new SequentialGenRandom());
+        var genRandom = new SequentialGenRandom();
+        CngGcmAuthenticatedEncryptor encryptor = new CngGcmAuthenticatedEncryptor(kdk, CachedAlgorithmHandles.AES_GCM, symmetricAlgorithmKeySizeInBytes: 128 / 8, genRandom: genRandom);
+        genRandom.Reset();
         ArraySegment<byte> plaintext = new ArraySegment<byte>(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7 }, 2, 3);
         ArraySegment<byte> aad = new ArraySegment<byte>(new byte[] { 7, 6, 5, 4, 3, 2, 1, 0 }, 1, 4);
 
@@ -129,4 +131,21 @@ public class GcmAuthenticatedEncryptorTests
         RoundtripEncryptionHelpers.AssertTryEncryptTryDecryptParity(encryptor, plaintext, aad);
     }
 #endif
+
+    [ConditionalFact]
+    [ConditionalRunTestOnlyOnWindows]
+    public void Constructor_PerformsSelfTest_ConsumesRandomBytes()
+    {
+        var genRandom = new SequentialGenRandom();
+        byte initialValue = genRandom.CurrentValue;
+
+        Secret kdk = new Secret(new byte[512 / 8]);
+        _ = new CngGcmAuthenticatedEncryptor(kdk,
+            CachedAlgorithmHandles.AES_GCM,
+            symmetricAlgorithmKeySizeInBytes: 256 / 8,
+            genRandom: genRandom);
+
+        // Indirectly testing that SelfTest ran by checking that random bytes were consumed
+        Assert.NotEqual(initialValue, genRandom.CurrentValue);
+    }
 }

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/Managed/ManagedAuthenticatedEncryptorTests.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/Managed/ManagedAuthenticatedEncryptorTests.cs
@@ -189,7 +189,7 @@ public class ManagedAuthenticatedEncryptorTests
         // but subsequent calls (used during encrypt/decrypt) return HMACSHA512 (64-byte digest).
         // The stored digest length won't match, causing the HMAC check to fail.
         Func<KeyedHashAlgorithm> inconsistentFactory = () =>
-            ++callCount <= 1
+            ++callCount <= 2
                 ? (KeyedHashAlgorithm)new HMACSHA256()
                 : new HMACSHA512();
 

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/Managed/ManagedAuthenticatedEncryptorTests.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/Managed/ManagedAuthenticatedEncryptorTests.cs
@@ -91,11 +91,13 @@ public class ManagedAuthenticatedEncryptorTests
     {
         // Arrange
         Secret kdk = new Secret(Encoding.UTF8.GetBytes("master key"));
+        var genRandom = new SequentialGenRandom();
         ManagedAuthenticatedEncryptor encryptor = new ManagedAuthenticatedEncryptor(kdk,
             symmetricAlgorithmFactory: Aes.Create,
             symmetricAlgorithmKeySizeInBytes: 256 / 8,
             validationAlgorithmFactory: () => new HMACSHA256(),
-            genRandom: new SequentialGenRandom());
+            genRandom: genRandom);
+        genRandom.Reset();
         ArraySegment<byte> plaintext = new ArraySegment<byte>(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7 }, 2, 3);
         ArraySegment<byte> aad = new ArraySegment<byte>(new byte[] { 7, 6, 5, 4, 3, 2, 1, 0 }, 1, 4);
 
@@ -175,5 +177,42 @@ public class ManagedAuthenticatedEncryptorTests
         var unprotectedData = protector.Unprotect(protectedData, out var expiration);
         Assert.Equal(jsonPayload, unprotectedData);
         Assert.True(expiration > DateTimeOffset.UtcNow, "Expiration should be in the future");
+    }
+
+    [Fact]
+    public void Constructor_SelfTest_Throws_WhenValidationAlgorithmFactoryIsInconsistent()
+    {
+        Secret kdk = new Secret(new byte[512 / 8]);
+        int callCount = 0;
+
+        // First call (constructor validation) returns HMACSHA256 (32-byte digest),
+        // but subsequent calls (used during encrypt/decrypt) return HMACSHA512 (64-byte digest).
+        // The stored digest length won't match, causing the HMAC check to fail.
+        Func<KeyedHashAlgorithm> inconsistentFactory = () =>
+            ++callCount <= 1
+                ? (KeyedHashAlgorithm)new HMACSHA256()
+                : new HMACSHA512();
+
+        Assert.Throws<CryptographicException>(() => new ManagedAuthenticatedEncryptor(kdk,
+            symmetricAlgorithmFactory: Aes.Create,
+            symmetricAlgorithmKeySizeInBytes: 256 / 8,
+            validationAlgorithmFactory: inconsistentFactory));
+    }
+
+    [Fact]
+    public void Constructor_PerformsSelfTest_ConsumesRandomBytes()
+    {
+        var genRandom = new SequentialGenRandom();
+        byte initialValue = genRandom.CurrentValue;
+
+        Secret kdk = new Secret(new byte[512 / 8]);
+        _ = new ManagedAuthenticatedEncryptor(kdk,
+            symmetricAlgorithmFactory: Aes.Create,
+            symmetricAlgorithmKeySizeInBytes: 256 / 8,
+            validationAlgorithmFactory: () => new HMACSHA256(),
+            genRandom: genRandom);
+
+        // Indirectly testing that SelfTest ran by checking that random bytes were consumed
+        Assert.NotEqual(initialValue, genRandom.CurrentValue);
     }
 }

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/Managed/ManagedAuthenticatedEncryptorTests.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/Managed/ManagedAuthenticatedEncryptorTests.cs
@@ -180,26 +180,6 @@ public class ManagedAuthenticatedEncryptorTests
     }
 
     [Fact]
-    public void Constructor_SelfTest_Throws_WhenValidationAlgorithmFactoryIsInconsistent()
-    {
-        Secret kdk = new Secret(new byte[512 / 8]);
-        int callCount = 0;
-
-        // First call (constructor validation) returns HMACSHA256 (32-byte digest),
-        // but subsequent calls (used during encrypt/decrypt) return HMACSHA512 (64-byte digest).
-        // The stored digest length won't match, causing the HMAC check to fail.
-        Func<KeyedHashAlgorithm> inconsistentFactory = () =>
-            ++callCount <= 2
-                ? (KeyedHashAlgorithm)new HMACSHA256()
-                : new HMACSHA512();
-
-        Assert.Throws<CryptographicException>(() => new ManagedAuthenticatedEncryptor(kdk,
-            symmetricAlgorithmFactory: Aes.Create,
-            symmetricAlgorithmKeySizeInBytes: 256 / 8,
-            validationAlgorithmFactory: inconsistentFactory));
-    }
-
-    [Fact]
     public void Constructor_PerformsSelfTest_ConsumesRandomBytes()
     {
         var genRandom = new SequentialGenRandom();

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/SequentialGenRandom.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/SequentialGenRandom.cs
@@ -11,6 +11,10 @@ internal unsafe class SequentialGenRandom : IBCryptGenRandom, IManagedGenRandom
 {
     private byte _value;
 
+    internal byte CurrentValue => _value;
+
+    internal void Reset() => _value = 0;
+
     public byte[] GenRandom(int numBytes)
     {
         byte[] bytes = new byte[numBytes];


### PR DESCRIPTION
Self test would run in some cases, see https://github.com/dotnet/aspnetcore/blob/ce0bb8b555cf68a38eb6599471b2374648c7e82d/src/DataProtection/DataProtection/src/DataProtectionBuilderExtensions.cs#L497

But as we've seen, the encryptors can run in different situations as well where the self test wouldn't run. This adds the self test to the ctor of all the encryptors and adds a couple tests to verify this.

`ManagedAuthenticatedEncryptorTests` was the only one that could directly test the self test runs, the other encryptors indirectly test that self test runs by checking if the random number generator was called.