### PR TITLE
Add support for TimeProvider in DataProtectionTokenProvider and DataProtectionTokenProviderOptions

### DIFF
--- a/src/Identity/Core/src/DataProtectionTokenProviderOptions.cs
+++ b/src/Identity/Core/src/DataProtectionTokenProviderOptions.cs
@@ -23,4 +23,9 @@ public class DataProtectionTokenProviderOptions
     /// The amount of time a generated token remains valid.
     /// </value>
     public TimeSpan TokenLifespan { get; set; } = TimeSpan.FromDays(1);
+
+    /// <summary>
+    /// Gives control over the timestamps for testing purposes.
+    /// </summary>
+    public TimeProvider? TimeProvider { get; set; }
 }

--- a/src/Identity/Core/src/DataProtectorTokenProvider.cs
+++ b/src/Identity/Core/src/DataProtectorTokenProvider.cs
@@ -32,6 +32,7 @@ public class DataProtectorTokenProvider<TUser> : IUserTwoFactorTokenProvider<TUs
         // Use the Name as the purpose which should usually be distinct from others
         Protector = dataProtectionProvider.CreateProtector(Name ?? "DataProtectorTokenProvider");
         Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        TimeProvider = Options.TimeProvider ?? TimeProvider.System;
     }
 
     /// <summary>
@@ -67,6 +68,11 @@ public class DataProtectorTokenProvider<TUser> : IUserTwoFactorTokenProvider<TUs
     public ILogger<DataProtectorTokenProvider<TUser>> Logger { get; }
 
     /// <summary>
+    /// Gets the <see cref="System.TimeProvider"/>.
+    /// </summary>
+    public TimeProvider TimeProvider { get; }
+
+    /// <summary>
     /// Generates a protected token for the specified <paramref name="user"/> as an asynchronous operation.
     /// </summary>
     /// <param name="purpose">The purpose the token will be used for.</param>
@@ -80,7 +86,7 @@ public class DataProtectorTokenProvider<TUser> : IUserTwoFactorTokenProvider<TUs
         var userId = await manager.GetUserIdAsync(user);
         using (var writer = ms.CreateWriter())
         {
-            writer.Write(DateTimeOffset.UtcNow);
+            writer.Write(TimeProvider.GetUtcNow());
             writer.Write(userId);
             writer.Write(purpose ?? "");
             string? stamp = null;
@@ -115,7 +121,7 @@ public class DataProtectorTokenProvider<TUser> : IUserTwoFactorTokenProvider<TUs
             {
                 var creationTime = reader.ReadDateTimeOffset();
                 var expirationTime = creationTime + Options.TokenLifespan;
-                if (expirationTime < DateTimeOffset.UtcNow)
+                if (expirationTime < TimeProvider.GetUtcNow())
                 {
                     Logger.InvalidExpirationTime();
                     return false;

--- a/src/Identity/Core/src/IdentityBuilderExtensions.cs
+++ b/src/Identity/Core/src/IdentityBuilderExtensions.cs
@@ -122,20 +122,4 @@ public static class IdentityBuilderExtensions
             options.TimeProvider ??= TimeProvider;
         }
     }
-
-    // Set TimeProvider from DI on all options instances, if not already set by tests.
-    private sealed class PostConfigureDataProtectionTokenProviderOptions : IPostConfigureOptions<DataProtectionTokenProviderOptions>
-    {
-        public PostConfigureDataProtectionTokenProviderOptions(TimeProvider? timeProvider = null)
-        {
-            TimeProvider = timeProvider;
-        }
-
-        private TimeProvider? TimeProvider { get; }
-
-        public void PostConfigure(string? name, DataProtectionTokenProviderOptions options)
-        {
-            options.TimeProvider ??= TimeProvider;
-        }
-    }
 }

