### PR TITLE
[release/8.0] Stop overwriting MicrosoftTemplateEngineAuthoringTasksVersion

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -232,12 +232,6 @@
     -->
     <MicrosoftNETTestSdkVersion>17.1.0-preview-20211109-03</MicrosoftNETTestSdkVersion>
     <!--
-      Also use a newer, publicly-released version of the templating engine than the Arcade default.
-      https://github.com/dotnet/templating/blob/main/docs/Localization.md recommends updating the version when
-      preview or stable versions are released to NuGet.org.
-    -->
-    <MicrosoftTemplateEngineAuthoringTasksVersion>8.0.100-alpha.1.22607.1</MicrosoftTemplateEngineAuthoringTasksVersion>
-    <!--
       Versions of Microsoft.CodeAnalysis packages referenced by analyzers shipped in the SDK.
       This need to be pinned since they're used in 3.1 apps and need to be loadable in VS 2019.
       If you update these versions, make sure to also update https://github.com/dotnet/aspnetcore/blob/main/eng/SourceBuildPrebuiltBaseline.xml


### PR DESCRIPTION
Fixes a CG alert