### PR TITLE
Use globalized type names in validations gen

### DIFF
--- a/src/Validation/gen/Emitters/ValidationsGenerator.Emitter.cs
+++ b/src/Validation/gen/Emitters/ValidationsGenerator.Emitter.cs
@@ -43,7 +43,7 @@ public sealed partial class ValidationsGenerator : IIncrementalGenerator
 namespace System.Runtime.CompilerServices
 {
     {{GeneratedCodeAttribute}}
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/gen/Emitters/ValidationsGenerator.Emitter.cs
+++ b/src/Validation/gen/Emitters/ValidationsGenerator.Emitter.cs
@@ -43,8 +43,8 @@ public sealed partial class ValidationsGenerator : IIncrementalGenerator
 namespace System.Runtime.CompilerServices
 {
     {{GeneratedCodeAttribute}}
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -122,7 +122,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);
@@ -355,7 +355,7 @@ namespace Microsoft.Extensions.Validation.Generated
             var typeName = validatableType.TypeFQN;
             cw.WriteLine($"if (type == typeof({typeName}))");
             cw.StartBlock();
-            cw.WriteLine($"validatableTypeInfo = new GeneratedValidatableTypeInfo(");
+            cw.WriteLine($"validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(");
             cw.Indent++;
             cw.WriteLine($"type: typeof({typeName}),");
             if (validatableType.Members.IsDefaultOrEmpty)
@@ -384,7 +384,7 @@ namespace Microsoft.Extensions.Validation.Generated
 
     private static void EmitValidatableMemberForCreate(ValidatableProperty member, CodeWriter cw)
     {
-        cw.WriteLine("new GeneratedValidatablePropertyInfo(");
+        cw.WriteLine("new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(");
         cw.Indent++;
         cw.WriteLine($"containingType: typeof({member.ContainingTypeFQN}),");
         cw.WriteLine($"propertyType: typeof({member.TypeFQN}),");
@@ -398,11 +398,11 @@ namespace Microsoft.Extensions.Validation.Generated
     {
         if (member.HasResourceDisplayAttribute)
         {
-            return $"new PropertyResourceDisplayName(typeof({member.ContainingTypeFQN}), \"{member.Name}\")";
+            return $"new global::Microsoft.Extensions.Validation.Generated.PropertyResourceDisplayName(typeof({member.ContainingTypeFQN}), \"{member.Name}\")";
         }
         if (member.DisplayName is not null)
         {
-            return $"new LiteralDisplayName({SymbolDisplay.FormatLiteral(member.DisplayName, quote: true)})";
+            return $"new global::Microsoft.Extensions.Validation.Generated.LiteralDisplayName({SymbolDisplay.FormatLiteral(member.DisplayName, quote: true)})";
         }
         return "null";
     }
@@ -411,11 +411,11 @@ namespace Microsoft.Extensions.Validation.Generated
     {
         if (validatableType.HasResourceDisplayAttribute)
         {
-            return $"new TypeResourceDisplayName(typeof({validatableType.TypeFQN}))";
+            return $"new global::Microsoft.Extensions.Validation.Generated.TypeResourceDisplayName(typeof({validatableType.TypeFQN}))";
         }
         if (validatableType.DisplayName is not null)
         {
-            return $"new LiteralDisplayName({SymbolDisplay.FormatLiteral(validatableType.DisplayName, quote: true)})";
+            return $"new global::Microsoft.Extensions.Validation.Generated.LiteralDisplayName({SymbolDisplay.FormatLiteral(validatableType.DisplayName, quote: true)})";
         }
         return "null";
     }

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.ParameterDisplayName_WithNameOnly#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.ParameterDisplayName_WithNameOnly#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -93,7 +93,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.ParameterDisplayName_WithNameOnly#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.ParameterDisplayName_WithNameOnly#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.ParameterDisplayName_WithResourceType#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.ParameterDisplayName_WithResourceType#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -93,7 +93,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.ParameterDisplayName_WithResourceType#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.ParameterDisplayName_WithResourceType#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.PropertyDisplayName_DisplayAttributeResourceTypeTakesPrecedenceOverDisplayNameAttribute#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.PropertyDisplayName_DisplayAttributeResourceTypeTakesPrecedenceOverDisplayNameAttribute#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,14 +74,14 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::ResourceOverDisplayNameType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::ResourceOverDisplayNameType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ResourceOverDisplayNameType),
                             propertyType: typeof(int),
                             name: "Value",
-                            displayNameInfo: new PropertyResourceDisplayName(typeof(global::ResourceOverDisplayNameType), "Value")
+                            displayNameInfo: new global::Microsoft.Extensions.Validation.Generated.PropertyResourceDisplayName(typeof(global::ResourceOverDisplayNameType), "Value")
                         ),
                     ],
                     displayNameInfo: null
