### PR TITLE
Fix API metadata to have problem+json ContentType when dealing with ProblemDetails

### DIFF
--- a/src/Http/Http.Abstractions/src/Metadata/ProducesResponseTypeMetadata.cs
+++ b/src/Http/Http.Abstractions/src/Metadata/ProducesResponseTypeMetadata.cs
@@ -3,7 +3,9 @@
 
 using System.Diagnostics;
 using System.Linq;
+using System.Net.Mime;
 using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Shared;
 using Microsoft.Net.Http.Headers;
 
@@ -84,5 +86,13 @@ public sealed class ProducesResponseTypeMetadata : IProducesResponseTypeMetadata
         return DebuggerHelpers.GetDebugText(nameof(StatusCode), StatusCode, nameof(ContentTypes), ContentTypes, nameof(Type), Type, includeNullValues: false, prefix: "Produces");
     }
 
-    internal static ProducesResponseTypeMetadata CreateUnvalidated(Type? type, int statusCode, IEnumerable<string> contentTypes) => new(statusCode, type, contentTypes);
+    internal static ProducesResponseTypeMetadata CreateUnvalidated(Type? type, int statusCode, IEnumerable<string> contentTypes)
+    {
+        if (type == typeof(ProblemDetails))
+        {
+            contentTypes = [MediaTypeNames.Application.ProblemJson];
+        }
+
+        return new(statusCode, type, contentTypes);
+    }
 }

