### PR TITLE
feat: adds support for describing SSE in OpenAPI 3.2.0

### DIFF
--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -11,6 +11,7 @@ using System.Globalization;
 using System.IO.Pipelines;
 using System.Linq;
 using System.Net.Http;
+using System.Net.ServerSentEvents;
 using System.Reflection;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
@@ -429,6 +430,7 @@ internal sealed class OpenApiDocumentService(
         // When multiple entries contribute different schemas for the same content-type, they
         // will be merged into an anyOf composite schema.
         var schemasByContentType = new Dictionary<string, List<IOpenApiSchema>>();
+        var contentTypesUsingItemSchema = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var apiResponseType in apiResponseTypes)
         {
@@ -443,10 +445,18 @@ internal sealed class OpenApiDocumentService(
                 IOpenApiSchema? schema = null;
                 if (apiResponseType.Type is { } responseType)
                 {
-                    schema = await _componentService.GetOrCreateSchemaAsync(document, responseType, scopedServiceProvider, schemaTransformers, null, cancellationToken);
-                    schema = apiResponseType.ShouldApplyNullableResponseSchema(apiDescription)
-                        ? schema.CreateOneOfNullableWrapper()
-                        : schema;
+                    if (IsServerSentEventsResponse(contentType, responseType, out var eventDataType))
+                    {
+                        var dataSchema = await _componentService.GetOrCreateSchemaAsync(document, eventDataType, scopedServiceProvider, schemaTransformers, null, cancellationToken);
+                        schema = CreateServerSentEventsItemSchema(dataSchema);
+                    }
+                    else
+                    {
+                        schema = await _componentService.GetOrCreateSchemaAsync(document, responseType, scopedServiceProvider, schemaTransformers, null, cancellationToken);
+                        schema = apiResponseType.ShouldApplyNullableResponseSchema(apiDescription)
+                            ? schema.CreateOneOfNullableWrapper()
+                            : schema;
+                    }
                 }
 
                 schema ??= new OpenApiSchema();
@@ -458,6 +468,10 @@ internal sealed class OpenApiDocumentService(
                 }
 
                 schemas.Add(schema);
+                if (IsServerSentEventsResponse(contentType, apiResponseType.Type, out _))
+                {
+                    contentTypesUsingItemSchema.Add(contentType);
+                }
             }
         }
 
@@ -466,7 +480,9 @@ internal sealed class OpenApiDocumentService(
             IOpenApiSchema finalSchema = schemas.Count == 1
                 ? schemas[0]
                 : new OpenApiSchema { AnyOf = [.. schemas] };
-            response.Content[contentType] = new OpenApiMediaType { Schema = finalSchema };
+            response.Content[contentType] = contentTypesUsingItemSchema.Contains(contentType)
+                ? new OpenApiMediaType { ItemSchema = finalSchema }
+                : new OpenApiMediaType { Schema = finalSchema };
         }
 
         // MVC's `ProducesAttribute` doesn't implement the produces metadata that the ApiExplorer
@@ -481,6 +497,43 @@ internal sealed class OpenApiDocumentService(
         }
 
         return response;