@@ -109,7 +109,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.PropertyDisplayName_DisplayAttributeResourceTypeTakesPrecedenceOverDisplayNameAttribute#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.PropertyDisplayName_DisplayAttributeResourceTypeTakesPrecedenceOverDisplayNameAttribute#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.PropertyDisplayName_DisplayAttributeTakesPrecedenceOverDisplayNameAttribute#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.PropertyDisplayName_DisplayAttributeTakesPrecedenceOverDisplayNameAttribute#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,14 +74,14 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::BothDisplayAttrsType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::BothDisplayAttrsType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::BothDisplayAttrsType),
                             propertyType: typeof(int),
                             name: "Value",
-                            displayNameInfo: new LiteralDisplayName("Display Attr Name")
+                            displayNameInfo: new global::Microsoft.Extensions.Validation.Generated.LiteralDisplayName("Display Attr Name")
                         ),
                     ],
                     displayNameInfo: null
@@ -109,7 +109,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.PropertyDisplayName_DisplayAttributeTakesPrecedenceOverDisplayNameAttribute#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.PropertyDisplayName_DisplayAttributeTakesPrecedenceOverDisplayNameAttribute#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.PropertyDisplayName_WithControlCharacters_EmitsValidLiteral#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.PropertyDisplayName_WithControlCharacters_EmitsValidLiteral#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,14 +74,14 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::PropertyControlCharsType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::PropertyControlCharsType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::PropertyControlCharsType),
                             propertyType: typeof(int),
                             name: "Value",
-                            displayNameInfo: new LiteralDisplayName("Line1\nLine2\tTabbed\rCR\"Quoted\"\\Slash")
+                            displayNameInfo: new global::Microsoft.Extensions.Validation.Generated.LiteralDisplayName("Line1\nLine2\tTabbed\rCR\"Quoted\"\\Slash")
                         ),
                     ],
                     displayNameInfo: null
@@ -109,7 +109,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.PropertyDisplayName_WithControlCharacters_EmitsValidLiteral#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.PropertyDisplayName_WithControlCharacters_EmitsValidLiteral#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.PropertyDisplayName_WithDisplayNameAttribute#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.PropertyDisplayName_WithDisplayNameAttribute#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,14 +74,14 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::DisplayNameAttrType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::DisplayNameAttrType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::DisplayNameAttrType),
                             propertyType: typeof(int),
                             name: "Value",
-                            displayNameInfo: new LiteralDisplayName("Friendly Name")
+                            displayNameInfo: new global::Microsoft.Extensions.Validation.Generated.LiteralDisplayName("Friendly Name")
                         ),
                     ],
                     displayNameInfo: null
@@ -109,7 +109,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.PropertyDisplayName_WithDisplayNameAttribute#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.PropertyDisplayName_WithDisplayNameAttribute#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.PropertyDisplayName_WithNameOnly#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.PropertyDisplayName_WithNameOnly#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.PropertyDisplayName_WithNameOnly#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.PropertyDisplayName_WithNameOnly#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,14 +74,14 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::PropertyDisplayNameType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::PropertyDisplayNameType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::PropertyDisplayNameType),
                             propertyType: typeof(int),
                             name: "Value",
-                            displayNameInfo: new LiteralDisplayName("My Custom Name")
+                            displayNameInfo: new global::Microsoft.Extensions.Validation.Generated.LiteralDisplayName("My Custom Name")
                         ),
                     ],
                     displayNameInfo: null
@@ -109,7 +109,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.PropertyDisplayName_WithResourceType#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.PropertyDisplayName_WithResourceType#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,14 +74,14 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::PropertyResourceDisplayNameType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::PropertyResourceDisplayNameType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::PropertyResourceDisplayNameType),
                             propertyType: typeof(int),
                             name: "Value",
-                            displayNameInfo: new PropertyResourceDisplayName(typeof(global::PropertyResourceDisplayNameType), "Value")
+                            displayNameInfo: new global::Microsoft.Extensions.Validation.Generated.PropertyResourceDisplayName(typeof(global::PropertyResourceDisplayNameType), "Value")
                         ),
                     ],
                     displayNameInfo: null
@@ -109,7 +109,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.PropertyDisplayName_WithResourceType#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.PropertyDisplayName_WithResourceType#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.PropertyDisplayName_WithoutDisplayAttribute_UsesPropertyName#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.PropertyDisplayName_WithoutDisplayAttribute_UsesPropertyName#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,10 +74,10 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::NoDisplayAttributeType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::NoDisplayAttributeType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::NoDisplayAttributeType),
                             propertyType: typeof(int),
                             name: "MyProperty",
@@ -109,7 +109,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.PropertyDisplayName_WithoutDisplayAttribute_UsesPropertyName#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.PropertyDisplayName_WithoutDisplayAttribute_UsesPropertyName#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.RecordPropertyDisplayName_LiteralOnConstructorParameter#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.RecordPropertyDisplayName_LiteralOnConstructorParameter#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,14 +74,14 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::RecordWithParamLiteralDisplay))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::RecordWithParamLiteralDisplay),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::RecordWithParamLiteralDisplay),
                             propertyType: typeof(int),
                             name: "Value",
