### PR TITLE
Scope default CSRF middleware to endpoints opting in via `IAntiforgeryMetadata`

### DIFF
--- a/src/DefaultBuilder/src/Internal/CsrfProtectionMiddleware.cs
+++ b/src/DefaultBuilder/src/Internal/CsrfProtectionMiddleware.cs
@@ -32,19 +32,21 @@ internal sealed partial class CsrfProtectionMiddleware
         _logger = logger;
     }
 
-    public async Task InvokeAsync(HttpContext context)
+    public Task InvokeAsync(HttpContext context)
     {
         context.Items[MiddlewareInvokedKeys.CsrfProtection] = MiddlewareInvokedKeys.Sentinel;
 
         var endpoint = context.GetEndpoint();
         if (endpoint?.Metadata.GetMetadata<IAntiforgeryMetadata>() is not { RequiresValidation: true })
         {
-            // No antiforgery metadata, or the endpoint opted out via DisableAntiforgery():
-            // mirror AntiforgeryMiddleware and pass through without recording a verdict.
-            await _next(context);
-            return;
+            return _next(context);
         }
 
+        return InvokeCoreAsync(context);
+    }
+
+    private async Task InvokeCoreAsync(HttpContext context)
+    {
         // This middleware does not short-circuit, but only records the verdict.
         // When the application also calls UseAntiforgery(),
         // the later AntiforgeryMiddleware may overwrite this verdict with the result of token-based validation.

--- a/src/DefaultBuilder/src/Internal/CsrfProtectionMiddleware.cs
+++ b/src/DefaultBuilder/src/Internal/CsrfProtectionMiddleware.cs
@@ -8,8 +8,10 @@ namespace Microsoft.AspNetCore.Antiforgery;
 
 /// <summary>
 /// Auto-injected middleware that enforces <see cref="ICsrfProtection"/> on incoming requests.
-/// Skips validation when the matched endpoint opted out via <c>DisableAntiforgery()</c>
-/// (i.e. carries <see cref="IAntiforgeryMetadata"/> with <see cref="IAntiforgeryMetadata.RequiresValidation"/> = <see langword="false"/>).
+/// Validation only runs when the matched endpoint opts in via <see cref="IAntiforgeryMetadata"/>
+/// with <see cref="IAntiforgeryMetadata.RequiresValidation"/> = <see langword="true"/>. Endpoints
+/// without any <see cref="IAntiforgeryMetadata"/> (e.g. unannotated minimal-API handlers) and
+/// endpoints that opted out via <c>DisableAntiforgery()</c> pass through unchanged.
 /// </summary>
 internal sealed partial class CsrfProtectionMiddleware
 {
@@ -32,12 +34,17 @@ internal sealed partial class CsrfProtectionMiddleware
 
     public async Task InvokeAsync(HttpContext context)
     {
-        // Recording that CsrfProtection was invoked
+        // The sentinel is set unconditionally even when validation is skipped: the FormFeature
+        // antiforgery backstop relies on it to detect that some antiforgery-style middleware ran
+        // on this request (see PR #67082). Without it, a re-executed pipeline (e.g. status code
+        // re-execute into an antiforgery-required endpoint) would throw "missing middleware".
         context.Items[MiddlewareInvokedKeys.CsrfProtection] = MiddlewareInvokedKeys.Sentinel;
 
         var endpoint = context.GetEndpoint();
-        if (endpoint?.Metadata.GetMetadata<IAntiforgeryMetadata>() is { RequiresValidation: false })
+        if (endpoint?.Metadata.GetMetadata<IAntiforgeryMetadata>() is not { RequiresValidation: true })
         {
+            // No antiforgery metadata, or the endpoint opted out via DisableAntiforgery():
+            // mirror AntiforgeryMiddleware and pass through without recording a verdict.
             await _next(context);
             return;
         }

--- a/src/DefaultBuilder/src/Internal/CsrfProtectionMiddleware.cs
+++ b/src/DefaultBuilder/src/Internal/CsrfProtectionMiddleware.cs
@@ -34,10 +34,6 @@ internal sealed partial class CsrfProtectionMiddleware
 
     public async Task InvokeAsync(HttpContext context)
     {
-        // The sentinel is set unconditionally even when validation is skipped: the FormFeature
-        // antiforgery backstop relies on it to detect that some antiforgery-style middleware ran
-        // on this request (see PR #67082). Without it, a re-executed pipeline (e.g. status code
-        // re-execute into an antiforgery-required endpoint) would throw "missing middleware".
         context.Items[MiddlewareInvokedKeys.CsrfProtection] = MiddlewareInvokedKeys.Sentinel;
 
         var endpoint = context.GetEndpoint();

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/CsrfProtectionIntegrationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/CsrfProtectionIntegrationTests.cs
@@ -143,7 +143,7 @@ public class CsrfProtectionIntegrationTests
         builder.WebHost.UseSetting("DisableCsrfProtection", value);
         using var app = builder.Build();
 
-        app.MapPost("/protected", EnforceCsrf);
+        app.MapPost("/protected", EnforceCsrf).WithMetadata(new RequireAntiforgeryTokenAttribute());
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -163,6 +163,9 @@ public class CsrfProtectionIntegrationTests
         builder.Services.RemoveAll<ICsrfProtection>();
         using var app = builder.Build();
 
+        // Endpoint deliberately has no IAntiforgeryMetadata — with ICsrfProtection removed AND no
+        // antiforgery middleware in the pipeline, this exercises the "no enforcement available"
+        // path: the request should pass through to the endpoint.
         app.MapPost("/protected", EnforceCsrf);
         await app.StartAsync();
 
@@ -182,7 +185,7 @@ public class CsrfProtectionIntegrationTests
         builder.Services.AddSingleton<ICsrfProtection, AlwaysAllowCsrfProtection>();
         using var app = builder.Build();
 
-        app.MapPost("/protected", EnforceCsrf);
+        app.MapPost("/protected", EnforceCsrf).WithMetadata(new RequireAntiforgeryTokenAttribute());
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -228,7 +231,7 @@ public class CsrfProtectionIntegrationTests
             options.AddDefaultPolicy(policy => policy.WithOrigins("https://trusted.example.com")));
         using var app = builder.Build();
 
-        app.MapPost("/protected", EnforceCsrf);
+        app.MapPost("/protected", EnforceCsrf).WithMetadata(new RequireAntiforgeryTokenAttribute());
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -248,7 +251,7 @@ public class CsrfProtectionIntegrationTests
             options.AddDefaultPolicy(policy => policy.AllowAnyOrigin()));
         using var app = builder.Build();
 
-        app.MapPost("/protected", EnforceCsrf);
+        app.MapPost("/protected", EnforceCsrf).WithMetadata(new RequireAntiforgeryTokenAttribute());
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -269,7 +272,7 @@ public class CsrfProtectionIntegrationTests
             options.AddDefaultPolicy(policy => policy.WithOrigins("https://trusted.example.com")));
         using var app = builder.Build();
 
-        app.MapPost("/protected", EnforceCsrf);
+        app.MapPost("/protected", EnforceCsrf).WithMetadata(new RequireAntiforgeryTokenAttribute());
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -291,7 +294,7 @@ public class CsrfProtectionIntegrationTests
         using var app = builder.Build();
 
         app.UseCors();
-        app.MapPost("/webhook", EnforceCsrf).RequireCors("Webhook");
+        app.MapPost("/webhook", EnforceCsrf).RequireCors("Webhook").WithMetadata(new RequireAntiforgeryTokenAttribute());
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -316,7 +319,7 @@ public class CsrfProtectionIntegrationTests
         using var app = builder.Build();
 
         app.UseCors();
-        app.MapPost("/webhook", EnforceCsrf).RequireCors("Webhook");
+        app.MapPost("/webhook", EnforceCsrf).RequireCors("Webhook").WithMetadata(new RequireAntiforgeryTokenAttribute());
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -339,7 +342,7 @@ public class CsrfProtectionIntegrationTests
 
         app.UseCors();
         // Inline-policy variant: RequireCors(lambda) builds a CorsPolicy and attaches it as ICorsPolicyMetadata.
-        app.MapPost("/webhook", EnforceCsrf).RequireCors(p => p.WithOrigins("https://stripe.example.com"));
+        app.MapPost("/webhook", EnforceCsrf).RequireCors(p => p.WithOrigins("https://stripe.example.com")).WithMetadata(new RequireAntiforgeryTokenAttribute());
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -361,7 +364,7 @@ public class CsrfProtectionIntegrationTests
             options.AddPolicy("Webhook", policy => policy.WithOrigins("https://stripe.example.com")));
         using var app = builder.Build();
 
