### PR TITLE
[Blazor] Execute `discoverBrowserConfiguration` on every enhanced navigation

### DIFF
--- a/src/Components/Web.JS/src/Rendering/DomMerging/DomSync.ts
+++ b/src/Components/Web.JS/src/Rendering/DomMerging/DomSync.ts
@@ -23,8 +23,6 @@ export function attachComponentDescriptorHandler(handler: DescriptorHandler) {
 export function registerAllComponentDescriptors(root: Node) {
   const webAssemblyOptions = discoverWebAssemblyOptions(root);
   if (webAssemblyOptions) { descriptorHandler?.setWebAssemblyOptions(webAssemblyOptions); }
-  const browserConfiguration = discoverBrowserConfiguration(root);
-  if (browserConfiguration?.webAssembly) { descriptorHandler?.setWebAssemblyOptions(browserConfiguration.webAssembly); }
   const descriptors = upgradeComponentCommentsToLogicalRootComments(root);
 
   for (const descriptor of descriptors) {
@@ -38,6 +36,10 @@ function preprocessAndSynchronizeDomContent(destination: CommentBoundedRange | N
   // Strip any WebAssembly metadata comments from the new content before building
   // the logical tree, so they don't end up as orphaned nodes in the logical children array
   discoverWebAssemblyOptions(newContent);
+
+  // Rediscover the browser configuration in the new content, in case WebAssembly hasn't started yet.
+  const browserConfiguration = discoverBrowserConfiguration(newContent);
+  if (browserConfiguration?.webAssembly) { descriptorHandler?.setWebAssemblyOptions(browserConfiguration.webAssembly); }
 
   // Start by recursively identifying component markers in the new content
   // and converting them into logical elements so they correctly participate

--- a/src/Components/Web.JS/src/Rendering/DomMerging/DomSync.ts
+++ b/src/Components/Web.JS/src/Rendering/DomMerging/DomSync.ts
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-import { AutoComponentDescriptor, ComponentDescriptor, ServerComponentDescriptor, WebAssemblyComponentDescriptor, WebAssemblyServerOptions, canMergeDescriptors, discoverComponents, discoverWebAssemblyOptions, mergeDescriptors } from '../../Services/ComponentDescriptorDiscovery';
+import { AutoComponentDescriptor, ComponentDescriptor, ServerComponentDescriptor, WebAssemblyComponentDescriptor, WebAssemblyServerOptions, canMergeDescriptors, discoverBrowserConfiguration, discoverComponents, discoverWebAssemblyOptions, mergeDescriptors } from '../../Services/ComponentDescriptorDiscovery';
 import { isInteractiveRootComponentElement } from '../BrowserRenderer';
 import { applyAnyDeferredValue } from '../DomSpecialPropertyUtil';
 import { LogicalElement, getLogicalChildrenArray, getLogicalNextSibling, getLogicalParent, getLogicalRootDescriptor, insertLogicalChild, insertLogicalChildBefore, isLogicalElement, toLogicalElement, toLogicalRootCommentElement } from '../LogicalElements';
@@ -23,6 +23,8 @@ export function attachComponentDescriptorHandler(handler: DescriptorHandler) {
 export function registerAllComponentDescriptors(root: Node) {
   const webAssemblyOptions = discoverWebAssemblyOptions(root);
   if (webAssemblyOptions) { descriptorHandler?.setWebAssemblyOptions(webAssemblyOptions); }
+  const browserConfiguration = discoverBrowserConfiguration(root);
+  if (browserConfiguration?.webAssembly) { descriptorHandler?.setWebAssemblyOptions(browserConfiguration.webAssembly); }
   const descriptors = upgradeComponentCommentsToLogicalRootComments(root);
 
   for (const descriptor of descriptors) {

--- a/src/Components/Web.JS/src/Services/ComponentDescriptorDiscovery.ts
+++ b/src/Components/Web.JS/src/Services/ComponentDescriptorDiscovery.ts
@@ -374,8 +374,8 @@ export type WebAssemblyComponentDescriptor = WebAssemblyComponentMarker & Descri
 export type AutoComponentDescriptor = AutoComponentMarker & DescriptorData;
 
 export type WebAssemblyServerOptions = {
-  environmentName: string,
-  environmentVariables: { [i: string]: string; }
+  environmentName?: string,
+  environmentVariables?: { [i: string]: string; }
 };
 
 type DescriptorData = {

--- a/src/Components/test/E2ETest/Tests/BrowserConfigurationTest.cs
+++ b/src/Components/test/E2ETest/Tests/BrowserConfigurationTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Components.TestServer.RazorComponents;
+using Microsoft.AspNetCore.Components.E2ETest;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.E2ETesting;
@@ -37,11 +38,17 @@ public class BrowserConfigurationTest(
         Navigate($"{ServerPathBase}/browser-configuration-env-vars-landing");
         Browser.Equal("static", () => Browser.Exists(By.Id("execution-mode")).Text);
 
+        // Capture a stable element to verify enhanced navigation (DOM preservation)
+        var htmlElement = Browser.Exists(By.TagName("html"));
+
         // Navigate to the WASM page via enhanced navigation (clicking a link)
         Browser.Click(By.Id("navigate-to-env-vars"));
 
         // Wait for WebAssembly to be interactive
         Browser.Equal("webassembly", () => Browser.Exists(By.Id("execution-mode")).Text);
+
+        // Verify the navigation was enhanced (same DOM) rather than a full page load
+        Browser.False(() => htmlElement.IsStale());
 
         // Verify environment variables are available even though WASM started via enhanced navigation
         Browser.Equal("test-value-from-server", () => Browser.Exists(By.Id("my-test-var")).Text);

--- a/src/Components/test/E2ETest/Tests/BrowserConfigurationTest.cs
+++ b/src/Components/test/E2ETest/Tests/BrowserConfigurationTest.cs
@@ -29,4 +29,22 @@ public class BrowserConfigurationTest(
         Browser.Equal("test-value-from-server", () => Browser.Exists(By.Id("my-test-var")).Text);
         Browser.Equal("another-test-value", () => Browser.Exists(By.Id("another-test-var")).Text);
     }
+
+    [Fact]
+    public void CanReceiveEnvironmentVariablesFromBrowserConfiguration_AfterEnhancedNavigation()
+    {
+        // Start on a static (SSR) page where WebAssembly is not running
+        Navigate($"{ServerPathBase}/browser-configuration-env-vars-landing");
+        Browser.Equal("static", () => Browser.Exists(By.Id("execution-mode")).Text);
+
+        // Navigate to the WASM page via enhanced navigation (clicking a link)
+        Browser.Click(By.Id("navigate-to-env-vars"));
+
+        // Wait for WebAssembly to be interactive
+        Browser.Equal("webassembly", () => Browser.Exists(By.Id("execution-mode")).Text);
+
+        // Verify environment variables are available even though WASM started via enhanced navigation
+        Browser.Equal("test-value-from-server", () => Browser.Exists(By.Id("my-test-var")).Text);
+        Browser.Equal("another-test-value", () => Browser.Exists(By.Id("another-test-var")).Text);
+    }
 }

--- a/src/Components/test/testassets/Components.WasmMinimal/Pages/BrowserConfigurationEnvVarsLanding.razor
+++ b/src/Components/test/testassets/Components.WasmMinimal/Pages/BrowserConfigurationEnvVarsLanding.razor
@@ -1,0 +1,9 @@
+@page "/browser-configuration-env-vars-landing"
+@using Microsoft.AspNetCore.Components.Routing
+@attribute [ExcludeFromInteractiveRouting]
+
+<h1>Browser Configuration Landing Page</h1>
+
+<p id="execution-mode">static</p>
+
+<a id="navigate-to-env-vars" href="browser-configuration-env-vars">Go to env vars page</a>


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/67067

Execute `discoverBrowserConfiguration` during enhanced navigation in `DomSync.ts`, so that WebAssembly started from a second page (via enhanced nav) receives the browser configuration (environment variables, environment name, etc.).

Previously, `discoverBrowserConfiguration` was only called on initial page load in `registerAllComponentDescriptors`. When a user navigated from an SSR page to a WASM page via enhanced navigation, the configuration was not re-discovered from the new DOM content.

**Changes:**
- Move `discoverBrowserConfiguration` call into `preprocessAndSynchronizeDomContent` so it runs on every enhanced navigation
- Add E2E test verifying env vars are received after enhanced navigation to a WASM page