### PR TITLE
Fix unresolved quarantine issue links from gh-aw regression

### DIFF
--- a/src/Components/test/E2ETest/ServerRenderingTests/RedirectionTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/RedirectionTest.cs
@@ -155,7 +155,7 @@ public class RedirectionTest : ServerTestBase<BasicTestAppServerSiteFixture<Razo
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/#aw_redirect1")]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/66709")]
     public void RedirectStreamingEnhancedGetToInternal(bool disableThrowNavigationException)
     {
         AppContext.SetSwitch("Microsoft.AspNetCore.Components.Endpoints.NavigationManager.DisableThrowNavigationException", disableThrowNavigationException);

--- a/src/ProjectTemplates/test/Templates.Blazor.Tests/BlazorWebTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Blazor.Tests/BlazorWebTemplateTest.cs
@@ -56,7 +56,7 @@ public class BlazorWebTemplateTest(ProjectFactoryFixture projectFactory) : Blazo
 
     [Theory]
     [InlineData(BrowserKind.Chromium)]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/#aw_passkeys1")]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/66708")]
     public async Task BlazorWebTemplate_CanUsePasskeys(BrowserKind browserKind)
     {
         var project = await CreateBuildPublishAsync(args: ["-int", "None", "-au", "Individual"]);


### PR DESCRIPTION
Replaces unresolved `#aw_passkeys1` and `#aw_redirect1` placeholder strings with actual issue numbers in `[QuarantinedTest]` attributes:

- `#aw_passkeys1` → #66708 (in BlazorWebTemplateTest.cs, from PR #66710)
- `#aw_redirect1` → #66709 (in RedirectionTest.cs, from PR #66711)

These placeholders were left unresolved due to a gh-aw platform regression where the bundle-based push path skips temporary ID substitution in committed file contents (github/gh-aw#32834).