### PR TITLE
Add special handling for array types in OpenAPI schema references.

### DIFF
--- a/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
@@ -119,7 +119,7 @@ internal static class JsonTypeInfoExtensions
         if (type.IsArray)
         {
             var elementType = type.GetElementType()!;
-            return $"{elementType.GetSchemaReferenceId(options)}Array";
+            return $"ArrayOf{elementType.GetSchemaReferenceId(options)}";
         }
 
         // Special handling for generic types that are collections

--- a/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
@@ -114,8 +114,8 @@ internal static class JsonTypeInfoExtensions
             return type.GetGenericArguments()[0].GetSchemaReferenceId(options);
         }
 
-        // Special handling for array types which use '[]' in their name that is not
-        // valid in OpenAPI schema keys (must match ^[a-zA-Z0-9\.\-_]+$).
+        // Special handling for array types whose names contain '[]', which is not
+        // valid in OpenAPI schema keys (must match ^[a-zA-Z0-9._-]+$).
         if (type.IsArray)
         {
             var elementType = type.GetElementType()!;

--- a/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonTypeInfoExtensions.cs
@@ -114,6 +114,14 @@ internal static class JsonTypeInfoExtensions
             return type.GetGenericArguments()[0].GetSchemaReferenceId(options);
         }
 
+        // Special handling for array types which use '[]' in their name that is not
+        // valid in OpenAPI schema keys (must match ^[a-zA-Z0-9\.\-_]+$).
+        if (type.IsArray)
+        {
+            var elementType = type.GetElementType()!;
+            return $"{elementType.GetSchemaReferenceId(options)}Array";
+        }
+
         // Special handling for generic types that are collections
         // Generic types become a concatenation of the generic type name and the type arguments
         if (type.IsGenericType)

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Extensions/JsonTypeInfoExtensionsTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Extensions/JsonTypeInfoExtensionsTests.cs
@@ -81,10 +81,10 @@ public class JsonTypeInfoExtensionsTests
         [typeof(Dictionary<string, List<string[]>>), null],
         [typeof(Dictionary<string, IEnumerable<string[]>>), null],
         [typeof(Foo<int>.Bar<string>.Baz), "BazOfintAndstring"],
-        [typeof(Ok<string[]>), "OkOfstringArray"],
-        [typeof(Ok<int[]>), "OkOfintArray"],
-        [typeof(Ok<Todo[]>), "OkOfTodoArray"],
-        [typeof(Ok<string[][]>), "OkOfstringArrayArray"],
+        [typeof(Ok<string[]>), "OkOfArrayOfstring"],
+        [typeof(Ok<int[]>), "OkOfArrayOfint"],
+        [typeof(Ok<Todo[]>), "OkOfArrayOfTodo"],
+        [typeof(Ok<string[][]>), "OkOfArrayOfArrayOfstring"],
     ];
 
     [Theory]

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Extensions/JsonTypeInfoExtensionsTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Extensions/JsonTypeInfoExtensionsTests.cs
@@ -81,6 +81,10 @@ public class JsonTypeInfoExtensionsTests
         [typeof(Dictionary<string, List<string[]>>), null],
         [typeof(Dictionary<string, IEnumerable<string[]>>), null],
         [typeof(Foo<int>.Bar<string>.Baz), "BazOfintAndstring"],
+        [typeof(Ok<string[]>), "OkOfstringArray"],
+        [typeof(Ok<int[]>), "OkOfintArray"],
+        [typeof(Ok<Todo[]>), "OkOfTodoArray"],
+        [typeof(Ok<string[][]>), "OkOfstringArrayArray"],
     ];
 
     [Theory]


### PR DESCRIPTION
This pull request enhances the handling of array types in OpenAPI schema reference IDs and updates the corresponding unit tests to cover these scenarios. The most important changes are grouped below:

Schema Reference ID Generation:

* Added special handling in `JsonTypeInfoExtensions.cs` so that array types (e.g., `string[]`) now generate schema reference IDs ending with `Array` instead of using invalid characters for OpenAPI schema keys. For example, `string[]` becomes `stringArray`, and `string[][]` becomes `stringArrayArray`.

Unit Test Coverage:

* Updated `JsonTypeInfoExtensionsTests.cs` to add test cases for types like `Ok<string[]>`, `Ok<int[]>`, `Ok<Todo[]>`, and `Ok<string[][]>`, ensuring the new schema reference ID logic for arrays is properly tested.

Fixes #66299 