### PR TITLE
Introduce namespacing for MvcTestingAppManifest.json

### DIFF
--- a/src/Mvc/Mvc.Testing/src/Microsoft.AspNetCore.Mvc.Testing.targets
+++ b/src/Mvc/Mvc.Testing/src/Microsoft.AspNetCore.Mvc.Testing.targets
@@ -2,6 +2,9 @@
 
   <PropertyGroup>
     <_MvcTestingTasksAssembly Condition="'$(_MvcTestingTasksAssembly)' == ''">$(MSBuildThisFileDirectory)..\..\tasks\netstandard2.0\Microsoft.AspNetCore.Mvc.Testing.Tasks.dll</_MvcTestingTasksAssembly>
+
+    <_MvcTestingManifestFileName Condition="'$(NamespaceMvcTestingManifest)' == 'True'">MvcTestingAppManifest.$(AssemblyName).json</_MvcTestingManifestFileName>
+    <_MvcTestingManifestFileName Condition="'$(NamespaceMvcTestingManifest)' != 'True'">MvcTestingAppManifest.json</_MvcTestingManifestFileName>
   </PropertyGroup>
   <UsingTask TaskName="GenerateMvcTestManifestTask" AssemblyFile="$(_MvcTestingTasksAssembly)"/>
 
@@ -35,14 +38,14 @@
       </_ManifestProjects>
     </ItemGroup>
 
-    <GenerateMvcTestManifestTask ManifestPath="$(IntermediateOutputPath)MvcTestingAppManifest.json" Projects="@(_ManifestProjects)"/>
+    <GenerateMvcTestManifestTask ManifestPath="$(IntermediateOutputPath)$(_MvcTestingManifestFileName)" Projects="@(_ManifestProjects)"/>
 
     <ItemGroup>
-      <ContentWithTargetPath Include="$(IntermediateOutputPath)MvcTestingAppManifest.json"
-        TargetPath="MvcTestingAppManifest.json"
+      <ContentWithTargetPath Include="$(IntermediateOutputPath)$(_MvcTestingManifestFileName)"
+        TargetPath="$(_MvcTestingManifestFileName)"
         CopyToOutputDirectory="PreserveNewest"
         CopyToPublishDirectory="Never"/>
-      <FileWrites Include="$(IntermediateOutputPath)MvcTestingAppManifest.json" />
+      <FileWrites Include="$(IntermediateOutputPath)$(_MvcTestingManifestFileName)" />
     </ItemGroup>
   </Target>
 
@@ -54,12 +57,12 @@
       <_DepsFileToPublish Include="$([System.IO.Path]::ChangeExtension('%(_ContentRootProjectReferences.Identity)', 'deps.json'))" />
     </ItemGroup>
 
-    <GenerateMvcTestManifestTask ManifestPath="$(PublishDir)MvcTestingAppManifest.json" Projects="@(_PublishManifestProjects)" />
-    
+    <GenerateMvcTestManifestTask ManifestPath="$(PublishDir)$(_MvcTestingManifestFileName)" Projects="@(_PublishManifestProjects)" />
+
     <ItemGroup>
       <_DepsFilesToPublishResolved Include="%(_DepsFileToPublish.FullPath)" Condition="Exists('%(_DepsFileToPublish.FullPath)')" />
     </ItemGroup>
-    
+
     <Copy SourceFiles="@(_DepsFilesToPublishResolved)" DestinationFolder="$(PublishDir)" SkipUnchangedFiles="true" Condition="@(_DepsFilesToPublishResolved->Count()) > 0" />
   </Target>
 
@@ -69,7 +72,7 @@
         Condition="'%(_ContentRootProjectReferences.Identity)' != ''"
         Include="$([System.IO.Path]::ChangeExtension('%(_ContentRootProjectReferences.ResolvedFrom)', '.deps.json'))" />
     </ItemGroup>
