### PR TITLE
[release/10.0] Pin Node.js to 24.14.1

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -704,9 +704,9 @@ extends:
             binlogPath: artifacts/log/Release/Build.binlog
             presteps:
             - task: NodeTool@0
-              displayName: Install Node 24.x
+              displayName: Install Node 24.14.1
               inputs:
-                versionSpec: 24.x
+                versionSpec: 24.14.1
             pool:
               name: $(DncEngInternalBuildPool)
               demands: ImageOverride -equals 1es-windows-2022

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -178,9 +178,9 @@ jobs:
           displayName: Start background dump collection
       - ${{ if eq(parameters.installNodeJs, 'true') }}:
         - task: NodeTool@0
-          displayName: Install Node 24.x
+          displayName: Install Node 24.14.1
           inputs:
-            versionSpec: 24.x
+            versionSpec: 24.14.1
       - ${{ if and(eq(parameters.agentOs, 'Windows'), eq(parameters.isAzDOTestingJob, true)) }}:
         - powershell: |
             Write-Host "##vso[task.setvariable variable=SeleniumProcessTrackingFolder]$(Build.SourcesDirectory)\artifacts\tmp\selenium\"
@@ -407,9 +407,9 @@ jobs:
           displayName: Start background dump collection
       - ${{ if eq(parameters.installNodeJs, 'true') }}:
         - task: NodeTool@0
-          displayName: Install Node 24.x
+          displayName: Install Node 24.14.1
           inputs:
-            versionSpec: 24.x
+            versionSpec: 24.14.1
       - ${{ if eq(parameters.agentOs, 'Windows') }}:
         - powershell: Write-Host "##vso[task.prependpath]$(DOTNET_CLI_HOME)\.dotnet\tools"
           displayName: Add dotnet tools to path


### PR DESCRIPTION
Backport of the Node.js pin from #66465. Node.js v24.15.0 causes intermittent native crashes (exit code 57005/0xDEAD) during npm ci on Windows CI agents.

Upstream issue: https://github.com/nodejs/node/issues/62991