### PR TITLE
Fix InputSelect handling of bool? to correctly preserve null value and added tests

### DIFF
--- a/src/Components/Web/src/Forms/InputSelect.cs
+++ b/src/Components/Web/src/Forms/InputSelect.cs
@@ -77,7 +77,7 @@ public class InputSelect<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTy
         }
         else if (typeof(TValue) == typeof(bool?))
         {
-            return value is not null && (bool)(object)value ? "true" : "false";
+            return value is not null ? ((bool)(object)value ? "true" : "false") : null;
         }
 
         return base.FormatValueAsString(value);

--- a/src/Components/Web/test/Forms/InputSelectTest.cs
+++ b/src/Components/Web/test/Forms/InputSelectTest.cs
@@ -169,6 +169,81 @@ public class InputSelectTest
     }
 
     [Fact]
+    public async Task ParsesCurrentValueWhenUsingNotNullableBool()
+    {
+        // Arrange
+        var model = new TestModel();
+        var rootComponent = new TestInputHostComponent<bool, TestInputSelect<bool>>
+        {
+            EditContext = new EditContext(model),
+            ValueExpression = () => model.NotNullableBool
+        };
+        var inputSelectComponent = await InputRenderer.RenderAndGetComponent(rootComponent);
+
+        // Act
+        inputSelectComponent.CurrentValueAsString = "true";
+
+        // Assert
+        Assert.True(inputSelectComponent.CurrentValue);
+
+        // Act
+        inputSelectComponent.CurrentValueAsString = "false";
+
+        // Assert
+        Assert.False(inputSelectComponent.CurrentValue);
+    }
+
+    [Fact]
+    public async Task ParsesCurrentValueWhenUsingNullableBool()
+    {
+        // Arrange
+        var model = new TestModel();
+        var rootComponent = new TestInputHostComponent<bool?, TestInputSelect<bool?>>
+        {
+            EditContext = new EditContext(model),
+            ValueExpression = () => model.NullableBool
+        };
+        var inputSelectComponent = await InputRenderer.RenderAndGetComponent(rootComponent);
+
+        // Act
+        inputSelectComponent.CurrentValueAsString = "true";
+
+        // Assert
+        Assert.True(inputSelectComponent.CurrentValue);
+
+        // Act
+        inputSelectComponent.CurrentValueAsString = "false";
+
+        // Assert
+        Assert.False(inputSelectComponent.CurrentValue);
+
+        // Act
+        inputSelectComponent.CurrentValueAsString = "";
+
+        // Assert
+        Assert.Null(inputSelectComponent.CurrentValue);
+    }
+
+    [Fact]
+    public async Task FormatsNullableBoolNullAsEmptyString()
+    {
+        // Arrange
+        var model = new TestModel { NullableBool = null };
+
+        var rootComponent = new TestInputHostComponent<bool?, TestInputSelect<bool?>>
+        {
+            EditContext = new EditContext(model),
+            ValueExpression = () => model.NullableBool
+        };
+
+        // Act
+        var component = await InputRenderer.RenderAndGetComponent(rootComponent);
+
+        // Assert
+        Assert.Null(component.CurrentValueAsString);
+    }
+
+    [Fact]
     public async Task ValidationErrorUsesDisplayAttributeName()
     {
         // Arrange


### PR DESCRIPTION
## Description:

InputSelect does not correctly handle bool? (nullable boolean) values.
When a bool? property is bound to an InputSelect:

- If the model value is null, the component formats it as "false" instead of null
- As a result, the UI incorrectly selects the "false" option instead of the empty/default option

This behavior is inconsistent with other nullable types such as:

- int?
- Guid?
- enum?

For those types, null correctly maps to an empty option (value="").

## Root Cause

The issue was caused by the absence of explicit handling for nullable boolean types in the **FormatValueAsString** method.

- The existing implementation treated bool? similarly to bool
- When the value was null, it was implicitly converted or interpreted as false
- This caused incorrect rendering, where the "false" option was selected instead of leaving the selection empty

## Testing

Added unit tests to validate both parsing and formatting behavior for **bool** and **bool?** types in **InputSelect**. The test fails without the fix and passes with it.

Fixes #54565 