### PR TITLE
Add AddHealthChecks(Action<HealthCheckServiceOptions>) overload

### DIFF
--- a/src/HealthChecks/HealthChecks/src/DependencyInjection/HealthCheckServiceCollectionExtensions.cs
+++ b/src/HealthChecks/HealthChecks/src/DependencyInjection/HealthCheckServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using Microsoft.AspNetCore.Shared;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
@@ -28,5 +30,27 @@ public static class HealthCheckServiceCollectionExtensions
         services.TryAddSingleton<HealthCheckService, DefaultHealthCheckService>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, HealthCheckPublisherHostedService>());
         return new HealthChecksBuilder(services);
+    }
+
+    /// <summary>
+    /// Adds the <see cref="HealthCheckService"/> to the container and configures the
+    /// <see cref="HealthCheckServiceOptions"/> used by the registered service.
+    /// </summary>
+    /// <remarks>
+    /// This operation is idempotent - multiple invocations will still only result in a single
+    /// <see cref="HealthCheckService"/> instance in the <see cref="IServiceCollection"/>. The
+    /// <paramref name="configureOptions"/> delegate is invoked every time the options instance is
+    /// constructed, allowing the method to be called repeatedly to compose registrations.
+    /// </remarks>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add the <see cref="HealthCheckService"/> to.</param>
+    /// <param name="configureOptions">A delegate that configures the <see cref="HealthCheckServiceOptions"/>.</param>
+    /// <returns>An instance of <see cref="IHealthChecksBuilder"/> from which health checks can be registered.</returns>
+    public static IHealthChecksBuilder AddHealthChecks(this IServiceCollection services, Action<HealthCheckServiceOptions> configureOptions)
+    {
+        ArgumentNullThrowHelper.ThrowIfNull(services);
+        ArgumentNullThrowHelper.ThrowIfNull(configureOptions);
+
+        services.Configure(configureOptions);
+        return services.AddHealthChecks();
     }
 }

--- a/src/HealthChecks/HealthChecks/src/PublicAPI.Unshipped.txt
+++ b/src/HealthChecks/HealthChecks/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+static Microsoft.Extensions.DependencyInjection.HealthCheckServiceCollectionExtensions.AddHealthChecks(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckServiceOptions!>! configureOptions) -> Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder!

--- a/src/HealthChecks/HealthChecks/test/DependencyInjection/ServiceCollectionExtensionsTest.cs
+++ b/src/HealthChecks/HealthChecks/test/DependencyInjection/ServiceCollectionExtensionsTest.cs
@@ -1,11 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -78,6 +80,56 @@ public class ServiceCollectionExtensionsTest
                 Assert.Null(actual.ImplementationInstance);
                 Assert.Null(actual.ImplementationFactory);
             });
+    }
+
+    [Fact]
+    public void AddHealthChecks_WithConfigureOptions_InvokesDelegateOnResolvedOptions()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var marker = new HealthCheckRegistration("marker", _ => Task.FromResult(HealthCheckResult.Healthy()), failureStatus: null, tags: null);
+
+        // Act
+        services.AddHealthChecks(options => options.Registrations.Add(marker));
+
+        // Assert
+        using var provider = services.BuildServiceProvider();
+        var resolved = provider.GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value;
+        Assert.Same(marker, Assert.Single(resolved.Registrations));
+    }
+
+    [Fact]
+    public void AddHealthChecks_WithConfigureOptions_ReturnsBuilderUsableForFurtherRegistration()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var fromOptions = new HealthCheckRegistration("from-options", _ => Task.FromResult(HealthCheckResult.Healthy()), failureStatus: null, tags: null);
+        var fromBuilder = new HealthCheckRegistration("from-builder", _ => Task.FromResult(HealthCheckResult.Healthy()), failureStatus: null, tags: null);
+
+        // Act
+        var builder = services.AddHealthChecks(options => options.Registrations.Add(fromOptions));
+        builder.Add(fromBuilder);
+
+        // Assert
+        using var provider = services.BuildServiceProvider();
+        var resolved = provider.GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value;
+        Assert.Equal(new[] { "from-options", "from-builder" }, resolved.Registrations.Select(r => r.Name).ToArray());
+    }
+
+    [Fact]
+    public void AddHealthChecks_WithConfigureOptions_ThrowsForNullServices()
+    {
+        IServiceCollection services = null!;
+
+        Assert.Throws<ArgumentNullException>(() => services.AddHealthChecks(_ => { }));
+    }
+
+    [Fact]
+    public void AddHealthChecks_WithConfigureOptions_ThrowsForNullConfigureDelegate()
+    {
+        var services = new ServiceCollection();
+
+        Assert.Throws<ArgumentNullException>(() => services.AddHealthChecks(configureOptions: null!));
     }
 
     private class DummyHostedService : IHostedService

