### PR TITLE
Use IValidatableTypeInfo.TryFindProperty instead of ValidationOptions.TryGetValidatablePropertyInfo

### DIFF
--- a/src/Components/Forms/src/EditContextDataAnnotationsExtensions.cs
+++ b/src/Components/Forms/src/EditContextDataAnnotationsExtensions.cs
@@ -83,7 +83,8 @@ public static partial class EditContextDataAnnotationsExtensions
 
 #pragma warning disable ASP0029 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
             if (_validationOptions is not null &&
-                _validationOptions.TryGetValidatablePropertyInfo(modelType, fieldIdentifier.FieldName, out var validatablePropertyInfo))
+                _validationOptions.TryGetValidatableTypeInfo(modelType, out var typeInfo) &&
+                typeInfo.TryFindProperty(fieldIdentifier.FieldName, _validationOptions) is { } validatablePropertyInfo)
             {
                 var cts = new CancellationTokenSource();
                 var task = ValidateFieldAsync(fieldIdentifier, validatablePropertyInfo, cts.Token);

--- a/src/Components/Forms/src/EditContextDataAnnotationsExtensions.cs
+++ b/src/Components/Forms/src/EditContextDataAnnotationsExtensions.cs
@@ -84,7 +84,7 @@ public static partial class EditContextDataAnnotationsExtensions
 #pragma warning disable ASP0029 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
             if (_validationOptions is not null &&
                 _validationOptions.TryGetValidatableTypeInfo(modelType, out var typeInfo) &&
-                typeInfo.TryFindProperty(fieldIdentifier.FieldName, _validationOptions) is { } validatablePropertyInfo)
+                typeInfo.TryFindProperty(fieldIdentifier.FieldName, _validationOptions, out var validatablePropertyInfo))
             {
                 var cts = new CancellationTokenSource();
                 var task = ValidateFieldAsync(fieldIdentifier, validatablePropertyInfo, cts.Token);

--- a/src/Validation/src/IValidatableTypeInfo.cs
+++ b/src/Validation/src/IValidatableTypeInfo.cs
@@ -26,5 +26,5 @@ public interface IValidatableTypeInfo
     /// <param name="propertyName">The name of the property to find its validatable property info.</param>
     /// <param name="validationOptions">The validation options.</param>
     /// <returns>The validatable property info, or null if not found.</returns>
-    IValidatablePropertyInfo? TryFindProperty(string propertyName, ValidationOptions validationOptions);
+    bool TryFindProperty(string propertyName, ValidationOptions validationOptions, [NotNullWhen(true)] out IValidatablePropertyInfo? validatablePropertyInfo);
 }

--- a/src/Validation/src/IValidatableTypeInfo.cs
+++ b/src/Validation/src/IValidatableTypeInfo.cs
@@ -25,6 +25,7 @@ public interface IValidatableTypeInfo
     /// </summary>
     /// <param name="propertyName">The name of the property to find its validatable property info.</param>
     /// <param name="validationOptions">The validation options.</param>
-    /// <returns>The validatable property info, or null if not found.</returns>
+    /// <param name="validatablePropertyInfo">The validatable property info, or null if not found.</param>
+    /// <returns>True if the property is found. Otherwise, false.</returns>
     bool TryFindProperty(string propertyName, ValidationOptions validationOptions, [NotNullWhen(true)] out IValidatablePropertyInfo? validatablePropertyInfo);
 }

