### PR TITLE
fix(s390x/ppc64le): set RuntimeIdentifier for BasicLinkedApp in DotNe…

### DIFF
--- a/src/Hosting/test/testassets/BasicLinkedApp/BasicLinkedApp.csproj
+++ b/src/Hosting/test/testassets/BasicLinkedApp/BasicLinkedApp.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <PublishTrimmed>true</PublishTrimmed>
+    <RuntimeIdentifier Condition="'$(DotNetBuild)' == 'true'">$(TargetRuntimeIdentifier)</RuntimeIdentifier>
     <TrimMode>link</TrimMode>
     <ILLinkTreatWarningsAsErrors>false</ILLinkTreatWarningsAsErrors>
     <!-- Revert after issue in https://github.com/dotnet/aspnetcore/pull/33187 is resolved. -->


### PR DESCRIPTION
## Summary

`BasicLinkedApp.csproj` has `PublishTrimmed=true` which causes NuGet restore to require runtime packs during source-build (`DotNetBuild=true`). Without an explicit `RuntimeIdentifier`, the SDK infers the portable `linux-s390x`/`linux-ppc64le` RID, but no such package exists on any public NuGet feed, only distro-specific packs (e.g. `rhel.10-s390x`) are bundled in the SDK.

This causes:
error NU1101: Unable to find package Microsoft.NETCore.App.Runtime.linux-s390x


The fix adds the same `RuntimeIdentifier` conditional already applied to `LinkabilityChecker` in #66383, so that `DotNetBuild` mode resolves to `$(TargetRuntimeIdentifier)` (the SDK-local distro-specific pack).


cc: @tmds 