### PR TITLE
Add cross-version DataProtection E2E tests

### DIFF
--- a/AspNetCore.slnx
+++ b/AspNetCore.slnx
@@ -182,6 +182,7 @@
   </Folder>
   <Folder Name="/src/DataProtection/DataProtection/">
     <Project Path="src/DataProtection/DataProtection/src/Microsoft.AspNetCore.DataProtection.csproj" />
+    <Project Path="src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.NuGetIntegrationTests/Microsoft.AspNetCore.DataProtection.NuGetIntegrationTests.csproj" />
     <Project Path="src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/Microsoft.AspNetCore.DataProtection.Tests.csproj" />
   </Folder>
   <Folder Name="/src/DataProtection/EntityFrameworkCore/">

--- a/src/DataProtection/DataProtection.slnf
+++ b/src/DataProtection/DataProtection.slnf
@@ -9,6 +9,7 @@
       "src\\DataProtection\\Cryptography.KeyDerivation\\src\\Microsoft.AspNetCore.Cryptography.KeyDerivation.csproj",
       "src\\DataProtection\\Cryptography.KeyDerivation\\test\\Microsoft.AspNetCore.Cryptography.KeyDerivation.Tests.csproj",
       "src\\DataProtection\\DataProtection\\src\\Microsoft.AspNetCore.DataProtection.csproj",
+      "src\\DataProtection\\DataProtection\\test\\Microsoft.AspNetCore.DataProtection.NuGetIntegrationTests\\Microsoft.AspNetCore.DataProtection.NuGetIntegrationTests.csproj",
       "src\\DataProtection\\DataProtection\\test\\Microsoft.AspNetCore.DataProtection.Tests\\Microsoft.AspNetCore.DataProtection.Tests.csproj",
       "src\\DataProtection\\EntityFrameworkCore\\src\\Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.csproj",
       "src\\DataProtection\\EntityFrameworkCore\\test\\Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.Test.csproj",

--- a/src/DataProtection/DataProtection/src/Microsoft.AspNetCore.DataProtection.csproj
+++ b/src/DataProtection/DataProtection/src/Microsoft.AspNetCore.DataProtection.csproj
@@ -48,6 +48,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.AspNetCore.DataProtection.Extensions.Tests" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.DataProtection.Tests" />
+    <InternalsVisibleTo Include="Microsoft.AspNetCore.DataProtection.NuGetIntegrationTests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
     <InternalsVisibleTo Include="KeyManagementSimulator" />
   </ItemGroup>

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.NuGetIntegrationTests/CrossVersionCompatibility_ManagedAuthenticatedEncryptor_Tests.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.NuGetIntegrationTests/CrossVersionCompatibility_ManagedAuthenticatedEncryptor_Tests.cs
@@ -1,0 +1,89 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Security.Cryptography;
+using Microsoft.AspNetCore.DataProtection.Managed;
+
+namespace Microsoft.AspNetCore.DataProtection.NuGetIntegrationTests;
+
+/// <summary>
+/// Cross-version compatibility tests that download a released NuGet package,
+/// load the ManagedAuthenticatedEncryptor from it via reflection in an isolated
+/// AssemblyLoadContext, and verify that payloads encrypted by the released version
+/// can be decrypted by the current source code (and vice versa).
+/// </summary>
+public class CrossVersionCompatibility_ManagedAuthenticatedEncryptor_Tests : IAsyncLifetime
+{
+    // Pin to a known-good released version. Update this when a new patch is verified.
+    private const string NuGetPackageVersion = "10.0.5";
+
+    private readonly NuGetEncryptorFactory _factory = new(NuGetPackageVersion);
+
+    private NuGetEncryptorWrapper _nugetEncryptor = null!;
+    private ManagedAuthenticatedEncryptor _currentEncryptor = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _factory.InitializeAsync();
+
+        _nugetEncryptor = _factory.CreateEncryptor();
+        _currentEncryptor = CreateCurrentEncryptor();
+    }
+
+    public Task DisposeAsync()
+    {
+        _factory.Dispose();
+        _currentEncryptor?.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public void CurrentCode_CanDecrypt_PayloadFromReleasedNuGet()
+    {
+        var plaintext = new ArraySegment<byte>("cross-version-test-payload"u8.ToArray());
+        var aad = new ArraySegment<byte>("cross-version-aad"u8.ToArray());
+
+        // Encrypt with released NuGet version, decrypt with current source code
+        var ciphertext = _nugetEncryptor.Encrypt(plaintext, aad);
+        var decrypted = _currentEncryptor.Decrypt(new ArraySegment<byte>(ciphertext), aad);
+
+        Assert.Equal(plaintext.ToArray(), decrypted);
+    }
+
+    [Fact]
+    public void ReleasedNuGet_CanDecrypt_PayloadFromCurrentCode()
+    {
+        var plaintext = new ArraySegment<byte>("cross-version-test-payload"u8.ToArray());
+        var aad = new ArraySegment<byte>("cross-version-aad"u8.ToArray());
+
+        // Encrypt with current source code, decrypt with released NuGet version
+        var ciphertext = _currentEncryptor.Encrypt(plaintext, aad);
+        var decrypted = _nugetEncryptor.Decrypt(new ArraySegment<byte>(ciphertext), aad);
+
+        Assert.Equal(plaintext.ToArray(), decrypted);
+    }
+
+    [Fact]
+    public void ReleasedNuGet_SelfTest_RoundTrips()
+    {
+        // verifies that NuGet is valid and can perofrm roundtrip well
+        var plaintext = new ArraySegment<byte>("self-test-roundtrip"u8.ToArray());
+        var aad = new ArraySegment<byte>("self-test-aad"u8.ToArray());
+
+        var ciphertext = _nugetEncryptor.Encrypt(plaintext, aad);
+        var decrypted = _nugetEncryptor.Decrypt(new ArraySegment<byte>(ciphertext), aad);
+
+        Assert.Equal(plaintext.ToArray(), decrypted);
+    }
+
+    private static ManagedAuthenticatedEncryptor CreateCurrentEncryptor()
+    {
+        return new ManagedAuthenticatedEncryptor(
+            new Secret(new byte[512 / 8]),
+            symmetricAlgorithmFactory: Aes.Create,
+            symmetricAlgorithmKeySizeInBytes: 256 / 8,
+            validationAlgorithmFactory: () => new HMACSHA256());
+    }
+}

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.NuGetIntegrationTests/CrossVersionCompatibility_ManagedAuthenticatedEncryptor_Tests.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.NuGetIntegrationTests/CrossVersionCompatibility_ManagedAuthenticatedEncryptor_Tests.cs
@@ -14,70 +14,109 @@ namespace Microsoft.AspNetCore.DataProtection.NuGetIntegrationTests;
 /// AssemblyLoadContext, and verify that payloads encrypted by the released version
 /// can be decrypted by the current source code (and vice versa).
 /// </summary>