+    }
+
+    private static bool IsServerSentEventsResponse(string contentType, Type? responseType, [NotNullWhen(true)] out Type? eventDataType)
+    {
+        if (IsServerSentEventsContentType(contentType)
+            && responseType is { IsConstructedGenericType: true }
+            && responseType.GetGenericTypeDefinition() == typeof(SseItem<>))
+        {
+            eventDataType = responseType.GetGenericArguments()[0];
+            return true;
+        }
+
+        eventDataType = null;
+        return false;
+    }
+
+    private static OpenApiSchema CreateServerSentEventsItemSchema(IOpenApiSchema dataSchema)
+        => new()
+        {
+            Type = JsonSchemaType.Object,
+            Required = new HashSet<string> { "data" },
+            Properties = new Dictionary<string, IOpenApiSchema>
+            {
+                ["data"] = dataSchema,
+                ["event"] = new OpenApiSchema { Type = JsonSchemaType.String },
+                ["id"] = new OpenApiSchema { Type = JsonSchemaType.String }
+            }
+        };
+
+    private static bool IsServerSentEventsContentType(string contentType)
+    {
+        var mediaTypeEnd = contentType.IndexOf(';');
+        var mediaType = mediaTypeEnd >= 0
+            ? contentType[..mediaTypeEnd]
+            : contentType;
+
+        return mediaType.Trim().Equals("text/event-stream", StringComparison.OrdinalIgnoreCase);
     }
 
     private async Task<List<IOpenApiParameter>?> GetParametersAsync(

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -431,7 +431,7 @@ internal sealed class OpenApiDocumentService(
         // When multiple entries contribute different schemas for the same content-type, they
         // will be merged into an anyOf composite schema.
         var schemasByContentType = new Dictionary<string, List<IOpenApiSchema>>();
-        var contentTypesUsingItemSchema = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        HashSet<string>? contentTypesUsingItemSchema = null;
 
         foreach (var apiResponseType in apiResponseTypes)
         {
@@ -471,6 +471,7 @@ internal sealed class OpenApiDocumentService(
                 schemas.Add(schema);
                 if (IsServerSentEventsResponse(contentType, apiResponseType.Type, out _))
                 {
+                    contentTypesUsingItemSchema ??= [with(StringComparer.OrdinalIgnoreCase)];
                     contentTypesUsingItemSchema.Add(contentType);
                 }
             }
@@ -481,7 +482,7 @@ internal sealed class OpenApiDocumentService(
             IOpenApiSchema finalSchema = schemas.Count == 1
                 ? schemas[0]
                 : new OpenApiSchema { AnyOf = [.. schemas] };
-            response.Content[contentType] = contentTypesUsingItemSchema.Contains(contentType)
+            response.Content[contentType] = contentTypesUsingItemSchema != null && contentTypesUsingItemSchema.Contains(contentType)
                 ? new OpenApiMediaType { ItemSchema = finalSchema }
                 : new OpenApiMediaType { Schema = finalSchema };
         }

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.ServerSentEvents;
 using System.Reflection;
+using System.Text.Json.Nodes;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
@@ -448,7 +449,7 @@ internal sealed class OpenApiDocumentService(
                     if (IsServerSentEventsResponse(contentType, responseType, out var eventDataType))
                     {
                         var dataSchema = await _componentService.GetOrCreateSchemaAsync(document, eventDataType, scopedServiceProvider, schemaTransformers, null, cancellationToken);
-                        schema = CreateServerSentEventsItemSchema(dataSchema);
+                        schema = CreateServerSentEventsItemSchema(document, dataSchema);
                     }
                     else
                     {
@@ -513,7 +514,7 @@ internal sealed class OpenApiDocumentService(
         return false;
     }
 
-    private static OpenApiSchema CreateServerSentEventsItemSchema(IOpenApiSchema dataSchema)
+    private static OpenApiSchema CreateServerSentEventsItemSchema(OpenApiDocument document, IOpenApiSchema dataSchema)
         => new()
         {
             Type = JsonSchemaType.Object,
@@ -521,10 +522,38 @@ internal sealed class OpenApiDocumentService(
             Properties = new Dictionary<string, IOpenApiSchema>
             {
                 ["data"] = dataSchema,
-                ["event"] = new OpenApiSchema { Type = JsonSchemaType.String },
+                ["event"] = CreateServerSentEventsEventSchema(document, dataSchema),
                 ["id"] = new OpenApiSchema { Type = JsonSchemaType.String }
             }
         };
+
+    private static OpenApiSchema CreateServerSentEventsEventSchema(OpenApiDocument document, IOpenApiSchema dataSchema)
+    {
+        var eventSchema = new OpenApiSchema { Type = JsonSchemaType.String };
+        var eventDataSchema = ResolveSchemaReference(document, dataSchema);
+        if (eventDataSchema.Discriminator?.Mapping is { Count: > 0 } mapping)
+        {
+            eventSchema.Enum = [.. mapping.Keys.Select(static eventName => JsonValue.Create(eventName)!)];
+        }
+        else if (eventDataSchema is OpenApiSchema { AnyOf.Count: > 0 } schema
+            && schema.IsUnion())
+        {
+            eventSchema.Enum =
+            [
+                .. schema.AnyOf
+                    .OfType<OpenApiSchemaReference>()
+                    .Select(static schemaReference => JsonValue.Create(schemaReference.Reference.Id)!)
+            ];
+        }
+
+        return eventSchema;
+    }
+
+    private static IOpenApiSchema ResolveSchemaReference(OpenApiDocument document, IOpenApiSchema schema)
+        => schema is OpenApiSchemaReference { Reference.Id: { } schemaId }
+            && document.Components?.Schemas?.TryGetValue(schemaId, out var targetSchema) is true
+            ? targetSchema
+            : schema;
 
     private static bool IsServerSentEventsContentType(string contentType)
     {

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -430,8 +430,7 @@ internal sealed class OpenApiDocumentService(
         // Collect schemas per content-type across all ApiResponseType entries in this group.
         // When multiple entries contribute different schemas for the same content-type, they
         // will be merged into an anyOf composite schema.
-        var schemasByContentType = new Dictionary<string, List<IOpenApiSchema>>();
-        HashSet<string>? contentTypesUsingItemSchema = null;
+        var schemasByContentType = new Dictionary<string, OpenApiResponseContentSchemas>();
 
         foreach (var apiResponseType in apiResponseTypes)
         {
@@ -444,12 +443,14 @@ internal sealed class OpenApiDocumentService(
             foreach (var contentType in apiResponseFormatContentTypes)
             {
                 IOpenApiSchema? schema = null;
+                var useItemSchema = false;
                 if (apiResponseType.Type is { } responseType)
                 {
                     if (IsServerSentEventsResponse(contentType, responseType, out var eventDataType))
                     {
                         var dataSchema = await _componentService.GetOrCreateSchemaAsync(document, eventDataType, scopedServiceProvider, schemaTransformers, null, cancellationToken);
                         schema = CreateServerSentEventsItemSchema(document, dataSchema);
+                        useItemSchema = true;
                     }
                     else
                     {
@@ -462,27 +463,23 @@ internal sealed class OpenApiDocumentService(
 
                 schema ??= new OpenApiSchema();
 
-                if (!schemasByContentType.TryGetValue(contentType, out var schemas))
+                if (!schemasByContentType.TryGetValue(contentType, out var contentTypeSchemas))
                 {
-                    schemas = [];
-                    schemasByContentType[contentType] = schemas;
+                    contentTypeSchemas = new OpenApiResponseContentSchemas();
+                    schemasByContentType[contentType] = contentTypeSchemas;
                 }
 
-                schemas.Add(schema);
-                if (IsServerSentEventsResponse(contentType, apiResponseType.Type, out _))
-                {
-                    contentTypesUsingItemSchema ??= [with(StringComparer.OrdinalIgnoreCase)];
-                    contentTypesUsingItemSchema.Add(contentType);
-                }
+                contentTypeSchemas.AddSchema(schema, useItemSchema);
             }
         }
 
-        foreach (var (contentType, schemas) in schemasByContentType)
+        foreach (var (contentType, contentTypeSchemas) in schemasByContentType)
         {
+            var schemas = contentTypeSchemas.Schemas;
             IOpenApiSchema finalSchema = schemas.Count == 1
                 ? schemas[0]
                 : new OpenApiSchema { AnyOf = [.. schemas] };
-            response.Content[contentType] = contentTypesUsingItemSchema != null && contentTypesUsingItemSchema.Contains(contentType)
+            response.Content[contentType] = contentTypeSchemas.UseItemSchema
                 ? new OpenApiMediaType { ItemSchema = finalSchema }
                 : new OpenApiMediaType { Schema = finalSchema };
         }
@@ -499,6 +496,19 @@ internal sealed class OpenApiDocumentService(
         }
 
         return response;
+    }
+
+    private sealed record OpenApiResponseContentSchemas
+    {
+        public List<IOpenApiSchema> Schemas { get; } = [];
+
+        public bool UseItemSchema { get; private set; }
+
+        public void AddSchema(IOpenApiSchema schema, bool useItemSchema)
+        {
+            Schemas.Add(schema);
+            UseItemSchema |= useItemSchema;
+        }
     }
 
     private static bool IsServerSentEventsResponse(string contentType, Type? responseType, [NotNullWhen(true)] out Type? eventDataType)

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -570,7 +570,7 @@ internal sealed class OpenApiDocumentService(
 
     private static bool IsServerSentEventsContentType(string contentType)
         => MediaTypeHeaderValue.TryParse(contentType, out var mediaType)
-            && mediaType.MatchesMediaType("text/event-stream");
+            && mediaType.MediaType.Equals("text/event-stream", StringComparison.OrdinalIgnoreCase);
 
     private async Task<List<IOpenApiParameter>?> GetParametersAsync(
         OpenApiDocument document,

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -498,15 +498,17 @@ internal sealed class OpenApiDocumentService(
         return response;
     }
 
-    private sealed record OpenApiResponseContentSchemas
+    private sealed class OpenApiResponseContentSchemas
     {
-        public List<IOpenApiSchema> Schemas { get; } = [];
+        private readonly List<IOpenApiSchema> _schemas = [];
+
+        public IReadOnlyList<IOpenApiSchema> Schemas => _schemas;
 
         public bool UseItemSchema { get; private set; }
 
         public void AddSchema(IOpenApiSchema schema, bool useItemSchema)
         {
-            Schemas.Add(schema);
+            _schemas.Add(schema);
             UseItemSchema |= useItemSchema;
         }
     }

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -569,14 +569,8 @@ internal sealed class OpenApiDocumentService(
             : schema;
 
     private static bool IsServerSentEventsContentType(string contentType)
-    {
-        var mediaTypeEnd = contentType.IndexOf(';');
-        var mediaType = mediaTypeEnd >= 0
-            ? contentType[..mediaTypeEnd]
-            : contentType;
-
-        return mediaType.Trim().Equals("text/event-stream", StringComparison.OrdinalIgnoreCase);
-    }
+        => MediaTypeHeaderValue.TryParse(contentType, out var mediaType)
+            && mediaType.MatchesMediaType("text/event-stream");
 
     private async Task<List<IOpenApiParameter>?> GetParametersAsync(
         OpenApiDocument document,

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Responses.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Responses.cs
@@ -90,6 +90,7 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
                 {
                     Assert.Equal("event", property.Key);
                     Assert.Equal(JsonSchemaType.String, property.Value.Type);
+                    Assert.Null(property.Value.Enum);
                 },
                 property =>
                 {
@@ -99,6 +100,50 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
         });
 
         static async IAsyncEnumerable<SseItem<Todo>> GetEvents()
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+    }
+
+    [Fact]
+    public async Task GetOpenApiResponse_UsesDiscriminatedUnionCasesForServerSentEventsEventSchema()
+    {
+        var builder = CreateBuilder();
+
+        builder.MapGet("/api/pets/events", () => TypedResults.ServerSentEvents(GetEvents()));
+
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var itemSchema = GetServerSentEventsItemSchema(document, "/api/pets/events");
+            var dataSchema = Assert.IsType<OpenApiSchemaReference>(itemSchema.Properties["data"]);
+            Assert.Equal(nameof(UnionPet), dataSchema.Reference.Id);
+            AssertEventSchema(itemSchema, [nameof(Kitten), nameof(Puppy)]);
+        });
+
+        static async IAsyncEnumerable<SseItem<UnionPet>> GetEvents()
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+    }
+
+    [Fact]
+    public async Task GetOpenApiResponse_UsesAbstractBaseDiscriminatorValuesForServerSentEventsEventSchema()
+    {
+        var builder = CreateBuilder();
+
+        builder.MapGet("/api/vehicles/events", () => TypedResults.ServerSentEvents(GetEvents()));
+
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var itemSchema = GetServerSentEventsItemSchema(document, "/api/vehicles/events");
+            var dataSchema = Assert.IsType<OpenApiSchemaReference>(itemSchema.Properties["data"]);
+            Assert.Equal(nameof(Vehicle), dataSchema.Reference.Id);
+            AssertEventSchema(itemSchema, ["car", "truck", "plane"]);
+        });
+
+        static async IAsyncEnumerable<SseItem<Vehicle>> GetEvents()
         {
             await Task.CompletedTask;
             yield break;
@@ -649,5 +694,47 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
             Assert.Equal("value", property.Key);
             Assert.Equal(100, property.Value.MaxLength);
         });
+    }
+
+    private static OpenApiSchema GetServerSentEventsItemSchema(OpenApiDocument document, string path)
+    {
+        var operation = Assert.Single(document.Paths[path].Operations.Values);
+        var response = Assert.Single(operation.Responses);
+        Assert.Equal("200", response.Key);
+        var content = Assert.Single(response.Value.Content);
+        Assert.Equal("text/event-stream", content.Key);
+        Assert.Null(content.Value.Schema);
+        return Assert.IsType<OpenApiSchema>(content.Value.ItemSchema);
+    }
+
+    private static void AssertEventSchema(OpenApiSchema itemSchema, string[] expectedEvents)
+    {
+        var eventSchema = Assert.IsType<OpenApiSchema>(itemSchema.Properties["event"]);
+        Assert.Equal(JsonSchemaType.String, eventSchema.Type);
+        Assert.NotNull(eventSchema.Enum);
+        Assert.Equal(expectedEvents.OrderBy(value => value), eventSchema.Enum.Select(value => value.GetValue<string>()).OrderBy(value => value));
+    }
+
+    [JsonDerivedType(typeof(Car), typeDiscriminator: "car")]
+    [JsonDerivedType(typeof(Truck), typeDiscriminator: "truck")]
+    [JsonDerivedType(typeof(Plane), typeDiscriminator: "plane")]
+    private abstract class Vehicle
+    {
+        public required string Make { get; set; }
+    }
+
+    private sealed class Car : Vehicle
+    {
+        public int Doors { get; set; }
+    }
+
+    private sealed class Truck : Vehicle
+    {
+        public double PayloadCapacity { get; set; }
+    }
+
+    private sealed class Plane : Vehicle
+    {
+        public double Wingspan { get; set; }
     }
 }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Responses.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Responses.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net.ServerSentEvents;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -58,6 +59,50 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
             Assert.Equal("Bad Request", response.Value.Description);
             Assert.Equal("application/json+problem", response.Value.Content.Keys.Single());
         });
+    }
+
+    [Fact]
+    public async Task GetOpenApiResponse_UsesItemSchemaForServerSentEvents()
+    {
+        var builder = CreateBuilder();
+
+        builder.MapGet("/api/todos/events", () => TypedResults.ServerSentEvents(GetEvents()));
+
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = Assert.Single(document.Paths["/api/todos/events"].Operations.Values);
+            var response = Assert.Single(operation.Responses);
+            Assert.Equal("200", response.Key);
+            var content = Assert.Single(response.Value.Content);
+            Assert.Equal("text/event-stream", content.Key);
+            Assert.Null(content.Value.Schema);
+            var itemSchema = Assert.IsType<OpenApiSchema>(content.Value.ItemSchema);
+            Assert.Equal(JsonSchemaType.Object, itemSchema.Type);
+            Assert.Equal(["data"], itemSchema.Required);
+            Assert.Collection(itemSchema.Properties.OrderBy(property => property.Key),
+                property =>
+                {
+                    Assert.Equal("data", property.Key);
+                    var dataSchema = Assert.IsType<OpenApiSchemaReference>(property.Value);
+                    Assert.Equal(nameof(Todo), dataSchema.Reference.Id);
+                },
+                property =>
+                {
+                    Assert.Equal("event", property.Key);
+                    Assert.Equal(JsonSchemaType.String, property.Value.Type);
+                },
+                property =>
+                {
+                    Assert.Equal("id", property.Key);
+                    Assert.Equal(JsonSchemaType.String, property.Value.Type);
+                });
+        });
+
+        static async IAsyncEnumerable<SseItem<Todo>> GetEvents()
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
     }
 
     [Fact]

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Responses.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Responses.cs
@@ -107,6 +107,35 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
     }
 
     [Fact]
+    public async Task GetOpenApiResponse_UsesSchemaAndItemSchemaForSameDataSchemaInDifferentMediaTypes()
+    {
+        var builder = CreateBuilder();
+
+        builder.MapGet("/api/todos/responses", () => { })
+            .WithMetadata(new ProducesResponseTypeMetadata(StatusCodes.Status200OK, typeof(Todo), ["application/json"]))
+            .WithMetadata(new ProducesResponseTypeMetadata(StatusCodes.Status200OK, typeof(SseItem<Todo>), ["text/event-stream"]));
+
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = Assert.Single(document.Paths["/api/todos/responses"].Operations.Values);
+            var response = Assert.Single(operation.Responses);
+            Assert.Equal("200", response.Key);
+            Assert.Equal(2, response.Value.Content.Count);
+
+            var jsonContent = response.Value.Content["application/json"];
+            var jsonSchema = Assert.IsType<OpenApiSchemaReference>(jsonContent.Schema);
+            Assert.Equal(nameof(Todo), jsonSchema.Reference.Id);
+            Assert.Null(jsonContent.ItemSchema);
+
+            var eventStreamContent = response.Value.Content["text/event-stream"];
+            Assert.Null(eventStreamContent.Schema);
+            var itemSchema = Assert.IsType<OpenApiSchema>(eventStreamContent.ItemSchema);
+            var dataSchema = Assert.IsType<OpenApiSchemaReference>(itemSchema.Properties["data"]);
+            Assert.Equal(nameof(Todo), dataSchema.Reference.Id);
+        });
+    }
+
+    [Fact]
     public async Task GetOpenApiResponse_UsesDiscriminatedUnionCasesForServerSentEventsEventSchema()
     {
         var builder = CreateBuilder();

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Responses.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.Responses.cs
@@ -107,6 +107,48 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
     }
 
     [Fact]
