### PR TITLE
[release/11.0-preview6] Add SignalR Auth Refresh support to server and .NET client

### DIFF
--- a/src/Servers/Connections.Abstractions/src/Features/IAuthenticationRefreshFeature.cs
+++ b/src/Servers/Connections.Abstractions/src/Features/IAuthenticationRefreshFeature.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Connections.Features;
+
+/// <summary>
+/// Feature for refreshing authentication on a connection.
+/// When present, indicates the connection supports authentication token refresh.
+/// </summary>
+public interface IAuthenticationRefreshFeature
+{
+    /// <summary>
+    /// Gets the initial token lifetime as provided by the server during negotiation.
+    /// Null if the server did not provide a token lifetime.
+    /// </summary>
+    TimeSpan? InitialTokenLifetime { get; }
+
+    /// <summary>
+    /// Sends a refresh request to the server with new authentication credentials.
+    /// Returns the updated token lifetime, or null if not provided.
+    /// </summary>
+    Task<TimeSpan?> RefreshAuthenticationAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Servers/Connections.Abstractions/src/Features/IConnectionUserRefreshFeature.cs
+++ b/src/Servers/Connections.Abstractions/src/Features/IConnectionUserRefreshFeature.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Security.Claims;
+
+namespace Microsoft.AspNetCore.Connections.Features;
+
+/// <summary>
+/// A feature that allows callbacks to be notified when the user associated with the connection is refreshed,
+/// for example, via an authentication refresh.
+/// </summary>
+public interface IConnectionUserRefreshFeature
+{
+    /// <summary>
+    /// Registers a callback to be invoked after the <see cref="IConnectionUserFeature.User"/> has been refreshed.
+    /// </summary>
+    /// <param name="callback">The callback to invoke with the refreshed principal and associated <paramref name="state"/>.</param>
+    /// <param name="state">The state to pass to <paramref name="callback"/>.</param>
+    /// <returns>An <see cref="IDisposable"/> that can be disposed to unregister the callback.</returns>
+    /// <remarks>
+    /// Callbacks should be quick and avoid blocking; the callback is invoked on the thread that performed the update.
+    /// Exceptions thrown from callbacks are not propagated to the caller of the update.
+    /// The previous principal is intentionally not exposed because its underlying resources
+    /// (for example a <c>WindowsIdentity</c>'s <c>SafeHandle</c>) may be disposed when the
+    /// authentication-refresh request completes, making later access unsafe.
+    /// </remarks>
+    IDisposable OnUserRefreshed(Action<ClaimsPrincipal, object?> callback, object? state);
+}

--- a/src/Servers/Connections.Abstractions/src/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Servers/Connections.Abstractions/src/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,7 @@
 #nullable enable
+Microsoft.AspNetCore.Connections.Features.IAuthenticationRefreshFeature
+Microsoft.AspNetCore.Connections.Features.IAuthenticationRefreshFeature.InitialTokenLifetime.get -> System.TimeSpan?
+Microsoft.AspNetCore.Connections.Features.IAuthenticationRefreshFeature.RefreshAuthenticationAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.TimeSpan?>!
+Microsoft.AspNetCore.Connections.Features.IConnectionUserRefreshFeature
+Microsoft.AspNetCore.Connections.Features.IConnectionUserRefreshFeature.OnUserRefreshed(System.Action<System.Security.Claims.ClaimsPrincipal!, object?>! callback, object? state) -> System.IDisposable!
 Microsoft.AspNetCore.Connections.Features.ITlsHandshakeFeature.Exception.get -> System.Exception?

--- a/src/Servers/Connections.Abstractions/src/PublicAPI/net11.0/PublicAPI.Unshipped.txt
+++ b/src/Servers/Connections.Abstractions/src/PublicAPI/net11.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,7 @@
 #nullable enable
+Microsoft.AspNetCore.Connections.Features.IAuthenticationRefreshFeature
+Microsoft.AspNetCore.Connections.Features.IAuthenticationRefreshFeature.InitialTokenLifetime.get -> System.TimeSpan?
+Microsoft.AspNetCore.Connections.Features.IAuthenticationRefreshFeature.RefreshAuthenticationAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.TimeSpan?>!
+Microsoft.AspNetCore.Connections.Features.IConnectionUserRefreshFeature
+Microsoft.AspNetCore.Connections.Features.IConnectionUserRefreshFeature.OnUserRefreshed(System.Action<System.Security.Claims.ClaimsPrincipal!, object?>! callback, object? state) -> System.IDisposable!
 Microsoft.AspNetCore.Connections.Features.ITlsHandshakeFeature.Exception.get -> System.Exception?

--- a/src/Servers/Connections.Abstractions/src/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Servers/Connections.Abstractions/src/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+Microsoft.AspNetCore.Connections.Features.IAuthenticationRefreshFeature
+Microsoft.AspNetCore.Connections.Features.IAuthenticationRefreshFeature.InitialTokenLifetime.get -> System.TimeSpan?
+Microsoft.AspNetCore.Connections.Features.IAuthenticationRefreshFeature.RefreshAuthenticationAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.TimeSpan?>!
+Microsoft.AspNetCore.Connections.Features.IConnectionUserRefreshFeature
+Microsoft.AspNetCore.Connections.Features.IConnectionUserRefreshFeature.OnUserRefreshed(System.Action<System.Security.Claims.ClaimsPrincipal!, object?>! callback, object? state) -> System.IDisposable!

--- a/src/Servers/Connections.Abstractions/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Servers/Connections.Abstractions/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+Microsoft.AspNetCore.Connections.Features.IAuthenticationRefreshFeature
+Microsoft.AspNetCore.Connections.Features.IAuthenticationRefreshFeature.InitialTokenLifetime.get -> System.TimeSpan?
+Microsoft.AspNetCore.Connections.Features.IAuthenticationRefreshFeature.RefreshAuthenticationAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.TimeSpan?>!
+Microsoft.AspNetCore.Connections.Features.IConnectionUserRefreshFeature
+Microsoft.AspNetCore.Connections.Features.IConnectionUserRefreshFeature.OnUserRefreshed(System.Action<System.Security.Claims.ClaimsPrincipal!, object?>! callback, object? state) -> System.IDisposable!

--- a/src/Servers/Connections.Abstractions/src/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/Servers/Connections.Abstractions/src/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+Microsoft.AspNetCore.Connections.Features.IAuthenticationRefreshFeature
+Microsoft.AspNetCore.Connections.Features.IAuthenticationRefreshFeature.InitialTokenLifetime.get -> System.TimeSpan?
+Microsoft.AspNetCore.Connections.Features.IAuthenticationRefreshFeature.RefreshAuthenticationAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.TimeSpan?>!
+Microsoft.AspNetCore.Connections.Features.IConnectionUserRefreshFeature
+Microsoft.AspNetCore.Connections.Features.IConnectionUserRefreshFeature.OnUserRefreshed(System.Action<System.Security.Claims.ClaimsPrincipal!, object?>! callback, object? state) -> System.IDisposable!

--- a/src/SignalR/clients/csharp/Client.Core/src/AuthenticationRefreshOptions.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/AuthenticationRefreshOptions.cs
@@ -1,0 +1,105 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.SignalR.Client;
+
+/// <summary>
+/// Configures automatic authentication token refresh for a <see cref="HubConnection"/>.
+/// </summary>
+public sealed class AuthenticationRefreshOptions
+{
+    /// <summary>
+    /// Enables automatic token refresh before the server-reported token expiration.
+    /// Default is <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    /// When enabled, the client schedules a refresh based on the <c>tokenLifetimeSeconds</c>
+    /// reported by the server in the negotiate (and subsequent refresh) responses. If the server
+    /// does not report a token lifetime, no automatic refresh is scheduled regardless of this setting;
+    /// the application may still call <see cref="HubConnection.RefreshAuthenticationAsync"/> manually.
+    /// </remarks>
+    public bool EnableAutoRefresh { get; set; } = true;
+
+    /// <summary>
+    /// How far before the server-reported token expiration the client should refresh.
+    /// The client schedules refresh at: <c>now + tokenLifetimeSeconds - RefreshBeforeExpiration</c>.
+    /// Default is 5 minutes.
+    /// </summary>
+    public TimeSpan RefreshBeforeExpiration
+    {
+        get;
+        set
+        {
+            if (value < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), value, "The value must be zero or greater.");
+            }
+
+            field = value;
+        }
+    } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Optional callback invoked after a successful authentication refresh.
+    /// </summary>
+    public Func<AuthenticationRefreshedContext, Task>? OnAuthenticationRefreshed { get; set; }
+
+    /// <summary>
+    /// Optional callback invoked when an authentication refresh attempt fails.
+    /// </summary>
+    public Func<AuthenticationRefreshFailedContext, Task>? OnAuthenticationRefreshFailed { get; set; }
+}
+
+/// <summary>
+/// Context passed to <see cref="AuthenticationRefreshOptions.OnAuthenticationRefreshed"/> after a successful refresh.
+/// </summary>
+public sealed class AuthenticationRefreshedContext
+{
+    internal AuthenticationRefreshedContext(HubConnection hubConnection, TimeSpan? newTokenLifetime)
+    {
+        HubConnection = hubConnection;
+        NewTokenLifetime = newTokenLifetime;
+        RefreshedAt = DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>
+    /// Gets the <see cref="HubConnection"/> whose authentication was refreshed.
+    /// </summary>
+    public HubConnection HubConnection { get; }
+
+    /// <summary>
+    /// Gets the new token lifetime reported by the server, or <c>null</c> if not provided.
+    /// </summary>
+    public TimeSpan? NewTokenLifetime { get; }
+
+    /// <summary>
+    /// Gets the time at which the refresh completed.
+    /// </summary>
+    public DateTimeOffset RefreshedAt { get; }
+}
+
+/// <summary>
+/// Context passed to <see cref="AuthenticationRefreshOptions.OnAuthenticationRefreshFailed"/> when a refresh attempt fails.
+/// </summary>
+public sealed class AuthenticationRefreshFailedContext
+{
+    internal AuthenticationRefreshFailedContext(HubConnection hubConnection, Exception exception)
+    {
+        HubConnection = hubConnection;
+        Exception = exception;
+    }
+
+    /// <summary>
+    /// Gets the <see cref="HubConnection"/> on which the refresh attempt failed.
+    /// </summary>
+    public HubConnection HubConnection { get; }
+
+    /// <summary>
+    /// Gets the exception that caused the refresh attempt to fail.
+    /// </summary>
+    public Exception Exception { get; }
+}

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.Log.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.Log.cs
@@ -340,5 +340,17 @@ public partial class HubConnection
 
         [LoggerMessage(94, LogLevel.Error, "Failed to bind argument received in stream '{StreamId}'.", EventName = "StreamBindingFailure")]
         public static partial void StreamBindingFailure(ILogger logger, string? streamId, Exception exception);
+
+        [LoggerMessage(95, LogLevel.Debug, "Starting authentication token refresh.", EventName = "AuthenticationRefreshStarting")]
+        public static partial void AuthenticationRefreshStarting(ILogger logger);
+
+        [LoggerMessage(96, LogLevel.Debug, "Authentication token refresh completed. New TTL: {TokenLifetime}.", EventName = "AuthenticationRefreshCompleted")]
+        public static partial void AuthenticationRefreshCompleted(ILogger logger, TimeSpan? tokenLifetime);
+
+        [LoggerMessage(97, LogLevel.Error, "Authentication token refresh failed.", EventName = "AuthenticationRefreshFailed")]
+        public static partial void AuthenticationRefreshFailed(ILogger logger, Exception exception);
+
+        [LoggerMessage(98, LogLevel.Error, "Authentication refresh user callback threw an exception.", EventName = "AuthenticationRefreshCallbackFailed")]
+        public static partial void AuthenticationRefreshCallbackFailed(ILogger logger, Exception exception);
     }
 }

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -89,6 +89,12 @@ public partial class HubConnection : IAsyncDisposable
 
     private bool _disposed;
 
+    // Authentication refresh fields
+    private Timer? _authRefreshTimer;
+    // The delay the authentication-refresh timer was last armed with. Exposed for tests to assert scheduling.
+    private TimeSpan _lastAuthenticationRefreshDelay;
+    private readonly AuthenticationRefreshOptions _authenticationRefreshOptions;
+
     /// <summary>
     /// Occurs when the connection is closed. The connection could be closed due to an error or due to either the server or client intentionally
     /// closing the connection without error.
@@ -254,6 +260,8 @@ public partial class HubConnection : IAsyncDisposable
         ServerTimeout = options?.Value.ServerTimeout ?? DefaultServerTimeout;
 
         KeepAliveInterval = options?.Value.KeepAliveInterval ?? DefaultKeepAliveInterval;
+
+        _authenticationRefreshOptions = serviceProvider.GetService<IOptions<AuthenticationRefreshOptions>>()?.Value ?? new AuthenticationRefreshOptions();
     }
 
     /// <summary>
@@ -547,7 +555,147 @@ public partial class HubConnection : IAsyncDisposable
         }
         startingConnectionState.ReceiveTask = ReceiveLoop(startingConnectionState);
 
+        // Schedule automatic authentication refresh if enabled and the server reported a token lifetime.
+        if (_authenticationRefreshOptions.EnableAutoRefresh)
+        {
+            var authenticationRefreshFeature = connection.Features.Get<IAuthenticationRefreshFeature>();
+            if (authenticationRefreshFeature?.InitialTokenLifetime is { } initialTokenLifetime && initialTokenLifetime > TimeSpan.Zero)
+            {
+                ScheduleAuthenticationRefresh(initialTokenLifetime);
+            }
+        }
+
         Log.Started(_logger);
+    }
+
+    /// <summary>
+    /// Sends a POST to the server's /refresh endpoint to refresh the authentication token.
+    /// The server re-authenticates and updates the connection's ClaimsPrincipal.
+    /// Returns the updated token lifetime, or null if not provided.
+    /// </summary>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>The new token lifetime from the server, or null.</returns>
+    public async Task<TimeSpan?> RefreshAuthenticationAsync(CancellationToken cancellationToken = default)
+    {
+        var connectionState = _state.CurrentConnectionStateUnsynchronized;
+        if (connectionState == null)
+        {
+            throw new InvalidOperationException("Cannot refresh authentication when the connection is not active.");
+        }
+
+        var connection = connectionState.Connection;
+        var authenticationRefreshFeature = connection.Features.Get<IAuthenticationRefreshFeature>();
+        if (authenticationRefreshFeature is null)
+        {
+            throw new InvalidOperationException("Authentication refresh is only supported with HTTP-based connections.");
+        }
+
+        TimeSpan? newTtl;
+        try
+        {
+            newTtl = await authenticationRefreshFeature.RefreshAuthenticationAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            var failedCallback = _authenticationRefreshOptions.OnAuthenticationRefreshFailed;
+            if (failedCallback is not null)
+            {
+                try
+                {
+                    await failedCallback(new AuthenticationRefreshFailedContext(this, ex)).ConfigureAwait(false);
+                }
+                catch (Exception callbackEx)
+                {
+                    Log.AuthenticationRefreshCallbackFailed(_logger, callbackEx);
+                }
+            }
+            throw;
+        }
+
+        // Reschedule the auto-refresh timer if the server reported a new lifetime.
+        if (_authenticationRefreshOptions.EnableAutoRefresh)
+        {
+            if (newTtl is { } tokenLifetime && tokenLifetime > TimeSpan.Zero)
+            {
+                ScheduleAuthenticationRefresh(tokenLifetime);
+            }
+        }
+
+        var refreshedCallback = _authenticationRefreshOptions.OnAuthenticationRefreshed;
+        if (refreshedCallback is not null)
+        {
+            try
+            {
+                await refreshedCallback(new AuthenticationRefreshedContext(this, newTtl)).ConfigureAwait(false);
+            }
+            catch (Exception callbackEx)
+            {
+                Log.AuthenticationRefreshCallbackFailed(_logger, callbackEx);
+            }
+        }
+
+        return newTtl;
+    }
+
+    /// <summary>
+    /// Schedules an automatic authentication refresh based on the server-provided token lifetime.
+    /// The refresh fires at: now + tokenLifetime - RefreshBeforeExpiration.
+    /// For short-lived tokens (TTL &lt; 2x RefreshBeforeExpiration), refreshes at half the TTL.
+    /// </summary>
+    internal void ScheduleAuthenticationRefresh(TimeSpan tokenLifetime)
+    {
+        var refreshBefore = _authenticationRefreshOptions.RefreshBeforeExpiration;
+        TimeSpan refreshIn;
+
+        if (tokenLifetime <= new TimeSpan(refreshBefore.Ticks * 2))
+        {
+            // Short-lived token: refresh at half the TTL to avoid spamming
+            refreshIn = new TimeSpan(tokenLifetime.Ticks / 2);
+        }
+        else
+        {
+            refreshIn = tokenLifetime - refreshBefore;
+        }
+
+        ScheduleAuthenticationRefreshAt(refreshIn);
+    }
+
+    /// <summary>
+    /// Arms the one-shot authentication-refresh timer to fire after <paramref name="refreshIn"/>, replacing any
+    /// existing timer. A minimum interval is enforced to avoid spamming the server.
+    /// </summary>
+    internal void ScheduleAuthenticationRefreshAt(TimeSpan refreshIn)
+    {
+        // Cancel any existing timer
+        _authRefreshTimer?.Dispose();
+
+        // Enforce a minimum interval to prevent spamming the server
+        var minimumRefreshInterval = TimeSpan.FromSeconds(30);
+        if (refreshIn < minimumRefreshInterval)
+        {
+            refreshIn = minimumRefreshInterval;
+        }
+
+        _authRefreshTimer = new Timer(
+            static state => _ = ((HubConnection)state!).OnAuthenticationRefreshTimerFired(),
+            this,
+            refreshIn,
+            Timeout.InfiniteTimeSpan); // One-shot timer
+        _lastAuthenticationRefreshDelay = refreshIn;
+    }
+
+    private async Task OnAuthenticationRefreshTimerFired()
+    {
+        try
+        {
+            Log.AuthenticationRefreshStarting(_logger);
+            var newTtl = await RefreshAuthenticationAsync().ConfigureAwait(false);
+            Log.AuthenticationRefreshCompleted(_logger, newTtl);
+        }
+        catch (Exception ex)
+        {
+            Log.AuthenticationRefreshFailed(_logger, ex);
+        }
     }
 
     private static ValueTask CloseAsync(ConnectionContext connection)
@@ -560,6 +708,10 @@ public partial class HubConnection : IAsyncDisposable
     // if we're disposing.
     private async Task StopAsyncCore(bool disposing)
     {
+        // Dispose the authentication refresh timer
+        _authRefreshTimer?.Dispose();
+        _authRefreshTimer = null;
+
         // StartAsync acquires the connection lock for the duration of the handshake.
         // ReconnectAsync also acquires the connection lock for reconnect attempts and handshakes.
         // Cancel the StopCts without acquiring the lock so we can short-circuit it.

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnectionBuilderExtensions.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnectionBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using Microsoft.AspNetCore.Shared;
 using Microsoft.AspNetCore.SignalR.Client.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -85,6 +86,20 @@ public static class HubConnectionBuilderExtensions
     public static IHubConnectionBuilder WithKeepAliveInterval(this IHubConnectionBuilder hubConnectionBuilder, TimeSpan interval)
     {
         hubConnectionBuilder.Services.Configure<HubConnectionOptions>(o => o.KeepAliveInterval = interval);
+        return hubConnectionBuilder;
+    }
+
+    /// <summary>
+    /// Configures automatic authentication token refresh for the <see cref="HubConnection" />.
+    /// </summary>
+    /// <param name="hubConnectionBuilder">The <see cref="IHubConnectionBuilder" /> to configure.</param>
+    /// <param name="configure">A delegate that configures the <see cref="AuthenticationRefreshOptions"/>.</param>
+    /// <returns>The same instance of the <see cref="IHubConnectionBuilder"/> for chaining.</returns>
+    public static IHubConnectionBuilder WithAuthenticationRefresh(this IHubConnectionBuilder hubConnectionBuilder, Action<AuthenticationRefreshOptions> configure)
+    {
+        ArgumentNullThrowHelper.ThrowIfNull(configure);
+
+        hubConnectionBuilder.Services.Configure(configure);
         return hubConnectionBuilder;
     }
 }

--- a/src/SignalR/clients/csharp/Client.Core/src/PublicAPI.Unshipped.txt
+++ b/src/SignalR/clients/csharp/Client.Core/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,20 @@
 #nullable enable
+Microsoft.AspNetCore.SignalR.Client.AuthenticationRefreshOptions
+Microsoft.AspNetCore.SignalR.Client.AuthenticationRefreshOptions.AuthenticationRefreshOptions() -> void
+Microsoft.AspNetCore.SignalR.Client.AuthenticationRefreshOptions.EnableAutoRefresh.get -> bool
+Microsoft.AspNetCore.SignalR.Client.AuthenticationRefreshOptions.EnableAutoRefresh.set -> void
+Microsoft.AspNetCore.SignalR.Client.AuthenticationRefreshOptions.RefreshBeforeExpiration.get -> System.TimeSpan
+Microsoft.AspNetCore.SignalR.Client.AuthenticationRefreshOptions.RefreshBeforeExpiration.set -> void
+Microsoft.AspNetCore.SignalR.Client.AuthenticationRefreshOptions.OnAuthenticationRefreshed.get -> System.Func<Microsoft.AspNetCore.SignalR.Client.AuthenticationRefreshedContext!, System.Threading.Tasks.Task!>?
+Microsoft.AspNetCore.SignalR.Client.AuthenticationRefreshOptions.OnAuthenticationRefreshed.set -> void
+Microsoft.AspNetCore.SignalR.Client.AuthenticationRefreshOptions.OnAuthenticationRefreshFailed.get -> System.Func<Microsoft.AspNetCore.SignalR.Client.AuthenticationRefreshFailedContext!, System.Threading.Tasks.Task!>?
+Microsoft.AspNetCore.SignalR.Client.AuthenticationRefreshOptions.OnAuthenticationRefreshFailed.set -> void
+Microsoft.AspNetCore.SignalR.Client.AuthenticationRefreshedContext
+Microsoft.AspNetCore.SignalR.Client.AuthenticationRefreshedContext.HubConnection.get -> Microsoft.AspNetCore.SignalR.Client.HubConnection!
+Microsoft.AspNetCore.SignalR.Client.AuthenticationRefreshedContext.NewTokenLifetime.get -> System.TimeSpan?
+Microsoft.AspNetCore.SignalR.Client.AuthenticationRefreshedContext.RefreshedAt.get -> System.DateTimeOffset
+Microsoft.AspNetCore.SignalR.Client.AuthenticationRefreshFailedContext
+Microsoft.AspNetCore.SignalR.Client.AuthenticationRefreshFailedContext.HubConnection.get -> Microsoft.AspNetCore.SignalR.Client.HubConnection!
+Microsoft.AspNetCore.SignalR.Client.AuthenticationRefreshFailedContext.Exception.get -> System.Exception!
+Microsoft.AspNetCore.SignalR.Client.HubConnection.RefreshAuthenticationAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.TimeSpan?>!
+static Microsoft.AspNetCore.SignalR.Client.HubConnectionBuilderExtensions.WithAuthenticationRefresh(this Microsoft.AspNetCore.SignalR.Client.IHubConnectionBuilder! hubConnectionBuilder, System.Action<Microsoft.AspNetCore.SignalR.Client.AuthenticationRefreshOptions!>! configure) -> Microsoft.AspNetCore.SignalR.Client.IHubConnectionBuilder!

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HeaderUserIdProvider.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HeaderUserIdProvider.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Security.Claims;
+
 namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests;
 
 internal class HeaderUserIdProvider : IUserIdProvider
