### PR TITLE
Fix array handling for JSON pointers when resolving OpenAPI schemas

### DIFF
--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO.Pipelines;
 using System.Linq;
 using System.Text.Json;
@@ -595,6 +596,9 @@ internal sealed class OpenApiSchemaService(
 
     private static JsonNode? ResolveReference(string refPath, JsonNode rootSchema)
     {
+        // The refPath is expected to be a JSON Pointer (RFC 6901)
+        // https://www.rfc-editor.org/info/rfc6901/
+        // It follows the URI Fragment Identifier Representation.
         if (string.IsNullOrWhiteSpace(refPath))
         {
             throw new InvalidOperationException("Reference path cannot be null or empty.");
@@ -605,37 +609,115 @@ internal sealed class OpenApiSchemaService(
             throw new InvalidOperationException($"Only fragment references (starting with '{OpenApiConstants.RefPrefix}') are supported. Found: {refPath}");
         }
 
-        var path = refPath.TrimStart('#', '/');
-        if (string.IsNullOrEmpty(path))
+        // We already checked that the path starts with '#'.
+        var currentPath = refPath.AsSpan().Slice(OpenApiConstants.RefPrefix.Length);
+        var currentNode = rootSchema;
+
+        while (currentPath.Length > 0)
         {
-            return rootSchema;
+            // https://www.rfc-editor.org/info/rfc6901/#section-3
+            // json-pointer    = *( "/" reference-token )
+            if (currentPath[0] != '/')
+            {
+                throw new InvalidOperationException($"Failed to resolve reference '{refPath}'. Expected '{currentPath}' to start with '/'");
+            }
+
+            var currentPathWithoutSlash = currentPath.Slice(1);
+            var indexOfNextPath = currentPathWithoutSlash.IndexOf('/');
+
+            var currentReferenceToken =
+                indexOfNextPath == -1
+                ? currentPathWithoutSlash
+                : currentPathWithoutSlash.Slice(0, indexOfNextPath);
+
+            var unescapedReferenceToken = ParseReferenceToken(currentReferenceToken);
+            currentNode = EvaluateReferenceToken(unescapedReferenceToken, currentNode, refPath);
+
+            currentPath = indexOfNextPath == -1
+                ? ReadOnlySpan<char>.Empty
+                : currentPathWithoutSlash.Slice(indexOfNextPath);
         }
 
-        var segments = path.Split('/');
-        var current = rootSchema;
+        return currentNode;
+    }
 
-        for (var i = 0; i < segments.Length; i++)
+    private static string ParseReferenceToken(ReadOnlySpan<char> referenceToken)
+    {
+        // https://www.rfc-editor.org/info/rfc6901/#section-4
+        // Evaluation of each reference token begins by decoding any escaped
+        // character sequence.  This is performed by first transforming any
+        // occurrence of the sequence '~1' to '/', and then transforming any
+        // occurrence of the sequence '~0' to '~'.  By performing the
+        // substitutions in this order, an implementation avoids the error of
+        // turning '~01' first into '~1' and then into '/', which would be
+        // incorrect (the string '~01' correctly becomes '~1' after
+        // transformation).
+        //
+        // NOTE: we unescape the possibly percent-encoded value even if
+        // STJ doesn't correctly percent-encode the ref today.
+        // See https://github.com/dotnet/runtime/issues/130162
+        if (referenceToken.Contains("~0", StringComparison.Ordinal) ||
+            referenceToken.Contains("~1", StringComparison.Ordinal))
         {
-            var segment = segments[i];
-            if (current is JsonObject currentObject)
-            {
-                if (currentObject.TryGetPropertyValue(segment, out var nextNode) && nextNode != null)
-                {
-                    current = nextNode;
-                }
-                else
-                {
-                    var partialPath = string.Join('/', segments.Take(i + 1));
-                    throw new InvalidOperationException($"Failed to resolve reference '{refPath}': path segment '{segment}' not found at '#{partialPath}'");
-                }
-            }
-            else
-            {
-                var partialPath = string.Join('/', segments.Take(i));
-                throw new InvalidOperationException($"Failed to resolve reference '{refPath}': cannot navigate beyond '#{partialPath}' - expected object but found {current?.GetType().Name ?? "null"}");
-            }
+            // Not common case, performance isn't super important.
+            return Uri.UnescapeDataString(referenceToken.ToString().Replace("~1", "/").Replace("~0", "~"));
         }
 
-        return current;
+        return Uri.UnescapeDataString(referenceToken.ToString());
+    }
+
+    private static JsonNode EvaluateReferenceToken(string unescapedReferenceToken, JsonNode currentNode, string fullJsonPointer)
+    {
+        if (currentNode is JsonObject currentObject)
+        {
+            // https://www.rfc-editor.org/info/rfc6901/#section-4
+            // If the currently referenced value is a JSON object, the new
+            // referenced value is the object member with the name identified by
+            // the reference token.  The member name is equal to the token if it
+            // has the same number of Unicode characters as the token and their
+            // code points are byte-by-byte equal.  No Unicode character
+            // normalization is performed.  If a referenced member name is not
+            // unique in an object, the member that is referenced is undefined
+            // and evaluation fails (see below).
+            if (!currentObject.TryGetPropertyValue(unescapedReferenceToken, out var referencedValue) ||
+                referencedValue is null)
+            {
+                throw new InvalidOperationException($"Failed to resolve reference '{fullJsonPointer}': property '{unescapedReferenceToken}' not found.");
+            }
+
+            return referencedValue;
+        }
+
+        if (currentNode is JsonArray currentArray)
+        {
+            // https://www.rfc-editor.org/info/rfc6901/#section-4
+            // If the currently referenced value is a JSON array, the reference
+            // token MUST contain either:
+            //   - characters comprised of digits (see ABNF below; note that
+            //     leading zeros are not allowed) that represent an unsigned
+            //     base-10 integer value, making the new referenced value the
+            //     array element with the zero-based index identified by the
+            //     token, or
+            //   - exactly the single character "-", making the new referenced
+            //     value the (nonexistent) member after the last array element.
+            //
+            // The ABNF syntax for array indices is:
+            // array-index = %x30 / ( %x31-39 *(%x30-39) )
+            //               ; "0", or digits without a leading "0"
+            if (!int.TryParse(unescapedReferenceToken, NumberStyles.Integer, CultureInfo.InvariantCulture, out var arrayIndex))
+            {
+                throw new InvalidOperationException($"Failed to resolve reference '{fullJsonPointer}': cannot navigate an array when the current token '{unescapedReferenceToken}' isn't a valid number");
+            }
+
+            if (unescapedReferenceToken.StartsWith('0', StringComparison.Ordinal) && unescapedReferenceToken.Length > 1)
+            {
+                throw new InvalidOperationException($"Failed to resolve reference '{fullJsonPointer}': array index '{unescapedReferenceToken}' has a leading zero, which is not allowed.");
+            }
+
+            return currentArray[arrayIndex]
+                ?? throw new InvalidOperationException($"Failed to resolve reference '{fullJsonPointer}': array index '{arrayIndex}' was not found.");
+        }
+
+        throw new InvalidOperationException($"Failed to resolve reference '{fullJsonPointer}': Unexpected JsonNode '{currentNode.GetType()}'");
     }
 }

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -704,7 +704,15 @@ internal sealed class OpenApiSchemaService(
             // The ABNF syntax for array indices is:
             // array-index = %x30 / ( %x31-39 *(%x30-39) )
             //               ; "0", or digits without a leading "0"
-            if (!int.TryParse(unescapedReferenceToken, NumberStyles.Integer, CultureInfo.InvariantCulture, out var arrayIndex))
+            //
+            // Note that the use of the "-" character to index an array will always
+            // result in such an error condition because by definition it refers to
+            // a nonexistent array element.  Thus, applications of JSON Pointer need
+            // to specify how that character is to be handled, if it is to be
+            // useful.
+            //
+            // In our case, "-" doesn't seem to be useful so we will throw.
+            if (!int.TryParse(unescapedReferenceToken, NumberStyles.None, CultureInfo.InvariantCulture, out var arrayIndex))
             {
                 throw new InvalidOperationException($"Failed to resolve reference '{fullJsonPointer}': cannot navigate an array when the current token '{unescapedReferenceToken}' isn't a valid number");
             }

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -643,6 +643,9 @@ internal sealed class OpenApiSchemaService(
 
     private static string ParseReferenceToken(ReadOnlySpan<char> referenceToken)
     {
+        // https://www.rfc-editor.org/info/rfc6901/#section-6
+        var unescapedReferenceToken = Uri.UnescapeDataString(referenceToken.ToString());
+
         // https://www.rfc-editor.org/info/rfc6901/#section-4
         // Evaluation of each reference token begins by decoding any escaped
         // character sequence.  This is performed by first transforming any
@@ -656,14 +659,13 @@ internal sealed class OpenApiSchemaService(
         // NOTE: we unescape the possibly percent-encoded value even if
         // STJ doesn't correctly percent-encode the ref today.
         // See https://github.com/dotnet/runtime/issues/130162
-        if (referenceToken.Contains("~0", StringComparison.Ordinal) ||
-            referenceToken.Contains("~1", StringComparison.Ordinal))
+        if (unescapedReferenceToken.Contains('~'))
         {
             // Not common case, performance isn't super important.
-            return Uri.UnescapeDataString(referenceToken.ToString().Replace("~1", "/").Replace("~0", "~"));
+            return unescapedReferenceToken.Replace("~1", "/").Replace("~0", "~");
         }
 
-        return Uri.UnescapeDataString(referenceToken.ToString());
+        return unescapedReferenceToken;
     }
 
     private static JsonNode EvaluateReferenceToken(string unescapedReferenceToken, JsonNode currentNode, string fullJsonPointer)

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentServiceTestsBase.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentServiceTestsBase.cs
@@ -29,15 +29,16 @@ using static Microsoft.AspNetCore.OpenApi.Tests.OpenApiOperationGeneratorTests;
 
 public abstract class OpenApiDocumentServiceTestBase
 {
-    public static async Task VerifyOpenApiDocument(IEndpointRouteBuilder builder, Action<OpenApiDocument> verifyOpenApiDocument)
+    public static async Task<OpenApiDocument> VerifyOpenApiDocument(IEndpointRouteBuilder builder, Action<OpenApiDocument> verifyOpenApiDocument)
         => await VerifyOpenApiDocument(builder, new OpenApiOptions(), verifyOpenApiDocument);
 
-    public static async Task VerifyOpenApiDocument(IEndpointRouteBuilder builder, OpenApiOptions openApiOptions, Action<OpenApiDocument> verifyOpenApiDocument, CancellationToken cancellationToken = default)
+    public static async Task<OpenApiDocument> VerifyOpenApiDocument(IEndpointRouteBuilder builder, OpenApiOptions openApiOptions, Action<OpenApiDocument> verifyOpenApiDocument, CancellationToken cancellationToken = default)
     {
         var documentService = CreateDocumentService(builder, openApiOptions);
         var scopedService = ((TestServiceProvider)builder.ServiceProvider).CreateScope();
         var document = await documentService.GetOpenApiDocumentAsync(scopedService.ServiceProvider, null, cancellationToken);
         verifyOpenApiDocument(document);
+        return document;
     }
 
     public static async Task VerifyOpenApiDocument(ActionDescriptor action, Action<OpenApiDocument> verifyOpenApiDocument, CancellationToken cancellationToken = default)

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.PolymorphicSchemas.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.PolymorphicSchemas.cs
@@ -312,7 +312,6 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             var operation = document.Paths["/api"].Operations[HttpMethod.Post];
             var requestBody = operation.RequestBody.Content;
             Assert.True(requestBody.TryGetValue("application/json", out var mediaType));
-            var schema = mediaType.Schema;
 
             foreach (var componentName in new[] { "DictionaryContainerBaseDictionaryContainerAlpha", "DictionaryContainerBaseDictionaryContainerBeta", "DictionaryContainerBaseDictionaryContainerGamma" })
             {

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.PolymorphicSchemas.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.PolymorphicSchemas.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Http;
+using System.Text.Json.Nodes;
 using Microsoft.AspNetCore.Builder;
 
 public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
@@ -294,5 +295,222 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             // Assert that the schema has a correct self-reference to the base-type. This points to the schema that contains the discriminator.
             Assert.Equal("Employee", ((OpenApiSchemaReference)employeeSchema.Properties["manager"]).Reference.Id);
         });
+    }
+
+    [Fact]
+    public async Task HandlesPolymorphicTypesWithDictionaryPropertiesOnDerivedTypes()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPost("/api", (DictionaryContainerBase container) => { });
+
+        // Assert
+        var document = await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths["/api"].Operations[HttpMethod.Post];
+            var requestBody = operation.RequestBody.Content;
+            Assert.True(requestBody.TryGetValue("application/json", out var mediaType));
+            var schema = mediaType.Schema;
+
+            foreach (var componentName in new[] { "DictionaryContainerBaseDictionaryContainerAlpha", "DictionaryContainerBaseDictionaryContainerBeta", "DictionaryContainerBaseDictionaryContainerGamma" })
+            {
+                Assert.True(document.Components.Schemas.TryGetValue(componentName, out var derivedSchema));
+
+                // Dictionary<string, string> Tags => { "type": "object", "additionalProperties": { "type": "string" } }
+                var tags = derivedSchema.Properties["tags"];
+                Assert.True(tags.Type.Value.HasFlag(JsonSchemaType.Object));
+                Assert.NotNull(tags.AdditionalProperties);
+                Assert.True(tags.AdditionalProperties.Type.Value.HasFlag(JsonSchemaType.String));
+
+                // Dictionary<string, string[]> Labels => additionalProperties is an array of strings and
+                // must not be an empty schema for any derived type.
+                var labels = derivedSchema.Properties["labels"];
+                Assert.True(labels.Type.Value.HasFlag(JsonSchemaType.Object));
+                Assert.NotNull(labels.AdditionalProperties);
+                Assert.True(labels.AdditionalProperties.Type.Value.HasFlag(JsonSchemaType.Array));
+                Assert.NotNull(labels.AdditionalProperties.Items);
+                Assert.True(labels.AdditionalProperties.Items.Type.Value.HasFlag(JsonSchemaType.String));
+            }
+        });
+
+        var actual = await document.SerializeAsJsonAsync(OpenApiSpecVersion.OpenApi3_2);
+        var expected = """
+            {
+              "openapi": "3.2.0",
+              "info": {
+                "title": "OpenApiDocumentServiceTests | Test",
+                "version": "1.0.0"
+              },
+              "paths": {
+                "/api": {
+                  "post": {
+                    "tags": [
+                      "OpenApiDocumentServiceTests"
+                    ],
+                    "requestBody": {
+                      "content": {
+                        "application/json": {
+                          "schema": {
+                            "$ref": "#/components/schemas/DictionaryContainerBase"
+                          }
+                        }
+                      }
+                    },
+                    "responses": {
+                      "200": {
+                        "description": "OK"
+                      }
+                    }
+                  }
+                }
+              },
+              "components": {
+                "schemas": {
+                  "DictionaryContainerBase": {
+                    "required": [
+                      "$type"
+                    ],
+                    "type": "object",
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/DictionaryContainerBaseDictionaryContainerAlpha"
+                      },
+                      {
+                        "$ref": "#/components/schemas/DictionaryContainerBaseDictionaryContainerBeta"
+                      },
+                      {
+                        "$ref": "#/components/schemas/DictionaryContainerBaseDictionaryContainerGamma"
+                      }
+                    ],
+                    "discriminator": {
+                      "propertyName": "$type",
+                      "mapping": {
+                        "alpha": "#/components/schemas/DictionaryContainerBaseDictionaryContainerAlpha",
+                        "beta": "#/components/schemas/DictionaryContainerBaseDictionaryContainerBeta",
+                        "gamma": "#/components/schemas/DictionaryContainerBaseDictionaryContainerGamma"
+                      }
+                    }
+                  },
+                  "DictionaryContainerBaseDictionaryContainerAlpha": {
+                    "required": [
+                      "tags",
+                      "labels"
+                    ],
+                    "type": "object",
+                    "properties": {
+                      "$type": {
+                        "enum": [
+                          "alpha"
+                        ],
+                        "type": "string"
+                      },
+                      "tags": {
+                        "type": [
+                          "null",
+                          "object"
+                        ],
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      },
+                      "labels": {
+                        "type": [
+                          "null",
+                          "object"
+                        ],
+                        "additionalProperties": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "DictionaryContainerBaseDictionaryContainerBeta": {
+                    "required": [
+                      "tags",
+                      "labels"
+                    ],
+                    "type": "object",
+                    "properties": {
+                      "$type": {
+                        "enum": [
+                          "beta"
+                        ],
+                        "type": "string"
+                      },
+                      "tags": {
+                        "type": [
+                          "null",
+                          "object"
+                        ],
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      },
+                      "labels": {
+                        "type": [
+                          "null",
+                          "object"
+                        ],
+                        "additionalProperties": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "DictionaryContainerBaseDictionaryContainerGamma": {
+                    "required": [
+                      "tags",
+                      "labels"
+                    ],
+                    "type": "object",
+                    "properties": {
+                      "$type": {
+                        "enum": [
+                          "gamma"
+                        ],
+                        "type": "string"
+                      },
+                      "tags": {
+                        "type": [
+                          "null",
+                          "object"
+                        ],
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      },
+                      "labels": {
+                        "type": [
+                          "null",
+                          "object"
+                        ],
+                        "additionalProperties": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "tags": [
+                {
+                  "name": "OpenApiDocumentServiceTests"
+                }
+              ]
+            }
+            """;
+
+        Assert.True(JsonNode.DeepEquals(JsonNode.Parse(actual), JsonNode.Parse(expected)));
     }
 }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Shared/SharedTypes.Polymorphism.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Shared/SharedTypes.Polymorphism.cs
