### PR TITLE
Switch HelixTestRunner from dotnet test to dotnet vstest

### DIFF
--- a/eng/tools/HelixTestRunner/TestRunner.cs
+++ b/eng/tools/HelixTestRunner/TestRunner.cs
@@ -252,7 +252,7 @@ public class TestRunner
             // (needed for future batching) and has a more predictable argument format.
             // Argument mapping: --filter → --testcasefilter, --blame-crash → --blame:CollectDump
             var commonTestArgs = $"vstest {Options.Target} --diag:\"{diagLog}\" --logger:xunit --logger:\"console;verbosity=normal\" " +
-                                 "--blame:CollectDump";
+                                 "--blame:CollectDump;CollectHangDump;TestTimeout=15min";
 
             var filter = Options.Quarantined
                 ? "Quarantined=true"

--- a/eng/tools/HelixTestRunner/TestRunner.cs
+++ b/eng/tools/HelixTestRunner/TestRunner.cs
@@ -246,52 +246,36 @@ public class TestRunner
             var testProcessTimeout = Options.Timeout.Subtract(TimeSpan.FromMinutes(5));
             var cts = new CancellationTokenSource(testProcessTimeout);
             var diagLog = Path.Combine(Environment.GetEnvironmentVariable("HELIX_WORKITEM_UPLOAD_ROOT"), "vstest.log");
-            var commonTestArgs = $"test {Options.Target} --diag:{diagLog} --logger xunit --logger \"console;verbosity=normal\" " +
-                                 "--blame-crash --blame-hang-timeout 15m";
-            if (Options.Quarantined)
+
+            // Use dotnet vstest instead of dotnet test. Both delegate to vstest.console
+            // internally, but dotnet vstest accepts multiple DLL paths as positional args
+            // (needed for future batching) and has a more predictable argument format.
+            // Argument mapping: --filter → --testcasefilter, --blame-crash → --blame:CollectDump
+            var commonTestArgs = $"vstest {Options.Target} --diag:\"{diagLog}\" --logger:xunit --logger:\"console;verbosity=normal\" " +
+                                 "--blame:CollectDump";
+
+            var filter = Options.Quarantined
+                ? "Quarantined=true"
+                : "Quarantined!=true|Quarantined=false";
+            var filterDesc = Options.Quarantined ? "quarantined" : "non-quarantined";
+
+            ProcessUtil.PrintMessage($"Running {filterDesc} tests.");
+            var result = await ProcessUtil.RunAsync($"{Options.DotnetRoot}/dotnet",
+                commonTestArgs + $" --testcasefilter:\"{filter}\"",
+                environmentVariables: EnvironmentVariables,
+                outputDataReceived: ProcessUtil.PrintMessage,
+                errorDataReceived: ProcessUtil.PrintErrorMessage,
+                throwOnError: false,
+                cancellationToken: cts.Token);
+
+            if (cts.Token.IsCancellationRequested)
             {
-                ProcessUtil.PrintMessage("Running quarantined tests.");
-
-                // Filter syntax: https://github.com/Microsoft/vstest-docs/blob/master/docs/filter.md
-                var result = await ProcessUtil.RunAsync($"{Options.DotnetRoot}/dotnet",
-                    commonTestArgs + " --filter \"Quarantined=true\"",
-                    environmentVariables: EnvironmentVariables,
-                    outputDataReceived: ProcessUtil.PrintMessage,
-                    errorDataReceived: ProcessUtil.PrintErrorMessage,
-                    throwOnError: false,
-                    cancellationToken: cts.Token);
-
-                if (cts.Token.IsCancellationRequested)
-                {
-                    ProcessUtil.PrintMessage($"Quarantined tests exceeded configured timeout: {testProcessTimeout.TotalMinutes}m.");
-                }
-                if (result.ExitCode != 0)
-                {
-                    ProcessUtil.PrintMessage($"Failure in quarantined tests. Exit code: {result.ExitCode}.");
-                }
+                ProcessUtil.PrintMessage($"Tests exceeded configured timeout: {testProcessTimeout.TotalMinutes}m.");
             }
-            else
+            if (result.ExitCode != 0)
             {
-                ProcessUtil.PrintMessage("Running non-quarantined tests.");
-
-                // Filter syntax: https://github.com/Microsoft/vstest-docs/blob/master/docs/filter.md
-                var result = await ProcessUtil.RunAsync($"{Options.DotnetRoot}/dotnet",
-                    commonTestArgs + " --filter \"Quarantined!=true|Quarantined=false\"",
-                    environmentVariables: EnvironmentVariables,
-                    outputDataReceived: ProcessUtil.PrintMessage,
-                    errorDataReceived: ProcessUtil.PrintErrorMessage,
-                    throwOnError: false,
-                    cancellationToken: cts.Token);
-
-                if (cts.Token.IsCancellationRequested)
-                {
-                    ProcessUtil.PrintMessage($"Non-quarantined tests exceeded configured timeout: {testProcessTimeout.TotalMinutes}m.");
-                }
-                if (result.ExitCode != 0)
-                {
-                    ProcessUtil.PrintMessage($"Failure in non-quarantined tests. Exit code: {result.ExitCode}.");
-                    exitCode = result.ExitCode;
-                }
+                ProcessUtil.PrintMessage($"Failure in {filterDesc} tests. Exit code: {result.ExitCode}.");
+                exitCode = result.ExitCode;
             }
         }
         catch (Exception e)

--- a/eng/tools/HelixTestRunner/TestRunner.cs
+++ b/eng/tools/HelixTestRunner/TestRunner.cs
@@ -275,7 +275,11 @@ public class TestRunner
             if (result.ExitCode != 0)
             {
                 ProcessUtil.PrintMessage($"Failure in {filterDesc} tests. Exit code: {result.ExitCode}.");
-                exitCode = result.ExitCode;
+                // Quarantined test failures are expected and should not fail the work item.
+                if (!Options.Quarantined)
+                {
+                    exitCode = result.ExitCode;
+                }
             }
         }
         catch (Exception e)


### PR DESCRIPTION
## Switch HelixTestRunner from `dotnet test` to `dotnet vstest`

### Why

Both commands delegate to `vstest.console` internally, but `dotnet vstest`:
- Accepts **multiple DLL paths** as positional arguments (needed for future batching work in #66808)
- Has a **more predictable argument format** (no ambiguity between project/solution/DLL parsing)
- Is **already used for test discovery** in `CheckTestDiscoveryAsync` (`dotnet vstest {target} -lt`)

### Argument mapping

| `dotnet test` | `dotnet vstest` |
|---|---|
| `--filter "expr"` | `--testcasefilter:"expr"` |
| `--blame-crash --blame-hang-timeout 15m` | `--blame:CollectDump` |
| `--logger name` | `--logger:name` |
| `--diag:path` | `--diag:"path"` |

### Other changes
- Deduplicates the quarantined/non-quarantined `if/else` branches into a shared filter variable
- No functional change to test execution — same vstest.console engine, same test results format