### PR TITLE
[Do not merge] Runtime hang bisect — preview.3.26176 (Mar 31)

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -17,6 +17,7 @@
     <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
     <add key="dotnet8-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8-transport/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-extensions-24c7e4f" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-extensions-24c7e4fc/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -6,9 +6,9 @@ This file should be imported by eng/Versions.props
 <Project>
   <PropertyGroup>
     <!-- dotnet-dotnet dependencies -->
-    <dotnetefPackageVersion>11.0.0-preview.6.26313.102</dotnetefPackageVersion>
-    <MicrosoftBclAsyncInterfacesPackageVersion>11.0.0-preview.6.26313.102</MicrosoftBclAsyncInterfacesPackageVersion>
-    <MicrosoftBclTimeProviderPackageVersion>11.0.0-preview.6.26313.102</MicrosoftBclTimeProviderPackageVersion>
+    <dotnetefPackageVersion>11.0.0-preview.3.26176.106</dotnetefPackageVersion>
+    <MicrosoftBclAsyncInterfacesPackageVersion>11.0.0-preview.3.26176.106</MicrosoftBclAsyncInterfacesPackageVersion>
+    <MicrosoftBclTimeProviderPackageVersion>11.0.0-preview.3.26176.106</MicrosoftBclTimeProviderPackageVersion>
     <MicrosoftDotNetArcadeSdkPackageVersion>11.0.0-beta.26313.102</MicrosoftDotNetArcadeSdkPackageVersion>
     <MicrosoftDotNetBuildTasksArchivesPackageVersion>11.0.0-beta.26313.102</MicrosoftDotNetBuildTasksArchivesPackageVersion>
     <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26313.102</MicrosoftDotNetBuildTasksInstallersPackageVersion>
@@ -16,105 +16,105 @@ This file should be imported by eng/Versions.props
     <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26313.102</MicrosoftDotNetHelixSdkPackageVersion>
     <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26313.102</MicrosoftDotNetRemoteExecutorPackageVersion>
     <MicrosoftDotNetSharedFrameworkSdkPackageVersion>11.0.0-beta.26313.102</MicrosoftDotNetSharedFrameworkSdkPackageVersion>
