### PR TITLE
Disable concurrent GC on macOS quarantine leg to avoid fork/GC deadlock

### DIFF
--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -119,27 +119,24 @@ jobs:
     isAzDOTestingJob: true
     enablePublishTestResults: false
     steps:
-    # The macOS agent pool is mixed: Apple Silicon hosts run the default osx-x64 SDK
-    # under Rosetta, which hits a GC<->fork() deadlock
-    # (https://github.com/dotnet/runtime/issues/89272) when the test launcher spawns
-    # child processes -- hanging the job until the 150-min timeout. This leg is uniquely
-    # affected because it runs tests locally (RunQuarantinedTests) rather than on Helix.
-    # On Apple Silicon, run natively under `arch -arm64` to avoid Rosetta entirely.
-    # Intel hosts (where `arch -arm64` is unsupported) keep running native osx-x64, which
-    # is not affected by the deadlock. Architecture is auto-detected from `uname -m`
-    # under whichever `arch` prefix is selected, so no explicit --arch is needed.
-    - bash: |
-        ARCH_PREFIX=
-        if arch -arm64 true 2>/dev/null; then ARCH_PREFIX="arch -arm64"; fi
-        $ARCH_PREFIX ./eng/build.sh --ci --nobl --all --no-build-java --pack
+    # This leg runs functional tests locally (RunQuarantinedTests) rather than on Helix,
+    # so the test launcher spawns many child processes via fork()/exec(). On macOS x64,
+    # fork() in a multithreaded .NET process can intermittently deadlock: the forked child
+    # hangs before exec() on a lock held at fork time by concurrent (background) GC
+    # (FlushProcessWriteBuffers / revisit_written_pages), while the parent blocks forever
+    # on the child status pipe -- hanging the job until the 150-min timeout
+    # (https://github.com/dotnet/runtime/issues/89272). Disabling concurrent GC removes the
+    # background-GC write-watch flush that races with fork(), avoiding the deadlock.
+    - bash: ./eng/build.sh --ci --nobl --all --no-build-java --pack
       displayName: Build
-    - bash: |
-        ARCH_PREFIX=
-        if arch -arm64 true 2>/dev/null; then ARCH_PREFIX="arch -arm64"; fi
-        $ARCH_PREFIX ./eng/build.sh --ci --nobl --all --no-build --no-build-java --test \
-          -p:RunQuarantinedTests=true -p:SkipHelixReadyTests=true
+      env:
+        DOTNET_gcConcurrent: 0
+    - bash: ./eng/build.sh --ci --nobl --all --no-build --no-build-java --test
+            -p:RunQuarantinedTests=true -p:SkipHelixReadyTests=true
       displayName: Run Quarantined Tests
       continueOnError: true
+      env:
+        DOTNET_gcConcurrent: 0
     - task: PublishTestResults@2
       displayName: Publish Quarantined Test Results
       inputs:

--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -119,14 +119,25 @@ jobs:
     isAzDOTestingJob: true
     enablePublishTestResults: false
     steps:
-    # Run natively on arm64 (via `arch -arm64`) instead of the default osx-x64 SDK,
-    # which the AzDO macOS agents otherwise run under Rosetta. Rosetta x64 hits a
-    # GC<->fork() deadlock (https://github.com/dotnet/runtime/issues/89272) when the
-    # test-launcher process spawns child processes, hanging the job until it times out.
-    - bash: arch -arm64 ./eng/build.sh --ci --nobl --all --no-build-java --pack --arch arm64
+    # The macOS agent pool is mixed: Apple Silicon hosts run the default osx-x64 SDK
+    # under Rosetta, which hits a GC<->fork() deadlock
+    # (https://github.com/dotnet/runtime/issues/89272) when the test launcher spawns
+    # child processes -- hanging the job until the 150-min timeout. This leg is uniquely
+    # affected because it runs tests locally (RunQuarantinedTests) rather than on Helix.
+    # On Apple Silicon, run natively under `arch -arm64` to avoid Rosetta entirely.
+    # Intel hosts (where `arch -arm64` is unsupported) keep running native osx-x64, which
+    # is not affected by the deadlock. Architecture is auto-detected from `uname -m`
+    # under whichever `arch` prefix is selected, so no explicit --arch is needed.
+    - bash: |
+        ARCH_PREFIX=
+        if arch -arm64 true 2>/dev/null; then ARCH_PREFIX="arch -arm64"; fi
+        $ARCH_PREFIX ./eng/build.sh --ci --nobl --all --no-build-java --pack
       displayName: Build
