### PR TITLE
Pre-generate publish-compressed framework assets during build

### DIFF
--- a/src/Assets/Microsoft.AspNetCore.App.Internal.Assets.csproj
+++ b/src/Assets/Microsoft.AspNetCore.App.Internal.Assets.csproj
@@ -54,4 +54,10 @@
       Text="'%(_MissingBlazorJSFile.Identity)' does not exist. Run 'npm run build' in the repo root to generate the file." />
   </Target>
 
+  <!-- Warm the publish-compressed assets here so parallel consumer publishes hit the incremental cache instead of racing the shared obj. -->
+  <Target Name="_PrecompressPublishAssets"
+          AfterTargets="Build"
+          DependsOnTargets="ResolvePublishCompressedStaticWebAssets"
+          Condition="'$(BuildNodeJS)' != 'false' and '$(CompressionEnabled)' == 'true'" />
+
 </Project>


### PR DESCRIPTION
## Problem

Parallel consumer publishes intermittently fail the `Build shared fx` / publish legs with:

```
Microsoft.NET.Sdk.StaticWebAssets.Compression.targets(359,5): error : The process cannot access the file '...compressed/publish/*.br' because it is being used by another process.
```

Root-caused from the binlog of build [1482653](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1482653) (`Tests: Helix x64 Subset 1 / Build shared fx`): two consumers (`Components.Authorization` on node 3, `Components.Gateway` on node 1) each trigger a **publish** of the shared `Microsoft.AspNetCore.App.Internal.Assets` project concurrently on different MSBuild nodes. Both run `GeneratePublishCompressedStaticWebAssets` against the **same** producer obj dir (`$(IntermediateOutputPath)compressed/publish`), so one writes the `.br` while the other reads/writes it → sharing violation. Survey: ~16/308 builds over 7 days on def 83.

The SDK ties the compressed output path to the producing project's `IntermediateOutputPath` (no per-consumer override exists), and the per-node result cache doesn't dedupe the publish invocation across nodes.

## Fix (mitigation)

Run the publish-compression once during `App.Internal.Assets`' own (single, ordered) build via an `AfterTargets="Build"` target. The compress tasks are incremental, so by the time consumers publish, the `.br`/`.gz` are already up-to-date and the concurrent invocations **skip the write** — leaving only safe concurrent reads.
