### PR TITLE
Fix eager load of currentKeyRing on resolving IDataProtector 

### DIFF
--- a/src/DataProtection/DataProtection/src/KeyManagement/KeyRingBasedDataProtectionProvider.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/KeyRingBasedDataProtectionProvider.cs
@@ -27,8 +27,8 @@ internal sealed unsafe class KeyRingBasedDataProtectionProvider : IDataProtectio
         // Always return the span-capable protector on .NET. It inspects the resolved encryptor at each Protect/Unprotect call
         // and falls back to the byte[] path when the encryptor does not implement ISpanAuthenticatedEncryptor.
         //
-        // We could deteremine whether the encryptor implements ISpanAuthenticatedEncryptor here and return the appropriate protector type,
-        // but that will force infra lookup (like db / storage) during startup, which is not expected. See dotnet/aspnetcore#67447.
+        // We could determine whether the encryptor implements ISpanAuthenticatedEncryptor here and return the appropriate protector type,
+        // but that forces a keyring resolve (which may hit the configured key store, e.g. database or blob storage) during startup, which is not expected. See dotnet/aspnetcore#67447.
         return new KeyRingBasedSpanDataProtector(
             logger: _logger,
             keyRingProvider: _keyRingProvider,

--- a/src/DataProtection/DataProtection/src/KeyManagement/KeyRingBasedDataProtectionProvider.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/KeyRingBasedDataProtectionProvider.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption;
 using Microsoft.AspNetCore.DataProtection.KeyManagement.Internal;
 using Microsoft.AspNetCore.Shared;
 using Microsoft.Extensions.Logging;
@@ -24,26 +23,23 @@ internal sealed unsafe class KeyRingBasedDataProtectionProvider : IDataProtectio
     {
         ArgumentNullThrowHelper.ThrowIfNull(purpose);
 
-        var currentKeyRing = _keyRingProvider.GetCurrentKeyRing();
-        var encryptor = currentKeyRing.DefaultAuthenticatedEncryptor;
-
 #if NET
-        if (encryptor is ISpanAuthenticatedEncryptor)
-        {
-            // allows caller to check if dataProtector supports Span APIs
-            // and use more performant APIs
-            return new KeyRingBasedSpanDataProtector(
-                logger: _logger,
-                keyRingProvider: _keyRingProvider,
-                originalPurposes: null,
-                newPurpose: purpose);
-        }
-#endif
-
+        // Always return the span-capable protector on .NET. It inspects the resolved encryptor at each Protect/Unprotect call
+        // and falls back to the byte[] path when the encryptor does not implement ISpanAuthenticatedEncryptor.
+        //
+        // We could deteremine whether the encryptor implements ISpanAuthenticatedEncryptor here and return the appropriate protector type,
+        // but that will force infra lookup (like db / storage) during startup, which is not expected. See dotnet/aspnetcore#67447.
+        return new KeyRingBasedSpanDataProtector(
+            logger: _logger,
+            keyRingProvider: _keyRingProvider,
+            originalPurposes: null,
+            newPurpose: purpose);
+#else
         return new KeyRingBasedDataProtector(
             logger: _logger,
             keyRingProvider: _keyRingProvider,
             originalPurposes: null,
             newPurpose: purpose);
+#endif
     }
 }

