### PR TITLE
Address file-based app user secrets feedback

### DIFF
--- a/src/Tools/Shared/SecretsHelpers/ProjectIdResolver.cs
+++ b/src/Tools/Shared/SecretsHelpers/ProjectIdResolver.cs
@@ -208,12 +208,13 @@ internal sealed class ProjectIdResolver
                 return null;
             }
 
-            var id = File.ReadAllText(outputFile)?.Trim();
+            var id = File.ReadAllText(outputFile).Trim();
             if (string.IsNullOrEmpty(id))
             {
                 _reporter.Verbose(outputBuilder.ToString());
                 _reporter.Verbose(errorBuilder.ToString());
                 _reporter.Error(SecretsHelpersResources.FormatError_ProjectMissingId(projectFile));
+                return null;
             }
             return id;
         }

--- a/src/Tools/Shared/SecretsHelpers/ProjectIdResolver.cs
+++ b/src/Tools/Shared/SecretsHelpers/ProjectIdResolver.cs
@@ -67,7 +67,6 @@ internal sealed class ProjectIdResolver
                     {
                         "build",
                         projectFile,
-                        "--disable-build-servers",
                         "--no-restore",
                         "/t:_ExtractUserSecretsMetadata", // defined in SecretManager.targets
                         "/p:_UserSecretsMetadataFile=" + outputFile,
@@ -77,7 +76,6 @@ internal sealed class ProjectIdResolver
                         "-verbosity:detailed",
                     }
             };
-            DisableBuildServerReuse(psi);
 
 #if DEBUG
             _reporter.Verbose($"Invoking '{psi.FileName} {string.Join(' ', psi.ArgumentList)}'");
@@ -140,75 +138,89 @@ internal sealed class ProjectIdResolver
 
     private string ResolveFileBasedApp(string projectFile, string configuration)
     {
-        var psi = new ProcessStartInfo
+        var outputFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        try
         {
-            FileName = DotNetMuxer.MuxerPathOrDefault(),
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            ArgumentList =
-                {
-                    "build",
-                    projectFile,
-                    "--nologo",
-                    "--disable-build-servers",
-                    "-getProperty=UserSecretsId",
-                    "/p:Configuration=" + configuration,
-                }
-        };
-        DisableBuildServerReuse(psi);
+            var psi = new ProcessStartInfo
+            {
+                FileName = DotNetMuxer.MuxerPathOrDefault(),
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                ArgumentList =
+                    {
+                        "build",
+                        projectFile,
+                        "--nologo",
+                        "--disable-build-servers",
+                        "--no-restore",
+                        "-getProperty=UserSecretsId",
+                        "-getResultOutputFile=" + outputFile,
+                        "/p:Configuration=" + configuration,
+                    }
+            };
+            DisableBuildServerReuse(psi);
 
 #if DEBUG
-        _reporter.Verbose($"Invoking '{psi.FileName} {string.Join(' ', psi.ArgumentList)}'");
+            _reporter.Verbose($"Invoking '{psi.FileName} {string.Join(' ', psi.ArgumentList)}'");
 #endif
 
-        using var process = new Process()
-        {
-            StartInfo = psi,
-        };
-
-        var outputBuilder = new StringBuilder();
-        var errorBuilder = new StringBuilder();
-        process.OutputDataReceived += (_, d) =>
-        {
-            if (!string.IsNullOrEmpty(d.Data))
+            using var process = new Process()
             {
-                outputBuilder.AppendLine(d.Data);
-            }
-        };
-        process.ErrorDataReceived += (_, d) =>
-        {
-            if (!string.IsNullOrEmpty(d.Data))
+                StartInfo = psi,
+            };
+
+            var outputBuilder = new StringBuilder();
+            var errorBuilder = new StringBuilder();
+            process.OutputDataReceived += (_, d) =>
             {
-                errorBuilder.AppendLine(d.Data);
+                if (!string.IsNullOrEmpty(d.Data))
+                {
+                    outputBuilder.AppendLine(d.Data);
+                }
+            };
+            process.ErrorDataReceived += (_, d) =>
+            {
+                if (!string.IsNullOrEmpty(d.Data))
+                {
+                    errorBuilder.AppendLine(d.Data);
+                }
+            };
+            process.Start();
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+            process.WaitForExit();
+
+            if (process.ExitCode != 0)
+            {
+                _reporter.Verbose(outputBuilder.ToString());
+                _reporter.Verbose(errorBuilder.ToString());
+                _reporter.Error($"Exit code: {process.ExitCode}");
+                _reporter.Error(SecretsHelpersResources.FormatError_ProjectFailedToLoad(projectFile));
+                return null;
             }
-        };
-        process.Start();
-        process.BeginOutputReadLine();
-        process.BeginErrorReadLine();
-        process.WaitForExit();
 
