### PR TITLE
Prevent null 'from' property from being serialized

### DIFF
--- a/src/Features/JsonPatch.SystemTextJson/src/Operations/OperationBase.cs
+++ b/src/Features/JsonPatch.SystemTextJson/src/Operations/OperationBase.cs
@@ -1,5 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
 namespace Microsoft.AspNetCore.JsonPatch.SystemTextJson.Operations;
 
 public class OperationBase
@@ -7,7 +8,7 @@ public class OperationBase
 	private string _op;
 	private OperationType _operationType;
 
-	[JsonIgnore]
+	[System.Text.Json.Serialization.JsonIgnore]
 	public OperationType OperationType
 	{
 		get
@@ -16,10 +17,10 @@ public class OperationBase
 		}
 	}
 
-	[JsonPropertyName(nameof(path))]
+	[System.Text.Json.Serialization.JsonPropertyName(nameof(path))]
 	public string path { get; set; }
 
-	[JsonPropertyName(nameof(op))]
+	[System.Text.Json.Serialization.JsonPropertyName(nameof(op))]
 	public string op
 	{
 		get
@@ -29,7 +30,7 @@ public class OperationBase
 		set
 		{
 			OperationType result;
-			if (!Enum.TryParse(value, ignoreCase: true, result: out result))
+			if (!System.Enum.TryParse(value, ignoreCase: true, result: out result))
 			{
 				result = OperationType.Invalid;
 			}
@@ -38,18 +39,18 @@ public class OperationBase
 		}
 	}
 