--- a/src/DataProtection/DataProtection/src/KeyManagement/KeyRingBasedDataProtector.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/KeyRingBasedDataProtector.cs
@@ -66,27 +66,26 @@ internal unsafe class KeyRingBasedDataProtector : IDataProtector, IPersistedData
     {
         ArgumentNullThrowHelper.ThrowIfNull(purpose);
 
-        var currentKeyRing = _keyRingProvider.GetCurrentKeyRing();
-        var encryptor = currentKeyRing.DefaultAuthenticatedEncryptor;
-
 #if NET
-        if (encryptor is ISpanAuthenticatedEncryptor)
-        {
-            // allows caller to check if dataProtector supports Span APIs
-            // and use more performant APIs
-            return new KeyRingBasedSpanDataProtector(
-                logger: _logger,
-                keyRingProvider: _keyRingProvider,
-                originalPurposes: Purposes,
-                newPurpose: purpose);
-        }
-#endif
-
+        // Always return the span-capable protector on .NET. It inspects the resolved encryptor at each Protect/Unprotect call
+        // and falls back to the byte[] path when the encryptor does not implement ISpanAuthenticatedEncryptor.
+        //
+        // We could determine whether the encryptor implements ISpanAuthenticatedEncryptor here and return the appropriate protector type,
+        // but that would force a keyring resolve (which may hit the configured key store, e.g. a database or blob storage) during startup.
+        // In hosted apps using AddDataProtection, the registered provider is first wrapped with the application discriminator, so app calls
+        // hit this method (not just KeyRingBasedDataProtectionProvider.CreateProtector). See dotnet/aspnetcore#67447.
+        return new KeyRingBasedSpanDataProtector(
+            logger: _logger,
+            keyRingProvider: _keyRingProvider,
+            originalPurposes: Purposes,
+            newPurpose: purpose);
+#else
         return new KeyRingBasedDataProtector(
             logger: _logger,
             keyRingProvider: _keyRingProvider,
             originalPurposes: Purposes,
             newPurpose: purpose);
+#endif
     }
 
     protected static string JoinPurposesForLog(IEnumerable<string> purposes)

--- a/src/DataProtection/DataProtection/src/KeyManagement/KeyRingBasedSpanDataProtector.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/KeyRingBasedSpanDataProtector.cs
@@ -40,16 +40,6 @@ internal unsafe class KeyRingBasedSpanDataProtector : KeyRingBasedDataProtector,
                 _logger.PerformingProtectOperationToKeyWithPurposes(defaultKeyId, JoinPurposesForLog(Purposes));
             }
 
-            if (defaultEncryptor is not ISpanAuthenticatedEncryptor spanEncryptor)
-            {
-                // If SpanDataProtector is used, but encryptor does not support Span'ish APIs, fallback to the byte[] path.
-                var result = Protect(plaintext.ToArray());
-                var span = destination.GetSpan(result.Length);
-                result.CopyTo(span);
-                destination.Advance(result.Length);
-                return;
-            }
-
             // We'll need to apply the default key id to the template if it hasn't already been applied.
             // If the default key id has been updated since the last call to Protect, also write back the updated template.
             var aad = _aadTemplate.GetAadForKey(defaultKeyId, isProtecting: true);
@@ -71,7 +61,18 @@ internal unsafe class KeyRingBasedSpanDataProtector : KeyRingBasedDataProtector,
             destination.Advance(preBufferSize);
 
             // Step 2: Perform encryption into the destination writer
-            spanEncryptor.Encrypt(plaintext, aad, ref destination);
+            if (defaultEncryptor is ISpanAuthenticatedEncryptor spanEncryptor)
+            {
+                spanEncryptor.Encrypt(plaintext, aad, ref destination);
+            }
+            else
+            {
+                // If SpanDataProtector is used, but encryptor does not support span-based APIs, fall-back to the byte[] path.
+                var ciphertext = defaultEncryptor.Encrypt(plaintext.ToArray(), aad);
+                var resultSpan = destination.GetSpan(ciphertext.Length);
+                ciphertext.CopyTo(resultSpan);
+                destination.Advance(ciphertext.Length);
+            }
 
             // At this point, destination := { magicHeader || keyId || encryptorSpecificProtectedPayload }
             // And we're done!
@@ -164,17 +165,18 @@ internal unsafe class KeyRingBasedSpanDataProtector : KeyRingBasedDataProtector,
             // At this point, actualCiphertext := { encryptorSpecificPayload },
             // so all that's left is to invoke the decryption routine directly.
 
-            if (requestedEncryptor is not ISpanAuthenticatedEncryptor spanEncryptor)
+            if (requestedEncryptor is ISpanAuthenticatedEncryptor spanEncryptor)
             {
-                // If SpanDataProtector is used, but encryptor does not support Span'ish APIs, fallback to the byte[] path.
+                spanEncryptor.Decrypt(actualCiphertext, aad, ref destination);
+            }
+            else
+            {
+                // If SpanDataProtector is used, but encryptor does not support span-based APIs, fall-back to the byte[] path.
                 var result = requestedEncryptor.Decrypt(actualCiphertext.ToArray(), aad.ToArray());
                 var span = destination.GetSpan(result.Length);
                 result.CopyTo(span);
                 destination.Advance(result.Length);
-                return;
             }
