### PR TITLE
[release/9.0] Fix KeyRingProvider thread pool starvation on cold start

### DIFF
--- a/src/DataProtection/DataProtection/src/KeyManagement/KeyRingProvider.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/KeyRingProvider.cs
@@ -360,11 +360,10 @@ internal sealed class KeyRingProvider : ICacheableKeyRingProvider, IKeyRingProvi
             existingTask = _cacheableKeyRingTask;
             if (existingTask is null)
             {
-                // The forceRefresh path skipped reading _cacheableKeyRing above; read it now
-                // (without disturbing existingCacheableKeyRing, which controls the stale-ring
-                // early-return below and must stay null for forceRefresh callers) so we can
-                // tell a true cold start from a stale-cache refresh.
-                if (existingCacheableKeyRing is null && Volatile.Read(ref _cacheableKeyRing) is null)
+                // The forceRefresh path skipped reading _cacheableKeyRing above; read it now.
+                existingCacheableKeyRing ??= Volatile.Read(ref _cacheableKeyRing);
+
+                if (existingCacheableKeyRing is null)
                 {
                     // Cold start: run the refresh inline on this thread. Scheduling the work
                     // onto TaskScheduler.Default would risk thread-pool starvation - if all

--- a/src/DataProtection/DataProtection/src/KeyManagement/KeyRingProvider.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/KeyRingProvider.cs
@@ -360,7 +360,45 @@ internal sealed class KeyRingProvider : ICacheableKeyRingProvider, IKeyRingProvi
             existingTask = _cacheableKeyRingTask;
             if (existingTask is null)
             {
-                // If there's no existing task, make one now
+                // The forceRefresh path skipped reading _cacheableKeyRing above; read it now
+                // (without disturbing existingCacheableKeyRing, which controls the stale-ring
+                // early-return below and must stay null for forceRefresh callers) so we can
+                // tell a true cold start from a stale-cache refresh.
+                if (existingCacheableKeyRing is null && Volatile.Read(ref _cacheableKeyRing) is null)
+                {
+                    // Cold start: run the refresh inline on this thread. Scheduling the work
+                    // onto TaskScheduler.Default would risk thread-pool starvation - if all
+                    // available pool threads are blocked waiting on the result, the queued
+                    // work item can't be picked up and the app hangs until the runtime
+                    // injects more threads. See https://github.com/dotnet/aspnetcore/issues/66380.
+                    //
+                    // Other concurrent callers are parked on _cacheableKeyRingLockObj while we
+                    // run; once we publish _cacheableKeyRing and release the lock, they wake up.
+                    // Non-force-refresh callers can then re-check the cache and return the
+                    // freshly populated ring, while forceRefresh callers observe that a cached
+                    // ring now exists and continue through the stale-cache refresh path below.
+                    // This matches the pre-#54675 behavior (https://github.com/dotnet/aspnetcore/pull/54675).
+                    CacheableKeyRing newCacheableKeyRing;
+                    try
+                    {
+                        newCacheableKeyRing = CacheableKeyRingProvider.GetCacheableKeyRing(utcNow);
+                    }
+                    catch (Exception ex)
+                    {
+                        // Cold-start branch: always a "reading" rather than "refreshing" failure, and
+                        // there's no stale ring to extend via WithTemporaryExtendedLifetime.
+                        // The async refresh path handles both concerns. We leave _cacheableKeyRing
+                        // and _cacheableKeyRingTask null, so the next caller retries from scratch.
+                        _logger.ErrorOccurredWhileReadingKeyRing(ex);
+                        throw;
+                    }
+
+                    Volatile.Write(ref _cacheableKeyRing, newCacheableKeyRing);
+                    return newCacheableKeyRing.KeyRing;
+                }
+
+                // Stale ring exists: dispatch the refresh asynchronously and let every other
+                // caller return the stale ring without waiting. This is the perf win from #54675.
                 // PERF: Closing over utcNow substantially slows down the fast case (valid cache) in micro-benchmarks
                 // (closing over `this` for CacheableKeyRingProvider doesn't seem impactful)
                 existingTask = Task.Factory.StartNew(
@@ -390,9 +428,8 @@ internal sealed class KeyRingProvider : ICacheableKeyRingProvider, IKeyRingProvi
         }
 
         // Prefer a stale cached key ring to blocking
-        if (existingCacheableKeyRing is not null)
+        if (!forceRefresh && existingCacheableKeyRing is not null)
         {
-            Debug.Assert(!forceRefresh, "Consumed cached key ring even though forceRefresh is true");
             Debug.Assert(!CacheableKeyRing.IsValid(existingCacheableKeyRing, utcNow), "Should have returned a valid cached key ring above");
             return existingCacheableKeyRing.KeyRing;
         }

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/KeyManagement/KeyRingProviderTests.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/KeyManagement/KeyRingProviderTests.cs
@@ -804,6 +804,48 @@ public class KeyRingProviderTests
         return CreateKeyRingProvider(mockKeyManager.Object, mockDefaultKeyResolver.Object, keyManagementOptions);
     }
 
+    // Regression test for https://github.com/dotnet/aspnetcore/issues/66380.
+    // On cold start (no cached key ring) the new async-refresh code path used to schedule
+    // the refresh work to TaskScheduler.Default and then block every caller on Task.Wait().
+    // When all available thread-pool threads were callers, the queued refresh work could
+    // not be picked up - producing thread-pool starvation and a multi-second freeze on
+    // start until the runtime's hill-climbing injected more threads.
+    //
+    // The starvation can't be reproduced deterministically in a unit test (the runtime's
+    // hill-climbing will eventually rescue the buggy code, so any timing-based assertion
+    // is flaky). We instead verify the underlying invariant that prevents starvation:
+    // on cold start, the calling thread itself must perform the refresh, not a pool worker.
+    // If this invariant holds, starvation is impossible by construction regardless of pool
+    // size or hill-climbing behavior.
+    [Fact]
+    public void GetCurrentKeyRing_ColdStart_RefreshRunsOnCallingThread()
+    {
+        var now = StringToDateTime("2015-03-01 00:00:00Z");
+        var expectedKeyRing = new Mock<IKeyRing>().Object;
+
+        var callingThreadId = Environment.CurrentManagedThreadId;
+        int? refreshThreadId = null;
+
+        var mockCacheableKeyRingProvider = new Mock<ICacheableKeyRingProvider>();
+        mockCacheableKeyRingProvider
+            .Setup(o => o.GetCacheableKeyRing(now))
+            .Returns(() =>
+            {
+                refreshThreadId = Environment.CurrentManagedThreadId;
+                return new CacheableKeyRing(
+                    expirationToken: CancellationToken.None,
+                    expirationTime: now.AddDays(1),
+                    keyRing: expectedKeyRing);
+            });
+
+        var keyRingProvider = CreateKeyRingProvider(mockCacheableKeyRingProvider.Object);
+
+        var keyRing = keyRingProvider.GetCurrentKeyRingCore(now);
+
+        Assert.Same(expectedKeyRing, keyRing);
+        Assert.Equal(callingThreadId, refreshThreadId);
+    }
+
     [Fact]
     public async Task MultipleThreadsSeeExpiredCachedValue()
     {


### PR DESCRIPTION
Backport of #66683 to release/9.0

`KeyRingProvider.GetCurrentKeyRingCoreNew` handles two states with one mechanism:
- **State A — stale ring exists.** The cached ring expired but a previous value is still in the field. Refresh work is dispatched onto `TaskScheduler.Default`; every caller takes the early-return and immediately gets the stale ring. Nobody blocks.
- **State B — no ring at all (cold start).** Same dispatch path runs, but now there is no stale ring to fall back on, so every caller falls through to `existingTask.Wait()` — pinning a thread-pool thread on a task that needs a free thread-pool thread to run. With a constrained pool (e.g. `ThreadPool.SetMaxThreads(16, …)` and 16 concurrent `Protect` calls — exactly the [issue's repro](https://github.com/dotnet/aspnetcore/issues/66380#issuecomment-4378856544)), every worker is parked waiting for a worker that doesn't exist. The runtime's hill climber eventually injects extra threads (~118 s in the report) and the app recovers, but during the freeze nothing makes progress.

Fix is to split up cold-start (no stale `cacheableKeyRing` yet) and do the synchronous load on the first thread acquiring lock. Others will be waiting on lock as in the old implementation.

Related #54675
Fixes #66380

## Customer Impact

A customer running ASP.NET Core on .NET 10 reported (#66380) that their app freezes on startup when several authenticated requests arrive concurrently. The app handles the first ~10 requests and then completely freezes for ~118 seconds with every thread‑pool thread stuck inside `KeyRingProvider.GetCurrentKeyRingCoreNew`, blocked in `Task.Wait()`. 

## Regression?

- [ ] Yes
- [ ] No

## Risk

There is a workaround that customers can apply today without waiting for this fix:

```csharp
AppContext.SetSwitch("Microsoft.AspNetCore.DataProtection.KeyManagement.DisableAsyncKeyRingUpdate", true);
```

- [ ] High
- [ ] Medium
- [x] Low

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

----

## When servicing release/2.3

- [ ] Make necessary changes in eng/PatchConfig.props