--- a/src/Http/Http.Abstractions/src/Metadata/ProducesResponseTypeMetadata.cs
+++ b/src/Http/Http.Abstractions/src/Metadata/ProducesResponseTypeMetadata.cs
@@ -88,7 +88,7 @@ public sealed class ProducesResponseTypeMetadata : IProducesResponseTypeMetadata
 
     internal static ProducesResponseTypeMetadata CreateUnvalidated(Type? type, int statusCode, IEnumerable<string> contentTypes)
     {
-        if (type == typeof(ProblemDetails))
+        if (type is not null && type.IsAssignableFrom(typeof(ProblemDetails)))
         {
             contentTypes = [MediaTypeNames.Application.ProblemJson];
         }

--- a/src/Http/Http.Abstractions/src/Metadata/ProducesResponseTypeMetadata.cs
+++ b/src/Http/Http.Abstractions/src/Metadata/ProducesResponseTypeMetadata.cs
@@ -88,7 +88,7 @@ public sealed class ProducesResponseTypeMetadata : IProducesResponseTypeMetadata
 
     internal static ProducesResponseTypeMetadata CreateUnvalidated(Type? type, int statusCode, IEnumerable<string> contentTypes)
     {
-        if (type is not null && type.IsAssignableFrom(typeof(ProblemDetails)))
+        if (type is not null && typeof(ProblemDetails).IsAssignableFrom(type))
         {
             contentTypes = [MediaTypeNames.Application.ProblemJson];
         }

--- a/src/Http/Http.Results/test/AcceptedAtRouteOfTResultTests.cs
+++ b/src/Http/Http.Results/test/AcceptedAtRouteOfTResultTests.cs
@@ -5,9 +5,10 @@ using System.Reflection;
 using System.Text;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
-using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Http.HttpResults;
@@ -134,6 +135,25 @@ public class AcceptedAtRouteOfTResultTests
         Assert.Equal(StatusCodes.Status202Accepted, producesResponseTypeMetadata.StatusCode);
         Assert.Equal(typeof(Todo), producesResponseTypeMetadata.Type);
         Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/json");
+
+        Assert.Contains(builder.Metadata, m => m is IDisableCookieRedirectMetadata);
+    }
+
+    [Fact]
+    public void PopulateMetadata_ProblemDetailsAddsProblemJsonMetadata()
+    {
+        // Arrange
+        AcceptedAtRoute<ProblemDetails> MyApi() { throw new NotImplementedException(); }
+        var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
+
+        // Act
+        PopulateMetadata<AcceptedAtRoute<ProblemDetails>>(((Delegate)MyApi).GetMethodInfo(), builder);
+
+        // Assert
+        var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
+        Assert.Equal(StatusCodes.Status202Accepted, producesResponseTypeMetadata.StatusCode);
+        Assert.Equal(typeof(ProblemDetails), producesResponseTypeMetadata.Type);
+        Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/problem+json");
 
         Assert.Contains(builder.Metadata, m => m is IDisableCookieRedirectMetadata);
     }

--- a/src/Http/Http.Results/test/AcceptedAtRouteResultTests.cs
+++ b/src/Http/Http.Results/test/AcceptedAtRouteResultTests.cs
@@ -77,7 +77,6 @@ public class AcceptedAtRouteResultTests
     {
         // Arrange
         AcceptedAtRoute MyApi() { throw new NotImplementedException(); }
-        var metadata = new List<object>();
         var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
 
         // Act

--- a/src/Http/Http.Results/test/AcceptedOfTResultTests.cs
+++ b/src/Http/Http.Results/test/AcceptedOfTResultTests.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Text;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.DependencyInjection;
@@ -64,7 +65,6 @@ public class AcceptedOfTResultTests
     {
         // Arrange
         Accepted<Todo> MyApi() { throw new NotImplementedException(); }
-        var metadata = new List<object>();
         var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
 
         // Act
@@ -75,6 +75,25 @@ public class AcceptedOfTResultTests
         Assert.Equal(StatusCodes.Status202Accepted, producesResponseTypeMetadata.StatusCode);
         Assert.Equal(typeof(Todo), producesResponseTypeMetadata.Type);
         Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/json");
+
+        Assert.Contains(builder.Metadata, m => m is IDisableCookieRedirectMetadata);
+    }
+
+    [Fact]
+    public void PopulateMetadata_ProblemDetailsAddsProblemJsonMetadata()
+    {
+        // Arrange
+        Accepted<ProblemDetails> MyApi() { throw new NotImplementedException(); }
+        var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
+
+        // Act
+        PopulateMetadata<Accepted<ProblemDetails>>(((Delegate)MyApi).GetMethodInfo(), builder);
+
+        // Assert
+        var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
+        Assert.Equal(StatusCodes.Status202Accepted, producesResponseTypeMetadata.StatusCode);
+        Assert.Equal(typeof(ProblemDetails), producesResponseTypeMetadata.Type);
+        Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/problem+json");
 
         Assert.Contains(builder.Metadata, m => m is IDisableCookieRedirectMetadata);
     }

--- a/src/Http/Http.Results/test/AcceptedResultTests.cs
+++ b/src/Http/Http.Results/test/AcceptedResultTests.cs
@@ -34,7 +34,6 @@ public class AcceptedResultTests
     {
         // Arrange
         Accepted MyApi() { throw new NotImplementedException(); }
-        var metadata = new List<object>();
         var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
 
         // Act

--- a/src/Http/Http.Results/test/BadRequestOfTResultTests.cs
+++ b/src/Http/Http.Results/test/BadRequestOfTResultTests.cs
@@ -107,7 +107,6 @@ public class BadRequestOfTResultTests
     {
         // Arrange
         BadRequest<Todo> MyApi() { throw new NotImplementedException(); }
-        var metadata = new List<object>();
         var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
 
         // Act
@@ -118,6 +117,25 @@ public class BadRequestOfTResultTests
         Assert.Equal(StatusCodes.Status400BadRequest, producesResponseTypeMetadata.StatusCode);
         Assert.Equal(typeof(Todo), producesResponseTypeMetadata.Type);
         Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/json");
+
+        Assert.Contains(builder.Metadata, m => m is IDisableCookieRedirectMetadata);
+    }
+
+    [Fact]
+    public void PopulateMetadata_ProblemDetailsAddsProblemJsonMetadata()
+    {
+        // Arrange
+        BadRequest<ProblemDetails> MyApi() { throw new NotImplementedException(); }
+        var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
+
+        // Act
+        PopulateMetadata<BadRequest<ProblemDetails>>(((Delegate)MyApi).GetMethodInfo(), builder);
+
+        // Assert
+        var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
+        Assert.Equal(StatusCodes.Status400BadRequest, producesResponseTypeMetadata.StatusCode);
+        Assert.Equal(typeof(ProblemDetails), producesResponseTypeMetadata.Type);
+        Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/problem+json");
 
         Assert.Contains(builder.Metadata, m => m is IDisableCookieRedirectMetadata);
     }

--- a/src/Http/Http.Results/test/BadRequestResultTests.cs
+++ b/src/Http/Http.Results/test/BadRequestResultTests.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Text;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.DependencyInjection;
@@ -47,7 +48,6 @@ public class BadRequestResultTests
     {
         // Arrange
         BadRequest MyApi() { throw new NotImplementedException(); }
-        var metadata = new List<object>();
         var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
 
         // Act

--- a/src/Http/Http.Results/test/BadRequestResultTests.cs
+++ b/src/Http/Http.Results/test/BadRequestResultTests.cs
@@ -7,7 +7,6 @@ using System.Reflection;
 using System.Text;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Metadata;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Http/Http.Results/test/ConflictOfTResultTests.cs
+++ b/src/Http/Http.Results/test/ConflictOfTResultTests.cs
@@ -85,7 +85,6 @@ public class ConflictOfTResultTests
     {
         // Arrange
         Conflict<Todo> MyApi() { throw new NotImplementedException(); }
-        var metadata = new List<object>();
         var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
 
         // Act
@@ -96,6 +95,25 @@ public class ConflictOfTResultTests
         Assert.Equal(StatusCodes.Status409Conflict, producesResponseTypeMetadata.StatusCode);
         Assert.Equal(typeof(Todo), producesResponseTypeMetadata.Type);
         Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/json");
+
+        Assert.Contains(builder.Metadata, m => m is IDisableCookieRedirectMetadata);
+    }
+
+    [Fact]
+    public void PopulateMetadata_ProblemDetailsAddsProblemJsonMetadata()
+    {
+        // Arrange
+        Conflict<ProblemDetails> MyApi() { throw new NotImplementedException(); }
+        var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
+
+        // Act
+        PopulateMetadata<Conflict<ProblemDetails>>(((Delegate)MyApi).GetMethodInfo(), builder);
+
+        // Assert
+        var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
+        Assert.Equal(StatusCodes.Status409Conflict, producesResponseTypeMetadata.StatusCode);
+        Assert.Equal(typeof(ProblemDetails), producesResponseTypeMetadata.Type);
+        Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/problem+json");
 
         Assert.Contains(builder.Metadata, m => m is IDisableCookieRedirectMetadata);
     }

--- a/src/Http/Http.Results/test/ConflictResultTests.cs
+++ b/src/Http/Http.Results/test/ConflictResultTests.cs
@@ -48,7 +48,6 @@ public class ConflictResultTests
     {
         // Arrange
         Conflict MyApi() { throw new NotImplementedException(); }
-        var metadata = new List<object>();
         var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
 
         // Act

--- a/src/Http/Http.Results/test/CreatedAtRouteOfTResultTests.cs
+++ b/src/Http/Http.Results/test/CreatedAtRouteOfTResultTests.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Microsoft.AspNetCore.Http.HttpResults;
 
@@ -93,7 +94,6 @@ public partial class CreatedAtRouteOfTResultTests
     {
         // Arrange
         CreatedAtRoute<Todo> MyApi() { throw new NotImplementedException(); }
-        var metadata = new List<object>();
         var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
 
         // Act
@@ -104,6 +104,25 @@ public partial class CreatedAtRouteOfTResultTests
         Assert.Equal(StatusCodes.Status201Created, producesResponseTypeMetadata.StatusCode);
         Assert.Equal(typeof(Todo), producesResponseTypeMetadata.Type);
         Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/json");
+
+        Assert.Contains(builder.Metadata, m => m is IDisableCookieRedirectMetadata);
+    }
+
+    [Fact]
+    public void PopulateMetadata_ProblemDetailsAddsProblemJsonMetadata()
+    {
+        // Arrange
+        CreatedAtRoute<ProblemDetails> MyApi() { throw new NotImplementedException(); }
+        var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
+
+        // Act
+        PopulateMetadata<CreatedAtRoute<ProblemDetails>>(((Delegate)MyApi).GetMethodInfo(), builder);
+
+        // Assert
+        var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
+        Assert.Equal(StatusCodes.Status201Created, producesResponseTypeMetadata.StatusCode);
+        Assert.Equal(typeof(ProblemDetails), producesResponseTypeMetadata.Type);
+        Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/problem+json");
 
         Assert.Contains(builder.Metadata, m => m is IDisableCookieRedirectMetadata);
     }

--- a/src/Http/Http.Results/test/CreatedAtRouteResultTests.cs
+++ b/src/Http/Http.Results/test/CreatedAtRouteResultTests.cs
@@ -75,7 +75,6 @@ public partial class CreatedAtRouteResultTests
     {
         // Arrange
         CreatedAtRoute MyApi() { throw new NotImplementedException(); }
-        var metadata = new List<object>();
         var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
 
         // Act

--- a/src/Http/Http.Results/test/CreatedOfTResultTests.cs
+++ b/src/Http/Http.Results/test/CreatedOfTResultTests.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Text;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.DependencyInjection;
@@ -99,7 +100,6 @@ public class CreatedOfTResultTests
     {
         // Arrange
         Created<Todo> MyApi() { throw new NotImplementedException(); }
-        var metadata = new List<object>();
         var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
 
         // Act
@@ -110,6 +110,25 @@ public class CreatedOfTResultTests
         Assert.Equal(StatusCodes.Status201Created, producesResponseTypeMetadata.StatusCode);
         Assert.Equal(typeof(Todo), producesResponseTypeMetadata.Type);
         Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/json");
+
+        Assert.Contains(builder.Metadata, m => m is IDisableCookieRedirectMetadata);
+    }
+
+    [Fact]
+    public void PopulateMetadata_ProblemDetailsAddsProblemJsonMetadata()
+    {
+        // Arrange
+        Created<ProblemDetails> MyApi() { throw new NotImplementedException(); }
+        var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
+
+        // Act
+        PopulateMetadata<Created<ProblemDetails>>(((Delegate)MyApi).GetMethodInfo(), builder);
+
+        // Assert
+        var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
+        Assert.Equal(StatusCodes.Status201Created, producesResponseTypeMetadata.StatusCode);
+        Assert.Equal(typeof(ProblemDetails), producesResponseTypeMetadata.Type);
+        Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/problem+json");
 
         Assert.Contains(builder.Metadata, m => m is IDisableCookieRedirectMetadata);
     }

--- a/src/Http/Http.Results/test/CreatedResultTests.cs
+++ b/src/Http/Http.Results/test/CreatedResultTests.cs
@@ -65,7 +65,6 @@ public class CreatedResultTests
     {
         // Arrange
         Created MyApi() { throw new NotImplementedException(); }
-        var metadata = new List<object>();
         var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
 
         // Act

--- a/src/Http/Http.Results/test/InternalServerErrorOfTResultTests.cs
+++ b/src/Http/Http.Results/test/InternalServerErrorOfTResultTests.cs
@@ -107,7 +107,6 @@ public class InternalServerErrorOfTResultTests
     {
         // Arrange
         InternalServerError<Todo> MyApi() { throw new NotImplementedException(); }
-        var metadata = new List<object>();
         var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
 
         // Act
@@ -118,6 +117,25 @@ public class InternalServerErrorOfTResultTests
         Assert.Equal(StatusCodes.Status500InternalServerError, producesResponseTypeMetadata.StatusCode);
         Assert.Equal(typeof(Todo), producesResponseTypeMetadata.Type);
         Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/json");
+
+        Assert.Contains(builder.Metadata, m => m is IDisableCookieRedirectMetadata);
+    }
+
+    [Fact]
+    public void PopulateMetadata_ProblemDetailsAddsProblemJsonMetadata()
+    {
+        // Arrange
+        InternalServerError<ProblemDetails> MyApi() { throw new NotImplementedException(); }
+        var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
+
+        // Act
+        PopulateMetadata<InternalServerError<ProblemDetails>>(((Delegate)MyApi).GetMethodInfo(), builder);
+
+        // Assert
+        var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
+        Assert.Equal(StatusCodes.Status500InternalServerError, producesResponseTypeMetadata.StatusCode);
+        Assert.Equal(typeof(ProblemDetails), producesResponseTypeMetadata.Type);
+        Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/problem+json");
 
         Assert.Contains(builder.Metadata, m => m is IDisableCookieRedirectMetadata);
     }

--- a/src/Http/Http.Results/test/InternalServerErrorResultTests.cs
+++ b/src/Http/Http.Results/test/InternalServerErrorResultTests.cs
@@ -47,7 +47,6 @@ public class InternalServerErrorResultTests
     {
         // Arrange
         InternalServerError MyApi() { throw new NotImplementedException(); }
-        var metadata = new List<object>();
         var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
 
         // Act

--- a/src/Http/Http.Results/test/NoContentResultTests.cs
+++ b/src/Http/Http.Results/test/NoContentResultTests.cs
@@ -44,7 +44,6 @@ public class NoContentResultTests
     {
         // Arrange
         NoContent MyApi() { throw new NotImplementedException(); }
-        var metadata = new List<object>();
         var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
 
         // Act

--- a/src/Http/Http.Results/test/NotFoundOfTResultTests.cs
+++ b/src/Http/Http.Results/test/NotFoundOfTResultTests.cs
@@ -4,6 +4,7 @@
 using System.Reflection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.DependencyInjection;
@@ -67,7 +68,6 @@ public class NotFoundOfTResultTests
     {
         // Arrange
         NotFound<Todo> MyApi() { throw new NotImplementedException(); }
-        var metadata = new List<object>();
         var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
 
         // Act
@@ -78,6 +78,25 @@ public class NotFoundOfTResultTests
         Assert.Equal(StatusCodes.Status404NotFound, producesResponseTypeMetadata.StatusCode);
         Assert.Equal(typeof(Todo), producesResponseTypeMetadata.Type);
         Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/json");
+
+        Assert.Contains(builder.Metadata, m => m is IDisableCookieRedirectMetadata);
+    }
+
+    [Fact]
+    public void PopulateMetadata_ProblemDetailsAddsProblemJsonMetadata()
+    {
+        // Arrange
+        NotFound<ProblemDetails> MyApi() { throw new NotImplementedException(); }
+        var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
+
+        // Act
+        PopulateMetadata<NotFound<ProblemDetails>>(((Delegate)MyApi).GetMethodInfo(), builder);
+
+        // Assert
+        var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
+        Assert.Equal(StatusCodes.Status404NotFound, producesResponseTypeMetadata.StatusCode);
+        Assert.Equal(typeof(ProblemDetails), producesResponseTypeMetadata.Type);
+        Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/problem+json");
 
         Assert.Contains(builder.Metadata, m => m is IDisableCookieRedirectMetadata);
     }

--- a/src/Http/Http.Results/test/NotFoundResultTests.cs
+++ b/src/Http/Http.Results/test/NotFoundResultTests.cs
@@ -43,7 +43,6 @@ public class NotFoundResultTests
     {
         // Arrange
         NotFound MyApi() { throw new NotImplementedException(); }
-        var metadata = new List<object>();
         var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
 
         // Act

--- a/src/Http/Http.Results/test/OkOfTResultTests.cs
+++ b/src/Http/Http.Results/test/OkOfTResultTests.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Text;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.DependencyInjection;
@@ -84,7 +85,6 @@ public class OkOfTResultTests
     {
         // Arrange
         Ok<Todo> MyApi() { throw new NotImplementedException(); }
-        var metadata = new List<object>();
         var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
 
         // Act
@@ -95,6 +95,25 @@ public class OkOfTResultTests
         Assert.Equal(StatusCodes.Status200OK, producesResponseTypeMetadata.StatusCode);
         Assert.Equal(typeof(Todo), producesResponseTypeMetadata.Type);
         Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/json");
+
+        Assert.Contains(builder.Metadata, m => m is IDisableCookieRedirectMetadata);
+    }
+
+    [Fact]
+    public void PopulateMetadata_ProblemDetailsAddsProblemJsonMetadata()
+    {
+        // Arrange
+        Ok<ProblemDetails> MyApi() { throw new NotImplementedException(); }
+        var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
+
+        // Act
+        PopulateMetadata<Ok<ProblemDetails>>(((Delegate)MyApi).GetMethodInfo(), builder);
+
+        // Assert
+        var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
+        Assert.Equal(StatusCodes.Status200OK, producesResponseTypeMetadata.StatusCode);
+        Assert.Equal(typeof(ProblemDetails), producesResponseTypeMetadata.Type);
+        Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/problem+json");
 
         Assert.Contains(builder.Metadata, m => m is IDisableCookieRedirectMetadata);
     }

--- a/src/Http/Http.Results/test/OkResultTests.cs
+++ b/src/Http/Http.Results/test/OkResultTests.cs
@@ -46,7 +46,6 @@ public class OkResultTests
     {
         // Arrange
         static Ok MyApi() { throw new NotImplementedException(); }
-        var metadata = new List<object>();
         var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
 
         // Act

--- a/src/Http/Http.Results/test/UnprocessableEntityOfTResultTests.cs
+++ b/src/Http/Http.Results/test/UnprocessableEntityOfTResultTests.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Text;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.DependencyInjection;
@@ -84,7 +85,6 @@ public class UnprocessableEntityOfTResultTests
     {
         // Arrange
         UnprocessableEntity<Todo> MyApi() { throw new NotImplementedException(); }
-        var metadata = new List<object>();
         var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
 
         // Act
@@ -95,6 +95,25 @@ public class UnprocessableEntityOfTResultTests
         Assert.Equal(StatusCodes.Status422UnprocessableEntity, producesResponseTypeMetadata.StatusCode);
         Assert.Equal(typeof(Todo), producesResponseTypeMetadata.Type);
         Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/json");
+
+        Assert.Contains(builder.Metadata, m => m is IDisableCookieRedirectMetadata);
+    }
+
+    [Fact]
+    public void PopulateMetadata_ProblemDetailsAddsProblemJsonMetadata()
+    {
+        // Arrange
+        UnprocessableEntity<ProblemDetails> MyApi() { throw new NotImplementedException(); }
+        var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
+
+        // Act
+        PopulateMetadata<UnprocessableEntity<ProblemDetails>>(((Delegate)MyApi).GetMethodInfo(), builder);
+
+        // Assert
+        var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
+        Assert.Equal(StatusCodes.Status422UnprocessableEntity, producesResponseTypeMetadata.StatusCode);
+        Assert.Equal(typeof(ProblemDetails), producesResponseTypeMetadata.Type);
+        Assert.Single(producesResponseTypeMetadata.ContentTypes, "application/problem+json");
 
         Assert.Contains(builder.Metadata, m => m is IDisableCookieRedirectMetadata);
     }

--- a/src/Http/Http.Results/test/UnprocessableEntityResultTests.cs
+++ b/src/Http/Http.Results/test/UnprocessableEntityResultTests.cs
@@ -47,7 +47,6 @@ public class UnprocessableEntityResultTests
     {
         // Arrange
         UnprocessableEntity MyApi() { throw new NotImplementedException(); }
-        var metadata = new List<object>();
         var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
 
         // Act

--- a/src/Http/Http.Results/test/ValidationProblemResultTests.cs
+++ b/src/Http/Http.Results/test/ValidationProblemResultTests.cs
@@ -95,7 +95,6 @@ public class ValidationProblemResultTests
     {
         // Arrange
         ValidationProblem MyApi() { throw new NotImplementedException(); }
-        var metadata = new List<object>();
         var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
 
         // Act


### PR DESCRIPTION
The OpenAPI implementation relies on the Mvc ApiExplorer, which relies on the metadata produced by `IEndpointMetadataProvider.PopulateMetadata`. This fixes `PopulateMetadata` (which calls `ProducesResponseTypeMetadata.CreateUnvalidated`) so that if we have ProblemDetails, we set the correct content type.

Fixes #58574