--- a/src/Validation/src/PublicAPI.Unshipped.txt
+++ b/src/Validation/src/PublicAPI.Unshipped.txt
@@ -49,6 +49,5 @@ Microsoft.Extensions.Validation.ValidatableTypeInfo.ValidatableTypeInfo(System.T
 Microsoft.Extensions.Validation.ValidationOptions.Localizer.get -> Microsoft.Extensions.Validation.IValidationLocalizer?
 Microsoft.Extensions.Validation.ValidationOptions.Localizer.set -> void
 Microsoft.Extensions.Validation.ValidationOptions.TryGetValidatableParameterInfo(System.Reflection.ParameterInfo! parameterInfo, out Microsoft.Extensions.Validation.IValidatableParameterInfo? validatableInfo) -> bool
-Microsoft.Extensions.Validation.ValidationOptions.TryGetValidatablePropertyInfo(System.Type! type, string! propertyName, out Microsoft.Extensions.Validation.IValidatablePropertyInfo? validatablePropertyInfo) -> bool
 Microsoft.Extensions.Validation.ValidationOptions.TryGetValidatableTypeInfo(System.Type! type, out Microsoft.Extensions.Validation.IValidatableTypeInfo? validatableTypeInfo) -> bool
 virtual Microsoft.Extensions.Validation.ValidatablePropertyInfo.ValidateAsync(object! containingObject, Microsoft.Extensions.Validation.ValidateContext! context, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!

--- a/src/Validation/src/PublicAPI.Unshipped.txt
+++ b/src/Validation/src/PublicAPI.Unshipped.txt
@@ -37,14 +37,14 @@ Microsoft.Extensions.Validation.IValidatableParameterInfo.ValidateAsync(object? 
 Microsoft.Extensions.Validation.IValidatablePropertyInfo
 Microsoft.Extensions.Validation.IValidatablePropertyInfo.ValidateAsync(object! containingObject, Microsoft.Extensions.Validation.ValidateContext! context, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Microsoft.Extensions.Validation.IValidatableTypeInfo
-Microsoft.Extensions.Validation.IValidatableTypeInfo.TryFindProperty(string! propertyName, Microsoft.Extensions.Validation.ValidationOptions! validationOptions) -> Microsoft.Extensions.Validation.IValidatablePropertyInfo?
+Microsoft.Extensions.Validation.IValidatableTypeInfo.TryFindProperty(string! propertyName, Microsoft.Extensions.Validation.ValidationOptions! validationOptions, out Microsoft.Extensions.Validation.IValidatablePropertyInfo? validatablePropertyInfo) -> bool
 Microsoft.Extensions.Validation.IValidatableTypeInfo.ValidateAsync(object? value, Microsoft.Extensions.Validation.ValidateContext! context, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Microsoft.Extensions.Validation.IValidationLocalizer
 Microsoft.Extensions.Validation.IValidationLocalizer.ResolveDisplayName(in Microsoft.Extensions.Validation.DisplayNameLocalizationContext context) -> string?
 Microsoft.Extensions.Validation.IValidationLocalizer.ResolveErrorMessage(in Microsoft.Extensions.Validation.ErrorMessageLocalizationContext context) -> string?
 Microsoft.Extensions.Validation.ValidatableParameterInfo.ValidatableParameterInfo(System.Type! parameterType, string! name, Microsoft.Extensions.Validation.DisplayNameInfo? displayNameInfo = null) -> void
 Microsoft.Extensions.Validation.ValidatablePropertyInfo.ValidatablePropertyInfo(System.Type! declaringType, System.Type! propertyType, string! name, Microsoft.Extensions.Validation.DisplayNameInfo? displayNameInfo = null) -> void
-Microsoft.Extensions.Validation.ValidatableTypeInfo.TryFindProperty(string! propertyName, Microsoft.Extensions.Validation.ValidationOptions! validationOptions) -> Microsoft.Extensions.Validation.IValidatablePropertyInfo?
+Microsoft.Extensions.Validation.ValidatableTypeInfo.TryFindProperty(string! propertyName, Microsoft.Extensions.Validation.ValidationOptions! validationOptions, out Microsoft.Extensions.Validation.IValidatablePropertyInfo? validatablePropertyInfo) -> bool
 Microsoft.Extensions.Validation.ValidatableTypeInfo.ValidatableTypeInfo(System.Type! type, System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.Validation.ValidatablePropertyInfo!>! members, Microsoft.Extensions.Validation.DisplayNameInfo? displayNameInfo = null) -> void
 Microsoft.Extensions.Validation.ValidationOptions.Localizer.get -> Microsoft.Extensions.Validation.IValidationLocalizer?
 Microsoft.Extensions.Validation.ValidationOptions.Localizer.set -> void

--- a/src/Validation/src/ValidatableTypeInfo.cs
+++ b/src/Validation/src/ValidatableTypeInfo.cs
@@ -16,7 +16,7 @@ public abstract class ValidatableTypeInfo : IValidatableTypeInfo
     private readonly int _membersCount;
     private readonly Type[] _implementedInterfaces;
 
-    /// <summary>T
+    /// <summary>
     /// Creates a new instance of <see cref="ValidatableTypeInfo"/>.
     /// </summary>
     /// <param name="type">The type being validated.</param>

--- a/src/Validation/src/ValidatableTypeInfo.cs
+++ b/src/Validation/src/ValidatableTypeInfo.cs
@@ -80,19 +80,20 @@ public abstract class ValidatableTypeInfo : IValidatableTypeInfo
     /// <param name="validationOptions">The <see cref="ValidationOptions"/> used to resolve metadata for super-types.</param>
     /// <returns>The matching <see cref="ValidatablePropertyInfo"/>, or <see langword="null"/> if no
     /// member with the specified name is declared on <see cref="Type"/> or any of its super-types.</returns>
-    public IValidatablePropertyInfo? TryFindProperty(string propertyName, ValidationOptions validationOptions)
+    public bool TryFindProperty(string propertyName, ValidationOptions validationOptions, [NotNullWhen(true)] out IValidatablePropertyInfo? validatablePropertyInfo)
     {
         if (FindLocalMember(propertyName) is { } localMember)
         {
-            return localMember;
+            validatablePropertyInfo = localMember;
+            return true;
         }
 
         foreach (var @interface in _implementedInterfaces)
         {
             if (validationOptions.TryGetValidatableTypeInfo(@interface, out var interfaceTypeInfo) &&
-                interfaceTypeInfo.TryFindProperty(propertyName, validationOptions) is { } interfaceProperty)
+                interfaceTypeInfo.TryFindProperty(propertyName, validationOptions, out validatablePropertyInfo))
             {
-                return interfaceProperty;
+                return true;
             }
         }
 
@@ -101,13 +102,14 @@ public abstract class ValidatableTypeInfo : IValidatableTypeInfo
         {
             if (validationOptions.TryGetValidatableTypeInfo(baseType, out var baseTypeTypeInfo))
             {
-                return baseTypeTypeInfo.TryFindProperty(propertyName, validationOptions);
+                return baseTypeTypeInfo.TryFindProperty(propertyName, validationOptions, out validatablePropertyInfo);
             }
 
             baseType = baseType.BaseType;
         }
 
-        return null;
+        validatablePropertyInfo = null;
+        return false;
     }
 
     private ValidatablePropertyInfo? FindLocalMember(string memberName)

--- a/src/Validation/src/ValidatableTypeInfo.cs
+++ b/src/Validation/src/ValidatableTypeInfo.cs
@@ -16,7 +16,7 @@ public abstract class ValidatableTypeInfo : IValidatableTypeInfo
     private readonly int _membersCount;
     private readonly Type[] _implementedInterfaces;
 
-    /// <summary>
+    /// <summary>T
     /// Creates a new instance of <see cref="ValidatableTypeInfo"/>.
     /// </summary>
     /// <param name="type">The type being validated.</param>
@@ -78,8 +78,9 @@ public abstract class ValidatableTypeInfo : IValidatableTypeInfo
     /// </remarks>
     /// <param name="propertyName">The CLR name of the property to find.</param>
     /// <param name="validationOptions">The <see cref="ValidationOptions"/> used to resolve metadata for super-types.</param>
-    /// <returns>The matching <see cref="ValidatablePropertyInfo"/>, or <see langword="null"/> if no
-    /// member with the specified name is declared on <see cref="Type"/> or any of its super-types.</returns>
+    /// <param name="validatablePropertyInfo">The matching <see cref="ValidatablePropertyInfo"/>, or <see langword="null"/> if no
+    /// member with the specified name is declared on <see cref="Type"/> or any of its super-types.</param>
+    /// <returns>True if the property was found. Otherwise, false.</returns>
     public bool TryFindProperty(string propertyName, ValidationOptions validationOptions, [NotNullWhen(true)] out IValidatablePropertyInfo? validatablePropertyInfo)
     {
         if (FindLocalMember(propertyName) is { } localMember)

--- a/src/Validation/src/ValidationOptions.cs
+++ b/src/Validation/src/ValidationOptions.cs
@@ -100,37 +100,4 @@ public class ValidationOptions
         validatableInfo = null;
         return false;
     }
-
-    /// <summary>
-    /// Attempts to get validation information for a property declared on the specified type or
-    /// any of its super-types.
-    /// </summary>
-    /// <param name="type">The type that declares or inherits the property.</param>
-    /// <param name="propertyName">The CLR property name to look up.</param>
-    /// <param name="validatablePropertyInfo">When this method returns, contains the validation information
-    /// for the property, if a property with the specified name was found; otherwise,
-    /// <see langword="null" />.</param>
-    /// <returns><see langword="true" /> if a validatable property with the specified name was found;
-    /// otherwise, <see langword="false" />.</returns>
-    /// <remarks>
-    /// Members declared directly on <paramref name="type"/> take precedence over members inherited
-    /// from super-types, matching the order in which <see cref="ValidatableTypeInfo.ValidateAsync"/>
-    /// visits members.
-    /// </remarks>
-    [Experimental("ASP0029", UrlFormat = "https://aka.ms/aspnet/analyzer/{0}")]
-    public bool TryGetValidatablePropertyInfo(Type type, string propertyName, [NotNullWhen(true)] out IValidatablePropertyInfo? validatablePropertyInfo)
-    {
-        ArgumentNullException.ThrowIfNull(type);
-        ArgumentNullException.ThrowIfNull(propertyName);
-
-        if (TryGetValidatableTypeInfo(type, out var typeInfo)
-            && typeInfo.TryFindProperty(propertyName, this) is { } property)
-        {
-            validatablePropertyInfo = property;
-            return true;
-        }
-
-        validatablePropertyInfo = null;
-        return false;
-    }
 }

--- a/src/Validation/test/Microsoft.Extensions.Validation.Tests/ValidatableTypeInfoTests.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.Tests/ValidatableTypeInfoTests.cs
@@ -649,31 +649,6 @@ public class ValidatableTypeInfoTests
     }
 
     [Fact]
-    public void TryGetValidatablePropertyInfo_ThrowsArgumentNullException_WhenTypeIsNull()
-    {
-        var options = new ValidationOptions();
-
-        Assert.Throws<ArgumentNullException>("type", () => options.TryGetValidatablePropertyInfo(null!, "Name", out _));
-    }
-
-    [Fact]
-    public void TryGetValidatablePropertyInfo_ThrowsArgumentNullException_WhenPropertyNameIsNull()
-    {
-        var options = new ValidationOptions();
-
-        Assert.Throws<ArgumentNullException>("propertyName", () => options.TryGetValidatablePropertyInfo(typeof(Person), null!, out _));
-    }
-
-    [Fact]
-    public void TryGetValidatablePropertyInfo_ReturnsFalse_WhenTypeNotRegistered()
-    {
-        var options = new ValidationOptions();
-
-        Assert.False(options.TryGetValidatablePropertyInfo(typeof(Person), "Name", out var propertyInfo));
-        Assert.Null(propertyInfo);
-    }
-
-    [Fact]
     public void TryGetValidatablePropertyInfo_ReturnsFalse_WhenPropertyNotFound()
     {
         var typeInfo = new TestValidatableTypeInfo(typeof(Person), []);
@@ -682,8 +657,7 @@ public class ValidatableTypeInfoTests
             { typeof(Person), typeInfo },
         });
 
-        Assert.False(options.TryGetValidatablePropertyInfo(typeof(Person), "NonExistent", out var propertyInfo));
-        Assert.Null(propertyInfo);
+        Assert.Null(typeInfo.TryFindProperty("NonExistent", options));
     }
 
     [Fact]