@@ -9,6 +11,14 @@ internal class HeaderUserIdProvider : IUserIdProvider
 
     public string GetUserId(HubConnectionContext connection)
     {
+        // Prefer the authenticated principal's NameIdentifier so the user id tracks the current
+        // token and changes when an authentication refresh swaps in a principal with a different subject.
+        var nameIdentifier = connection.User?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (!string.IsNullOrEmpty(nameIdentifier))
+        {
+            return nameIdentifier;
+        }
+
         // Super-insecure user id provider :). Don't use this for anything real!
         return connection.GetHttpContext()?.Request?.Headers?[HeaderName];
     }

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.AuthenticationRefresh.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.AuthenticationRefresh.cs
@@ -1,0 +1,391 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Net.Http;
+using System.Net.WebSockets;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http.Connections;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
+using Xunit;
+
+namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests;
+
+public partial class HubConnectionTests
+{
+    [Theory]
+    [MemberData(nameof(TransportTypes))]
+    public async Task CanRefreshAuthenticationAndContinueInvoking(HttpTransportType transportType)
+    {
+        await using (var server = await StartServer<Startup>())
+        {
+            async Task<string> AccessTokenProvider()
+            {
+                var httpResponse = await new HttpClient().GetAsync(server.Url + "/generateJwtToken");
+                httpResponse.EnsureSuccessStatusCode();
+                return await httpResponse.Content.ReadAsStringAsync();
+            }
+
+            var hubConnection = new HubConnectionBuilder()
+                .WithLoggerFactory(LoggerFactory)
+                .WithUrl(server.Url + "/authRefreshHub", transportType, options =>
+                {
+                    options.AccessTokenProvider = AccessTokenProvider;
+                })
+                .WithAuthenticationRefresh(o => o.EnableAutoRefresh = false)
+                .Build();
+            try
+            {
+                await hubConnection.StartAsync().DefaultTimeout();
+
+                var before = await hubConnection.InvokeAsync<string>(nameof(AuthenticationRefreshHub.Echo), "hello").DefaultTimeout();
+                Assert.Equal("hello", before);
+
+                var newTtl = await hubConnection.RefreshAuthenticationAsync().DefaultTimeout();
+                Assert.NotNull(newTtl);
+                Assert.True(newTtl > TimeSpan.Zero, $"Expected a positive token lifetime but got {newTtl}.");
+
+                var after = await hubConnection.InvokeAsync<string>(nameof(AuthenticationRefreshHub.Echo), "world").DefaultTimeout();
+                Assert.Equal("world", after);
+            }
+            catch (Exception ex)
+            {
+                LoggerFactory.CreateLogger<HubConnectionTests>().LogError(ex, "{ExceptionType} from test", ex.GetType().FullName);
+                throw;
+            }
+            finally
+            {
+                await hubConnection.DisposeAsync().DefaultTimeout();
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(TransportTypes))]
+    public async Task RefreshingAuthRemovingClaimBlocksAuthorizedMethod(HttpTransportType transportType)
+    {
+        await using (var server = await StartServer<Startup>())
+        {
+            var includeScope = true;
+            async Task<string> AccessTokenProvider()
+            {
+                var url = server.Url + "/generateJwtTokenWithScope?scope=" + (includeScope ? "true" : "false");
+                var httpResponse = await new HttpClient().GetAsync(url);
+                httpResponse.EnsureSuccessStatusCode();
+                return await httpResponse.Content.ReadAsStringAsync();
+            }
+
+            var hubConnection = new HubConnectionBuilder()
+                .WithLoggerFactory(LoggerFactory)
+                .WithUrl(server.Url + "/authRefreshHub", transportType, options =>
+                {
+                    options.AccessTokenProvider = AccessTokenProvider;
+                })
+                .WithAuthenticationRefresh(o => o.EnableAutoRefresh = false)
+                .Build();
+            try
+            {
+                await hubConnection.StartAsync().DefaultTimeout();
+
+                // Initial token has the scope claim, so the authorized method succeeds.
+                var result = await hubConnection.InvokeAsync<string>(nameof(AuthenticationRefreshHub.ScopeProtected)).DefaultTimeout();
+                Assert.Equal("ok", result);
+
+                // Refresh with a token that no longer carries the required claim.
+                includeScope = false;
+                await hubConnection.RefreshAuthenticationAsync().DefaultTimeout();
+
+                // The authorized method is now rejected by the server's policy.
+                await Assert.ThrowsAsync<HubException>(
+                    () => hubConnection.InvokeAsync<string>(nameof(AuthenticationRefreshHub.ScopeProtected)).DefaultTimeout());
+
+                // An unauthorized method still works, proving the connection itself is alive.
+                var echo = await hubConnection.InvokeAsync<string>(nameof(AuthenticationRefreshHub.Echo), "still here").DefaultTimeout();
+                Assert.Equal("still here", echo);
+            }
+            catch (Exception ex)
+            {
+                LoggerFactory.CreateLogger<HubConnectionTests>().LogError(ex, "{ExceptionType} from test", ex.GetType().FullName);
+                throw;
+            }
+            finally
+            {
+                await hubConnection.DisposeAsync().DefaultTimeout();
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(TransportTypes))]
+    public async Task RefreshingAuthAddingClaimAllowsAuthorizedMethod(HttpTransportType transportType)
+    {
+        await using (var server = await StartServer<Startup>())
+        {
+            var includeScope = false;
+            async Task<string> AccessTokenProvider()
+            {
+                var url = server.Url + "/generateJwtTokenWithScope?scope=" + (includeScope ? "true" : "false");
+                var httpResponse = await new HttpClient().GetAsync(url);
+                httpResponse.EnsureSuccessStatusCode();
+                return await httpResponse.Content.ReadAsStringAsync();
+            }
+
+            var hubConnection = new HubConnectionBuilder()
+                .WithLoggerFactory(LoggerFactory)
+                .WithUrl(server.Url + "/authRefreshHub", transportType, options =>
+                {
+                    options.AccessTokenProvider = AccessTokenProvider;
+                })
+                .WithAuthenticationRefresh(o => o.EnableAutoRefresh = false)
+                .Build();
+            try
+            {
+                await hubConnection.StartAsync().DefaultTimeout();
+
+                // Initial token lacks the scope claim, so the authorized method is rejected.
+                await Assert.ThrowsAsync<HubException>(
+                    () => hubConnection.InvokeAsync<string>(nameof(AuthenticationRefreshHub.ScopeProtected)).DefaultTimeout());
+
+                // Refresh with a token that now carries the required claim.
+                includeScope = true;
+                await hubConnection.RefreshAuthenticationAsync().DefaultTimeout();
+
+                // The authorized method now succeeds.
+                var result = await hubConnection.InvokeAsync<string>(nameof(AuthenticationRefreshHub.ScopeProtected)).DefaultTimeout();
+                Assert.Equal("ok", result);
+            }
+            catch (Exception ex)
+            {
+                LoggerFactory.CreateLogger<HubConnectionTests>().LogError(ex, "{ExceptionType} from test", ex.GetType().FullName);
+                throw;
+            }
+            finally
+            {
+                await hubConnection.DisposeAsync().DefaultTimeout();
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(TransportTypes))]
+    public async Task CanRefreshAuthenticationAfterReconnect(HttpTransportType transportType)
+    {
+        bool ExpectedErrors(WriteContext writeContext)
+        {
+            return writeContext.LoggerName == typeof(HubConnection).FullName &&
+                   (writeContext.EventId.Name == "ReconnectingWithError" ||
+                    // A stale one-shot authentication-refresh timer may fire during the reconnect gap and
+                    // observe a non-active connection; this is logged and benign.
+                    writeContext.EventId.Name == "AuthenticationRefreshFailed");
+        }
+
+        await using (var server = await StartServer<Startup>(ExpectedErrors))
+        {
+            async Task<string> AccessTokenProvider()
+            {
+                var httpResponse = await new HttpClient().GetAsync(server.Url + "/generateJwtToken");
+                httpResponse.EnsureSuccessStatusCode();
+                return await httpResponse.Content.ReadAsStringAsync();
+            }
+
+            var hubConnection = new HubConnectionBuilder()
+                .WithLoggerFactory(LoggerFactory)
+                .WithUrl(server.Url + "/authRefreshHub", transportType, options =>
+                {
+                    options.AccessTokenProvider = AccessTokenProvider;
+                })
+                .WithAuthenticationRefresh(o => o.EnableAutoRefresh = true)
+                .WithAutomaticReconnect()
+                .Build();
+            try
+            {
+                var reconnectingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                var reconnectedTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                hubConnection.Reconnecting += _ =>
+                {
+                    reconnectingTcs.TrySetResult();
+                    return Task.CompletedTask;
+                };
+                hubConnection.Reconnected += connectionId =>
+                {
+                    reconnectedTcs.TrySetResult(connectionId);
+                    return Task.CompletedTask;
+                };
+
+                await hubConnection.StartAsync().DefaultTimeout();
+                var initialConnectionId = hubConnection.ConnectionId;
+
+                // Refresh works on the original connection.
+                Assert.NotNull(await hubConnection.RefreshAuthenticationAsync().DefaultTimeout());
+
+                // Force a reconnect.
+                hubConnection.OnServerTimeout();
+
+                await reconnectingTcs.Task.DefaultTimeout();
+                var newConnectionId = await reconnectedTcs.Task.DefaultTimeout();
+                Assert.NotEqual(initialConnectionId, newConnectionId);
+
+                // Refresh must work against the freshly-established connection, proving the
+                // IAuthenticationRefreshFeature was re-acquired (and the auto-refresh timer re-armed) on reconnect.
+                var newTtl = await hubConnection.RefreshAuthenticationAsync().DefaultTimeout();
+                Assert.NotNull(newTtl);
+                Assert.True(newTtl > TimeSpan.Zero, $"Expected a positive token lifetime but got {newTtl}.");
+
+                var echo = await hubConnection.InvokeAsync<string>(nameof(AuthenticationRefreshHub.Echo), "reconnected").DefaultTimeout();
+                Assert.Equal("reconnected", echo);
+            }
+            catch (Exception ex)
+            {
+                LoggerFactory.CreateLogger<HubConnectionTests>().LogError(ex, "{ExceptionType} from test", ex.GetType().FullName);
+                throw;
+            }
+            finally
+            {
+                await hubConnection.DisposeAsync().DefaultTimeout();
+            }
+        }
+    }
+
+    [Fact]
+    public async Task StatefulReconnectWithChangedAuthenticationUpdatesHubUser()
+    {
+        await using (var server = await StartServer<Startup>(w => w.EventId.Name == "ReceivedUnexpectedResponse"))
+        {
+            var includeScope = false;
+            async Task<string> AccessTokenProvider()
+            {
+                var url = server.Url + "/generateJwtTokenWithScope?scope=" + (includeScope ? "true" : "false");
+                var httpResponse = await new HttpClient().GetAsync(url);
+                httpResponse.EnsureSuccessStatusCode();
+                return await httpResponse.Content.ReadAsStringAsync();
+            }
+
+            var websocket = new ClientWebSocket();
+            var connectedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var hubConnection = new HubConnectionBuilder()
+                .WithLoggerFactory(LoggerFactory)
+                .WithUrl(server.Url + "/authRefreshHub", HttpTransportType.WebSockets, options =>
+                {
+                    options.AccessTokenProvider = AccessTokenProvider;
+                    options.WebSocketFactory = async (context, token) =>
+                    {
+                        var current = websocket;
+                        var accessToken = await AccessTokenProvider();
+                        current.Options.SetRequestHeader("Authorization", $"Bearer {accessToken}");
+                        await current.ConnectAsync(context.Uri, token);
+                        connectedTcs.SetResult();
+                        return current;
+                    };
+                    options.UseStatefulReconnect = true;
+                })
+                .WithAuthenticationRefresh(o => o.EnableAutoRefresh = false)
+                .Build();
+            try
+            {
+                await hubConnection.StartAsync().DefaultTimeout();
+                await connectedTcs.Task.DefaultTimeout();
+
+                var originalConnectionId = hubConnection.ConnectionId;
+                await Assert.ThrowsAsync<HubException>(
+                    () => hubConnection.InvokeAsync<string>(nameof(AuthenticationRefreshHub.ScopeProtected)).DefaultTimeout());
+
+                includeScope = true;
+                connectedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                var originalWebsocket = websocket;
+                websocket = new ClientWebSocket();
+                originalWebsocket.Dispose();
+
+                await connectedTcs.Task.DefaultTimeout();
+
+                Assert.Equal(originalConnectionId, hubConnection.ConnectionId);
+                var result = await hubConnection.InvokeAsync<string>(nameof(AuthenticationRefreshHub.ScopeProtected)).DefaultTimeout();
+                Assert.Equal("ok", result);
+            }
+            catch (Exception ex)
+            {
+                LoggerFactory.CreateLogger<HubConnectionTests>().LogError(ex, "{ExceptionType} from test", ex.GetType().FullName);
+                throw;
+            }
+            finally
+            {
+                await hubConnection.DisposeAsync().DefaultTimeout();
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(TransportTypes))]
+    public async Task RefreshChangingUserIdentifierClosesConnection(HttpTransportType transportType)
+    {
+        await using (var server = await StartServer<Startup>())
+        {
+            // The SignalR UserIdentifier is derived from the JWT NameIdentifier claim, so changing
+            // the user name on refresh changes the connection's UserIdentifier and should close it.
+            var userName = "userA";
+            async Task<string> AccessTokenProvider()
+            {
+                var httpResponse = await new HttpClient().GetAsync(server.Url + "/generateJwtToken/" + userName);
+                httpResponse.EnsureSuccessStatusCode();
+                return await httpResponse.Content.ReadAsStringAsync();
+            }
+
+            var hubConnection = new HubConnectionBuilder()
+                .WithLoggerFactory(LoggerFactory)
+                .WithUrl(server.Url + "/authRefreshHub", transportType, options =>
+                {
+                    options.AccessTokenProvider = AccessTokenProvider;
+                })
+                .WithAuthenticationRefresh(o => o.EnableAutoRefresh = false)
+                .Build();
+            try
+            {
+                var received = Channel.CreateUnbounded<string>();
+                var closedTcs = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+                hubConnection.Closed += ex =>
+                {
+                    closedTcs.TrySetResult(ex);
+                    return Task.CompletedTask;
+                };
+                hubConnection.On<string>("Receive", message => received.Writer.TryWrite(message));
+
+                await hubConnection.StartAsync().DefaultTimeout();
+
+                // Before refresh, the connection is reachable under the original user id.
+                await hubConnection.InvokeAsync(nameof(AuthenticationRefreshHub.SendToUser), "userA", "before").DefaultTimeout();
+                Assert.Equal("before", await received.Reader.ReadAsync().AsTask().DefaultTimeout());
+
+                // Refresh with a token carrying a different NameIdentifier, changing the UserIdentifier.
+                userName = "userB";
+                var refreshTask = hubConnection.RefreshAuthenticationAsync();
+
+                await closedTcs.Task.DefaultTimeout();
+                try
+                {
+                    await refreshTask.DefaultTimeout();
+                }
+                catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException or OperationCanceledException)
+                {
+                    // The connection is expected to close when the refreshed principal maps to a different
+                    // SignalR UserIdentifier. Depending on timing, the manual refresh request can observe that
+                    // close before it completes.
+                }
+
+                Assert.Equal(HubConnectionState.Disconnected, hubConnection.State);
+            }
+            catch (Exception ex)
+            {
+                LoggerFactory.CreateLogger<HubConnectionTests>().LogError(ex, "{ExceptionType} from test", ex.GetType().FullName);
+                throw;
+            }
+            finally
+            {
+                await hubConnection.DisposeAsync().DefaultTimeout();
+            }
+        }
+    }
+}

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -2037,6 +2037,9 @@ public partial class HubConnectionTests : FunctionalTestBase
                 .WithLoggerFactory(LoggerFactory)
                 .WithUrl(server.Url + "/default", options =>
                 {
+                    // /default is unauthenticated, so HeaderUserIdProvider finds no NameIdentifier claim
+                    // and falls back to this header. If /default ever gains an authenticated principal,
+                    // the provider would return the principal's NameIdentifier instead of "SuperAdmin".
                     options.Headers.Add(HeaderUserIdProvider.HeaderName, "SuperAdmin");
                 })
                 .Build();

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/Hubs.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/Hubs.cs
@@ -327,3 +327,15 @@ public class HubWithAuthorization2 : Hub
 {
     public string Echo(string message) => TestHubMethodsImpl.Echo(message);
 }
+
+// Connection-level authorization (JwtBearer) is applied via endpoint routing in Startup;
+// the EnableAuthenticationRefresh connection option is set there as well.
+public class AuthenticationRefreshHub : Hub
+{
+    public string Echo(string message) => TestHubMethodsImpl.Echo(message);
+
+    [Authorize("AuthenticationRefreshScope")]
+    public string ScopeProtected() => "ok";
+
+    public Task SendToUser(string userId, string message) => Clients.User(userId).SendAsync("Receive", message);
+}

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/Startup.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/Startup.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.IO;
 using System.Security.Claims;
@@ -44,6 +45,11 @@ public class Startup
             {
                 policy.AddAuthenticationSchemes(NegotiateDefaults.AuthenticationScheme);
                 policy.RequireClaim(ClaimTypes.Name);
+            });
+            options.AddPolicy("AuthenticationRefreshScope", policy =>
+            {
+                policy.AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme);
+                policy.RequireClaim("scope", "signalr:invoke");
             });
         });
 
@@ -102,6 +108,13 @@ public class Startup
             endpoints.MapHub<HubWithAuthorization2>("/windowsauthhub")
                   .RequireAuthorization(new AuthorizeAttribute(NegotiateDefaults.AuthenticationScheme));
 
+            endpoints.MapHub<AuthenticationRefreshHub>("/authRefreshHub", o =>
+            {
+                o.EnableAuthenticationRefresh = true;
+                o.AllowStatefulReconnects = true;
+            })
+                  .RequireAuthorization(new AuthorizeAttribute(JwtBearerDefaults.AuthenticationScheme));
+
             endpoints.MapHub<TestHub>("/default-nowebsockets", options => options.Transports = HttpTransportType.LongPolling | HttpTransportType.ServerSentEvents);
 
             endpoints.MapHub<TestHub>("/negotiateProtocolVersion12", options =>
@@ -119,6 +132,14 @@ public class Startup
                 return context.Response.WriteAsync(GenerateJwtToken(name ?? "testuser"));
             });
 
+            // Like /generateJwtToken but optionally includes the "scope" claim required by the
+            // AuthenticationRefreshScope policy. Pass ?scope=false to omit it (used to exercise auth changes on refresh).
+            endpoints.MapGet("/generateJwtTokenWithScope/{name?}", (HttpContext context, string name) =>
+            {
+                var includeScope = context.Request.Query["scope"] != "false";
+                return context.Response.WriteAsync(GenerateJwtToken(name ?? "testuser", includeScope));
+            });
+
             endpoints.Map("/redirect/{*anything}", context =>
             {
                 return context.Response.WriteAsync(JsonConvert.SerializeObject(new
@@ -130,9 +151,13 @@ public class Startup
         });
     }
 
-    private string GenerateJwtToken(string name = "testuser")
+    private string GenerateJwtToken(string name = "testuser", bool includeScopeClaim = false)
     {
-        var claims = new[] { new Claim(ClaimTypes.NameIdentifier, name) };
+        var claims = new List<Claim> { new Claim(ClaimTypes.NameIdentifier, name) };
+        if (includeScopeClaim)
+        {
+            claims.Add(new Claim("scope", "signalr:invoke"));
+        }
         var credentials = new SigningCredentials(SecurityKey, SecurityAlgorithms.HmacSha256);
         var token = new JwtSecurityToken("SignalRTestServer", "SignalRTests", claims, expires: DateTime.Now.AddSeconds(5), signingCredentials: credentials);
         return JwtTokenHandler.WriteToken(token);

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionTests.AuthenticationRefresh.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionTests.AuthenticationRefresh.cs
@@ -1,0 +1,462 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections.Features;
+using Microsoft.AspNetCore.Http.Connections.Client;
+using Microsoft.AspNetCore.SignalR.Tests;
+using Microsoft.AspNetCore.InternalTesting;
+using Xunit;
+
+namespace Microsoft.AspNetCore.SignalR.Client.Tests;
+
+public partial class HttpConnectionTests
+{
+    public class RefreshAuthentication
+    {
+        private static void OnRefresh(TestHttpMessageHandler handler, Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> onRefresh)
+        {
+            handler.OnRequest((request, next, cancellationToken) =>
+            {
+                if (request.Method == HttpMethod.Post &&
+                    request.RequestUri.AbsolutePath.EndsWith("/refresh", StringComparison.Ordinal))
+                {
+                    return onRefresh(request, cancellationToken);
+                }
+                return next();
+            });
+        }
+
+        [Fact]
+        public async Task RefreshAuthenticationAsyncSendsFreshlyFetchedTokenNotCachedConnectToken()
+        {
+            // AccessTokenHttpMessageHandler caches the access token captured when the connection started
+            // and overwrites the Authorization header on each request. RefreshAuthenticationAsync must force
+            // a fresh token to be fetched so the /refresh request carries the new token.
+            var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
+            testHttpHandler.OnNegotiate((_, _) => ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationContent(negotiateVersion: 1)));
+            testHttpHandler.OnLongPoll(_ => ResponseUtils.CreateResponse(HttpStatusCode.NoContent));
+            testHttpHandler.OnLongPollDelete(_ => ResponseUtils.CreateResponse(HttpStatusCode.Accepted));
+
+            var refreshRequestTcs = new TaskCompletionSource<HttpRequestMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+            OnRefresh(testHttpHandler, (request, _) =>
+            {
+                refreshRequestTcs.TrySetResult(request);
+                return Task.FromResult(ResponseUtils.CreateResponse(HttpStatusCode.OK, "{\"connectionId\":\"abc\",\"tokenLifetimeSeconds\":60}"));
+            });
+
+            var currentToken = "old-token";
+            Task<string> AccessTokenProvider()
+            {
+                return Task.FromResult(currentToken);
+            }
+
+            using (var noErrorScope = new VerifyNoErrorsScope())
+            {
+                await WithConnectionAsync(
+                    CreateConnection(testHttpHandler, loggerFactory: noErrorScope.LoggerFactory, accessTokenProvider: AccessTokenProvider),
+                    async connection =>
+                    {
+                        await connection.StartAsync().DefaultTimeout();
+                        currentToken = "new-token";
+                        await ((IAuthenticationRefreshFeature)connection).RefreshAuthenticationAsync().DefaultTimeout();
+                    });
+            }
+
+            var request = await refreshRequestTcs.Task.DefaultTimeout();
+            Assert.NotNull(request.Headers.Authorization);
+            Assert.Equal("Bearer", request.Headers.Authorization.Scheme);
+            Assert.Equal("new-token", request.Headers.Authorization.Parameter);
+        }
+
+        [Fact]
+        public async Task RefreshAuthenticationAsyncUpdatesCachedTokenSoSubsequentTransportRequestsUseNewToken()
+        {
+            // RefreshAuthenticationAsync must update the cached access token so subsequent Long Polling
+            // sends/polls carry the refreshed token, not the stale connect-time token.
+            var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
+            testHttpHandler.OnNegotiate((_, _) => ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationContent(negotiateVersion: 1)));
+            testHttpHandler.OnLongPollDelete(_ => ResponseUtils.CreateResponse(HttpStatusCode.Accepted));
+
+            // The Long Polling transport reuses the handler's cached token (no IsNegotiate/IsRefresh flag) for each poll,
+            // so the Authorization header on a poll reflects whatever the cache currently holds.
+            var firstPollReceivedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseFirstPollTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var refreshedPollAuthTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var pollCount = 0;
+            testHttpHandler.OnLongPoll(async (request, _) =>
+            {
+                var poll = Interlocked.Increment(ref pollCount);
+                if (poll == 1)
+                {
+                    // A poll carrying the connect-time (old) token is in flight. Park it until the refresh completes.
+                    firstPollReceivedTcs.TrySetResult();
+                    await releaseFirstPollTcs.Task;
+                    return ResponseUtils.CreateResponse(HttpStatusCode.OK);
+                }
+
+                // The next poll is issued after the refresh updated the cache; capture its token and end the connection.
+                refreshedPollAuthTcs.TrySetResult(request.Headers.Authorization?.Parameter);
+                return ResponseUtils.CreateResponse(HttpStatusCode.NoContent);
+            });
+
+            OnRefresh(testHttpHandler, (_, _) =>
+                Task.FromResult(ResponseUtils.CreateResponse(HttpStatusCode.OK, "{\"connectionId\":\"abc\",\"tokenLifetimeSeconds\":60}")));
+
+            var currentToken = "old-token";
+            Task<string> AccessTokenProvider()
+            {
+                return Task.FromResult(currentToken);
+            }
+
+            using (var noErrorScope = new VerifyNoErrorsScope())
+            {
+                await WithConnectionAsync(
+                    CreateConnection(testHttpHandler, loggerFactory: noErrorScope.LoggerFactory, accessTokenProvider: AccessTokenProvider),
+                    async connection =>
+                    {
+                        await connection.StartAsync().DefaultTimeout();
+                        await firstPollReceivedTcs.Task.DefaultTimeout();
+
+                        currentToken = "new-token";
+                        await ((IAuthenticationRefreshFeature)connection).RefreshAuthenticationAsync().DefaultTimeout();
+
+                        // Allow the next poll to be issued now that the cache should hold the refreshed token.
+                        releaseFirstPollTcs.TrySetResult();
+
+                        var refreshedPollAuth = await refreshedPollAuthTcs.Task.DefaultTimeout();
+                        Assert.Equal("new-token", refreshedPollAuth);
+                    });
+            }
+        }
+
+        [Fact]
+        public async Task RefreshAuthenticationAsyncDoesNotUpdateCachedTokenWhenServerRejectsRefresh()
+        {
+            // When the server rejects a refresh (for example an OnAuthenticationRefresh policy denial returning 403), the freshly
+            // fetched token must NOT be committed to the handler's cache. Otherwise subsequent Long Polling polls/sends
+            // would carry the rejected token and the server would pick it up on the normal poll path, bypassing the
+            // refresh policy (and the UserIdentifier-change abort).
+            var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
+            testHttpHandler.OnNegotiate((_, _) => ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationContent(negotiateVersion: 1)));
+            testHttpHandler.OnLongPollDelete(_ => ResponseUtils.CreateResponse(HttpStatusCode.Accepted));
+
+            var firstPollReceivedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseFirstPollTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var nextPollAuthTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var pollCount = 0;
+            testHttpHandler.OnLongPoll(async (request, _) =>
+            {
+                var poll = Interlocked.Increment(ref pollCount);
+                if (poll == 1)
+                {
+                    // A poll carrying the connect-time (old) token is in flight. Park it until the (rejected) refresh completes.
+                    firstPollReceivedTcs.TrySetResult();
+                    await releaseFirstPollTcs.Task;
+                    return ResponseUtils.CreateResponse(HttpStatusCode.OK);
+                }
+
+                // Capture the token used by the poll issued after the rejected refresh, then end the connection.
+                nextPollAuthTcs.TrySetResult(request.Headers.Authorization?.Parameter);
+                return ResponseUtils.CreateResponse(HttpStatusCode.NoContent);
+            });
+
+            OnRefresh(testHttpHandler, (_, _) =>
+                Task.FromResult(ResponseUtils.CreateResponse(HttpStatusCode.Forbidden)));
+
+            var currentToken = "old-token";
+            Task<string> AccessTokenProvider()
+            {
+                return Task.FromResult(currentToken);
+            }
+
+            await WithConnectionAsync(
+                CreateConnection(testHttpHandler, accessTokenProvider: AccessTokenProvider),
+                async connection =>
+                {
+                    await connection.StartAsync().DefaultTimeout();
+                    await firstPollReceivedTcs.Task.DefaultTimeout();
+
+                    currentToken = "new-token";
+                    await Assert.ThrowsAsync<HttpRequestException>(() => ((IAuthenticationRefreshFeature)connection).RefreshAuthenticationAsync()).DefaultTimeout();
+
+                    // The rejected refresh must not have poisoned the cache; the next poll keeps the old token.
+                    releaseFirstPollTcs.TrySetResult();
+
+                    var nextPollAuth = await nextPollAuthTcs.Task.DefaultTimeout();
+                    Assert.Equal("old-token", nextPollAuth);
+                });
+        }
+
+        [Fact]
+        public async Task RefreshAuthenticationAsyncThrowsBeforeConnectionStarted()
+        {
+            using (var noErrorScope = new VerifyNoErrorsScope())
+            {
+                var connection = CreateConnection(loggerFactory: noErrorScope.LoggerFactory);
+                try
+                {
+                    var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                        () => ((IAuthenticationRefreshFeature)connection).RefreshAuthenticationAsync().DefaultTimeout());
+                    Assert.Equal("Cannot refresh authentication before the connection is started.", ex.Message);
+                }
+                finally
+                {
+                    await connection.DisposeAsync().DefaultTimeout();
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("http://fakeuri.org/", "http://fakeuri.org/refresh?id=connection-token")]
+        [InlineData("http://fakeuri.org", "http://fakeuri.org/refresh?id=connection-token")]
+        [InlineData("http://fakeuri.org/endpoint", "http://fakeuri.org/endpoint/refresh?id=connection-token")]
+        [InlineData("http://fakeuri.org/endpoint/", "http://fakeuri.org/endpoint/refresh?id=connection-token")]
+        public async Task RefreshAuthenticationAsyncPostsToRefreshUrlWithConnectionToken(string requestedUrl, string expectedRefreshUrl)
+        {
+            var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
+            testHttpHandler.OnNegotiate((_, _) => ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationContent(negotiateVersion: 1)));
+            testHttpHandler.OnLongPoll(_ => ResponseUtils.CreateResponse(HttpStatusCode.NoContent));
+            testHttpHandler.OnLongPollDelete(_ => ResponseUtils.CreateResponse(HttpStatusCode.Accepted));
+
+            var refreshRequestTcs = new TaskCompletionSource<HttpRequestMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+            OnRefresh(testHttpHandler, (request, _) =>
+            {
+                refreshRequestTcs.TrySetResult(request);
+                return Task.FromResult(ResponseUtils.CreateResponse(HttpStatusCode.OK, "{\"connectionId\":\"abc\",\"tokenLifetimeSeconds\":60}"));
+            });
+
+            using (var noErrorScope = new VerifyNoErrorsScope())
+            {
+                await WithConnectionAsync(
+                    CreateConnection(testHttpHandler, url: requestedUrl, loggerFactory: noErrorScope.LoggerFactory),
+                    async connection =>
+                    {
+                        await connection.StartAsync().DefaultTimeout();
+                        var ttl = await ((IAuthenticationRefreshFeature)connection).RefreshAuthenticationAsync().DefaultTimeout();
+                        Assert.Equal(TimeSpan.FromSeconds(60), ttl);
+                    });
+            }
+
+            var request = await refreshRequestTcs.Task.DefaultTimeout();
+            Assert.Equal(HttpMethod.Post, request.Method);
+            Assert.Equal(expectedRefreshUrl, request.RequestUri.ToString());
+        }
+
+        [Fact]
+        public async Task RefreshAuthenticationAsyncPostsToOriginalEndpointAfterRedirect()
+        {
+            // When negotiate redirects the client (e.g. Azure SignalR Service), the transport connects to the
+            // redirected endpoint, but /refresh is part of the auth plane and must target the ORIGINAL server
+            // endpoint that owns authentication, not the redirected URL.
+            var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
+            var negotiateCount = 0;
+            testHttpHandler.OnNegotiate((request, _) =>
+            {
+                negotiateCount++;
+                if (negotiateCount == 1)
+                {
+                    return ResponseUtils.CreateResponse(HttpStatusCode.OK,
+                        "{\"url\":\"http://redirected.example/hub?existing=true\",\"accessToken\":\"redirect-token\"}");
+                }
+
+                return ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationContent(negotiateVersion: 1));
+            });
+            testHttpHandler.OnLongPoll(_ => ResponseUtils.CreateResponse(HttpStatusCode.NoContent));
+            testHttpHandler.OnLongPollDelete(_ => ResponseUtils.CreateResponse(HttpStatusCode.Accepted));
+
+            var refreshRequestTcs = new TaskCompletionSource<HttpRequestMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+            OnRefresh(testHttpHandler, (request, _) =>
+            {
+                refreshRequestTcs.TrySetResult(request);
+                return Task.FromResult(ResponseUtils.CreateResponse(HttpStatusCode.OK, "{\"connectionId\":\"abc\",\"tokenLifetimeSeconds\":60}"));
+            });
+
+            using (var noErrorScope = new VerifyNoErrorsScope())
+            {
+                await WithConnectionAsync(
+                    CreateConnection(testHttpHandler, url: "http://original.example/hub", loggerFactory: noErrorScope.LoggerFactory),
+                    async connection =>
+                    {
+                        await connection.StartAsync().DefaultTimeout();
+                        // The transport followed the redirect to the redirected endpoint.
+                        Assert.Equal("http://redirected.example/hub", connection.RemoteEndPoint.ToString());
+
+                        var ttl = await ((IAuthenticationRefreshFeature)connection).RefreshAuthenticationAsync().DefaultTimeout();
+                        Assert.Equal(TimeSpan.FromSeconds(60), ttl);
+                    });
+            }
+            var request = await refreshRequestTcs.Task.DefaultTimeout();
+            Assert.Equal(HttpMethod.Post, request.Method);
+            Assert.Equal("http://original.example/hub/refresh?id=connection-token", request.RequestUri.ToString());
+        }
+
+        [Fact]
+        public async Task RefreshAuthenticationAsyncSendsBearerTokenWhenAccessTokenProviderConfigured()
+        {
+            var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
+            testHttpHandler.OnNegotiate((_, _) => ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationContent(negotiateVersion: 1)));
+            testHttpHandler.OnLongPoll(_ => ResponseUtils.CreateResponse(HttpStatusCode.NoContent));
+            testHttpHandler.OnLongPollDelete(_ => ResponseUtils.CreateResponse(HttpStatusCode.Accepted));
+
+            var refreshRequestTcs = new TaskCompletionSource<HttpRequestMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+            OnRefresh(testHttpHandler, (request, _) =>
+            {
+                refreshRequestTcs.TrySetResult(request);
+                return Task.FromResult(ResponseUtils.CreateResponse(HttpStatusCode.OK, "{\"connectionId\":\"abc\"}"));
+            });
+
+            var tokenCallCount = 0;
+            Task<string> AccessTokenProvider()
+            {
+                Interlocked.Increment(ref tokenCallCount);
+                return Task.FromResult("new-token");
+            }
+
+            using (var noErrorScope = new VerifyNoErrorsScope())
+            {
+                await WithConnectionAsync(
+                    CreateConnection(testHttpHandler, loggerFactory: noErrorScope.LoggerFactory, accessTokenProvider: AccessTokenProvider),
+                    async connection =>
+                    {
+                        await connection.StartAsync().DefaultTimeout();
+                        await ((IAuthenticationRefreshFeature)connection).RefreshAuthenticationAsync().DefaultTimeout();
+                    });
+            }
+
+            var request = await refreshRequestTcs.Task.DefaultTimeout();
+            Assert.NotNull(request.Headers.Authorization);
+            Assert.Equal("Bearer", request.Headers.Authorization.Scheme);
+            Assert.Equal("new-token", request.Headers.Authorization.Parameter);
+            Assert.True(tokenCallCount >= 1);
+        }
+
+        [Fact]
+        public async Task RefreshAuthenticationAsyncOmitsAuthorizationHeaderWhenAccessTokenProviderReturnsNull()
+        {
+            var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
+            testHttpHandler.OnNegotiate((_, _) => ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationContent(negotiateVersion: 1)));
+            testHttpHandler.OnLongPoll(_ => ResponseUtils.CreateResponse(HttpStatusCode.NoContent));
+            testHttpHandler.OnLongPollDelete(_ => ResponseUtils.CreateResponse(HttpStatusCode.Accepted));
+
+            var refreshRequestTcs = new TaskCompletionSource<HttpRequestMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+            OnRefresh(testHttpHandler, (request, _) =>
+            {
+                refreshRequestTcs.TrySetResult(request);
+                return Task.FromResult(ResponseUtils.CreateResponse(HttpStatusCode.OK, "{\"connectionId\":\"abc\"}"));
+            });
+
+            using (var noErrorScope = new VerifyNoErrorsScope())
+            {
+                await WithConnectionAsync(
+                    CreateConnection(testHttpHandler, loggerFactory: noErrorScope.LoggerFactory),
+                    async connection =>
+                    {
+                        await connection.StartAsync().DefaultTimeout();
+                        await ((IAuthenticationRefreshFeature)connection).RefreshAuthenticationAsync().DefaultTimeout();
+                    });
+            }
+
+            var request = await refreshRequestTcs.Task.DefaultTimeout();
+            Assert.Null(request.Headers.Authorization);
+        }
+
+        [Fact]
+        public async Task RefreshAuthenticationAsyncReturnsNullWhenTokenLifetimeMissing()
+        {
+            var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
+            testHttpHandler.OnNegotiate((_, _) => ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationContent(negotiateVersion: 1)));
+            testHttpHandler.OnLongPoll(_ => ResponseUtils.CreateResponse(HttpStatusCode.NoContent));
+            testHttpHandler.OnLongPollDelete(_ => ResponseUtils.CreateResponse(HttpStatusCode.Accepted));
+            OnRefresh(testHttpHandler, (_, _) =>
+                Task.FromResult(ResponseUtils.CreateResponse(HttpStatusCode.OK, "{\"connectionId\":\"abc\"}")));
+
+            using (var noErrorScope = new VerifyNoErrorsScope())
+            {
+                await WithConnectionAsync(
+                    CreateConnection(testHttpHandler, loggerFactory: noErrorScope.LoggerFactory),
+                    async connection =>
+                    {
+                        await connection.StartAsync().DefaultTimeout();
+                        var ttl = await ((IAuthenticationRefreshFeature)connection).RefreshAuthenticationAsync().DefaultTimeout();
+                        Assert.Null(ttl);
+                    });
+            }
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.Unauthorized)]
+        [InlineData(HttpStatusCode.NotFound)]
+        [InlineData(HttpStatusCode.Forbidden)]
+        public async Task RefreshAuthenticationAsyncThrowsOnHttpErrorStatus(HttpStatusCode status)
+        {
+            var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
+            testHttpHandler.OnNegotiate((_, _) => ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationContent(negotiateVersion: 1)));
+            testHttpHandler.OnLongPoll(_ => ResponseUtils.CreateResponse(HttpStatusCode.NoContent));
+            testHttpHandler.OnLongPollDelete(_ => ResponseUtils.CreateResponse(HttpStatusCode.Accepted));
+            OnRefresh(testHttpHandler, (_, _) => Task.FromResult(ResponseUtils.CreateResponse(status, "{\"error\":\"x\"}")));
+
+            await WithConnectionAsync(
+                CreateConnection(testHttpHandler),
+                async connection =>
+                {
+                    await connection.StartAsync().DefaultTimeout();
+                    await Assert.ThrowsAsync<HttpRequestException>(
+                        () => ((IAuthenticationRefreshFeature)connection).RefreshAuthenticationAsync().DefaultTimeout());
+                });
+        }
+
+        [Fact]
+        public async Task RefreshAuthenticationAsyncPropagatesNetworkException()
+        {
+            var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
+            testHttpHandler.OnNegotiate((_, _) => ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationContent(negotiateVersion: 1)));
+            testHttpHandler.OnLongPoll(_ => ResponseUtils.CreateResponse(HttpStatusCode.NoContent));
+            testHttpHandler.OnLongPollDelete(_ => ResponseUtils.CreateResponse(HttpStatusCode.Accepted));
+            OnRefresh(testHttpHandler, (_, _) => throw new HttpRequestException("network down"));
+
+            await WithConnectionAsync(
+                CreateConnection(testHttpHandler),
+                async connection =>
+                {
+                    await connection.StartAsync().DefaultTimeout();
+                    var ex = await Assert.ThrowsAsync<HttpRequestException>(
+                        () => ((IAuthenticationRefreshFeature)connection).RefreshAuthenticationAsync().DefaultTimeout());
+                    Assert.Equal("network down", ex.Message);
+                });
+        }
+
+        [Fact]
+        public async Task RefreshAuthenticationAsyncPropagatesCancellation()
+        {
+            var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
+            testHttpHandler.OnNegotiate((_, _) => ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationContent(negotiateVersion: 1)));
+            testHttpHandler.OnLongPoll(_ => ResponseUtils.CreateResponse(HttpStatusCode.NoContent));
+            testHttpHandler.OnLongPollDelete(_ => ResponseUtils.CreateResponse(HttpStatusCode.Accepted));
+
+            var requestReceivedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            OnRefresh(testHttpHandler, async (_, ct) =>
+            {
+                requestReceivedTcs.TrySetResult();
+                await Task.Delay(Timeout.Infinite, ct);
+                return ResponseUtils.CreateResponse(HttpStatusCode.OK);
+            });
+
+            await WithConnectionAsync(
+                CreateConnection(testHttpHandler),
+                async connection =>
+                {
+                    await connection.StartAsync().DefaultTimeout();
+                    using var cts = new CancellationTokenSource();
+                    var refreshTask = ((IAuthenticationRefreshFeature)connection).RefreshAuthenticationAsync(cts.Token);
+                    await requestReceivedTcs.Task.DefaultTimeout();
+                    cts.Cancel();
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => refreshTask.DefaultTimeout());
+                });
+        }
+    }
+}

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.AuthenticationRefresh.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.AuthenticationRefresh.cs
@@ -1,0 +1,602 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Connections.Features;
+using Microsoft.AspNetCore.Internal;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.AspNetCore.SignalR.Client.Internal;
+using Microsoft.AspNetCore.SignalR.Tests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Testing;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Microsoft.AspNetCore.SignalR.Client.Tests;
+
+public partial class HubConnectionTests
+{
+    public class AuthenticationRefresh : VerifiableLoggedTest
+    {
+        private static HubConnection BuildHubConnection(
+            TestConnection connection,
+            Action<IHubConnectionBuilder> configure = null)
+        {
+            var builder = new HubConnectionBuilder().WithUrl("http://example.com");
+
+            var delegateConnectionFactory = new DelegateConnectionFactory(
+                async endPoint =>
+                {
+                    connection.RemoteEndPoint = endPoint;
+                    return await connection.StartAsync();
+                });
+
+            builder.Services.AddSingleton<IConnectionFactory>(delegateConnectionFactory);
+
+            configure?.Invoke(builder);
+
+            return builder.Build();
+        }
+
+        private static Timer GetAuthenticationRefreshTimer(HubConnection hubConnection)
+        {
+            var field = typeof(HubConnection).GetField("_authRefreshTimer", BindingFlags.NonPublic | BindingFlags.Instance);
+            return (Timer)field.GetValue(hubConnection);
+        }
+
+        private static TimeSpan GetLastAuthenticationRefreshDelay(HubConnection hubConnection)
+        {
+            var field = typeof(HubConnection).GetField("_lastAuthenticationRefreshDelay", BindingFlags.NonPublic | BindingFlags.Instance);
+            return (TimeSpan)field.GetValue(hubConnection);
+        }
+
+        [Fact]
+        public async Task RefreshAuthenticationAsyncThrowsWhenConnectionNotActive()
+        {
+            using (StartVerifiableLog())
+            {
+                var connection = new TestConnection();
+                var hubConnection = BuildHubConnection(connection);
+                try
+                {
+                    var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                        () => hubConnection.RefreshAuthenticationAsync()).DefaultTimeout();
+                    Assert.Contains("not active", ex.Message);
+                }
+                finally
+                {
+                    await hubConnection.DisposeAsync().DefaultTimeout();
+                    await connection.DisposeAsync().DefaultTimeout();
+                }
+            }
+        }
+
+        [Fact]
+        public async Task RefreshAuthenticationAsyncThrowsWhenFeatureMissing()
+        {
+            using (StartVerifiableLog())
+            {
+                var connection = new TestConnection();
+                var hubConnection = BuildHubConnection(connection);
+                try
+                {
+                    await hubConnection.StartAsync().DefaultTimeout();
+
+                    var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                        () => hubConnection.RefreshAuthenticationAsync()).DefaultTimeout();
+                    Assert.Contains("HTTP-based connections", ex.Message);
+                }
+                finally
+                {
+                    await hubConnection.DisposeAsync().DefaultTimeout();
+                    await connection.DisposeAsync().DefaultTimeout();
+                }
+            }
+        }
+
+        [Fact]
+        public async Task RefreshAuthenticationAsyncInvokesFeatureAndReturnsTtl()
+        {
+            using (StartVerifiableLog())
+            {
+                var feature = new FakeAuthenticationRefreshFeature { NextTtl = TimeSpan.FromSeconds(3600) };
+                var connection = new TestConnection();
+                connection.Features.Set<IAuthenticationRefreshFeature>(feature);
+                var hubConnection = BuildHubConnection(connection);
+                try
+                {
+                    await hubConnection.StartAsync().DefaultTimeout();
+
+                    var ttl = await hubConnection.RefreshAuthenticationAsync().DefaultTimeout();
+
+                    Assert.Equal(TimeSpan.FromSeconds(3600), ttl);
+                    Assert.Equal(1, feature.RefreshCallCount);
+                }
+                finally
+                {
+                    await hubConnection.DisposeAsync().DefaultTimeout();
+                    await connection.DisposeAsync().DefaultTimeout();
+                }
+            }
+        }
+
+        [Fact]
+        public async Task RefreshAuthenticationAsyncInvokesOnAuthenticationRefreshedCallback()
+        {
+            using (StartVerifiableLog())
+            {
+                var feature = new FakeAuthenticationRefreshFeature { NextTtl = TimeSpan.FromSeconds(1800) };
+                var connection = new TestConnection();
+                connection.Features.Set<IAuthenticationRefreshFeature>(feature);
+
+                AuthenticationRefreshedContext capturedContext = null;
+                var hubConnection = BuildHubConnection(connection, builder =>
+                {
+                    builder.WithAuthenticationRefresh(o =>
+                    {
+                        o.EnableAutoRefresh = false;
+                        o.OnAuthenticationRefreshed = ctx =>
+                        {
+                            capturedContext = ctx;
+                            return Task.CompletedTask;
+                        };
+                    });
+                });
+                try
+                {
+                    await hubConnection.StartAsync().DefaultTimeout();
+                    await hubConnection.RefreshAuthenticationAsync().DefaultTimeout();
+
+                    Assert.NotNull(capturedContext);
+                    Assert.Same(hubConnection, capturedContext.HubConnection);
+                    Assert.Equal(TimeSpan.FromSeconds(1800), capturedContext.NewTokenLifetime);
+                }
+                finally
+                {
+                    await hubConnection.DisposeAsync().DefaultTimeout();
+                    await connection.DisposeAsync().DefaultTimeout();
+                }
+            }
+        }
+
+        [Fact]
+        public async Task RefreshAuthenticationAsyncInvokesOnAuthenticationRefreshFailedCallbackAndRethrows()
+        {
+            using (StartVerifiableLog())
+            {
+                var thrown = new InvalidOperationException("refresh boom");
+                var feature = new FakeAuthenticationRefreshFeature { ExceptionToThrow = thrown };
+                var connection = new TestConnection();
+                connection.Features.Set<IAuthenticationRefreshFeature>(feature);
+
+                AuthenticationRefreshFailedContext capturedContext = null;
+                var hubConnection = BuildHubConnection(connection, builder =>
+                {
+                    builder.WithAuthenticationRefresh(o =>
+                    {
+                        o.EnableAutoRefresh = false;
+                        o.OnAuthenticationRefreshFailed = ctx =>
+                        {
+                            capturedContext = ctx;
+                            return Task.CompletedTask;
+                        };
+                    });
+                });
+                try
+                {
+                    await hubConnection.StartAsync().DefaultTimeout();
+
+                    var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                        () => hubConnection.RefreshAuthenticationAsync()).DefaultTimeout();
+
+                    Assert.Same(thrown, ex);
+                    Assert.NotNull(capturedContext);
+                    Assert.Same(thrown, capturedContext.Exception);
+                    Assert.Same(hubConnection, capturedContext.HubConnection);
+                }
+                finally
+                {
+                    await hubConnection.DisposeAsync().DefaultTimeout();
+                    await connection.DisposeAsync().DefaultTimeout();
+                }
+            }
+        }
+
+        [Fact]
+        public async Task RefreshAuthenticationAsyncOnAuthenticationRefreshedCallbackExceptionIsSwallowed()
+        {
+            bool ExpectedErrors(WriteContext wc) =>
+                wc.LoggerName == typeof(HubConnection).FullName &&
+                wc.EventId.Name == "AuthenticationRefreshCallbackFailed";
+
+            using (StartVerifiableLog(expectedErrorsFilter: ExpectedErrors))
+            {
+                var feature = new FakeAuthenticationRefreshFeature { NextTtl = TimeSpan.FromSeconds(1200) };
+                var connection = new TestConnection();
+                connection.Features.Set<IAuthenticationRefreshFeature>(feature);
+
+                var hubConnection = BuildHubConnection(connection, builder =>
+                {
+                    builder.WithAuthenticationRefresh(o =>
+                    {
+                        o.EnableAutoRefresh = false;
+                        o.OnAuthenticationRefreshed = _ => throw new InvalidOperationException("callback boom");
+                    });
+                });
+                try
+                {
+                    await hubConnection.StartAsync().DefaultTimeout();
+
+                    // Should NOT throw - callback exception is logged & swallowed.
+                    var ttl = await hubConnection.RefreshAuthenticationAsync().DefaultTimeout();
+                    Assert.Equal(TimeSpan.FromSeconds(1200), ttl);
+                }
+                finally
+                {
+                    await hubConnection.DisposeAsync().DefaultTimeout();
+                    await connection.DisposeAsync().DefaultTimeout();
+                }
+            }
+        }
+
+        [Fact]
+        public async Task RefreshAuthenticationAsyncOnAuthenticationRefreshFailedCallbackExceptionIsSwallowedAndOriginalRethrown()
+        {
+            bool ExpectedErrors(WriteContext wc) =>
+                wc.LoggerName == typeof(HubConnection).FullName &&
+                wc.EventId.Name == "AuthenticationRefreshCallbackFailed";
+
+            using (StartVerifiableLog(expectedErrorsFilter: ExpectedErrors))
+            {
+                var original = new InvalidOperationException("refresh boom");
+                var feature = new FakeAuthenticationRefreshFeature { ExceptionToThrow = original };
+                var connection = new TestConnection();
+                connection.Features.Set<IAuthenticationRefreshFeature>(feature);
+
+                var hubConnection = BuildHubConnection(connection, builder =>
+                {
+                    builder.WithAuthenticationRefresh(o =>
+                    {
+                        o.EnableAutoRefresh = false;
+                        o.OnAuthenticationRefreshFailed = _ => throw new InvalidOperationException("failed-callback boom");
+                    });
+                });
+                try
+                {
+                    await hubConnection.StartAsync().DefaultTimeout();
+
+                    var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                        () => hubConnection.RefreshAuthenticationAsync()).DefaultTimeout();
+
+                    Assert.Same(original, ex);
+                }
+                finally
+                {
+                    await hubConnection.DisposeAsync().DefaultTimeout();
+                    await connection.DisposeAsync().DefaultTimeout();
+                }
+            }
+        }
+
+        [Fact]
+        public async Task StartSchedulesTimerWhenInitialTtlProvided()
+        {
+            using (StartVerifiableLog())
+            {
+                var feature = new FakeAuthenticationRefreshFeature { InitialTokenLifetime = TimeSpan.FromSeconds(3600) };
+                var connection = new TestConnection();
+                connection.Features.Set<IAuthenticationRefreshFeature>(feature);
+
+                var hubConnection = BuildHubConnection(connection);
+                try
+                {
+                    await hubConnection.StartAsync().DefaultTimeout();
+
+                    Assert.NotNull(GetAuthenticationRefreshTimer(hubConnection));
+                }
+                finally
+                {
+                    await hubConnection.DisposeAsync().DefaultTimeout();
+                    await connection.DisposeAsync().DefaultTimeout();
+                }
+            }
+        }
+
+        [Fact]
+        public async Task StartDoesNotScheduleTimerWhenEnableAutoRefreshFalse()
+        {
+            using (StartVerifiableLog())
+            {
+                var feature = new FakeAuthenticationRefreshFeature { InitialTokenLifetime = TimeSpan.FromSeconds(3600) };
+                var connection = new TestConnection();
+                connection.Features.Set<IAuthenticationRefreshFeature>(feature);
+
+                var hubConnection = BuildHubConnection(connection, builder =>
+                {
+                    builder.WithAuthenticationRefresh(o => o.EnableAutoRefresh = false);
+                });
+                try
+                {
+                    await hubConnection.StartAsync().DefaultTimeout();
+
+                    Assert.Null(GetAuthenticationRefreshTimer(hubConnection));
+                }
+                finally
+                {
+                    await hubConnection.DisposeAsync().DefaultTimeout();
+                    await connection.DisposeAsync().DefaultTimeout();
+                }
+            }
+        }
+
+        [Fact]
+        public async Task StartDoesNotScheduleTimerWhenFeatureMissing()
+        {
+            using (StartVerifiableLog())
+            {
+                var connection = new TestConnection();
+                var hubConnection = BuildHubConnection(connection);
+                try
+                {
+                    await hubConnection.StartAsync().DefaultTimeout();
+
+                    Assert.Null(GetAuthenticationRefreshTimer(hubConnection));
+                }
+                finally
+                {
+                    await hubConnection.DisposeAsync().DefaultTimeout();
+                    await connection.DisposeAsync().DefaultTimeout();
+                }
+            }
+        }
+
+        [Fact]
+        public async Task StartDoesNotScheduleTimerWhenInitialTtlIsZero()
+        {
+            using (StartVerifiableLog())
+            {
+                var feature = new FakeAuthenticationRefreshFeature { InitialTokenLifetime = TimeSpan.Zero };
+                var connection = new TestConnection();
+                connection.Features.Set<IAuthenticationRefreshFeature>(feature);
+
+                var hubConnection = BuildHubConnection(connection);
+                try
+                {
+                    await hubConnection.StartAsync().DefaultTimeout();
+
+                    Assert.Null(GetAuthenticationRefreshTimer(hubConnection));
+                }
+                finally
+                {
+                    await hubConnection.DisposeAsync().DefaultTimeout();
+                    await connection.DisposeAsync().DefaultTimeout();
+                }
+            }
+        }
+
+        [Fact]
+        public async Task StartDoesNotScheduleTimerWhenInitialTtlIsNull()
+        {
+            using (StartVerifiableLog())
+            {
+                var feature = new FakeAuthenticationRefreshFeature { InitialTokenLifetime = null };
+                var connection = new TestConnection();
+                connection.Features.Set<IAuthenticationRefreshFeature>(feature);
+
+                var hubConnection = BuildHubConnection(connection);
+                try
+                {
+                    await hubConnection.StartAsync().DefaultTimeout();
+
+                    Assert.Null(GetAuthenticationRefreshTimer(hubConnection));
+                }
+                finally
+                {
+                    await hubConnection.DisposeAsync().DefaultTimeout();
+                    await connection.DisposeAsync().DefaultTimeout();
+                }
+            }
+        }
+
+        [Fact]
+        public async Task RefreshReschedulesTimerWhenAutoRefreshEnabled()
+        {
+            using (StartVerifiableLog())
+            {
+                var feature = new FakeAuthenticationRefreshFeature
+                {
+                    InitialTokenLifetime = TimeSpan.FromSeconds(3600),
+                    NextTtl = TimeSpan.FromSeconds(7200),
+                };
+                var connection = new TestConnection();
+                connection.Features.Set<IAuthenticationRefreshFeature>(feature);
+
+                var hubConnection = BuildHubConnection(connection);
+                try
+                {
+                    await hubConnection.StartAsync().DefaultTimeout();
+                    var beforeTimer = GetAuthenticationRefreshTimer(hubConnection);
+                    Assert.NotNull(beforeTimer);
+
+                    await hubConnection.RefreshAuthenticationAsync().DefaultTimeout();
+                    var afterTimer = GetAuthenticationRefreshTimer(hubConnection);
+
+                    Assert.NotNull(afterTimer);
+                    Assert.NotSame(beforeTimer, afterTimer);
+                }
+                finally
+                {
+                    await hubConnection.DisposeAsync().DefaultTimeout();
+                    await connection.DisposeAsync().DefaultTimeout();
+                }
+            }
+        }
+
+        [Fact]
+        public async Task RefreshDoesNotRescheduleTimerWhenAutoRefreshDisabled()
+        {
+            using (StartVerifiableLog())
+            {
+                var feature = new FakeAuthenticationRefreshFeature { NextTtl = TimeSpan.FromSeconds(3600) };
+                var connection = new TestConnection();
+                connection.Features.Set<IAuthenticationRefreshFeature>(feature);
+
+                var hubConnection = BuildHubConnection(connection, builder =>
+                {
+                    builder.WithAuthenticationRefresh(o => o.EnableAutoRefresh = false);
+                });
+                try
+                {
+                    await hubConnection.StartAsync().DefaultTimeout();
+                    Assert.Null(GetAuthenticationRefreshTimer(hubConnection));
+
+                    await hubConnection.RefreshAuthenticationAsync().DefaultTimeout();
+
+                    Assert.Null(GetAuthenticationRefreshTimer(hubConnection));
+                }
+                finally
+                {
+                    await hubConnection.DisposeAsync().DefaultTimeout();
+                    await connection.DisposeAsync().DefaultTimeout();
+                }
+            }
+        }
+
+        [Fact]
+        public async Task RefreshDoesNotRescheduleWhenServerReturnsNoTtl()
+        {
+            using (StartVerifiableLog())
+            {
+                var feature = new FakeAuthenticationRefreshFeature
+                {
+                    InitialTokenLifetime = TimeSpan.FromSeconds(3600),
+                    NextTtl = null,
+                };
+                var connection = new TestConnection();
+                connection.Features.Set<IAuthenticationRefreshFeature>(feature);
+
+                var hubConnection = BuildHubConnection(connection);
+                try
+                {
+                    await hubConnection.StartAsync().DefaultTimeout();
+                    var beforeTimer = GetAuthenticationRefreshTimer(hubConnection);
+                    Assert.NotNull(beforeTimer);
+
+                    await hubConnection.RefreshAuthenticationAsync().DefaultTimeout();
+                    var afterTimer = GetAuthenticationRefreshTimer(hubConnection);
+
+                    Assert.Same(beforeTimer, afterTimer);
+                }
+                finally
+                {
+                    await hubConnection.DisposeAsync().DefaultTimeout();
+                    await connection.DisposeAsync().DefaultTimeout();
+                }
+            }
+        }
+
+        [Fact]
+        public async Task RefreshReschedulesWhenServerReturnsTtl()
+        {
+            using (StartVerifiableLog())
+            {
+                var feature = new FakeAuthenticationRefreshFeature
+                {
+                    InitialTokenLifetime = null,
+                    NextTtl = TimeSpan.FromSeconds(7200),
+                };
+                var connection = new TestConnection();
+                connection.Features.Set<IAuthenticationRefreshFeature>(feature);
+
+                var hubConnection = BuildHubConnection(connection);
+                try
+                {
+                    await hubConnection.StartAsync().DefaultTimeout();
+
+                    await hubConnection.RefreshAuthenticationAsync().DefaultTimeout();
+
+                    Assert.Equal(TimeSpan.FromSeconds(7200) - TimeSpan.FromMinutes(5), GetLastAuthenticationRefreshDelay(hubConnection));
+                }
+                finally
+                {
+                    await hubConnection.DisposeAsync().DefaultTimeout();
+                    await connection.DisposeAsync().DefaultTimeout();
+                }
+            }
+        }
+
+        [Fact]
+        public async Task DisposeDisposesAuthenticationRefreshTimer()
+        {
+            using (StartVerifiableLog())
+            {
+                var feature = new FakeAuthenticationRefreshFeature { InitialTokenLifetime = TimeSpan.FromSeconds(3600) };
+                var connection = new TestConnection();
+                connection.Features.Set<IAuthenticationRefreshFeature>(feature);
+
+                var hubConnection = BuildHubConnection(connection);
+                await hubConnection.StartAsync().DefaultTimeout();
+                Assert.NotNull(GetAuthenticationRefreshTimer(hubConnection));
+
+                await hubConnection.DisposeAsync().DefaultTimeout();
+                await connection.DisposeAsync().DefaultTimeout();
+
+                Assert.Null(GetAuthenticationRefreshTimer(hubConnection));
+            }
+        }
+
+        [Fact]
+        public void WithAuthenticationRefreshRegistersOptionsThroughDI()
+        {
+            var builder = new HubConnectionBuilder().WithUrl("http://example.com");
+            builder.WithAuthenticationRefresh(o =>
+            {
+                o.EnableAutoRefresh = false;
+                o.RefreshBeforeExpiration = TimeSpan.FromMinutes(7);
+            });
+
+            var sp = builder.Services.BuildServiceProvider();
+            var options = sp.GetRequiredService<IOptions<AuthenticationRefreshOptions>>().Value;
+
+            Assert.False(options.EnableAutoRefresh);
+            Assert.Equal(TimeSpan.FromMinutes(7), options.RefreshBeforeExpiration);
+        }
+
+        [Fact]
+        public void WithAuthenticationRefreshThrowsOnNullConfigure()
+        {
+            var builder = new HubConnectionBuilder().WithUrl("http://example.com");
+            Assert.Throws<ArgumentNullException>(() => builder.WithAuthenticationRefresh(null));
+        }
+
+        [Fact]
+        public void AuthenticationRefreshOptionsThrowsForNegativeRefreshBeforeExpiration()
+        {
+            var options = new AuthenticationRefreshOptions();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => options.RefreshBeforeExpiration = TimeSpan.FromTicks(-1));
+        }
+
+        private sealed class FakeAuthenticationRefreshFeature : IAuthenticationRefreshFeature
+        {
+            public TimeSpan? InitialTokenLifetime { get; set; }
+            public TimeSpan? NextTtl { get; set; }
+            public Exception ExceptionToThrow { get; set; }
+            public int RefreshCallCount { get; private set; }
+
+            public Task<TimeSpan?> RefreshAuthenticationAsync(CancellationToken cancellationToken = default)
+            {
+                RefreshCallCount++;
+                if (ExceptionToThrow is not null)
+                {
+                    return Task.FromException<TimeSpan?>(ExceptionToThrow);
+                }
+                return Task.FromResult(NextTtl);
+            }
+        }
+    }
+}

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
@@ -7,7 +7,9 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO.Pipelines;
 using System.Linq;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Net.WebSockets;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
