### PR TITLE
Adding StateHasChanged analyzer to flag unnecessary calls.

### DIFF
--- a/src/Components/Analyzers/src/DiagnosticDescriptors.cs
+++ b/src/Components/Analyzers/src/DiagnosticDescriptors.cs
@@ -111,4 +111,13 @@ internal static class DiagnosticDescriptors
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: CreateLocalizableResourceString(nameof(Resources.VirtualizeItemsProviderRequiresItemComparer_Description)));
+
+    public static readonly DiagnosticDescriptor UnnecessaryStateHasChangedCall = new(
+        "BL0012",
+        CreateLocalizableResourceString(nameof(Resources.UnnecessaryStateHasChangedCall_Title)),
+        CreateLocalizableResourceString(nameof(Resources.UnnecessaryStateHasChangedCall_Format)),
+        Usage,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: CreateLocalizableResourceString(nameof(Resources.UnnecessaryStateHasChangedCall_Description)));
 }

--- a/src/Components/Analyzers/src/Resources.resx
+++ b/src/Components/Analyzers/src/Resources.resx
@@ -223,7 +223,7 @@
     <value>StateHasChanged is unnecessary immediately before the first await and after the final await in component lifecycle methods or event handlers because ComponentBase already schedules renders at those points.</value>
   </data>
   <data name="UnnecessaryStateHasChangedCall_Format" xml:space="preserve">
-    <value>StateHasChanged is unnecessary here and can be removed.</value>
+    <value>StateHasChanged is unnecessary in method '{0}' and can be removed.</value>
   </data>
   <data name="UnnecessaryStateHasChangedCall_Title" xml:space="preserve">
     <value>Unnecessary StateHasChanged call</value>

--- a/src/Components/Analyzers/src/Resources.resx
+++ b/src/Components/Analyzers/src/Resources.resx
@@ -220,7 +220,7 @@
     <value>Virtualize with ItemsProvider requires ItemComparer</value>
   </data>
   <data name="UnnecessaryStateHasChangedCall_Description" xml:space="preserve">
-    <value>StateHasChanged is unnecessary immediately before the first await and after the final await in component lifecycle methods or event handlers because ComponentBase already schedules renders at those points.</value>
+    <value>StateHasChanged is unnecessary in synchronous component lifecycle methods or event handlers. In async lifecycle methods or event handlers, it is unnecessary before the first await and after the final await because ComponentBase already schedules renders at those points.</value>
   </data>
   <data name="UnnecessaryStateHasChangedCall_Format" xml:space="preserve">
     <value>StateHasChanged is unnecessary in method '{0}' and can be removed.</value>

--- a/src/Components/Analyzers/src/Resources.resx
+++ b/src/Components/Analyzers/src/Resources.resx
@@ -219,4 +219,13 @@
   <data name="VirtualizeItemsProviderRequiresItemComparer_Title" xml:space="preserve">
     <value>Virtualize with ItemsProvider requires ItemComparer</value>
   </data>
+  <data name="UnnecessaryStateHasChangedCall_Description" xml:space="preserve">
+    <value>StateHasChanged is unnecessary immediately after the first await and after the final await in component lifecycle methods or event handlers because ComponentBase already schedules renders at those points.</value>
+  </data>
+  <data name="UnnecessaryStateHasChangedCall_Format" xml:space="preserve">
+    <value>StateHasChanged is unnecessary here and can be removed.</value>
+  </data>
+  <data name="UnnecessaryStateHasChangedCall_Title" xml:space="preserve">
+    <value>Unnecessary StateHasChanged call</value>
+  </data>
 </root>

--- a/src/Components/Analyzers/src/Resources.resx
+++ b/src/Components/Analyzers/src/Resources.resx
@@ -220,7 +220,7 @@
     <value>Virtualize with ItemsProvider requires ItemComparer</value>
   </data>
   <data name="UnnecessaryStateHasChangedCall_Description" xml:space="preserve">
-    <value>StateHasChanged is unnecessary immediately after the first await and after the final await in component lifecycle methods or event handlers because ComponentBase already schedules renders at those points.</value>
+    <value>StateHasChanged is unnecessary immediately before the first await and after the final await in component lifecycle methods or event handlers because ComponentBase already schedules renders at those points.</value>
   </data>
   <data name="UnnecessaryStateHasChangedCall_Format" xml:space="preserve">
     <value>StateHasChanged is unnecessary here and can be removed.</value>

--- a/src/Components/Analyzers/src/Resources.resx
+++ b/src/Components/Analyzers/src/Resources.resx
@@ -228,4 +228,7 @@
   <data name="UnnecessaryStateHasChangedCall_Title" xml:space="preserve">
     <value>Unnecessary StateHasChanged call</value>
   </data>
+  <data name="UnnecessaryStateHasChangedCall_FixTitle" xml:space="preserve">
+    <value>Remove unnecessary StateHasChanged call.</value>
+  </data>
 </root>

--- a/src/Components/Analyzers/src/StateHasChangedAnalyzer.cs
+++ b/src/Components/Analyzers/src/StateHasChangedAnalyzer.cs
@@ -89,6 +89,17 @@ public sealed class StateHasChangedAnalyzer : DiagnosticAnalyzer
                 var body = methodDeclaration.Body;
                 if (body is null)
                 {
+                    // Handle expression-bodied methods like: void OnInitialized() => StateHasChanged();
+                    var expressionBody = methodDeclaration.ExpressionBody;
+                    if (expressionBody is not null &&
+                        expressionBody.Expression is InvocationExpressionSyntax expressionBodyInvocation &&
+                        IsStateHasChangedCall(syntaxContext.SemanticModel, expressionBodyInvocation))
+                    {
+                        var expressionBodyCallLocations = new Dictionary<int, Location>();
+                        AddCallLocation(expressionBodyCallLocations, expressionBodyInvocation);
+                        redundantCallLocationsByMethod.TryAdd(methodSymbol, expressionBodyCallLocations.Values.ToImmutableArray());
+                    }
+
                     return;
                 }
 

--- a/src/Components/Analyzers/src/StateHasChangedAnalyzer.cs
+++ b/src/Components/Analyzers/src/StateHasChangedAnalyzer.cs
@@ -161,7 +161,8 @@ public sealed class StateHasChangedAnalyzer : DiagnosticAnalyzer
                     {
                         endContext.ReportDiagnostic(Diagnostic.Create(
                             DiagnosticDescriptors.UnnecessaryStateHasChangedCall,
-                            location));
+                            location,
+                            method.Name));
                     }
                 }
             });

--- a/src/Components/Analyzers/src/StateHasChangedAnalyzer.cs
+++ b/src/Components/Analyzers/src/StateHasChangedAnalyzer.cs
@@ -50,7 +50,7 @@ public sealed class StateHasChangedAnalyzer : DiagnosticAnalyzer
 
             var eventCallbackFactoryType = context.Compilation.GetTypeByMetadataName(EventCallbackFactoryTypeName);
             var eventHandlerMethods = new ConcurrentDictionary<IMethodSymbol, byte>(SymbolEqualityComparer.Default);