-
-            spanEncryptor.Decrypt(actualCiphertext, aad, ref destination);
 
             // At this point, destination contains the decrypted plaintext
             // And we're done!

--- a/src/DataProtection/DataProtection/src/KeyManagement/KeyRingBasedSpanDataProtector.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/KeyRingBasedSpanDataProtector.cs
@@ -42,11 +42,7 @@ internal unsafe class KeyRingBasedSpanDataProtector : KeyRingBasedDataProtector,
 
             if (defaultEncryptor is not ISpanAuthenticatedEncryptor spanEncryptor)
             {
-                // This should never happen, since the IDataProtector should have
-                // checked the key ring provider to see if the span-based encryptor
-                // could be used.
-                // If we get here, it means the key ring provider is returning a different encryptor
-                // which would be very odd. But we'll check just in case and fall back to the old behavior if this happens.
+                // If SpanDataProtector is used, but encryptor does not support Span'ish APIs, fallback to the byte[] path.
                 var result = Protect(plaintext.ToArray());
                 var span = destination.GetSpan(result.Length);
                 result.CopyTo(span);
@@ -170,11 +166,7 @@ internal unsafe class KeyRingBasedSpanDataProtector : KeyRingBasedDataProtector,
 
             if (requestedEncryptor is not ISpanAuthenticatedEncryptor spanEncryptor)
             {
-                // This should never happen, since the IDataProtector should have
-                // checked the key ring provider to see if the span-based encryptor
-                // could be used.
-                // If we get here, it means the key ring provider is returning a different encryptor
-                // which would be very odd. But we'll check just in case and fall back to the old behavior if this happens.
+                // If SpanDataProtector is used, but encryptor does not support Span'ish APIs, fallback to the byte[] path.
                 var result = requestedEncryptor.Decrypt(actualCiphertext.ToArray(), aad.ToArray());
                 var span = destination.GetSpan(result.Length);
                 result.CopyTo(span);

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/KeyManagement/KeyRingBasedDataProtectorTests.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/KeyManagement/KeyRingBasedDataProtectorTests.cs
@@ -892,6 +892,25 @@ public class KeyRingBasedDataProtectorTests
     }
 #endif
 
+    [Fact]
+    public void CreateProtector_DoesNotResolveKeyRing()
+    {
+        // Regression test for https://github.com/dotnet/aspnetcore/issues/67447
+        // CreateProtector must NOT call IKeyRingProvider.GetCurrentKeyRing(). That would force
+        // a key-store round-trip during protector creation (e.g. during app startup), causing
+        // apps that persist keys to an unreachable external store to fail at boot instead of on first Protect/Unprotect. 
+
+        var mockKeyRingProvider = new Mock<IKeyRingProvider>(MockBehavior.Strict);
+        // No setup for GetCurrentKeyRing - any call will throw.
+
+        var provider = new KeyRingBasedDataProtectionProvider(mockKeyRingProvider.Object, NullLoggerFactory.Instance);
+
+        var protector = provider.CreateProtector("purpose");
+
+        Assert.NotNull(protector);
+        mockKeyRingProvider.Verify(o => o.GetCurrentKeyRing(), Times.Never);
+    }
+
     private static byte[] BuildAadFromPurposeStrings(Guid keyId, params string[] purposes)
     {
         var expectedAad = new byte[] { 0x09, 0xF0, 0xC9, 0xF0 } // magic header

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/KeyManagement/KeyRingBasedDataProtectorTests.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/KeyManagement/KeyRingBasedDataProtectorTests.cs
@@ -646,13 +646,13 @@ public class KeyRingBasedDataProtectorTests
     {
         byte[] plaintext = Encoding.UTF8.GetBytes(plaintextStr);
         var encryptorFactory = new AuthenticatedEncryptorFactory(NullLoggerFactory.Instance);
-        
+
         var configuration = new AuthenticatedEncryptorConfiguration
         {
             EncryptionAlgorithm = encryptionAlgorithm,
             ValidationAlgorithm = validationAlgorithm
         };
-        
+
         Key key = new Key(Guid.NewGuid(), DateTimeOffset.Now, DateTimeOffset.Now, DateTimeOffset.Now, configuration.CreateNewDescriptor(), new[] { encryptorFactory });
         var keyRing = new KeyRing(key, [ key ]);
         var mockKeyRingProvider = new Mock<IKeyRingProvider>();
@@ -669,7 +669,7 @@ public class KeyRingBasedDataProtectorTests
 
     [Theory]
     [InlineData(16)]     // 16 bytes
-    [InlineData(32)]     // 32 bytes  
+    [InlineData(32)]     // 32 bytes
     [InlineData(64)]     // 64 bytes
     [InlineData(128)]    // 128 bytes
     [InlineData(256)]    // 256 bytes
@@ -701,7 +701,7 @@ public class KeyRingBasedDataProtectorTests
 
     [Theory]
     [InlineData(16)]     // 16 bytes
-    [InlineData(32)]     // 32 bytes  
+    [InlineData(32)]     // 32 bytes
     [InlineData(64)]     // 64 bytes
     [InlineData(128)]    // 128 bytes
     [InlineData(256)]    // 256 bytes
@@ -730,7 +730,7 @@ public class KeyRingBasedDataProtectorTests
             originalPurposes: null,
             newPurpose: "purpose");
 
-        // Act - first protect the data  
+        // Act - first protect the data
         byte[] protectedData = protector.Protect(plaintext);
 
         var arrayBufferWriter = new ArrayBufferWriter<byte>(plaintextSize);
@@ -898,16 +898,19 @@ public class KeyRingBasedDataProtectorTests
         // Regression test for https://github.com/dotnet/aspnetcore/issues/67447
         // CreateProtector must NOT call IKeyRingProvider.GetCurrentKeyRing(). That would force
         // a key-store round-trip during protector creation (e.g. during app startup), causing
-        // apps that persist keys to an unreachable external store to fail at boot instead of on first Protect/Unprotect. 
+        // apps that persist keys to an unreachable external store to fail at boot instead of on first Protect/Unprotect.
 
         var mockKeyRingProvider = new Mock<IKeyRingProvider>(MockBehavior.Strict);
         // No setup for GetCurrentKeyRing - any call will throw.
 
         var provider = new KeyRingBasedDataProtectionProvider(mockKeyRingProvider.Object, NullLoggerFactory.Instance);
 
-        var protector = provider.CreateProtector("purpose");
+        // Chaining .CreateProtector() should all have to be lazy.
+        var appProtector = provider.CreateProtector("app");
+        var purposeProtector = appProtector.CreateProtector("purpose");
 
-        Assert.NotNull(protector);
+        Assert.NotNull(appProtector);
+        Assert.NotNull(purposeProtector);
         mockKeyRingProvider.Verify(o => o.GetCurrentKeyRing(), Times.Never);
     }
 


### PR DESCRIPTION
The reported bug eagerly resolves encryptor in order to determine whether `IAuthenticatedEncryptor` supports Span-based APIs (in other words is `ISpanAuthenticatedEncryptor`):
```csharp
        var currentKeyRing = _keyRingProvider.GetCurrentKeyRing();
        var encryptor = currentKeyRing.DefaultAuthenticatedEncryptor;
```

However, calling `_keyRingProvider.GetCurrentKeyRing()` is not free, and in case keys are persisted to an external store, we now load them (which may be problematic in startup scenarios).

----

The easy fix is to always return `KeyRingBasedSpanDataProtector` which is `ISpanDataProtector` - even if underlying `IAuthenticatedEncryptor` is not `ISpanAuthenticatedEncryptor` it simply fallbacks to allocatey `byte[]` APIs. 

However that is a bit misleading in the usage scenarios:
```csharp
class MyService
{
   private IDataProtector _dataProtector;
   
   public void DoDataProtection(Span<byte> input)
   {
      if (_dataProtector is ISpanDataProtector spanDataProtector)
      {
         spanDataProtector.TryProtect(input...); // ALSO calls byte[] under the hood - undiscoverable
      }
      else
      {
         _dataProtector.Protect(input); // byte[] API
      }
   }
}
```

So we can probably work on introducing new I**Span**DataProtectorProvider:
```diff
namespace Microsoft.AspNetCore.DataProtection;

+ public interface ISpanDataProtectionProvider : IDataProtectionProvider
{
+  ISpanDataProtector CreateSpanDataProtector(string purpose);
}
```

which will match the type with the expectations. But I think fallback is anyway a good choice, so we can simply keep it.

Fixes #67447