### PR TITLE
Fix warning layout in build command documentation

### DIFF
--- a/docs/BuildFromSource.md
+++ b/docs/BuildFromSource.md
@@ -22,11 +22,11 @@ To get started, fork this repo and then clone it locally. This workflow assumes 
 
 1. If you're on Windows, update the PowerShell execution policy on your machine. For more information on execution policies, review [the execution policy docs](https://learn.microsoft.com/powershell/module/microsoft.powershell.security/set-executionpolicy). To do this, open a PowerShell prompt and issue the following command:
 
+    > :warning: All Windows commands below assume a PowerShell prompt.
+
     ```powershell
     Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
     ```
-
-    > :warning: All Windows commands below assume a PowerShell prompt.
 
 1. If you're on Windows, install Visual Studio (even if you aren't using it to build) to get the required C++ components and native tools. To install Visual Studio on your machine, use the official installer script in the repo.
 


### PR DESCRIPTION
# Fix warning layout in build command documentation

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).

Small change to BuildFromSource.md warning layout at step 3

## Description
In step 3 of the 'To get started' instructions, a warning states "below" in reference to the command you must run which is not below, it is instead above the warning. The warning's text is incorrect in relation to step 3, where it appears below and not above the PowerShell command to be executed. Due to this, the warning has been moved so the wording could remain unchanged while correcting the technicality regarding the layout of the warning and the referenced command at step 3.