### PR TITLE
Surface dotnet-getdocument output to Terminal Logger

### DIFF
--- a/src/Tools/Extensions.ApiDescription.Server/src/build/Microsoft.Extensions.ApiDescription.Server.targets
+++ b/src/Tools/Extensions.ApiDescription.Server/src/build/Microsoft.Extensions.ApiDescription.Server.targets
@@ -64,7 +64,10 @@
 
     <Message Importance="high" Text="%0AGenerateOpenApiDocuments:" />
     <Message Importance="high" Text="  $(_DotNetGetDocumentCommand)" />
-    <Exec Command="$(_DotNetGetDocumentCommand)" LogStandardErrorAsError="true" />
+    <Exec Command="$(_DotNetGetDocumentCommand)"
+          LogStandardErrorAsError="true"
+          StandardOutputImportance="High"
+          StandardErrorImportance="High" />
   </Target>
 
   <!-- Unless this is an inner build or default timing is disabled, tie document retrieval into the build. -->


### PR DESCRIPTION
  ## Summary

  Fixes #62273.

  The `Microsoft.Extensions.ApiDescription.Server` MSBuild target invokes
  `dotnet-getdocument` via the `<Exec>` task. By default `<Exec>` captures
  stdout/stderr at `MessageImportance="Low"`, so MSBuild Terminal Logger
  (default in .NET 8+) hides the messages emitted by the tool — including
  `Generating document named '{name}'` and `Writing document '{name}' to
  '{path}'`.

  Users currently have to pass `--tl:off` or `-tlp:v=d` to see them, which
  is poorly discoverable.

  ## Change

  Add `StandardOutputImportance="High"` and `StandardErrorImportance="High"`
  to the `<Exec>` invocation in
  `src/Tools/Extensions.ApiDescription.Server/src/build/Microsoft.Extensions.ApiDescription.Server.targets`.

  These attributes have been part of the MSBuild `Exec` task for a long time
  (see also dotnet/msbuild#9810 for the broader Terminal Logger surfacing
  work), so there is no SDK-version risk.

  ## Behavior

  - **Before:** invocation logs from `dotnet-getdocument` are silent under
    Terminal Logger at default verbosity.
  - **After:** invocation logs are surfaced through the standard MSBuild
    high-importance pipeline and shown in Terminal Logger like any other
    high-priority build message.

  ## Risk

  Minimal. The change only raises the importance of messages already emitted
  by the tool. No new messages, no behavior change at any verbosity level
  where the messages were previously visible.