-            var redundantCallLocations = new ConcurrentBag<Location>();
+            var redundantCallLocationsByMethod = new ConcurrentDictionary<IMethodSymbol, ImmutableArray<Location>>(SymbolEqualityComparer.Default);
 
             // collect event handler methods
             context.RegisterOperationAction(operationContext =>
@@ -82,11 +82,6 @@ public sealed class StateHasChangedAnalyzer : DiagnosticAnalyzer
                 var methodDeclaration = (MethodDeclarationSyntax)syntaxContext.Node;
 
                 if (syntaxContext.SemanticModel.GetDeclaredSymbol(methodDeclaration) is not IMethodSymbol methodSymbol)
-                {
-                    return;
-                }
-
-                if (!IsTargetMethod(methodSymbol, eventHandlerMethods))
                 {
                     return;
                 }
@@ -136,19 +131,27 @@ public sealed class StateHasChangedAnalyzer : DiagnosticAnalyzer
                     return;
                 }
 
-                foreach (var location in callLocations.Values)
-                {
-                    redundantCallLocations.Add(location);
-                }
+                redundantCallLocationsByMethod.TryAdd(methodSymbol, callLocations.Values.ToImmutableArray());
             }, Microsoft.CodeAnalysis.CSharp.SyntaxKind.MethodDeclaration);
 
             context.RegisterSymbolEndAction(endContext =>
             {
-                foreach (var location in redundantCallLocations)
+                foreach (var methodAndLocations in redundantCallLocationsByMethod)
                 {
-                    endContext.ReportDiagnostic(Diagnostic.Create(
-                        DiagnosticDescriptors.UnnecessaryStateHasChangedCall,
-                        location));
+                    var method = methodAndLocations.Key;
+                    var locations = methodAndLocations.Value;
+
+                    if (!IsTargetMethod(method, eventHandlerMethods))
+                    {
+                        continue;
+                    }
+
+                    foreach (var location in locations)
+                    {
+                        endContext.ReportDiagnostic(Diagnostic.Create(
+                            DiagnosticDescriptors.UnnecessaryStateHasChangedCall,
+                            location));
+                    }
                 }
             });
         }, SymbolKind.NamedType);

--- a/src/Components/Analyzers/src/StateHasChangedAnalyzer.cs
+++ b/src/Components/Analyzers/src/StateHasChangedAnalyzer.cs
@@ -177,7 +177,7 @@ public sealed class StateHasChangedAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        if (IsTargetLifecycleMethod(method.OverriddenMethod ?? method))
+        if (method.OverriddenMethod is { } overridden && IsTargetLifecycleMethod(overridden))
         {
             return true;
         }
@@ -197,7 +197,8 @@ public sealed class StateHasChangedAnalyzer : DiagnosticAnalyzer
         return semanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol method &&
             method.MethodKind == MethodKind.Ordinary &&
             method.Parameters.Length == 0 &&
-            method.Name == "StateHasChanged";
+            method.Name == "StateHasChanged" &&
+            method.ContainingType.ToDisplayString() == ComponentsApi.ComponentBase.FullTypeName;
     }
 
     private static void AddCallLocation(Dictionary<int, Location> callLocations, InvocationExpressionSyntax stateCall)

--- a/src/Components/Analyzers/src/StateHasChangedAnalyzer.cs
+++ b/src/Components/Analyzers/src/StateHasChangedAnalyzer.cs
@@ -76,7 +76,7 @@ public sealed class StateHasChangedAnalyzer : DiagnosticAnalyzer
                 }
             }, OperationKind.Invocation);
 
