### PR TITLE
Fix unbounded memory allocation in TargetPickerUi debug proxy

### DIFF
--- a/src/Components/WebAssembly/Server/src/TargetPickerUi.cs
+++ b/src/Components/WebAssembly/Server/src/TargetPickerUi.cs
@@ -78,7 +78,7 @@ public class TargetPickerUi
                 bytesRead += readLen;
             }
             string str = Encoding.UTF8.GetString(_lengthBuffer, 0, bytesRead - 1);
-            if (!int.TryParse(str, out int messageLen))
+            if (!int.TryParse(str, System.Globalization.CultureInfo.InvariantCulture, out int messageLen) || messageLen < 0 || messageLen > 100 * 1024 * 1024)
             {
                 return "";
             }


### PR DESCRIPTION
Description of the issue:
In TargetPickerUi.cs, the ReceiveMessageLoop method reads a protocol message length from a TCP stream and immediately uses it to allocate a byte array (new byte[messageLen]). Because there was no upper bound check on messageLen, a malformed or maliciously crafted payload specifying an extremely large length could trigger an OutOfMemoryException, crashing the proxy and causing a denial of service (DoS).

Proposed fix:
Introduced validation for messageLen prior to array allocation. If the length is negative or exceeds a safe arbitrary limit (100 MB), the loop safely aborts by returning an empty string. This ensures the process memory limits are respected while accommodating reasonably large debug payloads like source maps.

**Found by Linux Verification Center (linuxtesting.org) with SVACE.**