### PR TITLE
Avoid recompiling the shared framework when publishing to the layout root

### DIFF
--- a/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.sfxproj
+++ b/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.sfxproj
@@ -181,13 +181,32 @@
     Publish the targeting pack to the layout root by copying the already-built files instead of invoking
     PublishToDisk through a nested <MSBuild> call that overrides OutputPath. Overriding OutputPath forks a
     new project configuration that rebuilds the pack's assemblies a second time. See
-    https://github.com/dotnet/msbuild/issues/12927. Running AfterTargets="Build" and reusing the
-    GetFilesToPublish list in this same configuration avoids the fork and the rebuild.
+    https://github.com/dotnet/msbuild/issues/12927.
+
+    We run AfterTargets="Build" and ask the project for its already-resolved file list via a nested
+    <MSBuild> call to _GetAllSharedFrameworkFiles. We do NOT depend on GetFilesToPublish directly, because
+    GetFilesToPublish populates the project-global FilesToPackage/_FilesToPackage items that arcade's Pack
+    path (_AddFilesToNuGetPackage) also consumes; resolving them in this configuration adds every assembly
+    to the package twice and trips NU5118. Capturing the file list through TargetOutputs into a private
+    item avoids mutating the packaging items, and passing no global property overrides reuses the file list
+    already computed for packaging (no extra compile). The layout TargetPath transform below mirrors
+    arcade's GetFilesToPublish for a TargetingPack.
   -->
-  <Target Name="PublishToSharedLayoutRoot" AfterTargets="Build" DependsOnTargets="GetFilesToPublish">
-    <Copy SourceFiles="@(FilesToPublish)"
-          DestinationFolder="$(TargetingPackLayoutRoot)%(FilesToPublish.TargetPath)%(FilesToPublish.Culture)"
-          Condition="'%(FilesToPublish.IsSymbolFile)' != 'true' or '%(FilesToPublish.IncludeAlways)' == 'true'"
+  <Target Name="PublishToSharedLayoutRoot" AfterTargets="Build">
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="_GetAllSharedFrameworkFiles">
+      <Output TaskParameter="TargetOutputs" ItemName="_TargetingPackLayoutPackagedFile" />
+    </MSBuild>
+
+    <ItemGroup>
+      <_TargetingPackLayoutFileToPublish Include="@(_TargetingPackLayoutPackagedFile)"
+          Condition="'%(_TargetingPackLayoutPackagedFile.PackOnly)' != 'true' and '%(_TargetingPackLayoutPackagedFile.TargetPath)' != ''">
+        <LayoutTargetPath>packs/$(PackageId)/$(Version)/%(_TargetingPackLayoutPackagedFile.TargetPath)/</LayoutTargetPath>
+      </_TargetingPackLayoutFileToPublish>
+    </ItemGroup>
+
+    <Copy SourceFiles="@(_TargetingPackLayoutFileToPublish)"
+          DestinationFolder="$(TargetingPackLayoutRoot)%(_TargetingPackLayoutFileToPublish.LayoutTargetPath)%(_TargetingPackLayoutFileToPublish.Culture)"
+          Condition="'%(_TargetingPackLayoutFileToPublish.IsSymbolFile)' != 'true' or '%(_TargetingPackLayoutFileToPublish.IncludeAlways)' == 'true'"
           OverwriteReadOnlyFiles="true"
           SkipUnchangedFiles="true" />
 

--- a/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.sfxproj
+++ b/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.sfxproj
@@ -177,9 +177,24 @@
         Overwrite="true" />
   </Target>
 
