### PR TITLE
Add validation to ResponseCachingKeyProvider delimiter characters

### DIFF
--- a/src/Middleware/ResponseCaching/samples/ResponseCachingSample/Startup.cs
+++ b/src/Middleware/ResponseCaching/samples/ResponseCachingSample/Startup.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.ResponseCaching;
 using Microsoft.Net.Http.Headers;
 
 namespace ResponseCachingSample;
@@ -20,17 +21,31 @@ public class Startup
             context.Response.GetTypedHeaders().CacheControl = new CacheControlHeaderValue()
             {
                 Public = true,
-                MaxAge = TimeSpan.FromSeconds(10)
+                MaxAge = TimeSpan.FromSeconds(60)
             };
-            context.Response.Headers.Vary = new string[] { "Accept-Encoding" };
 
-            await context.Response.WriteAsync("Hello World! " + DateTime.UtcNow);
+            var responseCachingFeature = context.Features.Get<IResponseCachingFeature>();
+            if (responseCachingFeature != null)
+            {
+                responseCachingFeature.VaryByQueryKeys = [ "*" ];
+            }
+
+            var user = context.Request.Query["user"].FirstOrDefault() ?? "(none)";
+            var theme = context.Request.Query["theme"].FirstOrDefault() ?? "(none)";
+
+            context.Response.ContentType = "text/plain";
+            await context.Response.WriteAsync($"User: {user} | Theme: {theme} | Generated: {DateTime.UtcNow:O}");
         });
     }
 
     public static Task Main(string[] args)
     {
         var host = new HostBuilder()
+            .ConfigureLogging(logging =>
+            {
+                logging.AddConsole();
+                logging.SetMinimumLevel(LogLevel.Information);
+            })
             .ConfigureWebHost(webHostBuilder =>
             {
                 webHostBuilder

--- a/src/Middleware/ResponseCaching/src/CacheKeyDelimiterException.cs
+++ b/src/Middleware/ResponseCaching/src/CacheKeyDelimiterException.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.ResponseCaching;
+
+internal sealed class CacheKeyDelimiterException : Exception
+{
+    public CacheKeyDelimiterException()
+        : base("The value contains invalid characters to cache.")
+    {
+    }
+}

--- a/src/Middleware/ResponseCaching/src/LoggerExtensions.cs
+++ b/src/Middleware/ResponseCaching/src/LoggerExtensions.cs
@@ -120,4 +120,8 @@ internal static partial class LoggerExtensions
         "However, the 'max-stale' cache directive was specified without an assigned value and a stale response of any age is accepted.",
         EventName = "ExpirationInfiniteMaxStaleSatisfied")]
     internal static partial void ExpirationInfiniteMaxStaleSatisfied(this ILogger logger, TimeSpan age, TimeSpan maxAge);
+
+    [LoggerMessage(30, LogLevel.Debug, "The request contains invalid characters and will not be cached.",
+        EventName = "RequestContainsInvalidCacheSymbols")]
+    internal static partial void RequestContainsInvalidCacheSymbols(this ILogger logger);
 }

--- a/src/Middleware/ResponseCaching/src/ResponseCachingKeyProvider.cs
+++ b/src/Middleware/ResponseCaching/src/ResponseCachingKeyProvider.cs
@@ -39,6 +39,10 @@ internal sealed class ResponseCachingKeyProvider : IResponseCachingKeyProvider
         ArgumentNullException.ThrowIfNull(context);
 
         var request = context.HttpContext.Request;
+
+        ThrowIfContainsDelimiters(request.PathBase.Value);
+        ThrowIfContainsDelimiters(request.Path.Value);
+
         var builder = _builderPool.Get();
 
         try
@@ -117,6 +121,7 @@ internal sealed class ResponseCachingKeyProvider : IResponseCachingKeyProvider
 
                     for (var j = 0; j < headerValuesArray.Length; j++)
                     {
+                        ThrowIfContainsDelimiters(headerValuesArray[j]);
                         builder.Append(headerValuesArray[j]);
                     }
                 }