-                            displayNameInfo: new LiteralDisplayName("Param Literal Name")
+                            displayNameInfo: new global::Microsoft.Extensions.Validation.Generated.LiteralDisplayName("Param Literal Name")
                         ),
                     ],
                     displayNameInfo: null
@@ -109,7 +109,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.RecordPropertyDisplayName_LiteralOnConstructorParameter#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.RecordPropertyDisplayName_LiteralOnConstructorParameter#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.RecordPropertyDisplayName_WithNameOnly#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.RecordPropertyDisplayName_WithNameOnly#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,14 +74,14 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::RecordWithDisplayName))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::RecordWithDisplayName),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::RecordWithDisplayName),
                             propertyType: typeof(int),
                             name: "Value",
-                            displayNameInfo: new LiteralDisplayName("Record Field Label")
+                            displayNameInfo: new global::Microsoft.Extensions.Validation.Generated.LiteralDisplayName("Record Field Label")
                         ),
                     ],
                     displayNameInfo: null
@@ -109,7 +109,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.RecordPropertyDisplayName_WithNameOnly#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.RecordPropertyDisplayName_WithNameOnly#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.RecordPropertyDisplayName_WithResourceType#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.RecordPropertyDisplayName_WithResourceType#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,14 +74,14 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::RecordWithResourceDisplayName))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::RecordWithResourceDisplayName),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::RecordWithResourceDisplayName),
                             propertyType: typeof(int),
                             name: "Value",
-                            displayNameInfo: new PropertyResourceDisplayName(typeof(global::RecordWithResourceDisplayName), "Value")
+                            displayNameInfo: new global::Microsoft.Extensions.Validation.Generated.PropertyResourceDisplayName(typeof(global::RecordWithResourceDisplayName), "Value")
                         ),
                     ],
                     displayNameInfo: null
@@ -109,7 +109,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.RecordPropertyDisplayName_WithResourceType#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.RecordPropertyDisplayName_WithResourceType#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.TypeDisplayName_WithDisplayNameAttribute#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.TypeDisplayName_WithDisplayNameAttribute#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,10 +74,10 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::TypeWithDisplayNameAttr))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::TypeWithDisplayNameAttr),
                     members: [],
-                    displayNameInfo: new LiteralDisplayName("Friendly Type")
+                    displayNameInfo: new global::Microsoft.Extensions.Validation.Generated.LiteralDisplayName("Friendly Type")
                 );
                 return true;
             }
@@ -102,7 +102,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.TypeDisplayName_WithDisplayNameAttribute#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.TypeDisplayName_WithDisplayNameAttribute#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.TypeDisplayName_WithNameOnly#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.TypeDisplayName_WithNameOnly#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,10 +74,10 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::TypeWithDisplayName))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::TypeWithDisplayName),
                     members: [],
-                    displayNameInfo: new LiteralDisplayName("My Model")
+                    displayNameInfo: new global::Microsoft.Extensions.Validation.Generated.LiteralDisplayName("My Model")
                 );
                 return true;
             }
@@ -102,7 +102,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.TypeDisplayName_WithNameOnly#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.TypeDisplayName_WithNameOnly#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.TypeDisplayName_WithResourceType#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.TypeDisplayName_WithResourceType#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,10 +74,10 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::TypeWithResourceDisplayName))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::TypeWithResourceDisplayName),
                     members: [],
-                    displayNameInfo: new TypeResourceDisplayName(typeof(global::TypeWithResourceDisplayName))
+                    displayNameInfo: new global::Microsoft.Extensions.Validation.Generated.TypeResourceDisplayName(typeof(global::TypeWithResourceDisplayName))
                 );
                 return true;
             }
@@ -102,7 +102,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.TypeDisplayName_WithResourceType#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorDisplayNameTests.TypeDisplayName_WithResourceType#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanDiscoverGeneratedValidatableTypeAttribute#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanDiscoverGeneratedValidatableTypeAttribute#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,16 +74,16 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::MyApp.Customer))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::MyApp.Customer),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::MyApp.Customer),
                             propertyType: typeof(string),
                             name: "Name",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::MyApp.Customer),
                             propertyType: typeof(string),
                             name: "Email",
@@ -115,7 +115,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanDiscoverGeneratedValidatableTypeAttribute#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanDiscoverGeneratedValidatableTypeAttribute#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanGenerateWhenAddValidationCalledMultipleTimes#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanGenerateWhenAddValidationCalledMultipleTimes#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,10 +74,10 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::ComplexType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::ComplexType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(int),
                             name: "IntegerWithRange",