@@ -696,8 +670,9 @@ public class ValidatableTypeInfoTests
             { typeof(Person), typeInfo },
         });
 
-        Assert.True(options.TryGetValidatablePropertyInfo(typeof(Person), "Name", out var propertyInfo));
-        Assert.Same(nameProperty, propertyInfo);
+        var retrievedNameProperty = typeInfo.TryFindProperty("Name", options);
+        Assert.NotNull(retrievedNameProperty);
+        Assert.Same(nameProperty, retrievedNameProperty);
     }
 
     [Fact]
@@ -716,13 +691,15 @@ public class ValidatableTypeInfoTests
             { typeof(DerivedEntity), derivedType },
         });
 
-        Assert.True(options.TryGetValidatablePropertyInfo(typeof(DerivedEntity), "Name", out var localProperty));
+        var localProperty = derivedType.TryFindProperty("Name", options);
+        Assert.NotNull(localProperty);
         Assert.Same(nameProperty, localProperty);
 
-        Assert.True(options.TryGetValidatablePropertyInfo(typeof(DerivedEntity), "Id", out var inheritedProperty));
+        var inheritedProperty = derivedType.TryFindProperty("Id", options);
+        Assert.NotNull(inheritedProperty);
         Assert.Same(idProperty, inheritedProperty);
 
