### PR TITLE
Specify "type" for enums in OpenAPI

### DIFF
--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -89,7 +89,7 @@ internal sealed class OpenApiSchemaService(
             {
                 schema = CreateSchemaForJsonPatch();
             }
-            else if (type.IsEnum && schema[OpenApiSchemaKeywords.EnumKeyword] is not null && schema[OpenApiSchemaKeywords.TypeKeyword] is null)
+            else if (type.IsEnum && schema is JsonObject && schema[OpenApiSchemaKeywords.EnumKeyword] is not null && schema[OpenApiSchemaKeywords.TypeKeyword] is null)
             {
                 schema[OpenApiSchemaKeywords.TypeKeyword] = "string";
             }

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -89,6 +89,11 @@ internal sealed class OpenApiSchemaService(
             {
                 schema = CreateSchemaForJsonPatch();
             }
+            else if (type.IsEnum && schema[OpenApiSchemaKeywords.EnumKeyword] is not null && schema[OpenApiSchemaKeywords.TypeKeyword] is null)
+            {
+                schema[OpenApiSchemaKeywords.TypeKeyword] = "string";
+            }
+
             // STJ uses `true` in place of an empty object to represent a schema that matches
             // anything (like the `object` type) or types with user-defined converters. We override
             // this default behavior here to match the format expected in OpenAPI v3.

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.ParameterSchemas.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.ParameterSchemas.cs
@@ -233,7 +233,7 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
         {
             var operation = document.Paths["/api"].Operations[HttpMethod.Get];
             var parameter = Assert.Single(operation.Parameters);
-            Assert.Null(parameter.Schema.Type);
+            Assert.Equal(JsonSchemaType.String, parameter.Schema.Type);
             Assert.Collection(parameter.Schema.Enum,
             value =>
             {


### PR DESCRIPTION
# Specify "type" for enums in OpenAPI

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

When encountering an enum in schema, we set the type to "string" instead of leaving it as null.

Fixes #61303