### PR TITLE
Verify test-quarantine Source B PRs via batched GraphQL

### DIFF
--- a/.github/workflows/test-quarantine.md
+++ b/.github/workflows/test-quarantine.md
@@ -214,25 +214,23 @@ GET https://vstmr.dev.azure.com/dnceng-public/public/_apis/testresults/resultsby
 
 **Source B is REQUIRED — do not skip it.** It captures flaky tests that only manifest in PR builds (which run more frequently than rolling builds). Skipping it leaves significant blind spots in quarantine coverage.
 
-Get all PR builds (`reasonFilter=pullRequest`) from the last 7 days. Use pagination (`$top=100` + `continuationToken`) and an explicit `minTime` to ensure all builds are retrieved. **To keep this efficient, use the following approach:**
+Get all PR builds (`reasonFilter=pullRequest`) from the last 7 days. Use pagination (`$top=100` + `continuationToken`) and an explicit `minTime` to ensure all builds are retrieved. **Do all of the following inside a single batched `python3` script** (`source_b.py`, per the data-collection method above) — list and group the builds, pre-filter, verify PRs in one batched GraphQL request, and aggregate — so that Source B costs only a couple of turns rather than one turn per PR. **Verifying PRs one at a time via the `pull_request_read` MCP tool is the single biggest token sink in this workflow and is prohibited here.**
 
-1. **Get the unique PR numbers** — extract PR numbers from `sourceBranch` (`refs/pull/{NUMBER}/merge`) across all PR builds. Deduplicate to get the set of unique PRs.
+1. **Group PR builds by PR number** — extract PR numbers from `sourceBranch` (`refs/pull/{NUMBER}/merge`) across all PR builds, and group the builds under each PR number.
 
-2. **Verify B2 and B3 for each unique PR** — call `pull_request_read` (method `get`) once per PR number (not per build):
-   - **(B2)** The PR **targets the `main` branch** — verify `base.ref` is `main`. Exclude PRs targeting release branches or any other non-main branch.
-   - **(B3)** The PR was **merged** — verify the `merged` field is `true`. Exclude open, draft, or abandoned PRs.
+2. **(B4) Pre-filter by failed builds — do this BEFORE any GitHub call.** From the Azure DevOps build data already in hand, keep only PR numbers that have **at least one build that `failed` or `partiallySucceeded`**. Discard every other PR now. This is correctness-preserving (a PR with no failed/partial build can never qualify) and it shrinks the set you must verify against GitHub — often from dozens to a handful, which is essential to staying within the token budget.
 
-   If you cannot verify a PR's status (e.g., rate limits), exclude it — never default to including it.
+3. **(B2 + B3) Verify the surviving PRs in one batched GraphQL request** — call the `verify_prs` helper in the API Reference, which POSTs a single GraphQL query per ~50 PRs to `https://api.github.com/graphql` and returns only the PRs that:
+   - **(B2)** target `main` — `baseRefName` is `main`; and
+   - **(B3)** were merged — `merged` is `true`.
 
-3. **For each qualifying PR, find all its builds** and apply:
-   - **(B1)** Keep only builds for the **final commit** — compare each build's `pr.sourceSha` (from `triggerInfo`) to the PR's `head.sha` from the `pull_request_read` response in step 2. Only include builds whose `pr.sourceSha` matches the PR's `head.sha`.
-   - **(B4)** At least one build in the group **failed** or **partially succeeded**.
+   The helper is **fail-closed** (any PR it cannot positively verify is excluded — never default to including) and **fail-loud** on systemic failures (missing token, `401`/`403`, primary rate-limit, or every request failing), so the run aborts visibly instead of silently reporting "no failures" because verification was dead. It also returns each verified PR's `headRefOid` for B1.
 
-4. **Get the failed test results** from the failed/partially-succeeded builds in qualifying groups.
+4. **(B1) Match builds to the merged commit** — for each verified PR, keep only builds whose `triggerInfo` `pr.sourceSha` equals that PR's `headRefOid` from step 3.
 
-**Run the build-listing and test-result collection (the pagination in the intro, plus steps 1, 3, and 4) inside a single batched `python3` script** (per the data-collection method above): write the qualifying failed test results to `/tmp/gh-aw/agent/source_b.json` and print only the aggregated per-test failure table. The exception is the step-2 verification, which uses the `pull_request_read` MCP tool: issue those calls together and keep their raw responses out of context — retain only each PR's `base.ref`, `merged`, and `head.sha`.
+5. **Collect the failed test results** from the `failed`/`partiallySucceeded` builds that survive B1, aggregate per-test failure counts, write the raw results to `/tmp/gh-aw/agent/source_b.json`, and print **only** the aggregated per-test failure table (plus the one-line verify summary). Never print raw build, test-result, or GraphQL JSON into your context.
 