--- a/src/HealthChecks/HealthChecks/test/DependencyInjection/ServiceCollectionExtensionsTest.cs
+++ b/src/HealthChecks/HealthChecks/test/DependencyInjection/ServiceCollectionExtensionsTest.cs
@@ -87,7 +87,7 @@ public class ServiceCollectionExtensionsTest
     {
         // Arrange
         var services = new ServiceCollection();
-        var marker = new HealthCheckRegistration("marker", _ => Task.FromResult(HealthCheckResult.Healthy()), failureStatus: null, tags: null);
+        var marker = new HealthCheckRegistration("marker", new DummyHealthCheck(), failureStatus: null, tags: null);
 
         // Act
         services.AddHealthChecks(options => options.Registrations.Add(marker));
@@ -103,8 +103,8 @@ public class ServiceCollectionExtensionsTest
     {
         // Arrange
         var services = new ServiceCollection();
-        var fromOptions = new HealthCheckRegistration("from-options", _ => Task.FromResult(HealthCheckResult.Healthy()), failureStatus: null, tags: null);
-        var fromBuilder = new HealthCheckRegistration("from-builder", _ => Task.FromResult(HealthCheckResult.Healthy()), failureStatus: null, tags: null);
+        var fromOptions = new HealthCheckRegistration("from-options", new DummyHealthCheck(), failureStatus: null, tags: null);
+        var fromBuilder = new HealthCheckRegistration("from-builder", new DummyHealthCheck(), failureStatus: null, tags: null);
 
         // Act
         var builder = services.AddHealthChecks(options => options.Registrations.Add(fromOptions));
@@ -130,6 +130,12 @@ public class ServiceCollectionExtensionsTest
         var services = new ServiceCollection();
 
         Assert.Throws<ArgumentNullException>(() => services.AddHealthChecks(configureOptions: null!));
+    }
+
+    private sealed class DummyHealthCheck : IHealthCheck
+    {
+        public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+            => Task.FromResult(HealthCheckResult.Healthy());
     }
 
     private class DummyHostedService : IHostedService


### PR DESCRIPTION
Fixes #8530.

## Summary

`services.AddHealthChecks()` returns an `IHealthChecksBuilder`, but does not currently expose a convenient way to configure `HealthCheckServiceOptions` (which `DefaultHealthCheckService` consumes via `IOptions<HealthCheckServiceOptions>`). Users today have to call `services.Configure<HealthCheckServiceOptions>(...)` separately and then `services.AddHealthChecks()` — two statements instead of one, and the relationship between them is not discoverable from the API surface.

This PR adds a new overload that takes a configuration delegate:

```csharp
public static IHealthChecksBuilder AddHealthChecks(
    this IServiceCollection services,
    Action<HealthCheckServiceOptions> configureOptions);
```

Usage:

```csharp
services.AddHealthChecks(options =>
{
    options.Registrations.Add(new HealthCheckRegistration(
        "marker",
        _ => Task.FromResult(HealthCheckResult.Healthy()),
        failureStatus: null,
        tags: null));
})
.AddCheck<MyHealthCheck>("my-check");
```

The overload internally calls `services.Configure(configureOptions)` and then delegates to the existing parameterless `AddHealthChecks()`, so the idempotency guarantee and the existing service registrations are preserved. The returned `IHealthChecksBuilder` remains usable for chained registrations.

## Changes

- `HealthCheckServiceCollectionExtensions.cs` — new overload with full XML docs.
- `PublicAPI.Unshipped.txt` — baselined the new API.
- `ServiceCollectionExtensionsTest.cs` — added four tests:
  - delegate is invoked on resolved options,
  - returned builder is usable for further registrations alongside the delegate,
  - null `services` throws `ArgumentNullException`,
  - null `configureOptions` throws `ArgumentNullException`.