### PR TITLE
Fix RDG check for endpoint uniqueness

### DIFF
--- a/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator/StaticRouteHandlerModel/Endpoint.cs
+++ b/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator/StaticRouteHandlerModel/Endpoint.cs
@@ -124,7 +124,7 @@ internal class Endpoint
 
         for (var i = 0; i < a.Parameters.Length; i++)
         {
-            if (!a.Parameters[i].SignatureEquals(b.Parameters[i]))
+            if (!a.Parameters[i].Equals(b.Parameters[i]))
             {
                 return false;
             }
@@ -141,7 +141,7 @@ internal class Endpoint
 
         foreach (var parameter in endpoint.Parameters)
         {
-            hashCode.Add(parameter.Type, SymbolEqualityComparer.Default);
+            hashCode.Add(parameter);
         }
 
         return hashCode.ToHashCode();

--- a/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator/StaticRouteHandlerModel/EndpointParameter.cs
+++ b/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator/StaticRouteHandlerModel/EndpointParameter.cs
@@ -601,15 +601,6 @@ internal class EndpointParameter
         SymbolEqualityComparer.IncludeNullability.Equals(other.Type, Type) &&
         other.KeyedServiceKey == KeyedServiceKey;
 
-    public bool SignatureEquals(object obj) =>
-        obj is EndpointParameter other &&
-        SymbolEqualityComparer.IncludeNullability.Equals(other.Type, Type) &&
-        // The name of the parameter matters when we are querying for a specific parameter using
-        // an indexer, like `context.Request.RouteValues["id"]` or `context.Request.Query["id"]`
-        // and when generating log messages for required bodies or services.
-        other.SymbolName == SymbolName &&
-        other.KeyedServiceKey == KeyedServiceKey;
-
     public override int GetHashCode()
     {
         var hashCode = new HashCode();

--- a/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator/StaticRouteHandlerModel/EndpointParameter.cs
+++ b/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator/StaticRouteHandlerModel/EndpointParameter.cs
@@ -596,6 +596,7 @@ internal class EndpointParameter
         obj is EndpointParameter other &&
         other.Source == Source &&
         other.SymbolName == SymbolName &&
+        other.LookupName == LookupName &&
         other.Ordinal == Ordinal &&
         other.IsOptional == IsOptional &&
         SymbolEqualityComparer.IncludeNullability.Equals(other.Type, Type) &&
@@ -604,8 +605,13 @@ internal class EndpointParameter
     public override int GetHashCode()
     {
         var hashCode = new HashCode();
+        hashCode.Add(Source);
         hashCode.Add(SymbolName);
+        hashCode.Add(LookupName);
+        hashCode.Add(Ordinal);
+        hashCode.Add(IsOptional);
         hashCode.Add(Type, SymbolEqualityComparer.IncludeNullability);
+        hashCode.Add(KeyedServiceKey);
         return hashCode.ToHashCode();
     }
 }

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.JsonBody.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.JsonBody.cs
@@ -111,6 +111,32 @@ app.MapPost("/", postTodoWithDefault){withFilter}
     }
 
     [Fact]
+    public async Task MapAction_ExplicitBodyParam_SharedDelegateSignature_PreservesEmptyBodyBehavior()
+    {
+        // Regression test for https://github.com/dotnet/aspnetcore/issues/66912.
+        // Two endpoints that share the same delegate signature (Todo) => IResult but differ only
+        // in their binding attribute ([FromBody] required vs [FromBody(EmptyBodyBehavior = Allow)])
+        // must each get their own interceptor. Otherwise the second endpoint's EmptyBodyBehavior is
+        // silently dropped and it incorrectly returns 400 for an empty body.
+        var source = """
+app.MapPost("/required", ([FromBody] Todo todo) => TypedResults.Ok(todo));
+app.MapPost("/allow-empty", ([FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Allow)] Todo todo) => TypedResults.Ok(todo));
+""";
+        var (_, compilation) = await RunGeneratorAsync(source);
+        var endpoints = GetEndpointsFromCompilation(compilation);
+
+        Assert.Equal(2, endpoints.Length);
+
+        var requiredHttpContext = CreateHttpContextWithEmptyJsonBody();
+        await endpoints[0].RequestDelegate(requiredHttpContext);
+        await VerifyResponseBodyAsync(requiredHttpContext, string.Empty, expectedStatusCode: 400);
+
+        var allowEmptyHttpContext = CreateHttpContextWithEmptyJsonBody();
+        await endpoints[1].RequestDelegate(allowEmptyHttpContext);
+        await VerifyResponseBodyAsync(allowEmptyHttpContext, string.Empty, expectedStatusCode: 200);
+    }
+
+    [Fact]
     public async Task MapAction_ExplicitBodyParam_ComplexReturn_Snapshot()
     {
         var expectedBody = """{"id":0,"name":"Test Item","isComplete":false}""";

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.cs
@@ -218,6 +218,35 @@ app.MapGet("/", getHeaderWithDefault);
         await VerifyResponseBodyAsync(httpContext, expectedBody, expectedStatusCode);
     }
 
+    [Fact]
+    public async Task MapAction_ExplicitHeaderParam_SharedDelegateSignature_PreservesBindingName()
+    {
+        // Regression test for https://github.com/dotnet/aspnetcore/pull/67591#discussion_r3521138229.
+        // Two endpoints that share the same delegate signature (string) => string but differ only in
+        // their [FromHeader(Name = ...)] binding name must each get their own interceptor. Otherwise
+        // the second endpoint silently reuses the first endpoint's header name.
+        var source = """
+app.MapGet("/a", ([FromHeader(Name = "X-Custom-A")] string value) => value);
+app.MapGet("/b", ([FromHeader(Name = "X-Custom-B")] string value) => value);
+""";
+        var (_, compilation) = await RunGeneratorAsync(source);
+        var endpoints = GetEndpointsFromCompilation(compilation);
+
+        Assert.Equal(2, endpoints.Length);
+
+        var httpContextA = CreateHttpContext();
+        httpContextA.Request.Headers["X-Custom-A"] = "from-a";
+        httpContextA.Request.Headers["X-Custom-B"] = "from-b";
+        await endpoints[0].RequestDelegate(httpContextA);
+        await VerifyResponseBodyAsync(httpContextA, "from-a");
+
+        var httpContextB = CreateHttpContext();
+        httpContextB.Request.Headers["X-Custom-A"] = "from-a";
+        httpContextB.Request.Headers["X-Custom-B"] = "from-b";
+        await endpoints[1].RequestDelegate(httpContextB);
+        await VerifyResponseBodyAsync(httpContextB, "from-b");
+    }
+
     public static object[][] MapAction_ExplicitServiceParam_SimpleReturn_Data
     {
         get


### PR DESCRIPTION
Fixes #66912

Before the fix, we considered the signature for both of the following endpoints as the same:

```csharp
app.MapPost("/required",    (Todo t) => "ok");
app.MapPost("/allow-empty", ([FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Allow)] Todo t) => "ok");
```

And so they collapsed into a single interceptor, even though they would otherwise have had different implementations.

This PR makes the equality of endpoint parameter stronger so that the parameter source and optionality are taken into account.

This removes SignatureEquals from EndpointParameter, which was a subset of EndpointParameter.Equals. And we now use EndpointParameter.Equals for correct and accurate equality.

In addition, Endpoint hash code calculation now considers the full hash code of the endpoint parameters, instead of taking only the type into account.