### PR TITLE
Rerun PostRoutingPipeline on Rerouting

### DIFF
--- a/src/DefaultBuilder/src/Internal/CsrfProtectionMiddleware.cs
+++ b/src/DefaultBuilder/src/Internal/CsrfProtectionMiddleware.cs
@@ -35,18 +35,19 @@ internal sealed partial class CsrfProtectionMiddleware
     public Task InvokeAsync(HttpContext context)
     {
         var endpoint = context.GetEndpoint();
-        var antiforgeryMetadata = endpoint?.Metadata.GetMetadata<IAntiforgeryMetadata>();
-
-        // Skip stamping the marker on the hot non-antiforgery path to avoid allocating the lazy HttpContext.Items dictionary.
-        // Still set it when:
-        //   - endpoint is null (a later re-routing may fall into an antiforgery-required page (e.g. via UseStatusCodePagesWithReExecute); this middleware does not re-run on reroute)
-        //   - the endpoint carries any IAntiforgeryMetadata (DisableAntiforgery, or RequiresValidation:true).
-        if (endpoint is null || antiforgeryMetadata is not null)
+        if (endpoint is null)
         {
-            context.Items[MiddlewareInvokedKeys.CsrfProtection] = MiddlewareInvokedKeys.Sentinel;
+            return _next(context);
         }
 
-        if (antiforgeryMetadata is not { RequiresValidation: true })
+        var antiforgeryMetadata = endpoint.Metadata.GetMetadata<IAntiforgeryMetadata>();
+        if (antiforgeryMetadata is null)
+        {
+            return _next(context);
+        }
+
+        context.Items[MiddlewareInvokedKeys.CsrfProtection] = MiddlewareInvokedKeys.Sentinel;
+        if (!antiforgeryMetadata.RequiresValidation)
         {
             return _next(context);
         }

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/CsrfProtectionIntegrationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/CsrfProtectionIntegrationTests.cs
@@ -1443,7 +1443,7 @@ public class CsrfProtectionIntegrationTests
     }
 
     [Fact]
