### PR TITLE
Capture gradle stderr and stacktrace in SignalR Java client builds

### DIFF
--- a/eng/targets/Java.Common.props
+++ b/eng/targets/Java.Common.props
@@ -2,6 +2,13 @@
   <PropertyGroup>
     <!-- Disable gradle daemon on CI since the CI seems to try to wait for the daemon to shut down, which it doesn't do -->
     <GradleOptions Condition="'$(ContinuousIntegrationBuild)' == 'true'">$(GradleOptions) -Dorg.gradle.daemon=false</GradleOptions>
+    <!--
+      On CI, make gradle failures debuggable: print full stacktraces on exceptions and use the plain console renderer
+      so output stays line-oriented (no ANSI escape codes, no overwritten progress lines). Without these flags a
+      compileJava failure ends with only "FAILURE: Build failed with an exception." in the captured output and the
+      actual cause is lost, leaving MSB3073 as the only signal.
+    -->
+    <GradleOptions Condition="'$(ContinuousIntegrationBuild)' == 'true'">$(GradleOptions) --stacktrace --console=plain</GradleOptions>
     <PackOnBuild>false</PackOnBuild>
   </PropertyGroup>
 </Project>

--- a/eng/targets/Java.Common.targets
+++ b/eng/targets/Java.Common.targets
@@ -51,7 +51,13 @@
     Inputs="@(JavaFiles);$(BaseIntermediateOutputPath)javafiles.cache"
     Outputs="@(BuildOutputFiles)">
     <Telemetry EventName="NETCORE_ENGINEERING_TELEMETRY" EventData="Category=Build" />
-    <Exec Command="$(JavaBuildArgs)" />
+    <!--
+      StandardErrorImportance="High" ensures gradle's stderr (where compilation errors and stack traces
+      are written) flows through MSBuild at high importance, so it shows up in the binlog and CI console
+      instead of being dropped or buried at default importance.
+    -->
+    <Exec Command="$(JavaBuildArgs)"
+          StandardErrorImportance="High" />
     <WriteLinesToFile Overwrite="true" File="$(BaseIntermediateOutputPath)build-sentinel" />
   </Target>
 
@@ -65,7 +71,8 @@
   <Target Name="Pack" Condition="'$(IsPackable)' == 'true'" DependsOnTargets="$(PackDependsOn)">
     <Telemetry EventName="NETCORE_ENGINEERING_TELEMETRY" EventData="Category=Pack" />
     <Message Text="> gradlew $(GradleOptions) publishToMavenLocal" Importance="high" />
-    <Exec Command="../gradlew $(GradleOptions) publishToMavenLocal" />
+    <Exec Command="../gradlew $(GradleOptions) publishToMavenLocal"
+          StandardErrorImportance="High" />
     <Message Importance="high" Text="$(PackageId) -> $(PackageOutputPath)%(JavaBuildFiles.Identity)" />
     <Copy SourceFiles="$(MSBuildProjectDirectory)\build\libs\%(JavaBuildFiles.Identity)" DestinationFolder="$(PackageOutputPath)" />
   </Target>


### PR DESCRIPTION
## Problem

When the SignalR Java client gradle build fails on CI (e.g. `signalr.client.java.core.javaproj` `compileJava` task), the only signal that reaches the binlog and AzDO timeline is MSB3073 reporting the gradle exit code:

```
error MSB3073: The command "../gradlew  -Dorg.gradle.daemon=false compileJava" exited with code 1.
```

Gradle's actual diagnostic output (`* What went wrong`, the `javac error:` lines, `Caused by` stack frames, etc.) is written to stderr but is logged at default importance, so it doesn't appear in the captured logs. The full gradle output we get in the binlog today for a failed run is literally:

```
> Task :core:generateVersionClass
> Task :core:compileJava
FAILURE: Build failed with an exception.
```

That makes every `compileJava` flake undebuggable without a re-run and leaves the failure signature too generic to file as a Known Build Error (since a regex on `MSB3073 ... gradlew compileJava` would silently match real Java-client regressions too).

Concrete instance found while triaging cross-PR CI noise: PR #66919 build 1448390 hit this on the `Test: Windows Server x64` leg with no visible cause despite a complete binlog being archived.

## Fix

Two small, low-risk changes:

* **`eng/targets/Java.Common.props`**: append `--stacktrace --console=plain` to `GradleOptions` when `$(ContinuousIntegrationBuild) == true`.
  * `--stacktrace` makes gradle print the full exception on failure.
  * `--console=plain` keeps output line-oriented (no ANSI escapes, no overwritten progress lines, which is what we want in archived CI logs).
* **`eng/targets/Java.Common.targets`**: set `StandardErrorImportance="High"` on the two `Exec` invocations of `gradlew` (the `compileJava` build step and the `publishToMavenLocal` pack step) so stderr flows through MSBuild at high importance and is captured in the binlog/console.

## Behavior preserved

* Local non-CI builds are unaffected — the props change is gated on `$(ContinuousIntegrationBuild) == true`.
* The exit code still drives task failure exactly as before; MSB3073 will still be emitted on a non-zero gradle exit.
* `javac`'s canonical `path:line: error:` lines remain eligible for MSBuild's built-in error/warning classification because `IgnoreStandardErrorWarningFormat` is left at its default (`false`).

## Why now

Diagnosed during a sweep of recent `aspnetcore-ci` PR-build failures. Of ~18 failed builds sampled, only one (#66919, 1448390) hit this specific gradle failure, but the diagnostic gap means future occurrences (and any related flake we should be quarantining or known-issue-tagging) cannot be triaged from the archived logs alone. Adding the stderr capture is a one-time "never lose the trail again" investment that costs nothing on success.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>