### PR TITLE
[release/9.0] Update Selenium and Playwright versions to match main

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -303,11 +303,11 @@
     <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     <NSwagApiDescriptionClientVersion>13.0.4</NSwagApiDescriptionClientVersion>
     <PhotinoNETVersion>2.5.2</PhotinoNETVersion>
-    <MicrosoftPlaywrightVersion>1.45.1</MicrosoftPlaywrightVersion>
+    <MicrosoftPlaywrightVersion>1.60.0</MicrosoftPlaywrightVersion>
     <PollyExtensionsHttpVersion>3.0.0</PollyExtensionsHttpVersion>
     <PollyVersion>7.2.4</PollyVersion>
-    <SeleniumSupportVersion>4.22.0</SeleniumSupportVersion>
-    <SeleniumWebDriverVersion>4.22.0</SeleniumWebDriverVersion>
+    <SeleniumSupportVersion>4.44.0</SeleniumSupportVersion>
+    <SeleniumWebDriverVersion>4.44.0</SeleniumWebDriverVersion>
     <SerilogExtensionsLoggingVersion>1.4.0</SerilogExtensionsLoggingVersion>
     <SerilogSinksFileVersion>4.0.0</SerilogSinksFileVersion>
     <StackExchangeRedisVersion>2.7.27</StackExchangeRedisVersion>

--- a/src/Components/benchmarkapps/Wasm.Performance/dockerfile
+++ b/src/Components/benchmarkapps/Wasm.Performance/dockerfile
@@ -30,7 +30,7 @@ RUN chmod +x /app/Wasm.Performance.Driver
 
 WORKDIR /app
 
-FROM mcr.microsoft.com/playwright/dotnet:v1.45.1-jammy-amd64 AS final
+FROM mcr.microsoft.com/playwright/dotnet:v1.60.0-noble-amd64 AS final
 COPY --from=build ./app ./
 COPY ./exec.sh ./
 


### PR DESCRIPTION
Bumps Selenium and Playwright versions in release/9.0 to match what is in `main` (from dotnet/aspnetcore@423a8c2).

- `MicrosoftPlaywrightVersion` -> `1.60.0`
- `SeleniumSupportVersion` -> `4.44.0`
- `SeleniumWebDriverVersion` -> `4.44.0`
- Wasm.Performance dockerfile playwright image -> `v1.60.0-noble-amd64`