### PR TITLE
Add dotnet user-secrets edit command

### DIFF
--- a/src/Tools/dotnet-user-secrets/src/CommandLineOptions.cs
+++ b/src/Tools/dotnet-user-secrets/src/CommandLineOptions.cs
@@ -55,6 +55,7 @@ public class CommandLineOptions
         app.Command("list", c => ListCommand.Configure(c, options));
         app.Command("clear", c => ClearCommand.Configure(c, options));
         app.Command("init", c => InitCommandFactory.Configure(c, options, optionFile));
+        app.Command("edit", c => EditCommand.Configure(c, options));
 
         // Show help information if no subcommand/option was specified.
         app.OnExecute(() => app.ShowHelp());

--- a/src/Tools/dotnet-user-secrets/src/Internal/EditCommand.cs
+++ b/src/Tools/dotnet-user-secrets/src/Internal/EditCommand.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Microsoft.Extensions.CommandLineUtils;
+
+namespace Microsoft.Extensions.SecretManager.Tools.Internal;
+
+internal sealed class EditCommand : ICommand
+{
+    internal Action<string, List<string>> _runProcess = (fileName, arguments) =>
+    {
+        using var p = Process.Start(fileName, arguments);
+        p.WaitForExit();
+    };
+
+    internal Func<string, string> _getEnvironmentVariable = Environment.GetEnvironmentVariable;
+
+    public static void Configure(CommandLineApplication command, CommandLineOptions options)
+    {
+        command.Description = "Edits the application secrets";
+        command.HelpOption();
+        command.OnExecute(() => { options.Command = new EditCommand(); });
+    }
+
+    public void Execute(CommandContext context)
+    {
+        if (!File.Exists(context.SecretStore.SecretsFilePath))
+        {
+            context.SecretStore.Save();
+        }
+
+        var (editor, editorArgs) = GetEditorAndArgs();
+        editorArgs.Add(context.SecretStore.SecretsFilePath);
+        _runProcess(editor, editorArgs);
+    }
+
+    private (string, List<string>) GetEditorAndArgs()
+    {
+        // Check to see if the user specified an editor using environment variables.
+        foreach (var envVar in new[] { "DOTNET_USER_SECRETS_EDITOR", "VISUAL", "EDITOR" })
+        {
+            var editor = _getEnvironmentVariable(envVar);
+            if (!string.IsNullOrWhiteSpace(editor))
+            {
+                // Treat environment-provided editors as executable paths only. Platform defaults can provide arguments separately.
+                return (editor, []);
+            }
+        }
+
+        return GetPlatformDefaultEditorAndArgs();
+    }
+
+    internal static (string, List<string>) GetPlatformDefaultEditorAndArgs()
+    {
+        return OperatingSystem.IsWindows() ? ("notepad.exe", []) :
+            OperatingSystem.IsMacOS() ? ("open", ["-t"]) :
+            OperatingSystem.IsLinux() ? ("xdg-open", []) :
+            ("vi", []);
+    }
+}

--- a/src/Tools/dotnet-user-secrets/src/Internal/SecretsStore.cs
+++ b/src/Tools/dotnet-user-secrets/src/Internal/SecretsStore.cs
@@ -23,7 +23,7 @@ public class SecretsStore
     private readonly string _secretsFilePath;
     private readonly IDictionary<string, string> _secrets;
 
-    public SecretsStore(string userSecretsId, IReporter reporter)
+    public SecretsStore(string userSecretsId, IReporter reporter, bool ignoreLoadErrors = false)
     {
         Ensure.NotNull(userSecretsId, nameof(userSecretsId));
 
@@ -34,7 +34,14 @@ public class SecretsStore
         Directory.CreateDirectory(secretDir);
 
         reporter.Verbose(Resources.FormatMessage_Secret_File_Path(_secretsFilePath));
-        _secrets = Load(userSecretsId);
+        try
+        {
+            _secrets = Load(userSecretsId);
+        }
+        catch (InvalidDataException) when (ignoreLoadErrors)
+        {
+            _secrets = new Dictionary<string, string>();
+        }
     }
 
     public string this[string key]

--- a/src/Tools/dotnet-user-secrets/src/Program.cs
+++ b/src/Tools/dotnet-user-secrets/src/Program.cs
@@ -85,7 +85,11 @@ public class Program
             return 1;
         }
 
