### PR TITLE
Normalize C++ PlatformToolsetVersion and centralize PlatformToolset

### DIFF
--- a/eng/targets/Cpp.Common.props
+++ b/eng/targets/Cpp.Common.props
@@ -20,8 +20,8 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>
     <Platform Condition="'$(Platform)' == ''">x64</Platform>
-    <PlatformToolsetVersion>v145</PlatformToolsetVersion>
-    <PlatformToolset>$(PlatformToolsetVersion)</PlatformToolset>
+    <PlatformToolsetVersion>145</PlatformToolsetVersion>
+    <PlatformToolset>v$(PlatformToolsetVersion)</PlatformToolset>
     <!-- If the following line is updated ensure that the /eng/scripts/vs.*.*.json files are updated to include the same version component too. -->
     <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.22621.0</WindowsTargetPlatformVersion>
   </PropertyGroup>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/IIS-Setup/IIS-Common/lib/IISSetup.CommonLib.vcxproj
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/IIS-Setup/IIS-Common/lib/IISSetup.CommonLib.vcxproj
@@ -38,7 +38,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup>
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>$(PlatformToolsetVersion)</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <WholeProgramOptimization>false</WholeProgramOptimization>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/IIS-Setup/iisca/lib/iisca.vcxproj
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/IIS-Setup/iisca/lib/iisca.vcxproj
@@ -81,7 +81,6 @@
   <PropertyGroup>
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>$(PlatformToolsetVersion)</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLibTests/CommonLibTests.vcxproj
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLibTests/CommonLibTests.vcxproj
@@ -9,7 +9,6 @@
     <ProjectGuid>{1eac8125-1765-4e2d-8cbe-56dc98a1c8c1}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v$(PlatformToolsetVersion)</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <IsTestProject>true</IsTestProject>
     <DisableArcadeTestFramework>true</DisableArcadeTestFramework>


### PR DESCRIPTION
- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

Salvage the build-infra change from #58167 (which is being closed) that normalizes how the C++ platform toolset is defined.

## Description

`Cpp.Common.props` is imported for every `.vcxproj` via the root `Directory.Build.props`, so the platform toolset only needs to be defined in one place. This change makes `PlatformToolsetVersion` a bare number (`145` instead of `v145`) and moves the `v` prefix into the single `PlatformToolset` definition (`v$(PlatformToolsetVersion)`). The per-project `<PlatformToolset>` declarations in the two IIS installer libs and `CommonLibTests` are now redundant, so they're removed and inherit `v145` from the shared props.

This is a pure normalization/de-dup: the effective toolset is unchanged (`v145` everywhere). Verified that `Cpp.Common.props` resolves to `PlatformToolset=v145`, and that `Microsoft.Cpp.Default.props` only sets a default when `PlatformToolset` is empty, so the inherited value is not clobbered after removing the local declarations.

Note: only the toolset-definition portion of #58167 is kept here. The static-analysis rule churn from that PR is intentionally dropped, and the `143` -> `145` bump plus the `vs.17.*` -> `vs.18.*` rename already landed on `main` via other commits.