### PR TITLE
[release/8.0] Update Selenium and Playwright versions to match main

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -305,11 +305,11 @@
     <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     <NSwagApiDescriptionClientVersion>13.0.4</NSwagApiDescriptionClientVersion>
     <PhotinoNETVersion>2.5.2</PhotinoNETVersion>
-    <MicrosoftPlaywrightVersion>1.28.0</MicrosoftPlaywrightVersion>
+    <MicrosoftPlaywrightVersion>1.60.0</MicrosoftPlaywrightVersion>
     <PollyExtensionsHttpVersion>3.0.0</PollyExtensionsHttpVersion>
     <PollyVersion>7.2.4</PollyVersion>
-    <SeleniumSupportVersion>4.17.0</SeleniumSupportVersion>
-    <SeleniumWebDriverVersion>4.17.0</SeleniumWebDriverVersion>
+    <SeleniumSupportVersion>4.44.0</SeleniumSupportVersion>
+    <SeleniumWebDriverVersion>4.44.0</SeleniumWebDriverVersion>
     <SerilogExtensionsLoggingVersion>1.4.0</SerilogExtensionsLoggingVersion>
     <SerilogSinksFileVersion>4.0.0</SerilogSinksFileVersion>
     <StackExchangeRedisVersion>2.7.27</StackExchangeRedisVersion>

--- a/src/ProjectTemplates/test/Templates.Blazor.Tests/BlazorWasmTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Blazor.Tests/BlazorWasmTemplateTest.cs
@@ -320,7 +320,7 @@ public class BlazorWasmTemplateTest : BlazorTemplateTest
 
         // Can navigate to the counter page
         await Task.WhenAll(
-            page.WaitForNavigationAsync(new() { UrlString = "**/counter" }),
+            page.WaitForURLAsync("**/counter"),
             page.WaitForSelectorAsync("h1 >> text=Counter"),
             page.WaitForSelectorAsync("p >> text=Current count: 0"),
             page.ClickAsync("a[href=counter]"));
@@ -333,36 +333,36 @@ public class BlazorWasmTemplateTest : BlazorTemplateTest
         if (usesAuth)
         {
             await Task.WhenAll(
-                page.WaitForNavigationAsync(new() { UrlString = "**/Identity/Account/Login**", WaitUntil = WaitUntilState.NetworkIdle }),
+                page.WaitForURLAsync("**/Identity/Account/Login**", new() { WaitUntil = WaitUntilState.NetworkIdle }),
                 page.ClickAsync("text=Log in"));
 
             await Task.WhenAll(
                 page.WaitForSelectorAsync("[name=\"Input.Email\"]"),
-                page.WaitForNavigationAsync(new() { UrlString = "**/Identity/Account/Register**", WaitUntil = WaitUntilState.NetworkIdle }),
+                page.WaitForURLAsync("**/Identity/Account/Register**", new() { WaitUntil = WaitUntilState.NetworkIdle }),
                 page.ClickAsync("text=Register as a new user"));
 
             var userName = $"{Guid.NewGuid()}@example.com";
             var password = "[PLACEHOLDER]-1a";
 
-            await page.TypeAsync("[name=\"Input.Email\"]", userName);
-            await page.TypeAsync("[name=\"Input.Password\"]", password);
-            await page.TypeAsync("[name=\"Input.ConfirmPassword\"]", password);
+            await page.FillAsync("[name=\"Input.Email\"]", userName);
+            await page.FillAsync("[name=\"Input.Password\"]", password);
+            await page.FillAsync("[name=\"Input.ConfirmPassword\"]", password);
 
             // We will be redirected to the RegisterConfirmation
             await Task.WhenAll(
-                page.WaitForNavigationAsync(new() { UrlString = "**/Identity/Account/RegisterConfirmation**", WaitUntil = WaitUntilState.NetworkIdle }),
+                page.WaitForURLAsync("**/Identity/Account/RegisterConfirmation**", new() { WaitUntil = WaitUntilState.NetworkIdle }),
                 page.ClickAsync("#registerSubmit"));
 
             // We will be redirected to the ConfirmEmail
             await Task.WhenAll(
-                page.WaitForNavigationAsync(new() { UrlString = "**/Identity/Account/ConfirmEmail**", WaitUntil = WaitUntilState.NetworkIdle }),
+                page.WaitForURLAsync("**/Identity/Account/ConfirmEmail**", new() { WaitUntil = WaitUntilState.NetworkIdle }),
                 page.ClickAsync("text=Click here to confirm your account"));
 
             // Now we can login
             await page.ClickAsync("text=Login");
             await page.WaitForSelectorAsync("[name=\"Input.Email\"]");
-            await page.TypeAsync("[name=\"Input.Email\"]", userName);
-            await page.TypeAsync("[name=\"Input.Password\"]", password);
+            await page.FillAsync("[name=\"Input.Email\"]", userName);
+            await page.FillAsync("[name=\"Input.Password\"]", password);
             await page.ClickAsync("#login-submit");
 
             // Need to navigate to fetch page

--- a/src/Shared/BrowserTesting/src/BrowserManagerConfiguration.cs
+++ b/src/Shared/BrowserTesting/src/BrowserManagerConfiguration.cs
@@ -205,7 +205,6 @@ public class BrowserManagerConfiguration
         Env = configuration.GetValue<Dictionary<string, string>>(nameof(BrowserTypeLaunchOptions.Env)),
         DownloadsPath = configuration.GetValue<string>(nameof(BrowserTypeLaunchOptions.DownloadsPath)),
         ExecutablePath = configuration.GetValue<string>(nameof(BrowserTypeLaunchOptions.ExecutablePath)),
-        Devtools = configuration.GetValue<bool?>(nameof(BrowserTypeLaunchOptions.Devtools)),
         Args = BindMultiValueMap(
             configuration.GetSection(nameof(BrowserTypeLaunchOptions.Args)),
             argsMap => argsMap.SelectMany(argNameValue => argNameValue.Value.Prepend(argNameValue.Key)).ToArray()),
@@ -342,7 +341,6 @@ public class BrowserManagerConfiguration
             Env = overrideOptions.Env != default ? overrideOptions.Env : defaultOptions.Env,
             DownloadsPath = overrideOptions.DownloadsPath != default ? overrideOptions.DownloadsPath : defaultOptions.DownloadsPath,
             ExecutablePath = overrideOptions.ExecutablePath != default ? overrideOptions.ExecutablePath : defaultOptions.ExecutablePath,
-            Devtools = overrideOptions.Devtools != default ? overrideOptions.Devtools : defaultOptions.Devtools,
             Args = overrideOptions.Args != default ? overrideOptions.Args : defaultOptions.Args,
             Headless = overrideOptions.Headless != default ? overrideOptions.Headless : defaultOptions.Headless,
             Timeout = overrideOptions.Timeout != default ? overrideOptions.Timeout : defaultOptions.Timeout,


### PR DESCRIPTION
Bumps Selenium and Playwright versions in release/8.0 to match what is in `main` (from dotnet/aspnetcore@423a8c2).

- `MicrosoftPlaywrightVersion` -> `1.60.0`
- `SeleniumSupportVersion` -> `4.44.0`
- `SeleniumWebDriverVersion` -> `4.44.0`