-            // collect unncessary StateHasChanged calls
+            // collect unnecessary StateHasChanged calls
             context.RegisterSyntaxNodeAction(syntaxContext =>
             {
                 var methodDeclaration = (MethodDeclarationSyntax)syntaxContext.Node;

--- a/src/Components/Analyzers/src/StateHasChangedAnalyzer.cs
+++ b/src/Components/Analyzers/src/StateHasChangedAnalyzer.cs
@@ -1,0 +1,216 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+#nullable enable
+
+namespace Microsoft.AspNetCore.Components.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class StateHasChangedAnalyzer : DiagnosticAnalyzer
+{
+    private const string EventCallbackFactoryTypeName = "Microsoft.AspNetCore.Components.EventCallbackFactory";
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(DiagnosticDescriptors.UnnecessaryStateHasChangedCall);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
+        context.RegisterSymbolStartAction(context =>
+        {
+            if (!ComponentSymbols.TryCreate(context.Compilation, out var symbols))
+            {
+                // Types we need are not defined.
+                return;
+            }
+
+            if (symbols.ComponentBaseType is null)
+            {
+                // ComponentBase availability guard.
+                return;
+            }
+
+            var type = (INamedTypeSymbol)context.Symbol;
+            if (!ComponentFacts.IsComponentBase(symbols, type))
+            {
+                // only applies to ComponentBase derived types.
+                return;
+            }
+
+            var eventCallbackFactoryType = context.Compilation.GetTypeByMetadataName(EventCallbackFactoryTypeName);
+            var eventHandlerMethods = new ConcurrentDictionary<IMethodSymbol, byte>(SymbolEqualityComparer.Default);
+            var redundantCallLocations = new ConcurrentBag<Location>();
+
+            // collect event handler methods
+            context.RegisterOperationAction(operationContext =>
+            {
+                if (eventCallbackFactoryType is null)
+                {
+                    return;
+                }
+
+                var invocation = (IInvocationOperation)operationContext.Operation;
+                if (!SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.ContainingType, eventCallbackFactoryType))
+                {
+                    return;
+                }
+
+                foreach (var argument in invocation.Arguments)
+                {
+                    var method = TryGetMethodFromOperation(argument.Value);
+                    if (method is not null)
+                    {
+                        eventHandlerMethods.TryAdd(method, 0);
+                    }
+                }
+            }, OperationKind.Invocation);
+
+            // collect unncessary StateHasChanged calls
+            context.RegisterSyntaxNodeAction(syntaxContext =>
+            {
+                var methodDeclaration = (MethodDeclarationSyntax)syntaxContext.Node;
+
+                if (syntaxContext.SemanticModel.GetDeclaredSymbol(methodDeclaration) is not IMethodSymbol methodSymbol)
+                {
+                    return;
+                }
+
+                if (!IsTargetMethod(methodSymbol, eventHandlerMethods))
+                {
+                    return;
+                }
+
+                var body = methodDeclaration.Body;
+                if (body is null)
+                {
+                    return;
+                }
+
+                var awaitExpressions = body.DescendantNodes(static node => !IsNestedFunctionLike(node)).OfType<AwaitExpressionSyntax>().OrderBy(n => n.SpanStart).ToList();
+                var stateCalls = body.DescendantNodes(static node => !IsNestedFunctionLike(node)).OfType<InvocationExpressionSyntax>()
+                    .Where(invocation => IsStateHasChangedCall(syntaxContext.SemanticModel, invocation))
+                    .OrderBy(invocation => invocation.SpanStart)
+                    .ToList();
+                if (stateCalls.Count == 0)
+                {
+                    // no call, no problems.
+                    return;
+                }
+
+                var callLocations = new Dictionary<int, Location>();
+                if (awaitExpressions.Count == 0)
+                {
+                    // no await expressions, all calls are potentially redundant
+                    foreach (var stateCall in stateCalls)
+                    {
+                        AddCallLocation(callLocations, stateCall);
+                    }
+                }
+                else
+                {
+                    var firstAwaitStart = awaitExpressions[0].SpanStart;
+                    var lastAwaitStart = awaitExpressions[awaitExpressions.Count - 1].SpanStart;
+                    foreach (var stateCall in stateCalls)
+                    {
+                        if (stateCall.SpanStart < firstAwaitStart || stateCall.SpanStart > lastAwaitStart)
+                        {
+                            // any calls before the first await or after the last one are redundant, because ComponentBase calls StateHasChanged afterwards.
+                            AddCallLocation(callLocations, stateCall);
+                        }
+                    }
+                }
+
+                if (callLocations.Count == 0)
+                {
+                    return;
+                }
+
+                foreach (var location in callLocations.Values)
+                {
+                    redundantCallLocations.Add(location);
+                }
+            }, Microsoft.CodeAnalysis.CSharp.SyntaxKind.MethodDeclaration);
+
+            context.RegisterSymbolEndAction(endContext =>
+            {
+                foreach (var location in redundantCallLocations)
+                {
+                    endContext.ReportDiagnostic(Diagnostic.Create(
+                        DiagnosticDescriptors.UnnecessaryStateHasChangedCall,
+                        location));
+                }
+            });
+        }, SymbolKind.NamedType);
+    }
+
+    // Targets of this analyzer are lifecycle methods (OnInitialized, OnParametersSet) and event handlers
+    private static bool IsTargetMethod(IMethodSymbol method, ConcurrentDictionary<IMethodSymbol, byte> eventHandlerMethods)
+    {
+        if (method.MethodKind != MethodKind.Ordinary)
+        {
+            return false;
+        }
+
+        if (IsTargetLifecycleMethod(method.OverriddenMethod ?? method))
+        {
+            return true;
+        }
+
+        return eventHandlerMethods.ContainsKey(method);
+    }
+
+    private static bool IsTargetLifecycleMethod(IMethodSymbol method)
+    {
+        return method.MethodKind == MethodKind.Ordinary &&
+            method.Parameters.Length == 0 &&
+            method.Name is "OnInitialized" or "OnInitializedAsync" or "OnParametersSet" or "OnParametersSetAsync";
+    }
+
+    private static bool IsStateHasChangedCall(SemanticModel semanticModel, InvocationExpressionSyntax invocation)
+    {
+        return semanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol method &&
+            method.MethodKind == MethodKind.Ordinary &&
+            method.Parameters.Length == 0 &&
+            method.Name == "StateHasChanged";
+    }
+
+    private static void AddCallLocation(Dictionary<int, Location> callLocations, InvocationExpressionSyntax stateCall)
+    {
+        if (!callLocations.ContainsKey(stateCall.SpanStart))
+        {
+            callLocations[stateCall.SpanStart] = stateCall.GetLocation();
+        }
+    }
+
+    // Exclude local functions/lambdas because those have their own flow and execution timing.
+    private static bool IsNestedFunctionLike(SyntaxNode node)
+    {
+        return node is LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax;
+    }
+
+    private static IMethodSymbol? TryGetMethodFromOperation(IOperation operation)
+    {
+        switch (operation)
+        {
+            case IMethodReferenceOperation methodReference:
+                return methodReference.Method;
+            case IDelegateCreationOperation delegateCreation when delegateCreation.Target is not null:
+                return TryGetMethodFromOperation(delegateCreation.Target);
+            case IConversionOperation conversion:
+                return TryGetMethodFromOperation(conversion.Operand);
+            default:
+                return null;
+        }
+    }
+}

--- a/src/Components/Analyzers/src/StateHasChangedCodeFixProvider.cs
+++ b/src/Components/Analyzers/src/StateHasChangedCodeFixProvider.cs
@@ -76,6 +76,6 @@ public class StateHasChangedCodeFixProvider : CodeFixProvider
         }
 
         var newRoot = root.RemoveNode(nodeToRemove, SyntaxRemoveOptions.KeepExteriorTrivia);
-        return Task.FromResult(document.WithSyntaxRoot(newRoot));
+        return Task.FromResult(newRoot is null ? document : document.WithSyntaxRoot(newRoot));
     }
 }

--- a/src/Components/Analyzers/src/StateHasChangedCodeFixProvider.cs
+++ b/src/Components/Analyzers/src/StateHasChangedCodeFixProvider.cs
@@ -48,7 +48,7 @@ public class StateHasChangedCodeFixProvider : CodeFixProvider
             return;
         }
 
-        var title = Title.ToString(CultureInfo.InvariantCulture);
+        var title = Title.ToString(CultureInfo.CurrentCulture);
         context.RegisterCodeFix(
             CodeAction.Create(
                 title: title,
@@ -65,7 +65,7 @@ public class StateHasChangedCodeFixProvider : CodeFixProvider
             ? (SyntaxNode)expressionStatement
             : invocation;
 
-        var newRoot = root.RemoveNode(nodeToRemove, SyntaxRemoveOptions.KeepNoTrivia);
+        var newRoot = root.RemoveNode(nodeToRemove, SyntaxRemoveOptions.KeepExteriorTrivia);
         return Task.FromResult(document.WithSyntaxRoot(newRoot));
     }
 }

--- a/src/Components/Analyzers/src/StateHasChangedCodeFixProvider.cs
+++ b/src/Components/Analyzers/src/StateHasChangedCodeFixProvider.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.AspNetCore.Components.Analyzers;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(StateHasChangedCodeFixProvider)), Shared]
+public class StateHasChangedCodeFixProvider : CodeFixProvider
+{
+    private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.UnnecessaryStateHasChangedCall_FixTitle), Resources.ResourceManager, typeof(Resources));
+
+    public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id);
+
+    public sealed override FixAllProvider GetFixAllProvider()
+    {
+        return WellKnownFixAllProviders.BatchFixer;
+    }
+
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+        {
+            return;
+        }
+
+        var diagnostic = context.Diagnostics.First();
+        var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+        var invocation = root.FindToken(diagnosticSpan.Start)
+            .Parent?
+            .AncestorsAndSelf()
+            .OfType<InvocationExpressionSyntax>()
+            .FirstOrDefault();
+
+        if (invocation is null)
+        {
+            return;
+        }
+
+        var title = Title.ToString(CultureInfo.InvariantCulture);
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: title,
+                createChangedDocument: cancellationToken => RemoveStateHasChangedCallAsync(context.Document, root, invocation, cancellationToken),
+                equivalenceKey: title),
+            diagnostic);
+    }
+
+    private static Task<Document> RemoveStateHasChangedCallAsync(Document document, SyntaxNode root, InvocationExpressionSyntax invocation, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var nodeToRemove = invocation.Parent is ExpressionStatementSyntax expressionStatement
+            ? (SyntaxNode)expressionStatement
+            : invocation;
+
+        var newRoot = root.RemoveNode(nodeToRemove, SyntaxRemoveOptions.KeepNoTrivia);
+        return Task.FromResult(document.WithSyntaxRoot(newRoot));
+    }
+}