-        var store = new SecretsStore(userSecretsId, reporter);
+        // Some commands should ignore potential load errors so that they can still operate on the secrets store
+        // (e.g. edit, clear), while other commands should fail if the secrets store cannot be loaded (e.g. list, remove).
+        var ignoreLoadErrors = options.Command is EditCommand or ClearCommand;
+
+        var store = new SecretsStore(userSecretsId, reporter, ignoreLoadErrors);
         var context = new Internal.CommandContext(store, reporter, _console);
         options.Command.Execute(context);
 

--- a/src/Tools/dotnet-user-secrets/test/EditCommandTest.cs
+++ b/src/Tools/dotnet-user-secrets/test/EditCommandTest.cs
@@ -1,0 +1,102 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Configuration.UserSecrets;
+using Microsoft.Extensions.Configuration.UserSecrets.Tests;
+using Microsoft.Extensions.SecretManager.Tools.Internal;
+using Microsoft.Extensions.Tools.Internal;
+using Xunit.Abstractions;
+
+namespace Microsoft.Extensions.SecretManager.Tools.Tests;
+
+public class EditCommandTest(UserSecretsTestFixture fixture, ITestOutputHelper output) : IClassFixture<UserSecretsTestFixture>
+{
+    [Fact]
+    public void UsesPlatformDefaultEditor()
+    {
+        fixture.GetTempSecretProject(out var userSecretsId);
+        var secretsFile = PathHelper.GetSecretsPathFromSecretsId(userSecretsId);
+        var reporter = new TestReporter(output);
+        var console = new TestConsole(output);
+        var secretsStore = new SecretsStore(userSecretsId, reporter, true);
+        var context = new CommandContext(secretsStore, reporter, console);
+
+        var actualEditorCalls = new List<ValueTuple<string, List<string>>>();
+        var command = new EditCommand
+        {
+            _getEnvironmentVariable = _ => null,
+            _runProcess = (editor, editorArgs) => actualEditorCalls.Add(ValueTuple.Create(editor, editorArgs))
+        };
+
+        var (platformDefaultEditor, platformDefaultEditorArgs) = EditCommand.GetPlatformDefaultEditorAndArgs();
+        Assert.False(string.IsNullOrEmpty(platformDefaultEditor));
+        command.Execute(context);
+        Assert.True(File.Exists(secretsFile));
+        Assert.Equal(new[] { (platformDefaultEditor, platformDefaultEditorArgs.Concat([secretsFile]).ToList()) }, actualEditorCalls);
+    }
+
+    [Fact]
+    public void UsesEditorSpecifiedByEnvironmentVariables()
+    {
+        fixture.GetTempSecretProject(out var userSecretsId);
+        var secretsFile = PathHelper.GetSecretsPathFromSecretsId(userSecretsId);
+        var reporter = new TestReporter(output);
+        var console = new TestConsole(output);
+        var secretsStore = new SecretsStore(userSecretsId, reporter, true);
+        var context = new CommandContext(secretsStore, reporter, console);
+
+        var fakeEnvironmentVariables = new Dictionary<string, string>();
+        var actualEditorCalls = new List<ValueTuple<string, List<string>>>();
+        var command = new EditCommand
+        {
+            _getEnvironmentVariable = fakeEnvironmentVariables.GetValueOrDefault,
+            _runProcess = (editor, editorArgs) => actualEditorCalls.Add(ValueTuple.Create(editor, editorArgs))
+        };
+
+        // EDITOR should be used if set
+        fakeEnvironmentVariables["EDITOR"] = "my-editor-1";
+        command.Execute(context);
+        Assert.True(File.Exists(secretsFile));
+        Assert.Equal(new[] { ("my-editor-1", new List<string> { secretsFile }) }, actualEditorCalls);
+        actualEditorCalls.Clear();
+
+        // VISUAL should be used if set, even if EDITOR is set.
+        fakeEnvironmentVariables["VISUAL"] = "my-editor-2";
+        command.Execute(context);
+        Assert.True(File.Exists(secretsFile));
+        Assert.Equal(new[] { ("my-editor-2", new List<string> { secretsFile }) }, actualEditorCalls);
+        actualEditorCalls.Clear();
+
+        // DOTNET_USER_SECRETS_EDITOR should be used if set, even if VISUAL and EDITOR are set.
+        fakeEnvironmentVariables["DOTNET_USER_SECRETS_EDITOR"] = "my-editor-3";
+        command.Execute(context);
+        Assert.True(File.Exists(secretsFile));
+        Assert.Equal(new[] { ("my-editor-3", new List<string> { secretsFile }) }, actualEditorCalls);
+    }
+
+    [Fact]
+    public void CanEditMalformedSecretsFile()
+    {
+        fixture.GetTempSecretProject(out var userSecretsId);
+        var secretsFile = PathHelper.GetSecretsPathFromSecretsId(userSecretsId);
+        Directory.CreateDirectory(Path.GetDirectoryName(secretsFile)!);
+        File.WriteAllText(secretsFile, "{"); // Intentionally malformed JSON to test that the editor is still launched.
+        var reporter = new TestReporter(output);
+        var console = new TestConsole(output);
+        var secretsStore = new SecretsStore(userSecretsId, reporter, true);
+        var context = new CommandContext(secretsStore, reporter, console);
+
+        var actualEditorCalls = new List<ValueTuple<string, List<string>>>();
+        var command = new EditCommand
+        {
+            _getEnvironmentVariable = _ => null,
+            _runProcess = (editor, editorArgs) => actualEditorCalls.Add(ValueTuple.Create(editor, editorArgs))
+        };
+
+        var (platformDefaultEditor, platformDefaultEditorArgs) = EditCommand.GetPlatformDefaultEditorAndArgs();
+        Assert.False(string.IsNullOrEmpty(platformDefaultEditor));
+        command.Execute(context);
+        Assert.True(File.Exists(secretsFile));
+        Assert.Equal(new[] { (platformDefaultEditor, platformDefaultEditorArgs.Concat([secretsFile]).ToList()) }, actualEditorCalls);
+    }
+}

