### PR TITLE
HTTP 2/3: treat messages containing connection-specific header fields malformed

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -49,6 +49,10 @@ internal sealed partial class Http2Connection : IHttp2StreamLifetimeHandler, IHt
     private static ReadOnlySpan<byte> ConnectionBytes => "connection"u8;
     private static ReadOnlySpan<byte> TeBytes => "te"u8;
     private static ReadOnlySpan<byte> TrailersBytes => "trailers"u8;
+    private static ReadOnlySpan<byte> TransferEncodingBytes => "transfer-encoding"u8;
+    private static ReadOnlySpan<byte> KeepAliveBytes => "keep-alive"u8;
+    private static ReadOnlySpan<byte> ProxyConnectionBytes => "proxy-connection"u8;
+    private static ReadOnlySpan<byte> UpgradeBytes => "upgrade"u8;
     private static ReadOnlySpan<byte> ConnectBytes => "CONNECT"u8;
     private static ReadOnlySpan<byte> ProtocolBytes => ":protocol"u8;
 
@@ -1843,9 +1847,15 @@ internal sealed partial class Http2Connection : IHttp2StreamLifetimeHandler, IHt
         }
     }
 
+    // https://www.rfc-editor.org/rfc/rfc9113#section-8.2.2
     private static bool IsConnectionSpecificHeaderField(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
     {
-        return name.SequenceEqual(ConnectionBytes) || (name.SequenceEqual(TeBytes) && !value.SequenceEqual(TrailersBytes));
+        return name.SequenceEqual(ConnectionBytes)
+            || name.SequenceEqual(TransferEncodingBytes)
+            || name.SequenceEqual(KeepAliveBytes)
+            || name.SequenceEqual(ProxyConnectionBytes)
+            || name.SequenceEqual(UpgradeBytes)
+            || (name.SequenceEqual(TeBytes) && !value.SequenceEqual(TrailersBytes));
     }
 
     private bool TryClose()

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -35,6 +35,10 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
     private static ReadOnlySpan<byte> ConnectionBytes => "connection"u8;
     private static ReadOnlySpan<byte> TeBytes => "te"u8;
     private static ReadOnlySpan<byte> TrailersBytes => "trailers"u8;
+    private static ReadOnlySpan<byte> TransferEncodingBytes => "transfer-encoding"u8;
+    private static ReadOnlySpan<byte> KeepAliveBytes => "keep-alive"u8;
+    private static ReadOnlySpan<byte> ProxyConnectionBytes => "proxy-connection"u8;
+    private static ReadOnlySpan<byte> UpgradeBytes => "upgrade"u8;
     private static ReadOnlySpan<byte> ConnectBytes => "CONNECT"u8;
 
     private const PseudoHeaderFields _mandatoryRequestPseudoHeaderFields =
@@ -542,9 +546,15 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
         }
     }
 
+    // https://www.rfc-editor.org/rfc/rfc9114#section-4.2
     private static bool IsConnectionSpecificHeaderField(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
     {
-        return name.SequenceEqual(ConnectionBytes) || (name.SequenceEqual(TeBytes) && !value.SequenceEqual(TrailersBytes));
+        return name.SequenceEqual(ConnectionBytes)
+            || name.SequenceEqual(TransferEncodingBytes)
+            || name.SequenceEqual(KeepAliveBytes)
+            || name.SequenceEqual(ProxyConnectionBytes)
+            || name.SequenceEqual(UpgradeBytes)
+            || (name.SequenceEqual(TeBytes) && !value.SequenceEqual(TrailersBytes));
     }
 
     protected override void OnRequestProcessingEnded()

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -3137,23 +3137,6 @@ public class Http2ConnectionTests : Http2TestBase
     }
 
     [Fact]
