### PR TITLE
Revert Node 24.14.1 pin in default-build.yml

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -179,16 +179,16 @@ jobs:
           displayName: Start background dump collection
       - ${{ if eq(parameters.installNodeJs, 'true') }}:
         - task: UseNode@1
-          displayName: Install Node 24.14.1
+          displayName: Install Node 24.x
           inputs:
-            version: 24.14.1
+            version: 24.x
         - task: Cache@2
           displayName: Cache node_modules
           continueOnError: true
           inputs:
-            key: '"node_modules" | "node24.14.1" | "$(Agent.OS)" | $(Build.SourcesDirectory)/package-lock.json'
+            key: '"node_modules" | "node24" | "$(Agent.OS)" | $(Build.SourcesDirectory)/package-lock.json'
             restoreKeys: |
-              "node_modules" | "node24.14.1" | "$(Agent.OS)"
+              "node_modules" | "node24" | "$(Agent.OS)"
             path: node_modules
       - ${{ if and(eq(parameters.agentOs, 'Windows'), eq(parameters.isAzDOTestingJob, true)) }}:
         - powershell: |
@@ -421,16 +421,16 @@ jobs:
           displayName: Start background dump collection
       - ${{ if eq(parameters.installNodeJs, 'true') }}:
         - task: UseNode@1
-          displayName: Install Node 24.14.1
+          displayName: Install Node 24.x
           inputs:
-            version: 24.14.1
+            version: 24.x
         - task: Cache@2
           displayName: Cache node_modules
           continueOnError: true
           inputs:
-            key: '"node_modules" | "node24.14.1" | "$(Agent.OS)" | $(Build.SourcesDirectory)/package-lock.json'
+            key: '"node_modules" | "node24" | "$(Agent.OS)" | $(Build.SourcesDirectory)/package-lock.json'
             restoreKeys: |
-              "node_modules" | "node24.14.1" | "$(Agent.OS)"
+              "node_modules" | "node24" | "$(Agent.OS)"
             path: node_modules
       - ${{ if eq(parameters.agentOs, 'Windows') }}:
         - powershell: Write-Host "##vso[task.prependpath]$(DOTNET_CLI_HOME)\.dotnet\tools"


### PR DESCRIPTION
## What

Undoes the **Node version pinning** `.yml` changes from #66465, while **keeping** the two `installNodeJs: false` additions **and** the `Cache@2` `continueOnError: true`.

Specifically reverts, in `.azure/pipelines/jobs/default-build.yml` (both job blocks):
- `Install Node 24.14.1` → `Install Node 24.x`
- `version: 24.14.1` → `version: 24.x`
- Cache/restore keys `node24.14.1` → `node24`

## Not touched

- The `installNodeJs: false` additions in `ci-public.yml` and `ci.yml` are **kept**.
- The `continueOnError: true` on the `Cache@2` node_modules task is **kept**.
- `ci.yml`'s Node-install block from #66465 was already removed on `main` by a later change, so nothing to revert there.
- Non-`.yml` changes from #66465 (`.npmrc`, `eng/Npm.Workspace.nodeproj`) are out of scope and untouched.

Relates to #66465