### PR TITLE
Fix OpenApiSchemaService to handle implementation different from Dictionary<,> for schema.Properties

### DIFF
--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -358,9 +358,8 @@ internal sealed class OpenApiSchemaService(
 
         if (schema.Properties is not null)
         {
-            foreach (var key in schema.Properties.Keys.ToList())
+            foreach (var (key, propertyValue) in schema.Properties.ToList())
             {
-                var propertyValue = schema.Properties[key];
                 var resolvedProperty = ResolveReferenceForSchema(document, propertyValue, rootSchemaId);
                 if (propertyValue is OpenApiSchema targetSchema &&
                     targetSchema.Metadata?.TryGetValue(OpenApiConstants.NullableProperty, out var isNullableProperty) == true &&

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -358,6 +358,8 @@ internal sealed class OpenApiSchemaService(
 
         if (schema.Properties is not null)
         {
+            // Materialize the collection first because IDictionary<TKey, TValue> implementations
+            // (e.g. SortedDictionary) may disallow modifying the collection while enumerating it.
             foreach (var (key, propertyValue) in schema.Properties.ToList())
             {
                 var resolvedProperty = ResolveReferenceForSchema(document, propertyValue, rootSchemaId);

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -358,18 +358,19 @@ internal sealed class OpenApiSchemaService(
 
         if (schema.Properties is not null)
         {
-            foreach (var property in schema.Properties)
+            foreach (var key in schema.Properties.Keys.ToList())
             {
-                var resolvedProperty = ResolveReferenceForSchema(document, property.Value, rootSchemaId);
-                if (property.Value is OpenApiSchema targetSchema &&
+                var propertyValue = schema.Properties[key];
+                var resolvedProperty = ResolveReferenceForSchema(document, propertyValue, rootSchemaId);
+                if (propertyValue is OpenApiSchema targetSchema &&
                     targetSchema.Metadata?.TryGetValue(OpenApiConstants.NullableProperty, out var isNullableProperty) == true &&
                     isNullableProperty is true)
                 {
-                    schema.Properties[property.Key] = resolvedProperty.CreateOneOfNullableWrapper();
+                    schema.Properties[key] = resolvedProperty.CreateOneOfNullableWrapper();
                 }
                 else
                 {
-                    schema.Properties[property.Key] = resolvedProperty;
+                    schema.Properties[key] = resolvedProperty;
                 }
             }
         }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/SchemaTransformerTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/SchemaTransformerTests.cs
@@ -942,6 +942,30 @@ public class SchemaTransformerTests : OpenApiDocumentServiceTestBase
         Assert.Equal([1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3], transformerOrder);
     }
 
+    [Fact]
+    public async Task SchemaTransformer_WithSortedDictionaryProperties_DoesNotThrow()
+    {
+        // Verifies that ResolveReferenceForSchema does not throw InvalidOperationException
+        // when schema.Properties is backed by a SortedDictionary (or any IDictionary
+        // that detects modification during enumeration).
+        var builder = CreateBuilder();
+
+        builder.MapPost("/todo", (Todo todo) => { });
+
+        var options = new OpenApiOptions();
+        options.AddSchemaTransformer((schema, context, cancellationToken) =>
+        {
+            if (schema.Properties is { Count: > 0 })
+            {
+                schema.Properties = new SortedDictionary<string, IOpenApiSchema>(schema.Properties);
+            }
+            return Task.CompletedTask;
+        });
+
+        // Should not throw InvalidOperationException: Collection was modified; enumeration operation may not execute.
+        await VerifyOpenApiDocument(builder, options, document => { });
+    }
+
     private class PolymorphicContainer
     {
         public string Name { get; }


### PR DESCRIPTION
This pull request addresses a potential runtime exception when handling OpenAPI schema properties that are stored in collections sensitive to modification during enumeration (such as `SortedDictionary`). The core fix involves modifying the way properties are iterated and updated, and a test is added to ensure robustness.

**Bug fix for property enumeration and update:**
- Changed the iteration over `schema.Properties` in `OpenApiSchemaService.cs` to first create a list of keys (`schema.Properties.Keys.ToList()`) and then update properties by key, preventing `InvalidOperationException` when `schema.Properties` is a collection like `SortedDictionary` that detects modification during enumeration.

**Test coverage improvements:**
- Added a new test `SchemaTransformer_WithSortedDictionaryProperties_DoesNotThrow` in `SchemaTransformerTests.cs` to verify that `ResolveReferenceForSchema` does not throw when `schema.Properties` is a `SortedDictionary`, ensuring the fix is validated and preventing regressions.

Fixes #67086
