### PR TITLE
SignalR .NET client: make auth refresh work behind a redirecting server (Azure SignalR)

### DIFF
--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionTests.AuthenticationRefresh.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionTests.AuthenticationRefresh.cs
@@ -296,6 +296,114 @@ public partial class HttpConnectionTests
         }
 
         [Fact]
+        public async Task RefreshAuthenticationAsyncAdoptsAccessTokenFromResponseForSubsequentTransportRequests()
+        {
+            // The client should adopt the optional returned refreshed access token as the transport credential so subsequent Long Polling polls/sends carry the refreshed token.
+            var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
+            testHttpHandler.OnNegotiate((_, _) => ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationContent(negotiateVersion: 1)));
+            testHttpHandler.OnLongPollDelete(_ => ResponseUtils.CreateResponse(HttpStatusCode.Accepted));
+
+            var firstPollReceivedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseFirstPollTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var refreshedPollAuthTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var pollCount = 0;
+            testHttpHandler.OnLongPoll(async (request, _) =>
+            {
+                var poll = Interlocked.Increment(ref pollCount);
+                if (poll == 1)
+                {
+                    // A poll carrying the connect-time token is in flight. Park it until the refresh completes.
+                    firstPollReceivedTcs.TrySetResult();
+                    await releaseFirstPollTcs.Task;
+                    return ResponseUtils.CreateResponse(HttpStatusCode.OK);
+                }
+
+                // The next poll is issued after the refresh adopted the response accessToken; capture its token.
+                refreshedPollAuthTcs.TrySetResult(request.Headers.Authorization?.Parameter);
+                return ResponseUtils.CreateResponse(HttpStatusCode.NoContent);
+            });
+
+            OnRefresh(testHttpHandler, (_, _) =>
+                Task.FromResult(ResponseUtils.CreateResponse(HttpStatusCode.OK,
+                    "{\"connectionId\":\"abc\",\"tokenLifetimeSeconds\":60,\"accessToken\":\"service-token\"}")));
+
+            // The application (app-plane) token never changes; the new transport credential comes from the response.
+            Task<string> AccessTokenProvider()
+            {
+                return Task.FromResult("app-token");
+            }
+
+            using (var noErrorScope = new VerifyNoErrorsScope())
+            {
+                await WithConnectionAsync(
+                    CreateConnection(testHttpHandler, loggerFactory: noErrorScope.LoggerFactory, accessTokenProvider: AccessTokenProvider),
+                    async connection =>
+                    {
+                        await connection.StartAsync().DefaultTimeout();
+                        await firstPollReceivedTcs.Task.DefaultTimeout();
+
+                        await ((IAuthenticationRefreshFeature)connection).RefreshAuthenticationAsync().DefaultTimeout();
+
+                        // Allow the next poll to be issued now that the cache should hold the refreshed service token.
+                        releaseFirstPollTcs.TrySetResult();
+
+                        var refreshedPollAuth = await refreshedPollAuthTcs.Task.DefaultTimeout();
+                        Assert.Equal("service-token", refreshedPollAuth);
+                    });
+            }
+        }
+
+        [Fact]
+        public async Task RefreshAuthenticationAsyncUsesApplicationTokenAfterRedirect()
+        {
+            // /refresh belongs to the application auth plane. The /refresh request must be authenticated with the application's own AccessTokenProvider token, not the redirected one.
+            var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
+            var negotiateCount = 0;
+            testHttpHandler.OnNegotiate((request, _) =>
+            {
+                negotiateCount++;
+                if (negotiateCount == 1)
+                {
+                    return ResponseUtils.CreateResponse(HttpStatusCode.OK,
+                        "{\"url\":\"http://redirected.example/hub?existing=true\",\"accessToken\":\"redirect-token\"}");
+                }
+
+                return ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationContent(negotiateVersion: 1));
+            });
+            testHttpHandler.OnLongPoll(_ => ResponseUtils.CreateResponse(HttpStatusCode.NoContent));
+            testHttpHandler.OnLongPollDelete(_ => ResponseUtils.CreateResponse(HttpStatusCode.Accepted));
+
+            var refreshRequestTcs = new TaskCompletionSource<HttpRequestMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+            OnRefresh(testHttpHandler, (request, _) =>
+            {
+                refreshRequestTcs.TrySetResult(request);
+                return Task.FromResult(ResponseUtils.CreateResponse(HttpStatusCode.OK, "{\"connectionId\":\"abc\",\"tokenLifetimeSeconds\":60}"));
+            });
+
+            // Transport (after redirect) uses "redirect-token"; the app-plane provider stays "app-token".
+            Task<string> AccessTokenProvider()
+            {
+                return Task.FromResult("app-token");
+            }
+
+            using (var noErrorScope = new VerifyNoErrorsScope())
+            {
+                await WithConnectionAsync(
+                    CreateConnection(testHttpHandler, url: "http://original.example/hub", loggerFactory: noErrorScope.LoggerFactory, accessTokenProvider: AccessTokenProvider),
+                    async connection =>
+                    {
+                        await connection.StartAsync().DefaultTimeout();
+                        await ((IAuthenticationRefreshFeature)connection).RefreshAuthenticationAsync().DefaultTimeout();
+                    });
+            }
+
+            var request = await refreshRequestTcs.Task.DefaultTimeout();
+            Assert.NotNull(request.Headers.Authorization);
+            Assert.Equal("Bearer", request.Headers.Authorization.Scheme);
+            Assert.Equal("app-token", request.Headers.Authorization.Parameter);
+        }
+
+        [Fact]
         public async Task RefreshAuthenticationAsyncSendsBearerTokenWhenAccessTokenProviderConfigured()
         {
             var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
@@ -804,6 +804,18 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
             _accessTokenProvider = () => Task.FromResult<string?>(accessToken);
             _accessTokenHandler?.UpdateCachedToken(accessToken);
         }