@@ -110,7 +110,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanGenerateWhenAddValidationCalledMultipleTimes#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanGenerateWhenAddValidationCalledMultipleTimes#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanUseBothFrameworkAndGeneratedValidatableTypeAttributes#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanUseBothFrameworkAndGeneratedValidatableTypeAttributes#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,16 +74,16 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::MyApp.Customer))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::MyApp.Customer),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::MyApp.Customer),
                             propertyType: typeof(string),
                             name: "Name",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::MyApp.Customer),
                             propertyType: typeof(string),
                             name: "Email",
@@ -96,16 +96,16 @@ namespace Microsoft.Extensions.Validation.Generated
             }
             if (type == typeof(global::MyApp.Product))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::MyApp.Product),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::MyApp.Product),
                             propertyType: typeof(string),
                             name: "ProductName",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::MyApp.Product),
                             propertyType: typeof(decimal),
                             name: "Price",
@@ -137,7 +137,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanUseBothFrameworkAndGeneratedValidatableTypeAttributes#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanUseBothFrameworkAndGeneratedValidatableTypeAttributes#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateClassTypesWithAttribute#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateClassTypesWithAttribute#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,16 +74,16 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::SubType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::SubType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::SubType),
                             propertyType: typeof(string),
                             name: "RequiredProperty",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::SubType),
                             propertyType: typeof(string),
                             name: "StringWithLength",
@@ -96,10 +96,10 @@ namespace Microsoft.Extensions.Validation.Generated
             }
             if (type == typeof(global::SubTypeWithInheritance))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::SubTypeWithInheritance),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::SubTypeWithInheritance),
                             propertyType: typeof(string),
                             name: "EmailString",
@@ -112,52 +112,52 @@ namespace Microsoft.Extensions.Validation.Generated
             }
             if (type == typeof(global::ComplexType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::ComplexType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(int),
                             name: "IntegerWithRange",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(int),
                             name: "IntegerWithRangeAndDisplayName",
-                            displayNameInfo: new LiteralDisplayName("Valid identifier")
+                            displayNameInfo: new global::Microsoft.Extensions.Validation.Generated.LiteralDisplayName("Valid identifier")
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(global::SubType),
                             name: "PropertyWithMemberAttributes",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(global::SubType),
                             name: "PropertyWithoutMemberAttributes",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(global::SubTypeWithInheritance),
                             name: "PropertyWithInheritance",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(global::System.Collections.Generic.List<global::SubType>),
                             name: "ListOfSubTypes",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(int),
                             name: "IntegerWithCustomValidationAttribute",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(int),
                             name: "PropertyWithMultipleAttributes",
@@ -189,7 +189,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateClassTypesWithAttribute#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateClassTypesWithAttribute#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateComplexTypes#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateComplexTypes#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,16 +74,16 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::SubType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::SubType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::SubType),
                             propertyType: typeof(string),
                             name: "RequiredProperty",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::SubType),
                             propertyType: typeof(string),
                             name: "StringWithLength",
@@ -96,10 +96,10 @@ namespace Microsoft.Extensions.Validation.Generated
             }
             if (type == typeof(global::SubTypeWithInheritance))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::SubTypeWithInheritance),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::SubTypeWithInheritance),
                             propertyType: typeof(string),
                             name: "EmailString",
@@ -112,58 +112,58 @@ namespace Microsoft.Extensions.Validation.Generated
             }
             if (type == typeof(global::ComplexType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::ComplexType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(int),
                             name: "IntegerWithRange",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(int),
                             name: "IntegerWithRangeAndDisplayName",
-                            displayNameInfo: new LiteralDisplayName("Valid identifier")
+                            displayNameInfo: new global::Microsoft.Extensions.Validation.Generated.LiteralDisplayName("Valid identifier")
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(global::SubType),
                             name: "PropertyWithMemberAttributes",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(global::SubType),
                             name: "PropertyWithoutMemberAttributes",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(global::SubTypeWithInheritance),
                             name: "PropertyWithInheritance",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(global::System.Collections.Generic.List<global::SubType>),
                             name: "ListOfSubTypes",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(int),
                             name: "IntegerWithDerivedValidationAttribute",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(int),
                             name: "IntegerWithCustomValidation",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(int),
                             name: "PropertyWithMultipleAttributes",
@@ -195,7 +195,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateComplexTypes#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateComplexTypes#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateComplexTypesWithJsonIgnore#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateComplexTypesWithJsonIgnore#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,10 +74,10 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::ComplexTypeWithJsonIgnore))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::ComplexTypeWithJsonIgnore),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexTypeWithJsonIgnore),
                             propertyType: typeof(int),
                             name: "ValidatedProperty",
@@ -90,10 +90,10 @@ namespace Microsoft.Extensions.Validation.Generated
             }
             if (type == typeof(global::RecordTypeWithJsonIgnore))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::RecordTypeWithJsonIgnore),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::RecordTypeWithJsonIgnore),
                             propertyType: typeof(int),
                             name: "ValidatedProperty",