-        app.MapPost("/protected", EnforceCsrf);
+        app.MapPost("/protected", EnforceCsrf).WithMetadata(new RequireAntiforgeryTokenAttribute());
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -389,7 +392,7 @@ public class CsrfProtectionIntegrationTests
         // UseCors is required because the endpoint carries CORS metadata; the CSRF middleware no longer
         // short-circuits, so the request now reaches the endpoint pipeline.
         app.UseCors();
-        app.MapPost("/no-cors", EnforceCsrf).WithMetadata(new Cors.DisableCorsAttribute());
+        app.MapPost("/no-cors", EnforceCsrf).WithMetadata(new Cors.DisableCorsAttribute()).WithMetadata(new RequireAntiforgeryTokenAttribute());
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -412,7 +415,7 @@ public class CsrfProtectionIntegrationTests
 
         app.UseRouting();
         app.UseCors();
-        app.MapPost("/webhook", EnforceCsrf).RequireCors("Webhook");
+        app.MapPost("/webhook", EnforceCsrf).RequireCors("Webhook").WithMetadata(new RequireAntiforgeryTokenAttribute());
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -434,7 +437,7 @@ public class CsrfProtectionIntegrationTests
         using var app = builder.Build();
 
         app.UseCors();
-        app.MapPost("/webhook", EnforceCsrf).RequireCors("Webhook");
+        app.MapPost("/webhook", EnforceCsrf).RequireCors("Webhook").WithMetadata(new RequireAntiforgeryTokenAttribute());
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -457,7 +460,7 @@ public class CsrfProtectionIntegrationTests
 
         app.UseRouting();
         app.UseCors();