@@ -138,6 +143,8 @@ internal sealed class ResponseCachingKeyProvider : IResponseCachingKeyProvider
 
                     for (var i = 0; i < queryArray.Length; i++)
                     {
+                        ThrowIfContainsDelimiters(queryArray[i].Key);
+
                         builder.Append(KeyDelimiter)
                             .AppendUpperInvariant(queryArray[i].Key)
                             .Append('=');
@@ -152,6 +159,7 @@ internal sealed class ResponseCachingKeyProvider : IResponseCachingKeyProvider
                                 builder.Append(KeySubDelimiter);
                             }
 
+                            ThrowIfContainsDelimiters(queryValueArray[j]);
                             builder.Append(queryValueArray[j]);
                         }
                     }
@@ -176,6 +184,7 @@ internal sealed class ResponseCachingKeyProvider : IResponseCachingKeyProvider
                                 builder.Append(KeySubDelimiter);
                             }
 
+                            ThrowIfContainsDelimiters(queryValueArray[j]);
                             builder.Append(queryValueArray[j]);
                         }
                     }
@@ -187,6 +196,14 @@ internal sealed class ResponseCachingKeyProvider : IResponseCachingKeyProvider
         finally
         {
             _builderPool.Return(builder);
+        }
+    }
+
+    internal static void ThrowIfContainsDelimiters(string? value)
+    {
+        if (!string.IsNullOrEmpty(value) && value.AsSpan().IndexOfAny(KeyDelimiter, KeySubDelimiter) >= 0)
+        {
+            throw new CacheKeyDelimiterException();
         }
     }
 

--- a/src/Middleware/ResponseCaching/src/ResponseCachingMiddleware.cs
+++ b/src/Middleware/ResponseCaching/src/ResponseCachingMiddleware.cs
@@ -203,7 +203,16 @@ public class ResponseCachingMiddleware
 
     internal async Task<bool> TryServeFromCacheAsync(ResponseCachingContext context)
     {
-        context.BaseKey = _keyProvider.CreateBaseKey(context);
+        try
+        {
+            context.BaseKey = _keyProvider.CreateBaseKey(context);
+        }
+        catch (CacheKeyDelimiterException)
+        {
+            _logger.RequestContainsInvalidCacheSymbols();
+            return false;
+        }
+
         var cacheEntry = _cache.Get(context.BaseKey);
 
         if (cacheEntry is CachedVaryByRules cachedVaryByRules)
@@ -211,12 +220,20 @@ public class ResponseCachingMiddleware
             // Request contains vary rules, recompute key(s) and try again
             context.CachedVaryByRules = cachedVaryByRules;
 
-            foreach (var varyKey in _keyProvider.CreateLookupVaryByKeys(context))
+            try
             {
-                if (await TryServeCachedResponseAsync(context, _cache.Get(varyKey)))
+                foreach (var varyKey in _keyProvider.CreateLookupVaryByKeys(context))
                 {
-                    return true;
+                    if (await TryServeCachedResponseAsync(context, _cache.Get(varyKey)))
+                    {
+                        return true;
+                    }
                 }
+            }
+            catch (CacheKeyDelimiterException)
+            {
+                _logger.RequestContainsInvalidCacheSymbols();
+                return false;
             }
         }
         else
@@ -263,7 +280,17 @@ public class ResponseCachingMiddleware
             // Generate a base key if none exist
             if (string.IsNullOrEmpty(context.BaseKey))
             {
-                context.BaseKey = _keyProvider.CreateBaseKey(context);
+                try
+                {
+                    context.BaseKey = _keyProvider.CreateBaseKey(context);
+                }
+                catch (CacheKeyDelimiterException)
+                {
+                    _logger.RequestContainsInvalidCacheSymbols();
+                    context.ShouldCacheResponse = false;
+                    context.ResponseCachingStream.DisableBuffering();
+                    return false;
+                }
             }
 
             // Check if any vary rules exist
@@ -290,7 +317,17 @@ public class ResponseCachingMiddleware
                 _logger.VaryByRulesUpdated(normalizedVaryHeaders.ToString(), normalizedVaryQueryKeys.ToString());
                 storeVaryByEntry = true;
 
-                context.StorageVaryKey = _keyProvider.CreateStorageVaryByKey(context);
+                try
+                {
+                    context.StorageVaryKey = _keyProvider.CreateStorageVaryByKey(context);
+                }
+                catch (CacheKeyDelimiterException)
+                {
+                    _logger.RequestContainsInvalidCacheSymbols();
+                    context.ShouldCacheResponse = false;
+                    context.ResponseCachingStream.DisableBuffering();
+                    return false;
+                }
             }
 
             // Ensure date header is set

