### PR TITLE
Drop redundant fixed in HttpSys SetDataChunkWithPinnedData

### DIFF
--- a/src/Servers/HttpSys/src/Helpers.cs
+++ b/src/Servers/HttpSys/src/Helpers.cs
@@ -2,14 +2,43 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Text;
+using Windows.Win32.Networking.HttpServer;
 
 namespace Microsoft.AspNetCore.Server.HttpSys;
 
 internal static class Helpers
 {
-    public static ReadOnlySpan<byte> ChunkTerminator => "0\r\n\r\n"u8;
-    public static ReadOnlySpan<byte> CRLF => "\r\n"u8;
+    private static ReadOnlySpan<byte> ChunkTerminator => "0\r\n\r\n"u8;
+    private static ReadOnlySpan<byte> CRLF => "\r\n"u8;
+
+    // HTTP.SYS reads a chunk's buffer asynchronously, long after the send has been
+    // queued, so the address has to stay valid for at least that long. These two are
+    // constants, so keep a single copy of each on the pinned object heap: the address
+    // is then stable for the life of the process and the chunks below can be built
+    // once, leaving callers with nothing to pin and no lifetime to track.
+    private static readonly byte[] PinnedChunkTerminator = AllocatePinned(ChunkTerminator);
+    private static readonly byte[] PinnedCRLF = AllocatePinned(CRLF);
+
+    internal static readonly HTTP_DATA_CHUNK ChunkTerminatorChunk = CreateMemoryChunk(PinnedChunkTerminator);
+    internal static readonly HTTP_DATA_CHUNK CRLFChunk = CreateMemoryChunk(PinnedCRLF);
+
+    private static byte[] AllocatePinned(ReadOnlySpan<byte> bytes)
+    {
+        var pinned = GC.AllocateUninitializedArray<byte>(bytes.Length, pinned: true);
+        bytes.CopyTo(pinned);
+        return pinned;
+    }
+
+    private static unsafe HTTP_DATA_CHUNK CreateMemoryChunk(byte[] pinnedBuffer)
+    {
+        var chunk = default(HTTP_DATA_CHUNK);
+        chunk.DataChunkType = HTTP_DATA_CHUNK_TYPE.HttpDataChunkFromMemory;
+        chunk.Anonymous.FromMemory.pBuffer = (void*)Marshal.UnsafeAddrOfPinnedArrayElement(pinnedBuffer, 0);
+        chunk.Anonymous.FromMemory.BufferLength = (uint)pinnedBuffer.Length;
+        return chunk;
+    }
 
     internal static ArraySegment<byte> GetChunkHeader(long size)
     {

--- a/src/Servers/HttpSys/src/RequestProcessing/ResponseBody.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/ResponseBody.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;
 using Windows.Win32;
@@ -282,10 +283,10 @@ internal sealed partial class ResponseBody : Stream
     {
         ref var chunk = ref chunks[chunkIndex++];
         chunk.DataChunkType = HTTP_DATA_CHUNK_TYPE.HttpDataChunkFromMemory;
-        fixed (byte* ptr = bytes)
-        {
-            chunk.Anonymous.FromMemory.pBuffer = ptr;
-        }
+        // Preserve null-on-empty; GetReference may return a non-null ref for empty spans.
+        chunk.Anonymous.FromMemory.pBuffer = bytes.IsEmpty
+            ? null
+            : (byte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(bytes));
         chunk.Anonymous.FromMemory.BufferLength = (uint)bytes.Length;
     }
 

--- a/src/Servers/HttpSys/src/RequestProcessing/ResponseBody.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/ResponseBody.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;
 using Windows.Win32;
@@ -194,7 +193,7 @@ internal sealed partial class ResponseBody : Stream
         if (chunked && !hasData && endOfRequest)
         {
             dataChunks = allocator.AllocAsSpan<HTTP_DATA_CHUNK>(1);
-            SetDataChunkWithPinnedData(dataChunks, ref currentChunk, Helpers.ChunkTerminator);
+            dataChunks[currentChunk++] = Helpers.ChunkTerminatorChunk;
             pins = default;
             return;
         }
@@ -246,11 +245,11 @@ internal sealed partial class ResponseBody : Stream
 
         if (chunked)
         {
-            SetDataChunkWithPinnedData(dataChunks, ref currentChunk, Helpers.CRLF);
+            dataChunks[currentChunk++] = Helpers.CRLFChunk;
 
             if (endOfRequest)
             {
-                SetDataChunkWithPinnedData(dataChunks, ref currentChunk, Helpers.ChunkTerminator);
+                dataChunks[currentChunk++] = Helpers.ChunkTerminatorChunk;
             }
         }
 
@@ -272,22 +271,16 @@ internal sealed partial class ResponseBody : Stream
         ArraySegment<byte> buffer,
         out GCHandle handle)
     {
-        handle = GCHandle.Alloc(buffer.Array, GCHandleType.Pinned);
-        SetDataChunkWithPinnedData(chunks, ref chunkIndex, new ReadOnlySpan<byte>((void*)(handle.AddrOfPinnedObject() + buffer.Offset), buffer.Count));
-    }
+        Debug.Assert(buffer.Count > 0, "Empty buffers should not produce a chunk.");
 
-    private static unsafe void SetDataChunkWithPinnedData(
-        Span<HTTP_DATA_CHUNK> chunks,
-        ref int chunkIndex,
-        ReadOnlySpan<byte> bytes)
-    {
+        // The handle keeps buffer.Array pinned until FreeDataBuffers releases it, which
+        // is what makes this address safe to hand to HTTP.SYS.
+        handle = GCHandle.Alloc(buffer.Array, GCHandleType.Pinned);
+
         ref var chunk = ref chunks[chunkIndex++];
         chunk.DataChunkType = HTTP_DATA_CHUNK_TYPE.HttpDataChunkFromMemory;
-        // Preserve null-on-empty; GetReference may return a non-null ref for empty spans.
-        chunk.Anonymous.FromMemory.pBuffer = bytes.IsEmpty
-            ? null
-            : (byte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(bytes));
-        chunk.Anonymous.FromMemory.BufferLength = (uint)bytes.Length;
+        chunk.Anonymous.FromMemory.pBuffer = (byte*)handle.AddrOfPinnedObject() + buffer.Offset;
+        chunk.Anonymous.FromMemory.BufferLength = (uint)buffer.Count;
     }
 
     private static void FreeDataBuffers(Span<GCHandle> pinnedBuffers)

--- a/src/Servers/HttpSys/src/RequestProcessing/ResponseStreamAsyncResult.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/ResponseStreamAsyncResult.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Windows.Win32.Foundation;
 using Windows.Win32.Networking.HttpServer;
@@ -168,10 +169,10 @@ internal sealed unsafe partial class ResponseStreamAsyncResult : IAsyncResult, I
     {
         ref var chunk = ref chunks[chunkIndex++];
         chunk.DataChunkType = HTTP_DATA_CHUNK_TYPE.HttpDataChunkFromMemory;
-        fixed (byte* ptr = bytes)
-        {
-            chunk.Anonymous.FromMemory.pBuffer = ptr;
-        }
+        // Preserve null-on-empty; GetReference may return a non-null ref for empty spans.
+        chunk.Anonymous.FromMemory.pBuffer = bytes.IsEmpty
+            ? null
+            : (byte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(bytes));
         chunk.Anonymous.FromMemory.BufferLength = (uint)bytes.Length;
     }
 

--- a/src/Servers/HttpSys/src/RequestProcessing/ResponseStreamAsyncResult.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/ResponseStreamAsyncResult.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Windows.Win32.Foundation;
 using Windows.Win32.Networking.HttpServer;
@@ -68,7 +67,7 @@ internal sealed unsafe partial class ResponseStreamAsyncResult : IAsyncResult, I
 
         if (chunked)
         {
-            SetDataChunkWithPinnedData(_dataChunks, ref currentChunk, Helpers.CRLF);
+            _dataChunks[currentChunk++] = Helpers.CRLFChunk;
         }
 
         // This call will pin needed memory
@@ -87,8 +86,9 @@ internal sealed unsafe partial class ResponseStreamAsyncResult : IAsyncResult, I
 
         if (chunked)
         {
-            // No need to update this chunk, CRLF, because it was already pinned.
-            // However, we increment the counter to ensure we are accounting for all sections.
+            // No need to update this chunk, CRLF, because it points at a permanently
+            // pinned buffer. However, we increment the counter to ensure we are
+            // accounting for all sections.
             currentChunk++;
         }
 
@@ -130,9 +130,9 @@ internal sealed unsafe partial class ResponseStreamAsyncResult : IAsyncResult, I
                 _dataChunks[1].Anonymous.FromFileHandle.FileHandle = (HANDLE)_fileStream.SafeFileHandle.DangerousGetHandle();
                 // Nothing to pin for the file handle.
 
-                // No need to pin the CRLF data
+                // No need to pin the CRLF data, the chunk points at a permanently pinned buffer.
                 int currentChunk = 2;
-                SetDataChunkWithPinnedData(_dataChunks, ref currentChunk, Helpers.CRLF);
+                _dataChunks[currentChunk++] = Helpers.CRLFChunk;
                 Debug.Assert(currentChunk == _dataChunks.Length);
             }
             else