-        app.MapPost("/webhook", EnforceCsrf).RequireCors("Webhook");
+        app.MapPost("/webhook", EnforceCsrf).RequireCors("Webhook").WithMetadata(new RequireAntiforgeryTokenAttribute());
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -583,8 +586,12 @@ public class CsrfProtectionIntegrationTests
         builder.WebHost.UseTestServer();
         var app = builder.Build();
 
-        app.MapPost("/protected", EnforceCsrf);
-        app.MapGet("/protected-get", EnforceCsrf);
+        // The CSRF middleware only runs validation when the matched endpoint opts in via
+        // IAntiforgeryMetadata (mirroring AntiforgeryMiddleware). Bare minimal-API handlers have
+        // no such metadata; attach RequireAntiforgeryTokenAttribute so these "protected" routes
+        // actually exercise the validation path the surrounding tests assert against.
+        app.MapPost("/protected", EnforceCsrf).WithMetadata(new RequireAntiforgeryTokenAttribute());
+        app.MapGet("/protected-get", EnforceCsrf).WithMetadata(new RequireAntiforgeryTokenAttribute());
         app.MapPost("/unprotected", EnforceCsrf).DisableAntiforgery();
 
         await app.StartAsync();
@@ -606,7 +613,7 @@ public class CsrfProtectionIntegrationTests
         // Sanity: the instance the container returns is the one we registered.
         Assert.Same(counting, app.Services.GetRequiredService<ICsrfProtection>());
 
-        app.MapPost("/protected", EnforceCsrf);
+        app.MapPost("/protected", EnforceCsrf).WithMetadata(new RequireAntiforgeryTokenAttribute());
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -632,7 +639,7 @@ public class CsrfProtectionIntegrationTests
         builder.Logging.ClearProviders().AddProvider(captureProvider).SetMinimumLevel(LogLevel.Debug);
         using var app = builder.Build();
 
-        app.MapPost("/protected", EnforceCsrf);
+        app.MapPost("/protected", EnforceCsrf).WithMetadata(new RequireAntiforgeryTokenAttribute());
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -754,19 +761,23 @@ public class CsrfProtectionIntegrationTests
     }
 
     [Fact]