--- a/src/Middleware/ResponseCaching/test/ResponseCachingKeyProviderTests.cs
+++ b/src/Middleware/ResponseCaching/test/ResponseCachingKeyProviderTests.cs
@@ -211,4 +211,106 @@ public class ResponseCachingKeyProviderTests
         Assert.Equal($"{context.CachedVaryByRules.VaryByKeyPrefix}{KeyDelimiter}H{KeyDelimiter}HeaderA=ValueA{KeyDelimiter}HeaderC={KeyDelimiter}Q{KeyDelimiter}QueryA=ValueA{KeyDelimiter}QueryC=",
             cacheKeyProvider.CreateStorageVaryByKey(context));
     }
+
+    [Theory]
+    [InlineData("\u001e")]
+    [InlineData("\u001f")]
+    [InlineData("before\u001eafter")]
+    [InlineData("before\u001fafter")]
+    public void ThrowIfContainsDelimiters_ThrowsForValuesWithDelimiters(string value)
+    {
+        Assert.Throws<CacheKeyDelimiterException>(() => ResponseCachingKeyProvider.ThrowIfContainsDelimiters(value));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("normalvalue")]
+    [InlineData("/path/to/resource")]
+    [InlineData("value with spaces")]
+    public void ThrowIfContainsDelimiters_DoesNotThrowForSafeValues(string value)
+    {
+        ResponseCachingKeyProvider.ThrowIfContainsDelimiters(value);
+    }
+
+    [Fact]
+    public void CreateBaseKey_Throws_IfPathContainsDelimiter()
+    {
+        var cacheKeyProvider = TestUtils.CreateTestKeyProvider();
+        var context = TestUtils.CreateTestContext();
+        context.HttpContext.Request.Method = HttpMethods.Get;
+        context.HttpContext.Request.Path = "/path\u001einjected";
+
+        Assert.Throws<CacheKeyDelimiterException>(() => cacheKeyProvider.CreateBaseKey(context));
+    }
+
+    [Fact]
+    public void CreateBaseKey_Throws_IfPathBaseContainsDelimiter()
+    {
+        var cacheKeyProvider = TestUtils.CreateTestKeyProvider();
+        var context = TestUtils.CreateTestContext();
+        context.HttpContext.Request.Method = HttpMethods.Get;
+        context.HttpContext.Request.PathBase = "/base\u001finjected";
+
+        Assert.Throws<CacheKeyDelimiterException>(() => cacheKeyProvider.CreateBaseKey(context));
+    }
+
+    [Fact]
+    public void CreateStorageVaryByKey_Throws_IfHeaderValueContainsDelimiter()
+    {
+        var cacheKeyProvider = TestUtils.CreateTestKeyProvider();
+        var context = TestUtils.CreateTestContext();
+        context.HttpContext.Request.Headers["HeaderA"] = "Value\u001eInjected";
+        context.CachedVaryByRules = new CachedVaryByRules()
+        {
+            Headers = new string[] { "HeaderA" }
+        };
+
+        Assert.Throws<CacheKeyDelimiterException>(() => cacheKeyProvider.CreateStorageVaryByKey(context));
+    }
+
+    [Fact]
+    public void CreateStorageVaryByKey_Throws_IfQueryKeyContainsDelimiter_WildcardMode()
+    {
+        var cacheKeyProvider = TestUtils.CreateTestKeyProvider();
+        var context = TestUtils.CreateTestContext();
+        context.HttpContext.Request.QueryString = new QueryString("?normal=value&injected\u001ekey=value");
+        context.CachedVaryByRules = new CachedVaryByRules()
+        {
+            VaryByKeyPrefix = FastGuid.NewGuid().IdString,
+            QueryKeys = new string[] { "*" }
+        };
+
+        Assert.Throws<CacheKeyDelimiterException>(() => cacheKeyProvider.CreateStorageVaryByKey(context));
+    }
+
+    [Fact]
+    public void CreateStorageVaryByKey_Throws_IfQueryValueContainsDelimiter_WildcardMode()
+    {
+        var cacheKeyProvider = TestUtils.CreateTestKeyProvider();
+        var context = TestUtils.CreateTestContext();
+        context.HttpContext.Request.QueryString = new QueryString("?key=value\u001einjected");
+        context.CachedVaryByRules = new CachedVaryByRules()
+        {
+            VaryByKeyPrefix = FastGuid.NewGuid().IdString,
+            QueryKeys = new string[] { "*" }
+        };
+
+        Assert.Throws<CacheKeyDelimiterException>(() => cacheKeyProvider.CreateStorageVaryByKey(context));
+    }
+
+    [Fact]
+    public void CreateStorageVaryByKey_Throws_IfQueryValueContainsDelimiter_ExplicitMode()
+    {
+        var cacheKeyProvider = TestUtils.CreateTestKeyProvider();
+        var context = TestUtils.CreateTestContext();
+        context.HttpContext.Request.QueryString = new QueryString("?QueryA=value\u001finjected");
+        context.CachedVaryByRules = new CachedVaryByRules()
+        {
+            VaryByKeyPrefix = FastGuid.NewGuid().IdString,
+            QueryKeys = new string[] { "QueryA" }
+        };
+
+        Assert.Throws<CacheKeyDelimiterException>(() => cacheKeyProvider.CreateStorageVaryByKey(context));
+    }
 }