-  <Target Name="PublishToSharedLayoutRoot" BeforeTargets="Build">
-    <MSBuild Projects="$(MSBuildProjectFullPath)"
-             Targets="PublishToDisk"
-             Properties="OutputPath=$(TargetingPackLayoutRoot)" />
+  <!--
+    Publish the targeting pack to the layout root by copying the already-built files instead of invoking
+    PublishToDisk through a nested <MSBuild> call that overrides OutputPath. Overriding OutputPath forks a
+    new project configuration that rebuilds the pack's assemblies a second time. See
+    https://github.com/dotnet/msbuild/issues/12927. Running AfterTargets="Build" and reusing the
+    GetFilesToPublish list in this same configuration avoids the fork and the rebuild.
+  -->
+  <Target Name="PublishToSharedLayoutRoot" AfterTargets="Build" DependsOnTargets="GetFilesToPublish">
+    <Copy SourceFiles="@(FilesToPublish)"
+          DestinationFolder="$(TargetingPackLayoutRoot)%(FilesToPublish.TargetPath)%(FilesToPublish.Culture)"
+          Condition="'%(FilesToPublish.IsSymbolFile)' != 'true' or '%(FilesToPublish.IncludeAlways)' == 'true'"
+          OverwriteReadOnlyFiles="true"
+          SkipUnchangedFiles="true" />
+
+    <!-- Fix file permissions in the layout dir, matching arcade's PublishToDisk target. -->
+    <Exec Condition="!$([MSBuild]::IsOsPlatform(Windows))" Command='find "$(TargetingPackLayoutRoot)" -type f -name "*" -exec chmod 644 {} \;' />
+    <Exec Condition="!$([MSBuild]::IsOsPlatform(Windows))" Command='find "$(TargetingPackLayoutRoot)" -type f -name "*.dylib" -exec chmod 755 {} \;' />
+    <Exec Condition="!$([MSBuild]::IsOsPlatform(Windows))" Command='find "$(TargetingPackLayoutRoot)" -type f -name "*.so" -exec chmod 755 {} \;' />
+    <Exec Condition="!$([MSBuild]::IsOsPlatform(Windows))" Command='find "$(TargetingPackLayoutRoot)" -type f ! -name "*.*" -exec chmod 755 {} \;' />
   </Target>
 </Project>

--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.sfxproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.sfxproj
@@ -139,19 +139,34 @@
     Publish the shared framework to the layout root by copying the already-built files, rather than
     invoking PublishToDisk through a nested <MSBuild> call that overrides OutputPath. Overriding
     OutputPath (a well-known global property) forks a new project configuration, and resolving the file
-    list under that forked configuration rebuilds the framework's assemblies a second time - the
+    list under that forked configuration rebuilds the framework's assemblies a second time, causing the
     intermittent MSB3030 PDB copy race described in https://github.com/dotnet/msbuild/issues/12927.
 