@@ -18,14 +20,13 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Shared;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using System.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Http.Connections.Client;
 
 /// <summary>
 /// Used to make a connection to an ASP.NET Core ConnectionHandler using an HTTP-based transport.
 /// </summary>
-public partial class HttpConnection : ConnectionContext, IConnectionInherentKeepAliveFeature
+public partial class HttpConnection : ConnectionContext, IConnectionInherentKeepAliveFeature, IAuthenticationRefreshFeature
 {
     // Not configurable on purpose, high enough that if we reach here, it's likely
     // a buggy server
@@ -47,6 +48,8 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
     private ITransport? _transport;
     private readonly ITransportFactory _transportFactory;
     private string? _connectionId;
+    private string? _connectionToken;
+    private TimeSpan? _initialTokenLifetime;
     private readonly ConnectionLogScope _logScope;
     private readonly ILoggerFactory _loggerFactory;
     private readonly Uri _url;
@@ -91,6 +94,9 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
 
     /// <inheritdoc />
     bool IConnectionInherentKeepAliveFeature.HasInherentKeepAlive => _hasInherentKeepAlive;
+
+    /// <inheritdoc />
+    TimeSpan? IAuthenticationRefreshFeature.InitialTokenLifetime => _initialTokenLifetime;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="HttpConnection"/> class.
@@ -159,6 +165,7 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
         _logScope = new ConnectionLogScope();
 
         Features.Set<IConnectionInherentKeepAliveFeature>(this);
+        Features.Set<IAuthenticationRefreshFeature>(this);
     }
 
     // Used by unit tests
@@ -512,6 +519,18 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
         return Utils.AppendQueryString(url, $"id={connectionId}");
     }
 
+    private static Uri CreateRefreshUrl(Uri url, string connectionToken)
+    {
+        var urlBuilder = new UriBuilder(url);
+        if (!urlBuilder.Path.EndsWith("/", StringComparison.Ordinal))
+        {
+            urlBuilder.Path += "/";
+        }
+
+        urlBuilder.Path += "refresh";
+        return Utils.AppendQueryString(urlBuilder.Uri, $"id={connectionToken}");
+    }
+
     private async Task StartTransport(Uri connectUrl, HttpTransportType transportType, TransferFormat transferFormat,
         CancellationToken cancellationToken, bool useStatefulReconnect)
     {
@@ -720,8 +739,79 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
         {
             negotiationResponse.ConnectionToken = _connectionId;
         }
+        _connectionToken = negotiationResponse.ConnectionToken;
+        _initialTokenLifetime = negotiationResponse.TokenLifetime;
 
         _logScope.ConnectionId = _connectionId;
         return negotiationResponse;
+    }
+
+    /// <inheritdoc />
+    async Task<TimeSpan?> IAuthenticationRefreshFeature.RefreshAuthenticationAsync(CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(_connectionToken))
+        {
+            throw new InvalidOperationException("Cannot refresh authentication before the connection is started.");
+        }
+
+        var refreshUri = CreateRefreshUrl(_url, _connectionToken);
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, refreshUri);
+
+        // Mark this as a refresh request so the AccessTokenHttpMessageHandler fetches a fresh access token
+        // (and updates its cache) rather than reusing the token captured when the connection started. Setting
+        // the Authorization header directly here is not sufficient because that handler overwrites it.
+#if NET5_0_OR_GREATER
+        request.Options.Set(new HttpRequestOptionsKey<bool>("IsRefresh"), true);
+#else
+        request.Properties.Add("IsRefresh", true);
+#endif
+
+        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+#pragma warning disable CA2016 // Forward the 'CancellationToken' parameter to methods
+        var responseBuffer = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+#pragma warning restore CA2016
+        // Parse the simple JSON response: { "tokenLifetimeSeconds": ... }
+        return ParseRefreshTokenLifetime(responseBuffer);
+    }
+
+    // Manually reads "tokenLifetimeSeconds" from the /refresh response with a Utf8JsonReader, consistent with
+    // NegotiateProtocol.ParseResponse rather than materializing a JsonDocument for a single optional value.
+    private static TimeSpan? ParseRefreshTokenLifetime(ReadOnlySpan<byte> content)
+    {
+        var reader = new Utf8JsonReader(content, isFinalBlock: true, state: default);
+
+        if (!reader.Read() || reader.TokenType != JsonTokenType.StartObject)
+        {
+            throw new System.IO.InvalidDataException("Invalid refresh response JSON: expected an object.");
+        }
+
+        TimeSpan? tokenLifetime = null;
+        while (reader.Read())
+        {
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.PropertyName:
+                    if (reader.ValueTextEquals("tokenLifetimeSeconds"u8))
+                    {
+                        reader.Read();
+                        if (reader.TokenType == JsonTokenType.Number)
+                        {
+                            tokenLifetime = TimeSpan.FromSeconds(reader.GetInt32());
+                        }
+                    }
+                    else
+                    {
+                        reader.Skip();
+                    }
+                    break;
+                case JsonTokenType.EndObject:
+                    return tokenLifetime;
+            }
+        }
+
+        return tokenLifetime;
     }
 }

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/AccessTokenHttpMessageHandler.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/AccessTokenHttpMessageHandler.cs
@@ -21,25 +21,50 @@ internal sealed class AccessTokenHttpMessageHandler : DelegatingHandler
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        var shouldRetry = true;
-        if (string.IsNullOrEmpty(_accessToken) ||
-            // Negotiate redirects likely will have a new access token so let's always grab a (potentially) new access token on negotiate
 #if NET5_0_OR_GREATER
-            request.Options.TryGetValue(new HttpRequestOptionsKey<bool>("IsNegotiate"), out var value) && value == true
+        var isNegotiate = request.Options.TryGetValue(new HttpRequestOptionsKey<bool>("IsNegotiate"), out var negotiateValue) && negotiateValue;
+        var isRefresh = request.Options.TryGetValue(new HttpRequestOptionsKey<bool>("IsRefresh"), out var refreshValue) && refreshValue;
 #else
-            request.Properties.TryGetValue("IsNegotiate", out var value) && value is true
+        var isNegotiate = request.Properties.TryGetValue("IsNegotiate", out var negotiateValue) && negotiateValue is true;
+        var isRefresh = request.Properties.TryGetValue("IsRefresh", out var refreshValue) && refreshValue is true;
 #endif
-            )
+
+        var shouldRetry = true;
+        // The token to attach to this request. Defaults to the cached token for normal transport
+        // requests (polls/sends), which must keep using whatever the cache currently holds.
+        var tokenForRequest = _accessToken;
+        if (string.IsNullOrEmpty(_accessToken) || isNegotiate || isRefresh)
         {
             shouldRetry = false;
-            _accessToken = await _httpConnection.GetAccessTokenAsync().ConfigureAwait(false);
+            // Negotiate redirects likely will have a new access token so let's always grab a (potentially) new access token on negotiate.
+            // Authentication refresh exists specifically to obtain a new access token, so always re-fetch on refresh too.
+            tokenForRequest = await _httpConnection.GetAccessTokenAsync().ConfigureAwait(false);
+
+            // For negotiate (and the initial fetch) adopt the new token immediately. For refresh, defer
+            // updating the cache until we know the server accepted the refresh (below): a rejected
+            // refresh (for example an OnAuthenticationRefresh denial returning 403) must not poison the cache and
+            // leak the rejected token onto subsequent transport requests (e.g. Long Polling polls/sends).
+            if (!isRefresh)
+            {
+                _accessToken = tokenForRequest;
+            }
         }
 
-        SetAccessToken(_accessToken, request);
+        SetAccessToken(tokenForRequest, request);
 
         var result = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+        if (isRefresh)
+        {
+            // Only adopt the refreshed token once the server has accepted the refresh, so subsequent
+            // transport requests use the new token. On rejection, keep the previously cached token.
+            if (result.IsSuccessStatusCode)
+            {
+                _accessToken = tokenForRequest;
+            }
+        }
         // retry once with a new token on auth failure
-        if (shouldRetry && result.StatusCode is HttpStatusCode.Unauthorized)
+        else if (shouldRetry && result.StatusCode is HttpStatusCode.Unauthorized)
         {
             HttpConnection.Log.RetryAccessToken(_httpConnection._logger, result.StatusCode);
             result.Dispose();

--- a/src/SignalR/common/Http.Connections.Common/src/NegotiateProtocol.cs
+++ b/src/SignalR/common/Http.Connections.Common/src/NegotiateProtocol.cs
@@ -36,6 +36,8 @@ public static class NegotiateProtocol
     private static readonly JsonEncodedText NegotiateVersionPropertyNameBytes = JsonEncodedText.Encode(NegotiateVersionPropertyName);
     private const string StatefulReconnectPropertyName = "useStatefulReconnect";
     private static readonly JsonEncodedText StatefulReconnectPropertyNameBytes = JsonEncodedText.Encode(StatefulReconnectPropertyName);
+    private const string TokenLifetimePropertyName = "tokenLifetimeSeconds";
+    private static readonly JsonEncodedText TokenLifetimePropertyNameBytes = JsonEncodedText.Encode(TokenLifetimePropertyName);
 
     // Used to detect ASP.NET SignalR Server connection attempt
     private static ReadOnlySpan<byte> ProtocolVersionPropertyNameBytes => "ProtocolVersion"u8;
@@ -90,6 +92,11 @@ public static class NegotiateProtocol
             if (response.Version > 0 && !string.IsNullOrEmpty(response.ConnectionToken))
             {
                 writer.WriteString(ConnectionTokenPropertyNameBytes, response.ConnectionToken);
+            }
+
+            if (response.TokenLifetime is { } tokenLifetime && tokenLifetime > TimeSpan.Zero)
+            {
+                writer.WriteNumber(TokenLifetimePropertyNameBytes, (int)Math.Min(tokenLifetime.TotalSeconds, int.MaxValue));
             }
 
             writer.WriteStartArray(AvailableTransportsPropertyNameBytes);
@@ -160,6 +167,7 @@ public static class NegotiateProtocol
             string? error = null;
             int version = 0;
             bool useStatefulReconnect = false;
+            TimeSpan? tokenLifetime = null;
 
             var completed = false;
             while (!completed && reader.CheckRead())
@@ -217,6 +225,10 @@ public static class NegotiateProtocol
                         {
                             useStatefulReconnect = reader.ReadAsBoolean(StatefulReconnectPropertyName);
                         }
+                        else if (reader.ValueTextEquals(TokenLifetimePropertyNameBytes.EncodedUtf8Bytes))
+                        {
+                            tokenLifetime = TimeSpan.FromSeconds(reader.ReadAsInt32(TokenLifetimePropertyName).GetValueOrDefault());
+                        }
                         else
                         {
                             reader.Skip();
@@ -262,6 +274,7 @@ public static class NegotiateProtocol
                 Error = error,
                 Version = version,
                 UseStatefulReconnect = useStatefulReconnect,
+                TokenLifetime = tokenLifetime,
             };
         }
         catch (Exception ex)