-    public async Task CsrfProtection_NonFormEndpoint_CrossOrigin_IsNotAutoRejected_ButRecordsInvalidVerdict()
+    public async Task CsrfProtection_NonFormEndpoint_CrossOrigin_PassesThrough_NoVerdictRecorded()
     {
-        // Behavior change: like token-based antiforgery, the CSRF middleware does not reject plain
-        // (non-form) endpoints on its own. It records the verdict; a consumer that never reads the
-        // feature simply runs. This documents that a bare MapPost is reachable cross-origin.
+        // The CSRF middleware mirrors AntiforgeryMiddleware: it only runs validation when the matched
+        // endpoint opts in via IAntiforgeryMetadata { RequiresValidation: true }. A bare MapPost has no
+        // such metadata, so the request passes through and no verdict is recorded on the feature.
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
         using var app = builder.Build();
 
+        var endpointInvoked = false;
         IAntiforgeryValidationFeature? capturedFeature = null;
+        object? observedMarker = null;
         app.MapPost("/plain", (HttpContext ctx) =>
         {
+            endpointInvoked = true;
             capturedFeature = ctx.Features.Get<IAntiforgeryValidationFeature>();
+            observedMarker = ctx.Items[CsrfProtectionInvokedKey];
             return "ok";
         });
         await app.StartAsync();
@@ -779,9 +790,82 @@ public class CsrfProtectionIntegrationTests
         var response = await client.SendAsync(request);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(endpointInvoked, "Endpoint should run when the CSRF middleware passes through.");
+        Assert.Null(capturedFeature);
+        // The sentinel is still set: it is the FormFeature backstop contract (PR #67082).
+        Assert.NotNull(observedMarker);
+    }
+
+    [Fact]
+    public async Task CsrfProtection_DisableAntiforgeryEndpoint_CrossOrigin_PassesThrough_NoVerdictRecorded()
+    {
+        // An endpoint that opted out via DisableAntiforgery() carries IAntiforgeryMetadata with
+        // RequiresValidation = false. The middleware must skip validation but still set the sentinel
+        // so the FormFeature backstop knows antiforgery-style middleware ran (PR #67082).
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        using var app = builder.Build();
+
+        var endpointInvoked = false;
+        IAntiforgeryValidationFeature? capturedFeature = null;
+        object? observedMarker = null;
+        app.MapPost("/exempt", (HttpContext ctx) =>
+        {
+            endpointInvoked = true;
+            capturedFeature = ctx.Features.Get<IAntiforgeryValidationFeature>();
+            observedMarker = ctx.Items[CsrfProtectionInvokedKey];
+            return "ok";
+        }).DisableAntiforgery();
+        await app.StartAsync();
+
+        var client = app.GetTestClient();
+        var request = new HttpRequestMessage(HttpMethod.Post, "/exempt");
+        request.Headers.Add("Sec-Fetch-Site", "cross-site");
+        request.Headers.Add("Origin", "https://evil.example.com");
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(endpointInvoked);
+        Assert.Null(capturedFeature);
+        Assert.NotNull(observedMarker);
+    }
+
+    [Fact]
+    public async Task CsrfProtection_RequiresValidationEndpoint_CrossOriginUntrustedOrigin_RecordsInvalidVerdict()
+    {
+        // An endpoint that opted IN via RequireAntiforgeryTokenAttribute (RequiresValidation = true)
+        // exercises the validation path: cross-site Sec-Fetch with an untrusted origin records
+        // IsValid = false on IAntiforgeryValidationFeature without short-circuiting.
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        using var app = builder.Build();
+
+        var endpointInvoked = false;
+        IAntiforgeryValidationFeature? capturedFeature = null;
+        object? observedMarker = null;
+        app.MapPost("/protected", (HttpContext ctx) =>
+        {
+            endpointInvoked = true;
+            capturedFeature = ctx.Features.Get<IAntiforgeryValidationFeature>();
+            observedMarker = ctx.Items[CsrfProtectionInvokedKey];
+            return "ok";
+        }).WithMetadata(new RequireAntiforgeryTokenAttribute());
+        await app.StartAsync();
+
+        var client = app.GetTestClient();
+        var request = new HttpRequestMessage(HttpMethod.Post, "/protected");
+        request.Headers.Add("Sec-Fetch-Site", "cross-site");
+        request.Headers.Add("Origin", "https://evil.example.com");
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(endpointInvoked);
         Assert.NotNull(capturedFeature);
-        Assert.False(capturedFeature!.IsValid, "CSRF middleware should still record the cross-origin denial on the feature.");
+        Assert.False(capturedFeature!.IsValid, "CSRF middleware should record the cross-origin denial on the feature.");
         Assert.NotNull(capturedFeature.Error);
+        Assert.NotNull(observedMarker);
     }
 
     [Fact]

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/CsrfProtectionIntegrationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/CsrfProtectionIntegrationTests.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -34,6 +35,7 @@ public class CsrfProtectionIntegrationTests
 
         var response = await client.SendAsync(request);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("protected", await response.Content.ReadAsStringAsync());
     }
 
     [Fact]
@@ -47,6 +49,7 @@ public class CsrfProtectionIntegrationTests
 
         var response = await client.SendAsync(request);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("allowed", await response.Content.ReadAsStringAsync());
     }
 
     [Fact]
@@ -60,6 +63,7 @@ public class CsrfProtectionIntegrationTests
 
         var response = await client.SendAsync(request);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("allowed", await response.Content.ReadAsStringAsync());
     }
 
     [Fact]