-        Assert.False(options.TryGetValidatablePropertyInfo(typeof(DerivedEntity), "NonExistent", out var missingProperty));
+        var missingProperty = derivedType.TryFindProperty("NonExistent", options);
         Assert.Null(missingProperty);
     }
 
@@ -742,7 +719,8 @@ public class ValidatableTypeInfoTests
             { typeof(DerivedEntity), derivedType },
         });
 
-        Assert.True(options.TryGetValidatablePropertyInfo(typeof(DerivedEntity), "Name", out var propertyInfo));
+        var propertyInfo = derivedType.TryFindProperty("Name", options);
+        Assert.NotNull(propertyInfo);
         Assert.Same(derivedNameProperty, propertyInfo);
     }
 
@@ -759,10 +737,11 @@ public class ValidatableTypeInfoTests
             { typeof(DerivedEntity), derivedType },
         });
 
-        Assert.True(options.TryGetValidatablePropertyInfo(typeof(DerivedEntity), "Name", out var localProperty));
+        var localProperty = derivedType.TryFindProperty("Name", options);
+        Assert.NotNull(localProperty);
         Assert.Same(nameProperty, localProperty);
 
-        Assert.False(options.TryGetValidatablePropertyInfo(typeof(DerivedEntity), "Id", out var inheritedProperty));
+        var inheritedProperty = derivedType.TryFindProperty("Id", options);
         Assert.Null(inheritedProperty);
     }
 