-**Every criterion above is mandatory — do not skip or approximate any of them.**
+**Every criterion (B1–B4) above is mandatory — do not skip or approximate any of them.**
 
 This captures two scenarios: (1) a PR that was retried and eventually passed, indicating flaky test failures on the earlier attempt, and (2) a PR that was merged on red because the only failures were flaky tests — engineers sometimes do this when the failures are clearly unrelated to their changes.
 
@@ -587,3 +585,72 @@ These are the key API endpoints. All are public and require no authentication:
 | Helix work item files | `GET https://helix.dot.net/api/2019-06-17/jobs/{JOB_ID}/workitems/{WI_NAME}/files` |
 | Helix console log | Download the `Link` URL from the files response for the file starting with `console.` |
 | Per-test log | Download the `Link` URL for the file named `{TestClass}_{TestMethod}.log` |
+
+### Source B helper: batched PR verification (`verify_prs`)
+
+Source B step 3 must verify B2/B3 for many PRs **without** calling the `pull_request_read` MCP tool per PR (one turn per PR exhausts the token budget). Use this helper inside `source_b.py` — it verifies up to ~50 PRs per single GraphQL request, is **fail-closed** (excludes any PR it cannot positively confirm) and **fail-loud** (aborts on systemic failures rather than silently excluding every PR and reporting a false "no failures"):
+
+```python
+import os, json, urllib.request, urllib.error
+
+def verify_prs(pr_numbers, chunk=50):
+    """Verify B2 (targets main) + B3 (merged) for many PRs via batched GraphQL.
+    Returns {pr_number: head_sha} for PRs confirmed merged into main; every other
+    PR is excluded. Aborts (fail-loud) on systemic verification failure."""
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if not token:
+        raise SystemExit("FATAL: no GITHUB_TOKEN/GH_TOKEN — refusing to silently exclude all PRs")
+    nums = sorted(set(pr_numbers))
+    verified, excluded = {}, 0
+    chunks_total = chunks_failed = 0
+    for k in range(0, len(nums), chunk):
+        batch = nums[k:k + chunk]
+        chunks_total += 1
+        aliases = "\n".join(
+            f'p{n}: pullRequest(number: {n}) {{ number baseRefName merged headRefOid }}'
+            for n in batch)
+        query = f'query {{ repository(owner: "dotnet", name: "aspnetcore") {{ {aliases} }} }}'
+        req = urllib.request.Request(
+            "https://api.github.com/graphql",
+            data=json.dumps({"query": query}).encode(),
+            headers={"Authorization": f"bearer {token}",
+                     "Content-Type": "application/json",
+                     "User-Agent": "aspnetcore-test-quarantine"})
+        try:
+            with urllib.request.urlopen(req, timeout=60) as r:
+                body = json.loads(r.read())
+        except urllib.error.HTTPError as e:
+            if e.code in (401, 403):  # bad/expired token or abuse block = systemic
+                raise SystemExit(f"FATAL: GitHub GraphQL {e.code} — aborting rather than excluding all PRs")
+            excluded += len(batch); chunks_failed += 1; continue   # transient: exclude this chunk
+        except Exception:
+            excluded += len(batch); chunks_failed += 1; continue   # timeout/network: exclude this chunk
+        # GraphQL returns data AND errors together. Exclude any alias named in an
+        # error path; primary rate-limit is systemic; other top-level errors mean
+        # we can't trust this chunk, so exclude the whole chunk.
+        errored, chunk_untrusted = set(), False
+        for err in body.get("errors") or []:
+            if err.get("type") == "RATE_LIMITED":
+                raise SystemExit("FATAL: GitHub GraphQL RATE_LIMITED — aborting rather than excluding all PRs")
+            path = err.get("path") or []
+            if path and isinstance(path[-1], str) and path[-1].startswith("p"):
+                errored.add(path[-1])
+            else:
+                chunk_untrusted = True
+        repo = (body.get("data") or {}).get("repository")
+        if repo is None or chunk_untrusted:
+            excluded += len(batch); chunks_failed += 1; continue
+        for alias, pr in repo.items():
+            if alias in errored or not pr or not pr.get("headRefOid"):
+                excluded += 1
+            elif pr.get("baseRefName") == "main" and pr.get("merged") is True:
+                verified[pr["number"]] = pr["headRefOid"]
+            else:
+                excluded += 1
+    if chunks_total and chunks_failed == chunks_total:
+        raise SystemExit("FATAL: every GraphQL verification request failed — aborting rather than excluding all PRs")
+    print(f"# B2/B3 verify: {len(verified)} merged-into-main, {excluded} excluded of {len(nums)} candidates")
+    return verified
+```
+
+GraphQL field mapping: `baseRefName` = REST `base.ref` (B2), `merged` = REST `merged` (B3), `headRefOid` = REST `head.sha` (used for the B1 `pr.sourceSha` match). `api.github.com` is on the firewall allow-list and `GITHUB_TOKEN` is available to the agent. Lower `chunk` to 25 if you ever see query-complexity throttling.

