### PR TITLE
Update triage agent to separate label and type instructions

### DIFF
--- a/.github/workflows/issue-triage-agent.lock.yml
+++ b/.github/workflows/issue-triage-agent.lock.yml
@@ -37,7 +37,7 @@
 #   - actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
 #   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-#   - github/gh-aw-actions/setup@f889c9c3c06adeaabccefc06e29c42733ee05dff # v0.75.0
+#   - github/gh-aw-actions/setup@efa55847f72aadb03490d955263ff911bf758700 # v0.74.8
 #
 # Container images used:
 #   - ghcr.io/github/gh-aw-firewall/agent:0.25.49
@@ -100,7 +100,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@f889c9c3c06adeaabccefc06e29c42733ee05dff # v0.75.0
+        uses: github/gh-aw-actions/setup@efa55847f72aadb03490d955263ff911bf758700 # v0.74.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -372,7 +372,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@f889c9c3c06adeaabccefc06e29c42733ee05dff # v0.75.0
+        uses: github/gh-aw-actions/setup@efa55847f72aadb03490d955263ff911bf758700 # v0.74.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1034,7 +1034,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@f889c9c3c06adeaabccefc06e29c42733ee05dff # v0.75.0
+        uses: github/gh-aw-actions/setup@efa55847f72aadb03490d955263ff911bf758700 # v0.74.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1173,7 +1173,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@f889c9c3c06adeaabccefc06e29c42733ee05dff # v0.75.0
+        uses: github/gh-aw-actions/setup@efa55847f72aadb03490d955263ff911bf758700 # v0.74.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1393,7 +1393,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@f889c9c3c06adeaabccefc06e29c42733ee05dff # v0.75.0
+        uses: github/gh-aw-actions/setup@efa55847f72aadb03490d955263ff911bf758700 # v0.74.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}

--- a/.github/workflows/issue-triage-agent.md
+++ b/.github/workflows/issue-triage-agent.md
@@ -300,10 +300,15 @@ Explain why in the comment instead.
 
 Classify the issue into one of these types:
 
-| Type label | When to use |
+| Type | When to use |
 |-----------|-------------|
-| `bug` | The report clearly identifies a behavior as a bug and it can be reproduced. Something is broken or behaving unexpectedly compared to its intended design. |
-| `feature-request` | The report asks for a behavior that is not currently implemented. This may be a brand-new feature or an addition/enhancement to an existing feature. |
+| `Bug` | The report clearly identifies a behavior as a bug and it can be reproduced. Something is broken or behaving unexpectedly compared to its intended design. |
+| `Feature` | The report asks for a behavior that is not currently implemented. This may be a brand-new feature or an addition/enhancement to an existing feature. |
+
+## Step 3: Additional Labels
+
+Classify the issue using one of these labels, if applicable:
+
 | `by-design` | The report describes a behavior that doesn't match the reporter's expectations, but the behavior is actually the intended design. |
 | `question` | The report describes expected behavior, asks for clarification on how to use the product, or is a general "How do I...?" question. Mark as answered when a response is provided. |
 | `external` | The report is not related to an area that the aspnetcore team owns directly. The issue should be moved to the appropriate repo or the customer should be asked to file through the appropriate channels (typically VS Feedback). |
@@ -312,11 +317,11 @@ Classify the issue into one of these types:
 | `test-failure` | CI/test infrastructure failure report. |
 | `performance` | Performance regression or optimization request. |
 
-Apply the single best type label. If the issue template already indicates the type
+Apply the single best label (if applicable). If the issue template already indicates the type
 (e.g., filed via the bug report template), trust that signal but verify it matches
 the actual content — reporters sometimes pick the wrong template.
 
-## Step 3: Regression Detection
+## Step 4: Regression Detection
 
 If the issue is classified as a `bug`, check whether it describes a **regression** —
 a behavior that previously worked in an older version but is now broken in a newer one.
@@ -338,7 +343,7 @@ is known and flag that more information may be needed from the author.
 
 If there is no indication of a regression, omit this section from the summary.
 
-## Step 4: Duplicate Detection
+## Step 5: Duplicate Detection
 
 Search for potential duplicates among recent open issues using the GitHub MCP
 Server tools:
@@ -359,7 +364,7 @@ Only flag an issue as a potential duplicate if you have **high confidence** that
 it describes the same problem or feature request. When in doubt, list it as
 "related" rather than "duplicate".
 
-## Step 5: Post Results
+## Step 6: Post Results
 
 Compose a single triage comment summarizing your findings. Structure it as:
 


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/aspnetcore/pull/66722.

The agent sometimes fails to add the "Feature" type. Likely because "feature-request" label is mentioned in the instructions.