@@ -73,6 +77,7 @@ public class CsrfProtectionIntegrationTests
 
         var response = await client.SendAsync(request);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("allowed", await response.Content.ReadAsStringAsync());
     }
 
     [Fact]
@@ -86,6 +91,7 @@ public class CsrfProtectionIntegrationTests
 
         var response = await client.SendAsync(request);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("passthrough", await response.Content.ReadAsStringAsync());
     }
 
     [Fact]
@@ -105,6 +111,7 @@ public class CsrfProtectionIntegrationTests
 
         var response = await client.SendAsync(request);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("passthrough", await response.Content.ReadAsStringAsync());
     }
 
     [Theory]
@@ -128,6 +135,7 @@ public class CsrfProtectionIntegrationTests
 
         var response = await client.SendAsync(request);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("passthrough", await response.Content.ReadAsStringAsync());
     }
 
     [Theory]
@@ -143,7 +151,7 @@ public class CsrfProtectionIntegrationTests
         builder.WebHost.UseSetting("DisableCsrfProtection", value);
         using var app = builder.Build();
 
-        app.MapPost("/protected", EnforceCsrf).WithMetadata(new RequireAntiforgeryTokenAttribute());
+        app.MapPost("/protected", EnforceCsrfProtected);
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -152,6 +160,7 @@ public class CsrfProtectionIntegrationTests
 
         var response = await client.SendAsync(request);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("protected", await response.Content.ReadAsStringAsync());
     }
 
     [Fact]
@@ -175,6 +184,7 @@ public class CsrfProtectionIntegrationTests
 
         var response = await client.SendAsync(request);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("passthrough", await response.Content.ReadAsStringAsync());
     }
 
     [Fact]
@@ -185,7 +195,7 @@ public class CsrfProtectionIntegrationTests
         builder.Services.AddSingleton<ICsrfProtection, AlwaysAllowCsrfProtection>();
         using var app = builder.Build();
 
-        app.MapPost("/protected", EnforceCsrf).WithMetadata(new RequireAntiforgeryTokenAttribute());
+        app.MapPost("/protected", EnforceCsrfProtected);
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -194,6 +204,7 @@ public class CsrfProtectionIntegrationTests
 
         var response = await client.SendAsync(request);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("allowed", await response.Content.ReadAsStringAsync());
     }
 
     [Fact]
@@ -207,6 +218,7 @@ public class CsrfProtectionIntegrationTests
 
         var response = await client.SendAsync(request);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("allowed", await response.Content.ReadAsStringAsync());
     }
 
     [Fact]
@@ -220,6 +232,7 @@ public class CsrfProtectionIntegrationTests
 
         var response = await client.SendAsync(request);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("protected", await response.Content.ReadAsStringAsync());
     }
 
     [Fact]
@@ -231,7 +244,7 @@ public class CsrfProtectionIntegrationTests
             options.AddDefaultPolicy(policy => policy.WithOrigins("https://trusted.example.com")));
         using var app = builder.Build();
 
-        app.MapPost("/protected", EnforceCsrf).WithMetadata(new RequireAntiforgeryTokenAttribute());
+        app.MapPost("/protected", EnforceCsrfProtected);
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -240,6 +253,7 @@ public class CsrfProtectionIntegrationTests
 
         var response = await client.SendAsync(request);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("allowed", await response.Content.ReadAsStringAsync());
     }
 
     [Fact]
@@ -251,7 +265,7 @@ public class CsrfProtectionIntegrationTests
             options.AddDefaultPolicy(policy => policy.AllowAnyOrigin()));
         using var app = builder.Build();
 
-        app.MapPost("/protected", EnforceCsrf).WithMetadata(new RequireAntiforgeryTokenAttribute());
+        app.MapPost("/protected", EnforceCsrfProtected);
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -261,6 +275,7 @@ public class CsrfProtectionIntegrationTests
 
         var response = await client.SendAsync(request);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("protected", await response.Content.ReadAsStringAsync());
     }
 
     [Fact]
@@ -272,7 +287,7 @@ public class CsrfProtectionIntegrationTests
             options.AddDefaultPolicy(policy => policy.WithOrigins("https://trusted.example.com")));
         using var app = builder.Build();
 
