### PR TITLE
Quarantine RedirectionTest.RedirectStreamingEnhancedPostToExternal

### DIFF
--- a/src/Components/test/E2ETest/ServerRenderingTests/RedirectionTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/RedirectionTest.cs
@@ -204,6 +204,7 @@ public class RedirectionTest : ServerTestBase<BasicTestAppServerSiteFixture<Razo
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/66869")]
     public void RedirectStreamingEnhancedPostToExternal(bool disableThrowNavigationException)
     {
         AppContext.SetSwitch("Microsoft.AspNetCore.Components.Endpoints.NavigationManager.DisableThrowNavigationException", disableThrowNavigationException);


### PR DESCRIPTION
Quarantines `RedirectionTest.RedirectStreamingEnhancedPostToExternal` which has failed 2 times in the `components-e2e` pipeline (definition 87) on `main` due to Selenium WebDriver initialization timeouts.

Failing builds:
- https://dev.azure.com/dnceng-public/public/_build/results?buildId=1436713&view=results
- https://dev.azure.com/dnceng-public/public/_build/results?buildId=1405887&view=results

Associated issue: #66869