-    <MicrosoftEntityFrameworkCorePackageVersion>11.0.0-preview.6.26313.102</MicrosoftEntityFrameworkCorePackageVersion>
-    <MicrosoftEntityFrameworkCoreDesignPackageVersion>11.0.0-preview.6.26313.102</MicrosoftEntityFrameworkCoreDesignPackageVersion>
-    <MicrosoftEntityFrameworkCoreInMemoryPackageVersion>11.0.0-preview.6.26313.102</MicrosoftEntityFrameworkCoreInMemoryPackageVersion>
-    <MicrosoftEntityFrameworkCoreRelationalPackageVersion>11.0.0-preview.6.26313.102</MicrosoftEntityFrameworkCoreRelationalPackageVersion>
-    <MicrosoftEntityFrameworkCoreSqlitePackageVersion>11.0.0-preview.6.26313.102</MicrosoftEntityFrameworkCoreSqlitePackageVersion>
-    <MicrosoftEntityFrameworkCoreSqlServerPackageVersion>11.0.0-preview.6.26313.102</MicrosoftEntityFrameworkCoreSqlServerPackageVersion>
-    <MicrosoftEntityFrameworkCoreToolsPackageVersion>11.0.0-preview.6.26313.102</MicrosoftEntityFrameworkCoreToolsPackageVersion>
-    <MicrosoftExtensionsCachingAbstractionsPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsCachingAbstractionsPackageVersion>
-    <MicrosoftExtensionsCachingMemoryPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsCachingMemoryPackageVersion>
-    <MicrosoftExtensionsConfigurationPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsConfigurationPackageVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
-    <MicrosoftExtensionsConfigurationBinderPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsConfigurationBinderPackageVersion>
-    <MicrosoftExtensionsConfigurationCommandLinePackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsConfigurationCommandLinePackageVersion>
-    <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>
-    <MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>
-    <MicrosoftExtensionsConfigurationIniPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsConfigurationIniPackageVersion>
-    <MicrosoftExtensionsConfigurationJsonPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsConfigurationJsonPackageVersion>
-    <MicrosoftExtensionsConfigurationUserSecretsPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsConfigurationUserSecretsPackageVersion>
-    <MicrosoftExtensionsConfigurationXmlPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsConfigurationXmlPackageVersion>
-    <MicrosoftExtensionsDependencyInjectionPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsDependencyInjectionPackageVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>
-    <MicrosoftExtensionsDependencyModelPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsDependencyModelPackageVersion>
-    <MicrosoftExtensionsDiagnosticsPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsDiagnosticsPackageVersion>
-    <MicrosoftExtensionsDiagnosticsAbstractionsPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsDiagnosticsAbstractionsPackageVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
-    <MicrosoftExtensionsFileProvidersCompositePackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsFileProvidersCompositePackageVersion>
-    <MicrosoftExtensionsFileProvidersPhysicalPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsFileProvidersPhysicalPackageVersion>
-    <MicrosoftExtensionsFileSystemGlobbingPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsFileSystemGlobbingPackageVersion>
-    <MicrosoftExtensionsHostFactoryResolverSourcesPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsHostFactoryResolverSourcesPackageVersion>
-    <MicrosoftExtensionsHostingPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsHostingPackageVersion>
-    <MicrosoftExtensionsHostingAbstractionsPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsHostingAbstractionsPackageVersion>
-    <MicrosoftExtensionsHttpPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsHttpPackageVersion>
-    <MicrosoftExtensionsLoggingPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsLoggingPackageVersion>
-    <MicrosoftExtensionsLoggingAbstractionsPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
-    <MicrosoftExtensionsLoggingConfigurationPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsLoggingConfigurationPackageVersion>
-    <MicrosoftExtensionsLoggingConsolePackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsLoggingConsolePackageVersion>
-    <MicrosoftExtensionsLoggingDebugPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsLoggingDebugPackageVersion>
-    <MicrosoftExtensionsLoggingEventLogPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsLoggingEventLogPackageVersion>
-    <MicrosoftExtensionsLoggingEventSourcePackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsLoggingEventSourcePackageVersion>
-    <MicrosoftExtensionsLoggingTraceSourcePackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsLoggingTraceSourcePackageVersion>
-    <MicrosoftExtensionsOptionsPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsOptionsPackageVersion>
-    <MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>
-    <MicrosoftExtensionsOptionsDataAnnotationsPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsOptionsDataAnnotationsPackageVersion>
-    <MicrosoftExtensionsPrimitivesPackageVersion>11.0.0-preview.6.26313.102</MicrosoftExtensionsPrimitivesPackageVersion>
-    <MicrosoftInternalRuntimeAspNetCoreTransportPackageVersion>11.0.0-preview.6.26313.102</MicrosoftInternalRuntimeAspNetCoreTransportPackageVersion>
-    <MicrosoftNETRuntimeMonoAOTCompilerTaskPackageVersion>11.0.0-preview.6.26313.102</MicrosoftNETRuntimeMonoAOTCompilerTaskPackageVersion>
-    <MicrosoftNETRuntimeWebAssemblySdkPackageVersion>11.0.0-preview.6.26313.102</MicrosoftNETRuntimeWebAssemblySdkPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-preview.6.26313.102</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftNETCoreBrowserDebugHostTransportPackageVersion>11.0.0-preview.6.26313.102</MicrosoftNETCoreBrowserDebugHostTransportPackageVersion>
-    <MicrosoftNETCorePlatformsPackageVersion>11.0.0-preview.6.26313.102</MicrosoftNETCorePlatformsPackageVersion>
-    <MicrosoftWebXdtPackageVersion>3.3.0-preview.6.26313.102</MicrosoftWebXdtPackageVersion>
-    <NuGetFrameworksPackageVersion>7.9.0-rc.31402</NuGetFrameworksPackageVersion>
-    <NuGetPackagingPackageVersion>7.9.0-rc.31402</NuGetPackagingPackageVersion>
-    <NuGetVersioningPackageVersion>7.9.0-rc.31402</NuGetVersioningPackageVersion>
-    <SystemCollectionsImmutablePackageVersion>11.0.0-preview.6.26313.102</SystemCollectionsImmutablePackageVersion>
-    <SystemCompositionPackageVersion>11.0.0-preview.6.26313.102</SystemCompositionPackageVersion>
-    <SystemConfigurationConfigurationManagerPackageVersion>11.0.0-preview.6.26313.102</SystemConfigurationConfigurationManagerPackageVersion>
-    <SystemDiagnosticsDiagnosticSourcePackageVersion>11.0.0-preview.6.26313.102</SystemDiagnosticsDiagnosticSourcePackageVersion>
-    <SystemDiagnosticsEventLogPackageVersion>11.0.0-preview.6.26313.102</SystemDiagnosticsEventLogPackageVersion>
-    <SystemDiagnosticsPerformanceCounterPackageVersion>11.0.0-preview.6.26313.102</SystemDiagnosticsPerformanceCounterPackageVersion>
-    <SystemDirectoryServicesProtocolsPackageVersion>11.0.0-preview.6.26313.102</SystemDirectoryServicesProtocolsPackageVersion>
-    <SystemFormatsAsn1PackageVersion>11.0.0-preview.6.26313.102</SystemFormatsAsn1PackageVersion>
-    <SystemFormatsCborPackageVersion>11.0.0-preview.6.26313.102</SystemFormatsCborPackageVersion>
-    <SystemIOHashingPackageVersion>11.0.0-preview.6.26313.102</SystemIOHashingPackageVersion>
-    <SystemIOPipelinesPackageVersion>11.0.0-preview.6.26313.102</SystemIOPipelinesPackageVersion>
-    <SystemMemoryDataPackageVersion>11.0.0-preview.6.26313.102</SystemMemoryDataPackageVersion>
-    <SystemNetHttpJsonPackageVersion>11.0.0-preview.6.26313.102</SystemNetHttpJsonPackageVersion>
-    <SystemNetHttpWinHttpHandlerPackageVersion>11.0.0-preview.6.26313.102</SystemNetHttpWinHttpHandlerPackageVersion>
-    <SystemNetServerSentEventsPackageVersion>11.0.0-preview.6.26313.102</SystemNetServerSentEventsPackageVersion>
-    <SystemNumericsTensorsPackageVersion>11.0.0-preview.6.26313.102</SystemNumericsTensorsPackageVersion>
-    <SystemReflectionMetadataPackageVersion>11.0.0-preview.6.26313.102</SystemReflectionMetadataPackageVersion>
-    <SystemResourcesExtensionsPackageVersion>11.0.0-preview.6.26313.102</SystemResourcesExtensionsPackageVersion>
-    <SystemRuntimeCachingPackageVersion>11.0.0-preview.6.26313.102</SystemRuntimeCachingPackageVersion>
-    <SystemSecurityCryptographyPkcsPackageVersion>11.0.0-preview.6.26313.102</SystemSecurityCryptographyPkcsPackageVersion>
-    <SystemSecurityCryptographyXmlPackageVersion>11.0.0-preview.6.26313.102</SystemSecurityCryptographyXmlPackageVersion>
-    <SystemSecurityPermissionsPackageVersion>11.0.0-preview.6.26313.102</SystemSecurityPermissionsPackageVersion>
-    <SystemServiceProcessServiceControllerPackageVersion>11.0.0-preview.6.26313.102</SystemServiceProcessServiceControllerPackageVersion>
-    <SystemTextEncodingsWebPackageVersion>11.0.0-preview.6.26313.102</SystemTextEncodingsWebPackageVersion>
-    <SystemTextJsonPackageVersion>11.0.0-preview.6.26313.102</SystemTextJsonPackageVersion>
-    <SystemThreadingAccessControlPackageVersion>11.0.0-preview.6.26313.102</SystemThreadingAccessControlPackageVersion>
-    <SystemThreadingChannelsPackageVersion>11.0.0-preview.6.26313.102</SystemThreadingChannelsPackageVersion>
-    <SystemThreadingRateLimitingPackageVersion>11.0.0-preview.6.26313.102</SystemThreadingRateLimitingPackageVersion>
+    <MicrosoftEntityFrameworkCorePackageVersion>11.0.0-preview.3.26176.106</MicrosoftEntityFrameworkCorePackageVersion>
+    <MicrosoftEntityFrameworkCoreDesignPackageVersion>11.0.0-preview.3.26176.106</MicrosoftEntityFrameworkCoreDesignPackageVersion>
+    <MicrosoftEntityFrameworkCoreInMemoryPackageVersion>11.0.0-preview.3.26176.106</MicrosoftEntityFrameworkCoreInMemoryPackageVersion>
+    <MicrosoftEntityFrameworkCoreRelationalPackageVersion>11.0.0-preview.3.26176.106</MicrosoftEntityFrameworkCoreRelationalPackageVersion>
+    <MicrosoftEntityFrameworkCoreSqlitePackageVersion>11.0.0-preview.3.26176.106</MicrosoftEntityFrameworkCoreSqlitePackageVersion>
+    <MicrosoftEntityFrameworkCoreSqlServerPackageVersion>11.0.0-preview.3.26176.106</MicrosoftEntityFrameworkCoreSqlServerPackageVersion>
+    <MicrosoftEntityFrameworkCoreToolsPackageVersion>11.0.0-preview.3.26176.106</MicrosoftEntityFrameworkCoreToolsPackageVersion>
+    <MicrosoftExtensionsCachingAbstractionsPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsCachingAbstractionsPackageVersion>
+    <MicrosoftExtensionsCachingMemoryPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsCachingMemoryPackageVersion>
+    <MicrosoftExtensionsConfigurationPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsConfigurationPackageVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
+    <MicrosoftExtensionsConfigurationBinderPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsConfigurationBinderPackageVersion>
+    <MicrosoftExtensionsConfigurationCommandLinePackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsConfigurationCommandLinePackageVersion>
+    <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>
+    <MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>
+    <MicrosoftExtensionsConfigurationIniPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsConfigurationIniPackageVersion>
+    <MicrosoftExtensionsConfigurationJsonPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsConfigurationJsonPackageVersion>
+    <MicrosoftExtensionsConfigurationUserSecretsPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsConfigurationUserSecretsPackageVersion>
+    <MicrosoftExtensionsConfigurationXmlPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsConfigurationXmlPackageVersion>
+    <MicrosoftExtensionsDependencyInjectionPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsDependencyInjectionPackageVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>
+    <MicrosoftExtensionsDependencyModelPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsDependencyModelPackageVersion>
+    <MicrosoftExtensionsDiagnosticsPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsDiagnosticsPackageVersion>
+    <MicrosoftExtensionsDiagnosticsAbstractionsPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsDiagnosticsAbstractionsPackageVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
+    <MicrosoftExtensionsFileProvidersCompositePackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsFileProvidersCompositePackageVersion>
+    <MicrosoftExtensionsFileProvidersPhysicalPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsFileProvidersPhysicalPackageVersion>
+    <MicrosoftExtensionsFileSystemGlobbingPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsFileSystemGlobbingPackageVersion>
+    <MicrosoftExtensionsHostFactoryResolverSourcesPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsHostFactoryResolverSourcesPackageVersion>
+    <MicrosoftExtensionsHostingPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsHostingPackageVersion>
+    <MicrosoftExtensionsHostingAbstractionsPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsHostingAbstractionsPackageVersion>
+    <MicrosoftExtensionsHttpPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsHttpPackageVersion>
+    <MicrosoftExtensionsLoggingPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsLoggingPackageVersion>
+    <MicrosoftExtensionsLoggingAbstractionsPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
+    <MicrosoftExtensionsLoggingConfigurationPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsLoggingConfigurationPackageVersion>
+    <MicrosoftExtensionsLoggingConsolePackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsLoggingConsolePackageVersion>
+    <MicrosoftExtensionsLoggingDebugPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsLoggingDebugPackageVersion>
+    <MicrosoftExtensionsLoggingEventLogPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsLoggingEventLogPackageVersion>
+    <MicrosoftExtensionsLoggingEventSourcePackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsLoggingEventSourcePackageVersion>
+    <MicrosoftExtensionsLoggingTraceSourcePackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsLoggingTraceSourcePackageVersion>
+    <MicrosoftExtensionsOptionsPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsOptionsPackageVersion>
+    <MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>
+    <MicrosoftExtensionsOptionsDataAnnotationsPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsOptionsDataAnnotationsPackageVersion>
+    <MicrosoftExtensionsPrimitivesPackageVersion>11.0.0-preview.3.26176.106</MicrosoftExtensionsPrimitivesPackageVersion>
+    <MicrosoftInternalRuntimeAspNetCoreTransportPackageVersion>11.0.0-preview.3.26176.106</MicrosoftInternalRuntimeAspNetCoreTransportPackageVersion>
+    <MicrosoftNETRuntimeMonoAOTCompilerTaskPackageVersion>11.0.0-preview.3.26176.106</MicrosoftNETRuntimeMonoAOTCompilerTaskPackageVersion>
+    <MicrosoftNETRuntimeWebAssemblySdkPackageVersion>11.0.0-preview.3.26176.106</MicrosoftNETRuntimeWebAssemblySdkPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-preview.3.26176.106</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreBrowserDebugHostTransportPackageVersion>11.0.0-preview.3.26176.106</MicrosoftNETCoreBrowserDebugHostTransportPackageVersion>
+    <MicrosoftNETCorePlatformsPackageVersion>11.0.0-preview.3.26176.106</MicrosoftNETCorePlatformsPackageVersion>
+    <MicrosoftWebXdtPackageVersion>3.3.0-preview.3.26176.106</MicrosoftWebXdtPackageVersion>
+    <NuGetFrameworksPackageVersion>7.6.0-rc.17706</NuGetFrameworksPackageVersion>
+    <NuGetPackagingPackageVersion>7.6.0-rc.17706</NuGetPackagingPackageVersion>
+    <NuGetVersioningPackageVersion>7.6.0-rc.17706</NuGetVersioningPackageVersion>
+    <SystemCollectionsImmutablePackageVersion>11.0.0-preview.3.26176.106</SystemCollectionsImmutablePackageVersion>
+    <SystemCompositionPackageVersion>11.0.0-preview.3.26176.106</SystemCompositionPackageVersion>
+    <SystemConfigurationConfigurationManagerPackageVersion>11.0.0-preview.3.26176.106</SystemConfigurationConfigurationManagerPackageVersion>
+    <SystemDiagnosticsDiagnosticSourcePackageVersion>11.0.0-preview.3.26176.106</SystemDiagnosticsDiagnosticSourcePackageVersion>
+    <SystemDiagnosticsEventLogPackageVersion>11.0.0-preview.3.26176.106</SystemDiagnosticsEventLogPackageVersion>
+    <SystemDiagnosticsPerformanceCounterPackageVersion>11.0.0-preview.3.26176.106</SystemDiagnosticsPerformanceCounterPackageVersion>
+    <SystemDirectoryServicesProtocolsPackageVersion>11.0.0-preview.3.26176.106</SystemDirectoryServicesProtocolsPackageVersion>
+    <SystemFormatsAsn1PackageVersion>11.0.0-preview.3.26176.106</SystemFormatsAsn1PackageVersion>
+    <SystemFormatsCborPackageVersion>11.0.0-preview.3.26176.106</SystemFormatsCborPackageVersion>
+    <SystemIOHashingPackageVersion>11.0.0-preview.3.26176.106</SystemIOHashingPackageVersion>
+    <SystemIOPipelinesPackageVersion>11.0.0-preview.3.26176.106</SystemIOPipelinesPackageVersion>
+    <SystemMemoryDataPackageVersion>11.0.0-preview.3.26176.106</SystemMemoryDataPackageVersion>
+    <SystemNetHttpJsonPackageVersion>11.0.0-preview.3.26176.106</SystemNetHttpJsonPackageVersion>
+    <SystemNetHttpWinHttpHandlerPackageVersion>11.0.0-preview.3.26176.106</SystemNetHttpWinHttpHandlerPackageVersion>
+    <SystemNetServerSentEventsPackageVersion>11.0.0-preview.3.26176.106</SystemNetServerSentEventsPackageVersion>
+    <SystemNumericsTensorsPackageVersion>11.0.0-preview.3.26176.106</SystemNumericsTensorsPackageVersion>
+    <SystemReflectionMetadataPackageVersion>11.0.0-preview.3.26176.106</SystemReflectionMetadataPackageVersion>
+    <SystemResourcesExtensionsPackageVersion>11.0.0-preview.3.26176.106</SystemResourcesExtensionsPackageVersion>
+    <SystemRuntimeCachingPackageVersion>11.0.0-preview.3.26176.106</SystemRuntimeCachingPackageVersion>
+    <SystemSecurityCryptographyPkcsPackageVersion>11.0.0-preview.3.26176.106</SystemSecurityCryptographyPkcsPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>11.0.0-preview.3.26176.106</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemSecurityPermissionsPackageVersion>11.0.0-preview.3.26176.106</SystemSecurityPermissionsPackageVersion>
+    <SystemServiceProcessServiceControllerPackageVersion>11.0.0-preview.3.26176.106</SystemServiceProcessServiceControllerPackageVersion>
+    <SystemTextEncodingsWebPackageVersion>11.0.0-preview.3.26176.106</SystemTextEncodingsWebPackageVersion>
+    <SystemTextJsonPackageVersion>11.0.0-preview.3.26176.106</SystemTextJsonPackageVersion>
+    <SystemThreadingAccessControlPackageVersion>11.0.0-preview.3.26176.106</SystemThreadingAccessControlPackageVersion>
+    <SystemThreadingChannelsPackageVersion>11.0.0-preview.3.26176.106</SystemThreadingChannelsPackageVersion>
+    <SystemThreadingRateLimitingPackageVersion>11.0.0-preview.3.26176.106</SystemThreadingRateLimitingPackageVersion>
     <!-- dotnet-extensions dependencies -->
