### PR TITLE
Revert "Fixes Problem Details casing bug (#59396)"

### DIFF
--- a/src/Http/Http.Extensions/src/DefaultProblemDetailsWriter.cs
+++ b/src/Http/Http.Extensions/src/DefaultProblemDetailsWriter.cs
@@ -56,6 +56,13 @@ internal sealed partial class DefaultProblemDetailsWriter : IProblemDetailsWrite
         ProblemDetailsDefaults.Apply(context.ProblemDetails, httpContext.Response.StatusCode);
 
         var traceId = Activity.Current?.Id ?? httpContext.TraceIdentifier;
+
+        // We shouldn't attempt to change the casing here.
+        // STJ doesn't respect the naming policy for JsonExtensionData as it won't round-trip otherwise.
+        // In addition, trying to special case traceId specifically can cause inconsistencies.
+        // See:
+        // https://github.com/dotnet/aspnetcore/issues/65543
+        // https://github.com/dotnet/aspnetcore/issues/66603
         context.ProblemDetails.Extensions["traceId"] = traceId;
 
         _options.CustomizeProblemDetails?.Invoke(context);

--- a/src/Http/Http.Extensions/src/DefaultProblemDetailsWriter.cs
+++ b/src/Http/Http.Extensions/src/DefaultProblemDetailsWriter.cs
@@ -56,8 +56,7 @@ internal sealed partial class DefaultProblemDetailsWriter : IProblemDetailsWrite
         ProblemDetailsDefaults.Apply(context.ProblemDetails, httpContext.Response.StatusCode);
 
         var traceId = Activity.Current?.Id ?? httpContext.TraceIdentifier;
-        var traceIdKeyName = _serializerOptions.PropertyNamingPolicy?.ConvertName("traceId") ?? "traceId";
-        context.ProblemDetails.Extensions[traceIdKeyName] = traceId;
+        context.ProblemDetails.Extensions["traceId"] = traceId;
 
         _options.CustomizeProblemDetails?.Invoke(context);
 

--- a/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
+++ b/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
@@ -85,7 +85,7 @@ public partial class DefaultProblemDetailsWriterTest
         //Assert
         stream.Position = 0;
         var result = await JsonSerializer.DeserializeAsync<Dictionary<string, object>>(stream, JsonSerializerOptions.Default);
-        Assert.Equal(result.Keys, new(new() { { "type", 0 }, { "title", 1 }, { "status", 2 }, { "detail", 3 }, { "instance", 4 }, { "extensionKey", 5 }, { "traceId", expectedTraceId } }));
+        Assert.Equal(result.Keys, new(new() { { "type", 0 }, { "title", 1 }, { "status", 2 }, { "detail", 3 }, { "instance", 4 }, { "extensionKey", 5 }, {"traceId", expectedTraceId } }));
     }
 
     [Fact]
@@ -117,7 +117,7 @@ public partial class DefaultProblemDetailsWriterTest
         //Assert
         stream.Position = 0;
         var result = await JsonSerializer.DeserializeAsync<Dictionary<string, object>>(stream, JsonSerializerOptions.Default);
-        Assert.Equal(result.Keys, new(new() { { "type", 0 }, { "title", 1 }, { "status", 2 }, { "detail", 3 }, { "instance", 4 }, { "errors", 5 }, { "traceId", expectedTraceId } }));
+        Assert.Equal(result.Keys, new(new() { { "type", 0 }, { "title", 1 }, { "status", 2 }, { "detail", 3 }, { "instance", 4 }, { "errors", 5 }, {"traceId", expectedTraceId } }));
     }
 
     [Fact]
@@ -687,57 +687,6 @@ public partial class DefaultProblemDetailsWriterTest
         }
 
         return context;
-    }
-
-    [Theory]
-    [InlineData("SnakeCaseLower", "trace_id")]
-    [InlineData("CamelCase", "traceId")]
-    [InlineData("KebabCaseLower", "trace-id")]
-    [InlineData("KebabCaseUpper", "TRACE-ID")]
-    [InlineData("SnakeCaseUpper", "TRACE_ID")]
-    public async Task TestPropertyNamingPolicyChanges(string caseSelection, string extensionVariableName)
-    {
-        // Arrange
-        JsonNamingPolicy propertyNamingPolicy = caseSelection switch
-        {
-            "CamelCase" => JsonNamingPolicy.CamelCase,
-            "KebabCaseLower" => JsonNamingPolicy.KebabCaseLower,
-            "KebabCaseUpper" => JsonNamingPolicy.KebabCaseUpper,
-            "SnakeCaseLower" => JsonNamingPolicy.SnakeCaseLower,
-            "SnakeCaseUpper" => JsonNamingPolicy.SnakeCaseUpper,
-            _ => JsonNamingPolicy.KebabCaseLower
-        };
-
-        var options = new JsonOptions();
-        options.SerializerOptions.PropertyNamingPolicy = propertyNamingPolicy;
-
-        var writer = GetWriter(jsonOptions: options);
-        var stream = new MemoryStream();
-        var context = CreateContext(stream);
-
-        var expectedTraceId = Activity.Current?.Id ?? context.TraceIdentifier;
-        var expectedProblem = new ProblemDetails()
-        {
-            Detail = "Custom Bad Request",
-            Instance = "Custom Bad Request",
-            Status = StatusCodes.Status400BadRequest,
-            Type = "https://tools.ietf.org/html/rfc9110#section-15.5.1-custom",
-            Title = "Custom Bad Request",
-        };
-        var problemDetailsContext = new ProblemDetailsContext()
-        {
-            HttpContext = context,
-            ProblemDetails = expectedProblem
-        };
-
-        //Act
-        await writer.WriteAsync(problemDetailsContext);
-        stream.Position = 0;
-        using var reader = new StreamReader(stream);
-        var json = await reader.ReadToEndAsync();
-
-        //Assert
-        Assert.Contains($"\"{extensionVariableName}\":\"{expectedTraceId}\"", json);
     }
 
     private static IServiceProvider CreateServices()


### PR DESCRIPTION
Reverts dotnet/aspnetcore#59876

Fixes #65543
Fixes #66603

This resolves the inconsistency of how the naming policy is applied and we let STJ do its thing. Note that the STJ behavior here looks intentional https://github.com/dotnet/runtime/issues/31167. Given that this can't round trip correctly, and that the current behavior is already very inconsistent, I think it's better to revert to the original behavior.