### PR TITLE
Collapse scheme-relative leading slashes in Rewrite middleware redirect/rewrite targets

### DIFF
--- a/src/Middleware/Rewrite/src/RedirectRule.cs
+++ b/src/Middleware/Rewrite/src/RedirectRule.cs
@@ -43,6 +43,7 @@ internal sealed class RedirectRule : IRule
         if (initMatchResults.Success)
         {
             var newPath = initMatchResults.Result(Replacement);
+            newPath = UrlNormalizer.CollapseLeadingSlashes(newPath);
             var response = context.HttpContext.Response;
 
             response.StatusCode = StatusCode;

--- a/src/Middleware/Rewrite/src/UrlActions/RedirectAction.cs
+++ b/src/Middleware/Rewrite/src/UrlActions/RedirectAction.cs
@@ -43,6 +43,8 @@ internal sealed class RedirectAction : UrlAction
             return;
         }
 
+        pattern = UrlNormalizer.CollapseLeadingSlashes(pattern);
+
         if (!pattern.Contains(Uri.SchemeDelimiter, StringComparison.Ordinal) && pattern[0] != '/')
         {
             pattern = '/' + pattern;
@@ -51,7 +53,6 @@ internal sealed class RedirectAction : UrlAction
 
         // url can either contain the full url or the path and query
         // always add to location header.
-        // TODO check for false positives
 
         var split = pattern.IndexOf('?');
         if (split >= 0 && QueryStringAppend)

--- a/src/Middleware/Rewrite/src/UrlActions/RewriteAction.cs
+++ b/src/Middleware/Rewrite/src/UrlActions/RewriteAction.cs
@@ -58,6 +58,12 @@ internal sealed class RewriteAction : UrlAction
             pattern = Uri.EscapeDataString(pattern);
         }
 
+        // Defense in depth: this rule does not emit a Location header itself, but the rewritten value is
+        // assigned to Request.Path below and a downstream component (or a later rule) may issue a redirect
+        // from it. PathString does not reject a leading '//' or '/\', so neutralize the scheme-relative
+        // shape here rather than auditing every downstream consumer.
+        pattern = UrlNormalizer.CollapseLeadingSlashes(pattern);
+
         // TODO PERF, substrings, object creation, etc.
         if (pattern.Contains(Uri.SchemeDelimiter, StringComparison.Ordinal))
         {

--- a/src/Middleware/Rewrite/src/UrlNormalizer.cs
+++ b/src/Middleware/Rewrite/src/UrlNormalizer.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Rewrite;
+
+internal static class UrlNormalizer
+{
+    // Collapses a leading run of '/' and '\' to a single '/' so a redirect/rewrite target cannot resolve as a
+    // scheme-relative authority. Mirrors the rejection predicate in SharedUrlHelper.IsLocalUrl.
+    public static string CollapseLeadingSlashes(string url)
+    {
+        if (url.Length < 2 || url[0] != '/' || (url[1] != '/' && url[1] != '\\'))
+        {
+            return url;
+        }
+
+        var i = 1;
+        while (i < url.Length && (url[i] == '/' || url[i] == '\\'))
+        {
+            i++;
+        }
+
+        return i == url.Length ? "/" : string.Concat("/", url.AsSpan(i));
+    }
+}

--- a/src/Middleware/Rewrite/test/ApacheModRewrite/ModRewriteMiddlewareTest.cs
+++ b/src/Middleware/Rewrite/test/ApacheModRewrite/ModRewriteMiddlewareTest.cs
@@ -37,6 +37,62 @@ public class ModRewriteMiddlewareTest
         Assert.Equal("/hello", response);
     }
 