-    <MicrosoftExtensionsCachingHybridPackageVersion>10.6.0</MicrosoftExtensionsCachingHybridPackageVersion>
-    <MicrosoftExtensionsDiagnosticsTestingPackageVersion>10.6.0</MicrosoftExtensionsDiagnosticsTestingPackageVersion>
+    <MicrosoftExtensionsCachingHybridPackageVersion>10.4.1</MicrosoftExtensionsCachingHybridPackageVersion>
+    <MicrosoftExtensionsDiagnosticsTestingPackageVersion>10.4.1</MicrosoftExtensionsDiagnosticsTestingPackageVersion>
     <MicrosoftExtensionsServiceDiscoveryPackageVersion>10.6.0</MicrosoftExtensionsServiceDiscoveryPackageVersion>
     <MicrosoftExtensionsServiceDiscoveryYarpPackageVersion>10.6.0</MicrosoftExtensionsServiceDiscoveryYarpPackageVersion>
-    <MicrosoftExtensionsTimeProviderTestingPackageVersion>10.6.0</MicrosoftExtensionsTimeProviderTestingPackageVersion>
+    <MicrosoftExtensionsTimeProviderTestingPackageVersion>10.4.1</MicrosoftExtensionsTimeProviderTestingPackageVersion>
     <!-- dotnet-msbuild dependencies -->
     <MicrosoftBuildPackageVersion>17.12.50</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>17.12.50</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildTasksCorePackageVersion>17.12.50</MicrosoftBuildTasksCorePackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>17.12.50</MicrosoftBuildUtilitiesCorePackageVersion>
     <!-- dotnet-optimization dependencies -->
