### PR TITLE
Fix DefaultApiProblemDetailsWriter CanWrite/WriteAsync metadata mismatch (#67053)

### DIFF
--- a/src/Mvc/Mvc.Core/src/Infrastructure/DefaultApiProblemDetailsWriter.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/DefaultApiProblemDetailsWriter.cs
@@ -34,10 +34,15 @@ internal sealed class DefaultApiProblemDetailsWriter : IProblemDetailsWriter
 
     public bool CanWrite(ProblemDetailsContext context)
     {
-        var controllerAttribute = context.AdditionalMetadata?.GetMetadata<ControllerAttribute>() ??
-            context.HttpContext.GetEndpoint()?.Metadata.GetMetadata<ControllerAttribute>();
+        // Match the metadata check performed in WriteAsync so this writer does not
+        // claim endpoints it will silently drop. Without this, ProblemDetailsService
+        // selects this writer for any controller endpoint and never falls back to
+        // the next-registered writer when [ApiController] (IApiBehaviorMetadata) is
+        // not present on the endpoint or SuppressMapClientErrors is enabled.
+        var apiControllerAttribute = context.AdditionalMetadata?.GetMetadata<IApiBehaviorMetadata>() ??
+            context.HttpContext.GetEndpoint()?.Metadata.GetMetadata<IApiBehaviorMetadata>();
 
-        return controllerAttribute != null;
+        return apiControllerAttribute != null && !_apiBehaviorOptions.SuppressMapClientErrors;
     }
 
     public ValueTask WriteAsync(ProblemDetailsContext context)
@@ -61,6 +66,28 @@ internal sealed class DefaultApiProblemDetailsWriter : IProblemDetailsWriter
             context.ProblemDetails.Detail,
             context.ProblemDetails.Instance);
 
