### PR TITLE
Implement ProblemDetailsService integration in SystemTextJsonOutputFormatter

### DIFF
--- a/src/Mvc/Mvc.Core/src/Formatters/SystemTextJsonOutputFormatter.cs
+++ b/src/Mvc/Mvc.Core/src/Formatters/SystemTextJsonOutputFormatter.cs
@@ -7,6 +7,7 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Mvc.Formatters;
 
@@ -64,6 +65,22 @@ public class SystemTextJsonOutputFormatter : TextOutputFormatter
         ArgumentNullException.ThrowIfNull(selectedEncoding);
 
         var httpContext = context.HttpContext;
+
+        // If the value being written is a ProblemDetails instance and an IProblemDetailsService
+        // is registered, give it a chance to write the response. This allows custom
+        // IProblemDetailsWriter implementations (registered via AddProblemDetails) to format
+        // ProblemDetails responses produced by MVC (including validation errors).
+        if (context.Object is ProblemDetails problemDetails &&
+            httpContext.RequestServices.GetService<IProblemDetailsService>() is { } problemDetailsService &&
+            await problemDetailsService.TryWriteAsync(new()
+            {
+                HttpContext = httpContext,
+                ProblemDetails = problemDetails,
+                AdditionalMetadata = httpContext.GetEndpoint()?.Metadata,
+            }))
+        {
+            return;
+        }
 
         // context.ObjectType reflects the declared model type when specified.
         // For polymorphic scenarios where the user declares a return type, but returns a derived type,

--- a/src/Mvc/Mvc.Core/src/Formatters/SystemTextJsonOutputFormatter.cs
+++ b/src/Mvc/Mvc.Core/src/Formatters/SystemTextJsonOutputFormatter.cs
@@ -75,8 +75,7 @@ public class SystemTextJsonOutputFormatter : TextOutputFormatter
             await problemDetailsService.TryWriteAsync(new()
             {
                 HttpContext = httpContext,
-                ProblemDetails = problemDetails,
-                AdditionalMetadata = httpContext.GetEndpoint()?.Metadata,
+                ProblemDetails = problemDetails
             }))
         {
             return;

--- a/src/Mvc/Mvc.Core/test/Formatters/SystemTextJsonOutputFormatterTest.cs
+++ b/src/Mvc/Mvc.Core/test/Formatters/SystemTextJsonOutputFormatterTest.cs
@@ -267,11 +267,11 @@ public partial class SystemTextJsonOutputFormatterTest : JsonOutputFormatterTest
         var problemDetailsService = new Mock<IProblemDetailsService>();
         problemDetailsService
             .Setup(s => s.TryWriteAsync(It.IsAny<ProblemDetailsContext>()))
-            .Callback<ProblemDetailsContext>(ctx =>
+            .Returns(async (ProblemDetailsContext ctx) =>
             {
-                ctx.HttpContext.Response.WriteAsync("custom-writer-output").GetAwaiter().GetResult();
-            })
-            .Returns(ValueTask.FromResult(true));
+                await ctx.HttpContext.Response.WriteAsync("custom-writer-output");
+                return true;
+            });
 
         var services = new ServiceCollection();
         services.AddSingleton(problemDetailsService.Object);
@@ -344,6 +344,98 @@ public partial class SystemTextJsonOutputFormatterTest : JsonOutputFormatterTest
         var actualContent = encoding.GetString(body.ToArray());
         Assert.Contains("\"title\":\"Bad Request\"", actualContent);
         Assert.Contains("\"status\":400", actualContent);