-    <optimizationlinuxarm64MIBCRuntimePackageVersion>1.0.0-prerelease.26309.1</optimizationlinuxarm64MIBCRuntimePackageVersion>
-    <optimizationlinuxx64MIBCRuntimePackageVersion>1.0.0-prerelease.26309.1</optimizationlinuxx64MIBCRuntimePackageVersion>
-    <optimizationwindows_ntarm64MIBCRuntimePackageVersion>1.0.0-prerelease.26309.1</optimizationwindows_ntarm64MIBCRuntimePackageVersion>
-    <optimizationwindows_ntx64MIBCRuntimePackageVersion>1.0.0-prerelease.26309.1</optimizationwindows_ntx64MIBCRuntimePackageVersion>
-    <optimizationwindows_ntx86MIBCRuntimePackageVersion>1.0.0-prerelease.26309.1</optimizationwindows_ntx86MIBCRuntimePackageVersion>
+    <optimizationlinuxarm64MIBCRuntimePackageVersion>1.0.0-prerelease.26153.1</optimizationlinuxarm64MIBCRuntimePackageVersion>
+    <optimizationlinuxx64MIBCRuntimePackageVersion>1.0.0-prerelease.26153.1</optimizationlinuxx64MIBCRuntimePackageVersion>
+    <optimizationwindows_ntarm64MIBCRuntimePackageVersion>1.0.0-prerelease.26153.1</optimizationwindows_ntarm64MIBCRuntimePackageVersion>
+    <optimizationwindows_ntx64MIBCRuntimePackageVersion>1.0.0-prerelease.26153.1</optimizationwindows_ntx64MIBCRuntimePackageVersion>
+    <optimizationwindows_ntx86MIBCRuntimePackageVersion>1.0.0-prerelease.26153.1</optimizationwindows_ntx86MIBCRuntimePackageVersion>
     <!-- dotnet-roslyn dependencies -->
     <MicrosoftCodeAnalysisCommonPackageVersion>4.13.0-3.24613.7</MicrosoftCodeAnalysisCommonPackageVersion>
     <MicrosoftCodeAnalysisCSharpPackageVersion>4.13.0-3.24613.7</MicrosoftCodeAnalysisCSharpPackageVersion>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -10,331 +10,331 @@
 <Dependencies>
   <Source Uri="https://github.com/dotnet/dotnet" Mapping="aspnetcore" Sha="06787fc66d5364230924d00f2c5c251aeb7a31cd" BarId="318609" />
   <ProductDependencies>
