### PR TITLE
Add IsActive and ActivationChanged to NavLink

### DIFF
--- a/src/Components/Web/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Web/src/PublicAPI.Unshipped.txt
@@ -11,6 +11,7 @@ Microsoft.AspNetCore.Components.Routing.NavLink.RelativeToCurrentUri.get -> bool
 Microsoft.AspNetCore.Components.Routing.NavLink.RelativeToCurrentUri.set -> void
 Microsoft.AspNetCore.Components.Routing.NavLink.ActivationChanged.get -> Microsoft.AspNetCore.Components.EventCallback<bool>
 Microsoft.AspNetCore.Components.Routing.NavLink.ActivationChanged.set -> void
+Microsoft.AspNetCore.Components.Routing.NavLink.IsActive.get -> bool
 *REMOVED*Microsoft.AspNetCore.Components.Forms.RemoteBrowserFileStreamOptions
 *REMOVED*Microsoft.AspNetCore.Components.Forms.RemoteBrowserFileStreamOptions.MaxBufferSize.get -> int
 *REMOVED*Microsoft.AspNetCore.Components.Forms.RemoteBrowserFileStreamOptions.MaxBufferSize.set -> void

--- a/src/Components/Web/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Web/src/PublicAPI.Unshipped.txt
@@ -9,6 +9,8 @@ Microsoft.AspNetCore.Components.Web.EnvironmentView.Include.get -> string?
 Microsoft.AspNetCore.Components.Web.EnvironmentView.Include.set -> void
 Microsoft.AspNetCore.Components.Routing.NavLink.RelativeToCurrentUri.get -> bool
 Microsoft.AspNetCore.Components.Routing.NavLink.RelativeToCurrentUri.set -> void
+Microsoft.AspNetCore.Components.Routing.NavLink.ActivationChanged.get -> Microsoft.AspNetCore.Components.EventCallback<bool>
+Microsoft.AspNetCore.Components.Routing.NavLink.ActivationChanged.set -> void
 *REMOVED*Microsoft.AspNetCore.Components.Forms.RemoteBrowserFileStreamOptions
 *REMOVED*Microsoft.AspNetCore.Components.Forms.RemoteBrowserFileStreamOptions.MaxBufferSize.get -> int
 *REMOVED*Microsoft.AspNetCore.Components.Forms.RemoteBrowserFileStreamOptions.MaxBufferSize.set -> void

--- a/src/Components/Web/src/Routing/NavLink.cs
+++ b/src/Components/Web/src/Routing/NavLink.cs
@@ -45,6 +45,13 @@ public class NavLink : ComponentBase, IDisposable
     public EventCallback<bool> ActivationChanged { get; set; }
 
     /// <summary>
+    /// Gets a value indicating whether the current URI matches the NavLink's href,
+    /// according to the configured <see cref="Match"/> behavior. The value is updated
+    /// as part of the standard component lifecycle and in response to location changes.
+    /// </summary>
+    public bool IsActive { get; private set; }
+
+    /// <summary>
     /// Gets or sets the computed CSS class based on whether or not the link is active.
     /// </summary>
     protected string? CssClass { get; set; }
@@ -99,6 +106,7 @@ public class NavLink : ComponentBase, IDisposable
 
         _hrefAbsolute = href == null ? null : NavigationManager.ToAbsoluteUri(href).AbsoluteUri;
         _isActive = ShouldMatch(NavigationManager.Uri);
+        IsActive = _isActive;
 
         _class = (string?)null;
         if (AdditionalAttributes != null && AdditionalAttributes.TryGetValue("class", out obj))
@@ -129,6 +137,7 @@ public class NavLink : ComponentBase, IDisposable
         if (shouldBeActiveNow != _isActive)
         {
             _isActive = shouldBeActiveNow;
+            IsActive = _isActive;
             UpdateCssClass();
             StateHasChanged();
             if (ActivationChanged.HasDelegate)

--- a/src/Components/Web/src/Routing/NavLink.cs
+++ b/src/Components/Web/src/Routing/NavLink.cs
@@ -121,7 +121,7 @@ public class NavLink : ComponentBase, IDisposable
         CssClass = _isActive ? CombineWithSpace(_class, ActiveClass ?? DefaultActiveClass) : _class;
     }
 
