### PR TITLE
Fix ServerVirtualizationTest

### DIFF
--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -3079,6 +3079,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         ScrollUntil(js, container, () => ScrollContainer(js, container, targetScrollTop),
             st => st < currentScrollTop - 100,
             $"scrollTop < {currentScrollTop - 100} after scrolling away from bottom");
+        WaitForRenderToSettle(container, js);
 
         var scrollTopBeforeSecondAppend = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
         var scrollHeightBeforeSecondAppend = (long)js.ExecuteScript("return arguments[0].scrollHeight", container);
@@ -3118,6 +3119,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
 
         ScrollUntil(js, container, () => ScrollContainer(js, container, 500),
             st => st > 200, "scrollTop > 200 after ScrollContainer(500)");
+        WaitForRenderToSettle(container, js);
 
         var scrollTopBefore = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
 


### PR DESCRIPTION
# Fix ServerVirtualizationTest

There were some flaky tests in the `ServerVirtualizationTest` due to missing `WaitForRenderToSettle` in them. This PR adds missing helper method for these tests making them deterministic. 

[Failed build](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1426223&view=results)