### PR TITLE
Update issue triage agent to use issue type instead of labels

### DIFF
--- a/.github/workflows/issue-triage-agent.lock.yml
+++ b/.github/workflows/issue-triage-agent.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"454ea342704b5f5397c65a94649ff267a0f08f0a7e95af7ea91f371f29cc49c7","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"bf6ec2f8045da58462a90d042ecd569b2d3aa531ca3ada88712b8adb3ed03ba9","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"d746ffe35508b1917358783b479e04febd2b8f71","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"bc56a0cad2f450c562810785ef38649c04db812a","version":"v0.72.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -209,20 +209,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_292d66ff03105728_EOF'
+          cat << 'GH_AW_PROMPT_6ca1ce76ed630efe_EOF'
           <system>
-          GH_AW_PROMPT_292d66ff03105728_EOF
+          GH_AW_PROMPT_6ca1ce76ed630efe_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_292d66ff03105728_EOF'
+          cat << 'GH_AW_PROMPT_6ca1ce76ed630efe_EOF'
           <safe-output-tools>
-          Tools: add_comment, add_labels(max:3), remove_labels, missing_tool, missing_data, noop
+          Tools: add_comment, add_labels(max:3), remove_labels, set_issue_type, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_292d66ff03105728_EOF
+          GH_AW_PROMPT_6ca1ce76ed630efe_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_292d66ff03105728_EOF'
+          cat << 'GH_AW_PROMPT_6ca1ce76ed630efe_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -251,12 +251,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_292d66ff03105728_EOF
+          GH_AW_PROMPT_6ca1ce76ed630efe_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_292d66ff03105728_EOF'
+          cat << 'GH_AW_PROMPT_6ca1ce76ed630efe_EOF'
           </system>
           {{#runtime-import .github/workflows/issue-triage-agent.md}}
-          GH_AW_PROMPT_292d66ff03105728_EOF
+          GH_AW_PROMPT_6ca1ce76ed630efe_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
@@ -456,16 +456,16 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_32c911e1d190b520_EOF'
-          {"add_comment":{"hide_older_comments":true,"max":1},"add_labels":{"allowed":["area-auth","area-blazor","area-commandlinetools","area-dataprotection","area-grpc","area-healthchecks","area-hosting","area-identity","area-infrastructure","area-middleware","area-minimal","area-mvc","area-networking","area-perf","area-routing","area-security","area-signalr","area-ui-rendering","area-unified-build","bug","feature-request","by-design","question","external","docs","api-proposal","test-failure","performance"],"max":3},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"remove_labels":{"allowed":["needs-area-label"],"max":1},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_32c911e1d190b520_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_d6bd623504a0edcb_EOF'
+          {"add_comment":{"hide_older_comments":true,"max":1},"add_labels":{"allowed":["area-auth","area-blazor","area-commandlinetools","area-dataprotection","area-grpc","area-healthchecks","area-hosting","area-identity","area-infrastructure","area-middleware","area-minimal","area-mvc","area-networking","area-perf","area-routing","area-security","area-signalr","area-ui-rendering","area-unified-build","by-design","question","external","docs","api-proposal","test-failure","performance"],"max":3},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"remove_labels":{"allowed":["needs-area-label"],"max":1},"report_incomplete":{},"set_issue_type":{"allowed":["Bug","Feature","Task","Epic"],"max":1}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_d6bd623504a0edcb_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
                 "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added. Supports reply_to_id for discussion threading.",
-                "add_labels": " CONSTRAINTS: Maximum 3 label(s) can be added. Only these labels are allowed: [\"area-auth\" \"area-blazor\" \"area-commandlinetools\" \"area-dataprotection\" \"area-grpc\" \"area-healthchecks\" \"area-hosting\" \"area-identity\" \"area-infrastructure\" \"area-middleware\" \"area-minimal\" \"area-mvc\" \"area-networking\" \"area-perf\" \"area-routing\" \"area-security\" \"area-signalr\" \"area-ui-rendering\" \"area-unified-build\" \"bug\" \"feature-request\" \"by-design\" \"question\" \"external\" \"docs\" \"api-proposal\" \"test-failure\" \"performance\"].",
+                "add_labels": " CONSTRAINTS: Maximum 3 label(s) can be added. Only these labels are allowed: [\"area-auth\" \"area-blazor\" \"area-commandlinetools\" \"area-dataprotection\" \"area-grpc\" \"area-healthchecks\" \"area-hosting\" \"area-identity\" \"area-infrastructure\" \"area-middleware\" \"area-minimal\" \"area-mvc\" \"area-networking\" \"area-perf\" \"area-routing\" \"area-security\" \"area-signalr\" \"area-ui-rendering\" \"area-unified-build\" \"by-design\" \"question\" \"external\" \"docs\" \"api-proposal\" \"test-failure\" \"performance\"].",
                 "remove_labels": " CONSTRAINTS: Maximum 1 label(s) can be removed. Only these labels can be removed: [needs-area-label]."
               },
               "repo_params": {},
@@ -605,6 +605,24 @@ jobs:
                     "maxLength": 1024
                   }
                 }
+              },
+              "set_issue_type": {
+                "defaultMax": 5,
+                "fields": {
+                  "issue_number": {
+                    "issueOrPRNumber": true
+                  },
+                  "issue_type": {
+                    "required": true,
+                    "type": "string",
+                    "sanitize": true,
+                    "maxLength": 128
+                  },
+                  "repo": {
+                    "type": "string",
+                    "maxLength": 256
+                  }
+                }
               }
             }
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
@@ -685,7 +703,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_9bf8a1803c340bd5_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_e909ddf6f155fc0d_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -729,7 +747,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_9bf8a1803c340bd5_EOF
+          GH_AW_MCP_CONFIG_e909ddf6f155fc0d_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1377,7 +1395,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":1},\"add_labels\":{\"allowed\":[\"area-auth\",\"area-blazor\",\"area-commandlinetools\",\"area-dataprotection\",\"area-grpc\",\"area-healthchecks\",\"area-hosting\",\"area-identity\",\"area-infrastructure\",\"area-middleware\",\"area-minimal\",\"area-mvc\",\"area-networking\",\"area-perf\",\"area-routing\",\"area-security\",\"area-signalr\",\"area-ui-rendering\",\"area-unified-build\",\"bug\",\"feature-request\",\"by-design\",\"question\",\"external\",\"docs\",\"api-proposal\",\"test-failure\",\"performance\"],\"max\":3},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"remove_labels\":{\"allowed\":[\"needs-area-label\"],\"max\":1},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":1},\"add_labels\":{\"allowed\":[\"area-auth\",\"area-blazor\",\"area-commandlinetools\",\"area-dataprotection\",\"area-grpc\",\"area-healthchecks\",\"area-hosting\",\"area-identity\",\"area-infrastructure\",\"area-middleware\",\"area-minimal\",\"area-mvc\",\"area-networking\",\"area-perf\",\"area-routing\",\"area-security\",\"area-signalr\",\"area-ui-rendering\",\"area-unified-build\",\"by-design\",\"question\",\"external\",\"docs\",\"api-proposal\",\"test-failure\",\"performance\"],\"max\":3},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"remove_labels\":{\"allowed\":[\"needs-area-label\"],\"max\":1},\"report_incomplete\":{},\"set_issue_type\":{\"allowed\":[\"Bug\",\"Feature\",\"Task\",\"Epic\"],\"max\":1}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/issue-triage-agent.md
+++ b/.github/workflows/issue-triage-agent.md
@@ -35,6 +35,9 @@ tools:
 safe-outputs:
   noop:
     report-as-issue: false