--- a/src/SignalR/common/Http.Connections.Common/src/NegotiationResponse.cs
+++ b/src/SignalR/common/Http.Connections.Common/src/NegotiationResponse.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Abstractions;
@@ -53,4 +54,10 @@ public class NegotiationResponse
     /// application (like SignalR) can react.
     /// </summary>
     public bool UseStatefulReconnect { get; set; }
+
+    /// <summary>
+    /// The amount of time until the authentication token expires. The client can use this to schedule a token refresh.
+    /// A null value indicates the server does not support authentication refresh or the token lifetime is unknown.
+    /// </summary>
+    public TimeSpan? TokenLifetime { get; set; }
 }

--- a/src/SignalR/common/Http.Connections.Common/src/PublicAPI.Unshipped.txt
+++ b/src/SignalR/common/Http.Connections.Common/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.AspNetCore.Http.Connections.NegotiationResponse.TokenLifetime.get -> System.TimeSpan?
+Microsoft.AspNetCore.Http.Connections.NegotiationResponse.TokenLifetime.set -> void

--- a/src/SignalR/common/Http.Connections/src/AuthenticationRefreshContext.cs
+++ b/src/SignalR/common/Http.Connections/src/AuthenticationRefreshContext.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Security.Claims;
+
+namespace Microsoft.AspNetCore.Http.Connections;
+
+/// <summary>
+/// Provides information about an in-flight authentication refresh to a
+/// <see cref="HttpConnectionDispatcherOptions.OnAuthenticationRefresh"/> callback so the application
+/// can accept or reject the refresh.
+/// </summary>
+public sealed class AuthenticationRefreshContext
+{
+    /// <summary>
+    /// The <see cref="Http.HttpContext"/> for the refresh request.
+    /// </summary>
+    public required HttpContext HttpContext { get; init; }
+
+    /// <summary>
+    /// The id of the connection being refreshed.
+    /// </summary>
+    public required string ConnectionId { get; init; }
+
+    /// <summary>
+    /// The <see cref="ClaimsPrincipal"/> currently associated with the connection
+    /// (before this refresh is applied).
+    /// </summary>
+    public required ClaimsPrincipal PreviousUser { get; init; }
+
+    /// <summary>
+    /// The <see cref="ClaimsPrincipal"/> produced by re-authenticating the refresh request.
+    /// This is the principal that will replace <see cref="PreviousUser"/> on the connection
+    /// if the callback returns <c>true</c>.
+    /// </summary>
+    public required ClaimsPrincipal NewUser { get; init; }
+
+    /// <summary>
+    /// The new authentication expiration time, or <see cref="DateTimeOffset.MaxValue"/>
+    /// when the authentication ticket has no expiration.
+    /// </summary>
+    public required DateTimeOffset NewExpiration { get; init; }
+
+}

--- a/src/SignalR/common/Http.Connections/src/AuthenticationRefreshMetadata.cs
+++ b/src/SignalR/common/Http.Connections/src/AuthenticationRefreshMetadata.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Http.Connections;
+
+/// <summary>
+/// Metadata to identify the /refresh endpoint for HTTP connections, used to refresh
+/// authentication on an existing connection without reconnecting.
+/// </summary>
+public sealed class AuthenticationRefreshMetadata
+{
+}

--- a/src/SignalR/common/Http.Connections/src/ConnectionEndpointRouteBuilderExtensions.cs
+++ b/src/SignalR/common/Http.Connections/src/ConnectionEndpointRouteBuilderExtensions.cs
@@ -18,6 +18,7 @@ namespace Microsoft.AspNetCore.Builder;
 public static class ConnectionEndpointRouteBuilderExtensions
 {
     private static readonly NegotiateMetadata _negotiateMetadata = new NegotiateMetadata();
+    private static readonly AuthenticationRefreshMetadata _authRefreshMetadata = new AuthenticationRefreshMetadata();
 
     /// <summary>
     /// Maps incoming requests with the specified path to the provided connection pipeline.
@@ -105,6 +106,20 @@ public static class ConnectionEndpointRouteBuilderExtensions
         // Add the negotiate metadata so this endpoint can be identified
         negotiateBuilder.WithMetadata(_negotiateMetadata);
         negotiateBuilder.WithMetadata(options);
+
+        // Build the refresh handler for authentication token refresh
+        if (options.EnableAuthenticationRefresh)
+        {
+            var refreshApp = endpoints.CreateApplicationBuilder();
+            refreshApp.Run(c => dispatcher.ExecuteRefreshAsync(c, options));
+            var refreshHandler = refreshApp.Build();
+
+            var refreshBuilder = endpoints.Map(pattern + "/refresh", refreshHandler);
+            conventionBuilders.Add(refreshBuilder);
+            // Add the authentication refresh metadata so this endpoint can be identified (e.g. by Azure SignalR Service SDK)
+            refreshBuilder.WithMetadata(_authRefreshMetadata);
+            refreshBuilder.WithMetadata(options);
+        }
 
         // build the execute handler part of the protocol
         app = endpoints.CreateApplicationBuilder();

--- a/src/SignalR/common/Http.Connections/src/HttpConnectionDispatcherOptions.cs
+++ b/src/SignalR/common/Http.Connections/src/HttpConnectionDispatcherOptions.cs
@@ -19,9 +19,6 @@ public class HttpConnectionDispatcherOptions
 
     private PipeOptions? _transportPipeOptions;
     private PipeOptions? _appPipeOptions;
-    private TimeSpan _transportSendTimeout;
-    private long _transportMaxBufferSize;
-    private long _applicationMaxBufferSize;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="HttpConnectionDispatcherOptions"/> class.
@@ -65,12 +62,12 @@ public class HttpConnectionDispatcherOptions
     /// </remarks>
     public long TransportMaxBufferSize
     {
-        get => _transportMaxBufferSize;
+        get;
         set
         {
             ArgumentOutOfRangeException.ThrowIfNegative(value);
 
-            _transportMaxBufferSize = value;
+            field = value;
         }
     }
 
@@ -82,12 +79,12 @@ public class HttpConnectionDispatcherOptions
     /// </remarks>
     public long ApplicationMaxBufferSize
     {
-        get => _applicationMaxBufferSize;
+        get;
         set
         {
             ArgumentOutOfRangeException.ThrowIfNegative(value);
 
-            _applicationMaxBufferSize = value;
+            field = value;
         }
     }
 
@@ -106,12 +103,12 @@ public class HttpConnectionDispatcherOptions
     /// </remarks>
     public TimeSpan TransportSendTimeout
     {
-        get => _transportSendTimeout;
+        get;
         set
         {
             ArgumentOutOfRangeException.ThrowIfEqual(value, TimeSpan.Zero);
 
-            _transportSendTimeout = value;
+            field = value;
         }
     }
 
@@ -132,7 +129,22 @@ public class HttpConnectionDispatcherOptions
     /// </remarks>
     public bool AllowStatefulReconnects { get; set; }
 
-    internal bool TransportSendTimeoutEnabled => _transportSendTimeout != Timeout.InfiniteTimeSpan;
+    /// <summary>
+    /// When set to <c>true</c>, enables the <c>/refresh</c> endpoint that allows clients to refresh their
+    /// authentication token without disconnecting. The server will re-authenticate the request and update
+    /// the connection's <see cref="System.Security.Claims.ClaimsPrincipal"/>.
+    /// </summary>
+    public bool EnableAuthenticationRefresh { get; set; }
+
+    /// <summary>
+    /// An optional callback invoked when the <c>/refresh</c> endpoint has successfully re-authenticated
+    /// the request but before the connection's user is replaced. Return <c>true</c> to accept the new
+    /// principal, or <c>false</c> to reject the refresh. When rejected, the endpoint responds with
+    /// HTTP 403 and the connection's current user remains in place.
+    /// </summary>
+    public Func<AuthenticationRefreshContext, ValueTask<bool>>? OnAuthenticationRefresh { get; set; }
+
+    internal bool TransportSendTimeoutEnabled => TransportSendTimeout != Timeout.InfiniteTimeSpan;
 
     // We initialize these lazily based on the state of the options specified here.
     // Though these are mutable it's extremely rare that they would be mutated past the

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
@@ -5,7 +5,6 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Security.Claims;
-using System.Security.Principal;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Abstractions;
 using Microsoft.AspNetCore.Connections.Features;
@@ -24,6 +23,7 @@ internal sealed partial class HttpConnectionContext : ConnectionContext,
                                      IConnectionItemsFeature,
                                      IConnectionTransportFeature,
                                      IConnectionUserFeature,
+                                     IConnectionUserRefreshFeature,
                                      IConnectionHeartbeatFeature,
                                      ITransferFormatFeature,
                                      IHttpContextFeature,
@@ -52,6 +52,13 @@ internal sealed partial class HttpConnectionContext : ConnectionContext,
     private bool _activeSend;
     private TimeSpan _startedSendTime;
     private bool _useStatefulReconnect;
+    // Guards User swaps in UpdateUser so concurrent /refresh requests (or long-polling polls racing
+    // explicit /refresh requests) can't roll the connection back to an older identity.
+    private readonly object _userLock = new object();
+    // True only for the WindowsIdentity user clone created by the first long-polling request.
+    private bool _ownsUserIdentities;
+    private readonly object _userRefreshCallbackLock = new object();
+    private List<UserRefreshedCallbackRegistration>? _userRefreshedCallbacks;
     private readonly object _sendingLock = new object();
     internal CancellationToken SendingToken { get; private set; }
 
@@ -87,6 +94,7 @@ internal sealed partial class HttpConnectionContext : ConnectionContext,
         // PERF: This type could just implement IFeatureCollection
         Features = new FeatureCollection();
         Features.Set<IConnectionUserFeature>(this);
+        Features.Set<IConnectionUserRefreshFeature>(this);
         Features.Set<IConnectionItemsFeature>(this);
         Features.Set<IConnectionIdFeature>(this);
         Features.Set<IConnectionTransportFeature>(this);
@@ -245,6 +253,111 @@ internal sealed partial class HttpConnectionContext : ConnectionContext,
         }
     }
 
+    public IDisposable OnUserRefreshed(Action<ClaimsPrincipal, object?> callback, object? state)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+
+        var registration = new UserRefreshedCallbackRegistration(this, callback, state);
+        lock (_userRefreshCallbackLock)
+        {
+            _userRefreshedCallbacks ??= new List<UserRefreshedCallbackRegistration>();
+            _userRefreshedCallbacks.Add(registration);
+        }
+
+        return registration;
+    }
+
+    private void RemoveUserRefreshedCallback(UserRefreshedCallbackRegistration registration)
+    {
+        lock (_userRefreshCallbackLock)
+        {
+            _userRefreshedCallbacks?.Remove(registration);
+        }
+    }
+
+    /// <summary>
+    /// Updates the User/ClaimsPrincipal on this connection and refreshes the authentication expiration.
+    /// </summary>
+    /// <param name="user">The refreshed principal to apply to the connection.</param>
+    /// <param name="authenticationExpiration">The expiration of the refreshed authentication.</param>
+    /// <remarks>
+    /// The update is skipped if <paramref name="authenticationExpiration"/> is older than the currently
+    /// applied <see cref="AuthenticationExpiration"/>. This makes the staleness check and the swap atomic
+    /// so a caller racing a concurrent refresh that already applied a newer token can't roll the connection
+    /// back to an older identity.
+    /// </remarks>
+    internal void UpdateUser(ClaimsPrincipal user, DateTimeOffset authenticationExpiration)
+    {
+        ClaimsPrincipal? previouslyOwnedUser = null;
+
+        lock (_userLock)
+        {
+            // A concurrent refresh (for example the /refresh endpoint racing a long-polling poll) may have
+            // already applied a newer token. Don't roll the connection back to an older one. Checking this
+            // under _userLock makes the decision atomic with the swap below.
+            if (authenticationExpiration != DateTimeOffset.MaxValue
+                && AuthenticationExpiration != DateTimeOffset.MaxValue
+                && authenticationExpiration < AuthenticationExpiration)
+            {
+                return;
+            }
+
+            if (_ownsUserIdentities && !ReferenceEquals(User, user))
+            {
+                previouslyOwnedUser = User;
+                _ownsUserIdentities = false;
+            }
+
+            User = user;
+            AuthenticationExpiration = authenticationExpiration;
+
+            // Also update the HttpContext's user if available
+            if (HttpContext is { } httpContext)
+            {
+                httpContext.User = user;
+            }
+        }
+
+        // Notify callbacks (e.g., the SignalR Hub layer) that the user has been updated. Invoke
+        // outside _userLock to avoid reentrancy/deadlock if a callback aborts/disposes the connection.
+        UserRefreshedCallbackRegistration[]? callbacks = null;
+        lock (_userRefreshCallbackLock)
+        {
+            if (_userRefreshedCallbacks is { Count: > 0 })
+            {
+                callbacks = _userRefreshedCallbacks.ToArray();
+            }
+        }
+
+        if (callbacks is not null)
+        {
+            foreach (var callback in callbacks)
+            {
+                try
+                {
+                    callback.Invoke(user);
+                }
+                catch (Exception ex)
+                {
+                    Log.UserRefreshedCallbackFailed(_logger, ex);
+                }
+            }
+        }
+
+        if (previouslyOwnedUser is not null)
+        {
+            DisposeOwnedIdentities(previouslyOwnedUser);
+        }
+    }
+
+    internal void MarkUserOwned()
+    {
+        lock (_userLock)
+        {
+            _ownsUserIdentities = true;
+        }
+    }
+
     public async Task DisposeAsync(bool closeGracefully = false)
     {
         Task disposeTask;
@@ -272,23 +385,37 @@ internal sealed partial class HttpConnectionContext : ConnectionContext,
         }
         finally
         {
+            ClaimsPrincipal? ownedUser = null;
+            lock (_userLock)
+            {
+                if (_ownsUserIdentities)
+                {
+                    ownedUser = User;
+                    _ownsUserIdentities = false;
+                }
+            }
+
+            if (ownedUser is not null)
+            {
+                DisposeOwnedIdentities(ownedUser);
+            }
+
             Cancellation?.Dispose();
 
             Cancellation = null;
-
-            // Long Polling clones the windows identity if set
-            if (TransportType == HttpTransportType.LongPolling && User?.Identity is WindowsIdentity)
-            {
-                foreach (var identity in User.Identities)
-                {
-                    (identity as IDisposable)?.Dispose();
-                }
-            }
 
             ServiceScope?.Dispose();
         }
 
         await disposeTask;
+    }
+
+    private static void DisposeOwnedIdentities(ClaimsPrincipal user)
+    {
+        foreach (var identity in user.Identities)
+        {
+            (identity as IDisposable)?.Dispose();
+        }
     }
 
     private async Task WaitOnTasks(Task applicationTask, Task transportTask, bool closeGracefully)
@@ -754,6 +881,28 @@ internal sealed partial class HttpConnectionContext : ConnectionContext,
         return UseStatefulReconnect == true || TransportType == HttpTransportType.LongPolling;
     }
 
+    private sealed class UserRefreshedCallbackRegistration(
+        HttpConnectionContext connection,
+        Action<ClaimsPrincipal, object?> callback,
+        object? state) : IDisposable
+    {
+        private HttpConnectionContext? _connection = connection;
+
+        public void Invoke(ClaimsPrincipal user)
+        {
+            if (_connection is not null)
+            {
+                callback(user, state);
+            }
+        }
+
+        public void Dispose()
+        {
+            var connection = Interlocked.Exchange(ref _connection, null);
+            connection?.RemoveUserRefreshedCallback(this);
+        }
+    }
+
     internal enum SetTransportState
     {
         Success,
@@ -789,5 +938,8 @@ internal sealed partial class HttpConnectionContext : ConnectionContext,
 
         [LoggerMessage(9, LogLevel.Trace, "{Timeout}ms elapsed attempting to send a message to the transport. Closing connection {TransportConnectionId}.", EventName = "TransportSendTimeout")]
         public static partial void TransportSendTimeout(ILogger logger, TimeSpan timeout, string transportConnectionId);
+
+        [LoggerMessage(10, LogLevel.Error, "An IConnectionUserRefreshFeature.OnUserRefreshed callback threw an exception.", EventName = "UserRefreshedCallbackFailed")]
+        public static partial void UserRefreshedCallbackFailed(ILogger logger, Exception exception);
     }
 }

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.Log.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.Log.cs
@@ -67,5 +67,8 @@ internal sealed partial class HttpConnectionDispatcher
 
         [LoggerMessage(18, LogLevel.Debug, "Exception from IStatefulReconnectFeature.NotifyOnReconnect callback.", EventName = "NotifyOnReconnectError")]
         public static partial void NotifyOnReconnectError(ILogger logger, Exception ex);
+
+        [LoggerMessage(19, LogLevel.Debug, "Authentication refresh for connection '{ConnectionId}' was rejected by OnAuthenticationRefresh callback.", EventName = "AuthenticationRefreshRejectedByCallback")]
+        public static partial void AuthenticationRefreshRejectedByCallback(ILogger logger, string connectionId);
     }
 }

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.Linq;
 using System.Security.Claims;
 using System.Security.Principal;
+using System.Text.Json;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
@@ -119,6 +121,227 @@ internal sealed partial class HttpConnectionDispatcher
         }
     }
 