@@ -782,13 +761,18 @@ public class ValidatableTypeInfoTests
             { typeof(DerivedEntity), new TestValidatableTypeInfo(typeof(DerivedEntity), [nameProperty]) },
         });
 
-        Assert.True(options.TryGetValidatablePropertyInfo(typeof(DerivedEntity), "Name", out var fromDerived));
+        Assert.True(options.TryGetValidatableTypeInfo(typeof(DerivedEntity), out var derivedEntityInfo));
+
+        var fromDerived = derivedEntityInfo.TryFindProperty("Name", options);
+        Assert.NotNull(fromDerived);
         Assert.Same(nameProperty, fromDerived);
 
-        Assert.True(options.TryGetValidatablePropertyInfo(typeof(DerivedEntity), "CreatedAt", out var fromIntermediate));
+        var fromIntermediate = derivedEntityInfo.TryFindProperty("CreatedAt", options);
+        Assert.NotNull(fromIntermediate);
         Assert.Same(createdAtProperty, fromIntermediate);
 
-        Assert.True(options.TryGetValidatablePropertyInfo(typeof(DerivedEntity), "Id", out var fromBase));
+        var fromBase = derivedEntityInfo.TryFindProperty("Id", options);
+        Assert.NotNull(fromBase);
         Assert.Same(idProperty, fromBase);
     }
 
@@ -808,7 +792,8 @@ public class ValidatableTypeInfoTests
             { typeof(AuditableThing), thingTypeInfo },
         });
 
-        Assert.True(options.TryGetValidatablePropertyInfo(typeof(AuditableThing), "CreatedAt", out var resolved));
+        var resolved = thingTypeInfo.TryFindProperty("CreatedAt", options);
+        Assert.NotNull(resolved);
         Assert.Same(auditedProperty, resolved);
     }
 

--- a/src/Validation/test/Microsoft.Extensions.Validation.Tests/ValidatableTypeInfoTests.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.Tests/ValidatableTypeInfoTests.cs
@@ -726,7 +726,7 @@ public class ValidatableTypeInfoTests
     }
 
     [Fact]
-    public void TryFindProperty_ReturnsNullForInheritedMember_WhenSuperTypeNotResolvable()
+    public void TryFindProperty_ReturnsFalseForInheritedMember_WhenSuperTypeNotResolvable()
     {
         // Only the derived type is registered. Local lookup still works; inherited members
         // remain unresolved and the method returns false without throwing.

--- a/src/Validation/test/Microsoft.Extensions.Validation.Tests/ValidatableTypeInfoTests.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.Tests/ValidatableTypeInfoTests.cs
@@ -649,7 +649,7 @@ public class ValidatableTypeInfoTests
     }
 
     [Fact]