@@ -125,7 +125,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateComplexTypesWithJsonIgnore#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateComplexTypesWithJsonIgnore#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateIValidatableObject#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateIValidatableObject#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,16 +74,16 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::SubType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::SubType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::SubType),
                             propertyType: typeof(string),
                             name: "RequiredProperty",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::SubType),
                             propertyType: typeof(string),
                             name: "StringWithLength",
@@ -96,7 +96,7 @@ namespace Microsoft.Extensions.Validation.Generated
             }
             if (type == typeof(global::ValidatableSubType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::ValidatableSubType),
                     members: [],
                     displayNameInfo: null
@@ -105,16 +105,16 @@ namespace Microsoft.Extensions.Validation.Generated
             }
             if (type == typeof(global::ComplexValidatableType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::ComplexValidatableType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexValidatableType),
                             propertyType: typeof(string),
                             name: "Value2",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexValidatableType),
                             propertyType: typeof(global::ValidatableSubType),
                             name: "SubType",
@@ -146,7 +146,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateIValidatableObject#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateIValidatableObject#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateIValidatableObject_WithoutPropertyValidations#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateIValidatableObject_WithoutPropertyValidations#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,7 +74,7 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::BaseClass))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::BaseClass),
                     members: [],
                     displayNameInfo: null
@@ -83,7 +83,7 @@ namespace Microsoft.Extensions.Validation.Generated
             }
             if (type == typeof(global::DerivedClass))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::DerivedClass),
                     members: [],
                     displayNameInfo: null
@@ -92,7 +92,7 @@ namespace Microsoft.Extensions.Validation.Generated
             }
             if (type == typeof(global::NestedClass))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::NestedClass),
                     members: [],
                     displayNameInfo: null
@@ -101,10 +101,10 @@ namespace Microsoft.Extensions.Validation.Generated
             }
             if (type == typeof(global::ComplexClass))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::ComplexClass),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexClass),
                             propertyType: typeof(global::NestedClass),
                             name: "NestedObject",
@@ -136,7 +136,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateIValidatableObject_WithoutPropertyValidations#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateIValidatableObject_WithoutPropertyValidations#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateMultipleNamespaces#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateMultipleNamespaces#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,10 +74,10 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::NamespaceOne.Type))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::NamespaceOne.Type),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::NamespaceOne.Type),
                             propertyType: typeof(string),
                             name: "StringWithLength",
@@ -90,10 +90,10 @@ namespace Microsoft.Extensions.Validation.Generated
             }
             if (type == typeof(global::NamespaceTwo.Type))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::NamespaceTwo.Type),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::NamespaceTwo.Type),
                             propertyType: typeof(string),
                             name: "StringWithLength",
@@ -125,7 +125,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateMultipleNamespaces#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateMultipleNamespaces#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateParameters#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateParameters#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,10 +74,10 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::TestService))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::TestService),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::TestService),
                             propertyType: typeof(int),
                             name: "Value",
@@ -109,7 +109,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateParameters#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateParameters#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidatePolymorphicTypes#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidatePolymorphicTypes#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,10 +74,10 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::DerivedType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::DerivedType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::DerivedType),
                             propertyType: typeof(string),
                             name: "Value3",
@@ -90,16 +90,16 @@ namespace Microsoft.Extensions.Validation.Generated
             }
             if (type == typeof(global::BaseType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::BaseType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::BaseType),
                             propertyType: typeof(int),
                             name: "Value1",
-                            displayNameInfo: new LiteralDisplayName("Value 1")
+                            displayNameInfo: new global::Microsoft.Extensions.Validation.Generated.LiteralDisplayName("Value 1")
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::BaseType),
                             propertyType: typeof(string),
                             name: "Value2",
@@ -112,10 +112,10 @@ namespace Microsoft.Extensions.Validation.Generated
             }
             if (type == typeof(global::DerivedValidatableType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::DerivedValidatableType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::DerivedValidatableType),
                             propertyType: typeof(string),
                             name: "Value3",
@@ -128,7 +128,7 @@ namespace Microsoft.Extensions.Validation.Generated
             }
             if (type == typeof(global::BaseValidatableType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::BaseValidatableType),
                     members: [],
                     displayNameInfo: null
@@ -137,16 +137,16 @@ namespace Microsoft.Extensions.Validation.Generated
             }
             if (type == typeof(global::ContainerType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::ContainerType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ContainerType),
                             propertyType: typeof(global::BaseType),
                             name: "BaseType",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ContainerType),
                             propertyType: typeof(global::BaseValidatableType),
                             name: "BaseValidatableType",
@@ -178,7 +178,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidatePolymorphicTypes#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidatePolymorphicTypes#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateRecordStructTypes#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateRecordStructTypes#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,16 +74,16 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::SubRecordStruct))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::SubRecordStruct),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::SubRecordStruct),
                             propertyType: typeof(string),
                             name: "RequiredProperty",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::SubRecordStruct),
                             propertyType: typeof(string),
                             name: "StringWithLength",
