### PR TITLE
Update MoqVersion to latest

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -138,7 +138,7 @@
     <AzureIdentityVersion>1.11.4</AzureIdentityVersion>
     <AngleSharpVersion>0.9.9</AngleSharpVersion>
     <BenchmarkDotNetVersion>0.13.0</BenchmarkDotNetVersion>
-    <CastleCoreVersion>4.2.1</CastleCoreVersion>
+    <CastleCoreVersion>5.2.1</CastleCoreVersion>
     <CommandLineParserVersion>2.3.0</CommandLineParserVersion>
     <FSharpCoreVersion>6.0.0</FSharpCoreVersion>
     <GoogleApiCommonProtosVersion>2.15.0</GoogleApiCommonProtosVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -159,7 +159,7 @@
     <MessagePackAnalyzerVersion>$(MessagePackVersion)</MessagePackAnalyzerVersion>
     <ModelContextProtocolVersion>1.2.0</ModelContextProtocolVersion>
     <ModelContextProtocolAspNetCoreVersion>$(ModelContextProtocolVersion)</ModelContextProtocolAspNetCoreVersion>
-    <MoqVersion>4.10.0</MoqVersion>
+    <MoqVersion>4.20.72</MoqVersion>
     <MonoCecilVersion>0.11.2</MonoCecilVersion>
     <MonoTextTemplatingVersion>2.2.1</MonoTextTemplatingVersion>
     <NewtonsoftJsonBsonVersion>1.0.2</NewtonsoftJsonBsonVersion>

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Validation/DefaultObjectValidatorTests.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Validation/DefaultObjectValidatorTests.cs
@@ -591,19 +591,10 @@ public class DefaultObjectValidatorTests
 
         var validator = CreateValidator();
 
-        var model = new Mock<IValidatableObject>();
-        model
-            .Setup(x => x.Validate(It.IsAny<ValidationContext>()))
-            .Callback((ValidationContext context) =>
-            {
-                var receivedService = context.GetService<IExampleService>();
-                Assert.Equal(service.Object, receivedService);
-                receivedService.DoSomething();
-            })
-            .Returns(new List<ValidationResult>());
+        var model = new MockedValidatableObject(service.Object);
 
         // Act
-        validator.Validate(actionContext, validationState, prefix: null, model: model.Object);
+        validator.Validate(actionContext, validationState, prefix: null, model: model);
 
         // Assert
         service.Verify();
@@ -1685,6 +1676,22 @@ public class DefaultObjectValidatorTests
 
                 return new DepthObject(MaxAllowedDepth, Depth + 1);
             }
+        }
+    }
+
+    private sealed class MockedValidatableObject : IValidatableObject
+    {
+        private readonly IExampleService _exampleService;
+
+        public MockedValidatableObject(IExampleService exampleService)
+            => _exampleService = exampleService;
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            var receivedService = validationContext.GetService<IExampleService>();
+            Assert.Equal(_exampleService, receivedService);
+
+            return new List<ValidationResult>();
         }
     }
 }

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Validation/DefaultObjectValidatorTests.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Validation/DefaultObjectValidatorTests.cs
@@ -1690,7 +1690,7 @@ public class DefaultObjectValidatorTests
         {
             var receivedService = validationContext.GetService<IExampleService>();
             Assert.Equal(_exampleService, receivedService);
-
+            receivedService.DoSomething();
             return new List<ValidationResult>();
         }
     }


### PR DESCRIPTION
This version of Moq is extremely old.

During the test run of Microsoft.AspNetCore.Mvc.TagHelpers.Test, I see lots of threadpool threads getting blocked:

<img width="2391" height="826" alt="image" src="https://github.com/user-attachments/assets/bbf922c9-b5bf-4e7a-bc7b-951a92e16094" />

<img width="1785" height="799" alt="image" src="https://github.com/user-attachments/assets/c90902aa-fc62-4e92-bec3-354894a963a6" />

This doesn't sound good, and **might** be cause of some of the flakiness we get.

Let's hope that the newer versions of Moq/Castle.Core are doing better job at not blocking threads.