--- a/src/Middleware/ResponseCaching/test/ResponseCachingMiddlewareTests.cs
+++ b/src/Middleware/ResponseCaching/test/ResponseCachingMiddlewareTests.cs
@@ -923,6 +923,104 @@ public class ResponseCachingMiddlewareTests
     }
 
     [Fact]
+    public async Task TryServeFromCacheAsync_ReturnsFalse_IfBaseKeyContainsDelimiters()
+    {
+        var sink = new TestSink();
+        var middleware = TestUtils.CreateTestMiddleware(testSink: sink);
+        var context = TestUtils.CreateTestContext();
+        context.HttpContext.Request.Path = "/path\u001einjected";
+
+        Assert.False(await middleware.TryServeFromCacheAsync(context));
+        TestUtils.AssertLoggedMessages(
+            sink.Writes,
+            LoggedMessage.RequestContainsInvalidCacheSymbols);
+    }
+
+    [Fact]
+    public async Task TryServeFromCacheAsync_ReturnsFalse_IfVaryByKeyContainsDelimiters()
+    {
+        var cache = new TestResponseCache();
+        var sink = new TestSink();
+        // Use real key provider so CreateLookupVaryByKeys invokes validation
+        var middleware = TestUtils.CreateTestMiddleware(testSink: sink, cache: cache);
+        var context = TestUtils.CreateTestContext();
+        context.HttpContext.Request.Method = HttpMethods.Get;
+        context.HttpContext.Request.QueryString = new QueryString("?key=value\u001einjected");
+
+        // Pre-set a base key so CreateBaseKey succeeds, then set up vary rules in cache
+        // so the middleware will call CreateLookupVaryByKeys -> CreateStorageVaryByKey
+        var baseKey = $"GET{(char)0x1e}{(char)0x1e}";
+        context.BaseKey = baseKey;
+        var varyByRules = new CachedVaryByRules()
+        {
+            VaryByKeyPrefix = FastGuid.NewGuid().IdString,
+            QueryKeys = new string[] { "*" }
+        };
+        cache.Set(baseKey, varyByRules, TimeSpan.Zero);
+
+        Assert.False(await middleware.TryServeFromCacheAsync(context));
+        TestUtils.AssertLoggedMessages(
+            sink.Writes,
+            LoggedMessage.RequestContainsInvalidCacheSymbols);
+    }
+
+    [Fact]
+    public void FinalizeCacheHeaders_ReturnsFalse_IfBaseKeyContainsDelimiters()
+    {
+        var sink = new TestSink();
+        var middleware = TestUtils.CreateTestMiddleware(testSink: sink, policyProvider: new ResponseCachingPolicyProvider());
+        var context = TestUtils.CreateTestContext();
+        context.HttpContext.Request.Path = "/path\u001einjected";
+        context.HttpContext.Response.Headers.CacheControl = new CacheControlHeaderValue()
+        {
+            Public = true
+        }.ToString();
+
+        middleware.ShimResponseStream(context);
+        middleware.FinalizeCacheHeaders(context);
+
+        Assert.False(context.ShouldCacheResponse);
+        Assert.False(context.ResponseCachingStream.BufferingEnabled);
+        TestUtils.AssertLoggedMessages(
+            sink.Writes,
+            LoggedMessage.RequestContainsInvalidCacheSymbols);
+    }
+
+    [Fact]
+    public void FinalizeCacheHeaders_ReturnsFalse_IfStorageVaryKeyContainsDelimiters()
+    {
+        var sink = new TestSink();
+        var middleware = TestUtils.CreateTestMiddleware(testSink: sink, policyProvider: new ResponseCachingPolicyProvider());
+        var context = TestUtils.CreateTestContext();
+        context.HttpContext.Request.QueryString = new QueryString("?key=value\u001einjected");
+        context.HttpContext.Response.Headers.CacheControl = new CacheControlHeaderValue()
+        {
+            Public = true
+        }.ToString();
+        context.HttpContext.Features.Set<IResponseCachingFeature>(new ResponseCachingFeature()
+        {
+            VaryByQueryKeys = new string[] { "*" }
+        });
+        // Pre-set BaseKey so CreateBaseKey is skipped (it would also throw)
+        context.BaseKey = "SomeBaseKey";
+
+        // ShimResponseStream also calls AddResponseCachingFeature, so remove ours first
+        context.HttpContext.Features.Set<IResponseCachingFeature>(null);
+        middleware.ShimResponseStream(context);
+        // Now re-set VaryByQueryKeys on the feature that ShimResponseStream added
+        context.HttpContext.Features.Get<IResponseCachingFeature>()!.VaryByQueryKeys = new string[] { "*" };
+
+        middleware.FinalizeCacheHeaders(context);
+
+        Assert.False(context.ShouldCacheResponse);
+        Assert.False(context.ResponseCachingStream.BufferingEnabled);
+        TestUtils.AssertLoggedMessages(
+            sink.Writes,
+            LoggedMessage.VaryByRulesUpdated,
+            LoggedMessage.RequestContainsInvalidCacheSymbols);
+    }
+
+    [Fact]
     public void GetOrderCasingNormalizedStringValues_NormalizesCasingToUpper()
     {
         var uppercaseStrings = new StringValues(new[] { "STRINGA", "STRINGB" });

--- a/src/Middleware/ResponseCaching/test/TestUtils.cs
+++ b/src/Middleware/ResponseCaching/test/TestUtils.cs
@@ -301,6 +301,7 @@ internal class LoggedMessage
     internal static LoggedMessage ResponseNotCached => new LoggedMessage(27, LogLevel.Information);
     internal static LoggedMessage ResponseContentLengthMismatchNotCached => new LoggedMessage(28, LogLevel.Warning);
     internal static LoggedMessage ExpirationInfiniteMaxStaleSatisfied => new LoggedMessage(29, LogLevel.Debug);
+    internal static LoggedMessage RequestContainsInvalidCacheSymbols => new LoggedMessage(30, LogLevel.Warning);
 
     private LoggedMessage(int evenId, LogLevel logLevel)
     {

--- a/src/Middleware/ResponseCaching/test/TestUtils.cs
+++ b/src/Middleware/ResponseCaching/test/TestUtils.cs
@@ -301,7 +301,7 @@ internal class LoggedMessage
     internal static LoggedMessage ResponseNotCached => new LoggedMessage(27, LogLevel.Information);
     internal static LoggedMessage ResponseContentLengthMismatchNotCached => new LoggedMessage(28, LogLevel.Warning);
     internal static LoggedMessage ExpirationInfiniteMaxStaleSatisfied => new LoggedMessage(29, LogLevel.Debug);
-    internal static LoggedMessage RequestContainsInvalidCacheSymbols => new LoggedMessage(30, LogLevel.Warning);
+    internal static LoggedMessage RequestContainsInvalidCacheSymbols => new LoggedMessage(30, LogLevel.Debug);
 
     private LoggedMessage(int evenId, LogLevel logLevel)
     {


### PR DESCRIPTION
Delimiter characters are not validated in the request, meaning users can get the "artificial" response instead of their real request.