### PR TITLE
fix: HostFiltering middleware improperly matches hosts with leading dot (#66652)

### DIFF
--- a/src/Http/Http.Abstractions/src/HostString.cs
+++ b/src/Http/Http.Abstractions/src/HostString.cs
@@ -262,8 +262,13 @@ public readonly struct HostString : IEquatable<HostString>
                 // .example.com
                 var allowedRoot = pattern.Subsegment(1);
 
-                var hostRoot = host.Subsegment(host.Length - allowedRoot.Length);
-                if (hostRoot.Equals(allowedRoot, StringComparison.OrdinalIgnoreCase))
+                var hostRootStart = host.Length - allowedRoot.Length;
+                var hostRoot = host.Subsegment(hostRootStart);
+                if (hostRoot.Equals(allowedRoot, StringComparison.OrdinalIgnoreCase)
+                    // The wildcard '*' must not match a value ending in '.', otherwise
+                    // the boundary with the leading '.' of allowedRoot would yield consecutive
+                    // dots (e.g., "..example.com" should not match "*.example.com").
+                    && host[hostRootStart - 1] != '.')
                 {
                     return true;
                 }

--- a/src/Http/Http.Abstractions/test/HostStringTest.cs
+++ b/src/Http/Http.Abstractions/test/HostStringTest.cs
@@ -153,6 +153,8 @@ public class HostStringTests
     [InlineData(":", "localhost")]
     [InlineData("example.com:443", "*.example.com")]
     [InlineData(".example.com:443", "*.example.com")]
+    [InlineData("..example.com:443", "*.example.com")]
+    [InlineData("foo..example.com:443", "*.example.com")]
     [InlineData("foo.com:443", "*.example.com")]
     [InlineData("foo.example.com.bar:443", "*.example.com")]
     [InlineData(".com:443", "*.com")]

--- a/src/Middleware/HostFiltering/test/HostFilteringMiddlewareTests.cs
+++ b/src/Middleware/HostFiltering/test/HostFilteringMiddlewareTests.cs
@@ -178,6 +178,8 @@ public class HostFilteringMiddlewareTests
     [InlineData(":", "localhost")]
     [InlineData("example.com:443", "*.example.com")]
     [InlineData(".example.com:443", "*.example.com")]
+    [InlineData("..example.com:443", "*.example.com")]
+    [InlineData("foo..example.com:443", "*.example.com")]
     [InlineData("foo.com:443", "*.example.com")]
     [InlineData("foo.example.com.bar:443", "*.example.com")]
     [InlineData(".com:443", "*.com")]


### PR DESCRIPTION
# fix: HostFiltering middleware improperly matches hosts with leading dot (#66652)

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making.

Fix wildcard host matching to reject leading-dot hosts

## Description

`HostString.MatchesAny` only checked that the host's trailing characters equaled the wildcard pattern's `.example.com` suffix, so a host like `..example.com` passed both the length check and the suffix comparison and was incorrectly accepted by a `*.example.com` pattern. The fix additionally requires that the character immediately preceding the matched root is not `.`, preventing `*` from matching an empty or dot-only label at the boundary. Added unit tests in `HostStringTest` and middleware tests in `HostFilteringMiddlewareTests` covering the leading-dot case.

Fixes #66652