### PR TITLE
Fix preview 5 regression for OpenApi nullable enums

### DIFF
--- a/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
@@ -367,12 +367,22 @@ internal static class JsonNodeSchemaExtensions
             var enumType = Nullable.GetUnderlyingType(paramType) ?? paramType;
             if (enumType.IsEnum && schema[OpenApiSchemaKeywords.EnumKeyword] is JsonArray)
             {
+                // While SupportsNullableProperty has the same implementation as IsNonBodyBindingSource today,
+                // and so it will always be true here. We keep the check to be future-proof.
+                var shouldAddNull = enumType != paramType && SupportsNullableProperty(source);
+
                 var memberNames = Enum.GetNames(enumType);
                 var enumArray = new JsonArray();
                 foreach (var name in memberNames)
                 {
                     enumArray.Add((JsonNode)name);
                 }
+
+                if (shouldAddNull)
+                {
+                    enumArray.Add(null);
+                }
+
                 schema[OpenApiSchemaKeywords.EnumKeyword] = enumArray;
 
                 // Also fix the default value — it was serialized using the naming policy

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/OpenApiDocumentEnumNamingPolicyIntegrationTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/OpenApiDocumentEnumNamingPolicyIntegrationTests.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+[UsesVerify]
+public sealed class OpenApiDocumentEnumNamingPolicyIntegrationTests : OpenApiDocumentServiceTestBase
+{
+    public static TheoryData<OpenApiSpecVersion> SpecVersions() => new()
+    {
+        OpenApiSpecVersion.OpenApi3_0,
+        OpenApiSpecVersion.OpenApi3_1,
+        OpenApiSpecVersion.OpenApi3_2,
+    };
+
+    [Theory]
+    [MemberData(nameof(SpecVersions))]
+    public async Task GetOpenApiParameters_NullableEnumWithGlobalNamingPolicy_NonBodySchemaEnumIncludesNull(OpenApiSpecVersion version)
+    {
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.ConfigureHttpJsonOptions(options =>
+        {
+            options.SerializerOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.KebabCaseLower));
+        });
+        var builder = CreateBuilder(serviceCollection);
+
+        builder.MapGet("/api/query", (Priority? priority) => { });
+
+        await VerifyDocument(builder, version);
+    }
+
+    [Theory]
+    [MemberData(nameof(SpecVersions))]
+    public async Task GetOpenApiRequestBody_NullableEnumWithGlobalNamingPolicy_BodySchemaEnumIncludesNull(OpenApiSpecVersion version)
+    {
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.ConfigureHttpJsonOptions(options =>
+        {
+            options.SerializerOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.KebabCaseLower));
+        });
+        var builder = CreateBuilder(serviceCollection);
+
+        builder.MapPost("/body-enum", ([FromBody] Priority? priority) => { });
+
+        await VerifyDocument(builder, version);
+    }
+
+    private static async Task VerifyDocument(IEndpointRouteBuilder builder, OpenApiSpecVersion version, [CallerMemberName] string testName = null)
+    {
+        OpenApiDocument capturedDocument = null;
+        await VerifyOpenApiDocument(builder, document => capturedDocument = document);
+        var json = await capturedDocument.SerializeAsJsonAsync(version);
+
+        var baseSnapshotsDirectory = SkipOnHelixAttribute.OnHelix()
+            ? Path.Combine(AppContext.BaseDirectory, "Integration", "snapshots")
+            : "snapshots";
+        var outputDirectory = Path.Combine(baseSnapshotsDirectory, version.ToString());
+
+        await Verify(json)
+            .UseDirectory(outputDirectory)
+            .UseMethodName(testName);
+    }
+}

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentEnumNamingPolicyIntegrationTests.GetOpenApiParameters_NullableEnumWithGlobalNamingPolicy_NonBodySchemaEnumIncludesNull.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentEnumNamingPolicyIntegrationTests.GetOpenApiParameters_NullableEnumWithGlobalNamingPolicy_NonBodySchemaEnumIncludesNull.verified.txt
@@ -1,0 +1,40 @@
+﻿{
+  "openapi": "3.0.4",
+  "info": {
+    "title": "OpenApiDocumentServiceTests | Test",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/api/query": {
+      "get": {
+        "tags": [
+          "OpenApiDocumentServiceTests"
+        ],
+        "parameters": [
+          {
+            "name": "priority",
+            "in": "query",
+            "schema": {
+              "enum": [
+                "HighPriority",
+                "MediumPriority",
+                "LowPriority",
+                null
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "OpenApiDocumentServiceTests"
+    }
+  ]
+}

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentEnumNamingPolicyIntegrationTests.GetOpenApiRequestBody_NullableEnumWithGlobalNamingPolicy_BodySchemaEnumIncludesNull.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentEnumNamingPolicyIntegrationTests.GetOpenApiRequestBody_NullableEnumWithGlobalNamingPolicy_BodySchemaEnumIncludesNull.verified.txt
@@ -1,0 +1,52 @@
+﻿{
+  "openapi": "3.0.4",
+  "info": {
+    "title": "OpenApiDocumentServiceTests | Test",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/body-enum": {
+      "post": {
+        "tags": [
+          "OpenApiDocumentServiceTests"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/Priority"
+                  }
+                ],
+                "nullable": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Priority": {
+        "enum": [
+          "high-priority",
+          "medium-priority",
+          "low-priority",
+          null
+        ]
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "OpenApiDocumentServiceTests"
+    }
+  ]
+}

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentEnumNamingPolicyIntegrationTests.GetOpenApiParameters_NullableEnumWithGlobalNamingPolicy_NonBodySchemaEnumIncludesNull.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentEnumNamingPolicyIntegrationTests.GetOpenApiParameters_NullableEnumWithGlobalNamingPolicy_NonBodySchemaEnumIncludesNull.verified.txt
@@ -1,0 +1,40 @@
+﻿{
+  "openapi": "3.1.2",
+  "info": {
+    "title": "OpenApiDocumentServiceTests | Test",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/api/query": {
+      "get": {
+        "tags": [
+          "OpenApiDocumentServiceTests"
+        ],
+        "parameters": [
+          {
+            "name": "priority",
+            "in": "query",
+            "schema": {
+              "enum": [
+                "HighPriority",
+                "MediumPriority",
+                "LowPriority",
+                null
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "OpenApiDocumentServiceTests"
+    }
+  ]
+}

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentEnumNamingPolicyIntegrationTests.GetOpenApiRequestBody_NullableEnumWithGlobalNamingPolicy_BodySchemaEnumIncludesNull.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentEnumNamingPolicyIntegrationTests.GetOpenApiRequestBody_NullableEnumWithGlobalNamingPolicy_BodySchemaEnumIncludesNull.verified.txt
@@ -1,0 +1,54 @@
+﻿{
+  "openapi": "3.1.2",
+  "info": {
+    "title": "OpenApiDocumentServiceTests | Test",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/body-enum": {
+      "post": {
+        "tags": [
+          "OpenApiDocumentServiceTests"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/Priority"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Priority": {
+        "enum": [
+          "high-priority",
+          "medium-priority",
+          "low-priority",
+          null
+        ]
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "OpenApiDocumentServiceTests"
+    }
+  ]
+}

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_2/OpenApiDocumentEnumNamingPolicyIntegrationTests.GetOpenApiParameters_NullableEnumWithGlobalNamingPolicy_NonBodySchemaEnumIncludesNull.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_2/OpenApiDocumentEnumNamingPolicyIntegrationTests.GetOpenApiParameters_NullableEnumWithGlobalNamingPolicy_NonBodySchemaEnumIncludesNull.verified.txt
@@ -1,0 +1,40 @@
+﻿{
+  "openapi": "3.2.0",
+  "info": {
+    "title": "OpenApiDocumentServiceTests | Test",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/api/query": {
+      "get": {
+        "tags": [
+          "OpenApiDocumentServiceTests"
+        ],
+        "parameters": [
+          {
+            "name": "priority",
+            "in": "query",
+            "schema": {
+              "enum": [
+                "HighPriority",
+                "MediumPriority",
+                "LowPriority",
+                null
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "OpenApiDocumentServiceTests"
+    }
+  ]
+}

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_2/OpenApiDocumentEnumNamingPolicyIntegrationTests.GetOpenApiRequestBody_NullableEnumWithGlobalNamingPolicy_BodySchemaEnumIncludesNull.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_2/OpenApiDocumentEnumNamingPolicyIntegrationTests.GetOpenApiRequestBody_NullableEnumWithGlobalNamingPolicy_BodySchemaEnumIncludesNull.verified.txt
@@ -1,0 +1,54 @@
+﻿{
+  "openapi": "3.2.0",
+  "info": {
+    "title": "OpenApiDocumentServiceTests | Test",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/body-enum": {
+      "post": {
+        "tags": [
+          "OpenApiDocumentServiceTests"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/Priority"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Priority": {
+        "enum": [
+          "high-priority",
+          "medium-priority",
+          "low-priority",
+          null
+        ]
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "OpenApiDocumentServiceTests"
+    }
+  ]
+}


### PR DESCRIPTION
This regressed in https://github.com/dotnet/aspnetcore/pull/66228

Previously, we were getting the "null" in the enum array, but in https://github.com/dotnet/aspnetcore/pull/66228 we started to write the array ourselves and we dropped the null for nullable enums. This makes sure that null is kept.