-public class CrossVersionCompatibility_ManagedAuthenticatedEncryptor_Tests : IAsyncLifetime
+public class CrossVersionCompatibility_ManagedAuthenticatedEncryptor_Tests : IClassFixture<NuGetEncryptorFactory>
 {
-    // Pin to a known-good released version. Update this when a new patch is verified.
-    private const string NuGetPackageVersion = "10.0.5";
+    private readonly NuGetEncryptorFactory _factory;
 
-    private readonly NuGetEncryptorFactory _factory = new(NuGetPackageVersion);
-
-    private NuGetEncryptorWrapper _nugetEncryptor = null!;
-    private ManagedAuthenticatedEncryptor _currentEncryptor = null!;
-
-    public async Task InitializeAsync()
+    public CrossVersionCompatibility_ManagedAuthenticatedEncryptor_Tests(NuGetEncryptorFactory factory)
     {
-        await _factory.InitializeAsync();
-
-        _nugetEncryptor = _factory.CreateEncryptor();
-        _currentEncryptor = CreateCurrentEncryptor();
+        _factory = factory;
     }
 
-    public Task DisposeAsync()
+    [Theory]
+    [InlineData("net9.0")]
+    [InlineData("net462")]
+    public void CurrentCode_CanDecrypt_PayloadFromReleasedNuGet(string targetFramework)
     {
-        _factory.Dispose();
-        _currentEncryptor?.Dispose();
-        return Task.CompletedTask;
-    }
-
-    [Fact]
-    public void CurrentCode_CanDecrypt_PayloadFromReleasedNuGet()
-    {
+        var nugetEncryptor = _factory.CreateEncryptor(targetFramework);
+        using var currentEncryptor = CreateCurrentEncryptor();
         var plaintext = new ArraySegment<byte>("cross-version-test-payload"u8.ToArray());
         var aad = new ArraySegment<byte>("cross-version-aad"u8.ToArray());
 
-        // Encrypt with released NuGet version, decrypt with current source code
-        var ciphertext = _nugetEncryptor.Encrypt(plaintext, aad);
-        var decrypted = _currentEncryptor.Decrypt(new ArraySegment<byte>(ciphertext), aad);
+        var ciphertext = nugetEncryptor.Encrypt(plaintext, aad);
+        var decrypted = currentEncryptor.Decrypt(new ArraySegment<byte>(ciphertext), aad);
 
         Assert.Equal(plaintext.ToArray(), decrypted);
     }
 
-    [Fact]
-    public void ReleasedNuGet_CanDecrypt_PayloadFromCurrentCode()
+    [Theory]
+    [InlineData("net9.0")]
+    [InlineData("net462")]
+    public void ReleasedNuGet_CanDecrypt_PayloadFromCurrentCode(string targetFramework)
     {
+        var nugetEncryptor = _factory.CreateEncryptor(targetFramework);
+        using var currentEncryptor = CreateCurrentEncryptor();
         var plaintext = new ArraySegment<byte>("cross-version-test-payload"u8.ToArray());
         var aad = new ArraySegment<byte>("cross-version-aad"u8.ToArray());
 
-        // Encrypt with current source code, decrypt with released NuGet version
-        var ciphertext = _currentEncryptor.Encrypt(plaintext, aad);
-        var decrypted = _nugetEncryptor.Decrypt(new ArraySegment<byte>(ciphertext), aad);
+        var ciphertext = currentEncryptor.Encrypt(plaintext, aad);
+        var decrypted = nugetEncryptor.Decrypt(new ArraySegment<byte>(ciphertext), aad);
 
         Assert.Equal(plaintext.ToArray(), decrypted);
     }
 
-    [Fact]
-    public void ReleasedNuGet_SelfTest_RoundTrips()
+    [Theory]
+    [InlineData("net9.0")]
+    [InlineData("net462")]
+    public void ReleasedNuGet_SelfTest_RoundTrips(string targetFramework)
     {
-        // verifies that NuGet is valid and can perofrm roundtrip well
+        var nugetEncryptor = _factory.CreateEncryptor(targetFramework);
         var plaintext = new ArraySegment<byte>("self-test-roundtrip"u8.ToArray());
         var aad = new ArraySegment<byte>("self-test-aad"u8.ToArray());
 
-        var ciphertext = _nugetEncryptor.Encrypt(plaintext, aad);
-        var decrypted = _nugetEncryptor.Decrypt(new ArraySegment<byte>(ciphertext), aad);
+        var ciphertext = nugetEncryptor.Encrypt(plaintext, aad);
+        var decrypted = nugetEncryptor.Decrypt(new ArraySegment<byte>(ciphertext), aad);
 
         Assert.Equal(plaintext.ToArray(), decrypted);
     }
 
+    [Fact]
+    public void CurrentNetCore_CanDecrypt_PayloadFromCurrentNetFx()
+    {
+        // Verifies current source: #if NET path can decrypt what #else path encrypted.
+        // Loads the source-built net462 DLL via ALC to get the #else code path.
+        var netFxEncryptor = _factory.CreateSourceBuiltNetFxEncryptor();
+        using var netCoreEncryptor = CreateCurrentEncryptor();
+        var plaintext = new ArraySegment<byte>("cross-tfm-current-code"u8.ToArray());
+        var aad = new ArraySegment<byte>("cross-tfm-aad"u8.ToArray());
+
+        var ciphertext = netFxEncryptor.Encrypt(plaintext, aad);
+        var decrypted = netCoreEncryptor.Decrypt(new ArraySegment<byte>(ciphertext), aad);
+
+        Assert.Equal(plaintext.ToArray(), decrypted);
+    }
+
+    [Fact]
+    public void CurrentNetFx_CanDecrypt_PayloadFromCurrentNetCore()
+    {
+        var netFxEncryptor = _factory.CreateSourceBuiltNetFxEncryptor();
+        using var netCoreEncryptor = CreateCurrentEncryptor();
+        var plaintext = new ArraySegment<byte>("cross-tfm-current-code"u8.ToArray());
+        var aad = new ArraySegment<byte>("cross-tfm-aad"u8.ToArray());
+
+        var ciphertext = netCoreEncryptor.Encrypt(plaintext, aad);
+        var decrypted = netFxEncryptor.Decrypt(new ArraySegment<byte>(ciphertext), aad);
+
+        Assert.Equal(plaintext.ToArray(), decrypted);
+    }
+
+    [Fact]
+    public void CurrentNetFx_SelfTest_RoundTrips()
+    {
+        // Verifies the source-built #else path can roundtrip on its own.
+        var netFxEncryptor = _factory.CreateSourceBuiltNetFxEncryptor();
+        var plaintext = new ArraySegment<byte>("netfx-self-test"u8.ToArray());
+        var aad = new ArraySegment<byte>("netfx-self-test-aad"u8.ToArray());
+
+        var ciphertext = netFxEncryptor.Encrypt(plaintext, aad);
+        var decrypted = netFxEncryptor.Decrypt(new ArraySegment<byte>(ciphertext), aad);
+
+        Assert.Equal(plaintext.ToArray(), decrypted);
+    }
+
+    /// <summary>
+    /// Creates a ManagedAuthenticatedEncryptor from current source code (net11, #if NET path).
+    /// </summary>
     private static ManagedAuthenticatedEncryptor CreateCurrentEncryptor()
     {
         return new ManagedAuthenticatedEncryptor(

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.NuGetIntegrationTests/Microsoft.AspNetCore.DataProtection.NuGetIntegrationTests.csproj
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.NuGetIntegrationTests/Microsoft.AspNetCore.DataProtection.NuGetIntegrationTests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.AspNetCore.Cryptography.Internal" />
+    <Reference Include="Microsoft.AspNetCore.DataProtection" />
+    <Reference Include="Microsoft.Extensions.DependencyInjection" />
+  </ItemGroup>
+
+</Project>

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.NuGetIntegrationTests/NuGetEncryptorFactory.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.NuGetIntegrationTests/NuGetEncryptorFactory.cs
@@ -13,25 +13,29 @@ using Microsoft.AspNetCore.DataProtection.Managed;
 namespace Microsoft.AspNetCore.DataProtection.NuGetIntegrationTests;
 
 /// <summary>
-/// Downloads a released NuGet package once, loads the ManagedAuthenticatedEncryptor
-/// from it via reflection in an isolated AssemblyLoadContext, and creates encryptors
-/// that use the same key material as current source code for cross-version testing.
+/// Downloads a released NuGet package (and its Cryptography.Internal dependency) once,
+/// then creates ManagedAuthenticatedEncryptor instances from any TFM in the package
+/// via reflection in isolated AssemblyLoadContexts.
+/// Implements <see cref="IAsyncLifetime"/> for xUnit's <c>IClassFixture</c>.
 /// </summary>
-internal sealed class NuGetEncryptorFactory : IDisposable
+public sealed class NuGetEncryptorFactory : IAsyncLifetime, IDisposable
 {
+    public const string DefaultPackageVersion = "9.0.15";
+
     private const string NuGetBaseUrl = "https://api.nuget.org/v3-flatcontainer";
-    private const string NuGetPackageId = "Microsoft.AspNetCore.DataProtection";
+    private const string DataProtectionPackageId = "Microsoft.AspNetCore.DataProtection";
+    private const string CryptoInternalPackageId = "Microsoft.AspNetCore.Cryptography.Internal";
 
-    private readonly string _tempDir;
     private readonly string _packageVersion;
+    private readonly string _tempDir;
 
-    private Assembly? _nugetAssembly;
-    private Type? _encryptorType;
-    private Type? _secretType;
-    private ConstructorInfo? _encryptorCtor;
-    private object? _genRandomInstance;
+    // Per-TFM directories containing DataProtection + Cryptography.Internal DLLs
+    private readonly Dictionary<string, string> _tfmDirs = new(StringComparer.OrdinalIgnoreCase);
 
-    public NuGetEncryptorFactory(string packageVersion)
+    /// <summary>Parameterless constructor used by xUnit's IClassFixture.</summary>
+    public NuGetEncryptorFactory() : this(DefaultPackageVersion) { }
+
+    internal NuGetEncryptorFactory(string packageVersion)
     {
         _packageVersion = packageVersion;
         _tempDir = Path.Combine(Path.GetTempPath(), $"dp-nuget-test-{Guid.NewGuid():N}");
@@ -39,93 +43,229 @@ internal sealed class NuGetEncryptorFactory : IDisposable
     }
 
     /// <summary>
-    /// Downloads and extracts the NuGet package, loading the DLL into an isolated ALC.
-    /// Call once before creating encryptors.
+    /// Downloads and extracts NuGet packages. Called once by xUnit when used as IClassFixture.
     /// </summary>
     public async Task InitializeAsync()
     {
-        var dllPath = await DownloadAndExtractNuGetDll();
-        var alc = new AssemblyLoadContext($"NuGet-{_packageVersion}", isCollectible: true);
-        _nugetAssembly = alc.LoadFromAssemblyPath(dllPath);
+        var dpLibDir = await DownloadAndExtractPackage(DataProtectionPackageId);
+        var cryptoLibDir = await DownloadAndExtractPackage(CryptoInternalPackageId);
 
-        // Resolve types using typeof().FullName for refactor safety
-        _secretType = _nugetAssembly.GetType(typeof(Secret).FullName!)
-            ?? throw new InvalidOperationException($"Cannot find {nameof(Secret)} type in NuGet assembly");
-        _encryptorType = _nugetAssembly.GetType(typeof(ManagedAuthenticatedEncryptor).FullName!)
-            ?? throw new InvalidOperationException($"Cannot find {nameof(ManagedAuthenticatedEncryptor)} type in NuGet assembly");
+        // For each TFM in the DataProtection package, stage a directory with both DLLs
+        foreach (var tfmDir in Directory.GetDirectories(dpLibDir))
+        {
+            var tfm = Path.GetFileName(tfmDir)!;
+            var stageDir = Path.Combine(_tempDir, "staged", tfm);
+            Directory.CreateDirectory(stageDir);
 
-        _encryptorCtor = _encryptorType.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
-            .FirstOrDefault(c => c.GetParameters().Length == 5)
-            ?? throw new InvalidOperationException($"Cannot find {nameof(ManagedAuthenticatedEncryptor)} 5-param constructor");
+            // Copy DataProtection DLL
+            foreach (var dll in Directory.GetFiles(tfmDir, "*.dll"))
+            {
+                File.Copy(dll, Path.Combine(stageDir, Path.GetFileName(dll)));
+            }
 
-        var genRandomImplType = _nugetAssembly.GetType(typeof(ManagedGenRandomImpl).FullName!)
-            ?? throw new InvalidOperationException($"Cannot find {nameof(ManagedGenRandomImpl)} type in NuGet assembly");
-        _genRandomInstance = genRandomImplType.GetField("Instance", BindingFlags.Public | BindingFlags.Static)?.GetValue(null)
-            ?? throw new InvalidOperationException($"Cannot find {nameof(ManagedGenRandomImpl)}.Instance");
+            // Copy matching Cryptography.Internal DLL (same TFM if available, else best match)
+            var cryptoTfmDir = FindBestMatchingTfmDir(cryptoLibDir, tfm);
+            if (cryptoTfmDir is not null)
+            {
+                foreach (var dll in Directory.GetFiles(cryptoTfmDir, "*.dll"))
+                {
+                    var dest = Path.Combine(stageDir, Path.GetFileName(dll));
+                    if (!File.Exists(dest))
+                    {
+                        File.Copy(dll, dest);
+                    }
+                }
+            }
+
+            _tfmDirs[tfm] = stageDir;
+        }
+    }
+
+    public Task DisposeAsync()
+    {
+        Dispose();
+        return Task.CompletedTask;
     }
 
     /// <summary>
-    /// Creates a ManagedAuthenticatedEncryptor from the downloaded NuGet assembly
-    /// using reflection and the same key material (all-zero 512-bit key).
+    /// Returns the TFM folder names available (e.g. "net9.0", "net462").
     /// </summary>
-    public NuGetEncryptorWrapper CreateEncryptor()
+    public string[] GetAvailableTargetFrameworks()
     {
-        if (_nugetAssembly is null)
+        EnsureInitialized();
+        return [.. _tfmDirs.Keys];
+    }
+
+    /// <summary>
+    /// Creates a ManagedAuthenticatedEncryptor from the specified TFM's DLL, loaded in an
+    /// isolated AssemblyLoadContext with proper dependency resolution.
+    /// Uses the same key material (all-zero 512-bit key) for cross-version testing.
+    /// </summary>
+    public NuGetEncryptorWrapper CreateEncryptor(string? targetFramework = null)
+    {
+        EnsureInitialized();
+
+        var tfm = targetFramework ?? PickBestModernTfm();
+        if (!_tfmDirs.TryGetValue(tfm, out var stageDir))
         {
-            throw new InvalidOperationException("Call InitializeAsync() before creating encryptors.");
+            throw new InvalidOperationException($"TFM '{tfm}' not available. Available: {string.Join(", ", _tfmDirs.Keys)}");
         }
 
-        var secretCtor = _secretType!.GetConstructor([typeof(byte[])])
-            ?? throw new InvalidOperationException("Cannot find Secret(byte[]) constructor");
+        var dllPath = Path.Combine(stageDir, $"{DataProtectionPackageId}.dll");
+        if (!File.Exists(dllPath))
+        {
+            throw new FileNotFoundException($"No DLL found at {dllPath}");
+        }
+
+        return CreateEncryptorFromDirectory(stageDir, dllPath, $"NuGet-{_packageVersion}-{tfm}");
+    }
+
+    /// <summary>
+    /// Creates a ManagedAuthenticatedEncryptor from the source-built net462 DLL (the #else path).
+    /// The DLL is loaded via ALC from the local build artifacts directory.
+    /// </summary>
+    public NuGetEncryptorWrapper CreateSourceBuiltNetFxEncryptor()
+    {
+        // Walk up from test output to find the DataProtection net462 build output.
+        // Test output:     artifacts/bin/Microsoft.AspNetCore.DataProtection.NuGetIntegrationTests/Debug/net11.0/
+        // Source output:   artifacts/bin/Microsoft.AspNetCore.DataProtection/Debug/net462/
+        var testAssemblyDir = Path.GetDirectoryName(typeof(NuGetEncryptorFactory).Assembly.Location)!;
+        var artifactsBinDir = Path.GetFullPath(Path.Combine(testAssemblyDir, "..", "..", ".."));
+        var netFxDir = Path.Combine(artifactsBinDir, "Microsoft.AspNetCore.DataProtection", "Debug", "net462");
+        var dllPath = Path.Combine(netFxDir, $"{DataProtectionPackageId}.dll");
+
+        if (!File.Exists(dllPath))
+        {
+            throw new FileNotFoundException(
+                $"Source-built net462 DLL not found at {dllPath}. " +
+                $"Ensure the DataProtection project is built for net462.");
+        }
+
+        return CreateEncryptorFromDirectory(netFxDir, dllPath, "SourceBuilt-net462");
+    }
+
+    private static NuGetEncryptorWrapper CreateEncryptorFromDirectory(string directory, string dllPath, string alcName)
+    {
+        var alc = new DirectoryAssemblyLoadContext(directory, alcName);
+        var assembly = alc.LoadFromAssemblyPath(dllPath);
+
+        var secretType = assembly.GetType(typeof(Secret).FullName!)
+            ?? throw new InvalidOperationException($"Cannot find {nameof(Secret)} in assembly ({alcName})");
+        var encryptorType = assembly.GetType(typeof(ManagedAuthenticatedEncryptor).FullName!)
+            ?? throw new InvalidOperationException($"Cannot find {nameof(ManagedAuthenticatedEncryptor)} in assembly ({alcName})");
+
+        var encryptorCtor = encryptorType.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            .FirstOrDefault(c => c.GetParameters().Length == 5)
+            ?? throw new InvalidOperationException($"Cannot find {nameof(ManagedAuthenticatedEncryptor)} 5-param constructor ({alcName})");
+
+        var genRandomImplType = assembly.GetType(typeof(ManagedGenRandomImpl).FullName!)
+            ?? throw new InvalidOperationException($"Cannot find {nameof(ManagedGenRandomImpl)} in assembly ({alcName})");
+        var genRandomInstance = genRandomImplType.GetField("Instance", BindingFlags.Public | BindingFlags.Static)?.GetValue(null)
+            ?? throw new InvalidOperationException($"Cannot find {nameof(ManagedGenRandomImpl)}.Instance ({alcName})");
+
+        var secretCtor = secretType.GetConstructor([typeof(byte[])])
+            ?? throw new InvalidOperationException($"Cannot find Secret(byte[]) constructor ({alcName})");
         var secret = secretCtor.Invoke([new byte[512 / 8]]);
 
         Func<SymmetricAlgorithm> symFactory = Aes.Create;
         Func<KeyedHashAlgorithm> hmacFactory = () => new HMACSHA256();
 
-        var encryptor = _encryptorCtor!.Invoke([secret, symFactory, 256 / 8, hmacFactory, _genRandomInstance!]);
-        return new NuGetEncryptorWrapper(encryptor, _encryptorType!);
+        var encryptor = encryptorCtor.Invoke([secret, symFactory, 256 / 8, hmacFactory, genRandomInstance]);
+        return new NuGetEncryptorWrapper(encryptor, encryptorType);
     }
 
     public void Dispose()
     {
-        try
+        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+    }
+
+    private void EnsureInitialized()
+    {
+        if (_tfmDirs.Count == 0)
         {
-            Directory.Delete(_tempDir, recursive: true);
-        }
-        catch
-        {
+            throw new InvalidOperationException("Call InitializeAsync() before using the factory.");
         }
     }
 
-    private async Task<string> DownloadAndExtractNuGetDll()
+    private string PickBestModernTfm()
     {
-        var nupkgPath = Path.Combine(_tempDir, $"{NuGetPackageId}.{_packageVersion}.nupkg");
-        var extractDir = Path.Combine(_tempDir, "extracted");
-
-        using var http = new HttpClient();
-        var url = $"{NuGetBaseUrl}/{NuGetPackageId.ToLowerInvariant()}/{_packageVersion}/{NuGetPackageId.ToLowerInvariant()}.{_packageVersion}.nupkg";
-        var bytes = await http.GetByteArrayAsync(url);
-        await File.WriteAllBytesAsync(nupkgPath, bytes);
-        ZipFile.ExtractToDirectory(nupkgPath, extractDir);
-
-        // Prefer the highest netX.0 TFM (not netstandard, not net4xx)
-        var libDir = Path.Combine(extractDir, "lib");
-        var bestTfm = Directory.GetDirectories(libDir)
-            .Select(d => Path.GetFileName(d)!)
+        return _tfmDirs.Keys
             .Where(t => t.StartsWith("net", StringComparison.Ordinal)
                      && !t.StartsWith("netstandard", StringComparison.Ordinal)
                      && !t.StartsWith("net4", StringComparison.Ordinal))
             .OrderByDescending(t => t)
             .FirstOrDefault()
             ?? throw new InvalidOperationException("No suitable TFM found in NuGet package");
+    }
 
-        var dllPath = Path.Combine(libDir, bestTfm, $"{NuGetPackageId}.dll");
-        if (!File.Exists(dllPath))
+    private async Task<string> DownloadAndExtractPackage(string packageId)
+    {
+        var extractDir = Path.Combine(_tempDir, packageId);
+        var nupkgPath = Path.Combine(_tempDir, $"{packageId}.{_packageVersion}.nupkg");
+
+        using var http = new HttpClient();
+        var url = $"{NuGetBaseUrl}/{packageId.ToLowerInvariant()}/{_packageVersion}/{packageId.ToLowerInvariant()}.{_packageVersion}.nupkg";
+        var bytes = await http.GetByteArrayAsync(url);
+        await File.WriteAllBytesAsync(nupkgPath, bytes);
+        ZipFile.ExtractToDirectory(nupkgPath, extractDir);
+
+        var libDir = Path.Combine(extractDir, "lib");
+        if (!Directory.Exists(libDir))
         {
-            throw new FileNotFoundException($"Expected DLL at {dllPath}");
+            throw new InvalidOperationException($"No lib/ folder found in {packageId} {_packageVersion}");
         }
 
-        return dllPath;
+        return libDir;
+    }
+
+    /// <summary>
+    /// Find the best matching TFM directory for a dependency package.
+    /// Exact match first, then fall back to compatible TFMs.
+    /// </summary>
+    private static string? FindBestMatchingTfmDir(string libDir, string targetTfm)
+    {
+        var exact = Path.Combine(libDir, targetTfm);
+        if (Directory.Exists(exact))
+        {
+            return exact;
+        }
+
+        // For netX.0 targets, try netstandard2.0 as fallback
+        var netstandard = Path.Combine(libDir, "netstandard2.0");
+        if (Directory.Exists(netstandard))
+        {
+            return netstandard;
+        }
+
+        // Return first available TFM as last resort
+        return Directory.GetDirectories(libDir).FirstOrDefault();
+    }
+
+    /// <summary>
+    /// AssemblyLoadContext that resolves dependencies from a directory before falling back
+    /// to the default context. This is needed when loading older NuGet DLLs that depend on
+    /// matching versions of Cryptography.Internal (which has different API surface per major version).
+    /// </summary>
+    private sealed class DirectoryAssemblyLoadContext : AssemblyLoadContext
+    {
+        private readonly string _directory;
+
+        public DirectoryAssemblyLoadContext(string directory, string name) : base(name, isCollectible: true)
+        {
+            _directory = directory;
+        }
+
+        protected override Assembly? Load(AssemblyName assemblyName)
+        {
+            var candidate = Path.Combine(_directory, $"{assemblyName.Name}.dll");
+            if (File.Exists(candidate))
+            {
+                return LoadFromAssemblyPath(candidate);
+            }
+
+            // Fall back to default context for framework assemblies
+            return null;
+        }
     }
 }
 
@@ -133,7 +273,7 @@ internal sealed class NuGetEncryptorFactory : IDisposable
 /// Wraps a ManagedAuthenticatedEncryptor loaded from a NuGet assembly,
 /// calling Encrypt/Decrypt via reflection to avoid type identity conflicts.
 /// </summary>
-internal sealed class NuGetEncryptorWrapper(object encryptor, Type encryptorType)
+public sealed class NuGetEncryptorWrapper(object encryptor, Type encryptorType)
 {
     private readonly object _encryptor = encryptor;
     private readonly MethodInfo _encrypt = encryptorType.GetMethod("Encrypt", BindingFlags.Public | BindingFlags.Instance)

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.NuGetIntegrationTests/NuGetEncryptorFactory.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.NuGetIntegrationTests/NuGetEncryptorFactory.cs
@@ -1,0 +1,149 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.IO.Compression;
+using System.Net.Http;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using Microsoft.AspNetCore.DataProtection.Managed;
+
+namespace Microsoft.AspNetCore.DataProtection.NuGetIntegrationTests;
+
+/// <summary>
+/// Downloads a released NuGet package once, loads the ManagedAuthenticatedEncryptor
+/// from it via reflection in an isolated AssemblyLoadContext, and creates encryptors
+/// that use the same key material as current source code for cross-version testing.
+/// </summary>
+internal sealed class NuGetEncryptorFactory : IDisposable
+{
+    private const string NuGetBaseUrl = "https://api.nuget.org/v3-flatcontainer";
+    private const string NuGetPackageId = "Microsoft.AspNetCore.DataProtection";
+
+    private readonly string _tempDir;
+    private readonly string _packageVersion;
+
+    private Assembly? _nugetAssembly;
+    private Type? _encryptorType;
+    private Type? _secretType;
+    private ConstructorInfo? _encryptorCtor;
+    private object? _genRandomInstance;
+
+    public NuGetEncryptorFactory(string packageVersion)
+    {
+        _packageVersion = packageVersion;
+        _tempDir = Path.Combine(Path.GetTempPath(), $"dp-nuget-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    /// <summary>
+    /// Downloads and extracts the NuGet package, loading the DLL into an isolated ALC.
+    /// Call once before creating encryptors.
+    /// </summary>
+    public async Task InitializeAsync()
+    {
+        var dllPath = await DownloadAndExtractNuGetDll();
+        var alc = new AssemblyLoadContext($"NuGet-{_packageVersion}", isCollectible: true);
+        _nugetAssembly = alc.LoadFromAssemblyPath(dllPath);
+
+        // Resolve types using typeof().FullName for refactor safety
+        _secretType = _nugetAssembly.GetType(typeof(Secret).FullName!)
+            ?? throw new InvalidOperationException($"Cannot find {nameof(Secret)} type in NuGet assembly");
+        _encryptorType = _nugetAssembly.GetType(typeof(ManagedAuthenticatedEncryptor).FullName!)
+            ?? throw new InvalidOperationException($"Cannot find {nameof(ManagedAuthenticatedEncryptor)} type in NuGet assembly");
+
+        _encryptorCtor = _encryptorType.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            .FirstOrDefault(c => c.GetParameters().Length == 5)
+            ?? throw new InvalidOperationException($"Cannot find {nameof(ManagedAuthenticatedEncryptor)} 5-param constructor");
+
+        var genRandomImplType = _nugetAssembly.GetType(typeof(ManagedGenRandomImpl).FullName!)
+            ?? throw new InvalidOperationException($"Cannot find {nameof(ManagedGenRandomImpl)} type in NuGet assembly");
+        _genRandomInstance = genRandomImplType.GetField("Instance", BindingFlags.Public | BindingFlags.Static)?.GetValue(null)
+            ?? throw new InvalidOperationException($"Cannot find {nameof(ManagedGenRandomImpl)}.Instance");
+    }
+
+    /// <summary>
+    /// Creates a ManagedAuthenticatedEncryptor from the downloaded NuGet assembly
+    /// using reflection and the same key material (all-zero 512-bit key).
+    /// </summary>
+    public NuGetEncryptorWrapper CreateEncryptor()
+    {
+        if (_nugetAssembly is null)
+        {
+            throw new InvalidOperationException("Call InitializeAsync() before creating encryptors.");
+        }
+
+        var secretCtor = _secretType!.GetConstructor([typeof(byte[])])
+            ?? throw new InvalidOperationException("Cannot find Secret(byte[]) constructor");
+        var secret = secretCtor.Invoke([new byte[512 / 8]]);
+
+        Func<SymmetricAlgorithm> symFactory = Aes.Create;
+        Func<KeyedHashAlgorithm> hmacFactory = () => new HMACSHA256();
+
+        var encryptor = _encryptorCtor!.Invoke([secret, symFactory, 256 / 8, hmacFactory, _genRandomInstance!]);
+        return new NuGetEncryptorWrapper(encryptor, _encryptorType!);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+        catch
+        {
+        }
+    }
+
+    private async Task<string> DownloadAndExtractNuGetDll()
+    {
+        var nupkgPath = Path.Combine(_tempDir, $"{NuGetPackageId}.{_packageVersion}.nupkg");
+        var extractDir = Path.Combine(_tempDir, "extracted");
+
+        using var http = new HttpClient();
+        var url = $"{NuGetBaseUrl}/{NuGetPackageId.ToLowerInvariant()}/{_packageVersion}/{NuGetPackageId.ToLowerInvariant()}.{_packageVersion}.nupkg";
+        var bytes = await http.GetByteArrayAsync(url);
+        await File.WriteAllBytesAsync(nupkgPath, bytes);
+        ZipFile.ExtractToDirectory(nupkgPath, extractDir);
+
+        // Prefer the highest netX.0 TFM (not netstandard, not net4xx)
+        var libDir = Path.Combine(extractDir, "lib");
+        var bestTfm = Directory.GetDirectories(libDir)
+            .Select(d => Path.GetFileName(d)!)
+            .Where(t => t.StartsWith("net", StringComparison.Ordinal)
+                     && !t.StartsWith("netstandard", StringComparison.Ordinal)
+                     && !t.StartsWith("net4", StringComparison.Ordinal))
+            .OrderByDescending(t => t)
+            .FirstOrDefault()
+            ?? throw new InvalidOperationException("No suitable TFM found in NuGet package");
+
+        var dllPath = Path.Combine(libDir, bestTfm, $"{NuGetPackageId}.dll");
+        if (!File.Exists(dllPath))
+        {
+            throw new FileNotFoundException($"Expected DLL at {dllPath}");
+        }
+
+        return dllPath;
+    }
+}
+
+/// <summary>
+/// Wraps a ManagedAuthenticatedEncryptor loaded from a NuGet assembly,
+/// calling Encrypt/Decrypt via reflection to avoid type identity conflicts.
+/// </summary>
+internal sealed class NuGetEncryptorWrapper(object encryptor, Type encryptorType)
+{
+    private readonly object _encryptor = encryptor;
+    private readonly MethodInfo _encrypt = encryptorType.GetMethod("Encrypt", BindingFlags.Public | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("Cannot find Encrypt method");
+    private readonly MethodInfo _decrypt = encryptorType.GetMethod("Decrypt", BindingFlags.Public | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("Cannot find Decrypt method");
+
+    public byte[] Encrypt(ArraySegment<byte> plaintext, ArraySegment<byte> aad)
+        => (byte[])_encrypt.Invoke(_encryptor, [plaintext, aad])!;
+
+    public byte[] Decrypt(ArraySegment<byte> ciphertext, ArraySegment<byte> aad)
+        => (byte[])_decrypt.Invoke(_encryptor, [ciphertext, aad])!;
+}


### PR DESCRIPTION
DataProtection is quite unique in the sense that both package of X version and X+1 version have to be compatible and be able to perform encrypt/decrypt between different versions.

For example, encrypting data via DataProtection of 10.0.5 and decrypting via 10.0.6 should give the same result as encrypting via 10.0.6 and decrypting via 10.0.5. And **also** should give the same result as encrypting/decrypting in the same package (but we have such units tests already).

I am proposing to introduce cross-version testing via downloading a good "known" (pinned) version of NuGet package that performs encryption and decryption correctly, and making a cross-version comparison between current-branch code and the pinned NuGet package.

As a starter I added tests for `ManagedAuthenticatedEncryptor`, but we can add for other encryptors as well.

Related #66335