### PR TITLE
Make AssertEmptyMigration whitespace-insensitive

### DIFF
--- a/src/ProjectTemplates/Shared/Project.cs
+++ b/src/ProjectTemplates/Shared/Project.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text.Json;
@@ -346,11 +347,13 @@ public class Project : IDisposable
         }";
 
         // This comparison can break depending on how GIT checked out newlines on different files.
-        Assert.Contains(RemoveNewLines(emptyMigration), RemoveNewLines(contents));
+        // Whitespace is also normalized so the assertion works regardless of indentation
+        // (e.g. block-scoped vs file-scoped namespaces in generated migrations).
+        Assert.Contains(NormalizeWhitespace(emptyMigration), NormalizeWhitespace(contents));
 
-        static string RemoveNewLines(string str)
+        static string NormalizeWhitespace(string str)
         {
-            return str.Replace("\n", string.Empty).Replace("\r", string.Empty);
+            return new string(str.Where(c => !char.IsWhiteSpace(c)).ToArray());
         }
     }
 


### PR DESCRIPTION
## Problem

Template tests that assert a freshly added EF migration is empty (e.g. `MvcTemplate_IndividualAuth`, `BlazorTemplate`, `RazorPagesTemplate`, `IdentityUIPackageTest`) started failing with:

```
Assert.Contains() Failure: Sub-string not found
String:    "using Microsoft.EntityFrameworkCore.Migra"...
Not found: "/// <inheritdoc />        protected overr"...
```

## Root cause

[dotnet/efcore@fe85801](https://github.com/dotnet/efcore/commit/fe85801f2da314587f3716a2bc5c718e9d1cffc9) changed EF Core's generated code (including migration files) from block-scoped namespaces to file-scoped namespaces. That dedents class members by 4 spaces.

`AssertEmptyMigration` did a `Contains` check against a literal string with the old 8-space indentation and only stripped newlines, so it no longer matched the dedented output.

## Fix

Normalize all whitespace when comparing. The literal only covers the `Up`/`Down` method bodies (not the namespace declaration itself), so a whitespace-insensitive substring match still verifies the migration body is empty and works for both block-scoped and file-scoped namespace output.

Example failing build: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1430507&view=ms.vss-test-web.build-test-results-tab&runId=39729748&resultId=100063