-    <Dependency Name="dotnet-ef" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="dotnet-ef" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
       <SourceBuildTarball RepoName="efcore" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.EntityFrameworkCore.InMemory" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.EntityFrameworkCore.InMemory" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.EntityFrameworkCore.Relational" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.EntityFrameworkCore.Relational" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.EntityFrameworkCore.Sqlite" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.EntityFrameworkCore.Sqlite" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.EntityFrameworkCore.SqlServer" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.EntityFrameworkCore.SqlServer" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.EntityFrameworkCore.Tools" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.EntityFrameworkCore.Tools" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.EntityFrameworkCore" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.EntityFrameworkCore" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.EntityFrameworkCore.Design" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.EntityFrameworkCore.Design" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Caching.Abstractions" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.Caching.Abstractions" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Caching.Memory" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.Caching.Memory" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Binder" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.Configuration.Binder" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.CommandLine" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.Configuration.CommandLine" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.FileExtensions" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.Configuration.FileExtensions" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Ini" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.Configuration.Ini" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.UserSecrets" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.Configuration.UserSecrets" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Xml" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.Configuration.Xml" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Diagnostics" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.Diagnostics" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Diagnostics.Abstractions" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.Diagnostics.Abstractions" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Composite" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Composite" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Physical" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Physical" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileSystemGlobbing" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.FileSystemGlobbing" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.HostFactoryResolver.Sources" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.HostFactoryResolver.Sources" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.Hosting" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Http" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.Http" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Configuration" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.Logging.Configuration" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.EventSource" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.Logging.EventSource" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.EventLog" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.Logging.EventLog" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.TraceSource" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.Logging.TraceSource" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Options.ConfigurationExtensions" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.Options.ConfigurationExtensions" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Options.DataAnnotations" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.Options.DataAnnotations" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Options" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.Options" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Internal.Runtime.AspNetCore.Transport" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Internal.Runtime.AspNetCore.Transport" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.DiagnosticSource" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="System.Diagnostics.DiagnosticSource" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="System.Diagnostics.EventLog" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="System.DirectoryServices.Protocols" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="System.DirectoryServices.Protocols" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="System.Formats.Asn1" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="System.Formats.Asn1" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="System.Formats.Cbor" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="System.Formats.Cbor" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Pipelines" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="System.IO.Pipelines" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="System.Net.Http.Json" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="System.Net.Http.Json" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="System.Net.Http.WinHttpHandler" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="System.Net.Http.WinHttpHandler" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="System.Net.ServerSentEvents" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="System.Net.ServerSentEvents" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.Metadata" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="System.Reflection.Metadata" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="System.Resources.Extensions" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Pkcs" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="System.Security.Cryptography.Pkcs" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="System.Security.Permissions" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="System.ServiceProcess.ServiceController" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="System.ServiceProcess.ServiceController" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Encodings.Web" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="System.Text.Encodings.Web" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Json" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="System.Text.Json" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="System.Threading.AccessControl" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="System.Threading.AccessControl" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="System.Threading.Channels" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="System.Threading.Channels" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="System.Threading.RateLimiting" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="System.Threading.RateLimiting" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Runtime.MonoAOTCompiler.Task" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.NET.Runtime.MonoAOTCompiler.Task" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Runtime.WebAssembly.Sdk" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.NET.Runtime.WebAssembly.Sdk" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Bcl.AsyncInterfaces" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Bcl.AsyncInterfaces" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
     <!-- Transitive package to provide coherency in dotnet/extensions -->
