### PR TITLE
Run template tests on changes to Version.Details

### DIFF
--- a/.azure/pipelines/template-tests-pr.yml
+++ b/.azure/pipelines/template-tests-pr.yml
@@ -19,6 +19,7 @@ pr:
     - src/ProjectTemplates/*
     - src/Components/*
     - src/Mvc/*
+    - eng/Version.Details.props
     - eng/Versions.props
 
 variables:


### PR DESCRIPTION
Today we don't run the template tests on changes to Version.Details, which caused us to miss a break introduced by https://github.com/dotnet/aspnetcore/pull/66741. 