### PR TITLE
Fix resource leaks and exception handling in OAuth and OpenIdConnect

### DIFF
--- a/src/Security/Authentication/OAuth/src/OAuthHandler.cs
+++ b/src/Security/Authentication/OAuth/src/OAuthHandler.cs
@@ -231,7 +231,8 @@ public class OAuthHandler<TOptions> : RemoteAuthenticationHandler<TOptions> wher
 
     private static OAuthTokenResponse PrepareFailedOAuthTokenResponse(HttpResponseMessage response, string body)
     {
-        var exception = OAuthTokenResponse.GetStandardErrorException(JsonDocument.Parse(body));
+        using var jsonDocument = JsonDocument.Parse(body);
+        var exception = OAuthTokenResponse.GetStandardErrorException(jsonDocument);
 
         if (exception is null)
         {

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
@@ -1471,8 +1471,8 @@ public class OpenIdConnectHandler : RemoteAuthenticationHandler<OpenIdConnectOpt
 
         if (validatedToken is not JsonWebToken)
         {
-            Logger.InvalidSecurityTokenTypeFromHandler(validatedToken?.GetType());
-            throw new SecurityTokenException(string.Format(CultureInfo.InvariantCulture, Resources.ValidatedSecurityTokenNotJsonWebToken, validatedToken?.GetType()));
+            Logger.InvalidSecurityTokenTypeFromHandler(validatedToken.GetType());
+            throw new SecurityTokenException(string.Format(CultureInfo.InvariantCulture, Resources.ValidatedSecurityTokenNotJsonWebToken, validatedToken.GetType()));
         }
 
         if (Options.UseTokenLifetime)

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
@@ -1017,7 +1017,7 @@ public class OpenIdConnectHandler : RemoteAuthenticationHandler<OpenIdConnectOpt
             var responseContent = await responseMessage.Content.ReadAsStringAsync(Context.RequestAborted);
             message = new OpenIdConnectMessage(responseContent);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is JsonException or ArgumentException or InvalidOperationException)
         {
             throw new OpenIdConnectProtocolException($"Failed to parse token response body as JSON. Status Code: {(int)responseMessage.StatusCode}. Content-Type: {responseMessage.Content.Headers.ContentType}", ex);
         }

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
@@ -1196,7 +1196,7 @@ public class OpenIdConnectHandler : RemoteAuthenticationHandler<OpenIdConnectOpt
                         return nonce;
                     }
                 }
-                catch (Exception ex)
+                catch (CryptographicException ex)
                 {
                     Logger.UnableToProtectNonceCookie(ex);
                 }

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
@@ -1458,7 +1458,7 @@ public class OpenIdConnectHandler : RemoteAuthenticationHandler<OpenIdConnectOpt
 
         if (validationResult.Exception != null)
         {
-            throw validationResult.Exception;
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(validationResult.Exception).Throw();
         }
 
         var validatedToken = validationResult.SecurityToken;


### PR DESCRIPTION
Description of the issues:
This PR addresses several static analysis warnings in OAuthHandler.cs and OpenIdConnectHandler.cs:
- Handle Leak: In OAuthHandler, a JsonDocument created via JsonDocument.Parse(body) was passed directly to a method without being disposed, relying heavily on the garbage collector and potentially causing memory/handle spikes under load.
- Broad Exception Handling: OpenIdConnectHandler had two generic catch (Exception ex) blocks (ReadNonceCookie and RedeemAuthorizationCodeAsync) that could silently swallow systemic errors (e.g., OutOfMemoryException or TaskCanceledException).
- Loss of Stack Trace: Re-throwing validationResult.Exception via throw ex; in ValidateTokenUsingHandlerAsync overwrote the original stack trace, making debugging extremely difficult and forcing the caller to catch a generic System.Exception.
- Unreachable Code: Redundant null-conditional operators were used on validatedToken right after an explicit null check that would throw if the object was null.

Proposed fixes:
- Assigned the JsonDocument to a using var declaration to guarantee disposal.
- Refactored the broad catch blocks to capture CryptographicException and Exception ex when (ex is JsonException or ArgumentException or InvalidOperationException) respectively.
- Replaced the direct generic throw with ExceptionDispatchInfo.Capture(validationResult.Exception).Throw() to propagate the exception safely while preserving its original stack trace.
- Removed the redundant ?. operators.

**Found by Linux Verification Center (linuxtesting.org) with SVACE.**