### PR TITLE
[experiment] Disable shared compilation on macOS to test VSD DispatchCache hang

### DIFF
--- a/eng/Workarounds.props
+++ b/eng/Workarounds.props
@@ -23,6 +23,11 @@
     <!-- We use the compiler toolset that comes from NuGet Packages rather than the SDK built-in.
     This one sets UseSharedCompilation to false by default. -->
     <UseSharedCompilation>true</UseSharedCompilation>
+    <!-- Experiment for https://github.com/dotnet/runtime/issues/128955: the long-lived macOS shared-compilation
+         server (VBCSCompiler) is the process spinning in the VSD DispatchCache self-loop hang. Disable shared
+         compilation when building on macOS so each csc runs as a fresh, short-lived process and cannot accumulate
+         into the corrupted dispatch cache. Non-macOS builds keep shared compilation for speed. -->
+    <UseSharedCompilation Condition="$([MSBuild]::IsOSPlatform('OSX'))">false</UseSharedCompilation>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
**Do not merge — experiment only.**

Tests the hypothesis (from a dotnet/runtime engineer) that the macOS VSD `DispatchCache` self-loop hang ([dotnet/runtime#128955](https://github.com/dotnet/runtime/issues/128955)) is caused by the long-lived shared-compilation server (`VBCSCompiler`) accumulating into a corrupted dispatch cache during the macOS build phase.

This sets `UseSharedCompilation=false` when building on macOS (via `$([MSBuild]::IsOSPlatform('OSX'))`), so each `csc` runs as a fresh short-lived process. Affects only the 3 macOS jobs in the public CI; Windows/Linux keep shared compilation.

Will be run through CI several times to check whether the hang disappears. Even if it does, this is only a workaround — the runtime-version bisection continues separately to identify the culprit version.