### PR TITLE
Rename SupportsNullableProperty to DoesNotSupportNullValue

### DIFF
--- a/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
@@ -403,7 +403,7 @@ internal static class JsonNodeSchemaExtensions
         }
 
         if (parameterDescription.Source is { } bindingSource
-            && SupportsNullableProperty(bindingSource)
+            && DoesNotSupportNullValue(bindingSource)
             && MapJsonNodeToSchemaType(schema[OpenApiSchemaKeywords.TypeKeyword]) is { } schemaTypes &&
             schemaTypes.HasFlag(JsonSchemaType.Null))
         {
@@ -412,7 +412,7 @@ internal static class JsonNodeSchemaExtensions
 
         // Parameters sourced from the header, query, route, and/or form cannot be nullable based on our binding
         // rules but can be optional.
-        static bool SupportsNullableProperty(BindingSource bindingSource) => bindingSource == BindingSource.Header
+        static bool DoesNotSupportNullValue(BindingSource bindingSource) => bindingSource == BindingSource.Header
             || bindingSource == BindingSource.Query
             || bindingSource == BindingSource.Path
             || bindingSource == BindingSource.Form


### PR DESCRIPTION
Following a discussion with @mikekistler, the method name is wrong. It's used actually in a code path that removes "null" flag.