-        app.MapPost("/protected", EnforceCsrf).WithMetadata(new RequireAntiforgeryTokenAttribute());
+        app.MapPost("/protected", EnforceCsrfProtected);
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -282,6 +297,7 @@ public class CsrfProtectionIntegrationTests
 
         var response = await client.SendAsync(request);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("protected", await response.Content.ReadAsStringAsync());
     }
 
     [Fact]
@@ -294,7 +310,7 @@ public class CsrfProtectionIntegrationTests
         using var app = builder.Build();
 
         app.UseCors();
-        app.MapPost("/webhook", EnforceCsrf).RequireCors("Webhook").WithMetadata(new RequireAntiforgeryTokenAttribute());
+        app.MapPost("/webhook", EnforceCsrfProtected).RequireCors("Webhook");
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -304,6 +320,7 @@ public class CsrfProtectionIntegrationTests
 
         var response = await client.SendAsync(request);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("allowed", await response.Content.ReadAsStringAsync());
     }
 
     [Fact]
@@ -319,7 +336,7 @@ public class CsrfProtectionIntegrationTests
         using var app = builder.Build();
 
         app.UseCors();
-        app.MapPost("/webhook", EnforceCsrf).RequireCors("Webhook").WithMetadata(new RequireAntiforgeryTokenAttribute());
+        app.MapPost("/webhook", EnforceCsrfProtected).RequireCors("Webhook");
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -330,6 +347,7 @@ public class CsrfProtectionIntegrationTests
 
         var response = await client.SendAsync(request);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("protected", await response.Content.ReadAsStringAsync());
     }
 
     [Fact]
@@ -342,7 +360,7 @@ public class CsrfProtectionIntegrationTests
 
         app.UseCors();
         // Inline-policy variant: RequireCors(lambda) builds a CorsPolicy and attaches it as ICorsPolicyMetadata.
-        app.MapPost("/webhook", EnforceCsrf).RequireCors(p => p.WithOrigins("https://stripe.example.com")).WithMetadata(new RequireAntiforgeryTokenAttribute());
+        app.MapPost("/webhook", EnforceCsrfProtected).RequireCors(p => p.WithOrigins("https://stripe.example.com"));
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -352,6 +370,7 @@ public class CsrfProtectionIntegrationTests
 
         var response = await client.SendAsync(request);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("allowed", await response.Content.ReadAsStringAsync());
     }
 
     [Fact]
@@ -364,7 +383,7 @@ public class CsrfProtectionIntegrationTests
             options.AddPolicy("Webhook", policy => policy.WithOrigins("https://stripe.example.com")));
         using var app = builder.Build();
 
-        app.MapPost("/protected", EnforceCsrf).WithMetadata(new RequireAntiforgeryTokenAttribute());
+        app.MapPost("/protected", EnforceCsrfProtected);
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -376,6 +395,7 @@ public class CsrfProtectionIntegrationTests
 
         var response = await client.SendAsync(request);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("protected", await response.Content.ReadAsStringAsync());
     }
 
     [Fact]
@@ -392,7 +412,7 @@ public class CsrfProtectionIntegrationTests
         // UseCors is required because the endpoint carries CORS metadata; the CSRF middleware no longer
         // short-circuits, so the request now reaches the endpoint pipeline.
         app.UseCors();
-        app.MapPost("/no-cors", EnforceCsrf).WithMetadata(new Cors.DisableCorsAttribute()).WithMetadata(new RequireAntiforgeryTokenAttribute());
+        app.MapPost("/no-cors", EnforceCsrfProtected).WithMetadata(new Cors.DisableCorsAttribute());
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -402,6 +422,7 @@ public class CsrfProtectionIntegrationTests
 
         var response = await client.SendAsync(request);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("protected", await response.Content.ReadAsStringAsync());
     }
 
     [Fact]
@@ -415,7 +436,7 @@ public class CsrfProtectionIntegrationTests
 
         app.UseRouting();
         app.UseCors();
-        app.MapPost("/webhook", EnforceCsrf).RequireCors("Webhook").WithMetadata(new RequireAntiforgeryTokenAttribute());
+        app.MapPost("/webhook", EnforceCsrfProtected).RequireCors("Webhook");
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -425,6 +446,7 @@ public class CsrfProtectionIntegrationTests
 
         var response = await client.SendAsync(request);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("allowed", await response.Content.ReadAsStringAsync());
     }
 
     [Fact]
@@ -437,7 +459,7 @@ public class CsrfProtectionIntegrationTests
         using var app = builder.Build();
 
         app.UseCors();