-    public async Task Repro_BlazorTemplatePipeline_CsrfMarkerIsStampedBeforeEndpoint_OnReroute()
+    public async Task Repro_BlazorTemplatePipeline_CsrfMarkerIsStampedBeforeEndpoint_WithStatusCodePagesMiddleware()
     {
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
@@ -1652,6 +1652,38 @@ public class CsrfProtectionIntegrationTests
         Assert.Contains(
             probe.ObservedEndpoints,
             e => e is not null && e.Metadata.GetMetadata<IAntiforgeryMetadata>() is { RequiresValidation: true });
+    }
+
+    [Fact]
+    public async Task CsrfProtection_UseStatusCodePagesWithReExecute_ReadsCorsMetadataOnReroutedEndpoint()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddCors(options =>
+            options.AddPolicy("Trusted", p => p.WithOrigins("https://trusted.example.com")));
+        using var app = builder.Build();
+
+        app.UseStatusCodePagesWithReExecute("/not-found");
+        app.UseCors();
+        app.MapPost("/not-found", EnforceCsrfProtected)
+            .RequireCors("Trusted")
+            .WithMetadata(new RequireAntiforgeryTokenAttribute());
+
+        await app.StartAsync();
+        var client = app.GetTestClient();
+
+        var trusted = new HttpRequestMessage(HttpMethod.Post, "/does-not-exist");
+        trusted.Headers.Add("Sec-Fetch-Site", "cross-site");
+        trusted.Headers.Add("Origin", "https://trusted.example.com");
+        var trustedResponse = await client.SendAsync(trusted);
+        Assert.Equal("allowed", await trustedResponse.Content.ReadAsStringAsync());
+
+        var untrusted = new HttpRequestMessage(HttpMethod.Post, "/does-not-exist");
+        untrusted.Headers.Add("Sec-Fetch-Site", "cross-site");
+        untrusted.Headers.Add("Origin", "https://evil.example.com");
+        var untrustedResponse = await client.SendAsync(untrusted);
+        Assert.Equal(HttpStatusCode.BadRequest, untrustedResponse.StatusCode);
+        Assert.Equal("protected", await untrustedResponse.Content.ReadAsStringAsync());
     }
 
     [Fact]

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/CsrfProtectionIntegrationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/CsrfProtectionIntegrationTests.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Rewrite;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -1417,15 +1418,265 @@ public class CsrfProtectionIntegrationTests
 
     private sealed class EndpointCapturingCsrfProtection : ICsrfProtection
     {
+        private readonly ICsrfProtection _inner;
+
+        public EndpointCapturingCsrfProtection()
+            : this(new DefaultCsrfProtection())
+        {
+        }
+
+        public EndpointCapturingCsrfProtection(ICsrfProtection inner)
+        {
+            _inner = inner;
+        }
+
         public List<Endpoint?> ObservedEndpoints { get; } = new();
 
-        public ValueTask<CsrfProtectionResult> ValidateAsync(HttpContext context)
+        public async ValueTask<CsrfProtectionResult> ValidateAsync(HttpContext context)
         {
             lock (ObservedEndpoints)
             {
                 ObservedEndpoints.Add(context.GetEndpoint());
             }
-            return ValueTask.FromResult(CsrfProtectionResult.Allowed());
+            return await _inner.ValidateAsync(context);
         }
+    }
+
+    [Fact]
+    public async Task Repro_BlazorTemplatePipeline_CsrfMarkerIsStampedBeforeEndpoint_OnReroute()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        using var app = builder.Build();
+
+        app.UseStatusCodePagesWithReExecute("/not-found", createScopeForStatusCodePages: true);
+
+        object? observedMarker = null;
+        app.MapGet("/", (HttpContext ctx) =>
+        {
+            ctx.Items.TryGetValue(CsrfProtectionInvokedKey, out observedMarker);
+            return "home";
+        }).WithMetadata(new RequireAntiforgeryTokenAttribute());
+        app.MapGet("/not-found", (HttpContext ctx) =>
+        {
+            ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+            return Task.CompletedTask;
+        }).WithMetadata(new RequireAntiforgeryTokenAttribute());
+
+        await app.StartAsync();
+        var client = app.GetTestClient();
+        var response = await client.GetAsync("/");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(observedMarker);
+    }
+
+    [Fact]
+    public async Task CsrfProtection_MultipleUseRouting_CsrfMarkerStamped()
+    {
+        var probe = new EndpointCapturingCsrfProtection();
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddSingleton<ICsrfProtection>(probe);
+        using var app = builder.Build();
+
+        app.UseRouting();
+        app.UseRouting();
+
+        object? observedMarker = null;
+        app.MapPost("/", (HttpContext ctx) =>
+        {
+            ctx.Items.TryGetValue(CsrfProtectionInvokedKey, out observedMarker);
+            return "home";
+        }).WithMetadata(new RequireAntiforgeryTokenAttribute());
+
+        await app.StartAsync();
+        var req = new HttpRequestMessage(HttpMethod.Post, "/");
+        req.Headers.Add("Sec-Fetch-Site", "same-origin");
+        var response = await app.GetTestClient().SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(observedMarker);
+        Assert.Equal(2, probe.ObservedEndpoints.Count);
+    }
+
+    [Fact]
+    public async Task CsrfProtection_ExplicitUseRoutingAndUseEndpoints_CsrfMarkerStamped()
+    {
+        var probe = new EndpointCapturingCsrfProtection();
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddSingleton<ICsrfProtection>(probe);
+        using var app = builder.Build();
+
+        app.UseRouting();
+
+        object? observedMarker = null;
+        app.UseEndpoints(endpoints =>
+        {
+            endpoints.MapPost("/", (HttpContext ctx) =>
+            {
+                ctx.Items.TryGetValue(CsrfProtectionInvokedKey, out observedMarker);
+                return "home";
+            }).WithMetadata(new RequireAntiforgeryTokenAttribute());
+        });
+
+        await app.StartAsync();
+        var req = new HttpRequestMessage(HttpMethod.Post, "/");
+        req.Headers.Add("Sec-Fetch-Site", "same-origin");
+        var response = await app.GetTestClient().SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(observedMarker);
+        Assert.Single(probe.ObservedEndpoints);
+    }
+
+    [Fact]
+    public async Task CsrfProtection_MapWhen_MainPipelineEndpoint_CsrfMarkerStamped()
+    {
+        var probe = new EndpointCapturingCsrfProtection();
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddSingleton<ICsrfProtection>(probe);
+        using var app = builder.Build();
+
+        app.MapWhen(
+            ctx => ctx.Request.Path.StartsWithSegments("/branch"),
+            branch => branch.Run(ctx => ctx.Response.WriteAsync("branch")));
+
+        object? observedMarker = null;
+        app.MapPost("/", (HttpContext ctx) =>
+        {
+            ctx.Items.TryGetValue(CsrfProtectionInvokedKey, out observedMarker);
+            return "home";
+        }).WithMetadata(new RequireAntiforgeryTokenAttribute());
+
+        await app.StartAsync();
+        var req = new HttpRequestMessage(HttpMethod.Post, "/");
+        req.Headers.Add("Sec-Fetch-Site", "same-origin");
+        var response = await app.GetTestClient().SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(observedMarker);
+        Assert.Single(probe.ObservedEndpoints);
+    }
+
+    [Fact]
+    public async Task CsrfProtection_MapWhenBranchTaken_MainEndpointNotHit()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        using var app = builder.Build();
+
+        app.MapWhen(
+            ctx => ctx.Request.Path.StartsWithSegments("/branch"),
+            branch => branch.Run(ctx => ctx.Response.WriteAsync("branch")));
+
+        app.MapGet("/", () => "home").WithMetadata(new RequireAntiforgeryTokenAttribute());
+
+        await app.StartAsync();
+        var response = await app.GetTestClient().GetAsync("/branch");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("branch", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task CsrfProtection_UsePathBase_CsrfMarkerStamped()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        using var app = builder.Build();
+
+        app.UsePathBase("/base");
+
+        object? observedMarker = null;
+        app.MapGet("/hello", (HttpContext ctx) =>
+        {
+            ctx.Items.TryGetValue(CsrfProtectionInvokedKey, out observedMarker);
+            return "hello";
+        }).WithMetadata(new RequireAntiforgeryTokenAttribute());
+
+        await app.StartAsync();
+        var response = await app.GetTestClient().GetAsync("/base/hello");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(observedMarker);
+    }
+
+    [Fact]
+    public async Task CsrfProtection_UseExceptionHandler_CsrfMarkerStampedOnErrorEndpoint()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        using var app = builder.Build();
+
+        app.UseExceptionHandler("/error");
+
+        object? observedMarkerOnError = null;
+        app.MapGet("/throw", (HttpContext _) => { throw new InvalidOperationException("boom"); });
+        app.MapGet("/error", (HttpContext ctx) =>
+        {
+            ctx.Items.TryGetValue(CsrfProtectionInvokedKey, out observedMarkerOnError);
+            return "error";
+        }).WithMetadata(new RequireAntiforgeryTokenAttribute());
+
+        await app.StartAsync();
+        var response = await app.GetTestClient().GetAsync("/throw");
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        Assert.NotNull(observedMarkerOnError);
+    }
+
+    [Fact]
+    public async Task CsrfProtection_UseStatusCodePagesWithReExecute_CsrfMarkerStampedOnReroutedRequest()
+    {
+        var probe = new EndpointCapturingCsrfProtection();
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddSingleton<ICsrfProtection>(probe);
+        using var app = builder.Build();
+
+        app.UseStatusCodePagesWithReExecute("/not-found");
+
+        app.MapGet("/not-found", (HttpContext ctx) =>
+        {
+            ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+            return ctx.Response.WriteAsync("not found");
+        }).WithMetadata(new RequireAntiforgeryTokenAttribute());
+
+        await app.StartAsync();
+        var response = await app.GetTestClient().GetAsync("/does-not-exist");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Contains(
+            probe.ObservedEndpoints,
+            e => e is not null && e.Metadata.GetMetadata<IAntiforgeryMetadata>() is { RequiresValidation: true });
+    }
+
+    [Fact]
+    public async Task CsrfProtection_UseRewriter_CsrfMarkerStampedOnRewrittenEndpoint()
+    {
+        var probe = new EndpointCapturingCsrfProtection();
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddSingleton<ICsrfProtection>(probe);
+        using var app = builder.Build();
+
+        app.UseRewriter(new RewriteOptions().AddRewrite("^old/(.*)", "new/$1", skipRemainingRules: true));
+
+        object? observedMarker = null;
+        app.MapGet("/new/{value}", (HttpContext ctx, string value) =>
+        {
+            ctx.Items.TryGetValue(CsrfProtectionInvokedKey, out observedMarker);
+            return value;
+        }).WithMetadata(new RequireAntiforgeryTokenAttribute());
+
+        await app.StartAsync();
+        var response = await app.GetTestClient().GetAsync("/old/hello");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(observedMarker);
+        Assert.Contains(probe.ObservedEndpoints, e => e is not null && e.Metadata.GetMetadata<IAntiforgeryMetadata>() is { RequiresValidation: true });
     }
 }

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/Microsoft.AspNetCore.Tests.csproj
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/Microsoft.AspNetCore.Tests.csproj
@@ -25,6 +25,7 @@
     <Reference Include="Microsoft.AspNetCore.HttpOverrides" />
     <Reference Include="Microsoft.AspNetCore.Routing" />
     <Reference Include="Microsoft.AspNetCore.Routing.Abstractions" />
