### PR TITLE
Rewrite docs/TriageProcess.md to be timeless and more comprehensive

### DIFF
--- a/docs/IssueManagementPolicies.md
+++ b/docs/IssueManagementPolicies.md
@@ -14,6 +14,10 @@ If a contributor reviews an issue and determines that more information is needed
 
 If the author does not post a response within **7 days**, the issue will be automatically closed. If the author responds within **7 days** after the issue is closed, the issue will be automatically re-opened. We recognize that you may not be able to respond immediately to our requests, we're happy to hear from you whenever you're able to provide the new information.
 
+### Needs: Repro
+
+When investigating an issue requires a minimal reproduction project, a contributor will apply the `Needs: Repro` label. This automatically posts a templated reply pointing to the [Bug Report Reproduction Guide](./repro.md) and applies `Needs: Author Feedback`, so the 7-day auto-close behavior described above also applies.
+
 ### PR: pending author input
 Similar to the `Needs Author Feedback` process above, PRs also require author input from time to time. When a member of our team asks for some follow-up changes from the author, we mark these PRs with `pr: pending author input` label. After doing so, we expect the author to respond within 14 days.
 If the author does not post a response or updates the PR within **14 days**, the issue will be automatically closed. If the author responds within **7 days** after the issue is closed, the issue will be automatically re-opened. We recognize that you may not be able to respond immediately to our requests, we're happy to hear from you whenever you're able to provide the new information.

