### PR TITLE
Fully dedupe aspnetcoretools build to fix NativeAOT sourcelink race

### DIFF
--- a/src/Tools/NativeAot/test/Microsoft.AspNetCore.Tools.NativeAot.Tests.csproj
+++ b/src/Tools/NativeAot/test/Microsoft.AspNetCore.Tools.NativeAot.Tests.csproj
@@ -24,14 +24,15 @@
 
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
     <!-- Sequence the aggregate tool build/publish before this test payload consumes its published files.
-         Build it with the same global properties as the solution traversal's build (TargetFramework only, no
-         explicit RuntimeIdentifier) so MSBuild dedupes onto that single build instead of spawning a second,
-         differently-keyed NativeAOT compile that races with it on the shared intermediate sourcelink file. -->
+         aspnetcoretools is single-targeted, so the solution traversal builds it with NO TargetFramework
+         (or RuntimeIdentifier) global property. Pass no explicit properties here so this reference resolves
+         to that same MSBuild project instance and dedupes onto it, instead of spawning a second, differently
+         keyed NativeAOT compile that races with it on the shared intermediate sourcelink file. -->
     <ProjectReference Include="..\aspnetcoretools\aspnetcoretools.csproj"
                       ReferenceOutputAssembly="false"
                       SkipGetTargetFrameworkProperties="true"
                       Targets="Build"
-                      Properties="TargetFramework=$(DefaultNetCoreTargetFramework)"
+                      UndefineProperties="TargetFramework;RuntimeIdentifier"
                       Private="false" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Fixes the intermittent NativeAOT build failure where `ilc` errors with:

```
The process cannot access the file '...\artifacts\obj\aspnetcoretools\Release\net11.0\win-x64\native\aspnetcoretools.sourcelink' because it is being used by another process.
```

### Why #67320 wasn't sufficient

#67320 changed the `NativeAot.Tests` → `aspnetcoretools` `ProjectReference` to pass `Properties="TargetFramework=$(DefaultNetCoreTargetFramework)"`, intending to dedupe onto the solution traversal's build. But `aspnetcoretools.csproj` is **single-targeted**, so the solution traversal builds it with **no** `TargetFramework` global property.

MSBuild keys a project instance by `(path + global-properties set)`. Passing `TargetFramework=net11.0` therefore produces a **different** key from the traversal's `{… no TargetFramework}` build, so the two are **not** deduped — they run two concurrent NativeAOT compiles that race on the shared intermediate `aspnetcoretools.sourcelink` file.

Binlog from build `1473385` (Tests: Helix x64 Subset 2) confirms two concurrent `Build` instances of `aspnetcoretools.csproj`, identical in every global property **except** `TargetFramework` (one `<none>`, one `net11.0`), with the `IOException` landing in the `TargetFramework=net11.0` instance.

### Fix

Drop the explicit property and `UndefineProperties="TargetFramework;RuntimeIdentifier"` so the reference resolves to the **same** project instance the traversal builds and dedupes onto it (the reference already sets `SkipGetTargetFrameworkProperties="true"`). Sequencing intent is preserved via the unchanged `ReferenceOutputAssembly="false"` / `Private="false"` build-order edge.