-    private async void OnLocationChanged(object? sender, LocationChangedEventArgs args)
+    private void OnLocationChanged(object? sender, LocationChangedEventArgs args)
     {
         // We could just re-render always, but for this component we know the
         // only relevant state change is to the _isActive property.
@@ -133,7 +133,7 @@ public class NavLink : ComponentBase, IDisposable
             StateHasChanged();
             if (ActivationChanged.HasDelegate)
             {
-                await ActivationChanged.InvokeAsync(_isActive);
+                _ = ActivationChanged.InvokeAsync(_isActive);
             }
         }
     }

--- a/src/Components/Web/src/Routing/NavLink.cs
+++ b/src/Components/Web/src/Routing/NavLink.cs
@@ -37,6 +37,14 @@ public class NavLink : ComponentBase, IDisposable
     public IReadOnlyDictionary<string, object>? AdditionalAttributes { get; set; }
 
     /// <summary>
+    /// Gets or sets a callback invoked with the current active state when it changes.
+    /// Use this to react to the active state from a parent component (e.g., to apply a
+    /// class to a surrounding element) when styling the <c>a</c> tag alone is not enough.
+    /// </summary>
+    [Parameter]
+    public EventCallback<bool> ActivationChanged { get; set; }
+
+    /// <summary>
     /// Gets or sets the computed CSS class based on whether or not the link is active.
     /// </summary>
     protected string? CssClass { get; set; }
@@ -113,7 +121,7 @@ public class NavLink : ComponentBase, IDisposable
         CssClass = _isActive ? CombineWithSpace(_class, ActiveClass ?? DefaultActiveClass) : _class;
     }
 
-    private void OnLocationChanged(object? sender, LocationChangedEventArgs args)
+    private async void OnLocationChanged(object? sender, LocationChangedEventArgs args)
     {
         // We could just re-render always, but for this component we know the
         // only relevant state change is to the _isActive property.
@@ -123,6 +131,10 @@ public class NavLink : ComponentBase, IDisposable
             _isActive = shouldBeActiveNow;
             UpdateCssClass();
             StateHasChanged();
+            if (ActivationChanged.HasDelegate)
+            {
+                await ActivationChanged.InvokeAsync(_isActive);
+            }
         }
     }
 

--- a/src/Components/Web/test/Routing/NavLinkTest.cs
+++ b/src/Components/Web/test/Routing/NavLinkTest.cs
@@ -107,6 +107,33 @@ public class NavLinkTest
         Assert.Equal(new[] { true, false }, capturedValues);
     }
 
+    [Fact]
+    public async Task IsActive_ReflectsCurrentActiveState()
+    {
+        var navigationManager = new TestNavigationManager();
+        navigationManager.Initialize("https://example.com/", "https://example.com/");
+
+        var renderer = new TestRenderer();
+        var component = new NavLink { NavigationManager = navigationManager };
+        var componentId = renderer.AssignRootComponentId(component);
+
+        var parameters = ParameterView.FromDictionary(new Dictionary<string, object?>
+        {
+            [nameof(NavLink.AdditionalAttributes)] = new Dictionary<string, object> { ["href"] = "/page" }
+        });
+
+        await renderer.RenderRootComponentAsync(componentId, parameters);
+        Assert.False(component.IsActive);
+
+        await renderer.Dispatcher.InvokeAsync(() => navigationManager.NavigateTo("/page"));
+        await Task.Delay(100);
+        Assert.True(component.IsActive);
+
+        await renderer.Dispatcher.InvokeAsync(() => navigationManager.NavigateTo("/elsewhere"));
+        await Task.Delay(100);
+        Assert.False(component.IsActive);
+    }
+
     private async Task<object?> RenderNavLinkAndGetAttributeAsync(
         string baseUri, string currentUri, string href, bool relativeToCurrentUri, string attributeName)
     {

--- a/src/Components/Web/test/Routing/NavLinkTest.cs
+++ b/src/Components/Web/test/Routing/NavLinkTest.cs
@@ -45,6 +45,68 @@ public class NavLinkTest
         Assert.Equal("active", classValue);
     }
 