--- a/docs/TriageProcess.md
+++ b/docs/TriageProcess.md
@@ -21,7 +21,8 @@ A triaged issue ends up in one of these states:
 | --- | --- |
 | **Closed** | Not actionable: duplicate, by-design, won't fix, can't repro, or already fixed. |
 | **Servicing milestone** (`N.0.x`) | A regression or high-impact bug in a supported release that warrants a patch. Subject to the [servicing bar](https://github.com/dotnet/aspnetcore/blob/main/docs/Servicing.md). |
-| **Current-release planning milestone** (`.NET N Planning`) | Candidate for the in-flight major release. Issues here are scheduled into specific release milestones (e.g. `N.0-previewX`) during team planning. |
+| **Current release milestone** (`N.0-previewX`) | Needs to be addressed in the next preview of the in-flight release — for example, a recent regression or a blocker for an in-progress feature. |
+| **Current-release planning milestone** (`.NET N Planning`) | Candidate for the in-flight major release. Issues here are scheduled into a specific `N.0-previewX` milestone during team planning. |
 | **`Backlog`** | Tracked but not committed to any release. Re-evaluated during release planning. |
 
 If we need more information from the reporter before we can triage, we apply the `Needs: Author Feedback` or `Needs: Repro` label and triage again once the information is provided. See [Issue Management Policies](https://github.com/dotnet/aspnetcore/blob/main/docs/IssueManagementPolicies.md) for how those labels behave.

--- a/docs/TriageProcess.md
+++ b/docs/TriageProcess.md
@@ -7,120 +7,90 @@ This document describes how issues filed in `dotnet/aspnetcore` are triaged. It 
 
 > **Need urgent help?** Customers needing urgent investigation should contact [Microsoft Support](https://dotnet.microsoft.com/platform/support).
 
-## What we triage and when
+## How we triage
 
-Every open issue without a milestone is considered untriaged. The team reviews untriaged issues regularly (typically weekly per area) and aims to make a decision quickly. Decisions are recorded as a **type label**, an **area label**, and a **milestone** — together they answer "what kind of issue is this, who owns it, and when (if ever) will we work on it?"
+The team reviews untriaged issues (open issues without a milestone) regularly. We try to respond to new issues as quickly as we can, but it may take a few days. Each triaged issue is given an **issue type**, an **area label**, and a **milestone** — together they answer "what kind of issue is this, who owns it, and when (if ever) are we planning to work on it?"
+
+A milestone reflects current intent, not a guarantee. Issues placed in a planning milestone may be rescheduled, moved to `Backlog`, or closed as priorities evolve.
 
 ## Triage outcomes
 
-Every triaged issue ends up in one of these states:
+A triaged issue ends up in one of these states:
 
 | Outcome | Meaning |
 | --- | --- |
-| **Closed** | Not actionable: invalid, duplicate, by-design, won't fix, can't repro, or already fixed. |
-| **Current release milestone** (e.g. the active `N.0` milestone) | Important enough to address in the in-flight release. Used sparingly. |
-| **Servicing milestone** (e.g. `N.0.x`) | A regression or high-impact bug in a supported release that warrants a patch. Subject to the [servicing bar](https://github.com/dotnet/aspnetcore/blob/main/docs/ReleasePlanning.md). |
-| **Next-release planning milestone** | Candidate for the next major .NET release; reviewed during sprint planning. |
-| **`Backlog`** | Tracked, but not committed to any release. Re-evaluated during release planning. |
-| **`Needs: Author Feedback`** | Waiting on the reporter for more information. May auto-close if no response. |
+| **Closed** | Not actionable: duplicate, by-design, won't fix, can't repro, or already fixed. |
+| **Servicing milestone** (`N.0.x`) | A regression or high-impact bug in a supported release that warrants a patch. Subject to the [servicing bar](https://github.com/dotnet/aspnetcore/blob/main/docs/Servicing.md). |
+| **Current-release planning milestone** (`.NET N Planning`) | Candidate for the in-flight major release. Issues here are scheduled into specific release milestones (e.g. `N.0-previewX`) during team planning. |
+| **`Backlog`** | Tracked but not committed to any release. Re-evaluated during release planning. |
 
-If the report depends on more information from the reporter, we apply `Needs: Author Feedback` first and triage again once we have what we need.
+If we need more information from the reporter before we can triage, we apply the `Needs: Author Feedback` or `Needs: Repro` label and triage again once the information is provided. See [Issue Management Policies](https://github.com/dotnet/aspnetcore/blob/main/docs/IssueManagementPolicies.md) for how those labels behave.
 
-## How we triage by issue type
+## Issue types
 
-Every triaged issue is tagged with a **type label**: `bug`, `enhancement` (feature), `Docs`, or `investigate` / `question`. The decision logic differs by type.
+Each triaged issue is assigned a [GitHub issue type](https://docs.github.com/en/issues/tracking-your-work-with-issues/configuring-a-custom-issue-type-list-for-an-organization): **Bug**, **Feature**, **Task**, or **Epic**. The decision logic differs by type.
 
-### Bug reports
+### Bug
 
-For something to be triaged as a bug, the issue should clearly describe:
+A good bug report describes:
 
 1. The expected behavior.
 2. The actual behavior.
-3. Steps to reproduce, ideally a minimal repro project.
-4. The .NET version and OS.
+3. The .NET version and OS.
+4. A minimal reproduction. See the [Bug Report Reproduction Guide](https://github.com/dotnet/aspnetcore/blob/main/docs/repro.md) for what we expect — typically a project hosted in a public GitHub repo. If a repro is missing, we apply `Needs: Repro`.
 
-Then we assess impact and severity, considering:
+We assess impact and severity by considering:
 
 - **Is it a regression in a currently supported release?** Regressions are weighted heavily and are the strongest candidates for servicing.
-- **Severity:** crash, data loss, security, hang, perf, or incorrect behavior with workaround?
+- **Severity:** crash, data loss, security, hang, perf, or incorrect behavior with a workaround?
 - **Reach:** how many users are likely affected? Common scenario or a niche edge case?
 - **Community signal:** 👍 reactions and substantive comments from distinct users.
-- **Workaround availability:** is there a reasonable user-side fix?
-
-Based on that:
-
-- **Critical / clear regression in a supported release** → servicing milestone (subject to servicing-bar approval).
-- **High-impact, reproducible** → next-release planning milestone.
-- **Real but low impact, or unclear impact** → `Backlog`, awaiting more signal.
-- **Cannot reproduce or insufficient information** → `Needs: Author Feedback`; close if no response.
-- **Caused by user code or environment** → close with an explanation.
-
-### Feature requests (`enhancement`)
-
-We weigh:
-
-- Alignment with the framework's goals and roadmap.
-- Size and design complexity.
-- Community demand (👍, comments, related issues, prior discussions).
-- Whether the scenario can already be achieved via extension points.
+- **Workaround availability.**
 
 Outcomes:
 
-- **Aligned and well-scoped** → next-release planning milestone for design review.
-- **Reasonable but not urgent** → `Backlog` to gather signal.
-- **Out of scope or unlikely to ship** → close with rationale and, where possible, a pointer to alternatives.
+- **Clear regression in a supported release with no good workaround** → servicing milestone, subject to the [servicing bar](https://github.com/dotnet/aspnetcore/blob/main/docs/Servicing.md) (which also weighs regression risk and forbids API changes in patches).
+- **High impact, reproducible** → current-release planning milestone.
+- **Real but low impact, or unclear impact** → `Backlog`.
+- **Caused by user code or environment** → close with explanation.
 
-### Investigations
+### Feature
 
-When a report could be a bug, environmental, or a misconfiguration, we apply the `investigate` label. Most investigations resolve to "user code / environment" and close; a minority surface as real bugs and re-triage as such.
+We try to prioritize the most important and impactful feature requests for each release. There are multiple factors that go into determining the priority of a feature. It's a balance between addressing key feedback, investing in key strategic directions, and satisfying Microsoft business needs. We also have to weigh the cost and risk of building, maintaining, and supporting the feature given the team's available resources.
 
-For investigations that require a process dump, ETW trace, or other diagnostic the reporter must provide, we set `Needs: Author Feedback`. If the reporter cannot or will not provide actionable diagnostics, the issue is closed; reopening is welcome once data is available.
+Outcomes:
 
-### Documentation issues
+- **Aligned and prioritized for the current release** → current-release planning milestone.
+- **Reasonable but not prioritized** → `Backlog` to gather signal.
+- **Out of scope** → close with rationale and, where possible, a pointer to alternatives.
 
-Tagged `Docs` and typically transferred to [`dotnet/AspNetCore.Docs`](https://github.com/dotnet/AspNetCore.Docs). High-traffic confusion may be addressed in the current release.
+### Task
 
-### Wrong area or wrong repo
+Engineering work that is neither a user-visible bug nor a new feature: refactors, perf improvements without a behavior change, test infrastructure, build/CI work, internal cleanups, and **documentation gaps**.
 
-If an issue belongs in another area or repo (e.g. `dotnet/runtime`, `dotnet/sdk`, `dotnet/AspNetCore.Docs`, `microsoft/reverse-proxy`), we transfer or re-label it during triage rather than holding it.
+Documentation tasks in this repo track technical content gaps that need to be filled by the ASP.NET Core engineering team. The engineering team provides the technical content to add to the docs by opening an issue with the content in the [`dotnet/AspNetCore.Docs`](https://github.com/dotnet/AspNetCore.Docs) repo. Doc issues should have type **Task** and the `Docs` label.
 
-## Milestone and release planning
+### Epic
 
-- **Sprint planning** (typically monthly): the team reviews issues in the next-release planning milestone and pulls the highest-impact items into the active sprint. Lower-impact items may be moved to `Backlog`.
-- **Release planning**: near the end of a release cycle, the team reviews `Backlog` and promotes items aligned with the next release's themes into the next-release planning milestone. See [ReleasePlanning.md](https://github.com/dotnet/aspnetcore/blob/main/docs/ReleasePlanning.md).
+Larger bodies of work that span multiple issues or releases.
 
-## Stale-issue cleanup
+## Investigations
 
-Issues that have been in `Backlog` across multiple releases without gaining traction are closed during release planning. Long-lived backlog age is itself a signal that an issue isn't impactful enough to act on; closing keeps the backlog meaningful. Reopening is welcome when new information or community demand emerges.
+When further investigation from our team is needed to determine the nature and impact of a reported issue, we apply the `investigate` label. Once the investigation is completed, the issue is triaged normally. Issues that don't have clear impact or severity may get closed without being investigated.
 
-## How decisions flow
+## Wrong repo
 
-```mermaid
-flowchart TD
-    A[New issue] --> B{Enough info?}
-    B -- No --> C[Needs: Author Feedback]
-    C -. no response .-> X[Close]
-    C -. info provided .-> B
-    B -- Yes --> D{Type?}
-    D -- Bug --> E{Impact / regression?}
-    D -- Feature --> F{Aligned with goals?}
-    D -- Investigation --> G[Investigate]
-    D -- Docs --> H[Transfer to docs repo]
-    D -- Out of scope / by design / duplicate --> X
-    E -- Critical / supported regression --> S[Servicing milestone]
-    E -- High impact --> P[Next-release planning]
-    E -- Low / unclear impact --> BL[Backlog]
-    F -- Yes --> P
-    F -- Maybe --> BL
-    F -- No --> X
-    G -- Real bug --> E
-    G -- User / env issue --> X
-    BL -. release planning .-> P
-    BL -. stale across releases .-> X
-```
+If an issue belongs in another repo (e.g. `dotnet/runtime`, `dotnet/sdk`, `dotnet/AspNetCore.Docs`, `dotnet/yarp`), we transfer it during triage.
+
+## Release planning
+
+Near the end of a release cycle, the team reviews `Backlog` and promotes items aligned with the next release into the next planning milestone. Issues that have stayed in `Backlog` across multiple releases without gaining traction are typically closed during this review — long backlog age is itself a signal that an issue isn't impactful enough to act on. Reopening is welcome when new information or community demand emerges.
+
+See [Release Planning](https://github.com/dotnet/aspnetcore/blob/main/docs/ReleasePlanning.md) for details.
 
 ## References
 
-- [Issue Management Policies](https://github.com/dotnet/aspnetcore/blob/main/docs/IssueManagementPolicies.md) — automation and labels.
+- [Issue Management Policies](https://github.com/dotnet/aspnetcore/blob/main/docs/IssueManagementPolicies.md) — automation and labels (`Needs: Author Feedback`, `Needs: Repro`, etc.).
+- [Bug Report Reproduction Guide](https://github.com/dotnet/aspnetcore/blob/main/docs/repro.md) — what we expect from a minimal repro.
 - [Release Planning](https://github.com/dotnet/aspnetcore/blob/main/docs/ReleasePlanning.md) — how releases are scoped.
-- [Servicing bar](https://github.com/dotnet/aspnetcore/blob/main/docs/ReleasePlanning.md) — what qualifies for a patch release.
+- [Servicing](https://github.com/dotnet/aspnetcore/blob/main/docs/Servicing.md) — Servicing bar and release process.

--- a/docs/TriageProcess.md
+++ b/docs/TriageProcess.md
@@ -1,83 +1,126 @@
 # Triage Process
 
-Managing a popular GitHub repo with a small team is not an easy task. It requires a good balance between creating new features while handling many investigations and bug fixes associated with existing ones.
+This document describes how issues filed in `dotnet/aspnetcore` are triaged. It is intended as:
 
-During the last couple of years the amount of incoming issues has been constantly growing. While this is a sign of a healthy framework and ecosystem surrounding it, it's becoming harder to react to all those issues.
-To be able to keep up with ever-evolving expectations, we're introducing a set of rules to help us better handle the incoming issues going forward.
+- A reference for the **.NET community** so you know what to expect after filing an issue.
+- A guide for **engineers joining the team** on how to triage incoming issues consistently.
 
-**Note:** Customers that need help with **urgent investigations** should contact [Microsoft Support](https://dotnet.microsoft.com/platform/support).
+> **Need urgent help?** Customers needing urgent investigation should contact [Microsoft Support](https://dotnet.microsoft.com/platform/support).
 
-## Goals
+## What we triage and when
 
-The goals of these rules are listed below in priority order:
+Every open issue without a milestone is considered untriaged. The team reviews untriaged issues regularly (typically weekly per area) and aims to make a decision quickly. Decisions are recorded as a **type label**, an **area label**, and a **milestone** — together they answer "what kind of issue is this, who owns it, and when (if ever) will we work on it?"
 
-- Make it easy to make triage decisions for each issue filed in this repository
-- Be able to easily prioritize issues for each milestone
-- Set proper expectations with customers regarding how issues are going to be handled
+## Triage outcomes
 
-## Triage Process Details
+Every triaged issue ends up in one of these states:
 
-The feature teams should be able to look through every single issue filed against this repository and be able to make a quick call regarding the nature of the issue.
-We will first categorize the issues and further handle these depending on the category the issue is in. The subsections below represent these categories and the rules we apply for them during our triage meeting.
+| Outcome | Meaning |
+| --- | --- |
+| **Closed** | Not actionable: invalid, duplicate, by-design, won't fix, can't repro, or already fixed. |
+| **Current release milestone** (e.g. the active `N.0` milestone) | Important enough to address in the in-flight release. Used sparingly. |
+| **Servicing milestone** (e.g. `N.0.x`) | A regression or high-impact bug in a supported release that warrants a patch. Subject to the [servicing bar](https://github.com/dotnet/aspnetcore/blob/main/docs/ReleasePlanning.md). |
+| **Next-release planning milestone** | Candidate for the next major .NET release; reviewed during sprint planning. |
+| **`Backlog`** | Tracked, but not committed to any release. Re-evaluated during release planning. |
+| **`Needs: Author Feedback`** | Waiting on the reporter for more information. May auto-close if no response. |
 
-### Information Gathering
+If the report depends on more information from the reporter, we apply `Needs: Author Feedback` first and triage again once we have what we need.
 
-In this phase we instruct the user on how to collect the appropriate diagnostics and see if they are able to address the issue with that additional information.  When we need user input we will mark the issue with `Needs: Author Feedback` label. Issues in this phase may be closed automatically if we do not receive timely responses, they often do not provide enough information for us to investigate further.
-We'll try to respond quickly to such issues (within days). If a user has collected all of the relevant diagnostics and the issue is still not apparent, then we will consider it for further [investigation](#investigations) by the team.
+## How we triage by issue type
 
-### Feature requests
-
-As soon as we identify an issue that represents an ask for a new feature, we will label the issue with the `enhancement` label.
-Most of the time, we will automatically move these issues into the `.NET 11 Planning` milestone for further review during one of our [sprint planning meetings](#milestone-planning).
-If we think the feature request is not aligned with our goals, we may choose to close it immediately.
-In some situations, however, we may choose to collect more feedback before acting on the issue. In these situations we will move the issue in the `Backlog` so that we can review it during the [release planning](#release-planning).
+Every triaged issue is tagged with a **type label**: `bug`, `enhancement` (feature), `Docs`, or `investigate` / `question`. The decision logic differs by type.
 
 ### Bug reports
 
-If it's immediately clear that the issue is related to a bug in the framework, we will apply the `bug` label to the issue.
+For something to be triaged as a bug, the issue should clearly describe:
 
-At this point, we will try to make a call regarding its impact and severity. If the issue is critical, we may choose to include it in our current milestone for immediate handling or potentially patching.
-If the bug is relatively high impact, we will move the issue into the `.NET 11 Planning` milestone to review during our [sprint planning](#milestone-planning) meeting.
-If the impact is unclear or the is a very corner case scenario, we may move it to the `Backlog` milestone to further evaluate the impact by reviewing customer upvotes / comments at a later time.
+1. The expected behavior.
+2. The actual behavior.
+3. Steps to reproduce, ideally a minimal repro project.
+4. The .NET version and OS.
+
+Then we assess impact and severity, considering:
+
+- **Is it a regression in a currently supported release?** Regressions are weighted heavily and are the strongest candidates for servicing.
+- **Severity:** crash, data loss, security, hang, perf, or incorrect behavior with workaround?
+- **Reach:** how many users are likely affected? Common scenario or a niche edge case?
+- **Community signal:** 👍 reactions and substantive comments from distinct users.
+- **Workaround availability:** is there a reasonable user-side fix?
+
+Based on that:
+
+- **Critical / clear regression in a supported release** → servicing milestone (subject to servicing-bar approval).
+- **High-impact, reproducible** → next-release planning milestone.
+- **Real but low impact, or unclear impact** → `Backlog`, awaiting more signal.
+- **Cannot reproduce or insufficient information** → `Needs: Author Feedback`; close if no response.
+- **Caused by user code or environment** → close with an explanation.
+
+### Feature requests (`enhancement`)
+
+We weigh:
+
+- Alignment with the framework's goals and roadmap.
+- Size and design complexity.
+- Community demand (👍, comments, related issues, prior discussions).
+- Whether the scenario can already be achieved via extension points.
+
+Outcomes:
+
+- **Aligned and well-scoped** → next-release planning milestone for design review.
+- **Reasonable but not urgent** → `Backlog` to gather signal.
+- **Out of scope or unlikely to ship** → close with rationale and, where possible, a pointer to alternatives.
 
 ### Investigations
 
-In many situations it's not immediately clear whether a specific issue reported is a bug or not. To be certain, the team will need to spend time to investigate it before making a call regarding the faith of the issue. In these situations we will apply the `investigate` label to the issue.
-In many situations, these issues turn out to be a result of some kind of misconfiguration in the user code.
-In some rare situations, however, these turn out to be caused by very impactful issues. So we will make a call during the triage whether we need to immediately investigate certain issues or not.
-If not, we will move the investigation to the `.NET 11 Planning` milestone to review during one of the upcoming [sprint planning meetings](#milestone-planning).
+When a report could be a bug, environmental, or a misconfiguration, we apply the `investigate` label. Most investigations resolve to "user code / environment" and close; a minority surface as real bugs and re-triage as such.
 
-### Documentation requests
+For investigations that require a process dump, ETW trace, or other diagnostic the reporter must provide, we set `Needs: Author Feedback`. If the reporter cannot or will not provide actionable diagnostics, the issue is closed; reopening is welcome once data is available.
 
-Some issues turn out to indicate user confusion around how to configure different aspects of the framework.
-When we determine such issues, we will mark these with the `Docs` label and move them into the `.NET 11 Planning` milestone to handle at a later time. The goal here will be to fill in the gaps or clarify our documentation, so that customers can be successful by using the guidance provided in the documentation.
-If we identify a documentation issue which too many customers are having trouble with, we may choose to address that in current milestone.
+### Documentation issues
 
-## Milestone Planning
+Tagged `Docs` and typically transferred to [`dotnet/AspNetCore.Docs`](https://github.com/dotnet/AspNetCore.Docs). High-traffic confusion may be addressed in the current release.
 
-Our milestones are usually a month long.
-Before each milestone we have one or more planning meetings, where we look through all the accumulated issues in the `.NET 11 Planning` milestone and choose the most important and impactful ones to handle during the next milestone. This will be a mixture of feature requests, bug fixes, documentation issues as well as some investigations.
+### Wrong area or wrong repo
 
-Note, that we will investigate only issues, which have accumulated more than certain number of upvotes and/or comments, which will indicate that there is some wider impact associated with it.
-We may not investigate issues which haven't received many votes/comments and choose to close these. The reason is that the impact is very scoped and potentially something is wrong in the user code. Consider asking these questions on StackOverflow.
+If an issue belongs in another area or repo (e.g. `dotnet/runtime`, `dotnet/sdk`, `dotnet/AspNetCore.Docs`, `microsoft/reverse-proxy`), we transfer or re-label it during triage rather than holding it.
 
-For some feature requests and bug reports, depending on the user involvement, we may choose to move these to the backlog at this point. What this means, is that they will not be looked at again up until the next major release planning.
+## Milestone and release planning
 
-## Release Planning
+- **Sprint planning** (typically monthly): the team reviews issues in the next-release planning milestone and pulls the highest-impact items into the active sprint. Lower-impact items may be moved to `Backlog`.
+- **Release planning**: near the end of a release cycle, the team reviews `Backlog` and promotes items aligned with the next release's themes into the next-release planning milestone. See [ReleasePlanning.md](https://github.com/dotnet/aspnetcore/blob/main/docs/ReleasePlanning.md).
 
-Once we approach the end of the release cycle (such as for .NET 10) we will look through the accumulated issues in the `Backlog` milestone. This is a long process as the amount of issues accumulated in this milestone is quite large.
+## Stale-issue cleanup
 
-We will try to prioritize issues with most community requests / upvotes assuming these are aligned with our goals.
-Issues, which we will think are candidates for the upcoming release, will be moved to the `.NET 11 Planning` milestone. This process is documented in more detail in the [Release Planning](https://github.com/dotnet/aspnetcore/blob/main/docs/ReleasePlanning.md) document.
+Issues that have been in `Backlog` across multiple releases without gaining traction are closed during release planning. Long-lived backlog age is itself a signal that an issue isn't impactful enough to act on; closing keeps the backlog meaningful. Reopening is welcome when new information or community demand emerges.
 
-## Cleanup
-As we go through all the issues in the Backlog milestone as part of our release planning process, we will also cleanup the milestone by closing low priority issues, which have stayed in the backlog for more than 2 releases. While some of these issues may seem reasonable, the fact that those haven't been addressed for such prolonged period of time indicate that they're not as important for the product as they may seem to be.
+## How decisions flow
 
-## Process Visualization
-
-The following diagram summarizes the processes detailed above:
-![image](https://user-images.githubusercontent.com/34246760/142244350-bd3484e2-fdee-450d-ac94-e0d192aa962a.png)
+```mermaid
+flowchart TD
+    A[New issue] --> B{Enough info?}
+    B -- No --> C[Needs: Author Feedback]
+    C -. no response .-> X[Close]
+    C -. info provided .-> B
+    B -- Yes --> D{Type?}
+    D -- Bug --> E{Impact / regression?}
+    D -- Feature --> F{Aligned with goals?}
+    D -- Investigation --> G[Investigate]
+    D -- Docs --> H[Transfer to docs repo]
+    D -- Out of scope / by design / duplicate --> X
+    E -- Critical / supported regression --> S[Servicing milestone]
+    E -- High impact --> P[Next-release planning]
+    E -- Low / unclear impact --> BL[Backlog]
+    F -- Yes --> P
+    F -- Maybe --> BL
+    F -- No --> X
+    G -- Real bug --> E
+    G -- User / env issue --> X
+    BL -. release planning .-> P
+    BL -. stale across releases .-> X
+```
 
 ## References
 
-We rely on some automation to help us with this process. You can learn more about some of these by reading our [Issue Management Policies](https://github.com/dotnet/aspnetcore/blob/main/docs/IssueManagementPolicies.md) document.
+- [Issue Management Policies](https://github.com/dotnet/aspnetcore/blob/main/docs/IssueManagementPolicies.md) — automation and labels.
+- [Release Planning](https://github.com/dotnet/aspnetcore/blob/main/docs/ReleasePlanning.md) — how releases are scoped.
+- [Servicing bar](https://github.com/dotnet/aspnetcore/blob/main/docs/ReleasePlanning.md) — what qualifies for a patch release.

--- a/docs/TriageProcess.md
+++ b/docs/TriageProcess.md
@@ -57,7 +57,7 @@ Outcomes:
 
 ### Feature
 
-We try to prioritize the most important and impactful feature requests for each release. There are multiple factors that go into determining the priority of a feature. It's a balance between addressing key feedback, investing in key strategic directions, and satisfying Microsoft business needs. We also have to weigh the cost and risk of building, maintaining, and supporting the feature given the team's available resources.
+We try to prioritize the most important and impactful feature requests for each release. There are multiple factors that go into determining the priority of a feature. It's a balance between addressing key feedback, investing in key strategic directions, and satisfying business needs. We also have to weigh the cost and risk of building, maintaining, and supporting the feature given the team's available resources.
 
 Outcomes:
 

--- a/docs/TriageProcess.md
+++ b/docs/TriageProcess.md
@@ -5,11 +5,11 @@ This document describes how issues filed in `dotnet/aspnetcore` are triaged. It 
 - A reference for the **.NET community** so you know what to expect after filing an issue.
 - A guide for **engineers joining the team** on how to triage incoming issues consistently.
 
-> **Need urgent help?** Customers needing urgent investigation should contact [Microsoft Support](https://dotnet.microsoft.com/platform/support).
+> **Need urgent help?** Customers needing urgent investigation should contact [Microsoft Support](https://dotnet.microsoft.com/platform/support). For security vulnerabilities, follow the [.NET security policy](https://github.com/dotnet/aspnetcore/security/policy) — please **do not** file a public issue.
 
 ## How we triage
 
-The team reviews untriaged issues (open issues without a milestone) regularly. We try to respond to new issues as quickly as we can, but it may take a few days. Each triaged issue is given an **issue type**, an **area label**, and a **milestone** — together they answer "what kind of issue is this, who owns it, and when (if ever) are we planning to work on it?"
+The team reviews untriaged issues (open issues without a milestone) regularly. We try to respond to new issues as quickly as we can, but it may take a few days. Each triaged issue is given an **issue type**, an **`area-*` label**, and a **milestone** — together they answer "what kind of issue is this, who owns it, and when (if ever) are we planning to work on it?"
 
 A milestone reflects current intent, not a guarantee. Issues placed in a planning milestone may be rescheduled, moved to `Backlog`, or closed as priorities evolve.
 
@@ -20,12 +20,12 @@ A triaged issue ends up in one of these states:
 | Outcome | Meaning |
 | --- | --- |
 | **Closed** | Not actionable: duplicate, by-design, won't fix, can't repro, or already fixed. |
-| **Servicing milestone** (`N.0.x`) | A regression or high-impact bug in a supported release that warrants a patch. Subject to the [servicing bar](https://github.com/dotnet/aspnetcore/blob/main/docs/Servicing.md). |
+| **Servicing milestone** (`N.0.x`) | A regression or high-impact bug in a supported release that warrants a patch. Subject to the [servicing bar](./Servicing.md). |
 | **Current release milestone** (`N.0-previewX`) | Needs to be addressed in the next preview of the in-flight release — for example, a recent regression or a blocker for an in-progress feature. |
 | **Current-release planning milestone** (`.NET N Planning`) | Candidate for the in-flight major release. Issues here are scheduled into a specific `N.0-previewX` milestone during team planning. |
 | **`Backlog`** | Tracked but not committed to any release. Re-evaluated during release planning. |
 
-If we need more information from the reporter before we can triage, we apply the `Needs: Author Feedback` or `Needs: Repro` label and triage again once the information is provided. See [Issue Management Policies](https://github.com/dotnet/aspnetcore/blob/main/docs/IssueManagementPolicies.md) for how those labels behave.
+If we need more information from the reporter before we can triage, we apply the `Needs: Author Feedback` or `Needs: Repro` label and triage again once the information is provided. See [Issue Management Policies](./IssueManagementPolicies.md) for how those labels behave.
 
 ## Issue types
 
@@ -38,7 +38,7 @@ A good bug report describes:
 1. The expected behavior.
 2. The actual behavior.
 3. The .NET version and OS.
-4. A minimal reproduction. See the [Bug Report Reproduction Guide](https://github.com/dotnet/aspnetcore/blob/main/docs/repro.md) for what we expect — typically a project hosted in a public GitHub repo. If a repro is missing, we apply `Needs: Repro`.
+4. A minimal reproduction. See the [Bug Report Reproduction Guide](./repro.md) for what we expect — typically a project hosted in a public GitHub repo. If a repro is missing, we apply `Needs: Repro`.
 
 We assess impact and severity by considering:
 
@@ -50,8 +50,9 @@ We assess impact and severity by considering:
 
 Outcomes:
 
-- **Clear regression in a supported release with no good workaround** → servicing milestone, subject to the [servicing bar](https://github.com/dotnet/aspnetcore/blob/main/docs/Servicing.md) (which also weighs regression risk and forbids API changes in patches).
-- **High impact, reproducible** → current-release planning milestone.
+- **Clear regression in a supported release with no good workaround** → servicing milestone, subject to the [servicing bar](./Servicing.md) (which also weighs regression risk and forbids API changes in patches).
+- **Recent regression on `main` or a blocker for in-progress work** → current release milestone (`N.0-previewX`).
+- **High impact, reproducible, but not blocking the next preview** → current-release planning milestone.
 - **Real but low impact, or unclear impact** → `Backlog`.
 - **Caused by user code or environment** → close with explanation.
 
@@ -61,6 +62,7 @@ We try to prioritize the most important and impactful feature requests for each 
 
 Outcomes:
 
+- **Committed for the next preview** → current release milestone (`N.0-previewX`).
 - **Aligned and prioritized for the current release** → current-release planning milestone.
 - **Reasonable but not prioritized** → `Backlog` to gather signal.
 - **Out of scope** → close with rationale and, where possible, a pointer to alternatives.
@@ -73,7 +75,7 @@ Documentation tasks in this repo track technical content gaps that need to be fi
 
 ### Epic
 
-Larger bodies of work that span multiple issues or releases.
+Larger bodies of work that span multiple issues or releases. Epics are usually created by the team to track a strategic investment and link the constituent Bug/Feature/Task issues; it's uncommon to assign Epic during inbound triage.
 
 ## Investigations
 
@@ -87,11 +89,11 @@ If an issue belongs in another repo (e.g. `dotnet/runtime`, `dotnet/sdk`, `dotne
 
 Near the end of a release cycle, the team reviews `Backlog` and promotes items aligned with the next release into the next planning milestone. Issues that have stayed in `Backlog` across multiple releases without gaining traction are typically closed during this review — long backlog age is itself a signal that an issue isn't impactful enough to act on. Reopening is welcome when new information or community demand emerges.
 
-See [Release Planning](https://github.com/dotnet/aspnetcore/blob/main/docs/ReleasePlanning.md) for details.
+See [Release Planning](./ReleasePlanning.md) for details.
 
 ## References
 
-- [Issue Management Policies](https://github.com/dotnet/aspnetcore/blob/main/docs/IssueManagementPolicies.md) — automation and labels (`Needs: Author Feedback`, `Needs: Repro`, etc.).
-- [Bug Report Reproduction Guide](https://github.com/dotnet/aspnetcore/blob/main/docs/repro.md) — what we expect from a minimal repro.
-- [Release Planning](https://github.com/dotnet/aspnetcore/blob/main/docs/ReleasePlanning.md) — how releases are scoped.
-- [Servicing](https://github.com/dotnet/aspnetcore/blob/main/docs/Servicing.md) — Servicing bar and release process.
+- [Issue Management Policies](./IssueManagementPolicies.md) — automation and labels (`Needs: Author Feedback`, `Needs: Repro`, etc.).
+- [Bug Report Reproduction Guide](./repro.md) — what we expect from a minimal repro.
+- [Release Planning](./ReleasePlanning.md) — how releases are scoped.
+- [Servicing](./Servicing.md) — Servicing bar and release process.


### PR DESCRIPTION
Rewrites `docs/TriageProcess.md` to be tighter, more comprehensive, and version-neutral. Also fills a small documentation gap in `docs/IssueManagementPolicies.md` for the `Needs: Repro` label.

## What changed

**Trimmed**
- Removed the "managing a popular GitHub repo is hard" preamble and the explicit "Goals" section.
- Replaced wordy per-section narratives with a tight outcome table and per-type checklists.
- Removed the externally-hosted PNG diagram. (A Mermaid flowchart was tried during review but dropped — the prose flow is sufficient.)

**Made timeless**
- Removed every reference to specific .NET versions (e.g. `.NET 11 Planning`).
- Uses role-based phrases instead: `servicing milestone (N.0.x)`, `current release milestone (N.0-previewX)`, `current-release planning milestone (.NET N Planning)`, `Backlog`. The doc no longer needs editing each release.

**Filled gaps the previous doc missed**
- Explicit list of all triage outcomes including **servicing** (the previous doc never mentioned it).
- Explicit impact-assessment criteria: regression-in-supported-release, severity, reach, 👍/comments, workaround availability.
- "What a good bug report contains" — useful for the community-facing audience.
- Explicit handling for wrong-repo issues, security vulnerabilities, investigations, and documentation tasks.
- Documents the `Needs: Repro` label automation in `IssueManagementPolicies.md`.

**Cross-document hygiene**
- Servicing bar, repro requirements, `Needs: *` automation, and release scoping all defer to the existing `Servicing.md` / `repro.md` / `IssueManagementPolicies.md` / `ReleasePlanning.md` docs rather than restating them.

## Audiences

The rewrite makes both audiences explicit at the top:
- Community members filing issues — what to expect.
- Engineers joining the team — how to triage consistently.