### PR TITLE
Add create-worktree skill and .worktrees isolation

### DIFF
--- a/.github/skills/author-analyzer-skill/SKILL.md
+++ b/.github/skills/author-analyzer-skill/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: author-analyzer-skill
+description: >-
+  Author, review, and ship Roslyn analyzers and code fixes in the dotnet/aspnetcore repo.
+  USE FOR writing a new DiagnosticAnalyzer or CodeFixProvider, reviewing an analyzer PR,
+  choosing a diagnostic ID/category/severity, wiring localized messages, registering well-known
+  types, writing analyzer/code-fix unit tests, fixing an analyzer false positive, diagnosing why a
+  code fix's "Fix all"/FixAll doesn't appear, or following the analyzer proposal-to-ship process.
+  Covers ASP/MVC/API/BL diagnostic IDs, DiagnosticDescriptors conventions, WellKnownTypes infra,
+  Microsoft.CodeAnalysis.Testing verifiers, performance/correctness rules, and do's & don'ts.
+  DO NOT USE FOR writing source generators, Razor compiler changes, or non-analyzer runtime code.
+---
+
+# Writing analyzers in ASP.NET Core
+
+This repo ships Roslyn analyzers and code fixes that guide users toward correct, secure, and performant ASP.NET Core code.
+
+> An analyzer runs on every build and live in the IDE, on every keystroke, across millions of nodes. A slow or wrong analyzer degrades everyone's experience. Hold a high bar: **when in doubt, don't report.**
+
+## Where analyzers live
+
+| Area | Analyzer project | ID prefix |
+|------|------------------|-----------|
+| Framework (minimal APIs, routing, Kestrel, auth, headers) | `src/Framework/AspNetCoreAnalyzers/src/Analyzers` | `ASP####` |
+| Code fixes for the above | `src/Framework/AspNetCoreAnalyzers/src/CodeFixes` | (none) |
+| MVC | `src/Mvc/Mvc.Analyzers` | `MVC####` |
+| MVC API (OpenAPI conventions) | `src/Mvc/Mvc.Api.Analyzers` | `API####` |
+| Blazor Components | `src/Components/Analyzers` | `BL####` |
+
+Pick the project matching the API area you are guarding. Most new work lands in the Framework set.
+
+> **Scope note.** This skill's conventions describe the **Framework set** (`src/Framework/AspNetCoreAnalyzers`), the model to follow for new analyzers. The MVC, API, and Components projects have their own, sometimes older patterns (e.g. inline diagnostic strings, or an analyzer that references Workspaces). When editing those, **match the surrounding area** rather than blindly applying the Framework conventions.
+
+## Decision: should this be an analyzer?
+
+Write one only when **all** hold (details in [references/process.md](references/process.md)):
+- The mistake is detectable at compile time from the current compilation's syntax/symbols/operations, at least for the common cases, **without false positives** (it need not catch every instance; see step 1).
+- It is actionable: the message (or a code fix) tells the user exactly what to change.
+- It is not already caught by the C# compiler.
+
+Runtime-only or highly context-dependent concerns belong in tests or docs, not an analyzer. For an opinionated or behavior-defining rule, run the design through an **analyzer proposal** first (issue template `60_analyzer_proposal.md`) so severity and false-positive scope get reviewed before it ships; routine or low-risk analyzers are often added without one.
+
+## Authoring workflow
+
+1. **Analyze the cases (a return-on-investment call).** Enumerate the **should-fire** cases (each a positive test) and the **should-not-fire** look-alikes that are correct/intentional (each a negative test). For the rest, be **aggressive: try to detect the issue**, and bail on a case only when you can name a concrete reason the return doesn't justify the cost, grounded in **effort, implementation complexity, and how common the case is**. Where the current compilation decides a case cheaply and unambiguously (for code that compiles), go for full coverage with no false positives. Where the common cases are cheap but the long tail is expensive or complex, cover the common cases and make the deeper analysis **opt-in**. Where reliable detection is impossible from here, stop and say so: an analyzer sees the current compilation's source plus referenced **symbols/metadata**, never referenced **bodies**, so cross-assembly facts (a reference's *implementation*, runtime values) usually aren't tractable. Don't decide the trade-off silently: record it in the PR description, give the **developer the call** through a configuration knob (effort/strictness, conservative default for live IDE use, stricter in CI) wherever the answer is use-case-dependent, and pin the line you drew with tests. See [process.md](references/process.md#1-analyze-the-cases-and-document-them).
+2. **Reserve the ID & design the diagnostic.** Pick the next free ID in the area's prefix, choose a [category](references/process.md#categories) and [severity](references/process.md#severity), and register it in `docs/list-of-diagnostics.md`. Add the descriptor to the area's `DiagnosticDescriptors.cs` using `CreateLocalizableResourceString(nameof(Resources.<Key>))` for title/message and the shared `GetHelpLinkUri(id)` helper. Add the strings to `Resources.resx`.
+3. **Write the analyzer.** Follow the canonical shape below. Prefer `IOperation`/symbol analysis over raw syntax. Cache well-known types once via the shared `WellKnownTypes` infra.
+4. **Write the code fix** (optional but encouraged) in the CodeFixes project.
+5. **Write tests** with the `CSharpAnalyzerVerifier`/`CSharpCodeFixVerifier` helpers and `{|#0:...|}` markup. See [references/testing.md](references/testing.md).
+6. **Build & test the area:** activate the local SDK first (`. ./activate.ps1` on Windows, `source activate.sh` otherwise), then run that area's `build.sh -test`, e.g. `./src/Framework/build.sh -test`.
+
+### Canonical analyzer shape
+
+```csharp
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class MyAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(DiagnosticDescriptors.MyRule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None); // skip generated code
+        context.EnableConcurrentExecution();                                     // required for IDE perf
+        context.RegisterCompilationStartAction(static compilationContext =>
+        {
+            // Cache well-known symbols ONCE per compilation, then close over them.
+            var wellKnownTypes = WellKnownTypes.GetOrCreate(compilationContext.Compilation);
+            compilationContext.RegisterOperationAction(
+                operationContext => Analyze(operationContext, wellKnownTypes),
+                OperationKind.Invocation);
+        });
+    }
+}
+```
+
+Need a new well-known type? Add it to the `WellKnownType` enum in the Framework set's `WellKnownTypeData.cs` (and the parallel metadata-name array), then resolve it through the cached `WellKnownTypes.GetOrCreate(compilation)` instance; use `.Get(...)` for types that must exist and `.GetOptional(...)` for ones that legitimately may be absent. Don't call `GetTypeByMetadataName` per node.
+
+Not every analyzer needs the compilation-start cache: if you don't look up well-known types, you can register an operation/symbol action directly in `Initialize` (e.g. `HeaderDictionaryIndexerAnalyzer`). Use `RegisterCompilationStartAction` when you need to resolve and cache symbols once per compilation. This `WellKnownTypes` infrastructure is the Framework set's; MVC/Components analyzers have their own symbol caches (e.g. `ComponentSymbols`).
+
+## The five rules that matter most
+
+These prevent the bugs that actually ship. Full catalog with citations in [references/best-practices.md](references/best-practices.md).
+
+1. **Cache, don't re-resolve.** When you need well-known symbols, resolve them once in `RegisterCompilationStartAction` and close over them; never store `Compilation`/`ISymbol`/`IOperation` in analyzer fields (they go stale across compilations, RS1008).
+2. **Be cheap and bail early.** Order checks cheapest-first and `return` immediately. No LINQ/allocations or `DescendantNodes()` walks in per-node callbacks. Prefer `IOperation` over syntax for semantics.
+3. **Compare symbols correctly.** Use `SymbolEqualityComparer.Default.Equals(...)`, never `==` (RS1024). In the Framework set, don't reference `Document`/`Solution`/`Workspace` types from an analyzer (RS1022, enforced via `EnforceExtendedAnalyzerRules`); only from a fixer.
+4. **Localize and link (Framework set).** A `DiagnosticDescriptor`'s title/message/description are `LocalizableResourceString` from `Resources.resx` (RS1007) with a help link; the title has no trailing period, the message ends with one. (Code-fix *action* titles may be plain strings.)
+5. **Don't cry wolf.** Bail on parse errors and interleaved `#directives`; report on the **smallest** meaningful span; pass data to the fixer via `diagnostic.Properties` instead of re-computing.
+
+## Code fixes
+
+- `[ExportCodeFixProvider(LanguageNames.CSharp), Shared]`; list exactly your IDs in `FixableDiagnosticIds`.
+- Override `GetFixAllProvider()`: return `WellKnownFixAllProviders.BatchFixer` for simple, local, non-overlapping fixes; a custom singleton `FixAllProvider` otherwise.
+- Every `CodeAction.Create(...)` needs a non-null `equivalenceKey` (RS1010). Keep the fix minimal, preserve trivia, accept and propagate `CancellationToken` with `ConfigureAwait(false)`.
+
+```csharp
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public sealed class MyFixer : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+        ImmutableArray.Create(DiagnosticDescriptors.MyRule.Id);
+
+    public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            context.RegisterCodeFix(
+                CodeAction.Create("Use the recommended API",
+                    ct => ApplyFixAsync(context.Document, root!, diagnostic, ct),
+                    equivalenceKey: DiagnosticDescriptors.MyRule.Id), // non-null key => FixAll works
+                diagnostic);
+        }
+    }
+}
+```
+
+> "Fix all occurrences" missing in the IDE almost always means a missing `GetFixAllProvider()` override or a null `equivalenceKey`.
+
+If a fix only needs symbols, an analyzer can pass pre-computed data through `diagnostic.Properties` so the fixer doesn't redo analysis.
+
+See [references/testing.md](references/testing.md) for test patterns and [references/conventions.md](references/conventions.md) for project/packaging/localization details.
+
+## Reviewing an analyzer change
+
+Apply the same bar: confirm the ID is reserved in `docs/list-of-diagnostics.md`, the descriptor is localized with a help link, `EnableConcurrentExecution`/`ConfigureGeneratedCodeAnalysis` are set, symbols are cached and compared with `SymbolEqualityComparer`, no Workspaces types leak into the analyzer, the reported span is minimal, false-positive guards exist, and there are positive **and** negative tests.

--- a/.github/skills/author-analyzer-skill/references/best-practices.md
+++ b/.github/skills/author-analyzer-skill/references/best-practices.md
@@ -1,0 +1,75 @@
+# Roslyn analyzer & code-fix best practices
+
+Each rule names the enforcing `RSxxxx` meta-analyzer where one exists, so you can look it up. `EnforceExtendedAnalyzerRules=true` in the Framework analyzer projects turns many of these on as build errors; treat them as hard requirements, not suggestions. Enforced rules are stated as one-liners (the `RS` code is the rationale); judgment calls are spelled out as *Trigger / Decision / Why / Scope*.
+
+## Table of contents
+- [Performance](#performance)
+- [Concurrency & state](#concurrency--state)
+- [Correctness](#correctness)
+- [Diagnostic design](#diagnostic-design)
+- [Code fixes](#code-fixes)
+- [Anti-patterns (do NOT do)](#anti-patterns-do-not-do)
+
+## Performance
+
+An analyzer's callbacks run on every node/symbol/operation of their kind, in every file, live in the IDE. Allocation and redundant work here are felt as editor lag.
+
+- **Cache well-known symbols once per compilation.** Resolve them inside `RegisterCompilationStartAction` and close over the result; never resolve per node/symbol. In this repo, use `WellKnownTypes.GetOrCreate(compilation)`.
+- Use `node.IsKind(SyntaxKind.X)`, not `node.Kind() == SyntaxKind.X` (RS1034).
+- Never call `Compilation.GetSemanticModel()` inside a callback (RS1030); use the model already on the action context. It bypasses the host's semantic-model cache and forces a full re-bind, causing visible IDE hangs.
+- No allocations in hot callbacks: avoid `new List<>()`, LINQ, and `DescendantNodes()` walks inside per-node/per-operation actions. Scope walks with `RegisterCodeBlockStartAction` / `RegisterOperationBlockStartAction`; when you must accumulate, reuse buffers or Roslyn's pooled collections (e.g. `ArrayBuilder<T>.GetInstance(...)`) where accessible.
+
+- **Prefer `IOperation`/symbol analysis over raw syntax.** *Trigger:* the check needs semantics (what a call resolves to, a type, a value) rather than pure source shape. *Decision:* register an operation or symbol action and read symbols/operations; reserve `RegisterSyntaxNodeAction` for purely structural checks. *Why:* operation/symbol analysis is faster, allocates less, and is language-version- and syntax-agnostic, so it keeps working when new C# syntax expresses the same construct. *Scope:* common (use syntax when the rule genuinely is about a token or structure, e.g. a missing modifier).
+- **Order gates cheapest-first and bail at the first failure.** *Trigger:* a callback that does any non-trivial work. *Decision:* check the cheap discriminators first (language version, a syntactic shape, parse errors) and `return` before the expensive semantic lookups. *Why:* the callback fires on huge numbers of nodes, so the common (non-matching) case must reach a `return` after only a few cheap comparisons. *Scope:* near-universal.
+
+## Concurrency & state
+
+- Call `context.EnableConcurrentExecution()` in `Initialize` (RS1026) so the host can parallelize.
+- **Analyzers must be stateless across compilations.** Never store `Compilation`, `ISymbol`, or `IOperation` (or anything holding them) in instance fields (RS1008); instances are reused across compilations and concurrent callbacks. Flow state through start-action closures.
+- With concurrency enabled, any state shared between your own callbacks must be thread-safe (`ConcurrentDictionary`, immutable collections). Don't depend on action ordering except the start to inner to end nesting guarantee, and don't rely on compilation-end actions running in the IDE.
+
+- **Configure generated-code analysis to match what the rule inspects.** *Trigger:* setting the `ConfigureGeneratedCodeAnalysis(...)` flags (RS1025), which every analyzer must call. *Decision:* pass `GeneratedCodeAnalysisFlags.None` for rules about hand-written code; pass `Analyze | ReportDiagnostics` when the rule must inspect generated output. *Why:* Razor/Blazor markup (`.razor`/`.cshtml`) compiles to generated C#, so a rule meant to flag that output is silently skipped under `None`. *Scope:* `None` is the common choice; switch only when the target is generated code.
+
+## Correctness
+
+- `SupportedDiagnostics` must list every descriptor you ever report (RS1005); expose it as a cached `ImmutableArray`.
+- Compare symbols with `SymbolEqualityComparer.Default` (RS1024), never `==`/`!=`; symbol identity isn't stable across compilations.
+- Diagnostic title/message/description are `LocalizableResourceString` (RS1007) with a non-null help link (RS1015, derived from the ID in this repo); the title has no trailing period (RS1031), the message ends with one (RS1032).
+- Diagnostic IDs are compile-time constants (RS1017), unique (RS1019), and must avoid reserved prefixes like `CS`/`CA`/`IDE` (RS1029); use the area prefix (`ASP`/`MVC`/`API`/`BL`).
+- Don't register a start action with no inner action (RS1012/RS1013).
+- **Don't reference `Microsoft.CodeAnalysis.Workspaces` types (`Document`, `Solution`, `Workspace`) from a `DiagnosticAnalyzer`.** *Trigger:* an analyzer (not a code fix) needs a `Document`/`Solution`/`Workspace`. *Decision:* keep those types in the code-fix assembly; do the analyzer's work with `Compilation`/`SemanticModel`/`IOperation` instead. *Why:* the Workspaces assembly isn't loaded during `dotnet build`, so referencing it makes the analyzer fail outside the IDE (RS1022, enforced in the Framework set via `EnforceExtendedAnalyzerRules`). *Scope:* firm for new analyzers; the Components and MVC API analyzer projects deliberately reference Workspaces for VS compatibility, so this is a Framework-set convention, not a repo-wide invariant. Match the area you edit.
+
+## Diagnostic design
+
+- **Severity:** see [process.md](process.md#severity); default-on `Warning` is the common choice.
+- Pass pre-computed data to the fixer via `diagnostic.Properties` (an `ImmutableDictionary<string,string?>`) so the fix doesn't redo semantic analysis.
+- Use `WellKnownDiagnosticTags.Unnecessary` for fade-out (grey) diagnostics; add the `CompilationEnd` tag to descriptors reported only from compilation-end actions (RS1037).
+
+- **Pick the registration kind from what the rule reasons about.** *Trigger:* choosing which `Register*Action` to use. *Decision:* a declared symbol uses `RegisterSymbolAction`; what executable code does uses `RegisterOperationAction`; pure syntactic shape uses `RegisterSyntaxNodeAction`; cross-file aggregation uses compilation start/end; a whole body with shared state uses operation-block start + inner + end. *Why:* the right granularity lets the host fire your callback only when relevant and hands you the typed model (symbol vs operation vs node) the check actually needs. *Scope:* near-universal.
+- **Report on the smallest meaningful span.** *Trigger:* choosing the `Location` to report. *Decision:* flag the keyword/token/operator at fault, not the whole statement or declaration. *Why:* the squiggle and the fix target follow that span, so a wide span misleads the reader and can make the code fix touch unrelated trivia. *Scope:* near-universal.
+- **Bail instead of guessing when the input is incomplete or ambiguous.** *Trigger:* the target node has parse errors (`GetDiagnostics().Any(d => d.Severity == Error)`), contains interleaved `#directives`, or the pattern can't be confirmed from symbols/operations. *Decision:* return without reporting. *Why:* the analyzer runs live on every keystroke over half-typed code, so a false positive erodes trust and gets the rule suppressed wholesale, whereas a missed diagnostic just defers a true hit to the next build. *Scope:* near-universal; when in doubt, don't report.
+- **Use a `DiagnosticSuppressor`, not an analyzer, to quiet an existing diagnostic.** *Trigger:* the goal is to silence a built-in compiler/other diagnostic that is a known false positive in an ASP.NET Core pattern (e.g. async-without-await in a minimal API handler). *Decision:* write a `DiagnosticSuppressor` for it; don't use a suppressor to hide your own analyzer's output. *Why:* suppressors are the supported channel for "this existing warning is wrong here," carrying a justification and leaving the rule enabled everywhere else. *Scope:* narrow (only for suppressing other tools' diagnostics).
+
+## Code fixes
+
+- `[ExportCodeFixProvider(LanguageNames.CSharp), Shared]`; `FixableDiagnosticIds` lists exactly the IDs handled.
+- Every `CodeAction` needs a non-null `equivalenceKey` (RS1010) and you must override `GetFixAllProvider()` (RS1016); without both, "Fix all occurrences" doesn't appear.
+- Keep fixes minimal and syntactically correct; preserve/transfer trivia and add `Formatter.Annotation` for reformatting. Propagate `CancellationToken` and `await ... .ConfigureAwait(false)`.
+
+- **Choose the `equivalenceKey` for the FixAll scope you want.** *Trigger:* setting the key on `CodeAction.Create(...)`. *Decision:* use the rule ID to batch all occurrences of the rule together; use a per-occurrence key to batch only identical fixes. *Why:* FixAll groups actions by equivalence key, so the key directly decides what "fix all" sweeps in one pass. *Scope:* common (the rule ID is the usual choice for a single uniform fix).
+- **Match the FixAll provider to the fix's complexity.** *Trigger:* implementing `GetFixAllProvider()`. *Decision:* return `WellKnownFixAllProviders.BatchFixer` when fixes are local, non-overlapping, and apply-changes only; write a singleton custom `FixAllProvider` otherwise. *Why:* `BatchFixer` re-applies the single-fix logic per diagnostic and merges the results, which breaks when fixes overlap or depend on one another. *Scope:* common (`BatchFixer` covers most mechanical fixes).
+
+## Anti-patterns (do NOT do)
+
+| ❌ Don't | ✅ Do | Enforced by |
+|---------|------|-------------|
+| Store `Compilation`/`ISymbol`/`IOperation` in a field | Close over them in a start action | RS1008 |
+| `Compilation.GetSemanticModel()` in a callback | Use the context's semantic model | RS1030 |
+| Reference `Document`/`Solution`/`Workspace` in an analyzer | Keep those in the code fix | RS1022 |
+| Compare symbols with `==` | `SymbolEqualityComparer.Default.Equals` | RS1024 |
+| Allocate / LINQ / `DescendantNodes()` in per-node callbacks | Pooled builders; scope to blocks | n/a |
+| Plain-string title/message | `LocalizableResourceString` | RS1007 |
+| `CodeAction.Create` without an equivalence key | Pass a stable `equivalenceKey` | RS1010 |
+| Report on a whole statement/declaration | Report on the smallest faulting span | n/a |
+| Report when the target has parse errors or interleaved directives | Bail out to avoid false positives | n/a |
+| Reuse a retired diagnostic ID | Allocate the next free ID | RS1019 |

--- a/.github/skills/author-analyzer-skill/references/conventions.md
+++ b/.github/skills/author-analyzer-skill/references/conventions.md
@@ -1,0 +1,86 @@
+# ASP.NET Core analyzer conventions
+
+Repo-specific conventions for adding or reviewing a diagnostic. **These describe the Framework set (`src/Framework/AspNetCoreAnalyzers`), the model for new analyzers.** MVC, MVC API, and Components analyzers diverge in places (noted below); when editing those, match the surrounding area.
+
+## Table of contents
+- [Diagnostic IDs & the registry](#diagnostic-ids--the-registry)
+- [DiagnosticDescriptors files](#diagnosticdescriptors-files)
+- [Localization (Resources.resx)](#localization-resourcesresx)
+- [Well-known types infrastructure](#well-known-types-infrastructure)
+- [Project layout & packaging](#project-layout--packaging)
+- [Release tracking status](#release-tracking-status)
+
+## Diagnostic IDs & the registry
+
+- Each area owns a prefix and an integer range: `ASP####` (Framework), `MVC####` (MVC), `API####` (MVC API), `BL####` (Components).
+- **`docs/list-of-diagnostics.md` is the human-facing registry, but it lags reality**: some shipped IDs aren't listed and reserved entries may be out of date. The authoritative list of which IDs are actually taken is the set of `DiagnosticDescriptors.cs` files; scan those (plus a grep of the area for the ID prefix) to find the next free number, and record the new ID in `docs/list-of-diagnostics.md` as well to keep the human registry current.
+- IDs are permanent and never reused. If a rule is removed, retire the ID; don't recycle it.
+- Gaps exist and are fine (e.g. `ASP0002` is skipped); take the next unused number.
+
+## DiagnosticDescriptors files
+
+Each area centralizes its descriptors in one `internal static class DiagnosticDescriptors` (e.g. `src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs`, `src/Mvc/Mvc.Analyzers/src/DiagnosticDescriptors.cs`, `src/Mvc/Mvc.Api.Analyzers/src/ApiDiagnosticDescriptors.cs`, `src/Components/Analyzers/src/DiagnosticDescriptors.cs`).
+
+Conventions in the Framework set (the model to copy):
+
+```csharp
+private const string Security = "Security";
+private const string Usage = "Usage";
+
+private static LocalizableResourceString CreateLocalizableResourceString(string resource)
+    => new(resource, Resources.ResourceManager, typeof(Resources));
+
+internal static readonly DiagnosticDescriptor DoNotUseModelBindingAttributesOnRouteHandlerParameters =
+    CreateDiagnosticDescriptor(
+        "ASP0003",
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_..._Title)),
+        CreateLocalizableResourceString(nameof(Resources.Analyzer_..._Message)),
+        Usage,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+// Help links are derived from the ID; do not hand-write them:
+private static DiagnosticDescriptor CreateDiagnosticDescriptor(
+    string id, LocalizableString title, LocalizableString messageFormat, string category,
+    DiagnosticSeverity defaultSeverity, bool isEnabledByDefault,
+    LocalizableString? description = null, params string[] customTags)
+    => new(id, title, messageFormat, category, defaultSeverity, isEnabledByDefault,
+           description, GetHelpLinkUri(id), customTags);
+
+private static string GetHelpLinkUri(string diagnosticId)
+    => $"https://learn.microsoft.com/aspnet/core/diagnostics/{diagnosticId.ToLowerInvariant()}";
+```
+
+- Descriptors are `static readonly` fields; declare once, never construct per invocation.
+- Categories used in-repo: `Usage`, `Security` (Framework); `Naming`, `Usage` (MVC); `Encapsulation`, `Usage` (Components). Use the standard [.NET analyzer categories](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/categories); prefer an existing one over inventing a new string.
+- Reference the descriptor from the analyzer's `SupportedDiagnostics` and from `ReportDiagnostic`.
+
+## Localization (Resources.resx)
+
+Diagnostic **title/message/description should be localizable** (RS1007). The Framework and Components sets wire this through the area's `Resources.resx` and the generated `Resources` accessor (the model to copy for new analyzers). *Note:* the MVC and MVC API analyzers currently use **inline string** descriptors without a help link, so don't "fix" them to match unless that's the point of your change; match the area.
+
+1. Add string entries to `src/.../Resources.resx`, naming them `Analyzer_<RuleName>_Title`, `Analyzer_<RuleName>_Message`, and optionally `_Description`. Use `{0}`/`{1}` placeholders in the message that line up with the `messageArgs` you pass to `Diagnostic.Create(...)`.
+2. Reference them via `CreateLocalizableResourceString(nameof(Resources.<Key>))`.
+3. Title is a heading with **no trailing period** (RS1031). Message is a sentence that **ends with a period** (RS1032).
+
+Code-fix titles do **not** need to be `LocalizableResourceString`; a plain `string` is fine (the `/preferreduilang` switch that motivates localized analyzer strings doesn't apply to fixes). Some Components fixers still localize their titles via `Resources` for consistency; either is acceptable.
+
+## Well-known types infrastructure
+
+Framework analyzers share a fast symbol cache instead of calling `Compilation.GetTypeByMetadataName` repeatedly (compiled into the project from `$(SharedSourceRoot)RoslynUtils/`):
+
+- `WellKnownTypeData.cs`: a `WellKnownType` enum of every type the analyzers need, plus the parallel array of fully-qualified metadata names.
+- `WellKnownTypes.cs`: `WellKnownTypes.GetOrCreate(compilation)` resolves and caches them per compilation (`BoundedCacheWithFactory`).
+
+To use a new type: add an enum member (namespace segments separated by `_`) and its metadata name in `WellKnownTypeData.cs`, then read it via the cached `WellKnownTypes` instance you obtained in `RegisterCompilationStartAction`. Never store the resolved symbol in an analyzer field.
+
+## Project layout & packaging
+
+- Framework analyzer `.csproj`: `TargetFramework=netstandard2.0`, `IncludeBuildOutput=false`, `Nullable=Enable`, `EnforceExtendedAnalyzerRules=true`, and `References` to `Microsoft.CodeAnalysis.CSharp` (`PrivateAssets=All`) and `Microsoft.CodeAnalysis.ExternalAccess.AspNetCore`. (Other areas' csprojs differ: Components/MVC API reference Workspaces; see the Workspaces rule in [best-practices.md](best-practices.md#correctness).)
+- Analyzers and code fixes are **separate projects** (e.g. `Microsoft.AspNetCore.App.Analyzers` and `Microsoft.AspNetCore.App.CodeFixes`); in the Framework set the analyzer assembly must not reference Workspaces, the code-fix assembly may (see the Workspaces rule in [best-practices.md](best-practices.md#correctness)).
+- `src/` and `test/` siblings per area; tests use `InternalsVisibleTo`.
+- Analyzers are packaged under `analyzers/dotnet/cs` and shipped in the shared framework / SDK; they are not standalone NuGet packages users install.
+
+## Release tracking status
+
+The Microsoft.CodeAnalysis release-tracking analyzer (RS2000-RS2008 / `AnalyzerReleases.*.md`) is **not** used in these projects; the descriptor files suppress RS2008 (`[SuppressMessage("MicrosoftCodeAnalysisReleaseTracking", "RS2008:...")]`). The source of truth for shipped IDs is `docs/list-of-diagnostics.md` plus the `DiagnosticDescriptors.cs` files. Don't add `AnalyzerReleases.Shipped.md`/`Unshipped.md` unless the repo convention changes; match the area you are editing.

--- a/.github/skills/author-analyzer-skill/references/process.md
+++ b/.github/skills/author-analyzer-skill/references/process.md
@@ -1,0 +1,87 @@
+# Process: designing, documenting, and shipping a new analyzer
+
+Map the cases first, build to that boundary, then document the analyzer in its PR. For a significant or behavior-defining rule, the same write-up can go through an analyzer proposal *before* implementation so severity, category, and false-positive scope are reviewed early; changing the severity of, or removing, a rule that already shipped is a churn/compat cost. Routine or low-risk analyzers are often added without a formal proposal, so use judgment based on how visible and opinionated the rule is.
+
+## Table of contents
+- [1. Analyze the cases (and document them)](#1-analyze-the-cases-and-document-them)
+- [Categories](#categories)
+- [Severity](#severity)
+- [2. Implement](#2-implement)
+- [3. Test, document, ship](#3-test-document-ship)
+- [Checklist](#checklist)
+
+## 1. Analyze the cases (and document them)
+
+Before coding, map the input space. This both bounds the implementation and becomes the analyzer's documentation. Start with the two concrete test sets:
+
+- **Should fire (true positives)**: each concrete pattern the rule flags. Enumerate the variants; each becomes a positive test.
+- **Should not fire (true negatives)**: look-alikes that are correct or intentional: already-correct code, a similar-but-different API, an explicit opt-out. Each becomes a negative test and is a false-positive guard.
+
+For everything beyond those two sets, coverage is a **return-on-investment call, not a binary include/exclude**. Default to being **aggressive: try to detect the issue.** Bail out of a case only when you can name a concrete reason the return doesn't justify the cost, grounded in:
+
+- **Effort and complexity**: the runtime cost in the per-keystroke IDE budget, and the implementation/maintenance complexity of detecting it reliably.
+- **Commonality and impact**: how often the case occurs and how much the mistake hurts.
+
+Investing where the return is high and skipping the low-return long tail is what 80/20 means here.
+
+- **Cheap and decidable: go for full coverage.** If the current compilation can decide the case unambiguously and cheaply, for code that compiles, flag all of it with no false positives.
+- **Common cases cheap, long tail expensive or complex: cover the common cases, make the rest opt-in.** Handle the common cases reliably, and offer the deeper analysis that catches the long tail behind a **configuration option** (an effort/strictness key read from `.editorconfig`/`AnalyzerConfigOptions`, e.g. a `dotnet_diagnostic`-style key or a `build_property`, read once in `RegisterCompilationStartAction`) with a conservative default, rather than dropping it silently or paying its cost for everyone. Live IDE editing stays fast; CI can opt into deeper, stricter analysis.
+- **Reliable detection impossible from here: stop, and say so.** When a case depends on a referenced assembly's *implementation*, runtime values, or whole-program reasoning that can't be made sound, detection isn't tractable. An analyzer reasons over the current compilation's source plus the **symbols/metadata** of its references, never their **bodies**, so cross-assembly facts usually fall here. Document it as a known limitation; offer an opt-in heuristic only if it earns its keep.
+
+**Give the developer the call, and show your work.** Record where you drew the line and why (effort, complexity, commonality) in the analyzer's documentation, and expose a configuration knob wherever the right answer depends on the consumer's context, so they can push for more or less detection.
+
+**Document the analyzer using the proposal template as the follow-up PR description.** The `60_analyzer_proposal.md` template (`.github/ISSUE_TEMPLATE/60_analyzer_proposal.md`, labels `api-suggestion`, `analyzer`) is the structure to explain the analyzer in its PR:
+
+- **Background and motivation**: the real problem (e.g. a perf pitfall, insecure pattern, or a better API). The bar: is it common and confusing enough to warrant an always-on check?
+- **Analyzer behavior and message**: when it fires and the exact message text.
+- **Category** and **severity** (from the lists below).
+- **Usage scenarios**: the *should-fire* and *should-not-fire* buckets, mirrored 1:1 by the tests.
+- **Non-goals and limitations**: the cases you chose not to detect (or made opt-in) and why, grounded in effort, complexity, and commonality, plus any configuration knob and its default.
+- **Risks**: false-positive surface, breaking changes, perf.
+
+Browse open issues labeled `analyzer` for prior art and to avoid duplicates. When a rule does go through formal review, it usually follows the [API review process](https://github.com/dotnet/aspnetcore/blob/main/docs/APIReviewProcess.md).
+
+## Categories
+
+Use the standard [.NET analyzer categories](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/categories). Pick the closest existing one; in-repo the common choices are **Usage**, **Security**, **Naming**, and **Encapsulation** (Components). Others: Design, Documentation, Globalization, Interoperability, Maintainability, Performance, Reliability, Style.
+
+## Severity
+
+See [configuring severity](https://learn.microsoft.com/visualstudio/code-quality/use-roslyn-analyzers#configure-severity-levels).
+
+| Severity | Use when |
+|----------|----------|
+| `Error` | The code is essentially always wrong / will fail at runtime or build; no legitimate exceptions. |
+| `Warning` | Strongly recommended fix, default-on. The most common choice for ASP.NET Core guidance. |
+| `Info` | A suggestion / lower-confidence improvement; surfaces lightly in the IDE. |
+| `Hidden` | No visible squiggle; exists mainly to light up a code fix or fade-out. |
+
+`isEnabledByDefault: true` for shipped rules unless there's a specific reason to default-off (e.g. an opt-in style rule). Users can always override per-project via `dotnet_diagnostic.<ID>.severity = ...` in `.editorconfig`; every `DiagnosticDescriptor` supports this automatically, so you rarely need a custom option. A separate **effort/strictness** option (above) is different from severity: severity controls how loudly a found issue is reported, the effort option controls how hard the analyzer looks.
+
+## 2. Implement
+
+1. **Reserve the ID** in `docs/list-of-diagnostics.md` and add the descriptor to the area's `DiagnosticDescriptors.cs` with localized strings + help link (see [conventions.md](conventions.md)).
+2. **Write the analyzer** following the canonical shape in the main SKILL and the [best practices](best-practices.md). Register any new well-known types in `WellKnownTypeData.cs`. Implement to the boundary from step 1: handle the decidable cases precisely and stop at the documented non-goals.
+3. **Write a code fix** if the correction is mechanical. Keep it minimal and FixAll-safe.
+4. Add `Resources.resx` strings for the title/message (and code-fix title if you localize it).
+
+## 3. Test, document, ship
+
+- Unit-test with the repo verifiers: positive (diagnostic at the marked span) **and** negative (no diagnostic) cases, plus code-fix before/after. Add boundary-pinning negative tests for the *too-expensive* and *undecidable* buckets so those gaps stay intentional. See [testing.md](testing.md).
+- Build & test the area with the local SDK activated: `. ./activate.ps1` (Windows) / `source activate.sh`, then `./src/<Area>/build.sh -test`.
+- The PR description is the analyzer's documentation (the buckets from step 1). User-facing docs for ASP IDs live at `learn.microsoft.com/aspnet/core/diagnostics/<id>` (the help link target); coordinate them with the PR.
+
+## Checklist
+
+- [ ] Cases analyzed: should-fire and should-not-fire enumerated; coverage trade-offs (effort, complexity, commonality) decided, with any non-goals and configuration knobs recorded.
+- [ ] Design reviewed, or a proposal filed (template `60_analyzer_proposal.md`), if the rule is opinionated or behavior-changing.
+- [ ] ID reserved in `docs/list-of-diagnostics.md`; descriptor added to `DiagnosticDescriptors.cs`.
+- [ ] Title/message in `Resources.resx`; title has no period, message ends with one.
+- [ ] Help link via `GetHelpLinkUri(id)` (don't hand-write).
+- [ ] `EnableConcurrentExecution()` + `ConfigureGeneratedCodeAnalysis(None)` set.
+- [ ] Well-known symbols cached via `WellKnownTypes.GetOrCreate`; nothing stored in fields.
+- [ ] `SymbolEqualityComparer.Default` for symbol comparisons; no Workspaces types in the analyzer.
+- [ ] Reports on the smallest span; false-positive guards (parse errors, directives) in place.
+- [ ] Code fix (if any): exported, `FixableDiagnosticIds` set, `GetFixAllProvider` overridden, non-null `equivalenceKey`, trivia preserved.
+- [ ] Positive + negative tests, including boundary tests for the documented non-goals; code-fix before/after tests; area `build.sh -test` green.
+- [ ] PR description documents behavior, the fire/no-fire scenarios, and the non-goals/limitations.

--- a/.github/skills/author-analyzer-skill/references/testing.md
+++ b/.github/skills/author-analyzer-skill/references/testing.md
@@ -1,0 +1,79 @@
+# Testing analyzers & code fixes
+
+Tests use **Microsoft.CodeAnalysis.Testing** through the repo's `CSharpAnalyzerVerifier<TAnalyzer>` and `CSharpCodeFixVerifier<TAnalyzer, TCodeFix>` helpers (in each area's `test/Verifiers/`). Tests are xUnit `[Fact]`/`[Theory]`. Copy the style of neighboring tests in the same area.
+
+## Table of contents
+- [Set up the verifier alias](#set-up-the-verifier-alias)
+- [Analyzer tests](#analyzer-tests)
+- [Code-fix tests](#code-fix-tests)
+- [What to cover](#what-to-cover)
+
+## Set up the verifier alias
+
+Alias the generic verifier to your analyzer at the top of the test file:
+
+```csharp
+using VerifyCS = Microsoft.AspNetCore.Analyzers.Verifiers.CSharpAnalyzerVerifier<
+    Microsoft.AspNetCore.Analyzers.Http.HeaderDictionaryIndexerAnalyzer>;
+```
+
+For code-fix tests, alias `CSharpCodeFixVerifier<TAnalyzer, TCodeFix>` instead.
+
+## Analyzer tests
+
+- Embed the test source as a string. The expected diagnostic location is marked inline with `{|#0:...|}` (location `0`, `1`, ...). The verifier sets `OutputKind = ConsoleApplication`, so **top-level statements work**, so write programs the way users do.
+- Assert with `new DiagnosticResult(DiagnosticDescriptors.MyRule).WithLocation(0)`, optionally `.WithMessage(...)` (use the generated `Resources.Format<Key>(args...)` helper) and `.WithArguments(...)`.
+
+```csharp
+[Fact]
+public async Task IHeaderDictionary_Get_MismatchCase_ReturnDiagnostic()
+{
+    await VerifyCS.VerifyAnalyzerAsync(@"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+var webApp = WebApplication.Create();
+webApp.Use(async (HttpContext context, System.Func<System.Threading.Tasks.Task> next) =>
+{
+    var s = {|#0:context.Request.Headers[""content-type""]|};
+    await next();
+});
+",
+        new DiagnosticResult(DiagnosticDescriptors.UseHeaderDictionaryPropertiesInsteadOfIndexer)
+            .WithLocation(0)
+            .WithMessage(Resources.FormatAnalyzer_HeaderDictionaryIndexer_Message("content-type", "ContentType")));
+}
+```
+
+- **Negative tests are mandatory.** For every "reports" test, write a "no diagnostic" sibling for the near-miss cases (different type, unknown member, already-correct code). Pass no `DiagnosticResult` to assert nothing fires:
+
+```csharp
+[Fact]
+public async Task IHeaderDictionary_Get_UnknownProperty_NoDiagnostic()
+    => await VerifyCS.VerifyAnalyzerAsync(@"/* source that must NOT trigger */");
+```
+
+## Code-fix tests
+
+`VerifyCodeFixAsync(source, expected, fixedSource)` runs the analyzer on `source`, applies the fix, and asserts the result equals `fixedSource`:
+
+```csharp
+await VerifyCS.VerifyCodeFixAsync(
+    source,                 // contains {|#0:...|}
+    new[] { new DiagnosticResult(DiagnosticDescriptors.MyRule).WithLocation(0) },
+    fixedSource);           // expected code after the fix
+```
+
+- Optional args on the repo helper: `expectedIterations` (`NumberOfFixAllIterations` for FixAll), `usageSource` (an extra unchanged source file), and `codeActionEquivalenceKey` (to pin which fix when several are offered; must match the analyzer's `equivalenceKey`).
+- `fixedSource` must compile and be correctly formatted; trailing trivia/indentation matters.
+
+## What to cover
+
+- ✅ Positive cases at the exact `{|#0:...|}` span, including each variant that should trigger.
+- ✅ Negative cases: similar-but-correct code, unrelated types, generated code, partial/erroneous code.
+- ✅ Boundary cases you chose not to cover: a `_NoDiagnostic` test for a case left to an opt-in (the expensive/complex long tail) and for an intractable cross-assembly case (the rule would need a referenced assembly's implementation). These pin the line you drew so a future change can't silently start firing on them or stop firing on a real case.
+- ✅ If the rule exposes a configurable effort/strictness option, test both the default (lenient) behavior and the strict mode, so the extra cases the strict mode catches stay verified.
+- ✅ Message arguments via the `Resources.Format...` helper so localization stays in sync.
+- ✅ Code fix: before → after for each shape, plus a FixAll iteration test when `BatchFixer` is used.
+- ✅ Reproduce any reported false-positive issue as a `_NoDiagnostic` regression test before fixing it.
+
+Run the suite with the local SDK activated (`. ./activate.ps1` / `source activate.sh`), then `./src/<Area>/build.sh -test` (e.g. `./src/Framework/build.sh -test`).

--- a/.github/skills/create-worktree/SKILL.md
+++ b/.github/skills/create-worktree/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: create-worktree
+description: >-
+  Where and how to create an isolated git worktree in the dotnet/aspnetcore repo. USE FOR creating or adding a worktree, "make me a worktree", spinning up a scratch branch checkout, or setting up an isolated working copy of this repo. Covers what plain git worktree knowledge misses here: nest the worktree under .worktrees/<name> (which ships committed isolation so it stays out of git status and never inherits the top-level build configuration), copy those barrier files if you place the worktree elsewhere in the repo, initialize the submodules a fresh worktree leaves empty (MessagePack-CSharp, googletest), and share the main checkout's already-provisioned .dotnet SDK instead of re-downloading gigabytes. DO NOT USE FOR sibling worktrees outside the repo, general git branching without a worktree, or non-aspnetcore repositories.
+---
+
+# Create a worktree (dotnet/aspnetcore)
+
+Use normal git, but get these repo-specific things right so the worktree is isolated and buildable. No script is needed; run the commands directly.
+
+## 1. Create it under `.worktrees/<name>`
+
+```bash
+git worktree add -b <name> .worktrees/<name> HEAD
+```
+
+`.worktrees/` ships with committed isolation: a nested `.gitignore` that keeps every worktree out of the parent's `git status`, plus empty `Directory.Build.props`/`.targets`, an `.editorconfig` with `root = true`, and a `<clear/>` `NuGet.config`. These cap configuration traversal so the worktree stays out of git and never inherits the top-level build configuration. Do not recreate those files when you use `.worktrees/`.
+
+If you instead place the worktree anywhere else inside the repo, copy those five files from `.worktrees/` into the directory that will contain the worktree, so it gets the same git-ignore and traversal-ceiling isolation. A sibling location outside the repo does not need them.
+
+## 2. Initialize submodules in the new worktree
+
+A fresh worktree has empty submodule working trees even though the main checkout is populated; builds that touch `src/submodules/MessagePack-CSharp` or `googletest` fail until you run:
+
+```bash
+git -C .worktrees/<name> submodule update --init --recursive
+```
+
+## 3. Share the `.dotnet` SDK
+
+A fresh worktree has no `.dotnet`, so restoring would re-provision the whole SDK (gigabytes). When the worktree's `global.json` `sdk.version` matches the main checkout's already-provisioned SDK, link the parent's `.dotnet` into the worktree instead of restoring:
+
+- Windows (no admin needed): `New-Item -ItemType Junction -Path <worktree>\.dotnet -Target <repo-root>\.dotnet`
+- Linux / macOS: `ln -s "<repo-root>/.dotnet" "<worktree>/.dotnet"`
+
+If the versions differ, run `./restore.cmd` (or `./restore.sh`) inside the worktree instead. Do not edit `global.json` to point `sdk.paths` at the parent SDK (it is tracked). When removing the worktree, delete the `.dotnet` link first (`cmd /c rmdir` on Windows, `rm` on Linux/macOS) so its target is not deleted through the link.

--- a/.worktrees/.editorconfig
+++ b/.worktrees/.editorconfig
@@ -1,0 +1,3 @@
+# Traversal ceiling: stops .editorconfig discovery from climbing past
+# .worktrees/ into the repo-root configuration.
+root = true

--- a/.worktrees/.gitignore
+++ b/.worktrees/.gitignore
@@ -1,0 +1,9 @@
+# Worktrees created here (e.g. by agents) must not be tracked or pollute the
+# parent's `git status`. Ignore everything in this folder except the committed
+# isolation files that keep those worktrees buildable and config-isolated.
+*
+!.gitignore
+!.editorconfig
+!Directory.Build.props
+!Directory.Build.targets
+!NuGet.config

--- a/.worktrees/Directory.Build.props
+++ b/.worktrees/Directory.Build.props
@@ -1,0 +1,3 @@
+<!-- Traversal ceiling: empty project stops MSBuild Directory.Build.props
+     discovery from climbing past .worktrees/ into the repo-root build. -->
+<Project />

--- a/.worktrees/Directory.Build.targets
+++ b/.worktrees/Directory.Build.targets
@@ -1,0 +1,3 @@
+<!-- Traversal ceiling: empty project stops MSBuild Directory.Build.targets
+     discovery from climbing past .worktrees/ into the repo-root build. -->
+<Project />

--- a/.worktrees/NuGet.config
+++ b/.worktrees/NuGet.config
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Traversal ceiling: clears every inherited section so repo-root package
+     sources never merge into content placed directly under .worktrees/. -->
+<configuration>
+  <config>
+    <clear />
+  </config>
+  <packageSources>
+    <clear />
+  </packageSources>
+  <packageSourceMapping>
+    <clear />
+  </packageSourceMapping>
+</configuration>

--- a/.worktrees/NuGet.config
+++ b/.worktrees/NuGet.config
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Traversal ceiling: clears every inherited section so repo-root package
-     sources never merge into content placed directly under .worktrees/. -->
+<!-- Traversal ceiling: clears the inherited source sections so repo-root package
+     sources never merge into content placed directly under .worktrees/.
+     The <config> section is deliberately left alone: it carries user/machine
+     settings such as globalPackagesFolder and proxy configuration, and clearing
+     it would silently redirect restores back to the default package cache. -->
 <configuration>
-  <config>
-    <clear />
-  </config>
   <packageSources>
     <clear />
   </packageSources>

--- a/eng/skill-evals/author-analyzer-skill/eval.vally.yaml
+++ b/eng/skill-evals/author-analyzer-skill/eval.vally.yaml
@@ -1,0 +1,148 @@
+name: author-analyzer-skill
+description: A/B eval for the author-analyzer-skill skill.
+type: capability
+defaults:
+  runs: 5
+  timeout: 300s
+  model: claude-opus-4.6
+  judge_model: claude-opus-4.6
+scoring:
+  weights:
+    output-matches: 0.3
+    prompt: 0.7
+  threshold: 0.6
+stimuli:
+- name: Author a new framework analyzer end-to-end
+  prompt: |
+    I'm working in the dotnet/aspnetcore repo. I want to add a brand new analyzer that warns
+    when someone calls IServiceCollection.AddControllers() more than once in the same project.
+    What are all the steps I need to follow, where do the files go, and what conventions does
+    this repo expect me to follow?
+  graders:
+  - type: output-matches
+    config:
+      pattern: (list-of-diagnostics|DiagnosticDescriptors)
+  - type: output-contains
+    config:
+      substring: EnableConcurrentExecution
+  - type: prompt
+  - type: pairwise
+  rubric:
+  - Says new analyzers require an approved proposal (analyzer proposal issue) before implementation, reviewed like an API
+  - Explains reserving a diagnostic ID (ASP prefix for the framework set) and registering it in the repo's diagnostics list plus a central DiagnosticDescriptors file
+  - Covers choosing a category and severity, and using localized resource strings with a help link for the message
+  - Mentions the analyzer must enable concurrent execution and configure generated-code analysis
+  - Says to add unit tests including both positive (fires) and negative (does not fire) cases and to build/test the area
+- name: Review an analyzer with performance and correctness bugs
+  prompt: |
+    Please review this Roslyn analyzer for problems and tell me what to change:
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class MyAnalyzer : DiagnosticAnalyzer
+    {
+        private INamedTypeSymbol _controllerType;
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSyntaxNodeAction(ctx =>
+            {
+                _controllerType = ctx.Compilation.GetTypeByMetadataName("Microsoft.AspNetCore.Mvc.ControllerBase");
+                var model = ctx.Compilation.GetSemanticModel(ctx.Node.SyntaxTree);
+                var symbol = model.GetDeclaredSymbol(ctx.Node);
+                if (symbol.ContainingType == _controllerType)
+                    ctx.ReportDiagnostic(Diagnostic.Create(Rule, ctx.Node.GetLocation()));
+            }, SyntaxKind.MethodDeclaration);
+        }
+    }
+  graders:
+  - type: output-contains
+    config:
+      substring: SymbolEqualityComparer
+  - type: output-matches
+    config:
+      pattern: (EnableConcurrentExecution|ConfigureGeneratedCodeAnalysis)
+  - type: prompt
+  - type: pairwise
+  rubric:
+  - Flags storing a symbol/compilation in an analyzer instance field as unsafe state that goes stale across compilations
+  - Flags resolving the well-known type on every node instead of caching it once per compilation in a compilation-start action
+  - Flags comparing symbols with == and says to use SymbolEqualityComparer.Default
+  - Flags calling Compilation.GetSemanticModel inside the callback as a performance problem; use the context's model
+  - Notes the analyzer is missing EnableConcurrentExecution and ConfigureGeneratedCodeAnalysis calls
+- name: Diagnose a non-working FixAll in a code fix
+  prompt: |
+    I added a CodeFixProvider for one of our ASP.NET Core analyzers. The single-line fix works,
+    but the "Fix all occurrences in document" option never appears in Visual Studio. What's wrong
+    and how do I make FixAll work?
+  graders:
+  - type: output-matches
+    config:
+      pattern: (GetFixAllProvider|BatchFixer)
+  - type: output-contains
+    config:
+      substring: equivalenceKey
+  - type: prompt
+  - type: pairwise
+  rubric:
+  - Identifies that the provider must override GetFixAllProvider (e.g. returning WellKnownFixAllProviders.BatchFixer)
+  - Identifies that every registered CodeAction needs a non-null equivalence key for FixAll to work
+  - Gives correct, minimal guidance without inventing unrelated causes
+- name: Fix an analyzer false positive without regressing
+  prompt: |
+    Users report that one of our ASP.NET Core analyzers reports a warning on perfectly valid code
+    when the relevant call is nested inside another lambda. How should I approach fixing this false
+    positive so it doesn't come back later, and is there anything about where the warning is reported
+    that I should reconsider?
+  graders:
+  - type: output-matches
+    config:
+      pattern: (test|regression)
+  - type: output-matches
+    config:
+      pattern: (false positive|negative)
+  - type: output-matches
+    config:
+      pattern: (?i)(span|location|where.*report|smallest)
+  - type: prompt
+  - type: pairwise
+  rubric:
+  - Recommends adding a guard so the analyzer does not report in the nested case, narrowing the condition rather than broadening it
+  - Recommends adding a 'no diagnostic' regression unit test reproducing the reported case before fixing
+  - Mentions reporting on the smallest meaningful span and/or bailing out when unsure to avoid false positives
+- name: Choose ID, project, and severity for a new analyzer
+  prompt: |
+    In dotnet/aspnetcore, I'm adding an analyzer that detects a misuse of minimal API route handlers.
+    Which diagnostic ID prefix should I use, which analyzer project does it belong in, where do I
+    record the ID, and how should I think about picking the severity?
+  graders:
+  - type: output-contains
+    config:
+      substring: ASP
+  - type: output-matches
+    config:
+      pattern: (Warning|severity)
+  - type: prompt
+  - type: pairwise
+  rubric:
+  - Says minimal API / framework analyzers use the ASP#### prefix and live in the Framework AspNetCoreAnalyzers project
+  - Says to record the new ID in the repo's list-of-diagnostics doc and the area's DiagnosticDescriptors file
+  - Gives sound severity guidance (Warning is the common default; Error only for always-wrong code; Info/Hidden for suggestions) and notes users can override severity via editorconfig
+- name: Write analyzer unit tests with the repo's harness
+  prompt: |
+    How do I write unit tests for a new analyzer in dotnet/aspnetcore so that I assert the warning
+    appears on a specific piece of code, and also assert that valid code produces no warning? Show
+    me the testing approach this repo uses.
+  graders:
+  - type: output-matches
+    config:
+      pattern: (\{\|#0:|VerifyAnalyzerAsync|CSharpAnalyzerVerifier)
+  - type: output-matches
+    config:
+      pattern: (no diagnostic|negative|does not)
+  - type: prompt
+  - type: pairwise
+  rubric:
+  - Describes the Microsoft.CodeAnalysis.Testing based verifier helpers the repo uses (CSharpAnalyzerVerifier / CSharpCodeFixVerifier)
+  - Shows marking the expected diagnostic location inline in the test source (e.g. {|#0:...|}) and asserting with a DiagnosticResult
+  - Explicitly includes a negative test that asserts valid code produces no diagnostic
+  - Mentions running the tests via the area's build script

--- a/eng/skill-evals/create-worktree/eval.vally.yaml
+++ b/eng/skill-evals/create-worktree/eval.vally.yaml
@@ -1,0 +1,91 @@
+name: create-worktree
+description: A/B eval for the create-worktree skill (isolated git worktrees under .worktrees/).
+type: capability
+
+# The skill is loaded per-variant by skill-vs-baseline.experiment.yaml (it varies
+# /environment/skills): the baseline runs with no skill, the skilled variant loads
+# create-worktree. Run this spec via `vally experiment run`, not `vally eval` directly.
+defaults:
+  runs: 5
+  timeout: 1200s
+  model: claude-opus-4.6
+  judge_model: claude-opus-4.6
+
+scoring:
+  weights:
+    output-matches: 0.3
+    prompt: 0.7
+  threshold: 0.6
+
+stimuli:
+  - name: create-worktree-to-work-on-a-branch
+    prompt: |
+      I'm working in the dotnet/aspnetcore repository and I want an agent to do some work on a new
+      branch without disturbing my main checkout. Set me up with a git worktree for that branch and
+      walk me through the exact steps so it ends up properly isolated and able to build. Where should
+      the worktree live, and what do I need to do after creating it?
+    graders:
+      - type: output-matches
+        config:
+          pattern: '(?i)\.worktrees'
+      - type: output-matches
+        config:
+          pattern: '(?i)submodule'
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - "Places the worktree project-local under .worktrees/<name> rather than as a sibling outside the repo"
+      - "Calls out that the nested worktree must be kept out of the parent's git status (e.g. via a committed .worktrees/.gitignore) so it does not pollute it"
+      - "Says submodules (MessagePack-CSharp / googletest) must be initialized inside the new worktree before building"
+      - "Addresses providing the .NET SDK to the worktree (sharing the parent .dotnet or running restore) instead of assuming it is inherited"
+
+  - name: worktree-build-fails-missing-submodules
+    prompt: |
+      I created a git worktree of the dotnet/aspnetcore repo and tried to build, but it fails with
+      errors about missing MessagePack and googletest sources under src/submodules. The main checkout
+      builds fine. What's wrong and how do I fix just this worktree?
+    graders:
+      - type: output-matches
+        config:
+          pattern: '(?i)submodule'
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - "Identifies that a fresh worktree starts with empty submodule working trees even though the main checkout is populated"
+      - "Gives the fix as running git submodule update --init --recursive inside the worktree"
+      - "Does not suggest re-cloning the whole repository or that the main checkout is broken"
+
+  - name: avoid-redownloading-sdk-per-worktree
+    prompt: |
+      Every time I spin up a new worktree of dotnet/aspnetcore, restoring pulls down the whole .NET SDK
+      again and eats gigabytes of disk. I already have the SDK provisioned in my main checkout. How can
+      a new worktree reuse that instead of downloading its own copy?
+    graders:
+      - type: output-matches
+        config:
+          pattern: '(?i)(junction|symlink|symbolic link|ln -s|mklink)'
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - "Recommends linking the worktree's .dotnet to the main checkout's already-provisioned .dotnet (junction on Windows, symlink on Linux/macOS)"
+      - "Explains this works because global.json resolves sdk.paths (.dotnet) relative to the worktree"
+      - "Notes the shared SDK is only valid while the global.json sdk.version matches, otherwise restore is needed"
+      - "Does NOT recommend editing global.json sdk.paths to point at the parent SDK"
+
+  - name: in-repo-worktree-config-inheritance
+    prompt: |
+      I want to create a git worktree inside the dotnet/aspnetcore repo, in a subfolder of the repo
+      root rather than as a sibling. Set it up so that MSBuild, NuGet, and editorconfig for projects in
+      that worktree do not pick up the configuration from the top-level repo folder above it, and
+      explain how that isolation is achieved.
+    graders:
+      - type: output-matches
+        config:
+          pattern: '(?i)(Directory\.Build|editorconfig|nuget|root\s*=\s*true|clear)'
+      - type: prompt
+      - type: pairwise
+    rubric:
+      - "Explains that Directory.Build.props/.targets, global.json, and .editorconfig stop at the first match walking up, and the worktree (a full checkout) carries its own at its root, so they do not inherit the parent's"
+      - "Notes that NuGet.config is the one that merges up the tree, and the repo's <clear/> makes the worktree's sources win"
+      - "Recommends nesting under .worktrees/ with barrier/ceiling files (or relies on the committed ones) to cap traversal"
+      - "Does not incorrectly claim the worktree silently inherits the repo-root configuration"

--- a/eng/skill-evals/skills-vs-baseline.experiment.yaml
+++ b/eng/skill-evals/skills-vs-baseline.experiment.yaml
@@ -1,0 +1,33 @@
+name: skills-vs-baseline
+
+# Controlled A/B for every skill that ships a Vally eval: the same stimuli run with
+# no skill (baseline) and with that skill loaded (skilled). Only /environment/skills
+# varies. Each eng/skill-evals/<skill>/eval.vally.yaml is picked up automatically, and
+# the skilled variant loads .github/skills/<skill> (via ${eval.parent}).
+#
+# NOTE: `vally experiment run` executes the agent in the current working directory, and
+# some stimuli ask the agent to act on the repo (e.g. create a worktree), so run it from
+# an isolated empty directory with an absolute path to this file (paths inside the
+# experiment resolve relative to this file's dir):
+#   mkdir /tmp/skill-eval && cd /tmp/skill-eval
+#   vally experiment run <repo>/eng/skill-evals/skills-vs-baseline.experiment.yaml --output-dir .
+# Run a single skill with: --variant skilled and a glob that matches one eval, or filter by tag.
+evals:
+  - "*/eval.vally.yaml"
+
+overrides:
+  runs: 5
+
+vary:
+  - /environment/skills
+
+baseline: baseline
+
+variants:
+  baseline:
+    environment:
+      skills: []
+  skilled:
+    environment:
+      skills:
+        - "../../.github/skills/${eval.parent}"


### PR DESCRIPTION
## Summary

Agents frequently create a git worktree to work in. Done naively in this repo, a nested worktree pollutes the main checkout's `git status`, fails to build (empty submodules, no SDK), or risks inheriting the top-level build configuration. This PR adds a committed, project-local worktree convention plus a Copilot skill that teaches agents how to use it.

## What's in here

- **`.worktrees/` committed isolation** (the convention):
  - `.worktrees/.gitignore` ignores every worktree subdirectory, so worktrees created under it never show up in the parent's `git status` (no per-clone `.git/info/exclude` needed).
  - `.worktrees/.editorconfig` (`root = true`), `Directory.Build.props`/`.targets` (empty `<Project />`), and `NuGet.config` (`<clear/>`) form a traversal **ceiling** so nothing under `.worktrees/` climbs into the repo-root MSBuild/NuGet/editorconfig configuration.

- **`.github/skills/create-worktree/SKILL.md`** — a knowledge-only skill (no scripts) covering the three repo-specific things plain `git worktree` knowledge misses:
  1. Create the worktree under `.worktrees/<name>` (and copy the barrier files if it is placed elsewhere in the repo).
  2. Initialize the submodules a fresh worktree leaves empty (`MessagePack-CSharp`, `googletest`).
  3. Share the main checkout's already-provisioned `.dotnet` SDK via a junction/symlink when `global.json` `sdk.version` matches, instead of re-downloading gigabytes.

- **`eng/skill-evals/create-worktree/eval.vally.yaml` + `eng/skill-evals/skill-vs-baseline.experiment.yaml`** — a Vally A/B eval (baseline vs skill), matching the move to Vally for skill evals.

## Why a worktree under `.worktrees/` is isolated

A worktree is a full checkout, so its own root `Directory.Build.props`/`.targets`, `global.json`, and `.editorconfig` (`root = true`) terminate MSBuild/SDK/editorconfig discovery before it reaches the repo root (these are stop-at-first-match). `NuGet.config` is the one that merges up the tree, but the repo's `<clear/>` makes the worktree's own sources win. The committed `.worktrees/` barrier files harden this for any loose content placed directly under `.worktrees/`.

## Eval results (Vally, runs=5, claude-opus-4.6)

| Stimulus | Baseline | With skill |
|---|---|---|
| Create a worktree to work on a branch | 0/5 | **5/5** |
| Avoid re-downloading the SDK per worktree | 3/5 | **5/5** |
| In-repo worktree config isolation | 5/5 | 5/5 |
| Build fails: missing submodule sources | 5/5 | 5/5 |

The skill activates in every skilled run and wins the two action scenarios (worktree placement, SDK sharing); it is neutral where the unaided agent is already strong.

Run it from an isolated empty directory (the stimuli ask the agent to create a worktree, so it acts on the cwd):

```
mkdir /tmp/cw-eval && cd /tmp/cw-eval
vally experiment run <repo>/eng/skill-evals/skill-vs-baseline.experiment.yaml --output-dir .
```