-    public Task HEADERS_Received_HeaderBlockContainsConnectionHeader_ConnectionError()
-    {
-        var headers = new[]
-        {
-            new KeyValuePair<string, string>(InternalHeaderNames.Method, "GET"),
-            new KeyValuePair<string, string>(InternalHeaderNames.Path, "/"),
-            new KeyValuePair<string, string>(InternalHeaderNames.Scheme, "http"),
-            new KeyValuePair<string, string>("connection", "keep-alive")
-        };
-
-        return HEADERS_Received_InvalidHeaderFields_ConnectionError(
-            headers,
-            CoreStrings.HttpErrorConnectionSpecificHeaderField,
-            expectedEndReason: ConnectionEndReason.InvalidRequestHeaders);
-    }
-
-    [Fact]
     public Task HEADERS_Received_HeaderBlockContainsTEHeader_ValueIsNotTrailers_ConnectionError()
     {
         var headers = new[]
@@ -3175,6 +3158,7 @@ public class Http2ConnectionTests : Http2TestBase
     [InlineData("keep-alive", "timeout=5, max=1000")]
     [InlineData("proxy-connection", "keep-alive")]
     [InlineData("upgrade", "websocket")]
+    [InlineData("connection", "keep-alive")]
     public Task HEADERS_Received_HeaderBlockContainsConnectionSpecificHeader_ConnectionError(string headerName, string headerValue)
     {
         var headers = new[]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -3136,29 +3136,13 @@ public class Http2ConnectionTests : Http2TestBase
             expectedEndReason: ConnectionEndReason.InvalidRequestHeaders);
     }
 
-    [Fact]
-    public Task HEADERS_Received_HeaderBlockContainsTEHeader_ValueIsNotTrailers_ConnectionError()
-    {
-        var headers = new[]
-        {
-            new KeyValuePair<string, string>(InternalHeaderNames.Method, "GET"),
-            new KeyValuePair<string, string>(InternalHeaderNames.Path, "/"),
-            new KeyValuePair<string, string>(InternalHeaderNames.Scheme, "http"),
-            new KeyValuePair<string, string>("te", "trailers, deflate")
-        };
-
-        return HEADERS_Received_InvalidHeaderFields_ConnectionError(
-            headers,
-            CoreStrings.HttpErrorConnectionSpecificHeaderField,
-            expectedEndReason: ConnectionEndReason.InvalidRequestHeaders);
-    }
-
     [Theory]
     [InlineData("transfer-encoding", "chunked")]
     [InlineData("keep-alive", "timeout=5, max=1000")]
     [InlineData("proxy-connection", "keep-alive")]
     [InlineData("upgrade", "websocket")]
     [InlineData("connection", "keep-alive")]
+    [InlineData("te", "trailers, deflate")]
     public Task HEADERS_Received_HeaderBlockContainsConnectionSpecificHeader_ConnectionError(string headerName, string headerValue)
     {
         var headers = new[]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -3170,6 +3170,27 @@ public class Http2ConnectionTests : Http2TestBase
             expectedEndReason: ConnectionEndReason.InvalidRequestHeaders);
     }
 
+    [Theory]
+    [InlineData("transfer-encoding", "chunked")]
+    [InlineData("keep-alive", "timeout=5, max=1000")]
+    [InlineData("proxy-connection", "keep-alive")]
+    [InlineData("upgrade", "websocket")]
+    public Task HEADERS_Received_HeaderBlockContainsConnectionSpecificHeader_ConnectionError(string headerName, string headerValue)
+    {
+        var headers = new[]
+        {
+            new KeyValuePair<string, string>(InternalHeaderNames.Method, "GET"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Path, "/"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Scheme, "http"),
+            new KeyValuePair<string, string>(headerName, headerValue)
+        };
+
+        return HEADERS_Received_InvalidHeaderFields_ConnectionError(
+            headers,
+            CoreStrings.HttpErrorConnectionSpecificHeaderField,
+            expectedEndReason: ConnectionEndReason.InvalidRequestHeaders);
+    }
+
     [Fact]
     public async Task HEADERS_Received_HeaderBlockContainsTEHeader_ValueIsTrailers_NoError()
     {

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
@@ -2490,6 +2490,24 @@ public class Http3StreamTests : Http3TestBase
         return HEADERS_Received_InvalidHeaderFields_StreamError(headers, CoreStrings.HttpErrorConnectionSpecificHeaderField);
     }
 