--- a/src/Components/Analyzers/src/StateHasChangedCodeFixProvider.cs
+++ b/src/Components/Analyzers/src/StateHasChangedCodeFixProvider.cs
@@ -61,9 +61,19 @@ public class StateHasChangedCodeFixProvider : CodeFixProvider
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var nodeToRemove = invocation.Parent is ExpressionStatementSyntax expressionStatement
-            ? (SyntaxNode)expressionStatement
-            : invocation;
+        SyntaxNode nodeToRemove;
+        if (invocation.Parent is ExpressionStatementSyntax expressionStatement)
+        {
+            nodeToRemove = expressionStatement;
+        }
+        else if (invocation.Parent is ArrowExpressionClauseSyntax { Parent: MethodDeclarationSyntax containingMethod })
+        {
+            nodeToRemove = containingMethod;
+        }
+        else
+        {
+            nodeToRemove = invocation;
+        }
 
         var newRoot = root.RemoveNode(nodeToRemove, SyntaxRemoveOptions.KeepExteriorTrivia);
         return Task.FromResult(document.WithSyntaxRoot(newRoot));

--- a/src/Components/Analyzers/test/StateHasChangedAnalyzerTest.cs
+++ b/src/Components/Analyzers/test/StateHasChangedAnalyzerTest.cs
@@ -89,14 +89,14 @@ public class StateHasChangedAnalyzerTest : DiagnosticVerifier
             new DiagnosticResult
             {
                 Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
-                Message = "StateHasChanged is unnecessary here and can be removed.",
+                Message = "StateHasChanged is unnecessary in method 'OnInitialized' and can be removed.",
                 Severity = DiagnosticSeverity.Warning,
                 Locations = new[] { new DiagnosticResultLocation("Test0.cs", 10, 17) }
             },
             new DiagnosticResult
             {
                 Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
-                Message = "StateHasChanged is unnecessary here and can be removed.",
+                Message = "StateHasChanged is unnecessary in method 'OnParametersSet' and can be removed.",
                 Severity = DiagnosticSeverity.Warning,
                 Locations = new[] { new DiagnosticResultLocation("Test0.cs", 15, 17) }
             });
@@ -154,28 +154,28 @@ public class StateHasChangedAnalyzerTest : DiagnosticVerifier
             new DiagnosticResult
             {
                 Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
-                Message = "StateHasChanged is unnecessary here and can be removed.",
+                Message = "StateHasChanged is unnecessary in method 'OnInitializedAsync' and can be removed.",
                 Severity = DiagnosticSeverity.Warning,
                 Locations = new[] { new DiagnosticResultLocation("Test0.cs", 14, 17) }
             },
             new DiagnosticResult
             {
                 Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
-                Message = "StateHasChanged is unnecessary here and can be removed.",
+                Message = "StateHasChanged is unnecessary in method 'OnInitializedAsync' and can be removed.",
                 Severity = DiagnosticSeverity.Warning,
                 Locations = new[] { new DiagnosticResultLocation("Test0.cs", 24, 17) }
             },
             new DiagnosticResult
             {
                 Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
-                Message = "StateHasChanged is unnecessary here and can be removed.",
+                Message = "StateHasChanged is unnecessary in method 'OnParametersSetAsync' and can be removed.",
                 Severity = DiagnosticSeverity.Warning,
                 Locations = new[] { new DiagnosticResultLocation("Test0.cs", 30, 17) }
             },
             new DiagnosticResult
             {
                 Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
-                Message = "StateHasChanged is unnecessary here and can be removed.",
+                Message = "StateHasChanged is unnecessary in method 'OnParametersSetAsync' and can be removed.",
                 Severity = DiagnosticSeverity.Warning,
                 Locations = new[] { new DiagnosticResultLocation("Test0.cs", 40, 17) }
             });
@@ -219,14 +219,14 @@ public class StateHasChangedAnalyzerTest : DiagnosticVerifier
             new DiagnosticResult
             {
                 Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
-                Message = "StateHasChanged is unnecessary here and can be removed.",
+                Message = "StateHasChanged is unnecessary in method 'OnRefreshClicked' and can be removed.",
                 Severity = DiagnosticSeverity.Warning,
                 Locations = new[] { new DiagnosticResultLocation("Test0.cs", 16, 17) }
             },
             new DiagnosticResult
             {
                 Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
-                Message = "StateHasChanged is unnecessary here and can be removed.",
+                Message = "StateHasChanged is unnecessary in method 'OnRefreshClicked' and can be removed.",
                 Severity = DiagnosticSeverity.Warning,
                 Locations = new[] { new DiagnosticResultLocation("Test0.cs", 26, 17) }
             });
@@ -253,14 +253,14 @@ public class StateHasChangedAnalyzerTest : DiagnosticVerifier
             new DiagnosticResult
             {
                 Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
-                Message = "StateHasChanged is unnecessary here and can be removed.",
+                Message = "StateHasChanged is unnecessary in method 'OnInitialized' and can be removed.",
                 Severity = DiagnosticSeverity.Warning,
                 Locations = new[] { new DiagnosticResultLocation("Test0.cs", 8, 56) }
             },
             new DiagnosticResult
             {
                 Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
-                Message = "StateHasChanged is unnecessary here and can be removed.",
+                Message = "StateHasChanged is unnecessary in method 'OnParametersSet' and can be removed.",
                 Severity = DiagnosticSeverity.Warning,
                 Locations = new[] { new DiagnosticResultLocation("Test0.cs", 10, 58) }
             });

--- a/src/Components/Analyzers/test/StateHasChangedAnalyzerTest.cs
+++ b/src/Components/Analyzers/test/StateHasChangedAnalyzerTest.cs
@@ -74,13 +74,11 @@ public class StateHasChangedAnalyzerTest : DiagnosticVerifier
         {
             protected override void OnInitialized()
             {
-                // unnecesary
                 StateHasChanged();
             }
 
             protected override void OnParametersSet()
             {
-                // unnecesary
                 StateHasChanged();
             }
         }
@@ -93,14 +91,14 @@ public class StateHasChangedAnalyzerTest : DiagnosticVerifier
                 Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
                 Message = "StateHasChanged is unnecessary here and can be removed.",
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 11, 17) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 10, 17) }
             },
             new DiagnosticResult
             {
                 Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
                 Message = "StateHasChanged is unnecessary here and can be removed.",
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 17, 17) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 15, 17) }
             });
     }
 
