### PR TITLE
Clean-up Public API for RF serialization

### DIFF
--- a/src/Components/Components/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Components/src/PublicAPI.Unshipped.txt
@@ -3,7 +3,6 @@ abstract Microsoft.AspNetCore.Components.CascadingParameterSubscription.Dispose(
 abstract Microsoft.AspNetCore.Components.CascadingParameterSubscription.GetCurrentValue() -> object?
 Microsoft.AspNetCore.Components.CascadingParameterSubscription
 Microsoft.AspNetCore.Components.CascadingParameterSubscription.CascadingParameterSubscription() -> void
-Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.SetAttributeValue(int frameIndex, object? value) -> void
 static Microsoft.AspNetCore.Components.NavigationManagerExtensions.GetUriWithFragment(this Microsoft.AspNetCore.Components.NavigationManager! navigationManager, string? fragment) -> string!
 Microsoft.AspNetCore.Components.NavigationOptions.RelativeToCurrentUri.get -> bool
 Microsoft.AspNetCore.Components.NavigationOptions.RelativeToCurrentUri.init -> void

--- a/src/Components/Components/src/Rendering/RenderTreeBuilder.cs
+++ b/src/Components/Components/src/Rendering/RenderTreeBuilder.cs
@@ -777,35 +777,6 @@ public sealed class RenderTreeBuilder : IDisposable
     public ArrayRange<RenderTreeFrame> GetFrames() =>
         _entries.ToRange();
 
-    /// <summary>
-    /// Replaces the attribute value of an existing attribute frame at the specified index.
-    /// This is used to update attribute values in-place after frames have been appended,
-    /// for example when wrapping <see cref="RenderFragment"/> delegates during serialization.
-    /// </summary>
-    /// <param name="frameIndex">The zero-based index of the attribute frame whose value should be replaced.</param>
-    /// <param name="value">The new attribute value.</param>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="frameIndex"/> is outside the range of appended frames.</exception>
-    /// <exception cref="InvalidOperationException">Thrown when the frame at <paramref name="frameIndex"/> is not of type <see cref="RenderTreeFrameType.Attribute"/>.</exception>
-    public void SetAttributeValue(int frameIndex, object? value)
-    {
-        var frames = _entries.Buffer;
-        var count = _entries.Count;
-
-        if ((uint)frameIndex >= (uint)count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(frameIndex));
-        }
-
-        ref var frame = ref frames[frameIndex];
-        if (frame.FrameTypeField != RenderTreeFrameType.Attribute)
-        {
-            throw new InvalidOperationException(
-                $"The frame at index {frameIndex} is of type '{frame.FrameTypeField}', not '{RenderTreeFrameType.Attribute}'.");
-        }
-
-        frame.AttributeValueField = value;
-    }
-
     internal void AssertTreeIsValid(IComponent component)
     {
         if (_openElementIndices.Count > 0)

--- a/src/Components/Shared/src/RenderFragmentCapture.cs
+++ b/src/Components/Shared/src/RenderFragmentCapture.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.RenderTree;
 
@@ -66,7 +67,7 @@ internal sealed class RenderFragmentCapture
             // soon as we hit the first non-Attribute frame.
             for (var j = i + 1; j < componentSubtreeEnd && frames.Array[j].FrameType is RenderTreeFrameType.Attribute; j++)
             {
-                ref readonly var attrFrame = ref frames.Array[j];
+                ref var attrFrame = ref frames.Array[j];
                 if (attrFrame.AttributeValue is RenderFragment innerRf)
                 {
                     var innerCapture = new RenderFragmentCapture(innerRf);
@@ -76,10 +77,19 @@ internal sealed class RenderFragmentCapture
                     // populates innerCapture._capturedFrames. Looking up the capture by frame
                     // index in _childCaptures would otherwise find an entry whose frames were
                     // never recorded.
-                    builder.SetAttributeValue(j, (RenderFragment)innerCapture.Invoke);
+                    //
+                    // RenderTreeFrame.AttributeValueField is internal to the core Components
+                    // assembly and this shared source compiles into other assemblies, so we
+                    // write to it directly through an UnsafeAccessor ref rather than widening
+                    // the public API or granting InternalsVisibleTo. frames.Array is the live
+                    // builder buffer, so this mutation is observed by the renderer.
+                    GetAttributeValueField(ref attrFrame) = (RenderFragment)innerCapture.Invoke;
                     _childCaptures[j - start] = innerCapture;
                 }
             }
         }
     }
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "AttributeValueField")]
+    private static extern ref object GetAttributeValueField(ref RenderTreeFrame frame);
 }


