### PR TITLE
Preserve TagHelper child content when appending output content

### DIFF
--- a/src/Razor/Razor.Runtime/src/Runtime/TagHelpers/TagHelperExecutionContext.cs
+++ b/src/Razor/Razor.Runtime/src/Runtime/TagHelpers/TagHelperExecutionContext.cs
@@ -64,7 +64,11 @@ public class TagHelperExecutionContext
         _allAttributes = new TagHelperAttributeList();
 
         Context = new TagHelperContext(tagName, _allAttributes, items, uniqueId);
-        Output = new TagHelperOutput(tagName, new TagHelperAttributeList(), GetChildContentAsync)
+        Output = new TagHelperOutput(
+            tagName,
+            new TagHelperAttributeList(),
+            GetChildContentAsync,
+            initializeContentFromChildContent: true)
         {
             TagMode = tagMode
         };

--- a/src/Razor/Razor.Runtime/test/Runtime/TagHelpers/TagHelperExecutionContextTest.cs
+++ b/src/Razor/Razor.Runtime/test/Runtime/TagHelpers/TagHelperExecutionContextTest.cs
@@ -85,6 +85,173 @@ public class TagHelperExecutionContextTest
     }
 
     [Fact]
+    public void Output_ContentAppendHtml_AppendsToChildContent()
+    {
+        // Arrange
+        var tagHelperContent = new DefaultTagHelperContent();
+        var executionContext = new TagHelperExecutionContext(
+            "select",
+            tagMode: TagMode.StartTagAndEndTag,
+            items: new Dictionary<object, object>(),
+            uniqueId: string.Empty,
+            executeChildContentAsync: () =>
+            {
+                tagHelperContent.AppendHtml("<option value=\"0\">(keine)</option>");
+                return Task.CompletedTask;
+            },
+            startTagHelperWritingScope: _ => { },
+            endTagHelperWritingScope: () => tagHelperContent);
+
+        // Act
+        executionContext.Output.Content.AppendHtml("<option value=\"1\">One</option>");
+
+        // Assert
+        Assert.Equal(
+            "<option value=\"0\">(keine)</option><option value=\"1\">One</option>",
+            executionContext.Output.Content.GetContent());
+    }
+
+    [Fact]
+    public void Output_ContentGet_DoesNotMarkContentAsModified()
+    {
+        // Arrange
+        var tagHelperContent = new DefaultTagHelperContent();
+        var executionContext = new TagHelperExecutionContext(
+            "p",
+            tagMode: TagMode.StartTagAndEndTag,
+            items: new Dictionary<object, object>(),
+            uniqueId: string.Empty,
+            executeChildContentAsync: () =>
+            {
+                tagHelperContent.AppendHtml("Child content");
+                return Task.CompletedTask;
+            },
+            startTagHelperWritingScope: _ => { },
+            endTagHelperWritingScope: () => tagHelperContent);
+
+        // Act
+        var content = executionContext.Output.Content;
+
+        // Assert
+        Assert.False(executionContext.Output.IsContentModified);
+        Assert.Equal("Child content", content.GetContent());
+    }
+
+    [Fact]
+    public void Output_ContentSetContent_ReplacesChildContent()
+    {
+        // Arrange
+        var tagHelperContent = new DefaultTagHelperContent();
+        var executionContext = new TagHelperExecutionContext(
+            "p",
+            tagMode: TagMode.StartTagAndEndTag,
+            items: new Dictionary<object, object>(),
+            uniqueId: string.Empty,
+            executeChildContentAsync: () =>
+            {
+                tagHelperContent.AppendHtml("Child content");
+                return Task.CompletedTask;
+            },
+            startTagHelperWritingScope: _ => { },
+            endTagHelperWritingScope: () => tagHelperContent);
+
+        // Act
+        executionContext.Output.Content.SetContent("Replacement content");
+
+        // Assert
+        Assert.True(executionContext.Output.IsContentModified);
+        Assert.Equal("Replacement content", executionContext.Output.Content.GetContent());
+    }
+
+    [Fact]
+    public void Output_ContentSetContent_DoesNotReadChildContent()
+    {
+        // Arrange
+        var childContentRead = false;
+        var executionContext = new TagHelperExecutionContext(
+            "p",
+            tagMode: TagMode.StartTagAndEndTag,
+            items: new Dictionary<object, object>(),
+            uniqueId: string.Empty,
+            executeChildContentAsync: () =>
+            {
+                childContentRead = true;
+                return Task.CompletedTask;
+            },
+            startTagHelperWritingScope: _ => { },
+            endTagHelperWritingScope: () => new DefaultTagHelperContent().AppendHtml("Child content"));
+
+        // Act
+        executionContext.Output.Content.SetContent("Replacement content");
+
+        // Assert
+        Assert.False(childContentRead);
+        Assert.Equal("Replacement content", executionContext.Output.Content.GetContent());
+    }
+
+    [Fact]
+    public void Output_ContentGetAfterSuppressOutput_DoesNotReadChildContent()
+    {
+        // Arrange
+        var childContentRead = false;
+        var executionContext = new TagHelperExecutionContext(
+            "p",
+            tagMode: TagMode.StartTagAndEndTag,
+            items: new Dictionary<object, object>(),
+            uniqueId: string.Empty,
+            executeChildContentAsync: () =>
+            {
+                childContentRead = true;
+                return Task.CompletedTask;
+            },
+            startTagHelperWritingScope: _ => { },
+            endTagHelperWritingScope: () => new DefaultTagHelperContent().AppendHtml("Child content"));
+
+        // Act
+        executionContext.Output.SuppressOutput();
+
+        // Assert
+        Assert.Empty(executionContext.Output.Content.GetContent());
+        Assert.False(childContentRead);
+    }
+
+    [Fact]
+    public void Output_Reinitialize_AllowsContentToReadNewChildContent()
+    {
+        // Arrange
+        var tagHelperContent = new DefaultTagHelperContent();
+        var executionContext = new TagHelperExecutionContext(
+            "p",
+            tagMode: TagMode.StartTagAndEndTag,
+            items: new Dictionary<object, object>(),
+            uniqueId: string.Empty,
+            executeChildContentAsync: () =>
+            {
+                tagHelperContent.AppendHtml("Child content");
+                return Task.CompletedTask;
+            },
+            startTagHelperWritingScope: _ => { },
+            endTagHelperWritingScope: () => tagHelperContent);
+        var content = executionContext.Output.Content;
+
+        // Act
+        executionContext.Reinitialize(
+            "p",
+            TagMode.StartTagAndEndTag,
+            items: new Dictionary<object, object>(),
+            uniqueId: string.Empty,
+            executeChildContentAsync: () =>
+            {
+                tagHelperContent.SetHtmlContent("Updated child content");
+                return Task.CompletedTask;
+            });
+
+        // Assert
+        Assert.NotSame(content, executionContext.Output.Content);
+        Assert.Equal("Updated child content", executionContext.Output.Content.GetContent());
+    }
+
+    [Fact]
     public async Task ExecutionContext_Reinitialize_UpdatesTagHelperOutputAsExpected()
     {
         // Arrange

--- a/src/Razor/Razor/src/Microsoft.AspNetCore.Razor.csproj
+++ b/src/Razor/Razor/src/Microsoft.AspNetCore.Razor.csproj
@@ -24,6 +24,7 @@ Microsoft.AspNetCore.Razor.TagHelpers.ITagHelper</Description>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.AspNetCore.Razor.Test" />
+    <InternalsVisibleTo Include="Microsoft.AspNetCore.Razor.Runtime" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.Razor.Runtime.Test" />
   </ItemGroup>
 </Project>

--- a/src/Razor/Razor/src/TagHelpers/TagHelperOutput.cs
+++ b/src/Razor/Razor/src/TagHelpers/TagHelperOutput.cs
@@ -17,6 +17,7 @@ public class TagHelperOutput : IHtmlContentContainer
     private TagHelperContent _content;
     private TagHelperContent _postContent;
     private TagHelperContent _postElement;
+    private readonly bool _initializeContentFromChildContent;
     private bool _wasSuppressOutputCalled;
 
     // Internal for testing
@@ -48,6 +49,16 @@ public class TagHelperOutput : IHtmlContentContainer
         TagName = tagName;
         _getChildContentAsync = getChildContentAsync;
         Attributes = attributes;
+    }
+
+    internal TagHelperOutput(
+        string tagName,
+        TagHelperAttributeList attributes,
+        Func<bool, HtmlEncoder, Task<TagHelperContent>> getChildContentAsync,
+        bool initializeContentFromChildContent)
+        : this(tagName, attributes, getChildContentAsync)
+    {
+        _initializeContentFromChildContent = initializeContentFromChildContent;
     }
 
     /// <summary>