@@ -119,38 +117,32 @@ public class StateHasChangedAnalyzerTest : DiagnosticVerifier
             protected override async Task OnInitializedAsync()
             {
                 _refreshCount++;
-                // unnecesary
                 StateHasChanged();
 
                 await Task.Delay(1);
 
                 _refreshCount++;
-                // necesary
                 StateHasChanged();
 
                 await Task.Delay(1);
 
                 _refreshCount++;
-                // unnecesary
                 StateHasChanged();
             }
 
             protected override async Task OnParametersSetAsync()
             {
                 _refreshCount++;
-                // unnecesary
                 StateHasChanged();
 
                 await Task.Delay(1);
 
                 _refreshCount++;
-                // necesary
                 StateHasChanged();
 
                 await Task.Delay(1);
 
                 _refreshCount++;
-                // unnecesary
                 StateHasChanged();
             }
         }
@@ -163,28 +155,28 @@ public class StateHasChangedAnalyzerTest : DiagnosticVerifier
                 Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
                 Message = "StateHasChanged is unnecessary here and can be removed.",
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 14, 17) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 13, 17) }
             },
             new DiagnosticResult
             {
                 Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
                 Message = "StateHasChanged is unnecessary here and can be removed.",
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 26, 17) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 23, 17) }
             },
             new DiagnosticResult
             {
                 Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
                 Message = "StateHasChanged is unnecessary here and can be removed.",
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 33, 17) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 29, 17) }
             },
             new DiagnosticResult
             {
                 Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
                 Message = "StateHasChanged is unnecessary here and can be removed.",
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 45, 17) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 39, 17) }
             });
     }
 
@@ -206,19 +198,16 @@ public class StateHasChangedAnalyzerTest : DiagnosticVerifier
             private async Task OnRefreshClicked()
             {
                 _refreshCount++;
-                // unnecesary
                 StateHasChanged();
 
                 await Task.Delay(1);
 
                 _refreshCount++;
-                // necesary
                 StateHasChanged();
 
                 await Task.Delay(1);
 
                 _refreshCount++;
-                // unnecesary
                 StateHasChanged();
             }
         }
@@ -231,14 +220,14 @@ public class StateHasChangedAnalyzerTest : DiagnosticVerifier
                 Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
                 Message = "StateHasChanged is unnecessary here and can be removed.",
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 17, 17) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 16, 17) }
             },
             new DiagnosticResult
             {
                 Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
                 Message = "StateHasChanged is unnecessary here and can be removed.",
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 29, 17) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 26, 17) }
             });
     }
 }

--- a/src/Components/Analyzers/test/StateHasChangedAnalyzerTest.cs
+++ b/src/Components/Analyzers/test/StateHasChangedAnalyzerTest.cs
@@ -39,7 +39,11 @@ public class StateHasChangedAnalyzerTest : DiagnosticVerifier
 
         public sealed class EventCallbackFactory
         {
+            public EventCallback Create(object receiver, Action callback) => default;
+
             public EventCallback Create(object receiver, Func<Task> callback) => default;
+
+            public EventCallback Create<T>(object receiver, Action<T> callback) => default;
         }
 
         public abstract class ComponentBase : IComponent
@@ -55,6 +59,8 @@ public class StateHasChangedAnalyzerTest : DiagnosticVerifier
             protected virtual Task OnParametersSetAsync() => Task.CompletedTask;
 
             public virtual Task SetParametersAsync(ParameterView parameters) => Task.CompletedTask;
+
+            protected Task InvokeAsync(Action workItem) => Task.CompletedTask;
 
             protected void StateHasChanged() { }
         }
@@ -264,5 +270,351 @@ public class StateHasChangedAnalyzerTest : DiagnosticVerifier
                 Severity = DiagnosticSeverity.Warning,
                 Locations = new[] { new DiagnosticResultLocation("Test0.cs", 10, 58) }
             });
