### PR TITLE
Make Kestrel accept loop fail fast on listener errors

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/ConnectionDispatcher.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/ConnectionDispatcher.cs
@@ -12,13 +12,15 @@ internal sealed class ConnectionDispatcher<T> where T : BaseConnectionContext
     private readonly ServiceContext _serviceContext;
     private readonly Func<T, Task> _connectionDelegate;
     private readonly TransportConnectionManager _transportConnectionManager;
+    private readonly Func<Exception, bool>? _fatalErrorHandler;
     private readonly TaskCompletionSource _acceptLoopTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-    public ConnectionDispatcher(ServiceContext serviceContext, Func<T, Task> connectionDelegate, TransportConnectionManager transportConnectionManager)
+    public ConnectionDispatcher(ServiceContext serviceContext, Func<T, Task> connectionDelegate, TransportConnectionManager transportConnectionManager, Func<Exception, bool>? fatalErrorHandler = null)
     {
         _serviceContext = serviceContext;
         _connectionDelegate = connectionDelegate;
         _transportConnectionManager = transportConnectionManager;
+        _fatalErrorHandler = fatalErrorHandler;
     }
 
     private KestrelTrace Log => _serviceContext.Log;
@@ -37,6 +39,8 @@ internal sealed class ConnectionDispatcher<T> where T : BaseConnectionContext
 
         async Task AcceptConnectionsAsync()
         {
+            Exception? acceptLoopException = null;
+
             try
             {
                 while (true)
@@ -70,12 +74,27 @@ internal sealed class ConnectionDispatcher<T> where T : BaseConnectionContext
             }
             catch (Exception ex)
             {
-                // REVIEW: If the accept loop ends should this trigger a server shutdown? It will manifest as a hang
-                Log.LogCritical(0, ex, "The connection listener failed to accept any new connections.");
+                // Any exception in the accept loop is fatal; restart the process
+                // to avoid a silent hang.
+                acceptLoopException = ex;
+
+                Log.LogCritical(0, ex, "The connection listener failed while accepting connections.");
+
+                if (_fatalErrorHandler is null || !_fatalErrorHandler(ex))
+                {
+                    Environment.FailFast("The connection listener failed while accepting connections.", ex);
+                }
             }
             finally
             {
-                _acceptLoopTcs.TrySetResult();
+                if (acceptLoopException is null)
+                {
+                    _acceptLoopTcs.TrySetResult();
+                }
+                else
+                {
+                    _acceptLoopTcs.TrySetException(acceptLoopException);
+                }
             }
         }
     }

--- a/src/Servers/Kestrel/Core/test/ConnectionDispatcherTests.cs
+++ b/src/Servers/Kestrel/Core/test/ConnectionDispatcherTests.cs
@@ -59,9 +59,16 @@ public class ConnectionDispatcherTests : LoggedTest
     {
         var serviceContext = new TestServiceContext(LoggerFactory);
 
-        var dispatcher = new ConnectionDispatcher<ConnectionContext>(serviceContext, _ => Task.CompletedTask, new TransportConnectionManager(serviceContext.ConnectionManager));
+        var dispatcher = new ConnectionDispatcher<ConnectionContext>(
+            serviceContext,
+            _ => Task.CompletedTask,
+            new TransportConnectionManager(serviceContext.ConnectionManager),
+            fatalErrorHandler: ex => true);
 
-        await dispatcher.StartAcceptingConnections(new ThrowingListener());
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => dispatcher.StartAcceptingConnections(new ThrowingListener()));
+
+        Assert.Equal("Unexpected error listening", exception.Message);
 
         var critical = TestSink.Writes.SingleOrDefault(m => m.LogLevel == LogLevel.Critical);
         Assert.NotNull(critical);


### PR DESCRIPTION

## Title
# Make Kestrel accept loop fail fast on listener errors

## Description

This change makes Kestrel more reliable when the listener fails while accepting new connections.
- If the accept loop hits an unexpected error, Kestrel now treats it as a fatal failure instead of hanging silently.
- It logs the failure and then terminates the process so the host can restart cleanly.

if accept loop fails, the server now fails fast and recovers instead of waiting forever.

Fixes https://github.com/dotnet/aspnetcore/issues/66942
