### PR TITLE
Added annotation for execution of RenderFragments during serialization

### DIFF
--- a/src/Components/Components/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Components/src/PublicAPI.Unshipped.txt
@@ -4,6 +4,8 @@ abstract Microsoft.AspNetCore.Components.CascadingParameterSubscription.GetCurre
 Microsoft.AspNetCore.Components.CascadingParameterSubscription
 Microsoft.AspNetCore.Components.CascadingParameterSubscription.CascadingParameterSubscription() -> void
 Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.SetAttributeValue(int frameIndex, object? value) -> void
+Microsoft.AspNetCore.Components.SerializationExecutionPolicyAttribute
+Microsoft.AspNetCore.Components.SerializationExecutionPolicyAttribute.SerializationExecutionPolicyAttribute() -> void
 static Microsoft.AspNetCore.Components.NavigationManagerExtensions.GetUriWithHash(this Microsoft.AspNetCore.Components.NavigationManager! navigationManager, string! hash) -> string!
 Microsoft.AspNetCore.Components.NavigationOptions.RelativeToCurrentUri.get -> bool
 Microsoft.AspNetCore.Components.NavigationOptions.RelativeToCurrentUri.init -> void

--- a/src/Components/Components/src/SerializationExecutionPolicyAttribute.cs
+++ b/src/Components/Components/src/SerializationExecutionPolicyAttribute.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components;
+
+/// <summary>
+/// Indicates that a RenderFragment parameter should be executed during serialization
+/// if it was not invoked during prerendering (e.g., due to conditional rendering).
+/// Apply this to individual <see cref="RenderFragment"/> parameters that should be
+/// serialized regardless of whether the component rendered them.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+public sealed class SerializationExecutionPolicyAttribute : Attribute
+{
+}

--- a/src/Components/Endpoints/src/Rendering/SSRRenderModeBoundary.cs
+++ b/src/Components/Endpoints/src/Rendering/SSRRenderModeBoundary.cs
@@ -112,21 +112,21 @@ internal class SSRRenderModeBoundary : IComponent
 
         ValidateParameters(_latestParameters);
 
-        if (_prerender)
+        // Replace each top-level RenderFragment parameter with a capture wrapper
+        // so that when the component invokes the fragment during rendering,
+        // the output frames are captured for later serialization.
+        var parametersDict = (Dictionary<string, object?>)_latestParameters;
+        foreach (var name in parametersDict.Keys.ToArray())
         {
-            // Replace each top-level RenderFragment parameter with a capture wrapper
-            // so that when the component invokes the fragment during prerendering,
-            // the output frames are captured for later serialization.
-            var parametersDict = (Dictionary<string, object?>)_latestParameters;
-            foreach (var name in parametersDict.Keys.ToArray())
+            if (parametersDict[name] is RenderFragment rf)
             {
-                if (parametersDict[name] is RenderFragment rf)
+                var capture = new RenderFragmentCapture(rf)
                 {
-                    var capture = new RenderFragmentCapture(rf);
-                    _topLevelCaptures ??= new();
-                    _topLevelCaptures[name] = capture;
-                    parametersDict[name] = (RenderFragment)capture.Invoke;
-                }
+                    HasSerializationExecutionPolicy = RenderFragmentSerializer.HasSerializationExecutionPolicy(_componentType, name)
+                };
+                _topLevelCaptures ??= new();
+                _topLevelCaptures[name] = capture;
+                parametersDict[name] = (RenderFragment)capture.Invoke;
             }
         }
 
@@ -242,14 +242,25 @@ internal class SSRRenderModeBoundary : IComponent
         var dict = new Dictionary<string, object?>(latestParameters.Count);
         foreach (var (name, value) in latestParameters)
         {
-            if (value is RenderFragment)
+            if (value is RenderFragment rf)
             {
-                if (_topLevelCaptures is null || !_topLevelCaptures.TryGetValue(name, out var capture))
+                var capture = _topLevelCaptures?.GetValueOrDefault(name) ?? new RenderFragmentCapture(rf)
                 {
-                    // If we didn't wrap the RenderFragment in a capture, it means prerendering is disabled.
-                    // If the capture is null, then fragment was conditionally rendered and didn't execute. In either case we can't serialize it.
-                    throw new InvalidOperationException(
-                        $"Cannot serialize RenderFragment parameter '{name}' for component '{_componentType.Name}', because the RenderFragment was not executed. It can be due to disabled prerendering or conditional rendering.");
+                    HasSerializationExecutionPolicy = RenderFragmentSerializer.HasSerializationExecutionPolicy(_componentType, name)
+                };
+
+                if (!capture.HasCapturedFrames)
+                {
+                    if (capture.HasSerializationExecutionPolicy)
+                    {
+                        capture.EnsureCaptured();
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException(
+                            $"Cannot serialize RenderFragment parameter '{name}' for component '{_componentType.Name}', because the RenderFragment was not executed during prerendering. " +
+                            $"Apply [SerializationExecutionPolicy] to the '{name}' property if the fragment should be serialized regardless of conditional rendering.");
+                    }
                 }
 
                 dict[name] = new SerializedRenderFragment

--- a/src/Components/Shared/src/RenderFragmentCapture.cs
+++ b/src/Components/Shared/src/RenderFragmentCapture.cs
@@ -71,7 +71,6 @@ internal sealed class RenderFragmentCapture
             }
 
             var componentSubtreeEnd = i + frame.ComponentSubtreeLength;
-
             // A component's attribute frames always sit right after the Component
             // frame in the render tree, with no other frame types mixed in. So we can stop as
             // soon as we hit the first non-Attribute frame.

--- a/src/Components/Shared/src/RenderFragmentCapture.cs
+++ b/src/Components/Shared/src/RenderFragmentCapture.cs
@@ -20,7 +20,17 @@ internal sealed class RenderFragmentCapture
         _original = original;
     }
 
