### PR TITLE
[release/10.0] Write gzip footer for resource-collection.js.gz

### DIFF
--- a/src/Components/Endpoints/src/Builder/ResourceCollectionUrlEndpoint.cs
+++ b/src/Components/Endpoints/src/Builder/ResourceCollectionUrlEndpoint.cs
@@ -82,9 +82,11 @@ internal partial class ResourceCollectionUrlEndpoint
     private static byte[] CreateGzipBytes(byte[] bytes)
     {
         using var gzipContent = new MemoryStream();
-        using var gzipStream = new GZipStream(gzipContent, CompressionLevel.Optimal, leaveOpen: true);
-        gzipStream.Write(bytes);
-        gzipStream.Flush();
+        using (var gzipStream = new GZipStream(gzipContent, CompressionLevel.Optimal, leaveOpen: true))
+        {
+            gzipStream.Write(bytes);
+        }
+
         return gzipContent.ToArray();
     }
 

--- a/src/Components/Endpoints/test/Builder/ResourceCollectionUrlEndpointTest.cs
+++ b/src/Components/Endpoints/test/Builder/ResourceCollectionUrlEndpointTest.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO.Compression;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Microsoft.AspNetCore.Components.Endpoints;
+
+public class ResourceCollectionUrlEndpointTest
+{
+    [Fact]
+    public async Task MapResourceCollectionEndpoints_GzipEndpointReturnsCompleteGzipPayload()
+    {
+        var endpoints = new List<Endpoint>();
+        var collection = new ResourceAssetCollection(
+        [
+            new("/_framework/app.dll",
+            [
+                new("integrity", "sha256-OriginalHash123456")
+            ])
+        ]);
+
+        ResourceCollectionUrlEndpoint.MapResourceCollectionEndpoints(
+            endpoints,
+            "_framework/resource-collection{0}.js{1}",
+            collection);
+
+        var gzipEndpoint = Assert.Single(endpoints.OfType<RouteEndpoint>(), endpoint => endpoint.RoutePattern.RawText == "_framework/resource-collection.js.gz");
+        var contentEndpoint = Assert.Single(
+            endpoints.OfType<RouteEndpoint>(),
+            endpoint => endpoint.RoutePattern.RawText == "_framework/resource-collection.js" &&
+                endpoint.Metadata.GetMetadata<ContentEncodingMetadata>() is null);
+
+        var gzipContext = new DefaultHttpContext();
+        await using var gzipResponseBody = new MemoryStream();
+        gzipContext.Response.Body = gzipResponseBody;
+
+        await gzipEndpoint.RequestDelegate!(gzipContext);
+
+        gzipResponseBody.Position = 0;
+        await using var decompressedBody = new MemoryStream();
+        await using (var gzipStream = new GZipStream(gzipResponseBody, CompressionMode.Decompress, leaveOpen: true))
+        {
+            await gzipStream.CopyToAsync(decompressedBody);
+        }
+
+        var contentContext = new DefaultHttpContext();
+        await using var contentResponseBody = new MemoryStream();
+        contentContext.Response.Body = contentResponseBody;
+
+        await contentEndpoint.RequestDelegate!(contentContext);
+
+        Assert.Equal("gzip", gzipContext.Response.Headers.ContentEncoding);
+        Assert.Equal(contentResponseBody.ToArray(), decompressedBody.ToArray());
+    }
+}


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspnetcore/pull/66242 to release/10.0

## Description

The generated `resource-collection.js.gz` payload was read before `GZipStream` disposal completed, so the gzip footer was omitted and some clients/tools rejected the response as truncated.

Update `CreateGzipBytes` to dispose `GZipStream` before reading the underlying `MemoryStream`. This ensures the final gzip trailer is written before the endpoint caches and serves the compressed bytes.

Fixes https://github.com/dotnet/aspnetcore/issues/66218

## Customer Impact

Some clients/tools rejected the response as truncated. See https://github.com/dotnet/aspnetcore/issues/66218

## Regression?

- [ ] Yes
- [x] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [x] Low

We're just ensuring the gzip trailer is correctly written as expected.

## Verification

- [ ] Manual (required)
- [x] Automated

Added unit test.

## Packaging changes reviewed?

- [x] Yes
- [ ] No
- [ ] N/A
