### PR TITLE
Fix OpenApi throwing exception on non-strict JsonNumberHandling

### DIFF
--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Schema;
+using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -32,7 +33,12 @@ internal sealed class OpenApiSchemaService(
     IOptionsMonitor<OpenApiOptions> optionsMonitor)
 {
     private readonly ConcurrentDictionary<Type, string?> _schemaIdCache = new();
-    private readonly OpenApiJsonSchemaContext _jsonSchemaContext = new(new(jsonOptions.Value.SerializerOptions));
+    private readonly OpenApiJsonSchemaContext _jsonSchemaContext = new(new(jsonOptions.Value.SerializerOptions)
+    {
+        // See comment about NumberHandling below.
+        NumberHandling = JsonNumberHandling.Strict,
+    });
+
     private readonly JsonSerializerOptions _jsonSerializerOptions = new(jsonOptions.Value.SerializerOptions)
     {
         // In order to properly handle the `RequiredAttribute` on type properties, add a modifier to support
@@ -50,7 +56,15 @@ internal sealed class OpenApiSchemaService(
                     .Any(attr => attr is RequiredAttribute);
                 propertyInfo.IsRequired |= hasRequiredAttribute ?? false;
             }
-        })
+        }),
+        // Overriding what the user provided so that our implementation that uses Utf8JsonReader doesn't
+        // need to care about this option.
+        // This is assumed to be safe as the serialization/deserialization happening via this options
+        // instance isn't supposed to be user visible.
+        // We only use this instance to:
+        // - resolve type info.
+        // - JsonSchemaExporter.GetJsonSchemaAsNode, which we then deserialize back.
+        NumberHandling = JsonNumberHandling.Strict,
     };
 
     private readonly JsonSchemaExporterOptions _configuration = new()

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Responses.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Responses.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -577,6 +578,26 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
             Assert.Equal("application/json", content.Key);
             Assert.NotNull(content.Value.Schema.AnyOf);
             Assert.Equal(2, content.Value.Schema.AnyOf.Count);
+        });
+    }
+
+    [Fact]
+    public async Task GetOpenApiResponse_WithNumberAsString_ShouldSerializeWithoutErrors()
+    {
+        // Arrange
+        var builder = CreateBuilder(serviceCollection: null, numberHandling: JsonNumberHandling.WriteAsString | JsonNumberHandling.AllowReadingFromString);
+
+        // Act
+        builder.MapGet("/myapi", () => new ModelWithStringAndStringLength(string.Empty));
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = Assert.Single(document.Paths["/myapi"].Operations.Values);
+            var response = Assert.Single(operation.Responses);
+            Assert.Equal("200", response.Key);
+            var kvp = Assert.Single(response.Value.Content);
+            Assert.Equal("application/json", kvp.Key);
         });
     }
 }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentServiceTestsBase.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentServiceTestsBase.cs
@@ -3,6 +3,7 @@
 
 using System.Reflection;
 using System.Text;
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
@@ -164,12 +165,12 @@ public abstract class OpenApiDocumentServiceTestBase
             new ServiceProviderIsService());
     }
 
-    internal static TestEndpointRouteBuilder CreateBuilder(IServiceCollection serviceCollection = null)
+    internal static TestEndpointRouteBuilder CreateBuilder(IServiceCollection serviceCollection = null, JsonNumberHandling numberHandling = JsonNumberHandling.Strict)
     {
         serviceCollection ??= new ServiceCollection();
         serviceCollection.ConfigureHttpJsonOptions(options =>
         {
-            options.SerializerOptions.NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.Strict;
+            options.SerializerOptions.NumberHandling = numberHandling;
         });
         var serviceProvider = new TestServiceProvider();
         serviceProvider.SetInternalServiceProvider(serviceCollection);

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Shared/SharedTypes.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Shared/SharedTypes.cs
@@ -19,6 +19,8 @@ using Microsoft.AspNetCore.Http;
 /// <param name="CreatedAt">The date and time when the to-do item was created.</param>
 internal record Todo(int Id, string Title, bool Completed, DateTime CreatedAt);
 
+internal record ModelWithStringAndStringLength([property: StringLength(100)] string Value);
+
 /// <summary>
 /// Represents a to-do item with a due date.
 /// </summary>


### PR DESCRIPTION
Alternative fix to #66847

Fixes https://github.com/dotnet/aspnetcore/issues/66111