-    
+
     <PropertyGroup>
         <_CreateHardLinksForMvcCopyDependencyFilesIfPossible Condition="'$(_CreateHardLinksForMvcCopyDependencyFilesIfPossible)' == ''">$(CreateHardLinksForCopyFilesToOutputDirectoryIfPossible)</_CreateHardLinksForMvcCopyDependencyFilesIfPossible>
         <_CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible Condition="'$(_CreateSymbolicLinksMvcCopyDependencyFilesIfPossible)' == ''">$(CreateSymbolicLinksForCopyFilesToOutputDirectoryIfPossible)</_CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible>

--- a/src/Mvc/Mvc.Testing/src/Resources.resx
+++ b/src/Mvc/Mvc.Testing/src/Resources.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -134,5 +134,8 @@
   </data>
   <data name="UseKestrelCanBeCalledBeforeInitialization" xml:space="preserve">
     <value>UseKestrel should be called before server initialization. Calling UseKestrel after the server was initialized will have no effect.</value>
+  </data>
+  <data name="MismatchedContentRoot" xml:space="preserve">
+    <value>Content root for assembly '{0}' is specified multiple times with different values.</value>
   </data>
 </root>

--- a/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
+++ b/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
@@ -374,8 +374,8 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
             return;
         }
 
-        var fromFile = File.Exists("MvcTestingAppManifest.json");
-        var contentRoot = fromFile ? GetContentRootFromFile("MvcTestingAppManifest.json") : GetContentRootFromAssembly();
+        var manifestFiles = Directory.GetFiles(Directory.GetCurrentDirectory(), "MvcTestingAppManifest*.json");
+        var contentRoot = manifestFiles.Length > 0 ? GetContentRootFromFiles(manifestFiles) : GetContentRootFromAssembly();
 
         if (contentRoot != null)
         {
@@ -387,14 +387,37 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
         }
     }
 
-    private static string? GetContentRootFromFile(string file)
+    private static string? GetContentRootFromFiles(string[] files)
     {
-        var data = JsonSerializer.Deserialize(File.ReadAllBytes(file), CustomJsonSerializerContext.Default.IDictionaryStringString)!;
+        IDictionary<string, string> mergedData;
+        if (files.Length == 1)
+        {
+            // Optimization: if we have exactly one manifest file, we can skip the merging logic and directly deserialize it to a dictionary.
+            mergedData = JsonSerializer.Deserialize(File.ReadAllBytes(files[0]), CustomJsonSerializerContext.Default.IDictionaryStringString)!;
+        }
+        else
+        {
+            mergedData = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var file in files)
+            {
+                var data = JsonSerializer.Deserialize(File.ReadAllBytes(file), CustomJsonSerializerContext.Default.IDictionaryStringString)!;
+                foreach (var kvp in data)
+                {
+                    if (mergedData.TryGetValue(kvp.Key, out var existingValue) && !string.Equals(existingValue, kvp.Value, StringComparison.Ordinal))
+                    {
+                        throw new InvalidOperationException(Resources.FormatMismatchedContentRoot(kvp.Key));
+                    }
+
+                    mergedData[kvp.Key] = kvp.Value;
+                }
+            }
+        }
+
         var key = typeof(TEntryPoint).Assembly.GetName().FullName;
 
         // If the `ContentRoot` is not provided in the app manifest, then return null
         // and fallback to setting the content root relative to the entrypoint's assembly.
-        if (!data.TryGetValue(key, out var contentRoot))
+        if (!mergedData.TryGetValue(key, out var contentRoot))
         {
             return null;
         }


### PR DESCRIPTION
# Introduce namespacing for MvcTestingAppManifest.json

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

When mutliple projects in a solution using a common output directory use the `Microsoft.AspNetCore.Mvc.Testing` package, during build the MvcTestingAppManifest.json is overwritten once per test project.

This leads to (random) exceptions when a content root is not configured, as reported in [#54243](https://github.com/dotnet/aspnetcore/issues/54243)

To address the issue, this pull request adds a flag that allows adding the test assembly name to the manifest file name, such that a solution build into a common directory may produce multiple manifest files. This ensures that there are no conflicts.

When loading the content root from the manifest, we look at all files in the current directory that follow the naming scheme, merging them to a single manifest dictionary.

The property is disabled by default, to ensure backward compatibility.

Fixes #54243
