### PR TITLE
Document SignalR stateful reconnect in spec docs

### DIFF
--- a/src/SignalR/docs/specs/HubProtocol.md
+++ b/src/SignalR/docs/specs/HubProtocol.md
@@ -31,8 +31,8 @@ In the SignalR protocol, the following types of messages can be sent:
 | `Completion`          | Callee, Caller | Indicates a previous `Invocation` or `StreamInvocation` has completed or a stream in an `Invocation` or `StreamInvocation` has completed. Contains an error if the invocation concluded with an error or the result of a non-streaming method invocation. The result will be absent for `void` methods. In case of streaming invocations no further `StreamItem` messages will be received. |
 | `CancelInvocation`    | Caller         | Sent by the client to cancel a streaming invocation on the server.                                                             |
 | `Ping`                | Caller, Callee | Sent by either party to check if the connection is active.                                                                     |
-| `Ack`                 | Caller, Callee | Sent by either party to acknowledge that messages have been received up to the provided sequence ID.                                                                |
-| `Sequence`            | Caller, Callee | Sent by either party as the first message when a connection reconnects. Specifies what sequence ID they will start sending messages starting at. Duplicate messages are possible to receive and should be ignored.                                                                    |
+| `Ack`                 | Caller, Callee | Sent by either party to acknowledge that messages have been received up to the provided sequence ID. See [Stateful Reconnect](#stateful-reconnect).                                                              |
+| `Sequence`            | Caller, Callee | Sent by either party as the first message when a connection reconnects. Specifies what sequence ID they will start sending messages starting at. Duplicate messages are possible to receive and should be ignored. See [Stateful Reconnect](#stateful-reconnect).                                                                  |
 
 After opening a connection to the server the client must send a `HandshakeRequest` message to the server as its first message. The handshake message is **always** a JSON message and contains the name of the format (protocol) as well as the version of the protocol that will be used for the duration of the connection. The server will reply with a `HandshakeResponse`, also always JSON, containing an error if the server does not support the protocol. If the server does not support the protocol requested by the client or the first message received from the client is not a `HandshakeRequest` message the server must close the connection. Both the `HandshakeRequest` and `HandshakeResponse` messages must be terminated by the ASCII character `0x1E` (record separator).
 
@@ -138,6 +138,86 @@ Keep alive behavior is achieved via the `Ping` message type. **Either endpoint**
 Ping messages do not have any payload, they are completely empty messages (aside from the encoding necessary to identify the message as a `Ping` message).
 
 The default ASP.NET Core implementation automatically pings both directions on active connections. These pings are at regular intervals, and allow detection of unexpected disconnects (for example, unplugging a server). If the client detects that the server has stopped pinging, the client will close the connection, and vice versa. If there's other traffic through the connection, keep-alive pings aren't needed. A `Ping` is only sent if the interval has elapsed without a message being sent.
+
+## Stateful Reconnect
+
+The SignalR Hub protocol supports a stateful reconnect mode in which both
+sides buffer the Hub messages they have sent and replay any that the peer
+has not acknowledged after the underlying connection is re-established.
+This makes transient disconnects transparent to the application.
+
+This section describes only the Hub-protocol behavior — the `Sequence` and
+`Ack` messages, the sequence-ID rules, and the replay obligation. How a
+particular transport signals "the same connection has been re-established"
+is out of scope for the Hub protocol; for the ASP.NET Core transports the
+opt-in and reconnect handshake are described in
+[`TransportProtocols.md`](./TransportProtocols.md#stateful-reconnect).
+
+### Trackable messages
+
+Only `HubInvocationMessage` types participate in sequence tracking:
+
+* `Invocation`
+* `StreamInvocation`
+* `StreamItem`
+* `Completion`
+* `CancelInvocation`
+
+`HandshakeRequest`, `HandshakeResponse`, `Ping`, `Close`, `Ack` and
+`Sequence` messages are **not** assigned a sequence ID and are not buffered
+for replay.
+
+### Sequence IDs
+
+Each endpoint maintains an outbound sequence counter for the trackable
+messages it sends to the peer, and an inbound sequence counter for the
+trackable messages it has received from the peer. The counters are
+independent.
+
+Sequence IDs:
+
+* Start at `1`.
+* Increment by exactly `1` for each trackable message sent.
+* Are scoped to a single Hub connection; they are not reset by a reconnect,
+  since the goal of the reconnect is to continue the same logical
+  conversation.
+
+A receiver processes incoming trackable messages in order. Any trackable
+message whose effective sequence ID is less than or equal to the highest
+ID the receiver has already processed is a duplicate and **must be
+ignored** (without being delivered to the application). Non-trackable
+messages are not subject to this rule and are processed normally.
+
+### `Ack` messages
+
+Either endpoint may periodically send an `Ack` whose `sequenceId` is the
+highest trackable inbound sequence ID it has processed so far. On receipt
+of an `Ack`, the sender may release (drop from its replay buffer) every
+buffered trackable message with a sequence ID less than or equal to the
+acknowledged value.
+
+`Ack` messages carry no other state; they may be coalesced and a fresh
+`Ack` always supersedes any previously-sent `Ack` for the same direction.
+
+### `Sequence` messages and reconnect
+
+After a reconnect each endpoint, before sending any further trackable
+messages on the re-established connection, must send a `Sequence` message
+whose `sequenceId` is the ID it will use for the **next** trackable
+message it sends. This is equivalent to one greater than the highest
+trackable ID it has previously sent, regardless of whether those messages
+were acknowledged.
+
+The receiver uses the `sequenceId` from the incoming `Sequence` message to
+align its inbound counter and discard duplicates: any subsequently
+received trackable message with an ID strictly less than the new starting
+ID is a duplicate from before the reconnect and must be ignored.
+
+After sending its `Sequence` message, an endpoint replays every buffered
+trackable message that has not yet been acknowledged by the peer, in the
+original send order. The `Sequence` message is sent even when there are
+no buffered messages to replay, so that the peer knows what sequence ID
+the next trackable message will carry.
 
 ## Example
 

--- a/src/SignalR/docs/specs/TransportProtocols.md
+++ b/src/SignalR/docs/specs/TransportProtocols.md
@@ -28,9 +28,11 @@ In the POST request the client sends a query string parameter with the key "nego
 * If the requested version is greater than the servers largest supported version the server will respond with its largest supported version
 The client may close the connection if the "negotiateVersion" in the response is not acceptable.
 
-*useAck:*
+*useStatefulReconnect:*
 
-In the POST request the client may include a query string parameter with the key "useAck" and the value of "true". If this is included the server will decide if it supports/allows the [ack protocol](#todo) described below, and return "useAck": "true" as a json property in the negotiate response if it will use the ack protocol. If true, the client can reconnect using the same transport and reuse the connectionToken/connectionId. The server may still reject the reconnect if it takes too long or for any reason it chooses. If false, the client must not reuse connectionToken/connectionId. If the "useAck" property is missing from the negotiate response this also implies false, so the ack protocol should not be used.
+In the POST request the client may include a query string parameter with the key "useStatefulReconnect" and the value of "true". If this is included the server will decide if it supports/allows [stateful reconnect](#stateful-reconnect) described below, and return `"useStatefulReconnect": true` as a json property in the negotiate response if it will use stateful reconnect. If true, the client can reconnect on the same transport and reuse the connectionToken/connectionId. The server may still reject the reconnect if it takes too long or for any reason it chooses. If false, the client must not reuse connectionToken/connectionId. If the "useStatefulReconnect" property is missing from the negotiate response this also implies false, so stateful reconnect should not be used.
+
+Stateful reconnect is only supported on the WebSockets transport. If the negotiated transport is not WebSockets the client must treat the negotiate response as if "useStatefulReconnect" were false even when the server returned true.
 
 -----------
 
@@ -145,7 +147,9 @@ The WebSockets transport is unique in that it is full duplex, and a persistent c
 
 The WebSocket transport is activated by making a WebSocket connection to `[endpoint-base]`. The **optional** `id` query string value is used to identify the connection to attach to. If there is no `id` query string value, a new connection is established. If the parameter is specified but there is no connection with the specified ID value, a `404 Not Found` response is returned. Upon receiving this request, the connection is established and the server responds with a WebSocket upgrade (`101 Switching Protocols`) immediately ready for frames to be sent/received. The WebSocket OpCode field is used to indicate the type of the frame (Text or Binary).
 
-Establishing a second WebSocket connection when there is already a WebSocket connection associated with the Endpoints connection is not permitted and will fail with a `409 Conflict` status code.
+When the client opts in to stateful reconnect (see [Stateful Reconnect](#stateful-reconnect)) it should also append the `useStatefulReconnect=true` query string parameter when opening the WebSocket. This signals that the request is a reconnect attempt for an existing connection and, on a fresh connection, that subsequent transport-level disconnects should be recoverable.
+
+Establishing a second WebSocket connection when there is already a WebSocket connection associated with the Endpoints connection is not permitted and will fail with a `409 Conflict` status code. The one exception is when stateful reconnect was negotiated on the original connection: in that case, opening a new WebSocket to `[endpoint-base]` with the same `id` reattaches to the existing connection and the previous WebSocket is closed. If the existing connection has already been cleaned up (for example, the reconnect grace period has elapsed) the server responds with `404 Not Found` instead.
 
 Errors while establishing the connection are handled by returning a `500 Server Error` status code as the response to the upgrade request. This includes errors initializing EndPoint types. Unhandled application errors trigger a WebSocket `Close` frame with reason code that matches the error as per the spec (for errors like messages being too large, or invalid UTF-8). For other unexpected errors during the connection, a  non-`1000 Normal Closure` status code is used.
 
@@ -205,3 +209,38 @@ When data is available, the server responds with a body in one of the two format
 If the `id` parameter is missing, a `400 Bad Request` response is returned. If there is no connection with the ID specified in `id`, a `404 Not Found` response is returned.
 
 When the client has finished with the connection, it can issue a `DELETE` request to `[endpoint-base]` (with the `id` in the query string) to gracefully terminate the connection. The server will complete the latest poll with `204` to indicate that it has shut down.
+
+## Stateful Reconnect
+
+Stateful reconnect lets a client transparently recover from a transport-level
+disconnect without losing in-flight messages. When enabled, each side buffers
+the messages it has sent and the receiver acknowledges the messages it has
+processed; on reconnect the unacknowledged messages are replayed in order.
+
+Stateful reconnect is opt-in on both sides and is only supported by the
+WebSockets transport.
+
+### Negotiation
+
+1. The client sends `useStatefulReconnect=true` on the `POST [endpoint-base]/negotiate` request (see the [`useStatefulReconnect`](#post-endpoint-basenegotiate-request) negotiate parameter above).
+2. The server returns `"useStatefulReconnect": true` in the negotiate response only when the endpoint has been configured to allow stateful reconnects.
+3. The client must treat the property as `false` when the response omits it, or when the negotiated transport is not WebSockets. In that case the connectionToken/connectionId must not be reused.
+
+### Reconnect flow
+
+When stateful reconnect was negotiated and the WebSocket transport drops, the
+client may attempt to reconnect by opening a new WebSocket to `[endpoint-base]`
+with the same `id` query string value (the connectionToken from the original
+negotiate response) and `useStatefulReconnect=true`. The server reattaches the
+new WebSocket to the existing connection and notifies the upper layer that
+the connection has been re-established; any message-level replay or recovery
+is the responsibility of that upper layer (for example, the Hub protocol — see
+[`HubProtocol.md`](./HubProtocol.md#stateful-reconnect)). If the server has
+already cleaned the connection up (timeout, disposal, or otherwise) it
+responds with `404 Not Found` and the client must restart the connection from
+negotiate.
+
+The transport itself does not buffer or acknowledge application messages; it
+only guarantees that, after a successful reattach, both sides see the same
+logical connection they had before the drop. Any framing for buffering,
+acknowledgment and replay is defined by the upper layer.


### PR DESCRIPTION
## Why

[Issue #53103](https://github.com/dotnet/aspnetcore/issues/53103) points out that `src/SignalR/docs/specs/TransportProtocols.md` is out of date with respect to the stateful reconnect feature: it names the negotiate property `useAck`, but the shipped wire name is `useStatefulReconnect`, and it links to a literal `[ack protocol](#todo)` placeholder section that was never written. `HubProtocol.md` already had the wire formats for the `Ack` and `Sequence` messages, but no description of when/why they are exchanged or how sequence IDs and replay actually work.

## What changed

**`TransportProtocols.md`**
- Renamed the negotiate query-string / response property from `useAck` to `useStatefulReconnect` to match `NegotiateProtocol.cs` and `HttpConnectionDispatcher.cs`.
- Replaced the dead `[ack protocol](#todo)` link with a real **Stateful Reconnect** section: opt-in handshake, WebSockets-only scope, and the reconnect flow (client reuses `connectionToken` on a new WebSocket, server reattaches instead of returning `409 Conflict`, `404` if the connection has already been cleaned up).
- Updated the WebSockets transport section to note that the "no second WebSocket" `409 Conflict` rule is relaxed for stateful-reconnect reattach.
- Scoped the transport's contract to reattach + notify the upper layer; explicitly defers buffering/ack/replay to upper layers, with the Hub protocol as a non-normative example.

**`HubProtocol.md`**
- Added cross-references from the existing `Ack` / `Sequence` rows in the message-summary table to the new semantics section.
- Added a **Stateful Reconnect** section that, after verifying against `src/SignalR/common/Shared/MessageBuffer.cs`, documents:
  - The trackable message set: `HubInvocationMessage` subtypes only (`Invocation`, `StreamInvocation`, `StreamItem`, `Completion`, `CancelInvocation`); `Ping`, `Close`, `Ack`, `Sequence` and handshakes are not tracked.
  - Per-direction 1-based sequence IDs that are not reset by a reconnect.
  - The duplicate-discard rule.
  - Periodic `Ack` semantics, including that a later `Ack` supersedes earlier ones for the same direction.
  - The `Sequence`-first reconnect handshake: `sequenceId` is `highest_sent + 1`, and the message is sent even when there are no buffered messages to replay so the peer knows where IDs continue.
- Kept the section transport-agnostic; `TransportProtocols.md` is mentioned only as an example transport binding.

Fixes #53103

## Notes for reviewers

- Docs-only change. No code is modified.
