### PR TITLE
Fix NativeAOT tool build race in NativeAot.Tests

### DIFF
--- a/src/Tools/NativeAot/test/Microsoft.AspNetCore.Tools.NativeAot.Tests.csproj
+++ b/src/Tools/NativeAot/test/Microsoft.AspNetCore.Tools.NativeAot.Tests.csproj
@@ -23,12 +23,15 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
-    <!-- Sequence the aggregate tool build/publish before this test payload consumes its published files. -->
+    <!-- Sequence the aggregate tool build/publish before this test payload consumes its published files.
+         Build it with the same global properties as the solution traversal's build (TargetFramework only, no
+         explicit RuntimeIdentifier) so MSBuild dedupes onto that single build instead of spawning a second,
+         differently-keyed NativeAOT compile that races with it on the shared intermediate sourcelink file. -->
     <ProjectReference Include="..\aspnetcoretools\aspnetcoretools.csproj"
                       ReferenceOutputAssembly="false"
                       SkipGetTargetFrameworkProperties="true"
                       Targets="Build"
-                      Properties="RuntimeIdentifier=$(NativeAotToolPublishRuntimeIdentifier);TargetRuntimeIdentifier=$(NativeAotToolPublishRuntimeIdentifier)"
+                      Properties="TargetFramework=$(DefaultNetCoreTargetFramework)"
                       Private="false" />
   </ItemGroup>
 


### PR DESCRIPTION
## Problem

The Build Tests Helix legs intermittently fail with:

```
System.IO.IOException: The process cannot access the file
'...\artifacts\obj\aspnetcoretools\Release\net11.0\win-x64\native\aspnetcoretools.sourcelink'
because it is being used by another process.
  at ILCompiler.SourceLinkWriter..ctor(...)
ilc exited with code 1
```

`aspnetcoretools` (the NativeAOT aggregate tool) is built **twice concurrently**:

1. By the solution traversal, with globals `{ ..., TargetFramework=net11.0 }` (no RID).
2. By `Microsoft.AspNetCore.Tools.NativeAot.Tests.csproj`'s `ProjectReference`, which passed explicit `RuntimeIdentifier`/`TargetRuntimeIdentifier` globals (no `TargetFramework`).

Because MSBuild caches project results by `(project, global properties)`, the two differing global-property sets are treated as **separate builds**, so two `ilc` processes NativeAOT-compile the project at the same time and race on the shared intermediate `.sourcelink` file. The failure is transient — it only fails when the two `IlcCompile` windows overlap.

## Fix

Build the reference with the **same** global properties the traversal uses (`TargetFramework` only, no explicit RID). MSBuild then dedupes the reference onto the traversal's single build instead of spawning a second compile, eliminating the race while keeping the build-ordering dependency that ensures the tool is published before the test gathers its Helix payload.

The published RID is unchanged: it is still resolved by the standalone build (and by the test's `NativeAotToolPublishRoot` glob) via `RuntimeIdentifier` → `TargetRuntimeIdentifier` → `NETCoreSdkRuntimeIdentifier`, so both the normal repo build and the VMR (cross-RID) build resolve the same RID as before.
