### PR TITLE
Fix JSInterop DefaultAsyncTimeout swallow issue

### DIFF
--- a/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
@@ -118,11 +118,11 @@ public abstract partial class JSRuntime : IJSRuntime, IDisposable
                 // We need to await here due to the using
                 return await InvokeAsync<TValue>(targetInstanceId, identifier, callType, cts.Token, args);
             }
-            catch (OperationCanceledException) when (cts.IsCancellationRequested)
+            catch (OperationCanceledException ex) when (cts.IsCancellationRequested)
             {
                 throw new JSException(
                     $"The JS interop call '{identifier}' timed out after {DefaultAsyncTimeout.Value.TotalMilliseconds}ms. " +
-                    $"The timeout is controlled by {nameof(DefaultAsyncTimeout)}.");
+                    $"The timeout is controlled by {nameof(DefaultAsyncTimeout)}.", ex);
             }
         }
 

--- a/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
@@ -113,8 +113,17 @@ public abstract partial class JSRuntime : IJSRuntime, IDisposable
         if (DefaultAsyncTimeout.HasValue)
         {
             using var cts = new CancellationTokenSource(DefaultAsyncTimeout.Value);
-            // We need to await here due to the using
-            return await InvokeAsync<TValue>(targetInstanceId, identifier, callType, cts.Token, args);
+            try
+            {
+                // We need to await here due to the using
+                return await InvokeAsync<TValue>(targetInstanceId, identifier, callType, cts.Token, args);
+            }
+            catch (OperationCanceledException) when (cts.IsCancellationRequested)
+            {
+                throw new JSException(
+                    $"The JS interop call '{identifier}' timed out after {DefaultAsyncTimeout.Value.TotalMilliseconds}ms. " +
+                    $"The timeout is controlled by {nameof(DefaultAsyncTimeout)}.");
+            }
         }
 
         return await InvokeAsync<TValue>(targetInstanceId, identifier, callType, CancellationToken.None, args);

--- a/src/JSInterop/Microsoft.JSInterop/test/JSRuntimeTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/JSRuntimeTest.cs
@@ -47,7 +47,8 @@ public class JSRuntimeTest
         var task = runtime.InvokeAsync<object>("test identifier 1", "arg1", 123, true);
 
         // Assert
-        await Assert.ThrowsAsync<TaskCanceledException>(async () => await task);
+        var ex = await Assert.ThrowsAsync<JSException>(async () => await task);
+        Assert.Equal("The JS interop call 'test identifier 1' timed out after 1000ms. The timeout is controlled by DefaultAsyncTimeout.", ex.Message);
     }
 
     [Fact]

--- a/src/JSInterop/Microsoft.JSInterop/test/JSRuntimeTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/JSRuntimeTest.cs
@@ -49,6 +49,7 @@ public class JSRuntimeTest
         // Assert
         var ex = await Assert.ThrowsAsync<JSException>(async () => await task);
         Assert.Equal("The JS interop call 'test identifier 1' timed out after 1000ms. The timeout is controlled by DefaultAsyncTimeout.", ex.Message);
+        Assert.IsType<TaskCanceledException>(ex.InnerException);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #21384.

**Root Cause:** When `DefaultAsyncTimeout` fires, the `CancellationTokenSource` triggers `tcs.TrySetCanceled()`, producing a task with `IsCanceled = true`. `ComponentBase` then swallows it in its catch blocks (since it ignores canceled tasks to handle normal component disposal).

**My approach:** Modify only the `InvokeAsync` overload that creates the `DefaultAsyncTimeout` CTS. Wrap the inner call in a try/catch that catches `OperationCanceledException` **only when** `cts.IsCancellationRequested` is true, and re-throws as a `JSException`.

**Why this avoids the previous issues:**
- No breaking changes — the `InvokeAsync(CancellationToken)` overload is untouched
- `ComponentBase` won't swallow it — `JSException` produces a faulted task (`IsCanceled = false`)
- User-supplied tokens still behave as before
- No new public API types required
- No changes to `ComponentBase.cs`