+    [Fact]
+    public async Task ActivationChanged_InvokedWhenNavigationChangesActiveState()
+    {
+        var navigationManager = new TestNavigationManager();
+        navigationManager.Initialize("https://example.com/", "https://example.com/");
+
+        var renderer = new TestRenderer();
+        var component = new NavLink { NavigationManager = navigationManager };
+        var componentId = renderer.AssignRootComponentId(component);
+
+        var callbackInvoked = false;
+        bool callbackValue = false;
+
+        var parameters = ParameterView.FromDictionary(new Dictionary<string, object?>
+        {
+            [nameof(NavLink.AdditionalAttributes)] = new Dictionary<string, object> { ["href"] = "/page" },
+            [nameof(NavLink.ActivationChanged)] = EventCallback.Factory.Create<bool>(component,
+                (value) =>
+                {
+                    callbackInvoked = true;
+                    callbackValue = value;
+                })
+        });
+
+        await renderer.RenderRootComponentAsync(componentId, parameters);
+
+        await renderer.Dispatcher.InvokeAsync(() => navigationManager.NavigateTo("/page"));
+
+        Assert.True(callbackInvoked);
+        Assert.True(callbackValue);
+    }
+
+    [Fact]
+    public async Task ActivationChanged_PassesCorrectBooleanValue()
+    {
+        var navigationManager = new TestNavigationManager();
+        navigationManager.Initialize("https://example.com/", "https://example.com/");
+
+        var renderer = new TestRenderer();
+        var component = new NavLink { NavigationManager = navigationManager };
+        var componentId = renderer.AssignRootComponentId(component);
+
+        var capturedValues = new List<bool>();
+
+        var parameters = ParameterView.FromDictionary(new Dictionary<string, object?>
+        {
+            [nameof(NavLink.AdditionalAttributes)] = new Dictionary<string, object> { ["href"] = "/target" },
+            [nameof(NavLink.ActivationChanged)] = EventCallback.Factory.Create<bool>(component,
+                (value) => capturedValues.Add(value))
+        });
+
+        await renderer.RenderRootComponentAsync(componentId, parameters);
+
+        await renderer.Dispatcher.InvokeAsync(() => navigationManager.NavigateTo("/target"));
+        await Task.Delay(100);
+
+        await renderer.Dispatcher.InvokeAsync(() => navigationManager.NavigateTo("/other"));
+        await Task.Delay(100);
+
+        Assert.Equal(new[] { true, false }, capturedValues);
+    }
+
     private async Task<object?> RenderNavLinkAndGetAttributeAsync(
         string baseUri, string currentUri, string href, bool relativeToCurrentUri, string attributeName)
     {
@@ -73,7 +135,9 @@ public class NavLinkTest
 
         protected override void NavigateToCore(string uri, NavigationOptions options)
         {
-            Uri = uri;
+            // Resolve to an absolute URI so the base-relative validation in the
+            // Uri setter accepts the new value.
+            Uri = ToAbsoluteUri(uri).AbsoluteUri;
             NotifyLocationChanged(false);
         }
     }


### PR DESCRIPTION
# Add IsActive and ActivationChanged to NavLink

## Description

The new APIs to NavLink to expose and react to its active state. IsActive provides the current active status of the link based on the configured Match behavior, and ActivationChanged notifies consumers whenever that state changes. This enables parent or surrounding elements (such as navigation containers, list items, or custom components) to respond to NavLink activation without duplicating the internal matching logic.

Name | Type | Description
-- | -- | --
IsActive | bool | Gets whether the NavLink is currently active.
ActivationChanged | EventCallback<bool> | Invoked when the active state changes, passing the current active state.


Fixes #40762