### PR TITLE
Reject connection-specific headers sent via HPACK/QPACK indexed names

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -1619,10 +1619,6 @@ internal sealed partial class Http2Connection : IHttp2StreamLifetimeHandler, IHt
 
         try
         {
-            // https://www.rfc-editor.org/rfc/rfc9113#section-8.2.2
-            // Connection-specific header fields make a message malformed regardless of how the header name was
-            // encoded. HPACK's indexed-name representation (e.g. the "transfer-encoding" entry at static table
-            // index 57) would otherwise let these fields bypass the check below, so validate every header type.
             if (IsConnectionSpecificHeaderField(name, value))
             {
                 throw new Http2ConnectionErrorException(CoreStrings.HttpErrorConnectionSpecificHeaderField, Http2ErrorCode.PROTOCOL_ERROR, ConnectionEndReason.InvalidRequestHeaders);

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -1619,6 +1619,15 @@ internal sealed partial class Http2Connection : IHttp2StreamLifetimeHandler, IHt
 
         try
         {
+            // https://www.rfc-editor.org/rfc/rfc9113#section-8.2.2
+            // Connection-specific header fields make a message malformed regardless of how the header name was
+            // encoded. HPACK's indexed-name representation (e.g. the "transfer-encoding" entry at static table
+            // index 57) would otherwise let these fields bypass the check below, so validate every header type.
+            if (IsConnectionSpecificHeaderField(name, value))
+            {
+                throw new Http2ConnectionErrorException(CoreStrings.HttpErrorConnectionSpecificHeaderField, Http2ErrorCode.PROTOCOL_ERROR, ConnectionEndReason.InvalidRequestHeaders);
+            }
+
             if (_requestHeaderParsingState == RequestHeaderParsingState.Trailers)
             {
                 // Just use name + value bytes and do full validation for request trailers.
@@ -1694,11 +1703,6 @@ internal sealed partial class Http2Connection : IHttp2StreamLifetimeHandler, IHt
 
     private void ValidateHeaderContent(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
     {
-        if (IsConnectionSpecificHeaderField(name, value))
-        {
-            throw new Http2ConnectionErrorException(CoreStrings.HttpErrorConnectionSpecificHeaderField, Http2ErrorCode.PROTOCOL_ERROR, ConnectionEndReason.InvalidRequestHeaders);
-        }
-
         // http://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2
         // A request or response containing uppercase header field names MUST be treated as malformed (Section 8.1.2.6).
         for (var i = 0; i < name.Length; i++)

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -312,10 +312,6 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
 
         try
         {
-            // https://www.rfc-editor.org/rfc/rfc9114#section-4.2
-            // Connection-specific header fields make a message malformed regardless of how the header name was
-            // encoded. A QPACK indexed-name representation (referencing a dynamic table entry inserted via the
-            // encoder stream) would otherwise let these fields bypass the check below, so validate every header type.
             if (IsConnectionSpecificHeaderField(name, value))
             {
                 throw new Http3StreamErrorException(CoreStrings.HttpErrorConnectionSpecificHeaderField, Http3ErrorCode.MessageError);

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -312,6 +312,15 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
 
         try
         {
+            // https://www.rfc-editor.org/rfc/rfc9114#section-4.2
+            // Connection-specific header fields make a message malformed regardless of how the header name was
+            // encoded. A QPACK indexed-name representation (referencing a dynamic table entry inserted via the
+            // encoder stream) would otherwise let these fields bypass the check below, so validate every header type.
+            if (IsConnectionSpecificHeaderField(name, value))
+            {
+                throw new Http3StreamErrorException(CoreStrings.HttpErrorConnectionSpecificHeaderField, Http3ErrorCode.MessageError);
+            }
+
             if (_requestHeaderParsingState == RequestHeaderParsingState.Trailers)
             {
                 // Just use name + value bytes and do full validation for request trailers.
@@ -378,11 +387,6 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
 
     private void ValidateHeaderContent(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
     {
-        if (IsConnectionSpecificHeaderField(name, value))
-        {
-            throw new Http3StreamErrorException(CoreStrings.HttpErrorConnectionSpecificHeaderField, Http3ErrorCode.MessageError);
-        }
-
         // http://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2
         // A request or response containing uppercase header field names MUST be treated as malformed (Section 8.1.2.6).
         for (var i = 0; i < name.Length; i++)

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -3160,6 +3160,35 @@ public class Http2ConnectionTests : Http2TestBase
     }
 
     [Fact]
+    public async Task HEADERS_Received_TransferEncodingWithHPackIndexedName_ConnectionError()
+    {
+        await InitializeConnectionAsync(_noopApplication);
+
+        // Reference the "transfer-encoding" name via HPACK's indexed-name representation (static table index 57)
+        // with a literal "chunked" value. This exercises the OnStaticIndexedHeader(index, value) path, which must
+        // still reject connection-specific header fields even though the name was not sent as a literal string.
+        var headerBlock = new byte[]
+        {
+            0x82,                       // :method: GET (indexed, static index 2)
+            0x84,                       // :path: / (indexed, static index 4)
+            0x86,                       // :scheme: http (indexed, static index 6)
+            0x0f, 0x2a,                 // Literal Header Field without Indexing - Indexed Name (static index 57: transfer-encoding)
+            0x07,                       // value length: 7
+            (byte)'c', (byte)'h', (byte)'u', (byte)'n', (byte)'k', (byte)'e', (byte)'d',
+        };
+
+        await SendHeadersAsync(1, Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM, headerBlock);
+
+        await WaitForConnectionErrorAsync<Http2ConnectionErrorException>(
+            ignoreNonGoAwayFrames: false,
+            expectedLastStreamId: 1,
+            expectedErrorCode: Http2ErrorCode.PROTOCOL_ERROR,
+            expectedErrorMessage: CoreStrings.HttpErrorConnectionSpecificHeaderField);
+
+        AssertConnectionEndReason(ConnectionEndReason.InvalidRequestHeaders);
+    }
+
+    [Fact]
     public async Task HEADERS_Received_HeaderBlockContainsTEHeader_ValueIsTrailers_NoError()
     {
         var headers = new[]


### PR DESCRIPTION
﻿Fixes a gap in #66669. Connection-specific header fields (`connection`, `transfer-encoding`, `keep-alive`, `proxy-connection`, `upgrade`, `te`) were only rejected when sent as an HPACK/QPACK **literal name + value**. When the header **name** was sent using an **indexed-name representation**, the check was skipped.

Concretely, `transfer-encoding` is entry **57** in the HPACK static table. A request encoding it as *Literal Header Field - Indexed Name* (index 57) with a literal value `chunked` was routed through `OnStaticIndexedHeader(index, value)` -> `HeaderType.StaticAndValue`, which never called `ValidateHeaderContent`, so `IsConnectionSpecificHeaderField` was never evaluated. This allowed `Transfer-Encoding: chunked` through on HTTP/2.

HTTP/3 has the same structural gap: QPACK's static table contains no connection-specific header, but an entry inserted into the QPACK **dynamic table** via the encoder stream (which isn't validated on that path) could then be referenced by a dynamic indexed name (`HeaderType.Dynamic`), bypassing the same check.

## Fix

Move the `IsConnectionSpecificHeaderField` check out of `ValidateHeaderContent` and to the top of `OnHeaderCore` in both `Http2Connection` and `Http3Stream`, so it runs for **every** header representation - fully indexed, indexed-name + literal value, and literal name + value - as well as trailers. The decoded `name`/`value` spans are always populated for these callbacks, so no additional decoding is required.

Only connection-specific header fields are affected; no other/legitimate headers change behavior.

## Tests

- Added `HEADERS_Received_TransferEncodingWithHPackIndexedName_ConnectionError`, which sends a hand-crafted HPACK block referencing `transfer-encoding` by static index 57 with a literal `chunked` value and asserts a `PROTOCOL_ERROR` connection error with `HttpErrorConnectionSpecificHeaderField`.
- Existing connection-specific / trailer / header-validation tests still pass (245 filtered tests green).

Refs #66669.
