### PR TITLE
Improve Kestrel accept-loop error handling

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/ConnectionDispatcher.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/ConnectionDispatcher.cs
@@ -79,7 +79,7 @@ internal sealed class ConnectionDispatcher<T> where T : BaseConnectionContext
                 }
                 catch (Exception ex)
                 {
-                    Log.LogError(0, ex, "The connection listener failed to process an accepted connection.");
+                    Log.LogError(0, ex, "The connection listener failed to process an accepted connection. ConnectionId: {ConnectionId}", connection.ConnectionId);
 
                     try
                     {

--- a/src/Servers/Kestrel/Core/src/Internal/ConnectionDispatcher.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/ConnectionDispatcher.cs
@@ -37,64 +37,70 @@ internal sealed class ConnectionDispatcher<T> where T : BaseConnectionContext
 
         async Task AcceptConnectionsAsync()
         {
-            while (true)
+            try
             {
-                T? connection;
-                try
+                while (true)
                 {
-                    connection = await listener.AcceptAsync();
-                }
-                catch (Exception ex)
-                {
-                    // REVIEW: If the accept loop ends should this trigger a server shutdown? It will manifest as a hang
-                    Log.LogCritical(0, ex, "The connection listener failed to accept any new connections.");
-                    break;
-                }
+                    T? connection;
+                    try
+                    {
+                        connection = await listener.AcceptAsync();
+                    }
+                    catch (Exception ex)
+                    {
+                        // REVIEW: If the accept loop ends should this trigger a server shutdown? It will manifest as a hang
+                        try
+                        {
+                            Log.LogCritical(0, ex, "The connection listener failed to accept any new connections.");
+                        }
+                        catch
+                        {
 
-                if (connection == null)
-                {
-                    // We're done listening
-                    break;
-                }
+                        }
+                        break;
+                    }
 
-                try
-                {
-                    // Add the connection to the connection manager before we queue it for execution
-                    var id = _transportConnectionManager.GetNewConnectionId();
-
-                    // Cache counter enabled state at the start of the connection.
-                    // This ensures that the state is consistent for the entire connection.
-                    var metricsContext = Metrics.CreateContext(connection);
-
-                    var kestrelConnection = new KestrelConnection<T>(
-                        id, _serviceContext, _transportConnectionManager, _connectionDelegate, connection, Log, metricsContext);
-
-                    _transportConnectionManager.AddConnection(id, kestrelConnection);
-
-                    Log.ConnectionAccepted(connection.ConnectionId);
-                    KestrelEventSource.Log.ConnectionQueuedStart(connection);
-                    Metrics.ConnectionQueuedStart(metricsContext);
-
-                    ThreadPool.UnsafeQueueUserWorkItem(kestrelConnection, preferLocal: false);
-                }
-                catch (Exception ex)
-                {
-                    Log.LogError(0, ex, "The connection listener failed to process an accepted connection. ConnectionId: {ConnectionId}", connection.ConnectionId);
+                    if (connection == null)
+                    {
+                        // We're done listening
+                        break;
+                    }
 
                     try
                     {
-                        connection.Abort(new ConnectionAbortedException("The accepted connection failed while processing."));
-                        await connection.DisposeAsync().ConfigureAwait(false);
-                    }
-                    catch
-                    {
-                    }
+                        // Add the connection to the connection manager before we queue it for execution
+                        var id = _transportConnectionManager.GetNewConnectionId();
+                        // Cache counter enabled state at the start of the connection.
+                        // This ensures that the state is consistent for the entire connection.
+                        var metricsContext = Metrics.CreateContext(connection);
+                        var kestrelConnection = new KestrelConnection<T>(
+                            id, _serviceContext, _transportConnectionManager, _connectionDelegate, connection, Log, metricsContext);
 
-                    continue;
+                        _transportConnectionManager.AddConnection(id, kestrelConnection);
+
+                        Log.ConnectionAccepted(connection.ConnectionId);
+                        KestrelEventSource.Log.ConnectionQueuedStart(connection);
+                        Metrics.ConnectionQueuedStart(metricsContext);
+
+                        ThreadPool.UnsafeQueueUserWorkItem(kestrelConnection, preferLocal: false);
+                    }
+                    catch (Exception ex)
+                    {
+                        try { Log.LogError(0, ex, "Unexpected error while processing accepted connection. ConnectionId: {ConnectionId}", connection.ConnectionId); } catch { }
+
+                        try
+                        {
+                            connection.Abort(new ConnectionAbortedException("Failed while processing."));
+                            await connection.DisposeAsync().ConfigureAwait(false);
+                        }
+                        catch { }
+                    }
                 }
             }
-
-            _acceptLoopTcs.TrySetResult();
+            finally
+            {
+                _acceptLoopTcs.TrySetResult();
+            }
         }
-    }
+     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/ConnectionDispatcher.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/ConnectionDispatcher.cs
@@ -37,18 +37,28 @@ internal sealed class ConnectionDispatcher<T> where T : BaseConnectionContext
 
         async Task AcceptConnectionsAsync()
         {
-            try
+            while (true)
             {
-                while (true)
+                T? connection;
+                try
                 {
-                    var connection = await listener.AcceptAsync();
+                    connection = await listener.AcceptAsync();
+                }
+                catch (Exception ex)
+                {
+                    // REVIEW: If the accept loop ends should this trigger a server shutdown? It will manifest as a hang
+                    Log.LogCritical(0, ex, "The connection listener failed to accept any new connections.");
+                    break;
+                }
 
-                    if (connection == null)
-                    {
-                        // We're done listening
-                        break;
-                    }
+                if (connection == null)
+                {
+                    // We're done listening
+                    break;
+                }
 
+                try
+                {
                     // Add the connection to the connection manager before we queue it for execution
                     var id = _transportConnectionManager.GetNewConnectionId();
 
@@ -67,16 +77,24 @@ internal sealed class ConnectionDispatcher<T> where T : BaseConnectionContext
 
                     ThreadPool.UnsafeQueueUserWorkItem(kestrelConnection, preferLocal: false);
                 }
+                catch (Exception ex)
+                {
+                    Log.LogError(0, ex, "The connection listener failed to process an accepted connection.");
+
+                    try
+                    {
+                        connection.Abort(new ConnectionAbortedException("The accepted connection failed while processing."));
+                        await connection.DisposeAsync().ConfigureAwait(false);
+                    }
+                    catch
+                    {
+                    }
+
+                    continue;
+                }
             }
-            catch (Exception ex)
-            {
-                // REVIEW: If the accept loop ends should this trigger a server shutdown? It will manifest as a hang
-                Log.LogCritical(0, ex, "The connection listener failed to accept any new connections.");
-            }
-            finally
-            {
-                _acceptLoopTcs.TrySetResult();
-            }
+
+            _acceptLoopTcs.TrySetResult();
         }
     }
 }

