### PR TITLE
Fix typos in code

### DIFF
--- a/src/Analyzers/Analyzers/src/StartupFacts.cs
+++ b/src/Analyzers/Analyzers/src/StartupFacts.cs
@@ -20,7 +20,7 @@ internal static class StartupFacts
             throw new ArgumentNullException(nameof(type));
         }
 
-        // It's not good enough to just look for a method called ConfigureServices or Configure as a hueristic.
+        // It's not good enough to just look for a method called ConfigureServices or Configure as a heuristic.
         // ConfigureServices might not appear in trivial cases, and Configure might be named ConfigureDevelopment
         // or something similar.
         //

--- a/src/Analyzers/Microsoft.AspNetCore.Analyzer.Testing/src/DiagnosticAnalyzerRunner.cs
+++ b/src/Analyzers/Microsoft.AspNetCore.Analyzer.Testing/src/DiagnosticAnalyzerRunner.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Analyzer.Testing;
 
 /// <summary>
 /// Base type for executing a <see cref="DiagnosticAnalyzer" />. Derived types implemented in the test assembly will
-/// correctly resolve reference assemblies required for compilaiton.
+/// correctly resolve reference assemblies required for compilation.
 /// </summary>
 public abstract class DiagnosticAnalyzerRunner
 {

--- a/src/Antiforgery/src/Internal/IClaimUidExtractor.cs
+++ b/src/Antiforgery/src/Internal/IClaimUidExtractor.cs
@@ -6,7 +6,7 @@ using System.Security.Claims;
 namespace Microsoft.AspNetCore.Antiforgery;
 
 /// <summary>
-/// This interface can extract unique identifers for a <see cref="ClaimsPrincipal"/>.
+/// This interface can extract unique identifiers for a <see cref="ClaimsPrincipal"/>.
 /// </summary>
 internal interface IClaimUidExtractor
 {

--- a/src/Components/Components/src/CascadingValueSource.cs
+++ b/src/Components/Components/src/CascadingValueSource.cs
@@ -28,7 +28,7 @@ public class CascadingValueSource<TValue> : ICascadingValueSupplier
     /// Constructs an instance of <see cref="CascadingValueSource{TValue}"/>.
     /// </summary>
     /// <param name="value">The initial value.</param>
-    /// <param name="isFixed">A flag to indicate whether the value is fixed. If false, all receipients will subscribe for update notifications, which you can issue by calling <see cref="NotifyChangedAsync()"/>. These subscriptions come at a performance cost, so if the value will not change, set <paramref name="isFixed"/> to true.</param>
+    /// <param name="isFixed">A flag to indicate whether the value is fixed. If false, all recipients will subscribe for update notifications, which you can issue by calling <see cref="NotifyChangedAsync()"/>. These subscriptions come at a performance cost, so if the value will not change, set <paramref name="isFixed"/> to true.</param>
     public CascadingValueSource(TValue value, bool isFixed) : this(isFixed)
     {
         _currentValue = value;
@@ -39,7 +39,7 @@ public class CascadingValueSource<TValue> : ICascadingValueSupplier
     /// </summary>
     /// <param name="name">A name for the cascading value. If set, <see cref="CascadingParameterAttribute"/> can be configured to match based on this name.</param>
     /// <param name="value">The initial value.</param>
-    /// <param name="isFixed">A flag to indicate whether the value is fixed. If false, all receipients will subscribe for update notifications, which you can issue by calling <see cref="NotifyChangedAsync()"/>. These subscriptions come at a performance cost, so if the value will not change, set <paramref name="isFixed"/> to true.</param>
+    /// <param name="isFixed">A flag to indicate whether the value is fixed. If false, all recipients will subscribe for update notifications, which you can issue by calling <see cref="NotifyChangedAsync()"/>. These subscriptions come at a performance cost, so if the value will not change, set <paramref name="isFixed"/> to true.</param>
     public CascadingValueSource(string name, TValue value, bool isFixed) : this(value, isFixed)
     {
         ArgumentNullException.ThrowIfNull(name);
@@ -50,7 +50,7 @@ public class CascadingValueSource<TValue> : ICascadingValueSupplier
     /// Constructs an instance of <see cref="CascadingValueSource{TValue}"/>.
     /// </summary>
     /// <param name="initialValueFactory">A callback that produces the initial value when first required.</param>
-    /// <param name="isFixed">A flag to indicate whether the value is fixed. If false, all receipients will subscribe for update notifications, which you can issue by calling <see cref="NotifyChangedAsync()"/>. These subscriptions come at a performance cost, so if the value will not change, set <paramref name="isFixed"/> to true.</param>
+    /// <param name="isFixed">A flag to indicate whether the value is fixed. If false, all recipients will subscribe for update notifications, which you can issue by calling <see cref="NotifyChangedAsync()"/>. These subscriptions come at a performance cost, so if the value will not change, set <paramref name="isFixed"/> to true.</param>
     public CascadingValueSource(Func<TValue> initialValueFactory, bool isFixed) : this(isFixed)
     {
         _initialValueFactory = initialValueFactory;
@@ -61,7 +61,7 @@ public class CascadingValueSource<TValue> : ICascadingValueSupplier
     /// </summary>
     /// <param name="name">A name for the cascading value. If set, <see cref="CascadingParameterAttribute"/> can be configured to match based on this name.</param>
     /// <param name="initialValueFactory">A callback that produces the initial value when first required.</param>
-    /// <param name="isFixed">A flag to indicate whether the value is fixed. If false, all receipients will subscribe for update notifications, which you can issue by calling <see cref="NotifyChangedAsync()"/>. These subscriptions come at a performance cost, so if the value will not change, set <paramref name="isFixed"/> to true.</param>
+    /// <param name="isFixed">A flag to indicate whether the value is fixed. If false, all recipients will subscribe for update notifications, which you can issue by calling <see cref="NotifyChangedAsync()"/>. These subscriptions come at a performance cost, so if the value will not change, set <paramref name="isFixed"/> to true.</param>
     public CascadingValueSource(string name, Func<TValue> initialValueFactory, bool isFixed) : this(initialValueFactory, isFixed)
     {
         ArgumentNullException.ThrowIfNull(name);

--- a/src/Components/Components/src/RenderTree/RenderTreeDiffBuilder.cs
+++ b/src/Components/Components/src/RenderTree/RenderTreeDiffBuilder.cs
@@ -163,7 +163,7 @@ internal static class RenderTreeDiffBuilder
                             //     we can pick either one to handle on this iteration, and the other will be
                             //     found and handled on the next iteration
                             // So all cases can be handled by the following simple criterion, which is pleasingly
-                            // symetrically opposite the case for newKey==null.
+                            // symmetrically opposite the case for newKey==null.
                             action = newKeyIsInOldTree ? DiffAction.Delete : DiffAction.Insert;
                         }
 

--- a/src/Components/Components/src/ResourceAssetCollection.cs
+++ b/src/Components/Components/src/ResourceAssetCollection.cs
@@ -53,7 +53,7 @@ public sealed class ResourceAssetCollection : IReadOnlyList<ResourceAsset>
     /// Gets the unique content-based URL for the specified static asset.
     /// </summary>
     /// <param name="key">The asset name.</param>
-    /// <returns>The unique URL if availabe, the same <paramref name="key"/> if not available.</returns>
+    /// <returns>The unique URL if available, the same <paramref name="key"/> if not available.</returns>
     public string this[string key] => _uniqueUrlMappings.TryGetValue(key, out var value) ? value.Url : key;
 
     /// <summary>

--- a/src/Components/Components/src/Routing/Router.cs
+++ b/src/Components/Components/src/Routing/Router.cs
@@ -292,7 +292,7 @@ public partial class Router : IComponent, IHandleAfterRender, IDisposable
                 Log.DisplayingNotFound(_logger, locationPath, _baseUri);
 
                 // We did not find a Component that matches the route.
-                // Only show the NotFound content if the application developer programatically got us here i.e we did not
+                // Only show the NotFound content if the application developer programmatically got us here i.e we did not
                 // intercept the navigation. In all other cases, force a browser navigation since this could be non-Blazor content.
                 RenderNotFound();
             }

--- a/src/Components/Endpoints/src/FormMapping/Converters/CollectionConverter.cs
+++ b/src/Components/Endpoints/src/FormMapping/Converters/CollectionConverter.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Components.Endpoints.FormMapping;
 // The buffer implements ICollection<T>, so we can add items to it.
 // The buffer does not implement ICollection<T>, so we need to use custom code to add items to it.
 // These aspects are captured in the TCollectionPolicy type parameter.
-// Instead of creating a hierachy with virtual members, we are using generics and virtual interface dispatch to achieve the same result.
+// Instead of creating a hierarchy with virtual members, we are using generics and virtual interface dispatch to achieve the same result.
 // This allows us to avoid virtual dispatch at runtime, and enables us to easily adapt to different types of collections.
 
 internal abstract class CollectionConverter<TCollection> : FormDataConverter<TCollection>
@@ -61,13 +61,13 @@ internal class CollectionConverter<TCollection, TCollectionPolicy, TBuffer, TEle
         TBuffer? buffer = default;
         bool foundCurrentElement;
         bool currentElementSuccess;
-        bool succeded;
+        bool succeeded;
         // Even though we have indexes, we special case 0 an 1 and use literals directly. We leave them in the indexes
         // collection because it makes other indexes align.
         try
         {
             context.PushPrefix("[0]");
-            succeded = _elementConverter.TryRead(ref context, _elementType, options, out currentElement!, out found);
+            succeeded = _elementConverter.TryRead(ref context, _elementType, options, out currentElement!, out found);
         }
         finally
         {
@@ -76,7 +76,7 @@ internal class CollectionConverter<TCollection, TCollectionPolicy, TBuffer, TEle
 
         if (!found)
         {
-            return TryReadSingleValueCollection(ref context, out result, ref found, ref buffer, ref succeded);
+            return TryReadSingleValueCollection(ref context, out result, ref found, ref buffer, ref succeeded);
         }
 
         // We already know we found an element;
@@ -90,7 +90,7 @@ internal class CollectionConverter<TCollection, TCollectionPolicy, TBuffer, TEle
         {
             context.PushPrefix("[1]");
             currentElementSuccess = _elementConverter.TryRead(ref context, _elementType, options, out currentElement!, out foundCurrentElement);
-            succeded = succeded && currentElementSuccess;
+            succeeded = succeeded && currentElementSuccess;
         }
         catch
         {
@@ -127,7 +127,7 @@ internal class CollectionConverter<TCollection, TCollectionPolicy, TBuffer, TEle
             {
                 context.PushPrefix(prefix);
                 currentElementSuccess = _elementConverter.TryRead(ref context, _elementType, options, out currentElement!, out foundCurrentElement);
-                succeded = succeded && currentElementSuccess;
+                succeeded = succeeded && currentElementSuccess;
             }
             catch
             {
@@ -147,11 +147,11 @@ internal class CollectionConverter<TCollection, TCollectionPolicy, TBuffer, TEle
         if (!foundCurrentElement)
         {
             result = TCollectionPolicy.ToResult(buffer);
-            if (!succeded)
+            if (!succeeded)
             {
                 context.AttachInstanceToErrors(result!);
             }
-            return succeded;
+            return succeeded;
         }
 
         // We need to compute the prefix for the index, since it's not precomputed.
@@ -170,7 +170,7 @@ internal class CollectionConverter<TCollection, TCollectionPolicy, TBuffer, TEle
             // We need to compute the prefix for the index, since it's not precomputed.
             if (!index.TryFormat(computedPrefix[1..], out var charsWritten, provider: CultureInfo.InvariantCulture))
             {
-                succeded = false;
+                succeeded = false;
                 break;
             }
 
@@ -179,7 +179,7 @@ internal class CollectionConverter<TCollection, TCollectionPolicy, TBuffer, TEle
                 computedPrefix[charsWritten + 1] = ']';
                 context.PushPrefix(computedPrefix[..(charsWritten + 2)]);
                 currentElementSuccess = _elementConverter.TryRead(ref context, _elementType, options, out currentElement!, out foundCurrentElement);
-                succeded = succeded && currentElementSuccess;
+                succeeded = succeeded && currentElementSuccess;
             }
             catch
             {
@@ -209,15 +209,15 @@ internal class CollectionConverter<TCollection, TCollectionPolicy, TBuffer, TEle
         }
         else
         {
-            if (!succeded)
+            if (!succeeded)
             {
                 context.AttachInstanceToErrors(result!);
             }
-            return succeded;
+            return succeeded;
         }
     }
 
-    private bool TryReadSingleValueCollection(ref FormDataReader context, out TCollection? result, ref bool found, ref TBuffer? buffer, ref bool succeded)
+    private bool TryReadSingleValueCollection(ref FormDataReader context, out TCollection? result, ref bool found, ref TBuffer? buffer, ref bool succeeded)
     {
         if (_elementConverter is ISingleValueConverter<TElement> singleValueConverter &&
             singleValueConverter.CanConvertSingleValue() &&
@@ -233,7 +233,7 @@ internal class CollectionConverter<TCollection, TCollectionPolicy, TBuffer, TEle
                 {
                     if (!singleValueConverter.TryConvertValue(ref context, value!, out var elementValue))
                     {
-                        succeded = false;
+                        succeeded = false;
                     }
                     else
                     {
@@ -242,7 +242,7 @@ internal class CollectionConverter<TCollection, TCollectionPolicy, TBuffer, TEle
                 }
                 catch (Exception ex)
                 {
-                    succeded = false;
+                    succeeded = false;
                     context.AddMappingError(ex, value);
                 }
             };
@@ -254,6 +254,6 @@ internal class CollectionConverter<TCollection, TCollectionPolicy, TBuffer, TEle
             result = default;
         }
 
-        return succeded;
+        return succeeded;
     }
 }

--- a/src/Components/Endpoints/src/FormMapping/Converters/DictionaryConverter.cs
+++ b/src/Components/Endpoints/src/FormMapping/Converters/DictionaryConverter.cs
@@ -37,7 +37,7 @@ internal sealed class DictionaryConverter<TDictionary, TDictionaryPolicy, TBuffe
         TBuffer buffer;
         bool foundCurrentValue;
         bool currentElementSuccess;
-        bool succeded = true;
+        bool succeeded = true;
 
         var keys = context.GetKeys();
         found = keys.HasValues();
@@ -60,12 +60,12 @@ internal sealed class DictionaryConverter<TDictionary, TDictionaryPolicy, TBuffe
         {
             context.PushPrefix(key.Span);
             currentElementSuccess = _valueConverter.TryRead(ref context, _elementType, options, out currentValue!, out foundCurrentValue);
-            succeded &= currentElementSuccess;
+            succeeded &= currentElementSuccess;
             context.PopPrefix(key.Span);
 
             if (!TKey.TryParse(key[1..^1].Span, CultureInfo.InvariantCulture, out var keyValue))
             {
-                succeded = false;
+                succeeded = false;
                 var currentPrefix = context.GetPrefix();
                 context.AddMappingError(
                     FormattableStringFactory.Create(FormDataResources.DictionaryUnparsableKey, key[1..^1], currentPrefix),
@@ -80,7 +80,7 @@ internal sealed class DictionaryConverter<TDictionary, TDictionaryPolicy, TBuffe
                 context.AddMappingError(
                      FormattableStringFactory.Create(FormDataResources.MaxCollectionSizeReached, "dictionary", maxCollectionSize),
                      null);
-                succeded = false;
+                succeeded = false;
                 break;
             }
 
@@ -88,10 +88,10 @@ internal sealed class DictionaryConverter<TDictionary, TDictionaryPolicy, TBuffe
         }
 
         result = TDictionaryPolicy.ToResult(buffer);
-        if (!succeded)
+        if (!succeeded)
         {
             context.AttachInstanceToErrors(result!);
         }
-        return succeded;
+        return succeeded;
     }
 }

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.css
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.css
@@ -18,7 +18,7 @@ th {
 
 /* Deep to make it easy for people adding a sort-indicator element in a custom HeaderTemplate */
 th ::deep .sort-indicator {
-    /* Preset width so the column width doen't change as the sort indicator appears/disappears */
+    /* Preset width so the column width doesn't change as the sort indicator appears/disappears */
     width: 1rem;
     height: 1rem;
     align-self: center;

--- a/src/Components/Server/src/Circuits/CircuitHost.cs
+++ b/src/Components/Server/src/Circuits/CircuitHost.cs
@@ -1012,13 +1012,13 @@ internal partial class CircuitHost : IAsyncDisposable
     {
         try
         {
-            var succeded = await Client.InvokeAsync<bool>(
+            var succeeded = await Client.InvokeAsync<bool>(
                 "JS.SavePersistedState",
                 CircuitId.Secret,
                 rootComponents,
                 applicationState,
                 cancellationToken: cancellation);
-            return succeded;
+            return succeeded;
         }
         catch (Exception ex)
         {
@@ -1132,7 +1132,7 @@ internal partial class CircuitHost : IAsyncDisposable
         [LoggerMessage(210, LogLevel.Debug, "Location change to '{URI}' in circuit '{CircuitId}' failed.", EventName = "LocationChangeFailed")]
         public static partial void LocationChangeFailed(ILogger logger, string uri, CircuitId circuitId, Exception exception);
 
-        [LoggerMessage(211, LogLevel.Debug, "Location is about to change to {URI} in ciruit '{CircuitId}'.", EventName = "LocationChanging")]
+        [LoggerMessage(211, LogLevel.Debug, "Location is about to change to {URI} in circuit '{CircuitId}'.", EventName = "LocationChanging")]
         public static partial void LocationChanging(ILogger logger, string uri, CircuitId circuitId);
 
         [LoggerMessage(212, LogLevel.Debug, "Failed to complete render batch '{RenderId}' in circuit host '{CircuitId}'.", EventName = "OnRenderCompletedFailed")]

--- a/src/Components/Server/src/Circuits/CircuitRegistry.cs
+++ b/src/Components/Server/src/Circuits/CircuitRegistry.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits;
 /// <see cref="DisconnectedCircuits"/> should ensure we no longer have to concern ourselves with entry expiration.
 ///
 /// Knowing when a client disconnected is not an exact science. There's a fair possibility that a client may reconnect before the server realizes.
-/// Consequently, we have to account for reconnects and disconnects occuring simultaneously as well as appearing out of order.
+/// Consequently, we have to account for reconnects and disconnects occurring simultaneously as well as appearing out of order.
 /// To manage this, we use a critical section to manage all state transitions.
 /// </remarks>
 #pragma warning disable CA1852 // Seal internal types
@@ -194,7 +194,7 @@ internal partial class CircuitRegistry
             }
 
             // CircuitHandler events do not need to be executed inside the critical section, however we
-            // a) do not want concurrent execution of handler events i.e. a  OnConnectionDownAsync occuring in tandem with a OnConnectionUpAsync for a single circuit.
+            // a) do not want concurrent execution of handler events i.e. a  OnConnectionDownAsync occurring in tandem with a OnConnectionUpAsync for a single circuit.
             // b) out of order connection-up \ connection-down events e.g. a client that disconnects as soon it finishes reconnecting.
 
             // Dispatch the circuit handlers inside the sync context to ensure the order of execution. CircuitHost executes circuit handlers inside of

--- a/src/Components/Server/src/Circuits/DefaultInMemoryCircuitPersistenceProvider.cs
+++ b/src/Components/Server/src/Circuits/DefaultInMemoryCircuitPersistenceProvider.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Components.Server.Circuits;
 
-// Default implmentation of ICircuitPersistenceProvider that uses an in-memory cache
+// Default implementation of ICircuitPersistenceProvider that uses an in-memory cache
 internal sealed partial class DefaultInMemoryCircuitPersistenceProvider : ICircuitPersistenceProvider
 {
     private readonly Lock _lock = new();

--- a/src/Components/Server/src/ComponentHub.cs
+++ b/src/Components/Server/src/ComponentHub.cs
@@ -426,7 +426,7 @@ internal sealed partial class ComponentHub : Hub
     }
 
     // Client initiated pauses work as follows:
-    // * The client calls PauseCircuit, we dissasociate the circuit from the connection.
+    // * The client calls PauseCircuit, we disassociate the circuit from the connection.
     // * We trigger the circuit pause to collect the current root components and dispose the current circuit.
     // * We push the current root components and application state to the client.
     //   * If that succeeds, the client receives the state and we are done.
@@ -434,7 +434,7 @@ internal sealed partial class ComponentHub : Hub
     // * The client will disconnect after receiving the state or after a 30s timeout.
     //   * From that point on, it can choose to resume the circuit by calling ResumeCircuit with or without the state
     //     depending on whether the transfer was successful.
-    // * Most of the time we expect the state push to succeed, if that fails, the possibilites are:
+    // * Most of the time we expect the state push to succeed, if that fails, the possibilities are:
     //   * Client tries to resume before the state has been saved to the server-side cache storage.
     //     * Resumption fails as the state is not there.
     //     * The state eventually makes it to the server-side cache storage, but the client will have already given up and

--- a/src/Components/Web.JS/src/GlobalExports.ts
+++ b/src/Components/Web.JS/src/GlobalExports.ts
@@ -24,7 +24,7 @@ import { ValidationService } from './Validation';
 
 
 // TODO: It's kind of hard to tell which .NET platform(s) some of these APIs are relevant to.
-// It's important to know this information when dealing with the possibility of mulitple .NET platforms being available.
+// It's important to know this information when dealing with the possibility of multiple .NET platforms being available.
 // e.g., which of these APIs need to account for there being multiple .NET runtimes, and which don't?
 
 // We should consider separating it all out so that we can easily identify the platform requirements of each API.

--- a/src/Components/Web.JS/src/JSInitializers/JSInitializers.ts
+++ b/src/Components/Web.JS/src/JSInitializers/JSInitializers.ts
@@ -44,7 +44,7 @@ export class JSInitializer {
   }
 
   async importInitializersAsync(initializerFiles: JSAsset[], initializerArguments: unknown[]): Promise<void> {
-    // This code is not called on WASM, because library intializers are imported by runtime.
+    // This code is not called on WASM, because library initializers are imported by runtime.
 
     await Promise.all(initializerFiles.map(f => importAndInvokeInitializer(this, f)));
 

--- a/src/Components/Web.JS/src/Rendering/DomMerging/DomSync.ts
+++ b/src/Components/Web.JS/src/Rendering/DomMerging/DomSync.ts
@@ -184,7 +184,7 @@ function treatAsMatch(destination: Node, source: Node) {
 
         const isDestinationInteractive = isInteractiveRootComponentElement(destinationAsLogicalElement);
         if (isDestinationInteractive) {
-          // Don't sync DOM content for already-interactive components becuase their content is managed
+          // Don't sync DOM content for already-interactive components because their content is managed
           // by the renderer.
         } else {
           synchronizeDomContentCore(destination, source);

--- a/src/Components/Web.JS/src/Services/WebRootComponentManager.ts
+++ b/src/Components/Web.JS/src/Services/WebRootComponentManager.ts
@@ -66,7 +66,7 @@ export class WebRootComponentManager implements DescriptorHandler, RootComponent
   private _webAssemblyOptions: WebAssemblyServerOptions | undefined;
 
   // Implements RootComponentManager.
-  // An empty array becuase all root components managed
+  // An empty array because all root components managed
   // by WebRootComponentManager are added and removed dynamically.
   public readonly initialComponents: never[] = [];
 
@@ -108,7 +108,7 @@ export class WebRootComponentManager implements DescriptorHandler, RootComponent
 
     // When encountering a component with a WebAssembly or Auto render mode,
     // start loading the WebAssembly runtime, even though we're not
-    // activating the component yet. This is becuase WebAssembly resources
+    // activating the component yet. This is because WebAssembly resources
     // may take a long time to load, so starting to load them now potentially reduces
     // the time to interactvity.
     if (descriptor.type === 'webassembly') {
@@ -488,7 +488,7 @@ export class WebRootComponentManager implements DescriptorHandler, RootComponent
     for (const operation of batch.operations) {
       switch (operation.type) {
         case 'remove': {
-          // We can stop tracking this component now that .NET has acknowedged its removal.
+          // We can stop tracking this component now that .NET has acknowledged its removal.
           const component = this._rootComponentsBySsrComponentId.get(operation.ssrComponentId);
           if (component) {
             this.unregisterComponent(component);

--- a/src/Components/WebAssembly/Authentication.Msal/src/PACKAGE.md
+++ b/src/Components/WebAssembly/Authentication.Msal/src/PACKAGE.md
@@ -14,7 +14,7 @@ dotnet add package Microsoft.Authentication.WebAssembly.Msal
 
 ### Usage
 
-For usage examples and documentation, refer to the [offical documentation](https://learn.microsoft.com/aspnet/core/blazor/security/webassembly) on Blazor WebAssembly security and identity.
+For usage examples and documentation, refer to the [official documentation](https://learn.microsoft.com/aspnet/core/blazor/security/webassembly) on Blazor WebAssembly security and identity.
 
 ## Feedback &amp; Contributing
 

--- a/src/Components/WebAssembly/Server/src/TargetPickerUi.cs
+++ b/src/Components/WebAssembly/Server/src/TargetPickerUi.cs
@@ -377,7 +377,7 @@ firefox --start-debugger-server 6000 -new-tab about:debugging");
             // - absolute (since v135 of chrome and edge)
             //      chrome example: https://chrome-devtools-frontend.appspot.com/serve_rev/@031848bc6ad02b97854f3d6154d3aefd0434756a/inspector.html?ws=localhost:9222/devtools/page/719FE9D3B43570193235446E0AB36859
             //      edge example: https://aka.ms/docs-landing-page/serve_rev/@4e2c41645f24197463afa2ab6aa999352ee8255c/inspector.html?ws=localhost:9222/devtools/page/3A4D56E09776321628432588FC9299F4
-            // - relative (managed as fallback for brosers with prior version)
+            // - relative (managed as fallback for browsers with prior version)
             //      example: /devtools/inspector.html?ws=localhost:9222/devtools/page/DAB7FB6187B554E10B0BD18821265734
             // The absolute url can't be used as-is because is not valid for debugging and cannot be made relative because of lack "devtools" segment
             // before "inspector.html" but we can keep the query string and append to the default "devtools/inspector.html" browser devtools page

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Models/InteractiveRequestOptions.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Models/InteractiveRequestOptions.cs
@@ -82,7 +82,7 @@ public sealed class InteractiveRequestOptions
         [UnconditionalSuppressMessage(
             "Trimming",
             "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code",
-            Justification = "The types this method deserializes are anotated with 'DynamicallyAccessedMembers' to prevent them from being linked out as part of 'TryAddAdditionalParameter'.")]
+            Justification = "The types this method deserializes are annotated with 'DynamicallyAccessedMembers' to prevent them from being linked out as part of 'TryAddAdditionalParameter'.")]
         static TValue Deserialize(JsonElement element) => element.Deserialize<TValue>()!;
     }
 

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/PACKAGE.md
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/PACKAGE.md
@@ -14,7 +14,7 @@ dotnet add package Microsoft.AspNetCore.Components.WebAssembly.Authentication
 
 ### Usage
 
-For usage examples and documentation, refer to the [offical documentation](https://learn.microsoft.com/aspnet/core/blazor/security/webassembly) on Blazor WebAssembly security and identity.
+For usage examples and documentation, refer to the [official documentation](https://learn.microsoft.com/aspnet/core/blazor/security/webassembly) on Blazor WebAssembly security and identity.
 
 ## Feedback &amp; Contributing
 

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Services/AccessTokenNotAvailableException.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Services/AccessTokenNotAvailableException.cs
@@ -49,7 +49,7 @@ public class AccessTokenNotAvailableException : Exception
     /// Navigates to <see cref="AccessTokenResult.InteractiveRequestUrl"/> using the given <see cref="AccessTokenResult.InteractionOptions"/>
     /// to allow refreshing the access token.
     /// </summary>
-    /// <param name="configureInteractionOptions">A callback to further configure the initial set of options to be passed during the interactive token adquisition flow.</param>
+    /// <param name="configureInteractionOptions">A callback to further configure the initial set of options to be passed during the interactive token acquisition flow.</param>
     public void Redirect(Action<InteractiveRequestOptions> configureInteractionOptions)
     {
         ArgumentNullException.ThrowIfNull(configureInteractionOptions);

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCallQueue.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCallQueue.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 
 // A mechanism for queuing JS-to-.NET calls so they aren't nested on the call stack and hence
-// have the same ordering behaviors as in Blazor Server. This eliminates serveral inconsistency
+// have the same ordering behaviors as in Blazor Server. This eliminates several inconsistency
 // problems and bugs that otherwise require special-case solutions in other parts of the code.
 //
 // The reason for not using an actual SynchronizationContext for this is that, historically,

--- a/src/Components/WebAssembly/WebAssembly/src/Services/LazyAssemblyLoader.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Services/LazyAssemblyLoader.cs
@@ -58,7 +58,7 @@ public sealed partial class LazyAssemblyLoader
         }
         catch (FileNotFoundException ex)
         {
-            throw new InvalidOperationException($"Unable to find the following assembly: {ex.FileName}. Make sure that the appplication is referencing the assemblies and that they are present in the output folder.");
+            throw new InvalidOperationException($"Unable to find the following assembly: {ex.FileName}. Make sure that the application is referencing the assemblies and that they are present in the output folder.");
         }
 
         return Task.FromResult<IEnumerable<Assembly>>(loadedAssemblies);

--- a/src/Components/benchmarkapps/Wasm.Performance/TestApp/Pages/PersonDisplay.razor
+++ b/src/Components/benchmarkapps/Wasm.Performance/TestApp/Pages/PersonDisplay.razor
@@ -18,7 +18,7 @@
         </div>
 
         <div>
-            <label>Adminstrator: </label>
+            <label>Administrator: </label>
             <InputCheckbox @bind-Value="Person.IsAdmin" />
         </div>
     </EditForm>

--- a/src/DataProtection/DataProtection/src/KeyManagement/XmlKeyManager.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/XmlKeyManager.cs
@@ -456,7 +456,7 @@ public sealed class XmlKeyManager : IKeyManager, IInternalXmlKeyManager
                 {
                     if (massRevocationDate < mostRecentMassRevocationDate)
                     {
-                        // Delete superceded mass revocation elements
+                        // Delete superseded mass revocation elements
                         deletableElementsArray[i].DeletionOrder = deletionOrderMassRevocation;
                     }
                 }

--- a/src/DataProtection/DataProtection/src/Repositories/IDefaultKeyStorageDirectory.cs
+++ b/src/DataProtection/DataProtection/src/Repositories/IDefaultKeyStorageDirectory.cs
@@ -6,7 +6,7 @@ using System.IO;
 namespace Microsoft.AspNetCore.DataProtection.Repositories;
 
 /// <summary>
-/// This interface enables overridding the default storage location of keys on disk
+/// This interface enables overriding the default storage location of keys on disk
 /// </summary>
 internal interface IDefaultKeyStorageDirectories
 {

--- a/src/DataProtection/DataProtection/src/XmlEncryption/DpapiNGXmlEncryptor.cs
+++ b/src/DataProtection/DataProtection/src/XmlEncryption/DpapiNGXmlEncryptor.cs
@@ -92,7 +92,7 @@ public sealed class DpapiNGXmlEncryptor : IXmlEncryptor
     }
 
     /// <summary>
-    /// Creates a rule string tied to the current Windows user and which is transferrable
+    /// Creates a rule string tied to the current Windows user and which is transferable
     /// across machines (backed up in AD).
     /// </summary>
     internal static string GetDefaultProtectionDescriptorString()

--- a/src/DataProtection/README.md
+++ b/src/DataProtection/README.md
@@ -7,7 +7,7 @@ Data Protection APIs for protecting and unprotecting data. You can find document
 The following contains a description of each sub-directory in the `DataProtection` directory.
 
 - `Abstractions`: Contains the source files for the main DataProtection interfaces like `IDataProtector` and `IDataProtectionProvider`
-- `Cryptography.Internal`: Contains the source files for cryptography infrastucture. Applications and libraries should not reference this package directly.
+- `Cryptography.Internal`: Contains the source files for cryptography infrastructure. Applications and libraries should not reference this package directly.
 - `Cryptography.KeyDerivation`: Contains the source files related to key derivation, i.e. PBKDF2
 - `DataProtection`: Contains the main implementation of DataProtection for ASP.NET Core to protect and unprotect data.
 - `EntityFrameworkCore`: Contains the implementation for storing data using EntityFrameworkCore

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/VirtualChars/CSharpVirtualCharService.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/VirtualChars/CSharpVirtualCharService.cs
@@ -207,7 +207,7 @@ internal class CSharpVirtualCharService : AbstractVirtualCharService
         // we skip the space and newline that follow the initial `"""`.
         var startLineInclusive = tokenIncludeDelimiters ? 1 : 0;
 
-        // Similarly, if we're on the very last chunk of hte multi-line raw string literal, then we don't want to
+        // Similarly, if we're on the very last chunk of the multi-line raw string literal, then we don't want to
         // include the line contents for the line that has the final `    """` on it.
         var lastLineExclusive = tokenIncludeDelimiters ? tokenSourceText.Lines.Count - 1 : tokenSourceText.Lines.Count;
 

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/VirtualChars/VirtualCharSequence.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/VirtualChars/VirtualCharSequence.cs
@@ -85,7 +85,7 @@ internal partial struct VirtualCharSequence
     public bool IsDefaultOrEmpty => IsDefault || IsEmpty;
 
     /// <summary>
-    /// Retreives a sub-sequence from this <see cref="VirtualCharSequence"/>.
+    /// Retrieves a sub-sequence from this <see cref="VirtualCharSequence"/>.
     /// </summary>
     public VirtualCharSequence GetSubSequence(TextSpan span)
        => new(_leafCharacters, new TextSpan(_span.Start + span.Start, span.Length));

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/FrameworkParametersCompletionProvider.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/FrameworkParametersCompletionProvider.cs
@@ -304,8 +304,8 @@ public sealed class FrameworkParametersCompletionProvider : CompletionProvider
                             semanticModel,
                             attributeArgument,
                             context.CancellationToken,
-                            out var identifer) &&
-                            identifer == "Route" &&
+                            out var identifier) &&
+                            identifier == "Route" &&
                             attributeArgument.Expression is LiteralExpressionSyntax literalExpression)
                         {
                             return literalExpression.Token;
@@ -416,9 +416,9 @@ public sealed class FrameworkParametersCompletionProvider : CompletionProvider
             {
                 if (argument.Expression is DeclarationExpressionSyntax declarationExpression &&
                     declarationExpression.Designation is SingleVariableDesignationSyntax variableDesignationSyntax &&
-                    variableDesignationSyntax.Identifier is { IsMissing: false } identifer)
+                    variableDesignationSyntax.Identifier is { IsMissing: false } identifier)
                 {
-                    builder.Add(identifer.ValueText);
+                    builder.Add(identifier.ValueText);
                 }
             }
         }
@@ -436,9 +436,9 @@ public sealed class FrameworkParametersCompletionProvider : CompletionProvider
                 foreach (var p in parameterList.Parameters)
                 {
                     if (p is ParameterSyntax parameter &&
-                        parameter.Identifier is { IsMissing: false } identifer)
+                        parameter.Identifier is { IsMissing: false } identifier)
                     {
-                        builder.Add(identifer.ValueText);
+                        builder.Add(identifier.ValueText);
                     }
                 }
             }

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/RouteUsageDetector.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/RouteUsageDetector.cs
@@ -289,8 +289,8 @@ internal static class RouteUsageDetector
 
         var stringSymbol = semanticModel.Compilation.GetSpecialType(SpecialType.System_String);
         var routeStringParameter = method.Parameters.FirstOrDefault(p => SymbolEqualityComparer.Default.Equals(stringSymbol, p.Type) &&
-            RouteStringSyntaxDetector.HasMatchingStringSyntaxAttribute(p, out var identifer) &&
-            identifer == "Route");
+            RouteStringSyntaxDetector.HasMatchingStringSyntaxAttribute(p, out var identifier) &&
+            identifier == "Route");
         if (routeStringParameter == null)
         {
             return null;

--- a/src/Framework/AspNetCoreAnalyzers/src/CodeFixes/Dependencies/ExtensionMethodsCompletionProvider.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/CodeFixes/Dependencies/ExtensionMethodsCompletionProvider.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage;
 /// <summary>
 /// This completion provider expands the completion list of target symbols defined in the
 /// ExtensionMethodsCache to include extension methods that can be invoked on the target
-/// type that are defined in auxillary packages. This completion provider is designed to be
+/// type that are defined in auxiliary packages. This completion provider is designed to be
 /// used in conjunction with the `AddPackageFixer` to recommend adding the missing packages
 /// extension methods are defined in.
 /// </summary>

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonTranscodingRouteAdapter.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonTranscodingRouteAdapter.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal;
 ///
 /// The purpose of this type is to add support for parameters spanning multiple segments and
 /// anonymous any or catch-all segments. This type transforms an HTTP route into an ASP.NET Core
-/// route by rewritting it to a compatible format and providing actions to reconstruct parameters
+/// route by rewriting it to a compatible format and providing actions to reconstruct parameters
 /// that span multiple segments.
 ///
 /// <para>

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonTranscodingServerCallContext.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonTranscodingServerCallContext.cs
@@ -51,7 +51,7 @@ internal sealed class JsonTranscodingServerCallContext : ServerCallContext, ISer
         IsJsonRequestContent = JsonRequestHelpers.HasJsonContentType(HttpContext.Request, out var charset);
         RequestEncoding = JsonRequestHelpers.GetEncodingFromCharset(charset) ?? Encoding.UTF8;
 
-        // HttpContext.Items is publically exposed as ServerCallContext.UserState.
+        // HttpContext.Items is publicly exposed as ServerCallContext.UserState.
         // Because this is a custom ServerCallContext, HttpContext must be added to UserState so GetHttpContext() continues to work.
         // https://github.com/grpc/grpc-dotnet/blob/7ef184f3c4cd62fbc3cde55e4bb3e16b58258ca1/src/Grpc.AspNetCore.Server/ServerCallContextExtensions.cs#L53-L61
         HttpContext.Items["__HttpContext"] = HttpContext;

--- a/src/Grpc/JsonTranscoding/src/Shared/Server/BindMethodFinder.cs
+++ b/src/Grpc/JsonTranscoding/src/Shared/Server/BindMethodFinder.cs
@@ -94,7 +94,7 @@ internal static class BindMethodFinder
         // We need to access the static BindService method on Foo which implicitly derives from Object.
         var baseType = serviceImplementation.BaseType;
 
-        // Handle services that have multiple levels of inheritence
+        // Handle services that have multiple levels of inheritance
         while (baseType?.BaseType?.BaseType != null)
         {
             baseType = baseType.BaseType;

--- a/src/Grpc/JsonTranscoding/src/Shared/Server/MethodOptions.cs
+++ b/src/Grpc/JsonTranscoding/src/Shared/Server/MethodOptions.cs
@@ -103,12 +103,12 @@ internal sealed class MethodOptions
     }
 
     /// <summary>
-    /// Creates method options by merging together the settings the specificed <see cref="GrpcServiceOptions"/> collection.
+    /// Creates method options by merging together the settings in the specified <see cref="GrpcServiceOptions"/> collection.
     /// The <see cref="GrpcServiceOptions"/> should be ordered with items arranged in ascending order of precedence.
-    /// When interceptors from multiple options are merged together they will be executed in reverse order of precendence.
+    /// When interceptors from multiple options are merged together they will be executed in reverse order of precedence.
     /// </summary>
     /// <param name="serviceOptions">A collection of <see cref="GrpcServiceOptions"/> instances, arranged in ascending order of precedence.</param>
-    /// <returns>A new <see cref="MethodOptions"/> instanced with settings merged from specifid <see cref="GrpcServiceOptions"/> collection.</returns>
+    /// <returns>A new <see cref="MethodOptions"/> instance with settings merged from the specified <see cref="GrpcServiceOptions"/> collection.</returns>
     public static MethodOptions Create(IEnumerable<GrpcServiceOptions> serviceOptions)
     {
         // This is required to get ensure that service methods without any explicit configuration

--- a/src/Grpc/JsonTranscoding/src/Shared/ServiceDescriptorHelpers.cs
+++ b/src/Grpc/JsonTranscoding/src/Shared/ServiceDescriptorHelpers.cs
@@ -103,7 +103,7 @@ internal static class ServiceDescriptorHelpers
     private static FieldDescriptor? GetFieldByName(MessageDescriptor messageDescriptor, string fieldName)
     {
         // Search fields by field name and JSON name. Both names can be referenced.
-        // JSON name takes precendence. If there are conflicts, then the last field with a name wins.
+        // JSON name takes precedence. If there are conflicts, then the last field with a name wins.
         // This logic matches how properties are used in JSON serialization's MessageTypeInfoResolver.
         var fields = messageDescriptor.Fields.InFieldNumberOrder();
 

--- a/src/Grpc/JsonTranscoding/src/Shared/X509CertificateHelpers.cs
+++ b/src/Grpc/JsonTranscoding/src/Shared/X509CertificateHelpers.cs
@@ -45,7 +45,7 @@ internal static class X509CertificateHelpers
 
                 // SubjectAlternativeNames might contain something other than a dNSName,
                 // so we have to parse through and only use the dNSNames
-                // <identifier><delimter><value><separator(s)>
+                // <identifier><delimiter><value><separator(s)>
 
                 string[] rawDnsEntries =
                     asnString.Split(new string[1] { X509SubjectAlternativeNameConstants.Separator }, StringSplitOptions.RemoveEmptyEntries);
@@ -142,7 +142,7 @@ internal static class X509CertificateHelpers
                 // e.g.,
                 // Windows: x509ExtensionFormattedString is: "DNS Name=not-real-subject-name, DNS Name=example.com"
                 // Linux:   x509ExtensionFormattedString is: "DNS:not-real-subject-name, DNS:example.com"
-                // Parse: <identifier><delimter><value><separator(s)>
+                // Parse: <identifier><delimiter><value><separator(s)>
 
                 int delimiterIndex = x509ExtensionFormattedString.IndexOf(subjectName1, StringComparison.Ordinal) - 1;
                 s_delimiter = x509ExtensionFormattedString[delimiterIndex];

--- a/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
@@ -252,7 +252,7 @@ internal sealed class HostingApplicationDiagnostics
             }
         }
 
-        // Logging Scope is finshed with
+        // Logging Scope is finished with
         context.Scope?.Dispose();
     }
 

--- a/src/Hosting/Server.IntegrationTesting/src/Deployers/RemoteWindowsDeployer/RemotePSSessionHelper.ps1
+++ b/src/Hosting/Server.IntegrationTesting/src/Deployers/RemoteWindowsDeployer/RemotePSSessionHelper.ps1
@@ -62,7 +62,7 @@ else
 
 Remove-PSSession $psSession
 
-# NOTE: Currenty there is no straight forward way to get the exit code from a remotely executing session, so
+# NOTE: Currently there is no straight forward way to get the exit code from a remotely executing session, so
 # we print out the exit code in the remote script and capture it's output to get the exit code.
 if($remoteResult.Length > 0)
 {

--- a/src/Hosting/TestHost/src/UpgradeFeature.cs
+++ b/src/Hosting/TestHost/src/UpgradeFeature.cs
@@ -9,7 +9,7 @@ internal sealed class UpgradeFeature : IHttpUpgradeFeature
 {
     public bool IsUpgradableRequest => false;
 
-    // TestHost provides an IHttpWebSocketFeature so it wont call UpgradeAsync()
+    // TestHost provides an IHttpWebSocketFeature so it won't call UpgradeAsync()
     public Task<Stream> UpgradeAsync()
     {
         throw new NotSupportedException();

--- a/src/Http/Authentication.Abstractions/src/IAuthenticationConfigurationProvider.cs
+++ b/src/Http/Authentication.Abstractions/src/IAuthenticationConfigurationProvider.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Configuration;
 namespace Microsoft.AspNetCore.Authentication;
 
 /// <summary>
-/// Provides an interface for implmenting a construct that provides
+/// Provides an interface for implementing a construct that provides
 /// access to authentication-related configuration sections.
 /// </summary>
 public interface IAuthenticationConfigurationProvider

--- a/src/Http/Headers/src/SetCookieHeaderValue.cs
+++ b/src/Http/Headers/src/SetCookieHeaderValue.cs
@@ -542,7 +542,7 @@ public class SetCookieHeaderValue
                 {
                     return 0;
                 }
-                // We don't want to include comma, becouse date may contain it (eg. Sun, 06 Nov...)
+                // We don't want to include comma, because date may contain it (eg. Sun, 06 Nov...)
                 var dateString = ReadToSemicolonOrEnd(input, ref offset, includeComma: false);
                 DateTimeOffset expirationDate;
                 if (!HttpRuleParser.TryStringToDate(dateString, out expirationDate))

--- a/src/Http/Http.Abstractions/src/FragmentString.cs
+++ b/src/Http/Http.Abstractions/src/FragmentString.cs
@@ -152,7 +152,7 @@ public readonly struct FragmentString : IEquatable<FragmentString>
     }
 
     /// <summary>
-    /// Evalutes if one fragment is not equal to another.
+    /// Evaluates if one fragment is not equal to another.
     /// </summary>
     /// <param name="left">A <see cref="FragmentString"/> instance.</param>
     /// <param name="right">A <see cref="FragmentString"/> instance.</param>

--- a/src/Http/Http.Abstractions/src/HostString.cs
+++ b/src/Http/Http.Abstractions/src/HostString.cs
@@ -131,7 +131,7 @@ public readonly struct HostString : IEquatable<HostString>
     /// Returns the value properly formatted and encoded for use in a URI in a HTTP header.
     /// Any Unicode is converted to punycode. IPv6 addresses will have brackets added if they are missing.
     /// </summary>
-    /// <returns>The <see cref="HostString"/> value formated for use in a URI or HTTP header.</returns>
+    /// <returns>The <see cref="HostString"/> value formatted for use in a URI or HTTP header.</returns>
     public string ToUriComponent()
     {
         if (!HasValue)

--- a/src/Http/Http.Abstractions/src/HttpProtocol.cs
+++ b/src/Http/Http.Abstractions/src/HttpProtocol.cs
@@ -38,7 +38,7 @@ public static class HttpProtocol
     public static readonly string Http2 = "HTTP/2";
 
     /// <summary>
-    ///  HTTP protcol version 3.
+    ///  HTTP protocol version 3.
     /// </summary>
     public static readonly string Http3 = "HTTP/3";
 

--- a/src/Http/Http.Abstractions/src/IEndpointFilter.cs
+++ b/src/Http/Http.Abstractions/src/IEndpointFilter.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.AspNetCore.Http;
 
 /// <summary>
-/// Provides an interface for implementing a filter targetting a route handler.
+/// Provides an interface for implementing a filter targeting a route handler.
 /// </summary>
 public interface IEndpointFilter
 {

--- a/src/Http/Http.Abstractions/src/Metadata/IRouteDiagnosticsMetadata.cs
+++ b/src/Http/Http.Abstractions/src/Metadata/IRouteDiagnosticsMetadata.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.AspNetCore.Http.Metadata;
 
 /// <summary>
-/// Interface for specifing diagnostics text for a route.
+/// Interface for specifying diagnostics text for a route.
 /// </summary>
 public interface IRouteDiagnosticsMetadata
 {

--- a/src/Http/Http.Abstractions/src/QueryString.cs
+++ b/src/Http/Http.Abstractions/src/QueryString.cs
@@ -207,7 +207,7 @@ public readonly struct QueryString : IEquatable<QueryString>
     }
 
     /// <summary>
-    /// Evalutes if the current query string is equal to <paramref name="other"/>.
+    /// Evaluates if the current query string is equal to <paramref name="other"/>.
     /// </summary>
     /// <param name="other">The <see cref="QueryString"/> to compare.</param>
     /// <returns><see langword="true"/> if the query strings are equal.</returns>

--- a/src/Http/Http.Abstractions/src/Routing/RouteValueDictionary.cs
+++ b/src/Http/Http.Abstractions/src/Routing/RouteValueDictionary.cs
@@ -122,7 +122,7 @@ internal class RouteValueDictionary : IDictionary<string, object?>, IReadOnlyDic
     /// property names are keys, and property values are the values, and copied into the dictionary.
     /// Only public instance non-index properties are considered.
     /// </remarks>
-    [RequiresUnreferencedCode("This constructor may perform reflection on the specificed value which may be trimmed if not referenced directly. Consider using a different overload to avoid this issue.")]
+    [RequiresUnreferencedCode("This constructor may perform reflection on the specified value which may be trimmed if not referenced directly. Consider using a different overload to avoid this issue.")]
     public RouteValueDictionary(object? values)
     {
         if (values is RouteValueDictionary dictionary)

--- a/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator/StaticRouteHandlerModel/Emitters/EndpointParameterEmitter.cs
+++ b/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator/StaticRouteHandlerModel/Emitters/EndpointParameterEmitter.cs
@@ -289,7 +289,7 @@ internal static class EndpointParameterEmitter
         codeWriter.WriteLine("return;");
         codeWriter.EndBlock();
 
-        // Required parameters are guranteed to be set by the time we reach this point
+        // Required parameters are guaranteed to be set by the time we reach this point
         // because they are either associated with a service that existed in DI or
         // the appropriate checks have already happened when binding from the JSON body.
         codeWriter.WriteLine(!endpointParameter.IsOptional

--- a/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator/StaticRouteHandlerModel/StaticRouteHandlerModel.Emitter.cs
+++ b/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator/StaticRouteHandlerModel/StaticRouteHandlerModel.Emitter.cs
@@ -448,7 +448,7 @@ internal static class StaticRouteHandlerModelEmitter
 
         for (var i = 0; i < endpoint.Parameters.Length; i++)
         {
-            // The null suppression operator on the GetArgument(...) call here is required because we'll occassionally be
+            // The null suppression operator on the GetArgument(...) call here is required because we'll occasionally be
             // dealing with nullable types here. We could try to do fancy things to branch the logic here depending on
             // the nullability, but at the end of the day we are going to call GetArguments(...) - at runtime the nullability
             // suppression operator doesn't come into play - so its not worth worrying about.

--- a/src/Http/Http.Features/src/IServiceProvidersFeature.cs
+++ b/src/Http/Http.Features/src/IServiceProvidersFeature.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.AspNetCore.Http.Features;
 
 /// <summary>
-/// Provides acccess to the request-scoped <see cref="IServiceProvider"/>.
+/// Provides access to the request-scoped <see cref="IServiceProvider"/>.
 /// </summary>
 public interface IServiceProvidersFeature
 {

--- a/src/Http/Http/src/Features/RouteValuesFeature.cs
+++ b/src/Http/Http/src/Features/RouteValuesFeature.cs
@@ -14,7 +14,7 @@ public class RouteValuesFeature : IRouteValuesFeature
     private RouteValueDictionary? _routeValues;
 
     /// <summary>
-    /// Gets or sets the <see cref="RouteValueDictionary"/> associated with the currrent
+    /// Gets or sets the <see cref="RouteValueDictionary"/> associated with the current
     /// request.
     /// </summary>
     public RouteValueDictionary RouteValues

--- a/src/Http/Http/src/StreamResponseBodyFeature.cs
+++ b/src/Http/Http/src/StreamResponseBodyFeature.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Http.Features;
 namespace Microsoft.AspNetCore.Http;
 
 /// <summary>
-/// An implementation of <see cref="IHttpResponseBodyFeature"/> that aproximates all of the APIs over the given Stream.
+/// An implementation of <see cref="IHttpResponseBodyFeature"/> that approximates all of the APIs over the given Stream.
 /// </summary>
 public class StreamResponseBodyFeature : IHttpResponseBodyFeature
 {

--- a/src/Http/Routing/src/InlineRouteParameterParser.cs
+++ b/src/Http/Routing/src/InlineRouteParameterParser.cs
@@ -163,7 +163,7 @@ public static class InlineRouteParameterParser
                         case '=':
                             // In the original implementation, the Regex would've backtracked if it encountered an
                             // unbalanced opening bracket followed by (not necessarily immediately) a delimiter.
-                            // Simply verifying that the parantheses will eventually be closed should suffice to
+                            // Simply verifying that the parentheses will eventually be closed should suffice to
                             // determine if the terminator needs to be consumed as part of the current constraint
                             // specification.
                             var indexOfClosingParantheses = routeParameter.IndexOf(')', currentIndex + 1);

--- a/src/Http/Routing/src/Matching/ContentEncodingMetadata.cs
+++ b/src/Http/Routing/src/Matching/ContentEncodingMetadata.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Routing.Matching;
 namespace Microsoft.AspNetCore.Routing;
 
 /// <summary>
-/// Metadata used to negotiate wich endpoint to select based on the value of the Accept-Encoding header.
+/// Metadata used to negotiate which endpoint to select based on the value of the Accept-Encoding header.
 /// </summary>
 /// <param name="value">The <c>Accept-Encoding</c> value this metadata represents.</param>
 /// <param name="quality">The server preference to apply to break ties.</param>

--- a/src/Http/Routing/src/Matching/DfaMatcherBuilder.cs
+++ b/src/Http/Routing/src/Matching/DfaMatcherBuilder.cs
@@ -127,7 +127,7 @@ internal sealed class DfaMatcherBuilder : MatcherBuilder
         public override IParameterPolicy Create(RoutePatternParameterPart parameter, string inlineText)
         {
             // Blindly check the cache to see if it contains a match.
-            // Only cachable parameter policies are in the cache, so a match will only be available if the parameter policy key is configured to a cachable parameter policy.
+            // Only cacheable parameter policies are in the cache, so a match will only be available if the parameter policy key is configured to a cacheable parameter policy.
             //
             // Note: Cache key is case sensitive. While the route prefix, e.g. "regex", is case-insensitive, the constraint could care about the case of the argument.
             if (_cachedParameters.TryGetValue(inlineText, out var parameterPolicy))
@@ -182,8 +182,8 @@ internal sealed class DfaMatcherBuilder : MatcherBuilder
         }
 
         // Each time we process a level of the DFA we keep a list of work items consisting on the nodes we need to evaluate
-        // their precendence and their parent nodes. We sort nodes by precedence on each level, which means that nodes are
-        // evaluated in the following order: (literals, constrained parameters/complex segments, parameters, constrainted catch-alls and catch-alls)
+        // their precedence and their parent nodes. We sort nodes by precedence on each level, which means that nodes are
+        // evaluated in the following order: (literals, constrained parameters/complex segments, parameters, constrained catch-alls and catch-alls)
         // When we process a stage we build a list of the next set of workitems we need to evaluate. We also keep around the
         // list of workitems from the previous level so that we can reuse all the nested lists while we are evaluating the current level.
         internal void ProcessLevel(int depth)
@@ -709,26 +709,26 @@ internal sealed class DfaMatcherBuilder : MatcherBuilder
             return Array.Empty<Candidate>();
         }
 
-        var candiates = new Candidate[endpoints.Count];
+        var candidates = new Candidate[endpoints.Count];
 
         var score = 0;
-        var examplar = endpoints[0];
-        candiates[0] = CreateCandidate(examplar, score);
+        var exemplar = endpoints[0];
+        candidates[0] = CreateCandidate(exemplar, score);
 
         for (var i = 1; i < endpoints.Count; i++)
         {
             var endpoint = endpoints[i];
-            if (!_comparer.Equals(examplar, endpoint))
+            if (!_comparer.Equals(exemplar, endpoint))
             {
                 // This endpoint doesn't have the same priority.
-                examplar = endpoint;
+                exemplar = endpoint;
                 score++;
             }
 
-            candiates[i] = CreateCandidate(endpoint, score);
+            candidates[i] = CreateCandidate(endpoint, score);
         }
 
-        return candiates;
+        return candidates;
     }
 
     // internal for tests

--- a/src/Http/Routing/src/Matching/HttpMethodMatcherPolicy.cs
+++ b/src/Http/Routing/src/Matching/HttpMethodMatcherPolicy.cs
@@ -188,7 +188,7 @@ public sealed class HttpMethodMatcherPolicy : MatcherPolicy, IEndpointComparerPo
 
             for (var j = 0; j < httpMethods.Count; j++)
             {
-                // An endpoint that allows CORS reqests will match both CORS and non-CORS
+                // An endpoint that allows CORS requests will match both CORS and non-CORS
                 // so we model it as both.
                 var httpMethod = httpMethods[j];
                 var key = new EdgeKey(httpMethod, acceptCorsPreFlight);
@@ -197,7 +197,7 @@ public sealed class HttpMethodMatcherPolicy : MatcherPolicy, IEndpointComparerPo
                     edges.Add(key, new List<Endpoint>());
                 }
 
-                // An endpoint that allows CORS reqests will match both CORS and non-CORS
+                // An endpoint that allows CORS requests will match both CORS and non-CORS
                 // so we model it as both.
                 if (acceptCorsPreFlight)
                 {
@@ -250,7 +250,7 @@ public sealed class HttpMethodMatcherPolicy : MatcherPolicy, IEndpointComparerPo
 
                     edges[key].Add(endpoint);
 
-                    // An endpoint that allows CORS reqests will match both CORS and non-CORS
+                    // An endpoint that allows CORS requests will match both CORS and non-CORS
                     // so we model it as both.
                     if (acceptCorsPreFlight)
                     {

--- a/src/Http/Routing/src/Matching/ILEmitTrieFactory.cs
+++ b/src/Http/Routing/src/Matching/ILEmitTrieFactory.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Routing.Matching;
 [RequiresDynamicCode("ILEmitTrieFactory uses runtime IL generation.")]
 internal static class ILEmitTrieFactory
 {
-    // The algorthm we use only works for ASCII text. If we find non-ASCII text in the input
+    // The algorithm we use only works for ASCII text. If we find non-ASCII text in the input
     // we need to reject it and let is be processed with a fallback technique.
     public const int NotAscii = int.MinValue;
 

--- a/src/Http/Routing/src/Patterns/RoutePatternFactory.cs
+++ b/src/Http/Routing/src/Patterns/RoutePatternFactory.cs
@@ -642,7 +642,7 @@ internal static class RoutePatternFactory
 
 #if !COMPONENTS
     /// <summary>
-    /// String policy references are infered to be regex constraints. Creating them is moved here to its own method so apps can
+    /// String policy references are inferred to be regex constraints. Creating them is moved here to its own method so apps can
     /// trim away the regex dependency when RoutePatternFactory.Parse(string) is used. This is the method typically used by the various Map methods.
     /// </summary>
     private static Dictionary<string, List<RoutePatternParameterPolicyReference>>? CreateRoutePatternPolicyReferences(RouteValueDictionary? parameterPolicies)
@@ -935,7 +935,7 @@ internal static class RoutePatternFactory
     }
 
     /// <summary>
-    /// Creates a <see cref="RoutePatternParameterPolicyReference"/> from the provided contraint.
+    /// Creates a <see cref="RoutePatternParameterPolicyReference"/> from the provided constraint.
     /// </summary>
     /// <param name="constraint">
     /// The constraint object, which must be of type <see cref="IRouteConstraint"/>
@@ -1026,7 +1026,7 @@ internal static class RoutePatternFactory
     /// Creates a <see cref="RoutePattern"/> that combines the specified patterns.
     /// </summary>
     /// <param name="left">A string representing the first part of the route.</param>
-    /// <param name="right">A stirng representing the second part of the route.</param>
+    /// <param name="right">A string representing the second part of the route.</param>
     /// <returns>The combined <see cref="RoutePattern"/>.</returns>
     /// <exception cref="InvalidOperationException"></exception>
     /// <exception cref="RoutePatternException"></exception>

--- a/src/Http/Routing/src/RouteEndpointDataSource.cs
+++ b/src/Http/Routing/src/RouteEndpointDataSource.cs
@@ -48,7 +48,7 @@ internal sealed class RouteEndpointDataSource : EndpointDataSource
             RouteAttributes = RouteAttributes.None,
             Conventions = conventions,
             FinallyConventions = finallyConventions,
-            InferMetadataFunc = null, // Metadata isn't infered from RequestDelegate endpoints
+            InferMetadataFunc = null, // Metadata isn't inferred from RequestDelegate endpoints
             CreateHandlerRequestDelegateFunc = createHandlerRequestDelegateFunc,
             Method = methodInfo // MethodInfo needed to resolve attributes for RequestDelegate endpoints
         });

--- a/src/Http/Routing/src/SuppressLinkGenerationMetadata.cs
+++ b/src/Http/Routing/src/SuppressLinkGenerationMetadata.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Routing;
 public sealed class SuppressLinkGenerationMetadata : ISuppressLinkGenerationMetadata
 {
     /// <summary>
-    /// Gets a value indicating whether the assocated endpoint should be used for link generation.
+    /// Gets a value indicating whether the associated endpoint should be used for link generation.
     /// </summary>
     public bool SuppressLinkGeneration => true;
 

--- a/src/Http/Routing/src/Template/RoutePrecedence.cs
+++ b/src/Http/Routing/src/Template/RoutePrecedence.cs
@@ -143,7 +143,7 @@ internal static class RoutePrecedence
     // Segments have the following order:
     // 5 - Literal segments
     // 4 - Multi-part segments && Constrained parameter segments
-    // 3 - Unconstrained parameter segements
+    // 3 - Unconstrained parameter segments
     // 2 - Constrained wildcard parameter segments
     // 1 - Unconstrained wildcard parameter segments
     private static int ComputeOutboundPrecedenceDigit(TemplateSegment segment)

--- a/src/Http/Routing/src/Template/TemplateBinder.cs
+++ b/src/Http/Routing/src/Template/TemplateBinder.cs
@@ -257,7 +257,7 @@ public class TemplateBinder
             var key = slots[i].Key;
             var value = slots[i].Value;
 
-            // Whether or not the value was explicitly provided is signficant when comparing
+            // Whether or not the value was explicitly provided is significant when comparing
             // ambient values. Remember that we're using a special sentinel value so that we
             // can tell the difference between an omitted value and an explicitly specified null.
             var hasExplicitValue = value != null;
@@ -427,7 +427,7 @@ public class TemplateBinder
     /// <param name="combinedValues">A dictionary that contains the parameters for the route.</param>
     /// <param name="parameterName">The name of the parameter.</param>
     /// <param name="constraint">The constraint object.</param>
-    /// <returns><see langword="true"/> if constraints were processed succesfully and false otherwise.</returns>
+    /// <returns><see langword="true"/> if constraints were processed successfully and false otherwise.</returns>
     public bool TryProcessConstraints(HttpContext? httpContext, RouteValueDictionary combinedValues, out string? parameterName, out IRouteConstraint? constraint)
     {
         var constraints = _constraints;
@@ -565,11 +565,11 @@ public class TemplateBinder
                     {
                         // If the value is not accepted, it is null or empty value in the
                         // middle of the segment. We accept this if the parameter is an
-                        // optional parameter and it is preceded by an optional seperator.
-                        // In this case, we need to remove the optional seperator that we
+                        // optional parameter and it is preceded by an optional separator.
+                        // In this case, we need to remove the optional separator that we
                         // have added to the URI
                         // Example: template = {id}.{format?}. parameters: id=5
-                        // In this case after we have generated "5.", we wont find any value
+                        // In this case after we have generated "5.", we won't find any value
                         // for format, so we remove '.' and generate 5.
                         if (!context.Accept(converted, parameterPart.EncodeSlashes))
                         {

--- a/src/Http/Routing/src/Template/TemplatePart.cs
+++ b/src/Http/Routing/src/Template/TemplatePart.cs
@@ -116,7 +116,7 @@ public class TemplatePart
     /// </summary>
     public bool IsOptional { get; private set; }
     /// <summary>
-    /// <see langword="true"/> if the route part represents an optional seperator.
+    /// <see langword="true"/> if the route part represents an optional separator.
     /// </summary>
     public bool IsOptionalSeperator { get; set; }
     /// <summary>
@@ -124,7 +124,7 @@ public class TemplatePart
     /// </summary>
     public string? Name { get; private set; }
     /// <summary>
-    /// The textual representation of the route parameter. Can be null. Used to represent route seperators and literal parts.
+    /// The textual representation of the route parameter. Can be null. Used to represent route separators and literal parts.
     /// </summary>
     public string? Text { get; private set; }
     /// <summary>

--- a/src/Http/Routing/src/Template/TemplateValuesResult.cs
+++ b/src/Http/Routing/src/Template/TemplateValuesResult.cs
@@ -18,7 +18,7 @@ public class TemplateValuesResult
     /// </summary>
     /// <remarks>
     /// This combines implicit (ambient) values from the <see cref="RouteData"/> of the current request
-    /// (if applicable), explictly provided values, and default values for parameters that appear in
+    /// (if applicable), explicitly provided values, and default values for parameters that appear in
     /// the route template.
     ///
     /// Implicit (ambient) values which are invalidated due to changes in values lexically earlier in the

--- a/src/Http/Routing/src/Tree/OutboundRouteEntry.cs
+++ b/src/Http/Routing/src/Tree/OutboundRouteEntry.cs
@@ -51,7 +51,7 @@ public class OutboundRouteEntry
     public string RouteName { get; set; }
 
     /// <summary>
-    /// Gets or sets the set of values that must be present for link genration.
+    /// Gets or sets the set of values that must be present for link generation.
     /// </summary>
     public RouteValueDictionary RequiredLinkValues { get; set; }
 

--- a/src/Http/Routing/src/Tree/UrlMatchingTree.cs
+++ b/src/Http/Routing/src/Tree/UrlMatchingTree.cs
@@ -41,7 +41,7 @@ internal class UrlMatchingTree
 
     internal void AddEntry(InboundRouteEntry entry)
     {
-        // The url matching tree represents all the routes asociated with a given
+        // The url matching tree represents all the routes associated with a given
         // order. Each node in the tree represents all the different categories
         // a segment can have for which there is a defined inbound route entry.
         // Each node contains a set of Matches that indicate all the routes for which
@@ -68,7 +68,7 @@ internal class UrlMatchingTree
         // in ascending order. For each tree it traverses each node starting from the root in the
         // following order: Literals, constrained parameters, parameters, constrained catch all routes, catch alls.
         // When it gets to a node of the same length as the route its trying to match, it simply looks at the list of
-        // candidates (which is in precence order) and tries to match the url against it.
+        // candidates (which is in presence order) and tries to match the url against it.
         //
 
         var current = Root;

--- a/src/Identity/Extensions.Stores/src/RoleStoreBase.cs
+++ b/src/Identity/Extensions.Stores/src/RoleStoreBase.cs
@@ -120,7 +120,7 @@ public abstract class RoleStoreBase<TRole, [DynamicallyAccessedMembers(Dynamical
     /// <param name="id">The id to convert.</param>
     /// <returns>An instance of <typeparamref name="TKey"/> representing the provided <paramref name="id"/>.</returns>
     [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code",
-        Justification = "TKey is annoated with RequiresUnreferencedCodeAttribute.All.")]
+        Justification = "TKey is annotated with RequiresUnreferencedCodeAttribute.All.")]
     public virtual TKey? ConvertIdFromString(string? id)
     {
         if (id == null)

--- a/src/Identity/Extensions.Stores/src/UserStoreBase.cs
+++ b/src/Identity/Extensions.Stores/src/UserStoreBase.cs
@@ -221,7 +221,7 @@ public abstract class UserStoreBase<TUser, [DynamicallyAccessedMembers(Dynamical
     /// <param name="id">The id to convert.</param>
     /// <returns>An instance of <typeparamref name="TKey"/> representing the provided <paramref name="id"/>.</returns>
     [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code",
-        Justification = "TKey is annoated with RequiresUnreferencedCodeAttribute.All.")]
+        Justification = "TKey is annotated with RequiresUnreferencedCodeAttribute.All.")]
     public virtual TKey? ConvertIdFromString(string? id)
     {
         if (id == null)

--- a/src/Installers/Windows/AspNetCoreModule-Setup/IIS-Setup/iisca/lib/consoleprops.cpp
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/IIS-Setup/iisca/lib/consoleprops.cpp
@@ -233,7 +233,7 @@ ScheduleSetConsolePropertiesCA(
 			goto exit;
 		}
 
-		// Only run if the comonent is installing or reinstalling
+		// Only run if the component is installing or reinstalling
 		if ( MsiUtilIsInstalling( installStateCurrent, installStateAction ) ||
 			MsiUtilIsReInstalling( installStateCurrent, installStateAction ) )
 		{
@@ -550,7 +550,7 @@ ExecuteSetConsolePropertiesCA(
 			pConsoleProps->dwScreenBufferSize.Y = (short) dwBufferHeight;
 
 			pConsoleProps->ColorTable[6] = RGB(238, 237, 240); // text color
-			pConsoleProps->ColorTable[5] = RGB(1, 36, 86); // backgroud color
+			pConsoleProps->ColorTable[5] = RGB(1, 36, 86); // background color
 			pConsoleProps->wFillAttribute = ((5 << 4) | 6 );
 
 

--- a/src/Installers/Windows/AspNetCoreModule-Setup/IIS-Setup/iisca/lib/elevatedsc.cpp
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/IIS-Setup/iisca/lib/elevatedsc.cpp
@@ -102,7 +102,7 @@ ScheduleMakeShortcutElevatedCA(
             goto exit;
         }
 
-        // Only run if the comonent is installing or reinstalling
+        // Only run if the component is installing or reinstalling
         if ( MsiUtilIsInstalling( installStateCurrent, installStateAction ) ||
             MsiUtilIsReInstalling( installStateCurrent, installStateAction ) )
         {

--- a/src/Installers/Windows/AspNetCoreModule-Setup/IIS-Setup/iisca/lib/hotfix.cpp
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/IIS-Setup/iisca/lib/hotfix.cpp
@@ -145,7 +145,7 @@ InstallWindowsHotfixQuietly(
     if ( FAILED(hr) )
     {
         DBGERROR_HR(hr);
-        IISLogWrite(SETUP_LOG_SEVERITY_ERROR, L"Error apppending wusa, hr=0x%x", hr);
+        IISLogWrite(SETUP_LOG_SEVERITY_ERROR, L"Error appending wusa, hr=0x%x", hr);
         goto exit;
     }
 
@@ -153,7 +153,7 @@ InstallWindowsHotfixQuietly(
     if ( FAILED(hr) )
     {
         DBGERROR_HR(hr);
-        IISLogWrite(SETUP_LOG_SEVERITY_ERROR, L"Error apppending hotfixpath, hr=0x%x", hr);
+        IISLogWrite(SETUP_LOG_SEVERITY_ERROR, L"Error appending hotfixpath, hr=0x%x", hr);
         goto exit;
     }
 
@@ -161,7 +161,7 @@ InstallWindowsHotfixQuietly(
     if ( FAILED(hr) )
     {
         DBGERROR_HR(hr);
-        IISLogWrite(SETUP_LOG_SEVERITY_ERROR, L"Error apppending end quote, hr=0x%x", hr);
+        IISLogWrite(SETUP_LOG_SEVERITY_ERROR, L"Error appending end quote, hr=0x%x", hr);
         goto exit;
     }
 
@@ -454,7 +454,7 @@ ScheduleInstallWindowsHotfixCA(
             if ( FAILED(hr) )
             {
                  IISLogWrite(SETUP_LOG_SEVERITY_ERROR, 
-                             L"Error gettting column %d from record, hr=0x%x",
+                             L"Error getting column %d from record, hr=0x%x",
                              CA_HOTFIX_CONDITION,
                              hr);
                  goto exit;

--- a/src/Installers/Windows/AspNetCoreModule-Setup/IIS-Setup/iisca/lib/msiutil.cpp
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/IIS-Setup/iisca/lib/msiutil.cpp
@@ -517,7 +517,7 @@ GenerateTempFileName(
     if ( FAILED(hr) )
     {
         DBGERROR_HR(hr);
-        IISLogWrite(SETUP_LOG_SEVERITY_ERROR, L"Error apppending \\, hr=0x%x", hr);
+        IISLogWrite(SETUP_LOG_SEVERITY_ERROR, L"Error appending \\, hr=0x%x", hr);
         goto exit;
     }
 

--- a/src/Installers/Windows/AspNetCoreModule-Setup/IIS-Setup/iisca/lib/secutils.cpp
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/IIS-Setup/iisca/lib/secutils.cpp
@@ -133,7 +133,7 @@ Routine Description:
 Arguments:
 
     pszFilePath - The path to the file where the DACL will be modified
-    cExplicitAccess - The count of EXPLICIT_ACCESS entires to add
+    cExplicitAccess - The count of EXPLICIT_ACCESS entries to add
     rgExplicitAccess - The EXPLICIT_ACCESS entries
 
 Return Value:
@@ -270,7 +270,7 @@ Return Value:
                              &cbUserAccount ) )
     {
         //
-        // We are expecing a FALSE return value since we
+        // We are expecting a FALSE return value since we
         // are obtaining required buffer sizes.
         //
         hr = HRESULT_FROM_WIN32( ERROR_INVALID_DATA );

--- a/src/Installers/Windows/AspNetCoreModule-Setup/IIS-Setup/iisca/lib/setup_log.cpp
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/IIS-Setup/iisca/lib/setup_log.cpp
@@ -336,7 +336,7 @@ IISLogInitialize(
 {
     HRESULT hr  = S_OK; 
   
-    //debug assert that it is always null. becaues previous custom action should have cleaned it up
+    //debug assert that it is always null. because previous custom action should have cleaned it up
     DBG_ASSERT( g_pSetupLog == NULL );
     
     if ( g_pSetupLog == NULL )

--- a/src/Installers/Windows/Wix.targets
+++ b/src/Installers/Windows/Wix.targets
@@ -1,7 +1,7 @@
 <Project>
   <!-- Set versioning properties after Arcade SDK targets have been imported. -->
   <PropertyGroup>
-    <!-- Actual upgrade code used in bundles to ensure upgrades withing a version band, e.g. 3.0.0.xxx -->
+    <!-- Actual upgrade code used in bundles to ensure upgrades within a version band, e.g. 3.0.0.xxx -->
     <_FileRevisionVersion>$(VersionSuffixDateStamp)</_FileRevisionVersion>
     <_FileRevisionVersion Condition=" '$(_FileRevisionVersion)' == '' ">42424</_FileRevisionVersion>
     <BundleVersion Condition="'$(BundleVersion)' != ''" >$(BundleVersion).$(_FileRevisionVersion)</BundleVersion>

--- a/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts
+++ b/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts
@@ -306,7 +306,7 @@ export module DotNet {
      * Invoked by the runtime to complete an asynchronous JavaScript function call started from .NET
      *
      * @param callId A value identifying the asynchronous operation.
-     * @param succeded Whether the operation succeeded or not.
+     * @param succeeded Whether the operation succeeded or not.
      * @param resultOrError The serialized result or the serialized error from the async operation.
      */
     endInvokeJSFromDotNet(callId: number, succeeded: boolean, resultOrError: any): void;

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
@@ -341,8 +341,8 @@ public static class DotNetDispatcher
     /// Accepts the byte array data being transferred from JS to DotNet.
     /// </summary>
     /// <param name="jsRuntime">The <see cref="JSRuntime"/>.</param>
-    /// <param name="id">Identifier for the byte array being transfered.</param>
-    /// <param name="data">Byte array to be transfered from JS.</param>
+    /// <param name="id">Identifier for the byte array being transferred.</param>
+    /// <param name="data">Byte array to be transferred from JS.</param>
     public static void ReceiveByteArray(JSRuntime jsRuntime, int id, byte[] data)
     {
         jsRuntime.ReceiveByteArray(id, data);

--- a/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
@@ -223,8 +223,8 @@ public abstract partial class JSRuntime : IJSRuntime, IDisposable
     /// <summary>
     /// Transfers a byte array from .NET to JS.
     /// </summary>
-    /// <param name="id">Atomically incrementing identifier for the byte array being transfered.</param>
-    /// <param name="data">Byte array to be transfered to JS.</param>
+    /// <param name="id">Atomically incrementing identifier for the byte array being transferred.</param>
+    /// <param name="data">Byte array to be transferred to JS.</param>
     protected internal virtual void SendByteArray(int id, byte[] data)
     {
         throw new NotSupportedException("JSRuntime subclasses are responsible for implementing byte array transfer to JS.");
@@ -233,8 +233,8 @@ public abstract partial class JSRuntime : IJSRuntime, IDisposable
     /// <summary>
     /// Accepts the byte array data being transferred from JS to DotNet.
     /// </summary>
-    /// <param name="id">Identifier for the byte array being transfered.</param>
-    /// <param name="data">Byte array to be transfered from JS.</param>
+    /// <param name="id">Identifier for the byte array being transferred.</param>
+    /// <param name="data">Byte array to be transferred from JS.</param>
     protected internal virtual void ReceiveByteArray(int id, byte[] data)
     {
         if (id == 0)

--- a/src/Middleware/CORS/src/Infrastructure/CorsPolicyBuilder.cs
+++ b/src/Middleware/CORS/src/Infrastructure/CorsPolicyBuilder.cs
@@ -25,7 +25,7 @@ public class CorsPolicyBuilder
     /// <summary>
     /// Creates a new instance of the <see cref="CorsPolicyBuilder"/>.
     /// </summary>
-    /// <param name="policy">The policy which will be used to intialize the builder.</param>
+    /// <param name="policy">The policy which will be used to initialize the builder.</param>
     public CorsPolicyBuilder(CorsPolicy policy)
     {
         Combine(policy);

--- a/src/Middleware/HeaderPropagation/src/HeaderPropagationMiddleware.cs
+++ b/src/Middleware/HeaderPropagation/src/HeaderPropagationMiddleware.cs
@@ -42,7 +42,7 @@ public class HeaderPropagationMiddleware
     /// <param name="context">The <see cref="HttpContext"/> for the current request.</param>
     public Task Invoke(HttpContext context)
     {
-        // We need to intialize the headers because the message handler will use this to detect misconfiguration.
+        // We need to initialize the headers because the message handler will use this to detect misconfiguration.
         var headers = _values.Headers ??= new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
 
         // Perf: avoid foreach since we don't define a struct enumerator.

--- a/src/Middleware/HttpOverrides/src/CertificateForwardingServiceExtensions.cs
+++ b/src/Middleware/HttpOverrides/src/CertificateForwardingServiceExtensions.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.HttpOverrides;
 namespace Microsoft.Extensions.DependencyInjection;
 
 /// <summary>
-/// Extension methods for using certificate fowarding.
+/// Extension methods for using certificate forwarding.
 /// </summary>
 public static class CertificateForwardingServiceExtensions
 {

--- a/src/Middleware/OutputCaching/src/OutputCachePolicyBuilder.cs
+++ b/src/Middleware/OutputCaching/src/OutputCachePolicyBuilder.cs
@@ -250,7 +250,7 @@ public sealed class OutputCachePolicyBuilder
     /// <summary>
     /// Adds a policy to tag the cached response.
     /// </summary>
-    /// <param name="tags">The tags to add to the cached reponse.</param>
+    /// <param name="tags">The tags to add to the cached response.</param>
     public OutputCachePolicyBuilder Tag(params string[] tags)
     {
         ArgumentNullException.ThrowIfNull(tags);
@@ -261,7 +261,7 @@ public sealed class OutputCachePolicyBuilder
     /// <summary>
     /// Adds a policy to change the cached response expiration.
     /// </summary>
-    /// <param name="expiration">The expiration of the cached reponse.</param>
+    /// <param name="expiration">The expiration of the cached response.</param>
     public OutputCachePolicyBuilder Expire(TimeSpan expiration)
     {
         return AddPolicy(new ExpirationPolicy(expiration));

--- a/src/Middleware/RateLimiting/src/DefaultCombinedLease.cs
+++ b/src/Middleware/RateLimiting/src/DefaultCombinedLease.cs
@@ -63,7 +63,7 @@ internal sealed class DefaultCombinedLease : RateLimitLease
 
         // Dispose endpoint lease first, then global lease (reverse order of when they were acquired)
         // Avoids issues where dispose might unblock a queued acquire and then the acquire fails when acquiring the next limiter.
-        // When disposing in reverse order there wont be any issues of unblocking an acquire that affects acquires on limiters in the chain after it
+        // When disposing in reverse order there won't be any issues of unblocking an acquire that affects acquires on limiters in the chain after it
         try
         {
             _endpointLease.Dispose();

--- a/src/Middleware/ResponseCompression/src/ResponseCompressionBody.cs
+++ b/src/Middleware/ResponseCompression/src/ResponseCompressionBody.cs
@@ -243,7 +243,7 @@ internal sealed class ResponseCompressionBody : Stream, IHttpResponseBodyFeature
             if (compressionProvider != null)
             {
                 // Can't use += as StringValues does not override operator+
-                // and the implict conversions will cause an incorrect string concat https://github.com/dotnet/runtime/issues/52507
+                // and the implicit conversions will cause an incorrect string concat https://github.com/dotnet/runtime/issues/52507
                 headers.ContentEncoding = StringValues.Concat(headers.ContentEncoding, compressionProvider.EncodingName);
                 headers.ContentMD5 = default; // Reset the MD5 because the content changed.
                 headers.ContentLength = default;

--- a/src/Middleware/Rewrite/src/ApacheModRewrite/ConditionPatternParser.cs
+++ b/src/Middleware/Rewrite/src/ApacheModRewrite/ConditionPatternParser.cs
@@ -185,7 +185,7 @@ internal sealed class ConditionPatternParser
                 }
             case 'l':
                 // name conflict with -l and -lt/-le, so the assumption is if there is no
-                // charcters after -l, we assume it a symbolic link
+                // characters after -l, we assume it a symbolic link
                 if (!context.Next())
                 {
                     return new ParsedModRewriteInput(invert, ConditionType.PropertyTest, OperationType.SymbolicLink, operand: null);

--- a/src/Middleware/Rewrite/src/IISUrlRewriteOptionsExtensions.cs
+++ b/src/Middleware/Rewrite/src/IISUrlRewriteOptionsExtensions.cs
@@ -20,7 +20,7 @@ public static class IISUrlRewriteOptionsExtensions
     /// <param name="fileProvider">The <see cref="IFileProvider"/> </param>
     /// <param name="filePath">The path to the file containing UrlRewrite rules.</param>
     /// <param name="alwaysUseManagedServerVariables">Server variables are by default sourced from the server if it supports the <see cref="IServerVariablesFeature"/> feature. Use <c>true</c> to disable that behavior</param>
-    [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required for backwards compatability")]
+    [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required for backwards compatibility")]
     public static RewriteOptions AddIISUrlRewrite(this RewriteOptions options, IFileProvider fileProvider, string filePath, bool alwaysUseManagedServerVariables = false)
     {
         ArgumentNullException.ThrowIfNull(options);

--- a/src/Middleware/Spa/SpaProxy/src/SpaProxyLaunchManager.cs
+++ b/src/Middleware/Spa/SpaProxy/src/SpaProxyLaunchManager.cs
@@ -342,7 +342,7 @@ rm {scriptPath};
                     // we now start a proxy every time.
                     // We can't guarantee that we stop/cleanup the proxy on every situation (for example if someone)
                     // kills this process in a "rude" way, but this gets 95% there.
-                    // For cases where the proxy is left open and where there might not be a "visible" window the recomendation
+                    // For cases where the proxy is left open and where there might not be a "visible" window the recommendation
                     // is to kill the process manually. (We will not fail, we will simply notify the proxy is "already" up.
                     if (!_spaProcess.CloseMainWindow())
                     {

--- a/src/Middleware/Spa/SpaServices.Extensions/src/Npm/NodeScriptRunner.cs
+++ b/src/Middleware/Spa/SpaServices.Extensions/src/Npm/NodeScriptRunner.cs
@@ -135,7 +135,7 @@ internal sealed class NodeScriptRunner : IDisposable
         {
             var message = $"Failed to start '{commandName}'. To resolve this:.\n\n"
                         + $"[1] Ensure that '{commandName}' is installed and can be found in one of the PATH directories.\n"
-                        + $"    Current PATH enviroment variable is: { Environment.GetEnvironmentVariable("PATH") }\n"
+                        + $"    Current PATH environment variable is: { Environment.GetEnvironmentVariable("PATH") }\n"
                         + "    Make sure the executable is in one of those directories, or update your PATH.\n\n"
                         + "[2] See the InnerException for further details of the cause.";
             throw new InvalidOperationException(message, ex);

--- a/src/Middleware/StaticFiles/src/StaticFilesEndpointRouteBuilderExtensions.cs
+++ b/src/Middleware/StaticFiles/src/StaticFilesEndpointRouteBuilderExtensions.cs
@@ -115,7 +115,7 @@ public static class StaticFilesEndpointRouteBuilderExtensions
     /// The order of the registered endpoint will be <c>int.MaxValue</c>.
     /// </para>
     /// <para>
-    /// This overload will use the provided <paramref name="pattern"/> verbatim. Use the <c>:nonfile</c> route contraint
+    /// This overload will use the provided <paramref name="pattern"/> verbatim. Use the <c>:nonfile</c> route constraint
     /// to exclude requests for static files.
     /// </para>
     /// </remarks>
@@ -156,7 +156,7 @@ public static class StaticFilesEndpointRouteBuilderExtensions
     /// The order of the registered endpoint will be <c>int.MaxValue</c>.
     /// </para>
     /// <para>
-    /// This overload will use the provided <paramref name="pattern"/> verbatim. Use the <c>:nonfile</c> route contraint
+    /// This overload will use the provided <paramref name="pattern"/> verbatim. Use the <c>:nonfile</c> route constraint
     /// to exclude requests for static files.
     /// </para>
     /// </remarks>

--- a/src/Mvc/Mvc.Abstractions/src/ModelBinding/ModelStateDictionary.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ModelBinding/ModelStateDictionary.cs
@@ -1009,7 +1009,7 @@ public class ModelStateDictionary : IReadOnlyDictionary<string, ModelStateEntry?
         private bool _visitedRoot;
 
         /// <summary>
-        /// Intializes a new instance of <see cref="Enumerator"/>.
+        /// Initializes a new instance of <see cref="Enumerator"/>.
         /// </summary>
         /// <param name="dictionary">The <see cref="ModelStateDictionary"/>.</param>
         /// <param name="prefix">The prefix.</param>

--- a/src/Mvc/Mvc.Api.Analyzers/src/ActualApiResponseMetadataFactory.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/src/ActualApiResponseMetadataFactory.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers;
 public static class ActualApiResponseMetadataFactory
 {
     /// <summary>
-    /// This method looks at individual return statments and attempts to parse the status code and the return type.
+    /// This method looks at individual return statements and attempts to parse the status code and the return type.
     /// Given an <see cref="IMethodBodyBaseOperation"/> for an action, this method inspects return statements in the body.
     /// If the returned type is not assignable from IActionResult, it assumes that an "object" value is being returned. e.g. return new Person();
     /// For return statements returning an action result, it attempts to infer the status code and return type. Helper methods in controller,

--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -135,7 +135,7 @@ internal sealed class EndpointMetadataApiDescriptionProvider : IApiDescriptionPr
         if (acceptsMetadata is not null)
         {
             // Add a default body parameter if there was no explicitly defined parameter associated with
-            // either the body or a form and the user explicity defined some metadata describing the
+            // either the body or a form and the user explicitly defined some metadata describing the
             // content types the endpoint consumes (such as Accepts<TRequest>(...) or [Consumes(...)]).
             if (!hasBodyOrFormFileParameter)
             {

--- a/src/Mvc/Mvc.Core/src/ApiExplorer/ApiConventionTypeMatchAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/ApiExplorer/ApiConventionTypeMatchAttribute.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer;
 public sealed class ApiConventionTypeMatchAttribute : Attribute
 {
     /// <summary>
-    /// Initialzes a new instance of <see cref="ApiConventionTypeMatchAttribute"/> with the specified <paramref name="matchBehavior"/>.
+    /// Initializes a new instance of <see cref="ApiConventionTypeMatchAttribute"/> with the specified <paramref name="matchBehavior"/>.
     /// </summary>
     /// <param name="matchBehavior">The <see cref="ApiConventionTypeMatchBehavior"/>.</param>
     public ApiConventionTypeMatchAttribute(ApiConventionTypeMatchBehavior matchBehavior)

--- a/src/Mvc/Mvc.Core/src/ApplicationModels/ActionAttributeRouteModel.cs
+++ b/src/Mvc/Mvc.Core/src/ApplicationModels/ActionAttributeRouteModel.cs
@@ -130,7 +130,7 @@ internal static class ActionAttributeRouteModel
     {
         if (controllerMetadata != null)
         {
-            // It is criticial to get the order in which metadata appears in endpoint metadata correct. More significant metadata
+            // It is critical to get the order in which metadata appears in endpoint metadata correct. More significant metadata
             // must appear later in the sequence. In this case, the values in `controllerMetadata` should have their order
             // preserved, but appear earlier than the entries in `selector.EndpointMetadata`.
             for (var i = 0; i < controllerMetadata.Count; i++)

--- a/src/Mvc/Mvc.Core/src/ApplicationModels/SelectorModel.cs
+++ b/src/Mvc/Mvc.Core/src/ApplicationModels/SelectorModel.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels;
 public class SelectorModel
 {
     /// <summary>
-    /// Intializes a new <see cref="SelectorModel"/>.
+    /// Initializes a new <see cref="SelectorModel"/>.
     /// </summary>
     public SelectorModel()
     {
@@ -20,7 +20,7 @@ public class SelectorModel
     }
 
     /// <summary>
-    /// Intializes a new <see cref="SelectorModel"/>.
+    /// Initializes a new <see cref="SelectorModel"/>.
     /// </summary>
     /// <param name="other">The <see cref="SelectorModel"/> to copy from.</param>
     public SelectorModel(SelectorModel other)

--- a/src/Mvc/Mvc.Core/src/Authorization/AuthorizeFilter.cs
+++ b/src/Mvc/Mvc.Core/src/Authorization/AuthorizeFilter.cs
@@ -139,7 +139,7 @@ public class AuthorizeFilter : IAsyncAuthorizationFilter, IFilterFactory
         {
             // When doing endpoint routing, MVC does not create filters for any authorization specific metadata i.e [Authorize] does not
             // get translated into AuthorizeFilter. Consequently, there are some rough edges when an application uses a mix of AuthorizeFilter
-            // explicilty configured by the user (e.g. global auth filter), and uses endpoint metadata.
+            // explicitly configured by the user (e.g. global auth filter), and uses endpoint metadata.
             // To keep the behavior of AuthFilter identical to pre-endpoint routing, we will gather auth data from endpoint metadata
             // and produce a policy using this. This would mean we would have effectively run some auth twice, but it maintains compat.
             var policyProvider = PolicyProvider ?? context.HttpContext.RequestServices.GetRequiredService<IAuthorizationPolicyProvider>();

--- a/src/Mvc/Mvc.Core/src/Builder/ControllerEndpointRouteBuilderExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/Builder/ControllerEndpointRouteBuilderExtensions.cs
@@ -239,7 +239,7 @@ public static class ControllerEndpointRouteBuilderExtensions
     /// The order of the registered endpoint will be <c>int.MaxValue</c>.
     /// </para>
     /// <para>
-    /// This overload will use the provided <paramref name="pattern"/> verbatim. Use the <c>:nonfile</c> route contraint
+    /// This overload will use the provided <paramref name="pattern"/> verbatim. Use the <c>:nonfile</c> route constraint
     /// to exclude requests for static files.
     /// </para>
     /// <para>
@@ -364,7 +364,7 @@ public static class ControllerEndpointRouteBuilderExtensions
     /// The order of the registered endpoint will be <c>int.MaxValue</c>.
     /// </para>
     /// <para>
-    /// This overload will use the provided <paramref name="pattern"/> verbatim. Use the <c>:nonfile</c> route contraint
+    /// This overload will use the provided <paramref name="pattern"/> verbatim. Use the <c>:nonfile</c> route constraint
     /// to exclude requests for static files.
     /// </para>
     /// <para>

--- a/src/Mvc/Mvc.Core/src/Infrastructure/AsyncEnumerableReader.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/AsyncEnumerableReader.cs
@@ -48,7 +48,7 @@ internal sealed class AsyncEnumerableReader
     /// </summary>
     /// <param name="type">The type to read.</param>
     /// <param name="reader">A delegate that when awaited reads the <see cref="IAsyncEnumerable{T}"/>.</param>
-    /// <returns><see langword="true" /> when <paramref name="type"/> is an instance of <see cref="IAsyncEnumerable{T}"/>, othwerise <see langword="false"/>.</returns>
+    /// <returns><see langword="true" /> when <paramref name="type"/> is an instance of <see cref="IAsyncEnumerable{T}"/>, otherwise <see langword="false"/>.</returns>
     public bool TryGetReader(Type type, [NotNullWhen(true)] out Func<object, CancellationToken, Task<ICollection>>? reader)
     {
         if (!_asyncEnumerableConverters.TryGetValue(type, out reader))

--- a/src/Mvc/Mvc.Core/src/Infrastructure/FileContentResultExecutor.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/FileContentResultExecutor.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure;
 public partial class FileContentResultExecutor : FileResultExecutorBase, IActionResultExecutor<FileContentResult>
 {
     /// <summary>
-    /// Intializes a new <see cref="FileContentResultExecutor"/>.
+    /// Initializes a new <see cref="FileContentResultExecutor"/>.
     /// </summary>
     /// <param name="loggerFactory">The factory used to create loggers.</param>
     public FileContentResultExecutor(ILoggerFactory loggerFactory)

--- a/src/Mvc/Mvc.Core/src/Infrastructure/FileResultExecutorBase.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/FileResultExecutorBase.cs
@@ -19,7 +19,7 @@ public class FileResultExecutorBase
     protected const int BufferSize = 64 * 1024;
 
     /// <summary>
-    /// Intializes a new <see cref="FileResultExecutorBase"/>.
+    /// Initializes a new <see cref="FileResultExecutorBase"/>.
     /// </summary>
     /// <param name="logger">The logger.</param>
     public FileResultExecutorBase(ILogger logger)

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Validation/ValidationVisitor.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Validation/ValidationVisitor.cs
@@ -443,9 +443,9 @@ public class ValidationVisitor
     }
 
     /// <summary>
-    /// Supress validation for a given key.
+    /// Suppress validation for a given key.
     /// </summary>
-    /// <param name="key">The key to supress.</param>
+    /// <param name="key">The key to suppress.</param>
     protected virtual void SuppressValidation(string key)
     {
         if (key == null)

--- a/src/Mvc/Mvc.Core/src/Routing/ActionEndpointDataSourceBase.cs
+++ b/src/Mvc/Mvc.Core/src/Routing/ActionEndpointDataSourceBase.cs
@@ -72,7 +72,7 @@ internal abstract class ActionEndpointDataSourceBase : EndpointDataSource, IDisp
     protected void Subscribe()
     {
         // IMPORTANT: this needs to be called by the derived class to avoid the fragile base class
-        // problem. We can't call this in the base-class constuctor because it's too early.
+        // problem. We can't call this in the base-class constructor because it's too early.
         //
         // It's possible for someone to override the collection provider without providing
         // change notifications. If that's the case we won't process changes.

--- a/src/Mvc/Mvc.Core/src/Routing/ActionEndpointFactory.cs
+++ b/src/Mvc/Mvc.Core/src/Routing/ActionEndpointFactory.cs
@@ -129,7 +129,7 @@ internal sealed class ActionEndpointFactory
             var requestDelegate = CreateRequestDelegate(action) ?? _requestDelegate;
             var attributeRoutePattern = RoutePatternFactory.Parse(action.AttributeRouteInfo.Template);
 
-            // Modify the route and required values to ensure required values can be successfully subsituted.
+            // Modify the route and required values to ensure required values can be successfully substituted.
             // Subsitituting required values into an attribute route pattern should always succeed.
             var (resolvedRoutePattern, resolvedRouteValues) = ResolveDefaultsAndRequiredValues(action, attributeRoutePattern);
 

--- a/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonInputFormatter.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonInputFormatter.cs
@@ -108,7 +108,7 @@ public partial class NewtonsoftJsonInputFormatter : TextInputFormatter, IInputFo
         if (readStream.CanSeek)
         {
             // The most common way of getting here is the user has request buffering on.
-            // However, request buffering isn't eager, and consequently it will peform pass-thru synchronous
+            // However, request buffering isn't eager, and consequently it will perform pass-thru synchronous
             // reads as part of the deserialization.
             // To avoid this, drain and reset the stream.
             var position = request.Body.Position;

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/FileProviderRazorProjectItem.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/FileProviderRazorProjectItem.cs
@@ -18,7 +18,7 @@ public class FileProviderRazorProjectItem : RazorProjectItem
     private bool _isRelativePhysicalPathSet;
 
     /// <summary>
-    /// Intializes a new instance of a <see cref="FileProviderRazorProjectItem"/>.
+    /// Initializes a new instance of a <see cref="FileProviderRazorProjectItem"/>.
     /// </summary>
     /// <param name="fileInfo">The file info.</param>
     /// <param name="basePath">The base path.</param>
@@ -29,7 +29,7 @@ public class FileProviderRazorProjectItem : RazorProjectItem
     }
 
     /// <summary>
-    /// Intializes a new instance of a <see cref="FileProviderRazorProjectItem"/>.
+    /// Initializes a new instance of a <see cref="FileProviderRazorProjectItem"/>.
     /// </summary>
     /// <param name="fileInfo">The file info.</param>
     /// <param name="basePath">The base path.</param>

--- a/src/Mvc/Mvc.Razor/src/MvcRazorDiagnosticListenerExtensions.cs
+++ b/src/Mvc/Mvc.Razor/src/MvcRazorDiagnosticListenerExtensions.cs
@@ -14,7 +14,7 @@ internal static class MvcRazorDiagnosticListenerExtensions
         IRazorPage page,
         ViewContext viewContext)
     {
-        // Inlinable fast-path check if Diagnositcs is enabled
+        // Inlinable fast-path check if Diagnostics is enabled
         if (diagnosticListener.IsEnabled())
         {
             BeforeViewPageImpl(diagnosticListener, page, viewContext);
@@ -44,7 +44,7 @@ internal static class MvcRazorDiagnosticListenerExtensions
         IRazorPage page,
         ViewContext viewContext)
     {
-        // Inlinable fast-path check if Diagnositcs is enabled
+        // Inlinable fast-path check if Diagnostics is enabled
         if (diagnosticListener.IsEnabled())
         {
             AfterViewPageImpl(diagnosticListener, page, viewContext);

--- a/src/Mvc/Mvc.RazorPages/src/ApplicationModels/CompiledPageActionDescriptorBuilder.cs
+++ b/src/Mvc/Mvc.RazorPages/src/ApplicationModels/CompiledPageActionDescriptorBuilder.cs
@@ -64,7 +64,7 @@ internal static class CompiledPageActionDescriptorBuilder
         var handlerMetatdata = applicationModel.HandlerTypeAttributes;
         var endpointMetadata = applicationModel.EndpointMetadata;
 
-        // It is criticial to get the order in which metadata appears in endpoint metadata correct. More significant metadata
+        // It is critical to get the order in which metadata appears in endpoint metadata correct. More significant metadata
         // must appear later in the sequence.
         // In this case, handlerMetadata is attributes on the Page \ PageModel, and endPointMetadata is configured via conventions. and
         // We consider the latter to be more significant.

--- a/src/Mvc/Mvc.RazorPages/src/ApplicationModels/DefaultPageApplicationModelProvider.cs
+++ b/src/Mvc/Mvc.RazorPages/src/ApplicationModels/DefaultPageApplicationModelProvider.cs
@@ -94,7 +94,7 @@ internal sealed class DefaultPageApplicationModelProvider : IPageApplicationMode
 
             // If a PageModel is specified, combine the attributes specified on the Page and the Model type.
             // Attributes that appear earlier in the are more significant. In this case, we'll treat attributes on the model (code)
-            // to be more signficant than the page (code-generated).
+            // to be more significant than the page (code-generated).
             handlerTypeAttributes = modelTypeInfo.GetCustomAttributes(inherit: true).Concat(pageTypeAttributes).ToArray();
         }
         else

--- a/src/Mvc/Mvc.RazorPages/src/Builder/RazorPagesEndpointRouteBuilderExtensions.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Builder/RazorPagesEndpointRouteBuilderExtensions.cs
@@ -107,7 +107,7 @@ public static class RazorPagesEndpointRouteBuilderExtensions
     /// The order of the registered endpoint will be <c>int.MaxValue</c>.
     /// </para>
     /// <para>
-    /// This overload will use the provided <paramref name="pattern"/> verbatim. Use the <c>:nonfile</c> route contraint
+    /// This overload will use the provided <paramref name="pattern"/> verbatim. Use the <c>:nonfile</c> route constraint
     /// to exclude requests for static files.
     /// </para>
     /// <para>
@@ -220,7 +220,7 @@ public static class RazorPagesEndpointRouteBuilderExtensions
     /// The order of the registered endpoint will be <c>int.MaxValue</c>.
     /// </para>
     /// <para>
-    /// This overload will use the provided <paramref name="pattern"/> verbatim. Use the <c>:nonfile</c> route contraint
+    /// This overload will use the provided <paramref name="pattern"/> verbatim. Use the <c>:nonfile</c> route constraint
     /// to exclude requests for static files.
     /// </para>
     /// <para>

--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageActionInvokerProvider.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageActionInvokerProvider.cs
@@ -77,7 +77,7 @@ internal sealed class PageActionInvokerProvider : IActionInvokerProvider
 
         if (page.CompiledPageDescriptor == null)
         {
-            // With legacy routing, we're forced to perform a blocking call. The exceptation is that
+            // With legacy routing, we're forced to perform a blocking call. The expectation is that
             // in the most common case - build time views or successsively cached runtime views - this should finish synchronously.
             page.CompiledPageDescriptor = _pageLoader.LoadAsync(page, EndpointMetadataCollection.Empty).GetAwaiter().GetResult();
         }

--- a/src/Mvc/Mvc.RazorPages/src/MvcRazorPagesDiagnosticListenerExtensions.cs
+++ b/src/Mvc/Mvc.RazorPages/src/MvcRazorPagesDiagnosticListenerExtensions.cs
@@ -23,7 +23,7 @@ internal static class MvcRazorPagesDiagnosticListenerExtensions
         Debug.Assert(arguments != null);
         Debug.Assert(instance != null);
 
-        // Inlinable fast-path check if Diagnositcs is enabled
+        // Inlinable fast-path check if Diagnostics is enabled
         if (diagnosticListener.IsEnabled())
         {
             BeforeHandlerMethodImpl(diagnosticListener, actionContext, handlerMethodDescriptor, arguments, instance);
@@ -59,7 +59,7 @@ internal static class MvcRazorPagesDiagnosticListenerExtensions
         Debug.Assert(arguments != null);
         Debug.Assert(instance != null);
 
-        // Inlinable fast-path check if Diagnositcs is enabled
+        // Inlinable fast-path check if Diagnostics is enabled
         if (diagnosticListener.IsEnabled())
         {
             AfterHandlerMethodImpl(diagnosticListener, actionContext, handlerMethodDescriptor, arguments, instance, result);
@@ -91,7 +91,7 @@ internal static class MvcRazorPagesDiagnosticListenerExtensions
         Debug.Assert(handlerExecutionContext != null);
         Debug.Assert(filter != null);
 
-        // Inlinable fast-path check if Diagnositcs is enabled
+        // Inlinable fast-path check if Diagnostics is enabled
         if (diagnosticListener.IsEnabled())
         {
             BeforeOnPageHandlerExecutionImpl(diagnosticListener, handlerExecutionContext, filter);
@@ -121,7 +121,7 @@ internal static class MvcRazorPagesDiagnosticListenerExtensions
         Debug.Assert(handlerExecutedContext != null);
         Debug.Assert(filter != null);
 
-        // Inlinable fast-path check if Diagnositcs is enabled
+        // Inlinable fast-path check if Diagnostics is enabled
         if (diagnosticListener.IsEnabled())
         {
             AfterOnPageHandlerExecutionImpl(diagnosticListener, handlerExecutedContext, filter);
@@ -151,7 +151,7 @@ internal static class MvcRazorPagesDiagnosticListenerExtensions
         Debug.Assert(handlerExecutingContext != null);
         Debug.Assert(filter != null);
 
-        // Inlinable fast-path check if Diagnositcs is enabled
+        // Inlinable fast-path check if Diagnostics is enabled
         if (diagnosticListener.IsEnabled())
         {
             BeforeOnPageHandlerExecutingImpl(diagnosticListener, handlerExecutingContext, filter);
@@ -181,7 +181,7 @@ internal static class MvcRazorPagesDiagnosticListenerExtensions
         Debug.Assert(handlerExecutingContext != null);
         Debug.Assert(filter != null);
 
-        // Inlinable fast-path check if Diagnositcs is enabled
+        // Inlinable fast-path check if Diagnostics is enabled
         if (diagnosticListener.IsEnabled())
         {
             AfterOnPageHandlerExecutingImpl(diagnosticListener, handlerExecutingContext, filter);
@@ -211,7 +211,7 @@ internal static class MvcRazorPagesDiagnosticListenerExtensions
         Debug.Assert(handlerExecutedContext != null);
         Debug.Assert(filter != null);
 
-        // Inlinable fast-path check if Diagnositcs is enabled
+        // Inlinable fast-path check if Diagnostics is enabled
         if (diagnosticListener.IsEnabled())
         {
             BeforeOnPageHandlerExecutedImpl(diagnosticListener, handlerExecutedContext, filter);
@@ -241,7 +241,7 @@ internal static class MvcRazorPagesDiagnosticListenerExtensions
         Debug.Assert(handlerExecutedContext != null);
         Debug.Assert(filter != null);
 
-        // Inlinable fast-path check if Diagnositcs is enabled
+        // Inlinable fast-path check if Diagnostics is enabled
         if (diagnosticListener.IsEnabled())
         {
             AfterOnPageHandlerExecutedImpl(diagnosticListener, handlerExecutedContext, filter);
@@ -271,7 +271,7 @@ internal static class MvcRazorPagesDiagnosticListenerExtensions
         Debug.Assert(handlerSelectedContext != null);
         Debug.Assert(filter != null);
 
-        // Inlinable fast-path check if Diagnositcs is enabled
+        // Inlinable fast-path check if Diagnostics is enabled
         if (diagnosticListener.IsEnabled())
         {
             BeforeOnPageHandlerSelectionImpl(diagnosticListener, handlerSelectedContext, filter);
@@ -301,7 +301,7 @@ internal static class MvcRazorPagesDiagnosticListenerExtensions
         Debug.Assert(handlerSelectedContext != null);
         Debug.Assert(filter != null);
 
-        // Inlinable fast-path check if Diagnositcs is enabled
+        // Inlinable fast-path check if Diagnostics is enabled
         if (diagnosticListener.IsEnabled())
         {
             AfterOnPageHandlerSelectionImpl(diagnosticListener, handlerSelectedContext, filter);
@@ -331,7 +331,7 @@ internal static class MvcRazorPagesDiagnosticListenerExtensions
         Debug.Assert(handlerSelectedContext != null);
         Debug.Assert(filter != null);
 
-        // Inlinable fast-path check if Diagnositcs is enabled
+        // Inlinable fast-path check if Diagnostics is enabled
         if (diagnosticListener.IsEnabled())
         {
             BeforeOnPageHandlerSelectedImpl(diagnosticListener, handlerSelectedContext, filter);
@@ -361,7 +361,7 @@ internal static class MvcRazorPagesDiagnosticListenerExtensions
         Debug.Assert(handlerSelectedContext != null);
         Debug.Assert(filter != null);
 
-        // Inlinable fast-path check if Diagnositcs is enabled
+        // Inlinable fast-path check if Diagnostics is enabled
         if (diagnosticListener.IsEnabled())
         {
             AfterOnPageHandlerSelectedImpl(diagnosticListener, handlerSelectedContext, filter);

--- a/src/Mvc/Mvc.TagHelpers/src/CacheTagHelper.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/CacheTagHelper.cs
@@ -127,7 +127,7 @@ public class CacheTagHelper : CacheTagHelperBase
             // can't be put inside a using block.
             entry.Dispose();
 
-            // Set the result on the TCS once we've committed the entry to the cache since commiting to the cache
+            // Set the result on the TCS once we've committed the entry to the cache since committing to the cache
             // may throw.
             tcs.SetResult(content);
             return content;

--- a/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
+++ b/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
@@ -262,7 +262,7 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
     }
 
     /// <summary>
-    /// Initializes the instance by configurating the host builder.
+    /// Initializes the instance by configuring the host builder.
     /// </summary>
     /// <exception cref="InvalidOperationException">Thrown if the provided <typeparamref name="TEntryPoint"/> type has no factory method.</exception>
     public void StartServer()

--- a/src/Mvc/Mvc.ViewFeatures/src/Filters/SaveTempDataFilter.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Filters/SaveTempDataFilter.cs
@@ -79,7 +79,7 @@ internal sealed class SaveTempDataFilter : IResourceFilter, IResultFilter
     {
         // If there is an unhandled exception, we would like to avoid setting tempdata as
         // the end user is going to see an error page anyway and also it helps us in avoiding
-        // accessing resources like Session too late in the request lifecyle where SessionFeature might
+        // accessing resources like Session too late in the request lifecycle where SessionFeature might
         // not be available.
         if (!context.HttpContext.Response.HasStarted && context.Exception != null)
         {

--- a/src/Mvc/Mvc.ViewFeatures/src/HtmlHelper.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/HtmlHelper.cs
@@ -1016,7 +1016,7 @@ public class HtmlHelper : IHtmlHelper, IViewContextAware
     /// <summary>
     /// Generate an id.
     /// </summary>
-    /// <param name="expression">The expresion.</param>
+    /// <param name="expression">The expression.</param>
     /// <returns>The id.</returns>
     protected virtual string GenerateId(string expression)
     {
@@ -1029,7 +1029,7 @@ public class HtmlHelper : IHtmlHelper, IViewContextAware
     /// Generate a label.
     /// </summary>
     /// <param name="modelExplorer">The <see cref="ModelExplorer"/>.</param>
-    /// <param name="expression">The expresion.</param>
+    /// <param name="expression">The expression.</param>
     /// <param name="labelText">The label text.</param>
     /// <param name="htmlAttributes">
     /// An <see cref="object"/> that contains the HTML attributes for the element. Alternatively, an
@@ -1111,7 +1111,7 @@ public class HtmlHelper : IHtmlHelper, IViewContextAware
     }
 
     /// <summary>
-    /// Geneate a name.
+    /// Generate a name.
     /// </summary>
     /// <param name="expression">The expression.</param>
     /// <returns>The name.</returns>

--- a/src/Mvc/Mvc.ViewFeatures/src/MvcViewFeaturesDiagnosticListenerExtensions.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/MvcViewFeaturesDiagnosticListenerExtensions.cs
@@ -16,7 +16,7 @@ internal static class MvcViewFeaturesDiagnosticListenerExtensions
         ViewComponentContext context,
         object viewComponent)
     {
-        // Inlinable fast-path check if Diagnositcs is enabled
+        // Inlinable fast-path check if Diagnostics is enabled
         if (diagnosticListener.IsEnabled())
         {
             BeforeViewComponentImpl(diagnosticListener, context, viewComponent);
@@ -43,7 +43,7 @@ internal static class MvcViewFeaturesDiagnosticListenerExtensions
         IViewComponentResult result,
         object viewComponent)
     {
-        // Inlinable fast-path check if Diagnositcs is enabled
+        // Inlinable fast-path check if Diagnostics is enabled
         if (diagnosticListener.IsEnabled())
         {
             AfterViewComponentImpl(diagnosticListener, context, result, viewComponent);
@@ -70,7 +70,7 @@ internal static class MvcViewFeaturesDiagnosticListenerExtensions
         ViewComponentContext context,
         IView view)
     {
-        // Inlinable fast-path check if Diagnositcs is enabled
+        // Inlinable fast-path check if Diagnostics is enabled
         if (diagnosticListener.IsEnabled())
         {
             ViewComponentBeforeViewExecuteImpl(diagnosticListener, context, view);
@@ -96,7 +96,7 @@ internal static class MvcViewFeaturesDiagnosticListenerExtensions
         ViewComponentContext context,
         IView view)
     {
-        // Inlinable fast-path check if Diagnositcs is enabled
+        // Inlinable fast-path check if Diagnostics is enabled
         if (diagnosticListener.IsEnabled())
         {
             ViewComponentAfterViewExecuteImpl(diagnosticListener, context, view);
@@ -122,7 +122,7 @@ internal static class MvcViewFeaturesDiagnosticListenerExtensions
         IView view,
         ViewContext viewContext)
     {
-        // Inlinable fast-path check if Diagnositcs is enabled
+        // Inlinable fast-path check if Diagnostics is enabled
         if (diagnosticListener.IsEnabled())
         {
             BeforeViewImpl(diagnosticListener, view, viewContext);
@@ -144,7 +144,7 @@ internal static class MvcViewFeaturesDiagnosticListenerExtensions
         IView view,
         ViewContext viewContext)
     {
-        // Inlinable fast-path check if Diagnositcs is enabled
+        // Inlinable fast-path check if Diagnostics is enabled
         if (diagnosticListener.IsEnabled())
         {
             AfterViewImpl(diagnosticListener, view, viewContext);
@@ -169,7 +169,7 @@ internal static class MvcViewFeaturesDiagnosticListenerExtensions
         string viewName,
         IView view)
     {
-        // Inlinable fast-path check if Diagnositcs is enabled
+        // Inlinable fast-path check if Diagnostics is enabled
         if (diagnosticListener.IsEnabled())
         {
             ViewFoundImpl(diagnosticListener, actionContext, isMainPage, viewResult, viewName, view);
@@ -200,7 +200,7 @@ internal static class MvcViewFeaturesDiagnosticListenerExtensions
         string viewName,
         IEnumerable<string> searchedLocations)
     {
-        // Inlinable fast-path check if Diagnositcs is enabled
+        // Inlinable fast-path check if Diagnostics is enabled
         if (diagnosticListener.IsEnabled())
         {
             ViewNotFoundImpl(diagnosticListener, actionContext, isMainPage, viewResult, viewName, searchedLocations);

--- a/src/Security/Authentication/Certificate/src/CertificateAuthenticationExtensions.cs
+++ b/src/Security/Authentication/Certificate/src/CertificateAuthenticationExtensions.cs
@@ -77,7 +77,7 @@ public static class CertificateAuthenticationAppBuilderExtensions
     /// <para>
     /// Certificate authentication uses a authentication handler that validates client certificate and
     /// raises an event where the certificate is resolved to a <see cref="ClaimsPrincipal"/>.
-    /// See <see href="https://tools.ietf.org/html/rfc5246#section-7.4.4"/> to read more about certicate authentication.
+    /// See <see href="https://tools.ietf.org/html/rfc5246#section-7.4.4"/> to read more about certificate authentication.
     /// </para>
     /// </summary>
     /// <param name="builder">The <see cref="AuthenticationBuilder"/>.</param>

--- a/src/Security/Authentication/Core/src/IDataSerializer.cs
+++ b/src/Security/Authentication/Core/src/IDataSerializer.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.AspNetCore.Authentication;
 
 /// <summary>
-/// Contract for serialzing authentication data.
+/// Contract for serializing authentication data.
 /// </summary>
 /// <typeparam name="TModel">The type of the model being serialized.</typeparam>
 public interface IDataSerializer<TModel>

--- a/src/Security/Authentication/Negotiate/src/NegotiateHandler.cs
+++ b/src/Security/Authentication/Negotiate/src/NegotiateHandler.cs
@@ -201,7 +201,7 @@ public class NegotiateHandler : AuthenticationHandler<NegotiateOptions>, IAuthen
 
             if (_negotiateState.Protocol == "NTLM" && !Options.PersistNtlmCredentials)
             {
-                // NTLM was already put in the persitence cache on the prior request so we could complete the handshake.
+                // NTLM was already put in the persistence cache on the prior request so we could complete the handshake.
                 // Take it out if we don't want it to persist.
                 Debug.Assert(object.ReferenceEquals(persistence?.State, _negotiateState),
                     "NTLM is a two stage process, it must have already been in the cache for the handshake to succeed.");

--- a/src/Security/Authentication/Negotiate/src/NegotiateOptions.cs
+++ b/src/Security/Authentication/Negotiate/src/NegotiateOptions.cs
@@ -28,14 +28,14 @@ public class NegotiateOptions : AuthenticationSchemeOptions
     }
 
     /// <summary>
-    /// Indicates if Kerberos credentials should be persisted and re-used for subsquent anonymous requests.
+    /// Indicates if Kerberos credentials should be persisted and re-used for subsequent anonymous requests.
     /// This option must not be used if connections may be shared by requests from different users.
     /// </summary>
     /// <value>Defaults to <see langword="false"/>.</value>
     public bool PersistKerberosCredentials { get; set; }
 
     /// <summary>
-    /// Indicates if NTLM credentials should be persisted and re-used for subsquent anonymous requests.
+    /// Indicates if NTLM credentials should be persisted and re-used for subsequent anonymous requests.
     /// This option must not be used if connections may be shared by requests from different users.
     /// </summary>
     /// <value>Defaults to <see langword="true"/>.</value>

--- a/src/Servers/HttpSys/src/IHttpSysRequestInfoFeature.cs
+++ b/src/Servers/HttpSys/src/IHttpSysRequestInfoFeature.cs
@@ -14,7 +14,7 @@ public interface IHttpSysRequestInfoFeature
 {
     /// <summary>
     /// A collection of the HTTP_REQUEST_INFO for the current request. The integer represents the identifying
-    /// HTTP_REQUEST_INFO_TYPE enum value. The Memory is opaque bytes that need to be interperted in the format
+    /// HTTP_REQUEST_INFO_TYPE enum value. The Memory is opaque bytes that need to be interpreted in the format
     /// specified by the enum value.
     /// </summary>
     public IReadOnlyDictionary<int, ReadOnlyMemory<byte>> RequestInfo { get; }

--- a/src/Servers/HttpSys/src/NativeInterop/RequestQueue.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/RequestQueue.cs
@@ -132,7 +132,7 @@ internal sealed partial class RequestQueue
     }
 
     /// <summary>
-    /// True if this instace created the queue instead of attaching to an existing one.
+    /// True if this instance created the queue instead of attaching to an existing one.
     /// </summary>
     internal bool Created { get; }
 

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestStreamAsyncResult.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestStreamAsyncResult.cs
@@ -122,7 +122,7 @@ internal sealed unsafe class RequestStreamAsyncResult : IAsyncResult, IDisposabl
 
     internal void Fail(Exception ex)
     {
-        // Make sure the Abort state is set before signaling the callback so we can avoid race condtions with user code.
+        // Make sure the Abort state is set before signaling the callback so we can avoid race conditions with user code.
         Dispose();
         _requestStream.Abort();
         if (_tcs.TrySetException(ex) && _callback != null)

--- a/src/Servers/HttpSys/src/SourceBuildStubs.cs
+++ b/src/Servers/HttpSys/src/SourceBuildStubs.cs
@@ -313,7 +313,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
     {
         /// <summary>
         /// A collection of the HTTP_REQUEST_INFO for the current request. The integer represents the identifying
-        /// HTTP_REQUEST_INFO_TYPE enum value. The Memory is opaque bytes that need to be interperted in the format
+        /// HTTP_REQUEST_INFO_TYPE enum value. The Memory is opaque bytes that need to be interpreted in the format
         /// specified by the enum value.
         /// </summary>
         public IReadOnlyDictionary<int, ReadOnlyMemory<byte>> RequestInfo { get; }

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxrResolver.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxrResolver.h
@@ -32,7 +32,7 @@ public:
     static
     void
     AppendArguments(
-        const std::wstring          &arugments,
+        const std::wstring          &applicationArguments,
         const std::filesystem::path &applicationPhysicalPath,
         std::vector<std::wstring>   &arguments,
         bool                        expandDllPaths = false

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/fx_ver.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/fx_ver.cpp
@@ -155,7 +155,7 @@ namespace aspnet
         assert(a.m_pre[0] == TEXT('-'));
         assert(b.m_pre[0] == TEXT('-'));
 
-        // First idenitifier starts at position 1
+        // First identifier starts at position 1
         size_t idStart = 1;
         for (size_t i = idStart; true; ++i)
         {
@@ -164,13 +164,13 @@ namespace aspnet
                 // Found first character with a difference
                 if (a.m_pre[i] == 0 && b.m_pre[i] == TEXT('.'))
                 {
-                    // identifiers both complete, b has an additional idenitifier
+                    // identifiers both complete, b has an additional identifier
                     return -1;
                 }
 
                 if (b.m_pre[i] == 0 && a.m_pre[i] == TEXT('.'))
                 {
-                    // identifiers both complete, a has an additional idenitifier
+                    // identifiers both complete, a has an additional identifier
                     return 1;
                 }
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/forwardinghandler.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/forwardinghandler.cpp
@@ -1276,7 +1276,7 @@ None
 
     case WINHTTP_CALLBACK_STATUS_SENDING_REQUEST:
         //
-        // This is a notification, not a completion.  This notifiation happens
+        // This is a notification, not a completion.  This notification happens
         // during the Send Request operation.
         //
         fAnotherCompletionExpected = TRUE;

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/websockethandler.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/websockethandler.cpp
@@ -217,7 +217,7 @@ WEBSOCKET_HANDLER::IndicateCompletionToIIS(
     //
     // close Websocket handle. This will triger a WinHttp callback
     // on handle close, then let IIS pipeline continue.
-    // Make sure no pending IO as there is no IIS websocket cancelation,
+    // Make sure no pending IO as there is no IIS websocket cancellation,
     // any unexpected callback will lead to AV. Revisit it once CanelOutGoingIO works
     //
     if (_hWebSocketRequest != nullptr && _dwOutstandingIo == 0)
@@ -246,7 +246,7 @@ Routine Description:
 
     This routine is called after the 101 response was successfully sent to
     the client.
-    This routine get's a websocket handle to winhttp,
+    This routine gets a websocket handle to winhttp,
     websocket handle to IIS's websocket context, and initiates IO
     in these two endpoints.
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/requesthandler_config.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/requesthandler_config.cpp
@@ -49,7 +49,7 @@ REQUESTHANDLER_CONFIG::CreateRequestHandlerConfig(
             goto Finished;
         }
 
-        // set appliction info here instead of inside Populate()
+        // set application info here instead of inside Populate()
         // as the destructor will delete the backend process
         hr = pRequestHandlerConfig->QueryApplicationPath()->Copy(pHttpApplication->GetApplicationId());
         if (FAILED(hr))
@@ -299,7 +299,7 @@ REQUESTHANDLER_CONFIG::Populate(
         &strHostingModel);
     if (FAILED(hr))
     {
-        // Swallow this error for backward compatability
+        // Swallow this error for backward compatibility
         // Use default behavior for empty string
         hr = S_OK;
     }

--- a/src/Servers/Kestrel/Core/src/Features/ITlsApplicationProtocolFeature.cs
+++ b/src/Servers/Kestrel/Core/src/Features/ITlsApplicationProtocolFeature.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Features;
 public interface ITlsApplicationProtocolFeature
 {
     /// <summary>
-    /// Gets the <see cref="ReadOnlyMemory{T}"/> represeting the application protocol.
+    /// Gets the <see cref="ReadOnlyMemory{T}"/> representing the application protocol.
     /// </summary>
     ReadOnlyMemory<byte> ApplicationProtocol { get; }
 }

--- a/src/Servers/Kestrel/Core/src/HttpsConfigurationService.cs
+++ b/src/Servers/Kestrel/Core/src/HttpsConfigurationService.cs
@@ -50,7 +50,7 @@ internal sealed class HttpsConfigurationService : IHttpsConfigurationService
 
     /// <inheritdoc />
     // If there's an initializer, it *can* be initialized, even though it might not be yet.
-    // Use explicit interface implentation so we don't accidentally call it within this class.
+    // Use explicit interface implementation so we don't accidentally call it within this class.
     bool IHttpsConfigurationService.IsInitialized => _isInitialized || _initializer is not null;
 
     /// <inheritdoc/>

--- a/src/Servers/Kestrel/Core/src/Internal/ConfigurationReader.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/ConfigurationReader.cs
@@ -367,7 +367,7 @@ internal sealed class CertificateConfig
     {
         ConfigSection = configSection;
 
-        // Bind explictly to preserve linkability
+        // Bind explicitly to preserve linkability
         Path = configSection[nameof(Path)];
         KeyPath = configSection[nameof(KeyPath)];
         Password = configSection[nameof(Password)];

--- a/src/Servers/Kestrel/Core/src/Internal/Http/ChunkWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/ChunkWriter.cs
@@ -22,7 +22,7 @@ internal static class ChunkWriter
 
         count = (total >> 2) + 3;
 
-        // This must be explicity typed as ReadOnlySpan<byte>
+        // This must be explicitly typed as ReadOnlySpan<byte>
         // It then becomes a non-allocating mapping to the data section of the assembly.
         // For more information see https://vcsjones.dev/2019/02/01/csharp-readonly-span-bytes-static
         ReadOnlySpan<byte> hex = "0123456789abcdef"u8;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
@@ -370,7 +370,7 @@ internal abstract partial class HttpHeaders : IHeaderDictionary
                 offset++;
                 if ((uint)offset > (uint)value.Length)
                 {
-                    // Consumed enitre string, move to next.
+                    // Consumed entire string, move to next.
                     break;
                 }
 
@@ -428,7 +428,7 @@ internal abstract partial class HttpHeaders : IHeaderDictionary
 
                 if ((uint)offset >= (uint)value.Length)
                 {
-                    // Consumed enitre string, move to next string.
+                    // Consumed entire string, move to next string.
                     connectionOptions |= potentialConnectionOptions;
                     break;
                 }
@@ -453,19 +453,19 @@ internal abstract partial class HttpHeaders : IHeaderDictionary
 
                 if ((uint)offset >= (uint)value.Length)
                 {
-                    // Consumed enitre string, move to next string.
+                    // Consumed entire string, move to next string.
                     connectionOptions |= potentialConnectionOptions;
                     break;
                 }
                 else if (c == ',')
                 {
-                    // Consumed value corretly.
+                    // Consumed value correctly.
                     connectionOptions |= potentialConnectionOptions;
                     // Skip comma.
                     offset++;
                     if ((uint)offset >= (uint)value.Length)
                     {
-                        // Consumed enitre string, move to next string.
+                        // Consumed entire string, move to next string.
                         break;
                     }
                     else

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -557,7 +557,7 @@ internal abstract partial class HttpProtocol : IHttpResponseControl
     {
         IncrementRequestHeadersCount();
 
-        // This method should be overriden in specific implementations and the base should be
+        // This method should be overridden in specific implementations and the base should be
         // called to validate the header count.
     }
 
@@ -593,7 +593,7 @@ internal abstract partial class HttpProtocol : IHttpResponseControl
     {
         try
         {
-            // We run the request processing loop in a seperate async method so per connection
+            // We run the request processing loop in a separate async method so per connection
             // exception handling doesn't complicate the generated asm for the loop.
             await ProcessRequests(application);
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -77,11 +77,11 @@ internal sealed class Http3Connection : IHttp3StreamLifetimeHandler, IRequestPro
     private void UpdateHighestOpenedRequestStreamId(long streamId)
     {
         // Only one thread will update the highest stream ID value at a time.
-        // Additional thread safty not required.
+        // Additional thread safety not required.
 
         if (_highestOpenedRequestStreamId >= streamId)
         {
-            // Double check here incase the streams are received out of order.
+            // Double check here in case the streams are received out of order.
             return;
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
@@ -201,7 +201,7 @@ internal sealed class KestrelEventSource : EventSource
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     [Event(9, Level = EventLevel.Informational)]
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Parameters passed to WriteEvent are all primative values.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Parameters passed to WriteEvent are all primitive values.")]
     private void TlsHandshakeStop(string connectionId, string sslProtocols, string applicationProtocol, string hostName)
     {
         WriteEvent(9, connectionId, sslProtocols, applicationProtocol, hostName);
@@ -379,7 +379,7 @@ internal sealed class KestrelEventSource : EventSource
 
     [NonEvent]
     [SkipLocalsInit]
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Parameters passed to WriteEvent are all primative values.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Parameters passed to WriteEvent are all primitive values.")]
     private unsafe void WriteEvent(int eventId, string? arg1, string? arg2, string? arg3, string? arg4, string? arg5)
     {
         const int EventDataCount = 5;

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelMetrics.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelMetrics.cs
@@ -368,7 +368,7 @@ internal sealed class KestrelMetrics
     public static bool TryGetHandshakeProtocol(SslProtocols protocols, [NotNullWhen(true)] out string? name, [NotNullWhen(true)] out string? version)
     {
         // Protocol should be either TLS 1.2 or 1.3. Many older SslProtocols are no longer supported.
-        // Logic for resolving older known values is still here out of an abundence of caution.
+        // Logic for resolving older known values is still here out of an abundance of caution.
 
 #pragma warning disable CS0618 // Type or member is obsolete
 #pragma warning disable SYSLIB0039 // Type or member is obsolete
@@ -428,7 +428,7 @@ internal sealed class KestrelMetrics
         {
             // Set end reason when either:
             // - Overwrite is true. For example, AppShutdownTimeout reason is forced when shutting down
-            //   the app reguardless of whether there is already a value.
+            //   the app regardless of whether there is already a value.
             // - New reason is an error type and there isn't already an error type set.
             //   In other words, first error wins.
             if (overwrite)

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/TimeoutControl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/TimeoutControl.cs
@@ -91,9 +91,9 @@ internal sealed class TimeoutControl : ITimeoutControl, IConnectionTimeoutFeatur
         // This isn't (currently) checked. Reasons:
         // - We're not sure how often people in the real-world run into this. If it
         //   becomes a problem then we'll need to revisit.
-        // - There isn't a way to get this information easily and efficently from msquic.
+        // - There isn't a way to get this information easily and efficiently from msquic.
         // - With QUIC, bytes can be received out of order. The connection window could
-        //   be filled up out of order so that availablility is low but there is still
+        //   be filled up out of order so that availability is low but there is still
         //   no data available to use. Would need a smarter way to handle this situation.
         if (_connectionInputFlowControl?.IsAvailabilityLow == true)
         {

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -217,7 +217,7 @@ public class KestrelServerOptions
     internal bool IsDevelopmentCertificateLoaded { get; set; }
 
     /// <summary>
-    /// Internal AppContext switch to toggle the WebTransport and HTTP/3 datagrams experiemental features.
+    /// Internal AppContext switch to toggle the WebTransport and HTTP/3 datagrams experimental features.
     /// </summary>
     private bool? _enableWebTransportAndH3Datagrams;
     internal bool EnableWebTransportAndH3Datagrams

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
@@ -582,7 +582,7 @@ internal sealed class HttpsConnectionMiddleware
             sslServerAuthenticationOptions.ServerCertificate = null;
             sslServerAuthenticationOptions.ServerCertificateSelectionCallback = (sender, host) =>
             {
-                // There is no ConnectionContext available durring the QUIC handshake.
+                // There is no ConnectionContext available during the QUIC handshake.
                 var cert = httpsOptions.ServerCertificateSelector(null, host);
                 if (cert != null)
                 {

--- a/src/Servers/Kestrel/shared/HPackHeaderWriter.cs
+++ b/src/Servers/Kestrel/shared/HPackHeaderWriter.cs
@@ -23,7 +23,7 @@ internal enum HeaderWriteResult : byte
 }
 
 // This file is used by Kestrel to write response headers and tests to write request headers.
-// To avoid adding test code to Kestrel this file is shared. Test specifc code is excluded from Kestrel by ifdefs.
+// To avoid adding test code to Kestrel this file is shared. Test specific code is excluded from Kestrel by ifdefs.
 internal static class HPackHeaderWriter
 {
     /// <summary>

--- a/src/Servers/Kestrel/shared/Http2HeadersEnumerator.cs
+++ b/src/Servers/Kestrel/shared/Http2HeadersEnumerator.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests;
 #nullable enable
 
 // This file is used by Kestrel to write response headers and tests to write request headers.
-// To avoid adding test code to Kestrel this file is shared. Test specifc code is excluded from Kestrel by ifdefs.
+// To avoid adding test code to Kestrel this file is shared. Test specific code is excluded from Kestrel by ifdefs.
 internal sealed class Http2HeadersEnumerator : IEnumerator<KeyValuePair<string, string>>
 {
     private enum HeadersType : byte

--- a/src/Servers/Kestrel/tools/CodeGenerator/HttpUtilities/HttpUtilities.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/HttpUtilities/HttpUtilities.cs
@@ -248,7 +248,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 
         if (method.Length > length)
         {
-            throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, "MethodAsciiString {0} length is greather than {1}", method, length));
+            throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, "MethodAsciiString {0} length is greater than {1}", method, length));
         }
         string result = method;
 

--- a/src/Servers/README.md
+++ b/src/Servers/README.md
@@ -11,7 +11,7 @@ ASP.NET Core Servers contains all servers that can be used in ASP.NET Core by de
 This folder contains all servers implementations related abstractions for ASP.NET Core.
 
 - [Kestrel/](Kestrel/): Contains the implementation of the Kestrel Web Server.
-- [IIS/](IIS/): Cotnains all code for the IIS Web Server and ASP.NET Core Module.
+- [IIS/](IIS/): Contains all code for the IIS Web Server and ASP.NET Core Module.
 - [HttpSys/](HttpSys/): Contains all code for the HTTP.sys Web Server.
 - [Connections.Abstractions/](Connections.Abstractions/): A set of abstractions for creating and using Connections; used in the server implementations and SignalR.
 

--- a/src/Shared/CertificateGeneration/CertificateManager.cs
+++ b/src/Shared/CertificateGeneration/CertificateManager.cs
@@ -1093,7 +1093,7 @@ internal abstract class CertificateManager
     public sealed class CertificateManagerEventSource : EventSource
     {
         [Event(1, Level = EventLevel.Verbose, Message = "Listing certificates from {0}\\{1}")]
-        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Parameters passed to WriteEvent are all primative values.")]
+        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Parameters passed to WriteEvent are all primitive values.")]
         public void ListCertificatesStart(StoreLocation location, StoreName storeName) => WriteEvent(1, location, storeName);
 
         [Event(2, Level = EventLevel.Verbose, Message = "Found certificates: {0}")]

--- a/src/Shared/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/UnixCertificateManager.cs
@@ -259,7 +259,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
             }
             catch
             {
-                // If we couldn't load the file, then we also can't safely overwite it.
+                // If we couldn't load the file, then we also can't safely overwrite it.
                 Log.UnixNotOverwritingCertificate(certPath);
                 return TrustLevel.None;
             }

--- a/src/Shared/Hpack/DynamicHPackEncoder.cs
+++ b/src/Shared/Hpack/DynamicHPackEncoder.cs
@@ -288,7 +288,7 @@ internal sealed class DynamicHPackEncoder
 }
 
 /// <summary>
-/// Hint for how the header should be encoded as HPack. This value can be overriden.
+/// Hint for how the header should be encoded as HPack. This value can be overridden.
 /// For example, a header that is larger than the dynamic table won't be indexed.
 /// </summary>
 internal enum HeaderEncodingHint

--- a/src/Shared/Http2cat/Http2CatReadMe.md
+++ b/src/Shared/Http2cat/Http2CatReadMe.md
@@ -1,6 +1,6 @@
 ## Http2Cat
 
-Http2Cat is a low level Http2 testing framework designed to excersize a server with frame level control. This can be useful for unit testing and compat testing.
+Http2Cat is a low level Http2 testing framework designed to exercise a server with frame level control. This can be useful for unit testing and compat testing.
 
 The framework is distributed as internal sources since it shares the basic building blocks from Kestrel's Http2 implementation (frames, enum flags, frame reading and writing, etc.). InternalsVisibleTo should not be used, any needed components should be moved to one of the shared code directories.
 

--- a/src/Shared/ParameterBindingMethodCache.cs
+++ b/src/Shared/ParameterBindingMethodCache.cs
@@ -430,7 +430,7 @@ internal sealed class ParameterBindingMethodCache
     [RequiresUnreferencedCode("Performs reflection on type hierarchy. This cannot be statically analyzed.")]
     private static bool TryGetExplicitIParsableTryParseMethod(Type type, out MethodInfo methodInfo)
     {
-        // Nested types by default use + as the delimeter between the containing type and the
+        // Nested types by default use + as the delimiter between the containing type and the
         // inner type. However when doing a method search this '+' symbol needs to be a '.' symbol.
         var typeName = TypeNameHelper.GetTypeDisplayName(type, fullName: true, nestedTypeDelimiter: '.');
         var name = $"System.IParsable<{typeName}>.TryParse";

--- a/src/Shared/PathNormalizer/PathNormalizer.cs
+++ b/src/Shared/PathNormalizer/PathNormalizer.cs
@@ -31,7 +31,7 @@ internal static class PathNormalizer
             }
             if (nextDotSegmentIndex < 0)
             {
-                // Copy the remianing src to dst, and return.
+                // Copy the remaining src to dst, and return.
                 currentSrc.CopyTo(src[writtenLength..]);
                 writtenLength += src.Length - readPointer;
                 return writtenLength;

--- a/src/Shared/ServerInfrastructure/StringUtilities.cs
+++ b/src/Shared/ServerInfrastructure/StringUtilities.cs
@@ -87,7 +87,7 @@ internal static class StringUtilities
     private static bool IsValidHeaderString(string value)
     {
         // Method for Debug.Assert to ensure BytesOrdinalEqualsStringAndAscii
-        // is not called with an unvalidated string comparitor.
+        // is not called with an unvalidated string comparator.
         try
         {
             if (value is null)
@@ -176,10 +176,10 @@ internal static class StringUtilities
         {
             var number = (int)tupleNumber;
             // Slice the buffer so we can use constant offsets in a backwards order
-            // and the highest index [7] will eliminate the bounds checks for all the lower indicies.
+            // and the highest index [7] will eliminate the bounds checks for all the lower indices.
             buffer = buffer.Slice(i);
 
-            // This must be explicity typed as ReadOnlySpan<byte>
+            // This must be explicitly typed as ReadOnlySpan<byte>
             // This then becomes a non-allocating mapping to the data section of the assembly.
             // If it is a var, Span<byte> or byte[], it allocates the byte array per call.
             ReadOnlySpan<byte> hexEncodeMap = "0123456789ABCDEF"u8;

--- a/src/Shared/StaticWebAssets/ManifestStaticWebAssetFileProvider.cs
+++ b/src/Shared/StaticWebAssets/ManifestStaticWebAssetFileProvider.cs
@@ -46,9 +46,9 @@ internal sealed partial class ManifestStaticWebAssetFileProvider : IFileProvider
 
         // Iterate over the path segments until we reach the destination. Whenever we encounter
         // a pattern, we start tracking it as well as the content root directory. On every segment
-        // we evalutate the directory to see if there is a subfolder with the current segment and
+        // we evaluate the directory to see if there is a subfolder with the current segment and
         // replace it on the dictionary if it exists or remove it if it does not.
-        // When we reach our destination we enumerate the files in that folder and evalute them against
+        // When we reach our destination we enumerate the files in that folder and evaluate them against
         // the pattern to compute the final list.
         HashSet<IFileInfo>? files = null;
         for (var i = 0; i < segments.Length; i++)

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -778,7 +778,7 @@ public partial class HubConnection : IAsyncDisposable
             }
             else
             {
-                // Reset StopCts if there isn't an active connection so that the next StartAsync wont immediately fail due to the token being canceled
+                // Reset StopCts if there isn't an active connection so that the next StartAsync won't immediately fail due to the token being canceled
                 _state.StopCts = new CancellationTokenSource();
             }
 

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnectionExtensions.StreamAsChannelAsync.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnectionExtensions.StreamAsChannelAsync.cs
@@ -276,7 +276,7 @@ public static partial class HubConnectionExtensions
         var inputChannel = await hubConnection.StreamAsChannelCoreAsync(methodName, typeof(TResult), args, cancellationToken).ConfigureAwait(false);
         var outputChannel = Channel.CreateUnbounded<TResult>();
 
-        // Intentionally avoid passing the CancellationToken to RunChannel. The token is only meant to cancel the intial setup, not the enumeration.
+        // Intentionally avoid passing the CancellationToken to RunChannel. The token is only meant to cancel the initial setup, not the enumeration.
         _ = RunChannel(inputChannel, outputChannel);
 
         return outputChannel.Reader;

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
@@ -732,7 +732,7 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
     {
         var negotiationResponse = await NegotiateAsync(uri, _httpClient, _logger, cancellationToken).ConfigureAwait(false);
         // If the negotiationVersion is greater than zero then we know that the negotiation response contains a
-        // connectionToken that will be required to conenct. Otherwise we just set the connectionId and the
+        // connectionToken that will be required to connect. Otherwise we just set the connectionId and the
         // connectionToken on the client to the same value.
         _connectionId = negotiationResponse.ConnectionId!;
         if (negotiationResponse.Version == 0)

--- a/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/LongPollingTransport.java
+++ b/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/LongPollingTransport.java
@@ -115,7 +115,7 @@ class LongPollingTransport implements Transport {
                             logger.debug("Message received.");
                             try {
                                 onReceiveThread.submit(() -> this.onReceive(response.getContent()));
-                            // it's possible for stop to be called while a request is in progress, if stop throws it wont wait for
+                            // it's possible for stop to be called while a request is in progress, if stop throws it won't wait for
                             // an in-progress poll to complete and will shutdown the thread. We should ignore the exception so we don't
                             // get an unhandled RX error
                             } catch(Exception e) {}

--- a/src/SignalR/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
+++ b/src/SignalR/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
@@ -885,7 +885,7 @@ describe("hubConnection", () => {
         }
     });
 
-    it("connection id is alwys null is negotiation is skipped", async () => {
+    it("connection id is always null if negotiation is skipped", async () => {
         try {
             const hubConnection = getConnectionBuilder(
                     HttpTransportType.WebSockets,

--- a/src/SignalR/common/Http.Connections.Common/src/AvailableTransport.cs
+++ b/src/SignalR/common/Http.Connections.Common/src/AvailableTransport.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 namespace Microsoft.AspNetCore.Http.Connections;
 
 /// <summary>
-/// Part of the <see cref="NegotiationResponse"/> that represents an individual transport and the trasfer formats the transport supports.
+/// Part of the <see cref="NegotiationResponse"/> that represents an individual transport and the transfer formats the transport supports.
 /// </summary>
 public class AvailableTransport
 {

--- a/src/SignalR/common/SignalR.Common/src/Protocol/HandshakeProtocol.cs
+++ b/src/SignalR/common/SignalR.Common/src/Protocol/HandshakeProtocol.cs
@@ -224,7 +224,7 @@ public static class HandshakeProtocol
         // For error messages, we want to print the payload as text
         string GetPayloadAsString()
         {
-            // REVIEW: Should we show hex for binary charaters?
+            // REVIEW: Should we show hex for binary characters?
             return Encoding.UTF8.GetString(payload.ToArray());
         }
 

--- a/src/SignalR/docs/specs/HubProtocol.md
+++ b/src/SignalR/docs/specs/HubProtocol.md
@@ -531,7 +531,7 @@ Example:
 ```
 
 ### Sequence Message Encoding
-A `Seqeunce` message is a JSON object with the following properties
+A `Sequence` message is a JSON object with the following properties
 
 * `type` - A `Number` with the literal value `9`, indicating that this message is a `Sequence`.
 * `sequenceId` - A `Number` specifying what the new starting message number will be. Only sent on reconnects.

--- a/src/SignalR/server/Specification.Tests/src/ScaleoutHubLifetimeManagerTests.cs
+++ b/src/SignalR/server/Specification.Tests/src/ScaleoutHubLifetimeManagerTests.cs
@@ -571,7 +571,7 @@ public abstract class ScaleoutHubLifetimeManagerTests<TBackplane> : HubLifetimeM
             connection1.Abort();
             await manager2.OnDisconnectedAsync(connection1).DefaultTimeout();
 
-            // Server should propogate connection closure so task isn't blocked
+            // Server should propagate connection closure so task isn't blocked
             var ex = await Assert.ThrowsAsync<HubException>(() => invoke1).DefaultTimeout();
             Assert.Equal("Connection disconnected.", ex.Message);
         }

--- a/src/Tools/README.md
+++ b/src/Tools/README.md
@@ -14,7 +14,7 @@ The folder contains command-line tools for ASP.NET Core. The following tools are
 
 ## Non-bundled tools
 
-The following tools are produced by us but not bundled in the .NET Core CLI. They must be aquired independently.
+The following tools are produced by us but not bundled in the .NET Core CLI. They must be acquired independently.
 
 - [Microsoft.dotnet-openapi](Microsoft.dotnet-openapi/README.md)
 


### PR DESCRIPTION
I used `codespell` across the repo, with a curated (Copilot assisted) ignore list and skip patterns to exclude test data, localized installer files (.wxl/.rtf/LCID), submodules, generated code, and `PublicAPI.txt` - places where "typos" are often intentional (test fixtures, non-English strings, public API names). I restricted auto-fixes to product source, then reviewed the full diff line-by-line.

BTW I skipped public-API typo: `FeatureReferences.Initalize`. That would be a breaking change.