### PR TITLE
Fix internal CI NativeAOT cross-build for ARM/ARM64/musl legs

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -130,6 +130,20 @@ extends:
     containers:
       azureLinuxBuildAmd64:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-build-amd64
+      # Cross-compilation prereq images (clang + /crossrootfs/<arch>) used by the AOT-publishing
+      # build legs (dotnet-dev-certs / dotnet-user-secrets / dotnet-user-jwts publish NativeAOT for
+      # every bundled RID). These provide the native toolchain + sysroot that NativeAOT cross-linking
+      # requires; the legs set ROOTFS_DIR and pass /p:CrossBuild=true so ILC emits --sysroot/--target.
+      azureLinuxCrossArm:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-arm
+      azureLinuxCrossArm64:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-arm64
+      azureLinuxCrossX64Musl:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-amd64-musl
+      azureLinuxCrossArmMusl:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-arm-musl
+      azureLinuxCrossArm64Musl:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-arm64-musl
     stages:
     - stage: build
       displayName: Build
@@ -361,12 +375,16 @@ extends:
             jobName: Linux_arm_build
             jobDisplayName: "Build: Linux ARM"
             agentOs: Linux
-            use1ESUbuntu: true
+            container: azureLinuxCrossArm
+            variables:
+            - name: ROOTFS_DIR
+              value: /crossrootfs/arm
             buildArgs:
               --arch arm
               --pack
               --all
               --no-build-java
+              -p:CrossBuild=true
               $(_ArcadePublishNonWindowsArg)
               -p:OnlyPackPlatformSpecificPackages=true
               -p:AssetManifestFileName=aspnetcore-Linux_arm.xml
@@ -393,13 +411,17 @@ extends:
             jobName: Linux_arm64_build
             jobDisplayName: "Build: Linux ARM64"
             agentOs: Linux
-            use1ESUbuntu: true
+            container: azureLinuxCrossArm64
+            variables:
+            - name: ROOTFS_DIR
+              value: /crossrootfs/arm64
             buildArgs:
               --arch arm64
               --pack
               --all
               --build-installers
               --no-build-java
+              -p:CrossBuild=true
               $(_ArcadePublishNonWindowsArg)
               -p:OnlyPackPlatformSpecificPackages=true
               -p:AssetManifestFileName=aspnetcore-Linux_arm64.xml
@@ -426,13 +448,17 @@ extends:
             jobName: Linux_musl_x64_build
             jobDisplayName: "Build: Linux Musl x64"
             agentOs: Linux
-            container: azureLinuxBuildAmd64
+            container: azureLinuxCrossX64Musl
+            variables:
+            - name: ROOTFS_DIR
+              value: /crossrootfs/x64
             buildArgs:
               --arch x64
               --os-name linux-musl
               --pack
               --all
               --no-build-java
+              -p:CrossBuild=true
               $(_ArcadePublishNonWindowsArg)
               -p:OnlyPackPlatformSpecificPackages=true
               -p:AssetManifestFileName=aspnetcore-Linux_musl_x64.xml
@@ -460,13 +486,17 @@ extends:
             jobName: Linux_musl_arm_build
             jobDisplayName: "Build: Linux Musl ARM"
             agentOs: Linux
-            container: azureLinuxBuildAmd64
+            container: azureLinuxCrossArmMusl
+            variables:
+            - name: ROOTFS_DIR
+              value: /crossrootfs/arm
             buildArgs:
               --arch arm
               --os-name linux-musl
               --pack
               --all
               --no-build-java
+              -p:CrossBuild=true
               $(_ArcadePublishNonWindowsArg)
               -p:OnlyPackPlatformSpecificPackages=true
               -p:AssetManifestFileName=aspnetcore-Linux_musl_arm.xml
@@ -493,13 +523,17 @@ extends:
             jobName: Linux_musl_arm64_build
             jobDisplayName: "Build: Linux Musl ARM64"
             agentOs: Linux
-            container: azureLinuxBuildAmd64
+            container: azureLinuxCrossArm64Musl
+            variables:
+            - name: ROOTFS_DIR
+              value: /crossrootfs/arm64
             buildArgs:
               --arch arm64
               --os-name linux-musl
               --pack
               --all
               --no-build-java
+              -p:CrossBuild=true
               $(_ArcadePublishNonWindowsArg)
               -p:OnlyPackPlatformSpecificPackages=true
               -p:AssetManifestFileName=aspnetcore-Linux_musl_arm64.xml


### PR DESCRIPTION
The dotnet-dev-certs/dotnet-user-secrets/dotnet-user-jwts tools now publish NativeAOT for every bundled RID (added by VMR backflow #66933). The internal-only ARM, ARM64 and musl build legs lacked a native cross toolchain, so ILC's lld cross-link failed (missing --sysroot / no clang).

Run these 5 legs in the dotnet-buildtools azurelinux cross-prereq containers (clang + /crossrootfs/<arch>), set ROOTFS_DIR, and pass /p:CrossBuild=true so LocateNativeCompiler.targets sets SysRoot=$(ROOTFS_DIR) and ILC emits --sysroot/--target. Mirrors how the VMR builds these RIDs.