+    public async Task ExecuteRefreshAsync(HttpContext context, HttpConnectionDispatcherOptions options)
+    {
+        var logScope = new ConnectionLogScope(connectionId: string.Empty);
+        using (_logger.BeginScope(logScope))
+        {
+            if (HttpMethods.IsPost(context.Request.Method))
+            {
+                await ProcessRefresh(context, options, logScope);
+            }
+            else
+            {
+                context.Response.ContentType = "text/plain";
+                context.Response.StatusCode = StatusCodes.Status405MethodNotAllowed;
+            }
+        }
+    }
+
+    private async Task ProcessRefresh(HttpContext context, HttpConnectionDispatcherOptions options, ConnectionLogScope logScope)
+    {
+        context.Response.ContentType = "application/json";
+
+        if (!options.EnableAuthenticationRefresh)
+        {
+            await WriteRefreshErrorAsync(context, StatusCodes.Status404NotFound, "refresh_disabled");
+            return;
+        }
+
+        // Get connection token from query string (same pattern as send/poll/delete)
+        var connectionToken = GetConnectionToken(context);
+        if (StringValues.IsNullOrEmpty(connectionToken))
+        {
+            await WriteRefreshErrorAsync(context, StatusCodes.Status400BadRequest, "missing_connection_token");
+            return;
+        }
+
+        // Look up the connection by connection token (private, not the public connectionId)
+        if (!_manager.TryGetConnection(connectionToken.ToString(), out var connection))
+        {
+            await WriteRefreshErrorAsync(context, StatusCodes.Status404NotFound, "connection_not_found");
+            return;
+        }
+
+        logScope.ConnectionId = connection.ConnectionId;
+
+        // Negotiate v0 connections have no private token (ConnectionId == ConnectionToken), so the
+        // caller would only need the public ConnectionId to POST to /refresh on behalf of any connection.
+        // Require v1+ (private token) to prevent unauthorized refreshes against known connection IDs.
+        if (string.Equals(connection.ConnectionId, connection.ConnectionToken, StringComparison.Ordinal))
+        {
+            await WriteRefreshErrorAsync(context, StatusCodes.Status400BadRequest, "unsupported_negotiate_version");
+            return;
+        }
+
+        // Use the AuthenticateResult the authorization middleware already produced for this request.
+        // The /refresh endpoint is stamped with the hub's authorization metadata, so the middleware
+        // authenticates it against the endpoint's declared schemes and exposes the result via
+        // IAuthenticateResultFeature — the same source negotiate and the connect/poll paths read. This keeps
+        // /refresh consistent with those paths and avoids re-authenticating against the app's default scheme,
+        // which throws or picks the wrong credential in multi-scheme apps.
+        var authResult = context.Features.Get<IAuthenticateResultFeature>()?.AuthenticateResult;
+        if (authResult is null || !authResult.Succeeded)
+        {
+            await WriteRefreshErrorAsync(context, StatusCodes.Status401Unauthorized, "invalid_token");
+            return;
+        }
+
+        var newPrincipal = authResult.Principal ?? context.User;
+        if (HasWindowsIdentity(connection.User) || HasWindowsIdentity(newPrincipal))
+        {
+            await WriteRefreshErrorAsync(context, StatusCodes.Status400BadRequest, "windows_identity_not_supported");
+            return;
+        }
+
+        var newExpiration = GetAuthenticationExpiration(authResult, context.User);
+
+        if (options.OnAuthenticationRefresh is { } callback)
+        {
+            var accepted = await InvokeAuthenticationRefreshCallbackAsync(connection, context, callback, newPrincipal, newExpiration);
+            if (!accepted)
+            {
+                await WriteRefreshErrorAsync(context, StatusCodes.Status403Forbidden, "permission_change_rejected");
+                return;
+            }
+        }
+
+        connection.UpdateUser(newPrincipal, newExpiration);
+
+        // Compute TTL for the response
+        int? tokenLifetimeSeconds = null;
+        if (newExpiration != DateTimeOffset.MaxValue)
+        {
+            var ttl = newExpiration - DateTimeOffset.UtcNow;
+            if (ttl.TotalSeconds > 0)
+            {
+                tokenLifetimeSeconds = (int)Math.Min(ttl.TotalSeconds, int.MaxValue);
+            }
+        }
+
+        // Write the refresh response
+        // Don't use thread static instance here because writer is used with async
+        var writer = new MemoryBufferWriter();
+        try
+        {
+            using var jsonWriter = new Utf8JsonWriter((IBufferWriter<byte>)writer);
+            jsonWriter.WriteStartObject();
+            if (tokenLifetimeSeconds.HasValue)
+            {
+                jsonWriter.WriteNumber("tokenLifetimeSeconds", tokenLifetimeSeconds.Value);
+            }
+            jsonWriter.WriteEndObject();
+            jsonWriter.Flush();
+
+            context.Response.ContentLength = writer.Length;
+            await writer.CopyToAsync(context.Response.Body);
+        }
+        finally
+        {
+            writer.Reset();
+        }
+    }
+
+    private static async Task WriteRefreshErrorAsync(HttpContext context, int statusCode, string error)
+    {
+        context.Response.StatusCode = statusCode;
+        context.Response.ContentType = "application/json";
+
+        // Don't use thread static instance here because writer is used with async
+        var writer = new MemoryBufferWriter();
+        try
+        {
+            using var jsonWriter = new Utf8JsonWriter((IBufferWriter<byte>)writer);
+            jsonWriter.WriteStartObject();
+            jsonWriter.WriteString("error", error);
+            jsonWriter.WriteEndObject();
+            jsonWriter.Flush();
+
+            context.Response.ContentLength = writer.Length;
+            await writer.CopyToAsync(context.Response.Body);
+        }
+        finally
+        {
+            writer.Reset();
+        }
+    }
+
+    // Runs the application-provided OnAuthenticationRefresh callback for a re-authenticated principal. Shared by the
+    // /refresh endpoint and the Long Polling poll path so both apply the same accept/reject policy.
+    private async ValueTask<bool> InvokeAuthenticationRefreshCallbackAsync(
+        HttpConnectionContext connection, HttpContext context,
+        Func<AuthenticationRefreshContext, ValueTask<bool>> callback, ClaimsPrincipal newPrincipal, DateTimeOffset newExpiration)
+    {
+        var refreshContext = new AuthenticationRefreshContext
+        {
+            HttpContext = context,
+            ConnectionId = connection.ConnectionId,
+            PreviousUser = connection.User ?? new ClaimsPrincipal(new ClaimsIdentity()),
+            NewUser = newPrincipal,
+            NewExpiration = newExpiration,
+        };
+
+        if (!await callback(refreshContext))
+        {
+            Log.AuthenticationRefreshRejectedByCallback(_logger, connection.ConnectionId);
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool ClaimsPrincipalContentEquals(ClaimsPrincipal current, ClaimsPrincipal incoming)
+    {
+        return SequenceEqual(current.Identities, incoming.Identities, ClaimsIdentityContentEquals);
+    }
+
+    private static bool ClaimsIdentityContentEquals(ClaimsIdentity current, ClaimsIdentity incoming)
+    {
+        if (!string.Equals(current.AuthenticationType, incoming.AuthenticationType, StringComparison.Ordinal)
+            || !string.Equals(current.NameClaimType, incoming.NameClaimType, StringComparison.Ordinal)
+            || !string.Equals(current.RoleClaimType, incoming.RoleClaimType, StringComparison.Ordinal)
+            || !string.Equals(current.Label, incoming.Label, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return SequenceEqual(current.Claims, incoming.Claims, ClaimContentEquals);
+    }
+
+    private static bool ClaimContentEquals(Claim current, Claim incoming)
+    {
+        return string.Equals(current.Type, incoming.Type, StringComparison.Ordinal)
+            && string.Equals(current.Value, incoming.Value, StringComparison.Ordinal)
+            && string.Equals(current.ValueType, incoming.ValueType, StringComparison.Ordinal)
+            && string.Equals(current.Issuer, incoming.Issuer, StringComparison.Ordinal)
+            && string.Equals(current.OriginalIssuer, incoming.OriginalIssuer, StringComparison.Ordinal);
+    }
+
+    private static bool SequenceEqual<T>(IEnumerable<T> current, IEnumerable<T> incoming, Func<T, T, bool> equals)
+    {
+        using var currentEnumerator = current.GetEnumerator();
+        using var incomingEnumerator = incoming.GetEnumerator();
+
+        while (true)
+        {
+            var currentHasValue = currentEnumerator.MoveNext();
+            if (currentHasValue != incomingEnumerator.MoveNext())
+            {
+                return false;
+            }
+
+            if (!currentHasValue)
+            {
+                return true;
+            }
+
+            if (!equals(currentEnumerator.Current, incomingEnumerator.Current))
+            {
+                return false;
+            }
+        }
+    }
+
     private async Task ExecuteAsync(HttpContext context, ConnectionDelegate connectionDelegate, HttpConnectionDispatcherOptions options, ConnectionLogScope logScope)
     {
         // set a tag to allow Application Performance Management tools to differentiate long running requests for reporting purposes
@@ -140,7 +363,7 @@ internal sealed partial class HttpConnectionDispatcher
                 return;
             }
 
-            if (!await EnsureConnectionStateAsync(connection, context, HttpTransportType.ServerSentEvents, supportedTransports, logScope))
+            if (!await EnsureConnectionStateAsync(connection, context, HttpTransportType.ServerSentEvents, supportedTransports, logScope, options))
             {
                 // Bad connection state. It's already set the response status code.
                 return;
@@ -191,7 +414,7 @@ internal sealed partial class HttpConnectionDispatcher
                 return;
             }
 
-            if (!await EnsureConnectionStateAsync(connection, context, transport, supportedTransports, logScope))
+            if (!await EnsureConnectionStateAsync(connection, context, transport, supportedTransports, logScope, options))
             {
                 // Bad connection state. It's already set the response status code.
                 return;
@@ -422,6 +645,23 @@ internal sealed partial class HttpConnectionDispatcher
         response.AvailableTransports = new List<AvailableTransport>();
         response.UseStatefulReconnect = useStatefulReconnect;
 
+        // If authentication refresh is enabled, compute token lifetime from auth properties
+        if (options.EnableAuthenticationRefresh)
+        {
+            var authenticateResult = context.Features.Get<IAuthenticateResultFeature>()?.AuthenticateResult;
+            var expiresUtc = authenticateResult is not null && !HasWindowsIdentity(authenticateResult.Principal ?? context.User)
+                ? authenticateResult.Properties?.ExpiresUtc
+                : null;
+            if (expiresUtc.HasValue && expiresUtc.Value != DateTimeOffset.MaxValue)
+            {
+                var ttl = expiresUtc.Value - DateTimeOffset.UtcNow;
+                if (ttl.TotalSeconds > 0)
+                {
+                    response.TokenLifetime = ttl;
+                }
+            }
+        }
+
         if ((options.Transports & HttpTransportType.WebSockets) != 0 && ServerHasWebSockets(context.Features))
         {
             response.AvailableTransports.Add(_webSocketAvailableTransport);
@@ -568,7 +808,7 @@ internal sealed partial class HttpConnectionDispatcher
         context.Response.ContentType = "text/plain";
     }
 
-    private async Task<bool> EnsureConnectionStateAsync(HttpConnectionContext connection, HttpContext context, HttpTransportType transportType, HttpTransportType supportedTransports, ConnectionLogScope logScope)
+    private async Task<bool> EnsureConnectionStateAsync(HttpConnectionContext connection, HttpContext context, HttpTransportType transportType, HttpTransportType supportedTransports, ConnectionLogScope logScope, HttpConnectionDispatcherOptions options)
     {
         if ((supportedTransports & transportType) == 0)
         {
@@ -625,15 +865,6 @@ internal sealed partial class HttpConnectionDispatcher
             {
                 // Set the request trace identifier to the current http request handling the poll
                 existing.TraceIdentifier = context.TraceIdentifier;
-
-                // Don't copy the identity if it's a windows identity
-                // We specifically clone the identity on first poll if it's a windows identity
-                // If we swapped the new User here we'd have to dispose the old identities which could race with the application
-                // trying to access the identity.
-                if (!(context.User.Identity is WindowsIdentity))
-                {
-                    existing.User = context.User;
-                }
             }
         }
         else
@@ -641,21 +872,134 @@ internal sealed partial class HttpConnectionDispatcher
             connection.HttpContext = context;
         }
 
-        if (connection.User is not null)
+        var isStatefulReconnect = transportType == HttpTransportType.WebSockets
+            && connection.UseStatefulReconnect
+            && connection.ApplicationTask is not null;
+
+        // On Long Polling each poll is a separate request that may carry a refreshed (or rotated) token.
+        // Stateful WebSocket reconnects also carry a fresh HTTP request after the SignalR handshake, so
+        // process changed principals through the authentication-refresh path instead of silently swapping
+        // only the lower-level HTTP connection user.
+        var newPrincipal = (transportType == HttpTransportType.LongPolling ? context.User : connection.HttpContext?.User)
+            ?? new ClaimsPrincipal();
+        var newExpiration = GetAuthenticationExpiration(connection, context);
+
+        var useAuthenticationRefreshPath = false;
+        var skipUserRefresh = false;
+        var currentUser = connection.User;
+        if (currentUser is not null)
         {
-            var originalName = connection.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-            var newName = connection.HttpContext?.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            var originalName = currentUser.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            var newName = newPrincipal.FindFirst(ClaimTypes.NameIdentifier)?.Value;
             if (originalName != newName)
             {
                 // Log warning, different user
                 Log.UserNameChanged(_logger, originalName, newName);
             }
+
+            // WindowsIdentity is cloned on first poll and must not be swapped here (disposing the old
+            // SafeHandles could race the application), so those connections keep the legacy behavior below.
+            var authRefreshEligible = options.EnableAuthenticationRefresh
+                && (transportType == HttpTransportType.LongPolling || isStatefulReconnect)
+                && !HasWindowsIdentity(newPrincipal)
+                && !HasWindowsIdentity(currentUser);
+
+            if (authRefreshEligible)
+            {
+                // A refreshed token presents either different claims or a different expiration; a request that
+                // carries the same token (same claims and expiration) is not treated as a refresh so we don't
+                // run the callback or fire UserRefreshed on every poll/reconnect.
+                var principalChanged = !ClaimsPrincipalContentEquals(currentUser, newPrincipal)
+                    || newExpiration != connection.AuthenticationExpiration;
+
+                // A request that arrives carrying an older token than the one already applied (e.g. a poll that
+                // raced an explicit /refresh) is stale: applying it would roll the connection back to an older identity.
+                var stale = newExpiration != DateTimeOffset.MaxValue
+                    && connection.AuthenticationExpiration != DateTimeOffset.MaxValue
+                    && newExpiration < connection.AuthenticationExpiration;
+
+                // Auth-refresh-eligible requests never fall through to the legacy raw swap below: that swap
+                // reads connection.User/HttpContext and rewrites it outside any lock, so it could roll back a
+                // token a concurrent /refresh just applied. Only a genuinely changed, non-stale token runs
+                // the refresh path; a stale (older) token or an idempotent (same) token leaves the connection's
+                // current principal/expiration untouched.
+                if (principalChanged && !stale)
+                {
+                    useAuthenticationRefreshPath = true;
+                }
+                else
+                {
+                    skipUserRefresh = true;
+                }
+            }
         }
 
-        // Setup the connection state from the http context
-        connection.User = connection.HttpContext?.User;
+        if (skipUserRefresh)
+        {
+            // Intentionally leave connection.User and AuthenticationExpiration untouched: either this request
+            // carries the same token already applied, or it lost the race against a newer token (e.g. an
+            // explicit /refresh). Rewriting the connection here would risk rolling it back to an older identity.
+            if (currentUser is not null && connection.HttpContext is { } httpContext)
+            {
+                httpContext.User = currentUser;
+            }
+        }
+        else if (useAuthenticationRefreshPath)
+        {
+            // Run the same authentication-refresh logic as the /refresh endpoint so the OnAuthenticationRefresh callback and
+            // hub-layer refresh notification run, instead of silently swapping connection.User on the poll/reconnect request.
+            if (options.OnAuthenticationRefresh is { } callback)
+            {
+                var accepted = await InvokeAuthenticationRefreshCallbackAsync(connection, context, callback, newPrincipal, newExpiration);
+                if (!accepted)
+                {
+                    // If a concurrent /refresh applied a newer token while the (possibly slow) callback ran,
+                    // this request's token is now stale. Don't tear down a connection that already holds a valid
+                    // newer token over a rejection of an older one; just let the poll continue.
+                    if (newExpiration != DateTimeOffset.MaxValue
+                        && connection.AuthenticationExpiration != DateTimeOffset.MaxValue
+                        && newExpiration < connection.AuthenticationExpiration)
+                    {
+                        return true;
+                    }
 
-        UpdateExpiration(connection, context);
+                    // The application rejected the refreshed principal. Tear the connection down rather than
+                    // keep serving it with a token the client has rotated away from. The connection.User and
+                    // the persisted HttpContext.User are intentionally left unchanged on this path.
+                    await WriteRefreshErrorAsync(context, StatusCodes.Status403Forbidden, "permission_change_rejected");
+                    connection.DisposeAndRemoveTask = _manager.DisposeAndRemoveAsync(connection, closeGracefully: false, HttpConnectionStopStatus.NormalClosure);
+                    return false;
+                }
+            }
+
+            // UpdateUser swaps connection.User and connection.HttpContext.User under the user lock and updates
+            // AuthenticationExpiration, so no separate swap or UpdateExpiration call is needed on this path.
+            // If a concurrent /refresh applied a newer token between the stale check and here, UpdateUser skips
+            // the rollback atomically with the swap.
+            connection.UpdateUser(newPrincipal, newExpiration);
+        }
+        else
+        {
+            // For Long Polling copy the latest principal onto the persisted HttpContext, unless it's a
+            // WindowsIdentity which is cloned on first poll and must not be swapped (SafeHandle disposal could
+            // race the application trying to access the identity).
+            if (transportType == HttpTransportType.LongPolling
+                && connection.HttpContext is { } pollContext
+                && !HasWindowsIdentity(context.User))
+            {
+                pollContext.User = context.User;
+            }
+
+            // Setup the connection state from the http context
+            connection.User = connection.HttpContext?.User;
+
+            if (transportType == HttpTransportType.LongPolling && connection.User?.Identity is WindowsIdentity)
+            {
+                connection.MarkUserOwned();
+            }
+
+            UpdateExpiration(connection, context);
+        }
 
         // Set the Connection ID on the logging scope so that logs from now on will have the
         // Connection ID metadata set.
@@ -671,8 +1015,37 @@ internal sealed partial class HttpConnectionDispatcher
         if (authenticateResultFeature is not null)
         {
             connection.AuthenticationExpiration =
-                authenticateResultFeature.AuthenticateResult?.Properties?.ExpiresUtc ?? DateTimeOffset.MaxValue;
+                authenticateResultFeature.AuthenticateResult is { } authenticateResult
+                    ? GetAuthenticationExpiration(authenticateResult, context.User)
+                    : DateTimeOffset.MaxValue;
         }
+    }
+
+    private static DateTimeOffset GetAuthenticationExpiration(HttpConnectionContext connection, HttpContext context)
+    {
+        var authenticateResultFeature = context.Features.Get<IAuthenticateResultFeature>();
+        if (authenticateResultFeature is null)
+        {
+            // No authenticate result for this request; keep the existing expiration rather than weakening
+            // it to "never expires".
+            return connection.AuthenticationExpiration;
+        }
+
+        return authenticateResultFeature.AuthenticateResult is { } authenticateResult
+            ? GetAuthenticationExpiration(authenticateResult, context.User)
+            : DateTimeOffset.MaxValue;
+    }
+
+    private static DateTimeOffset GetAuthenticationExpiration(AuthenticateResult authenticateResult, ClaimsPrincipal fallbackPrincipal)
+    {
+        return HasWindowsIdentity(authenticateResult.Principal ?? fallbackPrincipal)
+            ? DateTimeOffset.MaxValue
+            : authenticateResult.Properties?.ExpiresUtc ?? DateTimeOffset.MaxValue;
+    }
+
+    private static bool HasWindowsIdentity(ClaimsPrincipal? user)
+    {
+        return user?.Identities.Any(static identity => identity is WindowsIdentity) == true;
     }
 
     private static void CloneUser(HttpContext newContext, HttpContext oldContext)

--- a/src/SignalR/common/Http.Connections/src/PublicAPI.Unshipped.txt
+++ b/src/SignalR/common/Http.Connections/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,19 @@
 #nullable enable
+Microsoft.AspNetCore.Http.Connections.HttpConnectionDispatcherOptions.EnableAuthenticationRefresh.get -> bool
+Microsoft.AspNetCore.Http.Connections.HttpConnectionDispatcherOptions.EnableAuthenticationRefresh.set -> void
+Microsoft.AspNetCore.Http.Connections.AuthenticationRefreshMetadata
+Microsoft.AspNetCore.Http.Connections.AuthenticationRefreshMetadata.AuthenticationRefreshMetadata() -> void
+Microsoft.AspNetCore.Http.Connections.AuthenticationRefreshContext
+Microsoft.AspNetCore.Http.Connections.AuthenticationRefreshContext.AuthenticationRefreshContext() -> void
+Microsoft.AspNetCore.Http.Connections.AuthenticationRefreshContext.ConnectionId.get -> string!
+Microsoft.AspNetCore.Http.Connections.AuthenticationRefreshContext.ConnectionId.init -> void
+Microsoft.AspNetCore.Http.Connections.AuthenticationRefreshContext.HttpContext.get -> Microsoft.AspNetCore.Http.HttpContext!
+Microsoft.AspNetCore.Http.Connections.AuthenticationRefreshContext.HttpContext.init -> void
+Microsoft.AspNetCore.Http.Connections.AuthenticationRefreshContext.NewExpiration.get -> System.DateTimeOffset
+Microsoft.AspNetCore.Http.Connections.AuthenticationRefreshContext.NewExpiration.init -> void
+Microsoft.AspNetCore.Http.Connections.AuthenticationRefreshContext.NewUser.get -> System.Security.Claims.ClaimsPrincipal!
+Microsoft.AspNetCore.Http.Connections.AuthenticationRefreshContext.NewUser.init -> void
+Microsoft.AspNetCore.Http.Connections.AuthenticationRefreshContext.PreviousUser.get -> System.Security.Claims.ClaimsPrincipal!
+Microsoft.AspNetCore.Http.Connections.AuthenticationRefreshContext.PreviousUser.init -> void
+Microsoft.AspNetCore.Http.Connections.HttpConnectionDispatcherOptions.OnAuthenticationRefresh.get -> System.Func<Microsoft.AspNetCore.Http.Connections.AuthenticationRefreshContext!, System.Threading.Tasks.ValueTask<bool>>?
+Microsoft.AspNetCore.Http.Connections.HttpConnectionDispatcherOptions.OnAuthenticationRefresh.set -> void

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.AuthenticationRefresh.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.AuthenticationRefresh.cs
@@ -1,0 +1,1548 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Security.Claims;
+using System.Security.Principal;
+using System.Text;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Connections.Abstractions;
+using Microsoft.AspNetCore.Connections.Features;
+using Microsoft.AspNetCore.Http.Connections.Internal;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.AspNetCore.SignalR.Tests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.AspNetCore.Http.Connections.Tests;
+
+public partial class HttpConnectionDispatcherTests
+{
+    [Fact]
+    public async Task RefreshReturnsMethodNotAllowedForNonPost()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/foo/refresh";
+            context.Request.Method = "GET";
+            context.Response.Body = new MemoryStream();
+
+            await dispatcher.ExecuteRefreshAsync(context, new HttpConnectionDispatcherOptions { EnableAuthenticationRefresh = true });
+
+            Assert.Equal(StatusCodes.Status405MethodNotAllowed, context.Response.StatusCode);
+        }
+    }
+
+    [Fact]
+    public async Task RefreshReturnsNotFoundWhenDisabled()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/foo/refresh";
+            context.Request.Method = "POST";
+            context.Response.Body = new MemoryStream();
+
+            await dispatcher.ExecuteRefreshAsync(context, new HttpConnectionDispatcherOptions { EnableAuthenticationRefresh = false });
+
+            Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+            Assert.Equal("application/json", context.Response.ContentType);
+            var json = ReadJson(context.Response.Body);
+            AssertRefreshError(json, "refresh_disabled");
+        }
+    }
+
+    [Fact]
+    public async Task RefreshReturnsBadRequestWhenMissingConnectionToken()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/foo/refresh";
+            context.Request.Method = "POST";
+            context.Response.Body = new MemoryStream();
+
+            await dispatcher.ExecuteRefreshAsync(context, new HttpConnectionDispatcherOptions { EnableAuthenticationRefresh = true });
+
+            Assert.Equal(StatusCodes.Status400BadRequest, context.Response.StatusCode);
+            var json = ReadJson(context.Response.Body);
+            AssertRefreshError(json, "missing_connection_token");
+        }
+    }
+
+    [Fact]
+    public async Task RefreshReturnsNotFoundWhenConnectionDoesNotExist()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/foo/refresh";
+            context.Request.Method = "POST";
+            context.Response.Body = new MemoryStream();
+            context.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+            {
+                ["id"] = "does-not-exist",
+            });
+
+            await dispatcher.ExecuteRefreshAsync(context, new HttpConnectionDispatcherOptions { EnableAuthenticationRefresh = true });
+
+            Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+            var json = ReadJson(context.Response.Body);
+            AssertRefreshError(json, "connection_not_found");
+        }
+    }
+
+    [Fact]
+    public async Task RefreshReturnsUnauthorizedWhenAuthenticationFails()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+            var options = new HttpConnectionDispatcherOptions { EnableAuthenticationRefresh = true };
+            var connection = manager.CreateConnection(options, negotiateVersion: 1);
+
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/foo/refresh";
+            context.Request.Method = "POST";
+            context.Response.Body = new MemoryStream();
+            context.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+            {
+                ["id"] = connection.ConnectionToken,
+            });
+
+            // The authorization middleware produced a failed authentication result for this request.
+            context.Features.Set<IAuthenticateResultFeature>(new TestAuthenticateResultFeature(AuthenticateResult.Fail("Bad token")));
+
+            await dispatcher.ExecuteRefreshAsync(context, options);
+
+            Assert.Equal(StatusCodes.Status401Unauthorized, context.Response.StatusCode);
+            var json = ReadJson(context.Response.Body);
+            AssertRefreshError(json, "invalid_token");
+        }
+    }
+
+    [Fact]
+    public async Task RefreshUpdatesConnectionUserAndReturnsTokenLifetime()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+            var options = new HttpConnectionDispatcherOptions { EnableAuthenticationRefresh = true };
+            var connection = manager.CreateConnection(options, negotiateVersion: 1);
+
+            var originalUser = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("name", "old") }, "Test"));
+            connection.User = originalUser;
+            connection.AuthenticationExpiration = DateTimeOffset.UtcNow.AddMinutes(1);
+
+            var newUser = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("name", "new") }, "Test"));
+            var newExpires = DateTimeOffset.UtcNow.AddMinutes(30);
+            var authProps = new AuthenticationProperties { ExpiresUtc = newExpires };
+            var ticket = new AuthenticationTicket(newUser, authProps, "Test");
+
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/foo/refresh";
+            context.Request.Method = "POST";
+            context.Response.Body = new MemoryStream();
+            context.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+            {
+                ["id"] = connection.ConnectionToken,
+            });
+
+            context.Features.Set<IAuthenticateResultFeature>(new TestAuthenticateResultFeature(AuthenticateResult.Success(ticket)));
+
+            await dispatcher.ExecuteRefreshAsync(context, options);
+
+            Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+            Assert.Equal("application/json", context.Response.ContentType);
+
+            var json = ReadJson(context.Response.Body);
+            var ttl = json.Value<int?>("tokenLifetimeSeconds");
+            Assert.NotNull(ttl);
+            Assert.InRange(ttl.Value, 1, 1801);
+
+            Assert.Same(newUser, connection.User);
+            // ExpiresUtc round-trips through AuthenticationProperties' whole-second ("r") format, so the
+            // stored expiration is truncated to the second. Allow headroom so the sub-second truncation
+            // can't push this over the tolerance.
+            Assert.Equal(newExpires, connection.AuthenticationExpiration, TimeSpan.FromSeconds(2));
+        }
+    }
+
+    [Fact]
+    public async Task RefreshClampsTokenLifetimeToMaxInt()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+            var options = new HttpConnectionDispatcherOptions { EnableAuthenticationRefresh = true };
+            var connection = manager.CreateConnection(options, negotiateVersion: 1);
+
+            connection.User = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("name", "old") }, "Test"));
+            connection.AuthenticationExpiration = DateTimeOffset.UtcNow.AddMinutes(1);
+
+            var newUser = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("name", "new") }, "Test"));
+            var authProps = new AuthenticationProperties { ExpiresUtc = DateTimeOffset.UtcNow.AddYears(100) };
+            var ticket = new AuthenticationTicket(newUser, authProps, "Test");
+
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/foo/refresh";
+            context.Request.Method = "POST";
+            context.Response.Body = new MemoryStream();
+            context.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+            {
+                ["id"] = connection.ConnectionToken,
+            });
+
+            context.Features.Set<IAuthenticateResultFeature>(new TestAuthenticateResultFeature(AuthenticateResult.Success(ticket)));
+
+            await dispatcher.ExecuteRefreshAsync(context, options);
+
+            Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+
+            var json = ReadJson(context.Response.Body);
+            Assert.Equal(int.MaxValue, json.Value<int?>("tokenLifetimeSeconds"));
+        }
+    }
+
+    [Fact]
+    public async Task RefreshSucceedsWithoutExpiresUtcOmitsTokenLifetime()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+            var options = new HttpConnectionDispatcherOptions { EnableAuthenticationRefresh = true };
+            var connection = manager.CreateConnection(options, negotiateVersion: 1);
+
+            var newUser = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("name", "new") }, "Test"));
+            // No ExpiresUtc on AuthenticationProperties => server should fall back to MaxValue and omit TTL
+            var ticket = new AuthenticationTicket(newUser, new AuthenticationProperties(), "Test");
+
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/foo/refresh";
+            context.Request.Method = "POST";
+            context.Response.Body = new MemoryStream();
+            context.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+            {
+                ["id"] = connection.ConnectionToken,
+            });
+
+            context.Features.Set<IAuthenticateResultFeature>(new TestAuthenticateResultFeature(AuthenticateResult.Success(ticket)));
+
+            await dispatcher.ExecuteRefreshAsync(context, options);
+
+            Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+            var json = ReadJson(context.Response.Body);
+            Assert.Null(json["tokenLifetimeSeconds"]);
+            Assert.Empty(json.Properties());
+            Assert.Equal(DateTimeOffset.MaxValue, connection.AuthenticationExpiration);
+            Assert.Same(newUser, connection.User);
+        }
+    }
+
+    [ConditionalFact]
+    [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
+    public async Task RefreshRejectsWindowsIdentityPrincipal()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+            var options = new HttpConnectionDispatcherOptions { EnableAuthenticationRefresh = true };
+            var connection = manager.CreateConnection(options, negotiateVersion: 1);
+            var originalUser = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("name", "old") }, "Test"));
+            connection.User = originalUser;
+
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/foo/refresh";
+            context.Request.Method = "POST";
+            context.Response.Body = new MemoryStream();
+            context.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+            {
+                ["id"] = connection.ConnectionToken,
+            });
+
+            using var windowsIdentity = WindowsIdentity.GetAnonymous();
+            var newUser = new WindowsPrincipal(windowsIdentity);
+            var authProps = new AuthenticationProperties { ExpiresUtc = DateTimeOffset.UtcNow.AddMinutes(30) };
+            var ticket = new AuthenticationTicket(newUser, authProps, "Test");
+            context.Features.Set<IAuthenticateResultFeature>(new TestAuthenticateResultFeature(AuthenticateResult.Success(ticket)));
+
+            await dispatcher.ExecuteRefreshAsync(context, options);
+
+            Assert.Equal(StatusCodes.Status400BadRequest, context.Response.StatusCode);
+            var json = ReadJson(context.Response.Body);
+            AssertRefreshError(json, "windows_identity_not_supported");
+            Assert.Same(originalUser, connection.User);
+        }
+    }
+
+    [Fact]
+    public async Task RefreshUsesAuthenticateResultFeatureWithoutReauthenticating()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+            var options = new HttpConnectionDispatcherOptions { EnableAuthenticationRefresh = true };
+            var connection = manager.CreateConnection(options, negotiateVersion: 1);
+
+            connection.User = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("name", "old") }, "Test"));
+            connection.AuthenticationExpiration = DateTimeOffset.UtcNow.AddMinutes(1);
+
+            var newUser = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("name", "new") }, "Test"));
+            var newExpires = DateTimeOffset.UtcNow.AddMinutes(30);
+
+            var services = new ServiceCollection();
+            // Simulates a multi-scheme app with no default authenticate scheme: AuthenticateAsync() would throw.
+            // The refresh handler must not call it because the authorization middleware already authenticated
+            // the request against the endpoint's scheme and populated IAuthenticateResultFeature.
+            services.AddSingleton<IAuthenticationService>(new ThrowingAuthenticationService());
+            services.AddSingleton<IAuthenticationSchemeProvider>(new FakeAuthenticationSchemeProvider());
+
+            var context = new DefaultHttpContext();
+            context.RequestServices = services.BuildServiceProvider();
+            context.Request.Path = "/foo/refresh";
+            context.Request.Method = "POST";
+            context.Response.Body = new MemoryStream();
+            context.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+            {
+                ["id"] = connection.ConnectionToken,
+            });
+
+            var props = new AuthenticationProperties { ExpiresUtc = newExpires };
+            var ticket = new AuthenticationTicket(newUser, props, "Test");
+            context.Features.Set<IAuthenticateResultFeature>(new TestAuthenticateResultFeature(AuthenticateResult.Success(ticket)));
+
+            await dispatcher.ExecuteRefreshAsync(context, options);
+
+            Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+            Assert.Same(newUser, connection.User);
+            // ExpiresUtc round-trips through AuthenticationProperties' whole-second ("r") format, so the
+            // stored expiration is truncated to the second. Allow headroom so the sub-second truncation
+            // can't push this over the tolerance.
+            Assert.Equal(newExpires, connection.AuthenticationExpiration, TimeSpan.FromSeconds(2));
+            var json = ReadJson(context.Response.Body);
+            var ttl = json.Value<int?>("tokenLifetimeSeconds");
+            Assert.NotNull(ttl);
+            Assert.InRange(ttl.Value, 1, 1801);
+        }
+    }
+
+    [Fact]
+    public async Task RefreshDoesNotRollBackNewerPrincipalWhenOlderRefreshCompletesLast()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+            var connection = manager.CreateConnection(new HttpConnectionDispatcherOptions { EnableAuthenticationRefresh = true }, negotiateVersion: 1);
+
+            var originalUser = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("name", "original") }, "Test"));
+            connection.User = originalUser;
+            connection.AuthenticationExpiration = DateTimeOffset.UtcNow.AddMinutes(1);
+
+            var newerUser = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("name", "newer") }, "Test"));
+            var newerExpires = DateTimeOffset.UtcNow.AddMinutes(30);
+
+            var options = new HttpConnectionDispatcherOptions
+            {
+                EnableAuthenticationRefresh = true,
+                OnAuthenticationRefresh = _ =>
+                {
+                    connection.UpdateUser(newerUser, newerExpires);
+                    return ValueTask.FromResult(true);
+                },
+            };
+
+            var olderUser = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("name", "older") }, "Test"));
+            var olderExpires = DateTimeOffset.UtcNow.AddMinutes(5);
+            var ticket = new AuthenticationTicket(olderUser, new AuthenticationProperties { ExpiresUtc = olderExpires }, "Test");
+
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/foo/refresh";
+            context.Request.Method = "POST";
+            context.Response.Body = new MemoryStream();
+            context.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+            {
+                ["id"] = connection.ConnectionToken,
+            });
+            context.Features.Set<IAuthenticateResultFeature>(new TestAuthenticateResultFeature(AuthenticateResult.Success(ticket)));
+
+            await dispatcher.ExecuteRefreshAsync(context, options);
+
+            Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+            Assert.Same(newerUser, connection.User);
+            Assert.Equal(newerExpires, connection.AuthenticationExpiration, TimeSpan.FromSeconds(1));
+        }
+    }
+
+    [Fact]
+    public async Task RefreshReturnsUnauthorizedWhenAuthenticateResultFeatureMissing()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+            var options = new HttpConnectionDispatcherOptions { EnableAuthenticationRefresh = true };
+            var connection = manager.CreateConnection(options, negotiateVersion: 1);
+
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/foo/refresh";
+            context.Request.Method = "POST";
+            context.Response.Body = new MemoryStream();
+            context.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+            {
+                ["id"] = connection.ConnectionToken,
+            });
+
+            // No IAuthenticateResultFeature is present (no authorization middleware ran for the endpoint).
+            // /refresh relies on the middleware-produced result like the other endpoints and does not
+            // re-authenticate, so it cannot refresh and returns 401.
+            await dispatcher.ExecuteRefreshAsync(context, options);
+
+            Assert.Equal(StatusCodes.Status401Unauthorized, context.Response.StatusCode);
+            var json = ReadJson(context.Response.Body);
+            AssertRefreshError(json, "invalid_token");
+        }
+    }
+
+    [Fact]
+    public async Task RefreshRejectsNegotiateVersionZeroConnection()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+            var options = new HttpConnectionDispatcherOptions { EnableAuthenticationRefresh = true };
+            var connection = manager.CreateConnection(options, negotiateVersion: 0);
+            // v0: ConnectionId == ConnectionToken — no private token, so /refresh must be rejected
+            // to prevent any client that knows the public ConnectionId from refreshing on behalf of the connection.
+            Assert.Equal(connection.ConnectionId, connection.ConnectionToken);
+
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/foo/refresh";
+            context.Request.Method = "POST";
+            context.Response.Body = new MemoryStream();
+            context.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+            {
+                ["id"] = connection.ConnectionId,
+            });
+
+            context.Features.Set<IAuthenticateResultFeature>(new TestAuthenticateResultFeature(
+                AuthenticateResult.Success(new AuthenticationTicket(
+                    new ClaimsPrincipal(new ClaimsIdentity("Test")), "Test"))));
+
+            await dispatcher.ExecuteRefreshAsync(context, options);
+
+            Assert.Equal(StatusCodes.Status400BadRequest, context.Response.StatusCode);
+            var json = ReadJson(context.Response.Body);
+            AssertRefreshError(json, "unsupported_negotiate_version");
+        }
+    }
+
+    [Fact]
+    public async Task RefreshOnDisposedConnectionReturnsNotFound()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+            var options = new HttpConnectionDispatcherOptions { EnableAuthenticationRefresh = true };
+            var connection = manager.CreateConnection(options, negotiateVersion: 1);
+            var token = connection.ConnectionToken;
+
+            // Remove the connection from the manager (mimics dispose/timeout cleanup)
+            manager.RemoveConnection(token, HttpTransportType.None, HttpConnectionStopStatus.NormalClosure);
+
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/foo/refresh";
+            context.Request.Method = "POST";
+            context.Response.Body = new MemoryStream();
+            context.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+            {
+                ["id"] = token,
+            });
+
+            await dispatcher.ExecuteRefreshAsync(context, options);
+
+            Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+            var json = ReadJson(context.Response.Body);
+            AssertRefreshError(json, "connection_not_found");
+        }
+    }
+
+    [Fact]
+    public async Task NegotiateSetsTokenLifetimeWhenAuthenticationRefreshEnabled()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+            var context = BuildNegotiateContext(out var body);
+            var expiresUtc = DateTimeOffset.UtcNow.AddMinutes(30);
+            SetAuthenticateResultFeature(context, expiresUtc);
+
+            await dispatcher.ExecuteNegotiateAsync(context, new HttpConnectionDispatcherOptions { EnableAuthenticationRefresh = true });
+
+            var response = JsonConvert.DeserializeObject<JObject>(Encoding.UTF8.GetString(body.ToArray()));
+            var ttl = response.Value<int?>("tokenLifetimeSeconds");
+            Assert.NotNull(ttl);
+            Assert.InRange(ttl.Value, 1, 1801);
+        }
+    }
+
+    [Fact]
+    public async Task NegotiateDoesNotSetTokenLifetimeWhenAuthenticationRefreshDisabled()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+            var context = BuildNegotiateContext(out var body);
+            SetAuthenticateResultFeature(context, DateTimeOffset.UtcNow.AddMinutes(30));
+
+            await dispatcher.ExecuteNegotiateAsync(context, new HttpConnectionDispatcherOptions { EnableAuthenticationRefresh = false });
+
+            var response = JsonConvert.DeserializeObject<JObject>(Encoding.UTF8.GetString(body.ToArray()));
+            Assert.Null(response["tokenLifetimeSeconds"]);
+        }
+    }
+
+    [Fact]
+    public async Task NegotiateDoesNotSetTokenLifetimeWhenExpiresUtcMissing()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+            var context = BuildNegotiateContext(out var body);
+            SetAuthenticateResultFeature(context, expiresUtc: null);
+
+            await dispatcher.ExecuteNegotiateAsync(context, new HttpConnectionDispatcherOptions { EnableAuthenticationRefresh = true });
+
+            var response = JsonConvert.DeserializeObject<JObject>(Encoding.UTF8.GetString(body.ToArray()));
+            Assert.Null(response["tokenLifetimeSeconds"]);
+        }
+    }
+
+    [ConditionalFact]
+    [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
+    public async Task NegotiateDoesNotSetTokenLifetimeForWindowsIdentity()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+            var context = BuildNegotiateContext(out var body);
+            using var windowsIdentity = WindowsIdentity.GetAnonymous();
+            var principal = new WindowsPrincipal(windowsIdentity);
+            var props = new AuthenticationProperties { ExpiresUtc = DateTimeOffset.UtcNow.AddMinutes(30) };
+            var ticket = new AuthenticationTicket(principal, props, "Test");
+            context.Features.Set<IAuthenticateResultFeature>(new TestAuthenticateResultFeature(AuthenticateResult.Success(ticket)));
+
+            await dispatcher.ExecuteNegotiateAsync(context, new HttpConnectionDispatcherOptions { EnableAuthenticationRefresh = true });
+
+            var response = JsonConvert.DeserializeObject<JObject>(Encoding.UTF8.GetString(body.ToArray()));
+            Assert.Null(response["tokenLifetimeSeconds"]);
+        }
+    }
+
+    [Fact]
+    public void UpdateUserSetsUserAndAuthenticationExpiration()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var connection = manager.CreateConnection(new HttpConnectionDispatcherOptions(), negotiateVersion: 1);
+
+            var user = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("n", "v") }, "Test"));
+            var expiration = DateTimeOffset.UtcNow.AddMinutes(15);
+
+            // HttpContext is not set on this connection; UpdateUser should still update User + expiration.
+            connection.UpdateUser(user, expiration);
+
+            Assert.Same(user, connection.User);
+            Assert.Equal(expiration, connection.AuthenticationExpiration);
+        }
+    }
+
+    [Fact]
+    public void UpdateUserAlsoUpdatesHttpContextUserWhenPresent()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var connection = manager.CreateConnection(new HttpConnectionDispatcherOptions(), negotiateVersion: 1);
+            var httpContext = new DefaultHttpContext();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("n", "old") }, "Test"));
+            connection.HttpContext = httpContext;
+
+            var newUser = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("n", "new") }, "Test"));
+            connection.UpdateUser(newUser, DateTimeOffset.UtcNow.AddMinutes(15));
+
+            Assert.Same(newUser, connection.User);
+            Assert.Same(newUser, httpContext.User);
+        }
+    }
+
+    [Fact]
+    public async Task ScanClosesExpiredConnectionWhenAuthenticationRefreshEnabled()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var options = new HttpConnectionDispatcherOptions
+            {
+                CloseOnAuthenticationExpiration = true,
+                EnableAuthenticationRefresh = true,
+            };
+            var connection = manager.CreateConnection(options, negotiateVersion: 1);
+            connection.AuthenticationExpiration = DateTimeOffset.UtcNow.AddSeconds(-1);
+
+            manager.Scan();
+
+            await connection.ConnectionClosedRequested.WaitForCancellationAsync().DefaultTimeout();
+        }
+    }
+
+    [Fact]
+    public void HttpConnectionContextExposesUserRefreshFeature()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var connection = manager.CreateConnection(new HttpConnectionDispatcherOptions(), negotiateVersion: 1);
+
+            var feature = connection.Features.Get<IConnectionUserRefreshFeature>();
+
+            Assert.NotNull(feature);
+        }
+    }
+
+    [Fact]
+    public void UpdateUserInvokesUserRefreshedCallbackWithNewPrincipal()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var connection = manager.CreateConnection(new HttpConnectionDispatcherOptions(), negotiateVersion: 1);
+
+            var originalUser = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("n", "old") }, "Test"));
+            connection.User = originalUser;
+
+            var newUser = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("n", "new") }, "Test"));
+            ClaimsPrincipal capturedCurrent = null;
+            var feature = connection.Features.Get<IConnectionUserRefreshFeature>();
+            Assert.NotNull(feature);
+            feature.OnUserRefreshed((current, state) =>
+            {
+                capturedCurrent = current;
+            }, state: null);
+
+            connection.UpdateUser(newUser, DateTimeOffset.UtcNow.AddMinutes(15));
+
+            Assert.Same(newUser, capturedCurrent);
+        }
+    }
+
+    [Fact]
+    public void DisposedUserRefreshedRegistrationIsNotInvoked()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var connection = manager.CreateConnection(new HttpConnectionDispatcherOptions(), negotiateVersion: 1);
+
+            var feature = connection.Features.Get<IConnectionUserRefreshFeature>();
+            Assert.NotNull(feature);
+
+            var invoked = false;
+            var registration = feature.OnUserRefreshed((_, state) => invoked = true, state: null);
+            registration.Dispose();
+
+            var newUser = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("n", "new") }, "Test"));
+            connection.UpdateUser(newUser, DateTimeOffset.UtcNow.AddMinutes(15));
+
+            Assert.False(invoked);
+        }
+    }
+
+    [Fact]
+    public void UpdateUserSwallowsExceptionFromUserRefreshedCallback()
+    {
+        using (StartVerifiableLog(write => write.EventId.Name == "UserRefreshedCallbackFailed"))
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var connection = manager.CreateConnection(new HttpConnectionDispatcherOptions(), negotiateVersion: 1);
+
+            var feature = connection.Features.Get<IConnectionUserRefreshFeature>();
+            Assert.NotNull(feature);
+            feature.OnUserRefreshed((_, state) => throw new InvalidOperationException("boom"), state: null);
+
+            var newUser = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("n", "v") }, "Test"));
+            var expiration = DateTimeOffset.UtcNow.AddMinutes(15);
+
+            connection.UpdateUser(newUser, expiration);
+
+            Assert.Same(newUser, connection.User);
+            Assert.Equal(expiration, connection.AuthenticationExpiration);
+        }
+    }
+
+    [Fact]
+    public async Task RefreshInvokesOnAuthenticationRefreshCallbackAndAcceptsWhenTrue()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+
+            AuthenticationRefreshContext captured = null;
+            var options = new HttpConnectionDispatcherOptions
+            {
+                EnableAuthenticationRefresh = true,
+                OnAuthenticationRefresh = ctx =>
+                {
+                    captured = ctx;
+                    return ValueTask.FromResult(true);
+                },
+            };
+            var connection = manager.CreateConnection(options, negotiateVersion: 1);
+
+            var originalUser = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("name", "old") }, "Test"));
+            connection.User = originalUser;
+
+            var newUser = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("name", "new") }, "Test"));
+            var newExpires = DateTimeOffset.UtcNow.AddMinutes(30);
+            var ticket = new AuthenticationTicket(newUser, new AuthenticationProperties { ExpiresUtc = newExpires }, "Test");
+
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/foo/refresh";
+            context.Request.Method = "POST";
+            context.Response.Body = new MemoryStream();
+            context.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+            {
+                ["id"] = connection.ConnectionToken,
+            });
+
+            context.Features.Set<IAuthenticateResultFeature>(new TestAuthenticateResultFeature(AuthenticateResult.Success(ticket)));
+
+            await dispatcher.ExecuteRefreshAsync(context, options);
+
+            Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+            Assert.Same(newUser, connection.User);
+
+            Assert.NotNull(captured);
+            Assert.Same(context, captured.HttpContext);
+            Assert.Equal(connection.ConnectionId, captured.ConnectionId);
+            Assert.Same(originalUser, captured.PreviousUser);
+            Assert.Same(newUser, captured.NewUser);
+            Assert.Equal(newExpires, captured.NewExpiration, TimeSpan.FromSeconds(1));
+        }
+    }
+
+    [Fact]
+    public async Task RefreshReturnsForbiddenWhenOnAuthenticationRefreshReturnsFalse()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+
+            var options = new HttpConnectionDispatcherOptions
+            {
+                EnableAuthenticationRefresh = true,
+                OnAuthenticationRefresh = ctx =>
+                {
+                    return ValueTask.FromResult(false);
+                },
+            };
+            var connection = manager.CreateConnection(options, negotiateVersion: 1);
+
+            var originalUser = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("name", "old") }, "Test"));
+            connection.User = originalUser;
+            var originalExpiration = DateTimeOffset.UtcNow.AddMinutes(2);
+            connection.AuthenticationExpiration = originalExpiration;
+
+            var newUser = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("name", "new") }, "Test"));
+            var ticket = new AuthenticationTicket(newUser, new AuthenticationProperties { ExpiresUtc = DateTimeOffset.UtcNow.AddMinutes(30) }, "Test");
+
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/foo/refresh";
+            context.Request.Method = "POST";
+            context.Response.Body = new MemoryStream();
+            context.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+            {
+                ["id"] = connection.ConnectionToken,
+            });
+
+            context.Features.Set<IAuthenticateResultFeature>(new TestAuthenticateResultFeature(AuthenticateResult.Success(ticket)));
+
+            await dispatcher.ExecuteRefreshAsync(context, options);
+
+            Assert.Equal(StatusCodes.Status403Forbidden, context.Response.StatusCode);
+            var json = ReadJson(context.Response.Body);
+            AssertRefreshError(json, "permission_change_rejected");
+
+            // Connection state must NOT have been swapped.
+            Assert.Same(originalUser, connection.User);
+            Assert.Equal(originalExpiration, connection.AuthenticationExpiration);
+        }
+    }
+
+    [Fact]
+    public async Task RefreshDenyReturnsGenericError()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+
+            var options = new HttpConnectionDispatcherOptions
+            {
+                EnableAuthenticationRefresh = true,
+                OnAuthenticationRefresh = _ => ValueTask.FromResult(false),
+            };
+            var connection = manager.CreateConnection(options, negotiateVersion: 1);
+            connection.User = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("name", "old") }, "Test"));
+
+            var newUser = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("name", "new") }, "Test"));
+            var ticket = new AuthenticationTicket(newUser, new AuthenticationProperties(), "Test");
+
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/foo/refresh";
+            context.Request.Method = "POST";
+            context.Response.Body = new MemoryStream();
+            context.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+            {
+                ["id"] = connection.ConnectionToken,
+            });
+
+            context.Features.Set<IAuthenticateResultFeature>(new TestAuthenticateResultFeature(AuthenticateResult.Success(ticket)));
+
+            await dispatcher.ExecuteRefreshAsync(context, options);
+
+            Assert.Equal(StatusCodes.Status403Forbidden, context.Response.StatusCode);
+            var json = ReadJson(context.Response.Body);
+            AssertRefreshError(json, "permission_change_rejected");
+        }
+    }
+
+    [Fact]
+    public async Task RefreshOnAuthenticationRefreshCallbackExceptionPropagates()
+    {
+        using (StartVerifiableLog(expectedErrorsFilter: _ => true))
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+
+            var options = new HttpConnectionDispatcherOptions
+            {
+                EnableAuthenticationRefresh = true,
+                OnAuthenticationRefresh = _ => throw new InvalidOperationException("boom"),
+            };
+            var connection = manager.CreateConnection(options, negotiateVersion: 1);
+            var originalUser = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("name", "old") }, "Test"));
+            connection.User = originalUser;
+
+            var newUser = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("name", "new") }, "Test"));
+            var ticket = new AuthenticationTicket(newUser, new AuthenticationProperties(), "Test");
+
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/foo/refresh";
+            context.Request.Method = "POST";
+            context.Response.Body = new MemoryStream();
+            context.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+            {
+                ["id"] = connection.ConnectionToken,
+            });
+
+            context.Features.Set<IAuthenticateResultFeature>(new TestAuthenticateResultFeature(AuthenticateResult.Success(ticket)));
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => dispatcher.ExecuteRefreshAsync(context, options));
+
+            // Connection user untouched.
+            Assert.Same(originalUser, connection.User);
+        }
+    }
+
+    [Fact]
+    public void UpdateUserWithNoCallbacksDoesNotThrow()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var connection = manager.CreateConnection(new HttpConnectionDispatcherOptions(), negotiateVersion: 1);
+
+            // No callback registered with IConnectionUserRefreshFeature.OnUserRefreshed.
+            var newUser = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("n", "v") }, "Test"));
+            connection.UpdateUser(newUser, DateTimeOffset.UtcNow.AddMinutes(15));
+
+            Assert.Same(newUser, connection.User);
+        }
+    }
+
+    [Fact]
+    public void UpdateUserSetsUser()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var connection = manager.CreateConnection(new HttpConnectionDispatcherOptions(), negotiateVersion: 1);
+
+            var newUser = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("n", "v") }, "Test"));
+            connection.UpdateUser(newUser, DateTimeOffset.UtcNow.AddMinutes(15));
+
+            Assert.Same(newUser, connection.User);
+        }
+    }
+
+    [Fact]
+    public async Task LongPollingRefreshedPrincipalInvokesOnAuthenticationRefreshAndUpdatesUser()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var connection = manager.CreateConnection();
+            connection.TransportType = HttpTransportType.LongPolling;
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+
+            AuthenticationRefreshContext captured = null;
+            var options = new HttpConnectionDispatcherOptions
+            {
+                EnableAuthenticationRefresh = true,
+                OnAuthenticationRefresh = ctx =>
+                {
+                    captured = ctx;
+                    return ValueTask.FromResult(true);
+                },
+            };
+
+            var app = BuildTestConnectionHandlerApp(out var sp);
+
+            // First poll establishes the original principal on the connection.
+            var userA = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "userA") }, "Test"));
+            var expA = DateTimeOffset.UtcNow.AddMinutes(5);
+            var context1 = BuildAuthPollContext(connection, sp, userA, expA);
+            await dispatcher.ExecuteAsync(context1, options, app).DefaultTimeout();
+            Assert.Equal(StatusCodes.Status200OK, context1.Response.StatusCode);
+            Assert.Same(userA, connection.User);
+
+            // Second poll carries a refreshed token (different subject and later expiration).
+            var userB = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "userB") }, "Test"));
+            var expB = DateTimeOffset.UtcNow.AddMinutes(30);
+            var context2 = BuildAuthPollContext(connection, sp, userB, expB);
+            var pollTask = dispatcher.ExecuteAsync(context2, options, app);
+            await connection.Transport.Output.WriteAsync(Encoding.UTF8.GetBytes("Unblock")).AsTask().DefaultTimeout();
+            await pollTask.DefaultTimeout();
+
+            Assert.Equal(StatusCodes.Status200OK, context2.Response.StatusCode);
+
+            // The OnAuthenticationRefresh callback ran with the refreshed principal, and the connection was updated.
+            Assert.NotNull(captured);
+            Assert.Same(userA, captured.PreviousUser);
+            Assert.Same(userB, captured.NewUser);
+            Assert.Equal(expB, captured.NewExpiration, TimeSpan.FromSeconds(1));
+            Assert.Same(userB, connection.User);
+            Assert.Equal(expB, connection.AuthenticationExpiration, TimeSpan.FromSeconds(1));
+        }
+    }
+
+    [Fact]
+    public async Task LongPollingRefreshedPrincipalRejectedByOnAuthenticationRefreshTearsDownConnection()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var connection = manager.CreateConnection();
+            connection.TransportType = HttpTransportType.LongPolling;
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+
+            var options = new HttpConnectionDispatcherOptions
+            {
+                EnableAuthenticationRefresh = true,
+                OnAuthenticationRefresh = ctx =>
+                {
+                    return ValueTask.FromResult(false);
+                },
+            };
+
+            var app = BuildTestConnectionHandlerApp(out var sp);
+
+            var userA = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "userA") }, "Test"));
+            var expA = DateTimeOffset.UtcNow.AddMinutes(5);
+            var context1 = BuildAuthPollContext(connection, sp, userA, expA);
+            await dispatcher.ExecuteAsync(context1, options, app).DefaultTimeout();
+            Assert.Equal(StatusCodes.Status200OK, context1.Response.StatusCode);
+            Assert.Same(userA, connection.User);
+
+            // Second poll carries a refreshed token the application rejects.
+            var userB = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "userB") }, "Test"));
+            var expB = DateTimeOffset.UtcNow.AddMinutes(30);
+            var context2 = BuildAuthPollContext(connection, sp, userB, expB);
+            await dispatcher.ExecuteAsync(context2, options, app).DefaultTimeout();
+
+            Assert.Equal(StatusCodes.Status403Forbidden, context2.Response.StatusCode);
+            var json = ReadJson(context2.Response.Body);
+            AssertRefreshError(json, "permission_change_rejected");
+
+            // The connection principal must NOT have been swapped to the rejected one.
+            Assert.Same(userA, connection.User);
+
+            // The connection is torn down and removed from the manager.
+            Assert.NotNull(connection.DisposeAndRemoveTask);
+            await connection.DisposeAndRemoveTask.DefaultTimeout();
+            Assert.False(manager.TryGetConnection(connection.ConnectionToken, out _));
+        }
+    }
+
+    [Fact]
+    public async Task LongPollingPollCarryingSameTokenDoesNotInvokeOnAuthenticationRefresh()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var connection = manager.CreateConnection();
+            connection.TransportType = HttpTransportType.LongPolling;
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+
+            var refreshCount = 0;
+            var options = new HttpConnectionDispatcherOptions
+            {
+                EnableAuthenticationRefresh = true,
+                OnAuthenticationRefresh = _ =>
+                {
+                    refreshCount++;
+                    return ValueTask.FromResult(true);
+                },
+            };
+
+            var app = BuildTestConnectionHandlerApp(out var sp);
+
+            var user = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "userA") }, "Test"));
+            var exp = DateTimeOffset.UtcNow.AddMinutes(5);
+            var context1 = BuildAuthPollContext(connection, sp, user, exp);
+            await dispatcher.ExecuteAsync(context1, options, app).DefaultTimeout();
+            Assert.Equal(StatusCodes.Status200OK, context1.Response.StatusCode);
+            Assert.Same(user, connection.User);
+
+            // Second poll carries the SAME token (same subject and expiration) but as a distinct principal
+            // instance. This is not a refresh, so the callback should not run and the connection must NOT be
+            // swapped to the new instance (which would re-introduce the check-then-act rollback race against a
+            // concurrent /refresh); connection.User stays the principal already applied.
+            var samePrincipalDifferentInstance = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "userA") }, "Test"));
+            var context2 = BuildAuthPollContext(connection, sp, samePrincipalDifferentInstance, exp);
+            var pollTask = dispatcher.ExecuteAsync(context2, options, app);
+            await connection.Transport.Output.WriteAsync(Encoding.UTF8.GetBytes("Unblock")).AsTask().DefaultTimeout();
+            await pollTask.DefaultTimeout();
+
+            Assert.Equal(StatusCodes.Status200OK, context2.Response.StatusCode);
+            Assert.Equal(0, refreshCount);
+            Assert.Same(user, connection.User);
+        }
+    }
+
+    [Fact]
+    public async Task LongPollingPollWithChangedClaimsAndSameExpirationInvokesOnAuthenticationRefresh()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var connection = manager.CreateConnection();
+            connection.TransportType = HttpTransportType.LongPolling;
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+
+            AuthenticationRefreshContext captured = null;
+            var refreshCount = 0;
+            var options = new HttpConnectionDispatcherOptions
+            {
+                EnableAuthenticationRefresh = true,
+                OnAuthenticationRefresh = ctx =>
+                {
+                    refreshCount++;
+                    captured = ctx;
+                    return ValueTask.FromResult(true);
+                },
+            };
+
+            var app = BuildTestConnectionHandlerApp(out var sp);
+
+            var user = new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, "userA"),
+                new Claim(ClaimTypes.Role, "reader"),
+            }, "Test"));
+            var exp = DateTimeOffset.UtcNow.AddMinutes(5);
+            var context1 = BuildAuthPollContext(connection, sp, user, exp);
+            await dispatcher.ExecuteAsync(context1, options, app).DefaultTimeout();
+            Assert.Equal(StatusCodes.Status200OK, context1.Response.StatusCode);
+            Assert.Same(user, connection.User);
+
+            var changedClaimsUser = new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, "userA"),
+                new Claim(ClaimTypes.Role, "writer"),
+            }, "Test"));
+            var context2 = BuildAuthPollContext(connection, sp, changedClaimsUser, exp);
+            var pollTask = dispatcher.ExecuteAsync(context2, options, app);
+            await connection.Transport.Output.WriteAsync(Encoding.UTF8.GetBytes("Unblock")).AsTask().DefaultTimeout();
+            await pollTask.DefaultTimeout();
+
+            Assert.Equal(StatusCodes.Status200OK, context2.Response.StatusCode);
+            Assert.Equal(1, refreshCount);
+            Assert.NotNull(captured);
+            Assert.Same(user, captured.PreviousUser);
+            Assert.Same(changedClaimsUser, captured.NewUser);
+            Assert.Same(changedClaimsUser, connection.User);
+            Assert.Equal(exp, connection.AuthenticationExpiration, TimeSpan.FromSeconds(1));
+        }
+    }
+
+    [Fact]
+    public async Task LongPollingRefreshedPrincipalIgnoredWhenAuthenticationRefreshDisabled()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var connection = manager.CreateConnection();
+            connection.TransportType = HttpTransportType.LongPolling;
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+
+            var refreshCount = 0;
+            var options = new HttpConnectionDispatcherOptions
+            {
+                EnableAuthenticationRefresh = false,
+                OnAuthenticationRefresh = _ =>
+                {
+                    refreshCount++;
+                    return ValueTask.FromResult(true);
+                },
+            };
+
+            var app = BuildTestConnectionHandlerApp(out var sp);
+
+            var userA = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "userA") }, "Test"));
+            var context1 = BuildAuthPollContext(connection, sp, userA, DateTimeOffset.UtcNow.AddMinutes(5));
+            await dispatcher.ExecuteAsync(context1, options, app).DefaultTimeout();
+            Assert.Equal(StatusCodes.Status200OK, context1.Response.StatusCode);
+
+            // A changed principal on a poll with authentication-refresh disabled keeps the legacy raw-swap behavior:
+            // the callback never runs but connection.User still tracks the latest poll principal.
+            var userB = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "userB") }, "Test"));
+            var context2 = BuildAuthPollContext(connection, sp, userB, DateTimeOffset.UtcNow.AddMinutes(30));
+            var pollTask = dispatcher.ExecuteAsync(context2, options, app);
+            await connection.Transport.Output.WriteAsync(Encoding.UTF8.GetBytes("Unblock")).AsTask().DefaultTimeout();
+            await pollTask.DefaultTimeout();
+
+            Assert.Equal(StatusCodes.Status200OK, context2.Response.StatusCode);
+            Assert.Equal(0, refreshCount);
+            Assert.Same(userB, connection.User);
+        }
+    }
+
+    [Fact]
+    public async Task LongPollingStalePollDoesNotRollBackPrincipalOrExpiration()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var connection = manager.CreateConnection();
+            connection.TransportType = HttpTransportType.LongPolling;
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+
+            var refreshCount = 0;
+            var options = new HttpConnectionDispatcherOptions
+            {
+                EnableAuthenticationRefresh = true,
+                OnAuthenticationRefresh = _ =>
+                {
+                    refreshCount++;
+                    return ValueTask.FromResult(true);
+                },
+            };
+
+            var app = BuildTestConnectionHandlerApp(out var sp);
+
+            // First poll establishes the principal with a later expiration (mimics a token applied by /refresh).
+            var userA = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "userA") }, "Test"));
+            var laterExpiration = DateTimeOffset.UtcNow.AddMinutes(30);
+            var context1 = BuildAuthPollContext(connection, sp, userA, laterExpiration);
+            await dispatcher.ExecuteAsync(context1, options, app).DefaultTimeout();
+            Assert.Equal(StatusCodes.Status200OK, context1.Response.StatusCode);
+            Assert.Same(userA, connection.User);
+            Assert.Equal(laterExpiration, connection.AuthenticationExpiration, TimeSpan.FromSeconds(1));
+
+            // A delayed poll arrives carrying an OLDER token (earlier expiration) than the one already applied
+            // (e.g. it lost the race against an explicit /refresh). It must not roll the connection back.
+            var userB = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "userB") }, "Test"));
+            var earlierExpiration = DateTimeOffset.UtcNow.AddMinutes(5);
+            var context2 = BuildAuthPollContext(connection, sp, userB, earlierExpiration);
+            var pollTask = dispatcher.ExecuteAsync(context2, options, app);
+            await connection.Transport.Output.WriteAsync(Encoding.UTF8.GetBytes("Unblock")).AsTask().DefaultTimeout();
+            await pollTask.DefaultTimeout();
+
+            Assert.Equal(StatusCodes.Status200OK, context2.Response.StatusCode);
+            // No refresh callback fired and the connection kept the newer principal/expiration.
+            Assert.Equal(0, refreshCount);
+            Assert.Same(userA, connection.User);
+            Assert.Equal(laterExpiration, connection.AuthenticationExpiration, TimeSpan.FromSeconds(1));
+        }
+    }
+
+    [Fact]
+    public async Task LongPollingRejectionDoesNotTearDownConnectionWhenTokenSupersededDuringCallback()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var connection = manager.CreateConnection();
+            connection.TransportType = HttpTransportType.LongPolling;
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+
+            var app = BuildTestConnectionHandlerApp(out var sp);
+
+            // First poll establishes the principal.
+            var userA = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "userA") }, "Test"));
+            var initialExpiration = DateTimeOffset.UtcNow.AddMinutes(5);
+            var context1 = BuildAuthPollContext(connection, sp, userA, initialExpiration);
+
+            var options = new HttpConnectionDispatcherOptions
+            {
+                EnableAuthenticationRefresh = true,
+            };
+
+            await dispatcher.ExecuteAsync(context1, options, app).DefaultTimeout();
+            Assert.Equal(StatusCodes.Status200OK, context1.Response.StatusCode);
+
+            // A delayed poll carrying an older token runs the callback, but while the (slow) callback runs an
+            // explicit /refresh applies a NEWER token. The callback then rejects the older token. The
+            // connection must not be torn down for a token it has already moved past.
+            var newerUser = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "userC") }, "Test"));
+            var newerExpiration = DateTimeOffset.UtcNow.AddMinutes(30);
+            options.OnAuthenticationRefresh = ctx =>
+            {
+                // Simulate a concurrent /refresh landing a newer token mid-callback.
+                connection.UpdateUser(newerUser, newerExpiration);
+                return ValueTask.FromResult(false);
+            };
+
+            var userB = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "userB") }, "Test"));
+            var context2 = BuildAuthPollContext(connection, sp, userB, DateTimeOffset.UtcNow.AddMinutes(10));
+            var pollTask = dispatcher.ExecuteAsync(context2, options, app);
+            await connection.Transport.Output.WriteAsync(Encoding.UTF8.GetBytes("Unblock")).AsTask().DefaultTimeout();
+            await pollTask.DefaultTimeout();
+
+            // The poll proceeds (200), the connection is not torn down, and it keeps the newer token.
+            Assert.Equal(StatusCodes.Status200OK, context2.Response.StatusCode);
+            Assert.Null(connection.DisposeAndRemoveTask);
+            Assert.Same(newerUser, connection.User);
+            Assert.Equal(newerExpiration, connection.AuthenticationExpiration, TimeSpan.FromSeconds(1));
+        }
+    }
+
+    [Fact]
+    public async Task StatefulReconnectRefreshedPrincipalInvokesOnAuthenticationRefreshAndUpdatesUser()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var options = new HttpConnectionDispatcherOptions
+            {
+                AllowStatefulReconnects = true,
+                EnableAuthenticationRefresh = true,
+            };
+            options.WebSockets.CloseTimeout = TimeSpan.FromMilliseconds(1);
+            var connection = manager.CreateConnection(options, negotiateVersion: 1, useStatefulReconnect: true);
+            connection.TransportType = HttpTransportType.WebSockets;
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+
+            AuthenticationRefreshContext captured = null;
+            options.OnAuthenticationRefresh = ctx =>
+            {
+                captured = ctx;
+                return ValueTask.FromResult(true);
+            };
+
+            var services = new ServiceCollection();
+            var app = BuildReconnectConnectionHandlerApp(services);
+
+            var userA = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "userA") }, "Test"));
+            var expA = DateTimeOffset.UtcNow.AddMinutes(5);
+            var context1 = BuildAuthReconnectContext(connection, services, userA, expA);
+            var initialWebSocketTask = dispatcher.ExecuteAsync(context1, options, app);
+            var websocketFeature = (TestWebSocketConnectionFeature)context1.Features.Get<IHttpWebSocketFeature>();
+            await websocketFeature.Accepted.DefaultTimeout();
+
+            Assert.Same(userA, connection.User);
+            Assert.Equal(expA, connection.AuthenticationExpiration, TimeSpan.FromSeconds(1));
+
+            var userB = new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, "userA"),
+                new Claim(ClaimTypes.Role, "writer"),
+            }, "Test"));
+            var expB = DateTimeOffset.UtcNow.AddMinutes(30);
+            var context2 = BuildAuthReconnectContext(connection, services, userB, expB);
+            var reconnectWebSocketTask = dispatcher.ExecuteAsync(context2, options, app);
+
+            await initialWebSocketTask.DefaultTimeout();
+            websocketFeature = (TestWebSocketConnectionFeature)context2.Features.Get<IHttpWebSocketFeature>();
+            await websocketFeature.Accepted.DefaultTimeout();
+
+            Assert.NotNull(captured);
+            Assert.Same(userA, captured.PreviousUser);
+            Assert.Same(userB, captured.NewUser);
+            Assert.Equal(expB, captured.NewExpiration, TimeSpan.FromSeconds(1));
+            Assert.Same(userB, connection.User);
+            Assert.Equal(expB, connection.AuthenticationExpiration, TimeSpan.FromSeconds(1));
+
+            connection.Abort();
+            await reconnectWebSocketTask.DefaultTimeout();
+        }
+    }
+
+    [Fact]
+    public async Task StatefulReconnectCarryingSameTokenDoesNotInvokeOnAuthenticationRefresh()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var options = new HttpConnectionDispatcherOptions
+            {
+                AllowStatefulReconnects = true,
+                EnableAuthenticationRefresh = true,
+            };
+            options.WebSockets.CloseTimeout = TimeSpan.FromMilliseconds(1);
+            var connection = manager.CreateConnection(options, negotiateVersion: 1, useStatefulReconnect: true);
+            connection.TransportType = HttpTransportType.WebSockets;
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+
+            var refreshCount = 0;
+            options.OnAuthenticationRefresh = _ =>
+            {
+                refreshCount++;
+                return ValueTask.FromResult(true);
+            };
+
+            var services = new ServiceCollection();
+            var app = BuildReconnectConnectionHandlerApp(services);
+
+            var user = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "userA") }, "Test"));
+            var exp = DateTimeOffset.UtcNow.AddMinutes(5);
+            var context1 = BuildAuthReconnectContext(connection, services, user, exp);
+            var initialWebSocketTask = dispatcher.ExecuteAsync(context1, options, app);
+            var websocketFeature = (TestWebSocketConnectionFeature)context1.Features.Get<IHttpWebSocketFeature>();
+            await websocketFeature.Accepted.DefaultTimeout();
+
+            Assert.Same(user, connection.User);
+
+            var samePrincipalDifferentInstance = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "userA") }, "Test"));
+            var context2 = BuildAuthReconnectContext(connection, services, samePrincipalDifferentInstance, exp);
+            var reconnectWebSocketTask = dispatcher.ExecuteAsync(context2, options, app);
+
+            await initialWebSocketTask.DefaultTimeout();
+            websocketFeature = (TestWebSocketConnectionFeature)context2.Features.Get<IHttpWebSocketFeature>();
+            await websocketFeature.Accepted.DefaultTimeout();
+
+            Assert.Equal(0, refreshCount);
+            Assert.Same(user, connection.User);
+            Assert.Same(user, connection.HttpContext.User);
+
+            connection.Abort();
+            await reconnectWebSocketTask.DefaultTimeout();
+        }
+    }
+
+    [Fact]
+    public void UpdateUserSkipsOlderToken()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var connection = manager.CreateConnection(new HttpConnectionDispatcherOptions(), negotiateVersion: 1);
+
+            var userA = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("name", "A") }, "Test"));
+            var laterExpiration = DateTimeOffset.UtcNow.AddMinutes(30);
+            connection.UpdateUser(userA, laterExpiration);
+
+            var feature = connection.Features.Get<IConnectionUserRefreshFeature>();
+            var notified = 0;
+            feature.OnUserRefreshed((_, state) => notified++, state: null);
+
+            // An older token must be skipped (no swap, no notification).
+            var userB = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("name", "B") }, "Test"));
+            connection.UpdateUser(userB, DateTimeOffset.UtcNow.AddMinutes(5));
+
+            Assert.Same(userA, connection.User);
+            Assert.Equal(laterExpiration, connection.AuthenticationExpiration, TimeSpan.FromSeconds(1));
+            Assert.Equal(0, notified);
+
+            // A newer token is still applied.
+            var userC = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("name", "C") }, "Test"));
+            var newerExpiration = DateTimeOffset.UtcNow.AddMinutes(60);
+            connection.UpdateUser(userC, newerExpiration);
+
+            Assert.Same(userC, connection.User);
+            Assert.Equal(newerExpiration, connection.AuthenticationExpiration, TimeSpan.FromSeconds(1));
+            Assert.Equal(1, notified);
+        }
+    }
+
+    private static ConnectionDelegate BuildTestConnectionHandlerApp(out IServiceProvider serviceProvider)
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+        services.AddSingleton<TestConnectionHandler>();
+        services.AddLogging();
+        serviceProvider = services.BuildServiceProvider();
+        var builder = new ConnectionBuilder(serviceProvider);
+        builder.UseConnectionHandler<TestConnectionHandler>();
+        return builder.Build();
+    }
+
+    private static ConnectionDelegate BuildReconnectConnectionHandlerApp(IServiceCollection services)
+    {
+        var builder = new ConnectionBuilder(services.BuildServiceProvider());
+        builder.UseConnectionHandler<AuthenticationRefreshReconnectConnectionHandler>();
+        return builder.Build();
+    }
+
+    private static DefaultHttpContext BuildAuthPollContext(HttpConnectionContext connection, IServiceProvider serviceProvider, ClaimsPrincipal user, DateTimeOffset expiration)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/foo";
+        context.Request.Method = "GET";
+        context.RequestServices = serviceProvider;
+        context.Response.Body = new MemoryStream();
+        var values = new Dictionary<string, StringValues>
+        {
+            ["id"] = connection.ConnectionToken,
+            ["negotiateVersion"] = "1",
+        };
+        context.Request.Query = new QueryCollection(values);
+        context.User = user;
+
+        var props = new AuthenticationProperties { ExpiresUtc = expiration };
+        var ticket = new AuthenticationTicket(user, props, "Test");
+        context.Features.Set<IAuthenticateResultFeature>(new TestAuthenticateResultFeature(AuthenticateResult.Success(ticket)));
+        return context;
+    }
+
+    private static DefaultHttpContext BuildAuthReconnectContext(HttpConnectionContext connection, IServiceCollection services, ClaimsPrincipal user, DateTimeOffset expiration)
+    {
+        var context = MakeRequest("/foo", connection, services);
+        SetTransport(context, HttpTransportType.WebSockets);
+        context.User = user;
+
+        var props = new AuthenticationProperties { ExpiresUtc = expiration };
+        var ticket = new AuthenticationTicket(user, props, "Test");
+        context.Features.Set<IAuthenticateResultFeature>(new TestAuthenticateResultFeature(AuthenticateResult.Success(ticket)));
+        return context;
+    }
+
+    private static DefaultHttpContext BuildNegotiateContext(out MemoryStream body)
+    {
+        body = new MemoryStream();
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/foo";
+        context.Request.Method = "POST";
+        context.Request.QueryString = new QueryString("?negotiateVersion=1");
+        context.Response.Body = body;
+        var services = new ServiceCollection();
+        services.AddOptions();
+        context.RequestServices = services.BuildServiceProvider();
+        return context;
+    }
+
+    private static void SetAuthenticateResultFeature(HttpContext context, DateTimeOffset? expiresUtc)
+    {
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("n", "v") }, "Test"));
+        var props = new AuthenticationProperties();
+        if (expiresUtc.HasValue)
+        {
+            props.ExpiresUtc = expiresUtc.Value;
+        }
+        var ticket = new AuthenticationTicket(principal, props, "Test");
+        context.Features.Set<IAuthenticateResultFeature>(new TestAuthenticateResultFeature(AuthenticateResult.Success(ticket)));
+    }
+
+    private sealed class TestAuthenticateResultFeature : IAuthenticateResultFeature
+    {
+        public TestAuthenticateResultFeature(AuthenticateResult result) => AuthenticateResult = result;
+        public AuthenticateResult AuthenticateResult { get; set; }
+    }
+
+    private static JObject ReadJson(Stream body)
+    {
+        body.Position = 0;
+        using var reader = new StreamReader(body);
+        return JObject.Parse(reader.ReadToEnd());
+    }
+
+    private static void AssertRefreshError(JObject json, string error)
+    {
+        Assert.Equal(error, json.Value<string>("error"));
+        Assert.Null(json["error_description"]);
+    }
+
+    private sealed class ThrowingAuthenticationService : IAuthenticationService
+    {
+        public Task<AuthenticateResult> AuthenticateAsync(HttpContext context, string scheme) =>
+            throw new InvalidOperationException("No authenticationScheme was specified, and there was no DefaultAuthenticateScheme found.");
+        public Task ChallengeAsync(HttpContext context, string scheme, AuthenticationProperties properties) => Task.CompletedTask;
+        public Task ForbidAsync(HttpContext context, string scheme, AuthenticationProperties properties) => Task.CompletedTask;
+        public Task SignInAsync(HttpContext context, string scheme, ClaimsPrincipal principal, AuthenticationProperties properties) => Task.CompletedTask;
+        public Task SignOutAsync(HttpContext context, string scheme, AuthenticationProperties properties) => Task.CompletedTask;
+    }
+
+    private sealed class FakeAuthenticationSchemeProvider : IAuthenticationSchemeProvider
+    {
+        public Task<AuthenticationScheme> GetDefaultAuthenticateSchemeAsync() => Task.FromResult<AuthenticationScheme>(null);
+        public Task<AuthenticationScheme> GetDefaultChallengeSchemeAsync() => Task.FromResult<AuthenticationScheme>(null);
+        public Task<AuthenticationScheme> GetDefaultForbidSchemeAsync() => Task.FromResult<AuthenticationScheme>(null);
+        public Task<AuthenticationScheme> GetDefaultSignInSchemeAsync() => Task.FromResult<AuthenticationScheme>(null);
+        public Task<AuthenticationScheme> GetDefaultSignOutSchemeAsync() => Task.FromResult<AuthenticationScheme>(null);
+        public Task<IEnumerable<AuthenticationScheme>> GetAllSchemesAsync() => Task.FromResult(Enumerable.Empty<AuthenticationScheme>());
+        public Task<IEnumerable<AuthenticationScheme>> GetRequestHandlerSchemesAsync() => Task.FromResult(Enumerable.Empty<AuthenticationScheme>());
+        public Task<AuthenticationScheme> GetSchemeAsync(string name) => Task.FromResult<AuthenticationScheme>(null);
+        public void AddScheme(AuthenticationScheme scheme) { }
+        public void RemoveScheme(string name) { }
+    }
+
+    private sealed class AuthenticationRefreshReconnectConnectionHandler : ConnectionHandler
+    {
+        public override async Task OnConnectedAsync(ConnectionContext connection)
+        {
+#pragma warning disable CA2252 // This API requires opting into preview features
+            connection.Features.Get<IStatefulReconnectFeature>()?.OnReconnected(_ => Task.CompletedTask);
+#pragma warning restore CA2252 // This API requires opting into preview features
+
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, connection.ConnectionClosed);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+    }
+}

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -49,7 +49,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.AspNetCore.Http.Connections.Tests;
 
