### PR TITLE
Add endpoint metadata for redirect typed results

### DIFF
--- a/src/Http/Http.Results/src/RedirectHttpResult.cs
+++ b/src/Http/Http.Results/src/RedirectHttpResult.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -12,7 +15,7 @@ namespace Microsoft.AspNetCore.Http.HttpResults;
 /// An <see cref="IResult"/> that returns a Found (302), Moved Permanently (301), Temporary Redirect (307),
 /// or Permanent Redirect (308) response with a Location header to the supplied URL.
 /// </summary>
-public sealed partial class RedirectHttpResult : IResult
+public sealed partial class RedirectHttpResult : IResult, IEndpointMetadataProvider
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="RedirectHttpResult"/> class with the values
@@ -119,6 +122,15 @@ public sealed partial class RedirectHttpResult : IResult
         }
 
         return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(method);
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(StatusCodes.Status302Found, typeof(void)));
     }
 
     /// <summary>

--- a/src/Http/Http.Results/src/RedirectToRouteHttpResult.cs
+++ b/src/Http/Http.Results/src/RedirectToRouteHttpResult.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Internal;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -14,7 +17,7 @@ namespace Microsoft.AspNetCore.Http.HttpResults;
 /// or Permanent Redirect (308) response with a Location header.
 /// Targets a registered route.
 /// </summary>
-public sealed partial class RedirectToRouteHttpResult : IResult
+public sealed partial class RedirectToRouteHttpResult : IResult, IEndpointMetadataProvider
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="RedirectToRouteHttpResult"/> with the values
@@ -188,6 +191,15 @@ public sealed partial class RedirectToRouteHttpResult : IResult
         }
 
         return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(method);
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(StatusCodes.Status302Found, typeof(void)));
     }
 
     private static partial class Log

--- a/src/Http/Http.Results/test/RedirectResultTests.cs
+++ b/src/Http/Http.Results/test/RedirectResultTests.cs
@@ -1,7 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Reflection;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Internal;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
 
 namespace Microsoft.AspNetCore.Http.HttpResults;
 
@@ -82,6 +87,25 @@ public class RedirectResultTests : RedirectResultTestBase
         // Assert
         Assert.False(actual);
     }
+
+    [Fact]
+    public void PopulateMetadata_AddsResponseTypeMetadata()
+    {
+        // Arrange
+        RedirectHttpResult MyApi() { throw new NotImplementedException(); }
+        var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
+
+        // Act
+        PopulateMetadata<RedirectHttpResult>(((Delegate)MyApi).GetMethodInfo(), builder);
+
+        // Assert
+        var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
+        Assert.Equal(StatusCodes.Status302Found, producesResponseTypeMetadata.StatusCode);
+        Assert.Equal(typeof(void), producesResponseTypeMetadata.Type);
+    }
+
+    private static void PopulateMetadata<TResult>(MethodInfo method, EndpointBuilder builder)
+        where TResult : IEndpointMetadataProvider => TResult.PopulateMetadata(method, builder);
 
     protected override Task ExecuteAsync(HttpContext httpContext, string contentPath)
     {

--- a/src/Http/Http.Results/test/RedirectToRouteResultTests.cs
+++ b/src/Http/Http.Results/test/RedirectToRouteResultTests.cs
@@ -1,8 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Reflection;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -94,6 +98,25 @@ public class RedirectToRouteResultTests
         // Act & Assert
         await Assert.ThrowsAsync<ArgumentNullException>("httpContext", () => result.ExecuteAsync(httpContext));
     }
+
+    [Fact]
+    public void PopulateMetadata_AddsResponseTypeMetadata()
+    {
+        // Arrange
+        RedirectToRouteHttpResult MyApi() { throw new NotImplementedException(); }
+        var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
+
+        // Act
+        PopulateMetadata<RedirectToRouteHttpResult>(((Delegate)MyApi).GetMethodInfo(), builder);
+
+        // Assert
+        var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
+        Assert.Equal(StatusCodes.Status302Found, producesResponseTypeMetadata.StatusCode);
+        Assert.Equal(typeof(void), producesResponseTypeMetadata.Type);
+    }
+
+    private static void PopulateMetadata<TResult>(MethodInfo method, EndpointBuilder builder)
+        where TResult : IEndpointMetadataProvider => TResult.PopulateMetadata(method, builder);
 
     private static HttpContext GetHttpContext(string path)
     {


### PR DESCRIPTION
Infer 302 OpenAPI response metadata for typed redirect results.
 
 ## Description
 
 - [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
 - [x] You've included unit or integration tests for your change, where applicable.
 - [ ] You've included inline docs for your change, where applicable. (N/A)
 - [x] There's an open issue for the PR that you are making.
 
 Implemented `IEndpointMetadataProvider` for:
 - `RedirectHttpResult`
 - `RedirectToRouteHttpResult`
 
 Added `PopulateMetadata` to emit:
 - `ProducesResponseTypeMetadata(StatusCodes.Status302Found, typeof(void))`
 
 Added tests:
 - `RedirectResultTests.PopulateMetadata_AddsResponseTypeMetadata`
 - `RedirectToRouteResultTests.PopulateMetadata_AddsResponseTypeMetadata`
 
 `LocalRedirect` is implicitly covered because it uses `RedirectHttpResult` with `acceptLocalUrlOnly: true`.
 
 Fixes #66682