-    <Dependency Name="Microsoft.Bcl.TimeProvider" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Bcl.TimeProvider" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="System.Collections.Immutable" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="System.Collections.Immutable" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Hashing" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="System.IO.Hashing" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="System.Memory.Data" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="System.Memory.Data" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="System.Numerics.Tensors" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="System.Numerics.Tensors" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="System.Runtime.Caching" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="System.Runtime.Caching" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.BrowserDebugHost.Transport" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.NETCore.BrowserDebugHost.Transport" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Web.Xdt" Version="3.3.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.Web.Xdt" Version="3.3.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
-    <Dependency Name="System.Composition" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="System.Composition" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
     <!-- Dependencies required for source build to lift to the previously-source-built version. -->
     <!-- These versions are manually updated -->
@@ -358,9 +358,9 @@
   </ProductDependencies>
   <ToolsetDependencies>
     <!-- Listed explicitly to workaround https://github.com/dotnet/cli/issues/10528 -->
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="11.0.0-preview.6.26313.102">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="11.0.0-preview.3.26176.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
+      <Sha>7af60210ff756fa343088d4dc1b7080c200dea50</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26313.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
@@ -390,17 +390,17 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>06787fc66d5364230924d00f2c5c251aeb7a31cd</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Caching.Hybrid" Version="10.6.0">
+    <Dependency Name="Microsoft.Extensions.Caching.Hybrid" Version="10.4.1">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>52dc2880f21db9b0e7e83e030dbe3795651c9243</Sha>
+      <Sha>24c7e4fc4f08e94d9e977bac3ab7b352762e28b2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Diagnostics.Testing" Version="10.6.0">
+    <Dependency Name="Microsoft.Extensions.Diagnostics.Testing" Version="10.4.1">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>52dc2880f21db9b0e7e83e030dbe3795651c9243</Sha>
+      <Sha>24c7e4fc4f08e94d9e977bac3ab7b352762e28b2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0">
+    <Dependency Name="Microsoft.Extensions.TimeProvider.Testing" Version="10.4.1">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>52dc2880f21db9b0e7e83e030dbe3795651c9243</Sha>
+      <Sha>24c7e4fc4f08e94d9e977bac3ab7b352762e28b2</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.ServiceDiscovery" Version="10.6.0">
       <Uri>https://github.com/dotnet/extensions</Uri>
@@ -410,25 +410,25 @@
       <Uri>https://github.com/dotnet/extensions</Uri>
       <Sha>52dc2880f21db9b0e7e83e030dbe3795651c9243</Sha>
     </Dependency>
-    <Dependency Name="optimization.windows_nt-x64.MIBC.Runtime" Version="1.0.0-prerelease.26309.1">
+    <Dependency Name="optimization.windows_nt-x64.MIBC.Runtime" Version="1.0.0-prerelease.26153.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-optimization</Uri>
-      <Sha>b5964e83d71a6fbe08ae90fd5f5a2556917d27e6</Sha>
+      <Sha>b194351e54adc9538bb2a0b6a188f8f897fa223c</Sha>
     </Dependency>
-    <Dependency Name="optimization.windows_nt-x86.MIBC.Runtime" Version="1.0.0-prerelease.26309.1">
+    <Dependency Name="optimization.windows_nt-x86.MIBC.Runtime" Version="1.0.0-prerelease.26153.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-optimization</Uri>
-      <Sha>b5964e83d71a6fbe08ae90fd5f5a2556917d27e6</Sha>
+      <Sha>b194351e54adc9538bb2a0b6a188f8f897fa223c</Sha>
     </Dependency>
-    <Dependency Name="optimization.linux-x64.MIBC.Runtime" Version="1.0.0-prerelease.26309.1">
+    <Dependency Name="optimization.linux-x64.MIBC.Runtime" Version="1.0.0-prerelease.26153.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-optimization</Uri>
-      <Sha>b5964e83d71a6fbe08ae90fd5f5a2556917d27e6</Sha>
+      <Sha>b194351e54adc9538bb2a0b6a188f8f897fa223c</Sha>
     </Dependency>
-    <Dependency Name="optimization.windows_nt-arm64.MIBC.Runtime" Version="1.0.0-prerelease.26309.1">
+    <Dependency Name="optimization.windows_nt-arm64.MIBC.Runtime" Version="1.0.0-prerelease.26153.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-optimization</Uri>
-      <Sha>b5964e83d71a6fbe08ae90fd5f5a2556917d27e6</Sha>
+      <Sha>b194351e54adc9538bb2a0b6a188f8f897fa223c</Sha>
     </Dependency>
-    <Dependency Name="optimization.linux-arm64.MIBC.Runtime" Version="1.0.0-prerelease.26309.1">
+    <Dependency Name="optimization.linux-arm64.MIBC.Runtime" Version="1.0.0-prerelease.26153.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-optimization</Uri>
-      <Sha>b5964e83d71a6fbe08ae90fd5f5a2556917d27e6</Sha>
+      <Sha>b194351e54adc9538bb2a0b6a188f8f897fa223c</Sha>
     </Dependency>
     <!-- Dependencies required for source build to lift to the previously-source-built version. -->
     <!-- These versions are manually updated -->

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -30,7 +30,7 @@
       <!-- aspnetcore-quarantined-pr (quarantined-pr.yml) -->
       <ItemGroup>
         <HelixAvailableTargetQueue Include="Ubuntu.2404.Amd64.Open" Platform="Linux" />
-        <HelixAvailableTargetQueue Include="OSX.26.Arm64.Open" Platform="OSX" />
+        <HelixAvailableTargetQueue Include="OSX.15.Amd64.Open" Platform="OSX" />
         <HelixAvailableTargetQueue Include="Windows.Amd64.VS2026.Open" Platform="Windows" />
       </ItemGroup>
     </When>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "11.0.100-preview.6.26304.106",
