### PR TITLE
Suppress NuGet vulnerability audit warnings in RepoTasks

### DIFF
--- a/eng/tools/RepoTasks/RepoTasks.csproj
+++ b/eng/tools/RepoTasks/RepoTasks.csproj
@@ -12,8 +12,8 @@
     <TargetLatestDotNetRuntime>false</TargetLatestDotNetRuntime>
     <!-- No need to track public APIs of these MSBuild tasks. -->
     <AddPublicApiAnalyzers>false</AddPublicApiAnalyzers>
-    <!-- Suppress NuGet vulnerability audit warnings for transitive dependencies in this build-time tool. -->
-    <NoWarn>$(NoWarn);NU1903;NU1902;NU1901;NU1904</NoWarn>
+    <!-- Keep NuGet vulnerability audit warnings visible for transitive dependencies in this build-time tool without failing the build. -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/eng/tools/RepoTasks/RepoTasks.csproj
+++ b/eng/tools/RepoTasks/RepoTasks.csproj
@@ -12,6 +12,8 @@
     <TargetLatestDotNetRuntime>false</TargetLatestDotNetRuntime>
     <!-- No need to track public APIs of these MSBuild tasks. -->
     <AddPublicApiAnalyzers>false</AddPublicApiAnalyzers>
+    <!-- Suppress NuGet vulnerability audit warnings for transitive dependencies in this build-time tool. -->
+    <NoWarn>$(NoWarn);NU1903;NU1902;NU1901;NU1904</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
RepoTasks is a build-time MSBuild task project that is not shipped to customers. Suppress NU1901-NU1904 vulnerability audit warnings to unblock the internal CI pipeline, which has been 100% broken for 24+ hours due to a newly published advisory for the transitive dependency `System.Security.Cryptography.Xml` 8.0.0.

Relates to #66348