+        else
+        {
+#if NET5_0_OR_GREATER
+            request.Options.TryGetValue(new HttpRequestOptionsKey<string?>("RefreshRequestToken"), out var refreshRequestToken);
+#else
+            var refreshRequestToken = request.Properties.TryGetValue("RefreshRequestToken", out var stashedToken) ? stashedToken as string : null;
+#endif
+            if (!string.IsNullOrEmpty(refreshRequestToken))
+            {
+                _accessTokenHandler?.UpdateCachedToken(refreshRequestToken);
+            }
+        }
 
         return tokenLifetime;
     }

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
@@ -54,6 +54,7 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
     private readonly ILoggerFactory _loggerFactory;
     private readonly Uri _url;
     private Func<Task<string?>>? _accessTokenProvider;
+    private AccessTokenHttpMessageHandler? _accessTokenHandler;
 
     /// <inheritdoc />
     public override IDuplexPipe Transport
@@ -635,7 +636,8 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
             }
 
             // Apply the authorization header in a handler instead of a default header because it can change with each request
-            httpMessageHandler = new AccessTokenHttpMessageHandler(httpMessageHandler, this);
+            _accessTokenHandler = new AccessTokenHttpMessageHandler(httpMessageHandler, this);
+            httpMessageHandler = _accessTokenHandler;
         }
 
         // Wrap message handler after HttpMessageHandlerFactory to ensure not overridden
@@ -703,6 +705,16 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
             return _noAccessToken;
         }
         return _accessTokenProvider();
+    }
+
+    // Get the original app token used to authenticate the /refresh request.
+    internal Task<string?> GetRefreshRequestTokenAsync()
+    {
+        if (_httpConnectionOptions.AccessTokenProvider == null)
+        {
+            return _noAccessToken;
+        }
+        return _httpConnectionOptions.AccessTokenProvider();
     }
 
     private void CheckDisposed()
@@ -773,13 +785,25 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
 #pragma warning disable CA2016 // Forward the 'CancellationToken' parameter to methods
         var responseBuffer = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
 #pragma warning restore CA2016