-    public void TryGetValidatablePropertyInfo_ReturnsFalse_WhenPropertyNotFound()
+    public void TryFindProperty_ReturnsNull_WhenPropertyNotFound()
     {
         var typeInfo = new TestValidatableTypeInfo(typeof(Person), []);
         var options = new TestValidationOptions(new Dictionary<Type, ValidatableTypeInfo>
@@ -661,7 +661,7 @@ public class ValidatableTypeInfoTests
     }
 
     [Fact]
-    public void TryGetValidatablePropertyInfo_ReturnsMatchingProperty_WhenPresent()
+    public void TryFindProperty_ReturnsMatchingProperty_WhenPresent()
     {
         var nameProperty = CreatePropertyInfo(typeof(Person), typeof(string), "Name", "Name", []);
         var typeInfo = new TestValidatableTypeInfo(typeof(Person), [nameProperty]);
@@ -676,7 +676,7 @@ public class ValidatableTypeInfoTests
     }
 
     [Fact]
-    public void TryGetValidatablePropertyInfo_ReturnsInheritedProperty_FromSuperType()
+    public void TryFindProperty_ReturnsInheritedProperty_FromSuperType()
     {
         // BaseEntity declares Id; DerivedEntity declares Name. Looking up Id on the derived type
         // should resolve through the super-type info via the validation options resolver.
@@ -704,7 +704,7 @@ public class ValidatableTypeInfoTests
     }
 
     [Fact]
-    public void TryGetValidatablePropertyInfo_LocalDeclarationShadowsInheritedProperty()
+    public void TryFindProperty_LocalDeclarationShadowsInheritedProperty()
     {
         // If both base and derived declare a property with the same name, the derived (local)
         // declaration is returned, matching how ValidateAsync would visit derived members first.
@@ -725,7 +725,7 @@ public class ValidatableTypeInfoTests
     }
 
     [Fact]
-    public void TryGetValidatablePropertyInfo_ReturnsFalseForInheritedMember_WhenSuperTypeNotResolvable()
+    public void TryFindProperty_ReturnsNullForInheritedMember_WhenSuperTypeNotResolvable()
     {
         // Only the derived type is registered. Local lookup still works; inherited members
         // remain unresolved and the method returns false without throwing.
@@ -746,7 +746,7 @@ public class ValidatableTypeInfoTests
     }
 
     [Fact]
-    public void TryGetValidatablePropertyInfo_WalksMultipleInheritanceLevels()
+    public void TryFindProperty_WalksMultipleInheritanceLevels()
     {
         // Three-level chain: BaseEntity (Id) <- IntermediateEntity (CreatedAt) <- DerivedEntity (Name).
         // A lookup on DerivedEntity must reach members declared at every level of the chain.
@@ -777,7 +777,7 @@ public class ValidatableTypeInfoTests
     }
 
     [Fact]
-    public void TryGetValidatablePropertyInfo_ResolvesInterfaceDeclaredProperty()
+    public void TryFindProperty_ResolvesInterfaceDeclaredProperty()
     {
         // Property declared on an interface implemented by the target type. ValidatableTypeInfo's
         // _superTypes list is populated by GetAllImplementedTypes(), which includes interfaces.

--- a/src/Validation/test/Microsoft.Extensions.Validation.Tests/ValidatableTypeInfoTests.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.Tests/ValidatableTypeInfoTests.cs
@@ -649,7 +649,7 @@ public class ValidatableTypeInfoTests
     }
 
     [Fact]
-    public void TryFindProperty_ReturnsNull_WhenPropertyNotFound()
+    public void TryFindProperty_ReturnsFalse_WhenPropertyNotFound()
     {
         var typeInfo = new TestValidatableTypeInfo(typeof(Person), []);
         var options = new TestValidationOptions(new Dictionary<Type, ValidatableTypeInfo>
@@ -657,7 +657,8 @@ public class ValidatableTypeInfoTests
             { typeof(Person), typeInfo },
         });
 
-        Assert.Null(typeInfo.TryFindProperty("NonExistent", options));
+        Assert.False(typeInfo.TryFindProperty("NonExistent", options, out var validatablePropertyInfo));
+        Assert.Null(validatablePropertyInfo);
     }
 
     [Fact]
@@ -670,7 +671,7 @@ public class ValidatableTypeInfoTests
             { typeof(Person), typeInfo },
         });
 