-public class HttpConnectionDispatcherTests : VerifiableLoggedTest
+public partial class HttpConnectionDispatcherTests : VerifiableLoggedTest
 {
     [Fact]
     public async Task NegotiateVersionZeroReservesConnectionIdAndReturnsIt()

--- a/src/SignalR/common/Http.Connections/test/MapConnectionHandlerTests.cs
+++ b/src/SignalR/common/Http.Connections/test/MapConnectionHandlerTests.cs
@@ -353,6 +353,74 @@ public class MapConnectionHandlerTests
     }
 
     [Fact]
+    public void MapConnectionHandlerEndPointRoutingAppliesAuthenticationRefreshMetadataWhenEnabled()
+    {
+        void ConfigureRoutes(IEndpointRouteBuilder endpoints)
+        {
+            endpoints.MapConnectionHandler<AuthConnectionHandler>("/path", options =>
+            {
+                options.EnableAuthenticationRefresh = true;
+            });
+        }
+
+        using (var host = BuildWebHost(ConfigureRoutes))
+        {
+            host.Start();
+
+            var dataSource = host.Services.GetRequiredService<EndpointDataSource>();
+            // With EnableAuthenticationRefresh we register 3 endpoints (/negotiate, /refresh, /)
+            Assert.Collection(dataSource.Endpoints,
+                endpoint =>
+                {
+                    Assert.Equal("/path/negotiate", endpoint.DisplayName);
+                    Assert.Null(endpoint.Metadata.GetMetadata<AuthenticationRefreshMetadata>());
+                },
+                endpoint =>
+                {
+                    Assert.Equal("/path/refresh", endpoint.DisplayName);
+                    var metaData = endpoint.Metadata.GetMetadata<AuthenticationRefreshMetadata>();
+                    Assert.NotNull(metaData);
+                    var optionsMetaData = endpoint.Metadata.GetMetadata<HttpConnectionDispatcherOptions>();
+                    Assert.NotNull(optionsMetaData);
+                    Assert.True(optionsMetaData.EnableAuthenticationRefresh);
+                },
+                endpoint =>
+                {
+                    Assert.Equal("/path", endpoint.DisplayName);
+                    Assert.Null(endpoint.Metadata.GetMetadata<AuthenticationRefreshMetadata>());
+                });
+        }
+    }
+
+    [Fact]
+    public void MapConnectionHandlerDoesNotRegisterRefreshEndpointWhenAuthenticationRefreshDisabled()
+    {
+        void ConfigureRoutes(IEndpointRouteBuilder endpoints)
+        {
+            endpoints.MapConnectionHandler<AuthConnectionHandler>("/path");
+        }
+
+        using (var host = BuildWebHost(ConfigureRoutes))
+        {
+            host.Start();
+
+            var dataSource = host.Services.GetRequiredService<EndpointDataSource>();
+            // Without EnableAuthenticationRefresh only /negotiate and / are registered, and neither carries AuthenticationRefreshMetadata.
+            Assert.Collection(dataSource.Endpoints,
+                endpoint =>
+                {
+                    Assert.Equal("/path/negotiate", endpoint.DisplayName);
+                    Assert.Null(endpoint.Metadata.GetMetadata<AuthenticationRefreshMetadata>());
+                },
+                endpoint =>
+                {
+                    Assert.Equal("/path", endpoint.DisplayName);
+                    Assert.Null(endpoint.Metadata.GetMetadata<AuthenticationRefreshMetadata>());
+                });
+        }
+    }
+
+    [Fact]
     public void MapConnectionHandlerEndPointRoutingAppliesCorsMetadata()
     {
         void ConfigureRoutes(IEndpointRouteBuilder endpoints)

--- a/src/SignalR/common/Http.Connections/test/NegotiateProtocolTests.cs
+++ b/src/SignalR/common/Http.Connections/test/NegotiateProtocolTests.cs
@@ -105,14 +105,90 @@ public class NegotiateProtocolTests
             NegotiateProtocol.WriteResponse(new NegotiationResponse
             {
                 AvailableTransports = new List<AvailableTransport>
-                    {
-                        new AvailableTransport()
-                    }
+                {
+                    new AvailableTransport()
+                }
             }, writer);
 
             string json = Encoding.UTF8.GetString(writer.ToArray());
 
             Assert.Equal("{\"negotiateVersion\":0,\"availableTransports\":[{\"transport\":null,\"transferFormats\":[]}]}", json);
         }
