### PR TITLE
Apply API changes for `RequestCircuitPauseAsync`

### DIFF
--- a/src/Components/Server/src/Circuits/Circuit.cs
+++ b/src/Components/Server/src/Circuits/Circuit.cs
@@ -34,7 +34,7 @@ public sealed class Circuit
     /// <see langword="true"/> if the request was accepted and the client was asked to begin pausing;
     /// otherwise <see langword="false"/>.
     /// </returns>
-    public ValueTask<bool> RequestCircuitPauseAsync(CancellationToken cancellationToken = default)
+    public Task<bool> RequestCircuitPauseAsync(CancellationToken cancellationToken = default)
     {
         return _circuitHost.RequestPauseAsync(cancellationToken);
     }

--- a/src/Components/Server/src/Circuits/CircuitHost.cs
+++ b/src/Components/Server/src/Circuits/CircuitHost.cs
@@ -946,33 +946,33 @@ internal partial class CircuitHost : IAsyncDisposable
         return result;
     }
 
-    internal async ValueTask<bool> RequestPauseAsync(CancellationToken cancellationToken)
+    internal Task<bool> RequestPauseAsync(CancellationToken cancellationToken)
     {
         Log.ServerPauseRequested(_logger, CircuitId);
 
         if (_disposed)
         {
             Log.ServerPauseRejected(_logger, CircuitId);
-            return false;
+            return Task.FromResult(false);
         }
 
         if (!_initialized || !_onConnectionUpFired)
         {
             Log.ServerPauseRejected(_logger, CircuitId);
-            return false;
+            return Task.FromResult(false);
         }
 
         if (!Client.Connected)
         {
             Log.ServerPauseRejected(_logger, CircuitId);
-            return false;
+            return Task.FromResult(false);
         }
 
         // Dispatch the send onto the dispatcher to serialize with any sync work
         // (renders, event handlers) that may be in progress.
         // The client receives the message and decides when to actually pause via
         // an optional onPauseRequested callback in CircuitStartOptions.
-        return await Renderer.Dispatcher.InvokeAsync(async () =>
+        return Renderer.Dispatcher.InvokeAsync(async () =>
         {
             if (_disposed || !Client.Connected)
             {

--- a/src/Components/Server/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Server/src/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
 #nullable enable
-Microsoft.AspNetCore.Components.Server.Circuits.Circuit.RequestCircuitPauseAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<bool>
+Microsoft.AspNetCore.Components.Server.Circuits.Circuit.RequestCircuitPauseAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
 Microsoft.AspNetCore.Components.Server.ServerComponentsEndpointOptions.ConfigureConnection.get -> System.Action<Microsoft.AspNetCore.Http.Connections.HttpConnectionDispatcherOptions!>?
 Microsoft.AspNetCore.Components.Server.ServerComponentsEndpointOptions.ConfigureConnection.set -> void

--- a/src/Components/Server/test/Circuits/CircuitHostTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitHostTest.cs
@@ -709,7 +709,7 @@ public class CircuitHostTest
 
         renderStarted.Wait();
 
-        var pauseTask = Task.Run(() => circuitHost.RequestPauseAsync(CancellationToken.None).AsTask());
+        var pauseTask = Task.Run(() => circuitHost.RequestPauseAsync(CancellationToken.None));
 
         renderReleased = true;
         releaseRender.Set();
@@ -911,7 +911,7 @@ public class CircuitHostTest
         var circuitHost = await CreateConnectedCircuitHostAsync();
 
         var tasks = Enumerable.Range(0, 10)
-            .Select(_ => circuitHost.RequestPauseAsync(CancellationToken.None).AsTask())
+            .Select(_ => circuitHost.RequestPauseAsync(CancellationToken.None))
             .ToArray();
         var results = await Task.WhenAll(tasks);
 
@@ -948,7 +948,7 @@ public class CircuitHostTest
             hosts.Add(await CreateConnectedCircuitHostAsync());
         }
 
-        var tasks = hosts.Select(h => h.RequestPauseAsync(CancellationToken.None).AsTask()).ToArray();
+        var tasks = hosts.Select(h => h.RequestPauseAsync(CancellationToken.None)).ToArray();
         var results = await Task.WhenAll(tasks);
 
         Assert.All(results, Assert.True);
@@ -1060,7 +1060,7 @@ public class CircuitHostTest
     {
         var circuitHost = await CreateConnectedCircuitHostAsync();
 
-        var result = await Task.Run(() => circuitHost.Circuit.RequestCircuitPauseAsync().AsTask());
+        var result = await Task.Run(() => circuitHost.Circuit.RequestCircuitPauseAsync());
 
         Assert.True(result);
     }

--- a/src/Components/Web.JS/src/Platform/Circuits/CircuitManager.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/CircuitManager.ts
@@ -179,6 +179,7 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
     connection.on('JS.RequestPause', async () => {
       try {
         if (this._options.onPauseRequested) {
+          this._pauseAbortController?.abort();
           this._pauseAbortController = new AbortController();
           await this._options.onPauseRequested(this._pauseAbortController.signal);
         }

--- a/src/Components/Web.JS/src/Platform/Circuits/CircuitManager.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/CircuitManager.ts
@@ -57,6 +57,8 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
 
   private _isFirstRender = true;
 
+  private _pauseAbortController?: AbortController;
+
   public constructor(
     componentManager: RootComponentManager<ServerComponentDescriptor>,
     appState: string,
@@ -177,7 +179,8 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
     connection.on('JS.RequestPause', async () => {
       try {
         if (this._options.onPauseRequested) {
-          await this._options.onPauseRequested();
+          this._pauseAbortController = new AbortController();
+          await this._options.onPauseRequested(this._pauseAbortController.signal);
         }
         await this.pause(true);
       } catch (error) {
@@ -529,6 +532,7 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
     if (!this._startPromise) {
       // The circuit hasn't started, so there isn't anything to dispose.
       this._disposed = true;
+      this._pauseAbortController?.abort();
       return;
     }
 
@@ -537,6 +541,7 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
     await this._startPromise;
 
     this._disposed = true;
+    this._pauseAbortController?.abort();
     this._connection?.stop();
 
     // Dispose the circuit on the server immediately. Closing the SignalR connection alone

--- a/src/Components/Web.JS/src/Platform/Circuits/CircuitStartOptions.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/CircuitStartOptions.ts
@@ -20,7 +20,7 @@ export interface CircuitStartOptions {
   reconnectionHandler?: ReconnectionHandler;
   initializers : ServerInitializers;
   circuitHandlers: CircuitHandler[];
-  onPauseRequested?: () => Promise<void>;
+  onPauseRequested?: (signal: AbortSignal) => void | Promise<void>;
 }
 
 export function resolveOptions(userOptions?: Partial<CircuitStartOptions>): CircuitStartOptions {

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerTriggeredPauseTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerTriggeredPauseTest.cs
@@ -167,6 +167,30 @@ public class ServerTriggeredPauseTest : ServerTestBase<BasicTestAppServerSiteFix
         Browser.Equal("2", () => Browser.Exists(By.Id("persistent-counter-count")).Text);
     }
 
+    [Fact]
+    public void MultiplePauseRequests_CircuitPausesAndResumesCleanly()
+    {
+        Browser.Exists(By.Id("increment-persistent-counter-count")).Click();
+        Browser.Equal("1", () => Browser.Exists(By.Id("persistent-counter-count")).Text);
+
+        var circuitId = GetCircuitId();
+        var javascript = (IJavaScriptExecutor)Browser;
+        javascript.ExecuteScript($@"
+            DotNet.invokeMethodAsync('Components.TestServer', 'TriggerServerPause', '{circuitId}');
+            DotNet.invokeMethodAsync('Components.TestServer', 'TriggerServerPause', '{circuitId}');
+        ");
+
+        WaitForPausedUI();
+        ClickResumeButton();
+        WaitForResumedUI();
+
+        Browser.Equal("1", () => Browser.Exists(By.Id("persistent-counter-count")).Text);
+
+        // Verify the circuit is fully functional after the double-pause.
+        Browser.Exists(By.Id("increment-persistent-counter-count")).Click();
+        Browser.Equal("2", () => Browser.Exists(By.Id("persistent-counter-count")).Text);
+    }
+
     // resumeCircuit() sets _resumingState synchronously. pauseCircuit() checks it next.
     // JS single-threading guarantees the order.
     [Fact]


### PR DESCRIPTION
Suggestions: https://github.com/dotnet/aspnetcore/issues/66798#issuecomment-4594776355

- Change `ValueTask` to a `Task`
- Add `AbortSignal` to stop the "pause deferring" work when connection is being teared down.
- The callback doesn't have bolean return value so it's expected not to be honored in the JS code. 
https://github.com/dotnet/aspnetcore/blob/b8f35c26d5b37189fcf82aa2632d860bd6030c74/src/Components/Web.JS/src/Platform/Circuits/CircuitStartOptions.ts#L23
This remark was based on stale method snippet, from before https://github.com/dotnet/aspnetcore/pull/66265#discussion_r3122982211 design discussion.

Fixes https://github.com/dotnet/aspnetcore/issues/65062