### PR TITLE
Fix exception handling and culture-specific parsing in TargetPickerUi

### DIFF
--- a/src/Components/WebAssembly/Server/src/TargetPickerUi.cs
+++ b/src/Components/WebAssembly/Server/src/TargetPickerUi.cs
@@ -78,7 +78,7 @@ public class TargetPickerUi
                 bytesRead += readLen;
             }
             string str = Encoding.UTF8.GetString(_lengthBuffer, 0, bytesRead - 1);
-            if (!int.TryParse(str, out int messageLen))
+            if (!int.TryParse(str, System.Globalization.CultureInfo.InvariantCulture, out int messageLen))
             {
                 return "";
             }
@@ -121,7 +121,7 @@ public class TargetPickerUi
             {
                 await browserDebugClientConnect.ConnectAsync(endpoint.Address, 6000);
             }
-            catch (Exception)
+            catch (SocketException)
             {
                 context.Response.StatusCode = 404;
                 await context.Response.WriteAsync($@"WARNING:
@@ -275,7 +275,7 @@ firefox --start-debugger-server 6000 -new-tab about:debugging");
         {
             availableTabs = await GetOpenedBrowserTabs();
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException)
         {
             await context.Response.WriteAsync($@"
 <h1>Unable to find debuggable browser tab</h1>


### PR DESCRIPTION
Description of the issues:
This PR addresses static analysis warnings within TargetPickerUi.cs in the WebAssembly server components:

- Culture-dependent parsing: The method int.TryParse relied on the thread's default culture when reading the structural length of debug protocol messages, which could lead to parsing errors in environments with specific numeric formats.
- Generic Exception catching: Broad catch (Exception) blocks were being used. This practice could silently swallow critical system errors (like OutOfMemoryException), masking them as simple browser connectivity or parsing issues.

Proposed fixes:

- Updated int.TryParse to explicitly use CultureInfo.InvariantCulture.
- Replaced the overly broad catch (Exception) blocks with specific exception handling: catch (SocketException) for the debug client connection, and catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException) when querying browser tabs

**Found by Linux Verification Center (linuxtesting.org) with SVACE.**