### PR TITLE
Align quarantined-tests pipeline flags with ci-public

### DIFF
--- a/.azure/pipelines/quarantined-tests.yml
+++ b/.azure/pipelines/quarantined-tests.yml
@@ -27,13 +27,15 @@ jobs:
     timeoutInMinutes: 480
     steps:
     # Build the shared framework
-    - script: ./eng/build.cmd -ci -prepareMachine /bl:artifacts/log/Build.SharedFx.binlog -all -noBuildJava -pack -arch x64
+    - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine /bl:artifacts/log/Build.SharedFx.binlog -all -noBuildJava -pack -arch x64
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
+              /p:VsTestUseMSBuildOutput=false
       displayName: Build shared fx
     # -noBuildNative -noBuild to avoid repeating work done in the previous step.
-    - script: ./eng/build.cmd -ci -prepareMachine /bl:artifacts/log/Build.HelixTarget.binlog -all -noBuildNative -noBuild -noBuildJava -test
+    - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine /bl:artifacts/log/Build.HelixTarget.binlog -all -noBuildNative -noBuild -noBuildJava -test
               -projects eng\helix\helix.proj /p:RunQuarantinedTests=true /p:IsHelixJob=true
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
+              /p:VsTestUseMSBuildOutput=false
       displayName: Run build.cmd helix target
       continueOnError: true
       env:


### PR DESCRIPTION
Add `-nativeToolsOnMachine` and `/p:VsTestUseMSBuildOutput=false` to the quarantined-tests pipeline to match ci-public's Helix job. These missing flags are causing MSB4216 task host failures (`GenerateTestDevCert`, `ILLink`, `ComputeWasmBuildAssets`) that don't occur in ci-public.