-        if (process.ExitCode != 0)
-        {
-            _reporter.Verbose(outputBuilder.ToString());
-            _reporter.Verbose(errorBuilder.ToString());
-            _reporter.Error($"Exit code: {process.ExitCode}");
-            _reporter.Error(SecretsHelpersResources.FormatError_ProjectFailedToLoad(projectFile));
-            return null;
-        }
+            if (!File.Exists(outputFile))
+            {
+                _reporter.Verbose(outputBuilder.ToString());
+                _reporter.Verbose(errorBuilder.ToString());
+                _reporter.Error(SecretsHelpersResources.FormatError_ProjectMissingId(projectFile));
+                return null;
+            }
 
-        var id = outputBuilder
-            .ToString()
-            .Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries)
-            .LastOrDefault()
-            ?.Trim();
-        if (string.IsNullOrEmpty(id))
-        {
-            _reporter.Verbose(outputBuilder.ToString());
-            _reporter.Verbose(errorBuilder.ToString());
-            _reporter.Error(SecretsHelpersResources.FormatError_ProjectMissingId(projectFile));
+            var id = File.ReadAllText(outputFile)?.Trim();
+            if (string.IsNullOrEmpty(id))
+            {
+                _reporter.Verbose(outputBuilder.ToString());
+                _reporter.Verbose(errorBuilder.ToString());
+                _reporter.Error(SecretsHelpersResources.FormatError_ProjectMissingId(projectFile));
+            }
+            return id;
         }
-        return id;
+        finally
+        {
+            TryDelete(outputFile);
+        }
     }
 
     internal static bool IsFileBasedApp(string projectFile) =>

--- a/src/Tools/dotnet-user-jwts/test/UserJwtsTests.cs
+++ b/src/Tools/dotnet-user-jwts/test/UserJwtsTests.cs
@@ -139,6 +139,37 @@ public class UserJwtsTests(UserJwtsTestFixture fixture, ITestOutputHelper output
     }
 
     [Fact]
