### PR TITLE
Set IsPackable=true on Microsoft.AspNetCore.Components.Gateway so Pack produces the shipping nupkg

### DIFF
--- a/src/Components/Gateway/src/Microsoft.AspNetCore.Components.Gateway.csproj
+++ b/src/Components/Gateway/src/Microsoft.AspNetCore.Components.Gateway.csproj
@@ -6,6 +6,9 @@
     <AssemblyName>blazor-gateway</AssemblyName>
     <PackageId>Microsoft.AspNetCore.Components.Gateway</PackageId>
     <IsShippingPackage>true</IsShippingPackage>
+    <!-- Microsoft.NET.Sdk.Web defaults IsPackable to false. Override it so the
+         <NuspecFile> below is honored and the shipping package is produced. -->
+    <IsPackable>true</IsPackable>
     <Description>Gateway server for hosting standalone Blazor WebAssembly applications.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Assemblies should not reference this assembly directly -->


### PR DESCRIPTION
## Summary

`Microsoft.AspNetCore.Components.Gateway` is configured as a shipping package (`<IsShippingPackage>true</IsShippingPackage>`) with a custom `<NuspecFile>`, but no nupkg has been produced on the dnceng feeds since the project was added in #65982. Root cause: `Microsoft.NET.Sdk.Web.ProjectSystem.props` defaults `IsPackable` to `false`:

```xml
<IsPackable Condition="'$(IsPackable)' == ''">false</IsPackable>
```

Because Gateway uses `Sdk="Microsoft.NET.Sdk.Web"` and never overrides `IsPackable`, the Pack target silently no-ops ΓÇö the `<NuspecFile>` and `<IsShippingPackage>` settings are ignored. (The `Microsoft.AspNetCore.Components.WebAssembly.DevServer` project, which is the closest analog and ships correctly, uses plain `Microsoft.NET.Sdk` and so doesn't hit this default.)

## Fix

Set `<IsPackable>true</IsPackable>` explicitly in `Microsoft.AspNetCore.Components.Gateway.csproj`. One-line change.

## Verification

Before:

```
> .\eng\build.ps1 -pack -projects src\Components\Gateway\src\Microsoft.AspNetCore.Components.Gateway.csproj
Build succeeded.
    0 Warning(s)
    0 Error(s)
> Get-ChildItem artifacts\packages -Recurse -Filter '*.nupkg'
# (no output ΓÇö no package produced)
```

After:

```
> .\eng\build.ps1 -pack -projects src\Components\Gateway\src\Microsoft.AspNetCore.Components.Gateway.csproj
  Successfully created package 'artifacts\packages\Debug\Shipping\Microsoft.AspNetCore.Components.Gateway.11.0.0-dev.nupkg'.
  Successfully created package 'artifacts\packages\Debug\Shipping\Microsoft.AspNetCore.Components.Gateway.11.0.0-dev.symbols.nupkg'.
Build succeeded.
```

Inspecting the produced nupkg confirms the expected payload:

| Path | Notes |
| --- | --- |
| `Microsoft.AspNetCore.Components.Gateway.nuspec` | from existing `<NuspecFile>` |
| `build/Microsoft.AspNetCore.Components.Gateway.targets` | consumer-side props/targets |
| `tools/blazor-gateway.{dll,exe}` | the host |
| `tools/Yarp.ReverseProxy.dll`, `tools/Microsoft.Extensions.ServiceDiscovery*.dll`, `tools/System.IO.Hashing.dll` | dependencies |
| `tools/blazor-gateway.runtimeconfig.json`, `tools/web.config`, `tools/blazor-gateway.deps.json` | runtime config |
| `THIRD-PARTY-NOTICES.txt`, `Icon.png` | metadata |

## Why this matters for 11.0 P4

Without this fix, `dotnet add package Microsoft.AspNetCore.Components.Gateway --prerelease` returns no result on any feed, so the Gateway can only be exercised by building it locally and copying the host bits into a sample.

cc @javiercn