### PR DESCRIPTION
# Clean-up Public API for RF serialization

## Summary

Removes the newly added public `RenderTreeBuilder.SetAttributeValue(int, object?)` API and instead performs the same in-place frame mutation through an `[UnsafeAccessor]`. This keeps the `RenderFragment` serialization feature working without adding any new public surface to `RenderTreeBuilder`.

## Background

To serialize `RenderFragment` content across render mode boundaries, `RenderFragmentCapture` swaps each nested `RenderFragment` delegate in the live render buffer with a capture wrapper, so that when the nested component invokes its parameter, control flows through the wrapper and its frames get recorded. The original implementation (https://github.com/dotnet/aspnetcore/pull/66528) exposed a public `SetAttributeValue` method on `RenderTreeBuilder` to perform that swap. This PR removes that public API.

## Why a mutation accessor (or a public API) is needed — we can't write the value directly

`RenderFragmentCapture` already gets a `ref` to the exact frame in the live buffer (`ref var attrFrame = ref frames.Array[j]`), and `RenderTreeFrame` is a mutable struct, so the slot itself is writable. The blocker is **accessibility, not ref-ness**: there is no member we are allowed to assign through from this file.

- The public `RenderTreeFrame.AttributeValue` property is **get-only** — there is no public setter.
- The writable backing field, `RenderTreeFrame.AttributeValueField`, is **`internal`** to the core `Microsoft.AspNetCore.Components` assembly.
- `RenderFragmentCapture` is shared source that compiles into `Microsoft.AspNetCore.Components.Endpoints`, `.Server`, and `.WebAssembly` — none of which can see that internal field.

So even with a writable `ref RenderTreeFrame` in hand, `attrFrame.AttributeValueField = value` does not compile across the assembly boundary (CS0122), and `attrFrame.AttributeValue = value` does not compile because the property has no setter (CS0200). Bridging that gap requires *some* mechanism that has access to the internal field. The options are:

1. A **public API** on `RenderTreeBuilder` (the original `SetAttributeValue`) — but that permanently widens the public surface with a low-level, easily-misused mutation method.
2. **`InternalsVisibleTo`** for the three runtime assemblies — but that broadly exposes all of core's internals to them and causes unrelated `protected internal` override ripple across those projects.
3. **`[UnsafeAccessor]`** — resolves the internal `AttributeValueField` by name at the runtime layer and returns a `ref object` we can assign through, with no public API and no `InternalsVisibleTo`.

This PR takes option 3.

## Changes

- Removed `public void SetAttributeValue(int frameIndex, object? value)` from `RenderTreeBuilder` and its `PublicAPI.Unshipped.txt` entry.
- `RenderFragmentCapture.WrapNestedFragments` now writes the wrapper delegate into the live frame buffer via an `[UnsafeAccessor]`-generated `ref` accessor over `RenderTreeFrame.AttributeValueField`, instead of calling `builder.SetAttributeValue(...)`.

## Details

- The accessor binds to the field **by name** (`Name = "AttributeValueField"`), so a future rename of that field would surface as a `MissingFieldException` at first call rather than a compile-time error. The accessor sits next to the only call site to keep that coupling visible.
- Behavior is unchanged: `frames.Array` is the live builder buffer, so the write is observed by the renderer exactly as before.

## Testing

No test changes. The behavior is identical to the previous public-API implementation and is covered by the existing `RenderFragment` serialization tests.

Fixes #66828