-        app.MapPost("/webhook", EnforceCsrf).RequireCors("Webhook").WithMetadata(new RequireAntiforgeryTokenAttribute());
+        app.MapPost("/webhook", EnforceCsrfProtected).RequireCors("Webhook");
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -447,6 +469,7 @@ public class CsrfProtectionIntegrationTests
 
         var response = await client.SendAsync(request);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("allowed", await response.Content.ReadAsStringAsync());
     }
 
     [Fact]
@@ -460,7 +483,7 @@ public class CsrfProtectionIntegrationTests
 
         app.UseRouting();
         app.UseCors();
-        app.MapPost("/webhook", EnforceCsrf).RequireCors("Webhook").WithMetadata(new RequireAntiforgeryTokenAttribute());
+        app.MapPost("/webhook", EnforceCsrfProtected).RequireCors("Webhook");
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -470,6 +493,7 @@ public class CsrfProtectionIntegrationTests
 
         var response = await client.SendAsync(request);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("protected", await response.Content.ReadAsStringAsync());
     }
 
     [Fact]
@@ -552,6 +576,7 @@ public class CsrfProtectionIntegrationTests
 
         var response = await client.SendAsync(request);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("passthrough", await response.Content.ReadAsStringAsync());
     }
 
     // A type that mimics the framework holder's shape (a public instance method named CreateMiddleware returning a
@@ -567,17 +592,45 @@ public class CsrfProtectionIntegrationTests
         }
     }
 
-    // The CSRF middleware does not short-circuit; it records its verdict on IAntiforgeryValidationFeature and lets downstream consumers decide.
-    // This endpoint mirrors how a real consumer (the MVC antiforgery filter, minimal-API form binding, Razor Components) reacts to that verdict: reject when IsValid is false.
+    // Returns "passthrough" | "allowed" | "protected" (with 400) in the response body.
+    // Body strings make test intent explicit; "passthrough" disambiguates "feature not set"
+    // (CSRF middleware skipped because metadata is missing or RequiresValidation = false) from
+    // "allowed" (validation ran and recorded IsValid = true).
     private static string EnforceCsrf(HttpContext context)
     {
-        if (context.Features.Get<IAntiforgeryValidationFeature>() is { IsValid: false })
+        var feature = context.Features.Get<IAntiforgeryValidationFeature>();
+        if (feature is null)
         {
-            context.Response.StatusCode = StatusCodes.Status400BadRequest;
-            return "denied";
+            return "passthrough";
         }
 
-        return "ok";
+        if (!feature.IsValid)
+        {
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return "protected";
+        }
+
+        return "allowed";
+    }
+
+    // Same body as EnforceCsrf, but the [RequireAntiforgeryToken] attribute on the method gets
+    // reflected into endpoint metadata by Minimal API, so callers don't need .WithMetadata(...).
+    [RequireAntiforgeryToken]
+    private static string EnforceCsrfProtected(HttpContext context) => EnforceCsrf(context);
+
+    // Same body as EnforceCsrf, but the [FromForm] parameter causes RDF to call
+    // InferAntiforgeryMetadata -> AntiforgeryMetadata.ValidationRequired is attached automatically.
+    // Use this when the test specifically wants to exercise the RDF-inferred-metadata path.
+    private static string EnforceCsrfForm(HttpContext context, [FromForm] string? name = null)
+        => EnforceCsrf(context);
+
+    // Local [FromForm] attribute: there is no public Microsoft.AspNetCore.Http.FromFormAttribute,
+    // and this test project doesn't reference Microsoft.AspNetCore.Mvc.Core. Implementing
+    // IFromFormMetadata is enough for RDF to treat the parameter as form-bound.
+    [AttributeUsage(AttributeTargets.Parameter)]
+    private sealed class FromFormAttribute : Attribute, IFromFormMetadata
+    {
+        public string? Name => null;
     }
 
     private static async Task<WebApplication> CreateApp()
@@ -586,13 +639,11 @@ public class CsrfProtectionIntegrationTests
         builder.WebHost.UseTestServer();
         var app = builder.Build();
 
-        // The CSRF middleware only runs validation when the matched endpoint opts in via
-        // IAntiforgeryMetadata (mirroring AntiforgeryMiddleware). Bare minimal-API handlers have
-        // no such metadata; attach RequireAntiforgeryTokenAttribute so these "protected" routes
-        // actually exercise the validation path the surrounding tests assert against.
-        app.MapPost("/protected", EnforceCsrf).WithMetadata(new RequireAntiforgeryTokenAttribute());
-        app.MapGet("/protected-get", EnforceCsrf).WithMetadata(new RequireAntiforgeryTokenAttribute());
+        app.MapPost("/protected", EnforceCsrfProtected);
+        app.MapGet("/protected-get", EnforceCsrfProtected);
         app.MapPost("/unprotected", EnforceCsrf).DisableAntiforgery();