--- a/src/Identity/Core/src/IdentityBuilderExtensions.cs
+++ b/src/Identity/Core/src/IdentityBuilderExtensions.cs
@@ -31,6 +31,7 @@ public static class IdentityBuilderExtensions
         var phoneNumberProviderType = typeof(PhoneNumberTokenProvider<>).MakeGenericType(builder.UserType);
         var emailTokenProviderType = typeof(EmailTokenProvider<>).MakeGenericType(builder.UserType);
         var authenticatorProviderType = typeof(AuthenticatorTokenProvider<>).MakeGenericType(builder.UserType);
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<DataProtectionTokenProviderOptions>, PostConfigureDataProtectionTokenProviderOptions>());
         return builder.AddTokenProvider(TokenOptions.DefaultProvider, dataProtectionProviderType)
             .AddTokenProvider(TokenOptions.DefaultEmailProvider, emailTokenProviderType)
             .AddTokenProvider(TokenOptions.DefaultPhoneProvider, phoneNumberProviderType)
@@ -117,6 +118,22 @@ public static class IdentityBuilderExtensions
         private TimeProvider? TimeProvider { get; }
 
         public void PostConfigure(string? name, SecurityStampValidatorOptions options)
+        {
+            options.TimeProvider ??= TimeProvider;
+        }
+    }
+
+    // Set TimeProvider from DI on all options instances, if not already set by tests.
+    private sealed class PostConfigureDataProtectionTokenProviderOptions : IPostConfigureOptions<DataProtectionTokenProviderOptions>
+    {
+        public PostConfigureDataProtectionTokenProviderOptions(TimeProvider? timeProvider = null)
+        {
+            TimeProvider = timeProvider;
+        }
+
+        private TimeProvider? TimeProvider { get; }
+
+        public void PostConfigure(string? name, DataProtectionTokenProviderOptions options)
         {
             options.TimeProvider ??= TimeProvider;
         }

--- a/src/Identity/Core/src/IdentityServiceCollectionExtensions.cs
+++ b/src/Identity/Core/src/IdentityServiceCollectionExtensions.cs
@@ -189,21 +189,6 @@ public static class IdentityServiceCollectionExtensions
         }
     }
 
-    private sealed class PostConfigureDataProtectionTokenProviderOptions : IPostConfigureOptions<DataProtectionTokenProviderOptions>
-    {
-        public PostConfigureDataProtectionTokenProviderOptions(TimeProvider? timeProvider = null)
-        {
-            TimeProvider = timeProvider;
-        }
-
-        private TimeProvider? TimeProvider { get; }
-
-        public void PostConfigure(string? name, DataProtectionTokenProviderOptions options)
-        {
-            options.TimeProvider ??= TimeProvider;
-        }
-    }
-
     private sealed class CompositeIdentityHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger, UrlEncoder encoder)
         : SignInAuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
     {

--- a/src/Identity/Core/src/IdentityServiceCollectionExtensions.cs
+++ b/src/Identity/Core/src/IdentityServiceCollectionExtensions.cs
@@ -100,6 +100,7 @@ public static class IdentityServiceCollectionExtensions
         services.TryAddScoped<IdentityErrorDescriber>();
         services.TryAddScoped<ISecurityStampValidator, SecurityStampValidator<TUser>>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<SecurityStampValidatorOptions>, PostConfigureSecurityStampValidatorOptions>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<DataProtectionTokenProviderOptions>, PostConfigureDataProtectionTokenProviderOptions>());
         services.TryAddScoped<ITwoFactorSecurityStampValidator, TwoFactorSecurityStampValidator<TUser>>();
         services.TryAddScoped<IUserClaimsPrincipalFactory<TUser>, UserClaimsPrincipalFactory<TUser, TRole>>();
         services.TryAddScoped<IUserConfirmation<TUser>, DefaultUserConfirmation<TUser>>();
@@ -183,6 +184,21 @@ public static class IdentityServiceCollectionExtensions
         private TimeProvider? TimeProvider { get; }
 
         public void PostConfigure(string? name, SecurityStampValidatorOptions options)
