### PR TITLE
Update Microsoft.OpenApi to 3.6.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -199,7 +199,7 @@
     <MicrosoftDataSqlClientVersion>7.0.0</MicrosoftDataSqlClientVersion>
     <MicrosoftDataSqlClientExtensionsAzureVersion>1.0.0</MicrosoftDataSqlClientExtensionsAzureVersion>
     <MicrosoftOpenApiVersion>3.6.0</MicrosoftOpenApiVersion>
-    <MicrosoftOpenApiYamlReaderVersion>3.3.1</MicrosoftOpenApiYamlReaderVersion>
+    <MicrosoftOpenApiYamlReaderVersion>3.6.0</MicrosoftOpenApiYamlReaderVersion>
     <!-- dotnet tool versions (see also auto-updated DotnetEfVersion property). -->
     <DotnetDumpVersion>6.0.322601</DotnetDumpVersion>
     <DotnetServeVersion>1.10.93</DotnetServeVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -198,7 +198,7 @@
     <YarpReverseProxyVersion>2.3.0</YarpReverseProxyVersion>
     <MicrosoftDataSqlClientVersion>7.0.0</MicrosoftDataSqlClientVersion>
     <MicrosoftDataSqlClientExtensionsAzureVersion>1.0.0</MicrosoftDataSqlClientExtensionsAzureVersion>
-    <MicrosoftOpenApiVersion>3.3.1</MicrosoftOpenApiVersion>
+    <MicrosoftOpenApiVersion>3.6.0</MicrosoftOpenApiVersion>
     <MicrosoftOpenApiYamlReaderVersion>3.3.1</MicrosoftOpenApiYamlReaderVersion>
     <!-- dotnet tool versions (see also auto-updated DotnetEfVersion property). -->
     <DotnetDumpVersion>6.0.322601</DotnetDumpVersion>


### PR DESCRIPTION
The 3.3.1 version is marked as deprecated on NuGet. This PR updates to 3.6.0.