+    [Theory]
+    [InlineData("/legacy//example.com")]
+    [InlineData("/legacy///example.com")]
+    [InlineData(@"/legacy/\example.com")]
+    public async Task Invoke_RedirectCollapsesSchemeRelativeBackReference(string requestPath)
+    {
+        var options = new RewriteOptions().AddApacheModRewrite(new StringReader("RewriteRule /legacy/(.*) /$1 [R=302,L]"));
+        using var host = new HostBuilder()
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder
+                .UseTestServer()
+                .Configure(app =>
+                {
+                    app.UseRewriter(options);
+                    app.Run(context => context.Response.WriteAsync(context.Response.Headers.Location));
+                });
+            }).Build();
+
+        await host.StartAsync();
+
+        var server = host.GetTestServer();
+
+        var response = await server.CreateClient().GetAsync(requestPath);
+
+        Assert.Equal("/example.com", response.Headers.Location.OriginalString);
+    }
+
+    [Theory]
+    [InlineData("/legacy//example.com")]
+    [InlineData("/legacy///example.com")]
+    [InlineData(@"/legacy/\example.com")]
+    public async Task Invoke_RewriteCollapsesSchemeRelativeBackReference(string requestPath)
+    {
+        var options = new RewriteOptions().AddApacheModRewrite(new StringReader("RewriteRule /legacy/(.*) /$1"));
+        using var host = new HostBuilder()
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder
+                .UseTestServer()
+                .Configure(app =>
+                {
+                    app.UseRewriter(options);
+                    app.Run(context => context.Response.WriteAsync(context.Request.Path));
+                });
+            }).Build();
+
+        await host.StartAsync();
+
+        var server = host.GetTestServer();
+
+        var response = await server.CreateClient().GetStringAsync(requestPath);
+
+        Assert.Equal("/example.com", response);
+    }
+
     [Fact]
     public async Task Invoke_RewritePathTerminatesOnFirstSuccessOfRule()
     {

--- a/src/Middleware/Rewrite/test/IISUrlRewrite/MiddleWareTests.cs
+++ b/src/Middleware/Rewrite/test/IISUrlRewrite/MiddleWareTests.cs
@@ -47,6 +47,41 @@ public class MiddlewareTests
         Assert.Equal("/article.aspx?id=10&title=hey", response.Headers.Location.OriginalString);
     }
 