@@ -103,7 +114,9 @@ public class TagHelperOutput : IHtmlContentContainer
         {
             if (_content == null)
             {
-                _content = new DefaultTagHelperContent();
+                _content = _initializeContentFromChildContent ?
+                    new TagHelperOutputContent(GetChildContentAsync) :
+                    new DefaultTagHelperContent();
             }
 
             return _content;
@@ -189,7 +202,14 @@ public class TagHelperOutput : IHtmlContentContainer
 
         _preElement?.Reinitialize();
         _preContent?.Reinitialize();
-        _content?.Reinitialize();
+        if (_initializeContentFromChildContent)
+        {
+            _content = null;
+        }
+        else
+        {
+            _content?.Reinitialize();
+        }
         _postContent?.Reinitialize();
         _postElement?.Reinitialize();
 
@@ -209,7 +229,8 @@ public class TagHelperOutput : IHtmlContentContainer
         _wasSuppressOutputCalled = true;
         _preElement?.Clear();
         _preContent?.Clear();
-        _content?.Clear();
+        _content ??= new DefaultTagHelperContent();
+        _content.Clear();
         _postContent?.Clear();
         _postElement?.Clear();
     }
@@ -427,5 +448,201 @@ public class TagHelperOutput : IHtmlContentContainer
         }
 
         _postElement?.WriteTo(writer, encoder);