+        {
+            options.TimeProvider ??= TimeProvider;
+        }
+    }
+
+    private sealed class PostConfigureDataProtectionTokenProviderOptions : IPostConfigureOptions<DataProtectionTokenProviderOptions>
+    {
+        public PostConfigureDataProtectionTokenProviderOptions(TimeProvider? timeProvider = null)
+        {
+            TimeProvider = timeProvider;
+        }
+
+        private TimeProvider? TimeProvider { get; }
+
+        public void PostConfigure(string? name, DataProtectionTokenProviderOptions options)
         {
             options.TimeProvider ??= TimeProvider;
         }

--- a/src/Identity/Core/src/PostConfigureDataProtectionTokenProviderOptions.cs
+++ b/src/Identity/Core/src/PostConfigureDataProtectionTokenProviderOptions.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.Identity;
+
+// Set TimeProvider from DI on all options instances, if not already set by tests.
+internal sealed class PostConfigureDataProtectionTokenProviderOptions : IPostConfigureOptions<DataProtectionTokenProviderOptions>
+{
+    public PostConfigureDataProtectionTokenProviderOptions(TimeProvider? timeProvider = null)
+    {
+        TimeProvider = timeProvider;
+    }
+
+    private TimeProvider? TimeProvider { get; }
+
+    public void PostConfigure(string? name, DataProtectionTokenProviderOptions options)
+    {
+        options.TimeProvider ??= TimeProvider;
+    }
+}

--- a/src/Identity/Core/src/PublicAPI.Unshipped.txt
+++ b/src/Identity/Core/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+Microsoft.AspNetCore.Identity.DataProtectionTokenProviderOptions.TimeProvider.get -> System.TimeProvider?
+Microsoft.AspNetCore.Identity.DataProtectionTokenProviderOptions.TimeProvider.set -> void
+Microsoft.AspNetCore.Identity.DataProtectorTokenProvider<TUser>.TimeProvider.get -> System.TimeProvider!

--- a/src/Identity/test/Identity.Test/DataProtectorTokenProviderTest.cs
+++ b/src/Identity/test/Identity.Test/DataProtectorTokenProviderTest.cs
@@ -160,4 +160,30 @@ public class DataProtectorTokenProviderTest
 
         Assert.False(valid);
     }
+
+    [Fact]
+    public async Task TimeProviderFromDIIsInjectedViaAddIdentity()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IDataProtectionProvider>(new EphemeralDataProtectionProvider(new LoggerFactory()));
+        services.AddSingleton<TimeProvider>(timeProvider);
+        services.AddIdentity<PocoUser, PocoRole>()
+            .AddDefaultTokenProviders()
+            .AddUserStore<NoopUserStore>()
+            .AddRoleStore<NoopRoleStore>();
+
+        var sp = services.BuildServiceProvider();
+        var manager = sp.GetRequiredService<UserManager<PocoUser>>();
+        var user = new PocoUser("testuser");
+
+        var token = await manager.GenerateUserTokenAsync(user, TokenOptions.DefaultProvider, "purpose");
+
+        timeProvider.Advance(TimeSpan.FromDays(1) + TimeSpan.FromSeconds(1));
+
+        var valid = await manager.VerifyUserTokenAsync(user, TokenOptions.DefaultProvider, "purpose", token);
+
+        Assert.False(valid);
+    }
 }