+    [Theory]
+    [InlineData("transfer-encoding", "chunked")]
+    [InlineData("keep-alive", "timeout=5, max=1000")]
+    [InlineData("proxy-connection", "keep-alive")]
+    [InlineData("upgrade", "websocket")]
+    public Task HEADERS_Received_HeaderBlockContainsConnectionSpecificHeader_StreamError(string headerName, string headerValue)
+    {
+        var headers = new[]
+        {
+            new KeyValuePair<string, string>(InternalHeaderNames.Method, "GET"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Path, "/"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Scheme, "http"),
+            new KeyValuePair<string, string>(headerName, headerValue)
+        };
+
+        return HEADERS_Received_InvalidHeaderFields_StreamError(headers, CoreStrings.HttpErrorConnectionSpecificHeaderField);
+    }
+
     [Fact]
     public async Task HEADERS_Received_HeaderBlockContainsTEHeader_ValueIsTrailers_NoError()
     {

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
@@ -2462,26 +2462,13 @@ public class Http3StreamTests : Http3TestBase
         return HEADERS_Received_InvalidHeaderFields_StreamError(headers, CoreStrings.BadRequest_InvalidCharactersInHeaderName);
     }
 
-    [Fact]
-    public Task HEADERS_Received_HeaderBlockContainsTEHeader_ValueIsNotTrailers_ConnectionError()
-    {
-        var headers = new[]
-        {
-            new KeyValuePair<string, string>(InternalHeaderNames.Method, "GET"),
-            new KeyValuePair<string, string>(InternalHeaderNames.Path, "/"),
-            new KeyValuePair<string, string>(InternalHeaderNames.Scheme, "http"),
-            new KeyValuePair<string, string>("te", "trailers, deflate")
-        };
-
-        return HEADERS_Received_InvalidHeaderFields_StreamError(headers, CoreStrings.HttpErrorConnectionSpecificHeaderField);
-    }
-
     [Theory]
     [InlineData("transfer-encoding", "chunked")]
     [InlineData("keep-alive", "timeout=5, max=1000")]
     [InlineData("proxy-connection", "keep-alive")]
     [InlineData("upgrade", "websocket")]
     [InlineData("connection", "keep-alive")]
+    [InlineData("te", "trailers, deflate")]
     public Task HEADERS_Received_HeaderBlockContainsConnectionSpecificHeader_StreamError(string headerName, string headerValue)
     {
         var headers = new[]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
@@ -2463,20 +2463,6 @@ public class Http3StreamTests : Http3TestBase
     }
 
     [Fact]
-    public Task HEADERS_Received_HeaderBlockContainsConnectionHeader_ConnectionError()
-    {
-        var headers = new[]
-        {
-            new KeyValuePair<string, string>(InternalHeaderNames.Method, "GET"),
-            new KeyValuePair<string, string>(InternalHeaderNames.Path, "/"),
-            new KeyValuePair<string, string>(InternalHeaderNames.Scheme, "http"),
-            new KeyValuePair<string, string>("connection", "keep-alive")
-        };
-
-        return HEADERS_Received_InvalidHeaderFields_StreamError(headers, CoreStrings.HttpErrorConnectionSpecificHeaderField);
-    }
-
-    [Fact]
     public Task HEADERS_Received_HeaderBlockContainsTEHeader_ValueIsNotTrailers_ConnectionError()
     {
         var headers = new[]
@@ -2495,6 +2481,7 @@ public class Http3StreamTests : Http3TestBase
     [InlineData("keep-alive", "timeout=5, max=1000")]
     [InlineData("proxy-connection", "keep-alive")]
     [InlineData("upgrade", "websocket")]
+    [InlineData("connection", "keep-alive")]
     public Task HEADERS_Received_HeaderBlockContainsConnectionSpecificHeader_StreamError(string headerName, string headerValue)
     {
         var headers = new[]


### PR DESCRIPTION
Per RFC 9113 §8.2.2 (HTTP/2) and RFC 9114 §4.2 (HTTP/3), endpoints must treat any message containing connection-specific header fields as malformed. Kestrel's `IsConnectionSpecificHeaderField` in both `Http2Connection` and `Http3Stream` only checked for `Connection` and `TE`, missing the other four headers called out by the RFCs.