### PR TITLE
Propagate JsonSerializerOptions correctly during OpenAPI generation

### DIFF
--- a/src/OpenApi/src/Schemas/OpenApiJsonSchema.Helpers.cs
+++ b/src/OpenApi/src/Schemas/OpenApiJsonSchema.Helpers.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using Microsoft.AspNetCore.OpenApi;
 
 using OpenApiConstants = Microsoft.AspNetCore.OpenApi.OpenApiConstants;
@@ -18,8 +19,9 @@ internal sealed partial class OpenApiJsonSchema
     /// </summary>
     /// <typeparam name="T">The type of the elements that will populate the list.</typeparam>
     /// <param name="reader">The <see cref="Utf8JsonReader"/> to consume the list from.</param>
+    /// <param name="context">The <see cref="OpenApiJsonSchemaContext"/> to use for reading.</param>
     /// <returns>A list parsed from the JSON array.</returns>
-    public static List<T>? ReadList<T>(ref Utf8JsonReader reader)
+    private static List<T>? ReadList<T>(ref Utf8JsonReader reader, OpenApiJsonSchemaContext context)
     {
         if (reader.TokenType == JsonTokenType.Null)
         {
@@ -32,7 +34,7 @@ internal sealed partial class OpenApiJsonSchema
             reader.Read();
             while (reader.TokenType != JsonTokenType.EndArray)
             {
-                values.Add((T)JsonSerializer.Deserialize(ref reader, typeof(T), OpenApiJsonSchemaContext.Default)!);
+                values.Add((T)JsonSerializer.Deserialize(ref reader, typeof(T), context)!);
                 reader.Read();
             }
 
@@ -52,9 +54,10 @@ internal sealed partial class OpenApiJsonSchema
     /// </summary>
     /// <typeparam name="T">The type associated with the values in the dictionary.</typeparam>
     /// <param name="reader">The <see cref="Utf8JsonReader"/> to consume the dictionary from.</param>
+    /// <param name="context">The <see cref="OpenApiJsonSchemaContext"/> to use for reading.</param>
     /// <returns>A dictionary parsed from the JSON object.</returns>
     /// <exception cref="JsonException">Thrown if JSON object is not valid.</exception>
-    public static Dictionary<string, T>? ReadDictionary<T>(ref Utf8JsonReader reader)
+    private static Dictionary<string, T>? ReadDictionary<T>(ref Utf8JsonReader reader, OpenApiJsonSchemaContext context)
     {
         if (reader.TokenType == JsonTokenType.Null)
         {
@@ -77,17 +80,17 @@ internal sealed partial class OpenApiJsonSchema
 
             var key = reader.GetString()!;
             reader.Read();
-            values[key] = (T)JsonSerializer.Deserialize(ref reader, typeof(T), OpenApiJsonSchemaContext.Default)!;
+            values[key] = (T)JsonSerializer.Deserialize(ref reader, typeof(T), context)!;
             reader.Read();
         }
 
         return values;
     }
 
-    internal static JsonNode? ReadJsonNode(ref Utf8JsonReader reader)
+    private static JsonNode? ReadJsonNode(ref Utf8JsonReader reader)
         => ReadJsonNode(ref reader, out _);
 
-    internal static JsonNode? ReadJsonNode(ref Utf8JsonReader reader, out JsonSchemaType? type)
+    private static JsonNode? ReadJsonNode(ref Utf8JsonReader reader, out JsonSchemaType? type)
     {
         type = null;
         if (reader.TokenType == JsonTokenType.Null)
@@ -171,6 +174,12 @@ internal sealed partial class OpenApiJsonSchema
         return default;
     }
 
+    private static int GetInt32(ref Utf8JsonReader reader, OpenApiJsonSchemaContext context)
+        => JsonSerializer.Deserialize(ref reader, (JsonTypeInfo<int>)context.GetTypeInfo(typeof(int))!);
+
+    private static decimal GetDecimal(ref Utf8JsonReader reader, OpenApiJsonSchemaContext context)
+        => JsonSerializer.Deserialize(ref reader, (JsonTypeInfo<decimal>)context.GetTypeInfo(typeof(decimal))!);
+
     /// <summary>
     /// Read a property node from the given JSON reader instance.
     /// </summary>
@@ -180,13 +189,14 @@ internal sealed partial class OpenApiJsonSchema
     /// <param name="options">The <see cref="JsonSerializerOptions"/> instance.</param>
     public static void ReadProperty(ref Utf8JsonReader reader, string propertyName, OpenApiSchema schema, JsonSerializerOptions options)
     {
+        var context = (options.TypeInfoResolver as OpenApiJsonSchemaContext) ?? new OpenApiJsonSchemaContext(new(options));
         switch (propertyName)
         {
             case OpenApiSchemaKeywords.TypeKeyword:
                 reader.Read();
                 if (reader.TokenType == JsonTokenType.StartArray)
                 {
-                    var types = ReadList<string>(ref reader);
+                    var types = ReadList<string>(ref reader, context);
                     foreach (var type in types ?? [])
                     {
                         if (schema.Type is not null)
@@ -208,7 +218,7 @@ internal sealed partial class OpenApiJsonSchema
                 break;
             case OpenApiSchemaKeywords.EnumKeyword:
                 reader.Read();
-                var enumValues = ReadList<JsonNode>(ref reader);
+                var enumValues = ReadList<JsonNode>(ref reader, context);
                 if (enumValues is not null)
                 {
                     schema.Enum = enumValues;
@@ -233,46 +243,46 @@ internal sealed partial class OpenApiJsonSchema
                 break;
             case OpenApiSchemaKeywords.RequiredKeyword:
                 reader.Read();
-                schema.Required = ReadList<string>(ref reader)?.ToHashSet();
+                schema.Required = ReadList<string>(ref reader, context)?.ToHashSet();
                 break;
             case OpenApiSchemaKeywords.MinLengthKeyword:
                 reader.Read();
-                var minLength = reader.GetInt32();
+                var minLength = GetInt32(ref reader, context);
                 schema.MinLength = minLength;
                 break;
             case OpenApiSchemaKeywords.MinItemsKeyword:
                 reader.Read();
-                var minItems = reader.GetInt32();
+                var minItems = GetInt32(ref reader, context);
                 schema.MinItems = minItems;
                 break;
             case OpenApiSchemaKeywords.MaxLengthKeyword:
                 reader.Read();
-                var maxLength = reader.GetInt32();
+                var maxLength = GetInt32(ref reader, context);
                 schema.MaxLength = maxLength;
                 break;
             case OpenApiSchemaKeywords.MaxItemsKeyword:
                 reader.Read();
-                var maxItems = reader.GetInt32();
+                var maxItems = GetInt32(ref reader, context);
                 schema.MaxItems = maxItems;
                 break;
             case OpenApiSchemaKeywords.MinimumKeyword:
                 reader.Read();
-                var minimum = reader.GetDecimal();
+                var minimum = GetDecimal(ref reader, context);
                 schema.Minimum = minimum.ToString(CultureInfo.InvariantCulture);
                 break;
             case OpenApiSchemaKeywords.ExclusiveMinimum:
                 reader.Read();
-                var exclusiveMinimum = reader.GetDecimal();
+                var exclusiveMinimum = GetDecimal(ref reader, context);
                 schema.ExclusiveMinimum = exclusiveMinimum.ToString(CultureInfo.InvariantCulture);
                 break;
             case OpenApiSchemaKeywords.MaximumKeyword:
                 reader.Read();
-                var maximum = reader.GetDecimal();
+                var maximum = GetDecimal(ref reader, context);
                 schema.Maximum = maximum.ToString(CultureInfo.InvariantCulture);
                 break;
             case OpenApiSchemaKeywords.ExclusiveMaximum:
                 reader.Read();
-                var exclusiveMaximum = reader.GetDecimal();
+                var exclusiveMaximum = GetDecimal(ref reader, context);
                 schema.ExclusiveMaximum = exclusiveMaximum.ToString(CultureInfo.InvariantCulture);
                 break;
             case OpenApiSchemaKeywords.PatternKeyword:
@@ -282,7 +292,7 @@ internal sealed partial class OpenApiJsonSchema
                 break;
             case OpenApiSchemaKeywords.PropertiesKeyword:
                 reader.Read();
-                var props = ReadDictionary<OpenApiJsonSchema>(ref reader);
+                var props = ReadDictionary<OpenApiJsonSchema>(ref reader, context);
                 schema.Properties = props?.ToDictionary(p => p.Key, p => p.Value.Schema as IOpenApiSchema);
                 break;
             case OpenApiSchemaKeywords.AdditionalPropertiesKeyword:
@@ -298,13 +308,13 @@ internal sealed partial class OpenApiJsonSchema
             case OpenApiSchemaKeywords.AnyOfKeyword:
                 reader.Read();
                 schema.Type = JsonSchemaType.Object;
-                var anyOfSchemas = ReadList<OpenApiJsonSchema>(ref reader);
+                var anyOfSchemas = ReadList<OpenApiJsonSchema>(ref reader, context);
                 schema.AnyOf = anyOfSchemas?.Select(s => s.Schema as IOpenApiSchema).ToList();
                 break;
             case OpenApiSchemaKeywords.OneOfKeyword:
                 reader.Read();
                 schema.Type = JsonSchemaType.Object;
-                var oneOfSchemas = ReadList<OpenApiJsonSchema>(ref reader);
+                var oneOfSchemas = ReadList<OpenApiJsonSchema>(ref reader, context);
                 schema.OneOf = oneOfSchemas?.Select(s => s.Schema as IOpenApiSchema).ToList();
                 break;
             case OpenApiSchemaKeywords.DiscriminatorKeyword:
@@ -317,7 +327,7 @@ internal sealed partial class OpenApiJsonSchema
                 break;
             case OpenApiSchemaKeywords.DiscriminatorMappingKeyword:
                 reader.Read();
-                var mappings = ReadDictionary<string>(ref reader);
+                var mappings = ReadDictionary<string>(ref reader, context);
                 if (mappings is not null)
                 {
                     schema.Discriminator ??= new OpenApiDiscriminator();

--- a/src/OpenApi/src/Schemas/OpenApiJsonSchema.Helpers.cs
+++ b/src/OpenApi/src/Schemas/OpenApiJsonSchema.Helpers.cs
@@ -187,9 +187,9 @@ internal sealed partial class OpenApiJsonSchema
     /// <param name="propertyName">The name of the property the editor is currently consuming.</param>
     /// <param name="schema">The <see cref="OpenApiSchema"/> to write the given values to.</param>
     /// <param name="options">The <see cref="JsonSerializerOptions"/> instance.</param>
-    public static void ReadProperty(ref Utf8JsonReader reader, string propertyName, OpenApiSchema schema, JsonSerializerOptions options)
+    /// <param name="context">The <see cref="OpenApiJsonSchemaContext"/> instance.</param>
+    public static void ReadProperty(ref Utf8JsonReader reader, string propertyName, OpenApiSchema schema, JsonSerializerOptions options, OpenApiJsonSchemaContext context)
     {
-        var context = (options.TypeInfoResolver as OpenApiJsonSchemaContext) ?? new OpenApiJsonSchemaContext(new(options));
         switch (propertyName)
         {
             case OpenApiSchemaKeywords.TypeKeyword:

--- a/src/OpenApi/src/Schemas/OpenApiJsonSchema.cs
+++ b/src/OpenApi/src/Schemas/OpenApiJsonSchema.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.OpenApi;
 
 [JsonConverter(typeof(JsonConverter))]
 internal sealed partial class OpenApiJsonSchema(OpenApiSchema schema)
@@ -21,6 +22,8 @@ internal sealed partial class OpenApiJsonSchema(OpenApiSchema schema)
             {
                 throw new JsonException("Expected StartObject token to represent beginning of schema.");
             }
+
+            OpenApiJsonSchemaContext? context = null;
             reader.Read();
             do
             {
@@ -28,7 +31,8 @@ internal sealed partial class OpenApiJsonSchema(OpenApiSchema schema)
                 {
                     case JsonTokenType.PropertyName:
                         var propertyName = reader.GetString() ?? throw new JsonException("Encountered unexpected missing property name.");
-                        ReadProperty(ref reader, propertyName, schema, options);
+                        context ??= (options.TypeInfoResolver as OpenApiJsonSchemaContext) ?? new OpenApiJsonSchemaContext(new(options));
+                        ReadProperty(ref reader, propertyName, schema, options, context);
                         break;
                     case JsonTokenType.EndObject:
                         return new OpenApiJsonSchema(schema);

--- a/src/OpenApi/src/Schemas/OpenApiJsonSchemaContext.cs
+++ b/src/OpenApi/src/Schemas/OpenApiJsonSchemaContext.cs
@@ -8,5 +8,7 @@ namespace Microsoft.AspNetCore.OpenApi;
 
 [JsonSerializable(typeof(OpenApiJsonSchema))]
 [JsonSerializable(typeof(string))]
+[JsonSerializable(typeof(int))]
+[JsonSerializable(typeof(decimal))]
 [JsonSerializable(typeof(JsonNode))]
 internal sealed partial class OpenApiJsonSchemaContext : JsonSerializerContext { }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Responses.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Responses.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -577,6 +578,26 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
             Assert.Equal("application/json", content.Key);
             Assert.NotNull(content.Value.Schema.AnyOf);
             Assert.Equal(2, content.Value.Schema.AnyOf.Count);
+        });
+    }
+
+    [Fact]
+    public async Task GetOpenApiResponse_WithNumberAsString_ShouldSerializeWithoutErrors()
+    {
+        // Arrange
+        var builder = CreateBuilder(serviceCollection: null, numberHandling: JsonNumberHandling.WriteAsString | JsonNumberHandling.AllowReadingFromString);
+
+        // Act
+        builder.MapGet("/myapi", () => new ModelWithStringAndStringLength(string.Empty));
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = Assert.Single(document.Paths["/myapi"].Operations.Values);
+            var response = Assert.Single(operation.Responses);
+            Assert.Equal("200", response.Key);
+            var kvp = Assert.Single(response.Value.Content);
+            Assert.Equal("application/json", kvp.Key);
         });
     }
 }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Responses.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Responses.cs
@@ -598,6 +598,11 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
             Assert.Equal("200", response.Key);
             var kvp = Assert.Single(response.Value.Content);
             Assert.Equal("application/json", kvp.Key);
+            var schema = Assert.Single(document.Components.Schemas);
+            Assert.Equal(nameof(ModelWithStringAndStringLength), schema.Key);
+            var property = Assert.Single(schema.Value.Properties);
+            Assert.Equal("value", property.Key);
+            Assert.Equal(100, property.Value.MaxLength);
         });
     }
 }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentServiceTestsBase.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentServiceTestsBase.cs
@@ -3,6 +3,7 @@
 
 using System.Reflection;
 using System.Text;
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
@@ -164,12 +165,12 @@ public abstract class OpenApiDocumentServiceTestBase
             new ServiceProviderIsService());
     }
 
