### PR TITLE
Fix NU1903 suppression: use NoWarn instead of WarningsNotAsErrors

### DIFF
--- a/eng/tools/RepoTasks/RepoTasks.csproj
+++ b/eng/tools/RepoTasks/RepoTasks.csproj
@@ -12,8 +12,10 @@
     <TargetLatestDotNetRuntime>false</TargetLatestDotNetRuntime>
     <!-- No need to track public APIs of these MSBuild tasks. -->
     <AddPublicApiAnalyzers>false</AddPublicApiAnalyzers>
-    <!-- Keep NuGet vulnerability audit warnings visible for transitive dependencies in this build-time tool without failing the build. -->
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+    <!-- Suppress NuGet vulnerability audit warnings for transitive dependencies in this build-time tool.
+         Uses NoWarn instead of WarningsNotAsErrors because NuGet restore promotes audit warnings to errors
+         via its own mechanism that WarningsNotAsErrors does not override. -->
+    <NoWarn>$(NoWarn);NU1901;NU1902;NU1903;NU1904</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Problem

The internal pipeline has been **100% broken for 48+ hours** despite the NU1903 suppression in #66423. The previous fix used `WarningsNotAsErrors`, which only works during MSBuild's build phase. NuGet restore has its own mechanism for promoting audit warnings to errors, and `WarningsNotAsErrors` does not override it.

From [internal build 2959332](https://dev.azure.com/dnceng/internal/_build/results?buildId=2959332):
```
RepoTasks.csproj(0,0): error NU1903: (NETCORE_ENGINEERING_TELEMETRY=Restore) Package 'System.Security.Cryptography.Xml' 8.0.0 has a known high severity vulnerability
```

Note the `Restore` telemetry category — the error fires during NuGet restore, not build.

## Fix

Change `WarningsNotAsErrors` → `NoWarn` which suppresses the warning at all stages including restore. This matches the pattern used by other projects in the repo (`Components.Testing` tasks/tests/testassets).

Supersedes #66423. Needs backport to `release/10.0` and `release/11.0-preview4`.