### PR TITLE
Ensure HttpValidationProblemDetails status is set to 400 (BadRequest)

### DIFF
--- a/src/Http/Http.Extensions/test/ValidationFilterEndpointFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/ValidationFilterEndpointFactoryTests.cs
@@ -53,6 +53,7 @@ public class ValidationEndpointFilterFactoryTests : LoggedTest
 
         ms.Seek(0, SeekOrigin.Begin);
         var problemDetails = await JsonSerializer.DeserializeAsync<ProblemDetails>(ms, JsonSerializerOptions.Web);
+        Assert.Equal(StatusCodes.Status400BadRequest, problemDetails.Status);
 
         Assert.Equal("One or more validation errors occurred.", problemDetails.Title);
 

--- a/src/Http/Routing/src/ValidationEndpointFilterFactory.cs
+++ b/src/Http/Routing/src/ValidationEndpointFilterFactory.cs
@@ -96,7 +96,10 @@ internal static class ValidationEndpointFilterFactory
             {
                 context.HttpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
 
-                var problemDetails = new HttpValidationProblemDetails(validateContext.ValidationErrors);
+                var problemDetails = new HttpValidationProblemDetails(validateContext.ValidationErrors)
+                {
+                    Status = StatusCodes.Status400BadRequest
+                };
 
                 var problemDetailsService = context.HttpContext.RequestServices.GetService<IProblemDetailsService>();
                 if (problemDetailsService is not null)


### PR DESCRIPTION
Fixes #66601

Note that generally when our default problem details service is registered, this is not a problem. It's only a problem when the "fallback" path is used (see few lines below the code I modified in `ValidationEndpointFilterFactory`).

When our default problem details services are used, we already call `ProblemDetailsDefaults.Apply` which will set the status code.

I confirmed that the added assert in the existing test fails prior to the change in this PR.

I think generally and long-term, a better approach might be find a better place to call `ProblemDetailsDefaults.Apply` that ensures status code is always set and is always matching the response status code.

Thanks @BrennanConroy For spotting our this!