+        // Preserve the runtime ProblemDetails subtype. ValidationProblemDetails carries
+        // an Errors dictionary as a structural member which the factory-created
+        // ProblemDetails would otherwise drop silently.
+        if (context.ProblemDetails is ValidationProblemDetails validationProblemDetails)
+        {
+            var validationDetails = new ValidationProblemDetails(validationProblemDetails.Errors)
+            {
+                Status = problemDetails.Status,
+                Title = problemDetails.Title,
+                Type = problemDetails.Type,
+                Detail = problemDetails.Detail,
+                Instance = problemDetails.Instance,
+            };
+
+            foreach (var extension in problemDetails.Extensions)
+            {
+                validationDetails.Extensions[extension.Key] = extension.Value;
+            }
+
+            problemDetails = validationDetails;
+        }
+
         if (context.ProblemDetails?.Extensions is not null)
         {
             foreach (var extension in context.ProblemDetails.Extensions)
@@ -72,7 +99,7 @@ internal sealed class DefaultApiProblemDetailsWriter : IProblemDetailsWriter
         var formatterContext = new OutputFormatterWriteContext(
             context.HttpContext,
             _writerFactory.CreateWriter,
-            typeof(ProblemDetails),
+            problemDetails.GetType(),
             problemDetails);
 
         var selectedFormatter = _formatterSelector.SelectFormatter(

--- a/src/Mvc/Mvc.Core/test/Infrastructure/DefaultApiProblemDetailsWriterTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/DefaultApiProblemDetailsWriterTest.cs
@@ -51,7 +51,7 @@ public class DefaultApiProblemDetailsWriterTest
         Assert.Equal(expectedProblem.Instance, problemDetails.Instance);
     }
 
-        [Fact]
+    [Fact]
     public async Task WriteAsync_Works_WhenReplacingProblemDetailsUsingSetter()
     {
         // Arrange
@@ -119,7 +119,7 @@ public class DefaultApiProblemDetailsWriterTest
     }
 
     [Fact]
-    public void CanWrite_ReturnsFalse_WhenNotController()
+    public void CanWrite_ReturnsFalse_WhenNoEndpointMetadata()
     {
         // Arrange
         var writer = GetWriter();
@@ -134,9 +134,11 @@ public class DefaultApiProblemDetailsWriterTest
     }
 
     [Fact]
-    public void CanWrite_ReturnsTrue_WhenController()
+    public void CanWrite_ReturnsFalse_WhenControllerWithoutApiControllerAttribute()
     {
-        // Arrange
+        // Arrange - controller endpoint without [ApiController]; the writer
+        // would silently drop the body, so CanWrite must return false to let
+        // another IProblemDetailsWriter handle it.
         var writer = GetWriter();
         var stream = new MemoryStream();
         var context = CreateContext(stream, metadata: new EndpointMetadataCollection(new ControllerAttribute()));
@@ -145,7 +147,37 @@ public class DefaultApiProblemDetailsWriterTest
         var result = writer.CanWrite(new() { HttpContext = context });
 
         //Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void CanWrite_ReturnsTrue_WhenApiController()
+    {
+        // Arrange
+        var writer = GetWriter();
+        var stream = new MemoryStream();
+        var context = CreateContext(stream, metadata: new EndpointMetadataCollection(new ApiControllerAttribute(), new ControllerAttribute()));
+
+        //Act
+        var result = writer.CanWrite(new() { HttpContext = context });
+
+        //Assert
         Assert.True(result);
+    }
+
+    [Fact]
+    public void CanWrite_ReturnsFalse_WhenSuppressMapClientErrors()
+    {
+        // Arrange
+        var writer = GetWriter(options: new ApiBehaviorOptions() { SuppressMapClientErrors = true });
+        var stream = new MemoryStream();
+        var context = CreateContext(stream);
+
+        //Act
+        var result = writer.CanWrite(new() { HttpContext = context });
+
+        //Assert
+        Assert.False(result);
     }
 
     [Fact]
@@ -162,6 +194,124 @@ public class DefaultApiProblemDetailsWriterTest
         //Assert
         Assert.Equal(0, stream.Position);
         Assert.Equal(0, stream.Length);
+    }
+
+    [Fact]
+    public async Task WriteAsync_PreservesValidationProblemDetailsErrors()
+    {
+        // Arrange
+        var writer = GetWriter();
+        var stream = new MemoryStream();
+        var context = CreateContext(stream);
+
+        var expectedErrors = new Dictionary<string, string[]>
+        {
+            ["field"] = new[] { "is required" },
+        };
+        var expectedProblem = new ValidationProblemDetails(expectedErrors)
+        {
+            Detail = "Validation failed",
+            Instance = "/repro",
+            Status = StatusCodes.Status400BadRequest,
+            Type = "https://example.com/probs/validation",
+            Title = "One or more validation errors occurred.",
+        };
+        expectedProblem.Extensions["customField"] = "demonstrates extension preservation";
+
+        var problemDetailsContext = new ProblemDetailsContext()
+        {
+            HttpContext = context,
+            ProblemDetails = expectedProblem,
+        };
+
+        //Act
+        await writer.WriteAsync(problemDetailsContext);
+
+        //Assert
+        stream.Position = 0;
+        using var document = await JsonDocument.ParseAsync(stream);
+        var root = document.RootElement;
+
+        Assert.Equal(expectedProblem.Status, root.GetProperty("status").GetInt32());
+        Assert.Equal(expectedProblem.Type, root.GetProperty("type").GetString());
+        Assert.Equal(expectedProblem.Title, root.GetProperty("title").GetString());
+        Assert.Equal(expectedProblem.Detail, root.GetProperty("detail").GetString());
+        Assert.Equal(expectedProblem.Instance, root.GetProperty("instance").GetString());
+
+        var errors = root.GetProperty("errors");
+        Assert.Equal(JsonValueKind.Object, errors.ValueKind);
+        var fieldErrors = errors.GetProperty("field");
+        Assert.Equal(JsonValueKind.Array, fieldErrors.ValueKind);
+        Assert.Equal("is required", fieldErrors[0].GetString());
+
+        Assert.Equal("demonstrates extension preservation", root.GetProperty("customField").GetString());
+    }
+
+    [Fact]
+    public async Task WriteAsync_PassesValidationProblemDetailsRuntimeTypeToFormatter()
+    {
+        // Arrange - the formatter context's ObjectType drives XML/content-negotiation
+        // formatter selection (e.g. the validation problem details wrapper provider only
+        // matches when the declared type is ValidationProblemDetails). Capture the type.
+        var capturingFormatter = new CapturingFormatter();
+        var writer = GetWriter(formatter: capturingFormatter);
+        var stream = new MemoryStream();
+        var context = CreateContext(stream);
+
+        var expectedProblem = new ValidationProblemDetails(new Dictionary<string, string[]>
+        {
+            ["field"] = new[] { "is required" },
+        });
+
+        //Act
+        await writer.WriteAsync(new ProblemDetailsContext()
+        {
+            HttpContext = context,
+            ProblemDetails = expectedProblem,
+        });
+
+        //Assert
+        Assert.NotNull(capturingFormatter.LastContext);
+        Assert.Equal(typeof(ValidationProblemDetails), capturingFormatter.LastContext.ObjectType);
+        Assert.IsType<ValidationProblemDetails>(capturingFormatter.LastContext.Object);
+    }
+
+    [Fact]
+    public async Task WriterChain_FallsThroughToNextWriter_ForControllerWithoutApiControllerAttribute()
+    {
+        // Arrange - regression for https://github.com/dotnet/aspnetcore/issues/67053:
+        // a plain controller endpoint (no [ApiController]) must not be claimed and then
+        // silently dropped by DefaultApiProblemDetailsWriter. Simulate the writer-selection
+        // loop performed by ProblemDetailsService and verify the next writer runs.
+        var apiWriter = GetWriter();
+        var fallbackWriter = new RecordingWriter();
+        var writers = new IProblemDetailsWriter[] { apiWriter, fallbackWriter };
+
+        var stream = new MemoryStream();
+        var context = CreateContext(
+            stream,
+            metadata: new EndpointMetadataCollection(new ControllerAttribute()));
+        var problemDetailsContext = new ProblemDetailsContext()
+        {
+            HttpContext = context,
+            ProblemDetails = new ProblemDetails { Status = StatusCodes.Status404NotFound },
+        };
+
+        //Act - mirror ProblemDetailsService.TryWriteAsync
+        var written = false;
+        foreach (var writer in writers)
+        {
+            if (writer.CanWrite(problemDetailsContext))
+            {
+                await writer.WriteAsync(problemDetailsContext);
+                written = true;
+                break;
+            }
+        }
+
+        //Assert
+        Assert.True(written);
+        Assert.True(fallbackWriter.WriteAsyncCalled);
     }
 
     [Fact]
@@ -243,6 +393,32 @@ public class DefaultApiProblemDetailsWriterTest
         public Task WriteAsync(OutputFormatterWriteContext context)
         {
             return context.HttpContext.Response.WriteAsJsonAsync(context.Object);
+        }
+    }
+
+    private sealed class CapturingFormatter : IOutputFormatter
+    {
+        public OutputFormatterWriteContext LastContext { get; private set; }
+
+        public bool CanWriteResult(OutputFormatterCanWriteContext context) => true;
+
+        public Task WriteAsync(OutputFormatterWriteContext context)
+        {
+            LastContext = context;
+            return context.HttpContext.Response.WriteAsJsonAsync(context.Object);
+        }
+    }
+
+    private sealed class RecordingWriter : IProblemDetailsWriter
+    {
+        public bool WriteAsyncCalled { get; private set; }
+
+        public bool CanWrite(ProblemDetailsContext context) => true;
+
+        public ValueTask WriteAsync(ProblemDetailsContext context)
+        {
+            WriteAsyncCalled = true;
+            return ValueTask.CompletedTask;
         }
     }
 

