### PR TITLE
SqlServerCache: allow more control over SqlConnection

### DIFF
--- a/src/Caching/SqlServer/src/DatabaseOperations.cs
+++ b/src/Caching/SqlServer/src/DatabaseOperations.cs
@@ -29,9 +29,9 @@ internal sealed class DatabaseOperations : IDatabaseOperations
     private const string UtcNowParameterName = "UtcNow";
 
     public DatabaseOperations(
-        string connectionString, string schemaName, string tableName, ISystemClock systemClock)
+        Func<SqlConnection> connectionFactory, string schemaName, string tableName, ISystemClock systemClock)
     {
-        ConnectionString = connectionString;
+        ConnectionFactory = connectionFactory;
         SchemaName = schemaName;
         TableName = tableName;
         SystemClock = systemClock;
@@ -40,7 +40,7 @@ internal sealed class DatabaseOperations : IDatabaseOperations
 
     internal SqlQueries SqlQueries { get; }
 
-    internal string ConnectionString { get; }
+    internal Func<SqlConnection> ConnectionFactory { get; }
 
     internal string SchemaName { get; }
 
@@ -50,7 +50,7 @@ internal sealed class DatabaseOperations : IDatabaseOperations
 
     public void DeleteCacheItem(string key)
     {
-        using (var connection = new SqlConnection(ConnectionString))
+        using (var connection = ConnectionFactory())
         using (var command = new SqlCommand(SqlQueries.DeleteCacheItem, connection))
         {
             command.Parameters.AddCacheItemId(key);
@@ -65,7 +65,7 @@ internal sealed class DatabaseOperations : IDatabaseOperations
     {
         token.ThrowIfCancellationRequested();
 
-        using (var connection = new SqlConnection(ConnectionString))
+        using (var connection = ConnectionFactory())
         using (var command = new SqlCommand(SqlQueries.DeleteCacheItem, connection))
         {
             command.Parameters.AddCacheItemId(key);
@@ -117,7 +117,7 @@ internal sealed class DatabaseOperations : IDatabaseOperations
     {
         var utcNow = SystemClock.UtcNow;
 
-        using (var connection = new SqlConnection(ConnectionString))
+        using (var connection = ConnectionFactory())
         using (var command = new SqlCommand(SqlQueries.DeleteExpiredCacheItems, connection))
         {
             command.Parameters.AddWithValue(UtcNowParameterName, SqlDbType.DateTimeOffset, utcNow);
@@ -135,7 +135,7 @@ internal sealed class DatabaseOperations : IDatabaseOperations
         var absoluteExpiration = DatabaseOperations.GetAbsoluteExpiration(utcNow, options);
         DatabaseOperations.ValidateOptions(options.SlidingExpiration, absoluteExpiration);
 
-        using (var connection = new SqlConnection(ConnectionString))
+        using (var connection = ConnectionFactory())
         using (var upsertCommand = new SqlCommand(SqlQueries.SetCacheItem, connection))
         {
             upsertCommand.Parameters
@@ -175,7 +175,7 @@ internal sealed class DatabaseOperations : IDatabaseOperations
         var absoluteExpiration = DatabaseOperations.GetAbsoluteExpiration(utcNow, options);
         DatabaseOperations.ValidateOptions(options.SlidingExpiration, absoluteExpiration);
 
-        using (var connection = new SqlConnection(ConnectionString))
+        using (var connection = ConnectionFactory())
         using (var upsertCommand = new SqlCommand(SqlQueries.SetCacheItem, connection))
         {
             upsertCommand.Parameters
@@ -221,7 +221,7 @@ internal sealed class DatabaseOperations : IDatabaseOperations
         }
 
         byte[]? value = null;
-        using (var connection = new SqlConnection(ConnectionString))
+        using (var connection = ConnectionFactory())
         using (var command = new SqlCommand(query, connection))
         {
             command.Parameters
@@ -274,7 +274,7 @@ internal sealed class DatabaseOperations : IDatabaseOperations
         }
 
         byte[]? value = null;
-        using (var connection = new SqlConnection(ConnectionString))
+        using (var connection = ConnectionFactory())
         using (var command = new SqlCommand(query, connection))
         {
             command.Parameters

--- a/src/Caching/SqlServer/src/SqlServerCache.cs
+++ b/src/Caching/SqlServer/src/SqlServerCache.cs
@@ -7,7 +7,6 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Shared;
-using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Options;
@@ -34,8 +33,7 @@ public class SqlServerCache : IDistributedCache, IBufferDistributedCache
     /// Initializes a new instance of <see cref="SqlServerCache"/>.
     /// </summary>
     /// <param name="options">The configuration options.</param>
-    /// <param name="serviceProvider">The service provider used to resolve services for <see cref="SqlServerCacheOptions.ConnectionFactory"/>.</param>
-    public SqlServerCache(IOptions<SqlServerCacheOptions> options, IServiceProvider serviceProvider)
+    public SqlServerCache(IOptions<SqlServerCacheOptions> options)
     {
         var cacheOptions = options.Value;
 
@@ -71,9 +69,8 @@ public class SqlServerCache : IDistributedCache, IBufferDistributedCache
         _deleteExpiredCachedItemsDelegate = DeleteExpiredCacheItems;
         _defaultSlidingExpiration = cacheOptions.DefaultSlidingExpiration;
 
-        Func<SqlConnection> connectionFactory = cacheOptions.ConnectionFactory is not null
-            ? () => cacheOptions.ConnectionFactory(serviceProvider)
-            : () => new SqlConnection(cacheOptions.ConnectionString);
+        Func<SqlConnection> connectionFactory = cacheOptions.ConnectionFactory
+            ?? (() => new SqlConnection(cacheOptions.ConnectionString));
 
         _dbOperations = new DatabaseOperations(
             connectionFactory,

--- a/src/Caching/SqlServer/src/SqlServerCache.cs
+++ b/src/Caching/SqlServer/src/SqlServerCache.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Shared;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Options;
@@ -33,13 +34,19 @@ public class SqlServerCache : IDistributedCache, IBufferDistributedCache
     /// Initializes a new instance of <see cref="SqlServerCache"/>.
     /// </summary>
     /// <param name="options">The configuration options.</param>
-    public SqlServerCache(IOptions<SqlServerCacheOptions> options)
+    /// <param name="serviceProvider">The service provider used to resolve services for <see cref="SqlServerCacheOptions.ConnectionFactory"/>.</param>
+    public SqlServerCache(IOptions<SqlServerCacheOptions> options, IServiceProvider serviceProvider)
     {
         var cacheOptions = options.Value;
 
-        ArgumentThrowHelper.ThrowIfNullOrEmpty(cacheOptions.ConnectionString);
         ArgumentThrowHelper.ThrowIfNullOrEmpty(cacheOptions.SchemaName);
         ArgumentThrowHelper.ThrowIfNullOrEmpty(cacheOptions.TableName);
+
+        if (cacheOptions.ConnectionFactory is null && string.IsNullOrEmpty(cacheOptions.ConnectionString))
+        {
+            throw new ArgumentException(
+                $"Either {nameof(SqlServerCacheOptions.ConnectionString)} or {nameof(SqlServerCacheOptions.ConnectionFactory)} must be set.");
+        }
 
         if (cacheOptions.ExpiredItemsDeletionInterval.HasValue &&
             cacheOptions.ExpiredItemsDeletionInterval.Value < MinimumExpiredItemsDeletionInterval)
@@ -64,8 +71,12 @@ public class SqlServerCache : IDistributedCache, IBufferDistributedCache
         _deleteExpiredCachedItemsDelegate = DeleteExpiredCacheItems;
         _defaultSlidingExpiration = cacheOptions.DefaultSlidingExpiration;
 
+        Func<SqlConnection> connectionFactory = cacheOptions.ConnectionFactory is not null
+            ? () => cacheOptions.ConnectionFactory(serviceProvider)
+            : () => new SqlConnection(cacheOptions.ConnectionString);
+
         _dbOperations = new DatabaseOperations(
-            cacheOptions.ConnectionString,
+            connectionFactory,
             cacheOptions.SchemaName,
             cacheOptions.TableName,
             _systemClock);

--- a/src/Caching/SqlServer/src/SqlServerCacheOptions.cs
+++ b/src/Caching/SqlServer/src/SqlServerCacheOptions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Options;
 
@@ -28,7 +29,21 @@ public class SqlServerCacheOptions : IOptions<SqlServerCacheOptions>
     /// <summary>
     /// Gets or sets the connection string to the database.
     /// </summary>
+    /// <remarks>
+    /// Either <see cref="ConnectionString"/> or <see cref="ConnectionFactory"/> must be set, but not both.
+    /// </remarks>
     public string? ConnectionString { get; set; }
+
+    /// <summary>
+    /// Gets or sets a factory for creating <see cref="SqlConnection"/> instances.
+    /// Use this instead of <see cref="ConnectionString"/> when the connection requires dynamic configuration,
+    /// such as token-based authentication or runtime-resolved credentials.
+    /// </summary>
+    /// <remarks>
+    /// Either <see cref="ConnectionString"/> or <see cref="ConnectionFactory"/> must be set, but not both.
+    /// When set, <see cref="ConnectionString"/> is ignored.
+    /// </remarks>
+    public Func<IServiceProvider, SqlConnection>? ConnectionFactory { get; set; }
 
     /// <summary>
     /// Gets or sets the schema name of the table.

--- a/src/Caching/SqlServer/src/SqlServerCacheOptions.cs
+++ b/src/Caching/SqlServer/src/SqlServerCacheOptions.cs
@@ -43,7 +43,7 @@ public class SqlServerCacheOptions : IOptions<SqlServerCacheOptions>
     /// Either <see cref="ConnectionString"/> or <see cref="ConnectionFactory"/> must be set, but not both.
     /// When set, <see cref="ConnectionString"/> is ignored.
     /// </remarks>
-    public Func<IServiceProvider, SqlConnection>? ConnectionFactory { get; set; }
+    public Func<SqlConnection>? ConnectionFactory { get; set; }
 
     /// <summary>
     /// Gets or sets the schema name of the table.

--- a/src/Caching/SqlServer/test/SqlServerCacheServicesExtensionsTest.cs
+++ b/src/Caching/SqlServer/test/SqlServerCacheServicesExtensionsTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
@@ -58,5 +59,73 @@ public class SqlServerCacheServicesExtensionsTest
         var services = new ServiceCollection();
 
         Assert.Same(services, services.AddDistributedSqlServerCache(_ => { }));
+    }
+
+    [Fact]
+    public void AddDistributedSqlServerCache_ConnectionFactory_UsedInsteadOfConnectionString()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var factoryInvoked = false;
+
+        // Act
+        // ConnectionFactory can be set directly in the options action.
+        // The factory closes over whatever it needs at registration time —
+        // no IServiceProvider injection required on the cache itself.
+        services.AddDistributedSqlServerCache(options =>
+        {
+            options.SchemaName = "dbo";
+            options.TableName = "Cache";
+            options.ConnectionFactory = () =>
+            {
+                factoryInvoked = true;
+                return new SqlConnection("Server=fake");
+            };
+        });
+
+        // Assert: service resolves (factory is not invoked until a cache operation is performed)
+        var serviceProvider = services.BuildServiceProvider();
+        var cache = serviceProvider.GetRequiredService<IDistributedCache>();
+        Assert.IsType<SqlServerCache>(cache);
+        Assert.False(factoryInvoked);
+    }
+
+    [Fact]
+    public void AddDistributedSqlServerCache_ConnectionFactory_CanCaptureServicesViaIConfigureOptions()
+    {
+        // Arrange
+        // IConfigureOptions<T> is the idiomatic way to inject other services into options
+        // when the factory itself depends on a registered service (e.g. a token provider).
+        var services = new ServiceCollection();
+        services.AddSingleton<IFakeTokenService, FakeTokenService>();
+        SqlServerCachingServicesExtensions.AddSqlServerCacheServices(services);
+
+        services.AddOptions<SqlServerCacheOptions>()
+            .Configure<IFakeTokenService>((options, tokenService) =>
+            {
+                options.SchemaName = "dbo";
+                options.TableName = "Cache";
+                options.ConnectionFactory = () =>
+                {
+                    var conn = new SqlConnection("Server=fake");
+                    conn.AccessToken = tokenService.GetToken();
+                    return conn;
+                };
+            });
+
+        // Assert: service resolves and the token service was captured in the factory closure
+        var serviceProvider = services.BuildServiceProvider();
+        var cache = serviceProvider.GetRequiredService<IDistributedCache>();
+        Assert.IsType<SqlServerCache>(cache);
+    }
+
+    private interface IFakeTokenService
+    {
+        string GetToken();
+    }
+
+    private sealed class FakeTokenService : IFakeTokenService
+    {
+        public string GetToken() => "fake-token";
     }
 }

--- a/src/Caching/SqlServer/test/SqlServerCacheServicesExtensionsTest.cs
+++ b/src/Caching/SqlServer/test/SqlServerCacheServicesExtensionsTest.cs
@@ -98,7 +98,7 @@ public class SqlServerCacheServicesExtensionsTest
         // when the factory itself depends on a registered service (e.g. a token provider).
         var services = new ServiceCollection();
         services.AddSingleton<IFakeTokenService, FakeTokenService>();
-        SqlServerCachingServicesExtensions.AddSqlServerCacheServices(services);
+        services.AddDistributedSqlServerCache(_ => { });
 
         services.AddOptions<SqlServerCacheOptions>()
             .Configure<IFakeTokenService>((options, tokenService) =>

--- a/src/Caching/SqlServer/test/SqlServerCacheWithDatabaseTest.cs
+++ b/src/Caching/SqlServer/test/SqlServerCacheWithDatabaseTest.cs
@@ -11,7 +11,6 @@ using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Internal;
 using Xunit;
 
@@ -692,7 +691,7 @@ public class SqlServerCacheWithDatabaseTest
             options = GetCacheOptions();
         }
 
-        return new SqlServerCache(options, new ServiceCollection().BuildServiceProvider());
+        return new SqlServerCache(options);
     }
 
     private SqlServerCacheOptions GetCacheOptions(ISystemClock testClock = null)

--- a/src/Caching/SqlServer/test/SqlServerCacheWithDatabaseTest.cs
+++ b/src/Caching/SqlServer/test/SqlServerCacheWithDatabaseTest.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Internal;
 using Xunit;
 
@@ -691,7 +692,7 @@ public class SqlServerCacheWithDatabaseTest
             options = GetCacheOptions();
         }
 
-        return new SqlServerCache(options);
+        return new SqlServerCache(options, new ServiceCollection().BuildServiceProvider());
     }
 
     private SqlServerCacheOptions GetCacheOptions(ISystemClock testClock = null)


### PR DESCRIPTION
# SqlServerCache: allow more control over SqlConnection

Allow more control over SqlConnection creation inside of SqlServerCache. Useful when SqlConnection properties are modified due to some requirement (SspiContext setting, custom disposal, etc).

## Description

Check issue for more info.

Fixes #66510 