+    }
+
+    [Fact]
+    public void SyncEventHandlerAction_WithStateHasChanged_ReportsDiagnostic()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+
+        class TestComponent : ComponentBase
+        {
+            public EventCallback OnRefresh => EventCallbackFactory.Create(this, OnRefreshClicked);
+
+            private void OnRefreshClicked()
+            {
+                StateHasChanged();
+            }
+        }
+    }" + ComponentDeclarations;
+
+        VerifyCSharpDiagnostic(
+            test,
+            new DiagnosticResult
+            {
+                Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
+                Message = "StateHasChanged is unnecessary in method 'OnRefreshClicked' and can be removed.",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 12, 17) }
+            });
+    }
+
+    [Fact]
+    public void SingleAwaitLifecycleMethod_WithStateHasChanged_ReportsDiagnostic()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+        using System.Threading.Tasks;
+
+        class TestComponent : ComponentBase
+        {
+            protected override async Task OnInitializedAsync()
+            {
+                StateHasChanged();
+
+                await Task.Delay(1);
+            }
+        }
+    }" + ComponentDeclarations;
+
+        VerifyCSharpDiagnostic(
+            test,
+            new DiagnosticResult
+            {
+                Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
+                Message = "StateHasChanged is unnecessary in method 'OnInitializedAsync' and can be removed.",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 11, 17) }
+            });
+    }
+
+    [Fact]
+    public void SingleAwaitEventHandler_WithStateHasChanged_ReportsDiagnostic()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using System.Threading.Tasks;
+        using Microsoft.AspNetCore.Components;
+
+        class TestComponent : ComponentBase
+        {
+            public EventCallback OnRefresh => EventCallbackFactory.Create(this, OnRefreshClicked);
+
+            private async Task OnRefreshClicked()
+            {
+                StateHasChanged();
+
+                await Task.Delay(1);
+            }
+        }
+    }" + ComponentDeclarations;
+
+        VerifyCSharpDiagnostic(
+            test,
+            new DiagnosticResult
+            {
+                Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
+                Message = "StateHasChanged is unnecessary in method 'OnRefreshClicked' and can be removed.",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 13, 17) }
+            });
+    }
+
+    [Fact]
+    public void ExpressionBodiedEventHandler_WithStateHasChanged_ReportsDiagnostic()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+
+        class TestComponent : ComponentBase
+        {
+            public EventCallback OnRefresh => EventCallbackFactory.Create(this, OnRefreshClicked);
+
+            private void OnRefreshClicked() => StateHasChanged();
+        }
+    }" + ComponentDeclarations;
+
+        VerifyCSharpDiagnostic(
+            test,
+            new DiagnosticResult
+            {
+                Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
+                Message = "StateHasChanged is unnecessary in method 'OnRefreshClicked' and can be removed.",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 10, 48) }
+            });
+    }
+
+    [Fact]
+    public void MultiLevelInheritance_WithStateHasChanged_ReportsDiagnostic()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+
+        class MyBase : ComponentBase
+        {
+        }
+
+        class TestComponent : MyBase
+        {
+            protected override void OnInitialized()
+            {
+                StateHasChanged();
+            }
+        }
+    }" + ComponentDeclarations;
+
+        VerifyCSharpDiagnostic(
+            test,
+            new DiagnosticResult
+            {
+                Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
+                Message = "StateHasChanged is unnecessary in method 'OnInitialized' and can be removed.",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 14, 17) }
+            });
+    }
+
+    [Fact]
+    public void ExplicitThisQualifier_WithStateHasChanged_ReportsDiagnostic()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+
+        class TestComponent : ComponentBase
+        {
+            protected override void OnInitialized()
+            {
+                this.StateHasChanged();
+            }
+        }
+    }" + ComponentDeclarations;
+
+        VerifyCSharpDiagnostic(
+            test,
+            new DiagnosticResult
+            {
+                Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
+                Message = "StateHasChanged is unnecessary in method 'OnInitialized' and can be removed.",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 10, 17) }
+            });
+    }
+
+    [Fact]
+    public void SyncEventHandlerActionOfT_WithStateHasChanged_ReportsDiagnostic()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+
+        class TestComponent : ComponentBase
+        {
+            public EventCallback OnCountChangedCallback => EventCallbackFactory.Create<int>(this, OnCountChanged);
+
+            private void OnCountChanged(int value)
+            {
+                StateHasChanged();
+            }
+        }
+    }" + ComponentDeclarations;
+
+        VerifyCSharpDiagnostic(
+            test,
+            new DiagnosticResult
+            {
+                Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
+                Message = "StateHasChanged is unnecessary in method 'OnCountChanged' and can be removed.",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 12, 17) }
+            });
+    }
+
+    [Fact]
+    public void StateHasChangedBetweenTwoAwaits_DoesNotReportDiagnostic()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using System.Threading.Tasks;
+        using Microsoft.AspNetCore.Components;
+
+        class TestComponent : ComponentBase
+        {
+            protected override async Task OnInitializedAsync()
+            {
+                await Task.Delay(1);
+
+                StateHasChanged();
+
+                await Task.Delay(1);
+            }
+        }
+    }" + ComponentDeclarations;
+
+        VerifyCSharpDiagnostic(test);
+    }
+
+    [Fact]
+    public void NonComponentBaseClassWithOnInitialized_DoesNotReportDiagnostic()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        class TestComponent
+        {
+            protected void OnInitialized()
+            {
+                StateHasChanged();
+            }
+
+            protected void StateHasChanged()
+            {
+            }
+        }
+    }" + ComponentDeclarations;
+
+        VerifyCSharpDiagnostic(test);
+    }
+
+    [Fact]
+    public void StateHasChangedInsideNestedFunctionLike_DoesNotReportDiagnostic()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+
+        class TestComponent : ComponentBase
+        {
+            protected override void OnInitialized()
+            {
+                void Refresh() => StateHasChanged();
+                System.Action refresh = () => StateHasChanged();
+
+                Refresh();
+                refresh();
+            }
+        }
+    }" + ComponentDeclarations;
+
+        VerifyCSharpDiagnostic(test);
+    }
+
+    [Fact]
+    public void StateHasChangedInInvokeAsyncLambda_DoesNotReportDiagnostic()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+        using System.Threading.Tasks;
+
+        class TestComponent : ComponentBase
+        {
+            protected override async Task OnInitializedAsync()
+            {
+                await InvokeAsync(() => StateHasChanged());
+            }
+        }
+    }" + ComponentDeclarations;
+
+        VerifyCSharpDiagnostic(test);
+    }
+
+    [Fact]
+    public void PrivateMethodThatIsNotEventHandler_DoesNotReportDiagnostic()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+
+        class TestComponent : ComponentBase
+        {
+            private void Refresh()
+            {
+                StateHasChanged();
+            }
+        }
+    }" + ComponentDeclarations;
+
+        VerifyCSharpDiagnostic(test);
+    }
+
+    [Fact]
+    public void SetParametersAsync_WithStateHasChanged_DoesNotReportDiagnostic()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using System.Threading.Tasks;
+        using Microsoft.AspNetCore.Components;
+
+        class TestComponent : ComponentBase
+        {
+            public override Task SetParametersAsync(ParameterView parameters)
+            {
+                StateHasChanged();
+
+                return Task.CompletedTask;
+            }
+        }
+    }" + ComponentDeclarations;
+
+        VerifyCSharpDiagnostic(test);
     }
 }

--- a/src/Components/Analyzers/test/StateHasChangedAnalyzerTest.cs
+++ b/src/Components/Analyzers/test/StateHasChangedAnalyzerTest.cs
@@ -109,6 +109,7 @@ public class StateHasChangedAnalyzerTest : DiagnosticVerifier
     namespace ConsoleApplication1
     {
         using Microsoft.AspNetCore.Components;
+        using System.Threading.Tasks;
 
         class TestComponent : ComponentBase
         {
@@ -155,28 +156,28 @@ public class StateHasChangedAnalyzerTest : DiagnosticVerifier
                 Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
                 Message = "StateHasChanged is unnecessary here and can be removed.",
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 13, 17) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 14, 17) }
             },
             new DiagnosticResult
             {
                 Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
                 Message = "StateHasChanged is unnecessary here and can be removed.",
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 23, 17) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 24, 17) }
             },
             new DiagnosticResult
             {
                 Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
                 Message = "StateHasChanged is unnecessary here and can be removed.",
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 29, 17) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 30, 17) }
             },
             new DiagnosticResult
             {
                 Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
                 Message = "StateHasChanged is unnecessary here and can be removed.",
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 39, 17) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 40, 17) }
             });
     }
 

--- a/src/Components/Analyzers/test/StateHasChangedAnalyzerTest.cs
+++ b/src/Components/Analyzers/test/StateHasChangedAnalyzerTest.cs
@@ -231,4 +231,38 @@ public class StateHasChangedAnalyzerTest : DiagnosticVerifier
                 Locations = new[] { new DiagnosticResultLocation("Test0.cs", 26, 17) }
             });
     }
+
+    [Fact]
+    public void ExpressionBodyLifecycleMethod_WithStateHasChanged_ReportsDiagnostic()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+
+        class TestComponent : ComponentBase
+        {
+            protected override void OnInitialized() => StateHasChanged();
+
+            protected override void OnParametersSet() => StateHasChanged();
+        }
+    }" + ComponentDeclarations;
+
+        VerifyCSharpDiagnostic(
+            test,
+            new DiagnosticResult
+            {
+                Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
+                Message = "StateHasChanged is unnecessary here and can be removed.",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 8, 56) }
+            },
+            new DiagnosticResult
+            {
+                Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
+                Message = "StateHasChanged is unnecessary here and can be removed.",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 10, 58) }
+            });
+    }
 }