+    <Reference Include="Microsoft.AspNetCore.Rewrite" />
     <Reference Include="Microsoft.AspNetCore.Server.IIS" />
     <Reference Include="Microsoft.AspNetCore.Server.IISIntegration" />
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel" />

--- a/src/Http/Routing/src/EndpointRoutingMiddleware.cs
+++ b/src/Http/Routing/src/EndpointRoutingMiddleware.cs
@@ -55,16 +55,13 @@ internal sealed partial class EndpointRoutingMiddleware
         if (endpointRouteBuilder is IApplicationBuilder applicationBuilder &&
             applicationBuilder.Properties.TryGetValue(MiddlewareInvokedKeys.PostRoutingPipeline, out var value))
         {
-            // Consume the block so additional UseRouting() calls don't run it again.
-            applicationBuilder.Properties.Remove(MiddlewareInvokedKeys.PostRoutingPipeline);
-
             // Reject any custom user-placed code under PostRoutingPipeline
-            if (value is not Func<RequestDelegate, RequestDelegate> postRoutingMiddleware || !IsFrameworkPostRoutingMiddleware(postRoutingMiddleware))
+            if (value is not Func<RequestDelegate, RequestDelegate> postRoutingPipeline || !IsFrameworkPostRoutingMiddleware(postRoutingPipeline))
             {
                 throw new InvalidOperationException($"The '{MiddlewareInvokedKeys.PostRoutingPipeline}' application property is reserved for the framework and cannot be set by application code.");
             }
 
-            next = postRoutingMiddleware(next);
+            next = postRoutingPipeline(next);
         }
 
         _next = next;


### PR DESCRIPTION
As found out in #67588 and #67589, there are blazor template test which repros the bug with CsrfProtectionMiddleware used with `UseStatusCodePagesWithReExecute` on the same app. I reproduced it in `CsrfProtectionIntegrationTests` and am fixing in current PR.

The major change is to start reruning PostRoutingPipeline on each reroute - technically, that is a breaking change, but is safer and more explanative.

Related #67588