### PR TITLE
Fix docs issues

### DIFF
--- a/src/Validation/Localization/src/ValidationLocalizationServiceCollectionExtensions.cs
+++ b/src/Validation/Localization/src/ValidationLocalizationServiceCollectionExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.DependencyInjection;
 
 /// <summary>
 /// Extension methods for registering the default <see cref="IStringLocalizer"/>-based validation
-/// localizer (<see cref="DefaultValidationLocalizer"/>).
+/// localizer.
 /// </summary>
 public static class ValidationLocalizationServiceCollectionExtensions
 {
@@ -24,7 +24,7 @@ public static class ValidationLocalizationServiceCollectionExtensions
     /// Internally calls <see cref="LocalizationServiceCollectionExtensions.AddLocalization(IServiceCollection)"/>
     /// to ensure an <see cref="IStringLocalizerFactory"/> is registered, and registers an
     /// <see cref="IConfigureOptions{TOptions}"/> bridge that sets
-    /// <see cref="ValidationOptions.Localizer"/> to a <see cref="DefaultValidationLocalizer"/>
+    /// <see cref="ValidationOptions.Localizer"/> to a default
     /// instance (only when <see cref="ValidationOptions.Localizer"/> has not already been set).
     /// </para>
     /// <para>

--- a/src/Validation/src/ValidatableParameterInfo.cs
+++ b/src/Validation/src/ValidatableParameterInfo.cs
@@ -20,7 +20,7 @@ public abstract class ValidatableParameterInfo : IValidatableInfo
     /// </summary>
     /// <param name="parameterType">The <see cref="Type"/> associated with the parameter.</param>
     /// <param name="name">The parameter name.</param>
-    /// <param name="displayNameInfo">An optional <see cref="DisplayNameInfo"/> that resolves the
+    /// <param name="displayNameInfo">An optional strategy that resolves the
     /// display name for the parameter at validation time. When <see langword="null"/>, the
     /// validation pipeline uses <paramref name="name"/> as the display name.</param>
     protected ValidatableParameterInfo(

--- a/src/Validation/src/ValidatablePropertyInfo.cs
+++ b/src/Validation/src/ValidatablePropertyInfo.cs
@@ -20,7 +20,7 @@ public abstract class ValidatablePropertyInfo : IValidatableInfo
     /// <param name="declaringType">The <see cref="Type"/> that declares the property.</param>
     /// <param name="propertyType">The <see cref="Type"/> of the property.</param>
     /// <param name="name">The property name.</param>
-    /// <param name="displayNameInfo">An optional <see cref="DisplayNameInfo"/> that resolves the
+    /// <param name="displayNameInfo">An optional strategy that resolves the
     /// display name for the property at validation time. When <see langword="null"/>, the
     /// validation pipeline uses <paramref name="name"/> as the display name.</param>
     protected ValidatablePropertyInfo(

--- a/src/Validation/src/ValidatableTypeInfo.cs
+++ b/src/Validation/src/ValidatableTypeInfo.cs
@@ -21,7 +21,7 @@ public abstract class ValidatableTypeInfo : IValidatableInfo
     /// </summary>
     /// <param name="type">The type being validated.</param>
     /// <param name="members">The members that can be validated.</param>
-    /// <param name="displayNameInfo">An optional <see cref="DisplayNameInfo"/> that resolves the
+    /// <param name="displayNameInfo">An optional strategy that resolves the
     /// display name for the type at validation time. When <see langword="null"/>, the validation
     /// pipeline uses <see cref="System.Reflection.MemberInfo.Name"/> of <paramref name="type"/>
     /// as the display name.</param>


### PR DESCRIPTION
- The references to DisplayNameInfo weren't resolving in docs, presumably because they are resolving to the internal property of the same name.
- The references to DefaultValidationLocalizer fail because it's internal (and internal types aren't published on Learn).

See https://github.com/dotnet/dotnet-api-docs/pull/12732.