-        var retrievedNameProperty = typeInfo.TryFindProperty("Name", options);
+        Assert.True(typeInfo.TryFindProperty("Name", options, out var retrievedNameProperty));
         Assert.NotNull(retrievedNameProperty);
         Assert.Same(nameProperty, retrievedNameProperty);
     }
@@ -691,15 +692,15 @@ public class ValidatableTypeInfoTests
             { typeof(DerivedEntity), derivedType },
         });
 
-        var localProperty = derivedType.TryFindProperty("Name", options);
+        Assert.True(derivedType.TryFindProperty("Name", options, out var localProperty));
         Assert.NotNull(localProperty);
         Assert.Same(nameProperty, localProperty);
 
-        var inheritedProperty = derivedType.TryFindProperty("Id", options);
+        Assert.True(derivedType.TryFindProperty("Id", options, out var inheritedProperty));
         Assert.NotNull(inheritedProperty);
         Assert.Same(idProperty, inheritedProperty);
 
-        var missingProperty = derivedType.TryFindProperty("NonExistent", options);
+        Assert.False(derivedType.TryFindProperty("NonExistent", options, out var missingProperty));
         Assert.Null(missingProperty);
     }
 
@@ -719,7 +720,7 @@ public class ValidatableTypeInfoTests
             { typeof(DerivedEntity), derivedType },
         });
 
-        var propertyInfo = derivedType.TryFindProperty("Name", options);
+        Assert.True(derivedType.TryFindProperty("Name", options, out var propertyInfo));
         Assert.NotNull(propertyInfo);
         Assert.Same(derivedNameProperty, propertyInfo);
     }
@@ -737,11 +738,11 @@ public class ValidatableTypeInfoTests
             { typeof(DerivedEntity), derivedType },
         });
 
-        var localProperty = derivedType.TryFindProperty("Name", options);
+        Assert.True(derivedType.TryFindProperty("Name", options, out var localProperty));
         Assert.NotNull(localProperty);
         Assert.Same(nameProperty, localProperty);
 
-        var inheritedProperty = derivedType.TryFindProperty("Id", options);
+        Assert.False(derivedType.TryFindProperty("Id", options, out var inheritedProperty));
         Assert.Null(inheritedProperty);
     }
 
@@ -763,15 +764,15 @@ public class ValidatableTypeInfoTests
 
         Assert.True(options.TryGetValidatableTypeInfo(typeof(DerivedEntity), out var derivedEntityInfo));
 
-        var fromDerived = derivedEntityInfo.TryFindProperty("Name", options);
+        Assert.True(derivedEntityInfo.TryFindProperty("Name", options, out var fromDerived));
         Assert.NotNull(fromDerived);
         Assert.Same(nameProperty, fromDerived);
 
-        var fromIntermediate = derivedEntityInfo.TryFindProperty("CreatedAt", options);
+        Assert.True(derivedEntityInfo.TryFindProperty("CreatedAt", options, out var fromIntermediate));
         Assert.NotNull(fromIntermediate);
         Assert.Same(createdAtProperty, fromIntermediate);
 
-        var fromBase = derivedEntityInfo.TryFindProperty("Id", options);
+        Assert.True(derivedEntityInfo.TryFindProperty("Id", options, out var fromBase));
         Assert.NotNull(fromBase);
         Assert.Same(idProperty, fromBase);
     }
@@ -792,7 +793,7 @@ public class ValidatableTypeInfoTests
             { typeof(AuditableThing), thingTypeInfo },
         });
 
-        var resolved = thingTypeInfo.TryFindProperty("CreatedAt", options);
+        Assert.True(thingTypeInfo.TryFindProperty("CreatedAt", options, out var resolved));
         Assert.NotNull(resolved);
         Assert.Same(auditedProperty, resolved);
     }


### PR DESCRIPTION
This mostly goes the opposite way of https://github.com/dotnet/aspnetcore/issues/66955 and removes that public API.

When we split the interfaces, we already have a way to get properties from `IValidatableTypeInfo`. The `TryGetValidatablePropertyInfo` implementation simply just calls into the public API of `IValidatableTypeInfo` and so it's redundant to have both as public APIs.

The PR also switches the TryFindProperty to be bool-returning with out parameter. This is a change over the originally approved API which was discussed internally via email.

@oroztocil Let me know what you think, and we can take this to API review, assuming it's required for no-longer shipped APIs that were previously approved.