### PR TITLE
docs: add troubleshooting note for hidden GetDocument output

### DIFF
--- a/src/Tools/Extensions.ApiDescription.Server/README.md
+++ b/src/Tools/Extensions.ApiDescription.Server/README.md
@@ -6,3 +6,11 @@ MSBuild glue for OpenAPI document generation.
 
 See partner packages such as [NSwag.AspNetCore](https://www.nuget.org/packages/NSwag.AspNetCore/) or
 [Swashbuckle.AspNetCore](https://www.nuget.org/packages/Swashbuckle.AspNetCore/) for intended use.
+
+## Troubleshooting
+
+When using the .NET Terminal Logger, OpenAPI document generation output may not appear during `dotnet build`.
+
+To surface detailed OpenAPI document-generation output, use:
+
+    dotnet build -tlp:v=d


### PR DESCRIPTION
Adds a small troubleshooting note to the `Microsoft.Extensions.ApiDescription.Server` README for cases where OpenAPI/GetDocument output is hidden when using the default .NET Terminal Logger during `dotnet build`.

Issue #62273 mentions that running:

    dotnet build -tlp:v=d

surfaces the GetDocument output, and that documenting this behavior in the package README may be an acceptable solution.

Related to #62273.