--- a/src/Servers/Kestrel/Core/test/ConnectionDispatcherTests.cs
+++ b/src/Servers/Kestrel/Core/test/ConnectionDispatcherTests.cs
@@ -83,7 +83,7 @@ public class ConnectionDispatcherTests : LoggedTest
 
         var error = TestSink.Writes.SingleOrDefault(m => m.LogLevel == LogLevel.Error);
         Assert.NotNull(error);
-        Assert.StartsWith("The connection listener failed to process an accepted connection.", error.Message, StringComparison.Ordinal);
+        Assert.StartsWith("Unexpected error while processing accepted connection.", error.Message, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/Servers/Kestrel/Core/test/ConnectionDispatcherTests.cs
+++ b/src/Servers/Kestrel/Core/test/ConnectionDispatcherTests.cs
@@ -83,7 +83,7 @@ public class ConnectionDispatcherTests : LoggedTest
 
         var error = TestSink.Writes.SingleOrDefault(m => m.LogLevel == LogLevel.Error);
         Assert.NotNull(error);
-        Assert.Equal("The connection listener failed to process an accepted connection.", error.Message);
+        Assert.StartsWith("The connection listener failed to process an accepted connection.", error.Message, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/Servers/Kestrel/Core/test/ConnectionDispatcherTests.cs
+++ b/src/Servers/Kestrel/Core/test/ConnectionDispatcherTests.cs
@@ -2,13 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.IO.Pipelines;
 using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.InternalTesting;
@@ -67,6 +70,20 @@ public class ConnectionDispatcherTests : LoggedTest
         Assert.NotNull(critical);
         Assert.IsType<InvalidOperationException>(critical.Exception);
         Assert.Equal("Unexpected error listening", critical.Exception.Message);
+    }
+
+    [Fact]
+    public async Task StartAcceptingConnectionsContinuesAfterConnectionProcessingError()
+    {
+        var serviceContext = new TestServiceContext(LoggerFactory);
+
+        var dispatcher = new ConnectionDispatcher<ConnectionContext>(serviceContext, _ => Task.CompletedTask, new TransportConnectionManager(serviceContext.ConnectionManager));
+
+        await dispatcher.StartAcceptingConnections(new SingleConnectionListener(new ThrowingConnectionContext()));
+
+        var error = TestSink.Writes.SingleOrDefault(m => m.LogLevel == LogLevel.Error);
+        Assert.NotNull(error);
+        Assert.Equal("The connection listener failed to process an accepted connection.", error.Message);
     }
 
     [Fact]
@@ -140,6 +157,114 @@ public class ConnectionDispatcherTests : LoggedTest
         public ValueTask UnbindAsync(CancellationToken cancellationToken = default)
         {
             return default;
+        }
+    }
+
+    private sealed class SingleConnectionListener : IConnectionListener<ConnectionContext>
+    {
+        private readonly ConnectionContext _connection;
+        private bool _returnedConnection;
+
+        public SingleConnectionListener(ConnectionContext connection)
+        {
+            _connection = connection;
+        }
+
+        public EndPoint EndPoint { get; set; }
+
+        public ValueTask<ConnectionContext> AcceptAsync(CancellationToken cancellationToken = default)
+        {
+            if (_returnedConnection)
+            {
+                return default;
+            }
+
+            _returnedConnection = true;
+            return new ValueTask<ConnectionContext>(_connection);
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            return default;
+        }
+
+        public ValueTask UnbindAsync(CancellationToken cancellationToken = default)
+        {
+            return default;
+        }
+    }
+
+    private sealed class ThrowingConnectionContext : ConnectionContext
+    {
+        private readonly CancellationTokenSource _connectionClosedTokenSource = new CancellationTokenSource();
+        private readonly ThrowingFeatureCollection _features = new ThrowingFeatureCollection();
+
+        public ThrowingConnectionContext()
+        {
+            ConnectionId = Guid.NewGuid().ToString();
+            Features = _features;
+            Items = new ConnectionItems();
+            Transport = new DummyDuplexPipe();
+            ConnectionClosed = _connectionClosedTokenSource.Token;
+        }
+
+        public override string ConnectionId { get; set; }
+        public override IFeatureCollection Features { get; }
+        public override IDictionary<object, object> Items { get; set; }
+        public override IDuplexPipe Transport { get; set; }
+        public override CancellationToken ConnectionClosed { get; set; }
+        public override EndPoint LocalEndPoint { get; set; }
+        public override EndPoint RemoteEndPoint { get; set; }
+
+        public override void Abort() => _connectionClosedTokenSource.Cancel();
+
+        public override void Abort(ConnectionAbortedException abortReason) => _connectionClosedTokenSource.Cancel();
+
+        public override ValueTask DisposeAsync()
+        {
+            var duplexPipe = (DummyDuplexPipe)Transport;
+            duplexPipe.Input.Complete();
+            duplexPipe.Output.Complete();
+            _connectionClosedTokenSource.Dispose();
+            return default;
+        }
+
+        private sealed class DummyDuplexPipe : IDuplexPipe
+        {
+            public DummyDuplexPipe()
+            {
+                var pipe = new Pipe();
+                Input = pipe.Reader;
+                Output = pipe.Writer;
+            }
+
+            public PipeReader Input { get; }
+            public PipeWriter Output { get; }
+        }
+
+        private sealed class ThrowingFeatureCollection : IFeatureCollection
+        {
+            private readonly FeatureCollection _inner = new FeatureCollection();
+            private bool _isReadOnly;
+
+            public object this[Type key]
+            {
+                get => _inner[key];
+                set => _inner[key] = value;
+            }
+
+            public int Revision => _inner.Revision;
+            public bool IsReadOnly { get => _isReadOnly; set => _isReadOnly = value; }
+
+            public TFeature Get<TFeature>() => _inner.Get<TFeature>();
+
+            public void Set<TFeature>(TFeature feature)
+            {
+                throw new InvalidOperationException("The feature collection failed during connection processing.");
+            }
+
+            public IEnumerator<KeyValuePair<Type, object>> GetEnumerator() => _inner.GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         }
     }
 }


### PR DESCRIPTION
# Improve Kestrel accept-loop error handling

## Summary
Fix Kestrel accept-loop error handling, preserve AcceptAsync semantics, and add regression tests

## Description
ConnectionDispatcher now:

- logs AcceptAsync() failures as critical and breaks the accept loop (existing semantics)
- catches exceptions during post-accept setup/connection creation/processing
- logs an error, aborts/disposes that connection, and continues accepting

Fixes issue https://github.com/dotnet/aspnetcore/issues/66942