+    "version": "11.0.100-preview.3.26170.106",
     "paths": [
       ".dotnet",
       "$host$"
@@ -8,7 +8,7 @@
     "errorMessage": "The .NET SDK could not be found, run ./restore.cmd or ./restore.sh first."
   },
   "tools": {
-    "dotnet": "11.0.100-preview.6.26304.106",
+    "dotnet": "11.0.100-preview.3.26170.106",
     "runtimes": {
       "dotnet/x86": [
         "$(MicrosoftInternalRuntimeAspNetCoreTransportVersion)"

--- a/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
@@ -478,10 +478,6 @@ internal static class JsonNodeSchemaExtensions
         {
             schema[OpenApiConstants.SchemaId] = schemaReferenceId;
         }
-        if (context.TypeInfo.Kind == JsonTypeInfoKind.Union)
-        {
-            schema[OpenApiConstants.SchemaIsUnion] = true;
-        }
         // If the type is a non-abstract base class that is not one of the derived types then mark it as a base schema.
         if (context.BaseTypeInfo == context.TypeInfo &&
             IsNonAbstractTypeWithoutDerivedTypeReference(context))

--- a/src/Shared/CertificateGeneration/MacOSCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/MacOSCertificateManager.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
-using Microsoft.Win32.SafeHandles;
 
 namespace Microsoft.AspNetCore.Certificates.Generation;
 
@@ -102,14 +101,15 @@ internal sealed class MacOSCertificateManager : CertificateManager
             {
                 Log.MacOSTrustCommandStart($"{MacOSTrustCertificateCommandLine} {MacOSTrustCertificateCommandLineArguments}{tmpFile}");
             }
-
-            var exitStatus = Process.Run(new ProcessStartInfo(MacOSTrustCertificateCommandLine, MacOSTrustCertificateCommandLineArguments + tmpFile));
-            if (exitStatus.ExitCode != 0)
+            using (var process = Process.Start(MacOSTrustCertificateCommandLine, MacOSTrustCertificateCommandLineArguments + tmpFile))
             {
-                Log.MacOSTrustCommandError(exitStatus.ExitCode);
-                throw new InvalidOperationException("There was an error trusting the certificate.");
+                process.WaitForExit();
+                if (process.ExitCode != 0)
+                {
+                    Log.MacOSTrustCommandError(process.ExitCode);
+                    throw new InvalidOperationException("There was an error trusting the certificate.");
+                }
             }
-
             Log.MacOSTrustCommandEnd();
             return TrustLevel.Full;
         }
@@ -156,19 +156,17 @@ internal sealed class MacOSCertificateManager : CertificateManager
             // We can't guarantee that the temp file is in a directory with sensible permissions, but we're not exporting the private key
             ExportCertificate(certificate, tmpFile, includePrivateKey: false, password: null, CertificateKeyExportFormat.Pem);
 
-            using SafeFileHandle nullHandle = File.OpenNullHandle();
-            var checkTrustProcessStartInfo = new ProcessStartInfo(
+            using var checkTrustProcess = Process.Start(new ProcessStartInfo(
                 MacOSVerifyCertificateCommandLine,
                 string.Format(CultureInfo.InvariantCulture, MacOSVerifyCertificateCommandLineArgumentsFormat, tmpFile))
             {
+                RedirectStandardOutput = true,
                 // Do this to avoid showing output to the console when the cert is not trusted. It is trivial to export
                 // the cert and replicate the command to see details.
-                StandardOutputHandle = nullHandle,
-                StandardErrorHandle = nullHandle
-            };
-
-            var checkTrustProcessOutput = Process.Run(checkTrustProcessStartInfo);
-            return checkTrustProcessOutput.ExitCode == 0 ? TrustLevel.Full : TrustLevel.None;
+                RedirectStandardError = true,
+            });
+            checkTrustProcess!.WaitForExit();
+            return checkTrustProcess.ExitCode == 0 ? TrustLevel.Full : TrustLevel.None;
         }
         finally
         {
@@ -213,10 +211,12 @@ internal sealed class MacOSCertificateManager : CertificateManager
                     certificatePath
                 ));
 
-            var processExitStatus = Process.Run(processInfo);
-            if (processExitStatus.ExitCode != 0)
+            using var process = Process.Start(processInfo);
+            process!.WaitForExit();
+
+            if (process.ExitCode != 0)
             {
-                Log.MacOSRemoveCertificateTrustRuleError(processExitStatus.ExitCode);
+                Log.MacOSRemoveCertificateTrustRuleError(process.ExitCode);
             }
 
             Log.MacOSRemoveCertificateTrustRuleEnd();
@@ -254,14 +254,18 @@ internal sealed class MacOSCertificateManager : CertificateManager
             Log.MacOSRemoveCertificateFromKeyChainStart(keychain, GetDescription(certificate));
         }
 
-        var processOutput = Process.RunAndCaptureText(processInfo);
-        var exitCode = processOutput.ExitStatus.ExitCode;
-        if (exitCode != 0)
+        using (var process = Process.Start(processInfo))
         {
-            Log.MacOSRemoveCertificateFromKeyChainError(exitCode);
-            throw new InvalidOperationException($@"There was an error removing the certificate with thumbprint '{certificate.Thumbprint}'.
+            var output = process!.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
+            process.WaitForExit();
 
-{processOutput.StandardOutput}{processOutput.StandardError}");
+            if (process.ExitCode != 0)
+            {
+                Log.MacOSRemoveCertificateFromKeyChainError(process.ExitCode);
+                throw new InvalidOperationException($@"There was an error removing the certificate with thumbprint '{certificate.Thumbprint}'.
+
+{output}");
+            }
         }
 
         Log.MacOSRemoveCertificateFromKeyChainEnd();
@@ -351,13 +355,16 @@ internal sealed class MacOSCertificateManager : CertificateManager
             Log.MacOSAddCertificateToKeyChainStart(MacOSUserKeychain, GetDescription(certificate));
         }
 
-        var processOutput = Process.RunAndCaptureText(processInfo);
-        var exitCode = processOutput.ExitStatus.ExitCode;
-
-        if (exitCode != 0)
+        using (var process = Process.Start(processInfo))
         {
-            Log.MacOSAddCertificateToKeyChainError(exitCode, processOutput.StandardOutput + processOutput.StandardError);
-            throw new InvalidOperationException("Failed to add the certificate to the keychain. Are you running in a non-interactive session perhaps?");
+            var output = process!.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            if (process.ExitCode != 0)
+            {
+                Log.MacOSAddCertificateToKeyChainError(process.ExitCode, output);
+                throw new InvalidOperationException("Failed to add the certificate to the keychain. Are you running in a non-interactive session perhaps?");
+            }
         }
 
         Log.MacOSAddCertificateToKeyChainEnd();

--- a/src/Shared/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/UnixCertificateManager.cs
@@ -8,7 +8,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
-using Microsoft.Win32.SafeHandles;
 
 namespace Microsoft.AspNetCore.Certificates.Generation;
 
@@ -686,14 +685,15 @@ internal sealed partial class UnixCertificateManager : CertificateManager
         // Encode the PowerShell script to Base64 (UTF-16LE as required by PowerShell)
         var encodedCommand = Convert.ToBase64String(System.Text.Encoding.Unicode.GetBytes(powershellScript));
 
-        using SafeFileHandle nullHandle = File.OpenNullHandle();
         var startInfo = new ProcessStartInfo(PowerShellCommand, $"-NoProfile -NonInteractive -EncodedCommand {encodedCommand}")
         {
-            StandardOutputHandle = nullHandle,
-            StandardErrorHandle = nullHandle
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
         };
 
-        return Process.Run(startInfo).ExitCode == 0;
+        using var process = Process.Start(startInfo)!;
+        process.WaitForExit();
+        return process.ExitCode == 0;
     }
 
     /// <remarks>