@@ -96,22 +96,22 @@ namespace Microsoft.Extensions.Validation.Generated
             }
             if (type == typeof(global::ValidatableRecordStruct))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::ValidatableRecordStruct),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ValidatableRecordStruct),
                             propertyType: typeof(int),
                             name: "IntegerWithRange",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ValidatableRecordStruct),
                             propertyType: typeof(int),
                             name: "IntegerWithRangeAndDisplayName",
-                            displayNameInfo: new LiteralDisplayName("Valid identifier")
+                            displayNameInfo: new global::Microsoft.Extensions.Validation.Generated.LiteralDisplayName("Valid identifier")
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ValidatableRecordStruct),
                             propertyType: typeof(global::SubRecordStruct),
                             name: "SubProperty",
@@ -143,7 +143,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateRecordStructTypes#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateRecordStructTypes#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateRecordTypes#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateRecordTypes#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,16 +74,16 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::SubType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::SubType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::SubType),
                             propertyType: typeof(string),
                             name: "RequiredProperty",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::SubType),
                             propertyType: typeof(string),
                             name: "StringWithLength",
@@ -96,10 +96,10 @@ namespace Microsoft.Extensions.Validation.Generated
             }
             if (type == typeof(global::SubTypeWithInheritance))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::SubTypeWithInheritance),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::SubTypeWithInheritance),
                             propertyType: typeof(string),
                             name: "EmailString",
@@ -112,16 +112,16 @@ namespace Microsoft.Extensions.Validation.Generated
             }
             if (type == typeof(global::SubTypeWithoutConstructor))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::SubTypeWithoutConstructor),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::SubTypeWithoutConstructor),
                             propertyType: typeof(string),
                             name: "RequiredProperty",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::SubTypeWithoutConstructor),
                             propertyType: typeof(string),
                             name: "StringWithLength",
@@ -134,64 +134,64 @@ namespace Microsoft.Extensions.Validation.Generated
             }
             if (type == typeof(global::ValidatableRecord))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::ValidatableRecord),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ValidatableRecord),
                             propertyType: typeof(int),
                             name: "IntegerWithRange",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ValidatableRecord),
                             propertyType: typeof(int),
                             name: "IntegerWithRangeAndDisplayName",
-                            displayNameInfo: new LiteralDisplayName("Valid identifier")
+                            displayNameInfo: new global::Microsoft.Extensions.Validation.Generated.LiteralDisplayName("Valid identifier")
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ValidatableRecord),
                             propertyType: typeof(global::SubType),
                             name: "PropertyWithMemberAttributes",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ValidatableRecord),
                             propertyType: typeof(global::SubType),
                             name: "PropertyWithoutMemberAttributes",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ValidatableRecord),
                             propertyType: typeof(global::SubTypeWithInheritance),
                             name: "PropertyWithInheritance",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ValidatableRecord),
                             propertyType: typeof(global::SubTypeWithoutConstructor),
                             name: "PropertyOfSubtypeWithoutConstructor",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ValidatableRecord),
                             propertyType: typeof(global::System.Collections.Generic.List<global::SubType>),
                             name: "ListOfSubTypes",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ValidatableRecord),
                             propertyType: typeof(int),
                             name: "IntegerWithDerivedValidationAttribute",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ValidatableRecord),
                             propertyType: typeof(int),
                             name: "IntegerWithCustomValidation",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ValidatableRecord),
                             propertyType: typeof(int),
                             name: "PropertyWithMultipleAttributes",
@@ -223,7 +223,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateRecordTypes#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateRecordTypes#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateRecordTypesWithAttribute#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateRecordTypesWithAttribute#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,16 +74,16 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::SubType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::SubType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::SubType),
                             propertyType: typeof(string),
                             name: "RequiredProperty",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::SubType),
                             propertyType: typeof(string),
                             name: "StringWithLength",
@@ -96,10 +96,10 @@ namespace Microsoft.Extensions.Validation.Generated
             }
             if (type == typeof(global::SubTypeWithInheritance))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::SubTypeWithInheritance),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::SubTypeWithInheritance),
                             propertyType: typeof(string),
                             name: "EmailString",
