### PR TITLE
Enable control flow guard for native AOT tools

### DIFF
--- a/src/Tools/dotnet-dev-certs/src/dotnet-dev-certs.csproj
+++ b/src/Tools/dotnet-dev-certs/src/dotnet-dev-certs.csproj
@@ -15,6 +15,11 @@
   <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
     <PublishAot>true</PublishAot>
     <RuntimeIdentifiers>$(BundledToolTargetRuntimeIdentifiers)</RuntimeIdentifiers>
+    <!--
+      Enable control flow guard
+      https://github.com/dotnet/docs/blob/main/docs/core/deploying/native-aot/security.md#control-flow-guard
+    -->
+    <ControlFlowGuard>Guard</ControlFlowGuard>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tools/dotnet-user-jwts/src/dotnet-user-jwts.csproj
+++ b/src/Tools/dotnet-user-jwts/src/dotnet-user-jwts.csproj
@@ -16,6 +16,11 @@
   <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
     <PublishAot>true</PublishAot>
     <RuntimeIdentifiers>$(BundledToolTargetRuntimeIdentifiers)</RuntimeIdentifiers>
+    <!--
+      Enable control flow guard
+      https://github.com/dotnet/docs/blob/main/docs/core/deploying/native-aot/security.md#control-flow-guard
+    -->
+    <ControlFlowGuard>Guard</ControlFlowGuard>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tools/dotnet-user-secrets/src/dotnet-user-secrets.csproj
+++ b/src/Tools/dotnet-user-secrets/src/dotnet-user-secrets.csproj
@@ -16,6 +16,11 @@
   <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
     <PublishAot>true</PublishAot>
     <RuntimeIdentifiers>$(BundledToolTargetRuntimeIdentifiers)</RuntimeIdentifiers>
+    <!--
+      Enable control flow guard
+      https://github.com/dotnet/docs/blob/main/docs/core/deploying/native-aot/security.md#control-flow-guard
+    -->
+    <ControlFlowGuard>Guard</ControlFlowGuard>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Enable control flow guard for native AOT tools

Enables control flow guard for native AOT tools to fix binskim errors. Based on https://github.com/dotnet/sdk/pull/54171

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/3014971