+    }
+
+    [Fact]
+    public void WriteNegotiateResponseIncludesTokenLifetimeWhenSet()
+    {
+        using (MemoryBufferWriter writer = new MemoryBufferWriter())
+        {
+            NegotiateProtocol.WriteResponse(new NegotiationResponse
+            {
+                ConnectionId = "abc",
+                ConnectionToken = "tok",
+                Version = 1,
+                TokenLifetime = TimeSpan.FromSeconds(3600),
+            }, writer);
+
+            string json = Encoding.UTF8.GetString(writer.ToArray());
+
+            Assert.Contains("\"tokenLifetimeSeconds\":3600", json);
+        }
+    }
+
+    [Fact]
+    public void WriteNegotiateResponseClampsTokenLifetimeToMaxInt()
+    {
+        using (MemoryBufferWriter writer = new MemoryBufferWriter())
+        {
+            NegotiateProtocol.WriteResponse(new NegotiationResponse
+            {
+                ConnectionId = "abc",
+                ConnectionToken = "tok",
+                Version = 1,
+                TokenLifetime = TimeSpan.FromSeconds((double)int.MaxValue + 1),
+            }, writer);
+
+            string json = Encoding.UTF8.GetString(writer.ToArray());
+
+            Assert.Contains($"\"tokenLifetimeSeconds\":{int.MaxValue}", json);
+        }
+    }
+
+    [Fact]
+    public void WriteNegotiateResponseOmitsTokenLifetimeWhenNullOrZero()
+    {
+        using (MemoryBufferWriter writer = new MemoryBufferWriter())
+        {
+            NegotiateProtocol.WriteResponse(new NegotiationResponse
+            {
+                TokenLifetime = null,
+            }, writer);
+            Assert.DoesNotContain("tokenLifetimeSeconds", Encoding.UTF8.GetString(writer.ToArray()));
+        }
+
+        using (MemoryBufferWriter writer = new MemoryBufferWriter())
+        {
+            NegotiateProtocol.WriteResponse(new NegotiationResponse
+            {
+                TokenLifetime = TimeSpan.Zero,
+            }, writer);
+            Assert.DoesNotContain("tokenLifetimeSeconds", Encoding.UTF8.GetString(writer.ToArray()));
+        }
+    }
+
+    [Fact]
+    public void ParseNegotiateResponseReadsTokenLifetime()
+    {
+        var json = "{\"connectionId\":\"abc\",\"availableTransports\":[],\"tokenLifetimeSeconds\":1234}";
+        var response = NegotiateProtocol.ParseResponse(Encoding.UTF8.GetBytes(json));
+        Assert.Equal(TimeSpan.FromSeconds(1234), response.TokenLifetime);
+    }
+
+    [Fact]
+    public void ParseNegotiateResponseLeavesTokenLifetimeNullWhenAbsent()
+    {
+        var json = "{\"connectionId\":\"abc\",\"availableTransports\":[]}";
+        var response = NegotiateProtocol.ParseResponse(Encoding.UTF8.GetBytes(json));
+        Assert.Null(response.TokenLifetime);
     }
 }

--- a/src/SignalR/samples/JwtClientSample/Program.cs
+++ b/src/SignalR/samples/JwtClientSample/Program.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Concurrent;
 using System.Net.Http;
 using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.SignalR.Client;
@@ -21,24 +20,26 @@ class Program
 
     private const string ServerUrl = "http://localhost:54543";
 
-    private readonly ConcurrentDictionary<string, Task<string>> _tokens = new ConcurrentDictionary<string, Task<string>>(StringComparer.Ordinal);
-
     private async Task RunConnection(HttpTransportType transportType)
     {
         var userId = "C#" + transportType;
-        _tokens[userId] = GetJwtToken(userId);
 
         var hubConnection = new HubConnectionBuilder()
             .WithUrl(ServerUrl + "/broadcast", options =>
             {
                 options.Transports = transportType;
-                options.AccessTokenProvider = () => _tokens[userId];
+                options.AccessTokenProvider = () => GetJwtToken(userId);
+            })
+            .WithAuthenticationRefresh(o =>
+            {
+                o.RefreshBeforeExpiration = TimeSpan.FromSeconds(10);
             })
             .Build();
 
         var closedTcs = new TaskCompletionSource();
         hubConnection.Closed += e =>
         {
+            Console.WriteLine(e);
             closedTcs.SetResult();
             return Task.CompletedTask;
         };
@@ -56,20 +57,11 @@ class Program
             {
                 await Task.Delay(1000);
                 ticks++;
-                if (ticks % 15 == 0)
-                {
-                    // no need to refresh the token for websockets
-                    if (transportType != HttpTransportType.WebSockets)
-                    {
-                        _tokens[userId] = GetJwtToken(userId);
-                        Console.WriteLine($"[{userId}] Token refreshed");
-                    }
-                }
 
                 if (ticks % nextMsgAt == 0)
                 {
                     await hubConnection.SendAsync("Broadcast", userId, $"Hello at {DateTime.Now}");
-                    nextMsgAt = Random.Shared.Next(2, 5);
+                    nextMsgAt = Random.Shared.Next(20, 50);
                 }
             }
         }

--- a/src/SignalR/server/Core/src/Hub.cs
+++ b/src/SignalR/server/Core/src/Hub.cs
@@ -87,6 +87,24 @@ public abstract class Hub : IDisposable
     }
 
     /// <summary>
+    /// Called when the authenticated user on the connection has been refreshed, for example via the
+    /// SignalR authentication-refresh endpoint. The new <see cref="System.Security.Claims.ClaimsPrincipal"/> is
+    /// available on <see cref="HubCallerContext.User"/>.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+    /// <remarks>
+    /// This method is serialized with concurrent hub method invocations using the connection's
+    /// maximum-parallel-invocation limit. Client-result invocations are not supported from this method.
+    /// The previous principal is intentionally not exposed because its underlying resources
+    /// (for example a <see cref="System.Security.Principal.WindowsIdentity"/>'s <c>SafeHandle</c>)
+    /// may already be disposed by the time this method runs.
+    /// </remarks>
+    public virtual Task OnAuthenticationRefreshedAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
     /// Releases all resources currently used by this <see cref="Hub"/> instance.
     /// </summary>
     /// <param name="disposing"><c>true</c> if this method is being invoked by the <see cref="Dispose()"/> method,

--- a/src/SignalR/server/Core/src/HubConnectionContext.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContext.cs
@@ -50,8 +50,15 @@ public partial class HubConnectionContext
     private bool _receivedMessageTimeoutEnabled;
     private TimeSpan _receivedMessageElapsed;
     private long _receivedMessageTick;
-    private ClaimsPrincipal? _user;
     private bool _useStatefulReconnect;
+    private DefaultHubCallerContext? _hubCallerContext;
+    private string? _userIdentifier;
+
+    // IUserIdProvider.GetUserId receives the connection, not the candidate principal. During refresh this
+    // lets that synchronous call see the pending principal before publishing the refreshed hub state, so we
+    // can reject identifier changes without briefly exposing the new user to concurrent hub code.
+    [ThreadStatic]
+    private static UserIdProviderUserState? t_userIdProviderUserState;
 
     [MemberNotNullWhen(true, nameof(_messageBuffer))]
     internal bool UsingStatefulReconnect() => _useStatefulReconnect;
@@ -87,8 +94,6 @@ public partial class HubConnectionContext
             _closedRequestedRegistration = lifetimeNotification.ConnectionClosedRequested.Register(static (state) => ((HubConnectionContext)state!).AbortAllowReconnect(), this);
         }
 
-        HubCallerContext = new DefaultHubCallerContext(this);
-
         _lastSendTick = _timeProvider.GetTimestamp();
 
         var maxInvokeLimit = contextOptions.MaximumParallelInvocations;
@@ -109,7 +114,14 @@ public partial class HubConnectionContext
         }
     }
 
-    internal HubCallerContext HubCallerContext { get; }
+    internal HubCallerContext HubCallerContext
+    {
+        get
+        {
+            var hubCallerContext = Volatile.Read(ref _hubCallerContext);
+            return hubCallerContext ?? InitializeHubCallerContext();
+        }
+    }
 
     internal Exception? CloseException { get; private set; }
 
@@ -134,11 +146,13 @@ public partial class HubConnectionContext
     {
         get
         {
-            if (_user is null)
+            var userIdProviderState = t_userIdProviderUserState;
+            if (ReferenceEquals(userIdProviderState?.Connection, this))
             {
-                _user = Features.Get<IConnectionUserFeature>()?.User ?? new ClaimsPrincipal();
+                return userIdProviderState.User;
             }
-            return _user;
+
+            return HubCallerContext.User ?? new ClaimsPrincipal();
         }
     }
 
@@ -161,7 +175,66 @@ public partial class HubConnectionContext
     /// <summary>
     /// Gets or sets the user identifier for this connection.
     /// </summary>
-    public string? UserIdentifier { get; set; }
+    public string? UserIdentifier
+    {
+        get => Volatile.Read(ref _userIdentifier);
+        set
+        {
+            Volatile.Write(ref _userIdentifier, value);
+        }
+    }
+
+    private DefaultHubCallerContext InitializeHubCallerContext()
+    {
+        var hubCallerContext = new DefaultHubCallerContext(
+            this,
+            _connectionContext.Features.Get<IConnectionUserFeature>()?.User ?? new ClaimsPrincipal());
+        var existing = Interlocked.CompareExchange(ref _hubCallerContext, hubCallerContext, null);
+        if (existing is not null)
+        {
+            return existing;
+        }
+
+        return hubCallerContext;
+    }
+
+    private void PublishHubCallerContext(DefaultHubCallerContext hubCallerContext)
+    {
+        Interlocked.Exchange(ref _hubCallerContext, hubCallerContext);
+    }
+
+    internal string? GetUserIdentifier(ClaimsPrincipal user, IUserIdProvider userIdProvider)
+    {
+        var previousState = t_userIdProviderUserState;
+        t_userIdProviderUserState = new UserIdProviderUserState(this, user);
+        try
+        {
+            return userIdProvider.GetUserId(this);
+        }
+        finally
+        {
+            t_userIdProviderUserState = previousState;
+        }
+    }
+
+    internal void ApplyUserState(ClaimsPrincipal user, string? userIdentifier)
+    {
+        Volatile.Write(ref _userIdentifier, userIdentifier);
+        PublishHubCallerContext(new DefaultHubCallerContext(this, user));
+    }
+
+    private sealed class UserIdProviderUserState
+    {
+        public UserIdProviderUserState(HubConnectionContext connection, ClaimsPrincipal user)
+        {
+            Connection = connection;
+            User = user;
+        }
+
+        public HubConnectionContext Connection { get; }
+
+        public ClaimsPrincipal User { get; }
+    }
 
     /// <summary>
     /// Gets the protocol used by this connection.
@@ -612,7 +685,8 @@ public partial class HubConnectionContext
 
                                 _cachedPingMessage = Protocol.GetMessageBytes(PingMessage.Instance);
 
-                                UserIdentifier = userIdProvider.GetUserId(this);
+                                var user = Features.Get<IConnectionUserFeature>()?.User ?? new ClaimsPrincipal();
+                                ApplyUserState(user, GetUserIdentifier(user, userIdProvider));
 
                                 // != true needed because it could be null (which we treat as false)
                                 if (Features.Get<IConnectionInherentKeepAliveFeature>()?.HasInherentKeepAlive != true)
@@ -821,6 +895,7 @@ public partial class HubConnectionContext
         _messageBuffer?.Dispose();
         _closedRegistration.Dispose();
         _closedRequestedRegistration?.Dispose();
+        Interlocked.Exchange(ref _hubCallerContext, null);
 
         // Use _streamTracker to avoid lazy init from StreamTracker getter if it doesn't exist
         _streamTracker?.CompleteAll(new OperationCanceledException("The underlying connection was closed."));

--- a/src/SignalR/server/Core/src/HubConnectionHandler.cs
+++ b/src/SignalR/server/Core/src/HubConnectionHandler.cs
@@ -4,7 +4,9 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Security.Claims;
 using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.SignalR.Internal;
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Extensions.DependencyInjection;
@@ -144,6 +146,22 @@ public class HubConnectionHandler<[DynamicallyAccessedMembers(Hub.DynamicallyAcc
 
         // -- the connectionContext has been set up --
 
+        var userRefreshFeature = connection.Features.Get<IConnectionUserRefreshFeature>();
+        IDisposable? userRefreshedRegistration = null;
+        if (userRefreshFeature is not null)
+        {
+            // Serializes authentication-refresh handling for this connection so concurrent refreshes don't race the re-key.
+            var authenticationRefreshLock = new SemaphoreSlim(1, 1);
+            userRefreshedRegistration = userRefreshFeature.OnUserRefreshed(static (user, state) =>
+            {
+                var userRefreshedState = (UserRefreshedState)state!;
+                userRefreshedState.Handler.OnUserRefreshed(
+                    userRefreshedState.Connection,
+                    user,
+                    userRefreshedState.AuthenticationRefreshLock);
+            }, new UserRefreshedState(this, connectionContext, authenticationRefreshLock));
+        }
+
         try
         {
             await _lifetimeManager.OnConnectedAsync(connectionContext);
@@ -151,11 +169,64 @@ public class HubConnectionHandler<[DynamicallyAccessedMembers(Hub.DynamicallyAcc
         }
         finally
         {
+            userRefreshedRegistration?.Dispose();
+
             connectionContext.Cleanup();
 
             Log.ConnectedEnding(_logger);
             await _lifetimeManager.OnDisconnectedAsync(connectionContext);
         }
+    }
+
+    private void OnUserRefreshed(HubConnectionContext connection, ClaimsPrincipal user, SemaphoreSlim authenticationRefreshLock)
+    {
+        // Fire and forget; HandleUserRefreshedAsync serializes work per connection through authenticationRefreshLock.
+        _ = HandleUserRefreshedAsync(connection, user, authenticationRefreshLock);
+    }
+
+    private async Task HandleUserRefreshedAsync(HubConnectionContext connection, ClaimsPrincipal user, SemaphoreSlim authenticationRefreshLock)
+    {
+        await authenticationRefreshLock.WaitAsync();
+        try
+        {
+            // Recompute inside the lock so a concurrent refresh observes the latest principal and identifier.
+            var newUserId = connection.GetUserIdentifier(user, _userIdProvider);
+            if (!string.Equals(newUserId, connection.UserIdentifier, StringComparison.Ordinal))
+            {
+                var previousUserId = connection.UserIdentifier;
+                Log.UserIdentifierChangedOnRefresh(_logger, previousUserId, newUserId);
+                connection.Abort();
+                return;
+            }
+
+            connection.ApplyUserState(user, newUserId);
+        }
+        catch (Exception ex)
+        {
+            Log.ErrorApplyingAuthenticationRefresh(_logger, ex);
+            connection.Abort();
+            return;
+        }
+        finally
+        {
+            authenticationRefreshLock.Release();
+        }
+
+        // Fire and forget; the dispatcher serializes through ActiveInvocationLimit so the work runs
+        // alongside other hub invocations subject to the configured MaximumParallelInvocations.
+        _ = _dispatcher.OnAuthenticationRefreshedAsync(connection);
+    }
+
+    private sealed class UserRefreshedState(
+        HubConnectionHandler<THub> handler,
+        HubConnectionContext connection,
+        SemaphoreSlim authenticationRefreshLock)
+    {
+        public HubConnectionHandler<THub> Handler { get; } = handler;
+
+        public HubConnectionContext Connection { get; } = connection;
+
+        public SemaphoreSlim AuthenticationRefreshLock { get; } = authenticationRefreshLock;
     }
 
     private async Task RunHubAsync(HubConnectionContext connection)

--- a/src/SignalR/server/Core/src/HubConnectionHandlerLog.cs
+++ b/src/SignalR/server/Core/src/HubConnectionHandlerLog.cs
@@ -24,4 +24,10 @@ internal static partial class HubConnectionHandlerLog
 
     [LoggerMessage(6, LogLevel.Debug, "OnConnectedAsync ending.", EventName = "ConnectedEnding")]
     public static partial void ConnectedEnding(ILogger logger);
+
+    [LoggerMessage(7, LogLevel.Warning, "Authentication refresh produced a different user identifier (old: '{PreviousUserIdentifier}', new: '{NewUserIdentifier}'). Changing a connection's user identifier during refresh is not supported, so the connection is aborted.", EventName = "UserIdentifierChangedOnRefresh")]
+    public static partial void UserIdentifierChangedOnRefresh(ILogger logger, string? previousUserIdentifier, string? newUserIdentifier);
+
+    [LoggerMessage(8, LogLevel.Error, "Error when applying refreshed authentication state.", EventName = "ErrorApplyingAuthenticationRefresh")]
+    public static partial void ErrorApplyingAuthenticationRefresh(ILogger logger, Exception exception);
 }

--- a/src/SignalR/server/Core/src/Internal/DefaultHubCallerContext.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubCallerContext.cs
@@ -12,10 +12,12 @@ namespace Microsoft.AspNetCore.SignalR.Internal;
 internal sealed class DefaultHubCallerContext : HubCallerContext
 {
     private readonly HubConnectionContext _connection;
+    private readonly ClaimsPrincipal _user;
 
-    public DefaultHubCallerContext(HubConnectionContext connection)
+    public DefaultHubCallerContext(HubConnectionContext connection, ClaimsPrincipal user)
     {
         _connection = connection;
+        _user = user;
     }
 
     /// <inheritdoc />
@@ -25,7 +27,7 @@ internal sealed class DefaultHubCallerContext : HubCallerContext
     public override string? UserIdentifier => _connection.UserIdentifier;
 
     /// <inheritdoc />
-    public override ClaimsPrincipal? User => _connection.User;
+    public override ClaimsPrincipal? User => _user;
 
     /// <inheritdoc />
     public override IDictionary<object, object?> Items => _connection.Items;

--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -89,14 +89,15 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
         Activity? activity = null;
         try
         {
+            var hubCallerContext = connection.HubCallerContext;
             // OnConnectedAsync won't work with client results (ISingleClientProxy.InvokeAsync)
-            InitializeHub(hub, connection, invokeAllowed: false);
+            InitializeHub(hub, connection, hubCallerContext, invokeAllowed: false);
 
             activity = StartActivity(SignalRServerActivitySource.OnConnected, ActivityKind.Internal, linkedActivity: null, scope.ServiceProvider, nameof(hub.OnConnectedAsync), headers: null, _logger, connection);
 
             if (_onConnectedMiddleware != null)
             {
-                var context = new HubLifetimeContext(connection.HubCallerContext, scope.ServiceProvider, hub);
+                var context = new HubLifetimeContext(hubCallerContext, scope.ServiceProvider, hub);
                 await _onConnectedMiddleware(context);
             }
             else
@@ -125,13 +126,14 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
         Activity? activity = null;
         try
         {
-            InitializeHub(hub, connection);
+            var hubCallerContext = connection.HubCallerContext;
+            InitializeHub(hub, connection, hubCallerContext);
 
             activity = StartActivity(SignalRServerActivitySource.OnDisconnected, ActivityKind.Internal, linkedActivity: null, scope.ServiceProvider, nameof(hub.OnDisconnectedAsync), headers: null, _logger, connection);
 
             if (_onDisconnectedMiddleware != null)
             {
-                var context = new HubLifetimeContext(connection.HubCallerContext, scope.ServiceProvider, hub);
+                var context = new HubLifetimeContext(hubCallerContext, scope.ServiceProvider, hub);
                 await _onDisconnectedMiddleware(context, exception);
             }
             else
@@ -149,6 +151,49 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
             activity?.Stop();
             hubActivator.Release(hub);
         }
+    }
+
+    public override Task OnAuthenticationRefreshedAsync(HubConnectionContext connection)
+    {
+        // Acquire the per-connection invocation limit so that OnAuthenticationRefreshedAsync interleaves with hub method
+        // invocations the same way other invocations do (respecting MaximumParallelInvocations).
+        return connection.ActiveInvocationLimit.RunAsync(static state =>
+        {
+            var (dispatcher, connection) = state;
+            return dispatcher.InvokeOnAuthenticationRefreshedAsync(connection);
+        }, (this, connection)).AsTask();
+    }
+
+    private async Task<bool> InvokeOnAuthenticationRefreshedAsync(HubConnectionContext connection)
+    {
+        await using var scope = _serviceScopeFactory.CreateAsyncScope();
+
+        var hubActivator = scope.ServiceProvider.GetRequiredService<IHubActivator<THub>>();
+        var hub = hubActivator.Create();
+        Activity? activity = null;
+        try
+        {
+            var hubCallerContext = connection.HubCallerContext;
+            InitializeHub(hub, connection, hubCallerContext, invokeAllowed: false);
+
+            activity = StartActivity(SignalRServerActivitySource.OnAuthenticationRefreshed, ActivityKind.Internal, linkedActivity: null, scope.ServiceProvider, nameof(hub.OnAuthenticationRefreshedAsync), headers: null, _logger, connection);
+
+            await hub.OnAuthenticationRefreshedAsync();
+        }
+        catch (Exception ex)
+        {
+            // Must not throw out of a ChannelBasedSemaphore.RunAsync callback.
+            SetActivityError(activity, ex);
+            Log.FailedInvokingHubMethod(_logger, nameof(Hub.OnAuthenticationRefreshedAsync), ex);
+        }
+        finally
+        {
+            activity?.Stop();
+            hubActivator.Release(hub);
+        }
+
+        // Release the semaphore so other invocations can proceed.
+        return true;
     }
 
     public override Task DispatchMessageAsync(HubConnectionContext connection, HubMessage hubMessage)
@@ -329,8 +374,9 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
         {
             hubActivator = scope.ServiceProvider.GetRequiredService<IHubActivator<THub>>();
             hub = hubActivator.Create();
+            var hubCallerContext = connection.HubCallerContext;
 
-            if (!await IsHubMethodAuthorized(scope.ServiceProvider, connection, descriptor, hubMethodInvocationMessage.Arguments, hub))
+            if (!await IsHubMethodAuthorized(scope.ServiceProvider, hubCallerContext, descriptor, hubMethodInvocationMessage.Arguments, hub))
             {
                 Log.HubMethodNotAuthorized(_logger, hubMethodInvocationMessage.Target);
                 await SendInvocationError(hubMethodInvocationMessage.InvocationId, connection,
@@ -356,7 +402,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
                     return true;
                 }
 
-                InitializeHub(hub, connection);
+                InitializeHub(hub, connection, hubCallerContext);
                 Task? invocation = null;
 
                 var arguments = hubMethodInvocationMessage.Arguments;
@@ -377,7 +423,8 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
 
                 if (isStreamResponse)
                 {
-                    _ = StreamAsync(hubMethodInvocationMessage.InvocationId!, connection, arguments, scope, hubActivator, hub, cts, hubMethodInvocationMessage, descriptor);
+                    _ = StreamAsync(hubMethodInvocationMessage.InvocationId!, connection, hubCallerContext,
+                        arguments, scope, hubActivator, hub, cts, hubMethodInvocationMessage, descriptor);
                 }
                 else
                 {
@@ -389,6 +436,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
                                                         AsyncServiceScope scope,
                                                         IHubActivator<THub> hubActivator,
                                                         HubConnectionContext connection,
+                                                        HubCallerContext hubCallerContext,
                                                         HubMethodInvocationMessage hubMethodInvocationMessage,
                                                         bool isStreamCall,
                                                         CancellationTokenSource? cts)
@@ -425,7 +473,8 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
                         object? result;
                         try
                         {
-                            result = await dispatcher.ExecuteHubMethod(methodExecutor, hub, arguments, connection, scope.ServiceProvider);
+                            result = await dispatcher.ExecuteHubMethod(
+                                methodExecutor, hub, arguments, hubCallerContext, scope.ServiceProvider);
                             Log.SendingResult(logger, hubMethodInvocationMessage.InvocationId, methodExecutor);
                         }
                         catch (Exception ex)
@@ -472,7 +521,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
                         }
                     }
 
-                    invocation = ExecuteInvocation(this, methodExecutor, hub, arguments, scope, hubActivator, connection, hubMethodInvocationMessage, isStreamCall, cts);
+                    invocation = ExecuteInvocation(this, methodExecutor, hub, arguments, scope, hubActivator, connection, hubCallerContext, hubMethodInvocationMessage, isStreamCall, cts);
                 }
 
                 if (isStreamCall || isStreamResponse)
@@ -534,7 +583,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
         return scope.DisposeAsync();
     }
 
-    private async Task StreamAsync(string invocationId, HubConnectionContext connection, object?[] arguments, AsyncServiceScope scope,
+    private async Task StreamAsync(string invocationId, HubConnectionContext connection, HubCallerContext hubCallerContext, object?[] arguments, AsyncServiceScope scope,
         IHubActivator<THub> hubActivator, THub hub, CancellationTokenSource? streamCts, HubMethodInvocationMessage hubMethodInvocationMessage, HubMethodDescriptor descriptor)
     {
         string? error = null;
@@ -564,7 +613,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
             object? result;
             try
             {
-                result = await ExecuteHubMethod(descriptor.MethodExecutor, hub, arguments, connection, scope.ServiceProvider);
+                result = await ExecuteHubMethod(descriptor.MethodExecutor, hub, arguments, hubCallerContext, scope.ServiceProvider);
             }
             catch (Exception ex)
             {
@@ -636,11 +685,11 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
         }
     }
 
-    private ValueTask<object?> ExecuteHubMethod(ObjectMethodExecutor methodExecutor, THub hub, object?[] arguments, HubConnectionContext connection, IServiceProvider serviceProvider)
+    private ValueTask<object?> ExecuteHubMethod(ObjectMethodExecutor methodExecutor, THub hub, object?[] arguments, HubCallerContext hubCallerContext, IServiceProvider serviceProvider)
     {
         if (_invokeMiddleware != null)
         {
-            var invocationContext = new HubInvocationContext(methodExecutor, connection.HubCallerContext, serviceProvider, hub, arguments);
+            var invocationContext = new HubInvocationContext(methodExecutor, hubCallerContext, serviceProvider, hub, arguments);
             return _invokeMiddleware(invocationContext);
         }
 
@@ -688,14 +737,26 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
         await connection.WriteAsync(CompletionMessage.WithError(invocationId, errorMessage));
     }
 
-    private void InitializeHub(THub hub, HubConnectionContext connection, bool invokeAllowed = true)
+    private void InitializeHub(
+        THub hub,
+        HubConnectionContext connection,
+        HubCallerContext hubCallerContext,
+        bool invokeAllowed = true)
     {
-        hub.Clients = new HubCallerClients(_hubContext.Clients, connection.ConnectionId, connection.ActiveInvocationLimit) { InvokeAllowed = invokeAllowed };
-        hub.Context = connection.HubCallerContext;
+        hub.Clients = new HubCallerClients(_hubContext.Clients, connection.ConnectionId, connection.ActiveInvocationLimit)
+        {
+            InvokeAllowed = invokeAllowed
+        };
+        hub.Context = hubCallerContext;
         hub.Groups = _hubContext.Groups;
     }
 
-    private static Task<bool> IsHubMethodAuthorized(IServiceProvider provider, HubConnectionContext hubConnectionContext, HubMethodDescriptor descriptor, object?[] hubMethodArguments, Hub hub)
+    private static Task<bool> IsHubMethodAuthorized(
+        IServiceProvider provider,
+        HubCallerContext hubCallerContext,
+        HubMethodDescriptor descriptor,
+        object?[] hubMethodArguments,
+        Hub hub)
     {
         // If there are no policies we don't need to run auth
         if (descriptor.Policies.Count == 0)
@@ -703,7 +764,11 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
             return TaskCache.True;
         }
 
-        return IsHubMethodAuthorizedSlow(provider, hubConnectionContext.User, descriptor.Policies, new HubInvocationContext(hubConnectionContext.HubCallerContext, provider, hub, descriptor.MethodExecutor.MethodInfo, hubMethodArguments));
+        return IsHubMethodAuthorizedSlow(
+            provider,
+            hubCallerContext.User ?? new ClaimsPrincipal(),
+            descriptor.Policies,
+            new HubInvocationContext(hubCallerContext, provider, hub, descriptor.MethodExecutor.MethodInfo, hubMethodArguments));
     }
 
     private static async Task<bool> IsHubMethodAuthorizedSlow(IServiceProvider provider, ClaimsPrincipal principal, IList<IAuthorizeData> policies, HubInvocationContext resource)

--- a/src/SignalR/server/Core/src/Internal/HubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/HubDispatcher.cs
@@ -10,6 +10,7 @@ internal abstract class HubDispatcher<[DynamicallyAccessedMembers(Hub.Dynamicall
 {
     public abstract Task OnConnectedAsync(HubConnectionContext connection);
     public abstract Task OnDisconnectedAsync(HubConnectionContext connection, Exception? exception);
+    public abstract Task OnAuthenticationRefreshedAsync(HubConnectionContext connection);
     public abstract Task DispatchMessageAsync(HubConnectionContext connection, HubMessage hubMessage);
     public abstract IReadOnlyList<Type> GetParameterTypes(string name);
     public abstract string? GetTargetName(ReadOnlySpan<byte> targetUtf8Bytes);

--- a/src/SignalR/server/Core/src/Internal/SignalRServerActivitySource.cs
+++ b/src/SignalR/server/Core/src/Internal/SignalRServerActivitySource.cs
@@ -14,6 +14,7 @@ internal sealed class SignalRServerActivitySource
     internal const string InvocationIn = $"{Name}.InvocationIn";
     internal const string OnConnected = $"{Name}.OnConnected";
     internal const string OnDisconnected = $"{Name}.OnDisconnected";
+    internal const string OnAuthenticationRefreshed = $"{Name}.OnAuthenticationRefreshed";
 
     public ActivitySource ActivitySource { get; } = new ActivitySource(Name);
 }

--- a/src/SignalR/server/Core/src/PublicAPI.Unshipped.txt
+++ b/src/SignalR/server/Core/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+virtual Microsoft.AspNetCore.SignalR.Hub.OnAuthenticationRefreshedAsync() -> System.Threading.Tasks.Task!

--- a/src/SignalR/server/SignalR/test/Microsoft.AspNetCore.SignalR.Tests/DefaultHubLifetimeManagerTests.cs
+++ b/src/SignalR/server/SignalR/test/Microsoft.AspNetCore.SignalR.Tests/DefaultHubLifetimeManagerTests.cs
@@ -219,4 +219,5 @@ public class DefaultHubLifetimeManagerTests : HubLifetimeManagerTestsBase<Hub>
             Assert.False(connection2.ConnectionAborted.IsCancellationRequested);
         }
     }
+
 }

