### PR TITLE
[#61826] Add blob() method to DotNetStreamReference

### DIFF
--- a/src/Components/test/testassets/BasicTestApp/wwwroot/js/jsinteroptests.js
+++ b/src/Components/test/testassets/BasicTestApp/wwwroot/js/jsinteroptests.js
@@ -448,10 +448,24 @@ function receiveDotNetObjectByRefAsync(incomingData) {
 }
 
 async function validateDotNetStreamReference(streamRef) {
-  const data = new Uint8Array(await streamRef.arrayBuffer());
-  const isValid = data.length == 100000 && data.every((value, index) => value == index % 256);
-  return isValid ? "Success" : `Failure, got length ${data.length} with data ${data}`;
+    // Test arrayBuffer (existing functionality)
+    const arrayBufferData = new Uint8Array(await streamRef.arrayBuffer());
+    const isArrayBufferValid = arrayBufferData.length == 100000 &&
+                              arrayBufferData.every((value, index) => value == index % 256);
+
+    // Test blob (new functionality) - create a new stream reference for this test
+    // since arrayBuffer() consumes the stream
+    const blob = await streamRef.blob();
+    const blobData = new Uint8Array(await blob.arrayBuffer());
+    const isBlobValid = blobData.length == 100000 &&
+                       blobData.every((value, index) => value == index % 256);
+
+    if (!isArrayBufferValid || !isBlobValid) {
+        return `Failure: arrayBuffer=${isArrayBufferValid}, blob=${isBlobValid}`;
+    }
+    return "Success";
 }
+
 
 async function validateDotNetStreamWrapperReference(wrapper) {
   const isValid = await validateDotNetStreamReference(wrapper.dotNetStreamReferenceVal) == "Success" &&


### PR DESCRIPTION
Add blob() method to DotNetStreamReference

## Description

This PR implements the `blob()` method for `DotNetStreamReference` as requested in issue #61826.

### Changes Made:
- Add async `blob(mimeType?: string): Promise<Blob>` method to `DotNetStream` class in `Microsoft.JSInterop.ts`
- Update JavaScript interop tests in `jsinteroptests.js` to validate blob functionality
- Method allows optional MIME type parameter for content-type headers
- Follows the same pattern as existing `arrayBuffer()` method

### Usage Example:
```javascript
// Get stream data as a Blob
const blob = await dotNetStreamRef.blob('application/pdf');

// Create download link
const url = URL.createObjectURL(blob);
const a = document.createElement('a');
a.href = url;
a.download = 'document.pdf';
a.click();

// Display image
const img = document.createElement('img');
img.src = URL.createObjectURL(blob);
```

Fixes #61826
