### PR TITLE
[release/11.0-preview4] Update Blazor templates to use TempData

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/IdentityRedirectManager.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/IdentityRedirectManager.cs
@@ -1,20 +1,10 @@
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Identity;
-using BlazorWebCSharp._1.Data;
 
 namespace BlazorWebCSharp._1.Components.Account;
 
 internal sealed class IdentityRedirectManager(NavigationManager navigationManager)
 {
-    public const string StatusCookieName = "Identity.StatusMessage";
-
-    private static readonly CookieBuilder StatusCookieBuilder = new()
-    {
-        SameSite = SameSiteMode.Strict,
-        HttpOnly = true,
-        IsEssential = true,
-        MaxAge = TimeSpan.FromSeconds(5),
-    };
+    public const string StatusMessageKey = "Identity.StatusMessage";
 
     public void RedirectTo(string? uri)
     {
@@ -36,19 +26,7 @@ internal sealed class IdentityRedirectManager(NavigationManager navigationManage
         RedirectTo(newUri);
     }
 
-    public void RedirectToWithStatus(string uri, string message, HttpContext context)
-    {
-        context.Response.Cookies.Append(StatusCookieName, message, StatusCookieBuilder.Build(context));
-        RedirectTo(uri);
-    }
-
     private string CurrentPath => navigationManager.ToAbsoluteUri(navigationManager.Uri).GetLeftPart(UriPartial.Path);
 
     public void RedirectToCurrentPage() => RedirectTo(CurrentPath);
-
-    public void RedirectToCurrentPageWithStatus(string message, HttpContext context)
-        => RedirectToWithStatus(CurrentPath, message, context);
-
-    public void RedirectToInvalidUser(UserManager<ApplicationUser> userManager, HttpContext context)
-        => RedirectToWithStatus("Account/InvalidUser", $"Error: Unable to load user with ID '{userManager.GetUserId(context.User)}'.", context);
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/ConfirmEmailChange.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/ConfirmEmailChange.razor
@@ -21,6 +21,9 @@
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
 
+    [SupplyParameterFromTempData(Name = IdentityRedirectManager.StatusMessageKey)]
+    private string? IdentityStatusMessage { get; set; }
+
     [SupplyParameterFromQuery]
     private string? UserId { get; set; }
 
@@ -32,17 +35,20 @@
 
     protected override async Task OnInitializedAsync()
     {
+        message = IdentityStatusMessage;
+        IdentityStatusMessage = null;
+
         if (UserId is null || Email is null || Code is null)
         {
-            RedirectManager.RedirectToWithStatus(
-                "Account/Login", "Error: Invalid email change confirmation link.", HttpContext);
+            IdentityStatusMessage = "Error: Invalid email change confirmation link.";
+            RedirectManager.RedirectTo("Account/Login");
             return;
         }
 
         var user = await UserManager.FindByIdAsync(UserId);
         if (user is null)
         {
-            message = "Unable to find user with Id '{userId}'";
+            message = $"Error: Unable to find user with Id '{UserId}'";
             return;
         }
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/ExternalLogin.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/ExternalLogin.razor
@@ -23,7 +23,7 @@
 <h2>Associate your @ProviderDisplayName account.</h2>
 <hr />
 
-<div  class="alert alert-info">
+<div class="alert alert-info">
     You've successfully authenticated with <strong>@ProviderDisplayName</strong>.
     Please enter an email address for this site below and click the Register button to finish
     logging in.
@@ -53,6 +53,9 @@
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
 
+    [SupplyParameterFromTempData(Name = IdentityRedirectManager.StatusMessageKey)]
+    private string? IdentityStatusMessage { get; set; }
+
     [SupplyParameterFromForm]
     private InputModel Input { get; set; } = default!;
 
@@ -69,18 +72,22 @@
 
     protected override async Task OnInitializedAsync()
     {
+        message = IdentityStatusMessage;
+        IdentityStatusMessage = null;
         Input ??= new();
 
         if (RemoteError is not null)
         {
-            RedirectManager.RedirectToWithStatus("Account/Login", $"Error from external provider: {RemoteError}", HttpContext);
+            IdentityStatusMessage = $"Error from external provider: {RemoteError}";
+            RedirectManager.RedirectTo("Account/Login");
             return;
         }
 
         var info = await SignInManager.GetExternalLoginInfoAsync();
         if (info is null)
         {
-            RedirectManager.RedirectToWithStatus("Account/Login", "Error loading external login information.", HttpContext);
+            IdentityStatusMessage = "Error loading external login information.";
+            RedirectManager.RedirectTo("Account/Login");
             return;
         }
 
@@ -104,7 +111,8 @@
     {
         if (externalLoginInfo is null)
         {
-            RedirectManager.RedirectToWithStatus("Account/Login", "Error loading external login information.", HttpContext);
+            IdentityStatusMessage = "Error loading external login information.";
+            RedirectManager.RedirectTo("Account/Login");
             return;
         }
 
@@ -141,7 +149,8 @@
     {
         if (externalLoginInfo is null)
         {
-            RedirectManager.RedirectToWithStatus("Account/Login", "Error loading external login information during confirmation.", HttpContext);
+            IdentityStatusMessage = "Error loading external login information during confirmation.";
+            RedirectManager.RedirectTo("Account/Login");
             return;
         }
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/InvalidUser.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/InvalidUser.razor
@@ -1,7 +1,23 @@
 ﻿@page "/Account/InvalidUser"
 
+@using Microsoft.AspNetCore.Identity
+@using BlazorWebCSharp._1.Data
+@inject UserManager<ApplicationUser> UserManager
+
 <PageTitle>Invalid user</PageTitle>
 
 <h3>Invalid user</h3>
 
-<StatusMessage />
+<StatusMessage Message="@message" />
+
+@code {
+    private string? message;
+
+    [CascadingParameter]
+    private HttpContext HttpContext { get; set; } = default!;
+
+    protected override void OnInitialized()
+    {
+        message = $"Error: Unable to load user with ID '{UserManager.GetUserId(HttpContext.User)}'.";
+    }
+}

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Login.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Login.razor
@@ -82,6 +82,9 @@
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
 
+    [SupplyParameterFromTempData(Name = IdentityRedirectManager.StatusMessageKey)]
+    private string? IdentityStatusMessage { get; set; }
+
     [SupplyParameterFromForm]
     private InputModel Input { get; set; } = default!;
 
@@ -90,6 +93,8 @@
 
     protected override async Task OnInitializedAsync()
     {
+        errorMessage = IdentityStatusMessage;
+        IdentityStatusMessage = null;
         Input ??= new();
 
         editContext = new EditContext(Input);

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/ChangePassword.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/ChangePassword.razor
@@ -52,17 +52,22 @@
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
 
+    [SupplyParameterFromTempData(Name = IdentityRedirectManager.StatusMessageKey)]
+    private string? IdentityStatusMessage { get; set; }
+
     [SupplyParameterFromForm]
     private InputModel Input { get; set; } = default!;
 
     protected override async Task OnInitializedAsync()
     {
+        message = IdentityStatusMessage;
+        IdentityStatusMessage = null;
         Input ??= new();
 
         user = await UserManager.GetUserAsync(HttpContext.User);
         if (user is null)
         {
-            RedirectManager.RedirectToInvalidUser(UserManager, HttpContext);
+            RedirectManager.RedirectTo("Account/InvalidUser");
             return;
         }
 
@@ -77,7 +82,7 @@
     {
         if (user is null)
         {
-            RedirectManager.RedirectToInvalidUser(UserManager, HttpContext);
+            RedirectManager.RedirectTo("Account/InvalidUser");
             return;
         }
 
@@ -91,7 +96,8 @@
         await SignInManager.RefreshSignInAsync(user);
         Logger.LogInformation("User changed their password successfully.");
 
-        RedirectManager.RedirectToCurrentPageWithStatus("Your password has been changed", HttpContext);
+        IdentityStatusMessage = "Your password has been changed";
+        RedirectManager.RedirectToCurrentPage();
     }
 
     private sealed class InputModel

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/DeletePersonalData.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/DeletePersonalData.razor
@@ -45,17 +45,22 @@
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
 
+    [SupplyParameterFromTempData(Name = IdentityRedirectManager.StatusMessageKey)]
+    private string? IdentityStatusMessage { get; set; }
+
     [SupplyParameterFromForm]
     private InputModel Input { get; set; } = default!;
 
     protected override async Task OnInitializedAsync()
     {
+        message = IdentityStatusMessage;
+        IdentityStatusMessage = null;
         Input ??= new();
 
         user = await UserManager.GetUserAsync(HttpContext.User);
         if (user is null)
         {
-            RedirectManager.RedirectToInvalidUser(UserManager, HttpContext);
+            RedirectManager.RedirectTo("Account/InvalidUser");
             return;
         }
         requirePassword = await UserManager.HasPasswordAsync(user);
@@ -65,7 +70,7 @@
     {
         if (user is null)
         {
-            RedirectManager.RedirectToInvalidUser(UserManager, HttpContext);
+            RedirectManager.RedirectTo("Account/InvalidUser");
             return;
         }
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/Disable2fa.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/Disable2fa.razor
@@ -9,7 +9,7 @@
 
 <PageTitle>Disable two-factor authentication (2FA)</PageTitle>
 
-<StatusMessage />
+<StatusMessage Message="@message" />
 <h3>Disable two-factor authentication (2FA)</h3>
 
 <div class="alert alert-warning" role="alert">
@@ -30,17 +30,24 @@
 </div>
 
 @code {
+    private string? message;
     private ApplicationUser? user;
 
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
 
+    [SupplyParameterFromTempData(Name = IdentityRedirectManager.StatusMessageKey)]
+    private string? IdentityStatusMessage { get; set; }
+
     protected override async Task OnInitializedAsync()
     {
+        message = IdentityStatusMessage;
+        IdentityStatusMessage = null;
+
         user = await UserManager.GetUserAsync(HttpContext.User);
         if (user is null)
         {
-            RedirectManager.RedirectToInvalidUser(UserManager, HttpContext);
+            RedirectManager.RedirectTo("Account/InvalidUser");
             return;
         }
 
@@ -54,7 +61,7 @@
     {
         if (user is null)
         {
-            RedirectManager.RedirectToInvalidUser(UserManager, HttpContext);
+            RedirectManager.RedirectTo("Account/InvalidUser");
             return;
         }
 
@@ -66,9 +73,7 @@
 
         var userId = await UserManager.GetUserIdAsync(user);
         Logger.LogInformation("User with ID '{UserId}' has disabled 2fa.", userId);
-        RedirectManager.RedirectToWithStatus(
-            "Account/Manage/TwoFactorAuthentication",
-            "2fa has been disabled. You can reenable 2fa when you setup an authenticator app",
-            HttpContext);
+        IdentityStatusMessage = "2fa has been disabled. You can reenable 2fa when you setup an authenticator app";
+        RedirectManager.RedirectTo("Account/Manage/TwoFactorAuthentication");
     }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/Email.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/Email.razor
@@ -64,17 +64,22 @@
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
 
+    [SupplyParameterFromTempData(Name = IdentityRedirectManager.StatusMessageKey)]
+    private string? IdentityStatusMessage { get; set; }
+
     [SupplyParameterFromForm(FormName = "change-email")]
     private InputModel Input { get; set; } = default!;
 
     protected override async Task OnInitializedAsync()
     {
+        message = IdentityStatusMessage;
+        IdentityStatusMessage = null;
         Input ??= new();
 
         user = await UserManager.GetUserAsync(HttpContext.User);
         if (user is null)
         {
-            RedirectManager.RedirectToInvalidUser(UserManager, HttpContext);
+            RedirectManager.RedirectTo("Account/InvalidUser");
             return;
         }
 
@@ -94,7 +99,7 @@
 
         if (user is null)
         {
-            RedirectManager.RedirectToInvalidUser(UserManager, HttpContext);
+            RedirectManager.RedirectTo("Account/InvalidUser");
             return;
         }
 
@@ -119,7 +124,7 @@
 
         if (user is null)
         {
-            RedirectManager.RedirectToInvalidUser(UserManager, HttpContext);
+            RedirectManager.RedirectTo("Account/InvalidUser");
             return;
         }
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/EnableAuthenticator.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/EnableAuthenticator.razor
@@ -77,17 +77,22 @@ else
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
 
+    [SupplyParameterFromTempData(Name = IdentityRedirectManager.StatusMessageKey)]
+    private string? IdentityStatusMessage { get; set; }
+
     [SupplyParameterFromForm]
     private InputModel Input { get; set; } = default!;
 
     protected override async Task OnInitializedAsync()
     {
+        message = IdentityStatusMessage;
+        IdentityStatusMessage = null;
         Input ??= new();
 
         user = await UserManager.GetUserAsync(HttpContext.User);
         if (user is null)
         {
-            RedirectManager.RedirectToInvalidUser(UserManager, HttpContext);
+            RedirectManager.RedirectTo("Account/InvalidUser");
             return;
         }
 
@@ -98,7 +103,7 @@ else
     {
         if (user is null)
         {
-            RedirectManager.RedirectToInvalidUser(UserManager, HttpContext);
+            RedirectManager.RedirectTo("Account/InvalidUser");
             return;
         }
 
@@ -126,7 +131,8 @@ else
         }
         else
         {
-            RedirectManager.RedirectToWithStatus("Account/Manage/TwoFactorAuthentication", message, HttpContext);
+            IdentityStatusMessage = message;
+            RedirectManager.RedirectTo("Account/Manage/TwoFactorAuthentication");
         }
     }
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/ExternalLogins.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/ExternalLogins.razor
@@ -11,7 +11,7 @@
 
 <PageTitle>Manage your external logins</PageTitle>
 
-<StatusMessage />
+<StatusMessage Message="@message" />
 @if (currentLogins?.Count > 0)
 {
     <h3>Registered Logins</h3>
@@ -65,6 +65,7 @@
 @code {
     public const string LinkLoginCallbackAction = "LinkLoginCallback";
 
+    private string? message;
     private ApplicationUser? user;
     private IList<UserLoginInfo>? currentLogins;
     private IList<AuthenticationScheme>? otherLogins;
@@ -72,6 +73,9 @@
 
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
+
+    [SupplyParameterFromTempData(Name = IdentityRedirectManager.StatusMessageKey)]
+    private string? IdentityStatusMessage { get; set; }
 
     [SupplyParameterFromForm]
     private string? LoginProvider { get; set; }
@@ -84,10 +88,13 @@
 
     protected override async Task OnInitializedAsync()
     {
+        message = IdentityStatusMessage;
+        IdentityStatusMessage = null;
+
         user = await UserManager.GetUserAsync(HttpContext.User);
         if (user is null)
         {
-            RedirectManager.RedirectToInvalidUser(UserManager, HttpContext);
+            RedirectManager.RedirectTo("Account/InvalidUser");
             return;
         }
 
@@ -114,19 +121,21 @@
     {
         if (user is null)
         {
-            RedirectManager.RedirectToInvalidUser(UserManager, HttpContext);
+            RedirectManager.RedirectTo("Account/InvalidUser");
             return;
         }
 
         var result = await UserManager.RemoveLoginAsync(user, LoginProvider!, ProviderKey!);
         if (!result.Succeeded)
         {
-            RedirectManager.RedirectToCurrentPageWithStatus("Error: The external login was not removed.", HttpContext);
+            IdentityStatusMessage = "Error: The external login was not removed.";
+            RedirectManager.RedirectToCurrentPage();
         }
         else
         {
             await SignInManager.RefreshSignInAsync(user);
-            RedirectManager.RedirectToCurrentPageWithStatus("The external login was removed.", HttpContext);
+            IdentityStatusMessage = "The external login was removed.";
+            RedirectManager.RedirectToCurrentPage();
         }
     }
 
@@ -134,7 +143,7 @@
     {
         if (user is null)
         {
-            RedirectManager.RedirectToInvalidUser(UserManager, HttpContext);
+            RedirectManager.RedirectTo("Account/InvalidUser");
             return;
         }
 
@@ -142,7 +151,8 @@
         var info = await SignInManager.GetExternalLoginInfoAsync(userId);
         if (info is null)
         {
-            RedirectManager.RedirectToCurrentPageWithStatus("Error: Could not load external login info.", HttpContext);
+            IdentityStatusMessage = "Error: Could not load external login info.";
+            RedirectManager.RedirectToCurrentPage();
             return;
         }
 
@@ -152,11 +162,13 @@
             // Clear the existing external cookie to ensure a clean login process
             await HttpContext.SignOutAsync(IdentityConstants.ExternalScheme);
 
-            RedirectManager.RedirectToCurrentPageWithStatus("The external login was added.", HttpContext);
+            IdentityStatusMessage = "The external login was added.";
+            RedirectManager.RedirectToCurrentPage();
         }
         else
         {
-            RedirectManager.RedirectToCurrentPageWithStatus("Error: The external login was not added. External logins can only be associated with one account.", HttpContext);
+            IdentityStatusMessage = "Error: The external login was not added. External logins can only be associated with one account.";
+            RedirectManager.RedirectToCurrentPage();
         }
     }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/GenerateRecoveryCodes.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/GenerateRecoveryCodes.razor
@@ -45,12 +45,18 @@ else
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
 
+    [SupplyParameterFromTempData(Name = IdentityRedirectManager.StatusMessageKey)]
+    private string? IdentityStatusMessage { get; set; }
+
     protected override async Task OnInitializedAsync()
     {
+        message = IdentityStatusMessage;
+        IdentityStatusMessage = null;
+
         user = await UserManager.GetUserAsync(HttpContext.User);
         if (user is null)
         {
-            RedirectManager.RedirectToInvalidUser(UserManager, HttpContext);
+            RedirectManager.RedirectTo("Account/InvalidUser");
             return;
         }
 
@@ -65,7 +71,7 @@ else
     {
         if (user is null)
         {
-            RedirectManager.RedirectToInvalidUser(UserManager, HttpContext);
+            RedirectManager.RedirectTo("Account/InvalidUser");
             return;
         }
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/Index.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/Index.razor
@@ -11,7 +11,7 @@
 <PageTitle>Profile</PageTitle>
 
 <h3>Profile</h3>
-<StatusMessage />
+<StatusMessage Message="@message" />
 
 <div class="row">
     <div class="col-xl-6">
@@ -33,6 +33,7 @@
 </div>
 
 @code {
+    private string? message;
     private ApplicationUser? user;
     private string? username;
     private string? phoneNumber;
@@ -40,17 +41,22 @@
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
 
+    [SupplyParameterFromTempData(Name = IdentityRedirectManager.StatusMessageKey)]
+    private string? IdentityStatusMessage { get; set; }
+
     [SupplyParameterFromForm]
     private InputModel Input { get; set; } = default!;
 
     protected override async Task OnInitializedAsync()
     {
+        message = IdentityStatusMessage;
+        IdentityStatusMessage = null;
         Input ??= new();
 
         user = await UserManager.GetUserAsync(HttpContext.User);
         if (user is null)
         {
-            RedirectManager.RedirectToInvalidUser(UserManager, HttpContext);
+            RedirectManager.RedirectTo("Account/InvalidUser");
             return;
         }
 
@@ -64,7 +70,7 @@
     {
         if (user is null)
         {
-            RedirectManager.RedirectToInvalidUser(UserManager, HttpContext);
+            RedirectManager.RedirectTo("Account/InvalidUser");
             return;
         }
 
@@ -73,13 +79,15 @@
             var setPhoneResult = await UserManager.SetPhoneNumberAsync(user, Input.PhoneNumber);
             if (!setPhoneResult.Succeeded)
             {
-                RedirectManager.RedirectToCurrentPageWithStatus("Error: Failed to set phone number.", HttpContext);
+                IdentityStatusMessage = "Error: Failed to set phone number.";
+                RedirectManager.RedirectToCurrentPage();
                 return;
             }
         }
 
         await SignInManager.RefreshSignInAsync(user);
-        RedirectManager.RedirectToCurrentPageWithStatus("Your profile has been updated", HttpContext);
+        IdentityStatusMessage = "Your profile has been updated";
+        RedirectManager.RedirectToCurrentPage();
     }
 
     private sealed class InputModel

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/Passkeys.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/Passkeys.razor
@@ -13,7 +13,7 @@
 
 <h3>Manage your passkeys</h3>
 
-<StatusMessage />
+<StatusMessage Message="@message" />
 
 @if (currentPasskeys is { Count: > 0 })
 {
@@ -65,11 +65,15 @@ else
 @code {
     private const int MaxPasskeyCount = 100;
 
+    private string? message;
     private ApplicationUser? user;
     private IList<UserPasskeyInfo>? currentPasskeys;
 
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
+
+    [SupplyParameterFromTempData(Name = IdentityRedirectManager.StatusMessageKey)]
+    private string? IdentityStatusMessage { get; set; }
 
     [SupplyParameterFromForm]
     private string? Action { get; set; }
@@ -82,12 +86,14 @@ else
 
     protected override async Task OnInitializedAsync()
     {
+        message = IdentityStatusMessage;
+        IdentityStatusMessage = null;
         Input ??= new();
 
         user = await UserManager.GetUserAsync(HttpContext.User);
         if (user is null)
         {
-            RedirectManager.RedirectToInvalidUser(UserManager, HttpContext);
+            RedirectManager.RedirectTo("Account/InvalidUser");
             return;
         }
         currentPasskeys = await UserManager.GetPasskeysAsync(user);
@@ -97,32 +103,36 @@ else
     {
         if (user is null)
         {
-            RedirectManager.RedirectToInvalidUser(UserManager, HttpContext);
+            RedirectManager.RedirectTo("Account/InvalidUser");
             return;
         }
 
         if (!string.IsNullOrEmpty(Input.Error))
         {
-            RedirectManager.RedirectToCurrentPageWithStatus($"Error: {Input.Error}", HttpContext);
+            IdentityStatusMessage = $"Error: {Input.Error}";
+            RedirectManager.RedirectToCurrentPage();
             return;
         }
 
         if (string.IsNullOrEmpty(Input.CredentialJson))
         {
-            RedirectManager.RedirectToCurrentPageWithStatus("Error: The browser did not provide a passkey.", HttpContext);
+            IdentityStatusMessage = "Error: The browser did not provide a passkey.";
+            RedirectManager.RedirectToCurrentPage();
             return;
         }
 
         if (currentPasskeys!.Count >= MaxPasskeyCount)
         {
-            RedirectManager.RedirectToCurrentPageWithStatus($"Error: You have reached the maximum number of allowed passkeys.", HttpContext);
+            IdentityStatusMessage = "Error: You have reached the maximum number of allowed passkeys.";
+            RedirectManager.RedirectToCurrentPage();
             return;
         }
 
         var attestationResult = await SignInManager.PerformPasskeyAttestationAsync(Input.CredentialJson);
         if (!attestationResult.Succeeded)
         {
-            RedirectManager.RedirectToCurrentPageWithStatus($"Error: Could not add the passkey: {attestationResult.Failure.Message}", HttpContext);
+            IdentityStatusMessage = $"Error: Could not add the passkey: {attestationResult.Failure.Message}";
+            RedirectManager.RedirectToCurrentPage();
             return;
         }
 
@@ -135,14 +145,16 @@ else
         var addPasskeyResult = await UserManager.AddOrUpdatePasskeyAsync(user, attestationResult.Passkey);
         if (!addPasskeyResult.Succeeded)
         {
-            RedirectManager.RedirectToCurrentPageWithStatus("Error: The passkey could not be added to your account.", HttpContext);
+            IdentityStatusMessage = "Error: The passkey could not be added to your account.";
+            RedirectManager.RedirectToCurrentPage();
             return;
         }
 
         // If a name was inferred, go back to the passkeys list
         if (!string.IsNullOrEmpty(attestationResult.Passkey.Name))
         {
-            RedirectManager.RedirectToCurrentPageWithStatus("Your passkey was added successfully.", HttpContext);
+            IdentityStatusMessage = "Your passkey was added successfully.";
+            RedirectManager.RedirectToCurrentPage();
             return;
         }
 
@@ -162,7 +174,8 @@ else
                 await DeletePasskey();
                 break;
             default:
-                RedirectManager.RedirectToCurrentPageWithStatus($"Error: Unknown action '{Action}'.", HttpContext);
+                IdentityStatusMessage = $"Error: Unknown action '{Action}'.";
+                RedirectManager.RedirectToCurrentPage();
                 break;
         }
     }
@@ -171,7 +184,7 @@ else
     {
         if (user is null)
         {
-            RedirectManager.RedirectToInvalidUser(UserManager, HttpContext);
+            RedirectManager.RedirectTo("Account/InvalidUser");
             return;
         }
 
@@ -182,17 +195,20 @@ else
         }
         catch (FormatException)
         {
-            RedirectManager.RedirectToCurrentPageWithStatus("Error: The specified passkey ID had an invalid format.", HttpContext);
+            IdentityStatusMessage = "Error: The specified passkey ID had an invalid format.";
+            RedirectManager.RedirectToCurrentPage();
             return;
         }
 
         var result = await UserManager.RemovePasskeyAsync(user, credentialId);
         if (!result.Succeeded)
         {
-            RedirectManager.RedirectToCurrentPageWithStatus("Error: The passkey could not be deleted.", HttpContext);
+            IdentityStatusMessage = "Error: The passkey could not be deleted.";
+            RedirectManager.RedirectToCurrentPage();
             return;
         }
 
-        RedirectManager.RedirectToCurrentPageWithStatus("Passkey deleted successfully.", HttpContext);
+        IdentityStatusMessage = "Passkey deleted successfully.";
+        RedirectManager.RedirectToCurrentPage();
     }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/PersonalData.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/PersonalData.razor
@@ -8,7 +8,7 @@
 
 <PageTitle>Personal Data</PageTitle>
 
-<StatusMessage />
+<StatusMessage Message="@message" />
 <h3>Personal Data</h3>
 
 <div class="row">
@@ -28,15 +28,23 @@
 </div>
 
 @code {
+    private string? message;
+
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
 
+    [SupplyParameterFromTempData(Name = IdentityRedirectManager.StatusMessageKey)]
+    private string? IdentityStatusMessage { get; set; }
+
     protected override async Task OnInitializedAsync()
     {
-        var user  = await UserManager.GetUserAsync(HttpContext.User);
+        message = IdentityStatusMessage;
+        IdentityStatusMessage = null;
+
+        var user = await UserManager.GetUserAsync(HttpContext.User);
         if (user is null)
         {
-            RedirectManager.RedirectToInvalidUser(UserManager, HttpContext);
+            RedirectManager.RedirectTo("Account/InvalidUser");
         }
     }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/RenamePasskey.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/RenamePasskey.razor
@@ -37,6 +37,9 @@
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
 
+    [SupplyParameterFromTempData(Name = IdentityRedirectManager.StatusMessageKey)]
+    private string? IdentityStatusMessage { get; set; }
+
     [Parameter]
     public string? Id { get; set; }
 
@@ -45,12 +48,13 @@
 
     protected override async Task OnInitializedAsync()
     {
+        IdentityStatusMessage = null;
         Input ??= new();
 
         user = (await UserManager.GetUserAsync(HttpContext.User))!;
         if (user is null)
         {
-            RedirectManager.RedirectToInvalidUser(UserManager, HttpContext);
+            RedirectManager.RedirectTo("Account/InvalidUser");
             return;
         }
 
@@ -61,14 +65,16 @@
         }
         catch (FormatException)
         {
-            RedirectManager.RedirectToWithStatus("Account/Manage/Passkeys", "Error: The specified passkey ID had an invalid format.", HttpContext);
+            IdentityStatusMessage = "Error: The specified passkey ID had an invalid format.";
+            RedirectManager.RedirectTo("Account/Manage/Passkeys");
             return;
         }
 
         passkey = await UserManager.GetPasskeyAsync(user, credentialId);
         if (passkey is null)
         {
-            RedirectManager.RedirectToWithStatus("Account/Manage/Passkeys", "Error: The specified passkey could not be found.", HttpContext);
+            IdentityStatusMessage = "Error: The specified passkey could not be found.";
+            RedirectManager.RedirectTo("Account/Manage/Passkeys");
             return;
         }
     }
@@ -79,11 +85,13 @@
         var result = await UserManager.AddOrUpdatePasskeyAsync(user!, passkey);
         if (!result.Succeeded)
         {
-            RedirectManager.RedirectToWithStatus("Account/Manage/Passkeys", "Error: The passkey could not be updated.", HttpContext);
+            IdentityStatusMessage = "Error: The passkey could not be updated.";
+            RedirectManager.RedirectTo("Account/Manage/Passkeys");
             return;
         }
 
-        RedirectManager.RedirectToWithStatus("Account/Manage/Passkeys", "Passkey updated successfully.", HttpContext);
+        IdentityStatusMessage = "Passkey updated successfully.";
+        RedirectManager.RedirectTo("Account/Manage/Passkeys");
     }
 
     private sealed class InputModel

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/ResetAuthenticator.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/ResetAuthenticator.razor
@@ -10,7 +10,7 @@
 
 <PageTitle>Reset authenticator key</PageTitle>
 
-<StatusMessage />
+<StatusMessage Message="@message" />
 <h3>Reset authenticator key</h3>
 <div class="alert alert-warning" role="alert">
     <p>
@@ -30,15 +30,26 @@
 </div>
 
 @code {
+    private string? message;
+
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
+
+    [SupplyParameterFromTempData(Name = IdentityRedirectManager.StatusMessageKey)]
+    private string? IdentityStatusMessage { get; set; }
+
+    protected override void OnInitialized()
+    {
+        message = IdentityStatusMessage;
+        IdentityStatusMessage = null;
+    }
 
     private async Task OnSubmitAsync()
     {
         var user = await UserManager.GetUserAsync(HttpContext.User);
         if (user is null)
         {
-            RedirectManager.RedirectToInvalidUser(UserManager, HttpContext);
+            RedirectManager.RedirectTo("Account/InvalidUser");
             return;
         }
 
@@ -49,9 +60,7 @@
 
         await SignInManager.RefreshSignInAsync(user);
 
-        RedirectManager.RedirectToWithStatus(
-            "Account/Manage/EnableAuthenticator",
-            "Your authenticator app key has been reset, you will need to configure your authenticator app using the new key.",
-            HttpContext);
+        IdentityStatusMessage = "Your authenticator app key has been reset, you will need to configure your authenticator app using the new key.";
+        RedirectManager.RedirectTo("Account/Manage/EnableAuthenticator");
     }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/SetPassword.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/SetPassword.razor
@@ -43,17 +43,22 @@
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
 
+    [SupplyParameterFromTempData(Name = IdentityRedirectManager.StatusMessageKey)]
+    private string? IdentityStatusMessage { get; set; }
+
     [SupplyParameterFromForm]
     private InputModel Input { get; set; } = default!;
 
     protected override async Task OnInitializedAsync()
     {
+        message = IdentityStatusMessage;
+        IdentityStatusMessage = null;
         Input ??= new();
 
         user = await UserManager.GetUserAsync(HttpContext.User);
         if (user is null)
         {
-            RedirectManager.RedirectToInvalidUser(UserManager, HttpContext);
+            RedirectManager.RedirectTo("Account/InvalidUser");
             return;
         }
 
@@ -68,7 +73,7 @@
     {
         if (user is null)
         {
-            RedirectManager.RedirectToInvalidUser(UserManager, HttpContext);
+            RedirectManager.RedirectTo("Account/InvalidUser");
             return;
         }
 
@@ -80,7 +85,8 @@
         }
 
         await SignInManager.RefreshSignInAsync(user);
-        RedirectManager.RedirectToCurrentPageWithStatus("Your password has been set.", HttpContext);
+        IdentityStatusMessage = "Your password has been set.";
+        RedirectManager.RedirectToCurrentPage();
     }
 
     private sealed class InputModel

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/TwoFactorAuthentication.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Manage/TwoFactorAuthentication.razor
@@ -10,7 +10,7 @@
 
 <PageTitle>Two-factor authentication (2FA)</PageTitle>
 
-<StatusMessage />
+<StatusMessage Message="@message" />
 <h3>Two-factor authentication (2FA)</h3>
 @if (canTrack)
 {
@@ -70,6 +70,7 @@ else
 }
 
 @code {
+    private string? message;
     private bool canTrack;
     private bool hasAuthenticator;
     private int recoveryCodesLeft;
@@ -79,12 +80,18 @@ else
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
 
+    [SupplyParameterFromTempData(Name = IdentityRedirectManager.StatusMessageKey)]
+    private string? IdentityStatusMessage { get; set; }
+
     protected override async Task OnInitializedAsync()
     {
+        message = IdentityStatusMessage;
+        IdentityStatusMessage = null;
+
         var user = await UserManager.GetUserAsync(HttpContext.User);
         if (user is null)
         {
-            RedirectManager.RedirectToInvalidUser(UserManager, HttpContext);
+            RedirectManager.RedirectTo("Account/InvalidUser");
             return;
         }
 
@@ -99,8 +106,7 @@ else
     {
         await SignInManager.ForgetTwoFactorClientAsync();
 
-        RedirectManager.RedirectToCurrentPageWithStatus(
-            "The current browser has been forgotten. When you login again from this browser you will be prompted for your 2fa code.",
-            HttpContext);
+        IdentityStatusMessage = "The current browser has been forgotten. When you login again from this browser you will be prompted for your 2fa code.";
+        RedirectManager.RedirectToCurrentPage();
     }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Shared/StatusMessage.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Shared/StatusMessage.razor
@@ -1,29 +1,12 @@
-﻿@if (!string.IsNullOrEmpty(DisplayMessage))
+﻿@if (!string.IsNullOrEmpty(Message))
 {
-    var statusMessageClass = DisplayMessage.StartsWith("Error") ? "danger" : "success";
+    var statusMessageClass = Message.StartsWith("Error") ? "danger" : "success";
     <div class="alert alert-@statusMessageClass" role="alert">
-        @DisplayMessage
+        @Message
     </div>
 }
 
 @code {
-    private string? messageFromCookie;
-
     [Parameter]
     public string? Message { get; set; }
-
-    [CascadingParameter]
-    private HttpContext HttpContext { get; set; } = default!;
-
-    private string? DisplayMessage => Message ?? messageFromCookie;
-
-    protected override void OnInitialized()
-    {
-        messageFromCookie = HttpContext.Request.Cookies[IdentityRedirectManager.StatusCookieName];
-
-        if (messageFromCookie is not null)
-        {
-            HttpContext.Response.Cookies.Delete(IdentityRedirectManager.StatusCookieName);
-        }
-    }
 }


### PR DESCRIPTION
Backport of #65752 to release/11.0-preview4

# Update Blazor templates to use TempData

## Description

Updates the Blazor Identity project template to pass status messages between pages using `[SupplyParameterFromTempData]` instead of cookies. This replaces the custom cookie-based approach (`Identity.StatusMessage` cookie with a 5-second `MaxAge`) with the built-in TempData mechanism, which is simpler and follows standard ASP.NET Core patterns.

## Changes

### `IdentityRedirectManager.cs`
- Removed the `StatusCookieName` constant, `StatusCookieBuilder`, and all cookie-writing logic
- Added a `StatusMessageKey` constant (`"Identity.StatusMessage"`) for the TempData entry key
- **Removed** `RedirectToWithStatus`, `RedirectToCurrentPageWithStatus`, and `RedirectToInvalidUser` methods entirely — status message passing is now handled by the pages themselves via `[SupplyParameterFromTempData]`
- Removed unused `using` directives (`Microsoft.AspNetCore.Identity`, `BlazorWebCSharp._1.Data`)

### `StatusMessage.razor`
- Simplified to a pure presentational component that accepts a `[Parameter] string? Message`
- Removed the `HttpContext` cascading parameter, cookie reading logic, `messageFromCookie` field, and `DisplayMessage` computed property
- The component no longer reads from cookies; it relies on the caller to pass the message explicitly

### `InvalidUser.razor`
- Now generates the error message locally using `UserManager.GetUserId(HttpContext.User)` instead of receiving it through a redirect from `IdentityRedirectManager`

### Account pages (16 `.razor` files)
- Added `[SupplyParameterFromTempData(Name = IdentityRedirectManager.StatusMessageKey)]` property to each page for reading and writing status messages via TempData
- Each page reads `IdentityStatusMessage` during initialization and stores it in a local `message` field, then nulls it out (TempData is one-time-read)
- Replaced `RedirectManager.RedirectToWithStatus(url, message, HttpContext)` calls with setting `IdentityStatusMessage = message` followed by `RedirectManager.RedirectTo(url)`
- Replaced `RedirectManager.RedirectToInvalidUser(UserManager, HttpContext)` calls with `RedirectManager.RedirectTo("Account/InvalidUser")`
- Pages that previously used parameterless `<StatusMessage />` now pass the message explicitly: `<StatusMessage Message="@message" />`

### Minor fix
- Fixed a double-space typo in `ExternalLogin.razor` (`<div  class=` → `<div class=`)
- Fixed a bug in `ConfirmEmailChange.razor` where the error message string was not interpolated (`'{userId}'` → `'{UserId}'`)

## Customer Impact

Templates update to simplify them and show best practices. 

## Regression?

- [ ] Yes
- [x] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [x] Low

[Justify the selection above]

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

----

## When servicing release/2.3

- [ ] Make necessary changes in eng/PatchConfig.props