### PR TITLE
Preserve application/problem+json and application/problem+xml when using ProducesAttribute

### DIFF
--- a/src/Http/Http.Results/src/HttpResultsHelper.cs
+++ b/src/Http/Http.Results/src/HttpResultsHelper.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Net.Mime;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
@@ -32,6 +33,11 @@ internal static partial class HttpResultsHelper
         if (value is null)
         {
             return Task.CompletedTask;
+        }
+
+        if (value is ProblemDetails)
+        {
+            contentType = MediaTypeNames.Application.ProblemJson;
         }
 
         jsonSerializerOptions ??= ResolveJsonOptions(httpContext).SerializerOptions;

--- a/src/Http/Http.Results/test/HttpResultsHelperTests.cs
+++ b/src/Http/Http.Results/test/HttpResultsHelperTests.cs
@@ -4,6 +4,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http.Json;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -216,6 +217,35 @@ public partial class HttpResultsHelperTests
         Assert.True(three.IsComplete);
         Assert.Equal("Three", three.Name);
         Assert.Equal("ThreeChild", three.Child);
+    }
+
+    [Fact]
+    public async Task WriteResultAsJsonAsync_SetsProblemJsonContentType_ForProblemDetails()
+    {
+        const string Detail = "Explanation of something went wrong :'(";
+
+        // Arrange
+        var value = new ProblemDetails()
+        {
+            Detail = Detail,
+        };
+        var responseBodyStream = new MemoryStream();
+        var httpContext = CreateHttpContext(responseBodyStream);
+        var serializerOptions = new JsonOptions().SerializerOptions;
+
+        _ = new NotFound<ProblemDetails>(value);
+
+        // Act
+        await HttpResultsHelper.WriteResultAsJsonAsync(httpContext, NullLogger.Instance, value, jsonSerializerOptions: serializerOptions);
+
+        // Assert
+        var body = JsonSerializer.Deserialize<ProblemDetails>(responseBodyStream.ToArray(), serializerOptions);
+
+        Assert.NotNull(body);
+        Assert.Equal(Detail, body.Detail);
+        Assert.Equal(StatusCodes.Status404NotFound, body.Status);
+        Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.5.5", body.Type);
+        Assert.Equal("Not Found", body.Title);
     }
 
     private static async IAsyncEnumerable<JsonTodo> GetTodosAsync()

--- a/src/Mvc/Mvc.Core/src/Infrastructure/ObjectResultExecutor.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/ObjectResultExecutor.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Globalization;
+using System.Net.Mime;
 using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Formatters;
@@ -123,18 +124,27 @@ public partial class ObjectResultExecutor : IActionResultExecutor<ObjectResult>
     {
         Debug.Assert(result.ContentTypes != null);
 
-        // If the user sets the content type both on the ObjectResult (example: by Produces) and Response object,
-        // then the one set on ObjectResult takes precedence over the Response object
-        var responseContentType = context.HttpContext.Response.ContentType;
-        if (result.ContentTypes.Count == 0 && !string.IsNullOrEmpty(responseContentType))
-        {
-            result.ContentTypes.Add(responseContentType);
-        }
+        var wasEmpty = result.ContentTypes.Count == 0;
 
+        // When dealing with ProblemDetails, we always add ProblemJson and ProblemXml at the
+        // beginning of the list so that they are preferred over anything else.
         if (result.Value is ProblemDetails)
         {
-            result.ContentTypes.Add("application/problem+json");
-            result.ContentTypes.Add("application/problem+xml");
+            result.ContentTypes.Insert(0, MediaTypeNames.Application.ProblemJson);
+            result.ContentTypes.Insert(1, MediaTypeNames.Application.ProblemXml);
+        }
+
+        // If the user sets the content type both on the ObjectResult (example: by Produces) and Response object,
+        // then the one set on ObjectResult takes precedence over the Response object.
+        if (!wasEmpty)
+        {
+            return;
+        }
+
+        var responseContentType = context.HttpContext.Response.ContentType;
+        if (!string.IsNullOrEmpty(responseContentType))
+        {
+            result.ContentTypes.Add(responseContentType);
         }
     }
 