--- a/src/SignalR/server/SignalR/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.AuthenticationRefresh.cs
+++ b/src/SignalR/server/SignalR/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.AuthenticationRefresh.cs
@@ -1,0 +1,607 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Connections.Features;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.SignalR.Tests;
+
+public partial class HubConnectionHandlerTests
+{
+    [Fact]
+    public async Task UserPropertyReflectsLatestPrincipalAfterUserRefreshedCallback()
+    {
+        using (StartVerifiableLog())
+        {
+            var hubObserver = new AuthenticationRefreshObserver();
+            var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(
+                services => services.AddSingleton(hubObserver), LoggerFactory);
+            var connectionHandler = serviceProvider.GetService<HubConnectionHandler<AuthenticationRefreshHub>>();
+
+            using (var client = new TestClient())
+            {
+                var feature = new TestConnectionUserRefreshFeature();
+                client.Connection.Features.Set<IConnectionUserRefreshFeature>(feature);
+
+                var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+
+                var firstNameClaim = await client.InvokeAsync(nameof(AuthenticationRefreshHub.GetUserName)).DefaultTimeout();
+                Assert.Null(firstNameClaim.Error);
+                var originalName = (string?)firstNameClaim.Result;
+                Assert.False(string.IsNullOrEmpty(originalName));
+
+                var refreshedUser = new ClaimsPrincipal(new ClaimsIdentity(new[]
+                {
+                    new Claim(ClaimTypes.Name, "refreshed-user"),
+                }, "Test"));
+                client.Connection.User = refreshedUser;
+                feature.Raise(refreshedUser);
+                await hubObserver.RefreshedTask.DefaultTimeout();
+
+                var secondNameClaim = await client.InvokeAsync(nameof(AuthenticationRefreshHub.GetUserName)).DefaultTimeout();
+                Assert.Null(secondNameClaim.Error);
+                Assert.Equal("refreshed-user", secondNameClaim.Result);
+
+                client.Dispose();
+                await connectionHandlerTask.DefaultTimeout();
+            }
+        }
+    }
+
+    [Fact]
+    public async Task UserIdentifierIsAvailableBeforeAuthenticationRefresh()
+    {
+        using (StartVerifiableLog())
+        {
+            var hubObserver = new AuthenticationRefreshObserver();
+            var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(
+                services => services.AddSingleton(hubObserver), LoggerFactory);
+            var connectionHandler = serviceProvider.GetService<HubConnectionHandler<AuthenticationRefreshHub>>();
+
+            using (var client = new TestClient(userIdentifier: "initial-user"))
+            {
+                var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+
+                var pair = await client.InvokeAsync(nameof(AuthenticationRefreshHub.GetUserNameIdentifierAndUserIdentifier)).DefaultTimeout();
+                Assert.Null(pair.Error);
+                Assert.Equal("initial-user:initial-user", pair.Result);
+
+                client.Dispose();
+                await connectionHandlerTask.DefaultTimeout();
+            }
+        }
+    }
+
+    [Fact]
+    public async Task UserRefreshedFeatureCallbackDispatchesOnAuthenticationRefreshedAsyncToHub()
+    {
+        using (StartVerifiableLog())
+        {
+            var hubObserver = new AuthenticationRefreshObserver();
+            var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(
+                services => services.AddSingleton(hubObserver), LoggerFactory);
+            var connectionHandler = serviceProvider.GetService<HubConnectionHandler<AuthenticationRefreshHub>>();
+
+            using (var client = new TestClient())
+            {
+                var feature = new TestConnectionUserRefreshFeature();
+                client.Connection.Features.Set<IConnectionUserRefreshFeature>(feature);
+
+                var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+
+                var previousUser = client.Connection.User;
+                Assert.NotNull(previousUser);
+                var refreshedUser = new ClaimsPrincipal(new ClaimsIdentity(new[]
+                {
+                    new Claim(ClaimTypes.Name, "refreshed"),
+                    new Claim("scope", "extra"),
+                }, "Test"));
+                client.Connection.User = refreshedUser;
+                feature.Raise(refreshedUser);
+
+                var captured = await hubObserver.RefreshedTask.DefaultTimeout();
+                Assert.Equal("refreshed", captured);
+
+                client.Dispose();
+                await connectionHandlerTask.DefaultTimeout();
+            }
+        }
+    }
+
+    [Fact]
+    public async Task OnAuthenticationRefreshedAsyncSerializesWithInFlightHubInvocation()
+    {
+        using (StartVerifiableLog())
+        {
+            var hubObserver = new AuthenticationRefreshObserver();
+            var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(
+                services => services.AddSingleton(hubObserver), LoggerFactory);
+            var connectionHandler = serviceProvider.GetService<HubConnectionHandler<AuthenticationRefreshHub>>();
+
+            using (var client = new TestClient())
+            {
+                var feature = new TestConnectionUserRefreshFeature();
+                client.Connection.Features.Set<IConnectionUserRefreshFeature>(feature);
+
+                var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+
+                var invokeTask = client.InvokeAsync(nameof(AuthenticationRefreshHub.BlockUntilSignaled));
+                await hubObserver.HubMethodStarted.Task.DefaultTimeout();
+
+                var previousUser = client.Connection.User;
+                Assert.NotNull(previousUser);
+                var refreshedUser = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, "after") }, "Test"));
+                client.Connection.User = refreshedUser;
+                feature.Raise(refreshedUser);
+
+                Assert.False(hubObserver.RefreshedTask.IsCompleted);
+                await Task.Delay(50);
+                Assert.False(hubObserver.RefreshedTask.IsCompleted);
+
+                hubObserver.ReleaseHubMethod.SetResult();
+                var completion = await invokeTask.DefaultTimeout();
+                Assert.Null(completion.Error);
+                Assert.Equal(previousUser.Identity?.Name, await hubObserver.BlockedMethodUserNameAfterRelease.Task.DefaultTimeout());
+
+                var captured = await hubObserver.RefreshedTask.DefaultTimeout();
+                Assert.Equal("after", captured);
+
+                client.Dispose();
+                await connectionHandlerTask.DefaultTimeout();
+            }
+        }
+    }
+
+    [Fact]
+    public async Task RefreshWithSameUserIdentifierDoesNotAbortAndDispatches()
+    {
+        using (StartVerifiableLog())
+        {
+            var hubObserver = new AuthenticationRefreshObserver();
+            var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(
+                services => services.AddSingleton(hubObserver), LoggerFactory);
+            var connectionHandler = serviceProvider.GetService<HubConnectionHandler<AuthenticationRefreshHub>>();
+
+            using (var client = new TestClient(userIdentifier: "stable-user"))
+            {
+                var feature = new TestConnectionUserRefreshFeature();
+                client.Connection.Features.Set<IConnectionUserRefreshFeature>(feature);
+
+                var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+
+                var previousUser = client.Connection.User;
+                Assert.NotNull(previousUser);
+                // Same NameIdentifier (so DefaultUserIdProvider returns the same id), different other claims.
+                var refreshedUser = new ClaimsPrincipal(new ClaimsIdentity(new[]
+                {
+                    new Claim(ClaimTypes.NameIdentifier, "stable-user"),
+                    new Claim("role", "admin"),
+                }, "Test"));
+                client.Connection.User = refreshedUser;
+                feature.Raise(refreshedUser);
+
+                await hubObserver.RefreshedTask.DefaultTimeout();
+
+                var seenUser = await client.InvokeAsync(nameof(AuthenticationRefreshHub.GetUserClaim), "role").DefaultTimeout();
+                Assert.Null(seenUser.Error);
+                Assert.Equal("admin", seenUser.Result);
+
+                client.Dispose();
+                await connectionHandlerTask.DefaultTimeout();
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ExceptionFromOnAuthenticationRefreshedAsyncIsLoggedAndConnectionSurvives()
+    {
+        using (StartVerifiableLog(write => write.EventId.Name == "FailedInvokingHubMethod"))
+        {
+            var hubObserver = new AuthenticationRefreshObserver { ThrowFromOnAuthenticationRefreshed = true };
+            var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(
+                services => services.AddSingleton(hubObserver), LoggerFactory);
+            var connectionHandler = serviceProvider.GetService<HubConnectionHandler<AuthenticationRefreshHub>>();
+
+            using (var client = new TestClient())
+            {
+                var feature = new TestConnectionUserRefreshFeature();
+                client.Connection.Features.Set<IConnectionUserRefreshFeature>(feature);
+
+                var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+
+                var previousUser = client.Connection.User;
+                Assert.NotNull(previousUser);
+                var refreshedUser = new ClaimsPrincipal(new ClaimsIdentity(new[]
+                {
+                    new Claim(ClaimTypes.Name, "after"),
+                }, "Test"));
+                client.Connection.User = refreshedUser;
+                feature.Raise(refreshedUser);
+
+                // Wait until the hub method ran (and threw).
+                await hubObserver.RefreshedTask.DefaultTimeout();
+
+                // Semaphore must have been released — a subsequent invocation should complete.
+                var nameResult = await client.InvokeAsync(nameof(AuthenticationRefreshHub.GetUserName)).DefaultTimeout();
+                Assert.Null(nameResult.Error);
+                Assert.Equal("after", nameResult.Result);
+
+                client.Dispose();
+                await connectionHandlerTask.DefaultTimeout();
+            }
+        }
+    }
+
+    [Fact]
+    public async Task MultipleRefreshesEachDispatchInOrder()
+    {
+        using (StartVerifiableLog())
+        {
+            var hubObserver = new AuthenticationRefreshObserver { CaptureAll = true };
+            var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(
+                services => services.AddSingleton(hubObserver), LoggerFactory);
+            var connectionHandler = serviceProvider.GetService<HubConnectionHandler<AuthenticationRefreshHub>>();
+
+            using (var client = new TestClient())
+            {
+                var feature = new TestConnectionUserRefreshFeature();
+                client.Connection.Features.Set<IConnectionUserRefreshFeature>(feature);
+
+                var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+
+                var user1 = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, "u1") }, "Test"));
+                var user2 = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, "u2") }, "Test"));
+                var user3 = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, "u3") }, "Test"));
+
+                client.Connection.User = user1;
+                feature.Raise(user1);
+                client.Connection.User = user2;
+                feature.Raise(user2);
+                client.Connection.User = user3;
+                feature.Raise(user3);
+
+                await hubObserver.AllRefreshesCompleted(3).DefaultTimeout();
+                var captured = hubObserver.AllCapturedUserNames;
+                Assert.Equal(3, captured.Count);
+                Assert.Equal("u1", captured[0]);
+                Assert.Equal("u2", captured[1]);
+                Assert.Equal("u3", captured[2]);
+
+                client.Dispose();
+                await connectionHandlerTask.DefaultTimeout();
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ConnectionWithoutUserRefreshFeatureStillWorks()
+    {
+        using (StartVerifiableLog())
+        {
+            var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(_ => { }, LoggerFactory);
+            var connectionHandler = serviceProvider.GetService<HubConnectionHandler<MethodHub>>();
+
+            using (var client = new TestClient())
+            {
+                Assert.Null(client.Connection.Features.Get<IConnectionUserRefreshFeature>());
+
+                var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+
+                var completion = await client.InvokeAsync(nameof(MethodHub.Echo), "ping").DefaultTimeout();
+                Assert.Null(completion.Error);
+                Assert.Equal("ping", completion.Result);
+
+                client.Dispose();
+                await connectionHandlerTask.DefaultTimeout();
+            }
+        }
+    }
+
+    [Fact]
+    public async Task UserIdentifierChangeOnRefreshAbortsConnection()
+    {
+        using (StartVerifiableLog(write => write.EventId.Name == "UserIdentifierChangedOnRefresh"))
+        {
+            var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(_ => { }, LoggerFactory);
+            var connectionHandler = serviceProvider.GetService<HubConnectionHandler<MethodHub>>();
+
+            using (var client = new TestClient(userIdentifier: "user-1"))
+            {
+                var feature = new TestConnectionUserRefreshFeature();
+                client.Connection.Features.Set<IConnectionUserRefreshFeature>(feature);
+
+                var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+
+                var refreshedUser = new ClaimsPrincipal(new ClaimsIdentity(new[]
+                {
+                    new Claim(ClaimTypes.NameIdentifier, "user-2"),
+                }, "Test"));
+                client.Connection.User = refreshedUser;
+                feature.Raise(refreshedUser);
+
+                await connectionHandlerTask.DefaultTimeout();
+            }
+        }
+    }
+
+    [Fact]
+    public async Task UserIdProviderExceptionOnRefreshIsLoggedAndAbortsConnection()
+    {
+        using (StartVerifiableLog(write => write.EventId.Name == "ErrorApplyingAuthenticationRefresh"))
+        {
+            var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(
+                services => services.AddSingleton<IUserIdProvider, ThrowingRefreshUserIdProvider>(),
+                LoggerFactory);
+            var connectionHandler = serviceProvider.GetService<HubConnectionHandler<MethodHub>>();
+
+            using (var client = new TestClient(userIdentifier: "stable-user"))
+            {
+                var feature = new TestConnectionUserRefreshFeature();
+                client.Connection.Features.Set<IConnectionUserRefreshFeature>(feature);
+
+                var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+
+                var refreshedUser = new ClaimsPrincipal(new ClaimsIdentity(new[]
+                {
+                    new Claim(ClaimTypes.NameIdentifier, "stable-user"),
+                    new Claim("throw", "true"),
+                }, "Test"));
+                client.Connection.User = refreshedUser;
+                feature.Raise(refreshedUser);
+
+                await connectionHandlerTask.DefaultTimeout();
+            }
+        }
+    }
+
+    [Fact]
+    public async Task RefreshAddingRequiredClaimAllowsAuthorizedHubMethod()
+    {
+        using (StartVerifiableLog())
+        {
+            var hubObserver = new AuthenticationRefreshObserver();
+            var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(services =>
+            {
+                services.AddSingleton(hubObserver);
+                services.AddAuthorization(options =>
+                {
+                    options.AddPolicy("scope-policy", policy =>
+                    {
+                        policy.RequireClaim("scope", "admin");
+                        policy.AddAuthenticationSchemes("Default");
+                    });
+                });
+            }, LoggerFactory);
+            var connectionHandler = serviceProvider.GetService<HubConnectionHandler<AuthenticationRefreshHub>>();
+
+            using (var client = new TestClient(userIdentifier: "alice"))
+            {
+                client.Connection.User!.AddIdentity(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "alice") }));
+                var feature = new TestConnectionUserRefreshFeature();
+                client.Connection.Features.Set<IConnectionUserRefreshFeature>(feature);
+
+                var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+
+                // No "scope" claim yet -> policy denies.
+                var denied = await client.InvokeAsync(nameof(AuthenticationRefreshHub.ScopeProtected)).DefaultTimeout();
+                Assert.NotNull(denied.Error);
+                Assert.Contains("Failed to invoke", denied.Error);
+
+                // Refresh adds the required claim while preserving NameIdentifier so UserIdentifier doesn't change.
+                var refreshedUser = new ClaimsPrincipal(new ClaimsIdentity(new[]
+                {
+                    new Claim(ClaimTypes.NameIdentifier, "alice"),
+                    new Claim("scope", "admin"),
+                }, "Default"));
+                client.Connection.User = refreshedUser;
+                feature.Raise(refreshedUser);
+                await hubObserver.RefreshedTask.DefaultTimeout();
+
+                var allowed = await client.InvokeAsync(nameof(AuthenticationRefreshHub.ScopeProtected)).DefaultTimeout();
+                Assert.Null(allowed.Error);
+                Assert.Equal("ok", allowed.Result);
+
+                client.Dispose();
+                await connectionHandlerTask.DefaultTimeout();
+            }
+        }
+    }
+
+    [Fact]
+    public async Task RefreshRemovingRequiredClaimBlocksAuthorizedHubMethod()
+    {
+        using (StartVerifiableLog())
+        {
+            var hubObserver = new AuthenticationRefreshObserver();
+            var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(services =>
+            {
+                services.AddSingleton(hubObserver);
+                services.AddAuthorization(options =>
+                {
+                    options.AddPolicy("scope-policy", policy =>
+                    {
+                        policy.RequireClaim("scope", "admin");
+                        policy.AddAuthenticationSchemes("Default");
+                    });
+                });
+            }, LoggerFactory);
+            var connectionHandler = serviceProvider.GetService<HubConnectionHandler<AuthenticationRefreshHub>>();
+
+            using (var client = new TestClient(userIdentifier: "alice"))
+            {
+                client.Connection.User!.AddIdentity(new ClaimsIdentity(new[]
+                {
+                    new Claim(ClaimTypes.NameIdentifier, "alice"),
+                    new Claim("scope", "admin"),
+                }));
+                var feature = new TestConnectionUserRefreshFeature();
+                client.Connection.Features.Set<IConnectionUserRefreshFeature>(feature);
+
+                var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+
+                var allowed = await client.InvokeAsync(nameof(AuthenticationRefreshHub.ScopeProtected)).DefaultTimeout();
+                Assert.Null(allowed.Error);
+                Assert.Equal("ok", allowed.Result);
+
+                // Refresh drops the scope claim but keeps NameIdentifier so the connection isn't aborted.
+                var refreshedUser = new ClaimsPrincipal(new ClaimsIdentity(new[]
+                {
+                    new Claim(ClaimTypes.NameIdentifier, "alice"),
+                }, "Default"));
+                client.Connection.User = refreshedUser;
+                feature.Raise(refreshedUser);
+                await hubObserver.RefreshedTask.DefaultTimeout();
+
+                var denied = await client.InvokeAsync(nameof(AuthenticationRefreshHub.ScopeProtected)).DefaultTimeout();
+                Assert.NotNull(denied.Error);
+                Assert.Contains("Failed to invoke", denied.Error);
+
+                client.Dispose();
+                await connectionHandlerTask.DefaultTimeout();
+            }
+        }
+    }
+
+    private sealed class TestConnectionUserRefreshFeature : IConnectionUserRefreshFeature
+    {
+        private Action<ClaimsPrincipal, object?>? _callback;
+        private object? _state;
+
+        public IDisposable OnUserRefreshed(Action<ClaimsPrincipal, object?> callback, object? state)
+        {
+            _callback = callback;
+            _state = state;
+
+            return new CallbackRegistration(this);
+        }
+
+        public void Raise(ClaimsPrincipal current)
+        {
+            _callback?.Invoke(current, _state);
+        }
+
+        private sealed class CallbackRegistration(TestConnectionUserRefreshFeature feature) : IDisposable
+        {
+            public void Dispose()
+            {
+                feature._callback = null;
+                feature._state = null;
+            }
+        }
+    }
+
+    private sealed class AuthenticationRefreshObserver
+    {
+        private readonly TaskCompletionSource<string?> _tcs =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly List<string?> _allCaptured = new();
+        private readonly object _allLock = new();
+        private TaskCompletionSource? _allTcs;
+        private int _waitedCount;
+
+        public Task<string?> RefreshedTask => _tcs.Task;
+
+        public TaskCompletionSource HubMethodStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource ReleaseHubMethod { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource<string?> BlockedMethodUserNameAfterRelease { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public bool ThrowFromOnAuthenticationRefreshed { get; set; }
+
+        public bool CaptureAll { get; set; }
+
+        public IReadOnlyList<string?> AllCapturedUserNames
+        {
+            get { lock (_allLock) { return _allCaptured.ToArray(); } }
+        }
+
+        public Task AllRefreshesCompleted(int count)
+        {
+            lock (_allLock)
+            {
+                _waitedCount = count;
+                _allTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                if (_allCaptured.Count >= count)
+                {
+                    _allTcs.TrySetResult();
+                }
+                return _allTcs.Task;
+            }
+        }
+
+        public void Capture(string? contextUserName)
+        {
+            if (CaptureAll)
+            {
+                lock (_allLock)
+                {
+                    _allCaptured.Add(contextUserName);
+                    if (_allTcs is not null && _allCaptured.Count >= _waitedCount)
+                    {
+                        _allTcs.TrySetResult();
+                    }
+                }
+            }
+
+            _tcs.TrySetResult(contextUserName);
+        }
+    }
+
+    private sealed class AuthenticationRefreshHub : Hub
+    {
+        private readonly AuthenticationRefreshObserver _observer;
+
+        public AuthenticationRefreshHub(AuthenticationRefreshObserver observer)
+        {
+            _observer = observer;
+        }
+
+        public string? GetUserName() => Context.User?.Identity?.Name;
+
+        public string? GetUserClaim(string type) => Context.User?.FindFirst(type)?.Value;
+
+        public string? GetUserNameIdentifierAndUserIdentifier()
+        {
+            return $"{Context.User?.FindFirst(ClaimTypes.NameIdentifier)?.Value}:{Context.UserIdentifier}";
+        }
+
+        [Authorize("scope-policy")]
+        public string ScopeProtected() => "ok";
+
+        public async Task BlockUntilSignaled()
+        {
+            _observer.HubMethodStarted.TrySetResult();
+            await _observer.ReleaseHubMethod.Task;
+            _observer.BlockedMethodUserNameAfterRelease.TrySetResult(Context.User?.Identity?.Name);
+        }
+
+        public override Task OnAuthenticationRefreshedAsync()
+        {
+            _observer.Capture(Context.User?.Identity?.Name);
+            if (_observer.ThrowFromOnAuthenticationRefreshed)
+            {
+                throw new InvalidOperationException("boom from OnAuthenticationRefreshedAsync");
+            }
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ThrowingRefreshUserIdProvider : IUserIdProvider
+    {
+        public string? GetUserId(HubConnectionContext connection)
+        {
+            if (connection.User.HasClaim("throw", "true"))
+            {
+                throw new InvalidOperationException("boom from IUserIdProvider");
+            }
+
+            return connection.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        }
+    }
+}

--- a/src/SignalR/server/SignalR/test/Microsoft.AspNetCore.SignalR.Tests/MapSignalRTests.cs
+++ b/src/SignalR/server/SignalR/test/Microsoft.AspNetCore.SignalR.Tests/MapSignalRTests.cs
@@ -5,6 +5,7 @@ using System;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -140,6 +141,44 @@ public class MapSignalRTests
         }
 
         Assert.Equal(0, authCount);
+    }
+
+    [Fact]
+    public void MapHubAppliesAuthMetadataToRefreshEndpoint()
+    {
+        var policy1 = new AuthorizationPolicyBuilder().RequireAssertion(_ => true).Build();
+        var req = new TestRequirement();
+        using (var host = BuildWebHost(routes => routes.MapHub<AuthHub>("/path", options =>
+        {
+            options.EnableAuthenticationRefresh = true;
+        })
+        .RequireAuthorization(policy1)
+        .RequireAuthorization(policy => policy.AddRequirements(req))))
+        {
+            host.Start();
+
+            var dataSource = host.Services.GetRequiredService<EndpointDataSource>();
+            // We register 3 endpoints (/negotiate, /refresh and /)
+            Assert.Collection(dataSource.Endpoints,
+                endpoint =>
+                {
+                    Assert.Equal("/path/negotiate", endpoint.DisplayName);
+                    AssertAuthMetadata(endpoint, policy1, req);
+                    Assert.Null(endpoint.Metadata.GetMetadata<AuthenticationRefreshMetadata>());
+                },
+                endpoint =>
+                {
+                    Assert.Equal("/path/refresh", endpoint.DisplayName);
+                    AssertAuthMetadata(endpoint, policy1, req);
+                    Assert.NotNull(endpoint.Metadata.GetMetadata<AuthenticationRefreshMetadata>());
+                },
+                endpoint =>
+                {
+                    Assert.Equal("/path", endpoint.DisplayName);
+                    AssertAuthMetadata(endpoint, policy1, req);
+                    Assert.Null(endpoint.Metadata.GetMetadata<AuthenticationRefreshMetadata>());
+                });
+        }
     }
 
     [Fact]
@@ -390,6 +429,16 @@ public class MapSignalRTests
 
     private class TestRequirement : IAuthorizationRequirement
     {
+    }
+
+    private static void AssertAuthMetadata(Endpoint endpoint, AuthorizationPolicy policy, TestRequirement requirement)
+    {
+        Assert.Single(endpoint.Metadata.GetOrderedMetadata<IAuthorizeData>());
+        var policies = endpoint.Metadata.GetOrderedMetadata<AuthorizationPolicy>();
+        Assert.Equal(2, policies.Count);
+        Assert.Equal(policy, policies[0]);
+        Assert.Single(policies[1].Requirements);
+        Assert.Equal(requirement, policies[1].Requirements.First());
     }
 
     private IHost BuildWebHost(Action<IEndpointRouteBuilder> configure)

--- a/src/SignalR/server/StackExchangeRedis/src/RedisHubLifetimeManager.cs
+++ b/src/SignalR/server/StackExchangeRedis/src/RedisHubLifetimeManager.cs
@@ -103,7 +103,7 @@ public class RedisHubLifetimeManager<THub> : HubLifetimeManager<THub>, IDisposab
 
         if (!string.IsNullOrEmpty(connection.UserIdentifier))
         {
-            userTask = SubscribeToUser(connection);
+            userTask = SubscribeToUser(connection, connection.UserIdentifier);
         }
 
         await Task.WhenAll(connectionTask, userTask);
@@ -143,7 +143,7 @@ public class RedisHubLifetimeManager<THub> : HubLifetimeManager<THub>, IDisposab
 
         if (!string.IsNullOrEmpty(connection.UserIdentifier))
         {
-            tasks.Add(RemoveUserAsync(connection));
+            tasks.Add(RemoveUserAsync(connection, connection.UserIdentifier));
         }
 
         return Task.WhenAll(tasks);
@@ -354,9 +354,9 @@ public class RedisHubLifetimeManager<THub> : HubLifetimeManager<THub>, IDisposab
         await ack;
     }
 
-    private Task RemoveUserAsync(HubConnectionContext connection)
+    private Task RemoveUserAsync(HubConnectionContext connection, string userIdentifier)
     {
-        var userChannel = _channels.User(connection.UserIdentifier!);
+        var userChannel = _channels.User(userIdentifier);
 
         return _users.RemoveSubscriptionAsync(userChannel, connection, this, static (state, channelName) =>
         {
@@ -580,9 +580,9 @@ public class RedisHubLifetimeManager<THub> : HubLifetimeManager<THub>, IDisposab
         });
     }
 
-    private Task SubscribeToUser(HubConnectionContext connection)
+    private Task SubscribeToUser(HubConnectionContext connection, string userIdentifier)
     {
-        var userChannel = _channels.User(connection.UserIdentifier!);
+        var userChannel = _channels.User(userIdentifier);
 
         return _users.AddSubscriptionAsync(userChannel, connection, async (channelName, subscriptions) =>
         {


### PR DESCRIPTION
Backport of #67111 to `release/11.0-preview6`.

Cherry-picked from 8835dfcb307bdb30d975c2038b94d0a6d2d61724 (clean, no conflicts).

## Description

Adds SignalR Auth Refresh support to the server and .NET client.

**Server-side:**
- Add `/refresh` HTTP endpoint mapped alongside `/negotiate`
- Add `tokenLifetimeSeconds` to negotiate response (NegotiationResponse + NegotiateProtocol)
- Server re-authenticates on `/refresh` and updates connection's User and auth expiration
- Compute TTL from `AuthenticationProperties.ExpiresUtc`
- New virtual `Hub.OnAuthRefreshedAsync()` lifecycle hook

**.NET Client-side:**
- Add `IAuthRefreshFeature` interface in Connections.Abstractions
- `HttpConnection` implements `IAuthRefreshFeature`, POSTs to `/refresh` endpoint
- `HubConnection.RefreshAuthAsync()` discovers `IAuthRefreshFeature` via Features collection
- Auto-refresh timer schedules at: now + TTL - RefreshBeforeExpiration (default 5 min)

## Verification
- Changed production projects build cleanly.
- Server `HubConnectionHandlerTests.AuthenticationRefresh` and client `HttpConnection`/`HubConnection` auth-refresh unit tests pass locally.

/cc @BrennanConroy