### PR TITLE
Update resourceManagement for 10.0.8 milestone

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -632,7 +632,7 @@ configuration:
       then:
       - removeMilestone
       - addMilestone:
-          milestone: 10.0.7
+          milestone: 10.0.8
       description: '[Milestone Assignments] Assign Milestone to PRs merged to release/10.0 branch'
     - if:
       - payloadType: Pull_Request


### PR DESCRIPTION
10.0.7 is already released. I created a new milestone for 10.0.8, closed the 10.0.7 milestone, and updating resourceManagement to start adding 10.0.8 milestone.

We might have been adding 10.0.7 milestone for few recent PRs incorrectly.