--- a/src/Mvc/Mvc.Core/test/Infrastructure/ObjectResultExecutorTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/ObjectResultExecutorTest.cs
@@ -204,8 +204,11 @@ public class ObjectResultExecutorTest
         MediaTypeAssert.Equal("application/problem+json; charset=utf-8", httpContext.Response.ContentType);
     }
 
-    [Fact]
-    public async Task ExecuteAsync_ForProblemDetailsValue_UsesProblemDetailsXMLContentType_BasedOnAcceptHeader()
+    [Theory]
+    [InlineData("text/plain")]
+    [InlineData("application/xml")]
+    [InlineData("application/json")]
+    public async Task ExecuteAsync_ForProblemDetailsValue_UsesProblemDetailsXMLContentType_BasedOnAcceptHeader(string resultContentTypes)
     {
         // Arrange
         var executor = CreateExecutor();
@@ -216,7 +219,7 @@ public class ObjectResultExecutorTest
 
         var result = new ObjectResult(new ProblemDetails())
         {
-            ContentTypes = { "text/plain" }, // This will not be used
+            ContentTypes = { resultContentTypes }, // This will not be used
         };
         result.Formatters.Add(new TestJsonOutputFormatter());
         result.Formatters.Add(new TestXmlOutputFormatter()); // This will be chosen based on the Accept Headers "application/xml"
@@ -227,6 +230,27 @@ public class ObjectResultExecutorTest
 
         // Assert
         MediaTypeAssert.Equal("application/problem+xml; charset=utf-8", httpContext.Response.ContentType);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ForProblemDetailsValue_UsesPlainTextContentType_WhenNoJsonOrXmlFormattersAreAvailable()
+    {
+        // Arrange
+        var executor = CreateExecutor();
+
+        var httpContext = new DefaultHttpContext();
+        var actionContext = new ActionContext() { HttpContext = httpContext };
+        httpContext.Request.Headers.Accept = "text/plain";
+        httpContext.Response.ContentType = "text/plain";
+
+        var result = new ObjectResult(new ProblemDetails());
+        result.Formatters.Add(new TestStringOutputFormatter());
+
+        // Act
+        await executor.ExecuteAsync(actionContext, result);
+
+        // Assert
+        MediaTypeAssert.Equal("text/plain; charset=utf-8", httpContext.Response.ContentType);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #39802

What happens in this case is `InferContentTypes` is called with `result.ContentTypes` already having some content type (which might be `application/json`, for example, in case of `[Produces(MediaTypeNames.Application.Json)]`).

Previously we then added the `application/problem+json` and `application/problem+xml` to that list. However, `DefaultOutputFormatterSelector.SelectFormatter` will prefer `application/json` because it encounters it first.

This PR changes `InferContentTypes` to ensure that `application/problem+json` and `application/problem+xml` are added first to the list.

The test `ExecuteAsync_ForProblemDetailsValue_UsesProblemDetailsXMLContentType_BasedOnAcceptHeader` didn't originally capture the bug because:

- It sets `ObjectResult.ContentTypes` to `text/plain`
- `InferContentTypes` then adds `application/problem+json ` and `application/problem+xml` to the end of the list.
- However, because Accept header was set to `application/xml`, the test had the correct behavior and didn't capture the bug. Because the only content type that is compatible with Accept header is the correct `application/problem+xml`. The test was modified to parameterize the ObjectResult.ContentTypes. When the test input is `application/xml`, the bug would be captured by the test.
- In addition, another test case is added, to ensure that we correctly consider `Response.ContentType` when we are dealing with ProblemDetails, in case no formatter can handle json or xml. This test would capture a bug that might happen if `wasEmpty` is moved *after* we added the ProblemJson and ProblemXml.
