### PR TITLE
Enable WebAssembly debugging in Blazor Gateway

### DIFF
--- a/src/Components/Gateway/src/BlazorGateway.cs
+++ b/src/Components/Gateway/src/BlazorGateway.cs
@@ -84,6 +84,11 @@ public static class BlazorGateway
             app.UsePathBase(options.PathBase);
         }
 
+        if (app.Environment.IsDevelopment())
+        {
+            app.UseWebAssemblyDebugging();
+        }
+
         if (app.Environment.IsDevelopment() && options.HealthChecks.Enabled)
         {
             app.MapHealthChecks(options.HealthChecks.Path);

--- a/src/Components/Gateway/src/Microsoft.AspNetCore.Components.Gateway.csproj
+++ b/src/Components/Gateway/src/Microsoft.AspNetCore.Components.Gateway.csproj
@@ -29,6 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Reference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" />
     <Reference Include="Yarp.ReverseProxy" />
     <Reference Include="Microsoft.Extensions.ServiceDiscovery" />
     <Reference Include="Microsoft.Extensions.ServiceDiscovery.Yarp" />

--- a/src/Components/Gateway/test/Microsoft.AspNetCore.Components.Gateway.Tests.csproj
+++ b/src/Components/Gateway/test/Microsoft.AspNetCore.Components.Gateway.Tests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <Reference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" />
     <Reference Include="Microsoft.AspNetCore.TestHost" />
     <Reference Include="Microsoft.Extensions.ServiceDiscovery" />
     <Reference Include="Microsoft.Extensions.ServiceDiscovery.Yarp" />


### PR DESCRIPTION
## Summary

The Blazor Gateway (introduced in #66729) replaced the DevServer for standalone WASM templates but omitted the `UseWebAssemblyDebugging()` middleware call that the old DevServer included. This broke breakpoint debugging in Blazor WASM standalone projects.

## Root Cause

The old DevServer's `Startup.cs` called `app.UseWebAssemblyDebugging()` which registers the `/_framework/debug` endpoint that launches the debug proxy. The new Gateway did not include this.

Blazor Web App (Server/Auto) templates are unaffected because they call `UseWebAssemblyDebugging()` directly in their own `Program.cs`.

## Fix

- Add `app.UseWebAssemblyDebugging()` in development mode in `BlazorGateway.BuildWebHost()`
- Add the required `Microsoft.AspNetCore.Components.WebAssembly.Server` reference to both the Gateway project and its test project

## Testing

All 20 existing Gateway tests pass.

Fixes #67507