+    public bool HasSerializationExecutionPolicy { get; init; }
+
     public IReadOnlyDictionary<int, RenderFragmentCapture> ChildCaptures => _childCaptures;
+
+    public bool HasCapturedFrames => _capturedFrames is not null;
+
+    public void EnsureCaptured()
+    {
+        using var builder = new RenderTreeBuilder();
+        Invoke(builder);
+    }
 
     public void Invoke(RenderTreeBuilder builder)
     {
@@ -61,6 +71,7 @@ internal sealed class RenderFragmentCapture
             }
 
             var componentSubtreeEnd = i + frame.ComponentSubtreeLength;
+
             // A component's attribute frames always sit right after the Component
             // frame in the render tree, with no other frame types mixed in. So we can stop as
             // soon as we hit the first non-Attribute frame.
@@ -69,7 +80,10 @@ internal sealed class RenderFragmentCapture
                 ref readonly var attrFrame = ref frames.Array[j];
                 if (attrFrame.AttributeValue is RenderFragment innerRf)
                 {
-                    var innerCapture = new RenderFragmentCapture(innerRf);
+                    var innerCapture = new RenderFragmentCapture(innerRf)
+                    {
+                        HasSerializationExecutionPolicy = RenderFragmentSerializer.HasSerializationExecutionPolicy(frame.ComponentType, attrFrame.AttributeName!)
+                    };
                     // Replace the original delegate in the live render buffer with the wrapper.
                     // This is required so that when the nested component later invokes its
                     // RenderFragment parameter, control flows through innerCapture.Invoke and

--- a/src/Components/Shared/src/RenderFragmentSerializer.cs
+++ b/src/Components/Shared/src/RenderFragmentSerializer.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Components.Rendering;
@@ -13,6 +15,13 @@ namespace Microsoft.AspNetCore.Components;
 internal static partial class RenderFragmentSerializer
 {
     internal const string SerializedRenderFragmentValueType = "#RenderFragment";
+
+    private static readonly ConcurrentDictionary<(Type, string), bool> _serializationPolicyCache = new();
+
+    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Component types referenced in serialized RenderFragments are expected to be preserved by the application.")]
+    internal static bool HasSerializationExecutionPolicy(Type componentType, string parameterName) =>
+        _serializationPolicyCache.GetOrAdd((componentType, parameterName),
+            static key => key.Item1.GetProperty(key.Item2)?.GetCustomAttribute<SerializationExecutionPolicyAttribute>() is not null);
 
     /// Converts the captured render tree frames from a <see cref="RenderFragmentCapture"/> into a
     /// JSON-serializable tree of <see cref="RenderTreeNode"/> objects. This is the entry point for
@@ -175,11 +184,20 @@ internal static partial class RenderFragmentSerializer
         {
             if (!currentCapture.ChildCaptures.TryGetValue(frameIndex, out var nestedCapture))
             {
-                // If we get here, then it means that wrapping didn't happen, or it was not executed (e.g. SSRRenderBoundary in the case of disabled prerendering).
-                // TODO: https://github.com/dotnet/aspnetcore/issues/66739 - Add an opt-in annotation that tells the
-                // serializer to execute the RenderFragment directly when it wasn't invoked during prerendering.
-                throw new InvalidOperationException(
-                    $"Cannot serialize RenderFragment parameter '{frame.AttributeName}' because it was not captured during rendering.");
+                throw new InvalidOperationException($"Cannot serialize RenderFragment parameter '{frame.AttributeName}' because it was not captured during rendering.");
+            }
+
+            if (!nestedCapture.HasCapturedFrames)
+            {
+                if (nestedCapture.HasSerializationExecutionPolicy)
+                {
+                    nestedCapture.EnsureCaptured();
+                }
+                else
+                {
+                    throw new InvalidOperationException(
+                        $"Cannot serialize RenderFragment parameter '{frame.AttributeName}' because it was not captured during rendering.");
+                }
             }
 
             result = new RenderTreeAttribute

--- a/src/Components/Shared/src/RenderFragmentSerializer.cs
+++ b/src/Components/Shared/src/RenderFragmentSerializer.cs
@@ -21,7 +21,7 @@ internal static partial class RenderFragmentSerializer
     [UnconditionalSuppressMessage("Trimming", "IL2080", Justification = "Component types referenced in serialized RenderFragments are expected to be preserved by the application.")]
     internal static bool HasSerializationExecutionPolicy(Type componentType, string parameterName) =>
         _serializationPolicyCache.GetOrAdd((componentType, parameterName),
-            static key => key.Item1.GetProperty(key.Item2)?.GetCustomAttribute<SerializationExecutionPolicyAttribute>() is not null);
+            static key => key.Item1.GetProperty(key.Item2, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.IgnoreCase)?.GetCustomAttribute<SerializationExecutionPolicyAttribute>() is not null);
 
     /// Converts the captured render tree frames from a <see cref="RenderFragmentCapture"/> into a
     /// JSON-serializable tree of <see cref="RenderTreeNode"/> objects. This is the entry point for

--- a/src/Components/Shared/src/RenderFragmentSerializer.cs
+++ b/src/Components/Shared/src/RenderFragmentSerializer.cs
@@ -18,7 +18,7 @@ internal static partial class RenderFragmentSerializer
 
     private static readonly ConcurrentDictionary<(Type, string), bool> _serializationPolicyCache = new();
 
-    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Component types referenced in serialized RenderFragments are expected to be preserved by the application.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2080", Justification = "Component types referenced in serialized RenderFragments are expected to be preserved by the application.")]
     internal static bool HasSerializationExecutionPolicy(Type componentType, string parameterName) =>
         _serializationPolicyCache.GetOrAdd((componentType, parameterName),
             static key => key.Item1.GetProperty(key.Item2)?.GetCustomAttribute<SerializationExecutionPolicyAttribute>() is not null);

--- a/src/Components/test/E2ETest/ServerRenderingTests/RenderFragmentSerializationTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/RenderFragmentSerializationTest.cs
@@ -124,4 +124,22 @@ public class RenderFragmentSerializationTest : ServerTestBase<BasicTestAppServer
         Browser.Equal("Item 2", () => Browser.FindElement(By.Id("keyed-2")).Text);
         Browser.Equal("Item 3", () => Browser.FindElement(By.Id("keyed-3")).Text);
     }
+
+    [Theory]
+    [InlineData("server")]
+    [InlineData("wasm")]
+    public void RenderFragmentCrossesBoundary_ConditionallySkipped_SerializesWithAttribute(string mode)
+    {
+        // The component has [SerializationExecutionPolicyAttribute] and ShowContent=false,
+        // so the RenderFragment is NOT invoked during prerendering. The attribute allows
+        // the serializer to execute the fragment directly instead of throwing.
+        Navigate($"{ServerPathBase}/render-fragment-interactive?test=8&mode={mode}");
+
+        Browser.Equal("True", () => Browser.FindElement(By.Id("is-interactive-test8")).Text);
+
+        // Toggle ShowContent to true and verify the serialized fragment content appears.
+        // This proves the RenderFragment was actually captured and delivered across the boundary.
+        Browser.Click(By.Id("toggle-test8"));
+        Browser.Equal("Content after toggle", () => Browser.FindElement(By.Id("conditional-text")).Text);
+    }
 }

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/RenderFragmentInteractive.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/RenderFragmentInteractive.razor
@@ -73,6 +73,13 @@
     </TestContentPackage.RenderFragmentChild>
 }
 