--- a/src/Components/Analyzers/test/StateHasChangedAnalyzerTest.cs
+++ b/src/Components/Analyzers/test/StateHasChangedAnalyzerTest.cs
@@ -1,0 +1,244 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using TestHelper;
+
+namespace Microsoft.AspNetCore.Components.Analyzers.Test;
+
+public class StateHasChangedAnalyzerTest : DiagnosticVerifier
+{
+    protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new StateHasChangedAnalyzer();
+
+    private static readonly string ComponentDeclarations = @"
+    namespace Microsoft.AspNetCore.Components
+    {
+        using System;
+        using System.Threading.Tasks;
+
+        public struct ParameterView
+        {
+        }
+
+        public sealed class ParameterAttribute : Attribute
+        {
+            public bool CaptureUnmatchedValues { get; set; }
+        }
+
+        public sealed class CascadingParameterAttribute : Attribute
+        {
+        }
+
+        public interface IComponent { }
+
+        public struct EventCallback
+        {
+            public EventCallback(Func<Task> callback) { }
+        }
+
+        public sealed class EventCallbackFactory
+        {
+            public EventCallback Create(object receiver, Func<Task> callback) => default;
+        }
+
+        public abstract class ComponentBase : IComponent
+        {
+            public EventCallbackFactory EventCallbackFactory => default;
+
+            protected virtual void OnInitialized() { }
+
+            protected virtual Task OnInitializedAsync() => Task.CompletedTask;
+
+            protected virtual void OnParametersSet() { }
+
+            protected virtual Task OnParametersSetAsync() => Task.CompletedTask;
+
+            public virtual Task SetParametersAsync(ParameterView parameters) => Task.CompletedTask;
+
+            protected void StateHasChanged() { }
+        }
+    }
+";
+
+    [Fact]
+    public void OnLifecycleEvents_WithStateHasChanged_ReportsDiagnostic()
+    {
+
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+
+        class TestComponent : ComponentBase
+        {
+            protected override void OnInitialized()
+            {
+                // unnecesary
+                StateHasChanged();
+            }
+
+            protected override void OnParametersSet()
+            {
+                // unnecesary
+                StateHasChanged();
+            }
+        }
+    }" + ComponentDeclarations;
+
+        VerifyCSharpDiagnostic(
+            test,
+            new DiagnosticResult
+            {
+                Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
+                Message = "StateHasChanged is unnecessary here and can be removed.",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 11, 17) }
+            },
+            new DiagnosticResult
+            {
+                Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
+                Message = "StateHasChanged is unnecessary here and can be removed.",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 17, 17) }
+            });
+    }
+
+    [Fact]
+    public void OnAsyncLifecycleEvents_WithStateHasChanged_ReportsDiagnostic()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+
+        class TestComponent : ComponentBase
+        {
+            private int _refreshCount;
+
+            protected override async Task OnInitializedAsync()
+            {
+                _refreshCount++;
+                // unnecesary
+                StateHasChanged();
+
+                await Task.Delay(1);
+
+                _refreshCount++;
+                // necesary
+                StateHasChanged();
+
+                await Task.Delay(1);
+
+                _refreshCount++;
+                // unnecesary
+                StateHasChanged();
+            }
+
+            protected override async Task OnParametersSetAsync()
+            {
+                _refreshCount++;
+                // unnecesary
+                StateHasChanged();
+
+                await Task.Delay(1);
+
+                _refreshCount++;
+                // necesary
+                StateHasChanged();
+
+                await Task.Delay(1);
+
+                _refreshCount++;
+                // unnecesary
+                StateHasChanged();
+            }
+        }
+    }" + ComponentDeclarations;
+
+        VerifyCSharpDiagnostic(
+            test,
+            new DiagnosticResult
+            {
+                Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
+                Message = "StateHasChanged is unnecessary here and can be removed.",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 14, 17) }
+            },
+            new DiagnosticResult
+            {
+                Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
+                Message = "StateHasChanged is unnecessary here and can be removed.",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 26, 17) }
+            },
+            new DiagnosticResult
+            {
+                Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
+                Message = "StateHasChanged is unnecessary here and can be removed.",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 33, 17) }
+            },
+            new DiagnosticResult
+            {
+                Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
+                Message = "StateHasChanged is unnecessary here and can be removed.",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 45, 17) }
+            });
+    }
+
+    [Fact]
+    public void EventHandler_ReportsRedundantStateHasChangedCalls()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using System.Threading.Tasks;
+        using Microsoft.AspNetCore.Components;
+
+        class TestComponent : ComponentBase
+        {
+            private int _refreshCount;
+
+            public EventCallback OnRefresh => EventCallbackFactory.Create(this, OnRefreshClicked);
+
+            private async Task OnRefreshClicked()
+            {
+                _refreshCount++;
+                // unnecesary
+                StateHasChanged();
+
+                await Task.Delay(1);
+
+                _refreshCount++;
+                // necesary
+                StateHasChanged();
+
+                await Task.Delay(1);
+
+                _refreshCount++;
+                // unnecesary
+                StateHasChanged();
+            }
+        }
+    }" + ComponentDeclarations;
+
+        VerifyCSharpDiagnostic(
+            test,
+            new DiagnosticResult
+            {
+                Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
+                Message = "StateHasChanged is unnecessary here and can be removed.",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 17, 17) }
+            },
+            new DiagnosticResult
+            {
+                Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
+                Message = "StateHasChanged is unnecessary here and can be removed.",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 29, 17) }
+            });
+    }
+}

--- a/src/Components/Analyzers/test/StateHasChangedCodeFixProviderTest.cs
+++ b/src/Components/Analyzers/test/StateHasChangedCodeFixProviderTest.cs
@@ -37,6 +37,8 @@ public class StateHasChangedCodeFixProviderTest : CodeFixVerifier
 
         public sealed class EventCallbackFactory
         {
+            public EventCallback Create(object receiver, Action callback) => default;
+
             public EventCallback Create(object receiver, Func<Task> callback) => default;
         }
 
