### PR TITLE
Fix Blazor WASM Standalone HTTPS failure with Gateway

### DIFF
--- a/src/Components/Gateway/src/BlazorGateway.cs
+++ b/src/Components/Gateway/src/BlazorGateway.cs
@@ -39,6 +39,7 @@ public static class BlazorGateway
 
         builder.Services.AddServiceDiscovery();
 
+        builder.WebHost.UseKestrelHttpsConfiguration();
         builder.WebHost.UseStaticWebAssets();
 
         var appConfigs = builder.Configuration.GetSection("ClientApps")

--- a/src/Components/Gateway/test/BlazorGatewayTests.cs
+++ b/src/Components/Gateway/test/BlazorGatewayTests.cs
@@ -198,6 +198,21 @@ public class BlazorGatewayTests
         Assert.Equal(json, body, ignoreLineEndingDifferences: true);
     }
 
+    [Fact]
+    public async Task BuildWebHost_StartsWithHttpsUrl_WhenKestrelCertificateConfigured()
+    {
+        var builder = WebApplication.CreateSlimBuilder(new[] { "--urls", "https://127.0.0.1:0" });
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Kestrel:Certificates:Default:Path"] = Path.Combine(AppContext.BaseDirectory, "shared", "TestCertificates", "testCert.pfx"),
+            ["Kestrel:Certificates:Default:Password"] = "testPassword",
+        });
+
+        await using var app = BlazorGateway.BuildWebHost(builder);
+
+        await app.StartAsync();
+    }
+
     private static bool IsRedirect(HttpStatusCode status) =>
         status is HttpStatusCode.MovedPermanently
             or HttpStatusCode.Found

--- a/src/Components/Gateway/test/BlazorGatewayTests.cs
+++ b/src/Components/Gateway/test/BlazorGatewayTests.cs
@@ -201,16 +201,19 @@ public class BlazorGatewayTests
     [Fact]
     public async Task BuildWebHost_StartsWithHttpsUrl_WhenKestrelCertificateConfigured()
     {
+        var testCertificatePath = Path.Combine(AppContext.BaseDirectory, "shared", "TestCertificates", "testCert.pfx");
         var builder = WebApplication.CreateSlimBuilder(new[] { "--urls", "https://127.0.0.1:0" });
         builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
-            ["Kestrel:Certificates:Default:Path"] = Path.Combine(AppContext.BaseDirectory, "shared", "TestCertificates", "testCert.pfx"),
+            ["Kestrel:Certificates:Default:Path"] = testCertificatePath,
             ["Kestrel:Certificates:Default:Password"] = "testPassword",
         });
 
         await using var app = BlazorGateway.BuildWebHost(builder);
 
         await app.StartAsync();
+
+        Assert.Contains(app.Urls, address => address.StartsWith("https://127.0.0.1:", StringComparison.Ordinal));
     }
 
     private static bool IsRedirect(HttpStatusCode status) =>

--- a/src/Components/Gateway/test/Microsoft.AspNetCore.Components.Gateway.Tests.csproj
+++ b/src/Components/Gateway/test/Microsoft.AspNetCore.Components.Gateway.Tests.csproj
@@ -21,6 +21,7 @@
     <Reference Include="Microsoft.Extensions.ServiceDiscovery" />
     <Reference Include="Microsoft.Extensions.ServiceDiscovery.Yarp" />
     <Reference Include="Yarp.ReverseProxy" />
+    <Content Include="$(SharedSourceRoot)TestCertificates\*.pfx" LinkBase="shared\TestCertificates" CopyToOutputDirectory="PreserveNewest" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryExporterOpenTelemetryProtocolVersion)" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryExtensionsHostingVersion)" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="$(OpenTelemetryInstrumentationAspNetCoreVersion)" />


### PR DESCRIPTION
## Summary

The Blazor Gateway (introduced in #66729) replaced the DevServer for standalone WASM templates, switching from `Host.CreateDefaultBuilder` + `ConfigureWebHostDefaults` (which auto-configures Kestrel HTTPS) to `WebApplication.CreateSlimBuilder` (which does not).

This caused `blazorwasm` template projects to throw `InvalidOperationException: Call UseKestrelHttpsConfiguration() on IWebHostBuilder` when using an `https://` launch profile URL.

## Fix

Add `builder.WebHost.UseKestrelHttpsConfiguration()` to `BlazorGateway.BuildWebHost()` so Kestrel can bind HTTPS endpoints, matching the behavior of the old DevServer.

Fixes #67484