+@if (Test == 8)
+{
+    <TestContentPackage.ConditionalRenderFragmentChild @rendermode="renderMode" IdSuffix="test8" ShowContent="false">
+        <p id="conditional-text">Content after toggle</p>
+    </TestContentPackage.ConditionalRenderFragmentChild>
+}
+
 @code {
     [Parameter, SupplyParameterFromQuery(Name = "test")]
     public int Test { get; set; }

--- a/src/Components/test/testassets/TestContentPackage/ConditionalRenderFragmentChild.razor
+++ b/src/Components/test/testassets/TestContentPackage/ConditionalRenderFragmentChild.razor
@@ -1,0 +1,47 @@
+﻿@using Microsoft.AspNetCore.Components
+
+<div id="conditional-container-@IdSuffix">
+    <p>Interactive: <span id="is-interactive-@IdSuffix">@_isInteractive</span></p>
+    @if (ShowContent)
+    {
+        <div id="conditional-content-@IdSuffix">
+            @ChildContent
+        </div>
+    }
+    else
+    {
+        <div id="conditional-fallback-@IdSuffix">
+            <p>Content is hidden</p>
+        </div>
+    }
+    <button id="toggle-@IdSuffix" @onclick="Toggle">Toggle</button>
+    <p>ShowContent: <span id="show-content-value-@IdSuffix">@ShowContent</span></p>
+</div>
+
+@code {
+    private bool _isInteractive;
+
+    [Parameter, EditorRequired]
+    public string IdSuffix { get; set; } = default!;
+
+    [Parameter]
+    public bool ShowContent { get; set; }
+
+    [Parameter, SerializationExecutionPolicy]
+    public RenderFragment ChildContent { get; set; } = default!;
+
+    private void Toggle()
+    {
+        ShowContent = !ShowContent;
+        StateHasChanged();
+    }
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _isInteractive = true;
+            StateHasChanged();
+        }
+    }
+}