+    public void List_RejectsFileBasedAppFilePathThatDoesNotExist()
+    {
+        var appFile = Path.Combine(Path.GetTempPath(), "userjwtstest", Guid.NewGuid().ToString(), "does_not_exist.cs");
+        var app = new Program(_console);
+
+        app.Run(["list", "--file", appFile]);
+
+        Assert.Contains(Resources.FileOption_FileNotFound, _console.GetOutput());
+    }
+
+    [Fact]
+    public void List_RejectsFileBasedAppFilePathWithInvalidExtension()
+    {
+        var appDirectory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "userjwtstest", Guid.NewGuid().ToString()));
+        try
+        {
+            var appFile = Path.Combine(appDirectory.FullName, "foo.txt");
+            File.WriteAllText(appFile, string.Empty);
+            var app = new Program(_console);
+
+            app.Run(["list", "--file", appFile]);
+
+            Assert.Contains(Resources.FileOption_InvalidExtension, _console.GetOutput());
+        }
+        finally
+        {
+            Directory.Delete(appDirectory.FullName, true);
+        }
+    }
+
+    [Fact]
     public async Task Create_TokenAcceptedByJwtBearerHandler()
     {
         var project = Path.Combine(fixture.CreateProject(), "TestProject.csproj");
@@ -280,6 +311,31 @@ public class UserJwtsTests(UserJwtsTestFixture fixture, ITestOutputHelper output
     }
 
     [Fact]
+    public void Remove_RemovesGeneratedToken_WithFileBasedApp()
+    {
+        var appFile = fixture.CreateFileBasedApp();
+        var appsettings = Path.Combine(Path.GetDirectoryName(appFile), "appsettings.Development.json");
+        var app = new Program(_console);
+
+        try
+        {
+            app.Run(["create", "--file", appFile]);
+            var matches = Regex.Matches(_console.GetOutput(), "New JWT saved with ID '(.*?)'");
+            var id = matches.SingleOrDefault().Groups[1].Value;
+            app.Run(["create", "--file", appFile, "--scheme", "Scheme2"]);
+
+            app.Run(["remove", id, "--file", appFile]);
+            var appsettingsContent = File.ReadAllText(appsettings);
+            Assert.DoesNotContain(DevJwtsDefaults.Scheme, appsettingsContent);
+            Assert.Contains("Scheme2", appsettingsContent);
+        }
+        finally
+        {
+            DeleteUserJwtsDirectory(app);
+        }
+    }
+
+    [Fact]
     public void Remove_RemovesGeneratedTokenInGivenAppsettings()
     {
         var project = Path.Combine(fixture.CreateProject(), "TestProject.csproj");
@@ -334,6 +390,31 @@ public class UserJwtsTests(UserJwtsTestFixture fixture, ITestOutputHelper output
     }
 
     [Fact]
+    public void Clear_RemovesGeneratedTokens_WithFileBasedApp()
+    {
+        var appFile = fixture.CreateFileBasedApp();
+        var appsettings = Path.Combine(Path.GetDirectoryName(appFile), "appsettings.Development.json");
+        var app = new Program(_console);
+
+        try
+        {
+            app.Run(["create", "--file", appFile]);
+            app.Run(["create", "--file", appFile, "--scheme", "Scheme2"]);
+
+            Assert.Contains("New JWT saved", _console.GetOutput());
+
+            app.Run(["clear", "--file", appFile, "--force"]);
+            var appsettingsContent = File.ReadAllText(appsettings);
+            Assert.DoesNotContain(DevJwtsDefaults.Scheme, appsettingsContent);
+            Assert.DoesNotContain("Scheme2", appsettingsContent);
+        }
+        finally
+        {
+            DeleteUserJwtsDirectory(app);
+        }
+    }
+
+    [Fact]
     public void Key_CanResetSigningKey()
     {
         var project = Path.Combine(fixture.CreateProject(), "TestProject.csproj");
@@ -345,6 +426,27 @@ public class UserJwtsTests(UserJwtsTestFixture fixture, ITestOutputHelper output
 
         app.Run(new[] { "key", "--reset", "--force", "--project", project });
         Assert.Contains("New signing key created:", _console.GetOutput());
+    }
+
+    [Fact]
+    public void Key_CanResetSigningKey_WithFileBasedApp()
+    {
+        var appFile = fixture.CreateFileBasedApp();
+        var app = new Program(_console);
+
+        try
+        {
+            app.Run(["create", "--file", appFile]);
+            app.Run(["key", "--file", appFile]);
+            Assert.Contains("Signing Key:", _console.GetOutput());
+
+            app.Run(["key", "--reset", "--force", "--file", appFile]);
+            Assert.Contains("New signing key created:", _console.GetOutput());
+        }
+        finally
+        {
+            DeleteUserJwtsDirectory(app);
+        }
     }
 
     [Fact]

--- a/src/Tools/dotnet-user-secrets/src/CommandLineOptions.cs
+++ b/src/Tools/dotnet-user-secrets/src/CommandLineOptions.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.IO;
 using System.Reflection;
 using Microsoft.Extensions.CommandLineUtils;
 using Microsoft.Extensions.SecretManager.Tools.Internal;
@@ -75,6 +77,11 @@ public class CommandLineOptions
         if (options.File != null && options.Project != null)
         {
             throw new CommandParsingException(app, Resources.Error_ProjectAndFileOptions);
+        }
+
+        if (options.File is not null && !string.Equals(Path.GetExtension(options.File), ".cs", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new CommandParsingException(app, Resources.Error_FileInvalidExtension);
         }
 
         return options;

--- a/src/Tools/dotnet-user-secrets/src/Resources.resx
+++ b/src/Tools/dotnet-user-secrets/src/Resources.resx
@@ -166,6 +166,9 @@ Use the '--help' flag to see info.</value>
   <data name="Error_ProjectAndFileOptions" xml:space="preserve">
     <value>Cannot use both --file and --project options together.</value>
   </data>
+  <data name="Error_FileInvalidExtension" xml:space="preserve">
+    <value>The --file option only supports .cs file-based apps.</value>
+  </data>
   <data name="Error_InitNotSupportedForFileBasedApps" xml:space="preserve">
     <value>Init command is currently not supported for file-based apps. Please add '#:property UserSecretsId=...' manually.</value>
   </data>

--- a/src/Tools/dotnet-user-secrets/test/SecretManagerTests.cs
+++ b/src/Tools/dotnet-user-secrets/test/SecretManagerTests.cs
@@ -79,6 +79,30 @@ public class SecretManagerTests : IClassFixture<UserSecretsTestFixture>
     }
 
     [Fact]
+    public void Error_File_DoesNotExist()
+    {
+        var filePath = Path.Combine(_fixture.GetTempSecretProject(), "does_not_exist.cs");
+        var secretManager = CreateProgram();
+
+        secretManager.RunInternal("list", "--file", filePath);
+        Assert.Contains(SecretsHelpersResources.FormatError_File_NotFound(filePath), _console.GetOutput());
+    }
+
+    [Fact]
+    public void Error_File_InvalidExtension()
+    {
+        var filePath = Path.Combine(_fixture.GetTempSecretProject(), "foo.txt");
+        File.WriteAllText(filePath, string.Empty);
+        var secretManager = CreateProgram();
+
+        secretManager.RunInternal("list", "--file", filePath);
+        var output = _console.GetOutput();
+
+        Assert.Contains(Resources.Error_FileInvalidExtension, output);
+        Assert.DoesNotContain(SecretsHelpersResources.FormatError_ProjectFailedToLoad(filePath), output);
+    }
+
+    [Fact]
     public void Error_InitFile()
     {
         var dir = _fixture.CreateFileBasedApp(null);


### PR DESCRIPTION
## Summary
- Scope build-server disabling to file-based app UserSecretsId resolution only
- Add `--no-restore` and `-getResultOutputFile` for file-based app property reads
- Validate `dotnet user-secrets --file` extensions and add missing negative/FBA command coverage

## Validation
- `dotnet test src\Tools\dotnet-user-secrets\test\dotnet-user-secrets.Tests.csproj --no-restore --filter "FullyQualifiedName~SecretManagerTests|FullyQualifiedName~InitCommandTests"`
- `dotnet test src\Tools\dotnet-user-jwts\test\dotnet-user-jwts.Tests.csproj --no-restore --filter "FullyQualifiedName~UserJwtsTests" /p:UseIisNativeAssets=false`