### PR TITLE
Fix MapFallback handling in RDG

### DIFF
--- a/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator/RequestDelegateGenerator.Emitter.cs
+++ b/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator/RequestDelegateGenerator.Emitter.cs
@@ -30,7 +30,8 @@ public sealed partial class RequestDelegateGenerator : IIncrementalGenerator
         codeWriter.Indent++;
         codeWriter.WriteLine("this IEndpointRouteBuilder endpoints,");
         // MapFallback overloads that only take a delegate do not need a pattern argument
-        if (endpoint.HttpMethod != "MapFallback" || endpoint.Operation.Arguments.Length != 2)
+        var hasPatternParameter = endpoint.HttpMethod != "MapFallback" || endpoint.Operation.Arguments.Length != 2;
+        if (hasPatternParameter)
         {
             codeWriter.WriteLine(@"[StringSyntax(""Route"")] string pattern,");
         }
@@ -100,7 +101,7 @@ public sealed partial class RequestDelegateGenerator : IIncrementalGenerator
         codeWriter.WriteLine("endpoints,");
         // For `MapFallback` overloads that only take a delegate, provide the assumed default
         // Otherwise, pass the pattern provided from the MapX invocation
-        if (endpoint.HttpMethod != "MapFallback" && endpoint.Operation.Arguments.Length != 2)
+        if (hasPatternParameter)
         {
             codeWriter.WriteLine("pattern,");
         }

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.cs
@@ -12,6 +12,7 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Http.RequestDelegateGenerator.StaticRouteHandlerModel;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Primitives;
 
@@ -561,6 +562,21 @@ app.MapFallback((HttpContext httpContext, int id) =>
 
         Assert.Equal(42, httpContext.Items["id"]);
         Assert.Equal(200, httpContext.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task RequestDelegateCreation_SupportsMapFallback_UsesProvidedPattern()
+    {
+        var source = """
+app.MapFallback("{*path}", (HttpContext context) => "this is {*path}");
+app.MapFallback("{*path:nonfile}", (HttpContext context) => "this is {*path:nonfile}");
+""";
+        var (_, compilation) = await RunGeneratorAsync(source);
+        var endpoints = GetEndpointsFromCompilation(compilation).OfType<RouteEndpoint>().ToArray();
+
+        Assert.Equal(2, endpoints.Length);
+        Assert.Single(endpoints, e => e.RoutePattern.RawText == "{*path}");
+        Assert.Single(endpoints, e => e.RoutePattern.RawText == "{*path:nonfile}");
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #65992

The second condition used `&&` incorrectly. I'm reusing a local variable to reduce duplication as well.