+    }
+
+    private sealed class TagHelperOutputContent : TagHelperContent
+    {
+        private readonly DefaultTagHelperContent _content = new DefaultTagHelperContent();
+        private readonly Func<Task<TagHelperContent>> _getInitialContentAsync;
+        private IHtmlContent _initialContent;
+        private bool _initialContentLoaded;
+        private bool? _initialContentIsEmptyOrWhiteSpace;
+        private bool _isModified;
+
+        public TagHelperOutputContent(Func<Task<TagHelperContent>> getInitialContentAsync)
+        {
+            _getInitialContentAsync = getInitialContentAsync;
+        }
+
+        public override bool IsModified => _isModified;
+
+        public override bool IsEmptyOrWhiteSpace
+        {
+            get
+            {
+                EnsureInitialContentLoaded();
+
+                if (_isModified || _initialContent == null)
+                {
+                    return _content.IsEmptyOrWhiteSpace;
+                }
+
+                if (_initialContent is TagHelperContent tagHelperContent)
+                {
+                    return tagHelperContent.IsEmptyOrWhiteSpace;
+                }
+
+                _initialContentIsEmptyOrWhiteSpace ??= GetIsEmptyOrWhiteSpace(_initialContent);
+                return _initialContentIsEmptyOrWhiteSpace.Value;
+            }
+        }
+
+        public override TagHelperContent Append(string unencoded)
+        {
+            EnsureInitialContent();
+            _content.Append(unencoded);
+            _isModified = true;
+
+            return this;
+        }
+
+        public override TagHelperContent AppendHtml(IHtmlContent htmlContent)
+        {
+            EnsureInitialContent();
+            _content.AppendHtml(htmlContent);
+            _isModified = true;
+
+            return this;
+        }
+
+        public override TagHelperContent AppendHtml(string encoded)
+        {
+            EnsureInitialContent();
+            _content.AppendHtml(encoded);
+            _isModified = true;
+
+            return this;
+        }
+
+        public override TagHelperContent Clear()
+        {
+            _initialContent = null;
+            _initialContentLoaded = true;
+            _initialContentIsEmptyOrWhiteSpace = null;
+            _content.Clear();
+            _isModified = true;
+
+            return this;
+        }
+
+        public override void Reinitialize()
+        {
+            _initialContent = null;
+            _initialContentLoaded = false;
+            _initialContentIsEmptyOrWhiteSpace = null;
+            _content.Reinitialize();
+            _isModified = false;
+        }
+
+        public override void CopyTo(IHtmlContentBuilder destination)
+        {
+            ArgumentNullException.ThrowIfNull(destination);
+
+            EnsureInitialContentLoaded();
+
+            if (_isModified || _initialContent == null)
+            {
+                _content.CopyTo(destination);
+            }
+            else if (_initialContent is IHtmlContentContainer container)
+            {
+                container.CopyTo(destination);
+            }
+            else
+            {
+                destination.AppendHtml(_initialContent);
+            }
+        }
+
+        public override void MoveTo(IHtmlContentBuilder destination)
+        {
+            ArgumentNullException.ThrowIfNull(destination);
+
+            EnsureInitialContentLoaded();
+
+            if (_isModified || _initialContent == null)
+            {
+                _content.MoveTo(destination);
+            }
+            else if (_initialContent is IHtmlContentContainer container)
+            {
+                container.MoveTo(destination);
+            }
+            else
+            {
+                destination.AppendHtml(_initialContent);
+            }
+
+            Clear();
+        }
+
+        public override string GetContent() => GetContent(HtmlEncoder.Default);
+
+        public override string GetContent(HtmlEncoder encoder)
+        {
+            ArgumentNullException.ThrowIfNull(encoder);
+
+            using (var writer = new StringWriter())
+            {
+                WriteTo(writer, encoder);
+                return writer.ToString();
+            }
+        }
+
+        public override void WriteTo(TextWriter writer, HtmlEncoder encoder)
+        {
+            ArgumentNullException.ThrowIfNull(writer);
+            ArgumentNullException.ThrowIfNull(encoder);
+
+            EnsureInitialContentLoaded();
+
+            if (_isModified || _initialContent == null)
+            {
+                _content.WriteTo(writer, encoder);
+            }
+            else
+            {
+                _initialContent.WriteTo(writer, encoder);
+            }
+        }
+
+        private void EnsureInitialContent()
+        {
+            EnsureInitialContentLoaded();
+
+            if (!_isModified && _initialContent != null)
+            {
+                CopyInitialContentTo(_content);
+                _initialContent = null;
+                _initialContentLoaded = false;
+                _initialContentIsEmptyOrWhiteSpace = null;
+            }
+        }
+
+        private void EnsureInitialContentLoaded()
+        {
+            if (!_isModified && !_initialContentLoaded)
+            {
+                _initialContent = _getInitialContentAsync().GetAwaiter().GetResult();
+                _initialContentLoaded = true;
+            }
+        }
+
+        private void CopyInitialContentTo(IHtmlContentBuilder destination)
+        {
+            if (_initialContent is IHtmlContentContainer container)
+            {
+                container.CopyTo(destination);
+            }
+            else
+            {
+                destination.AppendHtml(_initialContent);
+            }
+        }
+
+        private static bool GetIsEmptyOrWhiteSpace(IHtmlContent content)
+        {
+            return new DefaultTagHelperContent().SetHtmlContent(content).IsEmptyOrWhiteSpace;
+        }
     }
 }


### PR DESCRIPTION
Fixes #29835

## Summary
- initialize `TagHelperOutput.Content` from cached child content so `AppendHtml` appends instead of replacing unmaterialized child markup
- keep plain `Content` reads from marking content as modified
- preserve replace semantics for `SetContent`/`SetHtmlContent`, suppress output behavior, and reinitialization reuse
- add focused `TagHelperOutput` regression tests

## Testing
- Not run: local repo restore artifacts are unavailable without running `restore.cmd`; `dotnet test` with the installed .NET 10 SDK reaches MSBuild but fails on missing `artifacts/bin/GenerateFiles/Directory.Build.props`.