@@ -163,17 +163,6 @@ internal sealed unsafe partial class ResponseStreamAsyncResult : IAsyncResult, I
         chunk.DataChunkType = HTTP_DATA_CHUNK_TYPE.HttpDataChunkFromMemory;
         // The address is not set until after we pin it with Overlapped
         chunk.Anonymous.FromMemory.BufferLength = (uint)segment.Count;
-    }
-
-    private static void SetDataChunkWithPinnedData(HTTP_DATA_CHUNK[] chunks, ref int chunkIndex, ReadOnlySpan<byte> bytes)
-    {
-        ref var chunk = ref chunks[chunkIndex++];
-        chunk.DataChunkType = HTTP_DATA_CHUNK_TYPE.HttpDataChunkFromMemory;
-        // Preserve null-on-empty; GetReference may return a non-null ref for empty spans.
-        chunk.Anonymous.FromMemory.pBuffer = bytes.IsEmpty
-            ? null
-            : (byte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(bytes));
-        chunk.Anonymous.FromMemory.BufferLength = (uint)bytes.Length;
     }
 
     internal SafeNativeOverlapped? NativeOverlapped


### PR DESCRIPTION
## Description

Drops the `fixed (byte* ptr = bytes)` block from the two `SetDataChunkWithPinnedData` helpers in HttpSys. The pin was redundant: the implementation captures `ptr` into `chunk.pBuffer` for HTTP.SYS to read later, so the `fixed` scope ends *before* the value is consumed. Safety always relied on the caller keeping the data alive, not the `fixed` block — the helper's name reflects that contract.