--- a/src/Identity/test/Identity.Test/DataProtectorTokenProviderTest.cs
+++ b/src/Identity/test/Identity.Test/DataProtectorTokenProviderTest.cs
@@ -1,0 +1,163 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+
+namespace Microsoft.AspNetCore.Identity.Test;
+
+public class DataProtectorTokenProviderTest
+{
+    private static DataProtectorTokenProvider<PocoUser> CreateProvider(DataProtectionTokenProviderOptions options = null)
+    {
+        var dataProtectionProvider = new EphemeralDataProtectionProvider(new LoggerFactory());
+        var optionsAccessor = new Mock<IOptions<DataProtectionTokenProviderOptions>>();
+        optionsAccessor.Setup(o => o.Value).Returns(options ?? new DataProtectionTokenProviderOptions());
+        var logger = new Mock<ILogger<DataProtectorTokenProvider<PocoUser>>>().Object;
+        return new DataProtectorTokenProvider<PocoUser>(dataProtectionProvider, optionsAccessor.Object, logger);
+    }
+
+    private static UserManager<PocoUser> CreateUserManager()
+        => MockHelpers.TestUserManager(new NoopUserStore());
+
+    [Fact]
+    public async Task GenerateAndValidateTokenSucceeds()
+    {
+        var provider = CreateProvider();
+        var manager = CreateUserManager();
+        var user = new PocoUser("testuser");
+
+        var token = await provider.GenerateAsync("purpose", manager, user);
+        var valid = await provider.ValidateAsync("purpose", token, manager, user);
+
+        Assert.True(valid);
+    }
+
+    [Fact]
+    public async Task ValidateFailsForDifferentPurpose()
+    {
+        var provider = CreateProvider();
+        var manager = CreateUserManager();
+        var user = new PocoUser("testuser");
+
+        var token = await provider.GenerateAsync("purpose1", manager, user);
+        var valid = await provider.ValidateAsync("purpose2", token, manager, user);
+
+        Assert.False(valid);
+    }
+
+    [Fact]
+    public async Task ValidateFailsForDifferentUser()
+    {
+        var provider = CreateProvider();
+        var manager = CreateUserManager();
+        var user1 = new PocoUser("user1");
+        var user2 = new PocoUser("user2");
+
+        var token = await provider.GenerateAsync("purpose", manager, user1);
+        var valid = await provider.ValidateAsync("purpose", token, manager, user2);
+
+        Assert.False(valid);
+    }
+
+    [Fact]
+    public async Task ValidateFailsAfterTokenLifespanExpires()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var options = new DataProtectionTokenProviderOptions
+        {
+            TokenLifespan = TimeSpan.FromHours(1),
+            TimeProvider = timeProvider,
+        };
+        var provider = CreateProvider(options);
+        var manager = CreateUserManager();
+        var user = new PocoUser("testuser");
+
+        var token = await provider.GenerateAsync("purpose", manager, user);
+
+        timeProvider.Advance(TimeSpan.FromHours(1) + TimeSpan.FromSeconds(1));
+
+        var valid = await provider.ValidateAsync("purpose", token, manager, user);
+
+        Assert.False(valid);
+    }
+
+    [Fact]
+    public async Task ValidateSucceedsWithinTokenLifespan()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var options = new DataProtectionTokenProviderOptions
+        {
+            TokenLifespan = TimeSpan.FromHours(1),
+            TimeProvider = timeProvider,
+        };
+        var provider = CreateProvider(options);
+        var manager = CreateUserManager();
+        var user = new PocoUser("testuser");
+
+        var token = await provider.GenerateAsync("purpose", manager, user);
+
+        timeProvider.Advance(TimeSpan.FromMinutes(59));
+
+        var valid = await provider.ValidateAsync("purpose", token, manager, user);
+
+        Assert.True(valid);
+    }
+
+    [Fact]
+    public async Task TimeProviderFromDIIsInjectedViaPostConfigure()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IDataProtectionProvider>(new EphemeralDataProtectionProvider(new LoggerFactory()));
+        services.AddSingleton<TimeProvider>(timeProvider);
+        services.AddIdentityCore<PocoUser>()
+            .AddDefaultTokenProviders()
+            .AddUserStore<NoopUserStore>();
+
+        var sp = services.BuildServiceProvider();
+        var manager = sp.GetRequiredService<UserManager<PocoUser>>();
+        var user = new PocoUser("testuser");
+
+        var token = await manager.GenerateUserTokenAsync(user, TokenOptions.DefaultProvider, "purpose");
+
+        timeProvider.Advance(TimeSpan.FromDays(1) + TimeSpan.FromSeconds(1));
+
+        var valid = await manager.VerifyUserTokenAsync(user, TokenOptions.DefaultProvider, "purpose", token);
+
+        Assert.False(valid);
+    }
+
+    [Fact]
+    public async Task TimeProviderFromDIDoesNotOverrideManuallySetTimeProvider()
+    {
+        var diTimeProvider = new FakeTimeProvider();
+        var optionsTimeProvider = new FakeTimeProvider();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IDataProtectionProvider>(new EphemeralDataProtectionProvider(new LoggerFactory()));
+        services.AddSingleton<TimeProvider>(diTimeProvider);
+        services.AddIdentityCore<PocoUser>()
+            .AddDefaultTokenProviders()
+            .AddUserStore<NoopUserStore>();
+        services.Configure<DataProtectionTokenProviderOptions>(o => o.TimeProvider = optionsTimeProvider);
+
+        var sp = services.BuildServiceProvider();
+        var manager = sp.GetRequiredService<UserManager<PocoUser>>();
+        var user = new PocoUser("testuser");
+
+        var token = await manager.GenerateUserTokenAsync(user, TokenOptions.DefaultProvider, "purpose");
+
+        // Advance only the options time provider — should cause expiry
+        optionsTimeProvider.Advance(TimeSpan.FromDays(1) + TimeSpan.FromSeconds(1));
+
+        var valid = await manager.VerifyUserTokenAsync(user, TokenOptions.DefaultProvider, "purpose", token);
+
+        Assert.False(valid);
+    }
+}