+    public async Task GetOpenApiResponse_UsesItemSchemaForServerSentEventsOfDataItems()
+    {
+        var builder = CreateBuilder();
+
+        builder.MapGet("/api/todos/data-events", () => TypedResults.ServerSentEvents(GetEvents()));
+
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var itemSchema = GetServerSentEventsItemSchema(document, "/api/todos/data-events");
+            var dataSchema = Assert.IsType<OpenApiSchemaReference>(itemSchema.Properties["data"]);
+            Assert.Equal(nameof(Todo), dataSchema.Reference.Id);
+        });
+
+        static async IAsyncEnumerable<Todo> GetEvents()
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+    }
+
+    [Fact]
+    public async Task GetOpenApiResponse_UsesItemSchemaForServerSentEventsOfStringItems()
+    {
+        var builder = CreateBuilder();
+
+        builder.MapGet("/api/messages/events", () => TypedResults.ServerSentEvents(GetEvents()));
+
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var itemSchema = GetServerSentEventsItemSchema(document, "/api/messages/events");
+            var dataSchema = Assert.IsType<OpenApiSchema>(itemSchema.Properties["data"]);
+            Assert.Equal(JsonSchemaType.String, dataSchema.Type);
+        });
+
+        static async IAsyncEnumerable<string> GetEvents()
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+    }
+
+    [Fact]
     public async Task GetOpenApiResponse_UsesSchemaAndItemSchemaForSameDataSchemaInDifferentMediaTypes()
     {
         var builder = CreateBuilder();


### PR DESCRIPTION
fixes #64379

## Examples

```yaml

# SseItem<Todo>
responses:
  '200':
    description: OK
    content:
      text/event-stream:
        itemSchema:
          type: object
          required:
            - data
          properties:
            data:
              $ref: '#/components/schemas/Todo'
            event:
              type: string
            id:
              type: string

# SseItem<UnionPet> where UnionPet = Kitten | Puppy
responses:
  '200':
    description: OK
    content:
      text/event-stream:
        itemSchema:
          type: object
          required:
            - data
          properties:
            data:
              $ref: '#/components/schemas/UnionPet'
            event:
              type: string
              enum:
                - Kitten
                - Puppy
            id:
              type: string

# SseItem<Vehicle>, where Vehicle is an abstract base type with JSON discriminators
responses:
  '200':
    description: OK
    content:
      text/event-stream:
        itemSchema:
          type: object
          required:
            - data
          properties:
            data:
              $ref: '#/components/schemas/Vehicle'
            event:
              type: string
              enum:
                - car
                - truck
                - plane
            id:
              type: string

```

CC @martincostello 