### PR TITLE
Fix public/unofficial CI NativeAOT cross-build for ARM/ARM64/musl legs

### DIFF
--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -336,13 +336,20 @@ stages:
         jobName: Linux_arm_build
         jobDisplayName: "Build: Linux ARM"
         agentOs: Linux
-        use1ESUbuntu: true
+        # NativeAOT cross-link (dotnet-dev-certs/user-secrets/user-jwts publish AOT for every
+        # bundled RID) needs a cross toolchain + sysroot, so run in the azurelinux cross-prereq
+        # container and pass ROOTFS_DIR + /p:CrossBuild=true (ILC emits --sysroot/--target).
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-arm
+        variables:
+        - name: ROOTFS_DIR
+          value: /crossrootfs/arm
         buildArgs:
           --arch arm
           --pack
           --all
           --no-build-java
           --publish
+          -p:CrossBuild=true
           -p:OnlyPackPlatformSpecificPackages=true
           -p:AssetManifestFileName=aspnetcore-Linux_arm.xml
           $(_BuildArgs)
@@ -368,7 +375,10 @@ stages:
         jobName: Linux_arm64_build
         jobDisplayName: "Build: Linux ARM64"
         agentOs: Linux
-        use1ESUbuntu: true
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-arm64
+        variables:
+        - name: ROOTFS_DIR
+          value: /crossrootfs/arm64
         steps:
         - script: ./eng/build.sh
               --ci
@@ -377,6 +387,7 @@ stages:
               --build-installers
               --all
               --no-build-java
+              -p:CrossBuild=true
               -p:OnlyPackPlatformSpecificPackages=true
               $(_BuildArgs)
               $(_InternalRuntimeDownloadArgs)
@@ -401,7 +412,10 @@ stages:
         jobName: Linux_musl_x64_build
         jobDisplayName: "Build: Linux Musl x64"
         agentOs: Linux
-        container: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-build-amd64
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-amd64-musl
+        variables:
+        - name: ROOTFS_DIR
+          value: /crossrootfs/x64
         buildArgs:
           --arch x64
           --os-name linux-musl
@@ -409,6 +423,7 @@ stages:
           --all
           --no-build-java
           --publish
+          -p:CrossBuild=true
           -p:OnlyPackPlatformSpecificPackages=true
           -p:AssetManifestFileName=aspnetcore-Linux_musl_x64.xml
           $(_BuildArgs)
@@ -435,7 +450,10 @@ stages:
         jobName: Linux_musl_arm_build
         jobDisplayName: "Build: Linux Musl ARM"
         agentOs: Linux
-        container: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-build-amd64
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-arm-musl
+        variables:
+        - name: ROOTFS_DIR
+          value: /crossrootfs/arm
         buildArgs:
           --arch arm
           --os-name linux-musl
@@ -443,6 +461,7 @@ stages:
           --all
           --no-build-java
           --publish
+          -p:CrossBuild=true
           -p:OnlyPackPlatformSpecificPackages=true
           -p:AssetManifestFileName=aspnetcore-Linux_musl_arm.xml
           $(_BuildArgs)
@@ -468,7 +487,10 @@ stages:
         jobName: Linux_musl_arm64_build
         jobDisplayName: "Build: Linux Musl ARM64"
         agentOs: Linux
-        container: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-build-amd64
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-arm64-musl
+        variables:
+        - name: ROOTFS_DIR
+          value: /crossrootfs/arm64
         buildArgs:
           --arch arm64
           --os-name linux-musl
@@ -476,6 +498,7 @@ stages:
           --all
           --no-build-java
           --publish
+          -p:CrossBuild=true
           -p:OnlyPackPlatformSpecificPackages=true
           -p:AssetManifestFileName=aspnetcore-Linux_musl_arm64.xml
           $(_BuildArgs)

--- a/.azure/pipelines/ci-unofficial.yml
+++ b/.azure/pipelines/ci-unofficial.yml
@@ -100,6 +100,20 @@ extends:
     containers:
       azureLinuxBuildAmd64:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-build-amd64
+      # Cross-compilation prereq images (clang + /crossrootfs/<arch>) used by the AOT-publishing
+      # build legs (dotnet-dev-certs / dotnet-user-secrets / dotnet-user-jwts publish NativeAOT for
+      # every bundled RID). These provide the native toolchain + sysroot that NativeAOT cross-linking
+      # requires; the legs set ROOTFS_DIR and pass /p:CrossBuild=true so ILC emits --sysroot/--target.
+      azureLinuxCrossArm:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-arm
+      azureLinuxCrossArm64:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-arm64
+      azureLinuxCrossX64Musl:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-amd64-musl
+      azureLinuxCrossArmMusl:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-arm-musl
+      azureLinuxCrossArm64Musl:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-arm64-musl
     stages:
     - stage: build
       displayName: Build
@@ -344,7 +358,10 @@ extends:
           jobName: Linux_arm_build
           jobDisplayName: "Build: Linux ARM"
           agentOs: Linux