-    - bash: arch -arm64 ./eng/build.sh --ci --nobl --all --no-build --no-build-java --test --arch arm64
-            -p:RunQuarantinedTests=true -p:SkipHelixReadyTests=true
+    - bash: |
+        ARCH_PREFIX=
+        if arch -arm64 true 2>/dev/null; then ARCH_PREFIX="arch -arm64"; fi
+        $ARCH_PREFIX ./eng/build.sh --ci --nobl --all --no-build --no-build-java --test \
+          -p:RunQuarantinedTests=true -p:SkipHelixReadyTests=true
       displayName: Run Quarantined Tests
       continueOnError: true
     - task: PublishTestResults@2

--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -119,9 +119,13 @@ jobs:
     isAzDOTestingJob: true
     enablePublishTestResults: false
     steps:
-    - bash: ./eng/build.sh --ci --nobl --all --no-build-java --pack
+    # Run natively on arm64 (via `arch -arm64`) instead of the default osx-x64 SDK,
+    # which the AzDO macOS agents otherwise run under Rosetta. Rosetta x64 hits a
+    # GC<->fork() deadlock (https://github.com/dotnet/runtime/issues/89272) when the
+    # test-launcher process spawns child processes, hanging the job until it times out.
+    - bash: arch -arm64 ./eng/build.sh --ci --nobl --all --no-build-java --pack --arch arm64
       displayName: Build
-    - bash: ./eng/build.sh --ci --nobl --all --no-build --no-build-java --test
+    - bash: arch -arm64 ./eng/build.sh --ci --nobl --all --no-build --no-build-java --test --arch arm64
             -p:RunQuarantinedTests=true -p:SkipHelixReadyTests=true
       displayName: Run Quarantined Tests
       continueOnError: true


### PR DESCRIPTION
## Problem

The `MacOS_Quarantined_Test` leg (def 86, `aspnetcore-quarantined-pr`) intermittently hangs until its 150-min timeout. Unlike the other quarantine legs, it runs functional tests **locally** (`RunQuarantinedTests=true`) rather than on Helix, so the test launcher spawns many child processes via fork()/exec() (Kestrel/Nginx/HttpSys/ServerComparison servers).

## Root cause

Dump analysis of a hung build (1484177, 5 minidump cores) confirmed a **fork()/exec() deadlock in a multithreaded .NET process on macOS x64**:

- The MSBuild driver process has a thread wedged in `ToolTask.ExecuteTool -> Process.Start() -> Interop.Sys.ForkAndExecProcess` -- blocked on the forked child's status pipe.
- The forked child deadlocks **before exec()** on a lock held at fork time by concurrent (background) GC (`FlushProcessWriteBuffers` / `revisit_written_pages` in a prior full-core analysis).
- This matches dotnet/runtime#89272. The cores are native x86_64 with **zero Rosetta artifacts** -- the hang reproduces on native Intel hosted agents, so it is **not** Rosetta-specific (refuting an earlier arm64-only theory). It is an intermittent race, so most runs still pass in 20-45 min.

## Fix

Set `DOTNET_gcConcurrent=0` on the macOS quarantine build and test steps. Disabling concurrent GC removes the background-GC write-watch flush that races with fork(), avoiding the deadlock without changing the runtime architecture.

## Validation

Re-running CI >=5 times (waiting for each build to fully complete, since `pr.autoCancel` cancels in-flight builds) to confirm the macOS leg returns to the normal 20-45 min range with no hang-dump artifacts.