### PR DESCRIPTION
This pull request enhances the `DataProtectorTokenProvider` in ASP.NET Core Identity by introducing support for `TimeProvider`, enabling improved testability and flexibility for time-dependent operations like token generation and validation. It also ensures that the `TimeProvider` can be injected via dependency injection (DI) or set directly in options, and adds a comprehensive suite of tests to verify these behaviors. This changes uses the same pattern already applied in the `SecurityStampValidator` class.

**Key changes:**

### TimeProvider support and integration

* Added a nullable `TimeProvider` property to `DataProtectionTokenProviderOptions` to allow overriding the system clock, primarily for testing scenarios.
* Updated `DataProtectorTokenProvider` to use the configured `TimeProvider` (falling back to `TimeProvider.System` if not set) for all time-based operations, replacing direct usage of `DateTimeOffset.UtcNow`. [[1]](diffhunk://#diff-796e03ce99958f08160b18260f566609626b22b95794dfc0cb6a640f403c2dc9R35) [[2]](diffhunk://#diff-796e03ce99958f08160b18260f566609626b22b95794dfc0cb6a640f403c2dc9R70-R74) [[3]](diffhunk://#diff-796e03ce99958f08160b18260f566609626b22b95794dfc0cb6a640f403c2dc9L83-R89) [[4]](diffhunk://#diff-796e03ce99958f08160b18260f566609626b22b95794dfc0cb6a640f403c2dc9L118-R124)
* Registered a new `PostConfigureDataProtectionTokenProviderOptions` class to set the `TimeProvider` from DI if not already set, mirroring the pattern used for `SecurityStampValidatorOptions`. This ensures consistent configuration via DI. [[1]](diffhunk://#diff-d13814023b0d3e3068c5da73cbccf7773d23c9b3d79dfe1aedbaa5f1ef0fef25R34) [[2]](diffhunk://#diff-d13814023b0d3e3068c5da73cbccf7773d23c9b3d79dfe1aedbaa5f1ef0fef25R125-R140) [[3]](diffhunk://#diff-ed7ad153d945d236deb5a82c669126823812c8638b8991ab8166618e5f2f61bbR103) [[4]](diffhunk://#diff-ed7ad153d945d236deb5a82c669126823812c8638b8991ab8166618e5f2f61bbR192-R206)

### Testing improvements

* Added a new test file `DataProtectorTokenProviderTest.cs` with comprehensive tests covering token generation/validation, token expiry based on custom `TimeProvider`, and correct precedence between DI-injected and manually set `TimeProvider`.

### Public API updates

* Updated the public API surface to include the new `TimeProvider` properties and accessors for both `DataProtectionTokenProviderOptions` and `DataProtectorTokenProvider<TUser>`.

Fixes #54639