### PR TITLE
Add HRESULT details to HttpSysListener initialization exception

### DIFF
--- a/src/Components/Testing/testassets/TestApp/Properties/launchSettings.json
+++ b/src/Components/Testing/testassets/TestApp/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "TestApp": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:55536;http://localhost:55537"
+    }
+  }
+}

--- a/src/Servers/HttpSys/src/HttpSysListener.cs
+++ b/src/Servers/HttpSys/src/HttpSysListener.cs
@@ -52,7 +52,8 @@ internal sealed partial class HttpSysListener : IDisposable
 
         if (!HttpApi.Supported)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException("HTTP Server API initialization failed.",
+                new Win32Exception((int)HttpApi.InitializationHResult));
         }
 
         MemoryPool = memoryPoolFactory.Create(new MemoryPoolOptions { Owner = "httpsys" });

--- a/src/Servers/HttpSys/src/NativeInterop/HttpApi.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/HttpApi.cs
@@ -34,6 +34,8 @@ internal static partial class HttpApi
     [LibraryImport(api_ms_win_core_io_LIB, SetLastError = true)]
     internal static partial uint CancelIoEx(SafeHandle handle, SafeNativeOverlapped overlapped);
 
+    internal static readonly uint InitializationHResult;
+
     internal unsafe delegate uint HttpGetRequestPropertyInvoker(SafeHandle requestQueueHandle, ulong requestId, HTTP_REQUEST_PROPERTY propertyId,
         void* qualifier, uint qualifierSize, void* output, uint outputSize, IntPtr bytesReturned, IntPtr overlapped);
 
@@ -77,7 +79,10 @@ internal static partial class HttpApi
     {
         var statusCode = PInvoke.HttpInitialize(Version, HTTP_INITIALIZE.HTTP_INITIALIZE_SERVER | HTTP_INITIALIZE.HTTP_INITIALIZE_CONFIG);
 
-        if (statusCode == ErrorCodes.ERROR_SUCCESS)
+        Supported = statusCode == ErrorCodes.ERROR_SUCCESS;
+        InitializationHResult = statusCode;
+
+        if (Supported)
         {
             Supported = true;
             HttpApiModule = SafeLibraryHandle.Open(HTTPAPI);


### PR DESCRIPTION
Add HRESULT details to HttpSysListener initialization exception

- [x] You've read the Contributor Guide and Code of Conduct.
- [ ] You've included unit or integration tests for your change, where applicable.
<!-- A functional test is not feasible as HttpInitialize always succeeds 
     on supported Windows environments -->
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making.

## Description
When `HttpInitialize` fails, the resulting `PlatformNotSupportedException` 
now includes the Win32 error code as an inner `Win32Exception`. 
This makes it easier to diagnose why HTTP Server API initialization failed.

Fixes https://github.com/dotnet/aspnetcore/issues/66858