+        problemDetailsService.Verify(s => s.TryWriteAsync(It.IsAny<ProblemDetailsContext>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task WriteResponseBodyAsync_FallsBackToJsonSerialization_WhenNoProblemDetailsServiceIsRegistered()
+    {
+        // Arrange
+        var problemDetails = new ProblemDetails { Status = 400, Title = "Bad Request" };
+
+        var services = new ServiceCollection();
+        var serviceProvider = services.BuildServiceProvider();
+
+        var formatter = SystemTextJsonOutputFormatter.CreateFormatter(new JsonOptions());
+
+        var mediaType = MediaTypeHeaderValue.Parse("application/problem+json; charset=utf-8");
+        var encoding = CreateOrGetSupportedEncoding(formatter, "utf-8", isDefaultEncoding: true);
+
+        var body = new MemoryStream();
+        var actionContext = GetActionContext(mediaType, body);
+        actionContext.HttpContext.RequestServices = serviceProvider;
+
+        var outputFormatterContext = new OutputFormatterWriteContext(
+            actionContext.HttpContext,
+            new TestHttpResponseStreamWriterFactory().CreateWriter,
+            typeof(ProblemDetails),
+            problemDetails)
+        {
+            ContentType = new StringSegment(mediaType.ToString()),
+        };
+
+        // Act
+        await formatter.WriteResponseBodyAsync(outputFormatterContext, Encoding.GetEncoding("utf-8"));
+
+        // Assert
+        var actualContent = encoding.GetString(body.ToArray());
+        Assert.Contains("\"title\":\"Bad Request\"", actualContent);
+        Assert.Contains("\"status\":400", actualContent);
+    }
+
+    [Fact]
+    public async Task WriteResponseBodyAsync_UsesProblemDetailsService_ForDerivedProblemDetails()
+    {
+        // Arrange
+        var problemDetails = new HttpValidationProblemDetails(new Dictionary<string, string[]>
+        {
+            ["Name"] = ["Required"],
+        })
+        {
+            Status = 400,
+            Title = "Validation failed",
+        };
+
+        ProblemDetailsContext capturedContext = null;
+        var problemDetailsService = new Mock<IProblemDetailsService>();
+        problemDetailsService
+            .Setup(s => s.TryWriteAsync(It.IsAny<ProblemDetailsContext>()))
+            .Returns(async (ProblemDetailsContext ctx) =>
+            {
+                capturedContext = ctx;
+                await ctx.HttpContext.Response.WriteAsync("custom-writer-output");
+                return true;
+            });
+
+        var services = new ServiceCollection();
+        services.AddSingleton(problemDetailsService.Object);
+        var serviceProvider = services.BuildServiceProvider();
+
+        var formatter = SystemTextJsonOutputFormatter.CreateFormatter(new JsonOptions());
+
+        var mediaType = MediaTypeHeaderValue.Parse("application/problem+json; charset=utf-8");
+        var encoding = CreateOrGetSupportedEncoding(formatter, "utf-8", isDefaultEncoding: true);
+
+        var body = new MemoryStream();
+        var actionContext = GetActionContext(mediaType, body);
+        actionContext.HttpContext.RequestServices = serviceProvider;
+
+        var outputFormatterContext = new OutputFormatterWriteContext(
+            actionContext.HttpContext,
+            new TestHttpResponseStreamWriterFactory().CreateWriter,
+            typeof(HttpValidationProblemDetails),
+            problemDetails)
+        {
+            ContentType = new StringSegment(mediaType.ToString()),
+        };
+
+        // Act
+        await formatter.WriteResponseBodyAsync(outputFormatterContext, Encoding.GetEncoding("utf-8"));
+
+        // Assert
+        var actualContent = encoding.GetString(body.ToArray());
+        Assert.Equal("custom-writer-output", actualContent);
+        Assert.Same(problemDetails, capturedContext.ProblemDetails);
         problemDetailsService.Verify(s => s.TryWriteAsync(It.IsAny<ProblemDetailsContext>()), Times.Once);
     }
 

--- a/src/Mvc/Mvc.Core/test/Formatters/SystemTextJsonOutputFormatterTest.cs
+++ b/src/Mvc/Mvc.Core/test/Formatters/SystemTextJsonOutputFormatterTest.cs
@@ -6,10 +6,13 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.DotNet.RemoteExecutor;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
+using Moq;
 
 namespace Microsoft.AspNetCore.Mvc.Formatters;
 
@@ -253,6 +256,95 @@ public partial class SystemTextJsonOutputFormatterTest : JsonOutputFormatterTest
         await Task.Yield();
 
         yield return new JsonPersonExtended() { Name = "Two", Age = 99 };
+    }
+
+    [Fact]
+    public async Task WriteResponseBodyAsync_UsesProblemDetailsService_WhenObjectIsProblemDetails()
+    {
+        // Arrange
+        var problemDetails = new ProblemDetails { Status = 400, Title = "Bad Request" };
+
+        var problemDetailsService = new Mock<IProblemDetailsService>();
+        problemDetailsService
+            .Setup(s => s.TryWriteAsync(It.IsAny<ProblemDetailsContext>()))
+            .Callback<ProblemDetailsContext>(ctx =>
+            {
+                ctx.HttpContext.Response.WriteAsync("custom-writer-output").GetAwaiter().GetResult();
+            })
+            .Returns(ValueTask.FromResult(true));
+
+        var services = new ServiceCollection();
+        services.AddSingleton(problemDetailsService.Object);
+        var serviceProvider = services.BuildServiceProvider();
+
+        var formatter = SystemTextJsonOutputFormatter.CreateFormatter(new JsonOptions());
+
+        var mediaType = MediaTypeHeaderValue.Parse("application/problem+json; charset=utf-8");
+        var encoding = CreateOrGetSupportedEncoding(formatter, "utf-8", isDefaultEncoding: true);
+
+        var body = new MemoryStream();
+        var actionContext = GetActionContext(mediaType, body);
+        actionContext.HttpContext.RequestServices = serviceProvider;
+
+        var outputFormatterContext = new OutputFormatterWriteContext(
+            actionContext.HttpContext,
+            new TestHttpResponseStreamWriterFactory().CreateWriter,
+            typeof(ProblemDetails),
+            problemDetails)
+        {
+            ContentType = new StringSegment(mediaType.ToString()),
+        };
+
+        // Act
+        await formatter.WriteResponseBodyAsync(outputFormatterContext, Encoding.GetEncoding("utf-8"));
+
+        // Assert
+        var actualContent = encoding.GetString(body.ToArray());
+        Assert.Equal("custom-writer-output", actualContent);
+        problemDetailsService.Verify(s => s.TryWriteAsync(It.IsAny<ProblemDetailsContext>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task WriteResponseBodyAsync_FallsBackToJsonSerialization_WhenProblemDetailsServiceReturnsFalse()
+    {
+        // Arrange
+        var problemDetails = new ProblemDetails { Status = 400, Title = "Bad Request" };
+
+        var problemDetailsService = new Mock<IProblemDetailsService>();
+        problemDetailsService
+            .Setup(s => s.TryWriteAsync(It.IsAny<ProblemDetailsContext>()))
+            .Returns(ValueTask.FromResult(false));
+
+        var services = new ServiceCollection();
+        services.AddSingleton(problemDetailsService.Object);
+        var serviceProvider = services.BuildServiceProvider();
+
+        var formatter = SystemTextJsonOutputFormatter.CreateFormatter(new JsonOptions());
+
+        var mediaType = MediaTypeHeaderValue.Parse("application/problem+json; charset=utf-8");
+        var encoding = CreateOrGetSupportedEncoding(formatter, "utf-8", isDefaultEncoding: true);
+
+        var body = new MemoryStream();
+        var actionContext = GetActionContext(mediaType, body);
+        actionContext.HttpContext.RequestServices = serviceProvider;
+
+        var outputFormatterContext = new OutputFormatterWriteContext(
+            actionContext.HttpContext,
+            new TestHttpResponseStreamWriterFactory().CreateWriter,
+            typeof(ProblemDetails),
+            problemDetails)
+        {
+            ContentType = new StringSegment(mediaType.ToString()),
+        };
+
+        // Act
+        await formatter.WriteResponseBodyAsync(outputFormatterContext, Encoding.GetEncoding("utf-8"));
+
+        // Assert
+        var actualContent = encoding.GetString(body.ToArray());
+        Assert.Contains("\"title\":\"Bad Request\"", actualContent);
+        Assert.Contains("\"status\":400", actualContent);
+        problemDetailsService.Verify(s => s.TryWriteAsync(It.IsAny<ProblemDetailsContext>()), Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
This pull request enhances the `SystemTextJsonOutputFormatter` in ASP.NET Core MVC to better support custom formatting of `ProblemDetails` responses. Specifically, it allows an `IProblemDetailsService` to handle the output of `ProblemDetails` objects, enabling more flexible and customizable error responses. Comprehensive tests have been added to ensure this new behavior works as expected and falls back to JSON serialization when appropriate.

**Enhancements to ProblemDetails formatting:**

* Updated `SystemTextJsonOutputFormatter` to check for an `IProblemDetailsService` when writing a `ProblemDetails` object. If present and it handles the response, the formatter returns early, allowing custom formatting of error responses.
* Added `Microsoft.Extensions.DependencyInjection` import to support service resolution in the formatter.

**Testing improvements:**

* Added unit tests to verify that the formatter uses `IProblemDetailsService` when available, and falls back to JSON serialization if the service does not handle the response. These tests use mocks to simulate the service's behavior.

Fixes #64486