@@ -706,16 +706,17 @@ internal sealed partial class UnixCertificateManager : CertificateManager
         // (The docs suggest that "-V -u A" should do this, but it seems to accept all certs.)
         var operation = nssDb.IsFirefox ? "-L" : "-V -u V";
 
-        using SafeFileHandle nullHandle = File.OpenNullHandle();
         var startInfo = new ProcessStartInfo(CertUtilCommand, $"-d sql:{nssDb.Path} -n {nickname} {operation}")
         {
-            StandardOutputHandle = nullHandle,
-            StandardErrorHandle = nullHandle
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
         };
 
         try
         {
-            return Process.Run(startInfo).ExitCode == 0;
+            using var process = Process.Start(startInfo)!;
+            process.WaitForExit();
+            return process.ExitCode == 0;
         }
         catch (Exception ex)
         {
@@ -734,16 +735,17 @@ internal sealed partial class UnixCertificateManager : CertificateManager
         var usage = nssDb.IsFirefox ? "C" : "P";
 
         // This silently clobbers an existing entry, so there's no need to check for existence first.
-        using SafeFileHandle nullHandle = File.OpenNullHandle();
         var startInfo = new ProcessStartInfo(CertUtilCommand, $"-d sql:{nssDb.Path} -n {nickname} -A -i {certificatePath} -t \"{usage},,\"")
         {
-            StandardOutputHandle = nullHandle,
-            StandardErrorHandle = nullHandle
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
         };
 
         try
         {
-            return Process.Run(startInfo).ExitCode == 0;
+            using var process = Process.Start(startInfo)!;
+            process.WaitForExit();
+            return process.ExitCode == 0;
         }
         catch (Exception ex)
         {
@@ -757,16 +759,17 @@ internal sealed partial class UnixCertificateManager : CertificateManager
     /// </remarks>
     private static bool TryRemoveCertificateFromNssDb(string nickname, NssDb nssDb)
     {
-        using SafeFileHandle nullHandle = File.OpenNullHandle();
         var startInfo = new ProcessStartInfo(CertUtilCommand, $"-d sql:{nssDb.Path} -D -n {nickname}")
         {
-            StandardOutputHandle = nullHandle,
-            StandardErrorHandle = nullHandle
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
         };
 
         try
         {
-            if (Process.Run(startInfo).ExitCode == 0)
+            using var process = Process.Start(startInfo)!;
+            process.WaitForExit();
+            if (process.ExitCode == 0)
             {
                 return true;
             }
@@ -936,15 +939,17 @@ internal sealed partial class UnixCertificateManager : CertificateManager
                 RedirectStandardError = true
             };
 
-            var processOutput = Process.RunAndCaptureText(processInfo);
+            using var process = Process.Start(processInfo);
+            var stdout = process!.StandardOutput.ReadToEnd();
 
-            if (processOutput.ExitStatus.ExitCode != 0)
+            process.WaitForExit();
+            if (process.ExitCode != 0)
             {
                 Log.UnixOpenSslVersionFailed();
                 return false;
             }
 
-            var match = OpenSslVersionRegex.Match(processOutput.StandardOutput);
+            var match = OpenSslVersionRegex.Match(stdout);
             if (!match.Success)
             {
                 Log.UnixOpenSslVersionParsingFailed();
@@ -978,15 +983,17 @@ internal sealed partial class UnixCertificateManager : CertificateManager
                 RedirectStandardError = true
             };
 
-            var processOutput = Process.RunAndCaptureText(processInfo);
-            
-            if (processOutput.ExitStatus.ExitCode != 0)
+            using var process = Process.Start(processInfo);
+            var stdout = process!.StandardOutput.ReadToEnd();
+
+            process.WaitForExit();
+            if (process.ExitCode != 0)
             {
                 Log.UnixOpenSslHashFailed(certificatePath);
                 return false;
             }
 
-            hash = processOutput.StandardOutput.Trim();
+            hash = stdout.Trim();
             return true;
         }
         catch (Exception ex)


### PR DESCRIPTION
**Do not merge.** Bisection probe for the macOS VSD `DispatchCache` hang (dotnet/runtime#128955, #128859).

Rolls the dotnet/dotnet runtime + SDK dependencies (`eng/Version.Details.xml`, `eng/Version.Details.props`, `global.json`) back to a coherent older codeflow snapshot, and reverts #63531 so the PR-check macOS test leg runs on the `OSX.15.Amd64.Open` Helix queue (where the hang reproduces). Goal: find which runtime version bump introduced the hang. Tests will be run ~3x.
**This probe:** VMR `11.0.0-preview.3.26176.106` / SDK `11.0.100-preview.3.26170.106` (codeflow #65987, Mar 31).