+    [Theory]
+    [InlineData("legacy//example.com")]
+    [InlineData("legacy///example.com")]
+    [InlineData(@"legacy/\example.com")]
+    public async Task Invoke_RedirectCollapsesSchemeRelativeBackReference(string requestPath)
+    {
+        var options = new RewriteOptions().AddIISUrlRewrite(new StringReader(@"<rewrite>
+                <rules>
+                <rule name=""Collapse"">
+                <match url=""^legacy/(.*)"" />
+                <action type=""Redirect"" url=""/{R:1}"" redirectType=""Found"" />
+                </rule>
+                </rules>
+                </rewrite>"));
+        using var host = new HostBuilder()
+             .ConfigureWebHost(webHostBuilder =>
+             {
+                 webHostBuilder
+                 .UseTestServer()
+                 .Configure(app =>
+                 {
+                     app.UseRewriter(options);
+                     app.Run(context => context.Response.WriteAsync(context.Response.Headers.Location));
+                 });
+             }).Build();
+
+        await host.StartAsync();
+
+        var server = host.GetTestServer();
+
+        var response = await server.CreateClient().GetAsync(requestPath);
+
+        Assert.Equal("/example.com", response.Headers.Location.OriginalString);
+    }
+
     [Fact]
     public async Task Invoke_RewritePathToPathAndQuery()
     {

--- a/src/Middleware/Rewrite/test/MiddlewareTests.cs
+++ b/src/Middleware/Rewrite/test/MiddlewareTests.cs
@@ -174,6 +174,37 @@ public class MiddlewareTests
         Assert.Equal(expectedUrl, response.Headers.Location.OriginalString);
     }
 
+    [Theory]
+    [InlineData("(.*)", "//example.com", "anything")]
+    [InlineData("(.*)", "///example.com", "anything")]
+    [InlineData("(.*)", @"/\example.com", "anything")]
+    [InlineData("(.*)", "//////example.com", "anything")]
+    [InlineData("legacy/(.*)", "/$1", "legacy//example.com")]
+    [InlineData("legacy/(.*)", "/$1", "legacy///example.com")]
+    [InlineData("legacy/(.*)", "/$1", @"legacy/\example.com")]
+    public async Task CheckRedirect_CollapsesSchemeRelativeTarget(string pattern, string replacement, string requestUrl)
+    {
+        var options = new RewriteOptions().AddRedirect(pattern, replacement, statusCode: StatusCodes.Status302Found);
+        using var host = new HostBuilder()
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder
+                .UseTestServer()
+                .Configure(app =>
+                {
+                    app.UseRewriter(options);
+                });
+            }).Build();
+
+        await host.StartAsync();
+
+        var server = host.GetTestServer();
+
+        var response = await server.CreateClient().GetAsync(requestUrl);
+
+        Assert.Equal("/example.com", response.Headers.Location.OriginalString);
+    }
+
     [Fact]
     public async Task RewriteRulesCanComeFromConfigureOptions()
     {


### PR DESCRIPTION
# Summary

`AddRedirect`, IIS URL Rewrite, and Apache `mod_rewrite` rules let a back-reference (or a literal rule replacement) produce a redirect/rewrite target that starts with `//`, `///`, or `/\` (and longer runs). When `PathBase` is empty, the resulting `Location` header is **scheme-relative** and resolves off-origin — i.e. an open redirect.

Example today:

```csharp
app.UseRewriter(new RewriteOptions()
    .AddRedirect("legacy/(.*)", "/$1", statusCode: 302));
```

# Fix

Introduce a small `internal static class UrlNormalizer` with one method:

```csharp
public static string CollapseLeadingSlashes(string url);
```

It mirrors the rejection predicate in `SharedUrlHelper.IsLocalUrl` but coerces instead of returning a `bool`: any leading run of `/` and `\` is collapsed to a single `/`. The fast-path is zero-allocation and reference-returning when the input does not begin with `//` or `/\`.

The helper is invoked at the three sinks that emit `Location` or mutate `Request.Path`:

| Sink                                          | Surface                                |
| --------------------------------------------- | -------------------------------------- |
| `RedirectRule.ApplyRule`                      | `AddRedirect(...)` rules               |
| `UrlActions.RedirectAction.ApplyAction`       | IIS / Apache redirect rule imports     |
| `UrlActions.RewriteAction.ApplyAction`        | Defense in depth for `Request.Path`    |

Also removes a stale `// TODO check for false positives` comment in `RedirectAction` that was tracking exactly this gap.

# Tests

Four new `[Theory]` methods covering all three surfaces, including back-reference-synthesized cases:

- `CheckRedirect_CollapsesSchemeRelativeTarget` — `AddRedirect` (7 rows)
- `Invoke_RedirectCollapsesSchemeRelativeBackReference` — IIS URL Rewrite (3 rows)
- `Invoke_RedirectCollapsesSchemeRelativeBackReference` — Apache `mod_rewrite`, `[R=302,L]` (3 rows)
- `Invoke_RewriteCollapsesSchemeRelativeBackReference` — Apache `mod_rewrite`, no `[R]` flag, asserts `Request.Path` (3 rows)

Each surface is covered for `//`, `///`, `//////`, and `/\` shapes, both as literal replacements and as `$1` / `{R:1}` captures.

# Compatibility

- **No public API surface change.** `PublicAPI.Shipped.txt` and `PublicAPI.Unshipped.txt` are byte-identical.
- All 42 pre-existing `Headers.Location` assertions in the Rewrite test suite still pass — full suite is **473 / 473** green.
- Behavior change is intentional and security-relevant: targets that were resolving as scheme-relative authorities now resolve as local paths. Prior behavior was an open redirect, not a documented contract, so no opt-out is added on `main`.

# Validation

```text
dotnet build src/Middleware/Rewrite/src/Microsoft.AspNetCore.Rewrite.csproj -c Debug
  → 0 errors, 0 warnings

dotnet test src/Middleware/Rewrite/test/Microsoft.AspNetCore.Rewrite.Tests.csproj -c Debug
  → total: 473, succeeded: 473, failed: 0, skipped: 0
```

### Fixes: #66486