-        // Parse the simple JSON response: { "tokenLifetimeSeconds": ... }
-        return ParseRefreshTokenLifetime(responseBuffer);
+        // Parse the /refresh response: { "tokenLifetimeSeconds"?: ..., "accessToken"?: ... }
+        var (tokenLifetime, accessToken) = ParseRefreshResponse(responseBuffer);
+
+        // Azure SignalR returns a refreshed service access token in the /refresh response body.
+        // Adopt it as the new transport credential, mirroring how the negotiate redirect captures the initial token,
+        // so Long Polling / SSE / reconnect use the refreshed token.
+        // Self-hosted SignalR omits accessToken and keeps the token the client already sent.
+        if (!string.IsNullOrEmpty(accessToken))
+        {
+            _accessTokenProvider = () => Task.FromResult<string?>(accessToken);
+            _accessTokenHandler?.UpdateCachedToken(accessToken);
+        }
+
+        return tokenLifetime;
     }
 
-    // Manually reads "tokenLifetimeSeconds" from the /refresh response with a Utf8JsonReader, consistent with
-    // NegotiateProtocol.ParseResponse rather than materializing a JsonDocument for a single optional value.
-    private static TimeSpan? ParseRefreshTokenLifetime(ReadOnlySpan<byte> content)
+    // Manually reads "tokenLifetimeSeconds" and the optional "accessToken" from the /refresh response with a
+    // Utf8JsonReader, consistent with NegotiateProtocol.ParseResponse rather than materializing a JsonDocument.
+    private static (TimeSpan? TokenLifetime, string? AccessToken) ParseRefreshResponse(ReadOnlySpan<byte> content)
     {
         var reader = new Utf8JsonReader(content, isFinalBlock: true, state: default);
 
@@ -789,6 +813,7 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
         }
 
         TimeSpan? tokenLifetime = null;
+        string? accessToken = null;
         while (reader.Read())
         {
             switch (reader.TokenType)
@@ -802,16 +827,24 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
                             tokenLifetime = TimeSpan.FromSeconds(reader.GetInt32());
                         }
                     }
+                    else if (reader.ValueTextEquals("accessToken"u8))
+                    {
+                        reader.Read();
+                        if (reader.TokenType == JsonTokenType.String)
+                        {
+                            accessToken = reader.GetString();
+                        }
+                    }
                     else
                     {
                         reader.Skip();
                     }
                     break;
                 case JsonTokenType.EndObject:
-                    return tokenLifetime;
+                    return (tokenLifetime, accessToken);
             }
         }
 
-        return tokenLifetime;
+        return (tokenLifetime, accessToken);
     }
 }

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
@@ -54,6 +54,7 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
     private readonly ILoggerFactory _loggerFactory;
     private readonly Uri _url;
     private Func<Task<string?>>? _accessTokenProvider;
+    private readonly Func<Task<string?>>? _appAccessTokenProvider;
     private AccessTokenHttpMessageHandler? _accessTokenHandler;
 
     /// <inheritdoc />
@@ -152,6 +153,8 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
 
         _logger = _loggerFactory.CreateLogger(typeof(HttpConnection));
         _httpConnectionOptions = httpConnectionOptions;
+        // Capture the app's access token provider now before any transport overwrites
+        _appAccessTokenProvider = httpConnectionOptions.AccessTokenProvider;
 
         _url = _httpConnectionOptions.Url;
 
@@ -710,11 +713,11 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
     // Get the original app token used to authenticate the /refresh request.
     internal Task<string?> GetRefreshRequestTokenAsync()
     {
-        if (_httpConnectionOptions.AccessTokenProvider == null)
+        if (_appAccessTokenProvider == null)
         {
             return _noAccessToken;
         }
-        return _httpConnectionOptions.AccessTokenProvider();
+        return _appAccessTokenProvider();
     }
 
     private void CheckDisposed()
@@ -752,7 +755,11 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
             negotiationResponse.ConnectionToken = _connectionId;
         }
         _connectionToken = negotiationResponse.ConnectionToken;
-        _initialTokenLifetime = negotiationResponse.TokenLifetime;
+        // Preserve a token lifetime reported by an earlier negotiate in the redirect chain.
+        if (negotiationResponse.TokenLifetime is not null)
+        {
+            _initialTokenLifetime = negotiationResponse.TokenLifetime;
+        }
 
         _logScope.ConnectionId = _connectionId;
         return negotiationResponse;

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/AccessTokenHttpMessageHandler.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/AccessTokenHttpMessageHandler.cs
@@ -50,23 +50,22 @@ internal sealed class AccessTokenHttpMessageHandler : DelegatingHandler
             {
                 _accessToken = tokenForRequest;
             }