+        // No IAntiforgeryMetadata at all → CSRF middleware skips validation entirely.
+        app.MapPost("/passthrough", EnforceCsrf);
 
         await app.StartAsync();
         return app;
@@ -613,7 +664,7 @@ public class CsrfProtectionIntegrationTests
         // Sanity: the instance the container returns is the one we registered.
         Assert.Same(counting, app.Services.GetRequiredService<ICsrfProtection>());
 
-        app.MapPost("/protected", EnforceCsrf).WithMetadata(new RequireAntiforgeryTokenAttribute());
+        app.MapPost("/protected", EnforceCsrfProtected);
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -624,6 +675,7 @@ public class CsrfProtectionIntegrationTests
             var response = await client.SendAsync(request);
             // Custom implementation always allows, so cross-site POST gets through.
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("allowed", await response.Content.ReadAsStringAsync());
         }
 
         Assert.Equal(3, counting.CallCount);
@@ -639,7 +691,7 @@ public class CsrfProtectionIntegrationTests
         builder.Logging.ClearProviders().AddProvider(captureProvider).SetMinimumLevel(LogLevel.Debug);
         using var app = builder.Build();
 
-        app.MapPost("/protected", EnforceCsrf).WithMetadata(new RequireAntiforgeryTokenAttribute());
+        app.MapPost("/protected", EnforceCsrfProtected);
         await app.StartAsync();
 
         var client = app.GetTestClient();
@@ -649,6 +701,7 @@ public class CsrfProtectionIntegrationTests
 
         var response = await client.SendAsync(request);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("protected", await response.Content.ReadAsStringAsync());
 
         var entry = Assert.Single(captureProvider.Entries);
         Assert.Equal(LogLevel.Debug, entry.Level);
@@ -866,6 +919,36 @@ public class CsrfProtectionIntegrationTests
         Assert.False(capturedFeature!.IsValid, "CSRF middleware should record the cross-origin denial on the feature.");
         Assert.NotNull(capturedFeature.Error);
         Assert.NotNull(observedMarker);
+    }
+
+    [Fact]
+    public async Task CsrfProtection_RdfInferredFormMetadata_CrossOriginUntrustedOrigin_Protects()
+    {
+        // RequestDelegateFactory's InferAntiforgeryMetadata path attaches AntiforgeryMetadata.ValidationRequired
+        // automatically when an endpoint parameter is form-bound. EnforceCsrfForm has a [FromForm] parameter,
+        // so the route opts into CSRF validation without an explicit RequireAntiforgeryTokenAttribute.
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        using var app = builder.Build();
+
+        app.MapPost("/form", EnforceCsrfForm);
+        await app.StartAsync();
+
+        var client = app.GetTestClient();
+        var request = new HttpRequestMessage(HttpMethod.Post, "/form")
+        {
+            Content = new FormUrlEncodedContent(new[] { new KeyValuePair<string, string>("name", "alice") }),
+        };
+        request.Headers.Add("Sec-Fetch-Site", "cross-site");
+        request.Headers.Add("Origin", "https://evil.example.com");
+
+        var response = await client.SendAsync(request);
+        // RDF's InferAntiforgeryMetadata attached AntiforgeryMetadata.ValidationRequired to the
+        // endpoint, so CSRF middleware ran validation and recorded IsValid = false. The minimal-API
+        // form-binding code then rejects the request with 400 before the handler executes, so the
+        // body is empty — distinct from "protected" which would prove the handler had run.
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(string.Empty, await response.Content.ReadAsStringAsync());
     }
 
     [Fact]


### PR DESCRIPTION
Aligns `CsrfProtectionMiddleware` with classic `AntiforgeryMiddleware`: validation runs only when the matched endpoint has `IAntiforgeryMetadata { RequiresValidation: true }`. Endpoints without metadata (plain `MapPost`, plain `[HttpPost]`) pass through, matching .NET 10 behavior — so no customer endpoint that worked on .NET 10 will start failing on .NET 11.

Blazor SSR and RDF form binding stay protected because they already attach `RequireAntiforgeryTokenAttribute` automatically. The `MiddlewareInvokedKeys.CsrfProtection` sentinel is still set unconditionally to preserve the `FormFeature` backstop contract from #67082.

Fixes #67424