### PR TITLE
Revert "Skip .NET SDK first-run experience in Helix work items"

### DIFF
--- a/eng/helix/content/runtests.cmd
+++ b/eng/helix/content/runtests.cmd
@@ -12,8 +12,6 @@ set $installPlaywright=%7
 REM Batch only supports up to 9 arguments using the %# syntax, need to shift to get more
 
 set DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-set DOTNET_NOLOGO=1
-set DOTNET_GENERATE_ASPNET_CERTIFICATE=false
 set PLAYWRIGHT_BROWSERS_PATH=%CD%\ms-playwright
 
 REM Avoid https://github.com/dotnet/aspnetcore/issues/41937 in current session.

--- a/eng/helix/content/runtests.sh
+++ b/eng/helix/content/runtests.sh
@@ -10,8 +10,6 @@ MAGENTA="\033[0;95m"
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-export DOTNET_NOLOGO=1
-export DOTNET_GENERATE_ASPNET_CERTIFICATE=false
 
 # Avoid https://github.com/dotnet/aspnetcore/issues/41937 in current session.
 unset ASPNETCORE_ENVIRONMENT

--- a/eng/tools/HelixTestRunner/TestRunner.cs
+++ b/eng/tools/HelixTestRunner/TestRunner.cs
@@ -28,17 +28,6 @@ public class TestRunner
             EnvironmentVariables.Add("PATH", Options.Path);
             EnvironmentVariables.Add("helix", Options.HelixQueue);
 
-            // Skip the .NET SDK first-run experience. On macOS Helix machines, the
-            // first-run HTTPS dev cert generation hangs for >2 minutes, causing the
-            // HelixTestRunner timeout to kill the dotnet process (exit code 130).
-            //
-            // DOTNET_SKIP_FIRST_TIME_EXPERIENCE is deprecated and no longer honored
-            // in .NET 8+. The replacement is individual controls:
-            // - DOTNET_NOLOGO: suppresses the welcome banner
-            // - DOTNET_GENERATE_ASPNET_CERTIFICATE: skips dev cert generation (the hang)
-            EnvironmentVariables.Add("DOTNET_NOLOGO", "1");
-            EnvironmentVariables.Add("DOTNET_GENERATE_ASPNET_CERTIFICATE", "false");
-
             ProcessUtil.PrintMessage($"Current Directory: {Options.HELIX_WORKITEM_ROOT}");
             var helixDir = Options.HELIX_WORKITEM_ROOT;
             ProcessUtil.PrintMessage($"Setting HELIX_DIR: {helixDir}");


### PR DESCRIPTION
Reverts dotnet/aspnetcore#66916

Fixes #66925