### PR DESCRIPTION
# Added annotation for execution of RenderFragments during serialization


## Summary

Introduces `[SerializationExecutionPolicy]` — an opt-in attribute for `RenderFragment` parameters that allows the serialization pipeline to execute the fragment directly when it was not invoked during prerendering (e.g., due to conditional rendering logic). This prevents the `InvalidOperationException` that previously occurred when a component conditionally skipped rendering a `RenderFragment` across a render mode boundary.

## Changes

- **New public API: `SerializationExecutionPolicyAttribute`** — `[AttributeUsage(AttributeTargets.Property)]`, sealed, with no members. Component authors apply it to `RenderFragment` properties. When present, the serializer force-executes the fragment to capture its output even if the component's `BuildRenderTree` did not invoke it.
- **`SSRRenderModeBoundary` updates** — `SetParametersAsync` now *always* wraps each top-level `RenderFragment` parameter with a `RenderFragmentCapture` (previously this was gated on `_prerender`). `BuildSerializableParameterView` uses the captured frames for serialization; if no frames were captured, it calls `EnsureCaptured()` when the parameter has `[SerializationExecutionPolicy]`, or throws an `InvalidOperationException` (with an updated message pointing users at the attribute) otherwise.
- **`RenderFragmentCapture` updates** — Adds `HasSerializationExecutionPolicy` (init-only), `HasCapturedFrames`, and `EnsureCaptured()` (executes the wrapped delegate against a fresh `RenderTreeBuilder` to force capture). The policy flag is also propagated when wrapping nested fragments in `WrapNestedFragments`.
- **`RenderFragmentSerializer` updates** — Adds `HasSerializationExecutionPolicy(Type, string)` helper that looks up the attribute via reflection, cached in a `ConcurrentDictionary<(Type, string), bool>`. `TrySerializeAttribute` now force-captures nested fragments that have the attribute but weren't rendered, instead of always throwing.

## How it works

1. During `SetParametersAsync`, `SSRRenderModeBoundary` wraps each `RenderFragment` parameter with a `RenderFragmentCapture` delegate (unconditionally — no longer gated on prerendering).
2. When the component invokes the fragment during rendering, the capture records the output frames.
3. If the component *doesn't* invoke the fragment (conditional rendering), the capture has no frames.
4. At serialization time:
   - If frames were captured → serialize them normally.
   - If no frames were captured **and** `[SerializationExecutionPolicy]` is present → call `EnsureCaptured()` to execute the fragment directly and capture its output.
   - If no frames were captured **and** no attribute → throw `InvalidOperationException` directing the author to apply `[SerializationExecutionPolicy]`.
5. Nested `RenderFragment` parameters within child components are recursively wrapped via `WrapNestedFragments()`, and their `HasSerializationExecutionPolicy` flag is resolved from the nested component's property.

## Testing

Adds one new E2E test scenario, `RenderFragmentCrossesBoundary_ConditionallySkipped_SerializesWithAttribute`, run against both Server and WebAssembly render modes. It uses a new test component `ConditionalRenderFragmentChild` (with `[SerializationExecutionPolicy]` on `ChildContent` and `ShowContent=false` initially) wired into the existing `RenderFragmentInteractive.razor` test page as test case 8. The test verifies that:

- The component becomes interactive (proving the fragment serialized successfully despite not being rendered during prerendering).
- After toggling `ShowContent` to `true`, the serialized fragment's content (`"Content after toggle"`) is displayed — proving the fragment was actually captured and delivered across the render mode boundary.

## Breaking Changes

None. Behavior for `RenderFragment` parameters without the new attribute is preserved (still throws `InvalidOperationException` when not invoked during prerendering, with a clearer error message pointing to the new opt-in attribute).

Fixes #66739
