### PR TITLE
Add AddHealthChecks(IServiceCollection, Action<HealthCheckServiceOptions>) overload

### DIFF
--- a/src/HealthChecks/HealthChecks/src/DependencyInjection/HealthCheckServiceCollectionExtensions.cs
+++ b/src/HealthChecks/HealthChecks/src/DependencyInjection/HealthCheckServiceCollectionExtensions.cs
@@ -29,4 +29,10 @@ public static class HealthCheckServiceCollectionExtensions
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, HealthCheckPublisherHostedService>());
         return new HealthChecksBuilder(services);
     }
+
+    public static IHealthChecksBuilder AddHealthChecks(this IServiceCollection services, Action<HealthCheckServiceOptions> configure)
+    {
+        services.Configure(configure);
+        return services.AddHealthChecks();
+    }
 }

--- a/src/HealthChecks/HealthChecks/src/PublicAPI.Unshipped.txt
+++ b/src/HealthChecks/HealthChecks/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+static Microsoft.Extensions.DependencyInjection.HealthCheckServiceCollectionExtensions.AddHealthChecks(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckServiceOptions!>! configure) -> Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder!

--- a/src/HealthChecks/HealthChecks/test/DependencyInjection/ServiceCollectionExtensionsTest.cs
+++ b/src/HealthChecks/HealthChecks/test/DependencyInjection/ServiceCollectionExtensionsTest.cs
@@ -80,6 +80,32 @@ public class ServiceCollectionExtensionsTest
             });
     }
 
+    [Fact]
+    public void AddHealthChecks_WithConfigureOptions_UsesOptionsConfiguration()
+    {
+        var services = new ServiceCollection();
+
+        services.AddHealthChecks(options => { });
+
+        Assert.Collection(services.OrderBy(s => s.ServiceType.FullName),
+            actual =>
+            {
+                Assert.Equal(ServiceLifetime.Singleton, actual.Lifetime);
+                Assert.Equal(typeof(HealthCheckService), actual.ServiceType);
+                Assert.Equal(typeof(DefaultHealthCheckService), actual.ImplementationType);
+                Assert.Null(actual.ImplementationInstance);
+                Assert.Null(actual.ImplementationFactory);
+            },
+            actual =>
+            {
+                Assert.Equal(ServiceLifetime.Singleton, actual.Lifetime);
+                Assert.Equal(typeof(IHostedService), actual.ServiceType);
+                Assert.Equal(typeof(HealthCheckPublisherHostedService), actual.ImplementationType);
+                Assert.Null(actual.ImplementationInstance);
+                Assert.Null(actual.ImplementationFactory);
+            });
+    }
+
     private class DummyHostedService : IHostedService
     {
         public Task StartAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
Adds an overload to configure HealthCheckServiceOptions via a delegate, matching the pattern used elsewhere in the DI extension methods.

Closes dotnet/aspnetcore#8530

# {PR title}

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

{Detail}

Fixes #{bug number} (in this specific format)