-          use1ESUbuntu: true
+          container: azureLinuxCrossArm
+          variables:
+          - name: ROOTFS_DIR
+            value: /crossrootfs/arm
           beforeBuild:
           - script: git submodule update --init
             displayName: Update submodules
@@ -354,6 +371,7 @@ extends:
             --all
             --no-build-java
             $(_ArcadePublishNonWindowsArg)
+            -p:CrossBuild=true
             -p:OnlyPackPlatformSpecificPackages=true
             -p:AssetManifestFileName=aspnetcore-Linux_arm.xml
             $(_BuildArgs)
@@ -378,7 +396,10 @@ extends:
           jobName: Linux_arm64_build
           jobDisplayName: "Build: Linux ARM64"
           agentOs: Linux
-          use1ESUbuntu: true
+          container: azureLinuxCrossArm64
+          variables:
+          - name: ROOTFS_DIR
+            value: /crossrootfs/arm64
           beforeBuild:
           - script: git submodule update --init
             displayName: Update submodules
@@ -389,6 +410,7 @@ extends:
             --build-installers
             --no-build-java
             $(_ArcadePublishNonWindowsArg)
+            -p:CrossBuild=true
             -p:OnlyPackPlatformSpecificPackages=true
             -p:AssetManifestFileName=aspnetcore-Linux_arm64.xml
             $(_BuildArgs)
@@ -413,7 +435,10 @@ extends:
           jobName: Linux_musl_x64_build
           jobDisplayName: "Build: Linux Musl x64"
           agentOs: Linux
-          container: azureLinuxBuildAmd64
+          container: azureLinuxCrossX64Musl
+          variables:
+          - name: ROOTFS_DIR
+            value: /crossrootfs/x64
           beforeBuild:
           - script: git submodule update --init
             displayName: Update submodules
@@ -424,6 +449,7 @@ extends:
             --all
             --no-build-java
             $(_ArcadePublishNonWindowsArg)
+            -p:CrossBuild=true
             -p:OnlyPackPlatformSpecificPackages=true
             -p:AssetManifestFileName=aspnetcore-Linux_musl_x64.xml
             $(_BuildArgs)
@@ -449,7 +475,10 @@ extends:
           jobName: Linux_musl_arm_build
           jobDisplayName: "Build: Linux Musl ARM"
           agentOs: Linux
-          container: azureLinuxBuildAmd64
+          container: azureLinuxCrossArmMusl
+          variables:
+          - name: ROOTFS_DIR
+            value: /crossrootfs/arm
           beforeBuild:
           - script: git submodule update --init
             displayName: Update submodules
@@ -460,6 +489,7 @@ extends:
             --all
             --no-build-java
             $(_ArcadePublishNonWindowsArg)
+            -p:CrossBuild=true
             -p:OnlyPackPlatformSpecificPackages=true
             -p:AssetManifestFileName=aspnetcore-Linux_musl_arm.xml
             $(_BuildArgs)
@@ -484,7 +514,10 @@ extends:
           jobName: Linux_musl_arm64_build
           jobDisplayName: "Build: Linux Musl ARM64"
           agentOs: Linux
-          container: azureLinuxBuildAmd64
+          container: azureLinuxCrossArm64Musl
+          variables:
+          - name: ROOTFS_DIR
+            value: /crossrootfs/arm64
           beforeBuild:
           - script: git submodule update --init
             displayName: Update submodules
@@ -495,6 +528,7 @@ extends:
             --all
             --no-build-java
             $(_ArcadePublishNonWindowsArg)
+            -p:CrossBuild=true
             -p:OnlyPackPlatformSpecificPackages=true
             -p:AssetManifestFileName=aspnetcore-Linux_musl_arm64.xml
             $(_BuildArgs)


### PR DESCRIPTION
Ports the fix from #67158 (which only touched the internal `ci.yml`) to `ci-public.yml` (def 83) and `ci-unofficial.yml`.

### Why
Codeflow #66933 (preview.6.26280, ~Jun 1) made `dotnet-dev-certs`, `dotnet-user-secrets`, and `dotnet-user-jwts` publish NativeAOT for every bundled RID. The cross Build legs (Linux ARM/ARM64/musl-x64/musl-arm/musl-arm64) lacked a cross toolchain + sysroot, so ILC's lld cross-link fails with `ld.lld: cannot open Scrt1.o` / `unable to find library -ldl/-lrt/-lm/-lgcc`. This breaks those 5 legs on every public-CI build.

### Fix
Run the affected legs in the azurelinux cross-prereq containers with `ROOTFS_DIR=/crossrootfs/<arch>` and `-p:CrossBuild=true`, mirroring #67158:
- `ci-public.yml`: inline cross images + per-leg `ROOTFS_DIR` variable + `-p:CrossBuild=true` (ARM64 leg threads CrossBuild through its inline `./eng/build.sh` script).
- `ci-unofficial.yml`: adds the 5 named cross container resources and references them per-leg with the same `ROOTFS_DIR` + `-p:CrossBuild=true`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>