### PR TITLE
Relabel perf improvements automatically

### DIFF
--- a/.github/workflows/relabel-perf-improvements.yml
+++ b/.github/workflows/relabel-perf-improvements.yml
@@ -24,9 +24,16 @@ permissions:
 
 jobs:
   relabel:
-    # Cheap pre-filter: only run on issues the bot just labeled "perf-regression",
-    # and skip forks outside the 'dotnet' org.
-    if: ${{ github.repository_owner == 'dotnet' && contains(github.event.issue.labels.*.name, 'perf-regression') }}
+    # Pre-filter: only run on issues the perf regression bot just filed
+    # with the canonical (area-perf + perf-regression) label pair, and
+    # skip forks outside the 'dotnet' org. Together these guarantee we
+    # only act on bot-authored perf issues — not, e.g., a human bug
+    # report that happens to carry a `perf-regression` label.
+    if: >-
+      ${{ github.repository_owner == 'dotnet'
+          && github.event.issue.user.login == 'pr-benchmarks[bot]'
+          && contains(github.event.issue.labels.*.name, 'area-perf')
+          && contains(github.event.issue.labels.*.name, 'perf-regression') }}
     runs-on: ubuntu-latest
     steps:
       - name: Detect direction and swap labels

--- a/.github/workflows/relabel-perf-improvements.yml
+++ b/.github/workflows/relabel-perf-improvements.yml
@@ -1,0 +1,86 @@
+name: Relabel benchmark perf issues
+
+# Re-labels issues opened by the perf regression bot:
+#   - if the body has only :thumbsup: (improvement signal in the bot's body
+#     templates), swap "perf-regression" for "perf-improvement"
+#   - otherwise (only :thumbsdown:, both, or neither — e.g. reliability /
+#     "Benchmark stopped running" issues), leave labels alone.
+#
+# Why thumbs and not the title?
+#   The bot's body templates already encode the per-metric direction:
+#     - rps:            :thumbsup: when Change > 0  (higher is better)
+#     - published-size: :thumbsup: when Change < 0  (lower is better)
+#     - start-time:     :thumbsup: when Change < 0  (lower is better)
+#     - reliability:    no thumbs (these aren't perf wins)
+#   So a single :thumbsup:/:thumbsdown: check works across all sources
+#   without this workflow needing to know which metric is which.
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  relabel:
+    # Cheap pre-filter: only run on issues the bot just labeled "perf-regression",
+    # and skip forks outside the 'dotnet' org.
+    if: ${{ github.repository_owner == 'dotnet' && contains(github.event.issue.labels.*.name, 'perf-regression') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Detect direction and swap labels
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const body = issue.body || '';
+            const title = issue.title || '';
+
+            const hasThumbsUp   = body.includes(':thumbsup:');
+            const hasThumbsDown = body.includes(':thumbsdown:');
+
+            // Only act on unambiguous, all-improvement issues.
+            // Both-thumbs (mixed) shouldn't happen today — the bot splits
+            // positive vs. negative regressions into separate issues — but
+            // if it ever does, leaving the issue alone is the safe default.
+            const isImprovement = hasThumbsUp && !hasThumbsDown;
+
+            core.info(
+              `#${issue.number} "${title}" — thumbsUp=${hasThumbsUp}, ` +
+              `thumbsDown=${hasThumbsDown}, isImprovement=${isImprovement}`
+            );
+
+            if (!isImprovement) {
+              core.info('Not an unambiguous improvement — leaving labels untouched.');
+              return;
+            }
+
+            const owner = context.repo.owner;
+            const repo  = context.repo.repo;
+            const issue_number = issue.number;
+
+            try {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number,
+                labels: ['perf-improvement'],
+              });
+              core.info(`Added perf-improvement to #${issue_number}.`);
+            } catch (e) {
+              core.setFailed(`Failed to add perf-improvement: ${e.message}`);
+              return;
+            }
+
+            try {
+              await github.rest.issues.removeLabel({
+                owner, repo, issue_number,
+                name: 'perf-regression',
+              });
+              core.info(`Removed perf-regression from #${issue_number}.`);
+            } catch (e) {
+              if (e.status === 404) {
+                core.info('perf-regression label was already absent.');
+              } else {
+                core.setFailed(`Failed to remove perf-regression: ${e.message}`);
+              }
+            }


### PR DESCRIPTION
## Description

Adds a small GitHub Actions workflow that runs on `issues: opened` and re-labels issues filed by the [dotnet/crank perf regression bot](https://github.com/dotnet/crank/tree/main/src/Microsoft.Crank.RegressionBot) when they actually report a *performance improvement* rather than a regression.

The bot currently labels every issue it files (regressions and improvements alike) with `area-perf` + `perf-regression`. The improvement-titled ones already exist in the open issues list — see [this filter](https://github.com/dotnet/aspnetcore/issues?q=is%3Aissue%20state%3Aopen%20label%3Aarea-perf%20%22Perf%20improvement%22%20in%3Atitle).

### How it decides direction

The bot's body templates already encode per-metric direction with `:thumbsup:` / `:thumbsdown:`:

- `rps`: `:thumbsup:` when `Change > 0` (higher is better)
- `published-size`: `:thumbsup:` when `Change < 0` (lower is better)
- `start-time`: `:thumbsup:` when `Change < 0` (lower is better)
- `reliability` ("Benchmark stopped running"): no thumbs

So a single `:thumbsup: && !:thumbsdown:` body check works uniformly across all metrics without this workflow needing per-metric knowledge. For unambiguous improvement issues it adds `perf-improvement` and removes `perf-regression`. Real regressions, mixed-thumbs (shouldn't happen — the bot splits positive vs. negative regressions into separate issues, but safe default), and reliability/no-thumbs issues are left untouched. The bot's issue dedup is keyed on an embedded MessagePack identifier (verified in crank's `Program.cs::UpdateIssues` / `GetRecentIssues`), not on labels, so post-creation relabels don't disturb its bookkeeping.

### Still needed

- **The `perf-improvement` label needs to be created** before this workflow can succeed.
- **Verify** *Settings → Actions → General → Workflow permissions* allows `permissions: issues: write`.

### Repo-convention adaptations

Two small differences from a vanilla `actions/github-script` workflow:

- `actions/github-script` is pinned to `d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0`, the SHA already in use across the repo's other workflows, instead of an unpinned tag.
- The job is gated on `github.repository_owner == 'dotnet'` so forks do not run it, matching the pattern in `locker.yml` and `labeler-predict-issues.yml`.

