### PR TITLE
Include LICENSE file in published SignalR npm packages

### DIFF
--- a/eng/scripts/npm/pack-workspace.mjs
+++ b/eng/scripts/npm/pack-workspace.mjs
@@ -3,7 +3,7 @@
 import { resolve, dirname } from 'path';
 import { execSync } from 'child_process';
 import fsExtra from 'fs-extra';
-const { existsSync, writeJsonSync, readJsonSync, moveSync } = fsExtra;
+const { existsSync, writeJsonSync, readJsonSync, moveSync, copySync, removeSync } = fsExtra;
 import { applyVersions } from './update-dependency-versions.mjs';
 
 // Valid actions are --update-versions and --create-packages
@@ -67,6 +67,12 @@ if (action === '--update-versions') {
 
 // For each package to pack run npm pack
 function createPackages(packagesToPack) {
+  // The repo's LICENSE file lives at the root of the workspace next to package.json.
+  const licenseSourcePath = resolve(dirname(workspacePath), 'LICENSE.txt');
+  if (!existsSync(licenseSourcePath)) {
+    throw new Error(`The license file ${licenseSourcePath} does not exist.`);
+  }
+
   for (const [packagePath, packageJson] of packagesToPack) {
     const packageName = packageJson.name;
     const packageVersion = defaultPackageVersion;
@@ -74,12 +80,29 @@ function createPackages(packagesToPack) {
     const normalizedPackageName = packageName.replace('@', '').replace('/', '-');
     const packageFileName = `${normalizedPackageName}-${packageVersion}.tgz`;
     const packageTarball = resolve(packageDir, `${packageFileName}`);
-    console.log(`Packing ${packageName}...`);
-    // Log and execute the command
-    console.log(`npm pack ${packageDir} --pack-destination ${packageOutputPath}`);
-    execSync(`npm pack ${packageDir} --pack-destination ${packageOutputPath}`, { stdio: 'inherit' });
 
-    console.log(`Packed ${packageName} to ${resolve(packageOutputPath, packageTarball)}`);
+    // Copy the repo's LICENSE file into the package directory so that it ships in the published
+    // package. npm always includes a top-level LICENSE file in the tarball, even when the
+    // package.json "files" allowlist is specified, so no changes to "files" are required.
+    const licenseDestPath = resolve(packageDir, 'LICENSE.txt');
+    const licenseAlreadyPresent = existsSync(licenseDestPath);
+    if (!licenseAlreadyPresent) {
+      copySync(licenseSourcePath, licenseDestPath);
+    }
+
+    try {
+      console.log(`Packing ${packageName}...`);
+      // Log and execute the command
+      console.log(`npm pack ${packageDir} --pack-destination ${packageOutputPath}`);
+      execSync(`npm pack ${packageDir} --pack-destination ${packageOutputPath}`, { stdio: 'inherit' });
+
+      console.log(`Packed ${packageName} to ${resolve(packageOutputPath, packageTarball)}`);
+    } finally {
+      // Remove the copied LICENSE file so we don't leave build artifacts in the source tree.
+      if (!licenseAlreadyPresent) {
+        removeSync(licenseDestPath);
+      }
+    }
   }
 }
 

--- a/eng/scripts/npm/pack-workspace.mjs
+++ b/eng/scripts/npm/pack-workspace.mjs
@@ -93,8 +93,8 @@ function createPackages(packagesToPack) {
     try {
       console.log(`Packing ${packageName}...`);
       // Log and execute the command
-      console.log(`npm pack "${packageDir}" --pack-destination "${packageOutputPath}"`);
-      execSync(`npm pack "${packageDir}" --pack-destination "${packageOutputPath}"`, { stdio: 'inherit' });
+      console.log(`npm pack ${packageDir} --pack-destination ${packageOutputPath}`);
+      execSync(`npm pack ${packageDir} --pack-destination ${packageOutputPath}`, { stdio: 'inherit' });
 
       console.log(`Packed ${packageName} to ${resolve(packageOutputPath, packageTarball)}`);
     } finally {

--- a/eng/scripts/npm/pack-workspace.mjs
+++ b/eng/scripts/npm/pack-workspace.mjs
@@ -93,8 +93,8 @@ function createPackages(packagesToPack) {
     try {
       console.log(`Packing ${packageName}...`);
       // Log and execute the command
-      console.log(`npm pack ${packageDir} --pack-destination ${packageOutputPath}`);
-      execSync(`npm pack ${packageDir} --pack-destination ${packageOutputPath}`, { stdio: 'inherit' });
+      console.log(`npm pack "${packageDir}" --pack-destination "${packageOutputPath}"`);
+      execSync(`npm pack "${packageDir}" --pack-destination "${packageOutputPath}"`, { stdio: 'inherit' });
 
       console.log(`Packed ${packageName} to ${resolve(packageOutputPath, packageTarball)}`);
     } finally {

--- a/src/SignalR/clients/ts/CHANGELOG.md
+++ b/src/SignalR/clients/ts/CHANGELOG.md
@@ -1,5 +1,9 @@
 Change log contains changes for both @microsoft/signalr and @microsoft/signalr-protocol-msgpack.
 
+## 11.0.0-preview.7
+
+- Include LICENSE.txt in bundled packages. [#67496](https://github.com/dotnet/aspnetcore/pull/67496)
+
 ## 11.0.0-preview.6
 
 - Removed invalid `/*#__PURE__*/` annotations from SignalR TypeScript client helper declarations. [#66778](https://github.com/dotnet/aspnetcore/pull/66778)


### PR DESCRIPTION
## Summary

The published `@microsoft/signalr` and `@microsoft/signalr-protocol-msgpack` npm packages do not contain the project `LICENSE` file. While both correctly set the `license` field in `package.json`, many OSS compliance and license-scanning tools rely on the full license text being present as a `LICENSE` file in the package, and currently report it as missing.

The license only exists at the repo root (`LICENSE.txt`), so `npm pack` (which runs per package directory) never picked it up.

## Approach

The npm packages are produced by `eng/scripts/npm/pack-workspace.mjs`, which runs `npm pack <packageDir>` for each public workspace package. This change copies the repo-root `LICENSE.txt` into each package directory just before `npm pack`, and removes it afterward in a `finally` block so no build artifact is left behind in the source tree (mirroring the existing version-bump/rename cleanup pattern).

No changes to the `files` allowlists are required: npm always includes a top-level `LICENSE` file in the tarball, even when `files` is specified.

## Notes

- Because the fix lives in the shared pack script, the license is now also shipped in the third public package built here, `@microsoft/dotnet-js-interop`. They are all the same MIT-licensed repo, so this is correct and consistent.

## Verification

- `npm pack --dry-run` against the real `@microsoft/signalr` package (with the LICENSE copied in) shows `LICENSE.txt` included in the tarball, and the source tree is clean afterward.
- Confirmed via an isolated test that npm auto-includes a top-level `LICENSE.txt` even when a restrictive `files` allowlist is set.

Fixes #67486