--- a/src/Tools/dotnet-user-secrets/test/SecretManagerTests.cs
+++ b/src/Tools/dotnet-user-secrets/test/SecretManagerTests.cs
@@ -354,6 +354,30 @@ public class SecretManagerTests : IClassFixture<UserSecretsTestFixture>
     }
 
     [Fact]
+    public void Clear_CanClearMalformedSecretsFile()
+    {
+        var projectPath = _fixture.GetTempSecretProject();
+        var secretManager = new Program(_console, projectPath);
+
+        // Clear once initially, to capture the expected contents of a cleared secrets file.
+        secretManager.RunInternal("clear", "-p", projectPath);
+        var expectedClearedFileContents = File.ReadAllText(secretManager.SecretsFilePath);
+
+        // Intentionally write malformed JSON to the secrets file.
+        File.WriteAllText(secretManager.SecretsFilePath, "{");
+
+        // Confirm that the list subcommand is unable to run due to the malformed content.
+        Assert.Throws<InvalidDataException>(() => secretManager.RunInternal("list", "-p", projectPath));
+
+        // Clear again and the contents of the secrets file should be reset.
+        secretManager.RunInternal("clear", "-p", projectPath);
+        Assert.Equal(expectedClearedFileContents, File.ReadAllText(secretManager.SecretsFilePath));
+
+        // Confirm that the list subcommand is now able to run successfully.
+        secretManager.RunInternal("list", "-p", projectPath);
+    }
+
+    [Fact]
     public void Init_When_Project_Has_No_Secrets_Id()
     {
         var projectPath = _fixture.CreateProject(null);


### PR DESCRIPTION
# Add dotnet user-secrets edit command

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Adds a new `dotnet user-secrets edit` command that opens the user secrets JSON file in an editor.

## Description

Adds a new `dotnet user-secrets edit` command that opens the user secrets JSON file in an editor, providing a convenient alternative way to view and edit an application's secrets.

The editor is selected from `DOTNET_USER_SECRETS_EDITOR`, `VISUAL`, then `EDITOR`.

For this initial implementation, environment variable values are treated as executable paths, not shell command strings, so embedded arguments like `code --wait` are not parsed.

If no editor is configured, the command falls back to `notepad.exe` on Windows, `open -t` on macOS, and `xdg-open` on Linux.

This PR also includes a change to the `dotnet user-secrets clear` command, allowing it to proceed even if the secrets file contains malformed JSON, whereas previously it would fail. The ability to clear a secrets file should not be affected by whether its current contents can be parsed successfully.