-    Instead we run AfterTargets="Build" (so the framework's files are already built) and reuse the file
-    list produced by GetFilesToPublish in this same configuration, then copy it to the layout root. This
-    mirrors the Copy that arcade's PublishToDisk target performs, without the OutputPath fork. Because we
-    no longer reuse the OutputPath-differentiated configuration, _PublishingToLayout is also no longer
-    needed to avoid the circular dependency that overriding OutputPath previously introduced.
+    Instead we run AfterTargets="Build" (so the framework's files are already built) and ask the project
+    for its already-resolved file list via a nested <MSBuild> call to _GetAllSharedFrameworkFiles. We do
+    NOT depend on GetFilesToPublish directly, because GetFilesToPublish populates the project-global
+    FilesToPackage/_FilesToPackage items that arcade's Pack path (_AddFilesToNuGetPackage) also consumes;
+    resolving them in this configuration adds every assembly to the package twice (the plain and the R2R
+    copy) and trips NU5118. By capturing the file list through TargetOutputs into a private item we avoid
+    mutating the packaging items, and because we pass no global property overrides the nested call reuses
+    the file list already computed for packaging (no extra compile). The layout TargetPath transform below
+    mirrors arcade's GetFilesToPublish for a RuntimePack.
   -->
-  <Target Name="PublishToSharedLayoutRoot" AfterTargets="Build" DependsOnTargets="GetFilesToPublish">
-    <Copy SourceFiles="@(FilesToPublish)"
-          DestinationFolder="$(SharedFrameworkLayoutRoot)%(FilesToPublish.TargetPath)%(FilesToPublish.Culture)"
-          Condition="'%(FilesToPublish.IsSymbolFile)' != 'true' or '%(FilesToPublish.IncludeAlways)' == 'true'"
+  <Target Name="PublishToSharedLayoutRoot" AfterTargets="Build">
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="_GetAllSharedFrameworkFiles">
+      <Output TaskParameter="TargetOutputs" ItemName="_SharedLayoutPackagedFile" />
+    </MSBuild>
+
+    <ItemGroup>
+      <_SharedLayoutFileToPublish Include="@(_SharedLayoutPackagedFile)"
+          Condition="'%(_SharedLayoutPackagedFile.PackOnly)' != 'true' and ($([System.String]::new('%(_SharedLayoutPackagedFile.TargetPath)').StartsWith('runtimes/')) or '%(_SharedLayoutPackagedFile.PublishOnly)' == 'true')">
+        <LayoutTargetPath>shared/$(SharedFrameworkName)/$(Version)/</LayoutTargetPath>
+      </_SharedLayoutFileToPublish>
+    </ItemGroup>
+
+    <Copy SourceFiles="@(_SharedLayoutFileToPublish)"
+          DestinationFolder="$(SharedFrameworkLayoutRoot)%(_SharedLayoutFileToPublish.LayoutTargetPath)%(_SharedLayoutFileToPublish.Culture)"
+          Condition="'%(_SharedLayoutFileToPublish.IsSymbolFile)' != 'true' or '%(_SharedLayoutFileToPublish.IncludeAlways)' == 'true'"
           OverwriteReadOnlyFiles="true"
           SkipUnchangedFiles="true" />
 

--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.sfxproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.sfxproj
@@ -139,7 +139,7 @@
     Publish the shared framework to the layout root by copying the already-built files, rather than
     invoking PublishToDisk through a nested <MSBuild> call that overrides OutputPath. Overriding
     OutputPath (a well-known global property) forks a new project configuration, and resolving the file
-    list under that forked configuration rebuilds the framework's assemblies a second time -- the
+    list under that forked configuration rebuilds the framework's assemblies a second time - the
     intermittent MSB3030 PDB copy race described in https://github.com/dotnet/msbuild/issues/12927.
 
     Instead we run AfterTargets="Build" (so the framework's files are already built) and reuse the file

--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.sfxproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.sfxproj
@@ -135,11 +135,31 @@
     <Warning Text="This project has native dependencies which were not built. Without this, tests may not function correctly. Run `build.cmd -BuildNative -BuildManaged` to build both C# and C++." />
   </Target>
 
-  <Target Name="PublishToSharedLayoutRoot" BeforeTargets="Build">
-    <!-- Set _PublishingToLayout=true to differentiate global properties for this nested MSBuild call and avoid an intermittent circular dependency involving GetFilesToPublish. -->
-    <MSBuild Projects="$(MSBuildProjectFullPath)"
-             Targets="PublishToDisk"
-             Properties="OutputPath=$(SharedFrameworkLayoutRoot);_PublishingToLayout=true" />
+  <!--
+    Publish the shared framework to the layout root by copying the already-built files, rather than
+    invoking PublishToDisk through a nested <MSBuild> call that overrides OutputPath. Overriding
+    OutputPath (a well-known global property) forks a new project configuration, and resolving the file
+    list under that forked configuration rebuilds the framework's assemblies a second time -- the
+    intermittent MSB3030 PDB copy race described in https://github.com/dotnet/msbuild/issues/12927.
+
+    Instead we run AfterTargets="Build" (so the framework's files are already built) and reuse the file
+    list produced by GetFilesToPublish in this same configuration, then copy it to the layout root. This
+    mirrors the Copy that arcade's PublishToDisk target performs, without the OutputPath fork. Because we
+    no longer reuse the OutputPath-differentiated configuration, _PublishingToLayout is also no longer
+    needed to avoid the circular dependency that overriding OutputPath previously introduced.
+  -->
+  <Target Name="PublishToSharedLayoutRoot" AfterTargets="Build" DependsOnTargets="GetFilesToPublish">
+    <Copy SourceFiles="@(FilesToPublish)"
+          DestinationFolder="$(SharedFrameworkLayoutRoot)%(FilesToPublish.TargetPath)%(FilesToPublish.Culture)"
+          Condition="'%(FilesToPublish.IsSymbolFile)' != 'true' or '%(FilesToPublish.IncludeAlways)' == 'true'"
+          OverwriteReadOnlyFiles="true"
+          SkipUnchangedFiles="true" />
+
+    <!-- Fix file permissions in the layout dir, matching arcade's PublishToDisk target. -->
+    <Exec Condition="!$([MSBuild]::IsOsPlatform(Windows))" Command='find "$(SharedFrameworkLayoutRoot)" -type f -name "*" -exec chmod 644 {} \;' />
+    <Exec Condition="!$([MSBuild]::IsOsPlatform(Windows))" Command='find "$(SharedFrameworkLayoutRoot)" -type f -name "*.dylib" -exec chmod 755 {} \;' />
+    <Exec Condition="!$([MSBuild]::IsOsPlatform(Windows))" Command='find "$(SharedFrameworkLayoutRoot)" -type f -name "*.so" -exec chmod 755 {} \;' />
+    <Exec Condition="!$([MSBuild]::IsOsPlatform(Windows))" Command='find "$(SharedFrameworkLayoutRoot)" -type f ! -name "*.*" -exec chmod 755 {} \;' />
   </Target>
 
   <Target Name="ReturnProductVersion" Returns="$(Version)" />


### PR DESCRIPTION
## Problem

The runtime and targeting-pack `sfxproj`s published the shared framework / targeting pack to the layout root by invoking arcade's `PublishToDisk` through a nested `<MSBuild>` call that **overrode `OutputPath`**:

```xml
<MSBuild Projects="$(MSBuildProjectFullPath)" Targets="PublishToDisk"
         Properties="OutputPath=$(SharedFrameworkLayoutRoot);_PublishingToLayout=true" />
```

`OutputPath` is a well-known global property, so overriding it forks a **second, non-deduplicated project instance**. That duplicate instance runs the framework project's `Build` (and its copy/output-stage targets) concurrently with the primary instance. The two instances race on the same `obj`/`bin` PDBs, which is the intermittent `MSB3030 "could not copy ... not found"` failure parallel consumers hit (dotnet/msbuild#12927). Note the race is in the copy stage and happens whether or not the duplicate instance actually recompiles — in incremental builds its `CoreCompile` usually skips as up-to-date but the copy targets still run.

## Fix

Run `PublishToSharedLayoutRoot` **`AfterTargets="Build"`** and copy the already-built files to the layout root in the **same** configuration, so there's no forked instance and no second actor to race.

To get the file list we call `_GetAllSharedFrameworkFiles` via a nested `<MSBuild>` and capture its `TargetOutputs` into a **private item** rather than depending on `GetFilesToPublish` directly. This matters: `GetFilesToPublish` populates the project-global `FilesToPackage`/`_FilesToPackage` items that arcade's Pack path (`_AddFilesToNuGetPackage`) also consumes, so resolving them in this configuration would add every assembly to the package twice (plain + R2R) and trip **NU5118**. Capturing through `TargetOutputs` into a private item avoids mutating the packaging items, and passing no global-property overrides means the nested call reuses the already-computed file list (no extra compile). The `LayoutTargetPath` transform mirrors arcade's `GetFilesToPublish` for a RuntimePack / TargetingPack.

`_PublishingToLayout` is removed — it only existed to keep the forked configuration distinct, which is no longer needed.

### Files
- `src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.sfxproj`
- `src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.sfxproj`

`SharedFrameworkLayoutRoot` / `TargetingPackLayoutRoot` are consumed only by other projects (e.g. test infra) that already build after these, so moving the publish from `BeforeTargets` to `AfterTargets="Build"` does not affect consumers.

## Validation

Before/after binlog diff (linux-x64):
- The forked `OutputPath=…/SharedFx.Layout/…` (and `TargetingPack.Layout`) project instance is **gone**.
- Redundant incremental re-entries drop sharply (skipped `CoreCompile` invocations 119 → 14); genuine compile count is unchanged (it was already deduped by incremental build).
- Layout roots are **byte-identical** before vs after: 136 files under `shared/Microsoft.AspNetCore.App/` and 405 under `packs/Microsoft.AspNetCore.App.Ref/`.

Fixes the recompile/PDB-race half of dotnet/msbuild#12927 and the NU5118 packaging error.