@@ -112,52 +112,52 @@ namespace Microsoft.Extensions.Validation.Generated
             }
             if (type == typeof(global::ComplexType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::ComplexType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(int),
                             name: "IntegerWithRange",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(int),
                             name: "IntegerWithRangeAndDisplayName",
-                            displayNameInfo: new LiteralDisplayName("Valid identifier")
+                            displayNameInfo: new global::Microsoft.Extensions.Validation.Generated.LiteralDisplayName("Valid identifier")
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(global::SubType),
                             name: "PropertyWithMemberAttributes",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(global::SubType),
                             name: "PropertyWithoutMemberAttributes",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(global::SubTypeWithInheritance),
                             name: "PropertyWithInheritance",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(global::System.Collections.Generic.List<global::SubType>),
                             name: "ListOfSubTypes",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(int),
                             name: "IntegerWithCustomValidationAttribute",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(int),
                             name: "PropertyWithMultipleAttributes",
@@ -189,7 +189,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateRecordTypesWithAttribute#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateRecordTypesWithAttribute#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateRecursiveTypes#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateRecursiveTypes#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,16 +74,16 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::RecursiveType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::RecursiveType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::RecursiveType),
                             propertyType: typeof(int),
                             name: "Value",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::RecursiveType),
                             propertyType: typeof(global::RecursiveType),
                             name: "Next",
@@ -115,7 +115,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateRecursiveTypes#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateRecursiveTypes#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateTypeWithParsableProperties#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateTypeWithParsableProperties#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateTypeWithParsableProperties#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateTypeWithParsableProperties#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,58 +74,58 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::ComplexTypeWithParsableProperties))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::ComplexTypeWithParsableProperties),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexTypeWithParsableProperties),
                             propertyType: typeof(global::System.Guid?),
                             name: "GuidWithRegularExpression",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexTypeWithParsableProperties),
                             propertyType: typeof(global::System.TimeOnly?),
                             name: "TimeOnlyWithRequiredValue",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexTypeWithParsableProperties),
                             propertyType: typeof(string),
                             name: "Url",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexTypeWithParsableProperties),
                             propertyType: typeof(global::System.DateOnly?),
                             name: "DateOnlyWithRange",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexTypeWithParsableProperties),
                             propertyType: typeof(global::System.DateTime?),
                             name: "DateTimeWithRange",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexTypeWithParsableProperties),
                             propertyType: typeof(decimal?),
                             name: "DecimalWithRange",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexTypeWithParsableProperties),
                             propertyType: typeof(global::System.TimeSpan?),
                             name: "TimeSpanWithHourRange",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexTypeWithParsableProperties),
                             propertyType: typeof(bool),
                             name: "BooleanWithRange",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexTypeWithParsableProperties),
                             propertyType: typeof(global::System.Version),
                             name: "VersionWithRegex",
@@ -157,7 +157,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateValidationAttributesOnClasses#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateValidationAttributesOnClasses#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,7 +74,7 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::NestedType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::NestedType),
                     members: [],
                     displayNameInfo: null
