### PR TITLE
Run template tests pipeline on changes in Versions.props

### DIFF
--- a/.azure/pipelines/template-tests-pr.yml
+++ b/.azure/pipelines/template-tests-pr.yml
@@ -19,6 +19,7 @@ pr:
     - src/ProjectTemplates/*
     - src/Components/*
     - src/Mvc/*
+    - eng/Versions.props
 
 variables:
 - name: _UseHelixOpenQueues


### PR DESCRIPTION
PR #66514 introduced a regression that wasn't caught because the pipeline was skipped. The Versions.props file carry versions that are used by the templates, and so changes there should trigger the tests.

Ideally, we might want to consider separating versions used only by templates to a separate file to avoid over-running the pipeline, but it's probably okay for now to do it this way, I think.

@wtgodbe 