@@ -133,3 +133,22 @@ internal class Manager : Employee
     public required string Department { get; set; }
 }
 
+// Type hierarchy for validating that dictionary-valued properties on the derived
+// types of a polymorphic base produce a complete schema for every derived type.
+// Regression test for https://github.com/dotnet/aspnetcore/issues/65759 where the
+// JSON pointers emitted by the STJ schema exporter (e.g. "#/anyOf/0/properties/...")
+// failed to resolve, leaving the second and subsequent derived types with an empty
+// `additionalProperties` schema.
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "$type")]
+[JsonDerivedType(typeof(DictionaryContainerAlpha), typeDiscriminator: "alpha")]
+[JsonDerivedType(typeof(DictionaryContainerBeta), typeDiscriminator: "beta")]
+[JsonDerivedType(typeof(DictionaryContainerGamma), typeDiscriminator: "gamma")]
+internal abstract class DictionaryContainerBase
+{
+    public required Dictionary<string, string> Tags { get; set; }
+    public required Dictionary<string, string[]> Labels { get; set; }
+}
+
+internal class DictionaryContainerAlpha : DictionaryContainerBase { }
+internal class DictionaryContainerBeta : DictionaryContainerBase { }
+internal class DictionaryContainerGamma : DictionaryContainerBase { }


### PR DESCRIPTION
# Fix array handling for JSON pointers when resolving OpenAPI schemas

Fixes #66800
Fixes #65759

The algorithm for resolving a reference (a JSON pointer) was naive and didn't implement the spec correctly.

1. It didn't handle retrieving a JsonArray element by index.
2. It didn't handle unescaping of `~1` and `~0`.
3. It didn't handle unescaping url-encoded values in the reference.

This PR attempts to implement it per the specification, referencing the relevant spec parts when needed.