### PR TITLE
Capture minidumps instead of full dumps for build/test hangs

### DIFF
--- a/eng/scripts/CaptureHangDumps.sh
+++ b/eng/scripts/CaptureHangDumps.sh
@@ -11,6 +11,16 @@
 # terminates the hung processes. Dumps are written next to the crash dumps that
 # upload-cores.sh already collects (dotnet-<pid>.core in the working directory),
 # so no additional upload wiring is required.
+#
+# We deliberately capture *minidumps* (--normal) rather than full dumps. A full
+# dump of a hung .NET process can be several GB; capturing several of them and
+# then uploading them as artifacts does not fit inside the cancelTimeout grace
+# window, so the upload is killed and no dump is ever published. A minidump is a
+# few tens of MB, captures in seconds, and uploads comfortably. createdump is
+# .NET-aware and includes the thread stacks and runtime/module memory the DAC
+# needs, so `clrthreads` / `clrstack` still work to identify the hung process and
+# its managed stack -- which is all a hang investigation needs (heap inspection
+# such as `dumpheap` is not).
 
 set -uo pipefail
 
@@ -85,8 +95,8 @@ for pid in $ordered; do
     break
   fi
   out="$wd/dotnet-${pid}.core"
-  echo "Capturing full dump for PID $pid -> $out"
-  if $sudo "$createdump" --full --name "$out" "$pid"; then
+  echo "Capturing minidump for PID $pid -> $out"
+  if $sudo "$createdump" --normal --name "$out" "$pid"; then
     # createdump may run under sudo and write a root-owned file; ensure the
     # agent account can read it for artifact upload.
     $sudo chmod 0644 "$out" 2>/dev/null || true


### PR DESCRIPTION
## Summary

The non-Windows hang-dump capture step (`eng/scripts/CaptureHangDumps.sh`) captured **full** dumps (`createdump --full`). On a hang these are multi-GB (~5.6 GB each on the macOS quarantine leg), and capturing several of them plus uploading them as artifacts does not fit inside the 15-minute `cancelTimeoutInMinutes` grace window — so **no hang dump is ever published**.

This switches the capture to **minidumps** (`createdump --normal`), which are tens of MB, capture in seconds, and upload comfortably within the grace window.

## Why this matters

The macOS quarantine test leg (`Tests: macOS`, def 86 / dnceng-public) has been intermittently **hanging for ~2 hours** and timing out. Investigating it requires the captured dump, but on every occurrence the dump never makes it off the agent. Concretely, on build 1482875's hung mac job:

- **Capture hang dumps**: `succeeded`, but took **~6m45s** producing 5×~5.6 GB cores.
- **Upload cores**: `failed` after **~7m27s** — killed at the 15-minute grace boundary; ~28 GB cannot upload in time. No log, no artifact.

So the dumps are captured on the agent every time; they just can't be uploaded. Shrinking them is the fix.

## Why `--normal` is sufficient

`createdump` is .NET-aware: even a normal minidump includes the thread stacks and the runtime/module memory the DAC needs to walk managed stacks. SOS `clrthreads` / `clrstack` continue to work, which is exactly what a hang investigation needs (identify the hung process and its managed stack). Full heap inspection (`dumpheap`, object graphs) is not needed to root-cause a hang, and that is the only thing dropped.

## Risk

Low. Only affects the diagnostic dump captured during the `or(failed(), canceled())` grace window on build/test hangs; no product or test behavior changes.