-	[JsonPropertyName(nameof(from))]
-	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	public string? from { get; set; }
+	[System.Text.Json.Serialization.JsonPropertyName(nameof(from))]
+	[System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+	public string from { get; set; }
 
 	public OperationBase()
 	{
 	}
 
-	public OperationBase(string op, string path, string? from)
+	public OperationBase(string op, string path, string from)
 	{
-		ArgumentNullThrowHelper.ThrowIfNull(op);
-		ArgumentNullThrowHelper.ThrowIfNull(path);
+		Microsoft.AspNetCore.Shared.ArgumentNullThrowHelper.ThrowIfNull(op);
+		Microsoft.AspNetCore.Shared.ArgumentNullThrowHelper.ThrowIfNull(path);
 
 		this.op = op;
 		this.path = path;

--- a/src/Features/JsonPatch.SystemTextJson/src/Operations/OperationBase.cs
+++ b/src/Features/JsonPatch.SystemTextJson/src/Operations/OperationBase.cs
@@ -1,10 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Text.Json.Serialization;
-using Microsoft.AspNetCore.Shared;
-
 namespace Microsoft.AspNetCore.JsonPatch.SystemTextJson.Operations;
 
 public class OperationBase
@@ -12,7 +8,7 @@ public class OperationBase
 	private string _op;
 	private OperationType _operationType;
 
-	[JsonIgnore]
+	[System.Text.Json.Serialization.JsonIgnore]
 	public OperationType OperationType
 	{
 		get
@@ -21,10 +17,10 @@ public class OperationBase
 		}
 	}
 
-	[JsonPropertyName(nameof(path))]
+	[System.Text.Json.Serialization.JsonPropertyName(nameof(path))]
 	public string path { get; set; }
 
-	[JsonPropertyName(nameof(op))]
+	[System.Text.Json.Serialization.JsonPropertyName(nameof(op))]
 	public string op
 	{
 		get
@@ -34,7 +30,7 @@ public class OperationBase
 		set
 		{
 			OperationType result;
-			if (!Enum.TryParse(value, ignoreCase: true, result: out result))
+			if (!System.Enum.TryParse(value, ignoreCase: true, result: out result))
 			{
 				result = OperationType.Invalid;
 			}
@@ -43,8 +39,8 @@ public class OperationBase
 		}
 	}
 
-	[JsonPropertyName(nameof(from))]
-	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	[System.Text.Json.Serialization.JsonPropertyName(nameof(from))]
+	[System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
 	public string from { get; set; }
 
 	public OperationBase()
@@ -53,8 +49,8 @@ public class OperationBase
 
 	public OperationBase(string op, string path, string from)
 	{
-		ArgumentNullThrowHelper.ThrowIfNull(op);
-		ArgumentNullThrowHelper.ThrowIfNull(path);
+		Microsoft.AspNetCore.Shared.ArgumentNullThrowHelper.ThrowIfNull(op);
+		Microsoft.AspNetCore.Shared.ArgumentNullThrowHelper.ThrowIfNull(path);
 
 		this.op = op;
 		this.path = path;

--- a/src/Features/JsonPatch.SystemTextJson/src/Operations/OperationBase.cs
+++ b/src/Features/JsonPatch.SystemTextJson/src/Operations/OperationBase.cs
@@ -1,68 +1,64 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-using System;
-using System.Text.Json.Serialization;
-using Microsoft.AspNetCore.Shared;
-
 namespace Microsoft.AspNetCore.JsonPatch.SystemTextJson.Operations;
 
 public class OperationBase
 {
-    private string _op;
-    private OperationType _operationType;
+	private string _op;
+	private OperationType _operationType;
 
-    [JsonIgnore]
-    public OperationType OperationType
-    {
-        get
-        {
-            return _operationType;
-        }
-    }
+	[JsonIgnore]
+	public OperationType OperationType
+	{
+		get
+		{
+			return _operationType;
+		}
+	}
 
-    [JsonPropertyName(nameof(path))]
-    public string path { get; set; }
+	[JsonPropertyName(nameof(path))]
+	public string path { get; set; }
 
-    [JsonPropertyName(nameof(op))]
-    public string op
-    {
-        get
-        {
-            return _op;
-        }
-        set
-        {
-            OperationType result;
-            if (!Enum.TryParse(value, ignoreCase: true, result: out result))
-            {
-                result = OperationType.Invalid;
-            }
-            _operationType = result;
-            _op = value;
-        }
-    }
+	[JsonPropertyName(nameof(op))]
+	public string op
+	{
+		get
+		{
+			return _op;
+		}
+		set
+		{
+			OperationType result;
+			if (!Enum.TryParse(value, ignoreCase: true, result: out result))
+			{
+				result = OperationType.Invalid;
+			}
+			_operationType = result;
+			_op = value;
+		}
+	}
 
-    [JsonPropertyName(nameof(from))]
-    public string from { get; set; }
+	[JsonPropertyName(nameof(from))]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string? from { get; set; }
 
-    public OperationBase()
-    {
-    }
+	public OperationBase()
+	{
+	}
 
-    public OperationBase(string op, string path, string from)
-    {
-        ArgumentNullThrowHelper.ThrowIfNull(op);
-        ArgumentNullThrowHelper.ThrowIfNull(path);
+	public OperationBase(string op, string path, string? from)
+	{
+		ArgumentNullThrowHelper.ThrowIfNull(op);
+		ArgumentNullThrowHelper.ThrowIfNull(path);
 
-        this.op = op;
-        this.path = path;
-        this.from = from;
-    }
+		this.op = op;
+		this.path = path;
+		this.from = from;
+	}
 
-    public bool ShouldSerializeFrom()
-    {
-        return (OperationType == OperationType.Move
-            || OperationType == OperationType.Copy);
-    }
+	public bool ShouldSerializeFrom()
+	{
+		return (OperationType == OperationType.Move
+			|| OperationType == OperationType.Copy);
+	}
 }

--- a/src/Features/JsonPatch.SystemTextJson/src/Operations/OperationBase.cs
+++ b/src/Features/JsonPatch.SystemTextJson/src/Operations/OperationBase.cs
@@ -1,6 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Shared;
+
 namespace Microsoft.AspNetCore.JsonPatch.SystemTextJson.Operations;
 
 public class OperationBase
@@ -8,7 +12,7 @@ public class OperationBase
 	private string _op;
 	private OperationType _operationType;
 
-	[System.Text.Json.Serialization.JsonIgnore]
+	[JsonIgnore]
 	public OperationType OperationType
 	{
 		get
@@ -17,10 +21,10 @@ public class OperationBase
 		}
 	}
 
-	[System.Text.Json.Serialization.JsonPropertyName(nameof(path))]
+	[JsonPropertyName(nameof(path))]
 	public string path { get; set; }
 
-	[System.Text.Json.Serialization.JsonPropertyName(nameof(op))]
+	[JsonPropertyName(nameof(op))]
 	public string op
 	{
 		get
@@ -30,7 +34,7 @@ public class OperationBase
 		set
 		{
 			OperationType result;
-			if (!System.Enum.TryParse(value, ignoreCase: true, result: out result))
+			if (!Enum.TryParse(value, ignoreCase: true, result: out result))
 			{
 				result = OperationType.Invalid;
 			}
@@ -39,8 +43,8 @@ public class OperationBase
 		}
 	}
 
-	[System.Text.Json.Serialization.JsonPropertyName(nameof(from))]
-	[System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+	[JsonPropertyName(nameof(from))]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public string from { get; set; }
 
 	public OperationBase()
@@ -49,8 +53,8 @@ public class OperationBase
 
 	public OperationBase(string op, string path, string from)
 	{
-		Microsoft.AspNetCore.Shared.ArgumentNullThrowHelper.ThrowIfNull(op);
-		Microsoft.AspNetCore.Shared.ArgumentNullThrowHelper.ThrowIfNull(path);
+		ArgumentNullThrowHelper.ThrowIfNull(op);
+		ArgumentNullThrowHelper.ThrowIfNull(path);
 
 		this.op = op;
 		this.path = path;

--- a/src/Features/JsonPatch.SystemTextJson/src/Operations/OperationBase.cs
+++ b/src/Features/JsonPatch.SystemTextJson/src/Operations/OperationBase.cs
@@ -1,65 +1,69 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Shared;
+
 namespace Microsoft.AspNetCore.JsonPatch.SystemTextJson.Operations;
 
 public class OperationBase
 {
-	private string _op;
-	private OperationType _operationType;
+    private string _op;
+    private OperationType _operationType;
 
-	[System.Text.Json.Serialization.JsonIgnore]
-	public OperationType OperationType
-	{
-		get
-		{
-			return _operationType;
-		}
-	}
+    [JsonIgnore]
+    public OperationType OperationType
+    {
+        get
+        {
+            return _operationType;
+        }
+    }
 
-	[System.Text.Json.Serialization.JsonPropertyName(nameof(path))]
-	public string path { get; set; }
+    [JsonPropertyName(nameof(path))]
+    public string path { get; set; }
 
-	[System.Text.Json.Serialization.JsonPropertyName(nameof(op))]
-	public string op
-	{
-		get
-		{
-			return _op;
-		}
-		set
-		{
-			OperationType result;
-			if (!System.Enum.TryParse(value, ignoreCase: true, result: out result))
-			{
-				result = OperationType.Invalid;
-			}
-			_operationType = result;
-			_op = value;
-		}
-	}
+    [JsonPropertyName(nameof(op))]
+    public string op
+    {
+        get
+        {
+            return _op;
+        }
+        set
+        {
+            OperationType result;
+            if (!Enum.TryParse(value, ignoreCase: true, result: out result))
+            {
+                result = OperationType.Invalid;
+            }
+            _operationType = result;
+            _op = value;
+        }
+    }
 
-	[System.Text.Json.Serialization.JsonPropertyName(nameof(from))]
-	[System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
-	public string from { get; set; }
+    [JsonPropertyName(nameof(from))]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string from { get; set; }
 
-	public OperationBase()
-	{
-	}
+    public OperationBase()
+    {
+    }
 
-	public OperationBase(string op, string path, string from)
-	{
-		Microsoft.AspNetCore.Shared.ArgumentNullThrowHelper.ThrowIfNull(op);
-		Microsoft.AspNetCore.Shared.ArgumentNullThrowHelper.ThrowIfNull(path);
+    public OperationBase(string op, string path, string from)
+    {
+        ArgumentNullThrowHelper.ThrowIfNull(op);
+        ArgumentNullThrowHelper.ThrowIfNull(path);
 
-		this.op = op;
-		this.path = path;
-		this.from = from;
-	}
+        this.op = op;
+        this.path = path;
+        this.from = from;
+    }
 
-	public bool ShouldSerializeFrom()
-	{
-		return (OperationType == OperationType.Move
-			|| OperationType == OperationType.Copy);
-	}
+    public bool ShouldSerializeFrom()
+    {
+        return (OperationType == OperationType.Move
+            || OperationType == OperationType.Copy);
+    }
 }

--- a/src/Features/JsonPatch.SystemTextJson/test/JsonPatchDocumentTest.cs
+++ b/src/Features/JsonPatch.SystemTextJson/test/JsonPatchDocumentTest.cs
@@ -1,258 +1,264 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Text.Json;
-using Microsoft.AspNetCore.JsonPatch.SystemTextJson.Converters;
-using Microsoft.AspNetCore.JsonPatch.SystemTextJson.Exceptions;
-using Microsoft.AspNetCore.JsonPatch.SystemTextJson.Operations;
-using Xunit;
-
 namespace Microsoft.AspNetCore.JsonPatch.SystemTextJson;
 
 public class JsonPatchDocumentTest
 {
-    [Fact]
-    public void InvalidPathAtBeginningShouldThrowException()
-    {
-        // Arrange
-        var patchDocument = new JsonPatchDocument();
+	[Fact]
+	public void InvalidPathAtBeginningShouldThrowException()
+	{
+		// Arrange
+		var patchDocument = new JsonPatchDocument();
 
-        // Act
-        var exception = Assert.Throws<JsonPatchException>(() =>
-        {
-            patchDocument.Add("//NewInt", 1);
-        });
+		// Act
+		var exception = Assert.Throws<JsonPatchException>(() =>
+		{
+			patchDocument.Add("//NewInt", 1);
+		});
 
-        // Assert
-        Assert.Equal(
-           "The provided string '//NewInt' is an invalid path.",
-            exception.Message);
-    }
+		// Assert
+		Assert.Equal(
+		   "The provided string '//NewInt' is an invalid path.",
+			exception.Message);
+	}
 
-    [Fact]
-    public void InvalidPathAtEndShouldThrowException()
-    {
-        // Arrange
-        var patchDocument = new JsonPatchDocument();
+	[Fact]
+	public void InvalidPathAtEndShouldThrowException()
+	{
+		// Arrange
+		var patchDocument = new JsonPatchDocument();
 
-        // Act
-        var exception = Assert.Throws<JsonPatchException>(() =>
-        {
-            patchDocument.Add("NewInt//", 1);
-        });
+		// Act
+		var exception = Assert.Throws<JsonPatchException>(() =>
+		{
+			patchDocument.Add("NewInt//", 1);
+		});
 
-        // Assert
-        Assert.Equal(
-           "The provided string 'NewInt//' is an invalid path.",
-            exception.Message);
-    }
+		// Assert
+		Assert.Equal(
+		   "The provided string 'NewInt//' is an invalid path.",
+			exception.Message);
+	}
 
-    [Fact]
-    public void NonGenericPatchDocToGenericMustSerialize()
-    {
-        // Arrange
-        var targetObject = new SimpleObject()
-        {
-            StringProperty = "A",
-            AnotherStringProperty = "B"
-        };
+	[Fact]
+	public void NonGenericPatchDocToGenericMustSerialize()
+	{
+		// Arrange
+		var targetObject = new SimpleObject()
+		{
+			StringProperty = "A",
+			AnotherStringProperty = "B"
+		};
 
-        var patchDocument = new JsonPatchDocument();
-        patchDocument.Copy("StringProperty", "AnotherStringProperty");
+		var patchDocument = new JsonPatchDocument();
+		patchDocument.Copy("StringProperty", "AnotherStringProperty");
 
-        var serialized = JsonSerializer.Serialize(patchDocument);
-        var deserialized = JsonSerializer.Deserialize<JsonPatchDocument<SimpleObject>>(serialized);
+		var serialized = JsonSerializer.Serialize(patchDocument);
+		var deserialized = JsonSerializer.Deserialize<JsonPatchDocument<SimpleObject>>(serialized);
 
-        // Act
-        deserialized.ApplyTo(targetObject);
+		// Act
+		deserialized.ApplyTo(targetObject);
 
-        // Assert
-        Assert.Equal("A", targetObject.AnotherStringProperty);
-    }
+		// Assert
+		Assert.Equal("A", targetObject.AnotherStringProperty);
+	}
 
-    public class Employee
-    {
-        public int EmployeeId { get; set; }
-        public string Name { get; set; }
-    }
+	public class Employee
+	{
+		public int EmployeeId { get; set; }
+		public string Name { get; set; }
+	}
 
-    public class SalariedEmployee : Employee
-    {
-        public decimal AnnualSalary { get; set; }
-    }
+	public class SalariedEmployee : Employee
+	{
+		public decimal AnnualSalary { get; set; }
+	}
 
-    public class Organization
-    {
-        public List<Employee> Employees { get; } = new();
-    }
+	public class Organization
+	{
+		public List<Employee> Employees { get; } = new();
+	}
 
-    [Fact]
-    public void ListWithGenericTypeWorkForSpecificChildren()
-    {
-        //Arrange
-        var org = new Organization();
-        // Populate Employees with two employees
-        org.Employees.Add(new SalariedEmployee { EmployeeId = 2, Name = "Jane", AnnualSalary = 50000 });
-        org.Employees.Add(new Employee { EmployeeId = 1, Name = "John" });
+	[Fact]
+	public void ListWithGenericTypeWorkForSpecificChildren()
+	{
+		//Arrange
+		var org = new Organization();
+		// Populate Employees with two employees
+		org.Employees.Add(new SalariedEmployee { EmployeeId = 2, Name = "Jane", AnnualSalary = 50000 });
+		org.Employees.Add(new Employee { EmployeeId = 1, Name = "John" });
 
-        var doc = new JsonPatchDocument<Organization>();
-        doc.Operations.Add(new Operations.Operation<Organization>("add", "/Employees/0/AnnualSalary", "", 100));
+		var doc = new JsonPatchDocument<Organization>();
+		doc.Operations.Add(new Operations.Operation<Organization>("add", "/Employees/0/AnnualSalary", "", 100));
 
-        // Act
-        doc.ApplyTo(org);
+		// Act
+		doc.ApplyTo(org);
 
-        // Assert
-        Assert.Equal(100, (org.Employees[0] as SalariedEmployee).AnnualSalary);
-    }
+		// Assert
+		Assert.Equal(100, (org.Employees[0] as SalariedEmployee).AnnualSalary);
+	}
 
-    [Fact]
-    public void GenericPatchDocToNonGenericMustSerialize()
-    {
-        // Arrange
-        var targetObject = new SimpleObject()
-        {
-            StringProperty = "A",
-            AnotherStringProperty = "B"
-        };
+	[Fact]
+	public void GenericPatchDocToNonGenericMustSerialize()
+	{
+		// Arrange
+		var targetObject = new SimpleObject()
+		{
+			StringProperty = "A",
+			AnotherStringProperty = "B"
+		};
 
-        var patchDocTyped = new JsonPatchDocument<SimpleObject>();
-        patchDocTyped.Copy(o => o.StringProperty, o => o.AnotherStringProperty);
+		var patchDocTyped = new JsonPatchDocument<SimpleObject>();
+		patchDocTyped.Copy(o => o.StringProperty, o => o.AnotherStringProperty);
 
-        var patchDocUntyped = new JsonPatchDocument();
-        patchDocUntyped.Copy("StringProperty", "AnotherStringProperty");
+		var patchDocUntyped = new JsonPatchDocument();
+		patchDocUntyped.Copy("StringProperty", "AnotherStringProperty");
 
-        var serializedTyped = JsonSerializer.Serialize(patchDocTyped);
-        var serializedUntyped = JsonSerializer.Serialize(patchDocUntyped);
-        var deserialized = JsonSerializer.Deserialize<JsonPatchDocument>(serializedTyped);
+		var serializedTyped = JsonSerializer.Serialize(patchDocTyped);
+		var serializedUntyped = JsonSerializer.Serialize(patchDocUntyped);
+		var deserialized = JsonSerializer.Deserialize<JsonPatchDocument>(serializedTyped);
 
-        // Act
-        deserialized.ApplyTo(targetObject);
+		// Act
+		deserialized.ApplyTo(targetObject);
 
-        // Assert
-        Assert.Equal("A", targetObject.AnotherStringProperty);
-    }
+		// Assert
+		Assert.Equal("A", targetObject.AnotherStringProperty);
+	}
 
-    [Fact]
-    public void Deserialization_Successful_ForValidJsonPatchDocument()
-    {
-        // Arrange
-        var doc = new SimpleObject()
-        {
-            StringProperty = "A",
-            DecimalValue = 10,
-            DoubleValue = 10,
-            FloatValue = 10,
-            IntegerValue = 10
-        };
+	[Fact]
+	public void Deserialization_Successful_ForValidJsonPatchDocument()
+	{
+		// Arrange
+		var doc = new SimpleObject()
+		{
+			StringProperty = "A",
+			DecimalValue = 10,
+			DoubleValue = 10,
+			FloatValue = 10,
+			IntegerValue = 10
+		};
 
-        var patchDocument = new JsonPatchDocument<SimpleObject>();
-        patchDocument.Replace(o => o.StringProperty, "B");
-        patchDocument.Replace(o => o.DecimalValue, 12);
-        patchDocument.Replace(o => o.DoubleValue, 12);
-        patchDocument.Replace(o => o.FloatValue, 12);
-        patchDocument.Replace(o => o.IntegerValue, 12);
+		var patchDocument = new JsonPatchDocument<SimpleObject>();
+		patchDocument.Replace(o => o.StringProperty, "B");
+		patchDocument.Replace(o => o.DecimalValue, 12);
+		patchDocument.Replace(o => o.DoubleValue, 12);
+		patchDocument.Replace(o => o.FloatValue, 12);
+		patchDocument.Replace(o => o.IntegerValue, 12);
 
-        // default: no envelope
-        var serialized = JsonSerializer.Serialize(patchDocument);
+		// default: no envelope
+		var serialized = JsonSerializer.Serialize(patchDocument);
 
-        // Act
-        var deserialized = JsonSerializer.Deserialize<JsonPatchDocument<SimpleObject>>(serialized);
+		// Act
+		var deserialized = JsonSerializer.Deserialize<JsonPatchDocument<SimpleObject>>(serialized);
 
-        // Assert
-        Assert.IsType<JsonPatchDocument<SimpleObject>>(deserialized);
-    }
+		// Assert
+		Assert.IsType<JsonPatchDocument<SimpleObject>>(deserialized);
+	}
 
-    [Fact]
-    public void Deserialization_Fails_ForInvalidJsonPatchDocument()
-    {
-        // Arrange
-        var serialized = "{\"Operations\": [{ \"op\": \"replace\", \"path\": \"/title\", \"value\": \"New Title\"}]}";
+	[Fact]
+	public void Deserialization_Fails_ForInvalidJsonPatchDocument()
+	{
+		// Arrange
+		var serialized = "{\"Operations\": [{ \"op\": \"replace\", \"path\": \"/title\", \"value\": \"New Title\"}]}";
 
-        // Act
-        var exception = Assert.Throws<JsonException>(() =>
-        {
-            var deserialized
-                = JsonSerializer.Deserialize<JsonPatchDocument>(serialized);
-        });
+		// Act
+		var exception = Assert.Throws<JsonException>(() =>
+		{
+			var deserialized
+				= JsonSerializer.Deserialize<JsonPatchDocument>(serialized);
+		});
 
-        // Assert
-        Assert.Equal("The JSON patch document was malformed and could not be parsed.", exception.Message);
-    }
+		// Assert
+		Assert.Equal("The JSON patch document was malformed and could not be parsed.", exception.Message);
+	}
 
-    [Fact]
-    public void Deserialization_Fails_ForInvalidTypedJsonPatchDocument()
-    {
-        // Arrange
-        var serialized = "{\"Operations\": [{ \"op\": \"replace\", \"path\": \"/title\", \"value\": \"New Title\"}]}";
+	[Fact]
+	public void Deserialization_Fails_ForInvalidTypedJsonPatchDocument()
+	{
+		// Arrange
+		var serialized = "{\"Operations\": [{ \"op\": \"replace\", \"path\": \"/title\", \"value\": \"New Title\"}]}";
 
-        // Act
-        var exception = Assert.Throws<JsonException>(() =>
-        {
-            var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
-            options.Converters.Add(new JsonConverterForJsonPatchDocumentOfT<SimpleObject>());
-            var deserialized
-                = JsonSerializer.Deserialize<JsonPatchDocument<SimpleObject>>(serialized, options);
-        });
+		// Act
+		var exception = Assert.Throws<JsonException>(() =>
+		{
+			var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+			options.Converters.Add(new JsonConverterForJsonPatchDocumentOfT<SimpleObject>());
+			var deserialized
+				= JsonSerializer.Deserialize<JsonPatchDocument<SimpleObject>>(serialized, options);
+		});
 
-        // Assert
-        Assert.Equal("The JSON patch document was malformed and could not be parsed.", exception.Message);
-    }
+		// Assert
+		Assert.Equal("The JSON patch document was malformed and could not be parsed.", exception.Message);
+	}
 
-    [Fact]
-    public void Deserialization_RespectsNamingPolicy()
-    {
-        // Arrange
-        var childToAdd = new SimpleObject
-        {
-            GuidValue = Guid.NewGuid(),
-            StringProperty = "some test data"
-        };
+	[Fact]
+	public void Deserialization_RespectsNamingPolicy()
+	{
+		// Arrange
+		var childToAdd = new SimpleObject
+		{
+			GuidValue = Guid.NewGuid(),
+			StringProperty = "some test data"
+		};
 
-        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
-        options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
-        options.DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault;
+		var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+		options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+		options.DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault;
 
-        var json = GeneratePatchDocumentJson(childToAdd, options);
+		var json = GeneratePatchDocumentJson(childToAdd, options);
 
-        var getTestObject = () => new SimpleObject() { SimpleObjectList = new() };
+		var getTestObject = () => new SimpleObject() { SimpleObjectList = new() };
 
-        //Act
-        var docSuccess = DeserializePatchDocumentWithNamingPolicy(json, JsonNamingPolicy.CamelCase);
-        var docFail = DeserializePatchDocumentWithNamingPolicy(json, JsonNamingPolicy.KebabCaseLower);
+		//Act
+		var docSuccess = DeserializePatchDocumentWithNamingPolicy(json, JsonNamingPolicy.CamelCase);
+		var docFail = DeserializePatchDocumentWithNamingPolicy(json, JsonNamingPolicy.KebabCaseLower);
 
-        // Assert
+		// Assert
 
-        // The following call should succeed
-        docSuccess.ApplyTo(getTestObject());
+		// The following call should succeed
+		docSuccess.ApplyTo(getTestObject());
 
-        // The following call should fail
-        Assert.Throws<JsonPatchException>(() =>
-        {
-            docFail.ApplyTo(getTestObject());
-        });
-    }
+		// The following call should fail
+		Assert.Throws<JsonPatchException>(() =>
+		{
+			docFail.ApplyTo(getTestObject());
+		});
+	}
 
-    private static JsonPatchDocument<SimpleObject> DeserializePatchDocumentWithNamingPolicy(string json, JsonNamingPolicy policy)
-    {
-        var compatibleSerializerOption = new JsonSerializerOptions(JsonSerializerDefaults.Web);
-        compatibleSerializerOption.PropertyNamingPolicy = policy;
-        var docSuccess = JsonSerializer.Deserialize<JsonPatchDocument<SimpleObject>>(json, compatibleSerializerOption);
-        return docSuccess;
-    }
+	private static JsonPatchDocument<SimpleObject> DeserializePatchDocumentWithNamingPolicy(string json, JsonNamingPolicy policy)
+	{
+		var compatibleSerializerOption = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+		compatibleSerializerOption.PropertyNamingPolicy = policy;
+		var docSuccess = JsonSerializer.Deserialize<JsonPatchDocument<SimpleObject>>(json, compatibleSerializerOption);
+		return docSuccess;
+	}
 
-    private string GeneratePatchDocumentJson(SimpleObject toAdd, JsonSerializerOptions jsonSerializerOptions)
-    {
-        var document = new JsonPatchDocument<SimpleObject>();
-        var operation = new Operation<SimpleObject>
-        {
-            op = "add",
-            path = "/simpleObjectList/-",
-            value = toAdd
-        };
-        document.Operations.Add(operation);
+	private string GeneratePatchDocumentJson(SimpleObject toAdd, JsonSerializerOptions jsonSerializerOptions)
+	{
+		var document = new JsonPatchDocument<SimpleObject>();
+		var operation = new Operation<SimpleObject>
+		{
+			op = "add",
+			path = "/simpleObjectList/-",
+			value = toAdd
+		};
+		document.Operations.Add(operation);
 
-        return JsonSerializer.Serialize<JsonPatchDocument<SimpleObject>>(document, jsonSerializerOptions);
-    }
+		return JsonSerializer.Serialize<JsonPatchDocument<SimpleObject>>(document, jsonSerializerOptions);
+	}
+
+	[Fact]
+	public void Serialization_DoesNotEmitFromProperty_ForAddOperation()
+	{
+		// Arrange
+		var patchDocument = new JsonPatchDocument();
+		patchDocument.Add("/a/b/c", new[] { "foo", "bar" });
+
+		// Act
+		var json = JsonSerializer.Serialize(patchDocument);
+
+		// Assert
+		Assert.DoesNotContain("\"from\":null", json);
+	}
 }

--- a/src/Features/JsonPatch.SystemTextJson/test/JsonPatchDocumentTest.cs
+++ b/src/Features/JsonPatch.SystemTextJson/test/JsonPatchDocumentTest.cs
@@ -4,6 +4,8 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using Xunit;
+using Microsoft.AspNetCore.JsonPatch.Exceptions;
+using Microsoft.AspNetCore.JsonPatch.SystemTextJson.Converters;
 namespace Microsoft.AspNetCore.JsonPatch.SystemTextJson;
 
 public class JsonPatchDocumentTest

--- a/src/Features/JsonPatch.SystemTextJson/test/JsonPatchDocumentTest.cs
+++ b/src/Features/JsonPatch.SystemTextJson/test/JsonPatchDocumentTest.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using Xunit;
-using Microsoft.AspNetCore.JsonPatch.Exceptions;
+using Microsoft.AspNetCore.JsonPatch.SystemTextJson.Exceptions;
 using Microsoft.AspNetCore.JsonPatch.SystemTextJson.Converters;
 namespace Microsoft.AspNetCore.JsonPatch.SystemTextJson;
 

--- a/src/Features/JsonPatch.SystemTextJson/test/JsonPatchDocumentTest.cs
+++ b/src/Features/JsonPatch.SystemTextJson/test/JsonPatchDocumentTest.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using Xunit;
 using Microsoft.AspNetCore.JsonPatch.SystemTextJson.Exceptions;
 using Microsoft.AspNetCore.JsonPatch.SystemTextJson.Converters;
+using Microsoft.AspNetCore.JsonPatch.SystemTextJson.Operations;
 namespace Microsoft.AspNetCore.JsonPatch.SystemTextJson;
 
 public class JsonPatchDocumentTest

--- a/src/Features/JsonPatch.SystemTextJson/test/JsonPatchDocumentTest.cs
+++ b/src/Features/JsonPatch.SystemTextJson/test/JsonPatchDocumentTest.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using Xunit;
 namespace Microsoft.AspNetCore.JsonPatch.SystemTextJson;
 
 public class JsonPatchDocumentTest

--- a/src/Features/JsonPatch.SystemTextJson/test/JsonPatchDocumentTest.cs
+++ b/src/Features/JsonPatch.SystemTextJson/test/JsonPatchDocumentTest.cs
@@ -1,270 +1,272 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
-using Xunit;
-using Microsoft.AspNetCore.JsonPatch.SystemTextJson.Exceptions;
 using Microsoft.AspNetCore.JsonPatch.SystemTextJson.Converters;
+using Microsoft.AspNetCore.JsonPatch.SystemTextJson.Exceptions;
 using Microsoft.AspNetCore.JsonPatch.SystemTextJson.Operations;
+using Xunit;
+
 namespace Microsoft.AspNetCore.JsonPatch.SystemTextJson;
 
 public class JsonPatchDocumentTest
 {
-	[Fact]
-	public void InvalidPathAtBeginningShouldThrowException()
-	{
-		// Arrange
-		var patchDocument = new JsonPatchDocument();
+    [Fact]
+    public void InvalidPathAtBeginningShouldThrowException()
+    {
+        // Arrange
+        var patchDocument = new JsonPatchDocument();
 
-		// Act
-		var exception = Assert.Throws<JsonPatchException>(() =>
-		{
-			patchDocument.Add("//NewInt", 1);
-		});
+        // Act
+        var exception = Assert.Throws<JsonPatchException>(() =>
+        {
+            patchDocument.Add("//NewInt", 1);
+        });
 
-		// Assert
-		Assert.Equal(
-		   "The provided string '//NewInt' is an invalid path.",
-			exception.Message);
-	}
+        // Assert
+        Assert.Equal(
+           "The provided string '//NewInt' is an invalid path.",
+            exception.Message);
+    }
 
-	[Fact]
-	public void InvalidPathAtEndShouldThrowException()
-	{
-		// Arrange
-		var patchDocument = new JsonPatchDocument();
+    [Fact]
+    public void InvalidPathAtEndShouldThrowException()
+    {
+        // Arrange
+        var patchDocument = new JsonPatchDocument();
 
-		// Act
-		var exception = Assert.Throws<JsonPatchException>(() =>
-		{
-			patchDocument.Add("NewInt//", 1);
-		});
+        // Act
+        var exception = Assert.Throws<JsonPatchException>(() =>
+        {
+            patchDocument.Add("NewInt//", 1);
+        });
 
-		// Assert
-		Assert.Equal(
-		   "The provided string 'NewInt//' is an invalid path.",
-			exception.Message);
-	}
+        // Assert
+        Assert.Equal(
+           "The provided string 'NewInt//' is an invalid path.",
+            exception.Message);
+    }
 
-	[Fact]
-	public void NonGenericPatchDocToGenericMustSerialize()
-	{
-		// Arrange
-		var targetObject = new SimpleObject()
-		{
-			StringProperty = "A",
-			AnotherStringProperty = "B"
-		};
+    [Fact]
+    public void NonGenericPatchDocToGenericMustSerialize()
+    {
+        // Arrange
+        var targetObject = new SimpleObject()
+        {
+            StringProperty = "A",
+            AnotherStringProperty = "B"
+        };
 
-		var patchDocument = new JsonPatchDocument();
-		patchDocument.Copy("StringProperty", "AnotherStringProperty");
+        var patchDocument = new JsonPatchDocument();
+        patchDocument.Copy("StringProperty", "AnotherStringProperty");
 
-		var serialized = JsonSerializer.Serialize(patchDocument);
-		var deserialized = JsonSerializer.Deserialize<JsonPatchDocument<SimpleObject>>(serialized);
+        var serialized = JsonSerializer.Serialize(patchDocument);
+        var deserialized = JsonSerializer.Deserialize<JsonPatchDocument<SimpleObject>>(serialized);
 
-		// Act
-		deserialized.ApplyTo(targetObject);
+        // Act
+        deserialized.ApplyTo(targetObject);
 
-		// Assert
-		Assert.Equal("A", targetObject.AnotherStringProperty);
-	}
+        // Assert
+        Assert.Equal("A", targetObject.AnotherStringProperty);
+    }
 
-	public class Employee
-	{
-		public int EmployeeId { get; set; }
-		public string Name { get; set; }
-	}
+    public class Employee
+    {
+        public int EmployeeId { get; set; }
+        public string Name { get; set; }
+    }
 
-	public class SalariedEmployee : Employee
-	{
-		public decimal AnnualSalary { get; set; }
-	}
+    public class SalariedEmployee : Employee
+    {
+        public decimal AnnualSalary { get; set; }
+    }
 
-	public class Organization
-	{
-		public List<Employee> Employees { get; } = new();
-	}
+    public class Organization
+    {
+        public List<Employee> Employees { get; } = new();
+    }
 
-	[Fact]
-	public void ListWithGenericTypeWorkForSpecificChildren()
-	{
-		//Arrange
-		var org = new Organization();
-		// Populate Employees with two employees
-		org.Employees.Add(new SalariedEmployee { EmployeeId = 2, Name = "Jane", AnnualSalary = 50000 });
-		org.Employees.Add(new Employee { EmployeeId = 1, Name = "John" });
+    [Fact]
+    public void ListWithGenericTypeWorkForSpecificChildren()
+    {
+        //Arrange
+        var org = new Organization();
+        // Populate Employees with two employees
+        org.Employees.Add(new SalariedEmployee { EmployeeId = 2, Name = "Jane", AnnualSalary = 50000 });
+        org.Employees.Add(new Employee { EmployeeId = 1, Name = "John" });
 
-		var doc = new JsonPatchDocument<Organization>();
-		doc.Operations.Add(new Operations.Operation<Organization>("add", "/Employees/0/AnnualSalary", "", 100));
+        var doc = new JsonPatchDocument<Organization>();
+        doc.Operations.Add(new Operations.Operation<Organization>("add", "/Employees/0/AnnualSalary", "", 100));
 
-		// Act
-		doc.ApplyTo(org);
+        // Act
+        doc.ApplyTo(org);
 
-		// Assert
-		Assert.Equal(100, (org.Employees[0] as SalariedEmployee).AnnualSalary);
-	}
+        // Assert
+        Assert.Equal(100, (org.Employees[0] as SalariedEmployee).AnnualSalary);
+    }
 
-	[Fact]
-	public void GenericPatchDocToNonGenericMustSerialize()
-	{
-		// Arrange
-		var targetObject = new SimpleObject()
-		{
-			StringProperty = "A",
-			AnotherStringProperty = "B"
-		};
+    [Fact]
+    public void GenericPatchDocToNonGenericMustSerialize()
+    {
+        // Arrange
+        var targetObject = new SimpleObject()
+        {
+            StringProperty = "A",
+            AnotherStringProperty = "B"
+        };
 
-		var patchDocTyped = new JsonPatchDocument<SimpleObject>();
-		patchDocTyped.Copy(o => o.StringProperty, o => o.AnotherStringProperty);
+        var patchDocTyped = new JsonPatchDocument<SimpleObject>();
+        patchDocTyped.Copy(o => o.StringProperty, o => o.AnotherStringProperty);
 
-		var patchDocUntyped = new JsonPatchDocument();
-		patchDocUntyped.Copy("StringProperty", "AnotherStringProperty");
+        var patchDocUntyped = new JsonPatchDocument();
+        patchDocUntyped.Copy("StringProperty", "AnotherStringProperty");
 
-		var serializedTyped = JsonSerializer.Serialize(patchDocTyped);
-		var serializedUntyped = JsonSerializer.Serialize(patchDocUntyped);
-		var deserialized = JsonSerializer.Deserialize<JsonPatchDocument>(serializedTyped);
+        var serializedTyped = JsonSerializer.Serialize(patchDocTyped);
+        var serializedUntyped = JsonSerializer.Serialize(patchDocUntyped);
+        var deserialized = JsonSerializer.Deserialize<JsonPatchDocument>(serializedTyped);
 
-		// Act
-		deserialized.ApplyTo(targetObject);
+        // Act
+        deserialized.ApplyTo(targetObject);
 
-		// Assert
-		Assert.Equal("A", targetObject.AnotherStringProperty);
-	}
+        // Assert
+        Assert.Equal("A", targetObject.AnotherStringProperty);
+    }
 
-	[Fact]
-	public void Deserialization_Successful_ForValidJsonPatchDocument()
-	{
-		// Arrange
-		var doc = new SimpleObject()
-		{
-			StringProperty = "A",
-			DecimalValue = 10,
-			DoubleValue = 10,
-			FloatValue = 10,
-			IntegerValue = 10
-		};
+    [Fact]
+    public void Deserialization_Successful_ForValidJsonPatchDocument()
+    {
+        // Arrange
+        var doc = new SimpleObject()
+        {
+            StringProperty = "A",
+            DecimalValue = 10,
+            DoubleValue = 10,
+            FloatValue = 10,
+            IntegerValue = 10
+        };
 
-		var patchDocument = new JsonPatchDocument<SimpleObject>();
-		patchDocument.Replace(o => o.StringProperty, "B");
-		patchDocument.Replace(o => o.DecimalValue, 12);
-		patchDocument.Replace(o => o.DoubleValue, 12);
-		patchDocument.Replace(o => o.FloatValue, 12);
-		patchDocument.Replace(o => o.IntegerValue, 12);
+        var patchDocument = new JsonPatchDocument<SimpleObject>();
+        patchDocument.Replace(o => o.StringProperty, "B");
+        patchDocument.Replace(o => o.DecimalValue, 12);
+        patchDocument.Replace(o => o.DoubleValue, 12);
+        patchDocument.Replace(o => o.FloatValue, 12);
+        patchDocument.Replace(o => o.IntegerValue, 12);
 
-		// default: no envelope
-		var serialized = JsonSerializer.Serialize(patchDocument);
+        // default: no envelope
+        var serialized = JsonSerializer.Serialize(patchDocument);
 
-		// Act
-		var deserialized = JsonSerializer.Deserialize<JsonPatchDocument<SimpleObject>>(serialized);
+        // Act
+        var deserialized = JsonSerializer.Deserialize<JsonPatchDocument<SimpleObject>>(serialized);
 
-		// Assert
-		Assert.IsType<JsonPatchDocument<SimpleObject>>(deserialized);
-	}
+        // Assert
+        Assert.IsType<JsonPatchDocument<SimpleObject>>(deserialized);
+    }
 
-	[Fact]
-	public void Deserialization_Fails_ForInvalidJsonPatchDocument()
-	{
-		// Arrange
-		var serialized = "{\"Operations\": [{ \"op\": \"replace\", \"path\": \"/title\", \"value\": \"New Title\"}]}";
+    [Fact]
+    public void Deserialization_Fails_ForInvalidJsonPatchDocument()
+    {
+        // Arrange
+        var serialized = "{\"Operations\": [{ \"op\": \"replace\", \"path\": \"/title\", \"value\": \"New Title\"}]}";
 
-		// Act
-		var exception = Assert.Throws<JsonException>(() =>
-		{
-			var deserialized
-				= JsonSerializer.Deserialize<JsonPatchDocument>(serialized);
-		});
+        // Act
+        var exception = Assert.Throws<JsonException>(() =>
+        {
+            var deserialized
+                = JsonSerializer.Deserialize<JsonPatchDocument>(serialized);
+        });
 
-		// Assert
-		Assert.Equal("The JSON patch document was malformed and could not be parsed.", exception.Message);
-	}
+        // Assert
+        Assert.Equal("The JSON patch document was malformed and could not be parsed.", exception.Message);
+    }
 
-	[Fact]
-	public void Deserialization_Fails_ForInvalidTypedJsonPatchDocument()
-	{
-		// Arrange
-		var serialized = "{\"Operations\": [{ \"op\": \"replace\", \"path\": \"/title\", \"value\": \"New Title\"}]}";
+    [Fact]
+    public void Deserialization_Fails_ForInvalidTypedJsonPatchDocument()
+    {
+        // Arrange
+        var serialized = "{\"Operations\": [{ \"op\": \"replace\", \"path\": \"/title\", \"value\": \"New Title\"}]}";
 
-		// Act
-		var exception = Assert.Throws<JsonException>(() =>
-		{
-			var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
-			options.Converters.Add(new JsonConverterForJsonPatchDocumentOfT<SimpleObject>());
-			var deserialized
-				= JsonSerializer.Deserialize<JsonPatchDocument<SimpleObject>>(serialized, options);
-		});
+        // Act
+        var exception = Assert.Throws<JsonException>(() =>
+        {
+            var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+            options.Converters.Add(new JsonConverterForJsonPatchDocumentOfT<SimpleObject>());
+            var deserialized
+                = JsonSerializer.Deserialize<JsonPatchDocument<SimpleObject>>(serialized, options);
+        });
 
-		// Assert
-		Assert.Equal("The JSON patch document was malformed and could not be parsed.", exception.Message);
-	}
+        // Assert
+        Assert.Equal("The JSON patch document was malformed and could not be parsed.", exception.Message);
+    }
 
-	[Fact]
-	public void Deserialization_RespectsNamingPolicy()
-	{
-		// Arrange
-		var childToAdd = new SimpleObject
-		{
-			GuidValue = Guid.NewGuid(),
-			StringProperty = "some test data"
-		};
+    [Fact]
+    public void Deserialization_RespectsNamingPolicy()
+    {
+        // Arrange
+        var childToAdd = new SimpleObject
+        {
+            GuidValue = Guid.NewGuid(),
+            StringProperty = "some test data"
+        };
 
-		var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
-		options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
-		options.DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault;
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+        options.DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault;
 
-		var json = GeneratePatchDocumentJson(childToAdd, options);
+        var json = GeneratePatchDocumentJson(childToAdd, options);
 
-		var getTestObject = () => new SimpleObject() { SimpleObjectList = new() };
+        var getTestObject = () => new SimpleObject() { SimpleObjectList = new() };
 
-		//Act
-		var docSuccess = DeserializePatchDocumentWithNamingPolicy(json, JsonNamingPolicy.CamelCase);
-		var docFail = DeserializePatchDocumentWithNamingPolicy(json, JsonNamingPolicy.KebabCaseLower);
+        //Act
+        var docSuccess = DeserializePatchDocumentWithNamingPolicy(json, JsonNamingPolicy.CamelCase);
+        var docFail = DeserializePatchDocumentWithNamingPolicy(json, JsonNamingPolicy.KebabCaseLower);
 
-		// Assert
+        // Assert
 
-		// The following call should succeed
-		docSuccess.ApplyTo(getTestObject());
+        // The following call should succeed
+        docSuccess.ApplyTo(getTestObject());
 
-		// The following call should fail
-		Assert.Throws<JsonPatchException>(() =>
-		{
-			docFail.ApplyTo(getTestObject());
-		});
-	}
+        // The following call should fail
+        Assert.Throws<JsonPatchException>(() =>
+        {
+            docFail.ApplyTo(getTestObject());
+        });
+    }
 
-	private static JsonPatchDocument<SimpleObject> DeserializePatchDocumentWithNamingPolicy(string json, JsonNamingPolicy policy)
-	{
-		var compatibleSerializerOption = new JsonSerializerOptions(JsonSerializerDefaults.Web);
-		compatibleSerializerOption.PropertyNamingPolicy = policy;
-		var docSuccess = JsonSerializer.Deserialize<JsonPatchDocument<SimpleObject>>(json, compatibleSerializerOption);
-		return docSuccess;
-	}
+    private static JsonPatchDocument<SimpleObject> DeserializePatchDocumentWithNamingPolicy(string json, JsonNamingPolicy policy)
+    {
+        var compatibleSerializerOption = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        compatibleSerializerOption.PropertyNamingPolicy = policy;
+        var docSuccess = JsonSerializer.Deserialize<JsonPatchDocument<SimpleObject>>(json, compatibleSerializerOption);
+        return docSuccess;
+    }
 
-	private string GeneratePatchDocumentJson(SimpleObject toAdd, JsonSerializerOptions jsonSerializerOptions)
-	{
-		var document = new JsonPatchDocument<SimpleObject>();
-		var operation = new Operation<SimpleObject>
-		{
-			op = "add",
-			path = "/simpleObjectList/-",
-			value = toAdd
-		};
-		document.Operations.Add(operation);
+    private string GeneratePatchDocumentJson(SimpleObject toAdd, JsonSerializerOptions jsonSerializerOptions)
+    {
+        var document = new JsonPatchDocument<SimpleObject>();
+        var operation = new Operation<SimpleObject>
+        {
+            op = "add",
+            path = "/simpleObjectList/-",
+            value = toAdd
+        };
+        document.Operations.Add(operation);
 
-		return JsonSerializer.Serialize<JsonPatchDocument<SimpleObject>>(document, jsonSerializerOptions);
-	}
+        return JsonSerializer.Serialize<JsonPatchDocument<SimpleObject>>(document, jsonSerializerOptions);
+    }
 
-	[Fact]
-	public void Serialization_DoesNotEmitFromProperty_ForAddOperation()
-	{
-		// Arrange
-		var patchDocument = new JsonPatchDocument();
-		patchDocument.Add("/a/b/c", new[] { "foo", "bar" });
+    [Fact]
+    public void Serialization_DoesNotEmitFromProperty_ForAddOperation()
+    {
+        // Arrange
+        var patchDocument = new JsonPatchDocument();
+        patchDocument.Add("/a/b/c", new[] { "foo", "bar" });
 
-		// Act
-		var json = JsonSerializer.Serialize(patchDocument);
+        // Act
+        var json = JsonSerializer.Serialize(patchDocument);
 
-		// Assert
-		Assert.DoesNotContain("\"from\":null", json);
-	}
+        // Assert
+        Assert.DoesNotContain("\"from\"", json);
+    }
 }

--- a/src/Features/JsonPatch.SystemTextJson/test/OperationBaseTests.cs
+++ b/src/Features/JsonPatch.SystemTextJson/test/OperationBaseTests.cs
@@ -1,40 +1,38 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Xunit;
-
 namespace Microsoft.AspNetCore.JsonPatch.SystemTextJson.Operations;
 
 public class OperationBaseTests
 {
-    [Theory]
-    [InlineData("ADd", OperationType.Add)]
-    [InlineData("Copy", OperationType.Copy)]
-    [InlineData("mOVE", OperationType.Move)]
-    [InlineData("REMOVE", OperationType.Remove)]
-    [InlineData("replace", OperationType.Replace)]
-    [InlineData("TeSt", OperationType.Test)]
-    public void SetValidOperationType(string op, OperationType operationType)
-    {
-        // Arrange
-        var operationBase = new OperationBase();
-        operationBase.op = op;
+	[Theory]
+	[InlineData("ADd", OperationType.Add)]
+	[InlineData("Copy", OperationType.Copy)]
+	[InlineData("mOVE", OperationType.Move)]
+	[InlineData("REMOVE", OperationType.Remove)]
+	[InlineData("replace", OperationType.Replace)]
+	[InlineData("TeSt", OperationType.Test)]
+	public void SetValidOperationType(string op, OperationType operationType)
+	{
+		// Arrange
+		var operationBase = new OperationBase();
+		operationBase.op = op;
 
-        // Act & Assert
-        Assert.Equal(operationType, operationBase.OperationType);
-    }
+		// Act & Assert
+		Assert.Equal(operationType, operationBase.OperationType);
+	}
 
-    [Theory]
-    [InlineData("invalid", OperationType.Invalid)]
-    [InlineData("coppy", OperationType.Invalid)]
-    [InlineData("notvalid", OperationType.Invalid)]
-    public void InvalidOperationType_SetsOperationTypeInvalid(string op, OperationType operationType)
-    {
-        // Arrange
-        var operationBase = new OperationBase();
-        operationBase.op = op;
+	[Theory]
+	[InlineData("invalid", OperationType.Invalid)]
+	[InlineData("coppy", OperationType.Invalid)]
+	[InlineData("notvalid", OperationType.Invalid)]
+	public void InvalidOperationType_SetsOperationTypeInvalid(string op, OperationType operationType)
+	{
+		// Arrange
+		var operationBase = new OperationBase();
+		operationBase.op = op;
 
-        // Act & Assert
-        Assert.Equal(operationType, operationBase.OperationType);
-    }
+		// Act & Assert
+		Assert.Equal(operationType, operationBase.OperationType);
+	}
 }

--- a/src/Features/JsonPatch.SystemTextJson/test/OperationBaseTests.cs
+++ b/src/Features/JsonPatch.SystemTextJson/test/OperationBaseTests.cs
@@ -1,38 +1,40 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Xunit;
+
 namespace Microsoft.AspNetCore.JsonPatch.SystemTextJson.Operations;
 
 public class OperationBaseTests
 {
-	[Xunit.Theory]
-	[Xunit.InlineData("ADd", OperationType.Add)]
-	[Xunit.InlineData("Copy", OperationType.Copy)]
-	[Xunit.InlineData("mOVE", OperationType.Move)]
-	[Xunit.InlineData("REMOVE", OperationType.Remove)]
-	[Xunit.InlineData("replace", OperationType.Replace)]
-	[Xunit.InlineData("TeSt", OperationType.Test)]
-	public void SetValidOperationType(string op, OperationType operationType)
-	{
-		// Arrange
-		var operationBase = new OperationBase();
-		operationBase.op = op;
+    [Theory]
+    [InlineData("ADd", OperationType.Add)]
+    [InlineData("Copy", OperationType.Copy)]
+    [InlineData("mOVE", OperationType.Move)]
+    [InlineData("REMOVE", OperationType.Remove)]
+    [InlineData("replace", OperationType.Replace)]
+    [InlineData("TeSt", OperationType.Test)]
+    public void SetValidOperationType(string op, OperationType operationType)
+    {
+        // Arrange
+        var operationBase = new OperationBase();
+        operationBase.op = op;
 
-		// Act & Assert
-		Xunit.Assert.Equal(operationType, operationBase.OperationType);
-	}
+        // Act & Assert
+        Assert.Equal(operationType, operationBase.OperationType);
+    }
 
-	[Xunit.Theory]
-	[Xunit.InlineData("invalid", OperationType.Invalid)]
-	[Xunit.InlineData("coppy", OperationType.Invalid)]
-	[Xunit.InlineData("notvalid", OperationType.Invalid)]
-	public void InvalidOperationType_SetsOperationTypeInvalid(string op, OperationType operationType)
-	{
-		// Arrange
-		var operationBase = new OperationBase();
-		operationBase.op = op;
+    [Theory]
+    [InlineData("invalid", OperationType.Invalid)]
+    [InlineData("coppy", OperationType.Invalid)]
+    [InlineData("notvalid", OperationType.Invalid)]
+    public void InvalidOperationType_SetsOperationTypeInvalid(string op, OperationType operationType)
+    {
+        // Arrange
+        var operationBase = new OperationBase();
+        operationBase.op = op;
 
-		// Act & Assert
-		Xunit.Assert.Equal(operationType, operationBase.OperationType);
-	}
+        // Act & Assert
+        Assert.Equal(operationType, operationBase.OperationType);
+    }
 }

--- a/src/Features/JsonPatch.SystemTextJson/test/OperationBaseTests.cs
+++ b/src/Features/JsonPatch.SystemTextJson/test/OperationBaseTests.cs
@@ -5,13 +5,13 @@ namespace Microsoft.AspNetCore.JsonPatch.SystemTextJson.Operations;
 
 public class OperationBaseTests
 {
-	[Theory]
-	[InlineData("ADd", OperationType.Add)]
-	[InlineData("Copy", OperationType.Copy)]
-	[InlineData("mOVE", OperationType.Move)]
-	[InlineData("REMOVE", OperationType.Remove)]
-	[InlineData("replace", OperationType.Replace)]
-	[InlineData("TeSt", OperationType.Test)]
+	[Xunit.Theory]
+	[Xunit.InlineData("ADd", OperationType.Add)]
+	[Xunit.InlineData("Copy", OperationType.Copy)]
+	[Xunit.InlineData("mOVE", OperationType.Move)]
+	[Xunit.InlineData("REMOVE", OperationType.Remove)]
+	[Xunit.InlineData("replace", OperationType.Replace)]
+	[Xunit.InlineData("TeSt", OperationType.Test)]
 	public void SetValidOperationType(string op, OperationType operationType)
 	{
 		// Arrange
@@ -19,13 +19,13 @@ public class OperationBaseTests
 		operationBase.op = op;
 
 		// Act & Assert
-		Assert.Equal(operationType, operationBase.OperationType);
+		Xunit.Assert.Equal(operationType, operationBase.OperationType);
 	}
 
-	[Theory]
-	[InlineData("invalid", OperationType.Invalid)]
-	[InlineData("coppy", OperationType.Invalid)]
-	[InlineData("notvalid", OperationType.Invalid)]
+	[Xunit.Theory]
+	[Xunit.InlineData("invalid", OperationType.Invalid)]
+	[Xunit.InlineData("coppy", OperationType.Invalid)]
+	[Xunit.InlineData("notvalid", OperationType.Invalid)]
 	public void InvalidOperationType_SetsOperationTypeInvalid(string op, OperationType operationType)
 	{
 		// Arrange
@@ -33,6 +33,6 @@ public class OperationBaseTests
 		operationBase.op = op;
 
 		// Act & Assert
-		Assert.Equal(operationType, operationBase.OperationType);
+		Xunit.Assert.Equal(operationType, operationBase.OperationType);
 	}
 }


### PR DESCRIPTION
Summary of the changes

## Summary

Prevent serialization of the `from` property when it is null.

## Changes

- Added `JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)` to the `from` property.
- Existing tests continue to pass.