### PR TITLE
Allow custom fallback content in SectionOutlet

### DIFF
--- a/src/Components/Components/src/Sections/SectionOutlet.cs
+++ b/src/Components/Components/src/Sections/SectionOutlet.cs
@@ -28,6 +28,11 @@ public sealed class SectionOutlet : IComponent, IDisposable
     /// </summary>
     [Parameter] public object? SectionId { get; set; }
 
+    /// <summary>
+    /// Gets or sets the <see cref="RenderFragment"/> to be rendered when no matching <see cref="SectionContent"/> provides data to this outlet.
+    /// </summary>
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+
     internal IComponent? CurrentLogicalParent => _currentContentProvider;
 
     void IComponent.Attach(RenderHandle renderHandle)
@@ -96,7 +101,7 @@ public sealed class SectionOutlet : IComponent, IDisposable
 
     private void BuildRenderTree(RenderTreeBuilder builder)
     {
-        var fragment = _currentContentProvider?.ChildContent ?? _emptyRenderFragment;
+        var fragment = _currentContentProvider?.ChildContent ?? ChildContent ?? _emptyRenderFragment;
 
         builder.OpenComponent<SectionOutletContentRenderer>(0);
         builder.SetKey(fragment);

--- a/src/Components/Components/src/Sections/SectionOutlet.cs
+++ b/src/Components/Components/src/Sections/SectionOutlet.cs
@@ -30,6 +30,11 @@ public sealed class SectionOutlet : IComponent, IDisposable
     /// </summary>
     [Parameter] public object? SectionId { get; set; }
 
+    /// <summary>
+    /// Gets or sets the <see cref="RenderFragment"/> to be rendered when no matching <see cref="SectionContent"/> provides data to this outlet.
+    /// </summary>
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+
     internal IComponent? CurrentLogicalParent => _currentContentProvider;
 
     void IComponent.Attach(RenderHandle renderHandle)
@@ -99,7 +104,7 @@ public sealed class SectionOutlet : IComponent, IDisposable
 
     private void BuildRenderTree(RenderTreeBuilder builder)
     {
-        var fragment = _currentContentProvider?.ChildContent ?? _emptyRenderFragment;
+        var fragment = _currentContentProvider?.ChildContent ?? ChildContent ?? _emptyRenderFragment;
 
         builder.OpenComponent<SectionOutletContentRenderer>(0);
         builder.SetKey(fragment);


### PR DESCRIPTION
# Allow custom fallback content in SectionOutlet

Add `ChildContent` parameter to `SectionOutlet` that renders a fallback when no matching `SectionContent` is registered. 

## Description

Previously, outlets rendered nothing when unpopulated. This change allows developers to explicitly define default component that displays only when the section has no active content providers. It provides explicit control over empty section states.

Fixes #52477
