### PR TITLE
Improve default Identity email wording for recipients who didn't initiate the action

### DIFF
--- a/src/Identity/test/Identity.FunctionalTests/MapIdentityApiTests.cs
+++ b/src/Identity/test/Identity.FunctionalTests/MapIdentityApiTests.cs
@@ -1410,7 +1410,7 @@ public class MapIdentityApiTests : LoggedTest
     private static string GetPasswordResetCode(TestEmail email)
     {
         // Update if we add more links to the email.
-        var confirmationMatch = Regex.Match(email.HtmlMessage, "code: (.*?)$");
+        var confirmationMatch = Regex.Match(email.HtmlMessage, "code: (.*?)(?:\\.|$)");
         Assert.True(confirmationMatch.Success);
         Assert.Equal(2, confirmationMatch.Groups.Count);
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/IdentityNoOpEmailSender.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/IdentityNoOpEmailSender.cs
@@ -10,11 +10,11 @@ internal sealed class IdentityNoOpEmailSender : IEmailSender<ApplicationUser>
     private readonly IEmailSender emailSender = new NoOpEmailSender();
 
     public Task SendConfirmationLinkAsync(ApplicationUser user, string email, string confirmationLink) =>
-        emailSender.SendEmailAsync(email, "Confirm your email", $"Please confirm your account by <a href='{confirmationLink}'>clicking here</a>.");
+        emailSender.SendEmailAsync(email, "Confirm your email", $"Please confirm your account by <a href='{confirmationLink}'>clicking here</a>. If you didn't request this email confirmation, you can ignore this email.");
 
     public Task SendPasswordResetLinkAsync(ApplicationUser user, string email, string resetLink) =>
-        emailSender.SendEmailAsync(email, "Reset your password", $"Please reset your password by <a href='{resetLink}'>clicking here</a>.");
+        emailSender.SendEmailAsync(email, "Reset your password", $"Please reset your password by <a href='{resetLink}'>clicking here</a>. If you didn't request a password reset, you can ignore this email.");
 
     public Task SendPasswordResetCodeAsync(ApplicationUser user, string email, string resetCode) =>
-        emailSender.SendEmailAsync(email, "Reset your password", $"Please reset your password using the following code: {resetCode}");
+        emailSender.SendEmailAsync(email, "Reset your password", $"Please reset your password using the following code: {resetCode}. If you didn't request a password reset, you can ignore this email.");
 }

--- a/src/Security/samples/Identity.ExternalClaims/Extensions/EmailSenderExtensions.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Extensions/EmailSenderExtensions.cs
@@ -15,7 +15,7 @@ public static class EmailSenderExtensions
     public static Task SendEmailConfirmationAsync(this IEmailSender emailSender, string email, string link)
     {
         return emailSender.SendEmailAsync(email, "Confirm your email",
-            $"Please confirm your account by <a href='{HtmlEncoder.Default.Encode(link)}'>clicking here</a>. If you didn't create an account, you can ignore this email.");
+            $"Please confirm your account by <a href='{HtmlEncoder.Default.Encode(link)}'>clicking here</a>. If you didn't request this email confirmation, you can ignore this email.");
     }
 
     public static Task SendResetPasswordAsync(this IEmailSender emailSender, string email, string callbackUrl)

--- a/src/Security/samples/Identity.ExternalClaims/Extensions/EmailSenderExtensions.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Extensions/EmailSenderExtensions.cs
@@ -15,12 +15,12 @@ public static class EmailSenderExtensions
     public static Task SendEmailConfirmationAsync(this IEmailSender emailSender, string email, string link)
     {
         return emailSender.SendEmailAsync(email, "Confirm your email",
-            $"Please confirm your account by <a href='{HtmlEncoder.Default.Encode(link)}'>clicking here</a>.");
+            $"Please confirm your account by <a href='{HtmlEncoder.Default.Encode(link)}'>clicking here</a>. If you didn't create an account, you can ignore this email.");
     }
 
     public static Task SendResetPasswordAsync(this IEmailSender emailSender, string email, string callbackUrl)
     {
         return emailSender.SendEmailAsync(email, "Reset Password",
-            $"Please reset your password by <a href='{HtmlEncoder.Default.Encode(callbackUrl)}'>clicking here</a>.");
+            $"Please reset your password by <a href='{HtmlEncoder.Default.Encode(callbackUrl)}'>clicking here</a>. If you didn't request a password reset, you can ignore this email.");
     }
 }

--- a/src/Shared/DefaultMessageEmailSender.cs
+++ b/src/Shared/DefaultMessageEmailSender.cs
@@ -10,11 +10,11 @@ internal sealed class DefaultMessageEmailSender<TUser>(IEmailSender emailSender)
     internal bool IsNoOp => emailSender is NoOpEmailSender;
 
     public Task SendConfirmationLinkAsync(TUser user, string email, string confirmationLink) =>
-        emailSender.SendEmailAsync(email, "Confirm your email", $"Please confirm your account by <a href='{confirmationLink}'>clicking here</a>.");
+        emailSender.SendEmailAsync(email, "Confirm your email", $"Please confirm your account by <a href='{confirmationLink}'>clicking here</a>. If you didn't create an account, you can ignore this email.");
 
     public Task SendPasswordResetLinkAsync(TUser user, string email, string resetLink) =>
-        emailSender.SendEmailAsync(email, "Reset your password", $"Please reset your password by <a href='{resetLink}'>clicking here</a>.");
+        emailSender.SendEmailAsync(email, "Reset your password", $"Please reset your password by <a href='{resetLink}'>clicking here</a>. If you didn't request a password reset, you can ignore this email.");
 
     public Task SendPasswordResetCodeAsync(TUser user, string email, string resetCode) =>
-        emailSender.SendEmailAsync(email, "Reset your password", $"Please reset your password using the following code: {resetCode}");
+        emailSender.SendEmailAsync(email, "Reset your password", $"Please reset your password using the following code: {resetCode}. If you didn't request a password reset, you can ignore this email.");
 }

--- a/src/Shared/DefaultMessageEmailSender.cs
+++ b/src/Shared/DefaultMessageEmailSender.cs
@@ -10,7 +10,7 @@ internal sealed class DefaultMessageEmailSender<TUser>(IEmailSender emailSender)
     internal bool IsNoOp => emailSender is NoOpEmailSender;
 
     public Task SendConfirmationLinkAsync(TUser user, string email, string confirmationLink) =>
-        emailSender.SendEmailAsync(email, "Confirm your email", $"Please confirm your account by <a href='{confirmationLink}'>clicking here</a>. If you didn't create an account, you can ignore this email.");
+        emailSender.SendEmailAsync(email, "Confirm your email", $"Please confirm your account by <a href='{confirmationLink}'>clicking here</a>. If you didn't request this email confirmation, you can ignore this email.");
 
     public Task SendPasswordResetLinkAsync(TUser user, string email, string resetLink) =>
         emailSender.SendEmailAsync(email, "Reset your password", $"Please reset your password by <a href='{resetLink}'>clicking here</a>. If you didn't request a password reset, you can ignore this email.");


### PR DESCRIPTION
# Improve default Identity email wording for recipients who didn't initiate the action

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

Adds a follow-up sentence to the default confirmation and password-reset emails
to inform recipients who did not initiate the action that they can safely ignore the email.

Note: The issue mentions `src/Identity/UI/src/Services/EmailSenderExtensions.cs` 
but this file does not exist in the repository. Verified against upstream/main.
Only the two existing files were updated.

Fixes #66643