-    internal static TestEndpointRouteBuilder CreateBuilder(IServiceCollection serviceCollection = null)
+    internal static TestEndpointRouteBuilder CreateBuilder(IServiceCollection serviceCollection = null, JsonNumberHandling numberHandling = JsonNumberHandling.Strict)
     {
         serviceCollection ??= new ServiceCollection();
         serviceCollection.ConfigureHttpJsonOptions(options =>
         {
-            options.SerializerOptions.NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.Strict;
+            options.SerializerOptions.NumberHandling = numberHandling;
         });
         var serviceProvider = new TestServiceProvider();
         serviceProvider.SetInternalServiceProvider(serviceCollection);

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Shared/SharedTypes.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Shared/SharedTypes.cs
@@ -19,6 +19,10 @@ using Microsoft.AspNetCore.Http;
 /// <param name="CreatedAt">The date and time when the to-do item was created.</param>
 internal record Todo(int Id, string Title, bool Completed, DateTime CreatedAt);
 
+/// <summary>
+/// Represents a model with a string value constrained by a maximum length.
+/// </summary>
+/// <param name="Value">The string value, limited to 100 characters.</param>
 internal record ModelWithStringAndStringLength([property: StringLength(100)] string Value);
 
 /// <summary>

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Shared/SharedTypes.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Shared/SharedTypes.cs
@@ -19,6 +19,8 @@ using Microsoft.AspNetCore.Http;
 /// <param name="CreatedAt">The date and time when the to-do item was created.</param>
 internal record Todo(int Id, string Title, bool Completed, DateTime CreatedAt);
 
+internal record ModelWithStringAndStringLength([property: StringLength(100)] string Value);
+
 /// <summary>
 /// Represents a to-do item with a due date.
 /// </summary>


### PR DESCRIPTION
Fixes #66111

- The source generated `OpenApiJsonSchemaContext.Default` uses default options (`new JsonSerializerOptions()`). This PR replaces usages of `OpenApiJsonSchemaContext.Default` and constructs a proper `OpenApiJsonSchemaContext` instance given the `JsonSerializationOptions`
- Marks few methods as private instead of internal for clarity about what's used outside the class.
- Avoids usages of `reader.GetInt32` and `reader.GetDecimal`. These methods are not aware of the json options at all. So, they can throw exceptions if the user specified `JsonNumberHandling.WriteAsString | JsonNumberHandling.AllowReadingFromString`.