### PR TITLE
Pin Node.js to 24.14.1 to avoid v24.15.0+ native crash

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -179,16 +179,16 @@ jobs:
           displayName: Start background dump collection
       - ${{ if eq(parameters.installNodeJs, 'true') }}:
         - task: UseNode@1
-          displayName: Install Node 24.x
+          displayName: Install Node 24.14.1
           inputs:
-            version: 24.x
+            version: 24.14.1
         - task: Cache@2
           displayName: Cache node_modules
           continueOnError: true
           inputs:
-            key: '"node_modules" | "node24" | "$(Agent.OS)" | $(Build.SourcesDirectory)/package-lock.json'
+            key: '"node_modules" | "node24.14.1" | "$(Agent.OS)" | $(Build.SourcesDirectory)/package-lock.json'
             restoreKeys: |
-              "node_modules" | "node24" | "$(Agent.OS)"
+              "node_modules" | "node24.14.1" | "$(Agent.OS)"
             path: node_modules
       - ${{ if and(eq(parameters.agentOs, 'Windows'), eq(parameters.isAzDOTestingJob, true)) }}:
         - powershell: |
@@ -433,16 +433,16 @@ jobs:
           displayName: Start background dump collection
       - ${{ if eq(parameters.installNodeJs, 'true') }}:
         - task: UseNode@1
-          displayName: Install Node 24.x
+          displayName: Install Node 24.14.1
           inputs:
-            version: 24.x
+            version: 24.14.1
         - task: Cache@2
           displayName: Cache node_modules
           continueOnError: true
           inputs:
-            key: '"node_modules" | "node24" | "$(Agent.OS)" | $(Build.SourcesDirectory)/package-lock.json'
+            key: '"node_modules" | "node24.14.1" | "$(Agent.OS)" | $(Build.SourcesDirectory)/package-lock.json'
             restoreKeys: |
-              "node_modules" | "node24" | "$(Agent.OS)"
+              "node_modules" | "node24.14.1" | "$(Agent.OS)"
             path: node_modules
       - ${{ if eq(parameters.agentOs, 'Windows') }}:
         - powershell: Write-Host "##vso[task.prependpath]$(DOTNET_CLI_HOME)\.dotnet\tools"


### PR DESCRIPTION
## Problem

Node.js **v24.15.0 and every later 24.x release** (24.16.0, 24.17.0, 24.18.0) cause **intermittent native crashes in `node.exe`** on Windows CI agents. The current signature is a Windows access violation during the rollup bundling step of the Components JS build:

```
npm error code 3221225477          # 0xC0000005 (STATUS_ACCESS_VIOLATION)
npm error command ... rollup -c --environment development --forceExit
eng\\Npm.Workspace.nodeproj(161,5): error MSB3073: ... exited with code -1073741819.
```

## Crash frequency per Node version (Build: Windows leg, past 7 days)

| Node | Released | Rollup crashes observed |
|---|---|---|
| 24.14.1 | Mar 24 | **0** |
| 24.16.0 | May 21 | 2 |
| 24.17.0 | Jun 17 | 3 |
| 24.18.0 | Jun 23 | 4 |

The crash spans the **entire post-24.15.0 line** — it is not unique to 24.18.0 (an earlier draft of this PR incorrectly pinned 24.17.0; data shows 24.17.0 also crashes). Frequency rises with each release. Example crashing builds: 1469128/1470089 (24.16.0), 1470543/1471858/1473856 (24.17.0), 1478676/1478854/1478907/1479647 (24.18.0).

## Context — repeat offender

This matches the earlier **v24.15.0** incident (0xDEAD during npm-ci extraction) that led to the original 24.14.1 pin (#66465 / #66621), reverted in #66979. With the pin gone, `24.x` floated up through 24.16/24.17/24.18 and hit the same class of upstream native crash. v24.14.1 ran Apr 24–Jun 8 with zero crashes.

## Fix

Re-pin to **24.14.1** (last release with zero observed crashes) in both `UseNode@1` blocks of `default-build.yml`, and bump cache keys `node24` → `node24.14.1`. This is an upstream Node/V8 Windows regression, so a code-side fix isn't viable; pin until a fixed 24.x ships.