### PR TITLE
Enable binary logging in quarantined-tests pipeline

### DIFF
--- a/.azure/pipelines/quarantined-tests.yml
+++ b/.azure/pipelines/quarantined-tests.yml
@@ -27,11 +27,11 @@ jobs:
     timeoutInMinutes: 480
     steps:
     # Build the shared framework
-    - script: ./eng/build.cmd -ci -prepareMachine -nobl -all -noBuildJava -pack -arch x64
+    - script: ./eng/build.cmd -ci -prepareMachine /bl:artifacts/log/Build.SharedFx.binlog -all -noBuildJava -pack -arch x64
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Build shared fx
     # -noBuildNative -noBuild to avoid repeating work done in the previous step.
-    - script: ./eng/build.cmd -ci -prepareMachine -nobl -all -noBuildNative -noBuild -noBuildJava -test
+    - script: ./eng/build.cmd -ci -prepareMachine /bl:artifacts/log/Build.HelixTarget.binlog -all -noBuildNative -noBuild -noBuildJava -test
               -projects eng\helix\helix.proj /p:RunQuarantinedTests=true /p:IsHelixJob=true
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.cmd helix target


### PR DESCRIPTION
The quarantined-tests pipeline (definition 84) has been failing 12/30 scheduled builds at the infrastructure level with `Build FAILED, 0 Warnings, 0 Errors` — a silent MSBuild failure that produces no diagnostic output. The `-nobl` flag was suppressing binary logs, making root cause analysis impossible.

Replace `-nobl` with `-bl:artifacts/log/Build.SharedFx.binlog` and `-bl:artifacts/log/Build.HelixTarget.binlog` so both build steps produce uniquely-named binlogs that get uploaded via the existing `artifacts/log/` artifact.

This blocks the quarantine unquarantine workflow — with only 18/30 builds producing test results, the max test appearance rate is 60%, below the 66% threshold needed to qualify tests for unquarantine.