@@ -83,22 +83,22 @@ namespace Microsoft.Extensions.Validation.Generated
             }
             if (type == typeof(global::ComplexType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::ComplexType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(int),
                             name: "X",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(int),
                             name: "Y",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(global::NestedType),
                             name: "ObjectProperty",
@@ -130,7 +130,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateValidationAttributesOnClasses#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateValidationAttributesOnClasses#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.DoesNotEmitForExemptTypes#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.DoesNotEmitForExemptTypes#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,10 +74,10 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::ComplexType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::ComplexType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(int),
                             name: "IntegerWithRange",
@@ -109,7 +109,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.DoesNotEmitForExemptTypes#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.DoesNotEmitForExemptTypes#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.DoesNotEmit_ForSkipValidationAttribute_OnClassProperties#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.DoesNotEmit_ForSkipValidationAttribute_OnClassProperties#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,10 +74,10 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::NestedType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::NestedType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::NestedType),
                             propertyType: typeof(int),
                             name: "IntegerWithRange",
@@ -90,10 +90,10 @@ namespace Microsoft.Extensions.Validation.Generated
             }
             if (type == typeof(global::NonSkippedBaseType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::NonSkippedBaseType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::NonSkippedBaseType),
                             propertyType: typeof(int),
                             name: "IntegerWithRange1",
@@ -106,10 +106,10 @@ namespace Microsoft.Extensions.Validation.Generated
             }
             if (type == typeof(global::NonSkippedSubType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::NonSkippedSubType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::NonSkippedSubType),
                             propertyType: typeof(int),
                             name: "IntegerWithRange2",
@@ -122,22 +122,22 @@ namespace Microsoft.Extensions.Validation.Generated
             }
             if (type == typeof(global::ComplexType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::ComplexType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(global::NestedType),
                             name: "ObjectProperty",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(global::System.Collections.Generic.List<global::NestedType>),
                             name: "ListOfNestedTypes",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(global::NonSkippedSubType),
                             name: "NonSkippedSubTypeProperty",
@@ -169,7 +169,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.DoesNotEmit_ForSkipValidationAttribute_OnClassProperties#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.DoesNotEmit_ForSkipValidationAttribute_OnClassProperties#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.DoesNotEmit_ForSkipValidationAttribute_OnEndpointParameters#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.DoesNotEmit_ForSkipValidationAttribute_OnEndpointParameters#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,10 +74,10 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::ComplexType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::ComplexType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(int),
                             name: "IntegerWithRange",
@@ -109,7 +109,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.DoesNotEmit_ForSkipValidationAttribute_OnEndpointParameters#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.DoesNotEmit_ForSkipValidationAttribute_OnEndpointParameters#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.DoesNotEmit_ForSkipValidationAttribute_OnRecordProperties#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.DoesNotEmit_ForSkipValidationAttribute_OnRecordProperties#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,10 +74,10 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::NestedType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::NestedType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::NestedType),
                             propertyType: typeof(int),
                             name: "IntegerWithRange",
@@ -90,10 +90,10 @@ namespace Microsoft.Extensions.Validation.Generated
             }
             if (type == typeof(global::ComplexType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::ComplexType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::ComplexType),
                             propertyType: typeof(global::NestedType),
                             name: "ObjectProperty",
@@ -125,7 +125,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.DoesNotEmit_ForSkipValidationAttribute_OnRecordProperties#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.DoesNotEmit_ForSkipValidationAttribute_OnRecordProperties#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.SkipsClassesWithNonAccessibleTypes#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.SkipsClassesWithNonAccessibleTypes#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,10 +74,10 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::AccessibilityTestType))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::AccessibilityTestType),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::AccessibilityTestType),
                             propertyType: typeof(string),
                             name: "PublicProperty",
@@ -109,7 +109,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.SkipsClassesWithNonAccessibleTypes#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.SkipsClassesWithNonAccessibleTypes#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.SkipsIndexerPropertiesOnTypes#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.SkipsIndexerPropertiesOnTypes#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,10 +74,10 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::TypeWithJsonElement))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::TypeWithJsonElement),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::TypeWithJsonElement),
                             propertyType: typeof(string),
                             name: "Name",
@@ -109,7 +109,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.SkipsIndexerPropertiesOnTypes#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.SkipsIndexerPropertiesOnTypes#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.SkipsNonReadableAndStaticProperties#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.SkipsNonReadableAndStaticProperties#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,10 +74,10 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::Address))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::Address),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::Address),
                             propertyType: typeof(string),
                             name: "Street",
@@ -90,16 +90,16 @@ namespace Microsoft.Extensions.Validation.Generated
             }
             if (type == typeof(global::Order))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::Order),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::Order),
                             propertyType: typeof(string),
                             name: "CustomerName",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::Order),
                             propertyType: typeof(global::Address),
                             name: "ShippingAddress",
@@ -131,7 +131,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.SkipsNonReadableAndStaticProperties#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.SkipsNonReadableAndStaticProperties#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.ValidatesPropertiesWithJsonIgnoreWhenWritingConditions#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.ValidatesPropertiesWithJsonIgnoreWhenWritingConditions#ValidatableInfoResolver.g.verified.cs
@@ -14,8 +14,8 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    file sealed class InterceptsLocationAttribute : System.Attribute
+    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)
         {
@@ -74,22 +74,22 @@ namespace Microsoft.Extensions.Validation.Generated
             validatableTypeInfo = null;
             if (type == typeof(global::JsonIgnoreConditionsModel))
             {
-                validatableTypeInfo = new GeneratedValidatableTypeInfo(
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
                     type: typeof(global::JsonIgnoreConditionsModel),
                     members: [
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::JsonIgnoreConditionsModel),
                             propertyType: typeof(string),
                             name: "PropertyWithWhenWritingDefault",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::JsonIgnoreConditionsModel),
                             propertyType: typeof(string),
                             name: "PropertyWithWhenWritingNull",
                             displayNameInfo: null
                         ),
-                        new GeneratedValidatablePropertyInfo(
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
                             containingType: typeof(global::JsonIgnoreConditionsModel),
                             propertyType: typeof(string),
                             name: "PropertyWithNever",
@@ -121,7 +121,7 @@ namespace Microsoft.Extensions.Validation.Generated
             // Use non-extension method to avoid infinite recursion.
             return global::Microsoft.Extensions.DependencyInjection.ValidationServiceCollectionExtensions.AddValidation(services, options =>
             {
-                options.Resolvers.Insert(0, new GeneratedValidatableInfoResolver());
+                options.Resolvers.Insert(0, new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableInfoResolver());
                 if (configureOptions is not null)
                 {
                     configureOptions(options);

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.ValidatesPropertiesWithJsonIgnoreWhenWritingConditions#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.ValidatesPropertiesWithJsonIgnoreWhenWritingConditions#ValidatableInfoResolver.g.verified.cs
@@ -14,7 +14,7 @@
 namespace System.Runtime.CompilerServices
 {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Validation.ValidationsGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42")]
-    [global::System.AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
     file sealed class InterceptsLocationAttribute : global::System.Attribute
     {
         public InterceptsLocationAttribute(int version, string data)


### PR DESCRIPTION
It's always a good practice to use `global::` in generated code to avoid any potential conflicts.