--- a/.github/workflows/test-quarantine.md
+++ b/.github/workflows/test-quarantine.md
@@ -591,7 +591,7 @@ These are the key API endpoints. All are public and require no authentication:
 Source B step 3 must verify B2/B3 for many PRs **without** calling the `pull_request_read` MCP tool per PR (one turn per PR exhausts the token budget). Use this helper inside `source_b.py` — it verifies up to ~50 PRs per single GraphQL request, is **fail-closed** (excludes any PR it cannot positively confirm) and **fail-loud** (aborts on systemic failures rather than silently excluding every PR and reporting a false "no failures"):
 
 ```python
-import os, json, urllib.request, urllib.error
+import os, re, json, urllib.request, urllib.error
 
 def verify_prs(pr_numbers, chunk=50):
     """Verify B2 (targets main) + B3 (merged) for many PRs via batched GraphQL.
@@ -632,9 +632,13 @@ def verify_prs(pr_numbers, chunk=50):
         for err in body.get("errors") or []:
             if err.get("type") == "RATE_LIMITED":
                 raise SystemExit("FATAL: GitHub GraphQL RATE_LIMITED — aborting rather than excluding all PRs")
-            path = err.get("path") or []
-            if path and isinstance(path[-1], str) and path[-1].startswith("p"):
-                errored.add(path[-1])
+            # A field/node error names its alias somewhere in the path, e.g.
+            # ["repository","p123"] or ["repository","p123","merged"]. Exclude just
+            # that PR; a path with no alias is untrustworthy for the whole chunk.
+            alias = next((p for p in (err.get("path") or [])
+                          if isinstance(p, str) and re.fullmatch(r"p\d+", p)), None)
+            if alias:
+                errored.add(alias)
             else:
                 chunk_untrusted = True
         repo = (body.get("data") or {}).get("repository")


### PR DESCRIPTION
Follow-up to #67085. The daily `test-quarantine` workflow keeps tripping the 25M effective-tokens rail. In the most recent failure the dominant cost was **Source B's PR verification**: the agent made ~71 sequential `pull_request_read` MCP calls (one per unique PR) to check base branch and merged status. Because every inference turn re-sends the whole conversation, that per-PR loop dominates token usage — and CI flakiness inflates the unique-PR count.

Prompt-only change to `.github/workflows/test-quarantine.md` (runtime-imported, so no lockfile recompile):

- **B4 prefilter first** — discard PRs with no `failed`/`partiallySucceeded` build (using Azure DevOps data already in hand) *before* any GitHub call. Correctness-preserving (such PRs can never qualify) and shrinks the set to verify from dozens to a handful.
- **Batched GraphQL verification** — replace the per-PR MCP loop with a `verify_prs` helper that verifies B2/B3 for ~50 PRs per single GraphQL request (~71 turns → ~1–2). `baseRefName`/`merged`/`headRefOid` map to REST `base.ref`/`merged`/`head.sha`; `headRefOid` feeds the B1 SHA match.
- **Fail-closed / fail-loud** — exclude any PR that can't be positively verified; abort visibly on systemic failure (missing token, 401/403, primary rate-limit, or every request failing) so the run never silently reports a false "no failures." Handles GraphQL partial errors and null nodes.
- **Aggregate-only output** — print only the per-test failure table; raw JSON goes to a file.

The `verify_prs` helper was validated offline against 8 scenarios (happy path, partial errors, and every fail-loud/fail-closed branch). `GITHUB_TOKEN` is available to the agent and `api.github.com` is firewall-allowed.