### PR TITLE
feat(OpenApi): surface document generation output in Terminal Logger docs

### DIFF
--- a/src/OpenApi/src/PACKAGE.md
+++ b/src/OpenApi/src/PACKAGE.md
@@ -38,6 +38,28 @@ app.Run();
 
 For more information on configuring and using Microsoft.AspNetCore.OpenApi, refer to the [official documentation](https://learn.microsoft.com/aspnet/core/fundamentals/minimal-apis/openapi).
 
+## Build-time Document Generation
+
+Microsoft.AspNetCore.OpenApi supports generating OpenAPI documents at build time via the `Microsoft.Extensions.ApiDescription.Server` package. When you run `dotnet build`, the document generation tool runs automatically.
+
+### Viewing Build-time Generation Output
+
+By default, the .NET 8+ Terminal Logger suppresses the document generation tool output. To see the full generation logs, including messages like `Generating document named 'v1'`, use one of the following approaches:
+
+* **Increase Terminal Logger verbosity**: Pass `-tlp:v=d` (detailed) to your build command:
+
+  ```sh
+  dotnet build -tlp:v=d
+  ```
+
+* **Disable the Terminal Logger**: Pass `--tl:off` to fall back to the classic logger, which shows all tool output:
+
+  ```sh
+  dotnet build --tl:off
+  ```
+
+This is particularly useful when debugging OpenAPI document generation issues.
+
 ## Main Types
 
 <!-- The main types provided in this library -->


### PR DESCRIPTION
## Summary

Surfaces information about OpenAPI build-time document generation visibility in the NuGet PACKAGE.md, addressing the issue where the new .NET 8 Terminal Logger suppresses the generation tool output by default.

## Problem

When running dotnet build with the Terminal Logger (the default in .NET 8+), the Microsoft.Extensions.ApiDescription.Server GetDocument tool output is suppressed. Users see no indication that document generation ran, making it difficult to debug generation issues.

## Solution

Documents the available workarounds in the package README:
- Use -tlp:v=d for detailed Terminal Logger verbosity to see generation output
- Use --tl:off to disable the Terminal Logger and fall back to classic logging

This approach is noted in the issue as an acceptable solution while the upstream MSBuild/SDK changes (dotnet/msbuild#9810, dotnet/sdk#43293) are tracked.

## Changes

- src/OpenApi/src/PACKAGE.md: Added a new section "Build-time Document Generation" documenting the Terminal Logger verbosity options

Fixes #62273