--- a/src/Mvc/Mvc.Core/test/Infrastructure/DefaultApiProblemDetailsWriterTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/DefaultApiProblemDetailsWriterTest.cs
@@ -272,7 +272,7 @@ public class DefaultApiProblemDetailsWriterTest
 
         //Assert
         Assert.NotNull(capturingFormatter.LastContext);
-        Assert.Equal(typeof(ValidationProblemDetails), capturingFormatter.LastContext.ObjectType);
+        Assert.Equal(typeof(ValidationProblemDetails), capturingFormatter.LastContext!.ObjectType);
         Assert.IsType<ValidationProblemDetails>(capturingFormatter.LastContext.Object);
     }
 
@@ -398,7 +398,7 @@ public class DefaultApiProblemDetailsWriterTest
 
     private sealed class CapturingFormatter : IOutputFormatter
     {
-        public OutputFormatterWriteContext LastContext { get; private set; }
+        public OutputFormatterWriteContext? LastContext { get; private set; }
 
         public bool CanWriteResult(OutputFormatterCanWriteContext context) => true;
 


### PR DESCRIPTION
Fixes #67053.

## Problem

`DefaultApiProblemDetailsWriter` had two related defects:

1. **`CanWrite` / `WriteAsync` metadata mismatch.** `CanWrite` looked up `ControllerAttribute` (auto-attached to every controller endpoint) while `WriteAsync` gated on `IApiBehaviorMetadata` (only present when `[ApiController]` is applied). Because [`ProblemDetailsService`](https://github.com/dotnet/aspnetcore/blob/main/src/Http/Http.Extensions/src/ProblemDetailsService.cs) picks the first writer whose `CanWrite` returns true and never tries another, controller endpoints without `[ApiController]` silently got an empty response body — no exception, no log, and no opportunity for `DefaultProblemDetailsWriter` (or a user-registered writer) to take over.
2. **`ValidationProblemDetails.Errors` silently dropped.** `WriteAsync` rebuilt the payload via `ProblemDetailsFactory.CreateProblemDetails(...)`, which always returns a plain `ProblemDetails`, and then only copied `Extensions`. The `Errors` dictionary on `ValidationProblemDetails` is a structural member (not an extension), so it was lost on every `[ApiController]` validation-failure response too.

## Fix

In [`DefaultApiProblemDetailsWriter.cs`](https://github.com/dotnet/aspnetcore/blob/main/src/Mvc/Mvc.Core/src/Infrastructure/DefaultApiProblemDetailsWriter.cs):

- `CanWrite` now mirrors `WriteAsync`'s checks: it requires `IApiBehaviorMetadata` on the endpoint and `!SuppressMapClientErrors`. Non-`[ApiController]` controllers and the suppression case now fall through to the next-registered `IProblemDetailsWriter`.
- `WriteAsync` preserves the runtime `ProblemDetails` subtype. When `context.ProblemDetails` is a `ValidationProblemDetails`, the rebuilt instance is also a `ValidationProblemDetails` carrying the original `Errors`. Factory-supplied extensions are copied first, then caller extensions overlay (preserving the existing precedence for non-validation responses). The runtime type is passed to `OutputFormatterWriteContext` so XML wrappers and content negotiation see the correct declared type.

## Tests

In [`DefaultApiProblemDetailsWriterTest.cs`](https://github.com/dotnet/aspnetcore/blob/main/src/Mvc/Mvc.Core/test/Infrastructure/DefaultApiProblemDetailsWriterTest.cs):

- `CanWrite_ReturnsFalse_WhenControllerWithoutApiControllerAttribute` — locks in the metadata-mismatch regression.
- `CanWrite_ReturnsTrue_WhenApiController` and `CanWrite_ReturnsFalse_WhenSuppressMapClientErrors` — cover the new gating.
- `WriteAsync_PreservesValidationProblemDetailsErrors` — asserts the serialized JSON contains `errors` and custom extensions.
- `WriteAsync_PassesValidationProblemDetailsRuntimeTypeToFormatter` — asserts `OutputFormatterWriteContext.ObjectType == typeof(ValidationProblemDetails)`, which is what the XML problem-details wrapper provider keys off.
- `WriterChain_FallsThroughToNextWriter_ForControllerWithoutApiControllerAttribute` — simulates `ProblemDetailsService.TryWriteAsync`'s writer-selection loop and verifies the next writer is invoked for plain controllers.

## Behavioral / compatibility notes

- `DefaultApiProblemDetailsWriter` is `internal sealed`; no public API surface changes.
- The `CanWrite` change is a deliberate, user-visible behavior change: plain (non-`[ApiController]`) controllers and the `SuppressMapClientErrors = true` case will now produce a body via `DefaultProblemDetailsWriter` instead of an empty body. This matches the documented intent and the reporter's "Expected Behavior" option 1.
- Switching `OutputFormatterWriteContext.ObjectType` from `typeof(ProblemDetails)` to `problemDetails.GetType()` is required for XML content negotiation to pick up the `ValidationProblemDetailsWrapperProvider` path.