### PR TITLE
Fix handling of get-only non-nullable properties in OpenAPI schema generation

### DIFF
--- a/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
@@ -537,7 +537,16 @@ internal static class JsonNodeSchemaExtensions
     {
         // Avoid setting explicit nullability annotations for `object` types so they continue to match on the catch
         // all schema (no type, no format, no constraints).
-        if (propertyInfo.PropertyType != typeof(object) && (propertyInfo.IsGetNullable || propertyInfo.IsSetNullable))
+        if (propertyInfo.PropertyType == typeof(object))
+        {
+            return;
+        }
+
+        // Only consider IsSetNullable when the property has a setter: a get-only non-nullable property should
+        // not be marked nullable just because STJ computes a nullable write-state for its backing field.
+        var isNullable = propertyInfo.IsGetNullable || (propertyInfo.Set is not null && propertyInfo.IsSetNullable);
+
+        if (isNullable)
         {
             if (MapJsonNodeToSchemaType(schema[OpenApiSchemaKeywords.TypeKeyword]) is { } schemaTypes &&
                 !schemaTypes.HasFlag(JsonSchemaType.Null))
@@ -545,8 +554,19 @@ internal static class JsonNodeSchemaExtensions
                 schema[OpenApiSchemaKeywords.TypeKeyword] = (schemaTypes | JsonSchemaType.Null).ToString();
             }
         }
-        if (schema.WillBeComponentized() &&
-            propertyInfo.PropertyType != typeof(object) && propertyInfo.ShouldApplyNullablePropertySchema())
+        else
+        {
+            // The underlying JsonSchemaExporter may have added "null" using IsSetNullable when no setter
+            // exists. Remove it so the schema correctly reflects the NRT non-nullable annotation.
+            if (MapJsonNodeToSchemaType(schema[OpenApiSchemaKeywords.TypeKeyword]) is { } schemaTypes &&
+                schemaTypes.HasFlag(JsonSchemaType.Null))
+            {
+                var withoutNull = schemaTypes & ~JsonSchemaType.Null;
+                schema[OpenApiSchemaKeywords.TypeKeyword] = withoutNull.ToString();
+            }
+        }
+
+        if (schema.WillBeComponentized() && propertyInfo.ShouldApplyNullablePropertySchema())
         {
             schema[OpenApiConstants.NullableProperty] = true;
         }

--- a/src/OpenApi/src/Extensions/TypeExtensions.cs
+++ b/src/OpenApi/src/Extensions/TypeExtensions.cs
@@ -104,6 +104,15 @@ internal static class TypeExtensions
 
         var nullabilityInfoContext = new NullabilityInfoContext();
         var nullabilityInfo = nullabilityInfoContext.Create(propertyInfo);
+
+        // For get-only properties (no setter) use the read-state; otherwise use the write-state.
+        // A get-only non-nullable property must not be reported as nullable merely because its
+        // write-state is Unknown/Nullable at runtime.
+        if (propertyInfo.SetMethod is null)
+        {
+            return nullabilityInfo.ReadState == NullabilityState.Nullable;
+        }
+        
         return nullabilityInfo.WriteState == NullabilityState.Nullable;
     }
 }

--- a/src/OpenApi/src/Extensions/TypeExtensions.cs
+++ b/src/OpenApi/src/Extensions/TypeExtensions.cs
@@ -105,14 +105,14 @@ internal static class TypeExtensions
         var nullabilityInfoContext = new NullabilityInfoContext();
         var nullabilityInfo = nullabilityInfoContext.Create(propertyInfo);
 
-        // For get-only properties (no setter) use the read-state; otherwise use the write-state.
+        // For properties that cannot be set by the serializer, use the read-state; otherwise use the write-state.
         // A get-only non-nullable property must not be reported as nullable merely because its
         // write-state is Unknown/Nullable at runtime.
-        if (propertyInfo.SetMethod is null)
+        if (jsonPropertyInfo.Set is null)
         {
             return nullabilityInfo.ReadState == NullabilityState.Nullable;
         }
-        
+
         return nullabilityInfo.WriteState == NullabilityState.Nullable;
     }
 }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.PropertySchemas.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.PropertySchemas.cs
@@ -654,17 +654,27 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             var operation = document.Paths["/api"].Operations[HttpMethod.Post];
             var schema = operation.RequestBody.Content.First().Value.Schema;
 
-            // Non-nullable get-only string property
+            // Non-nullable get-only string property (inline schema)
             var nameProperty = schema.Properties["name"];
             Assert.False(nameProperty.Type?.HasFlag(JsonSchemaType.Null), "get-only non-nullable string should not be nullable");
 
