### PR TITLE
Add verbose logging and diagnostics for npm ci 0xDEAD failures

### DIFF
--- a/eng/Npm.Workspace.nodeproj
+++ b/eng/Npm.Workspace.nodeproj
@@ -137,11 +137,48 @@
 
   <Target Name="Restore" Inputs="@(NpmInputFiles)" Outputs="@(NpmOutputFiles)">
     <Message Text="Restoring NPM packages..." Importance="high" />
+
+    <!-- Log environment diagnostics to help debug npm ci 0xDEAD crashes (https://github.com/dotnet/aspnetcore/issues/62807) -->
+    <Exec Command="node --version" ConsoleToMsBuild="true" Condition="'$(ContinuousIntegrationBuild)' == 'true'" />
+    <Exec Command="npm --version" ConsoleToMsBuild="true" Condition="'$(ContinuousIntegrationBuild)' == 'true'" />
+    <Exec Command="npm config get registry" WorkingDirectory="$(NpmWorkspaceRoot)" ConsoleToMsBuild="true" Condition="'$(ContinuousIntegrationBuild)' == 'true'" />
+    <Exec Command="npm config get cache" WorkingDirectory="$(NpmWorkspaceRoot)" ConsoleToMsBuild="true" Condition="'$(ContinuousIntegrationBuild)' == 'true'" />
+    <Exec Command="df -h ." WorkingDirectory="$(NpmWorkspaceRoot)"
+          ConsoleToMsBuild="true" Condition="'$(ContinuousIntegrationBuild)' == 'true' AND '$(OS)' != 'Windows_NT'" />
+    <Exec Command="powershell -NoProfile -Command &quot;Get-CimInstance Win32_LogicalDisk | Format-Table DeviceID, @{N='Size(GB)';E={[math]::Round($_.Size/1GB,1)}}, @{N='Free(GB)';E={[math]::Round($_.FreeSpace/1GB,1)}}, @{N='Use%%';E={[math]::Round(($_.Size-$_.FreeSpace)/$_.Size*100,0)}} -AutoSize&quot;"
+          ConsoleToMsBuild="true" Condition="'$(ContinuousIntegrationBuild)' == 'true' AND '$(OS)' == 'Windows_NT'" />
+
     <Exec
-      Command="npm ci"
+      Command="npm ci --loglevel verbose"
       WorkingDirectory="$(NpmWorkspaceRoot)"
       EnvironmentVariables="$(_NpmAdditionalEnvironmentVariables)"
-      ConsoleToMsBuild="true" />
+      ConsoleToMsBuild="true"
+      IgnoreExitCode="true">
+      <Output TaskParameter="ExitCode" PropertyName="_NpmCiExitCode" />
+    </Exec>
+
+    <!-- On failure, resolve the npm cache directory, copy debug logs to artifacts/log for upload, then dump to console -->
+    <Exec Command="npm config get cache" WorkingDirectory="$(NpmWorkspaceRoot)" ConsoleToMsBuild="true"
+          Condition="'$(_NpmCiExitCode)' != '0'">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_NpmCacheDir" />
+    </Exec>
+
+    <ItemGroup Condition="'$(_NpmCiExitCode)' != '0' AND '$(_NpmCacheDir)' != ''">
+      <_NpmDebugLogs Include="$(_NpmCacheDir)/_logs/*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_NpmDebugLogs)" DestinationFolder="$(ArtifactsDir)log/$(Configuration)/npm-logs/"
+          Condition="'$(_NpmCiExitCode)' != '0' AND '@(_NpmDebugLogs)' != ''"
+          ContinueOnError="true" />
+
+    <Exec Command="cat &quot;$(_NpmCacheDir)/_logs/&quot;*-debug-0.log 2>/dev/null || echo 'No npm debug log found'"
+          ConsoleToMsBuild="true" IgnoreExitCode="true"
+          Condition="'$(_NpmCiExitCode)' != '0' AND '$(OS)' != 'Windows_NT'" />
+    <Exec Command="for /f &quot;delims=&quot; %%i in ('dir /b &quot;$(_NpmCacheDir)\_logs\*-debug-0.log&quot; 2^>nul') do type &quot;$(_NpmCacheDir)\_logs\%%i&quot;"
+          ConsoleToMsBuild="true" IgnoreExitCode="true"
+          Condition="'$(_NpmCiExitCode)' != '0' AND '$(OS)' == 'Windows_NT'" />
+
+    <Error Text="npm ci failed with exit code $(_NpmCiExitCode). See verbose output and npm debug log above."
+           Condition="'$(_NpmCiExitCode)' != '0'" />
   </Target>
 
   <Target Name="Build" DependsOnTargets="Restore" Inputs="@(NpmBuildInputFiles)" Outputs="@(NpmBuildOutputFiles)">


### PR DESCRIPTION
## Problem

`npm ci` intermittently fails with exit code 57005 (`0xDEAD`) in CI, producing **zero diagnostic output** between "Restoring NPM packages..." and the MSB3073 error. The retry settings and `ConsoleToMsBuild` added in #66430 didn't help because npm crashes before writing anything.

From [build 1393671](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1393671), the full output is:
```
Restoring NPM packages...
[error] npm ci exited with code 57005.
```
No error details, no stack trace, no network diagnostics.

## Fix

1. **Pre-flight diagnostics**: Logs `node --version`, `npm --version`, `npm config list`, and disk space before `npm ci` runs — captured even on silent crashes
2. **`--loglevel verbose`**: npm logs each network request and registry operation before the crash point
3. **Capture npm debug log**: Uses `IgnoreExitCode` to let the build dump `.npm/_logs/*-debug-0.log` after failure instead of immediately aborting

This won't fix the crashes, but will give us the information needed to diagnose whether it's a network timeout, auth issue, disk space, or something else entirely.

Relates to #62807