@@ -159,6 +161,122 @@ public class StateHasChangedCodeFixProviderTest : CodeFixVerifier
         class TestComponent : ComponentBase
         {
             
+        }
+    }" + ComponentDeclarations;
+
+        VerifyCSharpFix(oldSource, newSource);
+    }
+
+    [Fact]
+    public void SyncEventHandler_RemovesUnnecessaryStateHasChangedCall()
+    {
+        var oldSource = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+
+        class TestComponent : ComponentBase
+        {
+            public EventCallback OnRefresh => EventCallbackFactory.Create(this, OnRefreshClicked);
+
+            private void OnRefreshClicked()
+            {
+                StateHasChanged();
+                var value = 1;
+            }
+        }
+    }" + ComponentDeclarations;
+
+        var newSource = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+
+        class TestComponent : ComponentBase
+        {
+            public EventCallback OnRefresh => EventCallbackFactory.Create(this, OnRefreshClicked);
+
+            private void OnRefreshClicked()
+            {
+                
+                var value = 1;
+            }
+        }
+    }" + ComponentDeclarations;
+
+        VerifyCSharpFix(oldSource, newSource);
+    }
+
+    [Fact]
+    public void ExpressionBodyOnParametersSetMethod_RemovesEntireMethod()
+    {
+        var oldSource = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+
+        class TestComponent : ComponentBase
+        {
+            protected override void OnParametersSet() => StateHasChanged();
+        }
+    }" + ComponentDeclarations;
+
+        var newSource = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+
+        class TestComponent : ComponentBase
+        {
+            
+        }
+    }" + ComponentDeclarations;
+
+        VerifyCSharpFix(oldSource, newSource);
+    }
+
+    [Fact]
+    public void EventHandler_WithStateHasChangedBetweenAwaits_RemovesOnlyRedundantCalls()
+    {
+        var oldSource = @"
+    namespace ConsoleApplication1
+    {
+        using System.Threading.Tasks;
+        using Microsoft.AspNetCore.Components;
+
+        class TestComponent : ComponentBase
+        {
+            public EventCallback OnRefresh => EventCallbackFactory.Create(this, OnRefreshClicked);
+
+            private async Task OnRefreshClicked()
+            {
+                StateHasChanged();
+                await Task.Delay(1);
+                StateHasChanged();
+                await Task.Delay(1);
+                StateHasChanged();
+            }
+        }
+    }" + ComponentDeclarations;
+
+        var newSource = @"
+    namespace ConsoleApplication1
+    {
+        using System.Threading.Tasks;
+        using Microsoft.AspNetCore.Components;
+
+        class TestComponent : ComponentBase
+        {
+            public EventCallback OnRefresh => EventCallbackFactory.Create(this, OnRefreshClicked);
+
+            private async Task OnRefreshClicked()
+            {
+                
+                await Task.Delay(1);
+                StateHasChanged();
+                await Task.Delay(1);
+                
+            }
         }
     }" + ComponentDeclarations;
 

--- a/src/Components/Analyzers/test/StateHasChangedCodeFixProviderTest.cs
+++ b/src/Components/Analyzers/test/StateHasChangedCodeFixProviderTest.cs
@@ -85,6 +85,7 @@ public class StateHasChangedCodeFixProviderTest : CodeFixVerifier
         {
             protected override void OnInitialized()
             {
+                
             }
         }
     }" + ComponentDeclarations;
@@ -124,9 +125,11 @@ public class StateHasChangedCodeFixProviderTest : CodeFixVerifier
         {
             protected override async Task OnInitializedAsync()
             {
+                
                 await Task.Delay(1);
                 StateHasChanged();
                 await Task.Delay(1);
+                
             }
         }
     }" + ComponentDeclarations;

--- a/src/Components/Analyzers/test/StateHasChangedCodeFixProviderTest.cs
+++ b/src/Components/Analyzers/test/StateHasChangedCodeFixProviderTest.cs
@@ -1,0 +1,140 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using TestHelper;
+
+namespace Microsoft.AspNetCore.Components.Analyzers.Test;
+
+public class StateHasChangedCodeFixProviderTest : CodeFixVerifier
+{
+    private static readonly string ComponentDeclarations = @"
+    namespace Microsoft.AspNetCore.Components
+    {
+        using System;
+        using System.Threading.Tasks;
+
+        public struct ParameterView
+        {
+        }
+
+        public sealed class ParameterAttribute : Attribute
+        {
+            public bool CaptureUnmatchedValues { get; set; }
+        }
+
+        public sealed class CascadingParameterAttribute : Attribute
+        {
+        }
+
+        public interface IComponent { }
+
+        public struct EventCallback
+        {
+            public EventCallback(Func<Task> callback) { }
+        }
+
+        public sealed class EventCallbackFactory
+        {
+            public EventCallback Create(object receiver, Func<Task> callback) => default;
+        }
+
+        public abstract class ComponentBase : IComponent
+        {
+            public EventCallbackFactory EventCallbackFactory => default;
+
+            protected virtual void OnInitialized() { }
+
+            protected virtual Task OnInitializedAsync() => Task.CompletedTask;
+
+            protected virtual void OnParametersSet() { }
+
+            protected virtual Task OnParametersSetAsync() => Task.CompletedTask;
+
+            public virtual Task SetParametersAsync(ParameterView parameters) => Task.CompletedTask;
+
+            protected void StateHasChanged() { }
+        }
+    }
+";
+
+    [Fact]
+    public void OnLifecycleMethod_RemovesUnnecessaryStateHasChangedCall()
+    {
+        var oldSource = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+
+        class TestComponent : ComponentBase
+        {
+            protected override void OnInitialized()
+            {
+                StateHasChanged();
+            }
+        }
+    }" + ComponentDeclarations;
+
+        var newSource = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+
+        class TestComponent : ComponentBase
+        {
+            protected override void OnInitialized()
+            {
+            }
+        }
+    }" + ComponentDeclarations;
+
+        VerifyCSharpFix(oldSource, newSource);
+    }
+
+    [Fact]
+    public void OnAsyncLifecycleMethod_RemovesOnlyReportedStateHasChangedCalls()
+    {
+        var oldSource = @"
+    namespace ConsoleApplication1
+    {
+        using System.Threading.Tasks;
+        using Microsoft.AspNetCore.Components;
+
+        class TestComponent : ComponentBase
+        {
+            protected override async Task OnInitializedAsync()
+            {
+                StateHasChanged();
+                await Task.Delay(1);
+                StateHasChanged();
+                await Task.Delay(1);
+                StateHasChanged();
+            }
+        }
+    }" + ComponentDeclarations;
+
+        var newSource = @"
+    namespace ConsoleApplication1
+    {
+        using System.Threading.Tasks;
+        using Microsoft.AspNetCore.Components;
+
+        class TestComponent : ComponentBase
+        {
+            protected override async Task OnInitializedAsync()
+            {
+                await Task.Delay(1);
+                StateHasChanged();
+                await Task.Delay(1);
+            }
+        }
+    }" + ComponentDeclarations;
+
+        VerifyCSharpFix(oldSource, newSource);
+    }
+
+    protected override CodeFixProvider GetCSharpCodeFixProvider() => new StateHasChangedCodeFixProvider();
+
+    protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new StateHasChangedAnalyzer();
+}

--- a/src/Components/Analyzers/test/StateHasChangedCodeFixProviderTest.cs
+++ b/src/Components/Analyzers/test/StateHasChangedCodeFixProviderTest.cs
@@ -137,6 +137,34 @@ public class StateHasChangedCodeFixProviderTest : CodeFixVerifier
         VerifyCSharpFix(oldSource, newSource);
     }
 
+    [Fact]
+    public void ExpressionBodyLifecycleMethod_RemovesEntireMethod()
+    {
+        var oldSource = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+
+        class TestComponent : ComponentBase
+        {
+            protected override void OnInitialized() => StateHasChanged();
+        }
+    }" + ComponentDeclarations;
+
+        var newSource = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+
+        class TestComponent : ComponentBase
+        {
+            
+        }
+    }" + ComponentDeclarations;
+
+        VerifyCSharpFix(oldSource, newSource);
+    }
+
     protected override CodeFixProvider GetCSharpCodeFixProvider() => new StateHasChangedCodeFixProvider();
 
     protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new StateHasChangedAnalyzer();


### PR DESCRIPTION
# Adding StateHasChanged analyzer to flag unnecessary calls.

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

Added an analyzer that warns of unnecessary StateHasChanged usages as described #65196.
Not sure if a code fix is necessary or not, but I added one anyway. 

First try at contributing here. Hopefully I got all the scenarios right. 

Fixes #65196