-            // Non-nullable get-only collection property
+            // Non-nullable get-only collection property (inline schema)
             var valuesProperty = schema.Properties["values"];
             Assert.False(valuesProperty.Type?.HasFlag(JsonSchemaType.Null), "get-only non-nullable IEnumerable<string> should not be nullable");
 
-            // Nullable get-only property must still be marked nullable
+            // Nullable get-only property must still be marked nullable (inline schema)
             var nullableNameProperty = schema.Properties["nullableName"];
             Assert.True(nullableNameProperty.Type?.HasFlag(JsonSchemaType.Null), "get-only nullable string should be nullable");
+
+            // Non-nullable get-only complex property (componentized schema): exercises ShouldApplyNullablePropertySchema
+            var todoProperty = schema.Properties["todo"];
+            Assert.Null(todoProperty.OneOf); // should not have a oneOf with null
+
+            // Nullable get-only complex property (componentized schema): must still emit oneOf with null
+            var nullableTodoProperty = schema.Properties["nullableTodo"];
+            Assert.NotNull(nullableTodoProperty.OneOf);
+            Assert.Equal(2, nullableTodoProperty.OneOf.Count);
+            Assert.Contains(nullableTodoProperty.OneOf, item => item.Type == JsonSchemaType.Null);
         });
     }
 
@@ -674,6 +684,8 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
         public string Name { get; } = string.Empty;
         public IEnumerable<string> Values { get; } = [];
         public string? NullableName { get; }
+        public Todo Todo { get; } = new(1, "Test", false, DateTime.UtcNow);
+        public Todo? NullableTodo { get; }
     }
 
     private class NullablePropertiesTestModel

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.PropertySchemas.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.PropertySchemas.cs
@@ -641,7 +641,41 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
         });
     }
 
+    [Fact]
+    public async Task GetOpenApiSchema_GetOnlyNonNullableProperties_NotMarkedNullable()
+    {
+        // Get-only non-nullable properties must not be reported as nullable in the schema.
+        var builder = CreateBuilder();
+
+        builder.MapPost("/api", (GetOnlyPropertiesModel model) => { });
+
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths["/api"].Operations[HttpMethod.Post];
+            var schema = operation.RequestBody.Content.First().Value.Schema;
+
+            // Non-nullable get-only string property
+            var nameProperty = schema.Properties["name"];
+            Assert.False(nameProperty.Type?.HasFlag(JsonSchemaType.Null), "get-only non-nullable string should not be nullable");
+
+            // Non-nullable get-only collection property
+            var valuesProperty = schema.Properties["values"];
+            Assert.False(valuesProperty.Type?.HasFlag(JsonSchemaType.Null), "get-only non-nullable IEnumerable<string> should not be nullable");
+
+            // Nullable get-only property must still be marked nullable
+            var nullableNameProperty = schema.Properties["nullableName"];
+            Assert.True(nullableNameProperty.Type?.HasFlag(JsonSchemaType.Null), "get-only nullable string should be nullable");
+        });
+    }
+
 #nullable enable
+    private class GetOnlyPropertiesModel
+    {
+        public string Name { get; } = string.Empty;
+        public IEnumerable<string> Values { get; } = [];
+        public string? NullableName { get; }
+    }
+
     private class NullablePropertiesTestModel
     {
         public int? NullableInt { get; set; }


### PR DESCRIPTION
This pull request improves how nullable reference types are handled in OpenAPI schema generation, ensuring that get-only non-nullable properties are not incorrectly marked as nullable in the generated schemas. The changes include updates to the logic for determining property nullability and add new tests to verify the correct behavior.

**Nullability handling improvements:**

* Updated `ApplyNullabilityContextInfo` in `JsonNodeSchemaExtensions.cs` to ensure that get-only non-nullable properties are not marked as nullable, and to only consider setter nullability if a setter exists. Also, removed the redundant check for `typeof(object)` in the componentization logic.
* Modified `ShouldApplyNullablePropertySchema` in `TypeExtensions.cs` to use the property's read-state for get-only properties, ensuring correct nullability detection for properties without setters.

**Testing enhancements:**

* Added a new test `GetOpenApiSchema_GetOnlyNonNullableProperties_NotMarkedNullable` in `OpenApiSchemaService.PropertySchemas.cs` to verify that get-only non-nullable properties are not marked as nullable, while get-only nullable properties are correctly marked. Introduced a supporting model class for the test.

Fixes #58192