+            else
+            {
+#if NET5_0_OR_GREATER
+                request.Options.Set(new HttpRequestOptionsKey<string?>("RefreshRequestToken"), tokenForRequest);
+#else
+                request.Properties["RefreshRequestToken"] = tokenForRequest;
+#endif
+            }
         }
 
         SetAccessToken(tokenForRequest, request);
 
         var result = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
-        if (isRefresh)
-        {
-            // Only adopt the refreshed token once the server has accepted the refresh, so subsequent
-            // transport requests use the new token. On rejection, keep the previously cached token.
-            if (result.IsSuccessStatusCode)
-            {
-                _accessToken = tokenForRequest;
-            }
-        }
         // retry once with a new token on auth failure
-        else if (shouldRetry && result.StatusCode is HttpStatusCode.Unauthorized)
+        if (shouldRetry && result.StatusCode is HttpStatusCode.Unauthorized)
         {
             HttpConnection.Log.RetryAccessToken(_httpConnection._logger, result.StatusCode);
             result.Dispose();

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/AccessTokenHttpMessageHandler.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/AccessTokenHttpMessageHandler.cs
@@ -38,7 +38,9 @@ internal sealed class AccessTokenHttpMessageHandler : DelegatingHandler
             shouldRetry = false;
             // Negotiate redirects likely will have a new access token so let's always grab a (potentially) new access token on negotiate.
             // Authentication refresh exists specifically to obtain a new access token, so always re-fetch on refresh too.
-            tokenForRequest = await _httpConnection.GetAccessTokenAsync().ConfigureAwait(false);
+            tokenForRequest = isRefresh
+                ? await _httpConnection.GetRefreshRequestTokenAsync().ConfigureAwait(false)
+                : await _httpConnection.GetAccessTokenAsync().ConfigureAwait(false);
 
             // For negotiate (and the initial fetch) adopt the new token immediately. For refresh, defer
             // updating the cache until we know the server accepted the refresh (below): a rejected
@@ -88,4 +90,7 @@ internal sealed class AccessTokenHttpMessageHandler : DelegatingHandler
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
         }
     }
+
+    // Adopts a token obtained outside the normal request flow as the cached transport credential.
+    internal void UpdateCachedToken(string? accessToken) => _accessToken = accessToken;
 }


### PR DESCRIPTION
# SignalR .NET client: make auth refresh work behind a redirecting server (Azure SignalR)

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Summary of the changes (Less than 80 chars)

Makes the SignalR `/refresh` flow work when negotiate redirects to another server and the transport token differs from the app token (i.e. the Azure SignalR), without changing how self-hosted SignalR behaves. See Azure SignalR's refresh flow at https://github.com/Azure/azure-signalr/issues/2282.

## Description

### Why

Behind Azure SignalR:

- Negotiate redirects: the app server authenticates the **app** token and reports `tokenLifetimeSeconds`; the service returns the **service** token the transport uses.
- `/refresh` must be sent with the **app** token, and its response returns a refreshed **service** token the transport must adopt.

The stock client didn't handle this, so refresh sent the wrong token, ignored the refreshed one, and lost the advertised lifetime across the redirect.

## Changes

1. **Send `/refresh` with the app token.** Added `GetRefreshRequestTokenAsync()`, used by `AccessTokenHttpMessageHandler` for refresh requests. The app provider is captured into a new `_appAccessTokenProvider` field **before** transports overwrite `HttpConnectionOptions.AccessTokenProvider` with the service token.

2. **Adopt the refreshed token from the `/refresh` response.** `ParseRefreshResponse` now reads an optional `accessToken` alongside `tokenLifetimeSeconds`; when present, it becomes the new transport credential (`UpdateCachedToken`), so Long Polling / SSE / reconnect keep working past the original token's expiry. Self-hosted omits `accessToken`, so this is a no-op there.

3. **Preserve `tokenLifetimeSeconds` across the redirect.** Only overwrite `_initialTokenLifetime` when a negotiate hop actually reports one, so the value from the app-server hop isn't nulled out by the redirect hop, which is needed for the client's auto-refresh scheduler.