+  set-issue-type:
+    allowed: ["Bug", "Feature", "Task", "Epic"]
+    max: 1
   add-labels:
     allowed:
       - area-auth
@@ -56,7 +59,6 @@ safe-outputs:
       - area-signalr
       - area-ui-rendering
       - area-unified-build
-      - bug
       - feature-request
       - by-design
       - question
@@ -79,7 +81,7 @@ You are an issue-triage agent for the **dotnet/aspnetcore** repository. Your job
 is to analyze a newly opened issue and perform three tasks:
 
 1. **Area classification** - assign the correct `area-*` label
-2. **Type classification** - assign a type label (bug, feature-request, etc.)
+2. **Type classification** - assign an issue type (not a label) (Bug, Feature, Task, or Epic)
 3. **Duplicate detection** - search for similar existing issues
 
 ## Issue to Triage

--- a/.github/workflows/issue-triage-agent.md
+++ b/.github/workflows/issue-triage-agent.md
@@ -59,7 +59,6 @@ safe-outputs:
       - area-signalr
       - area-ui-rendering
       - area-unified-build
-      - feature-request
       - by-design
       - question
       - external


### PR DESCRIPTION
I'm not sure if this will work, but might be worth trying.

FYI @danroth27

Docs: https://github.github.com/gh-aw/reference/safe-outputs/#set-issue-type-set-issue-type