### PR TITLE
Fix WebApplicationFactory thread-safety on concurrent WithWebHostBuilder/CreateClient

### DIFF
--- a/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
+++ b/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
@@ -41,6 +41,10 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
     private IWebHost? _webHost;
 #pragma warning restore ASPDEPR008 // IWebHost is obsolete
     private Uri? _webHostAddress;
+
+    // Guards _clients and _derivedFactories, which can be mutated and enumerated
+    // concurrently (parallel CreateClient/WithWebHostBuilder calls plus disposal).
+    private readonly object _syncRoot = new();
     private readonly List<HttpClient> _clients = new();
     private readonly List<WebApplicationFactory<TEntryPoint>> _derivedFactories = new();
 
@@ -126,7 +130,16 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
     /// by further customizing the <see cref="IWebHostBuilder"/> when calling
     /// <see cref="WebApplicationFactory{TEntryPoint}.WithWebHostBuilder(Action{IWebHostBuilder})"/>.
     /// </summary>
-    public IReadOnlyList<WebApplicationFactory<TEntryPoint>> Factories => _derivedFactories.AsReadOnly();
+    public IReadOnlyList<WebApplicationFactory<TEntryPoint>> Factories
+    {
+        get
+        {
+            lock (_syncRoot)
+            {
+                return _derivedFactories.ToArray();
+            }
+        }
+    }
 
     /// <summary>
     /// Gets the <see cref="WebApplicationFactoryClientOptions"/> used by <see cref="CreateClient()"/>.
@@ -163,7 +176,10 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
                 configuration(builder);
             });
 
-        _derivedFactories.Add(factory);
+        lock (_syncRoot)
+        {
+            _derivedFactories.Add(factory);
+        }
 
         return factory;
     }
@@ -700,7 +716,10 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
             client = new HttpClient(handlers[0]);
         }
 
-        _clients.Add(client);
+        lock (_syncRoot)
+        {
+            _clients.Add(client);
+        }
 
         ConfigureClient(client);
 
@@ -810,12 +829,21 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
             return;
         }
 
-        foreach (var client in _clients)
+        // Snapshot under the lock, then dispose outside it (don't hold the lock across async work).
+        HttpClient[] clients;
+        WebApplicationFactory<TEntryPoint>[] derivedFactories;
+        lock (_syncRoot)
+        {
+            clients = _clients.ToArray();
+            derivedFactories = _derivedFactories.ToArray();
+        }
+
+        foreach (var client in clients)
         {
             client.Dispose();
         }
 
-        foreach (var factory in _derivedFactories)
+        foreach (var factory in derivedFactories)
         {
             await ((IAsyncDisposable)factory).DisposeAsync().ConfigureAwait(false);
         }

--- a/src/Mvc/test/Mvc.FunctionalTests/WebApplicationFactoryThreadSafetyTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/WebApplicationFactoryThreadSafetyTests.cs
@@ -1,0 +1,84 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace Microsoft.AspNetCore.Mvc.FunctionalTests;
+
+// Regression tests for https://github.com/dotnet/aspnetcore/issues/67223:
+// concurrent List.Add on the factory's _clients / _derivedFactories tore the
+// backing array, surfacing as a NullReferenceException on dispose. Each test
+// repeats a few times so the race reproduces reliably against the unfixed code.
+public class WebApplicationFactoryThreadSafetyTests
+{
+    private static int WorkerCount => Math.Max(Environment.ProcessorCount, 4);
+
+    [Fact]
+    public async Task WithWebHostBuilder_ConcurrentCalls_DoNotCorruptDerivedFactories()
+    {
+        const int perWorker = 50;
+        var expected = WorkerCount * perWorker;
+
+        for (var iteration = 0; iteration < 10; iteration++)
+        {
+            // No server needed: WithWebHostBuilder just appends a derived factory.
+            await using var root = new WebApplicationFactory<BasicWebSite.Startup>();
+
+            await RunConcurrently(() =>
+            {
+                for (var i = 0; i < perWorker; i++)
+                {
+                    root.WithWebHostBuilder(_ => { });
+                }
+            });
+
+            var factories = root.Factories;
+
+            // A short count means an entry was dropped; a null slot means the array tore.
+            Assert.Equal(expected, factories.Count);
+            Assert.All(factories, factory => Assert.NotNull(factory));
+        }
+    }
+
+    [Fact]
+    public async Task CreateClient_ConcurrentCalls_DoNotCorruptClientList()
+    {
+        const int perWorker = 20;
+
+        for (var iteration = 0; iteration < 5; iteration++)
+        {
+            await using var factory = new WebApplicationFactory<BasicWebSite.Startup>();
+
+            // Start the server once so the concurrent calls race only _clients.Add, not StartServer.
+            factory.CreateClient().Dispose();
+
+            await RunConcurrently(() =>
+            {
+                for (var i = 0; i < perWorker; i++)
+                {
+                    factory.CreateClient().Dispose();
+                }
+            });
+        }
+    }
+
+    // Lines all workers up on a barrier so the Add calls collide as tightly as possible.
+    private static async Task RunConcurrently(Action body)
+    {
+        var workerCount = WorkerCount;
+        using var gate = new Barrier(workerCount);
+        var workers = new Task[workerCount];
+
+        for (var w = 0; w < workerCount; w++)
+        {
+            workers[w] = Task.Run(() =>
+            {
+                gate.SignalAndWait();
+                body();
+            });
+        }
+
+        await Task.WhenAll(workers);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #67223.

`WebApplicationFactory<TEntryPoint>` tracks its derived factories and HTTP clients in two plain `List<T>` fields (`_derivedFactories`, `_clients`). They are mutated by `WithWebHostBuilder` / `CreateClient` and later enumerated during `Dispose`/`DisposeAsync`, with no synchronization.

When a single root factory is shared across parallel tests — a common isolation pattern: one shared root per session, a derived per-test factory via `WithWebHostBuilder(...)` — concurrent `List.Add` races the backing-array resize. The array can tear, leaving a `null` slot or dropping entries. It typically goes unnoticed until the root is disposed and `DisposeAsyncCore` walks the list:

```csharp
foreach (var factory in _derivedFactories)
{
    await ((IAsyncDisposable)factory).DisposeAsync();  // factory is null -> NRE
}
```

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory`1.DisposeAsync()
```

## Change

Guard both lists with a private lock object at every access site:

- `WithWebHostBuilderCore` → `_derivedFactories.Add`
- `CreateDefaultClient` → `_clients.Add`
- `Factories` getter → returns a snapshot (`ToArray()`) under the lock instead of a live `AsReadOnly()` wrapper over a concurrently-mutated list
- `DisposeAsync` → snapshots both lists under the lock, then disposes **outside** the lock (so the lock isn't held across async / user work)

A plain `object` lock is used (rather than `System.Threading.Lock`) so the change is source-identical across servicing branches (the same unsynchronized lists exist back through .NET 8).

## Tests

Adds `WebApplicationFactoryThreadSafetyTests` with two regression tests that line workers up on a `Barrier` to maximize collision:

- `WithWebHostBuilder_ConcurrentCalls_DoNotCorruptDerivedFactories` — asserts no entries are dropped and no slot is null, then disposes (where the original NRE surfaced).
- `CreateClient_ConcurrentCalls_DoNotCorruptClientList` — starts the server once, then hammers `CreateClient` and disposes.

Both reproduce the corruption reliably against the unfixed code and pass with the fix.