### All 5 call sites verified

| Call site | Data | Why already at a stable address |
|---|---|---|
| `ResponseBody.cs:196`, `:248`, `:252` | `Helpers.ChunkTerminator` / `CRLF` | `"...\r\n..."u8` — embedded in assembly RVA section, never moved |
| `ResponseBody.cs:275` | span over `handle.AddrOfPinnedObject() + offset` | `GCHandle.Alloc(..., Pinned)`, freed by `FreeDataBuffers` |
| `ResponseStreamAsyncResult.cs:70`, `:134` | `Helpers.CRLF` | same UTF-8 literal |

UTF-8 literals (`"..."u8`) live in assembly metadata, not on the GC heap. The GCHandle-pinned site keeps the buffer alive for the lifetime of the chunk's use.

### Behavior preservation

`fixed (byte* ptr = bytes)` returns `null` when `bytes.IsEmpty`, regardless of how the span was constructed. `MemoryMarshal.GetReference(bytes)` does *not* — per [its documentation](https://learn.microsoft.com/dotnet/api/system.runtime.interopservices.memorymarshal.getreference), for an empty span built from a non-null pointer (e.g. a zero-length `ArraySegment` of a GCHandle-pinned array) it returns a non-null ref. The `bytes.IsEmpty ? null : ...` guard preserves the original null-on-empty semantic.

### Consistency with existing code

`ResponseStreamAsyncResult.cs:80` already uses the equivalent pattern for an externally-pinned array — `(void*)Marshal.UnsafeAddrOfPinnedArrayElement(...)` with no `fixed` block. The two helpers were the outliers in this file. This change aligns them with that neighboring pattern.

No behavior change at runtime; pure cleanup.